### PR TITLE
fix: register Mermaid Vue plugin for diagram rendering

### DIFF
--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -2,8 +2,12 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 import DefaultTheme from 'vitepress/theme'
-import type { Theme } from 'vitepress'
+import type { EnhanceAppContext } from 'vitepress'
+import { MermaidPlugin } from 'vitepress-plugin-mermaid'
 
 export default {
   extends: DefaultTheme,
-} satisfies Theme
+  enhanceApp({ app }: EnhanceAppContext) {
+    app.use(MermaidPlugin)
+  },
+}


### PR DESCRIPTION
## Summary
- Register `MermaidPlugin` in VitePress theme's `enhanceApp` so Mermaid diagrams render client-side
- Without this, the `withMermaid()` config wrapper handles markdown parsing but the Vue rendering component was missing

## Test plan
- [ ] Mermaid diagrams render on docs.sorcha.dev/reference/architecture
- [ ] Mermaid diagrams render on docs.sorcha.dev/reference/transaction-submission-flow
- [ ] Mermaid diagrams render on docs.sorcha.dev/reference/project-structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)