### PR TITLE
fix: rewrite problem section as opportunity with data journey diagram

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -142,40 +142,139 @@
     </section>
 
     <!-- ============================================================ -->
-    <!-- SECTION 2: THE PROBLEM — What's broken today                 -->
+    <!-- SECTION 2: THE OPPORTUNITY                                   -->
     <!-- ============================================================ -->
-    <section id="why" class="problem-section">
+    <section id="why" class="opportunity-section">
         <div class="container">
-            <div class="section-badge">The Problem</div>
-            <h2 class="section-title">Multi-Party Processes Are Broken</h2>
+            <div class="section-badge">The Opportunity</div>
+            <h2 class="section-title">You Already Share Sensitive Data Across Boundaries</h2>
             <p class="section-subtitle">
-                Every time organisations share data across boundaries, they accept risks
-                that no contract or NDA can truly eliminate.
+                Purchase orders, patient referrals, compliance reports, credentials —
+                your most valuable data crosses organisational lines every day.
+                What if every exchange was provable, private, and permanent?
             </p>
-            <div class="comparison-table">
-                <div class="comparison-col comparison-without">
-                    <div class="comparison-header">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg>
-                        Without Sorcha
+
+            <!-- Data Journey Diagram -->
+            <div class="journey-diagram">
+                <div class="journey-label">How data moves between organisations today</div>
+                <div class="journey-flow">
+                    <div class="journey-org">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>
+                        </div>
+                        <span class="journey-org-name">Your Organisation</span>
                     </div>
-                    <div class="comparison-item">You share <strong>entire documents</strong> when the recipient only needs three fields</div>
-                    <div class="comparison-item">You <strong>can't prove</strong> who changed what, or when</div>
-                    <div class="comparison-item">A single compromised system <strong>exposes everything</strong></div>
-                    <div class="comparison-item">Auditors ask for records and you <strong>hope they still exist</strong></div>
-                    <div class="comparison-item">Compliance is a <strong>manual checkbox exercise</strong></div>
-                    <div class="comparison-item">You need <strong>expensive intermediaries</strong> to establish trust</div>
+
+                    <div class="journey-gap">
+                        <div class="journey-gap-line"></div>
+                        <div class="journey-gap-risk">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                            Who sees what?
+                        </div>
+                    </div>
+
+                    <div class="journey-org">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                        </div>
+                        <span class="journey-org-name">Partner</span>
+                    </div>
+
+                    <div class="journey-gap">
+                        <div class="journey-gap-line"></div>
+                        <div class="journey-gap-risk">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                            Did they change it?
+                        </div>
+                    </div>
+
+                    <div class="journey-org">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                        </div>
+                        <span class="journey-org-name">Regulator</span>
+                    </div>
                 </div>
-                <div class="comparison-col comparison-with">
-                    <div class="comparison-header">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4"/></svg>
-                        With Sorcha
+
+                <!-- Protected journey -->
+                <div class="journey-protected-label">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+                    The same journey, with Sorcha
+                </div>
+                <div class="journey-flow journey-flow-protected">
+                    <div class="journey-org journey-org-protected">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>
+                        </div>
+                        <span class="journey-org-name">Your Organisation</span>
                     </div>
-                    <div class="comparison-item">Each party sees <strong>only the fields they're authorised</strong> to access</div>
-                    <div class="comparison-item">Every action is <strong>cryptographically signed</strong> and timestamped</div>
-                    <div class="comparison-item">Data is <strong>encrypted per-field</strong> — breach of one system reveals nothing</div>
-                    <div class="comparison-item">Records are <strong>immutable and replicated</strong> — they cannot be lost or altered</div>
-                    <div class="comparison-item">Compliance is <strong>built into the workflow</strong> — every step is auditable by design</div>
-                    <div class="comparison-item"><strong>Cryptographic trust</strong> replaces institutional trust — no middleman needed</div>
+
+                    <div class="journey-gap journey-gap-protected">
+                        <div class="journey-gap-line journey-gap-line-protected"></div>
+                        <div class="journey-gap-solution">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                            Selective disclosure
+                        </div>
+                    </div>
+
+                    <div class="journey-org journey-org-protected">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                        </div>
+                        <span class="journey-org-name">Partner</span>
+                    </div>
+
+                    <div class="journey-gap journey-gap-protected">
+                        <div class="journey-gap-line journey-gap-line-protected"></div>
+                        <div class="journey-gap-solution">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                            Signed &amp; immutable
+                        </div>
+                    </div>
+
+                    <div class="journey-org journey-org-protected">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                        </div>
+                        <span class="journey-org-name">Regulator</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Risk/Opportunity Cards -->
+            <div class="risk-grid">
+                <div class="risk-card">
+                    <div class="risk-scenario">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                        Data gets shared more broadly than intended
+                    </div>
+                    <p class="risk-context">You send a spreadsheet to a partner. They only need three columns, but they can see all twenty. Every forwarded email, every shared drive link — it widens the exposure.</p>
+                    <div class="risk-pivot">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                        Field-level disclosure means each party sees only their authorised view. The data itself enforces the boundary — not a policy document.
+                    </div>
+                </div>
+                <div class="risk-card">
+                    <div class="risk-scenario">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                        You can't prove who changed what, or when
+                    </div>
+                    <p class="risk-context">A supplier disputes the terms. A regulator asks for the original. Version control says "last modified by: unknown". The audit trail is a folder of attachments with no chain of custody.</p>
+                    <div class="risk-pivot">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                        Every action is cryptographically signed by the participant's wallet and hash-linked into an immutable chain. The maths proves it.
+                    </div>
+                </div>
+                <div class="risk-card">
+                    <div class="risk-scenario">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                        Records disappear when you need them most
+                    </div>
+                    <p class="risk-context">A server fails. A retention policy expires. A departing employee deletes a mailbox. The records you need for a dispute, an audit, or a compliance review are gone — and no one noticed until it mattered.</p>
+                    <div class="risk-pivot">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                        Peer-to-peer replication across the network means records are immutable and distributed. No single failure can destroy them.
+                    </div>
                 </div>
             </div>
         </div>

--- a/docs/site/landing.css
+++ b/docs/site/landing.css
@@ -953,76 +953,229 @@ body {
     color: var(--text-light);
 }
 
-/* ==================== PROBLEM / COMPARISON ==================== */
+/* ==================== OPPORTUNITY / JOURNEY / RISK ==================== */
 
-.problem-section {
+.opportunity-section {
     padding: 100px 24px;
     background: var(--background-alt);
     text-align: center;
 }
 
-.comparison-table {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 32px;
-    max-width: 960px;
-    margin: 0 auto;
+/* Data Journey Diagram */
+.journey-diagram {
+    max-width: 800px;
+    margin: 0 auto 56px;
+    background: white;
+    border-radius: var(--radius-lg);
+    padding: 40px 32px;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--border);
 }
 
-.comparison-column {
-    text-align: left;
+.journey-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 24px;
 }
 
-.comparison-header {
+.journey-flow {
     display: flex;
     align-items: center;
-    gap: 10px;
-    font-size: 1.15rem;
-    font-weight: 700;
-    padding: 16px 20px;
-    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-    margin-bottom: 0;
+    justify-content: center;
+    gap: 0;
+    margin-bottom: 32px;
 }
 
-.comparison-header svg {
+.journey-org {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    min-width: 100px;
+}
+
+.journey-org-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--background-alt);
+    border: 2px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.journey-org-icon svg {
+    stroke: var(--text-light);
+}
+
+.journey-org-name {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.journey-gap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 120px;
+}
+
+.journey-gap-line {
+    width: 100%;
+    height: 2px;
+    background: repeating-linear-gradient(
+        90deg,
+        #e53e3e 0px, #e53e3e 6px,
+        transparent 6px, transparent 12px
+    );
+    opacity: 0.5;
+}
+
+.journey-gap-risk {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #c53030;
+    background: rgba(229, 62, 62, 0.08);
+    padding: 4px 12px;
+    border-radius: 12px;
+    white-space: nowrap;
+}
+
+.journey-gap-risk svg {
+    stroke: #c53030;
     flex-shrink: 0;
 }
 
-.comparison-without .comparison-header {
-    background: rgba(229, 62, 62, 0.08);
-    color: #c53030;
-}
-
-.comparison-with .comparison-header {
-    background: rgba(72, 187, 120, 0.08);
-    color: #276749;
-}
-
-.comparison-item {
-    background: white;
-    padding: 16px 20px;
-    border-left: 3px solid transparent;
-    margin-bottom: 1px;
-    font-size: 0.92rem;
-    line-height: 1.6;
-    color: var(--text-light);
-}
-
-.comparison-without .comparison-item {
-    border-left-color: rgba(229, 62, 62, 0.3);
-}
-
-.comparison-with .comparison-item {
-    border-left-color: rgba(72, 187, 120, 0.3);
-}
-
-.comparison-item:last-child {
-    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
-}
-
-.comparison-item strong {
-    color: var(--text);
+/* Protected journey */
+.journey-protected-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.8rem;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #276749;
+    background: rgba(72, 187, 120, 0.1);
+    padding: 6px 16px;
+    border-radius: 20px;
+    margin-bottom: 20px;
+}
+
+.journey-protected-label svg {
+    stroke: #276749;
+}
+
+.journey-flow-protected {
+    margin-bottom: 0;
+}
+
+.journey-org-protected .journey-org-icon {
+    border-color: var(--primary);
+    background: rgba(102, 126, 234, 0.06);
+}
+
+.journey-org-protected .journey-org-icon svg {
+    stroke: var(--primary);
+}
+
+.journey-gap-line-protected {
+    background: var(--primary) !important;
+    opacity: 0.4;
+}
+
+.journey-gap-solution {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #276749;
+    background: rgba(72, 187, 120, 0.08);
+    padding: 4px 12px;
+    border-radius: 12px;
+    white-space: nowrap;
+}
+
+.journey-gap-solution svg {
+    stroke: #276749;
+    flex-shrink: 0;
+}
+
+/* Risk/Opportunity Cards */
+.risk-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 28px;
+}
+
+.risk-card {
+    background: white;
+    border-radius: var(--radius-lg);
+    padding: 32px 28px;
+    text-align: left;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.risk-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow);
+}
+
+.risk-scenario {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 12px;
+    line-height: 1.3;
+}
+
+.risk-scenario svg {
+    stroke: #c53030;
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
+.risk-context {
+    font-size: 0.9rem;
+    color: var(--text-light);
+    line-height: 1.65;
+    margin-bottom: 16px;
+}
+
+.risk-pivot {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: #276749;
+    background: rgba(72, 187, 120, 0.06);
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    border-left: 3px solid #48bb78;
+    line-height: 1.5;
+}
+
+.risk-pivot svg {
+    stroke: #48bb78;
+    flex-shrink: 0;
+    margin-top: 2px;
 }
 
 /* ==================== BENEFITS ==================== */
@@ -1661,9 +1814,25 @@ body {
         grid-template-columns: 1fr;
     }
 
-    .comparison-table {
+    .risk-grid {
         grid-template-columns: 1fr;
-        gap: 24px;
+    }
+
+    .journey-flow {
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .journey-gap {
+        min-width: auto;
+        flex-direction: row;
+        min-height: 48px;
+    }
+
+    .journey-gap-line,
+    .journey-gap-line-protected {
+        width: 2px !important;
+        height: 32px;
     }
 }
 

--- a/docs/site/landing.js
+++ b/docs/site/landing.js
@@ -79,7 +79,7 @@
 
         // Animate cards and sections
         const selectors = [
-            '.comparison-col', '.benefit-card',
+            '.risk-card', '.benefit-card',
             '.dad-card', '.standard-card', '.quantum-card',
             '.sector-card', '.toolkit-card',
             '.step-card', '.tech-item',

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -140,40 +140,139 @@
     </section>
 
     <!-- ============================================================ -->
-    <!-- SECTION 2: THE PROBLEM — What's broken today                 -->
+    <!-- SECTION 2: THE OPPORTUNITY                                   -->
     <!-- ============================================================ -->
-    <section id="why" class="problem-section">
+    <section id="why" class="opportunity-section">
         <div class="container">
-            <div class="section-badge">The Problem</div>
-            <h2 class="section-title">Multi-Party Processes Are Broken</h2>
+            <div class="section-badge">The Opportunity</div>
+            <h2 class="section-title">You Already Share Sensitive Data Across Boundaries</h2>
             <p class="section-subtitle">
-                Every time organisations share data across boundaries, they accept risks
-                that no contract or NDA can truly eliminate.
+                Purchase orders, patient referrals, compliance reports, credentials —
+                your most valuable data crosses organisational lines every day.
+                What if every exchange was provable, private, and permanent?
             </p>
-            <div class="comparison-table">
-                <div class="comparison-col comparison-without">
-                    <div class="comparison-header">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M15 9l-6 6M9 9l6 6"/></svg>
-                        Without Sorcha
+
+            <!-- Data Journey Diagram -->
+            <div class="journey-diagram">
+                <div class="journey-label">How data moves between organisations today</div>
+                <div class="journey-flow">
+                    <div class="journey-org">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>
+                        </div>
+                        <span class="journey-org-name">Your Organisation</span>
                     </div>
-                    <div class="comparison-item">You share <strong>entire documents</strong> when the recipient only needs three fields</div>
-                    <div class="comparison-item">You <strong>can't prove</strong> who changed what, or when</div>
-                    <div class="comparison-item">A single compromised system <strong>exposes everything</strong></div>
-                    <div class="comparison-item">Auditors ask for records and you <strong>hope they still exist</strong></div>
-                    <div class="comparison-item">Compliance is a <strong>manual checkbox exercise</strong></div>
-                    <div class="comparison-item">You need <strong>expensive intermediaries</strong> to establish trust</div>
+
+                    <div class="journey-gap">
+                        <div class="journey-gap-line"></div>
+                        <div class="journey-gap-risk">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                            Who sees what?
+                        </div>
+                    </div>
+
+                    <div class="journey-org">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                        </div>
+                        <span class="journey-org-name">Partner</span>
+                    </div>
+
+                    <div class="journey-gap">
+                        <div class="journey-gap-line"></div>
+                        <div class="journey-gap-risk">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                            Did they change it?
+                        </div>
+                    </div>
+
+                    <div class="journey-org">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                        </div>
+                        <span class="journey-org-name">Regulator</span>
+                    </div>
                 </div>
-                <div class="comparison-col comparison-with">
-                    <div class="comparison-header">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2 4-4"/></svg>
-                        With Sorcha
+
+                <!-- Protected journey -->
+                <div class="journey-protected-label">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+                    The same journey, with Sorcha
+                </div>
+                <div class="journey-flow journey-flow-protected">
+                    <div class="journey-org journey-org-protected">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>
+                        </div>
+                        <span class="journey-org-name">Your Organisation</span>
                     </div>
-                    <div class="comparison-item">Each party sees <strong>only the fields they're authorised</strong> to access</div>
-                    <div class="comparison-item">Every action is <strong>cryptographically signed</strong> and timestamped</div>
-                    <div class="comparison-item">Data is <strong>encrypted per-field</strong> — breach of one system reveals nothing</div>
-                    <div class="comparison-item">Records are <strong>immutable and replicated</strong> — they cannot be lost or altered</div>
-                    <div class="comparison-item">Compliance is <strong>built into the workflow</strong> — every step is auditable by design</div>
-                    <div class="comparison-item"><strong>Cryptographic trust</strong> replaces institutional trust — no middleman needed</div>
+
+                    <div class="journey-gap journey-gap-protected">
+                        <div class="journey-gap-line journey-gap-line-protected"></div>
+                        <div class="journey-gap-solution">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                            Selective disclosure
+                        </div>
+                    </div>
+
+                    <div class="journey-org journey-org-protected">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                        </div>
+                        <span class="journey-org-name">Partner</span>
+                    </div>
+
+                    <div class="journey-gap journey-gap-protected">
+                        <div class="journey-gap-line journey-gap-line-protected"></div>
+                        <div class="journey-gap-solution">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                            Signed &amp; immutable
+                        </div>
+                    </div>
+
+                    <div class="journey-org journey-org-protected">
+                        <div class="journey-org-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+                        </div>
+                        <span class="journey-org-name">Regulator</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Risk/Opportunity Cards -->
+            <div class="risk-grid">
+                <div class="risk-card">
+                    <div class="risk-scenario">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                        Data gets shared more broadly than intended
+                    </div>
+                    <p class="risk-context">You send a spreadsheet to a partner. They only need three columns, but they can see all twenty. Every forwarded email, every shared drive link — it widens the exposure.</p>
+                    <div class="risk-pivot">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                        Field-level disclosure means each party sees only their authorised view. The data itself enforces the boundary — not a policy document.
+                    </div>
+                </div>
+                <div class="risk-card">
+                    <div class="risk-scenario">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                        You can't prove who changed what, or when
+                    </div>
+                    <p class="risk-context">A supplier disputes the terms. A regulator asks for the original. Version control says "last modified by: unknown". The audit trail is a folder of attachments with no chain of custody.</p>
+                    <div class="risk-pivot">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                        Every action is cryptographically signed by the participant's wallet and hash-linked into an immutable chain. The maths proves it.
+                    </div>
+                </div>
+                <div class="risk-card">
+                    <div class="risk-scenario">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                        Records disappear when you need them most
+                    </div>
+                    <p class="risk-context">A server fails. A retention policy expires. A departing employee deletes a mailbox. The records you need for a dispute, an audit, or a compliance review are gone — and no one noticed until it mattered.</p>
+                    <div class="risk-pivot">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 12l2 2 4-4"/></svg>
+                        Peer-to-peer replication across the network means records are immutable and distributed. No single failure can destroy them.
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css
@@ -953,76 +953,229 @@ body {
     color: var(--text-light);
 }
 
-/* ==================== PROBLEM / COMPARISON ==================== */
+/* ==================== OPPORTUNITY / JOURNEY / RISK ==================== */
 
-.problem-section {
+.opportunity-section {
     padding: 100px 24px;
     background: var(--background-alt);
     text-align: center;
 }
 
-.comparison-table {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 32px;
-    max-width: 960px;
-    margin: 0 auto;
+/* Data Journey Diagram */
+.journey-diagram {
+    max-width: 800px;
+    margin: 0 auto 56px;
+    background: white;
+    border-radius: var(--radius-lg);
+    padding: 40px 32px;
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--border);
 }
 
-.comparison-column {
-    text-align: left;
+.journey-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 24px;
 }
 
-.comparison-header {
+.journey-flow {
     display: flex;
     align-items: center;
-    gap: 10px;
-    font-size: 1.15rem;
-    font-weight: 700;
-    padding: 16px 20px;
-    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-    margin-bottom: 0;
+    justify-content: center;
+    gap: 0;
+    margin-bottom: 32px;
 }
 
-.comparison-header svg {
+.journey-org {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    min-width: 100px;
+}
+
+.journey-org-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--background-alt);
+    border: 2px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.journey-org-icon svg {
+    stroke: var(--text-light);
+}
+
+.journey-org-name {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.journey-gap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 120px;
+}
+
+.journey-gap-line {
+    width: 100%;
+    height: 2px;
+    background: repeating-linear-gradient(
+        90deg,
+        #e53e3e 0px, #e53e3e 6px,
+        transparent 6px, transparent 12px
+    );
+    opacity: 0.5;
+}
+
+.journey-gap-risk {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #c53030;
+    background: rgba(229, 62, 62, 0.08);
+    padding: 4px 12px;
+    border-radius: 12px;
+    white-space: nowrap;
+}
+
+.journey-gap-risk svg {
+    stroke: #c53030;
     flex-shrink: 0;
 }
 
-.comparison-without .comparison-header {
-    background: rgba(229, 62, 62, 0.08);
-    color: #c53030;
-}
-
-.comparison-with .comparison-header {
-    background: rgba(72, 187, 120, 0.08);
-    color: #276749;
-}
-
-.comparison-item {
-    background: white;
-    padding: 16px 20px;
-    border-left: 3px solid transparent;
-    margin-bottom: 1px;
-    font-size: 0.92rem;
-    line-height: 1.6;
-    color: var(--text-light);
-}
-
-.comparison-without .comparison-item {
-    border-left-color: rgba(229, 62, 62, 0.3);
-}
-
-.comparison-with .comparison-item {
-    border-left-color: rgba(72, 187, 120, 0.3);
-}
-
-.comparison-item:last-child {
-    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
-}
-
-.comparison-item strong {
-    color: var(--text);
+/* Protected journey */
+.journey-protected-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.8rem;
     font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #276749;
+    background: rgba(72, 187, 120, 0.1);
+    padding: 6px 16px;
+    border-radius: 20px;
+    margin-bottom: 20px;
+}
+
+.journey-protected-label svg {
+    stroke: #276749;
+}
+
+.journey-flow-protected {
+    margin-bottom: 0;
+}
+
+.journey-org-protected .journey-org-icon {
+    border-color: var(--primary);
+    background: rgba(102, 126, 234, 0.06);
+}
+
+.journey-org-protected .journey-org-icon svg {
+    stroke: var(--primary);
+}
+
+.journey-gap-line-protected {
+    background: var(--primary) !important;
+    opacity: 0.4;
+}
+
+.journey-gap-solution {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #276749;
+    background: rgba(72, 187, 120, 0.08);
+    padding: 4px 12px;
+    border-radius: 12px;
+    white-space: nowrap;
+}
+
+.journey-gap-solution svg {
+    stroke: #276749;
+    flex-shrink: 0;
+}
+
+/* Risk/Opportunity Cards */
+.risk-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 28px;
+}
+
+.risk-card {
+    background: white;
+    border-radius: var(--radius-lg);
+    padding: 32px 28px;
+    text-align: left;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.risk-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow);
+}
+
+.risk-scenario {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--text);
+    margin-bottom: 12px;
+    line-height: 1.3;
+}
+
+.risk-scenario svg {
+    stroke: #c53030;
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
+.risk-context {
+    font-size: 0.9rem;
+    color: var(--text-light);
+    line-height: 1.65;
+    margin-bottom: 16px;
+}
+
+.risk-pivot {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    font-size: 0.88rem;
+    font-weight: 500;
+    color: #276749;
+    background: rgba(72, 187, 120, 0.06);
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    border-left: 3px solid #48bb78;
+    line-height: 1.5;
+}
+
+.risk-pivot svg {
+    stroke: #48bb78;
+    flex-shrink: 0;
+    margin-top: 2px;
 }
 
 /* ==================== BENEFITS ==================== */
@@ -1661,9 +1814,25 @@ body {
         grid-template-columns: 1fr;
     }
 
-    .comparison-table {
+    .risk-grid {
         grid-template-columns: 1fr;
-        gap: 24px;
+    }
+
+    .journey-flow {
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .journey-gap {
+        min-width: auto;
+        flex-direction: row;
+        min-height: 48px;
+    }
+
+    .journey-gap-line,
+    .journey-gap-line-protected {
+        width: 2px !important;
+        height: 32px;
     }
 }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.js
@@ -79,7 +79,7 @@
 
         // Animate cards and sections
         const selectors = [
-            '.comparison-col', '.benefit-card',
+            '.risk-card', '.benefit-card',
             '.dad-card', '.standard-card', '.quantum-card',
             '.sector-card', '.toolkit-card',
             '.step-card', '.tech-item',


### PR DESCRIPTION
## Summary
- Replaced negative "Multi-Party Processes Are Broken" comparison table with opportunity-focused approach
- New "You Already Share Sensitive Data Across Boundaries" framing
- Added data journey diagram: trust gaps between orgs (dashed red) → same flow with Sorcha protections (solid blue/green)
- Three risk/opportunity cards with relatable business scenarios and green-highlighted solution pivots
- Synced to both GitHub Pages (`docs/site/`) and Blazor UI (`wwwroot/`)

## Test plan
- [ ] Visit http://localhost/ — verify new opportunity section renders
- [ ] Check data journey diagram layout (horizontal on desktop, stacks on mobile)
- [ ] Verify risk cards show scenario → context → pivot with green left border
- [ ] Test responsive: 768px and below should stack journey vertically and risk cards to 1-col

🤖 Generated with [Claude Code](https://claude.com/claude-code)