### PR TITLE
fix: Fido2 JSON converter registration for WebAuthn deserialization

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
+using Fido2NetLib.Serialization;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using Sorcha.Tenant.Service.Endpoints;
@@ -23,9 +24,15 @@ builder.AddSorchaOpenApi("Sorcha Tenant Service API", "Multi-tenant organization
 // Add controllers and minimal API support
 builder.Services.AddEndpointsApiExplorer();
 
-// Configure JSON serialization to use string enum values
+// Configure JSON serialization: Fido2 converters first (for WebAuthn spec-compliant
+// enum values like "public-key"), then generic string enum converter as fallback.
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
+    foreach (var converter in FidoModelSerializerContext.Default.Options.Converters)
+    {
+        options.SerializerOptions.Converters.Add(converter);
+    }
+
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 


### PR DESCRIPTION
## Summary
- Fixes passkey registration verify step failing with `JsonException: The JSON value could not be converted to PublicKeyCredentialType`
- Root cause: ASP.NET's `JsonStringEnumConverter` doesn't map `"public-key"` → `PublicKeyCredentialType.PublicKey` (WebAuthn spec uses kebab-case)
- Fix: Register `FidoModelSerializerContext.Default.Options.Converters` in `ConfigureHttpJsonOptions` before the generic `JsonStringEnumConverter`
- Companion to PR #105 which fixed the serialization (response) side

## Test plan
- [x] Build passes with 0 warnings
- [x] 12/12 passkey tests pass (2 pre-existing isolation failures)
- [ ] CI Docker publish
- [ ] Passkey signup completes end-to-end on N1

🤖 Generated with [Claude Code](https://claude.com/claude-code)