### PR TITLE
fix: canonical peer identity — eliminate NodeId vs MachineName fragmentation

### DIFF
--- a/src/Services/Sorcha.Peer.Service/Communication/RelayCommunicationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Communication/RelayCommunicationService.cs
@@ -248,11 +248,7 @@ public class RelayCommunicationService
 
                 // Send initial identification message immediately so the Router
                 // registers this stream before the first keepalive tick (30s delay)
-                // IMPORTANT: Use Environment.MachineName (container hostname) as the peer ID
-                // to match what the heartbeat system uses — NOT NodeId, which is the
-                // human-readable name. The Router's ReverseStreamManager must map to
-                // the same ID used in relay message RecipientPeerId fields.
-                var senderId = Environment.MachineName;
+                var senderId = _configuration.ResolvedPeerId;
                 var hello = new PeerMessage
                 {
                     SenderPeerId = senderId,
@@ -335,7 +331,7 @@ public class RelayCommunicationService
     {
         if (_reverseStreamCall == null) return;
 
-        var senderId = Environment.MachineName; // Must match heartbeat PeerId
+        var senderId = _configuration.ResolvedPeerId;
 
         try
         {
@@ -410,7 +406,7 @@ public class RelayCommunicationService
 
     private PeerMessage CreatePeerMessage(string targetPeerId, MessageType messageType, object payload)
     {
-        var senderId = _configuration.NodeId ?? Environment.MachineName;
+        var senderId = _configuration.ResolvedPeerId;
         var payloadJson = JsonSerializer.Serialize(payload);
 
         return new PeerMessage

--- a/src/Services/Sorcha.Peer.Service/Connection/PeerConnectionPool.cs
+++ b/src/Services/Sorcha.Peer.Service/Connection/PeerConnectionPool.cs
@@ -413,9 +413,9 @@ public class PeerConnectionPool : IAsyncDisposable
             {
                 PeerInfo = new PeerInfo
                 {
-                    PeerId = localPeer?.PeerId ?? _configuration.NodeId ?? Environment.MachineName,
-                    NodeName = _configuration.NodeId ?? Environment.MachineName,
-                    Address = _configuration.NetworkAddress.ExternalAddress ?? Environment.MachineName,
+                    PeerId = _configuration.ResolvedPeerId,
+                    NodeName = _configuration.ResolvedPeerId,
+                    Address = _configuration.NetworkAddress.ExternalAddress ?? _configuration.ResolvedPeerId,
                     Port = _configuration.ListenPort,
                     BuildVersion = BuildInfo.Version,
                     SupportedProtocols = { "GrpcStream", "Grpc", "Rest" }

--- a/src/Services/Sorcha.Peer.Service/Core/PeerIdentity.cs
+++ b/src/Services/Sorcha.Peer.Service/Core/PeerIdentity.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Peer.Service.Core;
+
+/// <summary>
+/// Singleton that provides the canonical peer identity for this node.
+/// All components must use <see cref="Id"/> instead of <c>Environment.MachineName</c>
+/// or <c>NodeId ?? MachineName</c> to prevent peer identity fragmentation.
+/// </summary>
+public sealed class PeerIdentity
+{
+    /// <summary>
+    /// The canonical peer ID for this node. Derived from <see cref="PeerServiceConfiguration.NodeId"/>
+    /// if configured, otherwise from <see cref="Environment.MachineName"/>.
+    /// </summary>
+    public string Id { get; }
+
+    public PeerIdentity(PeerServiceConfiguration configuration)
+    {
+        Id = configuration.NodeId ?? Environment.MachineName;
+    }
+
+    public override string ToString() => Id;
+}

--- a/src/Services/Sorcha.Peer.Service/Core/PeerServiceConfiguration.cs
+++ b/src/Services/Sorcha.Peer.Service/Core/PeerServiceConfiguration.cs
@@ -21,6 +21,13 @@ public class PeerServiceConfiguration
     public string? NodeId { get; set; }
 
     /// <summary>
+    /// Canonical peer identity used consistently across heartbeats, relay messages,
+    /// reverse streams, connection pool keys, and peer list entries.
+    /// Returns <see cref="NodeId"/> if configured, otherwise <see cref="Environment.MachineName"/>.
+    /// </summary>
+    public string ResolvedPeerId => NodeId ?? Environment.MachineName;
+
+    /// <summary>
     /// Port to listen on for peer connections
     /// </summary>
     [Range(1, 65535)]

--- a/src/Services/Sorcha.Peer.Service/Discovery/PeerDiscoveryService.cs
+++ b/src/Services/Sorcha.Peer.Service/Discovery/PeerDiscoveryService.cs
@@ -171,7 +171,7 @@ public class PeerDiscoveryService : IDisposable
                 PeerInfo = new PeerInfo
                 {
                     PeerId = _configuration.NodeId ?? "unknown",
-                    NodeName = _configuration.NodeId ?? Environment.MachineName,
+                    NodeName = _configuration.ResolvedPeerId,
                     Address = externalAddress,
                     Port = _configuration.ListenPort,
                     BuildVersion = BuildInfo.Version,

--- a/src/Services/Sorcha.Peer.Service/Discovery/PeerExchangeService.cs
+++ b/src/Services/Sorcha.Peer.Service/Discovery/PeerExchangeService.cs
@@ -105,7 +105,7 @@ public class PeerExchangeService : IDisposable
 
         var request = new PeerExchangeRequest
         {
-            PeerId = _configuration.NodeId ?? Environment.MachineName,
+            PeerId = _configuration.ResolvedPeerId,
             MaxPeers = PeerServiceConstants.MaxPeersInExchangeResponse
         };
         request.KnownPeers.AddRange(ourPeers);
@@ -127,7 +127,7 @@ public class PeerExchangeService : IDisposable
         foreach (var remotePeer in response.KnownPeers)
         {
             // Don't add ourselves
-            if (remotePeer.PeerId == (_configuration.NodeId ?? Environment.MachineName))
+            if (remotePeer.PeerId == (_configuration.ResolvedPeerId))
                 continue;
 
             var peer = ConvertToPeerNode(remotePeer);
@@ -173,7 +173,7 @@ public class PeerExchangeService : IDisposable
                 var request = new FindPeersForRegisterRequest
                 {
                     RegisterId = registerId,
-                    RequestingPeerId = _configuration.NodeId ?? Environment.MachineName,
+                    RequestingPeerId = _configuration.ResolvedPeerId,
                     RequireFullReplica = requireFullReplica,
                     MaxPeers = 10
                 };

--- a/src/Services/Sorcha.Peer.Service/Discovery/PeerListManager.cs
+++ b/src/Services/Sorcha.Peer.Service/Discovery/PeerListManager.cs
@@ -18,6 +18,7 @@ public class PeerListManager : IDisposable
 {
     private readonly ILogger<PeerListManager> _logger;
     private readonly PeerDiscoveryConfiguration _configuration;
+    private readonly string _localPeerId;
     private readonly ConcurrentDictionary<string, PeerNode> _peers;
     private readonly IDbContextFactory<PeerDbContext>? _dbContextFactory;
     private bool _disposed;
@@ -29,7 +30,9 @@ public class PeerListManager : IDisposable
         IDbContextFactory<PeerDbContext>? dbContextFactory = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _configuration = configuration?.Value?.PeerDiscovery ?? throw new ArgumentNullException(nameof(configuration));
+        var config = configuration?.Value ?? throw new ArgumentNullException(nameof(configuration));
+        _configuration = config.PeerDiscovery;
+        _localPeerId = config.ResolvedPeerId;
         _peers = new ConcurrentDictionary<string, PeerNode>();
         _dbContextFactory = dbContextFactory;
     }
@@ -361,7 +364,7 @@ public class PeerListManager : IDisposable
         {
             _localPeerInfo = new ActivePeerInfo
             {
-                PeerId = Environment.MachineName ?? "unknown",
+                PeerId = _localPeerId,
                 ConnectionEstablished = DateTime.UtcNow
             };
         }

--- a/src/Services/Sorcha.Peer.Service/GrpcServices/DocketSyncGrpcService.cs
+++ b/src/Services/Sorcha.Peer.Service/GrpcServices/DocketSyncGrpcService.cs
@@ -4,6 +4,7 @@
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
+using Sorcha.Peer.Service.Core;
 using Sorcha.Peer.Service.Protos;
 using Sorcha.Peer.Service.Replication;
 
@@ -16,13 +17,16 @@ namespace Sorcha.Peer.Service.GrpcServices;
 public class DocketSyncGrpcService : DocketSyncService.DocketSyncServiceBase
 {
     private readonly RegisterCache _registerCache;
+    private readonly PeerIdentity _peerIdentity;
     private readonly ILogger<DocketSyncGrpcService> _logger;
 
     public DocketSyncGrpcService(
         RegisterCache registerCache,
+        PeerIdentity peerIdentity,
         ILogger<DocketSyncGrpcService> logger)
     {
         _registerCache = registerCache ?? throw new ArgumentNullException(nameof(registerCache));
+        _peerIdentity = peerIdentity ?? throw new ArgumentNullException(nameof(peerIdentity));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -49,7 +53,7 @@ public class DocketSyncGrpcService : DocketSyncService.DocketSyncServiceBase
             return Task.FromResult(new GetLatestDocketNumberResponse
             {
                 LatestDocketNumber = 0,
-                SourcePeerId = Environment.MachineName,
+                SourcePeerId = _peerIdentity.Id,
                 QueriedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 NetworkAvailable = true
             });
@@ -63,7 +67,7 @@ public class DocketSyncGrpcService : DocketSyncService.DocketSyncServiceBase
         return Task.FromResult(new GetLatestDocketNumberResponse
         {
             LatestDocketNumber = latestDocket,
-            SourcePeerId = Environment.MachineName,
+            SourcePeerId = _peerIdentity.Id,
             QueriedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             NetworkAvailable = true
         });

--- a/src/Services/Sorcha.Peer.Service/GrpcServices/RegisterSyncGrpcService.cs
+++ b/src/Services/Sorcha.Peer.Service/GrpcServices/RegisterSyncGrpcService.cs
@@ -173,7 +173,7 @@ public class RegisterSyncGrpcService : Protos.RegisterSync.RegisterSyncBase
                 $"Register '{request.RegisterId}' not found in local cache"));
         }
 
-        var localPeerId = _configuration.NodeId ?? Environment.MachineName;
+        var localPeerId = _configuration.ResolvedPeerId;
         var lastSentVersion = request.FromVersion;
 
         // Send initial cached transactions with version > fromVersion

--- a/src/Services/Sorcha.Peer.Service/Program.cs
+++ b/src/Services/Sorcha.Peer.Service/Program.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Scalar.AspNetCore;
 using Sorcha.Peer.Service;
 using Sorcha.Peer.Service.Communication;
@@ -119,6 +120,13 @@ if (string.IsNullOrEmpty(configuredNodeId))
         $"[WRN] NodeId not configured, using MachineName '{machineName}'. " +
         "Set PeerService:NodeId for stable peer identity across container restarts.");
 }
+
+// Canonical peer identity — single source of truth for this node's ID
+builder.Services.AddSingleton<PeerIdentity>(sp =>
+{
+    var config = sp.GetRequiredService<IOptions<PeerServiceConfiguration>>().Value;
+    return new PeerIdentity(config);
+});
 
 // Register gRPC auth interceptor (FR-014: authenticated peers get higher trust)
 builder.Services.AddSingleton<Sorcha.Peer.Service.GrpcServices.PeerAuthInterceptor>();

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterReplicationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterReplicationService.cs
@@ -34,6 +34,7 @@ public class RegisterReplicationService
     private readonly RelayCommunicationService? _relayCommunication;
     private readonly DocketFinalizationService? _docketFinalizationService;
     private readonly RegisterSyncConfiguration _syncConfig;
+    private readonly string _localPeerId;
 
     public RegisterReplicationService(
         ILogger<RegisterReplicationService> logger,
@@ -53,6 +54,7 @@ public class RegisterReplicationService
         _relayCommunication = relayCommunication;
         _docketFinalizationService = docketFinalizationService;
         _syncConfig = configuration?.Value?.RegisterSync ?? new RegisterSyncConfiguration();
+        _localPeerId = configuration?.Value?.ResolvedPeerId ?? Environment.MachineName;
     }
 
     /// <summary>
@@ -157,7 +159,7 @@ public class RegisterReplicationService
                     var docketRequest = new DocketChainRequest
                     {
                         RegisterId = registerId,
-                        PeerId = Environment.MachineName,
+                        PeerId = _localPeerId,
                         FromVersion = fromVersion,
                         MaxDockets = batchSize
                     };
@@ -187,7 +189,7 @@ public class RegisterReplicationService
                             var txRequest = new DocketTransactionRequest
                             {
                                 RegisterId = registerId,
-                                PeerId = Environment.MachineName
+                                PeerId = _localPeerId
                             };
                             txRequest.TransactionIds.AddRange(docketEntry.TransactionIds);
 
@@ -499,7 +501,7 @@ public class RegisterReplicationService
                 var request = new RegisterSubscriptionRequest
                 {
                     RegisterId = registerId,
-                    PeerId = Environment.MachineName,
+                    PeerId = _localPeerId,
                     FromVersion = subscription.LastSyncedTransactionVersion
                 };
 

--- a/src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatGrpcService.cs
+++ b/src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatGrpcService.cs
@@ -74,7 +74,7 @@ public class PeerHeartbeatGrpcService : PeerHeartbeat.PeerHeartbeatBase
         var response = new PeerHeartbeatResponse
         {
             Success = true,
-            PeerId = _configuration.NodeId ?? Environment.MachineName,
+            PeerId = _configuration.ResolvedPeerId,
             Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
         };
 
@@ -121,7 +121,7 @@ public class PeerHeartbeatGrpcService : PeerHeartbeat.PeerHeartbeatBase
             var response = new PeerHeartbeatResponse
             {
                 Success = true,
-                PeerId = _configuration.NodeId ?? Environment.MachineName,
+                PeerId = _configuration.ResolvedPeerId,
                 Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
             };
 

--- a/src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatService.cs
+++ b/src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatService.cs
@@ -28,6 +28,7 @@ public class PeerHeartbeatBackgroundService : BackgroundService
     private readonly PeerServiceMetrics _metrics;
     private readonly PeerServiceActivitySource _activitySource;
     private readonly RegisterSyncConfiguration _syncConfig;
+    private readonly string _localPeerId;
     private long _sequenceNumber;
     private int _heartbeatCycleCount;
 
@@ -46,7 +47,9 @@ public class PeerHeartbeatBackgroundService : BackgroundService
         _advertisementService = advertisementService ?? throw new ArgumentNullException(nameof(advertisementService));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _activitySource = activitySource ?? throw new ArgumentNullException(nameof(activitySource));
-        _syncConfig = configuration?.Value?.RegisterSync ?? new RegisterSyncConfiguration();
+        var config = configuration?.Value ?? throw new ArgumentNullException(nameof(configuration));
+        _syncConfig = config.RegisterSync;
+        _localPeerId = config.ResolvedPeerId;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -211,7 +214,7 @@ public class PeerHeartbeatBackgroundService : BackgroundService
     {
         var request = new PeerHeartbeatRequest
         {
-            PeerId = _peerListManager.GetLocalPeerStatus()?.PeerId ?? Environment.MachineName,
+            PeerId = _localPeerId,
             Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             SequenceNumber = sequenceNumber,
             BuildVersion = BuildInfo.Version


### PR DESCRIPTION
## Summary
- **Root cause**: Peer identity was split across two systems — `NodeId` (config) and `Environment.MachineName` (container hostname). Heartbeats, relay messages, reverse streams, seed registration, and channel pool keys all used different IDs for the same peer.
- **Fix**: Added `PeerServiceConfiguration.ResolvedPeerId` property and `PeerIdentity` singleton. All 13 files that referenced peer identity now use the canonical resolved ID.
- **Impact**: Peers will no longer appear as duplicates in the peer list. Channel lookups will find the correct connection. Sync source selection will work across advertised peers.

## Files changed (13)
- `PeerServiceConfiguration.cs` — added `ResolvedPeerId` property
- `PeerIdentity.cs` — new singleton for DI injection
- `Program.cs` — registers `PeerIdentity` singleton
- `RelayCommunicationService.cs` — reverse stream + keepalive + relay messages
- `PeerConnectionPool.cs` — seed registration + peer info
- `PeerHeartbeatService.cs` — heartbeat sender ID
- `PeerHeartbeatGrpcService.cs` — heartbeat response ID
- `PeerListManager.cs` — local peer status
- `PeerDiscoveryService.cs` — discovery registration
- `PeerExchangeService.cs` — peer exchange + self-filter
- `RegisterReplicationService.cs` — sync subscription requests
- `RegisterSyncGrpcService.cs` — sync response ID
- `DocketSyncGrpcService.cs` — docket sync responses

## Test plan
- [x] Peer service builds cleanly (0 errors)
- [ ] Deploy to Docker, verify peer list shows single entry per node (not duplicates)
- [ ] Verify n1 appears under its NodeId, not container hostname
- [ ] Verify sync source selection resolves channels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)