### PR TITLE
feat: enhanced user profile menu with JWT viewer and modal logout

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/JwtViewerDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/JwtViewerDialog.razor
@@ -1,0 +1,252 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using System.IdentityModel.Tokens.Jwt
+@using System.Security.Claims
+
+@inject IJSRuntime JSRuntime
+@inject ISnackbar Snackbar
+
+<MudDialog Style="max-width: 700px;">
+    <TitleContent>
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudIcon Icon="@Icons.Material.Filled.Token" Color="Color.Primary" />
+            <MudText Typo="Typo.h6">Bearer Token</MudText>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        @if (_claims.Count > 0)
+        {
+            @* Identity section *@
+            <MudText Typo="Typo.overline" Color="Color.Secondary" Class="mb-1">Identity</MudText>
+            <MudSimpleTable Dense="true" Bordered="true" Class="mb-4" Style="table-layout: fixed;">
+                <tbody>
+                    @foreach (var claim in _identityClaims)
+                    {
+                        <tr>
+                            <td style="width: 160px; font-weight: 500; white-space: nowrap;">@claim.Label</td>
+                            <td style="word-break: break-all; font-family: var(--mud-typography-body2-family); font-size: 0.85rem;">@claim.Value</td>
+                        </tr>
+                    }
+                </tbody>
+            </MudSimpleTable>
+
+            @* Organisation section *@
+            @if (_orgClaims.Count > 0)
+            {
+                <MudText Typo="Typo.overline" Color="Color.Secondary" Class="mb-1">Organisation</MudText>
+                <MudSimpleTable Dense="true" Bordered="true" Class="mb-4" Style="table-layout: fixed;">
+                    <tbody>
+                        @foreach (var claim in _orgClaims)
+                        {
+                            <tr>
+                                <td style="width: 160px; font-weight: 500; white-space: nowrap;">@claim.Label</td>
+                                <td style="word-break: break-all; font-family: var(--mud-typography-body2-family); font-size: 0.85rem;">@claim.Value</td>
+                            </tr>
+                        }
+                    </tbody>
+                </MudSimpleTable>
+            }
+
+            @* Roles section *@
+            @if (_roles.Count > 0)
+            {
+                <MudText Typo="Typo.overline" Color="Color.Secondary" Class="mb-1">Roles</MudText>
+                <MudStack Row="true" Spacing="1" Class="mb-4" Wrap="Wrap.Wrap">
+                    @foreach (var role in _roles)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@role</MudChip>
+                    }
+                </MudStack>
+            }
+
+            @* Token Lifetime section *@
+            <MudText Typo="Typo.overline" Color="Color.Secondary" Class="mb-1">Token Lifetime</MudText>
+            <MudSimpleTable Dense="true" Bordered="true" Class="mb-4" Style="table-layout: fixed;">
+                <tbody>
+                    @foreach (var claim in _lifetimeClaims)
+                    {
+                        <tr>
+                            <td style="width: 160px; font-weight: 500; white-space: nowrap;">@claim.Label</td>
+                            <td style="word-break: break-all; font-family: var(--mud-typography-body2-family); font-size: 0.85rem;">@claim.Value</td>
+                        </tr>
+                    }
+                    <tr>
+                        <td style="width: 160px; font-weight: 500; white-space: nowrap;">Remaining</td>
+                        <td>
+                            @if (_timeRemaining.HasValue)
+                            {
+                                <MudChip T="string" Size="Size.Small"
+                                         Color="@(_timeRemaining.Value.TotalMinutes < 5 ? Color.Warning : Color.Success)"
+                                         Variant="Variant.Filled">
+                                    @FormatTimeRemaining(_timeRemaining.Value)
+                                </MudChip>
+                            }
+                        </td>
+                    </tr>
+                </tbody>
+            </MudSimpleTable>
+
+            @* Raw Token (collapsible) *@
+            <MudExpansionPanels Elevation="0">
+                <MudExpansionPanel Text="Raw Token" MaxHeight="200" Dense="true">
+                    <div style="word-break: break-all; font-family: monospace; font-size: 0.75rem; line-height: 1.4; padding: 8px; background: var(--mud-palette-background-grey); border-radius: 4px; max-height: 180px; overflow: auto;">
+                        @AccessToken
+                    </div>
+                    <MudButton OnClick="CopyRawToken"
+                               Variant="Variant.Text"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.ContentCopy"
+                               Class="mt-2">
+                        Copy Token
+                    </MudButton>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Warning">No token available or token could not be decoded.</MudAlert>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Variant="Variant.Text">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter]
+    public string? AccessToken { get; set; }
+
+    private record ClaimDisplay(string Label, string Value);
+
+    private List<Claim> _claims = [];
+    private List<ClaimDisplay> _identityClaims = [];
+    private List<ClaimDisplay> _orgClaims = [];
+    private List<ClaimDisplay> _lifetimeClaims = [];
+    private List<string> _roles = [];
+    private TimeSpan? _timeRemaining;
+
+    // Known claim types to friendly labels
+    private static readonly Dictionary<string, string> ClaimLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["sub"] = "Subject",
+        ["name"] = "Display Name",
+        ["email"] = "Email",
+        ["jti"] = "Token ID",
+        ["token_type"] = "Token Type",
+        ["platform_user_id"] = "Platform User",
+        ["org_id"] = "Organisation ID",
+        ["org_name"] = "Organisation",
+        ["iss"] = "Issuer",
+        ["aud"] = "Audience",
+        ["iat"] = "Issued At",
+        ["nbf"] = "Not Before",
+        ["exp"] = "Expires",
+    };
+
+    private static readonly HashSet<string> IdentityClaimTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "sub", "name", "email", "platform_user_id", "token_type", "jti"
+    };
+
+    private static readonly HashSet<string> OrgClaimTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "org_id", "org_name", "delegated_user_id", "delegated_org_id"
+    };
+
+    private static readonly HashSet<string> LifetimeClaimTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "iat", "nbf", "exp", "iss", "aud"
+    };
+
+    private static readonly HashSet<string> RoleClaimTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "role", ClaimTypes.Role
+    };
+
+    protected override void OnInitialized()
+    {
+        if (string.IsNullOrEmpty(AccessToken))
+            return;
+
+        try
+        {
+            var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+            var jwt = handler.ReadJwtToken(AccessToken);
+            _claims = jwt.Claims.ToList();
+
+            _identityClaims = _claims
+                .Where(c => IdentityClaimTypes.Contains(c.Type))
+                .Select(c => new ClaimDisplay(ClaimLabels.GetValueOrDefault(c.Type, c.Type), c.Value))
+                .ToList();
+
+            _orgClaims = _claims
+                .Where(c => OrgClaimTypes.Contains(c.Type))
+                .Select(c => new ClaimDisplay(ClaimLabels.GetValueOrDefault(c.Type, c.Type), c.Value))
+                .ToList();
+
+            _roles = _claims
+                .Where(c => RoleClaimTypes.Contains(c.Type))
+                .Select(c => c.Value)
+                .Distinct()
+                .ToList();
+
+            _lifetimeClaims = _claims
+                .Where(c => LifetimeClaimTypes.Contains(c.Type))
+                .Select(c => new ClaimDisplay(
+                    ClaimLabels.GetValueOrDefault(c.Type, c.Type),
+                    FormatClaimValue(c.Type, c.Value)))
+                .ToList();
+
+            if (jwt.ValidTo > DateTime.MinValue)
+            {
+                _timeRemaining = jwt.ValidTo - DateTime.UtcNow;
+            }
+        }
+        catch
+        {
+            // Token decode failure — _claims stays empty, UI shows warning
+        }
+    }
+
+    private static string FormatClaimValue(string type, string value)
+    {
+        if (type is "iat" or "nbf" or "exp" && long.TryParse(value, out var epoch))
+        {
+            var dt = DateTimeOffset.FromUnixTimeSeconds(epoch);
+            return $"{dt.LocalDateTime:yyyy-MM-dd HH:mm:ss} ({value})";
+        }
+
+        return value;
+    }
+
+    private static string FormatTimeRemaining(TimeSpan ts)
+    {
+        if (ts.TotalSeconds <= 0) return "Expired";
+        if (ts.TotalMinutes < 1) return $"{ts.Seconds}s";
+        if (ts.TotalHours < 1) return $"{ts.Minutes}m {ts.Seconds}s";
+        return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+    }
+
+    private async Task CopyRawToken()
+    {
+        try
+        {
+            var success = await JSRuntime.InvokeAsync<bool>("clipboardInterop.copyText", AccessToken);
+            Snackbar.Add(success ? "Token copied to clipboard" : "Failed to copy", success ? Severity.Success : Severity.Error,
+                config => config.VisibleStateDuration = 2000);
+        }
+        catch
+        {
+            Snackbar.Add("Failed to copy to clipboard", Severity.Error);
+        }
+    }
+
+    private void Close()
+    {
+        MudDialog.Cancel();
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/LogoutConfirmDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/LogoutConfirmDialog.razor
@@ -1,0 +1,87 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using Sorcha.UI.Core.Services.Authentication
+@using Sorcha.UI.Core.Services.Configuration
+
+@inject IAuthenticationService AuthService
+@inject IConfigurationService ConfigurationService
+@inject CustomAuthenticationStateProvider AuthStateProvider
+@inject NavigationManager Navigation
+
+<MudDialog>
+    <TitleContent>
+        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+            <MudIcon Icon="@Icons.Material.Filled.Logout" Color="Color.Warning" />
+            <MudText Typo="Typo.h6">Sign Out</MudText>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <MudText Typo="Typo.body1" Class="mb-2">
+            Are you sure you want to sign out@(_orgName is not null ? $" from {_orgName}" : "")?
+        </MudText>
+        <MudText Typo="Typo.body2" Color="Color.Secondary">
+            Your session tokens will be cleared and you will be redirected to the login page.
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Variant="Variant.Text">Cancel</MudButton>
+        <MudButton OnClick="ConfirmLogout"
+                   Variant="Variant.Filled"
+                   Color="Color.Error"
+                   Disabled="_isLoggingOut"
+                   StartIcon="@Icons.Material.Filled.Logout">
+            @if (_isLoggingOut)
+            {
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                <span>Signing out...</span>
+            }
+            else
+            {
+                <span>Sign Out</span>
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter]
+    public string? OrgName { get; set; }
+
+    private string? _orgName;
+    private bool _isLoggingOut;
+
+    protected override void OnInitialized()
+    {
+        _orgName = OrgName;
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    private async Task ConfirmLogout()
+    {
+        _isLoggingOut = true;
+
+        try
+        {
+            var profileName = await ConfigurationService.GetActiveProfileNameAsync();
+            await AuthService.LogoutAsync(profileName);
+            AuthStateProvider.NotifyAuthenticationStateChanged();
+            MudDialog.Close(DialogResult.Ok(true));
+            Navigation.NavigateTo("/auth/login", forceLoad: true);
+        }
+        catch
+        {
+            // Even if logout fails, clear state and redirect
+            AuthStateProvider.NotifyAuthenticationStateChanged();
+            MudDialog.Close(DialogResult.Ok(true));
+            Navigation.NavigateTo("/auth/login", forceLoad: true);
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/UserProfileMenu.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/UserProfileMenu.razor
@@ -1,0 +1,163 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using System.IdentityModel.Tokens.Jwt
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Components.Authorization
+@using Sorcha.UI.Core.Services.Authentication
+@using Sorcha.UI.Core.Services.Configuration
+
+@inject AuthenticationStateProvider AuthStateProvider
+@inject ITokenCache TokenCache
+@inject IConfigurationService ConfigurationService
+@inject IDialogService DialogService
+@inject NavigationManager Navigation
+@inject ILocalizationService Loc
+
+<MudMenu Icon="@Icons.Material.Filled.AccountCircle" Color="Color.Inherit"
+         AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
+    <MudMenuItem>
+        <div class="d-flex align-center gap-3 py-2 px-1" style="min-width: 240px;">
+            <MudAvatar Color="Color.Primary" Size="Size.Medium">
+                @GetInitials()
+            </MudAvatar>
+            <div class="d-flex flex-column" style="min-width: 0;">
+                <MudText Typo="Typo.body1" Style="font-weight: 600;">
+                    @(_displayName ?? "User")
+                </MudText>
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                    @(_email ?? "")
+                </MudText>
+                @if (!string.IsNullOrEmpty(_orgName))
+                {
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mt-1">
+                        <MudIcon Icon="@Icons.Material.Filled.Business" Size="Size.Small" Color="Color.Secondary" />
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@_orgName</MudText>
+                    </MudStack>
+                }
+                @if (!string.IsNullOrEmpty(_role))
+                {
+                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined" Class="mt-1"
+                             Style="height: 20px; font-size: 0.7rem;">
+                        @_role
+                    </MudChip>
+                }
+            </div>
+        </div>
+    </MudMenuItem>
+    <MudDivider />
+    <MudMenuItem Icon="@Icons.Material.Filled.Token" OnClick="OpenJwtViewer">
+        View Token
+    </MudMenuItem>
+    <MudMenuItem Icon="@Icons.Material.Filled.Settings" OnClick="@(() => Navigation.NavigateTo("settings"))">
+        @Loc.T("nav.settings")
+    </MudMenuItem>
+    <MudDivider />
+    <MudMenuItem Icon="@Icons.Material.Filled.Logout" IconColor="Color.Error" OnClick="OpenLogoutDialog">
+        @Loc.T("nav.logout")
+    </MudMenuItem>
+</MudMenu>
+
+@code {
+    private string? _displayName;
+    private string? _email;
+    private string? _orgName;
+    private string? _role;
+    private string? _accessToken;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadUserInfoAsync();
+    }
+
+    private async Task LoadUserInfoAsync()
+    {
+        try
+        {
+            var profileName = await ConfigurationService.GetActiveProfileNameAsync();
+            var entry = await TokenCache.GetTokenAsync(profileName);
+
+            if (entry is null || entry.IsExpired)
+                return;
+
+            _accessToken = entry.AccessToken;
+
+            var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+            var jwt = handler.ReadJwtToken(entry.AccessToken);
+            var claims = jwt.Claims.ToList();
+
+            _displayName = claims.FirstOrDefault(c => c.Type == "name")?.Value;
+            _email = claims.FirstOrDefault(c => c.Type == "email")?.Value;
+            _orgName = claims.FirstOrDefault(c => c.Type == "org_name")?.Value;
+
+            var roles = claims
+                .Where(c => c.Type is "role" || c.Type == ClaimTypes.Role)
+                .Select(c => c.Value)
+                .ToList();
+            _role = roles.Count > 0 ? string.Join(", ", roles) : null;
+
+            // Fall back to sub if no display name
+            _displayName ??= claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+        }
+        catch
+        {
+            // Resilience: profile menu is non-critical
+        }
+    }
+
+    private string GetInitials()
+    {
+        if (string.IsNullOrWhiteSpace(_displayName))
+            return "?";
+
+        var parts = _displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2
+            ? $"{parts[0][0]}{parts[1][0]}".ToUpperInvariant()
+            : _displayName[..1].ToUpperInvariant();
+    }
+
+    private async Task OpenJwtViewer()
+    {
+        // Re-fetch token in case it was refreshed
+        try
+        {
+            var profileName = await ConfigurationService.GetActiveProfileNameAsync();
+            var entry = await TokenCache.GetTokenAsync(profileName);
+            _accessToken = entry?.AccessToken;
+        }
+        catch
+        {
+            // Use last known token
+        }
+
+        var parameters = new DialogParameters<JwtViewerDialog>
+        {
+            { x => x.AccessToken, _accessToken }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true,
+            CloseOnEscapeKey = true
+        };
+
+        await DialogService.ShowAsync<JwtViewerDialog>("Bearer Token", parameters, options);
+    }
+
+    private async Task OpenLogoutDialog()
+    {
+        var parameters = new DialogParameters<LogoutConfirmDialog>
+        {
+            { x => x.OrgName, _orgName }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Small,
+            CloseOnEscapeKey = true
+        };
+
+        await DialogService.ShowAsync<LogoutConfirmDialog>("Sign Out", parameters, options);
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 @using MudBlazor
 @using Sorcha.UI.Core.Services.Authentication
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Components.Shared
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
 @inject ITokenRefreshService TokenRefreshService
@@ -40,21 +41,7 @@
                         <MudBadge Content="@_unreadCount" Color="Color.Error" Overlap="true" />
                     }
                 </MudIconButton>
-                <MudMenu Icon="@Icons.Material.Filled.AccountCircle" Color="Color.Inherit" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
-                    <MudMenuItem>
-                        <div class="d-flex flex-column py-2 px-3">
-                            <MudText Typo="Typo.body2" Color="Color.Primary">@context.User.Identity?.Name</MudText>
-                            <MudText Typo="Typo.caption" Class="mt-1">@GetUserRole(context)</MudText>
-                        </div>
-                    </MudMenuItem>
-                    <MudDivider />
-                    <MudMenuItem Icon="@Icons.Material.Filled.Settings" OnClick="@(() => Navigation.NavigateTo("settings"))">
-                        @Loc.T("nav.settings")
-                    </MudMenuItem>
-                    <MudMenuItem Icon="@Icons.Material.Filled.Logout" OnClick="@HandleLogout">
-                        @Loc.T("nav.logout")
-                    </MudMenuItem>
-                </MudMenu>
+                <UserProfileMenu />
             </Authorized>
             <NotAuthorized>
                 <MudButton OnClick="@(() => Navigation.NavigateTo("/auth/login", forceLoad: true))" Variant="Variant.Text" Color="Color.Inherit" StartIcon="@Icons.Material.Filled.Login">
@@ -345,18 +332,6 @@
     private void ToggleDrawer()
     {
         _drawerOpen = !_drawerOpen;
-    }
-
-    private string GetUserRole(AuthenticationState authState)
-    {
-        var roleClaim = authState.User.Claims.FirstOrDefault(c => c.Type == System.Security.Claims.ClaimTypes.Role);
-        return roleClaim?.Value ?? "User";
-    }
-
-    private void HandleLogout()
-    {
-        // Navigate to logout page using relative path
-        Navigation.NavigateTo("auth/logout", forceLoad: false);
     }
 
     private void ToggleActivityLog()


### PR DESCRIPTION
## Summary
- Replaced minimal profile dropdown with rich `UserProfileMenu` showing avatar, display name, email, org name, and role chip
- Added `JwtViewerDialog` modal for token inspection — categorised claims (identity, org, roles, lifetime), countdown timer, raw token copy
- Added `LogoutConfirmDialog` modal that clears tokens client-side instead of redirecting to external logout page
- Extracted all profile logic from `MainLayout` into dedicated component

## Test plan
- [ ] Click profile icon — verify avatar, name, email, org, role displayed
- [ ] Click "View Token" — verify JWT claims grouped correctly, lifetime countdown visible
- [ ] Click "Copy Token" in raw section — verify clipboard works
- [ ] Click "Logout" — verify confirmation dialog appears, confirm clears session and redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)