### PR TITLE
feat: scope all register UI to subscribed registers (#113)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Blueprints/PublishBlueprintWizard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Blueprints/PublishBlueprintWizard.razor
@@ -8,6 +8,7 @@
 
 @inject IBlueprintApiService BlueprintApi
 @inject IRegisterService RegisterService
+@inject IRegisterSubscriptionService SubscriptionService
 
 <MudDialog>
     <TitleContent>
@@ -456,7 +457,10 @@
 
         try
         {
-            _registers = (await RegisterService.GetRegistersAsync()).ToList();
+            var subscriptions = await SubscriptionService.GetMySubscribedRegistersAsync();
+            var subscribedIds = subscriptions.Select(s => s.RegisterId).Where(id => !string.IsNullOrEmpty(id)).ToHashSet();
+            var allRegisters = await RegisterService.GetRegistersAsync();
+            _registers = allRegisters.Where(r => subscribedIds.Contains(r.Id)).ToList();
         }
         catch
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Participants/PublishParticipantDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Participants/PublishParticipantDialog.razor
@@ -198,6 +198,7 @@
 @code {
     [Inject] private IParticipantPublishingService PublishingService { get; set; } = default!;
     [Inject] private IRegisterService RegisterService { get; set; } = default!;
+    [Inject] private IRegisterSubscriptionService SubscriptionService { get; set; } = default!;
 
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
 
@@ -254,8 +255,10 @@
         _loadingRegisters = true;
         try
         {
-            var registers = await RegisterService.GetRegistersAsync();
-            _registers = registers.ToList();
+            var subscriptions = await SubscriptionService.GetMySubscribedRegistersAsync();
+            var subscribedIds = subscriptions.Select(s => s.RegisterId).Where(id => !string.IsNullOrEmpty(id)).ToHashSet();
+            var allRegisters = await RegisterService.GetRegistersAsync();
+            _registers = allRegisters.Where(r => subscribedIds.Contains(r.Id)).ToList();
         }
         catch
         {


### PR DESCRIPTION
## Summary

Scopes the two remaining unfiltered register queries to subscribed registers only:

- **PublishBlueprintWizard** — register dropdown now shows only subscribed registers
- **PublishParticipantDialog** — register dropdown now shows only subscribed registers

All 4 register-consuming UI components are now consistently scoped:
| Component | Status |
|-----------|--------|
| Registers page (`/registers`) | Already scoped |
| New Submission (`/my-workflows`) | Already scoped |
| PublishBlueprintWizard | **Now scoped** |
| PublishParticipantDialog | **Now scoped** |

Backend (Tenant Service endpoints, subscription model, subscription service) was already fully implemented. API Gateway route for `/api/registers/available` was already configured. No "Available Registers" redundancy found in admin pages.

Closes #113

## Test plan
- [x] Build: 0 errors
- [ ] Manual: Publish blueprint wizard only shows subscribed registers
- [ ] Manual: Publish participant dialog only shows subscribed registers

🤖 Generated with [Claude Code](https://claude.com/claude-code)