### PR TITLE
fix: implement cross-register wallet transaction query

### DIFF
--- a/src/Core/Sorcha.Register.Core/Managers/QueryManager.cs
+++ b/src/Core/Sorcha.Register.Core/Managers/QueryManager.cs
@@ -145,6 +145,63 @@ public class QueryManager
     }
 
     /// <summary>
+    /// Gets transactions by wallet address across all registers with pagination.
+    /// Returns items wrapped with register context (registerId, registerName).
+    /// </summary>
+    public async Task<PaginatedResult<CrossRegisterTransactionItem>> GetTransactionsByWalletAcrossRegistersAsync(
+        string walletAddress,
+        int page = 1,
+        int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
+        if (page < 1) page = 1;
+        if (pageSize < 1 || pageSize > 100) pageSize = 20;
+
+        var registers = (await _repository.GetRegistersAsync(cancellationToken)).ToList();
+        var allItems = new List<CrossRegisterTransactionItem>();
+
+        foreach (var register in registers)
+        {
+            var senderTxs = await _repository.GetAllTransactionsBySenderAddressAsync(
+                register.Id, walletAddress, cancellationToken);
+            var recipientTxs = await _repository.GetAllTransactionsByRecipientAddressAsync(
+                register.Id, walletAddress, cancellationToken);
+
+            var registerTxs = senderTxs.Concat(recipientTxs)
+                .DistinctBy(t => t.TxId)
+                .Select(t => new CrossRegisterTransactionItem
+                {
+                    Transaction = t,
+                    RegisterId = register.Id,
+                    RegisterName = register.Name
+                });
+
+            allItems.AddRange(registerTxs);
+        }
+
+        var sorted = allItems
+            .OrderByDescending(i => i.Transaction.TimeStamp)
+            .ToList();
+
+        var total = sorted.Count;
+        var items = sorted
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return new PaginatedResult<CrossRegisterTransactionItem>
+        {
+            Items = items,
+            Page = page,
+            PageSize = pageSize,
+            TotalCount = total,
+            TotalPages = (int)Math.Ceiling(total / (double)pageSize)
+        };
+    }
+
+    /// <summary>
     /// Gets transactions by previous transaction ID with pagination.
     /// Used for fork detection and chain traversal.
     /// </summary>
@@ -266,6 +323,16 @@ public class PaginatedResult<T>
     public int TotalPages { get; set; }
     public bool HasPreviousPage => Page > 1;
     public bool HasNextPage => Page < TotalPages;
+}
+
+/// <summary>
+/// A transaction item with register context for cross-register queries
+/// </summary>
+public class CrossRegisterTransactionItem
+{
+    public required TransactionModel Transaction { get; init; }
+    public required string RegisterId { get; init; }
+    public required string RegisterName { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -693,8 +693,10 @@ queryGroup.MapGet("/wallets/{address}/transactions", async (
         return Results.Ok(result);
     }
 
-    // Query across all registers (future enhancement)
-    return Results.BadRequest(new { error = "registerId is required" });
+    // Cross-register wallet query
+    var crossResult = await manager.GetTransactionsByWalletAcrossRegistersAsync(
+        address, page, pageSize);
+    return Results.Ok(crossResult);
 })
 .WithName("GetTransactionsByWallet")
 .WithSummary("Query transactions by wallet")

--- a/tests/Sorcha.Register.Core.Tests/Managers/QueryManagerTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Managers/QueryManagerTests.cs
@@ -556,6 +556,107 @@ public class QueryManagerTests
         result.Items[0].PrevTxId.Should().Be(targetPrevTxId);
     }
 
+    // ===== Cross-Register Wallet Query Tests =====
+
+    [Fact]
+    public async Task GetTransactionsByWalletAcrossRegistersAsync_ReturnsTransactionsFromMultipleRegisters()
+    {
+        // Arrange — create a second register and seed transactions in both
+        var register2 = new Sorcha.Register.Models.Register
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Name = "Second Register",
+            TenantId = "tenant123",
+            Height = 0,
+            Status = RegisterStatus.Offline
+        };
+        await _repository.InsertRegisterAsync(register2);
+
+        var walletAddress = "crossreg-wallet";
+        await _repository.InsertTransactionAsync(CreateTransactionForRegister(_testRegisterId, walletAddress, "recipient1"));
+        await _repository.InsertTransactionAsync(CreateTransactionForRegister(register2.Id, walletAddress, "recipient2"));
+
+        // Act
+        var result = await _manager.GetTransactionsByWalletAcrossRegistersAsync(walletAddress, 1, 20);
+
+        // Assert
+        result.TotalCount.Should().Be(2);
+        result.Items.Should().Contain(i => i.RegisterId == _testRegisterId);
+        result.Items.Should().Contain(i => i.RegisterId == register2.Id);
+        result.Items.Should().Contain(i => i.RegisterName == "Second Register");
+    }
+
+    [Fact]
+    public async Task GetTransactionsByWalletAcrossRegistersAsync_NoTransactions_ReturnsEmpty()
+    {
+        // Act
+        var result = await _manager.GetTransactionsByWalletAcrossRegistersAsync("nonexistent-wallet", 1, 20);
+
+        // Assert
+        result.TotalCount.Should().Be(0);
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTransactionsByWalletAcrossRegistersAsync_PaginatesCorrectly()
+    {
+        // Arrange — seed 5 transactions across 2 registers
+        var register2 = new Sorcha.Register.Models.Register
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Name = "Second Register",
+            TenantId = "tenant123",
+            Height = 0,
+            Status = RegisterStatus.Offline
+        };
+        await _repository.InsertRegisterAsync(register2);
+
+        var walletAddress = "paged-wallet";
+        for (int i = 0; i < 3; i++)
+            await _repository.InsertTransactionAsync(CreateTransactionForRegister(_testRegisterId, walletAddress, $"r{i}"));
+        for (int i = 0; i < 2; i++)
+            await _repository.InsertTransactionAsync(CreateTransactionForRegister(register2.Id, walletAddress, $"r{i}"));
+
+        // Act
+        var page1 = await _manager.GetTransactionsByWalletAcrossRegistersAsync(walletAddress, 1, 2);
+        var page2 = await _manager.GetTransactionsByWalletAcrossRegistersAsync(walletAddress, 2, 2);
+
+        // Assert
+        page1.Items.Should().HaveCount(2);
+        page1.TotalCount.Should().Be(5);
+        page1.TotalPages.Should().Be(3);
+        page2.Items.Should().HaveCount(2);
+    }
+
+    private TransactionModel CreateTransactionForRegister(string registerId, string senderWallet, string recipientWallet)
+    {
+        var txId = Guid.NewGuid().ToString("N") + new string('0', 64);
+        txId = txId.Substring(0, 64);
+
+        return new TransactionModel
+        {
+            RegisterId = registerId,
+            TxId = txId,
+            PrevTxId = string.Empty,
+            Version = 1,
+            SenderWallet = senderWallet,
+            RecipientsWallets = new[] { recipientWallet },
+            TimeStamp = DateTime.UtcNow,
+            PayloadCount = 1,
+            Payloads = new[]
+            {
+                new PayloadModel
+                {
+                    WalletAccess = new[] { senderWallet },
+                    PayloadSize = 1024,
+                    Hash = "payload_hash",
+                    Data = "encrypted_data"
+                }
+            },
+            Signature = "signature"
+        };
+    }
+
     // ===== Chain Traversal Tests (US2) =====
 
     [Fact]


### PR DESCRIPTION
## Summary
- Wallet transaction query endpoint returned 400 when no `registerId` was provided — the UI's `QueryByWalletAsync` is a cross-register query but the backend only supported per-register lookups
- Added `GetTransactionsByWalletAcrossRegistersAsync` to `QueryManager` that iterates all registers, queries each for the wallet address, and aggregates results with pagination
- Added `CrossRegisterTransactionItem` to wrap each transaction with register context (registerId, registerName)
- Updated endpoint to call cross-register method when `registerId` is null instead of returning 400

## Test plan
- [x] 3 new tests added (multi-register query, empty results, pagination)
- [x] All 36 QueryManager tests pass
- [ ] Docker rebuild and manual verification of wallet detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)