### PR TITLE
fix: resolve double-login race condition in Blazor WASM auth flow

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/FragmentTokenHandler.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/FragmentTokenHandler.razor
@@ -1,21 +1,18 @@
 @* SPDX-License-Identifier: MIT *@
 @* Copyright (c) 2026 Sorcha Contributors *@
-@using System.IdentityModel.Tokens.Jwt
-@using Microsoft.AspNetCore.Components.Authorization
-@using Sorcha.UI.Core.Models.Authentication
-@using Sorcha.UI.Core.Services.Authentication
-@using Sorcha.UI.Core.Services.Configuration
 @using Microsoft.JSInterop
 
 @inject IJSRuntime JSRuntime
-@inject ITokenCache TokenCache
-@inject IConfigurationService ConfigurationService
-@inject CustomAuthenticationStateProvider AuthStateProvider
 @inject NavigationManager NavigationManager
 
-@code {
-    private static readonly JwtSecurityTokenHandler JwtHandler = new() { MapInboundClaims = false };
+@*
+    Handles return URL navigation after login redirect.
+    Token consumption is handled exclusively by CustomAuthenticationStateProvider
+    to avoid race conditions — this component MUST NOT call getAndClear() or
+    otherwise consume/clear the fragment token.
+*@
 
+@code {
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender)
@@ -23,35 +20,8 @@
 
         try
         {
-            // First, try the legacy path: getAndClear() in case the auth provider hasn't consumed yet
-            var result = await JSRuntime.InvokeAsync<FragmentTokenResult?>("sorcha.fragmentHandoff.getAndClear");
-            if (result?.Token is not null)
-            {
-                // Auth provider hasn't consumed the token yet - process it here
-                var jwt = JwtHandler.ReadJwtToken(result.Token);
-                var expiresIn = (int)(jwt.ValidTo - DateTime.UtcNow).TotalSeconds;
-                if (expiresIn > 0)
-                {
-                    var profileName = await ConfigurationService.GetActiveProfileNameAsync();
-                    var cacheEntry = new TokenCacheEntry
-                    {
-                        AccessToken = result.Token,
-                        RefreshToken = result.Refresh,
-                        ExpiresAt = DateTime.UtcNow.AddSeconds(expiresIn),
-                        ProfileName = profileName,
-                        IssuedAt = DateTime.UtcNow
-                    };
-                    await TokenCache.StoreTokenAsync(profileName, cacheEntry);
-                    AuthStateProvider.NotifyAuthenticationStateChanged();
-                }
-
-                // Navigate to return URL or dashboard
-                var destination = IsValidReturnUrl(result.ReturnUrl) ? result.ReturnUrl! : "dashboard";
-                NavigationManager.NavigateTo(destination, forceLoad: false);
-                return;
-            }
-
-            // Token was already consumed by CustomAuthenticationStateProvider - just handle return URL
+            // Only handle return URL — token is consumed solely by CustomAuthenticationStateProvider.
+            // getReturnUrl() reads from a separate variable that clearTokenStaging() preserves.
             var returnUrl = await JSRuntime.InvokeAsync<string?>("sorcha.fragmentHandoff.getReturnUrl");
             if (IsValidReturnUrl(returnUrl))
             {
@@ -60,7 +30,7 @@
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Fragment token handoff failed: {ex.Message}");
+            Console.WriteLine($"Fragment return URL handling failed: {ex.Message}");
         }
     }
 
@@ -70,5 +40,4 @@
         // Only allow relative paths; reject protocol-relative ("//evil.com") and absolute URLs
         return url.StartsWith('/') && !url.StartsWith("//");
     }
-
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/RedirectToLogin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/RedirectToLogin.razor
@@ -1,0 +1,69 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+@using Microsoft.JSInterop
+
+@inject NavigationManager NavigationManager
+@inject IJSRuntime JSRuntime
+
+@*
+    Redirects to the server-rendered login page when the user is not authenticated.
+    Uses OnAfterRenderAsync instead of inline render code so the redirect happens
+    after a full render cycle — this gives any pending auth state changes (e.g.
+    fragment token consumption by CustomAuthenticationStateProvider) time to
+    propagate before we decide to navigate away.
+*@
+
+<div class="loading-container">
+    <div class="loading-spinner"></div>
+    <div class="loading-text">Checking authentication...</div>
+</div>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+            return;
+
+        try
+        {
+            // Safety check: if a fragment token is still pending (auth provider hasn't consumed it yet),
+            // wait briefly to give it a chance. This handles edge cases where OnAfterRenderAsync fires
+            // before the auth provider's JS interop calls complete.
+            var hasPending = await JSRuntime.InvokeAsync<string?>(
+                "localStorage.getItem", "sorcha:fragment-pending");
+
+            if (!string.IsNullOrEmpty(hasPending))
+            {
+                // Fragment token exists — the auth provider should be processing it.
+                // Wait and let the auth state update cascade; if it does, this component
+                // will be unmounted (replaced by the authorized content) before we redirect.
+                await Task.Delay(1000);
+
+                // Re-check: if the fragment was consumed during the delay, the auth state
+                // changed event should have caused CascadingAuthenticationState to re-render,
+                // unmounting this component. If we're still here, something went wrong.
+                hasPending = await JSRuntime.InvokeAsync<string?>(
+                    "localStorage.getItem", "sorcha:fragment-pending");
+
+                if (!string.IsNullOrEmpty(hasPending))
+                {
+                    // Still pending after 1s — likely a stuck state. Clear it and redirect.
+                    await JSRuntime.InvokeVoidAsync("sorcha.fragmentHandoff.clearTokenStaging");
+                }
+                else
+                {
+                    // Fragment was consumed but auth state didn't cascade to unmount us.
+                    // This shouldn't happen, but just in case — check one more time.
+                    return;
+                }
+            }
+        }
+        catch
+        {
+            // JS interop failure — fall through to redirect
+        }
+
+        var returnUrl = Uri.EscapeDataString(NavigationManager.Uri);
+        NavigationManager.NavigateTo($"/auth/login?returnUrl={returnUrl}", forceLoad: true);
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Routes.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Routes.razor
@@ -16,10 +16,7 @@
                     </div>
                 </Authorizing>
                 <NotAuthorized>
-                    @{
-                        var returnUrl = Uri.EscapeDataString(NavigationManager.Uri);
-                        NavigationManager.NavigateTo($"/auth/login?returnUrl={returnUrl}", forceLoad: true);
-                    }
+                    <Sorcha.UI.Web.Client.Components.RedirectToLogin />
                 </NotAuthorized>
             </AuthorizeRouteView>
             <FocusOnNavigate RouteData="@routeData" Selector="h1" />


### PR DESCRIPTION
## Summary

- **Root cause:** `FragmentTokenHandler.getAndClear()` raced with `CustomAuthenticationStateProvider.TryConsumeFragmentTokenAsync()` to consume the one-time fragment token after login redirect. When `FragmentTokenHandler` won (its `OnAfterRenderAsync` fired between the auth provider's `await` points), it destructively cleared all staging locations, causing the auth provider to return unauthenticated → immediate redirect back to login.
- **Fix:** Removed token consumption from `FragmentTokenHandler` (now only handles return URL). `CustomAuthenticationStateProvider` is the sole fragment token consumer. Added `RedirectToLogin` component with safety delay for pending fragment tokens.
- **Second login explained:** The first login's token was stored in encrypted localStorage by `FragmentTokenHandler` before `forceLoad` redirect killed WASM. On second visit, the encrypted cache had a valid token.

## Changes

- `FragmentTokenHandler.razor` — Stripped token handling; only calls `getReturnUrl()` now
- `RedirectToLogin.razor` — New component; redirects in `OnAfterRenderAsync` with 1s safety wait if fragment token pending
- `Routes.razor` — Uses `<RedirectToLogin />` in `<NotAuthorized>` instead of inline `NavigateTo`

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test Sorcha.UI.Core.Tests` — 903 passed
- [x] Docker rebuild + login with `admin@sorcha.local` — single login succeeds
- [x] Session persists across SPA navigation (dashboard → wallets)
- [x] Console: no auth-related errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)