### PR TITLE
fix: PR #138 review feedback + #139 PlatformUserOrgMembership gap

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/CollapsibleStatsPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/CollapsibleStatsPanel.razor
@@ -81,8 +81,14 @@
 
     private bool _isExpanded = true;
 
+    private bool _initializedExpanded;
+
     protected override void OnParametersSet()
     {
-        _isExpanded = IsExpanded;
+        if (!_initializedExpanded)
+        {
+            _isExpanded = IsExpanded;
+            _initializedExpanded = true;
+        }
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
@@ -57,9 +57,15 @@
 
     private bool _isExpanded = true;
 
+    private bool _initializedExpanded;
+
     protected override void OnParametersSet()
     {
-        _isExpanded = IsExpanded;
+        if (!_initializedExpanded)
+        {
+            _isExpanded = IsExpanded;
+            _initializedExpanded = true;
+        }
     }
 
     private async Task HandleOrganizationSelected(OrganizationDto org)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
@@ -187,7 +187,7 @@
         _filteredUsers = _selectedStatusFilter switch
         {
             "Active" => _users.Where(u => u.CompositeStatus == "Active").ToList(),
-            "Invited" => _users.Where(u => u.InvitationStatus == "Pending" || u.ProvisionedVia == "Invitation").ToList(),
+            "Invited" => _users.Where(u => u.CompositeStatus == "Invited").ToList(),
             "Unverified" => _users.Where(u => u.CompositeStatus == "Unverified").ToList(),
             _ => _users
         };

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IOrganizationAdminService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IOrganizationAdminService.cs
@@ -239,13 +239,20 @@ public record UserDto
     /// <summary>
     /// Derived composite status for UI display.
     /// </summary>
-    public string CompositeStatus => Status switch
+    public string CompositeStatus
     {
-        "Active" when !EmailVerified => "Unverified",
-        "Active" => "Active",
-        "Suspended" => "Suspended",
-        _ => Status
-    };
+        get
+        {
+            if (InvitationStatus == "Pending") return "Invited";
+            return Status switch
+            {
+                "Active" when !EmailVerified => "Unverified",
+                "Active" => "Active",
+                "Suspended" => "Suspended",
+                _ => Status
+            };
+        }
+    }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Organizations.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Organizations.razor
@@ -125,6 +125,22 @@
     {
         try
         {
+            // Org admins can only access their own org via deep link
+            if (!_isSystemAdmin)
+            {
+                if (AuthenticationState != null)
+                {
+                    var authState = await AuthenticationState;
+                    var orgIdClaim = authState.User.Claims
+                        .FirstOrDefault(c => c.Type == "org_id" || c.Type == "organization_id");
+                    if (orgIdClaim != null && Guid.TryParse(orgIdClaim.Value, out var userOrgId) && userOrgId != orgId)
+                    {
+                        _orgAdminError = "You do not have access to this organisation.";
+                        return;
+                    }
+                }
+            }
+
             _selectedOrganization = await OrganizationService.GetOrganizationAsync(orgId);
             if (_selectedOrganization == null)
             {

--- a/src/Services/Sorcha.Tenant.Service/Data/Repositories/IdentityRepository.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/Repositories/IdentityRepository.cs
@@ -102,9 +102,6 @@ public class IdentityRepository : IIdentityRepository
     }
 
 
-
-
-
     public async Task<ServicePrincipal?> GetServicePrincipalByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         return await _context.ServicePrincipals

--- a/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
@@ -242,12 +242,16 @@ public partial class OrganizationService : IOrganizationService
             throw new InvalidOperationException($"User with email {request.Email} already exists in this organization");
         }
 
+        // Look up existing PlatformUser by email to link identities
+        var platformUser = await _dbContext.PlatformUsers
+            .FirstOrDefaultAsync(p => p.Email.ToLower() == request.Email.ToLower(), cancellationToken);
+
         var user = new UserIdentity
         {
             OrganizationId = organizationId,
+            PlatformUserId = platformUser?.Id ?? Guid.Empty,
             Email = request.Email,
             DisplayName = request.DisplayName,
-            // TODO: ExternalIdpSubject removed from UserIdentity — external subject tracking moves to PlatformSocialLogin
             Roles = request.Roles,
             Status = IdentityStatus.Active,
             CreatedAt = DateTimeOffset.UtcNow
@@ -255,11 +259,31 @@ public partial class OrganizationService : IOrganizationService
 
         var created = await _identityRepository.CreateUserAsync(user, cancellationToken);
 
-        _logger.LogInformation(
-            "Added user {UserId} ({Email}) to organization {OrganizationId}",
-            created.Id, created.Email, organizationId);
+        // Create PlatformUserOrgMembership so the user can switch-org to this org
+        if (platformUser != null)
+        {
+            var existingMembership = await _dbContext.PlatformUserOrgMemberships
+                .FirstOrDefaultAsync(m => m.PlatformUserId == platformUser.Id && m.OrganizationId == organizationId, cancellationToken);
 
-        return UserResponse.FromEntity(created);
+            if (existingMembership == null)
+            {
+                _dbContext.PlatformUserOrgMemberships.Add(new PlatformUserOrgMembership
+                {
+                    PlatformUserId = platformUser.Id,
+                    OrganizationId = organizationId,
+                    Role = request.Roles.Any(r => r == UserRole.Administrator)
+                        ? UserRole.Administrator.ToString() : UserRole.Member.ToString(),
+                    JoinedAt = DateTimeOffset.UtcNow
+                });
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        _logger.LogInformation(
+            "Added user {UserId} ({Email}) to organization {OrganizationId} (PlatformUser: {HasPlatformUser})",
+            created.Id, created.Email, organizationId, platformUser != null);
+
+        return UserResponse.FromEntity(created, platformUser);
     }
 
     /// <inheritdoc />
@@ -361,15 +385,12 @@ public partial class OrganizationService : IOrganizationService
             return false; // Already verified
         }
 
-        // Set email as verified
+        // Set email as verified + record audit event in a single save
         platformUser.EmailVerified = true;
         platformUser.EmailVerifiedAt = DateTimeOffset.UtcNow;
         platformUser.VerificationToken = null;
         platformUser.VerificationTokenExpiresAt = null;
 
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        // Record audit event
         _dbContext.AuditLogEntries.Add(new AuditLogEntry
         {
             Timestamp = DateTimeOffset.UtcNow,
@@ -383,6 +404,7 @@ public partial class OrganizationService : IOrganizationService
                 ["targetEmail"] = user.Email
             }
         });
+
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(


### PR DESCRIPTION
## Summary

Addresses all review comments from PR #138 and fixes #139.

- **Single SaveChangesAsync** for email verify + audit entry (was double-save with audit gap)
- **AddUserToOrganizationAsync** now looks up existing PlatformUser by email, sets `UserIdentity.PlatformUserId`, and creates `PlatformUserOrgMembership` — enabling `switch-org` for admin-added users
- **Org admin deep-link guard** — non-system-admins can't access `/admin/organizations/{otherOrgId}`
- **CompositeStatus** now returns `"Invited"` for users with `InvitationStatus == "Pending"`
- **UserList filter** uses `CompositeStatus` consistently (was mixing property + raw field checks)
- **OrgSelectorPanel/CollapsibleStatsPanel** only set expanded state on first render (prevents re-render from overriding user's toggle)
- **Blank lines** removed in IdentityRepository.cs

Closes #139

## Test plan

- [x] 16/16 OrganizationServiceTests passing
- [x] Full solution build: 0 errors
- [ ] E2E Admin tests
- [ ] Manual: admin add-user → user can switch-org to that org

🤖 Generated with [Claude Code](https://claude.com/claude-code)