### PR TITLE
fix: UI audit — broken admin routes, toolbar truncation, version display

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/LoadBlueprintDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/LoadBlueprintDialog.razor
@@ -52,7 +52,7 @@
                                              Color="@(blueprint.Status == "published" ? Color.Success : Color.Default)">
                                         @blueprint.Status
                                     </MudChip>
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Info">v@blueprint.Version</MudChip>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Info">v@(blueprint.Version)</MudChip>
                                 </MudStack>
                             </div>
                             <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-2">

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/PropertiesPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/PropertiesPanel.razor
@@ -427,7 +427,7 @@
                             Class="mb-3" />
 
             <MudText Typo="Typo.subtitle2" Class="mt-4 mb-2">Metadata</MudText>
-            <MudText Typo="Typo.caption" Color="Color.Secondary">
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Style="word-break: break-all;">
                 ID: @editedBlueprint.Id
             </MudText>
             <MudText Typo="Typo.caption" Color="Color.Secondary">

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/OrgDashboard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/OrgDashboard.razor
@@ -1,7 +1,7 @@
 @* SPDX-License-Identifier: MIT *@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
-@page "/app/admin/identity"
+@page "/admin/identity"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize(Roles = "Administrator,SystemAdmin")]
 @using Microsoft.AspNetCore.Authorization

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SystemHealth.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SystemHealth.razor
@@ -1,7 +1,7 @@
 @* SPDX-License-Identifier: MIT *@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
-@page "/app/admin/health"
+@page "/admin/health"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize(Roles = "Administrator")]
 @using Microsoft.AspNetCore.Authorization

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
@@ -97,7 +97,7 @@
                                                  Color="@(blueprint.Status == "published" ? Color.Success : Color.Default)">
                                             @blueprint.Status
                                         </MudChip>
-                                        <MudText Typo="Typo.caption" Color="Color.Secondary">v@blueprint.Version</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">v@(blueprint.Version)</MudText>
                                     </MudStack>
                                 </CardHeaderContent>
                             </MudCardHeader>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer.razor
@@ -34,8 +34,8 @@
         <div style="flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0;">
             <!-- Toolbar inside diagram area -->
             <MudPaper Elevation="1" Class="pa-2" Style="border-radius: 0;">
-                <div class="d-flex align-center gap-2">
-                    <MudText Typo="Typo.h6" Class="mr-4">@CurrentBlueprint.Title</MudText>
+                <div class="d-flex align-center gap-2 flex-wrap">
+                    <MudText Typo="Typo.h6" Class="mr-4" Style="white-space: nowrap;">@CurrentBlueprint.Title</MudText>
 
                 <MudButton Color="Color.Primary"
                            Size="MudBlazor.Size.Small"


### PR DESCRIPTION
## Summary

- **Broken admin routes**: `SystemHealth.razor` and `OrgDashboard.razor` had `@page "/app/admin/..."` instead of `@page "/admin/..."` — the `/app/` base href caused double-prefixing, resulting in 404s when navigating from the sidebar
- **Blueprint version**: `v@blueprint.Version` was parsed by Razor as literal text (email-like syntax); fixed to `v@(blueprint.Version)` in both `Blueprints.razor` and `LoadBlueprintDialog.razor`
- **Designer toolbar**: Added `flex-wrap` to the toolbar's `d-flex` container so buttons flow to a second row instead of being clipped by `overflow: hidden` at all viewport widths
- **Properties panel**: Added `word-break: break-all` on the blueprint ID metadata line to prevent long GUIDs from overflowing

## Audit notes (no code changes needed)

- **JWT roles**: Confirmed admin user JWT contains all 5 roles (Administrator, SystemAdmin, Designer, Auditor, Member) — the Identity/System nav groups render correctly when viewport is tall enough to show them
- **Horizontal scrollbars**: No horizontal scrollbar issues found at any viewport width (1440px, 1280px, 1024px, 800px) — all pages flow correctly
- **Form validation**: MudBlazor form validation error persists after fixing fields (low priority, MudBlazor framework behaviour)

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test Sorcha.UI.Core.Tests` — 903 passed
- [x] Docker rebuild + verify `/app/admin/health` renders (was 404)
- [x] Docker rebuild + verify `/app/admin/identity` renders (was 404)
- [x] Blueprint card shows `v0` instead of `v@blueprint.Version`
- [x] Designer toolbar wraps to second row at standard viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)