### PR TITLE
fix: add transaction sequence number and SignedBy for validator replay protection

### DIFF
--- a/src/Common/Sorcha.ServiceClients/Validator/IValidatorServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients/Validator/IValidatorServiceClient.cs
@@ -19,6 +19,18 @@ public interface IValidatorServiceClient
     Task<TransactionSubmissionResult> SubmitTransactionAsync(
         TransactionSubmission request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the next sequence number for a wallet on a register (replay protection).
+    /// </summary>
+    /// <param name="registerId">Target register ID</param>
+    /// <param name="walletAddress">Sender wallet address</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The next valid sequence number to use for a transaction</returns>
+    Task<long> GetNextSequenceNumberAsync(
+        string registerId,
+        string walletAddress,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -36,6 +48,12 @@ public record TransactionSubmission
     public required DateTimeOffset CreatedAt { get; init; }
     public string? PreviousTransactionId { get; init; }
     public Dictionary<string, string>? Metadata { get; init; }
+
+    /// <summary>
+    /// Per-sender monotonic sequence number for replay protection (SEC-AUDIT 4.2).
+    /// Must equal sender's last sequence number + 1 on the target register.
+    /// </summary>
+    public long SequenceNumber { get; init; }
 }
 
 /// <summary>
@@ -46,6 +64,7 @@ public record SignatureInfo
     public required string PublicKey { get; init; }
     public required string SignatureValue { get; init; }
     public required string Algorithm { get; init; }
+    public string? SignedBy { get; init; }
 }
 
 /// <summary>

--- a/src/Common/Sorcha.ServiceClients/Validator/ValidatorServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients/Validator/ValidatorServiceClient.cs
@@ -157,6 +157,52 @@ public class ValidatorServiceClient : IValidatorServiceClient
         }
     }
 
+    /// <summary>
+    /// Gets the next sequence number for a wallet on a register (replay protection)
+    /// </summary>
+    public async Task<long> GetNextSequenceNumberAsync(
+        string registerId,
+        string walletAddress,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogDebug(
+                "Fetching next sequence number for wallet {WalletAddress} on register {RegisterId}",
+                walletAddress, registerId);
+
+            await SetAuthHeaderAsync(cancellationToken);
+
+            var response = await _httpClient.GetAsync(
+                $"/api/validators/{Uri.EscapeDataString(registerId)}/sequence/{Uri.EscapeDataString(walletAddress)}",
+                cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, cancellationToken);
+                var nextSeq = result.GetProperty("nextSequenceNumber").GetInt64();
+
+                _logger.LogDebug(
+                    "Next sequence number for wallet {WalletAddress} on register {RegisterId}: {SequenceNumber}",
+                    walletAddress, registerId, nextSeq);
+
+                return nextSeq;
+            }
+
+            _logger.LogWarning(
+                "Failed to get sequence number for wallet {WalletAddress} on register {RegisterId} (status: {StatusCode}). Defaulting to 1.",
+                walletAddress, registerId, response.StatusCode);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Error fetching sequence number for wallet {WalletAddress} on register {RegisterId}. Defaulting to 1.",
+                walletAddress, registerId);
+            return 1;
+        }
+    }
+
     private Task SetAuthHeaderAsync(CancellationToken cancellationToken) =>
         ServiceClientAuthHelper.SetAuthHeaderAsync(
             _httpClient, _serviceAuth, _logger, "Validator Service", cancellationToken);

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -519,8 +519,10 @@ public class ActionExecutionService : IActionExecutionService
         transaction.SenderWallet = request.SenderWallet;
         transaction.Signature = signResult.Signature;
 
-        // 12. Submit to Validator Service (mempool → docket → Register)
-        var submission = transaction.ToTransactionSubmission(signResult);
+        // 12. Fetch next sequence number for replay protection (SEC-AUDIT 4.2) and submit
+        var nextSeqNum = await _validatorClient.GetNextSequenceNumberAsync(
+            instance.RegisterId, request.SenderWallet, cancellationToken);
+        var submission = transaction.ToTransactionSubmission(signResult, nextSeqNum);
         var validatorResult = await _validatorClient.SubmitTransactionAsync(submission, cancellationToken);
 
         if (!validatorResult.Success)

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
@@ -198,7 +198,9 @@ public sealed class EncryptionBackgroundService : BackgroundService
             transaction.SenderWallet = workItem.SenderWallet;
             transaction.Signature = signResult.Signature;
 
-            var submission = transaction.ToTransactionSubmission(signResult);
+            var nextSeqNum = await validatorClient.GetNextSequenceNumberAsync(
+                workItem.RegisterId, workItem.SenderWallet, ct);
+            var submission = transaction.ToTransactionSubmission(signResult, nextSeqNum);
             var validatorResult = await validatorClient.SubmitTransactionAsync(submission, ct);
 
             if (!validatorResult.Success)

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
@@ -345,8 +345,9 @@ public class BuiltTransaction
     /// Maps BuiltTransaction fields to the Validator's expected format per data-model.md.
     /// </summary>
     /// <param name="signResult">The wallet sign result containing signature and public key bytes</param>
+    /// <param name="sequenceNumber">Per-sender monotonic sequence number for replay protection (SEC-AUDIT 4.2)</param>
     /// <returns>An TransactionSubmission ready for Validator Service submission</returns>
-    public TransactionSubmission ToTransactionSubmission(Sorcha.ServiceClients.Wallet.WalletSignResult signResult)
+    public TransactionSubmission ToTransactionSubmission(Sorcha.ServiceClients.Wallet.WalletSignResult signResult, long sequenceNumber = 0)
     {
         var payloadElement = JsonSerializer.Deserialize<JsonElement>(TransactionData);
 
@@ -364,11 +365,13 @@ public class BuiltTransaction
                 {
                     PublicKey = Base64Url.EncodeToString(signResult.PublicKey),
                     SignatureValue = Base64Url.EncodeToString(signResult.Signature),
-                    Algorithm = signResult.Algorithm
+                    Algorithm = signResult.Algorithm,
+                    SignedBy = SenderWallet
                 }
             ],
             CreatedAt = DateTimeOffset.UtcNow,
             PreviousTransactionId = Metadata.GetValueOrDefault("previousTxId")?.ToString(),
+            SequenceNumber = sequenceNumber,
             Metadata = new Dictionary<string, string>
             {
                 ["instanceId"] = Metadata.GetValueOrDefault("instanceId")?.ToString() ?? string.Empty,

--- a/src/Services/Sorcha.Tenant.Service/Services/ParticipantPublishingService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/ParticipantPublishingService.cs
@@ -246,6 +246,11 @@ public class ParticipantPublishingService : IParticipantPublishingService
 
         // Build and submit
         var payload = JsonSerializer.Deserialize<JsonElement>(payloadBytes);
+
+        // Fetch next sequence number for replay protection (SEC-AUDIT 4.2)
+        var nextSeqNum = await _validatorClient.GetNextSequenceNumberAsync(
+            registerId, signerWalletAddress, cancellationToken);
+
         var submission = new TransactionSubmission
         {
             TransactionId = txId,
@@ -254,13 +259,15 @@ public class ParticipantPublishingService : IParticipantPublishingService
             ActionId = null,
             Payload = payload,
             PayloadHash = payloadHash,
+            SequenceNumber = nextSeqNum,
             Signatures =
             [
                 new SignatureInfo
                 {
                     PublicKey = Base64Url.EncodeToString(signResult.PublicKey),
                     SignatureValue = Base64Url.EncodeToString(signResult.Signature),
-                    Algorithm = signResult.Algorithm
+                    Algorithm = signResult.Algorithm,
+                    SignedBy = signerWalletAddress
                 }
             ],
             CreatedAt = DateTimeOffset.UtcNow,
@@ -273,8 +280,8 @@ public class ParticipantPublishingService : IParticipantPublishingService
             }
         };
 
-        _logger.LogDebug("Submitting participant TX {TxId} to validator (v{Version})",
-            txId, record.Version);
+        _logger.LogDebug("Submitting participant TX {TxId} to validator (v{Version}, seq={SeqNum})",
+            txId, record.Version, nextSeqNum);
 
         var result = await _validatorClient.SubmitTransactionAsync(submission, cancellationToken);
 

--- a/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
@@ -70,9 +70,11 @@ public static class ValidationEndpoints
                     PublicKey = Base64Url.DecodeFromChars(s.PublicKey),
                     SignatureValue = Base64Url.DecodeFromChars(s.SignatureValue),
                     Algorithm = s.Algorithm,
+                    SignedBy = s.SignedBy,
                     SignedAt = request.CreatedAt
                 }).ToList(),
                 PayloadHash = request.PayloadHash,
+                SequenceNumber = (ulong)request.SequenceNumber,
                 PreviousTransactionId = request.PreviousTransactionId,
                 Priority = request.Priority,
                 Metadata = request.Metadata ?? new Dictionary<string, string>()
@@ -200,6 +202,12 @@ public record ValidateTransactionRequest
     public string? PreviousTransactionId { get; init; }
     public TransactionPriority Priority { get; init; } = TransactionPriority.Normal;
     public Dictionary<string, string>? Metadata { get; init; }
+
+    /// <summary>
+    /// Per-sender monotonic sequence number for replay protection (SEC-AUDIT 4.2).
+    /// Must equal sender's last sequence number + 1 on the target register.
+    /// </summary>
+    public long SequenceNumber { get; init; }
 }
 
 /// <summary>
@@ -210,5 +218,6 @@ public record SignatureRequest
     public required string PublicKey { get; init; }
     public required string SignatureValue { get; init; }
     public required string Algorithm { get; init; }
+    public string? SignedBy { get; init; }
 }
 


### PR DESCRIPTION
## Summary
- SEC-AUDIT 4.2 added sequence number validation to the Validator but the API contracts were never updated
- Transactions were failing with `VAL_REPLAY_001` (sequence number = 0) and `VAL_REPLAY_004` (no signer wallet)
- Added `SequenceNumber` to `TransactionSubmission` and `ValidateTransactionRequest`
- Added `SignedBy` to `SignatureInfo` and `SignatureRequest`
- Blueprint, Encryption, and Participant publishing services now fetch next sequence before submission
- Fixed sequence endpoint path (`/api/validators/` not `/api/v1/validators/`)
- **Action execution now ~3.5s** (was timing out at 60s)

## Test plan
- [x] Full solution builds with 0 errors
- [x] Action execution completes in ~3.5s with transaction confirmed in docket
- [x] Routing advances correctly (Submit → Review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)