### PR TITLE
feat: add node_name to peer proto and capture source IP

### DIFF
--- a/src/Apps/Sorcha.PeerRouter/GrpcServices/RouterDiscoveryService.cs
+++ b/src/Apps/Sorcha.PeerRouter/GrpcServices/RouterDiscoveryService.cs
@@ -60,10 +60,11 @@ public sealed class RouterDiscoveryService : PeerDiscovery.PeerDiscoveryBase
             });
         }
 
-        var isNew = _routingTable.RegisterPeer(peerInfo);
+        var isNew = _routingTable.RegisterPeer(peerInfo, context.Peer);
         _logger.LogInformation(
-            "Peer {PeerId} {Action} at {Address}:{Port} from {ClientAddress}",
+            "Peer {PeerId} ({NodeName}) {Action} at {Address}:{Port} from {ClientAddress}",
             peerInfo.PeerId,
+            peerInfo.NodeName,
             isNew ? "registered" : "updated",
             peerInfo.Address,
             peerInfo.Port,
@@ -145,7 +146,7 @@ public sealed class RouterDiscoveryService : PeerDiscovery.PeerDiscoveryBase
             if (IsSelf(peerInfo.PeerId))
                 continue;
 
-            _routingTable.RegisterPeer(peerInfo);
+            _routingTable.RegisterPeer(peerInfo, context.Peer);
             registeredCount++;
         }
 
@@ -223,6 +224,7 @@ public sealed class RouterDiscoveryService : PeerDiscovery.PeerDiscoveryBase
         var peerInfo = new PeerInfo
         {
             PeerId = entry.PeerId,
+            NodeName = entry.NodeName ?? "",
             Address = entry.Address,
             Port = entry.Port,
             LastSeen = entry.LastSeen.ToUnixTimeMilliseconds(),

--- a/src/Apps/Sorcha.PeerRouter/Services/RoutingTable.cs
+++ b/src/Apps/Sorcha.PeerRouter/Services/RoutingTable.cs
@@ -28,7 +28,7 @@ public sealed class RoutingTable
     /// Returns true if the peer was newly added, false if updated.
     /// If a stale (unhealthy) entry exists at the same IP:port, it is replaced.
     /// </summary>
-    public bool RegisterPeer(PeerInfo peerInfo)
+    public bool RegisterPeer(PeerInfo peerInfo, string? sourceAddress = null)
     {
         // Prevent the router from appearing in its own peer table
         if (!string.IsNullOrEmpty(_selfPeerId) &&
@@ -38,7 +38,7 @@ public sealed class RoutingTable
         }
 
         // Address-based dedup: remove stale entries at the same IP:port
-        var newIp = ExtractIp(peerInfo.Address);
+        var newIp = !string.IsNullOrEmpty(peerInfo.Address) ? ExtractIp(peerInfo.Address) : ExtractGrpcPeerIp(sourceAddress);
         var newPort = peerInfo.Port;
 
         foreach (var (existingId, existing) in _entries)
@@ -72,7 +72,7 @@ public sealed class RoutingTable
             _ =>
             {
                 isNew = true;
-                var entry = CreateEntry(peerInfo);
+                var entry = CreateEntry(peerInfo, sourceAddress);
                 _eventBuffer.Add(RouterEvent.Create(
                     RouterEventType.PeerConnected,
                     entry.PeerId,
@@ -84,12 +84,14 @@ public sealed class RoutingTable
             (_, existing) =>
             {
                 existing.Address = peerInfo.Address;
-                existing.IpAddress = ExtractIp(peerInfo.Address);
+                existing.IpAddress = !string.IsNullOrEmpty(peerInfo.Address) ? ExtractIp(peerInfo.Address) : ExtractGrpcPeerIp(sourceAddress);
                 existing.Port = peerInfo.Port;
                 existing.Capabilities = peerInfo.Capabilities;
                 existing.AdvertisedRegisters = [.. peerInfo.AdvertisedRegisters];
                 existing.LastSeen = DateTimeOffset.UtcNow;
                 existing.IsHealthy = true;
+                if (!string.IsNullOrEmpty(peerInfo.NodeName))
+                    existing.NodeName = peerInfo.NodeName;
                 return existing;
             });
 
@@ -237,16 +239,45 @@ public sealed class RoutingTable
     public int TotalCount => _entries.Count;
     public int HealthyCount => _entries.Values.Count(e => e.IsHealthy);
 
-    private static RoutingEntry CreateEntry(PeerInfo peerInfo) => new()
+    private static RoutingEntry CreateEntry(PeerInfo peerInfo, string? sourceAddress = null) => new()
     {
         PeerId = peerInfo.PeerId,
-        NodeName = string.IsNullOrEmpty(peerInfo.PeerId) ? null : null, // NodeName comes from future extension
+        NodeName = string.IsNullOrEmpty(peerInfo.NodeName) ? null : peerInfo.NodeName,
         Address = peerInfo.Address,
-        IpAddress = ExtractIp(peerInfo.Address),
+        IpAddress = !string.IsNullOrEmpty(peerInfo.Address) ? ExtractIp(peerInfo.Address) : ExtractGrpcPeerIp(sourceAddress),
         Port = peerInfo.Port,
         Capabilities = peerInfo.Capabilities,
         AdvertisedRegisters = [.. peerInfo.AdvertisedRegisters]
     };
+
+    /// <summary>
+    /// Extracts the IP address from a gRPC context.Peer string (e.g. "ipv4:1.2.3.4:5000").
+    /// </summary>
+    private static string ExtractGrpcPeerIp(string? contextPeer)
+    {
+        if (string.IsNullOrEmpty(contextPeer))
+            return "";
+
+        // gRPC Peer format: "ipv4:1.2.3.4:port" or "ipv6:[::1]:port"
+        if (contextPeer.StartsWith("ipv4:", StringComparison.OrdinalIgnoreCase))
+        {
+            var afterPrefix = contextPeer[5..];
+            var lastColon = afterPrefix.LastIndexOf(':');
+            return lastColon > 0 ? afterPrefix[..lastColon] : afterPrefix;
+        }
+
+        if (contextPeer.StartsWith("ipv6:", StringComparison.OrdinalIgnoreCase))
+        {
+            var afterPrefix = contextPeer[5..];
+            // IPv6 addresses are in brackets: [::1]:port
+            var closeBracket = afterPrefix.IndexOf(']');
+            if (closeBracket > 0 && afterPrefix.StartsWith('['))
+                return afterPrefix[1..closeBracket];
+            return afterPrefix;
+        }
+
+        return contextPeer;
+    }
 
     private static string ExtractIp(string address)
     {

--- a/src/Services/Sorcha.Peer.Service/Connection/PeerConnectionPool.cs
+++ b/src/Services/Sorcha.Peer.Service/Connection/PeerConnectionPool.cs
@@ -414,6 +414,7 @@ public class PeerConnectionPool : IAsyncDisposable
                 PeerInfo = new PeerInfo
                 {
                     PeerId = localPeer?.PeerId ?? _configuration.NodeId ?? Environment.MachineName,
+                    NodeName = _configuration.NodeId ?? Environment.MachineName,
                     Address = _configuration.NetworkAddress.ExternalAddress ?? Environment.MachineName,
                     Port = _configuration.ListenPort,
                     SupportedProtocols = { "GrpcStream", "Grpc", "Rest" }

--- a/src/Services/Sorcha.Peer.Service/Core/PeerNode.cs
+++ b/src/Services/Sorcha.Peer.Service/Core/PeerNode.cs
@@ -18,6 +18,11 @@ public class PeerNode : IEquatable<PeerNode>
     public string PeerId { get; set; } = string.Empty;
 
     /// <summary>
+    /// Human-readable display name for the peer node
+    /// </summary>
+    public string? NodeName { get; set; }
+
+    /// <summary>
     /// Network address of the peer (IP or hostname)
     /// </summary>
     [Required]

--- a/src/Services/Sorcha.Peer.Service/Discovery/PeerDiscoveryService.cs
+++ b/src/Services/Sorcha.Peer.Service/Discovery/PeerDiscoveryService.cs
@@ -171,6 +171,7 @@ public class PeerDiscoveryService : IDisposable
                 PeerInfo = new PeerInfo
                 {
                     PeerId = _configuration.NodeId ?? "unknown",
+                    NodeName = _configuration.NodeId ?? Environment.MachineName,
                     Address = externalAddress,
                     Port = _configuration.ListenPort,
                     SupportedProtocols = { "GrpcStream", "Grpc", "Rest" }
@@ -238,6 +239,7 @@ public class PeerDiscoveryService : IDisposable
         return new PeerNode
         {
             PeerId = peerInfo.PeerId,
+            NodeName = string.IsNullOrEmpty(peerInfo.NodeName) ? null : peerInfo.NodeName,
             Address = peerInfo.Address,
             Port = peerInfo.Port,
             SupportedProtocols = peerInfo.SupportedProtocols.ToList(),

--- a/src/Services/Sorcha.Peer.Service/Discovery/PeerDiscoveryServiceImpl.cs
+++ b/src/Services/Sorcha.Peer.Service/Discovery/PeerDiscoveryServiceImpl.cs
@@ -238,6 +238,7 @@ public class PeerDiscoveryServiceImpl : PeerDiscovery.PeerDiscoveryBase
         var peerInfo = new PeerInfo
         {
             PeerId = peer.PeerId,
+            NodeName = peer.NodeName ?? "",
             Address = peer.Address,
             Port = peer.Port,
             IsSeedNode = peer.IsSeedNode,
@@ -267,6 +268,7 @@ public class PeerDiscoveryServiceImpl : PeerDiscovery.PeerDiscoveryBase
         return new PeerNode
         {
             PeerId = peerInfo.PeerId,
+            NodeName = string.IsNullOrEmpty(peerInfo.NodeName) ? null : peerInfo.NodeName,
             Address = peerInfo.Address,
             Port = peerInfo.Port,
             SupportedProtocols = peerInfo.SupportedProtocols.ToList(),

--- a/src/Services/Sorcha.Peer.Service/Discovery/PeerExchangeService.cs
+++ b/src/Services/Sorcha.Peer.Service/Discovery/PeerExchangeService.cs
@@ -204,6 +204,7 @@ public class PeerExchangeService : IDisposable
         var info = new PeerInfo
         {
             PeerId = peer.PeerId,
+            NodeName = peer.NodeName ?? "",
             Address = peer.Address,
             Port = peer.Port,
             IsSeedNode = peer.IsSeedNode,

--- a/src/Services/Sorcha.Peer.Service/Protos/peer_discovery.proto
+++ b/src/Services/Sorcha.Peer.Service/Protos/peer_discovery.proto
@@ -61,6 +61,9 @@ message PeerInfo {
 
   // Whether this peer is a seed node
   bool is_seed_node = 8;
+
+  // Human-readable node name (e.g. "peer-001", "peer-dev")
+  string node_name = 9;
 }
 
 // Capabilities of a peer


### PR DESCRIPTION
## Summary
- **Proto change**: Add `node_name` (field 9) to `PeerInfo` message — backwards compatible, old peers send empty string
- **Peer Service**: Sends `NodeId` (or `MachineName`) as `node_name` in all registration, discovery, and exchange calls
- **PeerRouter**: Captures `context.Peer` (gRPC source address) as fallback IP when peer doesn't provide an address (NAT'd peers)
- **PeerRouter**: Populates and propagates `NodeName` through routing table and peer list responses

## Context
Peer table was showing container IDs (`864b62cdfc99`) with empty IP addresses — meaningless for debugging. Now peers send their human-readable `NodeId` and the router captures the NAT'd source IP as a fallback.

## Test plan
- [x] 84 PeerRouter tests pass
- [x] 572 Peer Service tests pass
- [x] Both projects build with 0 warnings
- [x] Deployed to n0.sorcha.dev — new revision active

🤖 Generated with [Claude Code](https://claude.com/claude-code)