### PR TITLE
feat: [SEC-011] Service-to-service auth for internal endpoints

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -42,7 +42,8 @@ This document now tracks **remaining work for the first production release**, or
 | SEC-008 | Wallet sign/decrypt delegate access — extend ownership check with DelegationService | P1 | 4h | 📋 | PR #170 added owner-only check; needs DelegationService.HasAccessAsync for delegated wallets (SignOnly for /sign, ReadOnly for /decrypt, etc.). Pattern exists on wallet detail endpoint (line 518). |
 | SEC-009 | Participant publishing wallet-link verification | P1 | 4h | 📋 | ParticipantPublishingService should verify signer wallet is linked to the participant being published. Currently accepts any wallet as signer. |
 | SEC-010 | Peer replication participant record re-validation | P2 | 8h | 📋 | Re-validate participant records during peer sync (verify signatures, check conflicts with existing records). Currently accepted verbatim. |
-| SEC-011 | Service-to-service authentication for internal endpoints | P1 | 8h | 📋 | Internal endpoints (Peer subscribe/unsubscribe, Register internal notifications, bulk-advertise) currently AllowAnonymous within Docker network. Add S2S JWT or shared-secret auth to prevent unauthorized internal API access. |
+| SEC-011 | Service-to-service authentication for internal endpoints | P1 | 8h | ✅ | Closed: RequireService policy on all 5 internal endpoints. Service clients attach JWT headers. |
+| SEC-011b | Defence-in-depth: per-service identity policies | P2 | 8h | 📋 | Check `service_name` claim per endpoint, scope enforcement, API Gateway internal route blocking, audit logging. Deferred from SEC-011. |
 
 ---
 

--- a/docs/superpowers/plans/2026-04-03-s2s-auth-gap-closure.md
+++ b/docs/superpowers/plans/2026-04-03-s2s-auth-gap-closure.md
@@ -1,0 +1,387 @@
+# SEC-011: S2S Auth Gap Closure — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Secure 5 open internal endpoints with `RequireService` policy and ensure all calling service clients attach JWT auth headers.
+
+**Architecture:** Apply the existing `RequireService` authorization policy (checks `token_type=service` claim) to the 5 unprotected internal endpoints. Add `SetAuthHeaderAsync()` calls to the 4 service client methods that currently skip auth. No new infrastructure — all components exist.
+
+**Tech Stack:** .NET 10 Minimal APIs, JWT Bearer auth, xUnit + FluentAssertions integration tests
+
+---
+
+### File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `src/Services/Sorcha.Register.Service/Program.cs` | Add RequireService to 3 internal endpoints |
+| Modify | `src/Services/Sorcha.Peer.Service/Program.cs` | Add RequireService to 2 subscription endpoints |
+| Modify | `src/Common/Sorcha.ServiceClients/Register/RegisterServiceClient.cs` | Add SetAuthHeaderAsync to 2 methods |
+| Modify | `src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs` | Add IServiceAuthClient + SetAuthHeaderAsync to 2 methods |
+| Modify | `src/Common/Sorcha.ServiceClients/Extensions/ServiceCollectionExtensions.cs` | Wire IServiceAuthClient into PeerServiceClient DI |
+| Modify | `tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs` | Add auth tests for 3 internal endpoints |
+| Modify | `.specify/MASTER-TASKS.md` | Mark SEC-011 complete, add SEC-011b |
+
+---
+
+### Task 1: Secure Register Service Internal Endpoints
+
+**Files:**
+- Modify: `src/Services/Sorcha.Register.Service/Program.cs:249-260, 401-407, 455-460`
+
+- [ ] **Step 1: Change GET /api/internal/registers auth**
+
+Replace lines 257-258:
+```csharp
+// Before:
+.AllowAnonymous()
+.ExcludeFromDescription();
+
+// After:
+.RequireAuthorization("RequireService")
+.ExcludeFromDescription();
+```
+Also update the `.WithDescription()` on line 255 — remove "Unauthenticated endpoint" wording:
+```csharp
+.WithDescription("Internal endpoint for Blueprint Service startup recovery. Returns minimal register info. Requires service token.")
+```
+
+- [ ] **Step 2: Change POST /api/internal/register-subscriptions auth**
+
+Replace lines 405-407:
+```csharp
+// Before:
+.AllowAnonymous()
+.ExcludeFromDescription();
+
+// After:
+.RequireAuthorization("RequireService")
+.ExcludeFromDescription();
+```
+
+- [ ] **Step 3: Change POST /api/internal/register-sync-status auth**
+
+Replace lines 459-460:
+```csharp
+// Before:
+.AllowAnonymous() // TODO(SEC-011): add S2S auth; currently open within Docker network
+.ExcludeFromDescription();
+
+// After:
+.RequireAuthorization("RequireService")
+.ExcludeFromDescription();
+```
+
+- [ ] **Step 4: Build to verify no compilation errors**
+
+Run: `dotnet build src/Services/Sorcha.Register.Service/`
+Expected: Build succeeded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/Sorcha.Register.Service/Program.cs
+git commit -m "feat(SEC-011): secure Register Service internal endpoints with RequireService"
+```
+
+---
+
+### Task 2: Secure Peer Service Subscription Endpoints
+
+**Files:**
+- Modify: `src/Services/Sorcha.Peer.Service/Program.cs:656-659, 690-693`
+
+- [ ] **Step 1: Add RequireService to POST subscribe**
+
+Replace line 659:
+```csharp
+// Before:
+    .WithTags("Registers"); // TODO(SEC-011): add S2S auth; currently open within Docker network
+
+// After:
+    .WithTags("Registers")
+    .RequireAuthorization("RequireService");
+```
+
+- [ ] **Step 2: Add RequireService to DELETE subscribe**
+
+Replace line 693:
+```csharp
+// Before:
+    .WithTags("Registers"); // TODO(SEC-011): add S2S auth; currently open within Docker network
+
+// After:
+    .WithTags("Registers")
+    .RequireAuthorization("RequireService");
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `dotnet build src/Services/Sorcha.Peer.Service/`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Services/Sorcha.Peer.Service/Program.cs
+git commit -m "feat(SEC-011): secure Peer Service subscribe endpoints with RequireService"
+```
+
+---
+
+### Task 3: Add Auth Headers to RegisterServiceClient Internal Methods
+
+**Files:**
+- Modify: `src/Common/Sorcha.ServiceClients/Register/RegisterServiceClient.cs:1416-1468`
+
+The `SetAuthHeaderAsync()` instance method already exists at line 55. Two methods skip it with comments saying "Internal endpoint is AllowAnonymous — no auth header". Fix both.
+
+- [ ] **Step 1: Add auth to GetInternalRegistersAsync**
+
+At line 1421-1424, replace:
+```csharp
+        _logger.LogDebug("Fetching internal register list for recovery");
+
+        // Internal endpoint is AllowAnonymous — no auth header
+        var response = await _httpClient.GetAsync(
+```
+With:
+```csharp
+        _logger.LogDebug("Fetching internal register list for recovery");
+
+        await SetAuthHeaderAsync(cancellationToken);
+
+        var response = await _httpClient.GetAsync(
+```
+
+- [ ] **Step 2: Add auth to NotifySubscriptionAsync**
+
+At line 1461-1464, replace:
+```csharp
+        _logger.LogDebug(
+            "Notifying Register Service of subscription {Action} for register {RegisterId}",
+            request.Action, request.RegisterId);
+
+        // Internal endpoint is AllowAnonymous — no auth header
+        var response = await _httpClient.PostAsJsonAsync(
+```
+With:
+```csharp
+        _logger.LogDebug(
+            "Notifying Register Service of subscription {Action} for register {RegisterId}",
+            request.Action, request.RegisterId);
+
+        await SetAuthHeaderAsync(cancellationToken);
+
+        var response = await _httpClient.PostAsJsonAsync(
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `dotnet build src/Common/Sorcha.ServiceClients/`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Common/Sorcha.ServiceClients/Register/RegisterServiceClient.cs
+git commit -m "feat(SEC-011): add auth headers to RegisterServiceClient internal methods"
+```
+
+---
+
+### Task 4: Add Auth Headers to PeerServiceClient
+
+**Files:**
+- Modify: `src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs:16-65, 380-479`
+- Modify: `src/Common/Sorcha.ServiceClients/Extensions/ServiceCollectionExtensions.cs`
+
+PeerServiceClient currently has no `IServiceAuthClient` dependency at all. Add it and wire auth into the two HTTP methods.
+
+- [ ] **Step 1: Add IServiceAuthClient to PeerServiceClient constructor**
+
+Add import at top of file:
+```csharp
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Helpers;
+```
+
+Add field after line 26 (`private bool _peerServiceUnavailableLogged;`):
+```csharp
+    private readonly IServiceAuthClient? _serviceAuth;
+```
+
+Update constructor signature at line 28-31 to accept optional auth client:
+```csharp
+    public PeerServiceClient(
+        IConfiguration configuration,
+        ILogger<PeerServiceClient> logger,
+        HttpClient? httpClient = null,
+        IServiceAuthClient? serviceAuth = null)
+    {
+```
+
+Assign after line 33:
+```csharp
+        _serviceAuth = serviceAuth;
+```
+
+Add private helper method after the constructor closing brace:
+```csharp
+    private async Task SetAuthHeaderAsync(CancellationToken cancellationToken)
+    {
+        if (_httpClient is null || _serviceAuth is null) return;
+        await ServiceClientAuthHelper.SetAuthHeaderAsync(
+            _httpClient, _serviceAuth, _logger, "Peer Service", cancellationToken);
+    }
+```
+
+- [ ] **Step 2: Add auth to SubscribeToRegisterAsync**
+
+At line 397, before the `PostAsJsonAsync` call, add:
+```csharp
+        await SetAuthHeaderAsync(cancellationToken);
+
+        var response = await _httpClient.PostAsJsonAsync(
+```
+
+- [ ] **Step 3: Add auth to UnsubscribeFromRegisterAsync**
+
+At line 448, before the `DeleteAsync` call, add:
+```csharp
+        await SetAuthHeaderAsync(cancellationToken);
+
+        var response = await _httpClient.DeleteAsync(
+```
+
+- [ ] **Step 4: Wire IServiceAuthClient in DI registration**
+
+In `src/Common/Sorcha.ServiceClients/Extensions/ServiceCollectionExtensions.cs`, find where PeerServiceClient is registered (look for `AddScoped<IPeerServiceClient`). Update to pass `IServiceAuthClient` through. Since PeerServiceClient uses constructor injection with optional parameters, and `IServiceAuthClient` is already registered as a singleton by `AddServiceClients`, no DI changes are needed — the container will resolve it automatically.
+
+Verify by checking the constructor: all parameters are resolvable (IConfiguration, ILogger, HttpClient via factory, IServiceAuthClient as singleton).
+
+- [ ] **Step 5: Build to verify**
+
+Run: `dotnet build src/Common/Sorcha.ServiceClients/`
+Expected: Build succeeded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs
+git commit -m "feat(SEC-011): add auth headers to PeerServiceClient subscribe methods"
+```
+
+---
+
+### Task 5: Integration Tests for Register Service Internal Endpoints
+
+**Files:**
+- Modify: `tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs`
+
+The test factory already provides `CreateUnauthenticatedClient()` and `CreateServiceClient()` (with `token_type=service`). Add tests verifying internal endpoints reject unauthenticated requests.
+
+- [ ] **Step 1: Add test for GET /api/internal/registers requires service auth**
+
+```csharp
+[Fact]
+public async Task InternalGetRegisters_WithoutAuth_ReturnsUnauthorized()
+{
+    // Arrange
+    using var client = _factory.CreateUnauthenticatedClient();
+
+    // Act
+    var response = await client.GetAsync("/api/internal/registers");
+
+    // Assert
+    response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+}
+
+[Fact]
+public async Task InternalGetRegisters_WithServiceToken_ReturnsOk()
+{
+    // Arrange
+    using var client = _factory.CreateServiceClient();
+
+    // Act
+    var response = await client.GetAsync("/api/internal/registers");
+
+    // Assert
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+}
+```
+
+- [ ] **Step 2: Add test for POST /api/internal/register-subscriptions requires service auth**
+
+```csharp
+[Fact]
+public async Task InternalRegisterSubscriptions_WithoutAuth_ReturnsUnauthorized()
+{
+    // Arrange
+    using var client = _factory.CreateUnauthenticatedClient();
+    var content = JsonContent.Create(new { registerId = "abcdef0123456789abcdef0123456789", action = "subscribe" });
+
+    // Act
+    var response = await client.PostAsync("/api/internal/register-subscriptions", content);
+
+    // Assert
+    response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+}
+```
+
+- [ ] **Step 3: Add test for POST /api/internal/register-sync-status requires service auth**
+
+```csharp
+[Fact]
+public async Task InternalSyncStatus_WithoutAuth_ReturnsUnauthorized()
+{
+    // Arrange
+    using var client = _factory.CreateUnauthenticatedClient();
+    var content = JsonContent.Create(new { registerId = "abcdef0123456789abcdef0123456789", syncState = "Active", peerConnectionActive = true });
+
+    // Act
+    var response = await client.PostAsync("/api/internal/register-sync-status", content);
+
+    // Assert
+    response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+}
+```
+
+- [ ] **Step 4: Run integration tests**
+
+Run: `dotnet test tests/Sorcha.Register.Service.IntegrationTests/ --filter "Internal" -v q`
+Expected: All new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
+git commit -m "test(SEC-011): add auth enforcement tests for internal endpoints"
+```
+
+---
+
+### Task 6: Update MASTER-TASKS and Documentation
+
+**Files:**
+- Modify: `.specify/MASTER-TASKS.md`
+
+- [ ] **Step 1: Mark SEC-011 complete and add SEC-011b**
+
+In `.specify/MASTER-TASKS.md`, update SEC-011:
+```markdown
+| SEC-011 | Service-to-service authentication for internal endpoints | P1 | 8h | ✅ | Closed: RequireService policy on all 5 internal endpoints. Service clients attach JWT headers. |
+| SEC-011b | Defence-in-depth: per-service identity policies | P2 | 8h | 📋 | Check `service_name` claim per endpoint, scope enforcement, API Gateway internal route blocking, audit logging. Deferred from SEC-011. |
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `dotnet test`
+Expected: All tests pass (no regressions from auth changes).
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add .specify/MASTER-TASKS.md
+git commit -m "docs(SEC-011): mark complete, add SEC-011b for defence-in-depth"
+```

--- a/docs/superpowers/specs/2026-04-03-s2s-auth-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-04-03-s2s-auth-gap-closure-design.md
@@ -1,0 +1,99 @@
+# SEC-011: Service-to-Service Auth Gap Closure
+
+**Date:** 2026-04-03
+**Status:** Approved
+**Scope:** Close 5 open internal endpoints with `RequireService` policy; defer per-service identity to SEC-011b
+
+---
+
+## Problem
+
+Five internal endpoints across Register Service and Peer Service accept unauthenticated requests. While Docker network isolation provides a degree of protection, any process that can reach the container network can call these endpoints — creating risks for topology disclosure, unauthorized subscription manipulation, and sync state tampering.
+
+The S2S auth infrastructure already exists (`ServiceAuthClient`, `RequireService` policy, `SetAuthHeaderAsync` helper) but was not applied to these endpoints during initial development.
+
+## Endpoints to Secure
+
+| # | Endpoint | Service | File | Current Auth |
+|---|---|---|---|---|
+| 1 | `GET /api/internal/registers` | Register | `Program.cs:249` | AllowAnonymous |
+| 2 | `POST /api/internal/register-subscriptions` | Register | `Program.cs:261` | AllowAnonymous |
+| 3 | `POST /api/internal/register-sync-status` | Register | `Program.cs:411` | AllowAnonymous |
+| 4 | `POST /api/registers/{id}/subscribe` | Peer | `Program.cs:659` | None |
+| 5 | `DELETE /api/registers/{id}/subscribe` | Peer | `Program.cs:693` | None |
+
+**Target state:** All five endpoints use `.RequireAuthorization("RequireService")`, which requires `token_type=service` in the JWT.
+
+## Callers to Verify
+
+Each calling service client must call `SetAuthHeaderAsync()` before making requests to these endpoints. Verify and fix if missing:
+
+| Client Class | Method | Calls Endpoint |
+|---|---|---|
+| `RegisterServiceClient` | `NotifySubscriptionAsync` | POST /api/internal/register-subscriptions |
+| `RegisterServiceClient` | `ReportSyncStatusAsync` | POST /api/internal/register-sync-status |
+| `RegisterServiceClient` | `GetInternalRegistersAsync` | GET /api/internal/registers |
+| `PeerServiceClient` | `SubscribeToRegisterAsync` | POST /api/registers/{id}/subscribe |
+| `PeerServiceClient` | `UnsubscribeFromRegisterAsync` | DELETE /api/registers/{id}/subscribe |
+
+## Service Principal Configuration
+
+Services that make S2S calls need `ServiceAuth:ClientId` and `ServiceAuth:ClientSecret` configured. Verify docker-compose.yml provides these environment variables for:
+
+- **Register Service** — calls Peer Service (subscribe/unsubscribe)
+- **Peer Service** — calls Register Service (sync status)
+- **Tenant Service** — calls Register Service (subscription notifications)
+- **Blueprint Service** — calls Register Service (internal register discovery)
+
+If any service lacks a service principal, create one via the Tenant Service admin API or seed script.
+
+## Implementation Steps
+
+1. **Register Service Program.cs** — replace `AllowAnonymous()` with `RequireAuthorization("RequireService")` on endpoints 1-3. Remove `TODO(SEC-011)` comments.
+2. **Peer Service Program.cs** — add `RequireAuthorization("RequireService")` to endpoints 4-5. Remove `TODO(SEC-011)` comments.
+3. **Service clients** — audit each caller method listed above. Add `SetAuthHeaderAsync()` where missing.
+4. **Docker-compose.yml** — ensure `ServiceAuth__ClientId` and `ServiceAuth__ClientSecret` env vars are set for all services that make S2S calls. Use shared `x-service-auth-env` anchor if not already present.
+5. **Service principal seeding** — verify that service principals exist for each calling service. Add to seed script if missing.
+6. **Tests** — for each secured endpoint, add integration test verifying:
+   - 401 when no token is provided
+   - 401 when a user token is provided (wrong token_type)
+   - 200 when a valid service token is provided
+
+## Testing Strategy
+
+- Unit tests: mock `RequireService` policy, verify endpoints reject unauthenticated calls
+- Integration tests (WebApplicationFactory): verify full auth pipeline with real JWT validation
+- Docker smoke test: `docker compose up`, confirm services can still communicate after auth is enforced
+
+## Deferred: SEC-011b — Defence-in-Depth
+
+The following enhancements provide per-service identity granularity. They should be implemented before production but are not required for the current gap closure:
+
+### Per-Service Identity Policies
+Check the `service_name` claim to restrict which service can call which endpoint:
+
+```csharp
+// Example: only peer-service can report sync status
+options.AddPolicy("RequirePeerService", policy =>
+    policy.RequireClaim("token_type", "service")
+          .RequireClaim("service_name", "peer-service"));
+```
+
+**Endpoint → Allowed Caller mapping:**
+
+| Endpoint | Allowed Service(s) |
+|---|---|
+| `GET /api/internal/registers` | blueprint-service, peer-service |
+| `POST /api/internal/register-subscriptions` | tenant-service |
+| `POST /api/internal/register-sync-status` | peer-service |
+| `POST /api/registers/{id}/subscribe` | register-service |
+| `DELETE /api/registers/{id}/subscribe` | register-service |
+
+### Scope Enforcement
+Validate the `scope` claim matches the operation. The `CanWriteDockets` policy already has a placeholder for this. Extend to all S2S operations.
+
+### API Gateway Internal Route Blocking
+Explicitly deny `/api/internal/*` in YARP configuration as belt-and-suspenders — even though the gateway currently doesn't proxy these paths, an explicit deny prevents accidental exposure if routes are reconfigured.
+
+### Audit Logging
+Log all S2S auth failures (401/403) with the calling service name and target endpoint for security monitoring.

--- a/src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs
@@ -74,7 +74,12 @@ public class PeerServiceClient : IPeerServiceClient, IDisposable
 
     private async Task SetAuthHeaderAsync(CancellationToken cancellationToken)
     {
-        if (_httpClient is null || _serviceAuth is null) return;
+        if (_httpClient is null || _serviceAuth is null)
+        {
+            _logger.LogWarning("SetAuthHeaderAsync skipped — {Missing} is null; request will be unauthenticated",
+                _serviceAuth is null ? "IServiceAuthClient" : "HttpClient");
+            return;
+        }
         await ServiceClientAuthHelper.SetAuthHeaderAsync(
             _httpClient, _serviceAuth, _logger, "Peer Service", cancellationToken);
     }

--- a/src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients/Peer/PeerServiceClient.cs
@@ -7,6 +7,8 @@ using Grpc.Net.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Sorcha.Peer.Service.Protos;
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Helpers;
 
 namespace Sorcha.ServiceClients.Peer;
 
@@ -24,13 +26,16 @@ public class PeerServiceClient : IPeerServiceClient, IDisposable
     private readonly string _localPeerId;
     private bool _disposed;
     private bool _peerServiceUnavailableLogged;
+    private readonly IServiceAuthClient? _serviceAuth;
 
     public PeerServiceClient(
         IConfiguration configuration,
         ILogger<PeerServiceClient> logger,
-        HttpClient? httpClient = null)
+        HttpClient? httpClient = null,
+        IServiceAuthClient? serviceAuth = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _serviceAuth = serviceAuth;
 
         _serviceAddress = configuration["ServiceClients:PeerService:Address"]
             ?? configuration["GrpcClients:PeerService:Address"]
@@ -65,6 +70,13 @@ public class PeerServiceClient : IPeerServiceClient, IDisposable
 
         _logger.LogInformation("PeerServiceClient initialized (gRPC: {Address}, HTTP: {HttpAddress}, PeerId: {PeerId})",
             _serviceAddress, httpAddress, _localPeerId);
+    }
+
+    private async Task SetAuthHeaderAsync(CancellationToken cancellationToken)
+    {
+        if (_httpClient is null || _serviceAuth is null) return;
+        await ServiceClientAuthHelper.SetAuthHeaderAsync(
+            _httpClient, _serviceAuth, _logger, "Peer Service", cancellationToken);
     }
 
     public async Task<List<ValidatorInfo>> QueryValidatorsAsync(
@@ -394,6 +406,7 @@ public class PeerServiceClient : IPeerServiceClient, IDisposable
                 return;
             }
 
+            await SetAuthHeaderAsync(cancellationToken);
             var response = await _httpClient.PostAsJsonAsync(
                 $"api/registers/{Uri.EscapeDataString(registerId)}/subscribe",
                 new { mode },
@@ -445,6 +458,7 @@ public class PeerServiceClient : IPeerServiceClient, IDisposable
                 return;
             }
 
+            await SetAuthHeaderAsync(cancellationToken);
             var response = await _httpClient.DeleteAsync(
                 $"api/registers/{Uri.EscapeDataString(registerId)}/subscribe",
                 cancellationToken);

--- a/src/Common/Sorcha.ServiceClients/Register/RegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients/Register/RegisterServiceClient.cs
@@ -1420,7 +1420,8 @@ public class RegisterServiceClient : IRegisterServiceClient
         {
             _logger.LogDebug("Fetching internal register list for recovery");
 
-            // Internal endpoint is AllowAnonymous — no auth header
+            await SetAuthHeaderAsync(cancellationToken);
+
             var response = await _httpClient.GetAsync(
                 "api/internal/registers",
                 cancellationToken);
@@ -1460,7 +1461,8 @@ public class RegisterServiceClient : IRegisterServiceClient
                 "Notifying Register Service of subscription {Action} for register {RegisterId}",
                 request.Action, request.RegisterId);
 
-            // Internal endpoint is AllowAnonymous — no auth header
+            await SetAuthHeaderAsync(cancellationToken);
+
             var response = await _httpClient.PostAsJsonAsync(
                 "api/internal/register-subscriptions",
                 request,

--- a/src/Services/Sorcha.Peer.Service/Program.cs
+++ b/src/Services/Sorcha.Peer.Service/Program.cs
@@ -656,7 +656,7 @@ app.MapPost("/api/registers/{registerId}/subscribe", async (
     .WithName("SubscribeToRegister")
     .WithSummary("Subscribe to a register for replication")
     .WithDescription("Creates a new subscription to replicate a register. Mode can be 'forward-only' (new transactions only) or 'full-replica' (complete docket chain pull).")
-    .WithTags("Registers"); // TODO(SEC-011): add S2S auth; currently open within Docker network
+    .WithTags("Registers").RequireAuthorization("RequireService");
 
 // Unsubscribe from a register
 app.MapDelete("/api/registers/{registerId}/subscribe", async (
@@ -690,7 +690,7 @@ app.MapDelete("/api/registers/{registerId}/subscribe", async (
     .WithName("UnsubscribeFromRegister")
     .WithSummary("Unsubscribe from a register")
     .WithDescription("Stops replication for a register. Cached data is retained unless ?purge=true is specified.")
-    .WithTags("Registers"); // TODO(SEC-011): add S2S auth; currently open within Docker network
+    .WithTags("Registers").RequireAuthorization("RequireService");
 
 // Purge cached data for a register
 app.MapDelete("/api/registers/{registerId}/cache", (string registerId, [FromServices] RegisterCache registerCache) =>

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -253,8 +253,8 @@ app.MapGet("/api/internal/registers", async (RegisterManager manager) =>
 })
 .WithName("InternalGetRegisters")
 .WithSummary("Internal: List all registers for service recovery")
-.WithDescription("Unauthenticated endpoint for Blueprint Service startup recovery. Returns minimal register info.")
-.AllowAnonymous()
+.WithDescription("Internal endpoint for Blueprint Service startup recovery. Returns minimal register info. Requires service token.")
+.RequireAuthorization("RequireService")
 .ExcludeFromDescription(); // Hidden from public OpenAPI docs
 
 // Internal endpoint for Tenant Service subscription notifications
@@ -403,7 +403,7 @@ app.MapPost("/api/internal/register-subscriptions", async (
 .WithName("InternalNotifyRegisterSubscription")
 .WithSummary("Internal: Notify of register subscription change")
 .WithDescription("Called by Tenant Service when an org subscribes/unsubscribes. Creates stub registers and triggers peer sync.")
-.AllowAnonymous()
+.RequireAuthorization("RequireService")
 .ExcludeFromDescription();
 
 // Internal endpoint: Peer Service reports sync state changes for a register.
@@ -456,7 +456,7 @@ app.MapPost("/api/internal/register-sync-status", async (
 .WithName("InternalReportSyncStatus")
 .WithSummary("Internal: Report peer sync status change")
 .WithDescription("Called by Peer Service when sync state changes. Maps sync state to RegisterStatus.")
-.AllowAnonymous() // TODO(SEC-011): add S2S auth; currently open within Docker network
+.RequireAuthorization("RequireService")
 .ExcludeFromDescription();
 
 var registersGroup = app.MapGroup("/api/registers")

--- a/tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
+++ b/tests/Sorcha.Register.Service.IntegrationTests/RegisterEndpointsTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net;
+using System.Net.Http.Json;
 using FluentAssertions;
 using Sorcha.Register.Service.IntegrationTests.Fixtures;
 
@@ -153,4 +154,62 @@ public class RegisterEndpointsTests : IAsyncLifetime
             HttpStatusCode.UnsupportedMediaType,
             HttpStatusCode.InternalServerError);
     }
+
+    #region Internal Endpoint Auth Tests
+
+    [Fact]
+    public async Task InternalGetRegisters_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Arrange
+        using var unauthenticatedClient = _factory.CreateUnauthenticatedClient();
+
+        // Act
+        var response = await unauthenticatedClient.GetAsync("/api/internal/registers");
+
+        // Assert
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task InternalGetRegisters_WithServiceToken_ReturnsOk()
+    {
+        // Arrange
+        using var serviceClient = _factory.CreateServiceClient();
+
+        // Act
+        var response = await serviceClient.GetAsync("/api/internal/registers");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task InternalRegisterSubscriptions_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Arrange
+        using var unauthenticatedClient = _factory.CreateUnauthenticatedClient();
+        var content = JsonContent.Create(new { registerId = "abcdef0123456789abcdef0123456789", action = "subscribe" });
+
+        // Act
+        var response = await unauthenticatedClient.PostAsync("/api/internal/register-subscriptions", content);
+
+        // Assert
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task InternalSyncStatus_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Arrange
+        using var unauthenticatedClient = _factory.CreateUnauthenticatedClient();
+        var content = JsonContent.Create(new { registerId = "abcdef0123456789abcdef0123456789", syncState = "Active", peerConnectionActive = true });
+
+        // Act
+        var response = await unauthenticatedClient.PostAsync("/api/internal/register-sync-status", content);
+
+        // Assert
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Secure 5 open internal endpoints with `RequireService` policy (`token_type=service` JWT claim)
- Add `SetAuthHeaderAsync()` to RegisterServiceClient and PeerServiceClient for internal calls
- Wire `IServiceAuthClient` into PeerServiceClient (was missing entirely)
- Add integration tests verifying 401 without token, 200 with service token
- Add SEC-011b task for defence-in-depth (per-service identity, scope enforcement)

## Endpoints secured
| Endpoint | Service |
|---|---|
| `GET /api/internal/registers` | Register |
| `POST /api/internal/register-subscriptions` | Register |
| `POST /api/internal/register-sync-status` | Register |
| `POST /api/registers/{id}/subscribe` | Peer |
| `DELETE /api/registers/{id}/subscribe` | Peer |

## Test plan
- [x] 4 new integration tests (3 auth rejection, 1 auth acceptance)
- [x] Full test suite passes (E2E and 1 Tenant crash are pre-existing)
- [ ] Docker smoke test: services can still communicate after auth enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)