### PR TITLE
fix: scope AddUserToOrganization duplicate check to target org

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
@@ -235,9 +235,11 @@ public partial class OrganizationService : IOrganizationService
             throw new ArgumentException($"Organization {organizationId} not found", nameof(organizationId));
         }
 
-        // Check if user already exists
-        var existingUser = await _identityRepository.GetUserByEmailAsync(request.Email, cancellationToken);
-        if (existingUser != null && existingUser.OrganizationId == organizationId)
+        // Check if user already exists in the target org (scoped check)
+        var existingUser = await _dbContext.UserIdentities
+            .FirstOrDefaultAsync(u => u.OrganizationId == organizationId
+                && u.Email.ToLower() == request.Email.ToLower(), cancellationToken);
+        if (existingUser != null)
         {
             throw new InvalidOperationException($"User with email {request.Email} already exists in this organization");
         }


### PR DESCRIPTION
## Summary

- Scopes the duplicate user check in `AddUserToOrganizationAsync` to the target org
- `GetUserByEmailAsync` was returning UserIdentity from ANY org, causing false "already exists" when adding a user to a second org
- Now queries `UserIdentities` directly with `WHERE OrganizationId == targetOrg AND Email == email`

## Test plan

- [x] 16/16 OrganizationServiceTests passing
- [x] Build: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)