### PR TITLE
fix: copy blueprint templates into Docker image for seeding

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Dockerfile
+++ b/src/Services/Sorcha.Blueprint.Service/Dockerfile
@@ -52,6 +52,9 @@ EXPOSE 8081
 # Copy published application
 COPY --from=publish /app/publish .
 
+# Copy blueprint templates for seeding on startup
+COPY blueprints/templates/ ./blueprints/templates/
+
 # Set environment variables
 ENV ASPNETCORE_URLS=http://+:8080
 ENV ASPNETCORE_HTTP_PORTS=8080


### PR DESCRIPTION
## Summary

- Add `COPY blueprints/templates/ ./blueprints/templates/` to Blueprint Service Dockerfile
- Fixes `TemplateSeedService` warning: "Templates directory not found at /app/blueprints/templates, skipping seed"
- All 10 templates now seeded on startup: 10 seeded, 0 skipped

## Test plan

- [x] `docker-compose down -v && docker-compose up -d --build`
- [x] Verify: `Template seeding complete: 10 seeded, 0 skipped`
- [x] No warnings or errors on Blueprint Service startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)