### PR TITLE
fix: PeerRouter stale peer eviction and relay enablement

### DIFF
--- a/docs/superpowers/specs/2026-03-16-peerrouter-stale-peer-management-design.md
+++ b/docs/superpowers/specs/2026-03-16-peerrouter-stale-peer-management-design.md
@@ -1,0 +1,65 @@
+# PeerRouter Stale Peer Management & Relay Enablement
+
+**Date:** 2026-03-16
+**Status:** Approved
+
+## Problem
+
+Container restarts generate new PeerIds (Docker container IDs via `Environment.MachineName`), creating ghost entries in the PeerRouter's routing table. The router marks stale peers unhealthy after 60s but never removes them, causing unbounded memory growth and a polluted `/peers` debug endpoint.
+
+Additionally, NAT'd peers cannot reach each other directly, requiring the router's existing relay mode to be enabled on the Azure deployment.
+
+## Design
+
+### 1. Two-Tier Eviction in RoutingTable (Router)
+
+- **Existing tier:** Mark peers unhealthy after 60s of no heartbeat (unchanged)
+- **New tier:** Remove entries entirely after configurable eviction timeout (default 3600s / 60 min)
+- New config: `PEERROUTER__EVICTION_TIMEOUT` / `--eviction-timeout`
+- New event type: `PeerEvicted`
+- `PeerTimeoutService` sweep handles both tiers in the same loop
+- `RoutingTable.EvictStalePeers(TimeSpan)` removes entries from the `ConcurrentDictionary` and emits `PeerEvicted` events
+
+### 2. Address-Based Dedup in RegisterPeer (Router)
+
+- On new peer registration, scan for existing **unhealthy** entries with the same IP:port
+- If found: silently remove the old entry, emit a `PeerReplaced` event with old/new PeerIds
+- Only replaces unhealthy entries (healthy peers at same address could be legitimate NAT scenarios)
+- New event type: `PeerReplaced`
+
+### 3. Startup Warning for Missing NodeId (Peer Service)
+
+- In `Program.cs`, if `PeerNetwork:NodeId` is null/empty, log a warning:
+  `"NodeId not configured, using MachineName '{name}'. Set PeerNetwork:NodeId for stable peer identity."`
+- No behaviour change — fallback to `Environment.MachineName` remains
+- Nudges toward correct configuration without breaking dev workflows
+
+### 4. Enable Relay on Azure Deployment
+
+- Set `PEERROUTER__ENABLE_RELAY=true` on the `peer-router` Container App
+- Relay implementation already exists in `RouterCommunicationService` — fully functional, just gated behind the config flag
+- No code changes required
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `PeerRouter/Models/RouterConfiguration.cs` | Add `EvictionTimeoutSeconds` property (default 3600), CLI arg `--eviction-timeout`, env var `PEERROUTER__EVICTION_TIMEOUT` |
+| `PeerRouter/Models/RouterEventType.cs` | Add `PeerReplaced` and `PeerEvicted` enum values |
+| `PeerRouter/Services/RoutingTable.cs` | Add `EvictStalePeers(TimeSpan)` method; add address-based dedup logic in `RegisterPeer()` |
+| `PeerRouter/Services/PeerTimeoutService.cs` | Inject eviction timeout; call `EvictStalePeers()` after `SweepUnhealthyPeers()` in the sweep loop |
+| `Peer.Service/Program.cs` | Add startup warning when `NodeId` is not configured |
+
+## What Doesn't Change
+
+- Proto definitions (no wire format changes)
+- Heartbeat processing logic
+- Health endpoint response shape
+- Existing 60s unhealthy marking behaviour
+- Relay implementation code (already complete)
+
+## Deployment Steps
+
+1. Build and push updated PeerRouter image to ACR
+2. Update Azure Container App with new image + `PEERROUTER__ENABLE_RELAY=true`
+3. Verify via `/health` endpoint (`relayEnabled: true`) and `/peers` (stale entries evicted after 60 min)

--- a/src/Apps/Sorcha.PeerRouter/Models/RouterConfiguration.cs
+++ b/src/Apps/Sorcha.PeerRouter/Models/RouterConfiguration.cs
@@ -36,6 +36,9 @@ public sealed record RouterConfiguration
     /// <summary>Seconds without a heartbeat before a peer is marked unhealthy.</summary>
     public int PeerTimeoutSeconds { get; init; } = 60;
 
+    /// <summary>Seconds after last heartbeat before a stale peer entry is removed entirely. Default: 3600 (60 min).</summary>
+    public int EvictionTimeoutSeconds { get; init; } = 3600;
+
     /// <summary>
     /// The router's peer identity on the network. Peers using this ID will be rejected
     /// from registration to prevent the router from appearing in its own peer table.
@@ -74,6 +77,9 @@ public sealed record RouterConfiguration
                 case "--peer-timeout" when i + 1 < args.Length:
                     config = config with { PeerTimeoutSeconds = int.Parse(args[++i]) };
                     break;
+                case "--eviction-timeout" when i + 1 < args.Length:
+                    config = config with { EvictionTimeoutSeconds = int.Parse(args[++i]) };
+                    break;
                 case "--peer-id" when i + 1 < args.Length:
                     config = config with { PeerId = args[++i] };
                     break;
@@ -104,6 +110,9 @@ public sealed record RouterConfiguration
 
         if (int.TryParse(Environment.GetEnvironmentVariable("PEERROUTER__PEER_TIMEOUT"), out var timeout))
             config = config with { PeerTimeoutSeconds = timeout };
+
+        if (int.TryParse(Environment.GetEnvironmentVariable("PEERROUTER__EVICTION_TIMEOUT"), out var eviction))
+            config = config with { EvictionTimeoutSeconds = eviction };
 
         var peerId = Environment.GetEnvironmentVariable("PEERROUTER__PEER_ID");
         if (!string.IsNullOrEmpty(peerId))

--- a/src/Apps/Sorcha.PeerRouter/Models/RouterEventType.cs
+++ b/src/Apps/Sorcha.PeerRouter/Models/RouterEventType.cs
@@ -16,5 +16,7 @@ public enum RouterEventType
     PeerExchanged,
     RelayForwarded,
     Error,
-    PeerHeartbeatRejected
+    PeerHeartbeatRejected,
+    PeerReplaced,
+    PeerEvicted
 }

--- a/src/Apps/Sorcha.PeerRouter/Services/PeerTimeoutService.cs
+++ b/src/Apps/Sorcha.PeerRouter/Services/PeerTimeoutService.cs
@@ -13,6 +13,7 @@ public sealed class PeerTimeoutService : BackgroundService
 {
     private readonly RoutingTable _routingTable;
     private readonly TimeSpan _timeout;
+    private readonly TimeSpan _evictionTimeout;
     private readonly TimeSpan _sweepInterval;
     private readonly ILogger<PeerTimeoutService> _logger;
 
@@ -23,14 +24,16 @@ public sealed class PeerTimeoutService : BackgroundService
     {
         _routingTable = routingTable;
         _timeout = TimeSpan.FromSeconds(config.PeerTimeoutSeconds);
+        _evictionTimeout = TimeSpan.FromSeconds(config.EvictionTimeoutSeconds);
         _sweepInterval = TimeSpan.FromSeconds(Math.Max(config.PeerTimeoutSeconds / 3, 5));
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogInformation("Peer timeout service started (timeout: {Timeout}s, sweep: {Sweep}s)",
-            _timeout.TotalSeconds, _sweepInterval.TotalSeconds);
+        _logger.LogInformation(
+            "Peer timeout service started (timeout: {Timeout}s, eviction: {Eviction}s, sweep: {Sweep}s)",
+            _timeout.TotalSeconds, _evictionTimeout.TotalSeconds, _sweepInterval.TotalSeconds);
 
         using var timer = new PeriodicTimer(_sweepInterval);
         while (await timer.WaitForNextTickAsync(stoppingToken))
@@ -41,6 +44,14 @@ public sealed class PeerTimeoutService : BackgroundService
                 _logger.LogInformation("Marked {Count} peer(s) as unhealthy: {Peers}",
                     unhealthy.Count,
                     string.Join(", ", unhealthy.Select(p => p.PeerId)));
+            }
+
+            var evicted = _routingTable.EvictStalePeers(_evictionTimeout);
+            if (evicted.Count > 0)
+            {
+                _logger.LogInformation("Evicted {Count} stale peer(s): {Peers}",
+                    evicted.Count,
+                    string.Join(", ", evicted.Select(p => p.PeerId)));
             }
         }
     }

--- a/src/Apps/Sorcha.PeerRouter/Services/RoutingTable.cs
+++ b/src/Apps/Sorcha.PeerRouter/Services/RoutingTable.cs
@@ -26,6 +26,7 @@ public sealed class RoutingTable
     /// <summary>
     /// Registers or updates a peer in the routing table.
     /// Returns true if the peer was newly added, false if updated.
+    /// If a stale (unhealthy) entry exists at the same IP:port, it is replaced.
     /// </summary>
     public bool RegisterPeer(PeerInfo peerInfo)
     {
@@ -34,6 +35,35 @@ public sealed class RoutingTable
             string.Equals(peerInfo.PeerId, _selfPeerId, StringComparison.OrdinalIgnoreCase))
         {
             return false;
+        }
+
+        // Address-based dedup: remove stale entries at the same IP:port
+        var newIp = ExtractIp(peerInfo.Address);
+        var newPort = peerInfo.Port;
+
+        foreach (var (existingId, existing) in _entries)
+        {
+            if (existingId == peerInfo.PeerId)
+                continue;
+
+            if (!existing.IsHealthy &&
+                existing.Port == newPort &&
+                string.Equals(existing.IpAddress, newIp, StringComparison.OrdinalIgnoreCase))
+            {
+                if (_entries.TryRemove(existingId, out _))
+                {
+                    _eventBuffer.Add(RouterEvent.Create(
+                        RouterEventType.PeerReplaced,
+                        existingId,
+                        existing.IpAddress,
+                        existing.Port,
+                        detail: new Dictionary<string, object?>
+                        {
+                            ["replaced_by"] = peerInfo.PeerId,
+                            ["reason"] = "Stale entry at same address replaced by new registration"
+                        }));
+                }
+            }
         }
 
         var isNew = false;
@@ -162,6 +192,40 @@ public sealed class RoutingTable
         }
 
         return markedUnhealthy;
+    }
+
+    /// <summary>
+    /// Removes peer entries that have been unhealthy for longer than the eviction timeout.
+    /// Returns the list of evicted peers.
+    /// </summary>
+    public IReadOnlyList<RoutingEntry> EvictStalePeers(TimeSpan evictionTimeout)
+    {
+        var cutoff = DateTimeOffset.UtcNow - evictionTimeout;
+        var evicted = new List<RoutingEntry>();
+
+        foreach (var (peerId, entry) in _entries)
+        {
+            if (!entry.IsHealthy && entry.LastSeen < cutoff)
+            {
+                if (_entries.TryRemove(peerId, out _))
+                {
+                    evicted.Add(entry);
+                    _eventBuffer.Add(RouterEvent.Create(
+                        RouterEventType.PeerEvicted,
+                        entry.PeerId,
+                        entry.IpAddress,
+                        entry.Port,
+                        entry.NodeName,
+                        new Dictionary<string, object?>
+                        {
+                            ["reason"] = "eviction_timeout",
+                            ["last_seen"] = entry.LastSeen.ToString("O")
+                        }));
+                }
+            }
+        }
+
+        return evicted;
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Peer.Service/Program.cs
+++ b/src/Services/Sorcha.Peer.Service/Program.cs
@@ -108,6 +108,16 @@ builder.AddSorchaOpenApi("Sorcha Peer Service API", "P2P networking, peer discov
 builder.Services.Configure<PeerServiceConfiguration>(
     builder.Configuration.GetSection("PeerService"));
 
+// Warn if NodeId is not explicitly configured (transient container IDs cause ghost peers)
+var configuredNodeId = builder.Configuration.GetValue<string>("PeerService:NodeId");
+if (string.IsNullOrEmpty(configuredNodeId))
+{
+    var machineName = Environment.MachineName;
+    Console.WriteLine(
+        $"[WRN] NodeId not configured, using MachineName '{machineName}'. " +
+        "Set PeerService:NodeId for stable peer identity across container restarts.");
+}
+
 // Register gRPC auth interceptor (FR-014: authenticated peers get higher trust)
 builder.Services.AddSingleton<Sorcha.Peer.Service.GrpcServices.PeerAuthInterceptor>();
 


### PR DESCRIPTION
## Summary
- **Two-tier eviction**: peers marked unhealthy after 60s (existing), entries removed after 60min (new configurable `PEERROUTER__EVICTION_TIMEOUT`)
- **Address-based dedup**: when a new peer registers at the same IP:port as a stale entry, the old ghost entry is silently replaced
- **Relay enabled on Azure**: `PEERROUTER__ENABLE_RELAY=true` set on n0.sorcha.dev for NAT'd peer communication
- **NodeId startup warning**: Peer Service logs a warning when `NodeId` isn't configured and falls back to transient `MachineName`

## Context
Container restarts generate new Docker container IDs used as PeerIds, creating ghost entries that accumulated forever (26 stale peers on n0.sorcha.dev). This PR adds eviction + dedup to prevent unbounded growth, and enables relay mode so NAT'd peers can communicate via the router.

## Test plan
- [x] 84 PeerRouter tests pass
- [x] PeerRouter and Peer Service build with 0 warnings
- [x] Deployed to n0.sorcha.dev — verified `relayEnabled: true`, clean peer table (1 peer, 0 ghosts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)