### PR TITLE
feat: PeerRouter UI filters, heartbeat rejection, and source clarity

### DIFF
--- a/src/Apps/Sorcha.PeerRouter/GrpcServices/RouterHeartbeatService.cs
+++ b/src/Apps/Sorcha.PeerRouter/GrpcServices/RouterHeartbeatService.cs
@@ -57,13 +57,46 @@ public sealed class RouterHeartbeatService : PeerHeartbeat.PeerHeartbeatBase
 
     /// <summary>
     /// Core heartbeat processing: touch peer, update register versions, emit event, build response.
+    /// Rejects heartbeats from unregistered peers, forcing them to re-register.
     /// </summary>
     private PeerHeartbeatResponse ProcessHeartbeat(PeerHeartbeatRequest request)
     {
         var peerId = request.PeerId;
         var found = _routingTable.TouchPeer(peerId);
 
-        if (found && request.RegisterVersions.Count > 0)
+        // Resolve the peer's actual address from the routing table for event clarity
+        var peer = _routingTable.GetPeer(peerId);
+        var ipAddress = peer?.IpAddress ?? "unknown";
+        var port = peer?.Port ?? 0;
+
+        if (!found)
+        {
+            _eventBuffer.Add(RouterEvent.Create(
+                RouterEventType.PeerHeartbeatRejected,
+                peerId,
+                ipAddress,
+                port,
+                detail: new Dictionary<string, object?>
+                {
+                    ["sequence"] = request.SequenceNumber,
+                    ["reason"] = "Peer not registered — must re-register"
+                }));
+
+            _logger.LogWarning(
+                "Heartbeat rejected from unregistered peer {PeerId} seq={Sequence}",
+                peerId,
+                request.SequenceNumber);
+
+            return new PeerHeartbeatResponse
+            {
+                Success = false,
+                PeerId = "router",
+                Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                Message = "Peer not registered"
+            };
+        }
+
+        if (request.RegisterVersions.Count > 0)
         {
             _routingTable.UpdateRegisterVersions(peerId, request.RegisterVersions);
         }
@@ -92,22 +125,21 @@ public sealed class RouterHeartbeatService : PeerHeartbeat.PeerHeartbeatBase
         _eventBuffer.Add(RouterEvent.Create(
             RouterEventType.PeerHeartbeat,
             peerId,
-            "heartbeat",
-            0,
+            ipAddress,
+            port,
             detail: detail));
 
         _logger.LogDebug(
-            "Heartbeat from {PeerId} seq={Sequence}, found={Found}",
+            "Heartbeat from {PeerId} seq={Sequence}",
             peerId,
-            request.SequenceNumber,
-            found);
+            request.SequenceNumber);
 
         return new PeerHeartbeatResponse
         {
-            Success = found,
+            Success = true,
             PeerId = "router",
             Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            Message = found ? "OK" : "Peer not registered"
+            Message = "OK"
         };
     }
 }

--- a/src/Apps/Sorcha.PeerRouter/Models/RouterEventType.cs
+++ b/src/Apps/Sorcha.PeerRouter/Models/RouterEventType.cs
@@ -15,5 +15,6 @@ public enum RouterEventType
     PeerListRequested,
     PeerExchanged,
     RelayForwarded,
-    Error
+    Error,
+    PeerHeartbeatRejected
 }

--- a/src/Apps/Sorcha.PeerRouter/wwwroot/index.html
+++ b/src/Apps/Sorcha.PeerRouter/wwwroot/index.html
@@ -156,6 +156,30 @@
         .event-type-PeerExchanged { color: #d29922; }
         .event-type-RelayForwarded { color: #f0883e; }
         .event-type-Error { color: #ff7b72; }
+        .event-type-PeerHeartbeatRejected { color: #f97583; }
+
+        .filter-bar {
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+            padding: 8px 16px;
+            border-bottom: 1px solid #30363d;
+            background: #0d1117;
+        }
+
+        .filter-btn {
+            padding: 3px 10px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 600;
+            border: 1px solid #30363d;
+            background: transparent;
+            cursor: pointer;
+            transition: opacity 0.15s;
+        }
+
+        .filter-btn.active { opacity: 1; }
+        .filter-btn.inactive { opacity: 0.35; }
 
         .event-time {
             color: #484f58;
@@ -258,6 +282,7 @@
                 Live Events
                 <span class="event-count" id="event-count">0 events</span>
             </div>
+            <div class="filter-bar" id="filter-bar"></div>
             <div class="panel-body" id="event-list">
                 <div class="no-data">Waiting for events...</div>
             </div>
@@ -269,8 +294,17 @@
         var EVENT_TYPE_NAMES = [
             'PeerConnected','PeerDisconnected','PeerHeartbeat',
             'RegisterAdvertised','PeerListRequested','PeerExchanged',
-            'RelayForwarded','Error'
+            'RelayForwarded','Error','PeerHeartbeatRejected'
         ];
+        var EVENT_TYPE_COLORS = {
+            PeerConnected: '#3fb950', PeerDisconnected: '#f85149',
+            PeerHeartbeat: '#58a6ff', RegisterAdvertised: '#d2a8ff',
+            PeerListRequested: '#79c0ff', PeerExchanged: '#d29922',
+            RelayForwarded: '#f0883e', Error: '#ff7b72',
+            PeerHeartbeatRejected: '#f97583'
+        };
+        var activeFilters = {};
+        EVENT_TYPE_NAMES.forEach(function(t) { activeFilters[t] = true; });
         var events = [];
         var eventSource = null;
         var reconnectDelay = 1000;
@@ -323,6 +357,24 @@
             return el;
         }
 
+        function buildFilterBar() {
+            var bar = document.getElementById('filter-bar');
+            clearChildren(bar);
+            EVENT_TYPE_NAMES.forEach(function(t) {
+                var btn = document.createElement('button');
+                btn.textContent = t;
+                btn.className = 'filter-btn ' + (activeFilters[t] ? 'active' : 'inactive');
+                btn.style.color = EVENT_TYPE_COLORS[t] || '#c9d1d9';
+                btn.style.borderColor = activeFilters[t] ? (EVENT_TYPE_COLORS[t] || '#30363d') : '#30363d';
+                btn.onclick = function() {
+                    activeFilters[t] = !activeFilters[t];
+                    buildFilterBar();
+                    renderEvents();
+                };
+                bar.appendChild(btn);
+            });
+        }
+
         function renderEvents() {
             var container = document.getElementById('event-list');
             var countEl = document.getElementById('event-count');
@@ -330,13 +382,18 @@
 
             clearChildren(container);
 
-            if (events.length === 0) {
-                container.appendChild(createTextEl('div', 'Waiting for events...', 'no-data'));
+            var filtered = events.filter(function(evt) {
+                return activeFilters[getTypeName(evt.type)];
+            });
+
+            if (filtered.length === 0) {
+                container.appendChild(createTextEl('div',
+                    events.length === 0 ? 'Waiting for events...' : 'No events match filter', 'no-data'));
                 return;
             }
 
-            for (var i = events.length - 1; i >= 0; i--) {
-                var evt = events[i];
+            for (var i = filtered.length - 1; i >= 0; i--) {
+                var evt = filtered[i];
                 var typeName = getTypeName(evt.type);
 
                 var row = document.createElement('div');
@@ -349,8 +406,10 @@
                 peerSpan.title = evt.peerId || '';
                 row.appendChild(peerSpan);
 
-                row.appendChild(createTextEl('span',
-                    (evt.ipAddress || '') + ':' + (evt.port || ''), 'event-detail'));
+                var source = (evt.ipAddress && evt.ipAddress !== 'unknown')
+                    ? evt.ipAddress + (evt.port ? ':' + evt.port : '')
+                    : shortenPeerId(evt.peerId);
+                row.appendChild(createTextEl('span', source, 'event-detail'));
 
                 container.appendChild(row);
             }
@@ -459,6 +518,7 @@
             }).catch(function() {});
         }
 
+        buildFilterBar();
         connectSSE();
         fetchPeers();
         fetchHealth();

--- a/src/Services/Sorcha.Peer.Service/Connection/PeerConnectionPool.cs
+++ b/src/Services/Sorcha.Peer.Service/Connection/PeerConnectionPool.cs
@@ -386,6 +386,25 @@ public class PeerConnectionPool : IAsyncDisposable
     }
 
     /// <summary>
+    /// Marks a peer's connection as disconnected so the reconnection loop
+    /// will re-establish the connection and re-register with the remote.
+    /// Unlike RecordFailureAsync, this does not increment failure counts —
+    /// it handles logical rejections (e.g. "Peer not registered") where
+    /// the transport is healthy but the remote has dropped the peer's state.
+    /// </summary>
+    public void MarkPeerForReconnection(string peerId)
+    {
+        if (_connections.TryGetValue(peerId, out var connection))
+        {
+            connection.IsConnected = false;
+            connection.ConsecutiveFailures = 0;
+            _logger.LogInformation(
+                "Peer {PeerId} marked for reconnection (logical rejection)",
+                peerId);
+        }
+    }
+
+    /// <summary>
     /// Gets the connection status for all peers.
     /// </summary>
     public IReadOnlyDictionary<string, bool> GetConnectionStatuses()

--- a/src/Services/Sorcha.Peer.Service/Observability/PeerServiceMetrics.cs
+++ b/src/Services/Sorcha.Peer.Service/Observability/PeerServiceMetrics.cs
@@ -37,6 +37,9 @@ public sealed class PeerServiceMetrics : IDisposable
     private readonly Counter<long> _pushNotificationsDelivered;
     private readonly Counter<long> _pushNotificationsFailed;
 
+    // Heartbeat rejection metrics
+    private readonly Counter<long> _heartbeatRejectionsReceived;
+
     // Failover metrics
     private readonly Counter<long> _failoverCount;
 
@@ -88,6 +91,12 @@ public sealed class PeerServiceMetrics : IDisposable
             name: "peer.push.notifications.failed",
             unit: "notifications",
             description: "Number of failed push notification deliveries");
+
+        // Heartbeat rejection counter (remote peer dropped our registration)
+        _heartbeatRejectionsReceived = _meter.CreateCounter<long>(
+            name: "peer.heartbeat.rejections",
+            unit: "rejections",
+            description: "Number of heartbeat rejections received from remote peers");
 
         // Failover event counter
         _failoverCount = _meter.CreateCounter<long>(
@@ -159,6 +168,23 @@ public sealed class PeerServiceMetrics : IDisposable
     public void RecordPushNotificationFailed(long count = 1)
     {
         _pushNotificationsFailed.Add(count);
+    }
+
+    /// <summary>
+    /// Records a heartbeat rejection from a remote peer.
+    /// Tracks per-peer rejection counts for future reliability scoring.
+    /// </summary>
+    /// <param name="peerId">The peer that rejected our heartbeat</param>
+    /// <param name="reason">Rejection reason from the remote peer</param>
+    public void RecordHeartbeatRejection(string peerId, string reason)
+    {
+        var tags = new TagList
+        {
+            { "peer_id", peerId },
+            { "reason", reason }
+        };
+
+        _heartbeatRejectionsReceived.Add(1, tags);
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatService.cs
+++ b/src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatService.cs
@@ -134,10 +134,25 @@ public class PeerHeartbeatBackgroundService : BackgroundService
 
             var latency = (DateTime.UtcNow - startTime).TotalMilliseconds;
 
+            var latencySpan = TimeSpan.FromMilliseconds(latency);
+            _metrics.RecordHeartbeatLatency(latency, peerId);
+
+            // Handle heartbeat rejection — remote peer has dropped our registration
+            // (e.g. we timed out of their routing table). Mark for reconnection so the
+            // existing reconnect loop re-registers us on the next cycle.
+            if (!response.Success)
+            {
+                _logger.LogWarning(
+                    "Heartbeat {Seq} rejected by peer {PeerId}: {Reason} — marking for reconnection",
+                    sequenceNumber, peerId, response.Message);
+                _metrics.RecordHeartbeatRejection(peerId, response.Message);
+                _connectionPool.MarkPeerForReconnection(peerId);
+                return;
+            }
+
             // Record success
             _connectionPool.RecordSuccess(peerId);
-            _metrics.RecordHeartbeatLatency(latency, peerId);
-            _activitySource.RecordSuccess(activity, TimeSpan.FromMilliseconds(latency));
+            _activitySource.RecordSuccess(activity, latencySpan);
 
             // Update peer's last seen time
             await _peerListManager.UpdateLastSeenAsync(peerId);

--- a/tests/Sorcha.PeerRouter.Tests/GrpcServices/RouterHeartbeatServiceTests.cs
+++ b/tests/Sorcha.PeerRouter.Tests/GrpcServices/RouterHeartbeatServiceTests.cs
@@ -68,6 +68,47 @@ public sealed class RouterHeartbeatServiceTests
     }
 
     [Fact]
+    public async Task SendHeartbeat_UnregisteredPeer_EmitsRejectedEvent()
+    {
+        var initialCount = _eventBuffer.Count;
+
+        var request = new PeerHeartbeatRequest
+        {
+            PeerId = "unknown-peer",
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            SequenceNumber = 42
+        };
+
+        await _service.SendHeartbeat(request, TestServerCallContext.Create());
+
+        _eventBuffer.Count.Should().BeGreaterThan(initialCount);
+        var lastEvent = _eventBuffer.GetSnapshot().Last();
+        lastEvent.Type.Should().Be(RouterEventType.PeerHeartbeatRejected);
+        lastEvent.PeerId.Should().Be("unknown-peer");
+    }
+
+    [Fact]
+    public async Task SendHeartbeat_RegisteredPeer_EmitsEventWithPeerAddress()
+    {
+        RegisterPeer("peer-1");
+        var initialCount = _eventBuffer.Count;
+
+        var request = new PeerHeartbeatRequest
+        {
+            PeerId = "peer-1",
+            Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            SequenceNumber = 1
+        };
+
+        await _service.SendHeartbeat(request, TestServerCallContext.Create());
+
+        var lastEvent = _eventBuffer.GetSnapshot().Last();
+        lastEvent.Type.Should().Be(RouterEventType.PeerHeartbeat);
+        lastEvent.IpAddress.Should().Be("10.0.0.1");
+        lastEvent.Port.Should().Be(5000);
+    }
+
+    [Fact]
     public async Task SendHeartbeat_UpdatesLastSeen()
     {
         RegisterPeer("peer-1");


### PR DESCRIPTION
## Summary
- **Event type filter bar** in the debug console UI — color-coded toggle buttons to show/hide event types (e.g. focus on just Heartbeat or PeerExchange)
- **Heartbeat rejection for unregistered peers** — new `PeerHeartbeatRejected` event type with clear reason; forces peers to re-register rather than silently accepting heartbeats from dropped peers
- **Source address clarity** — heartbeat events now show the peer's actual IP:port from the routing table instead of hardcoded `"heartbeat:0"`
- **Peer-side rejection handling** — peer service checks `response.Success`, logs rejection, records `peer.heartbeat.rejections` metric (per-peer tags for future reliability scoring), and marks connection for reconnection via existing reconnect loop
- **`MarkPeerForReconnection`** — new method on `PeerConnectionPool` that distinguishes logical rejections from transport failures (doesn't increment failure count)

## Test plan
- [x] PeerRouter builds with 0 warnings
- [x] Peer Service builds with 0 warnings
- [x] 84 PeerRouter tests pass (2 new: rejection event type, source address clarity)
- [x] 572 Peer Service tests pass
- [ ] Manual: deploy to Azure and verify filter bar works in debug console
- [ ] Manual: verify rejected heartbeats show as `PeerHeartbeatRejected` in event log

🤖 Generated with [Claude Code](https://claude.com/claude-code)