### PR TITLE
chore: bump GitHub Pages actions to Node.js 24

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,15 +27,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/site
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6 (Node.js 24)
- Bump `actions/upload-pages-artifact` v3 → v4 (Node.js 24) with `include-hidden-files: true` to preserve `.nojekyll`
- `configure-pages@v5` and `deploy-pages@v4` already current

Addresses the Node.js 20 deprecation warning (enforced June 2, 2026).

## Test plan
- [ ] Merge and verify GitHub Pages deployment succeeds
- [ ] Confirm `www.sorcha.dev` still serves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)