### PR TITLE
fix: platform-first login flow with org selection

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
@@ -52,6 +52,18 @@ public static class AuthEndpoints
             .ProducesValidationProblem()
             .Produces(StatusCodes.Status401Unauthorized);
 
+        // Complete login after org selection (public endpoint)
+        group.MapPost("/select-org", SelectOrg)
+            .WithName("SelectOrg")
+            .WithSummary("Complete login by selecting an organisation")
+            .WithDescription("After a login response with requires_org_selection=true, submit the platform login token "
+                + "and chosen organisation ID to receive access/refresh tokens.")
+            .AllowAnonymous()
+            .Produces<TokenResponse>()
+            .Produces<TwoFactorLoginResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status401Unauthorized);
+
         // Token refresh (public endpoint - requires valid refresh token)
         group.MapPost("/token/refresh", RefreshToken)
             .WithName("RefreshToken")
@@ -235,6 +247,24 @@ public static class AuthEndpoints
             return TypedResults.Unauthorized();
         }
 
+        // Org selection required: return org list with platform login token
+        if (result.OrgSelectionRequired)
+        {
+            return TypedResults.Ok(new OrgSelectionResponse
+            {
+                PlatformLoginToken = result.PlatformLoginToken!,
+                Organizations = result.AvailableOrganizations!
+                    .Select(o => new OrgSelectionEntry
+                    {
+                        OrganizationId = o.OrganizationId,
+                        Name = o.OrganizationName,
+                        Subdomain = o.Subdomain,
+                        Role = o.Role
+                    })
+                    .ToList()
+            });
+        }
+
         // 2FA required: return login token and available methods
         if (result.TwoFactorRequired)
         {
@@ -246,6 +276,47 @@ public static class AuthEndpoints
         }
 
         // Standard login: return tokens
+        return TypedResults.Ok(result.Tokens);
+    }
+
+    private static async Task<IResult> SelectOrg(
+        CompleteOrgSelectionRequest request,
+        ILoginService loginService,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.PlatformLoginToken))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["platform_login_token"] = ["Platform login token is required"]
+            });
+        }
+
+        if (request.OrganizationId == Guid.Empty)
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["organization_id"] = ["Organization ID is required"]
+            });
+        }
+
+        var result = await loginService.CompleteOrgSelectionAsync(
+            request.PlatformLoginToken, request.OrganizationId, cancellationToken);
+
+        if (!result.Success)
+        {
+            return TypedResults.Unauthorized();
+        }
+
+        if (result.TwoFactorRequired)
+        {
+            return TypedResults.Ok(new TwoFactorLoginResponse
+            {
+                LoginToken = result.LoginToken!,
+                AvailableMethods = result.AvailableMethods!.ToArray()
+            });
+        }
+
         return TypedResults.Ok(result.Tokens);
     }
 

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
@@ -303,6 +303,64 @@ public record Verify2FaRequest
 }
 
 /// <summary>
+/// Response when login requires org selection (user has multiple active orgs).
+/// </summary>
+public record OrgSelectionResponse
+{
+    /// <summary>Whether org selection is required.</summary>
+    [JsonPropertyName("requires_org_selection")]
+    public bool RequiresOrgSelection { get; init; } = true;
+
+    /// <summary>Short-lived token for completing org selection.</summary>
+    [JsonPropertyName("platform_login_token")]
+    public required string PlatformLoginToken { get; init; }
+
+    /// <summary>Available organisations to choose from.</summary>
+    [JsonPropertyName("organizations")]
+    public required IReadOnlyList<OrgSelectionEntry> Organizations { get; init; }
+
+    /// <summary>Human-readable message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; init; } = "Please select an organization to sign in to.";
+}
+
+/// <summary>
+/// An organisation entry in the org selection response.
+/// </summary>
+public record OrgSelectionEntry
+{
+    /// <summary>Organisation ID.</summary>
+    [JsonPropertyName("organization_id")]
+    public Guid OrganizationId { get; init; }
+
+    /// <summary>Organisation display name.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Organisation subdomain.</summary>
+    [JsonPropertyName("subdomain")]
+    public string Subdomain { get; init; } = string.Empty;
+
+    /// <summary>User's role in this organisation.</summary>
+    [JsonPropertyName("role")]
+    public string Role { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Request to complete login after org selection.
+/// </summary>
+public record CompleteOrgSelectionRequest
+{
+    /// <summary>Platform login token from the org selection response.</summary>
+    [JsonPropertyName("platform_login_token")]
+    public required string PlatformLoginToken { get; init; }
+
+    /// <summary>The chosen organisation ID.</summary>
+    [JsonPropertyName("organization_id")]
+    public required Guid OrganizationId { get; init; }
+}
+
+/// <summary>
 /// Request to switch the active organisation context.
 /// Issues a new JWT scoped to the target org.
 /// </summary>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
@@ -32,6 +32,26 @@
                 <button type="submit" class="btn btn-primary btn-lg w-100">Verify</button>
             </form>
         }
+        else if (Model.ShowOrgSelection)
+        {
+            <form method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="PlatformLoginToken" />
+                <input type="hidden" asp-for="ReturnUrl" />
+                <p class="text-muted mb-3">Select an organisation to sign in to:</p>
+                <div class="d-grid gap-2">
+                    @foreach (var org in Model.AvailableOrganizations!)
+                    {
+                        <button type="submit" name="SelectedOrgId" value="@org.OrganizationId"
+                                class="btn btn-outline-primary btn-lg text-start">
+                            <strong>@org.OrganizationName</strong>
+                            <br />
+                            <small class="text-muted">@org.Role</small>
+                        </button>
+                    }
+                </div>
+            </form>
+        }
         else
         {
             <form method="post">

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -75,9 +75,31 @@ public class LoginModel : PageModel
     public string? ReturnUrl { get; set; }
 
     /// <summary>
+    /// Platform login token for org selection flow.
+    /// </summary>
+    [BindProperty]
+    public string? PlatformLoginToken { get; set; }
+
+    /// <summary>
+    /// Selected organisation ID from the org picker.
+    /// </summary>
+    [BindProperty]
+    public Guid? SelectedOrgId { get; set; }
+
+    /// <summary>
     /// Whether to show the 2FA verification form.
     /// </summary>
     public bool ShowTwoFactor { get; set; }
+
+    /// <summary>
+    /// Whether to show the org selection form.
+    /// </summary>
+    public bool ShowOrgSelection { get; set; }
+
+    /// <summary>
+    /// Available organisations for the org picker.
+    /// </summary>
+    public List<OrgChoice>? AvailableOrganizations { get; set; }
 
     /// <summary>
     /// Available 2FA methods (e.g., "totp", "passkey").
@@ -111,6 +133,12 @@ public class LoginModel : PageModel
             return await Handle2FaAsync(ct);
         }
 
+        // Org selection completion flow
+        if (!string.IsNullOrEmpty(PlatformLoginToken) && SelectedOrgId.HasValue && SelectedOrgId != Guid.Empty)
+        {
+            return await HandleOrgSelectionAsync(ct);
+        }
+
         // Primary login flow
         if (!ModelState.IsValid)
         {
@@ -119,9 +147,40 @@ public class LoginModel : PageModel
 
         var result = await _loginService.LoginAsync(Email, Password, ct);
 
-        if (!result.Success && !result.TwoFactorRequired)
+        if (!result.Success && !result.TwoFactorRequired && !result.OrgSelectionRequired)
         {
             ErrorMessage = result.Error ?? "Login failed.";
+            return Page();
+        }
+
+        // Org selection required — show org picker
+        if (result.OrgSelectionRequired)
+        {
+            ShowOrgSelection = true;
+            PlatformLoginToken = result.PlatformLoginToken;
+            AvailableOrganizations = result.AvailableOrganizations;
+            return Page();
+        }
+
+        if (result.TwoFactorRequired)
+        {
+            ShowTwoFactor = true;
+            LoginToken = result.LoginToken;
+            AvailableMethods = result.AvailableMethods;
+            return Page();
+        }
+
+        return RedirectToApp(result.Tokens!);
+    }
+
+    private async Task<IActionResult> HandleOrgSelectionAsync(CancellationToken ct)
+    {
+        var result = await _loginService.CompleteOrgSelectionAsync(
+            PlatformLoginToken!, SelectedOrgId!.Value, ct);
+
+        if (!result.Success)
+        {
+            ErrorMessage = result.Error ?? "Organization selection failed. Please sign in again.";
             return Page();
         }
 

--- a/src/Services/Sorcha.Tenant.Service/Services/ILoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/ILoginService.cs
@@ -36,8 +36,24 @@ public record LoginResult(
     bool TwoFactorRequired = false,
     string? LoginToken = null,
     List<string>? AvailableMethods = null,
+    bool OrgSelectionRequired = false,
+    List<OrgChoice>? AvailableOrganizations = null,
+    string? PlatformLoginToken = null,
     string? Error = null,
     LoginErrorCode ErrorCode = LoginErrorCode.None);
+
+/// <summary>
+/// An organisation the user can choose to log into.
+/// </summary>
+/// <param name="OrganizationId">Organisation ID.</param>
+/// <param name="OrganizationName">Display name.</param>
+/// <param name="Subdomain">URL subdomain.</param>
+/// <param name="Role">User's role in this org.</param>
+public record OrgChoice(
+    Guid OrganizationId,
+    string OrganizationName,
+    string Subdomain,
+    string Role);
 
 /// <summary>
 /// Authenticates users with email and password. Handles BCrypt verification,
@@ -68,4 +84,14 @@ public interface ILoginService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Login result with tokens scoped to the target org, or 2FA challenge.</returns>
     Task<LoginResult> LoginAsync(string email, string password, string orgSubdomain, CancellationToken ct = default);
+
+    /// <summary>
+    /// Completes login after org selection. Uses the platform login token issued during
+    /// the initial login to identify the user, then issues a JWT scoped to the chosen org.
+    /// </summary>
+    /// <param name="platformLoginToken">Short-lived token from the org-selection login response.</param>
+    /// <param name="organizationId">The chosen organisation ID.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Login result with tokens scoped to the chosen org, or 2FA challenge.</returns>
+    Task<LoginResult> CompleteOrgSelectionAsync(string platformLoginToken, Guid organizationId, CancellationToken ct = default);
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/LoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/LoginService.cs
@@ -63,26 +63,16 @@ public class LoginService : ILoginService
 
         try
         {
-            // Look up user by email
-            var user = await _identityRepository.GetUserByEmailAsync(email, ct);
-
-            if (user is null || user.Status != IdentityStatus.Active)
+            // Authenticate against PlatformUser (cross-org identity)
+            var platformUser = await _platformUserService.GetByEmailAsync(email, ct);
+            if (platformUser is null || platformUser.Status != PlatformUserStatus.Active)
             {
-                _logger.LogWarning("Login failed: User not found or inactive - {Email}", email);
+                _logger.LogWarning("Login failed: PlatformUser not found or inactive - {Email}", email);
                 await _revocationService.IncrementFailedAuthAttemptsAsync(email, ct);
                 return new LoginResult(false, Error: "Invalid email or password.");
             }
 
-            // Look up PlatformUser for authentication fields
-            var platformUser = await _dbContext.PlatformUsers
-                .FirstOrDefaultAsync(p => p.Id == user.PlatformUserId, ct);
-            if (platformUser is null)
-            {
-                _logger.LogError("Login failed: PlatformUser not found for user {UserId}", user.Id);
-                return new LoginResult(false, Error: "Invalid email or password.");
-            }
-
-            // Validate password with progressive lockout on PlatformUser
+            // Validate password with progressive lockout
             var passwordResult = await _platformUserService.ValidatePasswordAsync(platformUser, password, ct);
 
             if (!passwordResult.Success)
@@ -107,56 +97,156 @@ public class LoginService : ILoginService
                 return new LoginResult(false, Error: "Invalid email or password.");
             }
 
-            // Get user's organization
-            var organization = await _organizationRepository.GetByIdAsync(user.OrganizationId, ct);
-
-            if (organization is null)
-            {
-                _logger.LogError("Login failed: Organization not found - {OrgId}", user.OrganizationId);
-                return new LoginResult(false, Error: "Invalid email or password.");
-            }
-
             // Reset failed attempts on successful password verification
             await _revocationService.ResetFailedAuthAttemptsAsync(email, ct);
 
-            // Check if user has TOTP 2FA or passkeys enabled
-            var totpStatus = await _totpService.GetStatusAsync(user.Id, ct);
-            var passkeys = await _passkeyService.GetCredentialsByOwnerAsync(user.PlatformUserId, ct);
-            var hasActivePasskeys = passkeys.Any(p => p.Status == CredentialStatus.Active);
+            // Get all org memberships with active orgs
+            var memberships = await _platformUserService.GetOrgMembershipsAsync(platformUser.Id, ct);
+            var orgIds = memberships.Select(m => m.OrganizationId).ToList();
 
-            if (totpStatus.IsEnabled || hasActivePasskeys)
+            var activeOrgs = await _dbContext.Organizations
+                .Where(o => orgIds.Contains(o.Id) && o.Status == OrganizationStatus.Active)
+                .ToListAsync(ct);
+
+            if (activeOrgs.Count == 0)
             {
-                // 2FA required: issue a short-lived login token instead of JWT
-                var loginToken = await _totpService.GenerateLoginTokenAsync(user.Id, ct);
-
-                var methods = new List<string>();
-                if (totpStatus.IsEnabled) methods.Add("totp");
-                if (hasActivePasskeys) methods.Add("passkey");
-
-                _logger.LogInformation("Login requires 2FA for user {Email} (UserId: {UserId}), methods: {Methods}",
-                    user.Email, user.Id, string.Join(", ", methods));
-
-                return new LoginResult(true, TwoFactorRequired: true,
-                    LoginToken: loginToken, AvailableMethods: methods);
+                _logger.LogWarning("Login failed: No active org memberships for {Email}", email);
+                return new LoginResult(false, Error: "No active organizations found for this account.");
             }
 
-            // No 2FA — standard login: update timestamp and issue JWT
-            user.LastLoginAt = DateTimeOffset.UtcNow;
-            await _identityRepository.UpdateUserAsync(user, ct);
+            // Single org — auto-select (no picker needed)
+            if (activeOrgs.Count == 1)
+            {
+                return await IssueTokensForOrgAsync(platformUser, activeOrgs[0], memberships, ct);
+            }
 
-            // Generate tokens
-            var tokenResponse = await _tokenService.GenerateUserTokenAsync(user, organization, user.PlatformUserId, ct);
+            // Multiple orgs — return org list for user to pick
+            var orgChoices = activeOrgs
+                .Join(memberships, o => o.Id, m => m.OrganizationId, (o, m) => new OrgChoice(
+                    o.Id, o.Name, o.Subdomain ?? "", m.Role))
+                .ToList();
 
-            _logger.LogInformation("User logged in successfully - {Email} (UserId: {UserId}, OrgId: {OrgId})",
-                user.Email, user.Id, organization.Id);
+            // Issue a platform login token (reuse TOTP token infra — short-lived, scoped to platform user)
+            // We use a UserIdentity ID for the token, so pick the first available identity
+            var anyIdentity = await _dbContext.UserIdentities
+                .FirstOrDefaultAsync(u => u.PlatformUserId == platformUser.Id && u.Status == IdentityStatus.Active, ct);
+            if (anyIdentity is null)
+            {
+                _logger.LogWarning("Login failed: No active UserIdentity for {Email}", email);
+                return new LoginResult(false, Error: "No active identity found for this account.");
+            }
 
-            return new LoginResult(true, Tokens: tokenResponse);
+            var platformLoginToken = await _totpService.GenerateLoginTokenAsync(anyIdentity.Id, ct);
+
+            _logger.LogInformation("Login requires org selection for {Email} — {Count} orgs available",
+                email, activeOrgs.Count);
+
+            return new LoginResult(true, OrgSelectionRequired: true,
+                AvailableOrganizations: orgChoices,
+                PlatformLoginToken: platformLoginToken);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Login failed with exception - {Email}", email);
             return new LoginResult(false, Error: "Invalid email or password.");
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<LoginResult> CompleteOrgSelectionAsync(string platformLoginToken, Guid organizationId, CancellationToken ct = default)
+    {
+        // Validate the platform login token
+        var userIdentityId = await _totpService.ValidateLoginTokenAsync(platformLoginToken, ct);
+        if (userIdentityId is null)
+        {
+            _logger.LogWarning("Org selection failed: invalid or expired platform login token");
+            return new LoginResult(false, Error: "Login session expired. Please sign in again.");
+        }
+
+        // Resolve platform user from the identity
+        var sourceIdentity = await _dbContext.UserIdentities
+            .FirstOrDefaultAsync(u => u.Id == userIdentityId.Value, ct);
+        if (sourceIdentity is null)
+        {
+            return new LoginResult(false, Error: "Invalid session.");
+        }
+
+        var platformUser = await _dbContext.PlatformUsers
+            .FirstOrDefaultAsync(p => p.Id == sourceIdentity.PlatformUserId, ct);
+        if (platformUser is null || platformUser.Status != PlatformUserStatus.Active)
+        {
+            return new LoginResult(false, Error: "Account is no longer active.");
+        }
+
+        // Verify membership in chosen org
+        var memberships = await _platformUserService.GetOrgMembershipsAsync(platformUser.Id, ct);
+        if (!memberships.Any(m => m.OrganizationId == organizationId))
+        {
+            _logger.LogWarning("Org selection failed: user {UserId} not a member of org {OrgId}",
+                platformUser.Id, organizationId);
+            return new LoginResult(false, Error: "You are not a member of this organization.");
+        }
+
+        var organization = await _organizationRepository.GetByIdAsync(organizationId, ct);
+        if (organization is null || organization.Status != OrganizationStatus.Active)
+        {
+            return new LoginResult(false, Error: "Organization is not available.");
+        }
+
+        return await IssueTokensForOrgAsync(platformUser, organization, memberships, ct);
+    }
+
+    /// <summary>
+    /// Issues JWT tokens for a user in a specific org, handling 2FA if needed.
+    /// </summary>
+    private async Task<LoginResult> IssueTokensForOrgAsync(
+        PlatformUser platformUser,
+        Organization organization,
+        IReadOnlyList<PlatformUserOrgMembership> memberships,
+        CancellationToken ct)
+    {
+        // Get UserIdentity in the target org
+        var user = await _dbContext.UserIdentities
+            .FirstOrDefaultAsync(u => u.PlatformUserId == platformUser.Id
+                && u.OrganizationId == organization.Id
+                && u.Status == IdentityStatus.Active, ct);
+
+        if (user is null)
+        {
+            _logger.LogWarning("Login failed: No active UserIdentity in org {OrgId} for platform user {PlatformUserId}",
+                organization.Id, platformUser.Id);
+            return new LoginResult(false, Error: "No active identity found in this organization.");
+        }
+
+        // Check if user has TOTP 2FA or passkeys enabled
+        var totpStatus = await _totpService.GetStatusAsync(user.Id, ct);
+        var passkeys = await _passkeyService.GetCredentialsByOwnerAsync(platformUser.Id, ct);
+        var hasActivePasskeys = passkeys.Any(p => p.Status == CredentialStatus.Active);
+
+        if (totpStatus.IsEnabled || hasActivePasskeys)
+        {
+            var loginToken = await _totpService.GenerateLoginTokenAsync(user.Id, ct);
+            var methods = new List<string>();
+            if (totpStatus.IsEnabled) methods.Add("totp");
+            if (hasActivePasskeys) methods.Add("passkey");
+
+            _logger.LogInformation("Login requires 2FA for {Email} in org {OrgId}, methods: {Methods}",
+                user.Email, organization.Id, string.Join(", ", methods));
+
+            return new LoginResult(true, TwoFactorRequired: true,
+                LoginToken: loginToken, AvailableMethods: methods);
+        }
+
+        // No 2FA — issue JWT
+        user.LastLoginAt = DateTimeOffset.UtcNow;
+        await _identityRepository.UpdateUserAsync(user, ct);
+
+        var tokenResponse = await _tokenService.GenerateUserTokenAsync(user, organization, platformUser.Id, ct);
+
+        _logger.LogInformation("User logged in successfully - {Email} (OrgId: {OrgId})",
+            user.Email, organization.Id);
+
+        return new LoginResult(true, Tokens: tokenResponse);
     }
 
     /// <inheritdoc />

--- a/tests/Sorcha.Tenant.Service.Tests/Infrastructure/TestDataSeeder.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Infrastructure/TestDataSeeder.cs
@@ -31,6 +31,14 @@ public static class TestDataSeeder
     public static readonly Guid MemberUserId = new("00000000-0000-0000-0001-000000000002");
     public static readonly Guid AuditorUserId = new("00000000-0000-0000-0001-000000000003");
 
+    // Well-known PlatformUser IDs (stable, not random)
+    public static readonly Guid AdminPlatformUserId = new("00000000-0000-0000-0002-000000000001");
+    public static readonly Guid MemberPlatformUserId = new("00000000-0000-0000-0002-000000000002");
+    public static readonly Guid AuditorPlatformUserId = new("00000000-0000-0000-0002-000000000003");
+
+    /// <summary>Default test password for all seeded users.</summary>
+    public const string DefaultTestPassword = "TestPassword123!";
+
     /// <summary>
     /// Seeds test data into the database context (idempotent - safe to call multiple times).
     /// </summary>
@@ -54,39 +62,75 @@ public static class TestDataSeeder
 
         context.Organizations.Add(testOrg);
 
-        // Create admin user
+        // Create PlatformUsers (cross-org identity with password hashes)
+        var passwordHash = BCrypt.Net.BCrypt.HashPassword(DefaultTestPassword);
+
+        var adminPlatformUser = new PlatformUser
+        {
+            Id = AdminPlatformUserId,
+            Email = "admin@test-org.sorcha.io",
+            DisplayName = "Admin User",
+            PasswordHash = passwordHash,
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var memberPlatformUser = new PlatformUser
+        {
+            Id = MemberPlatformUserId,
+            Email = "member@test-org.sorcha.io",
+            DisplayName = "Member User",
+            PasswordHash = passwordHash,
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var auditorPlatformUser = new PlatformUser
+        {
+            Id = AuditorPlatformUserId,
+            Email = "auditor@test-org.sorcha.io",
+            DisplayName = "Auditor User",
+            PasswordHash = passwordHash,
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+        context.PlatformUsers.AddRange(adminPlatformUser, memberPlatformUser, auditorPlatformUser);
+
+        // Create admin user identity
         var adminUser = new UserIdentity
         {
             Id = AdminUserId,
             Email = "admin@test-org.sorcha.io",
             DisplayName = "Admin User",
-            PlatformUserId = Guid.NewGuid(),
+            PlatformUserId = AdminPlatformUserId,
             Status = IdentityStatus.Active,
             Roles = new[] { UserRole.Administrator },
             OrganizationId = TestOrganizationId,
             CreatedAt = DateTimeOffset.UtcNow
         };
 
-        // Create member user
+        // Create member user identity
         var memberUser = new UserIdentity
         {
             Id = MemberUserId,
             Email = "member@test-org.sorcha.io",
             DisplayName = "Member User",
-            PlatformUserId = Guid.NewGuid(),
+            PlatformUserId = MemberPlatformUserId,
             Status = IdentityStatus.Active,
             Roles = new[] { UserRole.Member },
             OrganizationId = TestOrganizationId,
             CreatedAt = DateTimeOffset.UtcNow
         };
 
-        // Create auditor user
+        // Create auditor user identity
         var auditorUser = new UserIdentity
         {
             Id = AuditorUserId,
             Email = "auditor@test-org.sorcha.io",
             DisplayName = "Auditor User",
-            PlatformUserId = Guid.NewGuid(),
+            PlatformUserId = AuditorPlatformUserId,
             Status = IdentityStatus.Active,
             Roles = new[] { UserRole.Auditor },
             OrganizationId = TestOrganizationId,
@@ -94,6 +138,31 @@ public static class TestDataSeeder
         };
 
         context.UserIdentities.AddRange(adminUser, memberUser, auditorUser);
+
+        // Create org memberships
+        context.PlatformUserOrgMemberships.AddRange(
+            new PlatformUserOrgMembership
+            {
+                PlatformUserId = AdminPlatformUserId,
+                OrganizationId = TestOrganizationId,
+                Role = UserRole.Administrator.ToString(),
+                JoinedAt = DateTimeOffset.UtcNow
+            },
+            new PlatformUserOrgMembership
+            {
+                PlatformUserId = MemberPlatformUserId,
+                OrganizationId = TestOrganizationId,
+                Role = UserRole.Member.ToString(),
+                JoinedAt = DateTimeOffset.UtcNow
+            },
+            new PlatformUserOrgMembership
+            {
+                PlatformUserId = AuditorPlatformUserId,
+                OrganizationId = TestOrganizationId,
+                Role = UserRole.Auditor.ToString(),
+                JoinedAt = DateTimeOffset.UtcNow
+            }
+        );
 
         // Create test service principal with Argon2id-hashed secret
         // ServiceAuthService.VerifyClientSecret expects salt(16) + hash(32) = 48 bytes

--- a/tests/Sorcha.Tenant.Service.Tests/Services/LoginServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/LoginServiceTests.cs
@@ -15,8 +15,8 @@ using Sorcha.Tenant.Service.Services;
 namespace Sorcha.Tenant.Service.Tests.Services;
 
 /// <summary>
-/// Unit tests for <see cref="LoginService"/>: email/password authentication,
-/// progressive lockout via PlatformUserService, 2FA detection, rate limiting, and token issuance.
+/// Unit tests for <see cref="LoginService"/>: platform-first authentication,
+/// org selection, progressive lockout, 2FA detection, rate limiting, and token issuance.
 /// </summary>
 public class LoginServiceTests : IDisposable
 {
@@ -55,19 +55,6 @@ public class LoginServiceTests : IDisposable
             _platformUserService.Object,
             _logger);
 
-    private static UserIdentity CreateTestUser(string email = "user@test.com")
-    {
-        return new UserIdentity
-        {
-            Id = Guid.NewGuid(),
-            Email = email,
-            DisplayName = "Test User",
-            OrganizationId = Guid.NewGuid(),
-            PlatformUserId = Guid.NewGuid(),
-            Status = IdentityStatus.Active
-        };
-    }
-
     private PlatformUser SeedPlatformUser(Guid platformUserId, string email = "user@test.com")
     {
         var platformUser = new PlatformUser
@@ -84,8 +71,20 @@ public class LoginServiceTests : IDisposable
         return platformUser;
     }
 
-    private static Organization CreateTestOrg(Guid orgId) =>
-        new()
+    /// <summary>
+    /// Seeds the full user graph: PlatformUser, Organization, UserIdentity, OrgMembership.
+    /// Returns (platformUser, organization, userIdentity).
+    /// </summary>
+    private (PlatformUser platformUser, Organization org, UserIdentity identity) SeedFullUser(
+        string email = "user@test.com")
+    {
+        var platformUserId = Guid.NewGuid();
+        var orgId = Guid.NewGuid();
+        var identityId = Guid.NewGuid();
+
+        var platformUser = SeedPlatformUser(platformUserId, email);
+
+        var org = new Organization
         {
             Id = orgId,
             Name = "Test Organization",
@@ -93,6 +92,31 @@ public class LoginServiceTests : IDisposable
             Status = OrganizationStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow
         };
+        _dbContext.Organizations.Add(org);
+
+        var identity = new UserIdentity
+        {
+            Id = identityId,
+            Email = email,
+            DisplayName = "Test User",
+            OrganizationId = orgId,
+            PlatformUserId = platformUserId,
+            Status = IdentityStatus.Active
+        };
+        _dbContext.UserIdentities.Add(identity);
+
+        var membership = new PlatformUserOrgMembership
+        {
+            PlatformUserId = platformUserId,
+            OrganizationId = orgId,
+            Role = "Member",
+            JoinedAt = DateTimeOffset.UtcNow
+        };
+        _dbContext.PlatformUserOrgMemberships.Add(membership);
+
+        _dbContext.SaveChanges();
+        return (platformUser, org, identity);
+    }
 
     private void SetupNoRateLimit()
     {
@@ -123,13 +147,23 @@ public class LoginServiceTests : IDisposable
             .ReturnsAsync(new PasswordAuthResult(false));
     }
 
+    private void SetupPlatformUserLookup(PlatformUser platformUser, string email = "user@test.com")
+    {
+        _platformUserService.Setup(p => p.GetByEmailAsync(email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platformUser);
+    }
+
+    private void SetupOrgMemberships(Guid platformUserId, params PlatformUserOrgMembership[] memberships)
+    {
+        _platformUserService.Setup(p => p.GetOrgMembershipsAsync(platformUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memberships);
+    }
+
     [Fact]
-    public async Task LoginAsync_ValidCredentials_ReturnsTokens()
+    public async Task LoginAsync_ValidCredentials_SingleOrg_ReturnsTokens()
     {
         // Arrange
-        var user = CreateTestUser();
-        var org = CreateTestOrg(user.OrganizationId);
-        SeedPlatformUser(user.PlatformUserId);
+        var (platformUser, org, identity) = SeedFullUser();
         var expectedTokens = new TokenResponse
         {
             AccessToken = "access-token-123",
@@ -139,11 +173,16 @@ public class LoginServiceTests : IDisposable
         SetupNoRateLimit();
         SetupNo2Fa();
         SetupPasswordSuccess();
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
-        _orgRepo.Setup(r => r.GetByIdAsync(user.OrganizationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(org);
-        _tokenService.Setup(t => t.GenerateUserTokenAsync(user, org, It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        SetupPlatformUserLookup(platformUser);
+        SetupOrgMemberships(platformUser.Id, new PlatformUserOrgMembership
+        {
+            PlatformUserId = platformUser.Id,
+            OrganizationId = org.Id,
+            Role = "Member",
+            JoinedAt = DateTimeOffset.UtcNow
+        });
+        _tokenService.Setup(t => t.GenerateUserTokenAsync(
+                It.IsAny<UserIdentity>(), It.IsAny<Organization>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedTokens);
 
         var service = CreateService();
@@ -157,22 +196,80 @@ public class LoginServiceTests : IDisposable
         result.Tokens!.AccessToken.Should().Be("access-token-123");
         result.Tokens.RefreshToken.Should().Be("refresh-token-456");
         result.TwoFactorRequired.Should().BeFalse();
+        result.OrgSelectionRequired.Should().BeFalse();
 
         _revocationService.Verify(r => r.ResetFailedAuthAttemptsAsync("user@test.com", It.IsAny<CancellationToken>()), Times.Once);
         _identityRepo.Verify(r => r.UpdateUserAsync(It.Is<UserIdentity>(u => u.LastLoginAt != null), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
+    public async Task LoginAsync_ValidCredentials_MultipleOrgs_ReturnsOrgSelection()
+    {
+        // Arrange
+        var platformUserId = Guid.NewGuid();
+        var platformUser = SeedPlatformUser(platformUserId);
+
+        var org1 = new Organization
+        {
+            Id = Guid.NewGuid(), Name = "Org Alpha", Subdomain = "alpha",
+            Status = OrganizationStatus.Active, CreatedAt = DateTimeOffset.UtcNow
+        };
+        var org2 = new Organization
+        {
+            Id = Guid.NewGuid(), Name = "Org Beta", Subdomain = "beta",
+            Status = OrganizationStatus.Active, CreatedAt = DateTimeOffset.UtcNow
+        };
+        _dbContext.Organizations.AddRange(org1, org2);
+
+        var identity1 = new UserIdentity
+        {
+            Id = Guid.NewGuid(), Email = "user@test.com", DisplayName = "Test",
+            OrganizationId = org1.Id, PlatformUserId = platformUserId, Status = IdentityStatus.Active
+        };
+        var identity2 = new UserIdentity
+        {
+            Id = Guid.NewGuid(), Email = "user@test.com", DisplayName = "Test",
+            OrganizationId = org2.Id, PlatformUserId = platformUserId, Status = IdentityStatus.Active
+        };
+        _dbContext.UserIdentities.AddRange(identity1, identity2);
+        _dbContext.SaveChanges();
+
+        var memberships = new[]
+        {
+            new PlatformUserOrgMembership { PlatformUserId = platformUserId, OrganizationId = org1.Id, Role = "Admin", JoinedAt = DateTimeOffset.UtcNow },
+            new PlatformUserOrgMembership { PlatformUserId = platformUserId, OrganizationId = org2.Id, Role = "Member", JoinedAt = DateTimeOffset.UtcNow }
+        };
+
+        SetupNoRateLimit();
+        SetupPasswordSuccess();
+        SetupPlatformUserLookup(platformUser);
+        SetupOrgMemberships(platformUserId, memberships);
+        _totpService.Setup(t => t.GenerateLoginTokenAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("platform-login-token");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.LoginAsync("user@test.com", "correct-password");
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.OrgSelectionRequired.Should().BeTrue();
+        result.PlatformLoginToken.Should().Be("platform-login-token");
+        result.AvailableOrganizations.Should().HaveCount(2);
+        result.AvailableOrganizations!.Select(o => o.OrganizationName).Should().Contain("Org Alpha");
+        result.AvailableOrganizations!.Select(o => o.OrganizationName).Should().Contain("Org Beta");
+        result.Tokens.Should().BeNull();
+    }
+
+    [Fact]
     public async Task LoginAsync_InvalidPassword_ReturnsError()
     {
         // Arrange
-        var user = CreateTestUser();
-        SeedPlatformUser(user.PlatformUserId);
+        var (platformUser, _, _) = SeedFullUser();
         SetupNoRateLimit();
         SetupPasswordFailure();
-
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
+        SetupPlatformUserLookup(platformUser);
 
         var service = CreateService();
 
@@ -191,12 +288,9 @@ public class LoginServiceTests : IDisposable
     public async Task LoginAsync_AccountLocked_ReturnsLockedError()
     {
         // Arrange
-        var user = CreateTestUser();
-        SeedPlatformUser(user.PlatformUserId);
+        var (platformUser, _, _) = SeedFullUser();
         SetupNoRateLimit();
-
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
+        SetupPlatformUserLookup(platformUser);
         _platformUserService.Setup(p => p.ValidatePasswordAsync(
                 It.IsAny<PlatformUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PasswordAuthResult(false, IsLocked: true, LockedUntil: DateTimeOffset.UtcNow.AddMinutes(15)));
@@ -216,12 +310,9 @@ public class LoginServiceTests : IDisposable
     public async Task LoginAsync_PermanentlyLocked_ReturnsLockedError()
     {
         // Arrange
-        var user = CreateTestUser();
-        SeedPlatformUser(user.PlatformUserId);
+        var (platformUser, _, _) = SeedFullUser();
         SetupNoRateLimit();
-
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
+        SetupPlatformUserLookup(platformUser);
         _platformUserService.Setup(p => p.ValidatePasswordAsync(
                 It.IsAny<PlatformUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PasswordAuthResult(false, IsLocked: true, IsPermanentlyLocked: true));
@@ -242,9 +333,8 @@ public class LoginServiceTests : IDisposable
     {
         // Arrange
         SetupNoRateLimit();
-
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("nobody@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync((UserIdentity?)null);
+        _platformUserService.Setup(p => p.GetByEmailAsync("nobody@test.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformUser?)null);
 
         var service = CreateService();
 
@@ -262,23 +352,25 @@ public class LoginServiceTests : IDisposable
     public async Task LoginAsync_TwoFactorEnabled_ReturnsTwoFactorChallenge()
     {
         // Arrange
-        var user = CreateTestUser();
-        var org = CreateTestOrg(user.OrganizationId);
-        SeedPlatformUser(user.PlatformUserId);
-        SetupPasswordSuccess();
+        var (platformUser, org, identity) = SeedFullUser();
 
         SetupNoRateLimit();
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
-        _orgRepo.Setup(r => r.GetByIdAsync(user.OrganizationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(org);
+        SetupPasswordSuccess();
+        SetupPlatformUserLookup(platformUser);
+        SetupOrgMemberships(platformUser.Id, new PlatformUserOrgMembership
+        {
+            PlatformUserId = platformUser.Id,
+            OrganizationId = org.Id,
+            Role = "Member",
+            JoinedAt = DateTimeOffset.UtcNow
+        });
 
-        _totpService.Setup(t => t.GetStatusAsync(user.Id, It.IsAny<CancellationToken>()))
+        _totpService.Setup(t => t.GetStatusAsync(identity.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TotpStatusResult { IsEnabled = true });
         _passkeyService.Setup(p => p.GetCredentialsByOwnerAsync(
-                user.PlatformUserId, It.IsAny<CancellationToken>()))
+                platformUser.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<PasskeyCredential>());
-        _totpService.Setup(t => t.GenerateLoginTokenAsync(user.Id, It.IsAny<CancellationToken>()))
+        _totpService.Setup(t => t.GenerateLoginTokenAsync(identity.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync("login-token-abc");
 
         var service = CreateService();
@@ -293,7 +385,6 @@ public class LoginServiceTests : IDisposable
         result.AvailableMethods.Should().Contain("totp");
         result.Tokens.Should().BeNull();
 
-        // Should not issue JWT tokens when 2FA is required
         _tokenService.Verify(t => t.GenerateUserTokenAsync(
             It.IsAny<UserIdentity>(), It.IsAny<Organization>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -316,19 +407,21 @@ public class LoginServiceTests : IDisposable
         result.ErrorCode.Should().Be(LoginErrorCode.RateLimited);
 
         // Should not even attempt user lookup
-        _identityRepo.Verify(r => r.GetUserByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _platformUserService.Verify(p => p.GetByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task LoginAsync_InactiveUser_ReturnsError()
     {
-        // Arrange
-        var user = CreateTestUser();
-        user.Status = IdentityStatus.Suspended;
+        // Arrange — platform user exists but is suspended
+        var platformUser = SeedPlatformUser(Guid.NewGuid());
+        platformUser.Status = PlatformUserStatus.Suspended;
+        _dbContext.PlatformUsers.Update(platformUser);
+        _dbContext.SaveChanges();
 
         SetupNoRateLimit();
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
+        _platformUserService.Setup(p => p.GetByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platformUser);
 
         var service = CreateService();
 
@@ -344,18 +437,20 @@ public class LoginServiceTests : IDisposable
     public async Task LoginAsync_PasskeyEnabled_ReturnsTwoFactorWithPasskeyMethod()
     {
         // Arrange
-        var user = CreateTestUser();
-        var org = CreateTestOrg(user.OrganizationId);
-        SeedPlatformUser(user.PlatformUserId);
-        SetupPasswordSuccess();
+        var (platformUser, org, identity) = SeedFullUser();
 
         SetupNoRateLimit();
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
-        _orgRepo.Setup(r => r.GetByIdAsync(user.OrganizationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(org);
+        SetupPasswordSuccess();
+        SetupPlatformUserLookup(platformUser);
+        SetupOrgMemberships(platformUser.Id, new PlatformUserOrgMembership
+        {
+            PlatformUserId = platformUser.Id,
+            OrganizationId = org.Id,
+            Role = "Member",
+            JoinedAt = DateTimeOffset.UtcNow
+        });
 
-        _totpService.Setup(t => t.GetStatusAsync(user.Id, It.IsAny<CancellationToken>()))
+        _totpService.Setup(t => t.GetStatusAsync(identity.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TotpStatusResult { IsEnabled = false });
 
         var activePasskey = new PasskeyCredential
@@ -363,14 +458,14 @@ public class LoginServiceTests : IDisposable
             Id = Guid.NewGuid(),
             CredentialId = [1, 2, 3],
             PublicKeyCose = [4, 5, 6],
-            PlatformUserId = user.PlatformUserId,
+            PlatformUserId = platformUser.Id,
             Status = CredentialStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow
         };
         _passkeyService.Setup(p => p.GetCredentialsByOwnerAsync(
-                user.PlatformUserId, It.IsAny<CancellationToken>()))
+                platformUser.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new[] { activePasskey });
-        _totpService.Setup(t => t.GenerateLoginTokenAsync(user.Id, It.IsAny<CancellationToken>()))
+        _totpService.Setup(t => t.GenerateLoginTokenAsync(identity.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync("passkey-login-token");
 
         var service = CreateService();
@@ -387,18 +482,31 @@ public class LoginServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task LoginAsync_OrganizationNotFound_ReturnsError()
+    public async Task LoginAsync_NoActiveOrgs_ReturnsError()
     {
-        // Arrange
-        var user = CreateTestUser();
-        SeedPlatformUser(user.PlatformUserId);
-        SetupPasswordSuccess();
+        // Arrange — platform user exists but all orgs are suspended
+        var platformUserId = Guid.NewGuid();
+        var platformUser = SeedPlatformUser(platformUserId);
+        var orgId = Guid.NewGuid();
+
+        var org = new Organization
+        {
+            Id = orgId, Name = "Suspended Org", Subdomain = "suspended",
+            Status = OrganizationStatus.Suspended, CreatedAt = DateTimeOffset.UtcNow
+        };
+        _dbContext.Organizations.Add(org);
+        _dbContext.SaveChanges();
 
         SetupNoRateLimit();
-        _identityRepo.Setup(r => r.GetUserByEmailAsync("user@test.com", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(user);
-        _orgRepo.Setup(r => r.GetByIdAsync(user.OrganizationId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Organization?)null);
+        SetupPasswordSuccess();
+        SetupPlatformUserLookup(platformUser);
+        SetupOrgMemberships(platformUserId, new PlatformUserOrgMembership
+        {
+            PlatformUserId = platformUserId,
+            OrganizationId = orgId,
+            Role = "Member",
+            JoinedAt = DateTimeOffset.UtcNow
+        });
 
         var service = CreateService();
 
@@ -407,7 +515,7 @@ public class LoginServiceTests : IDisposable
 
         // Assert
         result.Success.Should().BeFalse();
-        result.Error.Should().Be("Invalid email or password.");
+        result.Error.Should().Contain("No active organizations");
     }
 
     [Fact]
@@ -498,6 +606,96 @@ public class LoginServiceTests : IDisposable
 
         // Act
         var result = await service.LoginAsync("user@test.com", "correct-password", "other");
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("not a member");
+    }
+
+    [Fact]
+    public async Task CompleteOrgSelectionAsync_ValidToken_IssuesTokens()
+    {
+        // Arrange
+        var (platformUser, org, identity) = SeedFullUser();
+        var expectedTokens = new TokenResponse
+        {
+            AccessToken = "org-selected-token",
+            RefreshToken = "org-selected-refresh"
+        };
+
+        SetupNo2Fa();
+        _totpService.Setup(t => t.ValidateLoginTokenAsync("platform-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(identity.Id);
+        _platformUserService.Setup(p => p.GetOrgMembershipsAsync(platformUser.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new PlatformUserOrgMembership
+                {
+                    PlatformUserId = platformUser.Id,
+                    OrganizationId = org.Id,
+                    Role = "Member",
+                    JoinedAt = DateTimeOffset.UtcNow
+                }
+            });
+        _orgRepo.Setup(r => r.GetByIdAsync(org.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(org);
+        _tokenService.Setup(t => t.GenerateUserTokenAsync(
+                It.IsAny<UserIdentity>(), It.IsAny<Organization>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedTokens);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.CompleteOrgSelectionAsync("platform-token", org.Id);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Tokens.Should().NotBeNull();
+        result.Tokens!.AccessToken.Should().Be("org-selected-token");
+    }
+
+    [Fact]
+    public async Task CompleteOrgSelectionAsync_ExpiredToken_ReturnsError()
+    {
+        // Arrange
+        _totpService.Setup(t => t.ValidateLoginTokenAsync("expired-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.CompleteOrgSelectionAsync("expired-token", Guid.NewGuid());
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("expired");
+    }
+
+    [Fact]
+    public async Task CompleteOrgSelectionAsync_NotMember_ReturnsError()
+    {
+        // Arrange
+        var (platformUser, org, identity) = SeedFullUser();
+        var otherOrgId = Guid.NewGuid();
+
+        _totpService.Setup(t => t.ValidateLoginTokenAsync("platform-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(identity.Id);
+        _platformUserService.Setup(p => p.GetOrgMembershipsAsync(platformUser.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new PlatformUserOrgMembership
+                {
+                    PlatformUserId = platformUser.Id,
+                    OrganizationId = org.Id,
+                    Role = "Member",
+                    JoinedAt = DateTimeOffset.UtcNow
+                }
+            });
+
+        var service = CreateService();
+
+        // Act — try to select a different org
+        var result = await service.CompleteOrgSelectionAsync("platform-token", otherOrgId);
 
         // Assert
         result.Success.Should().BeFalse();


### PR DESCRIPTION
## Summary
- **Login now authenticates against `PlatformUser` (cross-org identity)** instead of org-scoped `UserIdentity`, fixing non-deterministic org selection for multi-org users
- Single-org users get auto-selected (no UX change); multi-org users see an org picker before JWT issuance
- New `POST /api/auth/select-org` endpoint for completing login after org selection

## Changes
| File | Change |
|------|--------|
| `LoginService.cs` | Rewrote `LoginAsync(email, password)` for platform-first auth; added `CompleteOrgSelectionAsync` + `IssueTokensForOrgAsync` |
| `ILoginService.cs` | Added `OrgSelectionRequired`, `OrgChoice`, `CompleteOrgSelectionAsync` to interface |
| `AuthEndpoints.cs` | Added `POST /api/auth/select-org`; updated Login handler for org-selection response |
| `AuthDtos.cs` | Added `OrgSelectionResponse`, `OrgSelectionEntry`, `CompleteOrgSelectionRequest` |
| `Login.cshtml` + `.cs` | Added org picker step between password and token issuance |
| `TestDataSeeder.cs` | Seeds `PlatformUser` + `PlatformUserOrgMembership` alongside `UserIdentity` |
| `LoginServiceTests.cs` | Rewrote for platform-first flow; 16 tests (4 new), all passing |

## Test plan
- [x] 16/16 LoginServiceTests pass (single-org, multi-org, lockout, 2FA, rate-limit, org-selection)
- [x] 560/577 total Tenant Service tests pass (9 pre-existing failures unchanged)
- [ ] Manual: clean `docker-compose down -v && up`, login as admin@sorcha.local
- [ ] Manual: create second org, verify org picker appears on next login

🤖 Generated with [Claude Code](https://claude.com/claude-code)