### PR TITLE
fix: KebabCaseLower enum converter for WebAuthn deserialization

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
-using Fido2NetLib.Serialization;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using Sorcha.Tenant.Service.Endpoints;
@@ -24,16 +24,13 @@ builder.AddSorchaOpenApi("Sorcha Tenant Service API", "Multi-tenant organization
 // Add controllers and minimal API support
 builder.Services.AddEndpointsApiExplorer();
 
-// Configure JSON serialization: Fido2 converters first (for WebAuthn spec-compliant
-// enum values like "public-key"), then generic string enum converter as fallback.
+// Configure JSON serialization with kebab-case enum handling for WebAuthn spec compliance.
+// WebAuthn uses "public-key" (kebab-case) for PublicKeyCredentialType, which KebabCaseLower
+// handles for both serialization and deserialization.
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
-    foreach (var converter in FidoModelSerializerContext.Default.Options.Converters)
-    {
-        options.SerializerOptions.Converters.Add(converter);
-    }
-
-    options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    options.SerializerOptions.Converters.Add(
+        new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
 });
 
 // Add CORS - production restriction handled at API Gateway (YARP)


### PR DESCRIPTION
## Summary
- Previous fix (PR #106) registered `FidoModelSerializerContext.Default.Options.Converters` but that collection is **empty** (source-gen contexts don't expose converters)
- Fix: `JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower)` which correctly maps `"public-key"` ↔ `PublicKeyCredentialType.PublicKey` for both serialization and deserialization
- Verified with standalone test: deserialization of `"public-key"` works, serialization produces `"public-key"`

## Test plan
- [x] Build passes, 12/12 passkey tests pass
- [ ] CI Docker publish
- [ ] Passkey register + login end-to-end on N1

🤖 Generated with [Claude Code](https://claude.com/claude-code)