### PR TITLE
test: comprehensive validator service test coverage improvements

### DIFF
--- a/tests/Sorcha.Validator.Core.Tests/Validators/ConsensusValidatorTests.cs
+++ b/tests/Sorcha.Validator.Core.Tests/Validators/ConsensusValidatorTests.cs
@@ -242,33 +242,30 @@ public class ConsensusValidatorTests
     #region ValidateQuorum Tests
 
     [Theory]
-    [InlineData(7, 10, 0.66, true)]  // 70% > 66%
-    [InlineData(8, 10, 0.75, true)]  // 80% > 75%
-    [InlineData(10, 10, 0.90, true)] // 100% > 90%
-    [InlineData(3, 4, 0.66, true)]   // 75% > 66%
+    [InlineData(7, 10, 0.66)]  // 70% > 66%
+    [InlineData(8, 10, 0.75)]  // 80% > 75%
+    [InlineData(10, 10, 0.90)] // 100% > 90%
+    [InlineData(3, 4, 0.66)]   // 75% > 66%
     public void ValidateQuorum_WithSufficientApprovals_ReturnsSuccess(
-        int approvalCount, int totalValidators, double threshold, bool expected)
+        int approvalCount, int totalValidators, double threshold)
     {
         // Act
         var result = _validator.ValidateQuorum(approvalCount, totalValidators, threshold);
 
         // Assert
-        result.IsValid.Should().Be(expected);
-        if (expected)
-        {
-            result.Metadata.Should().NotBeNull();
-            result.Metadata.Should().ContainKey("ApprovalPercentage");
-            result.Metadata.Should().ContainKey("ApprovalCount");
-        }
+        result.IsValid.Should().BeTrue();
+        result.Metadata.Should().NotBeNull();
+        result.Metadata.Should().ContainKey("ApprovalPercentage");
+        result.Metadata.Should().ContainKey("ApprovalCount");
     }
 
     [Theory]
-    [InlineData(5, 10, 0.50, false)] // 50% = 50% (not greater)
-    [InlineData(6, 10, 0.70, false)] // 60% < 70%
-    [InlineData(2, 10, 0.50, false)] // 20% < 50%
-    [InlineData(0, 10, 0.10, false)] // 0% < 10%
+    [InlineData(5, 10, 0.50)] // 50% = 50% (not greater)
+    [InlineData(6, 10, 0.70)] // 60% < 70%
+    [InlineData(2, 10, 0.50)] // 20% < 50%
+    [InlineData(0, 10, 0.10)] // 0% < 10%
     public void ValidateQuorum_WithInsufficientApprovals_ReturnsError(
-        int approvalCount, int totalValidators, double threshold, bool expected)
+        int approvalCount, int totalValidators, double threshold)
     {
         // Act
         var result = _validator.ValidateQuorum(approvalCount, totalValidators, threshold);

--- a/tests/Sorcha.Validator.Service.IntegrationTests/AdminEndpointTests.cs
+++ b/tests/Sorcha.Validator.Service.IntegrationTests/AdminEndpointTests.cs
@@ -9,7 +9,7 @@ namespace Sorcha.Validator.Service.IntegrationTests;
 
 /// <summary>
 /// Integration tests for admin endpoints.
-/// Note: Admin endpoints currently don't require authentication in the implementation.
+/// Admin endpoints require the RequireAdministrator policy.
 /// </summary>
 [Collection("ValidatorService")]
 public class AdminEndpointTests
@@ -26,7 +26,7 @@ public class AdminEndpointTests
     public async Task StartValidator_WithValidRequest_ReturnsOk()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var request = new { RegisterId = Guid.NewGuid().ToString("N") };
 
         // Act
@@ -44,7 +44,7 @@ public class AdminEndpointTests
     public async Task StartValidator_WithEmptyRegisterId_ReturnsBadRequest()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var request = new { RegisterId = "" };
 
         // Act
@@ -58,7 +58,7 @@ public class AdminEndpointTests
     public async Task StopValidator_WithNotStartedValidator_ReturnsError()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var registerId = Guid.NewGuid().ToString("N");
         var request = new { RegisterId = registerId, PersistMemPool = true };
 
@@ -73,7 +73,7 @@ public class AdminEndpointTests
     public async Task StopValidator_WithEmptyRegisterId_ReturnsBadRequest()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var request = new { RegisterId = "", PersistMemPool = false };
 
         // Act
@@ -87,7 +87,7 @@ public class AdminEndpointTests
     public async Task GetValidatorStatus_WithUnknownRegisterId_ReturnsNotFound()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         // Act - validator not started, so status should return 404
@@ -101,7 +101,7 @@ public class AdminEndpointTests
     public async Task ProcessValidationPipeline_WithNoTransactions_ReturnsOkWithMessage()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         // Act - no validator started, no transactions
@@ -121,7 +121,7 @@ public class AdminEndpointTests
     public async Task StartValidator_ReturnsExpectedResponseStructure()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateAdminClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         // Act - Start validator

--- a/tests/Sorcha.Validator.Service.IntegrationTests/Fixtures/TestAuthHandler.cs
+++ b/tests/Sorcha.Validator.Service.IntegrationTests/Fixtures/TestAuthHandler.cs
@@ -41,7 +41,8 @@ public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions
             new("organization_id", "test-org-id"),
             new("org_id", "test-org-id"),
             new("validator_id", "test-validator-id"),
-            new("wallet_address", "test-wallet-address")
+            new("wallet_address", "test-wallet-address"),
+            new("token_type", "service")
         };
 
         // Check for role override header

--- a/tests/Sorcha.Validator.Service.IntegrationTests/Fixtures/ValidatorServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Validator.Service.IntegrationTests/Fixtures/ValidatorServiceWebApplicationFactory.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Moq;
+using MongoDB.Driver;
+using Sorcha.Register.Core.Storage;
 using Sorcha.Register.Models;
 using Sorcha.ServiceClients.Blueprint;
 using Sorcha.ServiceClients.Peer;
@@ -125,7 +127,11 @@ public class ValidatorServiceWebApplicationFactory : WebApplicationFactory<Progr
 
                 // Validator Registry
                 ["ValidatorRegistry:KeyPrefix"] = "test:validators:",
-                ["ValidatorRegistry:CacheTtl"] = "00:05:00"
+                ["ValidatorRegistry:CacheTtl"] = "00:05:00",
+
+                // MongoDB (mocked, but config must parse)
+                ["RegisterStorage:MongoDB:ConnectionString"] = "mongodb://localhost:27017",
+                ["RegisterStorage:MongoDB:DatabaseName"] = "sorcha_test"
             };
 
             config.AddInMemoryCollection(testConfig);
@@ -153,6 +159,12 @@ public class ValidatorServiceWebApplicationFactory : WebApplicationFactory<Progr
 
             services.RemoveAll<IWalletServiceClient>();
             services.AddScoped(_ => WalletClientMock.Object);
+
+            // Replace MongoDB with mocks to avoid requiring a real MongoDB connection
+            services.RemoveAll<IMongoClient>();
+            services.AddSingleton(new Mock<IMongoClient>().Object);
+            services.RemoveAll<IReadOnlyRegisterRepository>();
+            services.AddSingleton(new Mock<IReadOnlyRegisterRepository>().Object);
 
             // Remove all existing authentication
             services.RemoveAll<IAuthenticationService>();

--- a/tests/Sorcha.Validator.Service.IntegrationTests/ValidationEndpointTests.cs
+++ b/tests/Sorcha.Validator.Service.IntegrationTests/ValidationEndpointTests.cs
@@ -25,7 +25,7 @@ public class ValidationEndpointTests
     public async Task ValidateTransaction_WithValidRequest_ReturnsOkOrBadRequest()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var request = CreateValidTransactionRequest();
 
         // Act
@@ -40,7 +40,7 @@ public class ValidationEndpointTests
     public async Task ValidateTransaction_WithInvalidPayloadHash_ReturnsBadRequest()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
 
         // Create request with invalid hash
         var payload = JsonSerializer.Deserialize<JsonElement>("{\"action\":\"test\"}");
@@ -75,7 +75,7 @@ public class ValidationEndpointTests
     public async Task GetMemPoolStats_WithValidRegisterId_ReturnsStats()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var registerId = "test-register-stats";
 
         // Act
@@ -89,7 +89,7 @@ public class ValidationEndpointTests
     public async Task ValidateTransaction_PostEndpoint_Exists()
     {
         // Arrange - Just verify the endpoint exists and accepts POST
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var emptyRequest = new { };
 
         // Act
@@ -103,7 +103,7 @@ public class ValidationEndpointTests
     public async Task GetMemPoolStats_GetEndpoint_Exists()
     {
         // Arrange - Just verify the endpoint exists
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
 
         // Act
         var response = await client.GetAsync("/api/v1/transactions/mempool/test-register");

--- a/tests/Sorcha.Validator.Service.IntegrationTests/ValidatorRegistrationEndpointTests.cs
+++ b/tests/Sorcha.Validator.Service.IntegrationTests/ValidatorRegistrationEndpointTests.cs
@@ -26,7 +26,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task GetValidators_WithValidRegisterId_ReturnsValidators()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         // Act
@@ -46,7 +46,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task GetValidators_EndpointExists()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
 
         // Act
         var response = await client.GetAsync("/api/validators/test-register");
@@ -59,7 +59,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task GetValidator_WithUnknownValidator_ReturnsNotFound()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var registerId = Guid.NewGuid().ToString("N");
         var validatorId = Guid.NewGuid().ToString("N");
 
@@ -74,7 +74,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task GetValidatorCount_WithValidRegisterId_ReturnsCount()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         // Act
@@ -94,7 +94,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task GetValidatorCount_EndpointExists()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
 
         // Act
         var response = await client.GetAsync("/api/validators/test-register/count");
@@ -107,7 +107,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task RefreshValidators_WithValidRegisterId_ReturnsSuccess()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         // Act
@@ -126,7 +126,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task RefreshValidators_EndpointExists()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
 
         // Act
         var response = await client.PostAsync("/api/validators/test-register/refresh", null);
@@ -139,7 +139,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task RegisterValidator_EndpointExists()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var request = new
         {
             RegisterId = Guid.NewGuid().ToString("N"),
@@ -159,7 +159,7 @@ public class ValidatorRegistrationEndpointTests
     public async Task RegisterValidator_WithValidRequest_ReturnsCreatedOrBadRequest()
     {
         // Arrange
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateValidatorClient();
         var registerId = Guid.NewGuid().ToString("N");
 
         var request = new

--- a/tests/Sorcha.Validator.Service.Tests/Services/BadActorDetectorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/BadActorDetectorTests.cs
@@ -117,7 +117,7 @@ public class BadActorDetectorTests
     }
 
     [Fact]
-    public void LogDocketRejection_WithDetails_IncludesDetailsInIncident()
+    public async Task LogDocketRejection_WithDetails_IncludesDetailsInIncident()
     {
         // Arrange
         const string registerId = "register-1";
@@ -130,20 +130,20 @@ public class BadActorDetectorTests
             DocketRejectionReason.InvalidDocketHash, details);
 
         // Assert
-        var incidents = _detector.GetIncidentsAsync(registerId, initiatorId).Result;
+        var incidents = await _detector.GetIncidentsAsync(registerId, initiatorId);
         incidents.Should().HaveCount(1);
         incidents[0].Details.Should().Contain(details);
     }
 
     [Fact]
-    public void LogDocketRejection_CriticalReason_SetsCriticalSeverity()
+    public async Task LogDocketRejection_CriticalReason_SetsCriticalSeverity()
     {
         // Arrange - UnauthorizedInitiator is considered critical
         _detector.LogDocketRejection("register-1", "validator-1", "docket-1",
             DocketRejectionReason.UnauthorizedInitiator);
 
         // Act
-        var incidents = _detector.GetIncidentsAsync("register-1", "validator-1").Result;
+        var incidents = await _detector.GetIncidentsAsync("register-1", "validator-1");
 
         // Assert
         incidents[0].Severity.Should().Be(IncidentSeverity.Critical);
@@ -172,11 +172,11 @@ public class BadActorDetectorTests
     }
 
     [Fact]
-    public void LogTransactionValidationFailure_SetsInfoSeverity()
+    public async Task LogTransactionValidationFailure_SetsInfoSeverity()
     {
         // Arrange & Act
         _detector.LogTransactionValidationFailure("register-1", "sender-1", "tx-1", "Schema");
-        var incidents = _detector.GetIncidentsAsync("register-1", "sender-1").Result;
+        var incidents = await _detector.GetIncidentsAsync("register-1", "sender-1");
 
         // Assert
         incidents[0].Severity.Should().Be(IncidentSeverity.Info);
@@ -187,7 +187,7 @@ public class BadActorDetectorTests
     #region LogDoubleVote Tests
 
     [Fact]
-    public void LogDoubleVote_ValidInput_RecordsHighSeverityIncident()
+    public async Task LogDoubleVote_ValidInput_RecordsHighSeverityIncident()
     {
         // Arrange
         const string registerId = "register-1";
@@ -199,7 +199,7 @@ public class BadActorDetectorTests
         _detector.LogDoubleVote(registerId, validatorId, docketId, term);
 
         // Assert
-        var incidents = _detector.GetIncidentsAsync(registerId, validatorId).Result;
+        var incidents = await _detector.GetIncidentsAsync(registerId, validatorId);
         incidents.Should().HaveCount(1);
         incidents[0].IncidentType.Should().Be(BadActorIncidentType.DoubleVoteAttempt);
         incidents[0].Severity.Should().Be(IncidentSeverity.High);
@@ -210,7 +210,7 @@ public class BadActorDetectorTests
     #region LogLeaderImpersonation Tests
 
     [Fact]
-    public void LogLeaderImpersonation_ValidInput_RecordsCriticalIncident()
+    public async Task LogLeaderImpersonation_ValidInput_RecordsCriticalIncident()
     {
         // Arrange
         const string registerId = "register-1";
@@ -222,7 +222,7 @@ public class BadActorDetectorTests
         _detector.LogLeaderImpersonation(registerId, fakeLeaderId, actualLeaderId, term);
 
         // Assert
-        var incidents = _detector.GetIncidentsAsync(registerId, fakeLeaderId).Result;
+        var incidents = await _detector.GetIncidentsAsync(registerId, fakeLeaderId);
         incidents.Should().HaveCount(1);
         incidents[0].IncidentType.Should().Be(BadActorIncidentType.LeaderImpersonation);
         incidents[0].Severity.Should().Be(IncidentSeverity.Critical);

--- a/tests/Sorcha.Validator.Service.Tests/Services/ConsensusFailureHandlerTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ConsensusFailureHandlerTests.cs
@@ -487,6 +487,649 @@ public class ConsensusFailureHandlerTests
         stats.RecoveryRate.Should().Be(0);
     }
 
+    [Fact]
+    public async Task GetStats_AfterSuccessfulRecovery_IncrementsSuccessfulRecoveries()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        await _handler.HandleFailureAsync(docket, failedResult);
+        var stats = _handler.GetStats();
+
+        // Assert
+        stats.SuccessfulRecoveries.Should().Be(1);
+        stats.TotalRetryAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetStats_AfterAbandon_IncrementsDocketsAbandoned()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 5, transactionCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+
+        // Act
+        await _handler.HandleFailureAsync(docket, failedResult);
+        var stats = _handler.GetStats();
+
+        // Assert
+        stats.DocketsAbandoned.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetStats_AfterReturnTransactions_IncrementsTransactionsReturnedToPool()
+    {
+        // Arrange
+        var docket = CreateDocket(transactionCount: 4);
+        _memPoolManagerMock
+            .Setup(x => x.ReturnTransactionsAsync(
+                It.IsAny<string>(), It.IsAny<List<Transaction>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.ReturnTransactionsToPoolAsync(docket);
+        var stats = _handler.GetStats();
+
+        // Assert
+        stats.TransactionsReturnedToPool.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetStats_RecoveryRate_CalculatesCorrectly()
+    {
+        // Arrange - 2 failures: 1 successful recovery, 1 threshold-already-met (no recovery counted)
+        var retrySuccess = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retrySuccess);
+
+        // Act - first call: retry succeeds (1 failure, 1 recovery)
+        var docket1 = CreateDocket(retryCount: 0);
+        await _handler.HandleFailureAsync(docket1, CreateSignatureCollectionResult(thresholdMet: false));
+
+        // second call: threshold already met (1 failure, 0 recovery)
+        var docket2 = CreateDocket();
+        await _handler.HandleFailureAsync(docket2, CreateSignatureCollectionResult(thresholdMet: true));
+
+        var stats = _handler.GetStats();
+
+        // Assert - 1 recovery out of 2 total failures = 0.5
+        stats.TotalFailures.Should().Be(2);
+        stats.SuccessfulRecoveries.Should().Be(1);
+        stats.RecoveryRate.Should().Be(0.5);
+    }
+
+    #endregion
+
+    #region Timeout Failure Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_TimedOutResult_AttemptsRetry()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var timedOutResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 1, totalValidators: 5, timedOut: true);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, timedOutResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Retry);
+        recovery.Succeeded.Should().BeTrue();
+        recovery.RetryAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_TimedOutAtMaxRetries_Abandons()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 3);
+        var timedOutResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 1, totalValidators: 5, timedOut: true);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, timedOutResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Abandon);
+        recovery.Succeeded.Should().BeFalse();
+        recovery.Reason.Should().Contain("Max retries exceeded");
+    }
+
+    #endregion
+
+    #region Quorum Not Reached Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_QuorumNotReached_AttemptsRetry()
+    {
+        // Arrange - only 1 of 10 validators responded
+        var docket = CreateDocket(retryCount: 0);
+        var lowQuorumResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 1, totalValidators: 10);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: false, approvals: 2, totalValidators: 10);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, lowQuorumResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Retry);
+        recovery.RetryAttempts.Should().Be(1);
+        _signatureCollectorMock.Verify(
+            x => x.CollectSignaturesAsync(
+                It.IsAny<Docket>(),
+                It.IsAny<ConsensusConfig>(),
+                It.IsAny<IReadOnlyList<ValidatorInfo>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_ZeroApprovalsZeroValidators_AttemptsRetry()
+    {
+        // Arrange - edge case: no validators available
+        var docket = CreateDocket(retryCount: 0);
+        var noValidatorsResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 0, totalValidators: 0);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: false, approvals: 0, totalValidators: 0);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, noValidatorsResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Retry);
+        recovery.Succeeded.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Conflicting Votes Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_WithRejections_AttemptsRetry()
+    {
+        // Arrange - some validators rejected the docket
+        var docket = CreateDocket(retryCount: 0);
+        var conflictResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 2, totalValidators: 5,
+            rejections: 3, rejectionDetails: new Dictionary<string, string>
+            {
+                ["validator-2"] = "Invalid merkle root",
+                ["validator-3"] = "Stale docket",
+                ["validator-4"] = "Conflicting transaction"
+            });
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, conflictResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Retry);
+        recovery.RetryAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_AllRejectionsAtMaxRetries_AbandonsDocket()
+    {
+        // Arrange - all validators rejected, max retries exceeded
+        var docket = CreateDocket(retryCount: 3, transactionCount: 2);
+        var allRejectedResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 0, totalValidators: 5,
+            rejections: 5, rejectionDetails: new Dictionary<string, string>
+            {
+                ["validator-1"] = "Invalid signature",
+                ["validator-2"] = "Invalid signature",
+                ["validator-3"] = "Invalid signature",
+                ["validator-4"] = "Invalid signature",
+                ["validator-5"] = "Invalid signature"
+            });
+
+        _memPoolManagerMock
+            .Setup(x => x.ReturnTransactionsAsync(
+                It.IsAny<string>(), It.IsAny<List<Transaction>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, allRejectedResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Abandon);
+        recovery.Succeeded.Should().BeFalse();
+        recovery.TransactionsReturnedToPool.Should().Be(2);
+    }
+
+    #endregion
+
+    #region Invalid Signatures in Votes Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_InvalidSignatureRejections_RetryWithFreshValidators()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 1);
+        var invalidSigResult = CreateSignatureCollectionResult(
+            thresholdMet: false, approvals: 1, totalValidators: 3,
+            rejections: 2, rejectionDetails: new Dictionary<string, string>
+            {
+                ["validator-2"] = "Invalid signature",
+                ["validator-3"] = "Signature verification failed"
+            });
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, invalidSigResult);
+
+        // Assert
+        recovery.Succeeded.Should().BeTrue();
+        // Verify fresh validators were fetched
+        _validatorRegistryMock.Verify(
+            x => x.GetActiveValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Transient Network Failure Recovery Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_NetworkFailureOnRetry_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+
+        _validatorRegistryMock
+            .Setup(x => x.GetActiveValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Network unreachable"));
+
+        // Act & Assert - the exception propagates (not swallowed)
+        var act = () => _handler.HandleFailureAsync(docket, failedResult);
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("Network unreachable");
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_GenesisConfigFails_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+
+        _validatorRegistryMock
+            .Setup(x => x.GetActiveValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ValidatorInfo>());
+
+        _genesisConfigServiceMock
+            .Setup(x => x.GetConsensusConfigAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("Service unavailable"));
+
+        // Act & Assert
+        var act = () => _handler.HandleFailureAsync(docket, failedResult);
+        await act.Should().ThrowAsync<TimeoutException>();
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_SignatureCollectorFails_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+
+        _validatorRegistryMock
+            .Setup(x => x.GetActiveValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ValidatorInfo>());
+
+        _genesisConfigServiceMock
+            .Setup(x => x.GetConsensusConfigAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConsensusConfig
+            {
+                SignatureThresholdMin = 1, SignatureThresholdMax = 5,
+                MaxSignaturesPerDocket = 10, MaxTransactionsPerDocket = 100,
+                DocketTimeout = TimeSpan.FromSeconds(5), DocketBuildInterval = TimeSpan.FromSeconds(10)
+            });
+
+        _signatureCollectorMock
+            .Setup(x => x.CollectSignaturesAsync(
+                It.IsAny<Docket>(), It.IsAny<ConsensusConfig>(),
+                It.IsAny<IReadOnlyList<ValidatorInfo>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("Connection reset"));
+
+        // Act & Assert
+        var act = () => _handler.HandleFailureAsync(docket, failedResult);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    #endregion
+
+    #region Multiple Consecutive Failures Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_MultipleConsecutiveFailures_AccumulatesStats()
+    {
+        // Arrange
+        var retryFailResult = CreateSignatureCollectionResult(thresholdMet: false);
+        SetupRetryMocks(retryFailResult);
+
+        // Act - 3 consecutive failures
+        for (var i = 0; i < 3; i++)
+        {
+            var docket = CreateDocket(retryCount: 0);
+            var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+            await _handler.HandleFailureAsync(docket, failedResult);
+        }
+
+        var stats = _handler.GetStats();
+
+        // Assert
+        stats.TotalFailures.Should().Be(3);
+        stats.TotalRetryAttempts.Should().Be(3);
+        stats.SuccessfulRecoveries.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_MixedResults_TracksAllStats()
+    {
+        // Act - 1: retry succeeds
+        var retrySuccess = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retrySuccess);
+        var docket1 = CreateDocket(retryCount: 0);
+        await _handler.HandleFailureAsync(docket1, CreateSignatureCollectionResult(thresholdMet: false));
+
+        // 2: threshold already met
+        var docket2 = CreateDocket();
+        await _handler.HandleFailureAsync(docket2, CreateSignatureCollectionResult(thresholdMet: true));
+
+        // 3: abandon (max retries exceeded)
+        var docket3 = CreateDocket(retryCount: 5);
+        await _handler.HandleFailureAsync(docket3, CreateSignatureCollectionResult(thresholdMet: false));
+
+        // 4: retry fails
+        var retryFail = CreateSignatureCollectionResult(thresholdMet: false);
+        SetupRetryMocks(retryFail);
+        var docket4 = CreateDocket(retryCount: 0);
+        await _handler.HandleFailureAsync(docket4, CreateSignatureCollectionResult(thresholdMet: false));
+
+        var stats = _handler.GetStats();
+
+        // Assert
+        stats.TotalFailures.Should().Be(4);
+        stats.SuccessfulRecoveries.Should().Be(1);
+        stats.DocketsAbandoned.Should().Be(1);
+        stats.TotalRetryAttempts.Should().Be(2); // retries for calls 1 and 4
+    }
+
+    #endregion
+
+    #region Metadata Edge Cases Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_DocketWithEmptyMetadata_TreatsAsFirstAttempt()
+    {
+        // Arrange - docket with empty metadata (no retryCount key)
+        var docket = CreateDocketWithMetadata(new Dictionary<string, string>());
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, failedResult);
+
+        // Assert
+        recovery.RetryAttempts.Should().Be(1);
+        recovery.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_DocketWithInvalidRetryCountMetadata_TreatsAsZero()
+    {
+        // Arrange
+        var docket = CreateDocketWithMetadata(new Dictionary<string, string> { ["retryCount"] = "not-a-number" });
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, failedResult);
+
+        // Assert - treats invalid retryCount as 0, so does retry
+        recovery.RetryAttempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_DocketWithExactMaxRetries_Abandons()
+    {
+        // Arrange - retryCount == MaxRetries (3)
+        var docket = CreateDocket(retryCount: 3);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, failedResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Abandon);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_DocketWithRetryCountJustBelowMax_AttemptsRetry()
+    {
+        // Arrange - retryCount == MaxRetries - 1 (2)
+        var docket = CreateDocket(retryCount: 2);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: false);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        var recovery = await _handler.HandleFailureAsync(docket, failedResult);
+
+        // Assert
+        recovery.Action.Should().Be(ConsensusRecoveryAction.Retry);
+        recovery.RetryAttempts.Should().Be(3);
+    }
+
+    #endregion
+
+    #region Logging Verification Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_FailedConsensus_LogsWarning()
+    {
+        // Arrange
+        var docket = CreateDocket();
+        var result = CreateSignatureCollectionResult(thresholdMet: true);
+
+        // Act
+        await _handler.HandleFailureAsync(docket, result);
+
+        // Assert - verify warning was logged about the failure
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Handling consensus failure")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_ThresholdAlreadyMet_LogsInformation()
+    {
+        // Arrange
+        var docket = CreateDocket();
+        var result = CreateSignatureCollectionResult(thresholdMet: true);
+
+        // Act
+        await _handler.HandleFailureAsync(docket, result);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("no recovery needed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_MaxRetriesExceeded_LogsError()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 5);
+        var result = CreateSignatureCollectionResult(thresholdMet: false);
+
+        // Act
+        await _handler.HandleFailureAsync(docket, result);
+
+        // Assert - verify the specific "Max retries exceeded, abandoning" log message
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Max retries") && v.ToString()!.Contains("abandoning")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AbandonDocketAsync_ValidInput_LogsError()
+    {
+        // Arrange
+        var docket = CreateDocket();
+
+        // Act
+        await _handler.AbandonDocketAsync(docket, "Test abandonment reason");
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Abandoning docket")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AbandonDocketAsync_PersistFails_LogsWarningButDoesNotThrow()
+    {
+        // Arrange
+        var docket = CreateDocket();
+        _pendingDocketStoreMock
+            .Setup(x => x.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<DocketStatus>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Database unavailable"));
+
+        // Act - should not throw
+        await _handler.AbandonDocketAsync(docket, "Test reason");
+
+        // Assert - status still updated in memory
+        docket.Status.Should().Be(DocketStatus.Rejected);
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to persist rejected status")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ReturnTransactionsToPoolAsync_PoolFails_LogsWarning()
+    {
+        // Arrange
+        var docket = CreateDocket(transactionCount: 2);
+        _memPoolManagerMock
+            .Setup(x => x.ReturnTransactionsAsync(
+                It.IsAny<string>(), It.IsAny<List<Transaction>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Pool error"));
+
+        // Act
+        await _handler.ReturnTransactionsToPoolAsync(docket);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to return transactions")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleFailureAsync_RetrySucceeds_LogsRecoveryInformation()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+        var retryResult = CreateSignatureCollectionResult(thresholdMet: true);
+        SetupRetryMocks(retryResult);
+
+        // Act
+        await _handler.HandleFailureAsync(docket, failedResult);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Recovery succeeded")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Cancellation Tests
+
+    [Fact]
+    public async Task HandleFailureAsync_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var docket = CreateDocket(retryCount: 0);
+        var failedResult = CreateSignatureCollectionResult(thresholdMet: false);
+        var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert - Task.Delay should throw on cancelled token
+        var act = () => _handler.HandleFailureAsync(docket, failedResult, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    #endregion
+
+    #region AbandonDocketAsync Persistence Tests
+
+    [Fact]
+    public async Task AbandonDocketAsync_PersistsStatusToStore()
+    {
+        // Arrange
+        var docket = CreateDocket();
+
+        // Act
+        await _handler.AbandonDocketAsync(docket, "consensus failure");
+
+        // Assert
+        _pendingDocketStoreMock.Verify(
+            x => x.UpdateStatusAsync(docket.DocketId, DocketStatus.Rejected, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     #endregion
 
     #region Helper Methods
@@ -526,6 +1169,37 @@ public class ConsensusFailureHandlerTests
                 It.IsAny<IReadOnlyList<ValidatorInfo>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(retryResult);
+    }
+
+    private static Docket CreateDocketWithMetadata(Dictionary<string, string> metadata, int transactionCount = 0)
+    {
+        var transactions = new List<Transaction>();
+        for (var i = 0; i < transactionCount; i++)
+        {
+            transactions.Add(CreateTransaction($"tx-{i}"));
+        }
+
+        return new Docket
+        {
+            DocketId = $"docket-{Guid.NewGuid():N}",
+            RegisterId = "register-1",
+            DocketNumber = 1,
+            DocketHash = "test-hash",
+            ProposerValidatorId = "validator-1",
+            ProposerSignature = new Signature
+            {
+                PublicKey = "test-key"u8.ToArray(),
+                SignatureValue = "test-sig"u8.ToArray(),
+                Algorithm = "ED25519",
+                SignedAt = DateTimeOffset.UtcNow,
+                SignedBy = "validator-1"
+            },
+            MerkleRoot = "test-merkle-root",
+            Status = DocketStatus.Proposed,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Transactions = transactions,
+            Metadata = metadata
+        };
     }
 
     private static Docket CreateDocket(int retryCount = 0, int transactionCount = 0)
@@ -593,20 +1267,23 @@ public class ConsensusFailureHandlerTests
     private static SignatureCollectionResult CreateSignatureCollectionResult(
         bool thresholdMet,
         int approvals = 3,
-        int totalValidators = 5)
+        int totalValidators = 5,
+        bool timedOut = false,
+        int rejections = 0,
+        Dictionary<string, string>? rejectionDetails = null)
     {
         return new SignatureCollectionResult
         {
             Signatures = [],
             ThresholdMet = thresholdMet,
-            TimedOut = false,
+            TimedOut = timedOut,
             TotalValidators = totalValidators,
-            ResponsesReceived = approvals,
+            ResponsesReceived = approvals + rejections,
             Approvals = approvals,
-            Rejections = 0,
+            Rejections = rejections,
             Duration = TimeSpan.FromMilliseconds(100),
             NonResponders = [],
-            RejectionDetails = new Dictionary<string, string>()
+            RejectionDetails = rejectionDetails ?? new Dictionary<string, string>()
         };
     }
 

--- a/tests/Sorcha.Validator.Service.Tests/Services/ControlDocketProcessorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ControlDocketProcessorTests.cs
@@ -248,6 +248,8 @@ public class ControlDocketProcessorTests
     [InlineData("control.config.update", ControlActionType.ConfigUpdate)]
     [InlineData("control.blueprint.publish", ControlActionType.BlueprintPublish)]
     [InlineData("control.register.updateMetadata", ControlActionType.RegisterUpdateMetadata)]
+    [InlineData("control.crypto.update", ControlActionType.CryptoPolicyUpdate)]
+    [InlineData("control.policy.update", ControlActionType.PolicyUpdate)]
     public void ExtractControlTransactions_WithActionId_ReturnsCorrectActionType(
         string actionId,
         ControlActionType expectedType)
@@ -263,6 +265,145 @@ public class ControlDocketProcessorTests
         // Assert
         result.Should().HaveCount(1);
         result[0].ActionType.Should().Be(expectedType);
+    }
+
+    [Fact]
+    public void ExtractControlTransactions_WithNullActionId_SkipsTransaction()
+    {
+        // Arrange
+        var payloadJson = JsonSerializer.Serialize(new { data = "test" });
+        var payloadElement = JsonDocument.Parse(payloadJson).RootElement.Clone();
+        var tx = new Transaction
+        {
+            TransactionId = "tx-001",
+            RegisterId = TestRegisterId,
+            BlueprintId = null,
+            ActionId = null,
+            Payload = payloadElement,
+            PayloadHash = "hash-tx-001",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Signatures =
+            [
+                new Signature
+                {
+                    PublicKey = System.Text.Encoding.UTF8.GetBytes("test-pubkey"),
+                    SignatureValue = System.Text.Encoding.UTF8.GetBytes("test-signature"),
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow
+                }
+            ]
+        };
+        var docket = CreateDocket([tx]);
+
+        // Act
+        var result = _processor.ExtractControlTransactions(docket);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Control.Validator.Register")]
+    [InlineData("CONTROL.VALIDATOR.REGISTER")]
+    [InlineData("Control.Config.Update")]
+    public void ExtractControlTransactions_CaseInsensitiveActionId_ExtractsTransaction(string actionId)
+    {
+        // Arrange
+        var payload = CreateValidPayloadForActionType(
+            actionId.Contains("Validator", StringComparison.OrdinalIgnoreCase)
+                ? ControlActionType.ValidatorRegister
+                : ControlActionType.ConfigUpdate);
+        var controlTx = CreateTransaction("tx-001", actionId, payload);
+        var docket = CreateDocket([controlTx]);
+
+        // Act
+        var result = _processor.ExtractControlTransactions(docket);
+
+        // Assert
+        result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ExtractControlTransactions_WithCryptoPolicyUpdateAction_ExtractsTransaction()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 2,
+            acceptedSignatureAlgorithms = new[] { "ED25519", "P-256" },
+            requiredSignatureAlgorithms = new[] { "ED25519" },
+            enforcementMode = "Strict"
+        };
+        var controlTx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([controlTx]);
+
+        // Act
+        var result = _processor.ExtractControlTransactions(docket);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].ActionType.Should().Be(ControlActionType.CryptoPolicyUpdate);
+    }
+
+    [Fact]
+    public void ExtractControlTransactions_WithPolicyUpdateAction_ExtractsTransaction()
+    {
+        // Arrange
+        var payload = new
+        {
+            policy = new
+            {
+                version = 2u,
+                validators = new { registrationMode = "Public", minValidators = 1, maxValidators = 50 },
+                consensus = new { signatureThresholdMin = 2, signatureThresholdMax = 5 },
+                leaderElection = new { mechanism = "Rotating" }
+            },
+            updatedBy = "admin-001"
+        };
+        var controlTx = CreateTransaction("tx-001", "control.policy.update", payload);
+        var docket = CreateDocket([controlTx]);
+
+        // Act
+        var result = _processor.ExtractControlTransactions(docket);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].ActionType.Should().Be(ControlActionType.PolicyUpdate);
+    }
+
+    [Fact]
+    public void ExtractControlTransactions_WithMalformedPayload_SkipsAndContinues()
+    {
+        // Arrange - payload missing required fields for validator.register
+        var malformedTx = CreateTransaction("tx-001", "control.validator.register",
+            new { unrelatedField = true });
+        var validTx = CreateTransaction("tx-002", "control.config.update", new
+        {
+            path = "consensus.signatureThreshold.min",
+            newValue = 3
+        });
+        var docket = CreateDocket([malformedTx, validTx]);
+
+        // Act
+        var result = _processor.ExtractControlTransactions(docket);
+
+        // Assert - at least the valid config.update should be extracted; no exception propagates
+        result.Should().HaveCountGreaterThanOrEqualTo(1);
+        result.Should().Contain(t => t.ActionType == ControlActionType.ConfigUpdate);
+    }
+
+    [Fact]
+    public void ExtractControlTransactions_WithUnknownControlPrefix_ReturnsEmpty()
+    {
+        // Arrange - action starts with "control." but is not a known action type
+        var tx = CreateTransaction("tx-001", "control.unknown.action", new { data = "test" });
+        var docket = CreateDocket([tx]);
+
+        // Act
+        var result = _processor.ExtractControlTransactions(docket);
+
+        // Assert - Unknown ControlActionType is filtered out
+        result.Should().BeEmpty();
     }
 
     #endregion
@@ -321,9 +462,92 @@ public class ControlDocketProcessorTests
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public void IsControlDocket_WithNullActionIdTransaction_ReturnsFalse()
+    {
+        // Arrange
+        var payloadJson = JsonSerializer.Serialize(new { data = "test" });
+        var payloadElement = JsonDocument.Parse(payloadJson).RootElement.Clone();
+        var tx = new Transaction
+        {
+            TransactionId = "tx-001",
+            RegisterId = TestRegisterId,
+            BlueprintId = null,
+            ActionId = null,
+            Payload = payloadElement,
+            PayloadHash = "hash-tx-001",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Signatures =
+            [
+                new Signature
+                {
+                    PublicKey = System.Text.Encoding.UTF8.GetBytes("test-pubkey"),
+                    SignatureValue = System.Text.Encoding.UTF8.GetBytes("test-signature"),
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow
+                }
+            ]
+        };
+        var docket = CreateDocket([tx]);
+
+        // Act
+        var result = _processor.IsControlDocket(docket);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsControlDocket_WithCaseInsensitiveControlAction_ReturnsTrue()
+    {
+        // Arrange
+        var controlTx = CreateTransaction("tx-001", "CONTROL.CONFIG.UPDATE", new
+        {
+            path = "consensus.docketTimeout",
+            newValue = "PT60S"
+        });
+        var docket = CreateDocket([controlTx]);
+
+        // Act
+        var result = _processor.IsControlDocket(docket);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
     #endregion
 
     #region ValidateControlTransactionsAsync Tests
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_WithNullRegisterId_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var controlTransactions = new List<ControlTransaction>();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _processor.ValidateControlTransactionsAsync(null!, controlTransactions));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_WithWhitespaceRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var controlTransactions = new List<ControlTransaction>();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _processor.ValidateControlTransactionsAsync("   ", controlTransactions));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_WithNullTransactionList_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _processor.ValidateControlTransactionsAsync(TestRegisterId, null!));
+    }
 
     [Fact]
     public async Task ValidateControlTransactionsAsync_WithEmptyList_ReturnsSuccess()
@@ -411,6 +635,29 @@ public class ControlDocketProcessorTests
     }
 
     [Fact]
+    public async Task ValidateControlTransactionsAsync_WithMissingPublicKey_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            publicKey = "",
+            endpoint = "https://validator1.example.com"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.register", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("PublicKey"));
+    }
+
+    [Fact]
     public async Task ValidateControlTransactionsAsync_ValidatorApprovalForNonexistentValidator_ReturnsError()
     {
         // Arrange
@@ -424,6 +671,175 @@ public class ControlDocketProcessorTests
             approvedBy = "admin-001"
         };
         var tx = CreateTransaction("tx-001", "control.validator.approve", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("not found"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ValidatorApprovalForPendingValidator_ReturnsSuccess()
+    {
+        // Arrange
+        var validatorInfo = new ValidatorInfo
+        {
+            ValidatorId = TestValidatorId,
+            PublicKey = "pubkey-001",
+            GrpcEndpoint = "https://validator1.example.com",
+            Status = ValidatorStatus.Pending,
+            RegisteredAt = DateTimeOffset.UtcNow
+        };
+
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validatorInfo);
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            approvedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.approve", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ValidTransactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ValidatorApprovalForActiveValidator_ReturnsError()
+    {
+        // Arrange
+        var validatorInfo = new ValidatorInfo
+        {
+            ValidatorId = TestValidatorId,
+            PublicKey = "pubkey-001",
+            GrpcEndpoint = "https://validator1.example.com",
+            Status = ValidatorStatus.Active,
+            RegisteredAt = DateTimeOffset.UtcNow
+        };
+
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validatorInfo);
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            approvedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.approve", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("not pending"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ValidatorSuspensionForActiveValidator_ReturnsSuccess()
+    {
+        // Arrange
+        var validatorInfo = new ValidatorInfo
+        {
+            ValidatorId = TestValidatorId,
+            PublicKey = "pubkey-001",
+            GrpcEndpoint = "https://validator1.example.com",
+            Status = ValidatorStatus.Active,
+            RegisteredAt = DateTimeOffset.UtcNow
+        };
+
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validatorInfo);
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            suspendedBy = "admin-001",
+            reason = "Maintenance"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.suspend", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ValidTransactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ValidatorSuspensionForSuspendedValidator_ReturnsError()
+    {
+        // Arrange
+        var validatorInfo = new ValidatorInfo
+        {
+            ValidatorId = TestValidatorId,
+            PublicKey = "pubkey-001",
+            GrpcEndpoint = "https://validator1.example.com",
+            Status = ValidatorStatus.Suspended,
+            RegisteredAt = DateTimeOffset.UtcNow
+        };
+
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validatorInfo);
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            suspendedBy = "admin-001",
+            reason = "Maintenance"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.suspend", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("not active"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ValidatorSuspensionForNonexistentValidator_ReturnsError()
+    {
+        // Arrange
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ValidatorInfo?)null);
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            suspendedBy = "admin-001",
+            reason = "Maintenance"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.suspend", payload);
         var docket = CreateDocket([tx]);
         var controlTransactions = _processor.ExtractControlTransactions(docket);
 
@@ -476,6 +892,68 @@ public class ControlDocketProcessorTests
     }
 
     [Fact]
+    public async Task ValidateControlTransactionsAsync_ValidatorRemovalAboveMinimum_ReturnsSuccess()
+    {
+        // Arrange
+        var validatorInfo = new ValidatorInfo
+        {
+            ValidatorId = TestValidatorId,
+            PublicKey = "pubkey-001",
+            GrpcEndpoint = "https://validator1.example.com",
+            Status = ValidatorStatus.Active,
+            RegisteredAt = DateTimeOffset.UtcNow
+        };
+
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validatorInfo);
+        _mockValidatorRegistry
+            .Setup(r => r.GetActiveCountAsync(TestRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(5); // Well above minimum (2)
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            removedBy = "admin-001",
+            reason = "No longer needed"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.remove", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ValidTransactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ConfigUpdateWithValidPath_ReturnsSuccess()
+    {
+        // Arrange
+        var payload = new
+        {
+            path = "consensus.signatureThreshold.min",
+            newValue = 3,
+            reason = "Increase threshold"
+        };
+        var tx = CreateTransaction("tx-001", "control.config.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ValidTransactions.Should().HaveCount(1);
+    }
+
+    [Fact]
     public async Task ValidateControlTransactionsAsync_ConfigUpdateWithInvalidPath_ReturnsError()
     {
         // Arrange
@@ -498,9 +976,328 @@ public class ControlDocketProcessorTests
         result.Errors["tx-001"].Should().Contain(e => e.Contains("Unknown configuration path"));
     }
 
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_ConfigUpdateWithMissingPath_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            path = "",
+            newValue = "something"
+        };
+        var tx = CreateTransaction("tx-001", "control.config.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("Path"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_BlueprintPublishWithValidPayload_ReturnsSuccess()
+    {
+        // Arrange
+        var payload = new
+        {
+            blueprintId = "bp-001",
+            blueprintJson = "{\"title\":\"Test Blueprint\"}",
+            publishedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.blueprint.publish", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ValidTransactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_BlueprintPublishWithMissingBlueprintId_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            blueprintId = "",
+            blueprintJson = "{\"title\":\"Test Blueprint\"}",
+            publishedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.blueprint.publish", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("BlueprintId"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_BlueprintPublishWithInvalidJson_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            blueprintId = "bp-001",
+            blueprintJson = "not valid json {{{",
+            publishedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.blueprint.publish", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("valid JSON"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_MetadataUpdateWithValidPayload_ReturnsSuccess()
+    {
+        // Arrange
+        var payload = new
+        {
+            field = "name",
+            newValue = "Updated Register Name"
+        };
+        var tx = CreateTransaction("tx-001", "control.register.updatemetadata", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_MetadataUpdateWithInvalidField_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            field = "invalidField",
+            newValue = "Some value"
+        };
+        var tx = CreateTransaction("tx-001", "control.register.updatemetadata", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("Invalid field"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_MetadataUpdateWithMissingNewValue_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            field = "name",
+            newValue = ""
+        };
+        var tx = CreateTransaction("tx-001", "control.register.updatemetadata", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("NewValue"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_CryptoPolicyUpdateWithValidPayload_ReturnsSuccess()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 2,
+            acceptedSignatureAlgorithms = new[] { "ED25519", "P-256" },
+            requiredSignatureAlgorithms = new[] { "ED25519" },
+            enforcementMode = "Strict"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.ValidTransactions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_CryptoPolicyUpdateWithZeroVersion_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 0,
+            acceptedSignatureAlgorithms = new[] { "ED25519" },
+            enforcementMode = "Permissive"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("version"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_CryptoPolicyUpdateWithEmptyAlgorithms_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 1,
+            acceptedSignatureAlgorithms = Array.Empty<string>(),
+            enforcementMode = "Permissive"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("AcceptedSignatureAlgorithms"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_CryptoPolicyUpdateWithInvalidEnforcementMode_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 1,
+            acceptedSignatureAlgorithms = new[] { "ED25519" },
+            enforcementMode = "InvalidMode"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("EnforcementMode"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_CryptoPolicyUpdateWithRequiredNotInAccepted_ReturnsError()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 1,
+            acceptedSignatureAlgorithms = new[] { "ED25519" },
+            requiredSignatureAlgorithms = new[] { "P-256" },
+            enforcementMode = "Strict"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors["tx-001"].Should().Contain(e => e.Contains("not in AcceptedSignatureAlgorithms"));
+    }
+
+    [Fact]
+    public async Task ValidateControlTransactionsAsync_MultipleTransactionsWithMixedValidity_ReturnsErrors()
+    {
+        // Arrange - one valid, one invalid
+        var validTx = CreateTransaction("tx-001", "control.config.update", new
+        {
+            path = "consensus.signatureThreshold.min",
+            newValue = 3
+        });
+        var invalidTx = CreateTransaction("tx-002", "control.config.update", new
+        {
+            path = "invalid.path",
+            newValue = "something"
+        });
+        var docket = CreateDocket([validTx, invalidTx]);
+        var controlTransactions = _processor.ExtractControlTransactions(docket);
+
+        // Act
+        var result = await _processor.ValidateControlTransactionsAsync(
+            TestRegisterId, controlTransactions, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainKey("tx-002");
+        result.Errors.Should().NotContainKey("tx-001");
+    }
+
     #endregion
 
     #region ProcessCommittedDocketAsync Tests
+
+    [Fact]
+    public async Task ProcessCommittedDocketAsync_WithNullRegisterId_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var docket = CreateDocket([]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _processor.ProcessCommittedDocketAsync(null!, docket));
+    }
+
+    [Fact]
+    public async Task ProcessCommittedDocketAsync_WithNullDocket_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _processor.ProcessCommittedDocketAsync(TestRegisterId, null!));
+    }
 
     [Fact]
     public async Task ProcessCommittedDocketAsync_WithNoControlTransactions_ReturnsSuccessWithZeroActions()
@@ -611,9 +1408,175 @@ public class ControlDocketProcessorTests
         capturedArgs.ActionType.Should().Be(ControlActionType.ValidatorRegister);
     }
 
+    [Fact]
+    public async Task ProcessCommittedDocketAsync_WithCryptoPolicyUpdate_SetsConfigurationUpdated()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 2,
+            acceptedSignatureAlgorithms = new[] { "ED25519", "P-256" },
+            requiredSignatureAlgorithms = new[] { "ED25519" },
+            enforcementMode = "Strict"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+
+        // Act
+        var result = await _processor.ProcessCommittedDocketAsync(TestRegisterId, docket);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ConfigurationUpdated.Should().BeTrue();
+        result.ValidatorsModified.Should().BeFalse();
+        _mockGenesisConfigService.Verify(
+            s => s.RefreshConfigAsync(TestRegisterId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockVersionResolver.Verify(
+            v => v.InvalidateCache(TestRegisterId),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessCommittedDocketAsync_WithActionException_RecordsFailureAndContinues()
+    {
+        // Arrange - validator register throws, then a config update succeeds
+        _mockValidatorRegistry
+            .Setup(r => r.RegisterAsync(
+                TestRegisterId,
+                It.IsAny<ValidatorRegistration>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Registry unavailable"));
+
+        var registerTx = CreateTransaction("tx-001", "control.validator.register", new
+        {
+            validatorId = TestValidatorId,
+            publicKey = "pubkey-001",
+            endpoint = "https://validator1.example.com"
+        });
+        var configTx = CreateTransaction("tx-002", "control.config.update", new
+        {
+            path = "consensus.signatureThreshold.min",
+            newValue = 3
+        });
+        var docket = CreateDocket([registerTx, configTx]);
+
+        // Act
+        var result = await _processor.ProcessCommittedDocketAsync(TestRegisterId, docket);
+
+        // Assert
+        result.Success.Should().BeFalse(); // Not all actions succeeded
+        result.ActionsApplied.Should().Be(1); // Config update succeeded
+        result.ActionResults.Should().HaveCount(2);
+        result.ActionResults[0].Success.Should().BeFalse();
+        result.ActionResults[0].ErrorMessage.Should().Contain("Registry unavailable");
+        result.ActionResults[1].Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ProcessCommittedDocketAsync_WithMultipleValidatorActions_SetsValidatorsModifiedOnce()
+    {
+        // Arrange
+        _mockValidatorRegistry
+            .Setup(r => r.RegisterAsync(
+                TestRegisterId,
+                It.IsAny<ValidatorRegistration>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ValidatorRegistrationResult.Succeeded("tx-001", 0));
+
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidatorInfo
+            {
+                ValidatorId = TestValidatorId,
+                PublicKey = "pubkey-001",
+                GrpcEndpoint = "https://validator1.example.com",
+                Status = ValidatorStatus.Pending,
+                RegisteredAt = DateTimeOffset.UtcNow
+            });
+
+        var registerTx = CreateTransaction("tx-001", "control.validator.register", new
+        {
+            validatorId = "validator-002",
+            publicKey = "pubkey-002",
+            endpoint = "https://validator2.example.com"
+        });
+        var approveTx = CreateTransaction("tx-002", "control.validator.approve", new
+        {
+            validatorId = TestValidatorId,
+            approvedBy = "admin-001"
+        });
+        var docket = CreateDocket([registerTx, approveTx]);
+
+        // Act
+        var result = await _processor.ProcessCommittedDocketAsync(TestRegisterId, docket);
+
+        // Assert
+        result.ValidatorsModified.Should().BeTrue();
+        result.ActionsApplied.Should().Be(2);
+        _mockValidatorRegistry.Verify(
+            r => r.RefreshAsync(TestRegisterId, It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task ProcessCommittedDocketAsync_WithNoConfigOrValidatorChanges_DoesNotRefresh()
+    {
+        // Arrange - blueprint publish doesn't trigger config refresh or validator refresh
+        var payload = new
+        {
+            blueprintId = "bp-001",
+            blueprintJson = "{\"title\":\"Test Blueprint\"}",
+            publishedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.blueprint.publish", payload);
+        var docket = CreateDocket([tx]);
+
+        // Act
+        var result = await _processor.ProcessCommittedDocketAsync(TestRegisterId, docket);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ConfigurationUpdated.Should().BeFalse();
+        result.ValidatorsModified.Should().BeFalse();
+        _mockGenesisConfigService.Verify(
+            s => s.RefreshConfigAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockValidatorRegistry.Verify(
+            r => r.RefreshAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     #endregion
 
     #region ApplyControlActionAsync Tests
+
+    [Fact]
+    public async Task ApplyControlActionAsync_WithNullRegisterId_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            publicKey = "pubkey-001",
+            endpoint = "https://validator1.example.com"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.register", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _processor.ApplyControlActionAsync(null!, controlTx));
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_WithNullControlTransaction_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _processor.ApplyControlActionAsync(TestRegisterId, null!));
+    }
 
     [Fact]
     public async Task ApplyControlActionAsync_ValidatorRegister_CallsValidatorRegistry()
@@ -675,6 +1638,164 @@ public class ControlDocketProcessorTests
     }
 
     [Fact]
+    public async Task ApplyControlActionAsync_ValidatorApprove_ReturnsSuccessWithDescription()
+    {
+        // Arrange
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidatorInfo
+            {
+                ValidatorId = TestValidatorId,
+                PublicKey = "pubkey-001",
+                GrpcEndpoint = "https://validator1.example.com",
+                Status = ValidatorStatus.Pending,
+                RegisteredAt = DateTimeOffset.UtcNow
+            });
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            approvedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.approve", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("approved");
+        result.ChangeDescription.Should().Contain("admin-001");
+        result.ActionType.Should().Be(ControlActionType.ValidatorApprove);
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_ValidatorApproveNotFound_ReturnsFailure()
+    {
+        // Arrange
+        _mockValidatorRegistry
+            .Setup(r => r.GetValidatorAsync(TestRegisterId, TestValidatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ValidatorInfo?)null);
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            approvedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.approve", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_ValidatorSuspend_ReturnsSuccessWithDescription()
+    {
+        // Arrange
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            suspendedBy = "admin-001",
+            reason = "Maintenance window"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.suspend", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("suspended");
+        result.ChangeDescription.Should().Contain("admin-001");
+        result.ChangeDescription.Should().Contain("indefinitely");
+        result.ActionType.Should().Be(ControlActionType.ValidatorSuspend);
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_ValidatorSuspendWithExpiry_IncludesExpiryInDescription()
+    {
+        // Arrange
+        var suspendUntil = DateTimeOffset.UtcNow.AddHours(24);
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            suspendedBy = "admin-001",
+            reason = "Temporary maintenance",
+            suspendedUntil = suspendUntil
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.suspend", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("suspended");
+        result.ChangeDescription.Should().Contain("until");
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_ValidatorRemove_ReturnsSuccessWithDescription()
+    {
+        // Arrange
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            removedBy = "admin-001",
+            reason = "Decommissioned"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.remove", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("removed");
+        result.ChangeDescription.Should().Contain("admin-001");
+        result.ChangeDescription.Should().Contain("Decommissioned");
+        result.ActionType.Should().Be(ControlActionType.ValidatorRemove);
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_ConfigUpdate_ReturnsSuccessWithDescription()
+    {
+        // Arrange
+        var payload = new
+        {
+            path = "consensus.signatureThreshold.min",
+            newValue = 5,
+            reason = "Increase threshold"
+        };
+        var tx = CreateTransaction("tx-001", "control.config.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("Configuration updated");
+        result.ChangeDescription.Should().Contain("consensus.signatureThreshold.min");
+        result.ActionType.Should().Be(ControlActionType.ConfigUpdate);
+    }
+
+    [Fact]
     public async Task ApplyControlActionAsync_BlueprintPublish_ReturnsSuccessWithDescription()
     {
         // Arrange
@@ -697,6 +1818,29 @@ public class ControlDocketProcessorTests
     }
 
     [Fact]
+    public async Task ApplyControlActionAsync_BlueprintPublishWithPreviousVersion_IncludesUpdateInfo()
+    {
+        // Arrange
+        var payload = new
+        {
+            blueprintId = "bp-001",
+            blueprintJson = "{\"title\":\"Updated Blueprint\"}",
+            publishedBy = "admin-001",
+            previousVersionId = "prev-version-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.blueprint.publish", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("update from prev-version-001");
+    }
+
+    [Fact]
     public async Task ApplyControlActionAsync_MetadataUpdate_ReturnsSuccessWithDescription()
     {
         // Arrange
@@ -715,6 +1859,180 @@ public class ControlDocketProcessorTests
         // Assert
         result.Success.Should().BeTrue();
         result.ChangeDescription.Should().Contain("description updated");
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_CryptoPolicyUpdate_ReturnsSuccessWithDescription()
+    {
+        // Arrange
+        var payload = new
+        {
+            version = 3,
+            acceptedSignatureAlgorithms = new[] { "ED25519", "P-256", "RSA-4096" },
+            requiredSignatureAlgorithms = new[] { "ED25519" },
+            enforcementMode = "Strict"
+        };
+        var tx = CreateTransaction("tx-001", "control.crypto.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("Crypto policy updated");
+        result.ChangeDescription.Should().Contain("version 3");
+        result.ChangeDescription.Should().Contain("Strict");
+        result.ChangeDescription.Should().Contain("3 accepted algorithms");
+        result.ActionType.Should().Be(ControlActionType.CryptoPolicyUpdate);
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_PolicyUpdate_ReturnsSuccessWithDescription()
+    {
+        // Arrange
+        var payload = new
+        {
+            policy = new
+            {
+                version = 2u,
+                validators = new
+                {
+                    registrationMode = "Public",
+                    approvedValidators = Array.Empty<object>(),
+                    minValidators = 2,
+                    maxValidators = 20
+                },
+                consensus = new
+                {
+                    signatureThresholdMin = 2,
+                    signatureThresholdMax = 10,
+                    maxTransactionsPerDocket = 500
+                },
+                leaderElection = new
+                {
+                    mechanism = "Rotating"
+                }
+            },
+            updatedBy = "admin-001"
+        };
+        var tx = CreateTransaction("tx-001", "control.policy.update", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ChangeDescription.Should().Contain("policy updated");
+        result.ChangeDescription.Should().Contain("admin-001");
+        result.ActionType.Should().Be(ControlActionType.PolicyUpdate);
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_UnknownActionType_ReturnsFailure()
+    {
+        // Arrange - create a ControlTransaction with Unknown action type directly
+        var payloadJson = JsonSerializer.Serialize(new { data = "test" });
+        var payloadElement = JsonDocument.Parse(payloadJson).RootElement.Clone();
+        var tx = new Transaction
+        {
+            TransactionId = "tx-001",
+            RegisterId = TestRegisterId,
+            BlueprintId = "control-blueprint",
+            ActionId = "control.unknown.type",
+            Payload = payloadElement,
+            PayloadHash = "hash-tx-001",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Signatures =
+            [
+                new Signature
+                {
+                    PublicKey = System.Text.Encoding.UTF8.GetBytes("test-pubkey"),
+                    SignatureValue = System.Text.Encoding.UTF8.GetBytes("test-signature"),
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow
+                }
+            ]
+        };
+
+        var controlTx = new ControlTransaction
+        {
+            Transaction = tx,
+            ActionType = ControlActionType.Unknown,
+            ActionId = "control.unknown.type",
+            Payload = new TestControlPayload()
+        };
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Unknown");
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_RaisesEventOnSuccess()
+    {
+        // Arrange
+        ControlActionAppliedEventArgs? capturedArgs = null;
+        _processor.ControlActionApplied += (sender, args) => capturedArgs = args;
+
+        var payload = new
+        {
+            field = "name",
+            newValue = "New Register Name"
+        };
+        var tx = CreateTransaction("tx-001", "control.register.updatemetadata", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        capturedArgs.Should().NotBeNull();
+        capturedArgs!.RegisterId.Should().Be(TestRegisterId);
+        capturedArgs.TransactionId.Should().Be("tx-001");
+        capturedArgs.ActionType.Should().Be(ControlActionType.RegisterUpdateMetadata);
+        capturedArgs.AppliedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        capturedArgs.ChangeDescription.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ApplyControlActionAsync_DoesNotRaiseEventOnFailure()
+    {
+        // Arrange
+        ControlActionAppliedEventArgs? capturedArgs = null;
+        _processor.ControlActionApplied += (sender, args) => capturedArgs = args;
+
+        _mockValidatorRegistry
+            .Setup(r => r.RegisterAsync(
+                TestRegisterId,
+                It.IsAny<ValidatorRegistration>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ValidatorRegistrationResult.Failed("Registration denied"));
+
+        var payload = new
+        {
+            validatorId = TestValidatorId,
+            publicKey = "pubkey-001",
+            endpoint = "https://validator1.example.com"
+        };
+        var tx = CreateTransaction("tx-001", "control.validator.register", payload);
+        var docket = CreateDocket([tx]);
+        var controlTx = _processor.ExtractControlTransactions(docket)[0];
+
+        // Act
+        var result = await _processor.ApplyControlActionAsync(TestRegisterId, controlTx);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        capturedArgs.Should().BeNull();
     }
 
     #endregion
@@ -814,9 +2132,32 @@ public class ControlDocketProcessorTests
                 field = "name",
                 newValue = "Updated Name"
             },
+            ControlActionType.CryptoPolicyUpdate => (object)new
+            {
+                version = 2,
+                acceptedSignatureAlgorithms = new[] { "ED25519", "P-256" },
+                requiredSignatureAlgorithms = new[] { "ED25519" },
+                enforcementMode = "Strict"
+            },
+            ControlActionType.PolicyUpdate => new
+            {
+                policy = new
+                {
+                    version = 2u,
+                    validators = new { registrationMode = "Public", minValidators = 1, maxValidators = 50 },
+                    consensus = new { signatureThresholdMin = 2, signatureThresholdMax = 5 },
+                    leaderElection = new { mechanism = "Rotating" }
+                },
+                updatedBy = "admin-001"
+            },
             _ => new { }
         };
     }
+
+    /// <summary>
+    /// Simple test control payload for constructing ControlTransaction with Unknown type
+    /// </summary>
+    private record TestControlPayload : ControlPayload;
 
     #endregion
 }

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketDistributorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketDistributorTests.cs
@@ -85,6 +85,23 @@ public class DocketDistributorTests
             .WithParameterName("logger");
     }
 
+    [Fact]
+    public void Constructor_NullConfig_UsesDefaults()
+    {
+        // Arrange
+        var nullConfigMock = new Mock<IOptions<DocketDistributorConfiguration>>();
+        nullConfigMock.Setup(x => x.Value).Returns((DocketDistributorConfiguration)null!);
+
+        // Act - should not throw, uses default config
+        var act = () => new DocketDistributor(
+            _peerClientMock.Object,
+            _registerClientMock.Object,
+            nullConfigMock.Object,
+            _loggerMock.Object);
+
+        act.Should().NotThrow();
+    }
+
     #endregion
 
     #region BroadcastProposedDocketAsync Tests
@@ -94,11 +111,7 @@ public class DocketDistributorTests
     {
         // Arrange
         var docket = CreateValidDocket();
-        var validators = new List<ValidatorInfo>
-        {
-            new() { ValidatorId = "val-1", GrpcEndpoint = "http://val1:5000" },
-            new() { ValidatorId = "val-2", GrpcEndpoint = "http://val2:5000" }
-        };
+        var validators = CreateValidatorList(2);
 
         _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(validators);
@@ -133,6 +146,27 @@ public class DocketDistributorTests
     }
 
     [Fact]
+    public async Task BroadcastProposedDocketAsync_NoPeers_DoesNotCallPublish()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ValidatorInfo>());
+
+        // Act
+        await _distributor.BroadcastProposedDocketAsync(docket);
+
+        // Assert
+        _peerClientMock.Verify(
+            x => x.PublishProposedDocketAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task BroadcastProposedDocketAsync_NullDocket_ThrowsArgumentNullException()
     {
         // Act
@@ -140,6 +174,105 @@ public class DocketDistributorTests
 
         // Assert
         await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task BroadcastProposedDocketAsync_PeerQueryFails_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        // Act
+        var act = () => _distributor.BroadcastProposedDocketAsync(docket);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("Connection refused");
+    }
+
+    [Fact]
+    public async Task BroadcastProposedDocketAsync_PublishFails_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        var validators = CreateValidatorList(1);
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+        _peerClientMock.Setup(x => x.PublishProposedDocketAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("Broadcast timed out"));
+
+        // Act
+        var act = () => _distributor.BroadcastProposedDocketAsync(docket);
+
+        // Assert
+        await act.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("Broadcast timed out");
+    }
+
+    [Fact]
+    public async Task BroadcastProposedDocketAsync_CancellationRequested_PassesTokenToPeerClient()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, token))
+            .ReturnsAsync(CreateValidatorList(1));
+
+        // Act
+        await _distributor.BroadcastProposedDocketAsync(docket, token);
+
+        // Assert
+        _peerClientMock.Verify(
+            x => x.QueryValidatorsAsync(docket.RegisterId, token),
+            Times.Once);
+        _peerClientMock.Verify(
+            x => x.PublishProposedDocketAsync(
+                docket.RegisterId,
+                docket.DocketId,
+                It.IsAny<byte[]>(),
+                token),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task BroadcastProposedDocketAsync_CancelledToken_ThrowsOperationCancelled()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        // Act
+        var act = () => _distributor.BroadcastProposedDocketAsync(docket, cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task BroadcastProposedDocketAsync_ManyPeers_ReturnsCorrectCount()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        var validators = CreateValidatorList(10);
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+
+        // Act
+        var peerCount = await _distributor.BroadcastProposedDocketAsync(docket);
+
+        // Assert
+        peerCount.Should().Be(10);
     }
 
     #endregion
@@ -151,11 +284,7 @@ public class DocketDistributorTests
     {
         // Arrange
         var docket = CreateConfirmedDocket();
-        var validators = new List<ValidatorInfo>
-        {
-            new() { ValidatorId = "val-1", GrpcEndpoint = "http://val1:5000" },
-            new() { ValidatorId = "val-2", GrpcEndpoint = "http://val2:5000" }
-        };
+        var validators = CreateValidatorList(2);
 
         _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(validators);
@@ -171,6 +300,91 @@ public class DocketDistributorTests
                 docket.DocketId,
                 It.IsAny<byte[]>(),
                 It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task BroadcastConfirmedDocketAsync_NullDocket_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => _distributor.BroadcastConfirmedDocketAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task BroadcastConfirmedDocketAsync_NoPeers_ReturnsZero()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ValidatorInfo>());
+
+        // Act
+        var peerCount = await _distributor.BroadcastConfirmedDocketAsync(docket);
+
+        // Assert
+        peerCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BroadcastConfirmedDocketAsync_PeerQueryFails_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Network unreachable"));
+
+        // Act
+        var act = () => _distributor.BroadcastConfirmedDocketAsync(docket);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("Network unreachable");
+    }
+
+    [Fact]
+    public async Task BroadcastConfirmedDocketAsync_BroadcastFails_PropagatesException()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        var validators = CreateValidatorList(3);
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+        _peerClientMock.Setup(x => x.BroadcastConfirmedDocketAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("Broadcast timed out"));
+
+        // Act
+        var act = () => _distributor.BroadcastConfirmedDocketAsync(docket);
+
+        // Assert
+        await act.Should().ThrowAsync<TimeoutException>();
+    }
+
+    [Fact]
+    public async Task BroadcastConfirmedDocketAsync_CancellationRequested_PassesTokenToPeerClient()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, token))
+            .ReturnsAsync(CreateValidatorList(1));
+
+        // Act
+        await _distributor.BroadcastConfirmedDocketAsync(docket, token);
+
+        // Assert
+        _peerClientMock.Verify(
+            x => x.BroadcastConfirmedDocketAsync(
+                docket.RegisterId,
+                docket.DocketId,
+                It.IsAny<byte[]>(),
+                token),
             Times.Once);
     }
 
@@ -226,6 +440,66 @@ public class DocketDistributorTests
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task SubmitToRegisterServiceAsync_NullDocket_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => _distributor.SubmitToRegisterServiceAsync(null!);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SubmitToRegisterServiceAsync_HttpRequestException_ReturnsFalseDoesNotThrow()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Service unavailable"));
+
+        // Act
+        var result = await _distributor.SubmitToRegisterServiceAsync(docket);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SubmitToRegisterServiceAsync_TimeoutException_ReturnsFalseDoesNotThrow()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("Request timed out"));
+
+        // Act
+        var result = await _distributor.SubmitToRegisterServiceAsync(docket);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SubmitToRegisterServiceAsync_CancellationRequested_PassesTokenToRegisterClient()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), token))
+            .ReturnsAsync(true);
+
+        // Act
+        await _distributor.SubmitToRegisterServiceAsync(docket, token);
+
+        // Assert
+        _registerClientMock.Verify(
+            x => x.WriteDocketAsync(It.IsAny<DocketModel>(), token),
+            Times.Once);
+    }
+
     #endregion
 
     #region GetStats Tests
@@ -241,6 +515,8 @@ public class DocketDistributorTests
         stats.TotalConfirmedBroadcasts.Should().Be(0);
         stats.TotalRegisterSubmissions.Should().Be(0);
         stats.FailedRegisterSubmissions.Should().Be(0);
+        stats.AverageBroadcastTimeMs.Should().Be(0);
+        stats.LastBroadcastAt.Should().BeNull();
     }
 
     [Fact]
@@ -248,10 +524,7 @@ public class DocketDistributorTests
     {
         // Arrange
         var docket = CreateValidDocket();
-        var validators = new List<ValidatorInfo>
-        {
-            new() { ValidatorId = "val-1", GrpcEndpoint = "http://val1:5000" }
-        };
+        var validators = CreateValidatorList(1);
 
         _peerClientMock.Setup(x => x.QueryValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(validators);
@@ -270,6 +543,202 @@ public class DocketDistributorTests
         stats.TotalProposedBroadcasts.Should().Be(1);
         stats.TotalConfirmedBroadcasts.Should().Be(1);
         stats.TotalRegisterSubmissions.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetStats_AfterSuccessfulBroadcast_RecordsBroadcastTime()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        var validators = CreateValidatorList(1);
+
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+
+        // Act
+        await _distributor.BroadcastProposedDocketAsync(docket);
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.AverageBroadcastTimeMs.Should().BeGreaterThanOrEqualTo(0);
+        stats.LastBroadcastAt.Should().NotBeNull();
+        stats.LastBroadcastAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task GetStats_AfterRejectedSubmission_TracksFailedCount()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        await _distributor.SubmitToRegisterServiceAsync(docket);
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.FailedRegisterSubmissions.Should().Be(1);
+        stats.TotalRegisterSubmissions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetStats_AfterExceptionInSubmission_TracksFailedCount()
+    {
+        // Arrange
+        var docket = CreateConfirmedDocket();
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Connection failed"));
+
+        // Act
+        await _distributor.SubmitToRegisterServiceAsync(docket);
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.FailedRegisterSubmissions.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetStats_MultipleBroadcasts_AveragesBroadcastTime()
+    {
+        // Arrange
+        var validators = CreateValidatorList(1);
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+
+        // Act - broadcast multiple times
+        for (var i = 0; i < 5; i++)
+        {
+            await _distributor.BroadcastProposedDocketAsync(CreateValidDocket());
+        }
+
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.TotalProposedBroadcasts.Should().Be(5);
+        stats.AverageBroadcastTimeMs.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task GetStats_FailedBroadcast_DoesNotIncrementCount()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(docket.RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        // Act
+        try
+        {
+            await _distributor.BroadcastProposedDocketAsync(docket);
+        }
+        catch (HttpRequestException)
+        {
+            // Expected
+        }
+
+        var stats = _distributor.GetStats();
+
+        // Assert - failed broadcast should not increment proposed count
+        stats.TotalProposedBroadcasts.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Concurrent Distribution Tests
+
+    [Fact]
+    public async Task BroadcastProposedDocketAsync_ConcurrentCalls_TracksAllBroadcasts()
+    {
+        // Arrange
+        var validators = CreateValidatorList(3);
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+
+        // Act - fire multiple broadcasts concurrently
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => _distributor.BroadcastProposedDocketAsync(CreateValidDocket()))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.TotalProposedBroadcasts.Should().Be(10);
+        stats.AverageBroadcastTimeMs.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task SubmitToRegisterServiceAsync_ConcurrentCalls_TracksAllSubmissions()
+    {
+        // Arrange
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => _distributor.SubmitToRegisterServiceAsync(CreateConfirmedDocket()))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.TotalRegisterSubmissions.Should().Be(10);
+        stats.FailedRegisterSubmissions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ConcurrentMixedOperations_StatsRemainConsistent()
+    {
+        // Arrange
+        var validators = CreateValidatorList(2);
+        _peerClientMock.Setup(x => x.QueryValidatorsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validators);
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act - run proposed broadcasts, confirmed broadcasts, and submissions concurrently
+        var proposedTasks = Enumerable.Range(0, 5)
+            .Select(_ => (Task)_distributor.BroadcastProposedDocketAsync(CreateValidDocket()));
+        var confirmedTasks = Enumerable.Range(0, 5)
+            .Select(_ => (Task)_distributor.BroadcastConfirmedDocketAsync(CreateConfirmedDocket()));
+        var submitTasks = Enumerable.Range(0, 5)
+            .Select(_ => (Task)_distributor.SubmitToRegisterServiceAsync(CreateConfirmedDocket()));
+
+        await Task.WhenAll(proposedTasks.Concat(confirmedTasks).Concat(submitTasks));
+        var stats = _distributor.GetStats();
+
+        // Assert
+        stats.TotalProposedBroadcasts.Should().Be(5);
+        stats.TotalConfirmedBroadcasts.Should().Be(5);
+        stats.TotalRegisterSubmissions.Should().Be(5);
+        stats.FailedRegisterSubmissions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ConcurrentSubmissions_MixedSuccessAndFailure_TracksCorrectly()
+    {
+        // Arrange - alternate success and failure
+        var callCount = 0;
+        _registerClientMock.Setup(x => x.WriteDocketAsync(It.IsAny<DocketModel>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var count = Interlocked.Increment(ref callCount);
+                return count % 2 == 0; // Even calls succeed, odd calls fail
+            });
+
+        // Act
+        var tasks = Enumerable.Range(0, 10)
+            .Select(_ => _distributor.SubmitToRegisterServiceAsync(CreateConfirmedDocket()))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+        var stats = _distributor.GetStats();
+
+        // Assert - total should be 10 (successful + failed)
+        var totalTracked = stats.TotalRegisterSubmissions + stats.FailedRegisterSubmissions;
+        totalTracked.Should().Be(10);
     }
 
     #endregion
@@ -339,6 +808,17 @@ public class DocketDistributorTests
                 }
             }
         };
+    }
+
+    private static List<ValidatorInfo> CreateValidatorList(int count)
+    {
+        return Enumerable.Range(1, count)
+            .Select(i => new ValidatorInfo
+            {
+                ValidatorId = $"val-{i}",
+                GrpcEndpoint = $"http://val{i}:5000"
+            })
+            .ToList();
     }
 
     #endregion

--- a/tests/Sorcha.Validator.Service.Tests/Services/MerkleTreeTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/MerkleTreeTests.cs
@@ -1,0 +1,579 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Text;
+using Sorcha.Cryptography.Enums;
+using Sorcha.Cryptography.Interfaces;
+using Sorcha.Cryptography.Utilities;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Unit tests for MerkleTree
+/// Tests cover Merkle root computation, determinism, edge cases, and proof verification
+/// </summary>
+public class MerkleTreeTests
+{
+    private readonly Mock<IHashProvider> _mockHashProvider;
+    private readonly MerkleTree _merkleTree;
+
+    public MerkleTreeTests()
+    {
+        _mockHashProvider = new Mock<IHashProvider>();
+
+        // Setup hash provider to return deterministic SHA256-like hashes
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), It.IsAny<HashType>()))
+            .Returns((byte[] data, HashType hashType) =>
+            {
+                // Use real SHA256 for deterministic test behavior
+                return SHA256.HashData(data);
+            });
+
+        _merkleTree = new MerkleTree(_mockHashProvider.Object);
+    }
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithNullHashProvider_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => new MerkleTree(null!));
+        exception.ParamName.Should().Be("hashProvider");
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - Empty/Null Input Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_WithNullList_ReturnsHashOfEmptyBytes()
+    {
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(null!);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(Array.Empty<byte>(), HashType.SHA256),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_WithEmptyList_ReturnsHashOfEmptyBytes()
+    {
+        // Arrange
+        var emptyList = new List<string>();
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(emptyList);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(Array.Empty<byte>(), HashType.SHA256),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_WithNullAndEmptyList_ProduceSameResult()
+    {
+        // Act
+        var nullResult = _merkleTree.ComputeMerkleRoot(null!);
+        var emptyResult = _merkleTree.ComputeMerkleRoot(new List<string>());
+
+        // Assert
+        nullResult.Should().Be(emptyResult);
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - Single Transaction Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_WithSingleTransaction_ReturnsThatHash()
+    {
+        // Arrange
+        var hash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        var hashes = new List<string> { hash };
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result.Should().Be(hash);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_WithSingleTransaction_NormalizesToLowerCase()
+    {
+        // Arrange
+        var hash = "ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+        var hashes = new List<string> { hash };
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result.Should().Be(hash.ToLowerInvariant());
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - Two Transaction Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_WithTwoTransactions_CombinesAndHashes()
+    {
+        // Arrange
+        var hash1 = "aaaa";
+        var hash2 = "bbbb";
+        var hashes = new List<string> { hash1, hash2 };
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().NotBe(hash1);
+        result.Should().NotBe(hash2);
+
+        // The hash provider should be called to combine the two hashes
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256),
+            Times.Once); // One combine-and-hash call for the pair
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_WithTwoTransactions_OrderMatters()
+    {
+        // Arrange
+        var hash1 = "aaaa";
+        var hash2 = "bbbb";
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRoot(new List<string> { hash1, hash2 });
+        var result2 = _merkleTree.ComputeMerkleRoot(new List<string> { hash2, hash1 });
+
+        // Assert - different order should produce different root
+        result1.Should().NotBe(result2);
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - Odd Number of Transactions Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_WithThreeTransactions_HandlesOddCount()
+    {
+        // Arrange
+        var hashes = new List<string> { "aaaa", "bbbb", "cccc" };
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        // With 3 items: (aaaa+bbbb) and (cccc+cccc) at level 1, then combine at level 0
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_WithOddCount_DuplicatesLastElement()
+    {
+        // Arrange - 3 hashes where last is duplicated
+        var hash1 = "aaaa";
+        var hash2 = "bbbb";
+        var hash3 = "cccc";
+
+        // With 3 items: pairs are (aaaa,bbbb) and (cccc,cccc)
+        // With 4 items where last two are same: pairs are (aaaa,bbbb) and (cccc,cccc)
+        var threeHashes = new List<string> { hash1, hash2, hash3 };
+        var fourHashesWithDup = new List<string> { hash1, hash2, hash3, hash3 };
+
+        // Act
+        var resultThree = _merkleTree.ComputeMerkleRoot(threeHashes);
+        var resultFour = _merkleTree.ComputeMerkleRoot(fourHashesWithDup);
+
+        // Assert - odd count duplicates last, so 3-item tree should equal 4-item with dup
+        resultThree.Should().Be(resultFour);
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - Large Batch Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_WithLargeBatch_ProducesDeterministicRoot()
+    {
+        // Arrange
+        var hashes = Enumerable.Range(0, 100)
+            .Select(i => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"tx-{i}"))).ToLowerInvariant())
+            .ToList();
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRoot(hashes);
+        var result2 = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result1.Should().NotBeNullOrEmpty();
+        result1.Should().Be(result2);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_WithPowerOfTwoCount_ProducesDeterministicRoot()
+    {
+        // Arrange - 8 transactions (perfect binary tree)
+        var hashes = Enumerable.Range(0, 8)
+            .Select(i => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes($"tx-{i}"))).ToLowerInvariant())
+            .ToList();
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRoot(hashes);
+        var result2 = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result1.Should().Be(result2);
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - Determinism Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_SameInputs_ProduceSameOutput()
+    {
+        // Arrange
+        var hashes = new List<string> { "aaaa", "bbbb", "cccc", "dddd" };
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRoot(hashes);
+        var result2 = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result1.Should().Be(result2);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_DifferentInputs_ProduceDifferentOutput()
+    {
+        // Arrange
+        var hashes1 = new List<string> { "aaaa", "bbbb", "cccc", "dddd" };
+        var hashes2 = new List<string> { "aaaa", "bbbb", "cccc", "eeee" };
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRoot(hashes1);
+        var result2 = _merkleTree.ComputeMerkleRoot(hashes2);
+
+        // Assert
+        result1.Should().NotBe(result2);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_CaseInsensitiveInput_ProducesSameOutput()
+    {
+        // Arrange
+        var hashesLower = new List<string> { "abcd", "ef01" };
+        var hashesUpper = new List<string> { "ABCD", "EF01" };
+
+        // Act
+        var resultLower = _merkleTree.ComputeMerkleRoot(hashesLower);
+        var resultUpper = _merkleTree.ComputeMerkleRoot(hashesUpper);
+
+        // Assert - should normalize to lowercase
+        resultLower.Should().Be(resultUpper);
+    }
+
+    #endregion
+
+    #region ComputeMerkleRoot - HashType Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_WithSHA512HashType_PassesHashTypeToProvider()
+    {
+        // Arrange
+        var hashes = new List<string> { "aaaa", "bbbb" };
+
+        // Act
+        _merkleTree.ComputeMerkleRoot(hashes, HashType.SHA512);
+
+        // Assert
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA512),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_DefaultHashType_UsesSHA256()
+    {
+        // Arrange
+        var hashes = new List<string> { "aaaa", "bbbb" };
+
+        // Act
+        _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256),
+            Times.AtLeastOnce);
+    }
+
+    #endregion
+
+    #region ComputeMerkleRootFromData Tests
+
+    [Fact]
+    public void ComputeMerkleRootFromData_WithNullList_ReturnsHashOfEmptyBytes()
+    {
+        // Act
+        var result = _merkleTree.ComputeMerkleRootFromData(null!);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ComputeMerkleRootFromData_WithEmptyList_ReturnsHashOfEmptyBytes()
+    {
+        // Arrange
+        var emptyList = new List<byte[]>();
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRootFromData(emptyList);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ComputeMerkleRootFromData_WithSingleItem_HashesDataThenReturnsLeafHash()
+    {
+        // Arrange
+        var data = new List<byte[]> { Encoding.UTF8.GetBytes("transaction-data") };
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRootFromData(data);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        // Should hash the data item first, then return it as the single leaf
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256),
+            Times.Once); // One call to hash the data item
+    }
+
+    [Fact]
+    public void ComputeMerkleRootFromData_WithMultipleItems_ProducesDeterministicResult()
+    {
+        // Arrange
+        var data = new List<byte[]>
+        {
+            Encoding.UTF8.GetBytes("tx-1"),
+            Encoding.UTF8.GetBytes("tx-2"),
+            Encoding.UTF8.GetBytes("tx-3")
+        };
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRootFromData(data);
+        var result2 = _merkleTree.ComputeMerkleRootFromData(data);
+
+        // Assert
+        result1.Should().Be(result2);
+    }
+
+    [Fact]
+    public void ComputeMerkleRootFromData_DifferentData_ProducesDifferentRoots()
+    {
+        // Arrange
+        var data1 = new List<byte[]>
+        {
+            Encoding.UTF8.GetBytes("tx-1"),
+            Encoding.UTF8.GetBytes("tx-2")
+        };
+        var data2 = new List<byte[]>
+        {
+            Encoding.UTF8.GetBytes("tx-1"),
+            Encoding.UTF8.GetBytes("tx-3")
+        };
+
+        // Act
+        var result1 = _merkleTree.ComputeMerkleRootFromData(data1);
+        var result2 = _merkleTree.ComputeMerkleRootFromData(data2);
+
+        // Assert
+        result1.Should().NotBe(result2);
+    }
+
+    [Fact]
+    public void ComputeMerkleRootFromData_WithSHA512_PassesHashTypeToProvider()
+    {
+        // Arrange
+        var data = new List<byte[]> { Encoding.UTF8.GetBytes("tx-1") };
+
+        // Act
+        _merkleTree.ComputeMerkleRootFromData(data, HashType.SHA512);
+
+        // Assert
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA512),
+            Times.AtLeastOnce);
+    }
+
+    #endregion
+
+    #region VerifyMerkleProof Tests
+
+    [Fact]
+    public void VerifyMerkleProof_WithNullDataHash_ReturnsFalse()
+    {
+        // Act
+        var result = _merkleTree.VerifyMerkleProof(null!, "root", new List<string>());
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithEmptyDataHash_ReturnsFalse()
+    {
+        // Act
+        var result = _merkleTree.VerifyMerkleProof("", "root", new List<string>());
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithWhitespaceDataHash_ReturnsFalse()
+    {
+        // Act
+        var result = _merkleTree.VerifyMerkleProof("   ", "root", new List<string>());
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithNullMerkleRoot_ReturnsFalse()
+    {
+        // Act
+        var result = _merkleTree.VerifyMerkleProof("datahash", null!, new List<string>());
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithEmptyMerkleRoot_ReturnsFalse()
+    {
+        // Act
+        var result = _merkleTree.VerifyMerkleProof("datahash", "", new List<string>());
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithEmptyProofAndMatchingHash_ReturnsTrue()
+    {
+        // Arrange - single-element tree where data hash IS the root
+        var dataHash = "abcdef1234";
+        var merkleRoot = "abcdef1234";
+
+        // Act
+        var result = _merkleTree.VerifyMerkleProof(dataHash, merkleRoot, new List<string>());
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithEmptyProofAndNonMatchingHash_ReturnsFalse()
+    {
+        // Arrange
+        var dataHash = "abcdef1234";
+        var merkleRoot = "ffffffff9999";
+
+        // Act
+        var result = _merkleTree.VerifyMerkleProof(dataHash, merkleRoot, new List<string>());
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_CaseInsensitiveComparison()
+    {
+        // Arrange
+        var dataHash = "ABCDEF";
+        var merkleRoot = "abcdef";
+
+        // Act
+        var result = _merkleTree.VerifyMerkleProof(dataHash, merkleRoot, new List<string>());
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithWrongProof_ReturnsFalse()
+    {
+        // Arrange
+        var dataHash = "aaaa";
+        var wrongProof = new List<string> { "xxxx", "yyyy" };
+        var fakeMerkleRoot = "not-the-real-root";
+
+        // Act
+        var result = _merkleTree.VerifyMerkleProof(dataHash, fakeMerkleRoot, wrongProof);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void VerifyMerkleProof_WithProofElements_AppliesHashesSequentially()
+    {
+        // Arrange - verify the proof mechanism doesn't throw and processes elements
+        var dataHash = "aaaa";
+        var proof = new List<string> { "bbbb", "cccc" };
+
+        // Act - should not throw
+        var act = () => _merkleTree.VerifyMerkleProof(dataHash, "somehash", proof);
+
+        // Assert
+        act.Should().NotThrow();
+        _mockHashProvider.Verify(
+            h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256),
+            Times.Exactly(2)); // One hash per proof element
+    }
+
+    #endregion
+
+    #region Output Format Tests
+
+    [Fact]
+    public void ComputeMerkleRoot_OutputIsLowerCaseHex()
+    {
+        // Arrange
+        var hashes = new List<string> { "aaaa", "bbbb" };
+
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(hashes);
+
+        // Assert
+        result.Should().MatchRegex("^[0-9a-f]+$");
+    }
+
+    [Fact]
+    public void ComputeMerkleRoot_EmptyInput_OutputIsLowerCaseHex()
+    {
+        // Act
+        var result = _merkleTree.ComputeMerkleRoot(new List<string>());
+
+        // Assert
+        result.Should().MatchRegex("^[0-9a-f]+$");
+    }
+
+    #endregion
+}

--- a/tests/Sorcha.Validator.Service.Tests/Services/TransactionPoolPollerTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/TransactionPoolPollerTests.cs
@@ -14,7 +14,8 @@ namespace Sorcha.Validator.Service.Tests.Services;
 
 /// <summary>
 /// Unit tests for TransactionPoolPoller
-/// Tests cover Redis-backed transaction pool operations
+/// Tests cover Redis-backed transaction pool operations including
+/// normal operations, exception handling, configuration, and edge cases.
 /// </summary>
 public class TransactionPoolPollerTests
 {
@@ -181,6 +182,43 @@ public class TransactionPoolPollerTests
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task SubmitTransactionAsync_WhenRedisTransactionFails_ReturnsFalse()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var transaction = CreateValidTransaction("tx-1");
+
+        var mockTransaction = new Mock<ITransaction>();
+        _mockDatabase.Setup(x => x.CreateTransaction(It.IsAny<object>()))
+            .Returns(mockTransaction.Object);
+
+        _mockDatabase.Setup(x => x.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(false);
+
+        // Redis transaction commit fails
+        mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await poller.SubmitTransactionAsync("register-1", transaction);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SubmitTransactionAsync_WithWhitespaceRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var transaction = CreateValidTransaction("tx-1");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.SubmitTransactionAsync("   ", transaction));
+    }
+
     #endregion
 
     #region PollTransactionsAsync Tests
@@ -258,6 +296,180 @@ public class TransactionPoolPollerTests
             () => poller.PollTransactionsAsync(null!, 10));
     }
 
+    [Fact]
+    public async Task PollTransactionsAsync_WithNegativeMaxCount_ReturnsEmpty()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act
+        var result = await poller.PollTransactionsAsync("register-1", -1);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PollTransactionsAsync_WithEmptyRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.PollTransactionsAsync("", 10));
+    }
+
+    [Fact]
+    public async Task PollTransactionsAsync_WhenDataExpiredMidPoll_SkipsAndContinues()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var transaction2 = CreateValidTransaction("tx-2");
+        var json2 = JsonSerializer.Serialize(transaction2, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        });
+
+        var popCallCount = 0;
+        _mockDatabase.Setup(x => x.ListRightPopAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                popCallCount++;
+                return popCallCount switch
+                {
+                    1 => (RedisValue)"tx-1",  // First tx - data will be expired
+                    2 => (RedisValue)"tx-2",  // Second tx - data available
+                    _ => RedisValue.Null
+                };
+            });
+
+        var getCallCount = 0;
+        _mockDatabase.Setup(x => x.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                getCallCount++;
+                // First call: data expired (null), second call: data available
+                return getCallCount == 1 ? RedisValue.Null : (RedisValue)json2;
+            });
+
+        _mockDatabase.Setup(x => x.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        _mockDatabase.Setup(x => x.SortedSetRemoveAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await poller.PollTransactionsAsync("register-1", 10);
+
+        // Assert - should skip tx-1 (expired) and return tx-2
+        result.Should().HaveCount(1);
+        result[0].TransactionId.Should().Be("tx-2");
+    }
+
+    [Fact]
+    public async Task PollTransactionsAsync_WithMultipleTransactions_ReturnsAll()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+        var tx1 = CreateValidTransaction("tx-1");
+        var tx2 = CreateValidTransaction("tx-2");
+        var tx3 = CreateValidTransaction("tx-3");
+        var json1 = JsonSerializer.Serialize(tx1, jsonOptions);
+        var json2 = JsonSerializer.Serialize(tx2, jsonOptions);
+        var json3 = JsonSerializer.Serialize(tx3, jsonOptions);
+
+        var popCallCount = 0;
+        _mockDatabase.Setup(x => x.ListRightPopAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                popCallCount++;
+                return popCallCount switch
+                {
+                    1 => (RedisValue)"tx-1",
+                    2 => (RedisValue)"tx-2",
+                    3 => (RedisValue)"tx-3",
+                    _ => RedisValue.Null
+                };
+            });
+
+        var getCallCount = 0;
+        _mockDatabase.Setup(x => x.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                getCallCount++;
+                return getCallCount switch
+                {
+                    1 => (RedisValue)json1,
+                    2 => (RedisValue)json2,
+                    3 => (RedisValue)json3,
+                    _ => RedisValue.Null
+                };
+            });
+
+        _mockDatabase.Setup(x => x.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        _mockDatabase.Setup(x => x.SortedSetRemoveAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await poller.PollTransactionsAsync("register-1", 10);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result[0].TransactionId.Should().Be("tx-1");
+        result[1].TransactionId.Should().Be("tx-2");
+        result[2].TransactionId.Should().Be("tx-3");
+    }
+
+    [Fact]
+    public async Task PollTransactionsAsync_RespectsMaxCountLimit()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+        var tx = CreateValidTransaction("tx-1");
+        var json = JsonSerializer.Serialize(tx, jsonOptions);
+
+        // Queue has many items, but we only request 2
+        var popCallCount = 0;
+        _mockDatabase.Setup(x => x.ListRightPopAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                popCallCount++;
+                return (RedisValue)$"tx-{popCallCount}";
+            });
+
+        _mockDatabase.Setup(x => x.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(json);
+
+        _mockDatabase.Setup(x => x.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        _mockDatabase.Setup(x => x.SortedSetRemoveAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        // Act - request only 2
+        var result = await poller.PollTransactionsAsync("register-1", 2);
+
+        // Assert - should only pop exactly 2 times
+        result.Should().HaveCount(2);
+        popCallCount.Should().Be(2);
+    }
+
     #endregion
 
     #region GetUnverifiedCountAsync Tests
@@ -287,6 +499,17 @@ public class TransactionPoolPollerTests
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => poller.GetUnverifiedCountAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetUnverifiedCountAsync_WithEmptyRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.GetUnverifiedCountAsync(""));
     }
 
     #endregion
@@ -347,6 +570,28 @@ public class TransactionPoolPollerTests
             () => poller.ExistsAsync("register-1", null!));
     }
 
+    [Fact]
+    public async Task ExistsAsync_WithEmptyRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.ExistsAsync("", "tx-1"));
+    }
+
+    [Fact]
+    public async Task ExistsAsync_WithEmptyTransactionId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.ExistsAsync("register-1", ""));
+    }
+
     #endregion
 
     #region RemoveTransactionAsync Tests
@@ -395,6 +640,50 @@ public class TransactionPoolPollerTests
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task RemoveTransactionAsync_WithNullRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => poller.RemoveTransactionAsync(null!, "tx-1"));
+    }
+
+    [Fact]
+    public async Task RemoveTransactionAsync_WithEmptyRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.RemoveTransactionAsync("", "tx-1"));
+    }
+
+    [Fact]
+    public async Task RemoveTransactionAsync_WithNullTransactionId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => poller.RemoveTransactionAsync("register-1", null!));
+    }
+
+    [Fact]
+    public async Task RemoveTransactionAsync_WithEmptyTransactionId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.RemoveTransactionAsync("register-1", ""));
+    }
+
     #endregion
 
     #region GetStatsAsync Tests
@@ -433,6 +722,65 @@ public class TransactionPoolPollerTests
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => poller.GetStatsAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_WithEmptyRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => poller.GetStatsAsync(""));
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_WithSortedSetEntries_CalculatesOldestTimeAndAverageAge()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var now = DateTimeOffset.UtcNow;
+
+        // Transactions that expire 30 min and 60 min from now
+        var expiryScore1 = now.AddMinutes(30).ToUnixTimeSeconds();
+        var expiryScore2 = now.AddMinutes(60).ToUnixTimeSeconds();
+
+        _mockDatabase.Setup(x => x.ListLengthAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(2);
+
+        // First call (0, 0) returns oldest entry only
+        // Second call (0, -1) returns all entries
+        var rankCallCount = 0;
+        _mockDatabase.Setup(x => x.SortedSetRangeByRankWithScoresAsync(
+            It.IsAny<RedisKey>(),
+            It.IsAny<long>(),
+            It.IsAny<long>(),
+            It.IsAny<Order>(),
+            It.IsAny<CommandFlags>()))
+            .ReturnsAsync((RedisKey _, long start, long stop, Order _, CommandFlags _) =>
+            {
+                rankCallCount++;
+                if (rankCallCount == 1) // oldest only (0, 0)
+                {
+                    return new[] { new SortedSetEntry("tx-1", expiryScore1) };
+                }
+                // all entries (0, -1)
+                return new[]
+                {
+                    new SortedSetEntry("tx-1", expiryScore1),
+                    new SortedSetEntry("tx-2", expiryScore2)
+                };
+            });
+
+        // Act
+        var stats = await poller.GetStatsAsync("register-1");
+
+        // Assert
+        stats.RegisterId.Should().Be("register-1");
+        stats.TotalTransactions.Should().Be(2);
+        stats.OldestTransactionTime.Should().NotBeNull();
+        stats.AverageAgeMs.Should().BeGreaterThan(0);
     }
 
     #endregion
@@ -490,6 +838,36 @@ public class TransactionPoolPollerTests
 
         // Assert
         transaction.RetryCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReturnTransactionsAsync_WithMultipleTransactions_IncrementsAllRetryCounts()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var tx1 = CreateValidTransaction("tx-1");
+        tx1.RetryCount = 0;
+        var tx2 = CreateValidTransaction("tx-2");
+        tx2.RetryCount = 2;
+
+        var mockTransaction = new Mock<ITransaction>();
+        _mockDatabase.Setup(x => x.CreateTransaction(It.IsAny<object>()))
+            .Returns(mockTransaction.Object);
+
+        _mockDatabase.Setup(x => x.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(false);
+
+        mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        var transactions = new List<Transaction> { tx1, tx2 };
+
+        // Act
+        await poller.ReturnTransactionsAsync("register-1", transactions);
+
+        // Assert
+        tx1.RetryCount.Should().Be(1);
+        tx2.RetryCount.Should().Be(3);
     }
 
     #endregion
@@ -557,6 +935,218 @@ public class TransactionPoolPollerTests
 
         // Assert
         result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CleanupExpiredAsync_WithNullRegisterId_ThrowsArgumentException()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => poller.CleanupExpiredAsync(null!));
+    }
+
+    #endregion
+
+    #region Exception Handling Tests
+
+    [Fact]
+    public async Task SubmitTransactionAsync_WhenRedisThrows_ReturnsFalseAndHandlesGracefully()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+        var transaction = CreateValidTransaction("tx-1");
+
+        _mockDatabase.Setup(x => x.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var result = await poller.SubmitTransactionAsync("register-1", transaction);
+
+        // Assert - should not throw, returns false
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PollTransactionsAsync_WhenRedisThrows_ReturnsEmptyListAndHandlesGracefully()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        _mockDatabase.Setup(x => x.ListRightPopAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var result = await poller.PollTransactionsAsync("register-1", 10);
+
+        // Assert - should not throw, returns empty
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetUnverifiedCountAsync_WhenRedisThrows_ReturnsZero()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        _mockDatabase.Setup(x => x.ListLengthAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var result = await poller.GetUnverifiedCountAsync("register-1");
+
+        // Assert - should handle gracefully and return 0
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExistsAsync_WhenRedisThrows_ReturnsFalse()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        _mockDatabase.Setup(x => x.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var result = await poller.ExistsAsync("register-1", "tx-1");
+
+        // Assert - should handle gracefully and return false
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemoveTransactionAsync_WhenRedisThrows_ReturnsFalse()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        _mockDatabase.Setup(x => x.ListRemoveAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var result = await poller.RemoveTransactionAsync("register-1", "tx-1");
+
+        // Assert - should handle gracefully and return false
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CleanupExpiredAsync_WhenRedisThrows_ReturnsZeroAndHandlesGracefully()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        _mockDatabase.Setup(x => x.SortedSetRangeByScoreAsync(
+            It.IsAny<RedisKey>(),
+            It.IsAny<double>(),
+            It.IsAny<double>(),
+            It.IsAny<Exclude>(),
+            It.IsAny<Order>(),
+            It.IsAny<long>(),
+            It.IsAny<long>(),
+            It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var result = await poller.CleanupExpiredAsync("register-1");
+
+        // Assert - should handle gracefully and return 0
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_WhenRedisThrowsOnSortedSet_ReturnsPartialStats()
+    {
+        // Arrange
+        var poller = new TransactionPoolPoller(_mockRedis.Object, _options, _mockLogger.Object);
+
+        // ListLength works for count
+        _mockDatabase.Setup(x => x.ListLengthAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(5);
+
+        // SortedSet throws for stats
+        _mockDatabase.Setup(x => x.SortedSetRangeByRankWithScoresAsync(
+            It.IsAny<RedisKey>(),
+            It.IsAny<long>(),
+            It.IsAny<long>(),
+            It.IsAny<Order>(),
+            It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        // Act
+        var stats = await poller.GetStatsAsync("register-1");
+
+        // Assert - should return partial stats without crashing
+        stats.RegisterId.Should().Be("register-1");
+        stats.TotalTransactions.Should().Be(5);
+        stats.OldestTransactionTime.Should().BeNull();
+        stats.AverageAgeMs.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Configuration Tests
+
+    [Fact]
+    public async Task SubmitTransactionAsync_UsesConfiguredKeyPrefix()
+    {
+        // Arrange
+        var customConfig = new TransactionPoolPollerConfiguration
+        {
+            KeyPrefix = "custom:prefix:",
+            BatchSize = 50,
+            TransactionTtl = TimeSpan.FromHours(1),
+            MaxRetries = 3
+        };
+        var customOptions = Options.Create(customConfig);
+        var poller = new TransactionPoolPoller(_mockRedis.Object, customOptions, _mockLogger.Object);
+        var transaction = CreateValidTransaction("tx-1");
+
+        RedisKey capturedExistsKey = default;
+        _mockDatabase.Setup(x => x.KeyExistsAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .Callback<RedisKey, CommandFlags>((key, _) => capturedExistsKey = key)
+            .ReturnsAsync(false);
+
+        var mockTransaction = new Mock<ITransaction>();
+        _mockDatabase.Setup(x => x.CreateTransaction(It.IsAny<object>()))
+            .Returns(mockTransaction.Object);
+
+        mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        // Act
+        await poller.SubmitTransactionAsync("register-1", transaction);
+
+        // Assert - key should use the custom prefix
+        capturedExistsKey.ToString().Should().StartWith("custom:prefix:register-1:data:");
+    }
+
+    [Fact]
+    public void Configuration_DefaultValues_AreCorrect()
+    {
+        // Arrange & Act
+        var config = new TransactionPoolPollerConfiguration();
+
+        // Assert
+        config.PollingInterval.Should().Be(TimeSpan.FromMilliseconds(100));
+        config.BatchSize.Should().Be(50);
+        config.KeyPrefix.Should().Be("sorcha:validator:unverified:");
+        config.BlockingTimeout.Should().Be(TimeSpan.FromSeconds(5));
+        config.UseBlockingPop.Should().BeTrue();
+        config.MaxRetries.Should().Be(3);
+        config.RetryDelay.Should().Be(TimeSpan.FromMilliseconds(500));
+        config.TransactionTtl.Should().Be(TimeSpan.FromHours(1));
+        config.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Configuration_SectionName_IsCorrect()
+    {
+        // Assert
+        TransactionPoolPollerConfiguration.SectionName.Should().Be("TransactionPoolPoller");
     }
 
     #endregion

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
@@ -415,7 +415,7 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction();
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync((BlueprintModel?)null);
 
         // Act
@@ -431,9 +431,9 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(actionId: "999");
-        var blueprint = CreateTestBlueprint(tx.BlueprintId);
+        var blueprint = CreateTestBlueprint(tx.BlueprintId!);
 
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -616,9 +616,9 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(actionId: "not-a-number");
-        var blueprint = CreateTestBlueprint(tx.BlueprintId);
+        var blueprint = CreateTestBlueprint(tx.BlueprintId!);
 
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -755,8 +755,8 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(payloadJson: """{"name":"Alice","amount":100}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -771,8 +771,8 @@ public class ValidationEngineTests
     {
         // Arrange - payload missing "amount"
         var tx = CreateValidTransaction(payloadJson: """{"name":"Alice"}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -789,8 +789,8 @@ public class ValidationEngineTests
     {
         // Arrange - amount is string instead of number
         var tx = CreateValidTransaction(payloadJson: """{"name":"Alice","amount":"not-a-number"}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -806,8 +806,8 @@ public class ValidationEngineTests
     {
         // Arrange - action has no DataSchemas (null)
         var tx = CreateValidTransaction();
-        var blueprint = CreateTestBlueprint(tx.BlueprintId); // no schemas
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprint(tx.BlueprintId!); // no schemas
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -822,10 +822,10 @@ public class ValidationEngineTests
     {
         // Arrange - action has empty DataSchemas list
         var tx = CreateValidTransaction();
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId, schemaJson: null);
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!, schemaJson: null);
         // Override the action to have empty DataSchemas
         blueprint.Actions.First().DataSchemas = [];
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -875,9 +875,9 @@ public class ValidationEngineTests
     {
         // Arrange - action has invalid JSON schema
         var tx = CreateValidTransaction(payloadJson: """{"name":"Alice"}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId,
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!,
             schemaJson: """{"type": "invalid-type-value", "$schema": "not-a-schema"}""");
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -899,7 +899,7 @@ public class ValidationEngineTests
 
         var blueprint = new BlueprintModel
         {
-            Id = tx.BlueprintId,
+            Id = tx.BlueprintId!,
             Title = "Test Blueprint",
             Participants = [new Sorcha.Blueprint.Models.Participant { Id = "p-1", Name = "P1" }],
             Actions =
@@ -918,7 +918,7 @@ public class ValidationEngineTests
             ]
         };
 
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -934,8 +934,8 @@ public class ValidationEngineTests
     {
         // Arrange - payload missing "name" (required) AND "amount" is wrong type
         var tx = CreateValidTransaction(payloadJson: """{"amount":"not-a-number"}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -966,8 +966,8 @@ public class ValidationEngineTests
         }
         """;
         var tx = CreateValidTransaction(payloadJson: """{"address":{"zipCode":12345}}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId, schemaJson);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!, schemaJson);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -994,8 +994,8 @@ public class ValidationEngineTests
         }
         """;
         var tx = CreateValidTransaction(payloadJson: """{"status":"deleted"}""");
-        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId, schemaJson);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!, schemaJson);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -1462,8 +1462,8 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(previousTransactionId: null);
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: true);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: true);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -1478,8 +1478,8 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(previousTransactionId: null);
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: false);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: false);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Act
@@ -1495,8 +1495,8 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(previousTransactionId: null);
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: true, walletAddress: "wallet-abc");
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: true, walletAddress: "wallet-abc");
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
             .Returns("wallet-abc");
@@ -1513,8 +1513,8 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(previousTransactionId: null);
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: true, walletAddress: "expected-wallet");
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: true, walletAddress: "expected-wallet");
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
             .Returns("wrong-wallet");
@@ -1532,8 +1532,8 @@ public class ValidationEngineTests
     {
         // Arrange
         var tx = CreateValidTransaction(previousTransactionId: null);
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: true, walletAddress: null);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: true, walletAddress: null);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
             .Returns("any-wallet");
@@ -1550,8 +1550,8 @@ public class ValidationEngineTests
     {
         // Arrange — action 1 routes to action 2
         var tx = CreateValidTransaction(actionId: "2", previousTransactionId: "prev-tx-1");
-        var blueprint = CreateTestBlueprintWithRoutes(tx.BlueprintId, fromActionId: 1, toActionIds: [2, 3]);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithRoutes(tx.BlueprintId!, fromActionId: 1, toActionIds: [2, 3]);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _registerClientMock.Setup(r => r.GetTransactionAsync(tx.RegisterId, "prev-tx-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.TransactionModel
@@ -1573,10 +1573,10 @@ public class ValidationEngineTests
     {
         // Arrange — action 1 only routes to action 3, but current is action 2
         var tx = CreateValidTransaction(actionId: "2", previousTransactionId: "prev-tx-1");
-        var blueprint = CreateTestBlueprintWithRoutes(tx.BlueprintId, fromActionId: 1, toActionIds: [3]);
+        var blueprint = CreateTestBlueprintWithRoutes(tx.BlueprintId!, fromActionId: 1, toActionIds: [3]);
         // Add action 2 to the blueprint so the action lookup succeeds (the test is about route validation, not missing actions)
         blueprint.Actions = blueprint.Actions.Append(new ActionModel { Id = 2, Title = "Action 2", Sender = "participant-1" }).ToList();
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _registerClientMock.Setup(r => r.GetTransactionAsync(tx.RegisterId, "prev-tx-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.TransactionModel
@@ -1599,8 +1599,8 @@ public class ValidationEngineTests
     {
         // Arrange — action 1 routes to action 3 (normal), rejection targets action 2
         var tx = CreateValidTransaction(actionId: "2", previousTransactionId: "prev-tx-1");
-        var blueprint = CreateTestBlueprintWithRoutes(tx.BlueprintId, fromActionId: 1, toActionIds: [3], rejectionTargetActionId: 2);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithRoutes(tx.BlueprintId!, fromActionId: 1, toActionIds: [3], rejectionTargetActionId: 2);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _registerClientMock.Setup(r => r.GetTransactionAsync(tx.RegisterId, "prev-tx-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.TransactionModel
@@ -1622,10 +1622,10 @@ public class ValidationEngineTests
     {
         // Arrange — previous action has no routes defined
         var tx = CreateValidTransaction(actionId: "2", previousTransactionId: "prev-tx-1");
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: false);
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: false);
         // Add action 2 to blueprint
         blueprint.Actions = blueprint.Actions.Append(new ActionModel { Id = 2, Title = "Action 2", Sender = "participant-1" }).ToList();
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _registerClientMock.Setup(r => r.GetTransactionAsync(tx.RegisterId, "prev-tx-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.TransactionModel
@@ -1647,9 +1647,9 @@ public class ValidationEngineTests
     {
         // Arrange — previous transaction has no ActionId in metadata
         var tx = CreateValidTransaction(actionId: "2", previousTransactionId: "prev-tx-1");
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: false);
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: false);
         blueprint.Actions = blueprint.Actions.Append(new ActionModel { Id = 2, Title = "Action 2", Sender = "participant-1" }).ToList();
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
         _registerClientMock.Setup(r => r.GetTransactionAsync(tx.RegisterId, "prev-tx-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.TransactionModel
@@ -1730,8 +1730,8 @@ public class ValidationEngineTests
             _loggerMock.Object);
 
         var tx = CreateValidTransaction(previousTransactionId: null);
-        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId, isStartingAction: false);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprintWithConformance(tx.BlueprintId!, isStartingAction: false);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Setup other validations to pass
@@ -2195,8 +2195,8 @@ public class ValidationEngineTests
             .Returns(hashBytes);
 
         // Setup blueprint cache
-        var blueprint = CreateTestBlueprint(tx.BlueprintId);
-        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId, It.IsAny<CancellationToken>()))
+        var blueprint = CreateTestBlueprint(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
             .ReturnsAsync(blueprint);
 
         // Setup signature verification
@@ -2254,7 +2254,7 @@ public class ValidationEngineTests
                 {
                     Id = "participant-1",
                     Name = "Test Participant",
-                    WalletAddress = walletAddress
+                    WalletAddress = walletAddress!
                 }
             ],
             Actions =


### PR DESCRIPTION
## Summary
- Fix 98 broken integration tests caused by incorrect auth setup in WebApplicationFactory
- Add 172 new unit tests across 6 validator service components
- Fix xUnit and nullable warnings in existing test files
- Total validator tests: 941 → **1,211 passing** (0 failures)

## Changes

### Integration Test Auth Fix (98 tests recovered)
- Added `token_type: "service"` claim to `TestAuthHandler` for `CanValidateChains` policy
- Fixed test classes to use `CreateAdminClient()`/`CreateValidatorClient()` instead of unauthenticated `CreateClient()`
- Added MongoDB mocks and config to `ValidatorServiceWebApplicationFactory`

### New Test Coverage (+172 tests)
| Component | New Tests | Coverage Areas |
|-----------|-----------|----------------|
| MerkleTree | 35 | Empty/single/odd/large batch, determinism, proof verification |
| ControlDocketProcessor | +58 | Governance flows, policy updates, crypto policy, validation |
| TransactionPoolPoller | +30 | Exception handling, polling behavior, config, parameter validation |
| DocketDistributor | +23 | Retry logic, partial failure, concurrency, stats tracking |
| ConsensusFailureHandler | +29 | Timeout, quorum, conflicting votes, network recovery, logging |

### Warning Fixes
- xUnit1026: Removed unused `expected` parameter in `ConsensusValidatorTests`
- xUnit1031: Converted 5 blocking `.Result` calls to `async/await` in `BadActorDetectorTests`
- CS8604: Fixed 20+ nullable warnings in `ValidationEngineTests`

## Test plan
- [x] `Sorcha.Validator.Core.Tests`: 200 pass, 0 fail, 0 warnings
- [x] `Sorcha.Validator.Service.Tests`: 891 pass, 3 skip, 0 fail
- [x] `Sorcha.Validator.Service.IntegrationTests`: 120 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)