### PR TITLE
fix: flush SSE headers on connect for proxy compatibility

### DIFF
--- a/src/Apps/Sorcha.PeerRouter/Endpoints/EventStreamEndpoints.cs
+++ b/src/Apps/Sorcha.PeerRouter/Endpoints/EventStreamEndpoints.cs
@@ -52,6 +52,18 @@ public static class EventStreamEndpoints
 
         try
         {
+            // Send SSE comment to flush headers through reverse proxies (Envoy),
+            // then replay buffered events so clients get history on connect.
+            await ctx.Response.WriteAsync(": connected\n\n", ct);
+
+            foreach (var past in buffer.GetSnapshot())
+            {
+                var pastJson = JsonSerializer.Serialize(past, JsonOptions);
+                await ctx.Response.WriteAsync($"data: {pastJson}\n\n", ct);
+            }
+
+            await ctx.Response.Body.FlushAsync(ct);
+
             await foreach (var evt in buffer.FollowAsync(ct))
             {
                 var json = JsonSerializer.Serialize(evt, JsonOptions);


### PR DESCRIPTION
## Summary
- Send `: connected` SSE comment immediately on stream open to flush response headers through reverse proxies (Envoy in Azure Container Apps)
- Replay buffered events on connect so clients get history immediately
- Fixes debug page stuck on "Connecting..." when deployed behind Container Apps

## Test plan
- [x] Verified locally with `curl -N /events?follow` — receives `: connected` immediately
- [x] Verified on `https://n0.sorcha.dev` — debug page shows "Connected" (green badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)