### PR TITLE
fix: migrate MudForm.Validate() to ValidateAsync() + NuGet upgrades

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,14 +9,14 @@
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.5" />
     <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
     <!-- .NET Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.2" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.1.2" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.1.2" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.2" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.2" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.1.2" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.1.2" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.1.2" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.2.0" />
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
@@ -37,16 +37,16 @@
     <!-- Testing - Blazor -->
     <PackageVersion Include="bunit" Version="2.6.2" />
     <!-- Testing - Coverage -->
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <!-- Authentication -->
     <PackageVersion Include="Fido2.AspNet" Version="4.0.0" />
     <!-- Testing - Assertions -->
-    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <!-- gRPC -->
-    <PackageVersion Include="Google.Protobuf" Version="3.34.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
@@ -55,12 +55,12 @@
     <!-- SD-JWT -->
     <PackageVersion Include="HeroSD-JWT" Version="1.1.7" />
     <!-- JSON Processing -->
-    <PackageVersion Include="JsonE.Net" Version="3.0.0" />
-    <PackageVersion Include="JsonLogic" Version="6.0.0" />
+    <PackageVersion Include="JsonE.Net" Version="3.0.1" />
+    <PackageVersion Include="JsonLogic" Version="6.0.1" />
     <PackageVersion Include="JsonLogic.Net" Version="1.1.11" />
-    <PackageVersion Include="JsonPath.Net" Version="3.0.1" />
-    <PackageVersion Include="JsonSchema.Net" Version="9.1.2" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="7.1.2" />
+    <PackageVersion Include="JsonPath.Net" Version="3.0.2" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.1.3" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="7.1.3" />
     <!-- Microsoft ASP.NET Core -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
@@ -81,7 +81,7 @@
     <!-- Microsoft Extensions - Caching -->
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
     <!-- Microsoft Extensions - Configuration -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
@@ -118,11 +118,11 @@
     <!-- Source Link -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <!-- MongoDB -->
-    <PackageVersion Include="MongoDB.Driver" Version="3.7.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
     <!-- Testing - Mocking -->
     <PackageVersion Include="Moq" Version="4.20.72" />
     <!-- Blazor UI -->
-    <PackageVersion Include="MudBlazor" Version="9.1.0" />
+    <PackageVersion Include="MudBlazor" Version="9.2.0" />
     <!-- Crypto - Bitcoin -->
     <PackageVersion Include="NBitcoin" Version="9.0.5" />
     <!-- Load Testing -->
@@ -140,7 +140,7 @@
     <!-- Testing - NUnit -->
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <!-- OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
@@ -160,10 +160,10 @@
     <!-- Console -->
     <PackageVersion Include="ReadLine" Version="2.0.1" />
     <!-- HTTP Client -->
-    <PackageVersion Include="Refit" Version="10.0.1" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="10.0.1" />
+    <PackageVersion Include="Refit" Version="10.1.6" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
     <!-- OpenAPI -->
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.8" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.13" />
     <!-- Logging -->
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
@@ -175,7 +175,7 @@
     <!-- Console UI -->
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <!-- Redis -->
-    <PackageVersion Include="StackExchange.Redis" Version="2.12.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.12.4" />
     <!-- CLI -->
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <!-- JWT -->

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationForm.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationForm.razor
@@ -274,7 +274,7 @@
     {
         if (_form != null)
         {
-            await _form.Validate();
+            await _form.ValidateAsync();
         }
 
         if (!_isValid || (!IsEdit && !_subdomainIsValid))

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserForm.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserForm.razor
@@ -161,7 +161,7 @@
     {
         if (_form != null)
         {
-            await _form.Validate();
+            await _form.ValidateAsync();
         }
 
         if (!_isValid)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
@@ -230,7 +230,7 @@
 
         try
         {
-            await _form.Validate();
+            await _form.ValidateAsync();
             if (!_formValid)
             {
                 _saving = false;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Participants/ParticipantForm.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Participants/ParticipantForm.razor
@@ -78,7 +78,7 @@
     {
         if (_form == null) return;
 
-        await _form.Validate();
+        await _form.ValidateAsync();
         if (!_formIsValid) return;
 
         _submitting = true;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Participants/WalletLinkForm.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Participants/WalletLinkForm.razor
@@ -127,7 +127,7 @@
     {
         if (_form == null) return;
 
-        await _form.Validate();
+        await _form.ValidateAsync();
         if (!_formIsValid) return;
 
         _submitting = true;


### PR DESCRIPTION
## Summary
- Migrated deprecated `MudForm.Validate()` to `ValidateAsync()` in 5 Blazor components (MudBlazor 9.2.0 deprecation)
- Upgraded 17 NuGet packages to latest versions (Aspire 13.2.0, MudBlazor 9.2.0, FluentAssertions 8.9.0, Refit 10.1.6, etc.)
- Fixed `Microsoft.Extensions.Caching.StackExchangeRedis` version mismatch (10.0.3 → 10.0.5) required by Aspire 13.2.0

## Test plan
- [x] Solution builds with 0 errors and 0 new warnings
- [x] 903 UI Core tests pass
- [x] MudForm deprecation warnings eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)