### PR TITLE
fix: CodeQL alert remediation + Register.Core.Tests compilation + API docs

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -44,6 +44,7 @@ This document now tracks **remaining work for the first production release**, or
 | SEC-010 | Peer replication participant record re-validation | P2 | 8h | 📋 | Re-validate participant records during peer sync (verify signatures, check conflicts with existing records). Currently accepted verbatim. |
 | SEC-011 | Service-to-service authentication for internal endpoints | P1 | 8h | ✅ | Closed: RequireService policy on all 5 internal endpoints. Service clients attach JWT headers. |
 | SEC-011b | Defence-in-depth: per-service identity policies | P2 | 8h | 📋 | Check `service_name` claim per endpoint, scope enforcement, API Gateway internal route blocking, audit logging. Deferred from SEC-011. |
+| SEC-012 | CodeQL alert remediation — log injection, info exposure, resource leaks | P1 | 4h | ✅ | Fixed: AcsEmailSender private info exposure, HttpRequestMessage/FormUrlEncodedContent dispose, SystemWalletSigningService double-check-locking. Log injection alerts (19) confirmed already resolved in master. |
 
 ---
 
@@ -220,7 +221,7 @@ These are the **Tier 1** trust improvements identified in the transaction archit
 
 | Theme | Priority | Tasks | Effort | Focus |
 |-------|----------|-------|--------|-------|
-| 1. Security Hardening | P0 | 7 (2 ✅, 5 remaining) | 80-100h | Release blocker |
+| 1. Security Hardening | P0 | 8 (3 ✅, 5 remaining) | 80-100h | Release blocker — SEC-012 CodeQL fixes done |
 | 2. Production Infrastructure | P1 | 10 (1 ✅, 9 remaining) | 80-120h | Deployment readiness |
 | 3. Deferred Feature Gaps | P1-P2 | 16 (3 ✅, 13 remaining) | 58-78h | Close MVD gaps — GAP-005/018/019 done (075, 077) |
 | 4. Trust & Verification | P2 | 5 | 120-160h | Trust hardening |

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -1,7 +1,7 @@
 # Sorcha Platform - API Documentation
 
-**Version:** 2.2.0
-**Last Updated:** 2026-03-16
+**Version:** 2.3.0
+**Last Updated:** 2026-04-04
 **Status:** MVD Complete
 
 ---
@@ -1409,6 +1409,106 @@ Content-Type: application/json
 ```
 
 **Response:** `200 OK` — `changeType`, `currentVersion`, `proposedVersion`, `structuralHashCurrent`, `structuralHashNew`, `structuralFieldsChanged`.
+
+#### 8. Disable Dev Mode (Feature 078)
+
+Irreversibly disables dev mode on a register. Once disabled, field-level encryption becomes mandatory for all new transactions. This operation cannot be undone.
+
+```http
+POST /api/registers/{registerId}/disable-dev-mode
+```
+
+**Authorization:** Requires `CanManageRegisters` policy.
+
+**Response:** `200 OK`
+```json
+{
+  "registerId": "register-101",
+  "devMode": false,
+  "message": "Dev mode disabled. Field-level encryption is now required for new transactions."
+}
+```
+
+**Error:** `409 Conflict` — Dev mode is already disabled on this register.
+
+#### 9. Toggle Dev Mode
+
+Enables or disables dev mode on a register. When enabled, payloads are stored as plaintext with disclosure filtering at read time. When disabled, new payloads use envelope encryption.
+
+> **Note:** For production registers, prefer the one-way `POST /{registerId}/disable-dev-mode` endpoint above.
+
+```http
+PUT /api/registers/{registerId}/devmode
+```
+
+**Authorization:** Requires `CanManageRegisters` policy.
+
+**Request Body:**
+```json
+{
+  "enabled": false
+}
+```
+
+**Response:** `200 OK`
+```json
+{
+  "registerId": "register-101",
+  "devMode": false,
+  "effectiveFrom": "2026-03-16T12:00:00Z"
+}
+```
+
+**Error:** `404 Not Found` — Register not found.
+
+#### 10. Recovery Sync Status (Feature 078)
+
+Returns the current recovery/sync status for all local registers. Used for health monitoring of register replication.
+
+```http
+GET /health/sync
+```
+
+**Authorization:** None (health endpoint).
+
+**Response:** `200 OK`
+```json
+{
+  "status": "synced",
+  "registers": [
+    {
+      "registerId": "register-101",
+      "status": "synced",
+      "currentDocket": 42,
+      "targetDocket": 42,
+      "progressPercent": 100,
+      "docketsProcessed": 0,
+      "lastError": null,
+      "isStale": false
+    },
+    {
+      "registerId": "register-102",
+      "status": "recovering",
+      "currentDocket": 30,
+      "targetDocket": 42,
+      "progressPercent": 58,
+      "docketsProcessed": 7,
+      "lastError": null,
+      "isStale": false
+    }
+  ],
+  "checkedAt": "2026-03-16T12:00:00Z"
+}
+```
+
+**Status values:**
+- `synced` — Register is fully up-to-date with the network
+- `recovering` — Register is catching up with missed dockets
+- `stalled` — Recovery has stopped due to errors
+
+**Top-level `status`** reflects the aggregate: `synced` if all registers are synced, `stalled` if any are stalled, otherwise `recovering`.
+
+**Staleness detection:** A register in `recovering` status is flagged as `isStale: true` if no progress has been made in the last 10 seconds.
 
 ---
 

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -1435,7 +1435,7 @@ POST /api/registers/{registerId}/disable-dev-mode
 
 Enables or disables dev mode on a register. When enabled, payloads are stored as plaintext with disclosure filtering at read time. When disabled, new payloads use envelope encryption.
 
-> **Note:** For production registers, prefer the one-way `POST /{registerId}/disable-dev-mode` endpoint above.
+> **Security Warning:** This endpoint allows re-enabling dev mode, bypassing the one-way constraint. It is intended for development and testing only. For production registers, use the irreversible `POST /{registerId}/disable-dev-mode` endpoint above. Consider restricting this endpoint via API Gateway routing rules in production deployments.
 
 ```http
 PUT /api/registers/{registerId}/devmode
@@ -1469,7 +1469,7 @@ Returns the current recovery/sync status for all local registers. Used for healt
 GET /health/sync
 ```
 
-**Authorization:** None (health endpoint).
+**Authorization:** None (health endpoint). This endpoint exposes register IDs and sync state but no payload data. In production, restrict access via API Gateway routing rules to prevent external enumeration of private register IDs.
 
 **Response:** `200 OK`
 ```json

--- a/src/Common/Sorcha.ServiceClients.Http/Auth/ServiceAuthClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Auth/ServiceAuthClient.cs
@@ -96,7 +96,7 @@ public class ServiceAuthClient : IServiceAuthClient, IDisposable
                 "Service token refresh triggered for {ClientId} with scopes [{Scopes}]",
                 _clientId, _scopes);
 
-            var formData = new FormUrlEncodedContent(new Dictionary<string, string>
+            using var formData = new FormUrlEncodedContent(new Dictionary<string, string>
             {
                 ["grant_type"] = "client_credentials",
                 ["client_id"] = _clientId,

--- a/src/Common/Sorcha.ServiceClients.Http/Auth/TokenIntrospectionClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Auth/TokenIntrospectionClient.cs
@@ -44,7 +44,7 @@ public class TokenIntrospectionClient : ITokenIntrospectionClient
                 return null;
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/token/introspect")
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/api/auth/token/introspect")
             {
                 Content = new FormUrlEncodedContent(new Dictionary<string, string>
                 {

--- a/src/Common/Sorcha.ServiceClients.Http/SystemWallet/SystemWalletSigningService.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/SystemWallet/SystemWalletSigningService.cs
@@ -94,15 +94,17 @@ public class SystemWalletSigningService : ISystemWalletSigningService
 
     private async Task<string> EnsureWalletAsync(CancellationToken ct)
     {
-        if (_walletAddress is not null)
-            return _walletAddress;
+        var cached = Volatile.Read(ref _walletAddress);
+        if (cached is not null)
+            return cached;
 
         await _walletLock.WaitAsync(ct);
         try
         {
             // Double-check after acquiring lock
-            if (_walletAddress is not null)
-                return _walletAddress;
+            cached = Volatile.Read(ref _walletAddress);
+            if (cached is not null)
+                return cached;
 
             using var scope = _scopeFactory.CreateScope();
             var walletClient = scope.ServiceProvider.GetRequiredService<IWalletServiceClient>();

--- a/src/Services/Sorcha.Tenant.Service/Services/AcsEmailSender.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/AcsEmailSender.cs
@@ -45,7 +45,7 @@ public class AcsEmailSender : IEmailSender
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send email to {Recipient}: {Subject}", to, subject);
+            _logger.LogError(ex, "Failed to send email: {Subject}", subject);
             throw;
         }
     }

--- a/tests/Sorcha.Register.Core.Tests/Integration/GovernanceIntegrationTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Integration/GovernanceIntegrationTests.cs
@@ -52,7 +52,6 @@ public class GovernanceIntegrationTests
         {
             RegisterId = RegisterId,
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations = members.Select(m => MakeAttestation(m.did, m.role)).ToList()
         };

--- a/tests/Sorcha.Register.Core.Tests/Integration/RosterDeterminismTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Integration/RosterDeterminismTests.cs
@@ -26,7 +26,6 @@ public class RosterDeterminismTests
         {
             RegisterId = RegisterId,
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
             Attestations = members.Select(m => new RegisterAttestation
             {

--- a/tests/Sorcha.Register.Core.Tests/Managers/QueryManagerTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Managers/QueryManagerTests.cs
@@ -26,7 +26,6 @@ public class QueryManagerTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Name = "Test Register",
-            TenantId = "tenant123",
             Height = 0,
             Status = RegisterStatus.Offline
         };
@@ -566,7 +565,6 @@ public class QueryManagerTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Name = "Second Register",
-            TenantId = "tenant123",
             Height = 0,
             Status = RegisterStatus.Offline
         };
@@ -605,7 +603,6 @@ public class QueryManagerTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Name = "Second Register",
-            TenantId = "tenant123",
             Height = 0,
             Status = RegisterStatus.Offline
         };

--- a/tests/Sorcha.Register.Core.Tests/Managers/RegisterManagerTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Managers/RegisterManagerTests.cs
@@ -28,17 +28,15 @@ public class RegisterManagerTests
     {
         // Arrange
         var name = "Test Register";
-        var tenantId = "tenant123";
 
         // Act
-        var result = await _manager.CreateRegisterAsync(name, tenantId);
+        var result = await _manager.CreateRegisterAsync(name);
 
         // Assert
         result.Should().NotBeNull();
         result.Id.Should().NotBeNullOrWhiteSpace();
         result.Id.Length.Should().Be(32); // GUID without hyphens
         result.Name.Should().Be(name);
-        result.TenantId.Should().Be(tenantId);
         result.Height.Should().Be(0);
         result.Status.Should().Be(RegisterStatus.Offline);
         result.Advertise.Should().BeFalse();
@@ -51,10 +49,9 @@ public class RegisterManagerTests
     {
         // Arrange
         var name = "Test Register";
-        var tenantId = "tenant123";
 
         // Act
-        var result = await _manager.CreateRegisterAsync(name, tenantId);
+        var result = await _manager.CreateRegisterAsync(name);
 
         // Assert
         var events = _eventPublisher.GetPublishedEvents<RegisterCreatedEvent>();
@@ -63,7 +60,6 @@ public class RegisterManagerTests
         var evt = events.First();
         evt.RegisterId.Should().Be(result.Id);
         evt.Name.Should().Be(name);
-        evt.TenantId.Should().Be(tenantId);
     }
 
     [Theory]
@@ -73,7 +69,7 @@ public class RegisterManagerTests
     {
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(
-            async () => await _manager.CreateRegisterAsync(invalidName, "tenant123"));
+            async () => await _manager.CreateRegisterAsync(invalidName));
     }
 
     [Fact]
@@ -81,7 +77,7 @@ public class RegisterManagerTests
     {
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(
-            async () => await _manager.CreateRegisterAsync(null!, "tenant123"));
+            async () => await _manager.CreateRegisterAsync(null!));
     }
 
     [Fact]
@@ -92,7 +88,7 @@ public class RegisterManagerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            async () => await _manager.CreateRegisterAsync(tooLongName, "tenant123"));
+            async () => await _manager.CreateRegisterAsync(tooLongName));
 
         exception.Message.Should().Contain("between 1 and 38 characters");
     }
@@ -101,7 +97,7 @@ public class RegisterManagerTests
     public async Task CreateRegisterAsync_WithAdvertiseTrue_ShouldSetAdvertise()
     {
         // Act
-        var result = await _manager.CreateRegisterAsync("Test", "tenant123", advertise: true);
+        var result = await _manager.CreateRegisterAsync("Test", advertise: true);
 
         // Assert
         result.Advertise.Should().BeTrue();
@@ -111,7 +107,7 @@ public class RegisterManagerTests
     public async Task CreateRegisterAsync_WithPartialReplica_ShouldSetIsFullReplicaFalse()
     {
         // Act
-        var result = await _manager.CreateRegisterAsync("Test", "tenant123", isFullReplica: false);
+        var result = await _manager.CreateRegisterAsync("Test", isFullReplica: false);
 
         // Assert
         result.IsFullReplica.Should().BeFalse();
@@ -121,7 +117,7 @@ public class RegisterManagerTests
     public async Task GetRegisterAsync_WithExistingId_ShouldReturnRegister()
     {
         // Arrange
-        var created = await _manager.CreateRegisterAsync("Test", "tenant123");
+        var created = await _manager.CreateRegisterAsync("Test");
 
         // Act
         var result = await _manager.GetRegisterAsync(created.Id);
@@ -146,9 +142,9 @@ public class RegisterManagerTests
     public async Task GetAllRegistersAsync_ShouldReturnAllRegisters()
     {
         // Arrange
-        await _manager.CreateRegisterAsync("Register 1", "tenant123");
-        await _manager.CreateRegisterAsync("Register 2", "tenant456");
-        await _manager.CreateRegisterAsync("Register 3", "tenant123");
+        await _manager.CreateRegisterAsync("Register 1");
+        await _manager.CreateRegisterAsync("Register 2");
+        await _manager.CreateRegisterAsync("Register 3");
 
         // Act
         var result = await _manager.GetAllRegistersAsync();
@@ -158,26 +154,10 @@ public class RegisterManagerTests
     }
 
     [Fact]
-    public async Task GetRegistersByTenantAsync_ShouldReturnOnlyTenantRegisters()
-    {
-        // Arrange
-        await _manager.CreateRegisterAsync("Tenant1 Register 1", "tenant123");
-        await _manager.CreateRegisterAsync("Tenant2 Register", "tenant456");
-        await _manager.CreateRegisterAsync("Tenant1 Register 2", "tenant123");
-
-        // Act
-        var result = await _manager.GetRegistersByTenantAsync("tenant123");
-
-        // Assert
-        result.Should().HaveCount(2);
-        result.Should().OnlyContain(r => r.TenantId == "tenant123");
-    }
-
-    [Fact]
     public async Task UpdateRegisterAsync_ShouldUpdateRegister()
     {
         // Arrange
-        var register = await _manager.CreateRegisterAsync("Original Name", "tenant123");
+        var register = await _manager.CreateRegisterAsync("Original Name");
         register.Name = "Updated Name";
         register.Status = RegisterStatus.Online;
         register.Advertise = true;
@@ -197,7 +177,7 @@ public class RegisterManagerTests
     public async Task UpdateRegisterAsync_ShouldPersistChanges()
     {
         // Arrange
-        var register = await _manager.CreateRegisterAsync("Original", "tenant123");
+        var register = await _manager.CreateRegisterAsync("Original");
         register.Name = "Updated";
 
         // Act
@@ -209,62 +189,10 @@ public class RegisterManagerTests
     }
 
     [Fact]
-    public async Task DeleteRegisterAsync_WithValidTenant_ShouldDeleteRegister()
-    {
-        // Arrange
-        var register = await _manager.CreateRegisterAsync("Test", "tenant123");
-
-        // Act
-        await _manager.DeleteRegisterAsync(register.Id, "tenant123");
-
-        // Assert
-        var retrieved = await _manager.GetRegisterAsync(register.Id);
-        retrieved.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task DeleteRegisterAsync_ShouldPublishRegisterDeletedEvent()
-    {
-        // Arrange
-        var register = await _manager.CreateRegisterAsync("Test", "tenant123");
-        _eventPublisher.Clear();
-
-        // Act
-        await _manager.DeleteRegisterAsync(register.Id, "tenant123");
-
-        // Assert
-        var events = _eventPublisher.GetPublishedEvents<RegisterDeletedEvent>();
-        events.Should().HaveCount(1);
-
-        var evt = events.First();
-        evt.RegisterId.Should().Be(register.Id);
-        evt.TenantId.Should().Be("tenant123");
-    }
-
-    [Fact]
-    public async Task DeleteRegisterAsync_WithWrongTenant_ShouldThrowUnauthorizedAccessException()
-    {
-        // Arrange
-        var register = await _manager.CreateRegisterAsync("Test", "tenant123");
-
-        // Act & Assert
-        await Assert.ThrowsAsync<UnauthorizedAccessException>(
-            async () => await _manager.DeleteRegisterAsync(register.Id, "wrongTenant"));
-    }
-
-    [Fact]
-    public async Task DeleteRegisterAsync_WithNonExistentId_ShouldThrowInvalidOperationException()
-    {
-        // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await _manager.DeleteRegisterAsync("nonexistent", "tenant123"));
-    }
-
-    [Fact]
     public async Task ExistsAsync_WithExistingRegister_ShouldReturnTrue()
     {
         // Arrange
-        var register = await _manager.CreateRegisterAsync("Test", "tenant123");
+        var register = await _manager.CreateRegisterAsync("Test");
 
         // Act
         var result = await _manager.RegisterExistsAsync(register.Id);
@@ -287,9 +215,9 @@ public class RegisterManagerTests
     public async Task GetRegisterCountAsync_ShouldReturnCorrectCount()
     {
         // Arrange
-        await _manager.CreateRegisterAsync("Register 1", "tenant123");
-        await _manager.CreateRegisterAsync("Register 2", "tenant456");
-        await _manager.CreateRegisterAsync("Register 3", "tenant123");
+        await _manager.CreateRegisterAsync("Register 1");
+        await _manager.CreateRegisterAsync("Register 2");
+        await _manager.CreateRegisterAsync("Register 3");
 
         // Act
         var result = await _manager.GetRegisterCountAsync();
@@ -312,9 +240,9 @@ public class RegisterManagerTests
     public async Task CreateRegisterAsync_ShouldGenerateUniqueIds()
     {
         // Arrange & Act
-        var register1 = await _manager.CreateRegisterAsync("Register 1", "tenant123");
-        var register2 = await _manager.CreateRegisterAsync("Register 2", "tenant123");
-        var register3 = await _manager.CreateRegisterAsync("Register 3", "tenant123");
+        var register1 = await _manager.CreateRegisterAsync("Register 1");
+        var register2 = await _manager.CreateRegisterAsync("Register 2");
+        var register3 = await _manager.CreateRegisterAsync("Register 3");
 
         // Assert
         var ids = new[] { register1.Id, register2.Id, register3.Id };
@@ -337,7 +265,7 @@ public class RegisterManagerTests
     public async Task CreateRegisterAsync_ShouldDefaultToOfflineStatus(RegisterStatus expectedStatus)
     {
         // Act
-        var register = await _manager.CreateRegisterAsync("Test", "tenant123");
+        var register = await _manager.CreateRegisterAsync("Test");
 
         // Assert
         register.Status.Should().Be(RegisterStatus.Offline);

--- a/tests/Sorcha.Register.Core.Tests/Managers/RegisterManagerTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Managers/RegisterManagerTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Sorcha.Register.Core.Events;
 using Sorcha.Register.Core.Managers;
+using Sorcha.Register.Models;
 using Sorcha.Register.Models.Enums;
 using Sorcha.Register.Storage.InMemory;
 using Xunit;
@@ -269,5 +270,69 @@ public class RegisterManagerTests
 
         // Assert
         register.Status.Should().Be(RegisterStatus.Offline);
+    }
+
+    [Fact]
+    public async Task DeleteRegisterAsync_WithAuthorizedOwner_ShouldDeleteRegister()
+    {
+        // Arrange
+        var register = await _manager.CreateRegisterAsync("Test");
+        var attestations = new List<RegisterAttestation>
+        {
+            new() { Role = RegisterRole.Owner, Subject = "ws11qowner123" }
+        };
+
+        // Act
+        await _manager.DeleteRegisterAsync(register.Id, "ws11qowner123", attestations);
+
+        // Assert
+        var result = await _manager.GetRegisterAsync(register.Id);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteRegisterAsync_ShouldPublishRegisterDeletedEvent()
+    {
+        // Arrange
+        var register = await _manager.CreateRegisterAsync("Test");
+        var attestations = new List<RegisterAttestation>
+        {
+            new() { Role = RegisterRole.Owner, Subject = "ws11qowner123" }
+        };
+
+        // Act
+        await _manager.DeleteRegisterAsync(register.Id, "ws11qowner123", attestations);
+
+        // Assert
+        _eventPublisher.GetPublishedEvents().Should().Contain(e => e.Topic == "register:deleted");
+    }
+
+    [Fact]
+    public async Task DeleteRegisterAsync_WithUnauthorizedCaller_ShouldThrowUnauthorizedAccessException()
+    {
+        // Arrange
+        var register = await _manager.CreateRegisterAsync("Test");
+        var attestations = new List<RegisterAttestation>
+        {
+            new() { Role = RegisterRole.Owner, Subject = "ws11qowner123" }
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            async () => await _manager.DeleteRegisterAsync(register.Id, "ws11qunauthorized", attestations));
+    }
+
+    [Fact]
+    public async Task DeleteRegisterAsync_WithNonExistentId_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var attestations = new List<RegisterAttestation>
+        {
+            new() { Role = RegisterRole.Owner, Subject = "ws11qowner123" }
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _manager.DeleteRegisterAsync("nonexistent", "ws11qowner123", attestations));
     }
 }

--- a/tests/Sorcha.Register.Core.Tests/Managers/TransactionManagerTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Managers/TransactionManagerTests.cs
@@ -29,7 +29,6 @@ public class TransactionManagerTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Name = "Test Register",
-            TenantId = "tenant123",
             Height = 0,
             Status = RegisterStatus.Offline
         };

--- a/tests/Sorcha.Register.Core.Tests/Models/RegisterTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Models/RegisterTests.cs
@@ -25,7 +25,6 @@ public class RegisterTests
         register.Status.Should().Be(RegisterStatus.Offline);
         register.Advertise.Should().BeFalse();
         register.IsFullReplica.Should().BeTrue();
-        register.TenantId.Should().BeEmpty();
         register.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
         register.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
         register.Votes.Should().BeNull();
@@ -37,7 +36,6 @@ public class RegisterTests
         // Arrange
         var id = Guid.NewGuid().ToString("N");
         var name = "TestRegister";
-        var tenantId = "tenant-123";
         var createdAt = DateTime.UtcNow.AddHours(-1);
 
         // Act
@@ -49,7 +47,6 @@ public class RegisterTests
             Status = RegisterStatus.Online,
             Advertise = true,
             IsFullReplica = false,
-            TenantId = tenantId,
             CreatedAt = createdAt,
             UpdatedAt = DateTime.UtcNow,
             Votes = "some-votes"
@@ -62,7 +59,6 @@ public class RegisterTests
         register.Status.Should().Be(RegisterStatus.Online);
         register.Advertise.Should().BeTrue();
         register.IsFullReplica.Should().BeFalse();
-        register.TenantId.Should().Be(tenantId);
         register.CreatedAt.Should().Be(createdAt);
         register.Votes.Should().Be("some-votes");
     }
@@ -76,8 +72,7 @@ public class RegisterTests
         var register = new RegisterModel
         {
             Id = invalidId!,
-            Name = "TestRegister",
-            TenantId = "tenant-123"
+            Name = "TestRegister"
         };
 
         // Act
@@ -94,8 +89,7 @@ public class RegisterTests
         var register = new RegisterModel
         {
             Id = "tooshort",
-            Name = "TestRegister",
-            TenantId = "tenant-123"
+            Name = "TestRegister"
         };
 
         // Act
@@ -114,8 +108,7 @@ public class RegisterTests
         var register = new RegisterModel
         {
             Id = Guid.NewGuid().ToString("N"),
-            Name = invalidName!,
-            TenantId = "tenant-123"
+            Name = invalidName!
         };
 
         // Act
@@ -132,8 +125,7 @@ public class RegisterTests
         var register = new RegisterModel
         {
             Id = Guid.NewGuid().ToString("N"),
-            Name = new string('a', 39), // Max is 38
-            TenantId = "tenant-123"
+            Name = new string('a', 39) // Max is 38
         };
 
         // Act
@@ -141,26 +133,6 @@ public class RegisterTests
 
         // Assert
         validationResults.Should().ContainSingle(v => v.MemberNames.Contains("Name"));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData(null)]
-    public void Register_WithInvalidTenantId_ShouldFailValidation(string? invalidTenantId)
-    {
-        // Arrange
-        var register = new RegisterModel
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Name = "TestRegister",
-            TenantId = invalidTenantId!
-        };
-
-        // Act
-        var validationResults = ValidateModel(register);
-
-        // Assert
-        validationResults.Should().ContainSingle(v => v.MemberNames.Contains("TenantId"));
     }
 
     [Theory]
@@ -175,7 +147,6 @@ public class RegisterTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Name = "TestRegister",
-            TenantId = "tenant-123",
             Status = status
         };
 
@@ -193,8 +164,7 @@ public class RegisterTests
         var register = new RegisterModel
         {
             Id = Guid.NewGuid().ToString("N"),
-            Name = "TestRegister",
-            TenantId = "tenant-123"
+            Name = "TestRegister"
         };
 
         // Act
@@ -220,7 +190,6 @@ public class RegisterTests
             Status = RegisterStatus.Online,
             Advertise = true,
             IsFullReplica = true,
-            TenantId = "prod-tenant-001",
             CreatedAt = DateTime.UtcNow.AddDays(-30),
             UpdatedAt = DateTime.UtcNow,
             Votes = "{\"vote1\": true}"

--- a/tests/Sorcha.Register.Core.Tests/Services/AcceptanceFlowTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/AcceptanceFlowTests.cs
@@ -167,7 +167,6 @@ public class AcceptanceFlowTests
         result.RegisterId.Should().Be(roster.ControlRecord.RegisterId);
         result.Name.Should().Be(roster.ControlRecord.Name);
         result.CreatedAt.Should().Be(roster.ControlRecord.CreatedAt);
-        result.CreatedAt.Should().Be(roster.ControlRecord.CreatedAt);
     }
 
     // --- Sequential Add Operations ---

--- a/tests/Sorcha.Register.Core.Tests/Services/AcceptanceFlowTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/AcceptanceFlowTests.cs
@@ -32,7 +32,6 @@ public class AcceptanceFlowTests
             {
                 RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
                 Name = "Test Register",
-                TenantId = "tenant-1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {
@@ -167,7 +166,7 @@ public class AcceptanceFlowTests
 
         result.RegisterId.Should().Be(roster.ControlRecord.RegisterId);
         result.Name.Should().Be(roster.ControlRecord.Name);
-        result.TenantId.Should().Be(roster.ControlRecord.TenantId);
+        result.CreatedAt.Should().Be(roster.ControlRecord.CreatedAt);
         result.CreatedAt.Should().Be(roster.ControlRecord.CreatedAt);
     }
 

--- a/tests/Sorcha.Register.Core.Tests/Services/DIDResolverTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/DIDResolverTests.cs
@@ -95,7 +95,6 @@ public class DIDResolverTests
             {
                 RegisterId = registerId,
                 Name = "Test",
-                TenantId = "t1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations =
                 [

--- a/tests/Sorcha.Register.Core.Tests/Services/GovernanceProposalTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/GovernanceProposalTests.cs
@@ -31,7 +31,6 @@ public class GovernanceProposalTests
             {
                 RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
                 Name = "Test Register",
-                TenantId = "tenant-1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {

--- a/tests/Sorcha.Register.Core.Tests/Services/GovernanceQuorumFormulaTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/GovernanceQuorumFormulaTests.cs
@@ -208,7 +208,6 @@ public class GovernanceQuorumFormulaTests
         {
             RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
             Name = "Test Register",
-            TenantId = "tenant-001",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations = attestations
         };

--- a/tests/Sorcha.Register.Core.Tests/Services/GovernanceRosterServiceTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/GovernanceRosterServiceTests.cs
@@ -262,7 +262,6 @@ public class GovernanceRosterServiceTests
         {
             RegisterId = TestRegisterId,
             Name = "Test Register",
-            TenantId = "tenant-1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations = members.Select(m => new RegisterAttestation
             {

--- a/tests/Sorcha.Register.Core.Tests/Services/MixedDIDRosterTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/MixedDIDRosterTests.cs
@@ -65,7 +65,6 @@ public class MixedDIDRosterTests
             {
                 RegisterId = registerId,
                 Name = "Test",
-                TenantId = "t1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations =
                 [
@@ -126,7 +125,6 @@ public class MixedDIDRosterTests
             {
                 RegisterId = registerId,
                 Name = "Test",
-                TenantId = "t1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations =
                 [
@@ -182,7 +180,6 @@ public class MixedDIDRosterTests
             {
                 RegisterId = registerId,
                 Name = "Test",
-                TenantId = "t1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations =
                 [

--- a/tests/Sorcha.Register.Core.Tests/Services/QuorumCollectionTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/QuorumCollectionTests.cs
@@ -33,7 +33,6 @@ public class QuorumCollectionTests
             {
                 RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
                 Name = "Test Register",
-                TenantId = "tenant-1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {
@@ -79,7 +78,6 @@ public class QuorumCollectionTests
         {
             RegisterId = "test",
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations =
             [
@@ -109,7 +107,6 @@ public class QuorumCollectionTests
         {
             RegisterId = "test",
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations =
             [
@@ -148,7 +145,6 @@ public class QuorumCollectionTests
         {
             RegisterId = "test",
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations =
             [
@@ -196,7 +192,6 @@ public class QuorumCollectionTests
         {
             RegisterId = "test",
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations =
             [
@@ -246,7 +241,6 @@ public class QuorumCollectionTests
         {
             RegisterId = "test",
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations =
             [
@@ -317,7 +311,6 @@ public class QuorumCollectionTests
         {
             RegisterId = "test",
             Name = "Test",
-            TenantId = "t1",
             CreatedAt = DateTimeOffset.UtcNow,
             Attestations = attestations
         };

--- a/tests/Sorcha.Register.Core.Tests/Services/RemovalQuorumTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/RemovalQuorumTests.cs
@@ -32,7 +32,6 @@ public class RemovalQuorumTests
             {
                 RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
                 Name = "Test Register",
-                TenantId = "tenant-1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {

--- a/tests/Sorcha.Register.Core.Tests/Services/RemovalValidationTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/RemovalValidationTests.cs
@@ -32,7 +32,6 @@ public class RemovalValidationTests
             {
                 RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
                 Name = "Test Register",
-                TenantId = "tenant-1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {

--- a/tests/Sorcha.Register.Core.Tests/Services/TransferOwnershipTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/TransferOwnershipTests.cs
@@ -32,7 +32,6 @@ public class TransferOwnershipTests
             {
                 RegisterId = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
                 Name = "Test Register",
-                TenantId = "tenant-1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {

--- a/tests/Sorcha.Register.Core.Tests/Sorcha.Register.Core.Tests.csproj
+++ b/tests/Sorcha.Register.Core.Tests/Sorcha.Register.Core.Tests.csproj
@@ -27,6 +27,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Sorcha.Register.Core\Sorcha.Register.Core.csproj" />
     <ProjectReference Include="..\..\src\Core\Sorcha.Register.Storage.InMemory\Sorcha.Register.Storage.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.ServiceClients\Sorcha.ServiceClients.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- **CodeQL HIGH (19 log injection)**: Confirmed already resolved in master — no changes needed
- **CodeQL MEDIUM (2 info exposure)**: Fixed AcsEmailSender — removed recipient email from error log path
- **CodeQL WARNING (2 resource leaks)**: Added `using` to `HttpRequestMessage` in TokenIntrospectionClient and `FormUrlEncodedContent` in ServiceAuthClient
- **CodeQL WARNING (1 dead code)**: Fixed double-check-locking in SystemWalletSigningService with `Volatile.Read`
- **PeerRouter JS bug**: Confirmed already resolved in master
- **Issue #175 — Register.Core.Tests**: Removed stale `TenantId` references across 17 test files (68 compilation errors → 0)
- **Issue #175 — API docs**: Added disable-dev-mode, toggle-dev-mode, and sync-status endpoints to API-DOCUMENTATION.md
- **MASTER-TASKS.md**: Added SEC-012 as completed

## Test plan
- [x] Full solution build: 0 errors, 24 pre-existing warnings
- [ ] CI pipeline passes (build + tests)
- [ ] CodeQL alerts reduced after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)