### PR TITLE
fix: regenerate tenant migration with aligned snapshot

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260316141840_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260316141840_InitialCreate.Designer.cs
@@ -14,7 +14,7 @@ using Sorcha.Tenant.Service.Data;
 namespace Sorcha.Tenant.Service.Migrations
 {
     [DbContext(typeof(TenantDbContext))]
-    [Migration("20260316090053_InitialCreate")]
+    [Migration("20260316141840_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -1008,15 +1008,16 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Email")
-                        .IsUnique();
-
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("PlatformUserId")
                         .HasDatabaseName("IX_UserIdentity_PlatformUserId");
 
                     b.HasIndex("Status");
+
+                    b.HasIndex("OrganizationId", "Email")
+                        .IsUnique()
+                        .HasDatabaseName("UQ_UserIdentity_Org_Email");
 
                     b.ToTable("UserIdentities", "public");
                 });

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260316141840_InitialCreate.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260316141840_InitialCreate.cs
@@ -784,13 +784,6 @@ namespace Sorcha.Tenant.Service.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
-                name: "UQ_UserIdentity_Org_Email",
-                schema: "public",
-                table: "UserIdentities",
-                columns: new[] { "OrganizationId", "Email" },
-                unique: true);
-
-            migrationBuilder.CreateIndex(
                 name: "IX_UserIdentities_OrganizationId",
                 schema: "public",
                 table: "UserIdentities",
@@ -807,6 +800,13 @@ namespace Sorcha.Tenant.Service.Migrations
                 schema: "public",
                 table: "UserIdentities",
                 column: "PlatformUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "UQ_UserIdentity_Org_Email",
+                schema: "public",
+                table: "UserIdentities",
+                columns: new[] { "OrganizationId", "Email" },
+                unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "UQ_UserPreferences_UserId",

--- a/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
@@ -1005,15 +1005,16 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Email")
-                        .IsUnique();
-
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("PlatformUserId")
                         .HasDatabaseName("IX_UserIdentity_PlatformUserId");
 
                     b.HasIndex("Status");
+
+                    b.HasIndex("OrganizationId", "Email")
+                        .IsUnique()
+                        .HasDatabaseName("UQ_UserIdentity_Org_Email");
 
                     b.ToTable("UserIdentities", "public");
                 });


### PR DESCRIPTION
## Summary
- The `InitialCreate` migration snapshot was out of sync with the `TenantDbContext` model — `UserIdentity.Email` had a solo unique index instead of the composite `(OrganizationId, Email)` index required for multi-org
- This caused `PendingModelChangesWarning` on startup, which blocked migration execution entirely, leaving `PlatformUsers` and other tables missing from the database
- Regenerated the migration to align the snapshot with the current model

## Test plan
- [x] `docker-compose down -v && up` — migration applies cleanly, all tables created
- [x] Seed data created: System Admin Org, Public Org, admin PlatformUser + UserIdentity + OrgMembership
- [x] `curl POST /api/auth/login` with admin@sorcha.local returns JWT with correct org_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)