### PR TITLE
fix: genesis transaction type mapped as Action instead of Control

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -408,12 +408,16 @@ public class DocketBuildTriggerService : BackgroundService
                         ? Base64Url.EncodeToString(System.Text.Encoding.UTF8.GetBytes(t.Payload.GetRawText()))
                         : string.Empty;
 
-                    // Extract transaction type from metadata
+                    // Extract transaction type from metadata.
+                    // "Genesis" is used by RegisterCreationOrchestrator but isn't an enum member —
+                    // it maps to Control (genesis is a control record that bootstraps the register).
                     var txType = Sorcha.Register.Models.Enums.TransactionType.Action;
-                    if (t.Metadata.TryGetValue("Type", out var typeStr)
-                        && Enum.TryParse<Sorcha.Register.Models.Enums.TransactionType>(typeStr, ignoreCase: true, out var parsed))
+                    if (t.Metadata.TryGetValue("Type", out var typeStr))
                     {
-                        txType = parsed;
+                        if (typeStr.Equals("Genesis", StringComparison.OrdinalIgnoreCase))
+                            txType = Sorcha.Register.Models.Enums.TransactionType.Control;
+                        else if (Enum.TryParse<Sorcha.Register.Models.Enums.TransactionType>(typeStr, ignoreCase: true, out var parsed))
+                            txType = parsed;
                     }
 
                     return new Sorcha.Register.Models.TransactionModel


### PR DESCRIPTION
## Summary
- Genesis transactions were written to the register with `TransactionType=1` (Action) instead of `TransactionType=0` (Control)
- Root cause: `RegisterCreationOrchestrator` sets metadata `Type="Genesis"`, but `Enum.TryParse("Genesis")` fails silently because the enum has no `Genesis` member — falls back to default `Action`
- Fix: explicitly map `"Genesis"` to `TransactionType.Control` before the enum parse

## Test plan
- [x] Build: 0 warnings, 0 errors
- [ ] Docker: create new register, verify genesis transaction has `TransactionType: 0` (Control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)