### PR TITLE
feat: add default name and word count params to wallet wizard

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
@@ -191,6 +191,12 @@
     [SupplyParameterFromQuery(Name = "wizard")]
     public string? Wizard { get; set; }
 
+    [SupplyParameterFromQuery(Name = "name")]
+    public string? DefaultName { get; set; }
+
+    [SupplyParameterFromQuery(Name = "words")]
+    public int? DefaultWordCount { get; set; }
+
     private bool _isFirstLogin;
     private bool _isWizard;
 
@@ -220,6 +226,12 @@
     {
         _isFirstLogin = string.Equals(FirstLogin, "true", StringComparison.OrdinalIgnoreCase);
         _isWizard = string.Equals(Wizard, "true", StringComparison.OrdinalIgnoreCase);
+
+        if (!string.IsNullOrWhiteSpace(DefaultName))
+            request.Name = DefaultName;
+
+        if (DefaultWordCount is 12 or 15 or 18 or 21 or 24)
+            request.WordCount = DefaultWordCount.Value;
     }
 
     private async Task CreateWalletAsync()


### PR DESCRIPTION
## Summary
- Adds `name` and `words` query parameters to the CreateWallet razor component
- Allows pre-configuring the wizard for scripted scenarios, e.g. `/wallets/create?wizard=true&name=My+Wallet&words=24`
- Word count is validated against allowed values (12/15/18/21/24); invalid values are ignored

## Test plan
- [x] Builds with 0 errors
- [ ] Navigate to `/wallets/create?name=Test&words=24` and verify fields are pre-filled
- [ ] Navigate to `/wallets/create` and verify defaults unchanged (empty name, 12 words)

🤖 Generated with [Claude Code](https://claude.com/claude-code)