### PR TITLE
chore: package Sorcha.Agent as dotnet global tool via NuGet

### DIFF
--- a/.github/workflows/agent-publish.yml
+++ b/.github/workflows/agent-publish.yml
@@ -1,0 +1,69 @@
+name: Agent Publish — Pack & Push .NET Global Tool
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/Apps/Sorcha.Agent/**'
+
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Force publish Agent tool'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Bump patch version
+        id: version
+        run: |
+          CSPROJ="src/Apps/Sorcha.Agent/Sorcha.Agent.csproj"
+          CURRENT=$(grep -oP '<Version>\K[^<]+' "$CSPROJ")
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEW_PATCH=$((PATCH + 1))
+          NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+
+          sed -i "s|<Version>$CURRENT</Version>|<Version>$NEW_VERSION</Version>|" "$CSPROJ"
+          sed -i "s|<AssemblyVersion>[^<]*</AssemblyVersion>|<AssemblyVersion>$MAJOR.$MINOR.$NEW_PATCH.0</AssemblyVersion>|" "$CSPROJ"
+          sed -i "s|<FileVersion>[^<]*</FileVersion>|<FileVersion>$MAJOR.$MINOR.$NEW_PATCH.0</FileVersion>|" "$CSPROJ"
+
+          echo "old_version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped Sorcha.Agent from $CURRENT to $NEW_VERSION"
+
+      - name: Restore and Build
+        run: |
+          dotnet restore
+          dotnet build src/Apps/Sorcha.Agent/ --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack src/Apps/Sorcha.Agent/ --configuration Release --no-build -o ./nupkg
+
+      - name: Publish to NuGet.org
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "src/Apps/Sorcha.Agent/Sorcha.Agent.csproj"
+          git commit -m "chore: bump Sorcha.Agent to ${{ steps.version.outputs.new_version }}" || true
+          git push || true

--- a/src/Apps/Sorcha.Agent/README.md
+++ b/src/Apps/Sorcha.Agent/README.md
@@ -1,0 +1,188 @@
+# Sorcha Agent - Autonomous Actor for Decentralised Workflows
+
+**Version:** 1.0.0
+**Status:** Production Ready
+
+The Sorcha Agent is a cross-platform CLI tool that runs as an autonomous actor in [Sorcha](https://github.com/sorcha-platform/sorcha) decentralised register workflows. It listens for pending actions, makes decisions using pluggable engines (rules or AI), and submits responses — enabling fully automated multi-participant workflow execution.
+
+## Installation
+
+```bash
+# Install as a global tool
+dotnet tool install --global Sorcha.Agent
+
+# Verify installation
+sorcha-agent --version
+```
+
+## Quick Start
+
+### 1. Create an Actor Definition
+
+Actor definitions are JSON files that configure identity, inbox discovery, and decision-making:
+
+```json
+{
+  "actor": {
+    "name": "approver",
+    "description": "Automated approval agent"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "your-register-id",
+    "credentials": {
+      "email": "$env:AGENT_EMAIL",
+      "password": "$env:AGENT_PASSWORD",
+      "organizationId": "your-org-id"
+    },
+    "walletAddress": "your-wallet-address"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 30 }
+  },
+  "mode": "rules",
+  "rules": [
+    {
+      "actionName": "Review Request",
+      "condition": { "==": [true, true] },
+      "decision": "approve",
+      "payload": {
+        "approved": true,
+        "notes": "Auto-approved by agent"
+      }
+    }
+  ]
+}
+```
+
+### 2. Validate Configuration
+
+```bash
+sorcha-agent validate --config actor.json
+```
+
+This checks JSON structure, variable resolution, authentication, and SignalR connectivity.
+
+### 3. Run the Agent
+
+```bash
+sorcha-agent run --config actor.json
+```
+
+The agent will authenticate, connect to the inbox, and begin processing actions autonomously.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `sorcha-agent run --config <path>` | Start the autonomous actor loop |
+| `sorcha-agent validate --config <path>` | Pre-flight configuration checks |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--config` | Path to actor definition JSON (required) |
+| `--state` | Path to state.json for placeholder resolution |
+| `--verbose` | Enable debug-level logging |
+| `--quiet` | Errors only |
+
+## Decision Engines
+
+### Rules Engine (JSON Logic)
+
+Deterministic rule evaluation using [JSON Logic](https://jsonlogic.com/) syntax. Rules are evaluated top-to-bottom; first match wins.
+
+```json
+{
+  "mode": "rules",
+  "rules": [
+    {
+      "actionName": "Cost Approval",
+      "condition": { ">": [{ "var": "payload.cost" }, 500000] },
+      "decision": "reject",
+      "payload": { "reason": "Exceeds budget threshold" }
+    },
+    {
+      "actionName": "Cost Approval",
+      "condition": { "==": [true, true] },
+      "decision": "approve",
+      "payload": { "approved": true }
+    }
+  ]
+}
+```
+
+### AI Engine (Claude)
+
+LLM-powered decisions using a persona prompt and action context:
+
+```json
+{
+  "mode": "ai",
+  "ai": {
+    "provider": "anthropic",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.3,
+    "personaFile": "./persona.md",
+    "apiKeyEnvVar": "ANTHROPIC_API_KEY"
+  }
+}
+```
+
+## Variable Resolution
+
+- **`$env:VAR_NAME`** — Resolved from environment variables (recommended for secrets)
+- **`{{placeholder}}`** — Resolved from a `state.json` file (useful for dynamic IDs from setup scripts)
+
+## Pre-Actions
+
+Hooks that execute before payload submission, e.g. file uploads:
+
+```json
+{
+  "preActions": [
+    {
+      "type": "file-upload",
+      "config": {
+        "fieldName": "document",
+        "filePath": "./report.pdf",
+        "fileName": "report.pdf",
+        "contentType": "application/pdf"
+      }
+    }
+  ]
+}
+```
+
+## Features
+
+- **Dual Inbox Discovery** — Real-time SignalR + configurable HTTP polling with automatic deduplication
+- **Pluggable Decision Engines** — Rules (JSON Logic) or AI (Claude) with schema validation
+- **File Upload Pre-Actions** — Chunked encrypted file submission (up to 40MB)
+- **Resilient Execution** — Polly retry/circuit-breaker, SignalR auto-reconnect, JWT auto-refresh
+- **Audit Logging** — JSONL append-only trail of all decisions and submissions
+- **Cross-Platform** — Runs on Windows, macOS, and Linux
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Authentication error |
+| 4 | Validation error |
+| 6 | Configuration error |
+| 7 | Network error |
+| 8 | Service error |
+
+## Requirements
+
+- .NET 10 runtime
+- Access to a running Sorcha platform instance
+- Valid user credentials with wallet access
+
+## License
+
+[MIT](https://github.com/sorcha-platform/sorcha/blob/master/LICENSE)

--- a/src/Apps/Sorcha.Agent/Sorcha.Agent.csproj
+++ b/src/Apps/Sorcha.Agent/Sorcha.Agent.csproj
@@ -4,12 +4,29 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>sorcha-agent</AssemblyName>
     <RootNamespace>Sorcha.Agent</RootNamespace>
+
+    <!-- Global Tool Configuration -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>sorcha-agent</ToolCommandName>
+    <PackageId>Sorcha.Agent</PackageId>
+
+    <!-- Stable version for development -->
     <Version>1.0.0</Version>
-    <Description>Autonomous actor agent for Sorcha walkthrough execution</Description>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+
+    <Description>Autonomous actor agent for executing Sorcha decentralised register workflows</Description>
+    <PackageTags>sorcha;agent;automation;workflow;actor;decentralised</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Sorcha.Agent.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Package README -->
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Adds NuGet global tool packaging metadata to `Sorcha.Agent.csproj` (PackAsTool, ToolCommandName, PackageId, versioning)
- Creates consumer-facing `README.md` for the nuget.org listing page
- Adds `agent-publish.yml` CI workflow mirroring the existing `cli-publish.yml` pattern (auto patch bump + pack + push on master merge)

After merge, install with:
```bash
dotnet tool install --global Sorcha.Agent
sorcha-agent run --config actor.json
```

## Test plan

- [x] `dotnet build` passes in Release mode
- [x] `dotnet pack` produces `Sorcha.Agent.1.0.0.nupkg` successfully
- [ ] CI workflow triggers on merge and publishes to nuget.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)