### PR TITLE
fix: wire PeerDb PostgreSQL to Peer Service in Aspire and Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -333,6 +333,7 @@ services:
       ASPNETCORE_URLS: http://+:8080
       ASPNETCORE_HTTP_PORTS: "8080"
       ConnectionStrings__Redis: redis:6379
+      ConnectionStrings__PeerDb: Host=postgres;Database=sorcha_peer;Username=sorcha;Password=sorcha_dev_password
       MongoDB__ConnectionString: mongodb://sorcha:sorcha_dev_password@mongodb:27017
       MongoDB__DatabaseName: sorcha_system_register
       ServiceAuth__ClientId: service-peer

--- a/docker/postgres-init.sql
+++ b/docker/postgres-init.sql
@@ -13,9 +13,14 @@ WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_wallet')\gexec
 SELECT 'CREATE DATABASE sorcha_tenant'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_tenant')\gexec
 
+-- Create sorcha_peer database
+SELECT 'CREATE DATABASE sorcha_peer'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_peer')\gexec
+
 -- Grant all privileges to the sorcha user
 GRANT ALL PRIVILEGES ON DATABASE sorcha_wallet TO sorcha;
 GRANT ALL PRIVILEGES ON DATABASE sorcha_tenant TO sorcha;
+GRANT ALL PRIVILEGES ON DATABASE sorcha_peer TO sorcha;
 
 -- Log completion
-\echo 'Database initialization completed: sorcha_wallet and sorcha_tenant created'
+\echo 'Database initialization completed: sorcha_wallet, sorcha_tenant, and sorcha_peer created'

--- a/src/Apps/Sorcha.AppHost/AppHost.cs
+++ b/src/Apps/Sorcha.AppHost/AppHost.cs
@@ -15,6 +15,7 @@ var postgres = builder.AddPostgres("postgres")
 
 var tenantDb = postgres.AddDatabase("tenant-db", "sorcha_tenant");
 var walletDb = postgres.AddDatabase("wallet-db", "sorcha_wallet");
+var peerDb = postgres.AddDatabase("PeerDb", "sorcha_peer");
 
 // Add MongoDB for Register Service transaction storage
 var mongodb = builder.AddMongoDB("mongodb")
@@ -55,8 +56,9 @@ var walletService = builder.AddProject<Projects.Sorcha_Wallet_Service>("wallet-s
     .WithEnvironment("ServiceAuth__ClientSecret", "wallet-service-secret")
     .WithEnvironment("ServiceAuth__Scopes", "registers:write");
 
-// Add Peer Service with Redis reference (internal only)
+// Add Peer Service with database and Redis reference (internal only)
 var peerService = builder.AddProject<Projects.Sorcha_Peer_Service>("peer-service")
+    .WithReference(peerDb)
     .WithReference(redis)
     .WithEnvironment("JwtSettings__SigningKey", jwtSigningKey)
     .WithEnvironment("JwtSettings__Issuer", "https://localhost:7110")


### PR DESCRIPTION
## Summary
- Peer Service has EF Core + PostgreSQL support but AppHost wasn't configuring a database resource — fell back to InMemoryDatabase, losing peer topology on restart
- Added `sorcha_peer` database to Aspire AppHost, docker-compose, and postgres-init.sql

## Test plan
- [x] AppHost builds successfully
- [x] Peer Service Program.cs already handles both PostgreSQL and InMemory (lines 78-88)

🤖 Generated with [Claude Code](https://claude.com/claude-code)