### PR TITLE
docs: fix broken internal links and add CI link checker

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,20 @@
+name: Check Markdown Links
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check internal markdown links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config .lychee.toml
+            '**/*.md'
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,23 @@
+# Lychee link checker configuration
+# Only checks internal/local links to avoid external rate limiting
+
+# Exclude external URLs entirely - only check local file links
+exclude_path = [
+  "docs/archive/",
+  "docs/site/",
+  "docs/plans/",
+  "docs/superpowers/"
+]
+
+# Only check local file links, skip all network requests
+scheme = ["file"]
+
+# Skip external URLs
+exclude = [
+  "^https?://",
+  "^mailto:",
+  "^tel:"
+]
+
+# Don't require network access
+no_progress = true

--- a/.specify/UNIFIED-DESIGN-SUMMARY.md
+++ b/.specify/UNIFIED-DESIGN-SUMMARY.md
@@ -287,14 +287,14 @@ Notifies participants (SignalR)
 ## Documentation
 
 **Design Documents:**
-- [BLUEPRINT-SERVICE-UNIFIED-DESIGN.md](.specify/BLUEPRINT-SERVICE-UNIFIED-DESIGN.md) - Complete design specification
-- [BLUEPRINT-SERVICE-IMPLEMENTATION-PLAN.md](.specify/BLUEPRINT-SERVICE-IMPLEMENTATION-PLAN.md) - Detailed implementation plan (138 tasks)
+- [BLUEPRINT-SERVICE-UNIFIED-DESIGN.md](BLUEPRINT-SERVICE-UNIFIED-DESIGN.md) - Complete design specification
+- BLUEPRINT-SERVICE-IMPLEMENTATION-PLAN.md - Detailed implementation plan (138 tasks, archived)
 
 **Updated Architecture:**
 - [docs/architecture.md](../docs/reference/architecture.md) - Updated architecture documentation
 
 **Action Service Design (SUPERSEDED):**
-- [ACTION-SERVICE-DESIGN.md](.specify/ACTION-SERVICE-DESIGN.md) - Original action service design (for reference)
+- ACTION-SERVICE-DESIGN.md - Original action service design (archived, merged into unified design)
 - **Status:** Merged into unified design, no longer a separate service
 
 ---

--- a/.specify/spec.md
+++ b/.specify/spec.md
@@ -59,7 +59,7 @@ Create a production-grade distributed ledger platform that combines the benefits
 - Tenant-specific configuration and policies
 - API authentication and authorization
 
-**Current Status:** Boilerplate specification available at [sorcha-tenant-service.md](.specify/specs/sorcha-tenant-service.md)
+**Current Status:** Boilerplate specification available at [sorcha-tenant-service.md](specs/sorcha-tenant-service.md)
 Basic tenant isolation implemented at application level.
 
 **Dependencies:**
@@ -71,7 +71,7 @@ Basic tenant isolation implemented at application level.
 #### 2. Wallet Service
 **Purpose:** Secure wallet management and cryptographic operations
 
-**Specification:** [sorcha-wallet-service.md](.specify/specs/sorcha-wallet-service.md)
+**Specification:** [sorcha-wallet-service.md](specs/sorcha-wallet-service.md)
 
 **Key Features:**
 - HD wallet creation and recovery (BIP32/BIP39/BIP44)
@@ -94,7 +94,7 @@ Basic tenant isolation implemented at application level.
 #### 3. Register Service (To Be Specified)
 **Purpose:** Distributed ledger and block management
 
-**Current Status:** Boilerplate specification available at [sorcha-register-service.md](.specify/specs/sorcha-register-service.md)
+**Current Status:** Boilerplate specification available at [sorcha-register-service.md](specs/sorcha-register-service.md)
 Stub implementation provided for wallet service integration.
 
 **Key Features:**
@@ -468,12 +468,10 @@ The following items are explicitly out of scope for the current specification:
 
 ## References
 
-- [Project Constitution](.specify/constitution.md)
-- [Implementation Plan](.specify/plan.md)
+- [Project Constitution](constitution.md)
+- [Implementation Plan](MASTER-PLAN.md)
 - [Project README](../README.md)
-- [Deployment Documentation](../deploy/bicep/README.md)
 - [Troubleshooting Guide](../docs/guides/TROUBLESHOOTING.md)
-- [Dependency Upgrade Plan](../DEPENDENCY_UPGRADE_PLAN.md)
 
 ---
 

--- a/.specify/specs/sorcha-transaction-handler.md
+++ b/.specify/specs/sorcha-transaction-handler.md
@@ -4,7 +4,7 @@
 **Date:** 2025-11-13
 **Status:** Proposed
 **Related Constitution:** [constitution.md](../constitution.md)
-**Related Specification:** [Sorcha-cryptography-rewrite.md](Sorcha-cryptography-rewrite.md)
+**Related Specification:** [sorcha-cryptography-rewrite.md](sorcha-cryptography-rewrite.md)
 
 **Related Documentation:**
 - [Blockchain Transaction Format - JSON-LD Specification](../../docs/reference/blockchain-transaction-format.md)
@@ -703,7 +703,7 @@ public class PayloadOptions
 ## References
 
 - [Current Transaction Implementation](../../src/Common/SorchaPlatformCryptography/)
-- [Sorcha.Cryptography Specification](Sorcha-cryptography-rewrite.md)
+- [Sorcha.Cryptography Specification](sorcha-cryptography-rewrite.md)
 - [Bitcoin Transaction Format](https://developer.bitcoin.org/reference/transactions.html)
 
 ---

--- a/.specify/specs/sorcha-ui.md
+++ b/.specify/specs/sorcha-ui.md
@@ -56,7 +56,7 @@
 
 ### Why Replace Sorcha.Admin?
 
-**Sorcha.Admin** (Blazor Server) has the following critical issues documented in [KNOWN-ISSUES.md](../../src/Apps/Sorcha.Admin/KNOWN-ISSUES.md):
+**Sorcha.Admin** (Blazor Server) has the following critical issues:
 
 1. **❌ BLOCKING: Authentication State Not Displaying After Login**
    - Blazor Server circuit isolation prevents authentication state from persisting across navigation
@@ -2306,9 +2306,7 @@ Content-Security-Policy:
 ## Appendix B: References
 
 **Internal Documentation:**
-- [Sorcha.Admin README](../../src/Apps/Sorcha.Admin/README.md)
-- [Sorcha.Admin Feature Requirements](../../src/Apps/Sorcha.Admin/FEATURE-REQUIREMENTS.md)
-- [Sorcha.Admin Known Issues](../../src/Apps/Sorcha.Admin/KNOWN-ISSUES.md)
+- Sorcha.Admin (deprecated, replaced by Sorcha.UI)
 - [Sorcha Constitution](../constitution.md)
 - [Sorcha Architecture](../../docs/reference/architecture.md)
 

--- a/.specify/tasks/TASK-001-setup-crypto-library-project.md
+++ b/.specify/tasks/TASK-001-setup-crypto-library-project.md
@@ -13,8 +13,8 @@
 This is the foundational task for the Sorcha.Cryptography library rewrite. We need to create a clean, new library project with minimal dependencies and proper project structure.
 
 **Related Specifications:**
-- [Sorcha.Cryptography Rewrite Spec](../specs/Sorcha-cryptography-rewrite.md)
-- [Project Plan](../plan.md#project-structure)
+- [Sorcha.Cryptography Rewrite Spec](../specs/sorcha-cryptography-rewrite.md)
+- [Master Plan](../MASTER-PLAN.md)
 
 **Dependencies:**
 - None (first task)

--- a/.specify/tasks/TASK-002-implement-enums-and-models.md
+++ b/.specify/tasks/TASK-002-implement-enums-and-models.md
@@ -13,8 +13,8 @@
 Define the foundational enums and data models that will be used throughout the Sorcha.Cryptography library. These types form the contract between components and must be well-designed for extensibility and clarity.
 
 **Related Specifications:**
-- [Sorcha.Cryptography Rewrite Spec](../specs/Sorcha-cryptography-rewrite.md#functional-requirements)
-- [Project Plan](../plan.md)
+- [Sorcha.Cryptography Rewrite Spec](../specs/sorcha-cryptography-rewrite.md#functional-requirements)
+- [Master Plan](../MASTER-PLAN.md)
 
 **Dependencies:**
 - TASK-001 (Project setup must be complete)

--- a/.specify/tasks/TASK-003-implement-core-crypto-module.md
+++ b/.specify/tasks/TASK-003-implement-core-crypto-module.md
@@ -13,7 +13,7 @@
 Implement the core cryptographic module that handles key generation, digital signatures, encryption/decryption, and public key operations. This is the heart of the library and must be implemented with security and correctness as top priorities.
 
 **Related Specifications:**
-- [Sorcha.Cryptography Rewrite Spec - FR-1 through FR-4](../specs/Sorcha-cryptography-rewrite.md#fr-1-key-generation)
+- [Sorcha.Cryptography Rewrite Spec - FR-1 through FR-4](../specs/sorcha-cryptography-rewrite.md#fr-1-key-generation)
 - [Current CryptoModule Implementation](../../src/Common/SorchaPlatformCryptography/CryptoModule.cs)
 
 **Dependencies:**

--- a/docs/archive/cli-history/CHANGELOG-CLI-v1.0.2.md
+++ b/docs/archive/cli-history/CHANGELOG-CLI-v1.0.2.md
@@ -33,7 +33,7 @@ This release fixes a critical null reference exception in the `sorcha config lis
 
 ### 📚 Documentation
 
-4. **Updated CLI README** ([src/Apps/Sorcha.Cli/README.md](src/Apps/Sorcha.Cli/README.md))
+4. **Updated CLI README** ([src/Apps/Sorcha.Cli/README.md](../../../src/Apps/Sorcha.Cli/README.md))
    - Updated Quick Start section to reflect single default profile
    - Added comprehensive Configuration Commands section
    - Updated example outputs to use "docker" profile
@@ -145,7 +145,7 @@ sorcha config list
 |------|---------------|-------------|
 | [ConfigCommand.cs](src/Apps/Sorcha.Cli/Commands/ConfigCommand.cs) | 1 | Fixed null reference in profile list |
 | [ConfigurationService.cs](src/Apps/Sorcha.Cli/Services/ConfigurationService.cs) | 105 → 28 | Simplified default configuration |
-| [README.md](src/Apps/Sorcha.Cli/README.md) | Multiple | Updated documentation |
+| [README.md](../../../src/Apps/Sorcha.Cli/README.md) | Multiple | Updated documentation |
 
 ### Default Configuration Structure
 

--- a/docs/archive/cli-history/cli-docker-profile.md
+++ b/docs/archive/cli-history/cli-docker-profile.md
@@ -217,6 +217,6 @@ You can manually edit this file to customize the docker profile URLs if needed.
 
 ### Next Steps
 
-- See [CLI Documentation](./CLI-DOCUMENTATION.md) for all available commands
-- See [Docker Setup](../docker-compose.yml) for service configuration
-- See [API Gateway Configuration](../src/Apps/Sorcha.ApiGateway/) for routing details
+- See [CLI README](../../../src/Apps/Sorcha.Cli/README.md) for all available commands
+- See [Docker Setup](../../../docker-compose.yml) for service configuration
+- See [API Gateway Configuration](../../../src/Services/Sorcha.ApiGateway/) for routing details

--- a/docs/archive/completion-reports/peer-service-summary.md
+++ b/docs/archive/completion-reports/peer-service-summary.md
@@ -369,8 +369,8 @@ The Sorcha Peer Service represents a strategic investment in decentralization th
 
 ## Related Documents
 
-- [Detailed Design Document](peer-service-design.md) - Technical architecture and component design
-- [Implementation Plan](peer-service-implementation-plan.md) - Detailed sprint breakdown and deliverables
+- [Detailed Design Document](../implementation-plans/peer-service-design.md) - Technical architecture and component design
+- [Implementation Plan](../implementation-plans/peer-service-implementation-plan.md) - Detailed sprint breakdown and deliverables
 - [Architecture Overview](../../reference/architecture.md) - How Peer Service fits into overall Sorcha architecture
 - [Testing Guide](../../guides/testing/testing.md) - Testing strategy and best practices
 

--- a/docs/archive/completion-reports/register-service-phase1-2-completion.md
+++ b/docs/archive/completion-reports/register-service-phase1-2-completion.md
@@ -2,7 +2,7 @@
 
 **Date:** 2025-11-16
 **Status:** ✅ Completed
-**Related Specification:** [sorcha-register-service.md](../.specify/specs/sorcha-register-service.md)
+**Related Specification:** [sorcha-register-service.md](../../../.specify/specs/sorcha-register-service.md)
 **Next Phase:** [Phase 5 - API Layer Completion](register-service-phase5-completion.md) ✅ Completed 2025-11-16
 
 > **✅ UPDATE (2025-11-16):** Phase 5 (API Layer) has been completed! The Register Service now has:

--- a/docs/archive/completion-reports/register-service-phase5-completion.md
+++ b/docs/archive/completion-reports/register-service-phase5-completion.md
@@ -3,7 +3,7 @@
 **Date:** 2025-11-16
 **Status:** ✅ Completed
 **Phase:** Phase 5 - API Layer
-**Related Specification:** [sorcha-register-service.md](../.specify/specs/sorcha-register-service.md)
+**Related Specification:** [sorcha-register-service.md](../../../.specify/specs/sorcha-register-service.md)
 **Previous Phase:** [Phase 1 & 2 Completion](register-service-phase1-2-completion.md)
 
 ## Executive Summary

--- a/docs/archive/completion-reports/validator-service-progress-report.md
+++ b/docs/archive/completion-reports/validator-service-progress-report.md
@@ -632,10 +632,10 @@ ConsensusValidator: 0% (not tested yet)
 ## 🔗 Related Documentation
 
 - [Validator Service Compliance Report](validator-service-compliance-report.md)
-- [Validator Service Specification](.specify/specs/sorcha-validator-service.md)
-- [Master Plan](.specify/MASTER-PLAN.md)
-- [Master Tasks](.specify/MASTER-TASKS.md)
-- [Constitution](.specify/constitution.md)
+- [Validator Service Specification](../../../.specify/specs/sorcha-validator-service.md)
+- [Master Plan](../../../.specify/MASTER-PLAN.md)
+- [Master Tasks](../../../.specify/MASTER-TASKS.md)
+- [Constitution](../../../.specify/constitution.md)
 
 ---
 

--- a/docs/archive/completion-reports/wallet-service-status.md
+++ b/docs/archive/completion-reports/wallet-service-status.md
@@ -581,7 +581,7 @@ tests/
 **Next Review Date:** 2025-11-23 (after next sprint)
 **Contributors:** Claude AI Agent
 **Related Documents:**
-- [Wallet Service Specification](.specify/specs/sorcha-wallet-service.md)
-- [Project Constitution](.specify/constitution.md)
+- [Wallet Service Specification](../../../.specify/specs/sorcha-wallet-service.md)
+- [Project Constitution](../../../.specify/constitution.md)
 - [Development Status](../../reference/development-status.md)
 - [README](../README.md)

--- a/docs/archive/learnings/2025-11-16-validator-service-refactoring.md
+++ b/docs/archive/learnings/2025-11-16-validator-service-refactoring.md
@@ -570,6 +570,6 @@ Sorcha.sln
 
 - [ADR-005: Validator Service Security Boundary](../../reference/architecture/ADR-005-Validator-Service-Security-Boundary.md)
 - [Validator Service Design](../../reference/validator-service-design.md)
-- [Register Service Phase 1-2 Completion](../register-service-phase1-2-completion.md)
+- [Register Service Phase 1-2 Completion](../completion-reports/register-service-phase1-2-completion.md)
 - [XUnit Documentation](https://xunit.net/)
 - [FluentAssertions Documentation](https://fluentassertions.com/)

--- a/docs/archive/sessions/ADMIN-AUTH-FIXES.md
+++ b/docs/archive/sessions/ADMIN-AUTH-FIXES.md
@@ -215,9 +215,9 @@ None currently identified. All tests passing.
 ## Related Documentation
 
 - [JWT Configuration Guide](../../guides/JWT-CONFIGURATION.md)
-- [Sorcha.Admin Tests README](../tests/Sorcha.Admin.Tests/README.md)
-- [ProfileDefaults Source](../src/Apps/Sorcha.Admin/Models/Configuration/ProfileDefaults.cs)
-- [LoginDialog Source](../src/Apps/Sorcha.Admin/Components/Authentication/LoginDialog.razor)
+- [Sorcha.Admin Tests README](../../../tests/Sorcha.Admin.Tests/README.md)
+- [ProfileDefaults Source](../../../src/Apps/Sorcha.Admin/Models/Configuration/ProfileDefaults.cs)
+- [LoginDialog Source](../../../src/Apps/Sorcha.Admin/Components/Authentication/LoginDialog.razor)
 
 ## Deployment
 

--- a/docs/archive/sessions/ADMIN-AUTH-NAVIGATION-FIX.md
+++ b/docs/archive/sessions/ADMIN-AUTH-NAVIGATION-FIX.md
@@ -231,9 +231,9 @@ None currently identified.
 
 - [Admin Authentication Fixes](ADMIN-AUTH-FIXES.md) - Original authentication fixes
 - [JWT Configuration Guide](../../guides/JWT-CONFIGURATION.md)
-- [Sorcha.Admin Tests README](../tests/Sorcha.Admin.Tests/README.md)
-- [AuthenticatedHttpMessageHandler Source](../src/Apps/Sorcha.Admin/Services/Http/AuthenticatedHttpMessageHandler.cs)
-- [BrowserTokenCache Source](../src/Apps/Sorcha.Admin/Services/Authentication/BrowserTokenCache.cs)
+- [Sorcha.Admin Tests README](../../../tests/Sorcha.Admin.Tests/README.md)
+- [AuthenticatedHttpMessageHandler Source](../../../src/Apps/Sorcha.Admin/Services/Http/AuthenticatedHttpMessageHandler.cs)
+- [BrowserTokenCache Source](../../../src/Apps/Sorcha.Admin/Services/Authentication/BrowserTokenCache.cs)
 
 ## Deployment
 

--- a/docs/archive/sessions/DOCKER-BRIDGE-NETWORKING.md
+++ b/docs/archive/sessions/DOCKER-BRIDGE-NETWORKING.md
@@ -552,8 +552,8 @@ curl http://localhost/api/health
 - [Docker bridge networking documentation](https://docs.docker.com/network/bridge/)
 - [ASP.NET Core Kestrel HTTPS configuration](https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/endpoints)
 - [YARP Reverse Proxy documentation](https://microsoft.github.io/reverse-proxy/)
-- [Sorcha API Gateway README](../src/Services/Sorcha.ApiGateway/README.md)
-- [Sorcha Peer Service README](../src/Services/Sorcha.Peer.Service/README.md)
+- [Sorcha API Gateway README](../../../src/Services/Sorcha.ApiGateway/README.md)
+- [Sorcha Peer Service README](../../../src/Services/Sorcha.Peer.Service/README.md)
 
 ---
 

--- a/docs/archive/sessions/DOCKER-DOCUMENTATION-UPDATE-2026-01-01.md
+++ b/docs/archive/sessions/DOCKER-DOCUMENTATION-UPDATE-2026-01-01.md
@@ -299,7 +299,7 @@ docker logs sorcha-peer-service | grep "Successfully connected"
    - Use Scalar API docs for testing endpoints
 
 3. **Production Deployment**:
-   - Review [DEPLOYMENT.md](../../DEPLOYMENT.md)
+   - Review [DEPLOYMENT.md](../../guides/DEPLOYMENT.md)
    - Replace development certificates
    - Configure production secrets
    - Review [DOCKER-BRIDGE-NETWORKING.md](DOCKER-BRIDGE-NETWORKING.md)
@@ -345,6 +345,6 @@ docker logs sorcha-peer-service | grep "Successfully connected"
 **Author:** Claude Sonnet 4.5
 **Related Documents:**
 - [README.md](../README.md#option-3-using-docker-compose-production-like)
-- [DEPLOYMENT.md](../../DEPLOYMENT.md#docker-deployment)
+- [DEPLOYMENT.md](../../guides/DEPLOYMENT.md#docker-deployment)
 - [DOCKER-QUICK-START.md](../../getting-started/DOCKER-QUICK-START.md)
 - [DOCKER-BRIDGE-NETWORKING.md](DOCKER-BRIDGE-NETWORKING.md)

--- a/docs/archive/sessions/LEARNINGS.md
+++ b/docs/archive/sessions/LEARNINGS.md
@@ -389,7 +389,7 @@ with proper access to encryption keys and cryptographic operations.
 - [Architecture](../../reference/architecture.md)
 - [Validator Service Design](../../reference/validator-service-design.md)
 - [Testing Guide](../../guides/testing/testing.md)
-- [Security Guidelines](security-guidelines.md) (planned)
+- Security Guidelines (planned)
 
 ---
 

--- a/docs/archive/sessions/MACVLAN-IMPLEMENTATION-SUMMARY.md
+++ b/docs/archive/sessions/MACVLAN-IMPLEMENTATION-SUMMARY.md
@@ -296,8 +296,8 @@ Successfully connected to hub node n0.sorcha.dev
 
 ## 🔗 Related Documentation
 
-- [Docker macvlan Networking Guide](./DOCKER-MACVLAN-NETWORKING.md) - Complete setup guide
-- [CLI Implementation Success](./CLI-IMPLEMENTATION-SUCCESS.md) - CLI testing results
+- Docker macvlan Networking Guide (deprecated, see bridge networking)
+- CLI Implementation Success (archived)
 - [Peer Network Testing Summary](./PEER-NETWORK-TESTING-SUMMARY.md) - Peer network analysis
 
 ---

--- a/docs/archive/sessions/PEER-NETWORK-TESTING-SUMMARY.md
+++ b/docs/archive/sessions/PEER-NETWORK-TESTING-SUMMARY.md
@@ -345,8 +345,8 @@ When the following all pass, we're ready to proceed with terminology update:
 
 - **Issues Document**: [HUB-NODE-CONNECTIVITY-ISSUES.md](HUB-NODE-CONNECTIVITY-ISSUES.md)
 - **Azure Setup**: [AZURE-CUSTOM-DOMAIN-SETUP.md](../../guides/azure/AZURE-CUSTOM-DOMAIN-SETUP.md)
-- **Peer Service README**: [src/Services/Sorcha.Peer.Service/README.md](../src/Services/Sorcha.Peer.Service/README.md)
-- **CLI README**: [src/Apps/Sorcha.Cli/README.md](../src/Apps/Sorcha.Cli/README.md)
+- **Peer Service README**: [src/Services/Sorcha.Peer.Service/README.md](../../../src/Services/Sorcha.Peer.Service/README.md)
+- **CLI README**: [src/Apps/Sorcha.Cli/README.md](../../../src/Apps/Sorcha.Cli/README.md)
 
 ---
 

--- a/docs/getting-started/BOOTSTRAP-CREDENTIALS.md
+++ b/docs/getting-started/BOOTSTRAP-CREDENTIALS.md
@@ -325,7 +325,7 @@ Host=host.docker.internal;Port=5432;Database=sorcha_tenant;...
 
 - [Infrastructure Setup Guide](INFRASTRUCTURE-SETUP.md) - PostgreSQL, Redis, MongoDB deployment
 - [Authentication Setup Guide](../guides/AUTHENTICATION-SETUP.md) - JWT configuration and service integration
-- [Tenant Service Specification](.specify/specs/sorcha-tenant-service.md) - Complete API documentation
+- [Tenant Service Specification](../../.specify/specs/sorcha-tenant-service.md) - Complete API documentation
 
 ---
 

--- a/docs/getting-started/DOCKER-QUICK-START.md
+++ b/docs/getting-started/DOCKER-QUICK-START.md
@@ -342,7 +342,7 @@ Sorcha uses a **single bridge network** with port publishing:
 - **API Gateway**: Centralized HTTP/HTTPS ingress for all backend services
 - **gRPC Direct**: Peer services exposed directly for P2P communication
 
-See [DOCKER-BRIDGE-NETWORKING.md](DOCKER-BRIDGE-NETWORKING.md) for detailed architecture.
+See the [Network Architecture](#network-architecture) section above for detailed architecture.
 
 ---
 
@@ -389,7 +389,7 @@ See [DEPLOYMENT.md](../guides/DEPLOYMENT.md) for full production deployment guid
 
 - **Main README**: [../README.md](../README.md)
 - **Deployment Guide**: [DEPLOYMENT.md](../guides/DEPLOYMENT.md)
-- **Docker Networking**: [DOCKER-BRIDGE-NETWORKING.md](DOCKER-BRIDGE-NETWORKING.md)
+- **Docker Networking**: See [Network Architecture](#network-architecture) section above
 - **Port Configuration**: [PORT-CONFIGURATION.md](PORT-CONFIGURATION.md)
 - **Architecture**: [architecture.md](../reference/architecture.md)
 

--- a/docs/getting-started/FIRST-RUN-SETUP.md
+++ b/docs/getting-started/FIRST-RUN-SETUP.md
@@ -346,9 +346,9 @@ For production deployments, update these values:
 ## Related Documentation
 
 - [Port Configuration](./PORT-CONFIGURATION.md) - Complete port reference
-- [Authentication Setup](./AUTHENTICATION-SETUP.md) - JWT and auth configuration
-- [Architecture Overview](./architecture.md) - System architecture
-- [Development Status](./development-status.md) - Current completion status
+- [Authentication Setup](../guides/AUTHENTICATION-SETUP.md) - JWT and auth configuration
+- [Architecture Overview](../reference/architecture.md) - System architecture
+- [Development Status](../reference/development-status.md) - Current completion status
 
 ---
 

--- a/docs/getting-started/PORT-CONFIGURATION.md
+++ b/docs/getting-started/PORT-CONFIGURATION.md
@@ -364,7 +364,7 @@ https://peer.sorcha.io      - Peer
 
 ## See Also
 
-- [Development Status](./development-status.md) - Current implementation status
-- [Architecture Overview](./architecture.md) - System architecture diagrams
-- [API Documentation](./API-DOCUMENTATION.md) - API endpoint reference
+- [Development Status](../reference/development-status.md) - Current implementation status
+- [Architecture Overview](../reference/architecture.md) - System architecture diagrams
+- [API Documentation](../reference/API-DOCUMENTATION.md) - API endpoint reference
 - [README](../README.md) - Project overview and getting started

--- a/docs/getting-started/blueprint-quick-start.md
+++ b/docs/getting-started/blueprint-quick-start.md
@@ -651,10 +651,10 @@ Shows "Rejection Reason" field only when status = "rejected"
 ### Learn More
 
 📖 **Comprehensive Documentation:**
-- [Blueprint Architecture](./blueprint-architecture.md) - Deep dive into implementation
-- [JSON Logic Guide](./json-logic-guide.md) - Complete operator reference
-- [JSON-e Templates](./json-e-templates.md) - Dynamic blueprint generation
-- [Blueprint Format](./blueprint-format.md) - Complete specification
+- [Blueprint Architecture](../guides/blueprints/blueprint-architecture.md) - Deep dive into implementation
+- [JSON Logic Guide](../guides/blueprints/json-logic-guide.md) - Complete operator reference
+- [JSON-e Templates](../guides/blueprints/json-e-templates.md) - Dynamic blueprint generation
+- [Blueprint Format](../guides/blueprints/blueprint-format.md) - Complete specification
 
 ### Examples
 
@@ -765,4 +765,4 @@ Shows "Rejection Reason" field only when status = "rejected"
 
 **Happy Blueprint Building! 🎉**
 
-For questions or issues, see the [main documentation](./README.md) or create an issue on GitHub.
+For questions or issues, see the [main documentation](../README.md) or create an issue on GitHub.

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -223,14 +223,14 @@ Should show `10.0.100` or later.
 Now that you have Sorcha running, explore:
 
 - [Architecture Overview](../reference/architecture.md) - Understand the system design
-- [Blueprint Schema](blueprint-schema.md) - Learn the blueprint format
-- [API Reference](api-reference.md) - Explore the REST API
-- [Contributing](../CONTRIBUTING.md) - Help improve Sorcha
+- [Blueprint Format](../guides/blueprints/blueprint-format.md) - Learn the blueprint format
+- [API Reference](../reference/API-DOCUMENTATION.md) - Explore the REST API
+- [Contributing](../../CONTRIBUTING.md) - Help improve Sorcha
 
 ## Getting Help
 
-- Check the [Troubleshooting Guide](troubleshooting.md)
-- Browse [Documentation](README.md)
+- Check the [Troubleshooting Guide](../guides/TROUBLESHOOTING.md)
+- Browse [Documentation](../README.md)
 - Search [GitHub Issues](https://github.com/yourusername/sorcha/issues)
 - Ask in [GitHub Discussions](https://github.com/yourusername/sorcha/discussions)
 

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -702,6 +702,6 @@ docker-compose up -d
 
 ## Support
 
-- **Documentation**: [README.md](README.md)
+- **Documentation**: [docs README](../README.md)
 - **Troubleshooting**: [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 - **Issues**: https://github.com/yourusername/sorcha/issues

--- a/docs/guides/INTEGRATION-GUIDE.md
+++ b/docs/guides/INTEGRATION-GUIDE.md
@@ -788,7 +788,7 @@ curl http://localhost:5000/api/register/health
 ## Next Steps
 
 1. **Explore the API:** Visit http://localhost:5000/scalar/v1
-2. **Read API Documentation:** See [API-DOCUMENTATION.md](./API-DOCUMENTATION.md)
+2. **Read API Documentation:** See [API-DOCUMENTATION.md](../reference/API-DOCUMENTATION.md)
 3. **Review Examples:** Check `/examples` directory
 4. **Join Community:** GitHub Discussions
 

--- a/docs/guides/claude-code-guidelines.md
+++ b/docs/guides/claude-code-guidelines.md
@@ -961,7 +961,7 @@ Before submitting code, ask:
 - Changes should be reviewed by the architecture team
 
 **References:**
-- [Constitution](.specify/constitution.md)
+- [Constitution](../../.specify/constitution.md)
 - [Architecture](../reference/architecture.md)
-- [Contributing](../CONTRIBUTING.md)
-- [Unified Design Summary](.specify/UNIFIED-DESIGN-SUMMARY.md)
+- [Contributing](../../CONTRIBUTING.md)
+- [Unified Design Summary](../../.specify/UNIFIED-DESIGN-SUMMARY.md)

--- a/docs/reference/SECURITY-REQUIREMENTS.md
+++ b/docs/reference/SECURITY-REQUIREMENTS.md
@@ -371,8 +371,7 @@ This document MUST be reviewed:
 
 - [Architecture](architecture.md) - Overall system architecture
 - [Validator Service Design](validator-service-design.md) - Validator service specification
-- [Register Service Specification](../.specify/specs/sorcha-register-service.md) - Register service specification
-- [Learnings](LEARNINGS.md) - Development best practices and lessons learned
+- [Register Service Specification](../../.specify/specs/sorcha-register-service.md) - Register service specification
 
 ---
 

--- a/docs/reference/VALIDATOR-SERVICE-QUICK-REFERENCE.md
+++ b/docs/reference/VALIDATOR-SERVICE-QUICK-REFERENCE.md
@@ -361,7 +361,6 @@ Check SingularConsensus logs - currently should be empty since it does nothing.
 
 ## Additional Resources
 
-- Full Analysis: `./alpha-validator-service-analysis.md` (1035 lines, alpha reference)
-- Design Recommendations: `./SORCHA-VALIDATOR-DESIGN-RECOMMENDATIONS.md`
+- Full Design: [validator-service-design.md](./validator-service-design.md)
 - GitHub: https://github.com/sorcha-platform/sorcha
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -445,7 +445,7 @@ Peer-to-peer networking service for decentralized transaction distribution.
 
 **Location:** `src/Services/Sorcha.Peer.Service/`
 
-**Status:** Active Development - See [Peer Service Design](peer-service-design.md) and [Implementation Plan](peer-service-implementation-plan.md)
+**Status:** Active Development
 
 **Purpose:**
 Enable decentralized, peer-to-peer communication and transaction distribution across a network of Sorcha nodes without reliance on centralized infrastructure.
@@ -498,7 +498,7 @@ Peers Repeat Gossip → 90% Network Coverage in < 1 minute
 - Bloom filter for duplicate detection
 - Circuit breaker pattern for resilience
 
-**Implementation Timeline:** 20 weeks (10 sprints) - See [Implementation Plan](peer-service-implementation-plan.md)
+**Implementation Timeline:** 20 weeks (10 sprints)
 
 **Benefits:**
 - Decentralization - No single point of failure
@@ -848,7 +848,6 @@ Build Pipeline:
 
 ## Related Documentation
 
-- [Execution Model](execution-model.md)
-- [Blueprint Schema](blueprint-schema.md)
-- [API Reference](api-reference.md)
-- [Deployment Guide](deployment.md)
+- [Blueprint Format](../guides/blueprints/blueprint-format.md)
+- [API Reference](API-DOCUMENTATION.md)
+- [Deployment Guide](../guides/DEPLOYMENT.md)

--- a/docs/reference/architecture/ADR-005-Validator-Service-Security-Boundary.md
+++ b/docs/reference/architecture/ADR-005-Validator-Service-Security-Boundary.md
@@ -188,9 +188,9 @@ src/
 ## References
 
 - [Validator Service Design](../validator-service-design.md)
-- [Alpha Validator Analysis](../alpha-validator-service-analysis.md)
-- [Unified Design Summary](../../.specify/UNIFIED-DESIGN-SUMMARY.md)
-- [Register Service Phase 1-2 Completion](../register-service-phase1-2-completion.md)
+- [Validator Service Design](../validator-service-design.md)
+- [Unified Design Summary](../../../.specify/UNIFIED-DESIGN-SUMMARY.md)
+- [Register Service Phase 1-2 Completion](../../archive/completion-reports/register-service-phase1-2-completion.md)
 
 ---
 
@@ -203,4 +203,4 @@ This decision surfaced several important learnings:
 3. **Test-first development** helped us discover the boundary violation
 4. **Service decomposition** should follow security requirements, not just functional grouping
 
-See: [Learnings Document](../learnings/2025-11-16-validator-service-refactoring.md)
+See: [Learnings Document](../../archive/learnings/2025-11-16-validator-service-refactoring.md)

--- a/docs/reference/blockchain-transaction-format.md
+++ b/docs/reference/blockchain-transaction-format.md
@@ -417,8 +417,8 @@ All implementations MUST:
 - [Architecture](architecture.md)
 - [JSON-LD Implementation Summary](../guides/blueprints/json-ld-implementation-summary.md)
 - [Blueprint Architecture](../guides/blueprints/blueprint-architecture.md)
-- [Register Service Specification](../.specify/specs/sorcha-register-service.md)
-- [Transaction Handler Specification](../.specify/specs/sorcha-transaction-handler.md)
+- [Register Service Specification](../../.specify/specs/sorcha-register-service.md)
+- [Transaction Handler Specification](../../.specify/specs/sorcha-transaction-handler.md)
 
 ## Examples
 

--- a/docs/reference/development-status.md
+++ b/docs/reference/development-status.md
@@ -378,6 +378,6 @@ The platform is feature-complete for MVD but requires the following for producti
 **Owner:** Sorcha Architecture Team
 
 **See Also:**
-- [MASTER-PLAN.md](../.specify/MASTER-PLAN.md) - Implementation phases
-- [MASTER-TASKS.md](../.specify/MASTER-TASKS.md) - Task tracking
+- [MASTER-PLAN.md](../../.specify/MASTER-PLAN.md) - Implementation phases
+- [MASTER-TASKS.md](../../.specify/MASTER-TASKS.md) - Task tracking
 - [architecture.md](architecture.md) - System architecture

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -306,7 +306,7 @@ If you need to move a project:
 - [Architecture Overview](architecture.md)
 - [Testing Guide](../guides/testing/testing.md)
 - [Getting Started](../getting-started/getting-started.md)
-- [Contributing Guidelines](../CONTRIBUTING.md)
+- [Contributing Guidelines](../../CONTRIBUTING.md)
 
 ---
 

--- a/docs/reference/validator-service-design.md
+++ b/docs/reference/validator-service-design.md
@@ -1726,12 +1726,10 @@ public class ValidatorOrchestratorTests : IClassFixture<WebApplicationFactory<Pr
 
 ## Appendix B: Related Documentation
 
-- `alpha-validator-service-analysis.md` - Alpha Validator analysis
-- `SORCHA-VALIDATOR-DESIGN-RECOMMENDATIONS.md` - Design recommendations
-- `VALIDATOR-SERVICE-QUICK-REFERENCE.md` - Developer quick reference
-- `architecture.md` - Overall Sorcha architecture
-- `/docs/blueprint-schema.md` - Blueprint data format
-- `/.specify/UNIFIED-DESIGN-SUMMARY.md` - Unified design summary
+- [VALIDATOR-SERVICE-QUICK-REFERENCE.md](VALIDATOR-SERVICE-QUICK-REFERENCE.md) - Developer quick reference
+- [architecture.md](architecture.md) - Overall Sorcha architecture
+- [Blueprint Format](../guides/blueprints/blueprint-format.md) - Blueprint data format
+- [UNIFIED-DESIGN-SUMMARY.md](../../.specify/UNIFIED-DESIGN-SUMMARY.md) - Unified design summary
 
 ---
 

--- a/docs/reference/wallet-encryption-architecture.md
+++ b/docs/reference/wallet-encryption-architecture.md
@@ -575,10 +575,8 @@ For Docker deployments, ensure:
 
 ## Related Documentation
 
-- [Wallet Service Specification](../.specify/specs/sorcha-wallet-service.md)
-- [Cryptography Library](../src/Common/Sorcha.Cryptography/README.md)
-- [Docker Deployment Guide](./docker-deployment.md)
-- [Security Best Practices](./security-best-practices.md)
+- [Wallet Service Specification](../../.specify/specs/sorcha-wallet-service.md)
+- [Security Requirements](./SECURITY-REQUIREMENTS.md)
 
 ---
 

--- a/scripts/README-BOOTSTRAP.md
+++ b/scripts/README-BOOTSTRAP.md
@@ -530,5 +530,5 @@ See [LICENSE](../LICENSE) for license information.
 **Status:** Beta - Placeholder implementation pending CLI feature completion
 **Related Documents:**
 - [Sorcha CLI README](../src/Apps/Sorcha.Cli/README.md)
-- [CLI Specification](.specify/specs/sorcha-cli-admin-tool.md)
-- [MASTER-TASKS.md](.specify/MASTER-TASKS.md)
+- [CLI Specification](../.specify/specs/sorcha-cli-admin-tool.md)
+- [MASTER-TASKS.md](../.specify/MASTER-TASKS.md)

--- a/specs/001-hardware-crypto-enclaves/spec.md
+++ b/specs/001-hardware-crypto-enclaves/spec.md
@@ -266,9 +266,9 @@ An end-user accesses the Sorcha Blueprint Designer web interface. For client-sid
 
 ## Related Specifications
 
-- [Sorcha Cryptography Rewrite](.specify/specs/sorcha-cryptography-rewrite.md) - Core cryptographic library architecture
-- [Sorcha Wallet Service](.specify/specs/sorcha-wallet-service.md) - Wallet management service requiring secure key storage
-- [Sorcha Transaction Handler](.specify/specs/sorcha-transaction-handler.md) - Transaction signing using secure keys
+- [Sorcha Cryptography Rewrite](../../.specify/specs/sorcha-cryptography-rewrite.md) - Core cryptographic library architecture
+- [Sorcha Wallet Service](../../.specify/specs/sorcha-wallet-service.md) - Wallet management service requiring secure key storage
+- [Sorcha Transaction Handler](../../.specify/specs/sorcha-transaction-handler.md) - Transaction signing using secure keys
 
 ## References
 

--- a/specs/002-validator-service/quickstart.md
+++ b/specs/002-validator-service/quickstart.md
@@ -571,8 +571,8 @@ After familiarizing yourself with the Validator Service:
 
 ## Resources
 
-- **Sorcha Documentation**: [docs/](../../../docs/)
-- **Constitution**: [.specify/memory/constitution.md](../../../.specify/memory/constitution.md)
+- **Sorcha Documentation**: [docs/](../../docs/)
+- **Constitution**: [.specify/constitution.md](../../.specify/constitution.md)
 - **gRPC Guide**: [https://grpc.io/docs/languages/csharp/](https://grpc.io/docs/languages/csharp/)
 - **.NET Aspire**: [https://learn.microsoft.com/en-us/dotnet/aspire/](https://learn.microsoft.com/en-us/dotnet/aspire/)
 - **Blockchain Basics**: [https://en.wikipedia.org/wiki/Blockchain](https://en.wikipedia.org/wiki/Blockchain)

--- a/src/Apps/Sorcha.Cli/DEV-WORKFLOW.md
+++ b/src/Apps/Sorcha.Cli/DEV-WORKFLOW.md
@@ -271,7 +271,7 @@ For production releases, manual semantic versioning is recommended:
 
 ## 🎯 What to Implement Next
 
-Based on the [CLI specification](.specify/specs/sorcha-cli-admin-tool.md), the recommended implementation order is:
+Based on the [CLI specification](../../../.specify/specs/sorcha-cli-admin-tool.md), the recommended implementation order is:
 
 ### **Phase 1: Foundation (COMPLETE) ✅**
 - ✅ Auto-incrementing version
@@ -303,8 +303,8 @@ Based on the [CLI specification](.specify/specs/sorcha-cli-admin-tool.md), the r
 
 ## 📖 Related Documentation
 
-- **[CLI Specification](.specify/specs/sorcha-cli-admin-tool.md)** - Complete feature requirements
-- **[MASTER-TASKS.md](.specify/MASTER-TASKS.md)** - Task tracking
+- **[CLI Specification](../../../.specify/specs/sorcha-cli-admin-tool.md)** - Complete feature requirements
+- **[MASTER-TASKS.md](../../../.specify/MASTER-TASKS.md)** - Task tracking
 - **[README.md](README.md)** - CLI overview and installation
 
 ---
@@ -313,8 +313,8 @@ Based on the [CLI specification](.specify/specs/sorcha-cli-admin-tool.md), the r
 
 **For CLI development questions:**
 - Check this document first
-- Review the [CLI specification](.specify/specs/sorcha-cli-admin-tool.md)
-- Check [MASTER-TASKS.md](.specify/MASTER-TASKS.md) for implementation status
+- Review the [CLI specification](../../../.specify/specs/sorcha-cli-admin-tool.md)
+- Check [MASTER-TASKS.md](../../../.specify/MASTER-TASKS.md) for implementation status
 
 **For bugs or feature requests:**
 - Create a GitHub issue with label `cli-tool`

--- a/src/Services/Sorcha.ApiGateway/README.md
+++ b/src/Services/Sorcha.ApiGateway/README.md
@@ -719,7 +719,7 @@ docker-compose up -d
 - Bridge network (`sorcha-network`) for all services
 - Services communicate via Docker DNS (e.g., `http://wallet-service:8080`)
 - Published ports: 80 (HTTP), 443 (HTTPS)
-- See [docs/DOCKER-BRIDGE-NETWORKING.md](../../../docs/DOCKER-BRIDGE-NETWORKING.md) for complete details
+- See [DOCKER-QUICK-START.md](../../../docs/getting-started/DOCKER-QUICK-START.md) for complete details
 
 ### Docker (Standalone)
 

--- a/src/Services/Sorcha.Blueprint.Service/README.md
+++ b/src/Services/Sorcha.Blueprint.Service/README.md
@@ -561,7 +561,7 @@ Enable detailed logging:
 
 ## Resources
 
-- **Specification**: [.specify/specs/sorcha-blueprint-service.md](.specify/specs/)
+- **Specification**: [.specify/specs/](../../../.specify/specs/)
 - **API Reference**: [Scalar UI](https://localhost:7081/scalar)
 - **Architecture**: [docs/architecture.md](../../docs/reference/architecture.md)
 - **Development Status**: [docs/development-status.md](../../docs/reference/development-status.md)

--- a/src/Services/Sorcha.Peer.Service/README.md
+++ b/src/Services/Sorcha.Peer.Service/README.md
@@ -745,7 +745,7 @@ docker-compose up -d peer-service
 - Published ports: 50051 (hub), 50052 (peer)
 - TLS disabled for local development (`EnableTls: false`)
 - Configuration: `docker/appsettings.Bridge.json`
-- See [docs/DOCKER-BRIDGE-NETWORKING.md](../../../docs/DOCKER-BRIDGE-NETWORKING.md) for complete details
+- See [DOCKER-QUICK-START.md](../../../docs/getting-started/DOCKER-QUICK-START.md) for complete details
 
 **Verify Connection:**
 ```bash

--- a/src/Services/Sorcha.Register.Service/README.md
+++ b/src/Services/Sorcha.Register.Service/README.md
@@ -854,7 +854,7 @@ Recovery runs as a `BackgroundService` and reports status via the `/health/sync`
 
 ## Resources
 
-- **Specification**: [.specify/specs/sorcha-register-service.md](.specify/specs/sorcha-register-service.md)
+- **Specification**: [.specify/specs/sorcha-register-service.md](../../../.specify/specs/sorcha-register-service.md)
 - **API Reference**: [Scalar UI](https://localhost:7085/scalar)
 - **Architecture**: [docs/architecture.md](../../docs/reference/architecture.md)
 - **Development Status**: [docs/development-status.md](../../docs/reference/development-status.md)

--- a/src/Services/Sorcha.Validator.Service/README.md
+++ b/src/Services/Sorcha.Validator.Service/README.md
@@ -815,7 +815,6 @@ src/Common/Sorcha.Validator.Core/
 
 - **Specification:** [.specify/specs/sorcha-validator-service.md](./../../../.specify/specs/sorcha-validator-service.md)
 - **Design:** [docs/validator-service-design.md](./../../../docs/reference/validator-service-design.md)
-- **Implementation Plan:** [docs/validator-service-implementation-plan.md](./../../../docs/validator-service-implementation-plan.md)
 - **Architecture:** [docs/architecture.md](./../../../docs/reference/architecture.md)
 - **API Documentation:** [https://localhost:7087/scalar/v1](https://localhost:7087/scalar/v1) (when running)
 

--- a/src/Services/Sorcha.Wallet.Service/README.md
+++ b/src/Services/Sorcha.Wallet.Service/README.md
@@ -812,9 +812,9 @@ When a wallet is created via `WalletManager.CreateWalletAsync`, a recovery key i
 
 ## Resources
 
-- **Specification**: [.specify/specs/sorcha-wallet-service.md](.specify/specs/sorcha-wallet-service.md)
+- **Specification**: [.specify/specs/sorcha-wallet-service.md](../../../.specify/specs/sorcha-wallet-service.md)
 - **API Reference**: [Scalar UI](https://localhost:7084/scalar)
-- **Development Status**: [docs/wallet-service-status.md](../../docs/wallet-service-status.md)
+- **Development Status**: [docs/development-status.md](../../../docs/reference/development-status.md)
 - **Architecture**: [docs/architecture.md](../../docs/reference/architecture.md)
 - **BIP39 Standard**: [Bitcoin BIPs](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
 - **BIP44 Standard**: [Bitcoin BIPs](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)


### PR DESCRIPTION
## Summary

- Fix 100+ broken internal markdown links across 50 files in the codebase
- Add lychee-based CI link checker that runs on PRs modifying `*.md` files
- Create `.lychee.toml` config to check only internal/local links (excludes archive, site, plans, superpowers directories)

### Link fixes by category:
- **.specify/ path duplication**: Files inside `.specify/` referenced paths like `.specify/.specify/specs/...` instead of relative `specs/...`
- **docs/ cross-reference paths**: Files in `docs/getting-started/`, `docs/guides/`, `docs/reference/` used wrong relative paths to sibling directories
- **Missing target redirects**: Links to non-existent files redirected to correct existing equivalents (e.g., `blueprint-schema.md` to `guides/blueprints/blueprint-format.md`)
- **Case sensitivity**: Fixed `Sorcha-cryptography-rewrite.md` references to match actual filename `sorcha-cryptography-rewrite.md`
- **Archive path depth**: Fixed `docs/archive/` files with incorrect `../` depth for cross-references
- **Service READMEs**: Fixed relative paths from `src/Services/*/README.md` to `.specify/` and `docs/`
- **Scripts and walkthroughs**: Fixed paths from `scripts/` and `src/Apps/` to `.specify/` files

## Test plan

- [ ] Verify CI workflow triggers on markdown-modifying PRs
- [ ] Spot-check fixed links in key files (architecture.md, getting-started.md, service READMEs)
- [ ] Verify `.lychee.toml` excludes archive/site/plans directories as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)