### PR TITLE
fix: pending actions 400 for no-wallet users + WASM asset routing

### DIFF
--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -104,6 +104,18 @@
         "Match": { "Path": "/_content/{**catch-all}" },
         "Transforms": [ { "X-Forwarded": "Set" } ]
       },
+      "ui-app-framework": {
+        "ClusterId": "admin-cluster",
+        "Order": 1,
+        "Match": { "Path": "/app/_framework/{**catch-all}" },
+        "Transforms": [ { "PathRemovePrefix": "/app" }, { "X-Forwarded": "Set" } ]
+      },
+      "ui-app-content": {
+        "ClusterId": "admin-cluster",
+        "Order": 1,
+        "Match": { "Path": "/app/_content/{**catch-all}" },
+        "Transforms": [ { "PathRemovePrefix": "/app" }, { "X-Forwarded": "Set" } ]
+      },
       "ui-static": {
         "ClusterId": "admin-cluster",
         "Order": 100,

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
@@ -28,7 +28,7 @@ public static class ActionEndpoints
             var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
             if (string.IsNullOrEmpty(walletAddress))
             {
-                return Results.BadRequest(new { error = "No wallet_address claim in token" });
+                return Results.Ok(new { items = Array.Empty<object>(), totalCount = 0, page, pageSize });
             }
 
             var skip = (page - 1) * pageSize;
@@ -58,7 +58,7 @@ public static class ActionEndpoints
             var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
             if (string.IsNullOrEmpty(walletAddress))
             {
-                return Results.BadRequest(new { error = "No wallet_address claim in token" });
+                return Results.Ok(new { count = 0, urgentCount = 0 });
             }
 
             var count = await instanceStore.GetPendingActionCountByWalletAsync(walletAddress);


### PR DESCRIPTION
## Summary
- ActionEndpoints now returns empty 200 instead of 400 when JWT lacks wallet_address claim
- Added /app/_framework/ and /app/_content/ gateway routes to fix Blazor WASM loading on /app/* pages

## Test plan
- [x] Blueprint service and API gateway start healthy
- [ ] E2E tests re-run (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)