### PR TITLE
fix: AI blueprint designer tool execution and continuation loop

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/ChatHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/ChatHubConnection.cs
@@ -87,6 +87,11 @@ public class ChatHubConnection : IChatHubConnection
             .WithAutomaticReconnect(new CustomRetryPolicy(ReconnectDelays))
             .Build();
 
+        // AI tool execution can take 30-60+ seconds — increase timeout to prevent
+        // the client from disconnecting while the server processes tool calls
+        connection.ServerTimeout = TimeSpan.FromMinutes(3);
+        connection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
         RegisterEventHandlers(connection);
         return connection;
     }

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -127,7 +127,13 @@ builder.Services.AddHostedService<Sorcha.Blueprint.Service.Services.Implementati
 
 // Add SignalR (Sprint 5)
 // TODO: Add Redis backplane when Microsoft.AspNetCore.SignalR.StackExchangeRedis package is added
-builder.Services.AddSignalR();
+builder.Services.AddSignalR(options =>
+{
+    // AI tool execution can take 30-60+ seconds per turn with multiple continuation rounds.
+    // Default 30s client timeout causes disconnects during long AI processing.
+    options.ClientTimeoutInterval = TimeSpan.FromMinutes(3);
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+});
 
 // Add Notification service (Sprint 5)
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.INotificationService,

--- a/src/Services/Sorcha.Blueprint.Service/Services/AnthropicProviderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/AnthropicProviderService.cs
@@ -81,9 +81,19 @@ public class AnthropicProviderService : IAIProviderService
                 // Accumulate tool arguments
                 toolArgumentsJson += response.Delta.PartialJson;
             }
-            else if (response.Delta?.Type == "content_block_stop" && currentToolId != null && currentToolName != null)
+            else if (response.Delta?.StopReason != null)
             {
-                // End of tool use block - emit the complete tool use event
+                _logger.LogInformation("AI stream ended with stop reason: {StopReason}", response.Delta.StopReason);
+                yield return new StreamEnd(response.Delta.StopReason);
+            }
+            else if (currentToolId != null && currentToolName != null
+                     && response.Delta?.Type == null && response.ContentBlock?.Type == null)
+            {
+                // The SDK sends content_block_stop as an event with all-null properties.
+                // When we have an active tool and get this null event, the tool block is complete.
+                _logger.LogInformation("Tool block complete: {ToolName} (ID: {ToolId}), args: {ArgsLen} chars",
+                    currentToolName, currentToolId, toolArgumentsJson.Length);
+
                 JsonDocument arguments;
                 try
                 {
@@ -102,11 +112,6 @@ public class AnthropicProviderService : IAIProviderService
                 currentToolId = null;
                 currentToolName = null;
                 toolArgumentsJson = "";
-            }
-            else if (response.Delta?.StopReason != null)
-            {
-                _logger.LogInformation("AI stream ended with stop reason: {StopReason}", response.Delta.StopReason);
-                yield return new StreamEnd(response.Delta.StopReason);
             }
         }
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
@@ -270,78 +270,130 @@ public class ChatOrchestrationService : IChatOrchestrationService
         // Build system prompt with blueprint context if editing
         var systemPrompt = BuildSystemPrompt(session);
 
-        // Stream AI response
-        var responseContent = "";
-        var toolCalls = new List<ToolCall>();
-        var toolResults = new List<ToolResult>();
+        // Stream AI response with tool-use continuation loop.
+        // When Claude calls tools, stop_reason is "tool_use" — we must send the tool results
+        // back and stream another turn until Claude finishes with "end_turn".
+        const int maxContinuationTurns = 10; // Safety limit to prevent infinite loops
 
-        await foreach (var evt in _aiProvider.StreamCompletionAsync(
-            messages, toolDefinitions, systemPrompt, cancellationToken))
+        for (var turn = 0; turn < maxContinuationTurns; turn++)
         {
-            switch (evt)
+            var responseContent = "";
+            var toolCalls = new List<ToolCall>();
+            var toolResults = new List<ToolResult>();
+            string? stopReason = null;
+
+            await foreach (var evt in _aiProvider.StreamCompletionAsync(
+                messages, toolDefinitions, systemPrompt, cancellationToken))
             {
-                case TextChunk chunk:
-                    responseContent += chunk.Text;
-                    await onChunk(chunk.Text);
-                    break;
+                _logger.LogInformation("Stream event: {EventType}", evt.GetType().Name);
+                switch (evt)
+                {
+                    case TextChunk chunk:
+                        responseContent += chunk.Text;
+                        await onChunk(chunk.Text);
+                        break;
 
-                case ToolUse toolUse:
-                    var toolCall = new ToolCall
-                    {
-                        Id = toolUse.Id,
-                        ToolName = toolUse.Name,
-                        Arguments = toolUse.Arguments
-                    };
-                    toolCalls.Add(toolCall);
+                    case ToolUse toolUse:
+                        var toolCall = new ToolCall
+                        {
+                            Id = toolUse.Id,
+                            ToolName = toolUse.Name,
+                            Arguments = toolUse.Arguments
+                        };
+                        toolCalls.Add(toolCall);
 
-                    // Execute the tool
-                    var result = await _toolExecutor.ExecuteAsync(
-                        toolUse.Name, toolUse.Arguments, builder, cancellationToken);
+                        // Execute the tool
+                        var result = await _toolExecutor.ExecuteAsync(
+                            toolUse.Name, toolUse.Arguments, builder, cancellationToken);
 
-                    // Update result with correct tool call ID
-                    result = result with { ToolCallId = toolUse.Id };
-                    toolResults.Add(result);
+                        // Update result with correct tool call ID
+                        result = result with { ToolCallId = toolUse.Id };
+                        toolResults.Add(result);
 
-                    await onToolResult(toolUse.Name, result);
+                        await onToolResult(toolUse.Name, result);
 
-                    // If blueprint changed, notify and validate
-                    if (result.BlueprintChanged)
-                    {
-                        var draft = builder.BuildDraft();
-                        session.BlueprintDraft = draft;
-                        await _sessionStore.UpdateSessionAsync(session);
+                        // If blueprint changed, notify and validate
+                        if (result.BlueprintChanged)
+                        {
+                            var draft = builder.BuildDraft();
+                            session.BlueprintDraft = draft;
+                            await _sessionStore.UpdateSessionAsync(session);
 
-                        var validation = ValidateBlueprint(draft);
-                        await onBlueprintUpdate(draft, validation);
-                    }
-                    break;
+                            var validation = ValidateBlueprint(draft);
+                            await onBlueprintUpdate(draft, validation);
+                        }
+                        break;
 
-                case StreamEnd:
-                    // Stream completed
-                    break;
+                    case StreamEnd end:
+                        stopReason = end.StopReason;
+                        break;
 
-                case StreamError error:
-                    _logger.LogError("AI stream error: {Message}", error.Message);
-                    throw new InvalidOperationException($"AI service error: {error.Message}");
+                    case StreamError error:
+                        _logger.LogError("AI stream error: {Message}", error.Message);
+                        throw new InvalidOperationException($"AI service error: {error.Message}");
+                }
             }
-        }
 
-        // Store assistant message with tool calls and results
-        var assistantMessage = new ChatMessage
-        {
-            SessionId = sessionId,
-            Role = MessageRole.Assistant,
-            Content = responseContent,
-            ToolCalls = toolCalls.Count > 0 ? toolCalls : null,
-            ToolResults = toolResults.Count > 0 ? toolResults : null
-        };
-        await _sessionStore.AddMessageAsync(sessionId, assistantMessage);
+            // Store assistant message with tool calls and results
+            _logger.LogInformation("Stream loop ended. StopReason={StopReason}, tools={ToolCount}, text={TextLen}",
+                stopReason, toolCalls.Count, responseContent.Length);
+
+            // Store assistant message with tool calls only (NOT tool results).
+            // Tool results go in a separate user message for correct Anthropic API format:
+            // assistant: [text + tool_use blocks] → user: [tool_result blocks]
+            var assistantMessage = new ChatMessage
+            {
+                SessionId = sessionId,
+                Role = MessageRole.Assistant,
+                Content = responseContent,
+                ToolCalls = toolCalls.Count > 0 ? toolCalls : null
+            };
+
+            try
+            {
+                await _sessionStore.AddMessageAsync(sessionId, assistantMessage);
+                _logger.LogInformation("Stored assistant message for session {SessionId}", sessionId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "FAILED to store assistant message for session {SessionId}", sessionId);
+                throw;
+            }
+
+            // If Claude stopped because it used tools, send results back and continue
+            if (stopReason == "tool_use" && toolResults.Count > 0)
+            {
+                _logger.LogInformation(
+                    "Turn {Turn}: AI used {ToolCount} tools, sending results back for continuation",
+                    turn, toolResults.Count);
+
+                // Add tool results as a user message for the next turn
+                var toolResultMessage = new ChatMessage
+                {
+                    SessionId = sessionId,
+                    Role = MessageRole.User,
+                    Content = "",
+                    ToolResults = toolResults
+                };
+                _logger.LogInformation("Storing tool result message for session {SessionId}", sessionId);
+                await _sessionStore.AddMessageAsync(sessionId, toolResultMessage);
+
+                // Refresh messages for next iteration
+                _logger.LogInformation("Refreshing message history for continuation turn {Turn}", turn + 1);
+                messages = await _sessionStore.GetMessagesAsync(sessionId);
+                _logger.LogInformation("Continuation turn {Turn} starting with {MessageCount} messages", turn + 1, messages.Count);
+                continue;
+            }
+
+            // end_turn or max_tokens — we're done
+            _logger.LogDebug(
+                "Processed message in session {SessionId}, response length: {Length}, tools used: {ToolCount}, turns: {Turns}",
+                sessionId, responseContent.Length, toolCalls.Count, turn + 1);
+            break;
+        }
 
         // Update session activity
         await _sessionStore.UpdateSessionAsync(session);
-
-        _logger.LogDebug("Processed message in session {SessionId}, response length: {Length}, tools used: {ToolCount}",
-            sessionId, responseContent.Length, toolCalls.Count);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

- Fix four bugs preventing the AI blueprint designer from completing blueprint creation
- Tools now execute correctly, blueprint preview updates in real-time, and Claude provides a summary after building

## Bugs Fixed

1. **Tool-use continuation loop** — Claude calls tools and stops with `tool_use` reason, but results were never sent back. Added agentic loop (max 10 turns) that continues until `end_turn`.

2. **Anthropic SDK content_block_stop** — The SDK sends this event with all-null properties, not `Delta.Type=="content_block_stop"`. Fixed detection by matching null-property events when a tool block is active.

3. **Message format** — Assistant messages had both `ToolCalls` and `ToolResults`, breaking the Anthropic API which requires `tool_result` in a separate user message following the `tool_use` assistant message.

4. **SignalR timeout** — Default 30s timeout caused client disconnects during long AI processing. Increased to 3 minutes on both client (`ServerTimeout`) and server (`ClientTimeoutInterval`).

## Test plan

- [x] Fresh chat session creates blueprint with 3 participants and 3 actions
- [x] Blueprint preview updates in real-time as tools execute
- [x] Claude provides summary text after tool execution completes
- [x] Connection stays alive during full processing cycle
- [x] No popup errors on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)