### PR TITLE
fix: [Feature-067] address PR review — auth bypass, purpose validation, SignalR access check

### DIFF
--- a/src/Core/Sorcha.Register.Core/Managers/RegisterManager.cs
+++ b/src/Core/Sorcha.Register.Core/Managers/RegisterManager.cs
@@ -207,19 +207,20 @@ public class RegisterManager
 
     /// <summary>
     /// Deletes a register. System registers cannot be deleted.
-    /// Caller wallet address is checked against control record attestations when provided.
+    /// Caller wallet address is verified against control record attestations.
     /// </summary>
     /// <param name="registerId">Register ID to delete</param>
-    /// <param name="callerWalletAddress">Caller's wallet address from JWT (for attestation matching)</param>
-    /// <param name="controlRecordAttestations">Attestation subjects from the register's control record (optional — if null, attestation check is skipped)</param>
+    /// <param name="callerWalletAddress">Caller's wallet address from JWT (required for attestation matching)</param>
+    /// <param name="controlRecordAttestations">Attestation subjects from the register's control record (required)</param>
     /// <param name="cancellationToken">Cancellation token</param>
     public async Task DeleteRegisterAsync(
         string registerId,
         string? callerWalletAddress,
-        IReadOnlyList<RegisterAttestation>? controlRecordAttestations = null,
+        IReadOnlyList<RegisterAttestation> controlRecordAttestations,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        ArgumentNullException.ThrowIfNull(controlRecordAttestations);
 
         var register = await _repository.GetRegisterAsync(registerId, cancellationToken);
         if (register == null)
@@ -233,28 +234,27 @@ public class RegisterManager
             throw new UnauthorizedAccessException("System registers cannot be deleted");
         }
 
-        // If attestations are provided, verify caller is an Owner or Admin
-        if (controlRecordAttestations is not null && controlRecordAttestations.Count > 0)
-        {
-            if (string.IsNullOrEmpty(callerWalletAddress))
-            {
-                throw new UnauthorizedAccessException("Caller wallet address is required for register deletion authorization");
-            }
-
-            var isAuthorized = controlRecordAttestations.Any(a =>
-                (a.Role == RegisterRole.Owner || a.Role == RegisterRole.Admin)
-                && MatchesWalletAddress(a.Subject, callerWalletAddress));
-
-            if (!isAuthorized)
-            {
-                throw new UnauthorizedAccessException(
-                    $"Caller wallet {callerWalletAddress} is not an Owner or Admin of register {registerId}");
-            }
-        }
-        else if (controlRecordAttestations is not null && controlRecordAttestations.Count == 0)
+        // Guard against corrupted control records with no attestations
+        if (controlRecordAttestations.Count == 0)
         {
             throw new InvalidOperationException(
                 $"Register {registerId} has no attestations in its control record — cannot verify authorization. This may indicate data corruption.");
+        }
+
+        // Verify caller wallet address is present
+        if (string.IsNullOrEmpty(callerWalletAddress))
+        {
+            throw new UnauthorizedAccessException("Caller wallet address is required for register deletion");
+        }
+
+        // Verify caller is an Owner or Admin in the control record
+        var isAuthorized = controlRecordAttestations.Any(a =>
+            (a.Role == RegisterRole.Owner || a.Role == RegisterRole.Admin)
+            && MatchesWalletAddress(a.Subject, callerWalletAddress));
+
+        if (!isAuthorized)
+        {
+            throw new UnauthorizedAccessException("Caller is not authorized to delete this register");
         }
 
         await _repository.DeleteRegisterAsync(registerId, cancellationToken);
@@ -291,8 +291,16 @@ public class RegisterManager
             return string.Equals(extractedAddress, walletAddress, StringComparison.OrdinalIgnoreCase);
         }
 
-        // Also handle did:sorcha:user: prefix
-        const string userDidPrefix = "did:sorcha:";
+        // Handle did:sorcha:w: prefix (wallet-based DIDs used in attestations)
+        const string walletDidPrefix = "did:sorcha:w:";
+        if (attestationSubject.StartsWith(walletDidPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var extractedAddress = attestationSubject[walletDidPrefix.Length..];
+            return string.Equals(extractedAddress, walletAddress, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Handle did:sorcha:user: prefix
+        const string userDidPrefix = "did:sorcha:user:";
         if (attestationSubject.StartsWith(userDidPrefix, StringComparison.OrdinalIgnoreCase))
         {
             var extractedAddress = attestationSubject[userDidPrefix.Length..];

--- a/src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs
+++ b/src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs
@@ -2,19 +2,42 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.AspNetCore.SignalR;
+using Sorcha.ServiceClients.Subscription;
 
 namespace Sorcha.Register.Service.Hubs;
 
 /// <summary>
-/// SignalR hub for real-time register notifications
+/// SignalR hub for real-time register notifications.
+/// Subscription access is verified before allowing clients to join register groups.
 /// </summary>
 public class RegisterHub : Hub<IRegisterHubClient>
 {
+    private readonly ISubscriptionServiceClient _subscriptionClient;
+
     /// <summary>
-    /// Subscribe to register updates
+    /// Initializes the hub with subscription client for access checks
+    /// </summary>
+    public RegisterHub(ISubscriptionServiceClient subscriptionClient)
+    {
+        _subscriptionClient = subscriptionClient;
+    }
+
+    /// <summary>
+    /// Subscribe to register updates. Verifies the caller's org has an active subscription.
     /// </summary>
     public async Task SubscribeToRegister(string registerId)
     {
+        var orgIdClaim = Context.User?.FindFirst("org_id")?.Value;
+        if (!string.IsNullOrEmpty(orgIdClaim) && Guid.TryParse(orgIdClaim, out var orgId))
+        {
+            var subscribedIds = await _subscriptionClient.GetActiveRegisterIdsForOrgAsync(orgId);
+            if (!subscribedIds.Contains(registerId, StringComparer.OrdinalIgnoreCase))
+            {
+                // Not subscribed — deny the group join silently
+                return;
+            }
+        }
+
         await Groups.AddToGroupAsync(Context.ConnectionId, $"register:{registerId}");
     }
 

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -348,19 +348,50 @@ registersGroup.MapPut("/{id}", async (
 // </summary>
 registersGroup.MapDelete("/{id}", async (
     RegisterManager manager,
+    IRegisterRepository registerRepository,
     string id,
     HttpContext httpContext) =>
 {
     try
     {
         var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
-        await manager.DeleteRegisterAsync(id, walletAddress, cancellationToken: httpContext.RequestAborted);
+
+        // Load control record attestations from genesis transaction (docket 0)
+        var genesisTxs = await registerRepository.GetTransactionsByDocketAsync(id, 0, httpContext.RequestAborted);
+        var genesisTx = genesisTxs.FirstOrDefault();
+        var attestations = new List<RegisterAttestation>();
+
+        if (genesisTx?.Payloads is { Length: > 0 })
+        {
+            try
+            {
+                var payloadData = genesisTx.Payloads[0].Data;
+                if (!string.IsNullOrWhiteSpace(payloadData))
+                {
+                    var payloadBytes = payloadData.Contains('+') || payloadData.Contains('/') || payloadData.Contains('=')
+                        ? Convert.FromBase64String(payloadData)
+                        : System.Buffers.Text.Base64Url.DecodeFromChars(payloadData);
+                    var controlPayload = System.Text.Json.JsonSerializer.Deserialize<ControlTransactionPayload>(
+                        payloadBytes, new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    if (controlPayload?.Roster?.Attestations != null)
+                    {
+                        attestations = controlPayload.Roster.Attestations;
+                    }
+                }
+            }
+            catch
+            {
+                // Failed to deserialize — attestations list stays empty, caught by manager guard
+            }
+        }
+
+        await manager.DeleteRegisterAsync(id, walletAddress, attestations.AsReadOnly(), httpContext.RequestAborted);
         // SignalR notification handled by RegisterEventBridgeService via RegisterDeletedEvent
         return Results.NoContent();
     }
-    catch (UnauthorizedAccessException ex)
+    catch (UnauthorizedAccessException)
     {
-        return Results.Problem(title: "Forbidden", detail: ex.Message, statusCode: 403);
+        return Results.Problem(title: "Forbidden", detail: "You are not authorized to delete this register.", statusCode: 403);
     }
     catch (KeyNotFoundException)
     {
@@ -372,7 +403,7 @@ registersGroup.MapDelete("/{id}", async (
     }
     catch (InvalidOperationException ex) when (ex.Message.Contains("no attestations") || ex.Message.Contains("data corruption"))
     {
-        return Results.Problem(title: "Data integrity error", detail: ex.Message, statusCode: 500);
+        return Results.Problem(title: "Data integrity error", detail: "Control record is missing or corrupted.", statusCode: 500);
     }
 })
 .WithName("DeleteRegister")
@@ -412,10 +443,26 @@ var registerCreationGroup = app.MapGroup("/api/registers")
 registerCreationGroup.MapPost("/initiate", async (
     IRegisterCreationOrchestrator orchestrator,
     InitiateRegisterCreationRequest request,
+    HttpContext httpContext,
     CancellationToken cancellationToken) =>
 {
     try
     {
+        // Enforce CanCreateSystemRegisters policy for System purpose
+        if (request.Purpose == Sorcha.Register.Models.Enums.RegisterPurpose.System)
+        {
+            var orgId = httpContext.User.FindFirst("org_id")?.Value;
+            var isSystemAdminOrg = orgId == "00000000-0000-0000-0000-000000000001";
+            var isSystemAdmin = httpContext.User.IsInRole("SystemAdmin");
+            if (!isSystemAdminOrg || !isSystemAdmin)
+            {
+                return Results.Problem(
+                    title: "Forbidden",
+                    detail: "Only system administrators can create system registers.",
+                    statusCode: 403);
+            }
+        }
+
         var response = await orchestrator.InitiateAsync(request, cancellationToken);
         return Results.Ok(response);
     }

--- a/src/Services/Sorcha.Register.Service/Services/RegisterEventBridgeService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterEventBridgeService.cs
@@ -35,7 +35,7 @@ public class RegisterEventBridgeService : BackgroundService
             "register:created",
             async e =>
             {
-                _logger.LogDebug("Bridging RegisterCreated for {RegisterId} to register:{RegisterId}", e.RegisterId, e.RegisterId);
+                _logger.LogDebug("Bridging RegisterCreated for {RegisterId} to group register:{GroupRegisterId}", e.RegisterId, e.RegisterId);
                 await _hubContext.Clients
                     .Group($"register:{e.RegisterId}")
                     .RegisterCreated(e.RegisterId, e.Name);
@@ -46,7 +46,7 @@ public class RegisterEventBridgeService : BackgroundService
             "register:deleted",
             async e =>
             {
-                _logger.LogDebug("Bridging RegisterDeleted for {RegisterId} to register:{RegisterId}", e.RegisterId, e.RegisterId);
+                _logger.LogDebug("Bridging RegisterDeleted for {RegisterId} to group register:{GroupRegisterId}", e.RegisterId, e.RegisterId);
                 await _hubContext.Clients
                     .Group($"register:{e.RegisterId}")
                     .RegisterDeleted(e.RegisterId);
@@ -57,7 +57,7 @@ public class RegisterEventBridgeService : BackgroundService
             "register:status-changed",
             async e =>
             {
-                _logger.LogDebug("Bridging RegisterStatusChanged for {RegisterId} to register:{RegisterId}", e.RegisterId, e.RegisterId);
+                _logger.LogDebug("Bridging RegisterStatusChanged for {RegisterId} to group register:{GroupRegisterId}", e.RegisterId, e.RegisterId);
                 await _hubContext.Clients
                     .Group($"register:{e.RegisterId}")
                     .RegisterStatusChanged(e.RegisterId, e.NewStatus);


### PR DESCRIPTION
## Summary
Addresses all findings from the Claude Sonnet 4.6 PR review on #122.

- **CRITICAL**: DELETE endpoint now loads control record attestations from genesis transaction — was bypassing authorization entirely
- **CRITICAL**: System purpose validation added at `/initiate` endpoint — non-SystemAdmin callers get 403
- **HIGH**: SignalR `SubscribeToRegister` now verifies org subscription before allowing group join
- **HIGH**: Fixed DID prefix bug — added `did:sorcha:w:` and `did:sorcha:user:` prefixes for correct wallet matching
- **MEDIUM**: Sanitised 403 error responses — no longer expose internal details
- **MINOR**: Fixed duplicate structured log placeholders in event bridge

## Test plan
- [x] Solution builds with 0 errors
- [x] All register-related unit tests pass (0 failures)
- [x] Pre-existing Tenant Service failure unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)