### PR TITLE
fix: [Feature-031] address PR review — error state, null guard, parameter rematch

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Panels/CredentialGatePanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Panels/CredentialGatePanel.razor
@@ -9,7 +9,7 @@
 @inject ICredentialApiService CredentialApi
 @inject MudBlazor.IDialogService DialogService
 
-@if (Requirements.Any())
+@if (_requirements.Any())
 {
     <MudStack Spacing="2">
         <MudText Typo="Typo.subtitle2">
@@ -21,9 +21,21 @@
         {
             <MudProgressLinear Indeterminate="true" Color="MudBlazor.Color.Primary" Class="my-2" />
         }
+        else if (_matchError)
+        {
+            <MudAlert Severity="MudBlazor.Severity.Error" Dense="true">
+                <MudText Typo="Typo.body2">
+                    Failed to check credentials — please try again or check your connection.
+                </MudText>
+            </MudAlert>
+            <MudButton Variant="MudBlazor.Variant.Outlined" Size="MudBlazor.Size.Small"
+                       Color="MudBlazor.Color.Primary" OnClick="@(() => MatchCredentialsAsync())">
+                Retry
+            </MudButton>
+        }
         else
         {
-            @foreach (var req in Requirements)
+            @foreach (var req in _requirements)
             {
                 var match = _matchResults.FirstOrDefault(m =>
                     string.Equals(m.RequirementType, req.Type, StringComparison.OrdinalIgnoreCase));
@@ -61,7 +73,7 @@
                         {
                             <MudButton Variant="MudBlazor.Variant.Outlined" Size="MudBlazor.Size.Small"
                                        Color="MudBlazor.Color.Primary"
-                                       OnClick="@(() => SelectCredentialAsync(req, match!))">
+                                       OnClick="@(() => SelectCredentialAsync(req, match))">
                                 Select
                             </MudButton>
                         }
@@ -92,14 +104,18 @@
     [Parameter] public IEnumerable<CredentialRequirement> Requirements { get; set; } = [];
     [Parameter] public string WalletAddress { get; set; } = string.Empty;
 
+    private List<CredentialRequirement> _requirements = [];
     private List<CredentialMatchResult> _matchResults = [];
     private readonly Dictionary<string, CredentialPresentationInfo> _selectedCredentials = new();
     private bool _isLoading;
+    private bool _matchError;
     private bool _allRequirementsMet;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
-        if (!Requirements.Any() || string.IsNullOrEmpty(WalletAddress))
+        _requirements = Requirements.ToList();
+
+        if (!_requirements.Any() || string.IsNullOrEmpty(WalletAddress))
             return;
 
         await MatchCredentialsAsync();
@@ -108,12 +124,18 @@
     private async Task MatchCredentialsAsync()
     {
         _isLoading = true;
+        _matchError = false;
         StateHasChanged();
 
         try
         {
             _matchResults = await CredentialApi.MatchCredentialsAsync(
-                WalletAddress, Requirements.ToList());
+                WalletAddress, _requirements);
+        }
+        catch
+        {
+            _matchError = true;
+            _matchResults = [];
         }
         finally
         {
@@ -123,9 +145,9 @@
         }
     }
 
-    private async Task SelectCredentialAsync(CredentialRequirement requirement, CredentialMatchResult match)
+    private async Task SelectCredentialAsync(CredentialRequirement requirement, CredentialMatchResult? match)
     {
-        if (match.CredentialId is null) return;
+        if (match?.CredentialId is null) return;
 
         // Get full credential details for the dialog
         var detail = await CredentialApi.GetCredentialDetailAsync(WalletAddress, match.CredentialId);
@@ -172,6 +194,10 @@
                 CredentialId = dialogResult.SelectedCredentialId,
                 DisclosedClaims = dialogResult.SelectedClaims
                     .ToDictionary(c => c, c => (object)(detail.Claims?.GetValueOrDefault(c) ?? c)),
+                // TODO: RawPresentation (SD-JWT VP token) and KeyBindingProof are populated by
+                // ActionExecutionService on the server when the credential is presented during
+                // action submission. The UI collects the credential ID and disclosed claims;
+                // the server-side service creates the signed presentation using the wallet key.
                 RawPresentation = string.Empty,
                 KeyBindingProof = null
             };
@@ -200,12 +226,12 @@
 
     private void UpdateRequirementStatus()
     {
-        _allRequirementsMet = Requirements.All(req =>
+        _allRequirementsMet = _requirements.All(req =>
             _selectedCredentials.ContainsKey(req.Type));
 
         if (FormContext is not null)
         {
-            FormContext.CredentialGateSatisfied = _allRequirementsMet || !Requirements.Any();
+            FormContext.CredentialGateSatisfied = _allRequirementsMet || !_requirements.Any();
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes for Claude Sonnet 4.6 PR review on #130:

- **Bug**: Add `_matchError` state — service failures now show error alert with Retry button instead of misleading "No matching credential" warnings
- **Bug**: Fix null-forgiving operator on `match!` — `SelectCredentialAsync` now accepts `CredentialMatchResult?` with proper null guard
- **Design**: Materialise `Requirements` once via `OnParametersSetAsync` — avoids repeated IEnumerable enumeration, re-matches when parameters change
- **Docs**: TODO comment on `RawPresentation` — documents that SD-JWT VP token is created server-side

## Test plan
- [x] 901 UI Core tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)