### PR TITLE
feat: add OpenAPI request/response examples to top 10 endpoints

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/OpenApiExamples.cs
+++ b/src/Common/Sorcha.ServiceDefaults/OpenApiExamples.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// Helper methods for setting OpenAPI request/response examples on endpoint operations.
+/// Used with <c>.WithOpenApi(operation => { ... })</c> to provide example payloads
+/// that appear in Scalar UI documentation.
+/// </summary>
+public static class OpenApiExamples
+{
+    /// <summary>
+    /// Sets a JSON example on the request body of an OpenAPI operation.
+    /// </summary>
+    /// <param name="operation">The OpenAPI operation to modify.</param>
+    /// <param name="json">A JSON string representing the example request body.</param>
+    public static void SetRequestExample(OpenApiOperation operation, string json)
+    {
+        if (operation.RequestBody?.Content is null)
+            return;
+
+        if (operation.RequestBody.Content.TryGetValue("application/json", out var mediaType))
+        {
+            mediaType.Example = JsonNode.Parse(json);
+        }
+    }
+
+    /// <summary>
+    /// Sets a JSON example on a specific response status code of an OpenAPI operation.
+    /// </summary>
+    /// <param name="operation">The OpenAPI operation to modify.</param>
+    /// <param name="statusCode">The HTTP status code (e.g., "200", "201").</param>
+    /// <param name="json">A JSON string representing the example response body.</param>
+    public static void SetResponseExample(OpenApiOperation operation, string statusCode, string json)
+    {
+        if (operation.Responses is null)
+            return;
+
+        if (operation.Responses.TryGetValue(statusCode, out var response)
+            && response.Content is not null
+            && response.Content.TryGetValue("application/json", out var mediaType))
+        {
+            mediaType.Example = JsonNode.Parse(json);
+        }
+    }
+}
+
+/// <summary>
+/// An OpenAPI operation transformer that applies JSON examples to endpoints based on their operation ID.
+/// Register example entries via <see cref="AddExample"/> before adding this transformer to OpenAPI options.
+/// </summary>
+public sealed class EndpointExampleTransformer : IOpenApiOperationTransformer
+{
+    private readonly Dictionary<string, ExampleEntry> _examples = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Adds a request and/or response example for a specific endpoint identified by its operation ID.
+    /// The operation ID corresponds to the value set by <c>.WithName("...")</c> on the endpoint.
+    /// </summary>
+    /// <param name="operationId">The endpoint operation ID (from <c>.WithName()</c>).</param>
+    /// <param name="requestJson">JSON string for the request body example, or null if the endpoint has no request body.</param>
+    /// <param name="responseStatusCode">The HTTP status code for the response example (e.g., "200", "201").</param>
+    /// <param name="responseJson">JSON string for the response body example, or null to skip.</param>
+    /// <returns>This transformer instance for method chaining.</returns>
+    public EndpointExampleTransformer AddExample(
+        string operationId,
+        string? requestJson,
+        string responseStatusCode,
+        string? responseJson)
+    {
+        _examples[operationId] = new ExampleEntry(requestJson, responseStatusCode, responseJson);
+        return this;
+    }
+
+    /// <inheritdoc />
+    public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+    {
+        var operationId = operation.OperationId;
+        if (operationId is null || !_examples.TryGetValue(operationId, out var entry))
+            return Task.CompletedTask;
+
+        if (entry.RequestJson is not null)
+        {
+            OpenApiExamples.SetRequestExample(operation, entry.RequestJson);
+        }
+
+        if (entry.ResponseJson is not null)
+        {
+            OpenApiExamples.SetResponseExample(operation, entry.ResponseStatusCode, entry.ResponseJson);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private sealed record ExampleEntry(string? RequestJson, string ResponseStatusCode, string? ResponseJson);
+}

--- a/src/Common/Sorcha.ServiceDefaults/OpenApiExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/OpenApiExtensions.cs
@@ -21,8 +21,10 @@ public static class OpenApiExtensions
     /// <param name="builder">The host application builder.</param>
     /// <param name="title">The API title displayed in the OpenAPI document.</param>
     /// <param name="description">The API description displayed in the OpenAPI document.</param>
+    /// <param name="configureOptions">Optional callback to configure additional OpenAPI options such as operation transformers.</param>
     /// <returns>The builder for chaining.</returns>
-    public static TBuilder AddSorchaOpenApi<TBuilder>(this TBuilder builder, string title, string description)
+    public static TBuilder AddSorchaOpenApi<TBuilder>(this TBuilder builder, string title, string description,
+        Action<Microsoft.AspNetCore.OpenApi.OpenApiOptions>? configureOptions = null)
         where TBuilder : IHostApplicationBuilder
     {
         builder.Services.AddOpenApi(options =>
@@ -49,6 +51,9 @@ public static class OpenApiExtensions
 
                 return Task.CompletedTask;
             });
+
+            // Apply any additional configuration (e.g., operation transformers for examples)
+            configureOptions?.Invoke(options);
         });
 
         return builder;

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using Sorcha.Blueprint.Service.Storage;
 
 namespace Sorcha.Blueprint.Service.Endpoints;
@@ -49,7 +51,29 @@ public static class ActionEndpoints
         .WithName("GetPendingActions")
         .WithSummary("Get pending actions for the authenticated user")
         .WithDescription("Returns all pending actions across blueprint instances for the user's wallet address. "
-            + "Supports pagination. Urgency and blueprint filtering will be added in a future iteration.");
+            + "Supports pagination. Urgency and blueprint filtering will be added in a future iteration.")
+        .WithOpenApi(operation =>
+        {
+            OpenApiExamples.SetResponseExample(operation, "200", """
+                {
+                  "items": [
+                    {
+                      "instanceId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "actionId": "review-application",
+                      "blueprintTitle": "Construction Permit Application",
+                      "participantRole": "BuildingInspector",
+                      "status": "Pending",
+                      "createdAt": "2026-03-15T10:30:00Z",
+                      "dueDate": "2026-03-22T10:30:00Z"
+                    }
+                  ],
+                  "totalCount": 1,
+                  "page": 1,
+                  "pageSize": 20
+                }
+                """);
+            return operation;
+        });
 
         group.MapGet("/pending/count", async (
             HttpContext httpContext,

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/CredentialEndpoints.cs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using System.Security.Cryptography;
 using System.Text.Json;
+
 using Microsoft.AspNetCore.Mvc;
+
 using Sorcha.Blueprint.Models.Credentials;
 using Sorcha.Blueprint.Service.Services;
 using Sorcha.ServiceClients.Wallet;
@@ -34,7 +38,27 @@ public static class CredentialEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
-            .Produces(StatusCodes.Status404NotFound);
+            .Produces(StatusCodes.Status404NotFound)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "issuerWallet": "sorcha1abc123def456ghi789jkl012mno345",
+                      "reason": "Key compromise detected during security audit"
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "200", """
+                    {
+                      "credentialId": "urn:uuid:3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "revokedBy": "sorcha1abc123def456ghi789jkl012mno345",
+                      "revokedAt": "2026-03-15T10:30:00Z",
+                      "reason": "Key compromise detected during security audit",
+                      "status": "Revoked",
+                      "statusListUpdated": true
+                    }
+                    """);
+                return operation;
+            });
 
         credentialGroup.MapPost("/{credentialId}/suspend", SuspendCredential)
             .WithName("SuspendCredential")

--- a/src/Services/Sorcha.Register.Service/Endpoints/SystemRegisterEndpoints.cs
+++ b/src/Services/Sorcha.Register.Service/Endpoints/SystemRegisterEndpoints.cs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using System.Text.Json;
+
 using Sorcha.Blueprint.Models;
 using Sorcha.Register.Service.Services;
 
@@ -121,7 +124,39 @@ public static class SystemRegisterEndpoints
         .Produces<PublishBlueprintResponse>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status401Unauthorized)
-        .Produces(StatusCodes.Status500InternalServerError);
+        .Produces(StatusCodes.Status500InternalServerError)
+        .WithOpenApi(operation =>
+        {
+            OpenApiExamples.SetRequestExample(operation, """
+                {
+                  "blueprintId": "construction-permit-v1",
+                  "blueprint": {
+                    "title": "Construction Permit Application",
+                    "participants": [
+                      { "role": "Applicant", "description": "The person applying for a permit" },
+                      { "role": "BuildingInspector", "description": "Reviews and approves the application" }
+                    ],
+                    "actions": [
+                      { "id": "submit-application", "actor": "Applicant", "type": "Submit" },
+                      { "id": "review-application", "actor": "BuildingInspector", "type": "Review" }
+                    ]
+                  },
+                  "metadata": {
+                    "changeType": "structural",
+                    "author": "admin@acme.corp"
+                  }
+                }
+                """);
+            OpenApiExamples.SetResponseExample(operation, "201", """
+                {
+                  "transactionId": "tx:system-register:construction-permit-v1:a1b2c3d4",
+                  "blueprintId": "construction-permit-v1",
+                  "version": 1,
+                  "publishedAt": "2026-03-15T10:30:00Z"
+                }
+                """);
+            return operation;
+        });
 
         group.MapGet("/blueprints", async (
             SystemRegisterService service,

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using System.Security.Claims;
 using System.Text.Json;
 
@@ -39,7 +41,27 @@ public static class AuthEndpoints
             .Produces<TokenResponse>()
             .Produces<TwoFactorLoginResponse>(StatusCodes.Status200OK)
             .ProducesValidationProblem()
-            .Produces(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "email": "admin@acme.corp",
+                      "password": "SecureP@ss123",
+                      "organizationSubdomain": "acme-corp"
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "200", """
+                    {
+                      "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "refresh_token": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4...",
+                      "token_type": "Bearer",
+                      "expires_in": 3600,
+                      "scope": "openid profile email"
+                    }
+                    """);
+                return operation;
+            });
 
         // Verify 2FA code after login (public endpoint — uses loginToken)
         group.MapPost("/verify-2fa", Verify2Fa)
@@ -73,7 +95,25 @@ public static class AuthEndpoints
             .AllowAnonymous()
             .Produces<TokenResponse>()
             .ProducesValidationProblem()
-            .Produces(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "refreshToken": "dGhpcyBpcyBhIHJlZnJlc2ggdG9rZW4..."
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "200", """
+                    {
+                      "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                      "refresh_token": "bmV3IHJlZnJlc2ggdG9rZW4...",
+                      "token_type": "Bearer",
+                      "expires_in": 3600,
+                      "scope": "openid profile email"
+                    }
+                    """);
+                return operation;
+            });
 
         // Token revocation (requires authentication)
         group.MapPost("/token/revoke", RevokeToken)
@@ -125,7 +165,24 @@ public static class AuthEndpoints
             .WithDescription("Returns information about the currently authenticated user from their token claims.")
             .RequireAuthorization()
             .Produces<CurrentUserResponse>()
-            .Produces(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetResponseExample(operation, "200", """
+                    {
+                      "userId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "email": "admin@acme.corp",
+                      "displayName": "Alice Admin",
+                      "organizationId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+                      "organizationName": "Acme Corporation",
+                      "roles": ["Administrator"],
+                      "tokenType": "user",
+                      "scopes": ["openid", "profile", "email"],
+                      "authMethod": "password"
+                    }
+                    """);
+                return operation;
+            });
 
         // Self-registration with email/password (public endpoint)
         group.MapPost("/register", Register)
@@ -137,7 +194,26 @@ public static class AuthEndpoints
             .RequireRateLimiting("platform-auth")
             .Produces<SelfRegistrationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
-            .Produces(StatusCodes.Status403Forbidden);
+            .Produces(StatusCodes.Status403Forbidden)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "orgSubdomain": "public",
+                      "email": "user@example.com",
+                      "password": "MySecureP@ss456",
+                      "displayName": "Jane Doe"
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "201", """
+                    {
+                      "success": true,
+                      "userId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "message": "Verification email sent to user@example.com"
+                    }
+                    """);
+                return operation;
+            });
 
         // Passkey 2FA: get assertion options (public endpoint — uses loginToken)
         group.MapPost("/verify-passkey/options", VerifyPasskeyOptions)

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using System.Security.Claims;
+
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Data.Repositories;
 using Sorcha.Tenant.Service.Models;
@@ -34,7 +38,34 @@ public static class OrganizationEndpoints
             .Produces<OrganizationResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
             .Produces<ProblemDetails>(StatusCodes.Status409Conflict)
-            .Produces(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "name": "Acme Corporation",
+                      "subdomain": "acme-corp",
+                      "branding": {
+                        "primaryColor": "#2563EB",
+                        "companyTagline": "Building the future"
+                      }
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "201", """
+                    {
+                      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "name": "Acme Corporation",
+                      "subdomain": "acme-corp",
+                      "status": "Active",
+                      "createdAt": "2026-03-15T10:30:00Z",
+                      "branding": {
+                        "primaryColor": "#2563EB",
+                        "companyTagline": "Building the future"
+                      }
+                    }
+                    """);
+                return operation;
+            });
 
         group.MapGet("/", ListOrganizations)
             .WithName("ListOrganizations")

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using System.Text.Json;
 using System.Xml;
+
 using Microsoft.AspNetCore.Mvc;
+
 using Sorcha.Blueprint.Models.Credentials;
 using Sorcha.Cryptography.SdJwt;
 using Sorcha.Wallet.Core.Domain.Entities;
@@ -72,7 +76,34 @@ public static class CredentialEndpoints
             .WithDescription("Stores a pre-issued verifiable credential in the specified wallet.")
             .Produces<object>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
-            .Produces(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "credentialId": "urn:uuid:3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "type": "BuildingInspectorCertificate",
+                      "issuerDid": "did:sorcha:org:sorcha1abc123def456...",
+                      "subjectDid": "did:sorcha:org:sorcha1xyz789ghi012...",
+                      "claimsJson": "{\"name\":\"Jane Doe\",\"licenseNumber\":\"BI-2026-0042\",\"jurisdiction\":\"Dublin City\"}",
+                      "issuedAt": "2026-03-15T10:30:00Z",
+                      "expiresAt": "2027-03-15T10:30:00Z",
+                      "rawToken": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJkaWQ6c29yY2hhOm9yZzo..."
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "201", """
+                    {
+                      "id": "urn:uuid:3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                      "type": "BuildingInspectorCertificate",
+                      "issuerDid": "did:sorcha:org:sorcha1abc123def456...",
+                      "subjectDid": "did:sorcha:org:sorcha1xyz789ghi012...",
+                      "issuedAt": "2026-03-15T10:30:00Z",
+                      "expiresAt": "2027-03-15T10:30:00Z",
+                      "status": "Active"
+                    }
+                    """);
+                return operation;
+            });
 
         credentialGroup.MapPatch("/{credentialId}/status", UpdateCredentialStatus)
             .WithName("UpdateCredentialStatus")

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+#pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
+
 using System.Security.Claims;
 using System.Security.Cryptography;
+
 using Microsoft.AspNetCore.Mvc;
+
 using Sorcha.Cryptography.Enums;
 using Sorcha.Cryptography.Interfaces;
 using Sorcha.Cryptography.Models;
@@ -49,7 +53,41 @@ public static class WalletEndpoints
             .WithDescription("Creates a new HD wallet with the specified algorithm and returns the mnemonic phrase for backup")
             .Produces<CreateWalletResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem()
-            .Produces(StatusCodes.Status401Unauthorized);
+            .Produces(StatusCodes.Status401Unauthorized)
+            .WithOpenApi(operation =>
+            {
+                OpenApiExamples.SetRequestExample(operation, """
+                    {
+                      "name": "My Primary Wallet",
+                      "algorithm": "ED25519",
+                      "wordCount": 12,
+                      "enableHybrid": false
+                    }
+                    """);
+                OpenApiExamples.SetResponseExample(operation, "201", """
+                    {
+                      "wallet": {
+                        "address": "sorcha1abc123def456ghi789jkl012mno345",
+                        "name": "My Primary Wallet",
+                        "publicKey": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                        "algorithm": "ED25519",
+                        "status": "Active",
+                        "owner": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                        "tenant": "acme-corp",
+                        "createdAt": "2026-03-15T10:30:00Z",
+                        "updatedAt": "2026-03-15T10:30:00Z",
+                        "metadata": {}
+                      },
+                      "mnemonicWords": [
+                        "abandon", "ability", "able", "about",
+                        "above", "absent", "absorb", "abstract",
+                        "absurd", "abuse", "access", "accident"
+                      ],
+                      "warning": "IMPORTANT: Save your mnemonic phrase securely. It cannot be recovered if lost!"
+                    }
+                    """);
+                return operation;
+            });
 
         // POST /api/v1/wallets/recover - Recover wallet from mnemonic
         walletGroup.MapPost("/recover", RecoverWallet)


### PR DESCRIPTION
## Summary

- Add JSON request/response examples to the 10 most critical API endpoints across 4 services (Tenant, Wallet, Blueprint, Register)
- Create `OpenApiExamples` helper class and `EndpointExampleTransformer` in `Sorcha.ServiceDefaults` for reusable example-setting utilities
- Extend `AddSorchaOpenApi()` to accept optional `Action<OpenApiOptions>` callback for registering operation transformers
- Examples use `.WithOpenApi()` for co-location with endpoint definitions (deprecation warning suppressed via pragma)

### Endpoints with examples:
1. **POST /api/auth/login** -- Login with email/password (request + response)
2. **POST /api/auth/register** -- Self-register account (request + response)
3. **POST /api/auth/token/refresh** -- Refresh access token (request + response)
4. **GET /api/auth/me** -- Current user info (response only)
5. **POST /api/organizations/** -- Create organization (request + response)
6. **POST /api/v1/wallets/** -- Create wallet (request + response)
7. **POST /api/v1/wallets/{address}/credentials/** -- Store credential (request + response)
8. **GET /api/actions/pending** -- Pending actions list (response only)
9. **POST /api/system-register/publish** -- Publish blueprint (request + response)
10. **POST /api/v1/credentials/{id}/revoke** -- Revoke credential (request + response)

## Test plan
- [ ] Verify `dotnet build` succeeds with 0 errors
- [ ] Verify no new warnings introduced (ASPDEPR002 suppressed intentionally)
- [ ] Start services and confirm examples appear in Scalar UI at `/scalar`
- [ ] Verify examples match actual request/response DTO shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)