### PR TITLE
fix: update Wallet Service Dockerfile for Common-to-Core move

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Dockerfile
+++ b/src/Services/Sorcha.Wallet.Service/Dockerfile
@@ -9,11 +9,12 @@ WORKDIR /src
 COPY ["Directory.Packages.props", "."]
 COPY ["src/Services/Directory.Build.props", "src/Services/"]
 COPY ["src/Common/Directory.Build.props", "src/Common/"]
+COPY ["src/Core/Directory.Build.props", "src/Core/"]
 
 # Copy project files for restore
 COPY ["src/Services/Sorcha.Wallet.Service/Sorcha.Wallet.Service.csproj", "src/Services/Sorcha.Wallet.Service/"]
 COPY ["src/Common/Sorcha.ServiceDefaults/Sorcha.ServiceDefaults.csproj", "src/Common/Sorcha.ServiceDefaults/"]
-COPY ["src/Common/Sorcha.Wallet.Core/Sorcha.Wallet.Core.csproj", "src/Common/Sorcha.Wallet.Core/"]
+COPY ["src/Core/Sorcha.Wallet.Core/Sorcha.Wallet.Core.csproj", "src/Core/Sorcha.Wallet.Core/"]
 COPY ["src/Common/Sorcha.Cryptography/Sorcha.Cryptography.csproj", "src/Common/Sorcha.Cryptography/"]
 
 # Restore dependencies


### PR DESCRIPTION
## Summary
- Fixes broken `docker-compose build` for wallet-service caused by stale COPY path
- Updates `Sorcha.Wallet.Core` reference from `src/Common/` to `src/Core/` in the Dockerfile
- Adds missing `src/Core/Directory.Build.props` COPY instruction

## Test plan
- [ ] Run `docker-compose build wallet-service` and verify it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)