### PR TITLE
fix: relative navigation paths for /app/ base href

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
@@ -182,7 +182,7 @@
 
     private void NavigateToParticipant(ParticipantListItemViewModel participant)
     {
-        Navigation.NavigateTo($"/participants/{participant.OrganizationId}/{participant.Id}");
+        Navigation.NavigateTo($"participants/{participant.OrganizationId}/{participant.Id}");
     }
 
     private async Task ShowEditParticipantDialog(ParticipantListItemViewModel participant)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/BlueprintChat.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/BlueprintChat.razor
@@ -582,7 +582,7 @@
             if (result is { Canceled: false, Data: string blueprintId })
             {
                 // Navigate to edit the selected blueprint
-                Navigation.NavigateTo($"/designer/chat/{blueprintId}");
+                Navigation.NavigateTo($"designer/chat/{blueprintId}");
             }
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
@@ -26,7 +26,7 @@
                 Organisation <strong>@_resultName</strong> created successfully!
             </MudAlert>
             <MudText Typo="Typo.body2" Class="mb-2">Subdomain: <code>@_resultSubdomain</code></MudText>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => Navigation.NavigateTo("/"))">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => Navigation.NavigateTo("dashboard"))">
                 Go to Dashboard
             </MudButton>
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer.razor
@@ -964,7 +964,7 @@
         // Navigate to catalogue — full workflow initiation will be wired when
         // the Blueprint Publishing Blueprint can be instantiated as a workflow instance
         Snackbar.Add("Opening catalogue to publish blueprint (workflow integration pending)", Severity.Info);
-        Navigation.NavigateTo("/templates");
+        Navigation.NavigateTo("templates");
     }
 
     public void Dispose()

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
@@ -194,7 +194,7 @@ else
     @if (!_stats.IsLoaded && !_isLoading)
     {
         <MudAlert Severity="Severity.Warning" Class="mb-4">
-            @Loc.T("dashboard.statsError") <a href="/app/wallets" class="mud-alert-link">@Loc.T("dashboard.viewWallets")</a>
+            @Loc.T("dashboard.statsError") <a href="wallets" class="mud-alert-link">@Loc.T("dashboard.viewWallets")</a>
         </MudAlert>
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Index.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Index.razor
@@ -162,7 +162,7 @@
 
     private void NavigateToDetail(ParticipantListItemViewModel participant)
     {
-        Navigation.NavigateTo($"/participants/{participant.OrganizationId}/{participant.Id}");
+        Navigation.NavigateTo($"participants/{participant.OrganizationId}/{participant.Id}");
     }
 
     private static Color GetStatusColor(string status)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
@@ -265,7 +265,7 @@
         if ((_isWizard || _isFirstLogin) && walletAddress != null)
         {
             await WalletPreferences.SetDefaultWalletAsync(walletAddress);
-            Navigation.NavigateTo("/app/dashboard");
+            Navigation.NavigateTo("dashboard");
         }
         else if (walletAddress != null)
         {


### PR DESCRIPTION
## Summary
- Fixed 5 broken navigation links that bypassed the `/app/` base href, causing 404s when clicked
- Fixed 2 hardcoded `/app/` paths that work today but would break if the base path changes

## Changes
| File | Was | Now |
|------|-----|-----|
| BlueprintChat.razor | `/designer/chat/{id}` | `designer/chat/{id}` |
| Participants/Index.razor | `/participants/{org}/{id}` | `participants/{org}/{id}` |
| OrganizationDashboard.razor | `/participants/{org}/{id}` | `participants/{org}/{id}` |
| Designer.razor | `/templates` | `templates` |
| CreateOrganization.razor | `/` | `dashboard` |
| CreateWallet.razor | `/app/dashboard` | `dashboard` |
| Home.razor | `/app/wallets` | `wallets` |

## Test plan
- [ ] Navigate to each affected page and verify the link/button routes correctly under `/app/`
- [ ] Confirm `/auth/login` links (intentionally absolute) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)