### PR TITLE
fix: API Gateway TenantService HttpClient using wrong port

### DIFF
--- a/src/Services/Sorcha.ApiGateway/Program.cs
+++ b/src/Services/Sorcha.ApiGateway/Program.cs
@@ -31,7 +31,9 @@ builder.Services.AddSingleton<HealthAggregationService>();
 // Configure Tenant Service HTTP client for URL resolution
 builder.Services.AddHttpClient("TenantService", client =>
 {
-    var tenantServiceUrl = builder.Configuration.GetValue<string>("Services:TenantService:BaseUrl") ?? "http://tenant-service";
+    var tenantServiceUrl = builder.Configuration.GetValue<string>("Services:TenantService:BaseUrl")
+        ?? builder.Configuration.GetValue<string>("Services:Tenant:Url")
+        ?? "http://tenant-service:8080";
     client.BaseAddress = new Uri(tenantServiceUrl);
 });
 


### PR DESCRIPTION
## Summary

- Fix named `TenantService` HttpClient in API Gateway defaulting to `http://tenant-service` (port 80) instead of port 8080
- Fall through to `Services:Tenant:Url` config key (set by docker-compose) before defaulting to `:8080`
- Eliminates ~500+ Polly retry warnings per startup cycle

## Test plan

- [x] Rebuilt API Gateway, verified zero `Connection refused (tenant-service:80)` errors
- [x] All health checks passing via gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)