### PR TITLE
fix: remove dead tenant hub subscriptions and add list instances endpoint

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs
@@ -17,7 +17,6 @@ public class RegisterHubConnection : IAsyncDisposable
     private HubConnection? _hubConnection;
     private ConnectionState _connectionState = new();
     private readonly HashSet<string> _subscribedRegisters = [];
-    private string? _subscribedTenant;
     private CancellationTokenSource? _retryCts;
     private bool _disposed;
 
@@ -223,7 +222,7 @@ public class RegisterHubConnection : IAsyncDisposable
 
     /// <summary>
     /// Tears down the current connection and establishes a fresh one,
-    /// re-subscribing to all previously active registers and tenant.
+    /// re-subscribing to all previously active registers.
     /// </summary>
     public async Task ReconnectAsync(CancellationToken cancellationToken = default)
     {
@@ -282,51 +281,6 @@ public class RegisterHubConnection : IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Subscribes to tenant-wide events.
-    /// </summary>
-    public async Task SubscribeToTenantAsync(string tenantId, CancellationToken cancellationToken = default)
-    {
-        if (_hubConnection?.State != HubConnectionState.Connected)
-        {
-            _logger.LogWarning("Cannot subscribe to tenant {TenantId}: not connected", tenantId);
-            return;
-        }
-
-        try
-        {
-            await _hubConnection.InvokeAsync("SubscribeToTenant", tenantId, cancellationToken);
-            _subscribedTenant = tenantId;
-            _logger.LogDebug("Subscribed to tenant {TenantId}", tenantId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to subscribe to tenant {TenantId}", tenantId);
-        }
-    }
-
-    /// <summary>
-    /// Unsubscribes from tenant-wide events.
-    /// </summary>
-    public async Task UnsubscribeFromTenantAsync(string tenantId, CancellationToken cancellationToken = default)
-    {
-        if (_hubConnection?.State != HubConnectionState.Connected)
-        {
-            return;
-        }
-
-        try
-        {
-            await _hubConnection.InvokeAsync("UnsubscribeFromTenant", tenantId, cancellationToken);
-            _subscribedTenant = null;
-            _logger.LogDebug("Unsubscribed from tenant {TenantId}", tenantId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to unsubscribe from tenant {TenantId}", tenantId);
-        }
-    }
-
     private async Task ResubscribeAsync()
     {
         // Re-subscribe to all previously subscribed registers
@@ -340,20 +294,6 @@ public class RegisterHubConnection : IAsyncDisposable
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to re-subscribe to register {RegisterId}", registerId);
-            }
-        }
-
-        // Re-subscribe to tenant if applicable
-        if (!string.IsNullOrEmpty(_subscribedTenant))
-        {
-            try
-            {
-                await _hubConnection!.InvokeAsync("SubscribeToTenant", _subscribedTenant);
-                _logger.LogDebug("Re-subscribed to tenant {TenantId}", _subscribedTenant);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to re-subscribe to tenant {TenantId}", _subscribedTenant);
             }
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
@@ -250,7 +250,6 @@
         try
         {
             await HubConnection.StartAsync();
-            await HubConnection.SubscribeToTenantAsync(GetCurrentTenantId());
         }
         catch
         {
@@ -429,11 +428,6 @@
         }
     }
 
-    private string GetCurrentTenantId()
-    {
-        return _orgId != Guid.Empty ? _orgId.ToString() : "default-tenant";
-    }
-
     private async Task OnRegisterCreated(RegisterViewModel register)
     {
         // Refresh the register list after creation
@@ -448,18 +442,11 @@
         _ => Color.Default
     };
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         HubConnection.OnRegisterCreated -= OnRegisterCreatedViaSignalR;
         HubConnection.OnRegisterStatusChanged -= OnRegisterStatusChangedViaSignalR;
 
-        try
-        {
-            await HubConnection.UnsubscribeFromTenantAsync(GetCurrentTenantId());
-        }
-        catch
-        {
-            // Ignore errors during cleanup
-        }
+        return ValueTask.CompletedTask;
     }
 }

--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -293,6 +293,7 @@
 
       "blueprint-credentials": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/v1/credentials/{**catch-all}" } },
       "blueprint-blueprints":  { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/blueprints/{**catch-all}" } },
+      "blueprint-instances-list": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/instances" } },
       "blueprint-instances":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/instances/{**catch-all}" } },
       "blueprint-templates":   { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/templates/{**catch-all}" } },
       "blueprint-actions":     { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/actions/{**catch-all}" } },

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1456,6 +1456,44 @@ var instancesGroup = app.MapGroup("/api/instances")
     .RequireAuthorization("CanExecuteBlueprints");
 
 // <summary>
+// List workflow instances for the authenticated user's wallet
+// </summary>
+instancesGroup.MapGet("/", async (
+    HttpContext httpContext,
+    Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore,
+    Sorcha.Blueprint.Service.Models.InstanceState? status = null,
+    int page = 1,
+    int pageSize = 20) =>
+{
+    var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
+    if (string.IsNullOrEmpty(walletAddress))
+    {
+        return Results.Ok(new { items = Array.Empty<object>(), totalCount = 0, pageNumber = page, pageSize });
+    }
+
+    var skip = (page - 1) * pageSize;
+    var items = (await instanceStore.GetByParticipantWalletAsync(
+        walletAddress, status, skip, pageSize)).ToList();
+
+    // Get total count by querying without pagination
+    var allItems = await instanceStore.GetByParticipantWalletAsync(
+        walletAddress, status, 0, int.MaxValue);
+    var totalCount = allItems.Count();
+
+    return Results.Ok(new
+    {
+        items,
+        totalCount,
+        pageNumber = page,
+        pageSize
+    });
+})
+.WithName("ListInstances")
+.WithSummary("List workflow instances for the authenticated user")
+.WithDescription("Returns paginated workflow instances where the authenticated user's wallet is a participant. "
+    + "Supports optional status filtering (Active, Completed, Rejected, TimedOut, Cancelled).");
+
+// <summary>
 // Create a new workflow instance
 // </summary>
 instancesGroup.MapPost("/", async (

--- a/tests/Sorcha.UI.Core.Tests/Services/RegisterHubConnectionTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/RegisterHubConnectionTests.cs
@@ -210,26 +210,6 @@ public class RegisterHubConnectionTests
     }
 
     [Fact]
-    public async Task RegisterHubConnection_SubscribeToTenant_LogsWarning_WhenNotConnected()
-    {
-        // Arrange
-        var hubConnection = new RegisterHubConnection("http://localhost:5000", _mockLogger.Object);
-
-        // Act
-        await hubConnection.SubscribeToTenantAsync("test-tenant");
-
-        // Assert - Should log warning about not being connected
-        _mockLogger.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("not connected")),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
-    }
-
-    [Fact]
     public async Task RegisterHubConnection_StopAsync_DoesNotThrow_WhenNotStarted()
     {
         // Arrange
@@ -257,16 +237,6 @@ public class RegisterHubConnectionTests
 
         // Act & Assert - Should not throw, just return silently
         await hubConnection.UnsubscribeFromRegisterAsync("test-register");
-    }
-
-    [Fact]
-    public async Task RegisterHubConnection_UnsubscribeFromTenant_DoesNotThrow_WhenNotConnected()
-    {
-        // Arrange
-        var hubConnection = new RegisterHubConnection("http://localhost:5000", _mockLogger.Object);
-
-        // Act & Assert - Should not throw, just return silently
-        await hubConnection.UnsubscribeFromTenantAsync("test-tenant");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Remove dead `SubscribeToTenant`/`UnsubscribeFromTenant` calls from `RegisterHubConnection` and `Registers/Index.razor` — server-side methods were already removed, causing console errors
- Add `GET /api/instances` endpoint to Blueprint Service with `status` (InstanceState), `page`, `pageSize` query params, scoped to the user's `wallet_address` JWT claim
- Add YARP route for the bare `/api/instances` path (existing catch-all only matched sub-paths)
- Remove 2 associated dead-code tests from `RegisterHubConnectionTests`

## Test plan
- [x] Full solution builds with 0 errors
- [x] All 28 RegisterHubConnection tests pass
- [ ] Verify `UnsubscribeFromTenant` console error is gone
- [ ] Verify `GET /api/instances?status=active` returns 200 instead of 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)