### PR TITLE
fix: wallet sign returns 400 for KEM algorithms, fix transaction query URL

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TransactionService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TransactionService.cs
@@ -117,7 +117,7 @@ public class TransactionService : ITransactionService
     {
         try
         {
-            var url = $"/api/transactions/query?wallet={Uri.EscapeDataString(walletAddress)}&page={page}&pageSize={pageSize}";
+            var url = $"/api/register/query/wallets/{Uri.EscapeDataString(walletAddress)}/transactions?page={page}&pageSize={pageSize}";
 
             var response = await _httpClient.GetAsync(url, cancellationToken);
 

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -584,6 +584,16 @@ public static class WalletEndpoints
         {
             return Results.NotFound();
         }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("InvalidParameter"))
+        {
+            logger.LogWarning(ex, "Unsupported signing operation for wallet {Address}", address);
+            return Results.BadRequest(new ProblemDetails
+            {
+                Title = "Signing Not Supported",
+                Detail = $"This wallet's algorithm does not support signing operations. {ex.Message}",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to sign transaction for wallet {Address}", address);


### PR DESCRIPTION
## Summary
- **Sign 500 → 400**: ML-KEM-768 is a Key Encapsulation Mechanism, not a signature algorithm. The sign endpoint now returns 400 Bad Request with a clear message instead of 500
- **Transaction query 404**: UI was calling `/api/transactions/query?wallet=...` but the Register Service endpoint is at `/api/query/wallets/{address}/transactions`. Corrected to route through YARP gateway via `/api/register/query/wallets/{address}/transactions`

## Test plan
- [ ] Sign with ML-KEM-768 wallet returns 400 with descriptive error (not 500)
- [ ] Sign with ED25519/ML-DSA-65 wallets still works
- [ ] Transaction history tab loads without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)