### PR TITLE
fix: create owner subscription when register is created via UI

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/CreateRegisterWizard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/CreateRegisterWizard.razor
@@ -4,12 +4,15 @@
 @using Sorcha.Register.Models.Enums
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Models.Registers
+@using Microsoft.AspNetCore.Components.Authorization
 @using Sorcha.UI.Core.Models.Wallet
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Services.Wallet
 
 @inject IRegisterService RegisterService
+@inject IRegisterSubscriptionService SubscriptionService
 @inject IWalletApiService WalletService
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
 <MudDialog>
     <TitleContent>
@@ -458,6 +461,14 @@
 
     private bool HasValidWallet() => !string.IsNullOrEmpty(_selectedWalletAddress);
 
+    private async Task<Guid> GetOrgIdAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var orgClaim = authState.User.FindFirst("org_id")?.Value
+            ?? authState.User.FindFirst("organization_id")?.Value;
+        return Guid.TryParse(orgClaim, out var orgId) ? orgId : Guid.Empty;
+    }
+
     private string GetSelectedWalletName()
     {
         var wallet = _wallets.FirstOrDefault(w => w.Address == _selectedWalletAddress);
@@ -628,6 +639,14 @@
                     ErrorMessage = "Failed to finalize register creation. Please try again."
                 };
                 return;
+            }
+
+            // Create owner subscription so the register appears in the UI
+            var orgId = await GetOrgIdAsync();
+            if (orgId != Guid.Empty)
+            {
+                await SubscriptionService.CreateOwnerSubscriptionAsync(
+                    orgId, finalizeResponse.RegisterId, _name);
             }
 
             // Success - create view model for callback

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IRegisterSubscriptionService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IRegisterSubscriptionService.cs
@@ -81,6 +81,11 @@ public interface IRegisterSubscriptionService
     Task<RegisterSubscriptionDto?> SubscribeAsync(Guid orgId, string registerId, CancellationToken ct = default);
 
     /// <summary>
+    /// Create an owner subscription for a register the organisation just created.
+    /// </summary>
+    Task<RegisterSubscriptionDto?> CreateOwnerSubscriptionAsync(Guid orgId, string registerId, string? registerName, CancellationToken ct = default);
+
+    /// <summary>
     /// Unsubscribe an organisation from a register.
     /// </summary>
     Task<bool> UnsubscribeAsync(Guid orgId, string registerId, CancellationToken ct = default);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterSubscriptionService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterSubscriptionService.cs
@@ -73,6 +73,37 @@ public class RegisterSubscriptionService : IRegisterSubscriptionService
     }
 
     /// <inheritdoc />
+    public async Task<RegisterSubscriptionDto?> CreateOwnerSubscriptionAsync(
+        Guid orgId, string registerId, string? registerName, CancellationToken ct = default)
+    {
+        try
+        {
+            var payload = new { register_id = registerId, register_name = registerName, subscription_type = "Owner" };
+            var response = await _httpClient.PostAsJsonAsync(
+                $"/api/organizations/{Uri.EscapeDataString(orgId.ToString())}/register-subscriptions",
+                payload,
+                JsonDefaults.Api,
+                ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogWarning(
+                    "Failed to create owner subscription for register {RegisterId}: {StatusCode} - {Error}",
+                    registerId, response.StatusCode, error);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<RegisterSubscriptionDto>(JsonDefaults.Api, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating owner subscription for register {RegisterId}", registerId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<bool> UnsubscribeAsync(Guid orgId, string registerId, CancellationToken ct = default)
     {
         try

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -433,11 +433,8 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         // It will be written to Register Service database after docket creation
         // Validator Service handles the write after successful docket build
 
-        // TODO(T025): After UI register creation, the UI should call
-        // POST /api/organizations/{orgId}/register-subscriptions to create an Owner
-        // subscription via the Tenant Service. This requires the RegisterSubscription
-        // UI HTTP client (T028 in US5). Until then, the UI must manually subscribe
-        // after register creation.
+        // Owner subscription is created by the UI's CreateRegisterWizard after finalization
+        // via POST /api/organizations/{orgId}/register-subscriptions with subscription_type=Owner.
 
         return new FinalizeRegisterCreationResponse
         {

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/RegisterSubscriptionEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/RegisterSubscriptionEndpoints.cs
@@ -138,8 +138,13 @@ public static class RegisterSubscriptionEndpoints
 
         try
         {
-            var subscription = await subscriptionService.SubscribeAsync(
-                orgId, request.RegisterId, null, userId, cancellationToken);
+            var isOwner = string.Equals(request.SubscriptionType, "Owner", StringComparison.OrdinalIgnoreCase);
+
+            var subscription = isOwner
+                ? await subscriptionService.CreateOwnerSubscriptionAsync(
+                    orgId, request.RegisterId, request.RegisterName, userId, cancellationToken)
+                : await subscriptionService.SubscribeAsync(
+                    orgId, request.RegisterId, request.RegisterName, userId, cancellationToken);
 
             return TypedResults.Created(
                 $"/api/organizations/{orgId}/register-subscriptions/{request.RegisterId}",

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/RegisterSubscriptionDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/RegisterSubscriptionDtos.cs
@@ -15,6 +15,19 @@ public record SubscribeRequest
     /// </summary>
     [JsonPropertyName("register_id")]
     public required string RegisterId { get; init; }
+
+    /// <summary>
+    /// Optional human-readable register name (cached on the subscription).
+    /// </summary>
+    [JsonPropertyName("register_name")]
+    public string? RegisterName { get; init; }
+
+    /// <summary>
+    /// Subscription type: "Owner" or "Public" (default). Owner subscriptions are
+    /// immediately Active; Public subscriptions start as Pending.
+    /// </summary>
+    [JsonPropertyName("subscription_type")]
+    public string? SubscriptionType { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Registers created through the CreateRegisterWizard were invisible on the Registers page because no Owner subscription existed in the Tenant Service
- Extended the Subscribe endpoint to accept `subscription_type=Owner`, routing to `CreateOwnerSubscriptionAsync`
- CreateRegisterWizard now auto-creates an Owner subscription after successful register finalization
- Resolves TODO(T025) in RegisterCreationOrchestrator

## Test plan
- [x] Full solution builds with 0 errors
- [x] All 26 RegisterSubscription tests pass
- [x] All 903 UI Core tests pass
- [ ] Create a register via the wizard — verify it appears on the Registers page with "Owner" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)