### PR TITLE
fix: use Base64Url decode for blueprint recovery payload data

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1607,8 +1607,8 @@ app.MapGet("/api/registers/{registerId}/blueprints/published", async (
         string blueprintJson;
         try
         {
-            // Attempt base64 decode — payload is stored as base64 in MongoDB Binary fields
-            var bytes = Convert.FromBase64String(rawPayload);
+            // Payload data is Base64Url-encoded (via DocketSerializer → MongoDocumentMapper round-trip)
+            var bytes = Base64Url.DecodeFromChars(rawPayload.AsSpan());
             blueprintJson = System.Text.Encoding.UTF8.GetString(bytes);
         }
         catch (FormatException)


### PR DESCRIPTION
## Summary
- Fixed `JsonException` ('e' is an invalid start of a value) during Blueprint Service startup recovery
- The `/api/registers/{registerId}/blueprints/published` endpoint used `Convert.FromBase64String()` (standard Base64) but payload data is **Base64Url**-encoded via the `DocketSerializer` → MongoDB → `MongoDocumentMapper` round-trip
- Replaced with `Base64Url.DecodeFromChars()` to correctly decode the payload

## Test plan
- [ ] Start services and verify Blueprint Service logs no longer show deserialization warnings for `register-creation-v1` / `create-organisation-v1`
- [ ] Run Trade Finance walkthrough golden path scenario to confirm blueprint recovery works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)