### PR TITLE
fix: correct system-register URL and add auth to peer admin calls

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/PeerServiceAdmin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/PeerServiceAdmin.razor
@@ -1,7 +1,12 @@
 @using System.Net.Http.Json
+@using System.Net.Http.Headers
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Authentication
+@using Sorcha.UI.Core.Services.Configuration
 @inject HttpClient Http
+@inject IAuthenticationService AuthService
+@inject IConfigurationService ConfigService
 
 <MudGrid>
     <MudItem xs="12">
@@ -525,8 +530,20 @@
         }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
     }
 
+    private async Task SetAuthHeaderAsync()
+    {
+        var profileName = await ConfigService.GetActiveProfileNameAsync();
+        var token = await AuthService.GetAccessTokenAsync(profileName);
+        if (!string.IsNullOrEmpty(token))
+        {
+            Http.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+
     private async Task RefreshAll()
     {
+        await SetAuthHeaderAsync();
         await LoadServiceMetrics();
         if (serviceStatus?.IsRunning == true)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/SystemRegisterService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/SystemRegisterService.cs
@@ -29,7 +29,7 @@ public class SystemRegisterService : ISystemRegisterService
     {
         try
         {
-            var response = await _httpClient.GetAsync("/api/admin/system-register", ct);
+            var response = await _httpClient.GetAsync("/api/system-register", ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Failed to fetch system register status: {StatusCode}", response.StatusCode);
@@ -51,7 +51,7 @@ public class SystemRegisterService : ISystemRegisterService
         try
         {
             var response = await _httpClient.GetAsync(
-                $"/api/admin/system-register/blueprints?page={page}&pageSize={pageSize}", ct);
+                $"/api/system-register/blueprints?page={page}&pageSize={pageSize}", ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Failed to fetch system register blueprints: {StatusCode}", response.StatusCode);
@@ -74,7 +74,7 @@ public class SystemRegisterService : ISystemRegisterService
         try
         {
             var response = await _httpClient.GetAsync(
-                $"/api/admin/system-register/blueprints/{blueprintId}", ct);
+                $"/api/system-register/blueprints/{blueprintId}", ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Failed to fetch blueprint {BlueprintId}: {StatusCode}", blueprintId, response.StatusCode);
@@ -96,7 +96,7 @@ public class SystemRegisterService : ISystemRegisterService
         try
         {
             var response = await _httpClient.GetAsync(
-                $"/api/admin/system-register/blueprints/{blueprintId}/versions/{version}", ct);
+                $"/api/system-register/blueprints/{blueprintId}/versions/{version}", ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning("Failed to fetch blueprint {BlueprintId} version {Version}: {StatusCode}",

--- a/tests/Sorcha.UI.Core.Tests/Services/SystemRegisterServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/SystemRegisterServiceTests.cs
@@ -68,7 +68,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register")),
+                    req.RequestUri!.ToString().Contains("/api/system-register")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -98,7 +98,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register")),
+                    req.RequestUri!.ToString().Contains("/api/system-register")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -187,7 +187,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register/blueprints")),
+                    req.RequestUri!.ToString().Contains("/api/system-register/blueprints")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -216,7 +216,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register/blueprints")),
+                    req.RequestUri!.ToString().Contains("/api/system-register/blueprints")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -297,7 +297,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register/blueprints/bp-001")),
+                    req.RequestUri!.ToString().Contains("/api/system-register/blueprints/bp-001")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -328,7 +328,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register/blueprints/nonexistent")),
+                    req.RequestUri!.ToString().Contains("/api/system-register/blueprints/nonexistent")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -371,7 +371,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register/blueprints/bp-001/versions/1")),
+                    req.RequestUri!.ToString().Contains("/api/system-register/blueprints/bp-001/versions/1")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 
@@ -401,7 +401,7 @@ public class SystemRegisterServiceTests : IDisposable
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Get &&
-                    req.RequestUri!.ToString().Contains("/api/admin/system-register/blueprints/bp-001/versions/99")),
+                    req.RequestUri!.ToString().Contains("/api/system-register/blueprints/bp-001/versions/99")),
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(response);
 


### PR DESCRIPTION
## Summary
- **404 fix**: `SystemRegisterService` was calling `/api/admin/system-register` but the YARP gateway route and Register Service endpoint are at `/api/system-register` — removed the erroneous `admin/` prefix
- **401 fix**: `PeerServiceAdmin.razor` injected the plain `HttpClient` (no `AuthenticatedHttpMessageHandler`), so no JWT Bearer token was sent on peer API calls — added `IAuthenticationService`/`IConfigurationService` injection and `SetAuthHeaderAsync()` to set the token before API calls

## Test plan
- [x] `SystemRegisterServiceTests` — all 10 tests pass with updated URL assertions
- [ ] Verify `/api/system-register` returns 200 in browser console (no more 404)
- [ ] Verify `/api/peer/peers` and related endpoints return 200 (no more 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)