### PR TITLE
fix: Blueprint Service events DB and instances list endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__Redis: redis:6379
       ConnectionStrings__mongodb: mongodb://sorcha:sorcha_dev_password@mongodb:27017
+      ConnectionStrings__EventsDb: Host=postgres;Database=sorcha_events;Username=sorcha;Password=sorcha_dev_password;Timeout=30;Command Timeout=30
       # AI Provider configuration (Anthropic Claude API)
       AIProvider__ApiKey: ${ANTHROPIC_API_KEY:-}
       AIProvider__Model: claude-sonnet-4-5-20250929
@@ -137,6 +138,8 @@ services:
       redis:
         condition: service_healthy
       mongodb:
+        condition: service_healthy
+      postgres:
         condition: service_healthy
       wallet-service:
         condition: service_healthy

--- a/src/Apps/Sorcha.AppHost/AppHost.cs
+++ b/src/Apps/Sorcha.AppHost/AppHost.cs
@@ -15,6 +15,7 @@ var postgres = builder.AddPostgres("postgres")
 
 var tenantDb = postgres.AddDatabase("tenant-db", "sorcha_tenant");
 var walletDb = postgres.AddDatabase("wallet-db", "sorcha_wallet");
+var eventsDb = postgres.AddDatabase("EventsDb", "sorcha_events");
 
 // Add MongoDB for Register Service transaction storage
 var mongodb = builder.AddMongoDB("mongodb")
@@ -34,8 +35,9 @@ var tenantService = builder.AddProject<Projects.Sorcha_Tenant_Service>("tenant-s
     .WithEnvironment("JwtSettings__Issuer", "https://localhost:7110")
     .WithEnvironment("JwtSettings__Audience__0", "https://sorcha.local");
 
-// Add Blueprint Service with Redis reference (internal only)
+// Add Blueprint Service with Redis and Events DB references (internal only)
 var blueprintService = builder.AddProject<Projects.Sorcha_Blueprint_Service>("blueprint-service")
+    .WithReference(eventsDb)
     .WithReference(redis)
     .WithEnvironment("JwtSettings__SigningKey", jwtSigningKey)
     .WithEnvironment("JwtSettings__Issuer", "https://localhost:7110")

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -130,7 +130,7 @@ builder.Services.AddDbContext<Sorcha.Blueprint.Service.Data.BlueprintEventsDbCon
     if (!string.IsNullOrEmpty(eventsConnStr))
         options.UseNpgsql(eventsConnStr, npgsql => npgsql.EnableRetryOnFailure(3));
     else
-        options.UseSqlite("DataSource=BlueprintEvents.db");
+        throw new InvalidOperationException("ConnectionStrings:EventsDb is required. Configure a PostgreSQL connection string.");
 });
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IEventService,
     Sorcha.Blueprint.Service.Services.Implementation.EventService>();
@@ -231,6 +231,14 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 var logger = app.Logger;
+
+// Ensure Activity Events database schema exists (043)
+using (var scope = app.Services.CreateScope())
+{
+    var eventsDb = scope.ServiceProvider.GetRequiredService<Sorcha.Blueprint.Service.Data.BlueprintEventsDbContext>();
+    eventsDb.Database.EnsureCreated();
+    logger.LogInformation("Activity Events database schema ensured");
+}
 
 // Configure the HTTP request pipeline
 app.MapDefaultEndpoints();
@@ -1442,6 +1450,34 @@ notificationGroup.MapPost("/transaction-confirmed", async (
 var instancesGroup = app.MapGroup("/api/instances")
     .WithTags("Instances")
     .RequireAuthorization("CanExecuteBlueprints");
+
+/// <summary>
+/// List workflow instances with optional status filter
+/// </summary>
+instancesGroup.MapGet("/", async (
+    Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore,
+    string? status = null,
+    int page = 1,
+    int pageSize = 20) =>
+{
+    Sorcha.Blueprint.Service.Models.InstanceState? stateFilter = null;
+    if (!string.IsNullOrEmpty(status) && Enum.TryParse<Sorcha.Blueprint.Service.Models.InstanceState>(status, true, out var parsed))
+        stateFilter = parsed;
+
+    var skip = (Math.Max(1, page) - 1) * Math.Clamp(pageSize, 1, 100);
+    var (items, totalCount) = await instanceStore.GetAllAsync(stateFilter, skip, Math.Clamp(pageSize, 1, 100));
+
+    return Results.Ok(new
+    {
+        items,
+        totalCount,
+        page,
+        pageSize
+    });
+})
+.WithName("ListInstances")
+.WithSummary("List workflow instances")
+.WithDescription("List workflow instances with optional status filter and pagination");
 
 /// <summary>
 /// Create a new workflow instance

--- a/src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Service.csproj
+++ b/src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Service.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="YamlDotNet" />
     <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" />

--- a/src/Services/Sorcha.Blueprint.Service/Storage/IInstanceStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/IInstanceStore.cs
@@ -35,6 +35,20 @@ public interface IInstanceStore
     Task<Instance> UpdateAsync(Instance instance, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets all instances with optional state filter and pagination
+    /// </summary>
+    /// <param name="state">Optional state filter</param>
+    /// <param name="skip">Number of items to skip</param>
+    /// <param name="take">Number of items to take</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of instances and total count</returns>
+    Task<(IEnumerable<Instance> Items, int TotalCount)> GetAllAsync(
+        InstanceState? state = null,
+        int skip = 0,
+        int take = 20,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets all instances for a blueprint
     /// </summary>
     /// <param name="blueprintId">The blueprint ID</param>

--- a/src/Services/Sorcha.Blueprint.Service/Storage/InMemoryInstanceStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/InMemoryInstanceStore.cs
@@ -64,6 +64,29 @@ public class InMemoryInstanceStore : IInstanceStore
     }
 
     /// <inheritdoc/>
+    public Task<(IEnumerable<Instance> Items, int TotalCount)> GetAllAsync(
+        InstanceState? state = null,
+        int skip = 0,
+        int take = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _instances.Values.AsEnumerable();
+
+        if (state.HasValue)
+        {
+            query = query.Where(i => i.State == state.Value);
+        }
+
+        var totalCount = query.Count();
+        var items = query
+            .OrderByDescending(i => i.CreatedAt)
+            .Skip(skip)
+            .Take(take);
+
+        return Task.FromResult((items, totalCount));
+    }
+
+    /// <inheritdoc/>
     public Task<IEnumerable<Instance>> GetByBlueprintAsync(
         string blueprintId,
         InstanceState? state = null,

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/BlueprintServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/BlueprintServiceWebApplicationFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +49,14 @@ public class BlueprintServiceWebApplicationFactory : WebApplicationFactory<Progr
 
         builder.ConfigureServices(services =>
         {
+            // Replace BlueprintEventsDbContext with in-memory provider for testing
+            var eventsDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<Data.BlueprintEventsDbContext>));
+            if (eventsDescriptor != null)
+                services.Remove(eventsDescriptor);
+            services.AddDbContext<Data.BlueprintEventsDbContext>(options =>
+                options.UseInMemoryDatabase($"TestEvents-{Guid.NewGuid()}"));
+
             // Remove the real Redis output caching
             services.RemoveAll<IDistributedCache>();
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Sorcha.Blueprint.Service.Tests.csproj
+++ b/tests/Sorcha.Blueprint.Service.Tests/Sorcha.Blueprint.Service.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />


### PR DESCRIPTION
## Summary
- Fix 500 on `/api/events/unread-count`: add PostgreSQL connection string for BlueprintEventsDbContext, `EnsureCreated` on startup, remove SQLite fallback
- Fix 405 on `GET /api/instances`: add `GetAllAsync` to `IInstanceStore` and list endpoint with status filter and pagination
- Wire EventsDb PostgreSQL in docker-compose and Aspire AppHost
- Update test factory with InMemory BlueprintEventsDbContext

## Test plan
- [x] Blueprint Service builds with 0 errors
- [x] EventService tests pass (14 tests)
- [x] Docker container rebuilt and verified startup logs show "Activity Events database schema ensured"
- [ ] Browser console errors resolved after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)