### PR TITLE
fix: [085] Critical review fixes — server-side sessions, orphan cleanup

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceField.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceField.razor
@@ -322,14 +322,27 @@
             using var uploadStream = browserFile.OpenReadStream(effectiveMax);
             var buffer = new byte[ChunkSize];
 
+            // Upload session ID returned by the server on the first chunk.
+            // Sent back on all subsequent chunks so the server reuses the same
+            // encryption session (and master key).
+            string? uploadSessionId = null;
+
             while (bytesUploaded < totalBytes)
             {
                 int bytesRead = await ReadExactAsync(uploadStream, buffer, ChunkSize);
                 if (bytesRead == 0) break;
 
                 var chunkData = buffer[..bytesRead];
-                var txId = await PostChunkAsync(info, chunkIndex, totalChunks, chunkData);
-                info.ChunkTransactionIds.Add(txId);
+                var chunkResult = await PostChunkAsync(info, chunkIndex, totalChunks, chunkData, uploadSessionId);
+                info.ChunkTransactionIds.Add(chunkResult.ChunkTransactionId);
+
+                // Capture session ID from the first response; use on all subsequent chunks
+                if (chunkIndex == 0)
+                {
+                    uploadSessionId = chunkResult.UploadSessionId;
+                    // Salt returned by the server — not secret, needed for FileReference
+                    info.Salt = chunkResult.SaltBase64 ?? string.Empty;
+                }
 
                 bytesUploaded += bytesRead;
                 info.Progress = totalBytes > 0 ? (double)bytesUploaded / totalBytes * 100.0 : 100.0;
@@ -354,13 +367,15 @@
 
     /// <summary>
     /// POST a single chunk to the Blueprint Service chunk endpoint as JSON.
-    /// Returns the chunk transaction ID assigned by the server.
+    /// Returns the full server response including the chunk transaction ID,
+    /// upload session ID, and salt.
     /// </summary>
-    private async Task<string> PostChunkAsync(
+    private async Task<ChunkUploadResponse> PostChunkAsync(
         FileReferenceInfo info,
         int chunkIndex,
         int totalChunks,
-        byte[] data)
+        byte[] data,
+        string? uploadSessionId)
     {
         var request = new
         {
@@ -370,7 +385,8 @@
             totalChunks,
             fileHash = $"sha256:{info.Hash}",
             contentType = info.ContentType,
-            contentBase64 = Convert.ToBase64String(data)
+            contentBase64 = Convert.ToBase64String(data),
+            uploadSessionId  // null on first chunk; server-assigned ID on subsequent chunks
         };
 
         var response = await Http.PostAsJsonAsync("/api/file-chunks", request);
@@ -379,7 +395,7 @@
         var result = await response.Content.ReadFromJsonAsync<ChunkUploadResponse>();
         if (result?.ChunkTransactionId is null)
             throw new InvalidOperationException("Server did not return a chunk transaction ID.");
-        return result.ChunkTransactionId;
+        return result;
     }
 
     /// <summary>
@@ -433,5 +449,11 @@
 
     // ── Nested response DTO ───────────────────────────────────────────────────
 
-    private sealed record ChunkUploadResponse(string ChunkTransactionId);
+    /// <summary>
+    /// Subset of FileChunkSubmissionResponse used by the Blazor client.
+    /// </summary>
+    private sealed record ChunkUploadResponse(
+        string ChunkTransactionId,
+        string? UploadSessionId,
+        string? SaltBase64);
 }

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/FileChunkEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/FileChunkEndpoints.cs
@@ -4,6 +4,7 @@
 using System.Security.Claims;
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 
 using Sorcha.Blueprint.Models;
 using Sorcha.Blueprint.Service.Models.Responses;
@@ -39,8 +40,10 @@ public static class FileChunkEndpoints
                 "once all chunks for a file have been received. The caller must submit all chunks " +
                 "(0 to totalChunks-1) before the parent action can be finalised. " +
                 "Each chunk must not exceed 4 MB and the total chunk count must not exceed 10. " +
-                "On the first chunk (chunkIndex 0), the server generates a master key and salt " +
-                "and returns them in the response. Subsequent chunks must supply the same values.")
+                "On the first chunk (no uploadSessionId), the server creates an upload session, " +
+                "stores the master key server-side, and returns an opaque uploadSessionId plus the " +
+                "salt. Subsequent chunks must supply the uploadSessionId to reuse the same encryption " +
+                "session. The salt (not the master key) is returned so the client can build a FileReference.")
             .Produces<FileChunkSubmissionResponse>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -51,6 +54,7 @@ public static class FileChunkEndpoints
         [FromBody] FileChunkSubmissionRequest request,
         IActionStore actionStore,
         ITransactionBuilderService txBuilder,
+        IMemoryCache memoryCache,
         HttpContext httpContext,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
@@ -105,29 +109,45 @@ public static class FileChunkEndpoints
             return Results.StatusCode(StatusCodes.Status413RequestEntityTooLarge);
         }
 
-        // Resolve or generate the upload session (master key + salt).
-        // First chunk (or absent session fields): server generates a fresh session.
-        // Subsequent chunks: caller supplies the master key and salt from the first chunk response.
+        // Resolve or create the server-side upload session (master key + salt).
+        // The master key never leaves the server — only the opaque session ID and the
+        // non-secret salt are returned to the client.
         byte[] masterFileKey;
         byte[] salt;
+        string uploadSessionId;
 
-        if (request.MasterKeyBase64 is not null && request.SaltBase64 is not null)
+        if (!string.IsNullOrEmpty(request.UploadSessionId))
         {
-            try
+            // Subsequent chunk: look up the existing session from cache
+            var cacheKey = $"file-upload-session:{request.UploadSessionId}";
+            if (!memoryCache.TryGetValue(cacheKey, out FileUploadSessionCache? sessionCache) || sessionCache is null)
             {
-                masterFileKey = Convert.FromBase64String(request.MasterKeyBase64);
-                salt = Convert.FromBase64String(request.SaltBase64);
+                return Results.BadRequest(new
+                {
+                    error = "Upload session not found or expired. Upload sessions last 30 minutes. " +
+                            "Please restart the upload from the first chunk."
+                });
             }
-            catch (FormatException)
-            {
-                return Results.BadRequest(new { error = "MasterKeyBase64 or SaltBase64 is not valid Base64." });
-            }
+
+            masterFileKey = sessionCache.MasterFileKey;
+            salt = sessionCache.Salt;
+            uploadSessionId = request.UploadSessionId;
         }
         else
         {
+            // First chunk: create a new session and cache it with a 30-minute TTL
             var session = txBuilder.CreateFileUploadSession();
             masterFileKey = session.MasterFileKey;
             salt = session.Salt;
+            uploadSessionId = Guid.NewGuid().ToString("N");
+
+            var cacheKey = $"file-upload-session:{uploadSessionId}";
+            memoryCache.Set(cacheKey, new FileUploadSessionCache(masterFileKey, salt),
+                new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30),
+                    Size = 1
+                });
         }
 
         // Encrypt the chunk server-side using a per-chunk HKDF-derived key
@@ -171,11 +191,19 @@ public static class FileChunkEndpoints
                 ChunkTransactionId = chunkTxId,
                 ChunkIndex = request.ChunkIndex,
                 Timestamp = timestamp,
-                MasterKeyBase64 = Convert.ToBase64String(masterFileKey),
+                UploadSessionId = uploadSessionId,
                 SaltBase64 = Convert.ToBase64String(salt)
             });
     }
 }
+
+/// <summary>
+/// Server-side state for an in-progress multi-chunk file upload session.
+/// Stored in <see cref="IMemoryCache"/> for the lifetime of the upload (30 minutes).
+/// The master key is held exclusively on the server; only the opaque session ID and
+/// the non-secret salt are returned to the client.
+/// </summary>
+internal sealed record FileUploadSessionCache(byte[] MasterFileKey, byte[] Salt);
 
 /// <summary>
 /// Request to submit a single file chunk for server-side encryption and staging.
@@ -220,18 +248,11 @@ public record FileChunkSubmissionRequest
     public required string ContentBase64 { get; init; }
 
     /// <summary>
-    /// Base64-encoded 32-byte master file key from a previous chunk response.
-    /// Omit on the first chunk — the server generates a new session.
-    /// Required on chunks 1+ to maintain a consistent encryption session across all chunks.
+    /// Opaque upload session identifier returned by the server on the first chunk response.
+    /// Omit on the first chunk — the server creates a new session and returns the ID.
+    /// Required on chunks 1+ so the server can retrieve the shared encryption session.
     /// </summary>
-    public string? MasterKeyBase64 { get; init; }
-
-    /// <summary>
-    /// Base64-encoded 32-byte salt from a previous chunk response.
-    /// Omit on the first chunk — the server generates a new session.
-    /// Required on chunks 1+ to maintain a consistent encryption session across all chunks.
-    /// </summary>
-    public string? SaltBase64 { get; init; }
+    public string? UploadSessionId { get; init; }
 }
 
 /// <summary>
@@ -255,14 +276,15 @@ public record FileChunkSubmissionResponse
     public required DateTimeOffset Timestamp { get; init; }
 
     /// <summary>
-    /// Base64-encoded 32-byte master file key for this upload session.
-    /// Must be supplied unchanged in all subsequent chunk requests for the same file.
+    /// Opaque upload session identifier. Must be included in all subsequent chunk requests
+    /// for the same file so the server can retrieve the shared encryption session.
+    /// The master key is held exclusively on the server and is never returned to the client.
     /// </summary>
-    public required string MasterKeyBase64 { get; init; }
+    public required string UploadSessionId { get; init; }
 
     /// <summary>
     /// Base64-encoded 32-byte salt for this upload session.
-    /// Must be supplied unchanged in all subsequent chunk requests for the same file.
+    /// Not secret — store this in the FileReference so the validator can derive per-chunk keys.
     /// </summary>
     public required string SaltBase64 { get; init; }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -124,6 +124,9 @@ builder.Services.AddSingleton<Sorcha.Cryptography.SdJwt.ISdJwtService, Sorcha.Cr
 // Add JsonLogic expression cache (singleton - shared across scoped evaluators)
 builder.Services.AddSingleton<Sorcha.Blueprint.Engine.Caching.JsonLogicCache>();
 
+// Add IMemoryCache for server-side upload session management (file chunk encryption keys)
+builder.Services.AddMemoryCache(options => options.SizeLimit = 10_000);
+
 // Add Action service layer (Sprint 3)
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IActionResolverService, Sorcha.Blueprint.Service.Services.Implementation.ActionResolverService>();
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IPayloadResolverService, Sorcha.Blueprint.Service.Services.Implementation.PayloadResolverService>();

--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreActionStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreActionStore.cs
@@ -251,12 +251,14 @@ public class EfCoreActionStore : IActionStore
     {
         await using var context = await _contextFactory.CreateDbContextAsync();
 
-        // An orphan is a FileMetadata row whose TransactionHash has no matching Action row
-        // and whose CreatedAt is before the supplied threshold.
+        // Chunks are stored with TransactionHash = "pending" until an action claims them.
+        // A chunk is an orphan when it is still unclaimed ("pending") AND old enough that
+        // no in-flight upload could still be completing.
+        // Claimed chunks (TransactionHash != "pending") are never orphans — they belong to
+        // a finalised action regardless of whether the action row exists yet.
         var orphans = await context.FileMetadata
             .AsNoTracking()
-            .Where(f => f.CreatedAt < olderThan &&
-                        !context.Actions.Any(a => a.TransactionHash == f.TransactionHash))
+            .Where(f => f.TransactionHash == "pending" && f.CreatedAt < olderThan)
             .Select(f => new { f.Id, f.TransactionHash })
             .ToListAsync();
 

--- a/src/Services/Sorcha.Blueprint.Service/Storage/InMemoryActionStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/InMemoryActionStore.cs
@@ -114,19 +114,20 @@ public class InMemoryActionStore : IActionStore
     {
         var orphans = new List<(string FileId, string TransactionHash)>();
 
-        foreach (var (txHash, files) in _fileMetadata)
-        {
-            // An orphan is a file whose parent action transaction does not exist in the store.
-            if (_actions.ContainsKey(txHash))
-                continue;
+        // Chunks are stored with TransactionHash = "pending" until an action claims them.
+        // A chunk is an orphan when it is still unclaimed ("pending") AND old enough that
+        // no in-flight upload could still be completing.
+        // Claimed chunks (TransactionHash != "pending") are never orphans — they belong to
+        // a finalised action regardless of whether the action record exists yet.
+        if (!_fileMetadata.TryGetValue("pending", out var pendingFiles))
+            return Task.FromResult<IReadOnlyList<(string, string)>>(orphans);
 
-            foreach (var fileId in files.Keys)
+        foreach (var fileId in pendingFiles.Keys)
+        {
+            var key = $"pending:{fileId}";
+            if (_fileStoredAt.TryGetValue(key, out var storedAt) && storedAt < olderThan)
             {
-                var key = $"{txHash}:{fileId}";
-                if (_fileStoredAt.TryGetValue(key, out var storedAt) && storedAt < olderThan)
-                {
-                    orphans.Add((fileId, txHash));
-                }
+                orphans.Add((fileId, "pending"));
             }
         }
 

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/FileDownloadEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/FileDownloadEndpoints.cs
@@ -52,7 +52,7 @@ public static class FileDownloadEndpoints
         [FromQuery] string? registerId,
         [FromQuery] string? actionTxId,
         [FromQuery] string? fieldName,
-        [FromQuery] int fileIndex,
+        [FromQuery] int? fileIndex,
         IFileReassemblyService reassemblyService,
         IWalletRepository walletRepository,
         HttpContext context,
@@ -90,7 +90,9 @@ public static class FileDownloadEndpoints
             });
         }
 
-        if (fileIndex < 0)
+        // fileIndex defaults to 0 when not supplied (nullable int with no value = first file)
+        var resolvedFileIndex = fileIndex ?? 0;
+        if (resolvedFileIndex < 0)
         {
             return Results.BadRequest(new ProblemDetails
             {
@@ -139,14 +141,14 @@ public static class FileDownloadEndpoints
                 registerId,
                 actionTxId,
                 fieldName,
-                fileIndex,
+                resolvedFileIndex,
                 cancellationToken);
         }
         catch (Exception ex)
         {
             logger.LogError(ex,
                 "Failed to prepare download for wallet {Address}, action {ActionTxId}, field {FieldName}[{FileIndex}]",
-                address, actionTxId, fieldName, fileIndex);
+                address, actionTxId, fieldName, resolvedFileIndex);
             return Results.Problem(
                 title: "Download Preparation Failed",
                 detail: "An error occurred while fetching or decrypting the file. " +
@@ -159,7 +161,7 @@ public static class FileDownloadEndpoints
             return Results.NotFound(new ProblemDetails
             {
                 Title = "File Not Found",
-                Detail = $"No file found at field '{fieldName}' (index {fileIndex}) " +
+                Detail = $"No file found at field '{fieldName}' (index {resolvedFileIndex}) " +
                          $"in transaction '{actionTxId}', or wallet '{address}' is not an authorised recipient.",
                 Status = StatusCodes.Status404NotFound
             });
@@ -180,7 +182,6 @@ public static class FileDownloadEndpoints
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("integrity check failed"))
         {
-            await buffer.DisposeAsync();
             logger.LogError(ex,
                 "Integrity check FAILED for {FileName}, wallet {Address}",
                 downloadResult.FileName, address);


### PR DESCRIPTION
## Summary

- Server-side upload sessions via IMemoryCache replace client round-trip of master key
- Master key never leaves server boundary (security fix)
- Orphan cleanup query fixed to not delete active chunks
- Double dispose and fileIndex default fixed

## Addresses Claude review findings on PR #197

| Severity | Issue | Fix |
|----------|-------|-----|
| Critical | Multi-chunk files encrypted with different keys | Server-side IMemoryCache sessions with 30-min TTL |
| Critical | Orphan cleanup deletes all active chunks | Query checks TransactionHash == "pending" AND age |
| Security | Master key in HTTP response bodies | Removed — only opaque session ID returned |
| Bug | Double dispose on MemoryStream | Removed explicit DisposeAsync |
| Quality | fileIndex missing default | Nullable int with ?? 0 |

## Test plan

- [x] 130 existing unit tests pass
- [x] All projects build with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)