### PR TITLE
fix: complete Member→Consumer rename across remaining files

### DIFF
--- a/src/Common/Sorcha.Tenant.Models/TokenClaims.cs
+++ b/src/Common/Sorcha.Tenant.Models/TokenClaims.cs
@@ -106,7 +106,7 @@ public class TokenClaims
     public required string TokenType { get; init; }
 
     /// <summary>
-    /// User roles within organization (e.g., "Administrator", "Auditor", "Member").
+    /// User roles within organization (e.g., "Administrator", "Auditor", "Consumer").
     /// Empty array for public identities.
     /// Custom claim: "roles".
     /// </summary>
@@ -182,7 +182,7 @@ public class TokenClaims
     {
         public const string Administrator = "Administrator";
         public const string Auditor = "Auditor";
-        public const string Member = "Member";
+        public const string Consumer = "Consumer";
     }
 
 }

--- a/tests/Sorcha.Auth.IntegrationTests/UserAuthFlowTests.cs
+++ b/tests/Sorcha.Auth.IntegrationTests/UserAuthFlowTests.cs
@@ -96,7 +96,7 @@ public class UserAuthFlowTests : IAsyncLifetime
             userId: "user-123",
             email: "test@sorcha.io",
             orgId: "org-456",
-            role: "Member");
+            role: "Consumer");
 
         // Assert: decode and verify claims
         var handler = new JwtSecurityTokenHandler();
@@ -122,7 +122,7 @@ public class UserAuthFlowTests : IAsyncLifetime
     [Fact]
     public async Task ValidUserToken_AccessesProtectedEndpoint()
     {
-        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Member");
+        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Consumer");
         var response = await SendRequest("/api/test/protected", token);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -133,7 +133,7 @@ public class UserAuthFlowTests : IAsyncLifetime
     [Fact]
     public async Task UserWithOrgId_AccessesOrgProtectedEndpoint()
     {
-        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Member");
+        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Consumer");
         var response = await SendRequest("/api/test/org-protected", token);
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -144,7 +144,7 @@ public class UserAuthFlowTests : IAsyncLifetime
     [Fact]
     public async Task UserWithoutOrgId_RejectedFromOrgProtectedEndpoint()
     {
-        var token = GenerateUserToken("user-123", "test@sorcha.io", orgId: null, role: "Member");
+        var token = GenerateUserToken("user-123", "test@sorcha.io", orgId: null, role: "Consumer");
         var response = await SendRequest("/api/test/org-protected", token);
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
@@ -155,7 +155,7 @@ public class UserAuthFlowTests : IAsyncLifetime
     [Fact]
     public async Task ExpiredUserToken_ReturnsUnauthorized()
     {
-        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Member",
+        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Consumer",
             notBefore: DateTime.UtcNow.AddMinutes(-10),
             expires: DateTime.UtcNow.AddSeconds(-60));
 
@@ -245,7 +245,7 @@ public class UserAuthFlowTests : IAsyncLifetime
     [Fact]
     public async Task UserTokenWithWrongKey_ReturnsUnauthorized()
     {
-        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Member",
+        var token = GenerateUserToken("user-123", "test@sorcha.io", "org-456", "Consumer",
             signingKey: "completely-different-signing-key-that-is-at-least-32-characters-long");
 
         var response = await SendRequest("/api/test/protected", token);
@@ -359,7 +359,7 @@ public class UserAuthFlowTests : IAsyncLifetime
                 new Claim(ClaimTypes.NameIdentifier, "user-123"),
                 new Claim(ClaimTypes.Email, "test@sorcha.io"),
                 new Claim(TokenClaimConstants.OrgId, "org-456"),
-                new Claim(ClaimTypes.Role, "Member")
+                new Claim(ClaimTypes.Role, "Consumer")
             };
 
             var accessToken = new JwtSecurityToken(

--- a/tests/Sorcha.Tenant.Models.Tests/OrganizationContextTests.cs
+++ b/tests/Sorcha.Tenant.Models.Tests/OrganizationContextTests.cs
@@ -24,7 +24,7 @@ public class OrganizationContextTests
             OrganizationName = "Acme Corporation",
             UserId = userId,
             UserEmail = "admin@acme.com",
-            Roles = ["Administrator", "Member"],
+            Roles = ["Administrator", "Consumer"],
             IsServicePrincipal = false,
             IsPlatformUser = false,
             ServiceName = null
@@ -35,7 +35,7 @@ public class OrganizationContextTests
         context.OrganizationName.Should().Be("Acme Corporation");
         context.UserId.Should().Be(userId);
         context.UserEmail.Should().Be("admin@acme.com");
-        context.Roles.Should().BeEquivalentTo(["Administrator", "Member"]);
+        context.Roles.Should().BeEquivalentTo(["Administrator", "Consumer"]);
         context.IsServicePrincipal.Should().BeFalse();
         context.IsPlatformUser.Should().BeFalse();
         context.ServiceName.Should().BeNull();

--- a/tests/Sorcha.Tenant.Models.Tests/TokenClaimsTests.cs
+++ b/tests/Sorcha.Tenant.Models.Tests/TokenClaimsTests.cs
@@ -145,7 +145,7 @@ public class TokenClaimsTests
     {
         TokenClaims.RoleNames.Administrator.Should().Be("Administrator");
         TokenClaims.RoleNames.Auditor.Should().Be("Auditor");
-        TokenClaims.RoleNames.Member.Should().Be("Member");
+        TokenClaims.RoleNames.Consumer.Should().Be("Consumer");
     }
 
     [Fact]

--- a/tests/Sorcha.Tenant.Service.IntegrationTests/Fixtures/TestAuthHandler.cs
+++ b/tests/Sorcha.Tenant.Service.IntegrationTests/Fixtures/TestAuthHandler.cs
@@ -106,7 +106,7 @@ public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions
         }
         else
         {
-            claims.Add(new Claim(ClaimTypes.Role, "Member"));
+            claims.Add(new Claim(ClaimTypes.Role, "Consumer"));
         }
 
         var identity = new ClaimsIdentity(claims, SchemeName);

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/ParticipantEndpointsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/ParticipantEndpointsTests.cs
@@ -478,7 +478,7 @@ public class ParticipantEndpointsTests : IClassFixture<TenantServiceWebApplicati
         var orgId = TestDataSeeder.TestOrganizationId;
         var customName = "Custom Display Name";
         var auditorClient = _factory.CreateClient();
-        auditorClient.DefaultRequestHeaders.Add("X-Test-Role", "Member");
+        auditorClient.DefaultRequestHeaders.Add("X-Test-Role", "Consumer");
         auditorClient.DefaultRequestHeaders.Add("X-Test-User-Id", TestDataSeeder.AuditorUserId.ToString());
         auditorClient.DefaultRequestHeaders.Add("X-Test-Organization-Id", orgId.ToString());
 

--- a/tests/Sorcha.Tenant.Service.Tests/Infrastructure/TenantServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Infrastructure/TenantServiceWebApplicationFactory.cs
@@ -289,7 +289,7 @@ public class TenantServiceWebApplicationFactory : WebApplicationFactory<Program>
     public HttpClient CreateMemberClient()
     {
         var client = CreateClient();
-        client.DefaultRequestHeaders.Add("X-Test-Role", "Member");
+        client.DefaultRequestHeaders.Add("X-Test-Role", "Consumer");
         client.DefaultRequestHeaders.Add("X-Test-User-Id", TestDataSeeder.MemberUserId.ToString());
         client.DefaultRequestHeaders.Add("X-Test-Organization-Id", TestDataSeeder.TestOrganizationId.ToString());
         return client;

--- a/tests/Sorcha.Tenant.Service.Tests/Services/LoginServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/LoginServiceTests.cs
@@ -109,7 +109,7 @@ public class LoginServiceTests : IDisposable
         {
             PlatformUserId = platformUserId,
             OrganizationId = orgId,
-            Role = "Member",
+            Role = "Consumer",
             JoinedAt = DateTimeOffset.UtcNow
         };
         _dbContext.PlatformUserOrgMemberships.Add(membership);
@@ -178,7 +178,7 @@ public class LoginServiceTests : IDisposable
         {
             PlatformUserId = platformUser.Id,
             OrganizationId = org.Id,
-            Role = "Member",
+            Role = "Consumer",
             JoinedAt = DateTimeOffset.UtcNow
         });
         _tokenService.Setup(t => t.GenerateUserTokenAsync(
@@ -237,7 +237,7 @@ public class LoginServiceTests : IDisposable
         var memberships = new[]
         {
             new PlatformUserOrgMembership { PlatformUserId = platformUserId, OrganizationId = org1.Id, Role = "Admin", JoinedAt = DateTimeOffset.UtcNow },
-            new PlatformUserOrgMembership { PlatformUserId = platformUserId, OrganizationId = org2.Id, Role = "Member", JoinedAt = DateTimeOffset.UtcNow }
+            new PlatformUserOrgMembership { PlatformUserId = platformUserId, OrganizationId = org2.Id, Role = "Consumer", JoinedAt = DateTimeOffset.UtcNow }
         };
 
         SetupNoRateLimit();
@@ -361,7 +361,7 @@ public class LoginServiceTests : IDisposable
         {
             PlatformUserId = platformUser.Id,
             OrganizationId = org.Id,
-            Role = "Member",
+            Role = "Consumer",
             JoinedAt = DateTimeOffset.UtcNow
         });
 
@@ -446,7 +446,7 @@ public class LoginServiceTests : IDisposable
         {
             PlatformUserId = platformUser.Id,
             OrganizationId = org.Id,
-            Role = "Member",
+            Role = "Consumer",
             JoinedAt = DateTimeOffset.UtcNow
         });
 
@@ -504,7 +504,7 @@ public class LoginServiceTests : IDisposable
         {
             PlatformUserId = platformUserId,
             OrganizationId = orgId,
-            Role = "Member",
+            Role = "Consumer",
             JoinedAt = DateTimeOffset.UtcNow
         });
 
@@ -550,7 +550,7 @@ public class LoginServiceTests : IDisposable
         {
             PlatformUserId = platformUserId,
             OrganizationId = orgId,
-            Role = "Member",
+            Role = "Consumer",
             JoinedAt = DateTimeOffset.UtcNow
         };
 
@@ -633,7 +633,7 @@ public class LoginServiceTests : IDisposable
                 {
                     PlatformUserId = platformUser.Id,
                     OrganizationId = org.Id,
-                    Role = "Member",
+                    Role = "Consumer",
                     JoinedAt = DateTimeOffset.UtcNow
                 }
             });
@@ -687,7 +687,7 @@ public class LoginServiceTests : IDisposable
                 {
                     PlatformUserId = platformUser.Id,
                     OrganizationId = org.Id,
-                    Role = "Member",
+                    Role = "Consumer",
                     JoinedAt = DateTimeOffset.UtcNow
                 }
             });

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CouncilCredentialFlowTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CouncilCredentialFlowTests.cs
@@ -953,9 +953,9 @@ public class CouncilCredentialFlowTests : MultiUserTestBase
         // passwords and can get tokens), then add them to the council org via admin API.
         var staffUsers = new[]
         {
-            (Email: IdDeptEmail, DisplayName: "ID Department", TokenKey: "id-dept", Roles: new[] { "Member" }),
-            (Email: ServiceDeptEmail, DisplayName: "Service Department", TokenKey: "service-dept", Roles: new[] { "Member" }),
-            (Email: ReturnDeptEmail, DisplayName: "Fulfilment Department", TokenKey: "return-dept", Roles: new[] { "Member" }),
+            (Email: IdDeptEmail, DisplayName: "ID Department", TokenKey: "id-dept", Roles: new[] { "Consumer" }),
+            (Email: ServiceDeptEmail, DisplayName: "Service Department", TokenKey: "service-dept", Roles: new[] { "Consumer" }),
+            (Email: ReturnDeptEmail, DisplayName: "Fulfilment Department", TokenKey: "return-dept", Roles: new[] { "Consumer" }),
         };
 
         // Phase 1: Register as PlatformUsers via public org

--- a/tests/Sorcha.Validator.Service.Tests/AuthenticationTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/AuthenticationTests.cs
@@ -108,7 +108,7 @@ public class AuthenticationTests
     {
         var principal = CreatePrincipal(
             new Claim(TokenClaimConstants.TokenType, TokenClaimConstants.TokenTypeUser),
-            new Claim(ClaimTypes.Role, "Member"));
+            new Claim(ClaimTypes.Role, "Consumer"));
         var result = await _authorizationService.AuthorizeAsync(principal, "CanValidateChains");
         result.Succeeded.Should().BeFalse();
     }
@@ -176,7 +176,7 @@ public class AuthenticationTests
     public async Task RequireAdministrator_WithMemberRole_Fails()
     {
         var principal = CreatePrincipal(
-            new Claim(ClaimTypes.Role, "Member"));
+            new Claim(ClaimTypes.Role, "Consumer"));
         var result = await _authorizationService.AuthorizeAsync(principal, "RequireAdministrator");
         result.Succeeded.Should().BeFalse();
     }


### PR DESCRIPTION
## Summary

Follow-up to #144 — fixes 11 files missed in the initial rename:

- `TokenClaims.RoleNames.Member` → `Consumer` (constant + doc comment)  
- Test fixtures and integration tests still referencing `"Member"` as a role string
- Note: `ParticipantRole.Member` (blueprint workflow domain) intentionally NOT renamed

## Test plan
- [x] Build: 0 errors
- [x] Tenant.Models.Tests: 119/119 pass
- [x] LoginServiceTests + DashboardServiceTests: 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)