### PR TITLE
fix: CSP blocking server-rendered auth pages

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -245,7 +245,7 @@ public static class Extensions
             var path = context.Request.Path.Value ?? "";
             if (path.StartsWith("/scalar", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/admin", StringComparison.OrdinalIgnoreCase) ||
-                path.StartsWith("/login", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("/auth", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/design", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/app", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/explorer", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
## Summary
- Replace `/login` with `/auth` in CSP path allowlist (`UseApiSecurityHeaders`)
- PR #33 moved login to `/auth/login` but CSP still checked `/login`, causing `default-src 'none'` to apply to all auth pages
- The `/auth` prefix covers both `/auth/*` pages and `/auth-static/*` resources

## Root Cause
Browser console errors showed:
- `Applying inline style violates CSP directive 'default-src 'none''`
- `Executing inline script violates CSP directive 'default-src 'none''`
- 500 error on login page load

The strict API CSP was being applied to HTML pages, blocking all styles, scripts, and connections.

## Test plan
- [ ] Navigate to `/auth/login` — page renders with styles and scripts
- [ ] Passkey button works (inline script executes)
- [ ] Form submission works (CSP allows connect-src)
- [ ] API endpoints still get strict `default-src 'none'` CSP

🤖 Generated with [Claude Code](https://claude.com/claude-code)