### PR TITLE
fix: WebAuthn passkey serialization and N1 FIDO2 config

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -39,6 +39,9 @@ services:
     image: sorchadev/tenant-service:latest
     environment:
       <<: *jwt-env
+      Fido2__ServerDomain: n1.sorcha.dev
+      Fido2__ServerName: Sorcha
+      Fido2__Origins__0: https://n1.sorcha.dev
 
   peer-service:
     image: sorchadev/peer-service:latest

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Security.Claims;
+using System.Text.Json;
 
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
@@ -632,7 +633,7 @@ public static class AuthEndpoints
             return TypedResults.Ok(new PasskeyAssertionOptionsResponse
             {
                 TransactionId = result.TransactionId,
-                Options = result.Options
+                Options = JsonDocument.Parse(result.Options.ToJson()).RootElement
             });
         }
         catch (Exception ex)

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PasskeyEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PasskeyEndpoints.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Security.Claims;
+using System.Text.Json;
 
 using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Models.Dtos;
@@ -131,7 +132,7 @@ public static class PasskeyEndpoints
             return TypedResults.Ok(new PasskeyRegistrationOptionsResponse
             {
                 TransactionId = result.TransactionId,
-                Options = result.Options
+                Options = JsonDocument.Parse(result.Options.ToJson()).RootElement
             });
         }
         catch (Exception ex)

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
+
 using Microsoft.EntityFrameworkCore;
 
 using Sorcha.Tenant.Service.Data;
@@ -138,7 +140,7 @@ public static class PublicPasskeyEndpoints
             return TypedResults.Ok(new PasskeyRegistrationOptionsResponse
             {
                 TransactionId = result.TransactionId,
-                Options = result.Options
+                Options = JsonDocument.Parse(result.Options.ToJson()).RootElement
             });
         }
         catch (Exception ex)
@@ -302,7 +304,7 @@ public static class PublicPasskeyEndpoints
             return TypedResults.Ok(new PasskeyAssertionOptionsResponse
             {
                 TransactionId = result.TransactionId,
-                Options = result.Options
+                Options = JsonDocument.Parse(result.Options.ToJson()).RootElement
             });
         }
         catch (Exception ex)

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/PasskeyDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/PasskeyDtos.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using Fido2NetLib;
@@ -32,9 +33,11 @@ public record PasskeyRegistrationOptionsResponse
 
     /// <summary>
     /// FIDO2 credential creation options to pass to the browser WebAuthn API.
+    /// Serialized as JsonElement to preserve Fido2NetLib's custom JSON converters
+    /// (e.g., "public-key" instead of "PublicKey" for credential type).
     /// </summary>
     [JsonPropertyName("options")]
-    public required object Options { get; init; }
+    public required JsonElement Options { get; init; }
 }
 
 /// <summary>
@@ -182,7 +185,8 @@ public record PasskeyAssertionOptionsResponse
 
     /// <summary>
     /// FIDO2 assertion options to pass to the browser WebAuthn API.
+    /// Serialized as JsonElement to preserve Fido2NetLib's custom JSON converters.
     /// </summary>
     [JsonPropertyName("options")]
-    public required object Options { get; init; }
+    public required JsonElement Options { get; init; }
 }

--- a/src/Services/Sorcha.Tenant.Service/appsettings.json
+++ b/src/Services/Sorcha.Tenant.Service/appsettings.json
@@ -28,7 +28,8 @@
     "ServerDomain": "localhost",
     "ServerName": "Sorcha Tenant Service",
     "Origins": [
-      "https://localhost:7080"
+      "https://localhost:7080",
+      "http://localhost"
     ],
     "TimestampDriftTolerance": 300000,
     "MDSAccessKey": null,


### PR DESCRIPTION
## Summary
- **Fixed passkey registration failure** — `pubKeyCredParams[].type` was serialized as `"PublicKey"` instead of `"public-key"` (WebAuthn spec), causing browser to reject options with "Required parameters missing in `options.publicKey`"
- **Root cause:** DTO `Options` property typed as `object` bypassed Fido2NetLib's custom `JsonConverter`s. Changed to `JsonElement` with pre-serialization via `ToJson()`
- **Added FIDO2 config for N1** — `Fido2:ServerDomain` was defaulting to `localhost` instead of `n1.sorcha.dev`
- **Added `http://localhost` origin** for local Docker passkey support

## Test plan
- [x] Build passes with 0 warnings
- [x] 12/12 passkey unit tests pass (2 pre-existing isolation failures unchanged)
- [ ] CI Docker publish builds new tenant-service image
- [ ] After deploy to N1: verify passkey registration flow works in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)