### PR TITLE
fix: login 500 (antiforgery SSL) and incorrect auth URLs

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -49,7 +49,7 @@
                 </MudMenu>
             </Authorized>
             <NotAuthorized>
-                <MudButton Href="auth/login" Variant="Variant.Text" Color="Color.Inherit" StartIcon="@Icons.Material.Filled.Login">
+                <MudButton OnClick="@(() => Navigation.NavigateTo("/auth/login", forceLoad: true))" Variant="Variant.Text" Color="Color.Inherit" StartIcon="@Icons.Material.Filled.Login">
                     @Loc.T("nav.signIn")
                 </MudButton>
             </NotAuthorized>
@@ -213,7 +213,7 @@
             </Authorized>
             <NotAuthorized>
                 <MudNavMenu>
-                    <MudNavLink Href="auth/login" Icon="@Icons.Material.Filled.Login">
+                    <MudNavLink OnClick="@(() => Navigation.NavigateTo("/auth/login", forceLoad: true))" Icon="@Icons.Material.Filled.Login">
                         @Loc.T("nav.signIn")
                     </MudNavLink>
                 </MudNavMenu>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -103,8 +103,8 @@
                 <a href="#use-cases" class="nav-link">Use Cases</a>
                 <a href="#features" class="nav-link">Features</a>
                 <a href="/app/help" class="nav-link">Help</a>
-                <a href="/app/auth/login" class="btn btn-outline">Sign In</a>
-                <a href="/app/auth/login" class="btn btn-primary">Get Started</a>
+                <a href="/auth/login" class="btn btn-outline">Sign In</a>
+                <a href="/auth/login" class="btn btn-primary">Get Started</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation">
                 <span></span><span></span><span></span>
@@ -126,7 +126,7 @@
                 signed, every record is immutable, and every credential is verifiable.
             </p>
             <div class="hero-actions">
-                <a href="/app/auth/login" class="btn btn-primary btn-lg">
+                <a href="/auth/login" class="btn btn-primary btn-lg">
                     Start Building
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
                 </a>
@@ -650,7 +650,7 @@
             <h2>Ready to Build Trust Into Your Workflows?</h2>
             <p>Start designing secure, multi-party processes with cryptographic guarantees and verifiable credentials — no blockchain expertise required.</p>
             <div class="cta-actions">
-                <a href="/app/auth/login" class="btn btn-primary btn-lg">
+                <a href="/auth/login" class="btn btn-primary btn-lg">
                     Get Started Free
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
                 </a>
@@ -681,7 +681,7 @@
                     <h4>Resources</h4>
                     <a href="/app/help">Documentation</a>
                     <a href="https://github.com/StuartF303/Sorcha" target="_blank" rel="noopener">GitHub</a>
-                    <a href="/app/auth/login">Sign In</a>
+                    <a href="/auth/login">Sign In</a>
                 </div>
                 <div class="footer-col">
                     <h4>Standards</h4>

--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using Sorcha.Tenant.Service.Endpoints;
 using Sorcha.ServiceClients.Extensions;
@@ -89,6 +90,18 @@ builder.Services.AddRateLimiter(options =>
     });
 });
 
+// Configure ForwardedHeaders for Docker/reverse proxy support
+// The API Gateway terminates TLS and forwards HTTP internally — the tenant service
+// must trust X-Forwarded-Proto so antiforgery sees the original HTTPS request.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor |
+                               ForwardedHeaders.XForwardedProto |
+                               ForwardedHeaders.XForwardedHost;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 // Add Razor Pages for server-rendered auth UI
 builder.Services.AddRazorPages();
 builder.Services.AddAntiforgery(options =>
@@ -96,7 +109,7 @@ builder.Services.AddAntiforgery(options =>
     options.Cookie.Name = "Sorcha.Auth.AF";
     options.Cookie.Path = "/auth";
     options.Cookie.SameSite = SameSiteMode.Strict;
-    options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
 });
 
 // Add health checks (PostgreSQL and Redis when configured)
@@ -118,6 +131,9 @@ var app = builder.Build();
 
 // Map default endpoints (OpenAPI, health checks)
 app.MapDefaultEndpoints();
+
+// Trust forwarded headers from API Gateway (must be before any middleware that checks scheme)
+app.UseForwardedHeaders();
 
 // Add Serilog HTTP request logging (OPS-001)
 app.UseSerilogLogging();


### PR DESCRIPTION
## Summary
- **Antiforgery 500 fix**: Added `UseForwardedHeaders()` to Tenant Service so it trusts `X-Forwarded-Proto` from the API Gateway. Changed `SecurePolicy` from `Always` to `SameAsRequest` since internal Docker traffic is HTTP.
- **Landing page URLs**: Changed `/app/auth/login` → `/auth/login` in `index.html` (5 links). The `/app/` prefix routes to the Blazor SPA which doesn't serve Razor Pages.
- **MainLayout navigation**: Changed `Href="auth/login"` to `NavigateTo("/auth/login", forceLoad: true)` to break out of the Blazor SPA and hit the server-rendered login page.

## Root Cause
1. API Gateway terminates TLS → forwards HTTP to Tenant Service → antiforgery rejects non-SSL request
2. Landing page linked to `/app/auth/login` (Blazor SPA) instead of `/auth/login` (Razor Pages via gateway)
3. Blazor's NavigationManager intercepted relative `auth/login` links, never leaving the SPA

## Test plan
- [ ] `curl http://localhost/auth/login` returns 200 with login HTML
- [ ] Landing page "Sign In" / "Get Started" buttons navigate to Razor login page
- [ ] MainLayout sign-in button navigates to Razor login page (not Blazor 404)
- [ ] Login form submits successfully (antiforgery token works)
- [ ] Signup page also loads: `curl http://localhost/auth/signup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)