### PR TITLE
fix: use relative paths for wallet navigation in MyWallet page

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyWallet.razor
@@ -25,7 +25,7 @@
                 Manage your cryptographic wallets and identity
             </MudText>
         </MudStack>
-        <MudButton Href="/wallets/create" Color="Color.Primary" Variant="Variant.Filled"
+        <MudButton Href="wallets/create" Color="Color.Primary" Variant="Variant.Filled"
                    StartIcon="@Icons.Material.Filled.Add">
             Create Wallet
         </MudButton>
@@ -58,7 +58,7 @@
                     Title="No Wallets"
                     Description="Create your first wallet to start participating in workflows."
                     ActionText="Create Wallet"
-                    OnAction="@(() => Navigation.NavigateTo("/wallets/create"))" />
+                    OnAction="@(() => Navigation.NavigateTo("wallets/create"))" />
     }
     else
     {
@@ -91,7 +91,7 @@
         </MudGrid>
 
         <MudStack Row="true" Justify="Justify.Center" Class="mt-4">
-            <MudButton Href="/wallets" Color="Color.Primary" Variant="Variant.Outlined"
+            <MudButton Href="wallets" Color="Color.Primary" Variant="Variant.Outlined"
                        StartIcon="@Icons.Material.Filled.ManageAccounts">
                 Manage All Wallets
             </MudButton>


### PR DESCRIPTION
## Summary
- MyWallet.razor used absolute paths (`Href="/wallets"`, `Href="/wallets/create"`) which bypass the `/app/` base href, causing 404 when navigating from the My Wallet page
- Changed to relative paths (`Href="wallets"`) to correctly resolve under `/app/`

## Test plan
- [ ] Click "Manage All Wallets" on My Wallet page — navigates to `/app/wallets`
- [ ] Click "Create Wallet" on My Wallet page — navigates to `/app/wallets/create`
- [ ] Empty state "Create Wallet" action works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)