### PR TITLE
fix: regenerate tenant InitialCreate migration with pending model changes

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260317171639_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260317171639_InitialCreate.Designer.cs
@@ -14,7 +14,7 @@ using Sorcha.Tenant.Service.Data;
 namespace Sorcha.Tenant.Service.Migrations
 {
     [DbContext(typeof(TenantDbContext))]
-    [Migration("20260316141840_InitialCreate")]
+    [Migration("20260317171639_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -375,6 +375,45 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.HasIndex("OrganizationId", "Email", "Status");
 
                     b.ToTable("OrgInvitations", "public");
+                });
+
+            modelBuilder.Entity("Sorcha.Tenant.Service.Models.OrgRecoveryConfig", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CreatedBy")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<Guid>("OrganizationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("RecoveryKeyId")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("RecoveryPublicKey")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<DateTimeOffset?>("RotatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OrganizationId")
+                        .IsUnique()
+                        .HasDatabaseName("IX_OrgRecoveryConfig_OrganizationId");
+
+                    b.ToTable("OrgRecoveryConfigs", "public");
                 });
 
             modelBuilder.Entity("Sorcha.Tenant.Service.Models.Organization", b =>

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260317171639_InitialCreate.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260317171639_InitialCreate.cs
@@ -146,6 +146,24 @@ namespace Sorcha.Tenant.Service.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "OrgRecoveryConfigs",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RecoveryPublicKey = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    RecoveryKeyId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    RotatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrgRecoveryConfigs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "ParticipantIdentities",
                 schema: "public",
                 columns: table => new
@@ -653,6 +671,13 @@ namespace Sorcha.Tenant.Service.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_OrgRecoveryConfig_OrganizationId",
+                schema: "public",
+                table: "OrgRecoveryConfigs",
+                column: "OrganizationId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Audit_Actor_Time",
                 schema: "public",
                 table: "ParticipantAuditEntries",
@@ -857,6 +882,10 @@ namespace Sorcha.Tenant.Service.Migrations
 
             migrationBuilder.DropTable(
                 name: "OrgInvitations",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "OrgRecoveryConfigs",
                 schema: "public");
 
             migrationBuilder.DropTable(

--- a/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
@@ -374,6 +374,45 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.ToTable("OrgInvitations", "public");
                 });
 
+            modelBuilder.Entity("Sorcha.Tenant.Service.Models.OrgRecoveryConfig", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CreatedBy")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<Guid>("OrganizationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("RecoveryKeyId")
+                        .IsRequired()
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
+                    b.Property<string>("RecoveryPublicKey")
+                        .IsRequired()
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<DateTimeOffset?>("RotatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OrganizationId")
+                        .IsUnique()
+                        .HasDatabaseName("IX_OrgRecoveryConfig_OrganizationId");
+
+                    b.ToTable("OrgRecoveryConfigs", "public");
+                });
+
             modelBuilder.Entity("Sorcha.Tenant.Service.Models.Organization", b =>
                 {
                     b.Property<Guid>("Id")


### PR DESCRIPTION
## Summary
- Tenant service migration had `PendingModelChangesWarning` preventing table creation
- `ServicePrincipals` table never created, causing 500s on service token auth
- This cascaded: validator couldn't get tokens → couldn't init system wallet → slow startup
- Squashed into fresh InitialCreate (no production data). 23 tables.

## Test plan
- [x] Tenant service starts healthy in Docker
- [x] Wallet service starts healthy
- [x] Validator service starts healthy (no more auth retry loops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)