### PR TITLE
fix: login redirect loop when Web Crypto API unavailable on HTTP

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Authentication/CustomAuthenticationStateProvider.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Authentication/CustomAuthenticationStateProvider.cs
@@ -115,9 +115,6 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider
             if (string.IsNullOrEmpty(json))
                 return null;
 
-            // Clear token staging (preserves returnUrl for FragmentTokenHandler navigation)
-            await _jsRuntime.InvokeVoidAsync("sorcha.fragmentHandoff.clearTokenStaging");
-
             var result = JsonSerializer.Deserialize<FragmentTokenResult>(json, CaseInsensitiveJson);
             if (result?.Token is null)
                 return null;
@@ -135,7 +132,13 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider
                 IssuedAt = jwt.IssuedAt
             };
 
+            // Store token BEFORE clearing staging — if store fails, token is preserved
+            // for FragmentTokenHandler fallback
             await _tokenCache.StoreTokenAsync(profileName, entry);
+
+            // Clear token staging only after successful store
+            await _jsRuntime.InvokeVoidAsync("sorcha.fragmentHandoff.clearTokenStaging");
+
             return entry;
         }
         catch

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Encryption/BrowserEncryptionProvider.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Encryption/BrowserEncryptionProvider.cs
@@ -7,16 +7,28 @@ namespace Sorcha.UI.Core.Services.Encryption;
 /// <summary>
 /// Browser-based encryption provider using Web Crypto API.
 /// Persists encryption key in LocalStorage to survive page refreshes.
+/// Falls back to plaintext storage when Web Crypto is unavailable (HTTP non-localhost).
 /// </summary>
 public class BrowserEncryptionProvider : IEncryptionProvider
 {
     private const string KeyStorageKey = "sorcha:encryption-key";
+    private const string PlaintextPrefix = "plain:";
     private readonly IJSRuntime _jsRuntime;
     private string? _cachedKey;
+    private bool? _cryptoAvailable;
 
     public BrowserEncryptionProvider(IJSRuntime jsRuntime)
     {
         _jsRuntime = jsRuntime;
+    }
+
+    /// <summary>
+    /// Checks and caches whether Web Crypto API is available.
+    /// </summary>
+    private async Task<bool> IsCryptoAvailableAsync()
+    {
+        _cryptoAvailable ??= await IsAvailableAsync();
+        return _cryptoAvailable.Value;
     }
 
     /// <summary>
@@ -33,7 +45,7 @@ public class BrowserEncryptionProvider : IEncryptionProvider
 
         // Try to load existing key from LocalStorage
         var existingKey = await _jsRuntime.InvokeAsync<string?>("localStorage.getItem", KeyStorageKey);
-        
+
         if (!string.IsNullOrEmpty(existingKey))
         {
             _cachedKey = existingKey;
@@ -44,7 +56,7 @@ public class BrowserEncryptionProvider : IEncryptionProvider
         var newKey = await GenerateKeyAsync();
         await _jsRuntime.InvokeVoidAsync("localStorage.setItem", KeyStorageKey, newKey);
         _cachedKey = newKey;
-        
+
         return newKey;
     }
 
@@ -54,6 +66,12 @@ public class BrowserEncryptionProvider : IEncryptionProvider
         if (string.IsNullOrEmpty(plaintext))
         {
             throw new ArgumentException("Plaintext cannot be null or empty", nameof(plaintext));
+        }
+
+        // Fall back to plaintext when Web Crypto is unavailable (HTTP non-localhost)
+        if (!await IsCryptoAvailableAsync())
+        {
+            return PlaintextPrefix + plaintext;
         }
 
         var key = await GetOrCreateKeyAsync();
@@ -70,6 +88,12 @@ public class BrowserEncryptionProvider : IEncryptionProvider
         if (string.IsNullOrEmpty(ciphertext))
         {
             throw new ArgumentException("Ciphertext cannot be null or empty", nameof(ciphertext));
+        }
+
+        // Handle plaintext fallback values
+        if (ciphertext.StartsWith(PlaintextPrefix))
+        {
+            return ciphertext[PlaintextPrefix.Length..];
         }
 
         if (!ciphertext.Contains(':'))


### PR DESCRIPTION
## Summary

- **BrowserEncryptionProvider**: Added plaintext fallback (`plain:` prefix) when `crypto.subtle` is unavailable (HTTP non-localhost contexts). `DecryptAsync` handles both encrypted and plaintext-prefixed values.
- **CustomAuthenticationStateProvider**: Reordered `TryConsumeFragmentTokenAsync` to store token BEFORE clearing fragment staging, preventing irrecoverable token loss if store fails.

**Root cause**: `crypto.subtle` (Web Crypto API) requires a secure context (HTTPS or `localhost`). On `http://host.docker.internal`, `EncryptionHelper.generateKey()` threw, causing `StoreTokenAsync` to fail. The fragment token had already been cleared from staging, so no fallback could recover it — resulting in an infinite login redirect loop.

**Verified**: Browser MCP login test succeeded on `http://host.docker.internal`. 877 UI Core unit tests pass.

## Test plan

- [x] Login via `http://host.docker.internal` lands on dashboard (browser MCP verified)
- [x] Token stored with `plain:` prefix in localStorage
- [x] No console errors after login (only favicon 404)
- [x] 877 UI Core unit tests pass
- [ ] E2E FirstUserJourneyTests pass against Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)