### PR TITLE
fix: resolve duplicate endpoint names in Tenant Service

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
@@ -183,7 +183,7 @@ public static class AuthEndpoints
 
         // Create organisation (self-service, authenticated)
         group.MapPost("/create-org", CreateOrganization)
-            .WithName("CreateOrganization")
+            .WithName("CreateOrganizationSelfService")
             .WithSummary("Create a new private organisation")
             .WithDescription("Self-service org creation for public org members. Validates eligibility "
                 + "(email verified, within org limit, subdomain available) and atomically provisions "

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
@@ -45,7 +45,7 @@ public static class PlatformOrgEndpoints
             .RequireAuthorization("RequireSystemAdmin");
 
         group.MapGet("/{orgId:guid}/users", GetOrganizationUsers)
-            .WithName("GetOrganizationUsers")
+            .WithName("GetOrganizationUsersPlatform")
             .WithSummary("View organisation user list")
             .WithDescription("Returns paginated user list for an org. Read-only audit view.")
             .RequireAuthorization("RequirePlatformAuditor");


### PR DESCRIPTION
## Summary
- Tenant Service fails to start in Docker due to duplicate endpoint names introduced by the Platform Org Topology feature

## Changes
- Rename `CreateOrganization` → `CreateOrganizationSelfService` on `POST /api/auth/create-org`
- Rename `GetOrganizationUsers` → `GetOrganizationUsersPlatform` on `GET /api/platform/organizations/{orgId}/users`

## Test plan
- [x] `dotnet build` succeeds
- [x] Docker container starts without duplicate endpoint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)