### PR TITLE
feat: configure Peer Service seed node to n0.sorcha.dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -339,11 +339,16 @@ services:
       PeerService__PublicAddress: "${PEER_PUBLIC_ADDRESS:-}"
       PeerService__Port: "5000"
       PeerService__EnableTls: "false"
-      # Cross-machine seed node (configured via .env for each machine)
-      PeerService__SeedNodes__SeedNodes__0__NodeId: "${SEED_PEER_NODE_ID:-}"
-      PeerService__SeedNodes__SeedNodes__0__Hostname: "${SEED_PEER_HOST:-}"
-      PeerService__SeedNodes__SeedNodes__0__Port: "${SEED_PEER_PORT:-50051}"
-      PeerService__SeedNodes__SeedNodes__0__EnableTls: "false"
+      # Azure-hosted PeerRouter seed node (n0.sorcha.dev)
+      PeerService__SeedNodes__SeedNodes__0__NodeId: "n0"
+      PeerService__SeedNodes__SeedNodes__0__Hostname: "n0.sorcha.dev"
+      PeerService__SeedNodes__SeedNodes__0__Port: "443"
+      PeerService__SeedNodes__SeedNodes__0__EnableTls: "true"
+      # Additional cross-machine seed node (configured via .env for each machine)
+      PeerService__SeedNodes__SeedNodes__1__NodeId: "${SEED_PEER_NODE_ID:-}"
+      PeerService__SeedNodes__SeedNodes__1__Hostname: "${SEED_PEER_HOST:-}"
+      PeerService__SeedNodes__SeedNodes__1__Port: "${SEED_PEER_PORT:-5000}"
+      PeerService__SeedNodes__SeedNodes__1__EnableTls: "false"
     volumes:
       - dataprotection-keys:/home/app/.aspnet/DataProtection-Keys
     depends_on:

--- a/src/Apps/Sorcha.AppHost/AppHost.cs
+++ b/src/Apps/Sorcha.AppHost/AppHost.cs
@@ -63,7 +63,12 @@ var peerService = builder.AddProject<Projects.Sorcha_Peer_Service>("peer-service
     .WithEnvironment("JwtSettings__Audience", "https://sorcha.local")
     .WithEnvironment("ServiceAuth__ClientId", "service-peer")
     .WithEnvironment("ServiceAuth__ClientSecret", "peer-service-secret")
-    .WithEnvironment("ServiceAuth__Scopes", "registers:write registers:read");
+    .WithEnvironment("ServiceAuth__Scopes", "registers:write registers:read")
+    // Azure-hosted PeerRouter seed node
+    .WithEnvironment("PeerService__SeedNodes__SeedNodes__0__NodeId", "n0")
+    .WithEnvironment("PeerService__SeedNodes__SeedNodes__0__Hostname", "n0.sorcha.dev")
+    .WithEnvironment("PeerService__SeedNodes__SeedNodes__0__Port", "443")
+    .WithEnvironment("PeerService__SeedNodes__SeedNodes__0__EnableTls", "true");
 
 // Add Register Service with MongoDB, Redis, and Peer Service reference
 var registerService = builder.AddProject<Projects.Sorcha_Register_Service>("register-service")

--- a/src/Services/Sorcha.Peer.Service/appsettings.Development.json
+++ b/src/Services/Sorcha.Peer.Service/appsettings.Development.json
@@ -19,6 +19,16 @@
     "BootstrapNodes": [],
     "EnablePeerDiscovery": true,
     "MaxPeers": 50,
+    "SeedNodes": {
+      "SeedNodes": [
+        {
+          "NodeId": "n0",
+          "Hostname": "n0.sorcha.dev",
+          "Port": 443,
+          "EnableTls": true
+        }
+      ]
+    },
     "HubNode": {
       "IsHubNode": false,
       "ExpectedHostnamePattern": "*.sorcha.dev",


### PR DESCRIPTION
## Summary
- Configures `n0.sorcha.dev:443` (Azure Container Apps PeerRouter) as the default seed node for Peer Service
- Added to all three config locations for belt-and-braces coverage:
  - `appsettings.Development.json` — local `dotnet run` development
  - `docker-compose.yml` — Docker deployment (slot 0 = n0, slot 1 = custom via `.env`)
  - `AppHost.cs` — .NET Aspire orchestration
- Uses TLS (port 443) since PeerRouter is behind Container Apps' managed SSL

## Test plan
- [ ] Run Peer Service locally and verify it connects to `n0.sorcha.dev` seed node
- [ ] Check `https://n0.sorcha.dev` debug page shows the peer as connected
- [ ] Verify Docker Compose starts with seed node configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)