### PR TITLE
fix: deserialize nested wallet response in CreateWalletAsync

### DIFF
--- a/src/Common/Sorcha.ServiceClients/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients/Wallet/WalletServiceClient.cs
@@ -483,8 +483,10 @@ public class WalletServiceClient : IWalletServiceClient
                 "/api/v1/wallets", requestBody, JsonOptions, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            return await response.Content.ReadFromJsonAsync<WalletInfo>(cancellationToken)
+            var createResponse = await response.Content.ReadFromJsonAsync<CreateWalletResponse>(JsonOptions, cancellationToken)
                 ?? throw new InvalidOperationException("Create wallet response was null");
+            return createResponse.Wallet
+                ?? throw new InvalidOperationException("Create wallet response had no wallet data");
         }
         catch (Exception ex)
         {
@@ -504,6 +506,12 @@ public class WalletServiceClient : IWalletServiceClient
     // =========================================================================
     // Response DTOs
     // =========================================================================
+
+    private sealed class CreateWalletResponse
+    {
+        [JsonPropertyName("wallet")]
+        public WalletInfo? Wallet { get; set; }
+    }
 
     private sealed class SystemWalletResponse
     {


### PR DESCRIPTION
## Summary
- `WalletServiceClient.CreateWalletAsync()` was deserializing the wallet service response directly to `WalletInfo`, but the endpoint returns a `CreateWalletResponse` with a nested `wallet` property
- This caused org wallet provisioning to fail on every clean Docker startup, exhausting all 5 retries
- Added a private `CreateWalletResponse` wrapper DTO to properly extract the nested wallet data

## Test plan
- [x] Verified fix on clean Docker instance — system admin org wallet provisioned successfully
- [x] Full solution builds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)