### PR TITLE
fix: #114 — add wallet_address JWT claim to token generation and refresh

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/CurrentUserWalletService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/CurrentUserWalletService.cs
@@ -21,7 +21,7 @@ public interface ICurrentUserWalletService
 /// Retrieves the current user's wallet address from the authentication state.
 /// Caches the result for the lifetime of the scoped instance (wallet doesn't change during session).
 /// </summary>
-public class CurrentUserWalletService : ICurrentUserWalletService
+public class CurrentUserWalletService : ICurrentUserWalletService, IDisposable
 {
     private readonly AuthenticationStateProvider _authStateProvider;
     private string? _cachedWalletAddress;
@@ -33,6 +33,20 @@ public class CurrentUserWalletService : ICurrentUserWalletService
     public CurrentUserWalletService(AuthenticationStateProvider authStateProvider)
     {
         _authStateProvider = authStateProvider;
+        _authStateProvider.AuthenticationStateChanged += OnAuthStateChanged;
+    }
+
+    private void OnAuthStateChanged(Task<AuthenticationState> task)
+    {
+        // Invalidate cached wallet address so next call reads from the fresh JWT
+        _hasCached = false;
+        _cachedWalletAddress = null;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _authStateProvider.AuthenticationStateChanged -= OnAuthStateChanged;
     }
 
     /// <inheritdoc />

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
@@ -5,8 +5,13 @@
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize]
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Authentication
+@using Sorcha.UI.Core.Services.Configuration
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferences
+@inject IAuthenticationService AuthService
+@inject IConfigurationService ConfigService
+@inject CustomAuthenticationStateProvider AuthStateProvider
 @inject NavigationManager Navigation
 @inject ISnackbar Snackbar
 @inject IJSRuntime JS
@@ -260,6 +265,20 @@
             Array.Clear(response.MnemonicWords, 0, response.MnemonicWords.Length);
         }
         response = null;
+
+        // Refresh the JWT so the new wallet_address claim is included.
+        // The Tenant Service looks up linked wallets during token generation,
+        // so after wallet creation + link, the refreshed token will carry wallet_address.
+        try
+        {
+            var profileName = await ConfigService.GetActiveProfileNameAsync();
+            await AuthService.RefreshTokenAsync(profileName);
+            AuthStateProvider.NotifyAuthenticationStateChanged();
+        }
+        catch
+        {
+            // Non-critical: token will be refreshed on next background cycle
+        }
 
         // Always set default wallet on first wallet creation (wizard or first-login)
         if ((_isWizard || _isFirstLogin) && walletAddress != null)

--- a/src/Services/Sorcha.Tenant.Service/Services/TokenService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TokenService.cs
@@ -24,6 +24,7 @@ public class TokenService : ITokenService
     private readonly ITokenRevocationService _revocationService;
     private readonly IIdentityRepository _identityRepository;
     private readonly IOrganizationRepository _organizationRepository;
+    private readonly IParticipantRepository _participantRepository;
     private readonly ILogger<TokenService> _logger;
     private readonly JwtSecurityTokenHandler _tokenHandler;
     private readonly SigningCredentials? _signingCredentials;
@@ -34,12 +35,14 @@ public class TokenService : ITokenService
         ITokenRevocationService revocationService,
         IIdentityRepository identityRepository,
         IOrganizationRepository organizationRepository,
+        IParticipantRepository participantRepository,
         ILogger<TokenService> logger)
     {
         _config = options?.Value ?? new JwtConfiguration();
         _revocationService = revocationService ?? throw new ArgumentNullException(nameof(revocationService));
         _identityRepository = identityRepository ?? throw new ArgumentNullException(nameof(identityRepository));
         _organizationRepository = organizationRepository ?? throw new ArgumentNullException(nameof(organizationRepository));
+        _participantRepository = participantRepository ?? throw new ArgumentNullException(nameof(participantRepository));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _tokenHandler = new JwtSecurityTokenHandler();
         _tokenHandler.MapInboundClaims = false;
@@ -100,6 +103,9 @@ public class TokenService : ITokenService
         {
             claims.Add(new Claim(ClaimTypes.Role, role.ToString()));
         }
+
+        // Add wallet_address claim from user's first active linked wallet
+        await AddWalletAddressClaimAsync(claims, user.Id, organization.Id, cancellationToken);
 
         var accessTokenExpiry = DateTimeOffset.UtcNow.AddMinutes(_config.AccessTokenLifetimeMinutes);
         var refreshTokenExpiry = DateTimeOffset.UtcNow.AddHours(_config.RefreshTokenLifetimeHours);
@@ -277,6 +283,13 @@ public class TokenService : ITokenService
             foreach (var role in user.Roles)
             {
                 claims.Add(new Claim(ClaimTypes.Role, role.ToString()));
+            }
+
+            // Add wallet_address claim from user's first active linked wallet
+            var orgIdForWallet = organization?.Id ?? (Guid.TryParse(orgId, out var parsedOrgId) ? parsedOrgId : (Guid?)null);
+            if (orgIdForWallet.HasValue)
+            {
+                await AddWalletAddressClaimAsync(claims, userGuid, orgIdForWallet.Value, cancellationToken);
             }
 
             var accessToken = GenerateToken(claims, accessTokenExpiry);
@@ -461,6 +474,33 @@ public class TokenService : ITokenService
         }
 
         return GenerateToken(claims, expiry);
+    }
+
+    /// <summary>
+    /// Looks up the user's first active linked wallet address and adds it as a JWT claim.
+    /// Fails silently if the user has no participant record or no linked wallets.
+    /// </summary>
+    private async Task AddWalletAddressClaimAsync(
+        List<Claim> claims, Guid userId, Guid organizationId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var participant = await _participantRepository.GetByUserAndOrgAsync(userId, organizationId, cancellationToken);
+            if (participant is null)
+                return;
+
+            var walletLinks = await _participantRepository.GetWalletLinksAsync(participant.Id, includeRevoked: false, cancellationToken);
+            var firstActive = walletLinks.FirstOrDefault();
+            if (firstActive is not null)
+            {
+                claims.Add(new Claim("wallet_address", firstActive.WalletAddress));
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-critical: wallet_address is optional — don't fail token generation
+            _logger.LogWarning(ex, "Failed to resolve wallet_address for user {UserId} in org {OrgId}", userId, organizationId);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

The `wallet_address` JWT claim was never written during token generation or refresh, causing Blueprint Service `ActionEndpoints` to silently return empty results for all users' pending actions.

### Changes

**TokenService** (`Sorcha.Tenant.Service`):
- Added `IParticipantRepository` dependency to look up user's linked wallets
- New `AddWalletAddressClaimAsync()` method resolves the first active wallet link for the user's participant in the current org
- Called in both `GenerateUserTokenAsync` and `RefreshTokenAsync`
- Fails silently — wallet_address is optional, token generation continues without it

**CreateWallet.razor** (`Sorcha.UI.Web.Client`):
- After wallet creation, triggers JWT refresh so `wallet_address` appears immediately
- Notifies `AuthenticationStateProvider` so UI components pick up the change

**CurrentUserWalletService** (`Sorcha.UI.Core`):
- Subscribes to `AuthenticationStateChanged` to invalidate cached wallet address on token refresh
- Implements `IDisposable` for event handler cleanup

### What this fixes
- `/api/actions/pending` returns actual pending actions instead of empty array
- `/api/actions/pending/count` returns correct count for badge display
- `CurrentUserWalletService.GetWalletAddressAsync()` returns the address from JWT
- After wallet creation, the token is refreshed so the wallet is immediately usable

### Not changed (deferred)
- MyActions.razor dead `WorkflowService` code — needs separate assessment of whether `IWorkflowService` is used by other paths
- ActionsHubConnection reconnect — the hub validates via `IParticipantServiceClient` (service call), not JWT claim, so reconnect isn't strictly needed

## Test plan
- [x] `dotnet build` — 0 errors (full solution)
- [x] Tenant Service tests — 574 passed, 8 failed (all pre-existing: IdpConfig, SocialCallback, Registration)
- [x] UI Core tests — 903 passed
- [x] TokenService mock interface unchanged — all consumers use `Mock<ITokenService>`

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)