### PR TITLE
infra: N1 VM deployment config and scripts

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Docker Compose override for n1.sorcha.dev debug deployment
+# Usage: docker compose -f docker-compose.yml -f docker-compose.n1.yml up -d
+#
+# This override:
+# - Sets INSTALLATION_NAME to n1.sorcha.dev (JWT issuer/audience)
+# - Pulls pre-built images from DockerHub (sorchadev/*)
+# - Configures peer service identity as n1.sorcha.dev
+# - SSL handled by Caddy installed on the host (not in Docker)
+
+x-jwt-env: &jwt-env
+  JwtSettings__InstallationName: n1.sorcha.dev
+  JwtSettings__SigningKey: ${JWT_SIGNING_KEY:-c29yY2hhLW4xLXNvcmNoYS1kZXYta2V5LTIwMjYtbWluLTI1Ni1iaXRzLXNlY3VyZQ==}
+
+services:
+  # ===========================
+  # Application Services - override JWT and peer config
+  # ===========================
+
+  blueprint-service:
+    image: sorchadev/blueprint-service:latest
+    environment:
+      <<: *jwt-env
+      AIProvider__ApiKey: ${ANTHROPIC_API_KEY:-}
+
+  wallet-service:
+    image: sorchadev/wallet-service:latest
+    environment:
+      <<: *jwt-env
+
+  register-service:
+    image: sorchadev/register-service:latest
+    environment:
+      <<: *jwt-env
+
+  tenant-service:
+    image: sorchadev/tenant-service:latest
+    environment:
+      <<: *jwt-env
+
+  peer-service:
+    image: sorchadev/peer-service:latest
+    environment:
+      <<: *jwt-env
+      PeerService__NodeId: n1.sorcha.dev
+      PeerService__PublicAddress: ${N1_PUBLIC_IP:-n1.sorcha.dev}
+
+  validator-service:
+    image: sorchadev/validator-service:latest
+    environment:
+      <<: *jwt-env
+
+  sorcha-ui-web:
+    image: sorchadev/ui-web:latest
+
+  api-gateway:
+    image: sorchadev/api-gateway:latest
+    ports:
+      - "8880:8080"    # Internal only - Caddy on host handles 80/443
+    environment:
+      <<: *jwt-env
+      Dashboard__AspireDashboardUrl: https://n1.sorcha.dev:18888
+      # Disable HTTPS on gateway - Caddy handles TLS
+      ASPNETCORE_URLS: http://+:8080

--- a/docker-compose.ports.yml
+++ b/docker-compose.ports.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Port override for n1.sorcha.dev - moves API Gateway off 80/443
+# so Caddy can handle TLS termination with Let's Encrypt
+# Usage: docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml up -d
+
+services:
+  api-gateway:
+    ports: !override
+      - "8880:8080"

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,18 @@
+n1.sorcha.dev {
+	# Automatic HTTPS via Let's Encrypt
+	# Caddy handles certificate provisioning and renewal
+
+	# Proxy all traffic to the API Gateway
+	reverse_proxy api-gateway:8080
+
+	# Aspire dashboard on subdomain path
+	handle_path /aspire/* {
+		reverse_proxy aspire-dashboard:18888
+	}
+
+	# Logging
+	log {
+		output stdout
+		format console
+	}
+}

--- a/infra/n1-params.json
+++ b/infra/n1-params.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroupName": { "value": "sorcha-n1" },
+    "location": { "value": "uksouth" },
+    "vmSize": { "value": "Standard_B2as_v2" },
+    "adminUsername": { "value": "sorcha" },
+    "sshPublicKey": { "value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKNWI5kaFRzw0Pl69WBc7X00AtxQzuQbXzcjsM0BQDYCR64Fb3Be3GZ7cT4oqK4ZtHa7TAL74QO27cFxOW3fSOeDhfr9EWH4Kdq3m62hmdVD/CnjOsRk9LJT27+Zmn/nu+eW//PtCQnRrOVE7VtUmDVGcZ+fs+JolA+fwS/bs8SnT+1rB9k7UjJvoXjnA7VxrGlWnTzGIuzjGZYW3nuYcFQjp333iMPsYR+BS/RZpOC8LsIPwDWaxlSXaRxJtQcyrE6OoZZXEXRWRbI5d29roJt1/767DhVLDFEX1kp+r0YwUx9Ibgj89QSay6qLUjyOHX9l2H/Jja3WmGt2CAE6lR" },
+    "allowedSshCidr": { "value": "92.40.195.17/32" }
+  }
+}

--- a/infra/n1-vm-resources.bicep
+++ b/infra/n1-vm-resources.bicep
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// Azure VM resources for Sorcha n1 debug node
+// Creates: NSG, VNet, Public IP, NIC, VM with cloud-init
+
+@description('Azure region')
+param location string
+
+@description('VM admin username')
+param adminUsername string
+
+@description('SSH public key')
+@secure()
+param sshPublicKey string
+
+@description('VM size')
+param vmSize string
+
+@description('Allowed SSH CIDR')
+param allowedSshCidr string
+
+@description('Resource tags')
+param tags object
+
+// ============================================================================
+// Network Security Group
+// ============================================================================
+resource nsg 'Microsoft.Network/networkSecurityGroups@2024-01-01' = {
+  name: 'sorcha-n1-nsg'
+  location: location
+  tags: tags
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowSSH'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: allowedSshCidr
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+        }
+      }
+      {
+        name: 'AllowHTTP'
+        properties: {
+          priority: 200
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '80'
+        }
+      }
+      {
+        name: 'AllowHTTPS'
+        properties: {
+          priority: 210
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '443'
+        }
+      }
+      {
+        name: 'AllowAspireDashboard'
+        properties: {
+          priority: 300
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: allowedSshCidr
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '18888'
+        }
+      }
+      {
+        name: 'AllowPeerGrpc'
+        properties: {
+          priority: 310
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '50051'
+        }
+      }
+    ]
+  }
+}
+
+// ============================================================================
+// Virtual Network
+// ============================================================================
+resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
+  name: 'sorcha-n1-vnet'
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: 'default'
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          networkSecurityGroup: {
+            id: nsg.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+// ============================================================================
+// Public IP Address (Static for DNS)
+// ============================================================================
+resource publicIp 'Microsoft.Network/publicIPAddresses@2024-01-01' = {
+  name: 'sorcha-n1-pip'
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    dnsSettings: {
+      domainNameLabel: 'sorcha-n1'
+    }
+  }
+}
+
+// ============================================================================
+// Network Interface
+// ============================================================================
+resource nic 'Microsoft.Network/networkInterfaces@2024-01-01' = {
+  name: 'sorcha-n1-nic'
+  location: location
+  tags: tags
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: publicIp.id
+          }
+          subnet: {
+            id: vnet.properties.subnets[0].id
+          }
+        }
+      }
+    ]
+  }
+}
+
+// ============================================================================
+// Cloud-init script (installs Docker + sets up Sorcha directory)
+// ============================================================================
+var cloudInitTemplate = '''
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+  - jq
+  - htop
+
+runcmd:
+  # Install Docker CE
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable" > /etc/apt/sources.list.d/docker.list
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  # Add admin user to docker group
+  - usermod -aG docker __ADMIN_USER__
+  # Create Sorcha working directory
+  - mkdir -p /opt/sorcha
+  - chown __ADMIN_USER__:__ADMIN_USER__ /opt/sorcha
+  # Create data directories
+  - mkdir -p /opt/sorcha/data
+  - chown __ADMIN_USER__:__ADMIN_USER__ /opt/sorcha/data
+  # Enable and start Docker
+  - systemctl enable docker
+  - systemctl start docker
+  # Signal that cloud-init is done
+  - touch /opt/sorcha/.cloud-init-complete
+
+final_message: "Sorcha n1 VM ready"
+'''
+var cloudInit = replace(cloudInitTemplate, '__ADMIN_USER__', adminUsername)
+
+// ============================================================================
+// Virtual Machine
+// ============================================================================
+resource vm 'Microsoft.Compute/virtualMachines@2024-07-01' = {
+  name: 'sorcha-n1-vm'
+  location: location
+  tags: tags
+  properties: {
+    hardwareProfile: {
+      vmSize: vmSize
+    }
+    osProfile: {
+      computerName: 'sorcha-n1'
+      adminUsername: adminUsername
+      linuxConfiguration: {
+        disablePasswordAuthentication: true
+        ssh: {
+          publicKeys: [
+            {
+              path: '/home/${adminUsername}/.ssh/authorized_keys'
+              keyData: sshPublicKey
+            }
+          ]
+        }
+      }
+      customData: base64(cloudInit)
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'Canonical'
+        offer: 'ubuntu-24_04-lts'
+        sku: 'server'
+        version: 'latest'
+      }
+      osDisk: {
+        name: 'sorcha-n1-osdisk'
+        createOption: 'FromImage'
+        diskSizeGB: 30
+        managedDisk: {
+          storageAccountType: 'Premium_LRS'
+        }
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nic.id
+        }
+      ]
+    }
+    diagnosticsProfile: {
+      bootDiagnostics: {
+        enabled: true
+      }
+    }
+  }
+}
+
+// ============================================================================
+// Auto-shutdown schedule (save costs - off overnight)
+// ============================================================================
+resource autoShutdown 'Microsoft.DevTestLab/schedules@2018-09-15' = {
+  name: 'shutdown-computevm-${vm.name}'
+  location: location
+  tags: tags
+  properties: {
+    status: 'Enabled'
+    taskType: 'ComputeVmShutdownTask'
+    dailyRecurrence: {
+      time: '2300' // 11 PM UTC (11 PM GMT)
+    }
+    timeZoneId: 'GMT Standard Time'
+    targetResourceId: vm.id
+    notificationSettings: {
+      status: 'Disabled'
+    }
+  }
+}
+
+// ============================================================================
+// Outputs
+// ============================================================================
+output publicIpAddress string = publicIp.properties.ipAddress
+output vmFqdn string = publicIp.properties.dnsSettings.fqdn
+output vmName string = vm.name
+output vmId string = vm.id

--- a/infra/n1-vm.bicep
+++ b/infra/n1-vm.bicep
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// Azure VM deployment for Sorcha n1.sorcha.dev debug node
+// Single VM running docker-compose with all services
+// Estimated cost: ~$55/month (B2as_v2 + static IP + disk)
+
+targetScope = 'subscription'
+
+@description('Azure region for resources')
+param location string = 'uksouth'
+
+@description('Resource group name')
+param resourceGroupName string = 'sorcha-n1'
+
+@description('VM admin username')
+param adminUsername string = 'sorcha'
+
+@description('SSH public key for VM access')
+@secure()
+param sshPublicKey string
+
+@description('VM size - B2as_v2 (2 vCPU, 8GB RAM, AMD) is cheapest for 8GB')
+param vmSize string = 'Standard_B2as_v2'
+
+@description('Your public IP for SSH access (CIDR notation, e.g. 203.0.113.50/32)')
+param allowedSshCidr string
+
+@description('Tags for all resources')
+param tags object = {
+  Environment: 'dev'
+  Application: 'Sorcha'
+  Node: 'n1'
+  ManagedBy: 'Bicep'
+}
+
+// Resource Group
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+  tags: tags
+}
+
+// Deploy all resources into the resource group
+module vmResources 'n1-vm-resources.bicep' = {
+  scope: rg
+  name: 'n1-vm-resources'
+  params: {
+    location: location
+    adminUsername: adminUsername
+    sshPublicKey: sshPublicKey
+    vmSize: vmSize
+    allowedSshCidr: allowedSshCidr
+    tags: tags
+  }
+}
+
+// Outputs
+output resourceGroupName string = rg.name
+output vmPublicIp string = vmResources.outputs.publicIpAddress
+output vmFqdn string = vmResources.outputs.vmFqdn
+output sshCommand string = 'ssh ${adminUsername}@${vmResources.outputs.publicIpAddress}'
+output sorchaUrl string = 'http://${vmResources.outputs.publicIpAddress}'

--- a/scripts/n1-deploy.ps1
+++ b/scripts/n1-deploy.ps1
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# One-command deployment script for Sorcha n1.sorcha.dev debug node
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login)
+#   - SSH key pair (~/.ssh/id_rsa.pub or specify -SshKeyPath)
+#   - Docker images pushed to DockerHub (sorchadev/*)
+#
+# Usage:
+#   .\n1-deploy.ps1                          # Full deploy (infra + setup)
+#   .\n1-deploy.ps1 -SkipInfra               # Skip Bicep, just upload and start
+#   .\n1-deploy.ps1 -SshCidr "1.2.3.4/32"    # Restrict SSH to your IP
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ResourceGroup = "sorcha-n1",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Location = "uksouth",
+
+    [Parameter(Mandatory = $false)]
+    [string]$VmSize = "Standard_B2as_v2",
+
+    [Parameter(Mandatory = $false)]
+    [string]$SshKeyPath = "$env:USERPROFILE\.ssh\id_rsa.pub",
+
+    [Parameter(Mandatory = $false)]
+    [string]$SshCidr,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipInfra,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipSetup,
+
+    [Parameter(Mandatory = $false)]
+    [string]$AdminUsername = "sorcha"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+Write-Host ""
+Write-Host "╔════════════════════════════════════════════════╗" -ForegroundColor Cyan
+Write-Host "║   Sorcha n1.sorcha.dev Deployment             ║" -ForegroundColor Cyan
+Write-Host "╚════════════════════════════════════════════════╝" -ForegroundColor Cyan
+Write-Host ""
+
+# ============================================================================
+# Prerequisites
+# ============================================================================
+Write-Host "[1/6] Checking prerequisites..." -ForegroundColor Yellow
+
+# Azure CLI
+try {
+    $azAccount = az account show --output json 2>$null | ConvertFrom-Json
+    Write-Host "  ✓ Azure CLI: $($azAccount.user.name) ($($azAccount.name))" -ForegroundColor Green
+}
+catch {
+    Write-Error "Not logged in to Azure. Run: az login"
+    exit 1
+}
+
+# SSH key
+if (-not (Test-Path $SshKeyPath)) {
+    Write-Error "SSH public key not found at: $SshKeyPath"
+    Write-Host "  Generate one with: ssh-keygen -t ed25519" -ForegroundColor Yellow
+    exit 1
+}
+$sshPubKey = Get-Content $SshKeyPath -Raw
+Write-Host "  ✓ SSH key: $SshKeyPath" -ForegroundColor Green
+
+# Determine SSH CIDR (auto-detect if not provided)
+if ([string]::IsNullOrEmpty($SshCidr)) {
+    Write-Host "  Detecting your public IP..." -ForegroundColor Gray
+    try {
+        $myIp = (Invoke-RestMethod -Uri "https://api.ipify.org" -TimeoutSec 5).Trim()
+        $SshCidr = "$myIp/32"
+        Write-Host "  ✓ SSH restricted to: $SshCidr" -ForegroundColor Green
+    }
+    catch {
+        Write-Warning "Could not detect public IP. Using 0.0.0.0/0 (open SSH - change this!)"
+        $SshCidr = "0.0.0.0/0"
+    }
+}
+else {
+    Write-Host "  ✓ SSH restricted to: $SshCidr" -ForegroundColor Green
+}
+
+Write-Host ""
+
+# ============================================================================
+# Deploy Infrastructure (Bicep)
+# ============================================================================
+if (-not $SkipInfra) {
+    Write-Host "[2/6] Deploying Azure infrastructure..." -ForegroundColor Yellow
+    Write-Host "  Resource Group: $ResourceGroup" -ForegroundColor Gray
+    Write-Host "  Location: $Location" -ForegroundColor Gray
+    Write-Host "  VM Size: $VmSize" -ForegroundColor Gray
+    Write-Host ""
+
+    $bicepFile = Join-Path $repoRoot "infra\n1-vm.bicep"
+
+    $deployOutput = az deployment sub create `
+        --location $Location `
+        --template-file $bicepFile `
+        --parameters resourceGroupName=$ResourceGroup `
+        --parameters location=$Location `
+        --parameters vmSize=$VmSize `
+        --parameters adminUsername=$AdminUsername `
+        --parameters sshPublicKey="$sshPubKey" `
+        --parameters allowedSshCidr=$SshCidr `
+        --output json 2>&1
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Bicep deployment failed: $deployOutput"
+        exit 1
+    }
+
+    $deployment = $deployOutput | ConvertFrom-Json
+    $vmIp = $deployment.properties.outputs.vmPublicIp.value
+    $vmFqdn = $deployment.properties.outputs.vmFqdn.value
+
+    Write-Host "  ✓ VM deployed: $vmIp ($vmFqdn)" -ForegroundColor Green
+}
+else {
+    Write-Host "[2/6] Skipping infrastructure (--SkipInfra)..." -ForegroundColor Gray
+
+    # Get existing VM IP
+    $vmIp = az vm list-ip-addresses `
+        --resource-group $ResourceGroup `
+        --name "sorcha-n1-vm" `
+        --query "[0].virtualMachine.network.publicIpAddresses[0].ipAddress" `
+        --output tsv 2>$null
+
+    if ([string]::IsNullOrEmpty($vmIp)) {
+        Write-Error "Cannot find VM in resource group '$ResourceGroup'. Run without -SkipInfra first."
+        exit 1
+    }
+
+    Write-Host "  ✓ Existing VM: $vmIp" -ForegroundColor Green
+}
+
+Write-Host ""
+
+# ============================================================================
+# Wait for cloud-init
+# ============================================================================
+Write-Host "[3/6] Waiting for VM to be ready (cloud-init)..." -ForegroundColor Yellow
+
+$maxAttempts = 30
+$attempt = 0
+$sshReady = $false
+
+while ($attempt -lt $maxAttempts -and -not $sshReady) {
+    $attempt++
+    try {
+        $result = ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes `
+            "${AdminUsername}@${vmIp}" "test -f /opt/sorcha/.cloud-init-complete && echo ready || echo waiting" 2>$null
+
+        if ($result -eq "ready") {
+            $sshReady = $true
+            Write-Host "  ✓ VM is ready (cloud-init complete)" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  Cloud-init still running... ($attempt/$maxAttempts)" -ForegroundColor Gray
+            Start-Sleep -Seconds 10
+        }
+    }
+    catch {
+        Write-Host "  SSH not ready yet... ($attempt/$maxAttempts)" -ForegroundColor Gray
+        Start-Sleep -Seconds 10
+    }
+}
+
+if (-not $sshReady) {
+    Write-Warning "Cloud-init may still be running. Continuing anyway..."
+}
+
+Write-Host ""
+
+# ============================================================================
+# Upload compose files and scripts
+# ============================================================================
+Write-Host "[4/6] Uploading compose files and scripts..." -ForegroundColor Yellow
+
+$filesToUpload = @(
+    @{Local = "$repoRoot\docker-compose.yml"; Remote = "/opt/sorcha/docker-compose.yml" },
+    @{Local = "$repoRoot\docker-compose.n1.yml"; Remote = "/opt/sorcha/docker-compose.n1.yml" },
+    @{Local = "$repoRoot\docker\postgres-init.sql"; Remote = "/opt/sorcha/docker/postgres-init.sql" },
+    @{Local = "$repoRoot\docker\certs\aspnetapp.pfx"; Remote = "/opt/sorcha/docker/certs/aspnetapp.pfx" },
+    @{Local = "$repoRoot\scripts\n1-setup-remote.sh"; Remote = "/opt/sorcha/n1-setup-remote.sh" }
+)
+
+# Create subdirectories on remote
+ssh -o StrictHostKeyChecking=no "${AdminUsername}@${vmIp}" "mkdir -p /opt/sorcha/docker/certs"
+
+foreach ($file in $filesToUpload) {
+    if (Test-Path $file.Local) {
+        Write-Host "  Uploading $($file.Local | Split-Path -Leaf)..." -ForegroundColor Gray
+        scp -o StrictHostKeyChecking=no $file.Local "${AdminUsername}@${vmIp}:$($file.Remote)"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to upload $($file.Local)"
+            exit 1
+        }
+    }
+    else {
+        Write-Warning "File not found, skipping: $($file.Local)"
+    }
+}
+
+# Make setup script executable
+ssh -o StrictHostKeyChecking=no "${AdminUsername}@${vmIp}" "chmod +x /opt/sorcha/n1-setup-remote.sh"
+
+# Create .env file on remote with the public IP
+$envContent = @"
+# n1.sorcha.dev environment
+N1_PUBLIC_IP=$vmIp
+INSTALLATION_NAME=n1.sorcha.dev
+"@
+ssh -o StrictHostKeyChecking=no "${AdminUsername}@${vmIp}" "cat > /opt/sorcha/.env << 'ENVEOF'
+$envContent
+ENVEOF"
+
+Write-Host "  ✓ All files uploaded" -ForegroundColor Green
+Write-Host ""
+
+# ============================================================================
+# Run setup on VM
+# ============================================================================
+if (-not $SkipSetup) {
+    Write-Host "[5/6] Running setup on VM..." -ForegroundColor Yellow
+    Write-Host ""
+
+    ssh -o StrictHostKeyChecking=no -t "${AdminUsername}@${vmIp}" "cd /opt/sorcha && ./n1-setup-remote.sh"
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Setup script returned non-zero. Check VM logs."
+    }
+}
+else {
+    Write-Host "[5/6] Skipping setup (--SkipSetup)..." -ForegroundColor Gray
+}
+
+Write-Host ""
+
+# ============================================================================
+# Summary
+# ============================================================================
+Write-Host "[6/6] Deployment complete!" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "╔════════════════════════════════════════════════════════════╗" -ForegroundColor Green
+Write-Host "║   n1.sorcha.dev Deployed Successfully!                   ║" -ForegroundColor Green
+Write-Host "╚════════════════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host ""
+Write-Host "  VM IP:             $vmIp" -ForegroundColor White
+Write-Host "  SSH:               ssh ${AdminUsername}@${vmIp}" -ForegroundColor White
+Write-Host "  API Gateway:       http://${vmIp}" -ForegroundColor White
+Write-Host "  Aspire Dashboard:  http://${vmIp}:18888" -ForegroundColor White
+Write-Host "  Scalar API Docs:   http://${vmIp}/scalar/" -ForegroundColor White
+Write-Host ""
+Write-Host "  DNS Setup:" -ForegroundColor Cyan
+Write-Host "  Create an A record: n1.sorcha.dev -> $vmIp" -ForegroundColor White
+Write-Host ""
+Write-Host "  CLI Setup:" -ForegroundColor Cyan
+Write-Host "  sorcha config set activeProfile n1" -ForegroundColor White
+Write-Host "  sorcha auth login --profile n1" -ForegroundColor White
+Write-Host ""
+Write-Host "  Reset all data:" -ForegroundColor Cyan
+Write-Host "  .\scripts\n1-reset.ps1" -ForegroundColor White
+Write-Host ""
+Write-Host "  Auto-shutdown:" -ForegroundColor Cyan
+Write-Host "  VM auto-shuts down at 11 PM GMT to save costs" -ForegroundColor White
+Write-Host "  Start it with: az vm start -g $ResourceGroup -n sorcha-n1-vm" -ForegroundColor White
+Write-Host ""

--- a/scripts/n1-reset.ps1
+++ b/scripts/n1-reset.ps1
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Reset n1.sorcha.dev - tears down all containers and volumes, pulls fresh images,
+# restarts everything, and optionally re-bootstraps.
+#
+# This is the equivalent of "Docker Desktop down -v" + fresh start.
+#
+# Usage:
+#   .\n1-reset.ps1                    # Reset and re-bootstrap
+#   .\n1-reset.ps1 -SkipBootstrap     # Reset without bootstrap
+#   .\n1-reset.ps1 -UpdateCompose     # Also upload latest compose files before reset
+#   .\n1-reset.ps1 -StartVm           # Start the VM first (if auto-shutdown stopped it)
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$ResourceGroup = "sorcha-n1",
+
+    [Parameter(Mandatory = $false)]
+    [string]$AdminUsername = "sorcha",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipBootstrap,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$UpdateCompose,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$StartVm,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$Yes
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+Write-Host ""
+Write-Host "╔════════════════════════════════════════════════╗" -ForegroundColor Cyan
+Write-Host "║   Sorcha n1.sorcha.dev Reset                  ║" -ForegroundColor Cyan
+Write-Host "╚════════════════════════════════════════════════╝" -ForegroundColor Cyan
+Write-Host ""
+
+# ============================================================================
+# Get VM IP
+# ============================================================================
+Write-Host "Finding n1 VM..." -ForegroundColor Yellow
+
+# Start VM if requested (after auto-shutdown)
+if ($StartVm) {
+    Write-Host "  Starting VM..." -ForegroundColor Gray
+    az vm start --resource-group $ResourceGroup --name "sorcha-n1-vm" --output none
+    Write-Host "  ✓ VM started" -ForegroundColor Green
+    Start-Sleep -Seconds 10
+}
+
+$vmIp = az vm list-ip-addresses `
+    --resource-group $ResourceGroup `
+    --name "sorcha-n1-vm" `
+    --query "[0].virtualMachine.network.publicIpAddresses[0].ipAddress" `
+    --output tsv 2>$null
+
+if ([string]::IsNullOrEmpty($vmIp)) {
+    Write-Error "Cannot find VM. Is it deployed? Run n1-deploy.ps1 first."
+    exit 1
+}
+
+# Check VM is running
+$vmState = az vm get-instance-view `
+    --resource-group $ResourceGroup `
+    --name "sorcha-n1-vm" `
+    --query "instanceView.statuses[1].displayStatus" `
+    --output tsv 2>$null
+
+if ($vmState -ne "VM running") {
+    Write-Error "VM is not running (status: $vmState). Use -StartVm to start it."
+    exit 1
+}
+
+Write-Host "  ✓ VM: $vmIp ($vmState)" -ForegroundColor Green
+Write-Host ""
+
+# ============================================================================
+# Confirm
+# ============================================================================
+if (-not $Yes) {
+    Write-Host "This will:" -ForegroundColor Yellow
+    Write-Host "  1. Stop all Sorcha containers on n1" -ForegroundColor White
+    Write-Host "  2. Delete ALL data volumes (PostgreSQL, MongoDB, Redis)" -ForegroundColor White
+    Write-Host "  3. Pull latest images from DockerHub" -ForegroundColor White
+    Write-Host "  4. Start fresh containers" -ForegroundColor White
+    if (-not $SkipBootstrap) {
+        Write-Host "  5. Re-bootstrap (create org, admin user)" -ForegroundColor White
+    }
+    Write-Host ""
+    Write-Host "  ⚠  ALL DATA ON n1 WILL BE PERMANENTLY DELETED!" -ForegroundColor Red
+    Write-Host ""
+
+    $response = Read-Host "Continue? (yes/no)"
+    if ($response -ne "yes" -and $response -ne "y") {
+        Write-Host "Cancelled." -ForegroundColor Yellow
+        exit 0
+    }
+    Write-Host ""
+}
+
+# ============================================================================
+# Upload latest compose files (optional)
+# ============================================================================
+if ($UpdateCompose) {
+    Write-Host "Uploading latest compose files..." -ForegroundColor Yellow
+
+    $filesToUpload = @(
+        @{Local = "$repoRoot\docker-compose.yml"; Remote = "/opt/sorcha/docker-compose.yml" },
+        @{Local = "$repoRoot\docker-compose.n1.yml"; Remote = "/opt/sorcha/docker-compose.n1.yml" },
+        @{Local = "$repoRoot\docker\postgres-init.sql"; Remote = "/opt/sorcha/docker/postgres-init.sql" },
+        @{Local = "$repoRoot\docker\certs\aspnetapp.pfx"; Remote = "/opt/sorcha/docker/certs/aspnetapp.pfx" },
+        @{Local = "$repoRoot\scripts\n1-setup-remote.sh"; Remote = "/opt/sorcha/n1-setup-remote.sh" }
+    )
+
+    ssh -o StrictHostKeyChecking=no "${AdminUsername}@${vmIp}" "mkdir -p /opt/sorcha/docker/certs"
+
+    foreach ($file in $filesToUpload) {
+        if (Test-Path $file.Local) {
+            scp -o StrictHostKeyChecking=no $file.Local "${AdminUsername}@${vmIp}:$($file.Remote)"
+        }
+    }
+
+    ssh -o StrictHostKeyChecking=no "${AdminUsername}@${vmIp}" "chmod +x /opt/sorcha/n1-setup-remote.sh"
+    Write-Host "  ✓ Files uploaded" -ForegroundColor Green
+    Write-Host ""
+}
+
+# ============================================================================
+# Run reset on VM
+# ============================================================================
+Write-Host "Running reset on n1..." -ForegroundColor Yellow
+Write-Host ""
+
+$resetArgs = "--reset"
+if ($SkipBootstrap) {
+    $resetArgs += " --skip-bootstrap"
+}
+
+ssh -o StrictHostKeyChecking=no -t "${AdminUsername}@${vmIp}" "cd /opt/sorcha && ./n1-setup-remote.sh $resetArgs"
+
+Write-Host ""
+Write-Host "╔════════════════════════════════════════════════╗" -ForegroundColor Green
+Write-Host "║   n1.sorcha.dev Reset Complete!                ║" -ForegroundColor Green
+Write-Host "╚════════════════════════════════════════════════╝" -ForegroundColor Green
+Write-Host ""
+Write-Host "  API Gateway:  http://${vmIp}" -ForegroundColor White
+Write-Host "  Dashboard:    http://${vmIp}:18888" -ForegroundColor White
+Write-Host ""
+
+if (-not $SkipBootstrap) {
+    Write-Host "  Next: Bootstrap the platform:" -ForegroundColor Cyan
+    Write-Host "  sorcha bootstrap --profile n1" -ForegroundColor White
+    Write-Host ""
+}

--- a/scripts/n1-setup-remote.sh
+++ b/scripts/n1-setup-remote.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Remote setup script for n1.sorcha.dev
+# This script runs ON the Azure VM to:
+# 1. Pull latest DockerHub images
+# 2. Start all services via docker-compose
+# 3. Wait for services to be healthy
+# 4. Run bootstrap (create org, admin user, service principal)
+#
+# Usage: ./n1-setup-remote.sh [--reset] [--skip-bootstrap]
+
+set -euo pipefail
+
+SORCHA_DIR="/opt/sorcha"
+COMPOSE_CMD="docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml"
+MAX_WAIT=300  # 5 minutes max wait for healthy services
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()  { echo -e "${CYAN}==> ${NC}$1"; }
+ok()   { echo -e "${GREEN}✓ ${NC}$1"; }
+warn() { echo -e "${YELLOW}⚠ ${NC}$1"; }
+err()  { echo -e "${RED}✗ ${NC}$1"; }
+
+# Parse arguments
+RESET=false
+SKIP_BOOTSTRAP=false
+for arg in "$@"; do
+    case $arg in
+        --reset) RESET=true ;;
+        --skip-bootstrap) SKIP_BOOTSTRAP=true ;;
+        *) warn "Unknown argument: $arg" ;;
+    esac
+done
+
+cd "$SORCHA_DIR"
+
+echo ""
+echo "╔════════════════════════════════════════════════╗"
+echo "║     Sorcha n1.sorcha.dev Setup                ║"
+echo "╚════════════════════════════════════════════════╝"
+echo ""
+
+# Check Docker is running
+log "Checking Docker..."
+if ! docker info > /dev/null 2>&1; then
+    err "Docker is not running. Waiting for cloud-init to complete..."
+    # Wait for cloud-init if first boot
+    for i in $(seq 1 60); do
+        if [ -f "$SORCHA_DIR/.cloud-init-complete" ] && docker info > /dev/null 2>&1; then
+            break
+        fi
+        echo "  Waiting... ($i/60)"
+        sleep 5
+    done
+    if ! docker info > /dev/null 2>&1; then
+        err "Docker failed to start. Check cloud-init logs: sudo cat /var/log/cloud-init-output.log"
+        exit 1
+    fi
+fi
+ok "Docker is running"
+
+# Check compose files exist
+if [ ! -f "$SORCHA_DIR/docker-compose.yml" ]; then
+    err "docker-compose.yml not found in $SORCHA_DIR"
+    err "Run n1-deploy.ps1 first to upload compose files"
+    exit 1
+fi
+
+# Reset if requested (equivalent to 'docker desktop down -v')
+if [ "$RESET" = true ]; then
+    log "Resetting all data (docker compose down -v)..."
+    $COMPOSE_CMD down -v --remove-orphans 2>/dev/null || true
+    ok "All containers and volumes removed"
+    echo ""
+fi
+
+# Pull latest images from DockerHub
+log "Pulling latest images from DockerHub..."
+$COMPOSE_CMD pull
+ok "All images pulled"
+
+# Fix wallet encryption key permissions
+log "Setting up wallet encryption volume permissions..."
+docker volume create sorcha_wallet-encryption-keys 2>/dev/null || true
+docker run --rm -v sorcha_wallet-encryption-keys:/data alpine chown -R 1654:1654 /data 2>/dev/null || true
+ok "Wallet encryption permissions set"
+
+# Start services
+log "Starting all services..."
+$COMPOSE_CMD up -d
+ok "Compose up complete"
+
+# Wait for services to be healthy
+log "Waiting for services to become healthy..."
+SERVICES=(
+    "sorcha-redis"
+    "sorcha-postgres"
+    "sorcha-mongodb"
+    "sorcha-wallet-service"
+    "sorcha-tenant-service"
+    "sorcha-register-service"
+    "sorcha-validator-service"
+    "sorcha-blueprint-service"
+    "sorcha-peer-service"
+    "sorcha-api-gateway"
+)
+
+elapsed=0
+all_healthy=false
+
+while [ $elapsed -lt $MAX_WAIT ]; do
+    healthy_count=0
+    total=${#SERVICES[@]}
+
+    for svc in "${SERVICES[@]}"; do
+        status=$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null || echo "not_found")
+        case $status in
+            healthy) healthy_count=$((healthy_count + 1)) ;;
+            *) ;;
+        esac
+    done
+
+    if [ $healthy_count -eq $total ]; then
+        all_healthy=true
+        break
+    fi
+
+    echo "  Healthy: $healthy_count/$total (${elapsed}s elapsed)"
+    sleep 10
+    elapsed=$((elapsed + 10))
+done
+
+if [ "$all_healthy" = true ]; then
+    ok "All $total services are healthy!"
+else
+    warn "Timeout waiting for all services. Current status:"
+    for svc in "${SERVICES[@]}"; do
+        status=$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null || echo "not_found")
+        if [ "$status" = "healthy" ]; then
+            echo -e "  ${GREEN}✓${NC} $svc"
+        else
+            echo -e "  ${RED}✗${NC} $svc ($status)"
+        fi
+    done
+    warn "Continuing anyway - some services may still be starting..."
+fi
+
+echo ""
+
+# Run bootstrap
+if [ "$SKIP_BOOTSTRAP" = true ]; then
+    log "Skipping bootstrap (--skip-bootstrap flag)"
+else
+    log "Running bootstrap..."
+
+    # Wait a few extra seconds for API Gateway to fully initialize routes
+    sleep 5
+
+    # Bootstrap via direct Tenant Service API calls
+    TENANT_URL="http://localhost:5450"
+    GATEWAY_URL="http://localhost:80"
+
+    # Check if already bootstrapped
+    HEALTH_RESPONSE=$(curl -s "$GATEWAY_URL/health" 2>/dev/null || echo "")
+    if [ -z "$HEALTH_RESPONSE" ]; then
+        HEALTH_RESPONSE=$(curl -s "$TENANT_URL/health" 2>/dev/null || echo "")
+    fi
+
+    if [ -z "$HEALTH_RESPONSE" ]; then
+        warn "Cannot reach services for bootstrap. You can bootstrap manually later:"
+        warn "  ssh sorcha@n1.sorcha.dev"
+        warn "  cd /opt/sorcha && ./n1-setup-remote.sh --skip-bootstrap"
+        warn "  # Then use CLI: sorcha bootstrap --profile n1"
+    else
+        ok "Services are reachable"
+        log "Bootstrap the platform using the CLI from your local machine:"
+        echo ""
+        echo "  sorcha bootstrap --profile n1"
+        echo ""
+        echo "  Or non-interactive:"
+        echo "  sorcha bootstrap --profile n1 --non-interactive \\"
+        echo "    --org-name 'Sorcha Dev' \\"
+        echo "    --subdomain 'dev' \\"
+        echo "    --admin-email 'admin@sorcha.dev' \\"
+        echo "    --admin-name 'Admin' \\"
+        echo "    --admin-password 'Dev_Pass_2026!' \\"
+        echo "    --create-sp --sp-name 'n1-automation'"
+        echo ""
+    fi
+fi
+
+echo ""
+echo "╔════════════════════════════════════════════════╗"
+echo "║     n1.sorcha.dev Setup Complete!              ║"
+echo "╚════════════════════════════════════════════════╝"
+echo ""
+echo "  API Gateway:       http://n1.sorcha.dev"
+echo "  Aspire Dashboard:  http://n1.sorcha.dev:18888"
+echo "  Scalar API Docs:   http://n1.sorcha.dev/scalar/"
+echo ""
+echo "  To reset all data:"
+echo "    ./n1-setup-remote.sh --reset"
+echo ""
+echo "  To view logs:"
+echo "    docker compose -f docker-compose.yml -f docker-compose.n1.yml logs -f"
+echo ""

--- a/src/Apps/Sorcha.Cli/config.template.json
+++ b/src/Apps/Sorcha.Cli/config.template.json
@@ -28,6 +28,18 @@
       "verifySsl": false,
       "timeoutSeconds": 30
     },
+    "n1": {
+      "name": "n1",
+      "tenantServiceUrl": "https://n1.sorcha.dev/tenant",
+      "registerServiceUrl": "https://n1.sorcha.dev/register",
+      "peerServiceUrl": "https://n1.sorcha.dev/peer",
+      "walletServiceUrl": "https://n1.sorcha.dev/wallet",
+      "blueprintServiceUrl": "https://n1.sorcha.dev/blueprint",
+      "authTokenUrl": "https://n1.sorcha.dev/tenant/api/service-auth/token",
+      "defaultClientId": "sorcha-cli",
+      "verifySsl": true,
+      "timeoutSeconds": 30
+    },
     "production": {
       "name": "production",
       "tenantServiceUrl": "https://tenant.sorcha.io",


### PR DESCRIPTION
## Summary
- Add Azure Bicep templates for N1 VM provisioning (`infra/n1-vm.bicep`, `infra/n1-vm-resources.bicep`, `infra/n1-params.json`)
- Add Docker Compose overrides for N1 node and port configuration
- Add Caddy reverse proxy config (`docker/caddy/Caddyfile`)
- Add deployment scripts: `n1-deploy.ps1`, `n1-reset.ps1`, `n1-setup-remote.sh`
- Update CLI config template and Blueprint Engine XML docs

## Test plan
- [ ] Verify Bicep templates validate with `az bicep build`
- [ ] Confirm docker-compose overrides work with `docker-compose -f docker-compose.yml -f docker-compose.n1.yml up`
- [ ] Test deployment scripts on target VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)