### PR TITLE
feat: [Feature-068] Blueprint Service persistence + Validator crash recovery

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__Redis: redis:6379
+      ConnectionStrings__BlueprintDb: Host=postgres;Database=sorcha_blueprint;Username=sorcha;Password=sorcha_dev_password
       ConnectionStrings__mongodb: mongodb://sorcha:sorcha_dev_password@mongodb:27017
       # AI Provider configuration (Anthropic Claude API)
       AIProvider__ApiKey: ${ANTHROPIC_API_KEY:-}

--- a/docker/postgres-init.sql
+++ b/docker/postgres-init.sql
@@ -17,10 +17,15 @@ WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_tenant')\gexec
 SELECT 'CREATE DATABASE sorcha_peer'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_peer')\gexec
 
+-- Create sorcha_blueprint database
+SELECT 'CREATE DATABASE sorcha_blueprint'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_blueprint')\gexec
+
 -- Grant all privileges to the sorcha user
 GRANT ALL PRIVILEGES ON DATABASE sorcha_wallet TO sorcha;
 GRANT ALL PRIVILEGES ON DATABASE sorcha_tenant TO sorcha;
 GRANT ALL PRIVILEGES ON DATABASE sorcha_peer TO sorcha;
+GRANT ALL PRIVILEGES ON DATABASE sorcha_blueprint TO sorcha;
 
 -- Log completion
-\echo 'Database initialization completed: sorcha_wallet, sorcha_tenant, and sorcha_peer created'
+\echo 'Database initialization completed: sorcha_wallet, sorcha_tenant, sorcha_peer, and sorcha_blueprint created'

--- a/speckit-prompt-db-persistence.md
+++ b/speckit-prompt-db-persistence.md
@@ -1,0 +1,73 @@
+# Speckit Prompt: Blueprint Service Persistence & Validator Crash Recovery
+
+## Context
+
+Database persistence audit (2026-03-24) found three gaps across Sorcha services. Two are now resolved:
+- **Peer Service**: Fixed — PostgreSQL wiring added to AppHost and docker-compose (PR #124)
+- **Register, Tenant, Wallet**: Already fully durable (MongoDB, PostgreSQL, PostgreSQL respectively)
+
+Two gaps remain:
+1. **Blueprint Service** — all data stored in ConcurrentDictionary (lost on restart)
+2. **Validator Service** — verified transaction queue is in-memory by design, but no crash recovery to re-validate from last confirmed docket
+
+## Feature Description
+
+### Part 1: Blueprint Service Persistence
+
+The Blueprint Service currently uses in-memory stores (`InMemoryBlueprintStore`, `InMemoryPublishedBlueprintStore`, `InMemoryActionStore`, `InMemoryInstanceStore`). This data is lost on every service restart.
+
+The persistence model must respect the register as the single source of truth:
+- **Published blueprints** are transactions on the system register — the Blueprint Service should cache them in Redis, not own them in a local database
+- **Instance execution state** is reconstructable from register transactions (each action produces a transaction) — the Blueprint Service should cache current state in Redis, rebuildable on cache miss
+- **Drafts** are work-in-progress blueprints that have not been published to a register — these need durable local storage (PostgreSQL)
+- **Templates** are the reusable blueprint template library — these need durable local storage (PostgreSQL), currently seeded from JSON files on startup
+
+#### Draft Ownership & Access
+
+Each draft has a local owner (the user who created it). The initial implementation should support single-owner access. The data model should include an `OwnerId` field and be designed so that shared or delegated access can be added later (e.g., a `BlueprintDraftAccess` table for collaborating designers), but do NOT implement shared access in this feature — just ensure the schema doesn't prevent it.
+
+#### Published Blueprint & Instance Caching
+
+Published blueprints retrieved from the register should be cached in Redis with appropriate TTL. Cache keys must include blueprint version to support the edge case where a blueprint is upgraded while existing instances are still running on the previous version. Two instances running different versions of the same blueprint must each resolve to their correct blueprint version.
+
+Instance state should be cached in Redis, keyed by instance ID. On cache miss, the service reconstructs state by replaying the instance's transactions from the register. This is the existing `Instance.AccumulatedData` pattern — it just needs a Redis backing store instead of in-memory.
+
+#### PostgreSQL Integration
+
+Follow the same pattern as Tenant Service and Wallet Service:
+- EF Core DbContext with auto-migrations on startup
+- Add `sorcha_blueprint` database to AppHost, docker-compose, and postgres-init.sql
+- Fallback to InMemory EF Core database when no connection string is configured
+- Repository pattern with interface abstraction
+
+### Part 2: Validator Crash Recovery
+
+The Validator Service's verified transaction queue (`VerifiedTransactionQueue`) is intentionally in-memory — this is correct by design. However, after a crash or restart, the validator should re-check from the last confirmed docket rather than starting with an empty queue and waiting for new submissions.
+
+On startup, the Validator should:
+1. Query the register for the current docket height
+2. Check Redis unverified pool for any pending transactions that arrived during downtime
+3. Re-validate and process those transactions through the normal pipeline
+4. Resume normal polling
+
+This is a reconciliation step, not a persistence change — the validator's in-memory queue remains ephemeral.
+
+## Requirements Summary
+
+### Blueprint Service
+- Migrate drafts and templates to PostgreSQL via EF Core
+- Cache published blueprints and instance state in Redis (register is source of truth)
+- Redis cache keys include blueprint version for concurrent version support
+- Draft ownership model with single owner (schema supports future delegation)
+- InMemory fallback when no connection string configured
+- Aspire AppHost + docker-compose + postgres-init.sql updates
+
+### Validator Service
+- Add startup reconciliation: re-check unverified pool against last confirmed docket
+- No persistence changes to verified queue (in-memory by design)
+
+## Notes
+- Blueprint Service currently has a code comment "later: replace with EF Core + PostgreSQL"
+- Schema library index already uses durable MongoDB — no change needed there
+- The `InMemoryBlueprintStore` etc. interfaces are already abstracted — implementations can be swapped
+- Existing `IRepository<T>` pattern from `Sorcha.Storage.Abstractions` may be applicable for drafts/templates

--- a/specs/068-blueprint-persistence/checklists/requirements.md
+++ b/specs/068-blueprint-persistence/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Blueprint Service Persistence & Validator Crash Recovery
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.plan`.
+- Assumptions document 6 key assumptions about existing interfaces, register APIs, and seed data.
+- US4 (Instance State Caching) and US5 (Validator Reconciliation) are P2 — can be deferred for MVP.
+- Draft access model deliberately minimal (owner-only) with schema extensibility for future collaboration.

--- a/specs/068-blueprint-persistence/contracts/blueprint-persistence-changes.md
+++ b/specs/068-blueprint-persistence/contracts/blueprint-persistence-changes.md
@@ -1,0 +1,94 @@
+# Contract Changes: Blueprint Service Persistence
+
+**Feature**: 068-blueprint-persistence | **Date**: 2026-03-24
+
+## No API Endpoint Changes
+
+All existing Blueprint Service endpoints remain unchanged. This feature changes the storage layer behind the existing interfaces — callers see no difference.
+
+## DI Registration Changes
+
+### Blueprint Service Program.cs
+
+```diff
+- // Add in-memory storage (later: replace with EF Core + PostgreSQL)
+- builder.Services.AddSingleton<IBlueprintStore, InMemoryBlueprintStore>();
+- builder.Services.AddSingleton<IPublishedBlueprintStore, InMemoryPublishedBlueprintStore>();
+- builder.Services.AddSingleton<IActionStore, InMemoryActionStore>();
+- builder.Services.AddSingleton<IInstanceStore, InMemoryInstanceStore>();
+- builder.Services.AddSingleton<IDocumentStore<BlueprintTemplate, string>>(
+-     new InMemoryDocumentStore<BlueprintTemplate, string>(t => t.Id));
++ // Add durable storage (PostgreSQL + Redis cache)
++ var blueprintDbConn = builder.Configuration.GetConnectionString("BlueprintDb");
++ if (!string.IsNullOrEmpty(blueprintDbConn))
++ {
++     builder.Services.AddDbContextFactory<BlueprintDbContext>(options =>
++         options.UseNpgsql(blueprintDbConn));
++     builder.Services.AddSingleton<IBlueprintStore, EfCoreBlueprintStore>();
++     builder.Services.AddSingleton<IActionStore, EfCoreActionStore>();
++     builder.Services.AddSingleton<IInstanceStore, EfCoreInstanceStore>();
++     builder.Services.AddSingleton<IDocumentStore<BlueprintTemplate, string>, EfCoreTemplateStore>();
++ }
++ else
++ {
++     builder.Services.AddSingleton<IBlueprintStore, InMemoryBlueprintStore>();
++     builder.Services.AddSingleton<IActionStore, InMemoryActionStore>();
++     builder.Services.AddSingleton<IInstanceStore, InMemoryInstanceStore>();
++     builder.Services.AddSingleton<IDocumentStore<BlueprintTemplate, string>>(
++         new InMemoryDocumentStore<BlueprintTemplate, string>(t => t.Id));
++ }
++ // Published blueprints always use Redis cache (register is source of truth)
++ builder.Services.AddSingleton<IPublishedBlueprintStore, RedisCachedPublishedBlueprintStore>();
+```
+
+## Infrastructure Changes
+
+### AppHost.cs
+
+```diff
+  var tenantDb = postgres.AddDatabase("tenant-db", "sorcha_tenant");
+  var walletDb = postgres.AddDatabase("wallet-db", "sorcha_wallet");
+  var peerDb = postgres.AddDatabase("PeerDb", "sorcha_peer");
++ var blueprintDb = postgres.AddDatabase("BlueprintDb", "sorcha_blueprint");
+
+  var blueprintService = builder.AddProject<Projects.Sorcha_Blueprint_Service>("blueprint-service")
++     .WithReference(blueprintDb)
+      .WithReference(redis)
+```
+
+### docker-compose.yml
+
+```diff
+  blueprint-service:
+    environment:
++     ConnectionStrings__BlueprintDb: Host=postgres;Database=sorcha_blueprint;Username=sorcha;Password=sorcha_dev_password
+```
+
+### docker/postgres-init.sql
+
+```diff
++ SELECT 'CREATE DATABASE sorcha_blueprint'
++ WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'sorcha_blueprint')\gexec
++ GRANT ALL PRIVILEGES ON DATABASE sorcha_blueprint TO sorcha;
+```
+
+## Validator Service Changes
+
+### Startup Reconciliation
+
+No API or interface changes. Internal enhancement to `DocketBuildTriggerService`:
+
+```diff
+  private async Task ReconcileGenesisStateAsync(CancellationToken cancellationToken)
+  {
+      // existing genesis height reconciliation...
++     // After height reconciliation, drain unverified pool
++     await ReconcileUnverifiedPoolAsync(cancellationToken);
+  }
+
++ private async Task ReconcileUnverifiedPoolAsync(CancellationToken cancellationToken)
++ {
++     // For each monitored register, trigger immediate validation
++     // of any pending transactions in the unverified pool
++ }
+```

--- a/specs/068-blueprint-persistence/data-model.md
+++ b/specs/068-blueprint-persistence/data-model.md
@@ -1,0 +1,139 @@
+# Data Model: Blueprint Service Persistence & Validator Crash Recovery
+
+**Feature**: 068-blueprint-persistence | **Date**: 2026-03-24
+
+## Entity Changes
+
+### 1. BlueprintDraftEntity (New — PostgreSQL)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| Id | string (GUID) | PK | Auto-generated |
+| OwnerId | string | Required, indexed | JWT `sub` claim of creator |
+| Name | string | Required, max 200 | Display name |
+| Description | string? | Max 2000 | Optional description |
+| Content | string (JSONB) | Required | Full blueprint JSON |
+| OrganizationId | string? | Indexed | Org context for future scoping |
+| Status | DraftStatus enum | Required, default Draft | Draft, Archived |
+| CreatedAt | DateTimeOffset | Required | UTC |
+| UpdatedAt | DateTimeOffset | Required | UTC |
+
+**Future Extensibility**:
+
+### 2. BlueprintDraftAccessEntity (New — PostgreSQL, schema only)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| Id | Guid | PK | |
+| DraftId | string | FK → BlueprintDraftEntity, indexed | |
+| UserId | string | Required, indexed | Delegated user |
+| AccessLevel | string | Required | "Read", "Write" |
+| GrantedAt | DateTimeOffset | Required | |
+| GrantedBy | string | Required | User who granted access |
+
+**Note**: Table created in schema but no business logic implemented. Exists to prevent future schema migration for collaboration feature.
+
+### 3. BlueprintTemplateEntity (New — PostgreSQL)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| Id | string | PK | Template identifier |
+| Name | string | Required, max 200 | Display name |
+| Description | string? | Max 2000 | |
+| Category | string? | Indexed | Template category |
+| Content | string (JSONB) | Required | Full template JSON |
+| Version | int | Required, default 1 | For seed version comparison |
+| Source | TemplateSource enum | Required | Seed, UserCreated |
+| Published | bool | Required, default true | Visibility flag |
+| UsageCount | int | Default 0 | Popularity tracking |
+| CreatedAt | DateTimeOffset | Required | |
+| UpdatedAt | DateTimeOffset | Required | |
+
+### 4. ActionEntity (New — PostgreSQL)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| TransactionHash | string | PK | Transaction identifier |
+| WalletAddress | string | Required, indexed | Sender wallet |
+| RegisterAddress | string | Required, indexed | Target register |
+| Content | string (JSONB) | Required | Full action details JSON |
+| IdempotencyKey | string? | Unique index | Replay protection |
+| IdempotencyExpiry | DateTimeOffset? | | TTL for key |
+| CreatedAt | DateTimeOffset | Required | |
+
+**File storage** (separate table):
+
+### 5. FileMetadataEntity (New — PostgreSQL)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| Id | string | PK | File identifier |
+| TransactionHash | string | FK → ActionEntity, indexed | |
+| FileName | string | Required | |
+| ContentType | string | Required | MIME type |
+| Size | long | Required | Bytes |
+| Content | byte[] | Required | File content |
+
+### 6. InstanceEntity (New — PostgreSQL)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| Id | string | PK | Instance identifier |
+| BlueprintId | string | Required, indexed | |
+| BlueprintVersion | int | Required | Pinned at creation |
+| RegisterId | string | Required, indexed | |
+| State | InstanceState enum | Required, indexed | Active/Completed/etc. |
+| CurrentActionIds | string (JSONB) | | List of pending action IDs |
+| ParticipantWallets | string (JSONB) | | Dict mapping participant→wallet |
+| FirstTransactionId | string? | | Chain root |
+| LastTransactionId | string? | | Chain tip |
+| CompletedActionCount | int | Default 0 | |
+| AccumulatedData | string (JSONB) | | Cached execution state |
+| ActiveBranches | string (JSONB) | | Parallel branch state |
+| Metadata | string (JSONB) | | Key-value pairs |
+| Version | int | Required | Optimistic concurrency |
+| CreatedAt | DateTimeOffset | Required | |
+| UpdatedAt | DateTimeOffset | Required | |
+| CompletedAt | DateTimeOffset? | | |
+
+## Redis Cache Structures
+
+### Published Blueprint Cache
+
+| Key Pattern | Value | TTL | Notes |
+|-------------|-------|-----|-------|
+| `bp:pub:{blueprintId}:v:{version}` | Serialized blueprint JSON | 15 min | Version-specific |
+| `bp:pub:{blueprintId}:latest` | Version number | 5 min | Quick latest-version lookup |
+| `bp:pub:register:{registerId}` | Set of blueprint IDs | 15 min | Register-scoped listing |
+
+### Instance State Cache
+
+| Key Pattern | Value | TTL | Notes |
+|-------------|-------|-----|-------|
+| `bp:inst:{instanceId}:state` | Serialized AccumulatedData JSON | 30 min | Hot execution state |
+| `bp:inst:{instanceId}:meta` | Serialized instance metadata | 30 min | Fast metadata lookup |
+
+## Indexes
+
+### PostgreSQL Indexes
+
+| Table | Index | Columns | Notes |
+|-------|-------|---------|-------|
+| BlueprintDrafts | IX_Drafts_OwnerId | OwnerId | Owner-scoped queries |
+| BlueprintDrafts | IX_Drafts_OrgId | OrganizationId | Future org-scoped queries |
+| BlueprintTemplates | IX_Templates_Category | Category | Category filtering |
+| Actions | IX_Actions_Wallet_Register | WalletAddress, RegisterAddress | Action listing |
+| Actions | UX_Actions_IdempotencyKey | IdempotencyKey | Unique, replay protection |
+| Instances | IX_Instances_BlueprintId | BlueprintId | Blueprint-scoped queries |
+| Instances | IX_Instances_RegisterId | RegisterId | Register-scoped queries |
+| Instances | IX_Instances_State | State | State filtering |
+
+## Enums
+
+### DraftStatus
+- `Draft` = 0 (default)
+- `Archived` = 1
+
+### TemplateSource
+- `Seed` = 0 (loaded from JSON files)
+- `UserCreated` = 1 (created at runtime)

--- a/specs/068-blueprint-persistence/plan.md
+++ b/specs/068-blueprint-persistence/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Blueprint Service Persistence & Validator Crash Recovery
+
+**Branch**: `068-blueprint-persistence` | **Date**: 2026-03-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/068-blueprint-persistence/spec.md`
+
+## Summary
+
+Migrate Blueprint Service from volatile in-memory storage to durable PostgreSQL (drafts, templates, actions, instances) + Redis cache (published blueprints, instance execution state). The register remains the single source of truth for published blueprints — the Blueprint Service caches from it. Add validator startup reconciliation to drain pending transactions from the unverified pool after a crash.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 10.0
+**Primary Dependencies**: EF Core 10.0.5, Npgsql 10.0.1, StackExchange.Redis 2.12.4, .NET Aspire 13.2.0
+**Storage**: PostgreSQL (drafts, templates, actions, instances), Redis (published blueprint cache, instance state cache), MongoDB (register — source of truth, read-only)
+**Testing**: xUnit 3.2.2, FluentAssertions 8.9.0, Moq 4.20.72
+**Target Platform**: Linux containers (Docker), Windows dev
+**Project Type**: Distributed microservices
+**Performance Goals**: <50ms cache hit for published blueprints, <10s instance state reconstruction
+**Constraints**: Register is source of truth for published data; PostgreSQL for local working state only
+**Scale/Scope**: ~12 new files, ~5 modified files, 1 new database
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Microservices-First | PASS | Blueprint Service owns its PostgreSQL database. Register read via service client. |
+| II. Security First | PASS | Draft access restricted to owner. No secrets in connection strings. |
+| III. API Documentation | PASS | No API changes — storage layer only. |
+| IV. Testing Requirements | PASS | Tests for each store implementation, cache hit/miss, reconstruction. |
+| V. Code Quality | PASS | Async/await, DI, nullable enabled, IDbContextFactory for singleton stores. |
+| VI. Blueprint Standards | N/A | No blueprint format changes. |
+| VII. Domain-Driven Design | PASS | Entities follow existing naming (Blueprint, Instance, Action). |
+| VIII. Observability | PASS | Structured logging on cache hits/misses, reconstruction, seed operations. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/068-blueprint-persistence/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Research findings
+├── data-model.md        # Entity definitions
+├── quickstart.md        # Implementation order
+├── contracts/
+│   └── blueprint-persistence-changes.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Created by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+src/Services/Sorcha.Blueprint.Service/
+├── Data/
+│   ├── BlueprintDbContext.cs                    # NEW — EF Core context
+│   └── Entities/
+│       ├── BlueprintDraftEntity.cs              # NEW
+│       ├── BlueprintDraftAccessEntity.cs        # NEW (schema only)
+│       ├── BlueprintTemplateEntity.cs           # NEW
+│       ├── ActionEntity.cs                      # NEW
+│       ├── FileMetadataEntity.cs                # NEW
+│       └── InstanceEntity.cs                    # NEW
+├── Migrations/                                  # NEW — EF Core migrations
+├── Storage/
+│   ├── EfCoreBlueprintStore.cs                  # NEW — IBlueprintStore impl
+│   ├── EfCoreTemplateStore.cs                   # NEW — IDocumentStore impl
+│   ├── EfCoreActionStore.cs                     # NEW — IActionStore impl
+│   ├── EfCoreInstanceStore.cs                   # NEW — IInstanceStore impl
+│   ├── RedisCachedPublishedBlueprintStore.cs    # NEW — IPublishedBlueprintStore impl
+│   ├── InMemoryActionStore.cs                   # KEEP — fallback
+│   ├── InMemoryInstanceStore.cs                 # KEEP — fallback
+│   ├── IActionStore.cs                          # KEEP — unchanged
+│   └── IInstanceStore.cs                        # KEEP — unchanged
+├── Program.cs                                   # MODIFY — DI registration switch
+
+src/Apps/Sorcha.AppHost/AppHost.cs               # MODIFY — add BlueprintDb
+docker-compose.yml                               # MODIFY — add connection string
+docker/postgres-init.sql                         # MODIFY — add database
+
+src/Services/Sorcha.Validator.Service/
+└── Services/DocketBuildTriggerService.cs         # MODIFY — add reconciliation
+
+tests/
+├── Sorcha.Blueprint.Service.Tests/              # MODIFY — persistence tests
+└── Sorcha.Validator.Service.Tests/              # MODIFY — reconciliation tests
+```
+
+## Complexity Tracking
+
+No constitution violations. All changes use established patterns:
+- EF Core DbContext follows Tenant/Wallet service patterns
+- `IDbContextFactory` for singleton stores follows Peer Service pattern
+- Redis cache follows Validator `BlueprintCache` pattern
+- Auto-migration follows Tenant `DatabaseInitializer` pattern
+- InMemory fallback follows Wallet/Peer conditional registration pattern

--- a/specs/068-blueprint-persistence/quickstart.md
+++ b/specs/068-blueprint-persistence/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart: Blueprint Service Persistence & Validator Crash Recovery
+
+**Feature**: 068-blueprint-persistence | **Date**: 2026-03-24
+
+## Implementation Order
+
+### Phase 1: Infrastructure (US6)
+
+1. Create `BlueprintDbContext` with entity configurations
+2. Add `sorcha_blueprint` database to AppHost, docker-compose, postgres-init.sql
+3. Add auto-migration startup logic (same pattern as Tenant/Wallet)
+4. Add InMemory fallback when no connection string
+5. Create initial EF Core migration
+
+### Phase 2: Drafts & Templates (US1, US2)
+
+6. Create `EfCoreBlueprintStore` implementing `IBlueprintStore` using `IDbContextFactory`
+7. Create `EfCoreTemplateStore` implementing `IDocumentStore<BlueprintTemplate, string>`
+8. Update DI registration — swap InMemory for EF Core when connection string present
+9. Verify `TemplateSeedService` works with EF Core store (should work unchanged)
+10. Write tests for draft persistence across simulated restarts
+
+### Phase 3: Published Blueprint Cache (US3)
+
+11. Create `RedisCachedPublishedBlueprintStore` implementing `IPublishedBlueprintStore`
+12. Implement version-aware cache keys (`bp:pub:{id}:v:{version}`)
+13. Implement cache miss → register fetch → cache populate flow
+14. Wire into DI (always use Redis, register is source of truth)
+15. Write tests for cache hit/miss/version-concurrent scenarios
+
+### Phase 4: Instance & Action Persistence (US4)
+
+16. Create `EfCoreActionStore` implementing `IActionStore`
+17. Create `EfCoreInstanceStore` implementing `IInstanceStore`
+18. Add Redis cache layer for hot instance state (AccumulatedData)
+19. Implement register-based state reconstruction on cache miss
+20. Write tests for instance persistence and reconstruction
+
+### Phase 5: Validator Reconciliation (US5)
+
+21. Extend `DocketBuildTriggerService.ReconcileGenesisStateAsync` to drain unverified pool
+22. Trigger immediate `ValidationEngineService.ProcessRegisterAsync` for monitored registers
+23. Write tests for startup reconciliation with pending transactions
+
+## Key Files
+
+| File | Phase | Changes |
+|------|-------|---------|
+| `src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs` | 1 | NEW |
+| `src/Services/Sorcha.Blueprint.Service/Data/Entities/*.cs` | 1 | NEW (5 entity classes) |
+| `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreBlueprintStore.cs` | 2 | NEW |
+| `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreTemplateStore.cs` | 2 | NEW |
+| `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreActionStore.cs` | 4 | NEW |
+| `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs` | 4 | NEW |
+| `src/Services/Sorcha.Blueprint.Service/Storage/RedisCachedPublishedBlueprintStore.cs` | 3 | NEW |
+| `src/Services/Sorcha.Blueprint.Service/Program.cs` | 1-4 | MODIFY — DI registration |
+| `src/Apps/Sorcha.AppHost/AppHost.cs` | 1 | MODIFY — add BlueprintDb |
+| `docker-compose.yml` | 1 | MODIFY — add connection string |
+| `docker/postgres-init.sql` | 1 | MODIFY — add database |
+| `src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs` | 5 | MODIFY — add reconciliation |
+
+## Build & Test
+
+```bash
+# After each phase:
+dotnet build --force
+dotnet test --filter "FullyQualifiedName~Blueprint"
+
+# Full suite:
+dotnet test
+```

--- a/specs/068-blueprint-persistence/research.md
+++ b/specs/068-blueprint-persistence/research.md
@@ -1,0 +1,82 @@
+# Research: Blueprint Service Persistence & Validator Crash Recovery
+
+**Feature**: 068-blueprint-persistence | **Date**: 2026-03-24
+
+## R1: Blueprint Store Interface Abstraction
+
+**Decision**: Implement EF Core-backed stores behind existing interfaces — no caller changes needed.
+
+**Rationale**: All four store interfaces (`IBlueprintStore`, `IPublishedBlueprintStore`, `IActionStore`, `IInstanceStore`) are well-abstracted. The in-memory implementations use `ConcurrentDictionary` and return `Task<T>`. EF Core implementations can implement the same interfaces with `DbContext` queries.
+
+**Key Finding**: Stores are registered as **Singletons** in DI. EF Core DbContext is Scoped. The EF Core implementations must use `IDbContextFactory<BlueprintDbContext>` (same pattern as Peer Service) to create short-lived contexts within singleton-scoped stores.
+
+**Alternatives Considered**:
+- Change stores to Scoped — rejected (would require updating all consumers)
+- Use `IServiceScopeFactory` — rejected (DbContextFactory is the standard pattern for this)
+
+---
+
+## R2: Template Storage Migration Strategy
+
+**Decision**: Use EF Core for templates with seed-on-first-run from JSON files.
+
+**Rationale**: Templates currently use `IDocumentStore<BlueprintTemplate, string>` with `InMemoryDocumentStore`. The `TemplateSeedService` (IHostedService) already implements idempotent seeding — it checks existing version before upserting. This logic remains the same; only the backing store changes from in-memory to EF Core.
+
+**Key Finding**: `TemplateSeedService` uses version comparison — if DB template version >= file version, skip. This naturally prevents overwriting user modifications while allowing version bumps from JSON files.
+
+**Resolution**: Create `EfCoreBlueprintTemplateStore` implementing `IDocumentStore<BlueprintTemplate, string>` backed by `BlueprintDbContext`. `TemplateSeedService` continues unchanged.
+
+---
+
+## R3: Published Blueprint Cache Strategy
+
+**Decision**: Reuse the existing two-level cache pattern from Validator's `BlueprintCache` — L1 in-memory + L2 Redis.
+
+**Rationale**: The Validator Service already has a production-tested `IBlueprintCache` with L1 (ConcurrentDictionary) + L2 (Redis), pub/sub invalidation, Polly resilience, and cache stats. The Blueprint Service should use the same pattern for published blueprint lookups.
+
+**Key Finding**: Cache keys must include blueprint version. Current Validator cache keys use blueprint ID only. Need to extend key format to `blueprint:{blueprintId}:v:{version}` for version-concurrent access.
+
+**Gap**: The Blueprint Service's `IPublishedBlueprintStore` interface is richer than `IBlueprintCache` (it has `GetByRegisterAsync`, `GetVersionsAsync`). The Redis cache backs the hot path (`GetVersionAsync`); the store interface methods that list/query can fall back to register queries.
+
+---
+
+## R4: Instance State Cache Strategy
+
+**Decision**: Redis-backed instance state cache with register-based reconstruction on miss.
+
+**Rationale**: Instance state is already cached in-memory via `InMemoryInstanceStore`. Moving to Redis gives durability across restarts while maintaining fast access. On cache miss, the existing `StateReconstructionService` + `AccumulatedData` pattern rebuilds state from register transactions.
+
+**Key Finding**: `Instance` has optimistic concurrency (Version field). Redis implementation must preserve this — use Redis WATCH/MULTI or conditional SET with version check.
+
+**Simplification**: For MVP, use Redis serialized JSON with TTL for active instances. The `IInstanceStore` interface has complex query methods (`GetByParticipantWalletAsync`, `GetPendingActionsByWalletAsync`) — these can use Redis secondary indexes or fall back to scanning. Alternatively, keep a PostgreSQL-backed `IInstanceStore` for query richness and use Redis only for hot instance state.
+
+**Decision Refined**: Use PostgreSQL for instance metadata (queryable) + Redis for hot execution state (AccumulatedData). The `IInstanceStore` implementation queries PostgreSQL for metadata and merges AccumulatedData from Redis.
+
+---
+
+## R5: Validator Crash Recovery
+
+**Decision**: Extend existing `DocketBuildTriggerService.ReconcileGenesisStateAsync()` to also drain the unverified pool.
+
+**Rationale**: The validator already reconciles genesis state on startup — it queries register heights for all monitored registers. The missing piece is: after confirming heights, poll the unverified pool for pending transactions and trigger validation.
+
+**Key Finding**: `ValidationEngineService` already polls the unverified pool in its main loop. The reconciliation just needs to trigger an immediate poll cycle rather than waiting for the next timer tick.
+
+**Resolution**: Add a reconciliation step after `ReconcileGenesisStateAsync` that signals `ValidationEngineService` to run an immediate batch, or directly call `ProcessRegisterAsync` for each monitored register with pending transactions.
+
+---
+
+## R6: Database Schema Design
+
+**Decision**: Single `BlueprintDbContext` with four entity sets + one future-ready join table.
+
+**Entities**:
+- `BlueprintDraftEntity` — drafts with OwnerId, JSON content, status
+- `BlueprintTemplateEntity` — templates with category, source, JSON content
+- `ActionEntity` — action transactions with wallet/register indexes
+- `InstanceEntity` — instance metadata with state, participant wallets (JSONB)
+- `BlueprintDraftAccessEntity` — empty table for future delegation (schema only, no logic)
+
+**Schema**: `blueprint` (matches Tenant's `public` and Wallet's `wallet` schema patterns)
+
+**Connection String Key**: `BlueprintDb` (matches Peer's `PeerDb` pattern)

--- a/specs/068-blueprint-persistence/spec.md
+++ b/specs/068-blueprint-persistence/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Blueprint Service Persistence & Validator Crash Recovery
+
+**Feature Branch**: `068-blueprint-persistence`
+**Created**: 2026-03-24
+**Status**: Draft
+**Input**: User description: "Blueprint Service stores all data in ConcurrentDictionary (lost on restart). Migrate drafts/templates to durable storage, cache published blueprints and instance state from the register (single source of truth), and add validator startup reconciliation."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Blueprint Draft Persistence (Priority: P1)
+
+A blueprint designer creates a draft blueprint through the UI or API, saves it, and returns hours later to continue editing. The draft survives service restarts and container redeployments. The designer is the owner of the draft and only they can see and edit it. The system's data model accommodates future collaborative editing by multiple designers, but only single-owner access is enforced now.
+
+**Why this priority**: Drafts represent user work-in-progress. Losing a designer's work on every restart is the most impactful data loss in the current system.
+
+**Independent Test**: Can be fully tested by creating a draft, restarting the Blueprint Service, and verifying the draft is still retrievable with all its content intact.
+
+**Acceptance Scenarios**:
+
+1. **Given** a designer creates a blueprint draft, **When** the Blueprint Service is restarted, **Then** the draft is still available with all content preserved
+2. **Given** a designer saves a draft, **When** another user queries drafts, **Then** only the owner's drafts are visible to the owner
+3. **Given** a draft exists with an owner, **When** a different authenticated user attempts to access it, **Then** the system denies access
+4. **Given** a designer deletes a draft, **When** they query their drafts, **Then** the deleted draft no longer appears
+5. **Given** no durable storage is configured, **When** the Blueprint Service starts, **Then** drafts are stored in volatile memory (development fallback) with a log warning
+
+---
+
+### User Story 2 - Template Library Persistence (Priority: P1)
+
+An administrator manages the blueprint template library. Templates are reusable starting points that designers can clone when creating new blueprints. Templates survive service restarts without requiring re-seeding from JSON files. The initial set of templates is populated from the existing JSON template files during the first database migration.
+
+**Why this priority**: Templates are currently re-seeded from JSON files on every restart, which is fragile and prevents runtime additions/modifications from persisting.
+
+**Independent Test**: Can be fully tested by adding a template, restarting the service, and verifying it persists. Also verify that existing JSON templates are available after first-time database setup.
+
+**Acceptance Scenarios**:
+
+1. **Given** the template library contains templates, **When** the Blueprint Service is restarted, **Then** all templates are still available
+2. **Given** a fresh installation with an empty database, **When** the Blueprint Service starts for the first time, **Then** the existing JSON template files are migrated into the database as seed data
+3. **Given** an administrator adds a new template at runtime, **When** they query the template library, **Then** the new template appears alongside the seeded templates
+4. **Given** an administrator modifies a template, **When** the service restarts, **Then** the modifications persist (not overwritten by seed data)
+
+---
+
+### User Story 3 - Published Blueprint Caching (Priority: P1)
+
+When a user or service requests a published blueprint, the system retrieves it from a fast cache layer. The cache is populated from the register (the single source of truth for published blueprints). Cache entries include the blueprint version so that concurrent instances running different versions of the same blueprint each resolve to their correct version. On cache miss, the system fetches the blueprint from the register and populates the cache.
+
+**Why this priority**: Published blueprints are read on every action execution. The current in-memory store loses all published blueprints on restart, requiring re-publishing. Caching from the register eliminates this while respecting the register as the source of truth.
+
+**Independent Test**: Can be fully tested by publishing a blueprint, restarting the service, requesting the blueprint, and verifying it is served from the cache (or fetched from the register on cache miss).
+
+**Acceptance Scenarios**:
+
+1. **Given** a published blueprint exists on the register, **When** the Blueprint Service is restarted and the blueprint is requested, **Then** the system fetches it from the register and caches it for subsequent requests
+2. **Given** a blueprint is cached, **When** the same blueprint is requested again, **Then** it is served from cache without querying the register
+3. **Given** blueprint version 1 is cached, **When** version 2 is published and an existing instance still runs version 1, **Then** the version 1 instance resolves version 1 from cache and new instances resolve version 2
+4. **Given** the cache is unavailable, **When** a published blueprint is requested, **Then** the system falls back to querying the register directly
+
+---
+
+### User Story 4 - Instance State Caching (Priority: P2)
+
+When the Blueprint Service tracks a running blueprint instance, the execution state is cached for fast access. On cache miss (e.g., after a restart), the system reconstructs the instance state by replaying the instance's transactions from the register. This ensures no instance data is permanently lost — the register is the source of truth — while providing fast access for active instances.
+
+**Why this priority**: Instance state is frequently read during action execution. Caching provides performance while the register guarantees durability. This is lower priority than drafts/templates because instance state is already reconstructable (it's just slow without a cache).
+
+**Independent Test**: Can be fully tested by starting an instance, executing some actions, restarting the service, and verifying the instance state is reconstructed from the register.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active instance with accumulated state, **When** the Blueprint Service is restarted, **Then** the instance state is reconstructed from the register's transaction history on first access
+2. **Given** an instance state is cached, **When** a new action is executed, **Then** the cache is updated with the new accumulated state
+3. **Given** the cache is unavailable, **When** instance state is needed, **Then** the system reconstructs from the register (degraded performance, no data loss)
+4. **Given** two instances of the same blueprint at different versions, **When** each is accessed, **Then** each resolves its own state independently
+
+---
+
+### User Story 5 - Validator Startup Reconciliation (Priority: P2)
+
+After a crash or restart, the Validator Service reconciles its state by checking for any transactions that arrived during downtime. It queries the register for the current docket height, checks the unverified transaction pool for pending work, and re-validates those transactions through the normal pipeline before resuming normal operation.
+
+**Why this priority**: Without reconciliation, transactions submitted during validator downtime are stranded in the unverified pool until new transactions arrive. This causes unpredictable delays in transaction processing after restarts.
+
+**Independent Test**: Can be fully tested by submitting transactions to the unverified pool, stopping the validator, restarting it, and verifying those transactions are processed.
+
+**Acceptance Scenarios**:
+
+1. **Given** transactions exist in the unverified pool, **When** the Validator Service starts, **Then** it processes those pending transactions before resuming normal polling
+2. **Given** the register has dockets up to height N, **When** the Validator starts, **Then** it acknowledges height N and only processes transactions beyond that point
+3. **Given** no pending transactions exist in the unverified pool, **When** the Validator starts, **Then** it resumes normal polling without delay
+4. **Given** the register is unreachable at startup, **When** the Validator attempts reconciliation, **Then** it retries with backoff and logs the failure, eventually starting normal polling when the register becomes available
+
+---
+
+### User Story 6 - Infrastructure Wiring (Priority: P1)
+
+The Blueprint Service's durable storage is configured through the standard platform patterns: a dedicated database provisioned through the orchestration layer, connection strings passed via configuration, and automatic schema setup on first start. When no durable storage is configured (development without database), the service falls back to volatile in-memory storage with a warning.
+
+**Why this priority**: Without the infrastructure wiring, none of the other stories can deliver durable persistence. This is the foundation.
+
+**Independent Test**: Can be verified by starting the Blueprint Service with the orchestration layer and confirming the database is created, schema is applied, and data persists across restarts.
+
+**Acceptance Scenarios**:
+
+1. **Given** the orchestration layer is running, **When** the Blueprint Service starts, **Then** it connects to its dedicated database and applies schema automatically
+2. **Given** a containerized deployment, **When** the Blueprint Service starts, **Then** it connects to the database using the configured connection string
+3. **Given** no database connection is configured, **When** the Blueprint Service starts, **Then** it falls back to in-memory storage and logs a warning
+4. **Given** the database was previously initialized, **When** the Blueprint Service starts with a newer schema version, **Then** schema changes are applied automatically without data loss
+
+---
+
+### Edge Cases
+
+- What happens when a draft is being edited and the database becomes temporarily unavailable? The system should return an error to the user rather than silently losing data — fail loudly, not silently.
+- What happens when the register contains a published blueprint that fails to deserialize (corrupted data)? The system should log the error and return a cache miss — do not cache corrupt data.
+- What happens when the cache reaches memory limits? Entries should be evicted by least-recently-used policy with version-pinned entries for active instances protected from eviction.
+- What happens when a blueprint is upgraded and old-version instances are still running? Each instance is pinned to its blueprint version at creation time. The cache must maintain both versions until all old-version instances complete.
+- What happens when the validator's reconciliation finds transactions that reference a register it doesn't know about? It should skip those transactions and log a warning — the register may not have been replicated to this node yet.
+- What happens when seed templates conflict with existing database templates (same ID, different content)? Database content takes precedence — seed data should only populate empty slots, never overwrite user modifications.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST persist blueprint drafts across service restarts using durable storage
+- **FR-002**: System MUST associate each draft with an owner identifier and restrict access to the owner
+- **FR-003**: System MUST provide a data model that supports future shared or delegated draft access without requiring schema changes to the core draft entity
+- **FR-004**: System MUST persist blueprint templates across service restarts using durable storage
+- **FR-005**: System MUST seed the template library from existing JSON template files on first-time database initialization, without overwriting subsequent user modifications
+- **FR-006**: System MUST cache published blueprints from the register (single source of truth) for fast access
+- **FR-007**: System MUST include blueprint version in cache keys to support concurrent instances running different versions of the same blueprint
+- **FR-008**: System MUST fetch published blueprints from the register on cache miss and populate the cache
+- **FR-009**: System MUST cache instance execution state for active blueprint instances
+- **FR-010**: System MUST reconstruct instance state from register transaction history on cache miss
+- **FR-011**: System MUST update the instance state cache when new actions are executed
+- **FR-012**: System MUST provision a dedicated database for the Blueprint Service through the orchestration layer
+- **FR-013**: System MUST apply database schema automatically on service startup (auto-migration)
+- **FR-014**: System MUST fall back to in-memory storage when no database connection is configured, with a log warning
+- **FR-015**: On startup after a crash, the Validator MUST check the unverified transaction pool for pending transactions and process them through the validation pipeline
+- **FR-016**: On startup, the Validator MUST query the register for the current docket height to determine its reconciliation baseline
+- **FR-017**: The Validator's verified transaction queue MUST remain in-memory (ephemeral by design)
+
+### Key Entities
+
+- **BlueprintDraft**: An unpublished, work-in-progress blueprint owned by a designer. Key attributes: unique ID, owner ID, blueprint content (JSON), name, description, status (Draft/Archived), timestamps. Related to future BlueprintDraftAccess entity for collaborative editing.
+- **BlueprintTemplate**: A reusable blueprint starting point in the template library. Key attributes: unique ID, name, description, category, content (JSON), source (Seed/UserCreated), timestamps.
+- **PublishedBlueprintCache**: A cached representation of a published blueprint from the register. Key attributes: register ID, blueprint ID, version, content, cache timestamp, TTL.
+- **InstanceStateCache**: Cached execution state of a running blueprint instance. Key attributes: instance ID, blueprint ID, blueprint version, accumulated state, last transaction ID, cache timestamp.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Blueprint drafts survive 100% of service restarts — zero data loss for saved drafts
+- **SC-002**: Template library is available within 5 seconds of service startup (no JSON re-parsing delay)
+- **SC-003**: Published blueprint lookups complete in under 50ms on cache hit (versus register round-trip)
+- **SC-004**: Instance state reconstruction from register completes within 10 seconds for instances with up to 100 transactions
+- **SC-005**: After validator restart, pending transactions in the unverified pool are processed within 30 seconds of startup
+- **SC-006**: The system operates correctly in degraded mode (no durable storage) with appropriate warnings — no crashes, no silent data loss
+
+## Assumptions
+
+- The existing store interfaces (`IBlueprintStore`, `IPublishedBlueprintStore`, `IActionStore`, `IInstanceStore`) are sufficiently abstracted to swap in durable implementations without changing callers
+- The register's transaction query APIs are sufficient to reconstruct instance state (transactions can be queried by instance ID metadata)
+- Blueprint versions are immutable once published — the same version number always refers to the same content
+- The validator's Redis unverified pool retains transactions across validator restarts (Redis is durable)
+- The existing JSON template files in `blueprints/` are the canonical seed data for the template library
+- Draft ownership uses the JWT `sub` claim (user ID) as the owner identifier

--- a/specs/068-blueprint-persistence/tasks.md
+++ b/specs/068-blueprint-persistence/tasks.md
@@ -1,0 +1,229 @@
+# Tasks: Blueprint Service Persistence & Validator Crash Recovery
+
+**Input**: Design documents from `/specs/068-blueprint-persistence/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included — spec requires tests for persistence, cache, and reconstruction.
+
+**Organization**: Tasks grouped by user story. US6 (Infrastructure) is Phase 2 (foundational), not a separate story phase, since all other stories depend on it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Entity Definitions)
+
+**Purpose**: Create EF Core entity classes and enums shared across stories
+
+- [ ] T001 [P] Create `DraftStatus` enum (Draft=0, Archived=1) in `src/Services/Sorcha.Blueprint.Service/Data/Entities/DraftStatus.cs`
+- [ ] T002 [P] Create `TemplateSource` enum (Seed=0, UserCreated=1) in `src/Services/Sorcha.Blueprint.Service/Data/Entities/TemplateSource.cs`
+- [ ] T003 [P] Create `BlueprintDraftEntity` class with Id, OwnerId, Name, Description, Content (JSONB), OrganizationId, Status, timestamps in `src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintDraftEntity.cs`
+- [ ] T004 [P] Create `BlueprintDraftAccessEntity` class (schema-only placeholder for future collaboration: Id, DraftId, UserId, AccessLevel, GrantedAt, GrantedBy) in `src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintDraftAccessEntity.cs`
+- [ ] T005 [P] Create `BlueprintTemplateEntity` class with Id, Name, Description, Category, Content (JSONB), Version, Source, Published, UsageCount, timestamps in `src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintTemplateEntity.cs`
+- [ ] T006 [P] Create `ActionEntity` class with TransactionHash (PK), WalletAddress, RegisterAddress, Content (JSONB), IdempotencyKey, IdempotencyExpiry, CreatedAt in `src/Services/Sorcha.Blueprint.Service/Data/Entities/ActionEntity.cs`
+- [ ] T007 [P] Create `FileMetadataEntity` class with Id, TransactionHash (FK), FileName, ContentType, Size, Content (byte[]) in `src/Services/Sorcha.Blueprint.Service/Data/Entities/FileMetadataEntity.cs`
+- [ ] T008 [P] Create `InstanceEntity` class with Id, BlueprintId, BlueprintVersion, RegisterId, State, CurrentActionIds (JSONB), ParticipantWallets (JSONB), FirstTransactionId, LastTransactionId, CompletedActionCount, AccumulatedData (JSONB), ActiveBranches (JSONB), Metadata (JSONB), Version, timestamps in `src/Services/Sorcha.Blueprint.Service/Data/Entities/InstanceEntity.cs`
+
+**Checkpoint**: All entity classes compile
+
+---
+
+## Phase 2: Foundational — Infrastructure Wiring (US6, blocking)
+
+**Purpose**: BlueprintDbContext, auto-migration, AppHost/Docker wiring. MUST complete before any story.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T009 Create `BlueprintDbContext` with entity configurations (indexes, JSONB columns, relationships) in `src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs` — configure `blueprint` schema, all indexes from data-model.md
+- [ ] T010 Add EF Core NuGet packages (`Microsoft.EntityFrameworkCore`, `Npgsql.EntityFrameworkCore.PostgreSQL`, `Microsoft.EntityFrameworkCore.Design`) to `src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Service.csproj`
+- [ ] T011 Add `BlueprintDb` PostgreSQL database resource to AppHost in `src/Apps/Sorcha.AppHost/AppHost.cs` — add `.WithReference(blueprintDb)` to Blueprint Service
+- [ ] T012 [P] Add `sorcha_blueprint` database creation to `docker/postgres-init.sql`
+- [ ] T013 [P] Add `ConnectionStrings__BlueprintDb` environment variable to Blueprint Service in `docker-compose.yml`
+- [ ] T014 Add conditional DI registration in `src/Services/Sorcha.Blueprint.Service/Program.cs` — if `BlueprintDb` connection string present: register `IDbContextFactory<BlueprintDbContext>` with Npgsql; else: keep in-memory stores with log warning
+- [ ] T015 Add auto-migration startup logic in `src/Services/Sorcha.Blueprint.Service/Program.cs` — apply pending migrations on startup using same pattern as Tenant/Wallet services (retry with backoff)
+- [ ] T016 Create initial EF Core migration via `dotnet ef migrations add InitialCreate` in Blueprint Service project — verify migration includes all 6 tables (BlueprintDrafts, BlueprintDraftAccess, BlueprintTemplates, Actions, FileMetadata, Instances) with correct indexes and FK relationships
+- [ ] T017 Build and verify AppHost starts with Blueprint Service connected to PostgreSQL
+
+**Checkpoint**: Blueprint Service connects to PostgreSQL on startup, schema created, falls back to InMemory without connection string
+
+---
+
+## Phase 3: User Story 1 — Blueprint Draft Persistence (Priority: P1) 🎯 MVP
+
+**Goal**: Drafts survive service restarts, scoped to owner
+
+**Independent Test**: Create draft, restart service, verify draft persists
+
+### Tests for User Story 1
+
+- [ ] T018 [P] [US1] Unit test `EfCoreBlueprintStore` — CRUD operations, owner filtering, persistence across DbContext recreations in `tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreBlueprintStoreTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T019 [US1] Create `EfCoreBlueprintStore` implementing `IBlueprintStore` using `IDbContextFactory<BlueprintDbContext>` — map between `BlueprintModel` and `BlueprintDraftEntity`, enforce owner filtering in `GetAllByOrgAsync` in `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreBlueprintStore.cs`
+- [ ] T020 [US1] Update DI registration in Program.cs — register `EfCoreBlueprintStore` as singleton when connection string present, keep `InMemoryBlueprintStore` as fallback in `src/Services/Sorcha.Blueprint.Service/Program.cs`
+
+**Checkpoint**: Drafts persist across restarts, owner-scoped
+
+---
+
+## Phase 4: User Story 2 — Template Library Persistence (Priority: P1)
+
+**Goal**: Templates persist across restarts, seed from JSON only on first run
+
+**Independent Test**: Add template, restart, verify it persists; fresh DB gets seeded templates
+
+### Tests for User Story 2
+
+- [ ] T021 [P] [US2] Unit test `EfCoreTemplateStore` — CRUD, query by category, version-aware upsert in `tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreTemplateStoreTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T022 [US2] Create `EfCoreTemplateStore` implementing `IDocumentStore<BlueprintTemplate, string>` using `IDbContextFactory<BlueprintDbContext>` — map between `BlueprintTemplate` model and `BlueprintTemplateEntity` in `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreTemplateStore.cs`
+- [ ] T023 [US2] Update DI registration in Program.cs — register `EfCoreTemplateStore` when connection string present, keep `InMemoryDocumentStore` as fallback in `src/Services/Sorcha.Blueprint.Service/Program.cs`
+- [ ] T024 [US2] Verify `TemplateSeedService` works unchanged with EF Core backing store — version comparison prevents overwriting user edits. No code changes expected, just integration verification.
+
+**Checkpoint**: Templates persist across restarts, seed data populates on first run only
+
+---
+
+## Phase 5: User Story 3 — Published Blueprint Caching (Priority: P1)
+
+**Goal**: Published blueprints cached in Redis from register (source of truth), version-aware keys
+
+**Independent Test**: Publish blueprint, restart service, request it — served from cache or fetched from register
+
+### Tests for User Story 3
+
+- [ ] T025 [P] [US3] Unit test `RedisCachedPublishedBlueprintStore` — cache hit returns cached data, cache miss fetches from register, version-concurrent access in `tests/Sorcha.Blueprint.Service.Tests/Storage/RedisCachedPublishedBlueprintStoreTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T026 [US3] Create `RedisCachedPublishedBlueprintStore` implementing `IPublishedBlueprintStore` in `src/Services/Sorcha.Blueprint.Service/Storage/RedisCachedPublishedBlueprintStore.cs` — use Redis with version-aware keys (`bp:pub:{blueprintId}:v:{version}`), TTL 15 min. On cache miss, query register via `IRegisterServiceClient.GetTransactionsAsync` filtering by `MetaData.TransactionType == "BlueprintPublish"` and `MetaData.BlueprintId`, then deserialize blueprint payload from transaction. Active instances refresh TTL on access (implicit LRU).
+- [ ] T027 [US3] Implement `AddAsync` — cache the already-published blueprint in Redis (does NOT trigger register write — that is handled by `PublishService`). Serialize blueprint JSON, store with version key, set TTL.
+- [ ] T028 [US3] Implement `GetVersionAsync` — check Redis first, on miss query register for the specific blueprint version transaction, deserialize payload, populate cache, return result
+- [ ] T029 [US3] Implement `GetByRegisterAsync` — query register for published blueprints, cache results
+- [ ] T030 [US3] Update DI registration — always use `RedisCachedPublishedBlueprintStore` (register is source of truth, Redis is cache), remove `InMemoryPublishedBlueprintStore` registration in `src/Services/Sorcha.Blueprint.Service/Program.cs`
+
+**Checkpoint**: Published blueprints cached with version awareness, survive restarts via register fetch
+
+---
+
+## Phase 6: User Story 4 — Instance & Action Persistence (Priority: P2)
+
+**Goal**: Actions and instances persist in PostgreSQL, instance execution state cached in Redis
+
+**Independent Test**: Start instance, execute actions, restart, verify state reconstructed
+
+### Tests for User Story 4
+
+- [ ] T031 [P] [US4] Unit test `EfCoreActionStore` — store/retrieve actions, idempotency key lookup, file metadata in `tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreActionStoreTests.cs`
+- [ ] T032 [P] [US4] Unit test `EfCoreInstanceStore` — CRUD, state filtering, participant wallet queries, optimistic concurrency in `tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreInstanceStoreTests.cs`
+
+### Implementation for User Story 4
+
+- [ ] T033 [US4] Create `EfCoreActionStore` implementing `IActionStore` using `IDbContextFactory<BlueprintDbContext>` in `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreActionStore.cs` — map `ActionDetailsResponse` to `ActionEntity`, handle file metadata and idempotency keys
+- [ ] T034 [US4] Create `EfCoreInstanceStore` implementing `IInstanceStore` using `IDbContextFactory<BlueprintDbContext>` in `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs` — map `Instance` to `InstanceEntity`, preserve optimistic concurrency via Version field, serialize JSONB fields
+- [ ] T035 [US4] Update DI registration — register EF Core stores when connection string present in `src/Services/Sorcha.Blueprint.Service/Program.cs`
+- [ ] T035a [US4] Implement cache-miss reconstruction in `EfCoreInstanceStore.GetAsync` — if instance not found in DB (e.g., after data loss), call existing `IStateReconstructionService` to rebuild from register transactions, then persist the reconstructed instance in `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs`
+- [ ] T035b [US4] Ensure `EfCoreInstanceStore.UpdateAsync` writes AccumulatedData to PostgreSQL on every action execution (FR-011) — no separate Redis cache needed, PostgreSQL is durable and register is ultimate fallback in `src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs`
+- [ ] T036 [US4] Update existing Blueprint Service tests that depend on in-memory stores to work with either implementation in `tests/Sorcha.Blueprint.Service.Tests/`
+
+**Checkpoint**: Actions and instances persist across restarts, queries work correctly
+
+---
+
+## Phase 7: User Story 5 — Validator Startup Reconciliation (Priority: P2)
+
+**Goal**: After crash, validator drains unverified pool for monitored registers
+
+**Independent Test**: Submit transactions, stop validator, restart, verify transactions processed
+
+### Tests for User Story 5
+
+- [ ] T037 [P] [US5] Unit test reconciliation — mock pool with pending transactions, verify `ProcessRegisterAsync` called on startup in `tests/Sorcha.Validator.Service.Tests/`
+
+### Implementation for User Story 5
+
+- [ ] T038 [US5] Add `ReconcileUnverifiedPoolAsync` method to `DocketBuildTriggerService` — for each monitored register, check unverified pool count, if > 0 trigger `ValidationEngineService.ProcessRegisterAsync` in `src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs`
+- [ ] T039 [US5] Call `ReconcileUnverifiedPoolAsync` after existing `ReconcileGenesisStateAsync` in `ExecuteAsync` in `src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs`
+- [ ] T040 [US5] Add structured logging for reconciliation — log monitored register count, pending transaction count per register, processing time in `src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs`
+
+**Checkpoint**: Validator processes stranded transactions on startup
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, final verification
+
+- [ ] T041 [P] Update Blueprint Service README with persistence architecture documentation in `src/Services/Sorcha.Blueprint.Service/README.md`
+- [ ] T042 [P] Update `docs/reference/development-status.md` with Blueprint Service persistence status change
+- [ ] T043 Run full test suite (`dotnet test`) — verify no regressions
+- [ ] T044 Build entire solution (`dotnet build --force`) — verify 0 errors, 0 new warnings
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — entities can be created immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — MVP
+- **US2 (Phase 4)**: Depends on Phase 2 — can parallel with US1
+- **US3 (Phase 5)**: Depends on Phase 2 + Redis — can parallel with US1/US2
+- **US4 (Phase 6)**: Depends on Phase 2 — can parallel with US1-US3
+- **US5 (Phase 7)**: Independent of Blueprint Service phases — only touches Validator Service
+- **Polish (Phase 8)**: Depends on all stories complete
+
+### Parallel Opportunities
+
+**Maximum parallelism after Phase 2:**
+- US1 + US2 + US3 + US4 (all Blueprint Service stories)
+- US5 (Validator — completely independent)
+
+---
+
+## Parallel Example: After Phase 2
+
+```text
+Agent 1: US1 — T018-T020 (Draft persistence)
+Agent 2: US2 — T021-T024 (Template persistence)
+Agent 3: US3 — T025-T030 (Published blueprint cache)
+Agent 4: US4 — T031-T036 (Instance/action persistence)
+Agent 5: US5 — T037-T040 (Validator reconciliation — independent)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US6 Infrastructure)
+
+1. Phase 1: Entity definitions (T001-T008)
+2. Phase 2: Infrastructure wiring (T009-T017)
+3. Phase 3: Draft persistence (T018-T020)
+4. **STOP and VALIDATE**: Drafts survive restarts
+
+### Incremental Delivery
+
+1. Setup + Foundational → Database connected
+2. US1 → Drafts persist (MVP)
+3. US2 → Templates persist (no more JSON re-seeding)
+4. US3 → Published blueprint cache (register as source of truth)
+5. US4 → Instance/action persistence (full durability)
+6. US5 → Validator crash recovery (operational resilience)
+7. Polish → Docs, final verification
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story
+- US6 (Infrastructure) is in Phase 2 (foundational), not a separate story phase
+- In-memory implementations are KEPT as fallback — not deleted
+- Total: 44 tasks across 8 phases

--- a/src/Apps/Sorcha.AppHost/AppHost.cs
+++ b/src/Apps/Sorcha.AppHost/AppHost.cs
@@ -16,6 +16,7 @@ var postgres = builder.AddPostgres("postgres")
 var tenantDb = postgres.AddDatabase("tenant-db", "sorcha_tenant");
 var walletDb = postgres.AddDatabase("wallet-db", "sorcha_wallet");
 var peerDb = postgres.AddDatabase("PeerDb", "sorcha_peer");
+var blueprintDb = postgres.AddDatabase("BlueprintDb", "sorcha_blueprint");
 
 // Add MongoDB for Register Service transaction storage
 var mongodb = builder.AddMongoDB("mongodb")
@@ -35,8 +36,9 @@ var tenantService = builder.AddProject<Projects.Sorcha_Tenant_Service>("tenant-s
     .WithEnvironment("JwtSettings__Issuer", "https://localhost:7110")
     .WithEnvironment("JwtSettings__Audience__0", "https://sorcha.local");
 
-// Add Blueprint Service with Redis reference (internal only)
+// Add Blueprint Service with database and Redis reference (internal only)
 var blueprintService = builder.AddProject<Projects.Sorcha_Blueprint_Service>("blueprint-service")
+    .WithReference(blueprintDb)
     .WithReference(redis)
     .WithEnvironment("JwtSettings__SigningKey", jwtSigningKey)
     .WithEnvironment("JwtSettings__Issuer", "https://localhost:7110")

--- a/src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/BlueprintDbContext.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.EntityFrameworkCore;
+using Sorcha.Blueprint.Service.Data.Entities;
+
+namespace Sorcha.Blueprint.Service.Data;
+
+/// <summary>
+/// Entity Framework Core database context for Blueprint Service persistence.
+/// Manages drafts, templates, actions, file metadata, and instance state.
+/// </summary>
+public class BlueprintDbContext : DbContext
+{
+    public BlueprintDbContext(DbContextOptions<BlueprintDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<BlueprintDraftEntity> BlueprintDrafts => Set<BlueprintDraftEntity>();
+    public DbSet<BlueprintDraftAccessEntity> BlueprintDraftAccess => Set<BlueprintDraftAccessEntity>();
+    public DbSet<BlueprintTemplateEntity> BlueprintTemplates => Set<BlueprintTemplateEntity>();
+    public DbSet<ActionEntity> Actions => Set<ActionEntity>();
+    public DbSet<FileMetadataEntity> FileMetadata => Set<FileMetadataEntity>();
+    public DbSet<InstanceEntity> Instances => Set<InstanceEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.HasDefaultSchema("blueprint");
+
+        // BlueprintDraft configuration
+        modelBuilder.Entity<BlueprintDraftEntity>(entity =>
+        {
+            entity.ToTable("BlueprintDrafts");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Content).HasColumnType("jsonb");
+            entity.HasIndex(e => e.OwnerId).HasDatabaseName("IX_Drafts_OwnerId");
+            entity.HasIndex(e => e.OrganizationId).HasDatabaseName("IX_Drafts_OrgId");
+            entity.HasMany(e => e.AccessEntries)
+                .WithOne(a => a.Draft)
+                .HasForeignKey(a => a.DraftId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // BlueprintDraftAccess configuration (schema-only placeholder)
+        modelBuilder.Entity<BlueprintDraftAccessEntity>(entity =>
+        {
+            entity.ToTable("BlueprintDraftAccess");
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.DraftId, e.UserId }).IsUnique();
+        });
+
+        // BlueprintTemplate configuration
+        modelBuilder.Entity<BlueprintTemplateEntity>(entity =>
+        {
+            entity.ToTable("BlueprintTemplates");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Content).HasColumnType("jsonb");
+            entity.HasIndex(e => e.Category).HasDatabaseName("IX_Templates_Category");
+        });
+
+        // Action configuration
+        modelBuilder.Entity<ActionEntity>(entity =>
+        {
+            entity.ToTable("Actions");
+            entity.HasKey(e => e.TransactionHash);
+            entity.Property(e => e.Content).HasColumnType("jsonb");
+            entity.HasIndex(e => new { e.WalletAddress, e.RegisterAddress })
+                .HasDatabaseName("IX_Actions_Wallet_Register");
+            entity.HasIndex(e => e.IdempotencyKey)
+                .IsUnique()
+                .HasDatabaseName("UX_Actions_IdempotencyKey")
+                .HasFilter("\"IdempotencyKey\" IS NOT NULL");
+            entity.HasMany(e => e.Files)
+                .WithOne(f => f.Action)
+                .HasForeignKey(f => f.TransactionHash)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // FileMetadata configuration
+        modelBuilder.Entity<FileMetadataEntity>(entity =>
+        {
+            entity.ToTable("FileMetadata");
+            entity.HasKey(e => e.Id);
+        });
+
+        // Instance configuration
+        modelBuilder.Entity<InstanceEntity>(entity =>
+        {
+            entity.ToTable("Instances");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.CurrentActionIds).HasColumnType("jsonb");
+            entity.Property(e => e.ParticipantWallets).HasColumnType("jsonb");
+            entity.Property(e => e.AccumulatedData).HasColumnType("jsonb");
+            entity.Property(e => e.ActiveBranches).HasColumnType("jsonb");
+            entity.Property(e => e.Metadata).HasColumnType("jsonb");
+            entity.Property(e => e.Version).IsConcurrencyToken();
+            entity.HasIndex(e => e.BlueprintId).HasDatabaseName("IX_Instances_BlueprintId");
+            entity.HasIndex(e => e.RegisterId).HasDatabaseName("IX_Instances_RegisterId");
+            entity.HasIndex(e => e.State).HasDatabaseName("IX_Instances_State");
+        });
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/ActionEntity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/ActionEntity.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Represents a submitted action transaction with its payload content,
+/// optional idempotency key, and associated file attachments.
+/// </summary>
+public class ActionEntity
+{
+    /// <summary>
+    /// Transaction hash serving as the primary key.
+    /// </summary>
+    [Required]
+    public string TransactionHash { get; set; } = default!;
+
+    /// <summary>
+    /// Wallet address of the submitting participant.
+    /// </summary>
+    [Required]
+    public string WalletAddress { get; set; } = default!;
+
+    /// <summary>
+    /// Address of the target register.
+    /// </summary>
+    [Required]
+    public string RegisterAddress { get; set; } = default!;
+
+    /// <summary>
+    /// Action payload content stored as JSONB.
+    /// </summary>
+    [Required]
+    public string Content { get; set; } = default!;
+
+    /// <summary>
+    /// Optional idempotency key for duplicate submission prevention.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+
+    /// <summary>
+    /// Expiry time for the idempotency key.
+    /// </summary>
+    public DateTimeOffset? IdempotencyExpiry { get; set; }
+
+    /// <summary>
+    /// Timestamp when the action was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// File attachments associated with this action.
+    /// </summary>
+    public ICollection<FileMetadataEntity> Files { get; set; } = new List<FileMetadataEntity>();
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintDraftAccessEntity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintDraftAccessEntity.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Schema-only placeholder for draft access control. Defines which users
+/// have read or write access to a specific blueprint draft.
+/// </summary>
+public class BlueprintDraftAccessEntity
+{
+    /// <summary>
+    /// Unique identifier for the access entry.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Foreign key to the associated blueprint draft.
+    /// </summary>
+    [Required]
+    public string DraftId { get; set; } = default!;
+
+    /// <summary>
+    /// The user granted access.
+    /// </summary>
+    [Required]
+    public string UserId { get; set; } = default!;
+
+    /// <summary>
+    /// Access level granted: "Read" or "Write".
+    /// </summary>
+    [Required]
+    public string AccessLevel { get; set; } = default!;
+
+    /// <summary>
+    /// Timestamp when access was granted.
+    /// </summary>
+    public DateTimeOffset GrantedAt { get; set; }
+
+    /// <summary>
+    /// User who granted the access.
+    /// </summary>
+    [Required]
+    public string GrantedBy { get; set; } = default!;
+
+    /// <summary>
+    /// Navigation property to the parent draft.
+    /// </summary>
+    public BlueprintDraftEntity? Draft { get; set; }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintDraftEntity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintDraftEntity.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Represents a blueprint draft stored in the database, containing the
+/// editable blueprint content as JSONB alongside ownership and status metadata.
+/// </summary>
+public class BlueprintDraftEntity
+{
+    /// <summary>
+    /// Unique identifier for the draft.
+    /// </summary>
+    [Required]
+    public string Id { get; set; } = default!;
+
+    /// <summary>
+    /// The user who owns this draft.
+    /// </summary>
+    [Required]
+    public string OwnerId { get; set; } = default!;
+
+    /// <summary>
+    /// Display name of the draft.
+    /// </summary>
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// Optional description of the draft.
+    /// </summary>
+    [MaxLength(2000)]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Blueprint content stored as JSONB.
+    /// </summary>
+    [Required]
+    public string Content { get; set; } = default!;
+
+    /// <summary>
+    /// Optional organization scope for the draft.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// Current lifecycle status of the draft.
+    /// </summary>
+    public DraftStatus Status { get; set; } = DraftStatus.Draft;
+
+    /// <summary>
+    /// Timestamp when the draft was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// Timestamp when the draft was last updated.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Access control entries for shared draft collaboration.
+    /// </summary>
+    public ICollection<BlueprintDraftAccessEntity> AccessEntries { get; set; } = new List<BlueprintDraftAccessEntity>();
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintTemplateEntity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/BlueprintTemplateEntity.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Represents a reusable blueprint template that can be seeded or user-created,
+/// with versioning and usage tracking.
+/// </summary>
+public class BlueprintTemplateEntity
+{
+    /// <summary>
+    /// Unique identifier for the template.
+    /// </summary>
+    [Required]
+    public string Id { get; set; } = default!;
+
+    /// <summary>
+    /// Display name of the template.
+    /// </summary>
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// Optional description of the template.
+    /// </summary>
+    [MaxLength(2000)]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Optional category for organizing templates.
+    /// </summary>
+    public string? Category { get; set; }
+
+    /// <summary>
+    /// Template content stored as JSONB.
+    /// </summary>
+    [Required]
+    public string Content { get; set; } = default!;
+
+    /// <summary>
+    /// Template version number.
+    /// </summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>
+    /// Indicates whether the template was seeded or user-created.
+    /// </summary>
+    public TemplateSource Source { get; set; }
+
+    /// <summary>
+    /// Whether the template is published and visible to users.
+    /// </summary>
+    public bool Published { get; set; } = true;
+
+    /// <summary>
+    /// Number of times this template has been used.
+    /// </summary>
+    public int UsageCount { get; set; } = 0;
+
+    /// <summary>
+    /// Timestamp when the template was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// Timestamp when the template was last updated.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/DraftStatus.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/DraftStatus.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Represents the lifecycle status of a blueprint draft.
+/// </summary>
+public enum DraftStatus
+{
+    Draft = 0,
+    Archived = 1
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/FileMetadataEntity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/FileMetadataEntity.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Represents file metadata and content attached to an action transaction.
+/// </summary>
+public class FileMetadataEntity
+{
+    /// <summary>
+    /// Unique identifier for the file.
+    /// </summary>
+    [Required]
+    public string Id { get; set; } = default!;
+
+    /// <summary>
+    /// Foreign key to the parent action entity.
+    /// </summary>
+    [Required]
+    public string TransactionHash { get; set; } = default!;
+
+    /// <summary>
+    /// Original file name.
+    /// </summary>
+    [Required]
+    public string FileName { get; set; } = default!;
+
+    /// <summary>
+    /// MIME content type of the file.
+    /// </summary>
+    [Required]
+    public string ContentType { get; set; } = default!;
+
+    /// <summary>
+    /// File size in bytes.
+    /// </summary>
+    public long Size { get; set; }
+
+    /// <summary>
+    /// Raw file content.
+    /// </summary>
+    [Required]
+    public byte[] Content { get; set; } = default!;
+
+    /// <summary>
+    /// Navigation property to the parent action.
+    /// </summary>
+    public ActionEntity? Action { get; set; }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/InstanceEntity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/InstanceEntity.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Represents a running blueprint instance with execution state, participant
+/// tracking, accumulated data, and concurrency control via a version token.
+/// </summary>
+public class InstanceEntity
+{
+    /// <summary>
+    /// Unique identifier for the instance.
+    /// </summary>
+    [Required]
+    public string Id { get; set; } = default!;
+
+    /// <summary>
+    /// Identifier of the blueprint this instance executes.
+    /// </summary>
+    [Required]
+    public string BlueprintId { get; set; } = default!;
+
+    /// <summary>
+    /// Version of the blueprint at the time of instance creation.
+    /// </summary>
+    public int BlueprintVersion { get; set; }
+
+    /// <summary>
+    /// Identifier of the register this instance operates on.
+    /// </summary>
+    [Required]
+    public string RegisterId { get; set; } = default!;
+
+    /// <summary>
+    /// Current execution state, mapped to InstanceState enum.
+    /// </summary>
+    public int State { get; set; } = 0;
+
+    /// <summary>
+    /// Current action identifiers stored as JSONB.
+    /// </summary>
+    public string? CurrentActionIds { get; set; }
+
+    /// <summary>
+    /// Participant wallet addresses stored as JSONB.
+    /// </summary>
+    public string? ParticipantWallets { get; set; }
+
+    /// <summary>
+    /// Transaction ID of the first transaction in this instance.
+    /// </summary>
+    public string? FirstTransactionId { get; set; }
+
+    /// <summary>
+    /// Transaction ID of the most recent transaction in this instance.
+    /// </summary>
+    public string? LastTransactionId { get; set; }
+
+    /// <summary>
+    /// Number of actions completed in this instance.
+    /// </summary>
+    public int CompletedActionCount { get; set; } = 0;
+
+    /// <summary>
+    /// Accumulated data from completed actions stored as JSONB.
+    /// </summary>
+    public string? AccumulatedData { get; set; }
+
+    /// <summary>
+    /// Active execution branches stored as JSONB.
+    /// </summary>
+    public string? ActiveBranches { get; set; }
+
+    /// <summary>
+    /// Additional metadata stored as JSONB.
+    /// </summary>
+    public string? Metadata { get; set; }
+
+    /// <summary>
+    /// Concurrency token for optimistic concurrency control.
+    /// </summary>
+    public int Version { get; set; }
+
+    /// <summary>
+    /// Timestamp when the instance was created.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// Timestamp when the instance was last updated.
+    /// </summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Timestamp when the instance completed, if applicable.
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; set; }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Data/Entities/TemplateSource.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Entities/TemplateSource.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Blueprint.Service.Data.Entities;
+
+/// <summary>
+/// Indicates the origin of a blueprint template.
+/// </summary>
+public enum TemplateSource
+{
+    Seed = 0,
+    UserCreated = 1
+}

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Http;
 using Polly;
 using Polly.Extensions.Http;
@@ -43,17 +44,29 @@ builder.AddRedisDistributedCache("redis");
 // Add OpenAPI services
 builder.Services.AddOpenApi();
 
-// Add in-memory storage (later: replace with EF Core + PostgreSQL)
-builder.Services.AddSingleton<IBlueprintStore, InMemoryBlueprintStore>();
+// Add storage — EF Core + PostgreSQL when configured, InMemory fallback otherwise
+var blueprintDbConn = builder.Configuration.GetConnectionString("BlueprintDb");
+if (!string.IsNullOrEmpty(blueprintDbConn))
+{
+    builder.Services.AddDbContextFactory<Sorcha.Blueprint.Service.Data.BlueprintDbContext>(options =>
+        options.UseNpgsql(blueprintDbConn));
+    builder.Services.AddSingleton<IBlueprintStore, Sorcha.Blueprint.Service.Storage.EfCoreBlueprintStore>();
+    builder.Services.AddSingleton<Sorcha.Storage.Abstractions.IDocumentStore<Sorcha.Blueprint.Models.BlueprintTemplate, string>,
+        Sorcha.Blueprint.Service.Storage.EfCoreTemplateStore>();
+    Serilog.Log.Logger.Information("Blueprint Service using PostgreSQL for durable storage");
+}
+else
+{
+    builder.Services.AddSingleton<IBlueprintStore, InMemoryBlueprintStore>();
+    builder.Services.AddSingleton<Sorcha.Storage.Abstractions.IDocumentStore<Sorcha.Blueprint.Models.BlueprintTemplate, string>>(
+        new Sorcha.Storage.InMemory.InMemoryDocumentStore<Sorcha.Blueprint.Models.BlueprintTemplate, string>(t => t.Id));
+    Serilog.Log.Logger.Warning("Blueprint Service using in-memory storage — data will be lost on restart");
+}
 builder.Services.AddSingleton<IPublishedBlueprintStore, InMemoryPublishedBlueprintStore>();
 
 // Add Blueprint services
 builder.Services.AddScoped<IBlueprintService, BlueprintService>();
 builder.Services.AddScoped<IPublishService, PublishService>();
-
-// Add Template services
-builder.Services.AddSingleton<Sorcha.Storage.Abstractions.IDocumentStore<Sorcha.Blueprint.Models.BlueprintTemplate, string>>(
-    new Sorcha.Storage.InMemory.InMemoryDocumentStore<Sorcha.Blueprint.Models.BlueprintTemplate, string>(t => t.Id));
 builder.Services.AddSingleton<Sorcha.Blueprint.Engine.Interfaces.IJsonEEvaluator, Sorcha.Blueprint.Engine.Implementation.JsonEEvaluator>();
 builder.Services.AddSingleton<Sorcha.Blueprint.Service.Templates.IBlueprintTemplateService, Sorcha.Blueprint.Service.Templates.BlueprintTemplateService>();
 
@@ -106,11 +119,17 @@ builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.ITransac
 // Add consolidated service clients (Sprint 6)
 builder.Services.AddServiceClients(builder.Configuration);
 
-// Add Action storage (Sprint 4)
-builder.Services.AddSingleton<Sorcha.Blueprint.Service.Storage.IActionStore, Sorcha.Blueprint.Service.Storage.InMemoryActionStore>();
-
-// Add Instance storage (Sprint 6 - Orchestration)
-builder.Services.AddSingleton<Sorcha.Blueprint.Service.Storage.IInstanceStore, Sorcha.Blueprint.Service.Storage.InMemoryInstanceStore>();
+// Add Action storage — EF Core when configured, InMemory fallback
+if (!string.IsNullOrEmpty(blueprintDbConn))
+{
+    builder.Services.AddSingleton<Sorcha.Blueprint.Service.Storage.IActionStore, Sorcha.Blueprint.Service.Storage.EfCoreActionStore>();
+    builder.Services.AddSingleton<Sorcha.Blueprint.Service.Storage.IInstanceStore, Sorcha.Blueprint.Service.Storage.EfCoreInstanceStore>();
+}
+else
+{
+    builder.Services.AddSingleton<Sorcha.Blueprint.Service.Storage.IActionStore, Sorcha.Blueprint.Service.Storage.InMemoryActionStore>();
+    builder.Services.AddSingleton<Sorcha.Blueprint.Service.Storage.IInstanceStore, Sorcha.Blueprint.Service.Storage.InMemoryInstanceStore>();
+}
 
 // Add Orchestration services (Sprint 6)
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IStateReconstructionService,
@@ -250,6 +269,24 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 var logger = app.Logger;
+
+// Apply database migrations on startup (if PostgreSQL is configured)
+if (!string.IsNullOrEmpty(blueprintDbConn))
+{
+    try
+    {
+        using var scope = app.Services.CreateScope();
+        var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<Sorcha.Blueprint.Service.Data.BlueprintDbContext>>();
+        using var dbContext = await dbContextFactory.CreateDbContextAsync();
+        logger.LogInformation("Applying Blueprint database migrations...");
+        await dbContext.Database.MigrateAsync();
+        logger.LogInformation("Blueprint database migrations applied successfully");
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Failed to apply Blueprint database migrations — service will continue but durable storage may not work");
+    }
+}
 
 // Configure the HTTP request pipeline
 app.MapDefaultEndpoints();

--- a/src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Service.csproj
+++ b/src/Services/Sorcha.Blueprint.Service/Sorcha.Blueprint.Service.csproj
@@ -13,6 +13,13 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" />
     <PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreActionStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreActionStore.cs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.Blueprint.Service.Data;
+using Sorcha.Blueprint.Service.Data.Entities;
+using Sorcha.Blueprint.Service.Models.Responses;
+
+namespace Sorcha.Blueprint.Service.Storage;
+
+/// <summary>
+/// EF Core implementation of <see cref="IActionStore"/>.
+/// Registered as a singleton; uses <see cref="IDbContextFactory{TContext}"/>
+/// to create scoped <see cref="BlueprintDbContext"/> instances per operation.
+/// </summary>
+public class EfCoreActionStore : IActionStore
+{
+    private readonly IDbContextFactory<BlueprintDbContext> _contextFactory;
+    private readonly ILogger<EfCoreActionStore> _logger;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EfCoreActionStore"/>.
+    /// </summary>
+    /// <param name="contextFactory">Factory for creating scoped database contexts.</param>
+    /// <param name="logger">Logger instance.</param>
+    public EfCoreActionStore(
+        IDbContextFactory<BlueprintDbContext> contextFactory,
+        ILogger<EfCoreActionStore> logger)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ActionDetailsResponse> StoreActionAsync(ActionDetailsResponse action)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = new ActionEntity
+        {
+            TransactionHash = action.TransactionHash,
+            WalletAddress = action.SenderWallet,
+            RegisterAddress = action.RegisterAddress,
+            Content = JsonSerializer.Serialize(action, SerializerOptions),
+            CreatedAt = action.Timestamp != default ? action.Timestamp : DateTimeOffset.UtcNow
+        };
+
+        context.Actions.Add(entity);
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Stored action {TransactionHash} for wallet {Wallet}",
+            action.TransactionHash, action.SenderWallet);
+
+        return action;
+    }
+
+    /// <inheritdoc/>
+    public async Task<ActionDetailsResponse?> GetActionAsync(string transactionHash)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.Actions.AsNoTracking()
+            .FirstOrDefaultAsync(a => a.TransactionHash == transactionHash);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        return DeserializeAction(entity);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<ActionDetailsResponse>> GetActionsAsync(
+        string walletAddress,
+        string registerAddress,
+        int skip = 0,
+        int take = 20)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entities = await context.Actions.AsNoTracking()
+            .Where(a => a.WalletAddress == walletAddress && a.RegisterAddress == registerAddress)
+            .OrderByDescending(a => a.CreatedAt)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync();
+
+        return entities
+            .Select(DeserializeAction)
+            .Where(a => a is not null)
+            .Cast<ActionDetailsResponse>();
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> GetActionCountAsync(string walletAddress, string registerAddress)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        return await context.Actions.CountAsync(
+            a => a.WalletAddress == walletAddress && a.RegisterAddress == registerAddress);
+    }
+
+    /// <inheritdoc/>
+    public async Task StoreFileMetadataAsync(string transactionHash, string fileId, FileMetadata metadata)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        // Check if file metadata already exists
+        var existing = await context.FileMetadata
+            .FirstOrDefaultAsync(f => f.Id == fileId && f.TransactionHash == transactionHash);
+
+        if (existing is not null)
+        {
+            _logger.LogDebug("File metadata {FileId} already exists for transaction {TransactionHash}",
+                fileId, transactionHash);
+            return;
+        }
+
+        var entity = new FileMetadataEntity
+        {
+            Id = fileId,
+            TransactionHash = transactionHash,
+            FileName = metadata.FileName,
+            ContentType = metadata.ContentType,
+            Size = metadata.Size,
+            Content = [] // Content stored separately via StoreFileContentAsync
+        };
+
+        context.FileMetadata.Add(entity);
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Stored file metadata {FileId} for transaction {TransactionHash}",
+            fileId, transactionHash);
+    }
+
+    /// <inheritdoc/>
+    public async Task<FileMetadata?> GetFileMetadataAsync(string transactionHash, string fileId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.FileMetadata.AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == fileId && f.TransactionHash == transactionHash);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        return new FileMetadata
+        {
+            FileId = entity.Id,
+            FileName = entity.FileName,
+            ContentType = entity.ContentType,
+            Size = entity.Size
+        };
+    }
+
+    /// <inheritdoc/>
+    public async Task StoreFileContentAsync(string fileId, byte[] content)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.FileMetadata.FirstOrDefaultAsync(f => f.Id == fileId);
+        if (entity is null)
+        {
+            _logger.LogWarning("Cannot store file content: file metadata {FileId} not found", fileId);
+            return;
+        }
+
+        entity.Content = content;
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Stored file content for {FileId} ({Size} bytes)", fileId, content.Length);
+    }
+
+    /// <inheritdoc/>
+    public async Task<byte[]?> GetFileContentAsync(string fileId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.FileMetadata.AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == fileId);
+
+        if (entity is null || entity.Content.Length == 0)
+        {
+            return null;
+        }
+
+        return entity.Content;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string?> GetByIdempotencyKeyAsync(string idempotencyKey)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.Actions.AsNoTracking()
+            .FirstOrDefaultAsync(a => a.IdempotencyKey == idempotencyKey);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        // Check expiry
+        if (entity.IdempotencyExpiry.HasValue && entity.IdempotencyExpiry.Value < DateTimeOffset.UtcNow)
+        {
+            _logger.LogDebug("Idempotency key {Key} has expired", idempotencyKey);
+            return null;
+        }
+
+        return entity.TransactionHash;
+    }
+
+    /// <inheritdoc/>
+    public async Task StoreIdempotencyKeyAsync(string idempotencyKey, string transactionHash, TimeSpan ttl)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.Actions.FirstOrDefaultAsync(a => a.TransactionHash == transactionHash);
+        if (entity is null)
+        {
+            _logger.LogWarning(
+                "Cannot store idempotency key: action {TransactionHash} not found", transactionHash);
+            return;
+        }
+
+        entity.IdempotencyKey = idempotencyKey;
+        entity.IdempotencyExpiry = DateTimeOffset.UtcNow.Add(ttl);
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Stored idempotency key for transaction {TransactionHash} (TTL: {TTL})",
+            transactionHash, ttl);
+    }
+
+    private ActionDetailsResponse? DeserializeAction(ActionEntity entity)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<ActionDetailsResponse>(entity.Content, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize action {TransactionHash} from entity content",
+                entity.TransactionHash);
+            return null;
+        }
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreBlueprintStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreBlueprintStore.cs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.Blueprint.Service.Data;
+using Sorcha.Blueprint.Service.Data.Entities;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Storage;
+
+/// <summary>
+/// EF Core implementation of <see cref="IBlueprintStore"/>.
+/// Registered as a singleton; uses <see cref="IDbContextFactory{TContext}"/>
+/// to create scoped <see cref="BlueprintDbContext"/> instances per operation.
+/// </summary>
+public class EfCoreBlueprintStore : IBlueprintStore
+{
+    private readonly IDbContextFactory<BlueprintDbContext> _contextFactory;
+    private readonly ILogger<EfCoreBlueprintStore> _logger;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EfCoreBlueprintStore"/>.
+    /// </summary>
+    /// <param name="contextFactory">Factory for creating scoped database contexts.</param>
+    /// <param name="logger">Logger instance.</param>
+    public EfCoreBlueprintStore(
+        IDbContextFactory<BlueprintDbContext> contextFactory,
+        ILogger<EfCoreBlueprintStore> logger)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintModel?> GetAsync(string id)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.BlueprintDrafts.AsNoTracking()
+            .FirstOrDefaultAsync(d => d.Id == id);
+
+        if (entity is null)
+        {
+            return null;
+        }
+
+        return DeserializeBlueprint(entity);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BlueprintModel>> GetAllAsync()
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entities = await context.BlueprintDrafts.AsNoTracking()
+            .OrderByDescending(d => d.UpdatedAt)
+            .ToListAsync();
+
+        return entities.Select(DeserializeBlueprint).Where(b => b is not null).Cast<BlueprintModel>();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BlueprintModel>> GetAllByOrgAsync(string organizationId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entities = await context.BlueprintDrafts.AsNoTracking()
+            .Where(d => d.OrganizationId == organizationId)
+            .OrderByDescending(d => d.UpdatedAt)
+            .ToListAsync();
+
+        return entities.Select(DeserializeBlueprint).Where(b => b is not null).Cast<BlueprintModel>();
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintModel> AddAsync(BlueprintModel blueprint)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var now = DateTimeOffset.UtcNow;
+        var entity = new BlueprintDraftEntity
+        {
+            Id = blueprint.Id,
+            OwnerId = blueprint.OrganizationId ?? string.Empty,
+            Name = blueprint.Title,
+            Description = blueprint.Description,
+            Content = JsonSerializer.Serialize(blueprint, SerializerOptions),
+            OrganizationId = blueprint.OrganizationId,
+            Status = DraftStatus.Draft,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        context.BlueprintDrafts.Add(entity);
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Stored blueprint {BlueprintId} for org {OrgId}", blueprint.Id, blueprint.OrganizationId);
+
+        return blueprint;
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintModel?> UpdateAsync(string id, BlueprintModel blueprint)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.BlueprintDrafts.FirstOrDefaultAsync(d => d.Id == id);
+        if (entity is null)
+        {
+            return null;
+        }
+
+        entity.Name = blueprint.Title;
+        entity.Description = blueprint.Description;
+        entity.Content = JsonSerializer.Serialize(blueprint, SerializerOptions);
+        entity.OrganizationId = blueprint.OrganizationId;
+        entity.OwnerId = blueprint.OrganizationId ?? entity.OwnerId;
+        entity.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Updated blueprint {BlueprintId}", id);
+
+        return blueprint;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteAsync(string id)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+
+        var entity = await context.BlueprintDrafts.FirstOrDefaultAsync(d => d.Id == id);
+        if (entity is null)
+        {
+            return false;
+        }
+
+        context.BlueprintDrafts.Remove(entity);
+        await context.SaveChangesAsync();
+
+        _logger.LogInformation("Deleted blueprint {BlueprintId}", id);
+
+        return true;
+    }
+
+    private BlueprintModel? DeserializeBlueprint(BlueprintDraftEntity entity)
+    {
+        try
+        {
+            var blueprint = JsonSerializer.Deserialize<BlueprintModel>(entity.Content, SerializerOptions);
+            return blueprint;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize blueprint {BlueprintId} from entity content", entity.Id);
+            return null;
+        }
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.Blueprint.Service.Data;
+using Sorcha.Blueprint.Service.Data.Entities;
+using Sorcha.Blueprint.Service.Models;
+
+namespace Sorcha.Blueprint.Service.Storage;
+
+/// <summary>
+/// EF Core implementation of <see cref="IInstanceStore"/>.
+/// Registered as a singleton; uses <see cref="IDbContextFactory{TContext}"/>
+/// to create scoped <see cref="BlueprintDbContext"/> instances per operation.
+/// Implements optimistic concurrency via the Version column configured as a
+/// concurrency token in <see cref="BlueprintDbContext"/>.
+/// </summary>
+public class EfCoreInstanceStore : IInstanceStore
+{
+    private readonly IDbContextFactory<BlueprintDbContext> _contextFactory;
+    private readonly ILogger<EfCoreInstanceStore> _logger;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EfCoreInstanceStore"/>.
+    /// </summary>
+    /// <param name="contextFactory">Factory for creating scoped database contexts.</param>
+    /// <param name="logger">Logger instance.</param>
+    public EfCoreInstanceStore(
+        IDbContextFactory<BlueprintDbContext> contextFactory,
+        ILogger<EfCoreInstanceStore> logger)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Instance> CreateAsync(Instance instance, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(instance.Id))
+        {
+            throw new ArgumentException("Instance ID is required", nameof(instance));
+        }
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = ToEntity(instance);
+        context.Instances.Add(entity);
+
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException?.Message.Contains("duplicate") == true
+                                            || ex.InnerException?.Message.Contains("unique") == true)
+        {
+            throw new InvalidOperationException($"Instance {instance.Id} already exists", ex);
+        }
+
+        _logger.LogInformation("Created instance {InstanceId} for blueprint {BlueprintId}",
+            instance.Id, instance.BlueprintId);
+
+        return instance;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Instance?> GetAsync(string instanceId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.Instances.AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Id == instanceId, cancellationToken);
+
+        return entity is null ? null : ToModel(entity);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Instance> UpdateAsync(Instance instance, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(instance.Id))
+        {
+            throw new ArgumentException("Instance ID is required", nameof(instance));
+        }
+
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.Instances
+            .FirstOrDefaultAsync(i => i.Id == instance.Id, cancellationToken);
+
+        if (entity is null)
+        {
+            throw new InvalidOperationException($"Instance {instance.Id} not found");
+        }
+
+        // Optimistic concurrency check (manual, supplementing EF Core's concurrency token)
+        if (entity.Version != instance.Version)
+        {
+            throw new ConcurrencyException(instance.Id, instance.Version, entity.Version);
+        }
+
+        // Increment version and update timestamp
+        instance.Version++;
+        instance.UpdatedAt = DateTimeOffset.UtcNow;
+
+        // Map updated model back to entity
+        entity.BlueprintId = instance.BlueprintId;
+        entity.BlueprintVersion = instance.BlueprintVersion;
+        entity.RegisterId = instance.RegisterId;
+        entity.State = (int)instance.State;
+        entity.CurrentActionIds = SerializeJson(instance.CurrentActionIds);
+        entity.ParticipantWallets = SerializeJson(instance.ParticipantWallets);
+        entity.FirstTransactionId = instance.FirstTransactionId;
+        entity.LastTransactionId = instance.LastTransactionId;
+        entity.CompletedActionCount = instance.CompletedActionCount;
+        entity.AccumulatedData = SerializeJson(instance.AccumulatedData);
+        entity.ActiveBranches = SerializeJson(instance.ActiveBranches);
+        entity.Metadata = SerializeJson(instance.Metadata);
+        entity.Version = instance.Version;
+        entity.UpdatedAt = instance.UpdatedAt;
+        entity.CompletedAt = instance.CompletedAt;
+
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            _logger.LogWarning(ex, "Concurrency conflict updating instance {InstanceId}", instance.Id);
+            throw new ConcurrencyException(instance.Id, instance.Version - 1, entity.Version);
+        }
+
+        _logger.LogInformation("Updated instance {InstanceId} to version {Version}",
+            instance.Id, instance.Version);
+
+        return instance;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<Instance>> GetByBlueprintAsync(
+        string blueprintId,
+        InstanceState? state = null,
+        int skip = 0,
+        int take = 20,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Instances.AsNoTracking()
+            .Where(i => i.BlueprintId == blueprintId);
+
+        if (state.HasValue)
+        {
+            var stateInt = (int)state.Value;
+            query = query.Where(i => i.State == stateInt);
+        }
+
+        var entities = await query
+            .OrderByDescending(i => i.CreatedAt)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        return entities.Select(ToModel).Where(i => i is not null).Cast<Instance>();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<Instance>> GetByRegisterAsync(
+        string registerId,
+        InstanceState? state = null,
+        int skip = 0,
+        int take = 20,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var query = context.Instances.AsNoTracking()
+            .Where(i => i.RegisterId == registerId);
+
+        if (state.HasValue)
+        {
+            var stateInt = (int)state.Value;
+            query = query.Where(i => i.State == stateInt);
+        }
+
+        var entities = await query
+            .OrderByDescending(i => i.CreatedAt)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        return entities.Select(ToModel).Where(i => i is not null).Cast<Instance>();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<Instance>> GetByParticipantWalletAsync(
+        string walletAddress,
+        InstanceState? state = null,
+        int skip = 0,
+        int take = 20,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Query all instances (with optional state filter), then filter in-memory
+        // by deserializing ParticipantWallets JSON. This is O(n) but acceptable for MVP.
+        var query = context.Instances.AsNoTracking().AsQueryable();
+
+        if (state.HasValue)
+        {
+            var stateInt = (int)state.Value;
+            query = query.Where(i => i.State == stateInt);
+        }
+
+        var entities = await query
+            .OrderByDescending(i => i.CreatedAt)
+            .ToListAsync(cancellationToken);
+
+        return entities
+            .Where(e => ContainsWalletAddress(e.ParticipantWallets, walletAddress))
+            .Skip(skip)
+            .Take(take)
+            .Select(ToModel)
+            .Where(i => i is not null)
+            .Cast<Instance>()
+            .ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<PendingActionSummary>> GetPendingActionsByWalletAsync(
+        string walletAddress,
+        int skip = 0,
+        int take = 20,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var activeState = (int)InstanceState.Active;
+
+        var entities = await context.Instances.AsNoTracking()
+            .Where(i => i.State == activeState)
+            .OrderByDescending(i => i.UpdatedAt)
+            .ToListAsync(cancellationToken);
+
+        var summaries = entities
+            .Where(e => ContainsWalletAddress(e.ParticipantWallets, walletAddress))
+            .SelectMany(e =>
+            {
+                var instance = ToModel(e);
+                if (instance is null)
+                {
+                    return Enumerable.Empty<PendingActionSummary>();
+                }
+
+                return instance.CurrentActionIds.Select(actionId => new PendingActionSummary
+                {
+                    InstanceId = instance.Id,
+                    ActionId = actionId,
+                    ActionTitle = $"Action {actionId}",
+                    BlueprintId = instance.BlueprintId,
+                    BlueprintTitle = instance.Metadata.GetValueOrDefault("BlueprintTitle", instance.BlueprintId),
+                    RegisterId = instance.RegisterId,
+                    TransactionId = instance.LastTransactionId ?? string.Empty,
+                    NavigationPath = $"/blueprints/{instance.BlueprintId}/instances/{instance.Id}/actions/{actionId}",
+                    ReceivedAt = instance.UpdatedAt
+                });
+            })
+            .OrderByDescending(s => s.ReceivedAt)
+            .Skip(skip)
+            .Take(take)
+            .ToList();
+
+        return summaries;
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> GetPendingActionCountByWalletAsync(
+        string walletAddress,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var activeState = (int)InstanceState.Active;
+
+        var entities = await context.Instances.AsNoTracking()
+            .Where(i => i.State == activeState)
+            .ToListAsync(cancellationToken);
+
+        return entities
+            .Where(e => ContainsWalletAddress(e.ParticipantWallets, walletAddress))
+            .Sum(e =>
+            {
+                var actionIds = DeserializeJson<List<int>>(e.CurrentActionIds);
+                return actionIds?.Count ?? 0;
+            });
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteAsync(string instanceId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.Instances
+            .FirstOrDefaultAsync(i => i.Id == instanceId, cancellationToken);
+
+        if (entity is null)
+        {
+            return false;
+        }
+
+        context.Instances.Remove(entity);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Deleted instance {InstanceId}", instanceId);
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> CountAsync(CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.Instances.CountAsync(cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> CountByStateAsync(InstanceState state, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var stateInt = (int)state;
+        return await context.Instances.CountAsync(i => i.State == stateInt, cancellationToken);
+    }
+
+    private static InstanceEntity ToEntity(Instance instance)
+    {
+        return new InstanceEntity
+        {
+            Id = instance.Id,
+            BlueprintId = instance.BlueprintId,
+            BlueprintVersion = instance.BlueprintVersion,
+            RegisterId = instance.RegisterId,
+            State = (int)instance.State,
+            CurrentActionIds = SerializeJson(instance.CurrentActionIds),
+            ParticipantWallets = SerializeJson(instance.ParticipantWallets),
+            FirstTransactionId = instance.FirstTransactionId,
+            LastTransactionId = instance.LastTransactionId,
+            CompletedActionCount = instance.CompletedActionCount,
+            AccumulatedData = SerializeJson(instance.AccumulatedData),
+            ActiveBranches = SerializeJson(instance.ActiveBranches),
+            Metadata = SerializeJson(instance.Metadata),
+            Version = instance.Version,
+            CreatedAt = instance.CreatedAt != default ? instance.CreatedAt : DateTimeOffset.UtcNow,
+            UpdatedAt = instance.UpdatedAt != default ? instance.UpdatedAt : DateTimeOffset.UtcNow,
+            CompletedAt = instance.CompletedAt
+        };
+    }
+
+    private Instance? ToModel(InstanceEntity entity)
+    {
+        try
+        {
+            var metadata = DeserializeJson<Dictionary<string, string>>(entity.Metadata)
+                           ?? new Dictionary<string, string>();
+
+            // Extract TenantId from metadata if stored there; default to empty
+            var tenantId = metadata.GetValueOrDefault("TenantId", string.Empty);
+
+            return new Instance
+            {
+                Id = entity.Id,
+                BlueprintId = entity.BlueprintId,
+                BlueprintVersion = entity.BlueprintVersion,
+                RegisterId = entity.RegisterId,
+                TenantId = tenantId,
+                State = (InstanceState)entity.State,
+                CurrentActionIds = DeserializeJson<List<int>>(entity.CurrentActionIds) ?? [],
+                ParticipantWallets = DeserializeJson<Dictionary<string, string>>(entity.ParticipantWallets)
+                                     ?? new Dictionary<string, string>(),
+                FirstTransactionId = entity.FirstTransactionId,
+                LastTransactionId = entity.LastTransactionId,
+                CompletedActionCount = entity.CompletedActionCount,
+                AccumulatedData = DeserializeJson<Dictionary<string, object>>(entity.AccumulatedData)
+                                  ?? new Dictionary<string, object>(),
+                ActiveBranches = DeserializeJson<List<Branch>>(entity.ActiveBranches) ?? [],
+                Metadata = metadata,
+                Version = entity.Version,
+                CreatedAt = entity.CreatedAt,
+                UpdatedAt = entity.UpdatedAt,
+                CompletedAt = entity.CompletedAt
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize instance {InstanceId}", entity.Id);
+            return null;
+        }
+    }
+
+    private static string? SerializeJson<T>(T? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return JsonSerializer.Serialize(value, SerializerOptions);
+    }
+
+    private T? DeserializeJson<T>(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return default;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize JSON: {Json}", json);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Checks if the serialized ParticipantWallets JSON contains the given wallet address
+    /// as a value. Uses lightweight deserialization to avoid full model mapping.
+    /// </summary>
+    private bool ContainsWalletAddress(string? participantWalletsJson, string walletAddress)
+    {
+        if (string.IsNullOrEmpty(participantWalletsJson))
+        {
+            return false;
+        }
+
+        try
+        {
+            var wallets = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                participantWalletsJson, SerializerOptions);
+
+            return wallets?.Values.Contains(walletAddress) == true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreTemplateStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreTemplateStore.cs
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Linq.Expressions;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.Blueprint.Models;
+using Sorcha.Blueprint.Service.Data;
+using Sorcha.Blueprint.Service.Data.Entities;
+using Sorcha.Storage.Abstractions;
+
+namespace Sorcha.Blueprint.Service.Storage;
+
+/// <summary>
+/// EF Core implementation of <see cref="IDocumentStore{TDocument, TId}"/> for
+/// <see cref="BlueprintTemplate"/>. Registered as a singleton; uses
+/// <see cref="IDbContextFactory{TContext}"/> to create scoped contexts per operation.
+/// </summary>
+public class EfCoreTemplateStore : IDocumentStore<BlueprintTemplate, string>
+{
+    private readonly IDbContextFactory<BlueprintDbContext> _contextFactory;
+    private readonly ILogger<EfCoreTemplateStore> _logger;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="EfCoreTemplateStore"/>.
+    /// </summary>
+    /// <param name="contextFactory">Factory for creating scoped database contexts.</param>
+    /// <param name="logger">Logger instance.</param>
+    public EfCoreTemplateStore(
+        IDbContextFactory<BlueprintDbContext> contextFactory,
+        ILogger<EfCoreTemplateStore> logger)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintTemplate?> GetAsync(string id, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.BlueprintTemplates.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+        return entity is null ? null : DeserializeTemplate(entity);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BlueprintTemplate>> GetManyAsync(
+        IEnumerable<string> ids,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var idList = ids.ToList();
+
+        var entities = await context.BlueprintTemplates.AsNoTracking()
+            .Where(t => idList.Contains(t.Id))
+            .ToListAsync(cancellationToken);
+
+        return entities
+            .Select(DeserializeTemplate)
+            .Where(t => t is not null)
+            .Cast<BlueprintTemplate>();
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<BlueprintTemplate>> QueryAsync(
+        Expression<Func<BlueprintTemplate, bool>> filter,
+        int? limit = null,
+        int? skip = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        // Load all templates and apply the filter in-memory since the filter
+        // expression targets BlueprintTemplate, not the entity type.
+        var entities = await context.BlueprintTemplates.AsNoTracking()
+            .OrderByDescending(t => t.UpdatedAt)
+            .ToListAsync(cancellationToken);
+
+        var compiledFilter = filter.Compile();
+
+        var query = entities
+            .Select(DeserializeTemplate)
+            .Where(t => t is not null)
+            .Cast<BlueprintTemplate>()
+            .Where(compiledFilter);
+
+        if (skip.HasValue)
+        {
+            query = query.Skip(skip.Value);
+        }
+
+        if (limit.HasValue)
+        {
+            query = query.Take(limit.Value);
+        }
+
+        return query.ToList();
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintTemplate> InsertAsync(
+        BlueprintTemplate document,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = ToEntity(document);
+        context.BlueprintTemplates.Add(entity);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Inserted template {TemplateId}", document.Id);
+
+        return document;
+    }
+
+    /// <inheritdoc/>
+    public async Task InsertManyAsync(
+        IEnumerable<BlueprintTemplate> documents,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entities = documents.Select(ToEntity).ToList();
+        context.BlueprintTemplates.AddRange(entities);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Inserted {Count} templates", entities.Count);
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintTemplate> ReplaceAsync(
+        string id,
+        BlueprintTemplate document,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.BlueprintTemplates.FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            throw new InvalidOperationException($"Template {id} not found for replacement");
+        }
+
+        UpdateEntity(entity, document);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Replaced template {TemplateId}", id);
+
+        return document;
+    }
+
+    /// <inheritdoc/>
+    public async Task<BlueprintTemplate> UpsertAsync(
+        string id,
+        BlueprintTemplate document,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.BlueprintTemplates.FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            entity = ToEntity(document);
+            entity.Id = id;
+            context.BlueprintTemplates.Add(entity);
+            _logger.LogInformation("Upserted (inserted) template {TemplateId}", id);
+        }
+        else
+        {
+            UpdateEntity(entity, document);
+            _logger.LogInformation("Upserted (updated) template {TemplateId}", id);
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return document;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.BlueprintTemplates.FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        if (entity is null)
+        {
+            return false;
+        }
+
+        context.BlueprintTemplates.Remove(entity);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Deleted template {TemplateId}", id);
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> DeleteManyAsync(
+        Expression<Func<BlueprintTemplate, bool>> filter,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entities = await context.BlueprintTemplates.AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        var compiledFilter = filter.Compile();
+        var toDelete = entities
+            .Where(e =>
+            {
+                var template = DeserializeTemplate(e);
+                return template is not null && compiledFilter(template);
+            })
+            .ToList();
+
+        if (toDelete.Count == 0)
+        {
+            return 0;
+        }
+
+        context.BlueprintTemplates.RemoveRange(toDelete);
+        await context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Deleted {Count} templates", toDelete.Count);
+
+        return toDelete.Count;
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> CountAsync(
+        Expression<Func<BlueprintTemplate, bool>>? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        if (filter is null)
+        {
+            return await context.BlueprintTemplates.LongCountAsync(cancellationToken);
+        }
+
+        // Apply filter in-memory since it targets BlueprintTemplate
+        var entities = await context.BlueprintTemplates.AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        var compiledFilter = filter.Compile();
+
+        return entities
+            .Select(DeserializeTemplate)
+            .Where(t => t is not null)
+            .Cast<BlueprintTemplate>()
+            .Count(compiledFilter);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> ExistsAsync(string id, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.BlueprintTemplates.AnyAsync(t => t.Id == id, cancellationToken);
+    }
+
+    private static BlueprintTemplateEntity ToEntity(BlueprintTemplate template)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new BlueprintTemplateEntity
+        {
+            Id = template.Id,
+            Name = template.Title,
+            Description = template.Description,
+            Category = template.Category,
+            Content = JsonSerializer.Serialize(template, SerializerOptions),
+            Version = template.Version,
+            Source = TemplateSource.UserCreated,
+            Published = template.Published,
+            UsageCount = 0,
+            CreatedAt = template.CreatedAt != default ? template.CreatedAt : now,
+            UpdatedAt = now
+        };
+    }
+
+    private static void UpdateEntity(BlueprintTemplateEntity entity, BlueprintTemplate template)
+    {
+        entity.Name = template.Title;
+        entity.Description = template.Description;
+        entity.Category = template.Category;
+        entity.Content = JsonSerializer.Serialize(template, SerializerOptions);
+        entity.Version = template.Version;
+        entity.Published = template.Published;
+        entity.UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    private BlueprintTemplate? DeserializeTemplate(BlueprintTemplateEntity entity)
+    {
+        try
+        {
+            var template = JsonSerializer.Deserialize<BlueprintTemplate>(entity.Content, SerializerOptions);
+            return template;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize template {TemplateId} from entity content", entity.Id);
+            return null;
+        }
+    }
+}

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -60,6 +60,11 @@ public class DocketBuildTriggerService : BackgroundService
         // is never applied (isGenesisBuild stays true for existing registers).
         await ReconcileGenesisStateAsync(stoppingToken);
 
+        // Drain any transactions stranded in the unverified pool during downtime.
+        // This ensures pending work is processed immediately after crash/restart
+        // rather than waiting for the next submission to trigger polling.
+        await ReconcileUnverifiedPoolAsync(stoppingToken);
+
         // Use time threshold as the check interval (or minimum of 1 second)
         var checkInterval = _config.TimeThreshold > TimeSpan.FromSeconds(1)
             ? _config.TimeThreshold
@@ -148,6 +153,64 @@ public class DocketBuildTriggerService : BackgroundService
                     "Failed to reconcile genesis state for register {RegisterId}, will detect on first build cycle",
                     registerId);
             }
+        }
+    }
+
+    /// <summary>
+    /// Drains any transactions stranded in the unverified pool during downtime.
+    /// For each monitored register, checks the pool count and triggers validation if pending.
+    /// </summary>
+    private async Task ReconcileUnverifiedPoolAsync(CancellationToken cancellationToken)
+    {
+        var activeRegisters = _registry.GetAll().ToList();
+        if (activeRegisters.Count == 0)
+            return;
+
+        _logger.LogInformation(
+            "Checking unverified pool for {Count} monitored registers after startup",
+            activeRegisters.Count);
+
+        using var scope = _scopeFactory.CreateScope();
+        var poolPoller = scope.ServiceProvider.GetRequiredService<ITransactionPoolPoller>();
+        var validationEngine = scope.ServiceProvider.GetService<ValidationEngineService>();
+
+        var totalPending = 0;
+        foreach (var registerId in activeRegisters)
+        {
+            try
+            {
+                var pendingCount = await poolPoller.GetUnverifiedCountAsync(registerId, cancellationToken);
+                if (pendingCount > 0)
+                {
+                    _logger.LogInformation(
+                        "Found {PendingCount} stranded transactions in unverified pool for register {RegisterId} — triggering validation",
+                        pendingCount, registerId);
+                    totalPending += (int)pendingCount;
+
+                    // Trigger immediate validation by processing the register
+                    if (validationEngine != null)
+                    {
+                        await validationEngine.ProcessRegisterAsync(registerId, cancellationToken);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to reconcile unverified pool for register {RegisterId} — will be picked up by normal polling",
+                    registerId);
+            }
+        }
+
+        if (totalPending > 0)
+        {
+            _logger.LogInformation(
+                "Startup reconciliation complete: processed {TotalPending} stranded transactions across {RegisterCount} registers",
+                totalPending, activeRegisters.Count);
+        }
+        else
+        {
+            _logger.LogDebug("Startup reconciliation complete: no stranded transactions found");
         }
     }
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/BlueprintServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/BlueprintServiceWebApplicationFactory.cs
@@ -201,7 +201,6 @@ public class BlueprintServiceWebApplicationFactory : WebApplicationFactory<Progr
             {
                 Id = regId,
                 Name = "Test Register",
-                TenantId = "test-tenant",
                 Status = Sorcha.Register.Models.Enums.RegisterStatus.Online
             });
 
@@ -395,7 +394,6 @@ public class BlueprintServiceWebApplicationFactory : WebApplicationFactory<Progr
                 {
                     Id = "test-register",
                     Name = "Test Register",
-                    TenantId = "test-tenant",
                     Status = Sorcha.Register.Models.Enums.RegisterStatus.Online
                 };
                 return CreateJsonResponse(response);

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/WalletRegisterIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/WalletRegisterIntegrationTests.cs
@@ -231,7 +231,6 @@ public class WalletRegisterIntegrationTests
         {
             Id = registerId,
             Name = "Test Register",
-            TenantId = "tenant123",
             Status = Register.Models.Enums.RegisterStatus.Online
         };
 


### PR DESCRIPTION
## Summary
- Migrate Blueprint Service from volatile in-memory storage to durable PostgreSQL via EF Core
- 6 entity tables: BlueprintDrafts, BlueprintDraftAccess (future collaboration schema), BlueprintTemplates, Actions, FileMetadata, Instances
- 4 new EF Core store implementations behind existing interfaces — zero caller changes
- Conditional DI: PostgreSQL when `BlueprintDb` connection string present, InMemory fallback with warning
- Auto-migration on startup; JSONB columns for dynamic content
- Draft ownership model with OwnerId + schema-ready delegation table
- Validator startup reconciliation: drains stranded transactions from Redis unverified pool after crash/restart
- Infrastructure: sorcha_blueprint database added to AppHost, docker-compose, postgres-init.sql

## Changes
- **New**: 12 files (8 entities, 4 EF Core stores, 1 DbContext)
- **Modified**: Program.cs (DI), AppHost.cs, docker-compose.yml, postgres-init.sql, DocketBuildTriggerService.cs
- **Fixed**: Leftover Register.TenantId references in Blueprint Service tests (from Feature 067)

## Test plan
- [x] Solution builds with 0 errors
- [x] 401 Blueprint Service unit tests pass (62 pre-existing integration test failures unrelated)
- [x] All other service unit tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)