### PR TITLE
chore: fix Microsoft.Bcl.Memory vulnerability (CVE high severity)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,13 +1,13 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- AI / MCP -->
     <PackageVersion Include="Anthropic.SDK" Version="5.10.0" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.0.0" />
-
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
     <!-- .NET Aspire -->
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
     <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.1.2" />
@@ -17,47 +17,34 @@
     <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.1.2" />
     <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.1.2" />
     <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.1.2" />
-
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
-
     <!-- Testing - Fixtures -->
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
-
     <!-- Azure -->
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
-
+    <PackageVersion Include="Azure.Identity" Version="1.19.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.9.0" />
     <!-- Security -->
-    <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
-
+    <PackageVersion Include="BCrypt.Net-Next" Version="4.1.0" />
     <!-- Benchmarking -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.7" />
-
     <!-- Blazor -->
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
-
     <!-- Cryptography -->
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2" />
-
     <!-- Testing - Blazor -->
     <PackageVersion Include="bunit" Version="2.6.2" />
-
     <!-- Testing - Coverage -->
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-
     <!-- Authentication -->
     <PackageVersion Include="Fido2.AspNet" Version="4.0.0" />
-
     <!-- Testing - Assertions -->
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
-
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.34.0" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
@@ -65,200 +52,152 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
-
     <!-- SD-JWT -->
     <PackageVersion Include="HeroSD-JWT" Version="1.1.7" />
-
     <!-- JSON Processing -->
-    <PackageVersion Include="JsonE.Net" Version="2.5.1" />
-    <PackageVersion Include="JsonLogic" Version="5.5.0" />
+    <PackageVersion Include="JsonE.Net" Version="3.0.0" />
+    <PackageVersion Include="JsonLogic" Version="6.0.0" />
     <PackageVersion Include="JsonLogic.Net" Version="1.1.11" />
-    <PackageVersion Include="JsonPath.Net" Version="2.2.0" />
-    <PackageVersion Include="JsonSchema.Net" Version="8.0.5" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="6.0.0" />
-
+    <PackageVersion Include="JsonPath.Net" Version="3.0.1" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.1.2" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="7.1.2" />
     <!-- Microsoft ASP.NET Core -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.4.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
     <!-- Microsoft Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <!-- Microsoft Extensions - Caching -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.3" />
-
     <!-- Microsoft Extensions - Configuration -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
     <!-- Microsoft Extensions - DI -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <!-- Microsoft Extensions - Health -->
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
     <!-- Microsoft Extensions - Hosting -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
     <!-- Microsoft Extensions - HTTP -->
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
-
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
     <!-- Microsoft Extensions - Logging -->
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <!-- Microsoft Extensions - Options -->
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
     <!-- Microsoft Extensions - Service Discovery -->
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
     <!-- Microsoft JSInterop -->
-    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.3" />
-
+    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.5" />
     <!-- Testing - SDK -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-
     <!-- Testing - Playwright -->
-    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.57.0" />
-
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
     <!-- Source Link -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
-
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <!-- MongoDB -->
-    <PackageVersion Include="MongoDB.Driver" Version="3.6.0" />
-
+    <PackageVersion Include="MongoDB.Driver" Version="3.7.0" />
     <!-- Testing - Mocking -->
     <PackageVersion Include="Moq" Version="4.20.72" />
-
     <!-- Blazor UI -->
-    <PackageVersion Include="MudBlazor" Version="9.0.0" />
-
+    <PackageVersion Include="MudBlazor" Version="9.1.0" />
     <!-- Crypto - Bitcoin -->
-    <PackageVersion Include="NBitcoin" Version="9.0.4" />
-
+    <PackageVersion Include="NBitcoin" Version="9.0.5" />
     <!-- Load Testing -->
-    <PackageVersion Include="NBomber" Version="6.2.0" />
-    <PackageVersion Include="NBomber.Http" Version="6.1.0" />
-
+    <PackageVersion Include="NBomber" Version="6.3.0" />
+    <PackageVersion Include="NBomber.Http" Version="6.2.0" />
     <!-- Crypto - BLS -->
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
-
     <!-- Email -->
     <PackageVersion Include="MailKit" Version="4.15.1" />
-
     <!-- JSON Serialization -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-
     <!-- PostgreSQL -->
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <!-- Testing - NUnit -->
-    <PackageVersion Include="NUnit" Version="4.4.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
-
     <!-- OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.14.0-beta.1" />
-
     <!-- OTP -->
     <PackageVersion Include="Otp.NET" Version="1.4.1" />
-
     <!-- Resilience -->
-    <PackageVersion Include="Polly" Version="8.6.5" />
-    <PackageVersion Include="Polly.Extensions" Version="8.6.5" />
-
+    <PackageVersion Include="Polly" Version="8.6.6" />
+    <PackageVersion Include="Polly.Extensions" Version="8.6.6" />
     <!-- QR Code -->
     <PackageVersion Include="QRCoder" Version="1.7.0" />
-
     <!-- Console -->
     <PackageVersion Include="ReadLine" Version="2.0.1" />
-
     <!-- HTTP Client -->
     <PackageVersion Include="Refit" Version="10.0.1" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
-
     <!-- OpenAPI -->
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.50" />
-
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.8" />
     <!-- Logging -->
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-
     <!-- Encoding -->
     <PackageVersion Include="SimpleBase" Version="5.6.0" />
-
     <!-- Crypto - Sodium -->
     <PackageVersion Include="Sodium.Core" Version="1.4.0" />
-
     <!-- Console UI -->
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
-
     <!-- Redis -->
-    <PackageVersion Include="StackExchange.Redis" Version="2.11.8" />
-
+    <PackageVersion Include="StackExchange.Redis" Version="2.12.1" />
     <!-- CLI -->
-    <PackageVersion Include="System.CommandLine" Version="2.0.3" />
-
+    <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <!-- JWT -->
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
-
     <!-- Security -->
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.3" />
-
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
     <!-- Rate Limiting -->
-    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.3" />
-
+    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.5" />
     <!-- Testing - Containers -->
-    <PackageVersion Include="Testcontainers" Version="4.10.0" />
-    <PackageVersion Include="Testcontainers.MongoDb" Version="4.10.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.2.0" />
-
     <!-- Testing - xUnit -->
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-
     <!-- YAML -->
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-
     <!-- Reverse Proxy -->
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
-
     <!-- Blazor Diagrams -->
-    <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.4" />
+    <PackageVersion Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Pin `Microsoft.Bcl.Memory` from vulnerable 9.0.0 to 10.0.5 (fixes [GHSA-73j8-2gch-69rq](https://github.com/advisories/GHSA-73j8-2gch-69rq))
- Enable `CentralPackageTransitivePinningEnabled` in `Directory.Packages.props` to automatically override transitive dependency versions
- Bulk NuGet package updates (Microsoft.* 10.0.3→10.0.5, JsonSchema.Net, MongoDB.Driver, MudBlazor, etc.)

## Test plan
- [x] `dotnet build --force` — 0 warnings, 0 errors
- [ ] Verify no runtime regressions from package updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)