### PR TITLE
fix: copy blueprint schemas into Docker image

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Dockerfile
+++ b/src/Services/Sorcha.Blueprint.Service/Dockerfile
@@ -52,8 +52,9 @@ EXPOSE 8081
 # Copy published application
 COPY --from=publish /app/publish .
 
-# Copy blueprint templates for seeding on startup
+# Copy blueprint templates and schemas for seeding on startup
 COPY blueprints/templates/ ./blueprints/templates/
+COPY blueprints/schemas/ ./blueprints/schemas/
 
 # Set environment variables
 ENV ASPNETCORE_URLS=http://+:8080


### PR DESCRIPTION
## Summary
- Added missing `COPY blueprints/schemas/ ./blueprints/schemas/` to Blueprint Service Dockerfile
- The LocalSchemaProvider was showing **Degraded** with 0 schemas because the schemas directory wasn't in the Docker image
- All 26 local schemas now load successfully on container startup

## Test plan
- [x] Rebuilt Blueprint Service with `--no-cache`
- [x] Verified container logs show "Upserted 26 schemas from Sorcha Local"
- [x] Confirmed admin UI at `/app/admin/schema-providers` shows Healthy with 26 schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)