### PR TITLE
fix: correct IDP config client URL from /idp-config to /idp

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Identity/IdpConfigurationClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Identity/IdpConfigurationClientService.cs
@@ -25,7 +25,7 @@ public class IdpConfigurationClientService : IIdpConfigurationClientService
     }
 
     private static string BaseUrl(Guid organizationId) =>
-        $"/api/organizations/{Uri.EscapeDataString(organizationId.ToString())}/idp-config";
+        $"/api/organizations/{Uri.EscapeDataString(organizationId.ToString())}/idp";
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<IdpConfigurationDto>> GetIdpConfigurationsAsync(


### PR DESCRIPTION
## Summary
- UI `IdpConfigurationClientService` was calling `/api/organizations/{orgId}/idp-config` but the Tenant Service endpoint is `/api/organizations/{orgId}/idp`, causing 404 on the identity dashboard page

## Test plan
- [ ] Open identity dashboard page — no more 404 console error for idp-config
- [ ] IDP configuration CRUD operations work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)