### PR TITLE
docs: refresh CLAUDE.md project counts and structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ docker-compose up -d
 
 # Access points:
 # - API Gateway:      http://localhost:80
-# - Main UI:          http://localhost/app
-# - Aspire Dashboard: http://localhost:18888
+# - Main UI (direct): http://localhost:5400
+# - Main UI (gated):  http://localhost/app
+# - Aspire Dashboard: http://localhost:19888
 
 # CLI tool (after build):
 # dotnet run --project src/Apps/Sorcha.Cli -- --help
@@ -69,12 +70,15 @@ dotnet restore && dotnet build && dotnet test
 | Service | Status | Port (Docker/Aspire) | Purpose |
 |---------|--------|---------------------|---------|
 | Blueprint | 100% | 5000 / 7000 | Workflow management, SignalR |
-| Register | 100% | 5290 / 7290 | Distributed ledger, OData |
+| Register | 100% | 5380 / 7290 | Distributed ledger, OData |
 | Wallet | 98% | internal / 7001 | Crypto operations, HD wallets |
-| Tenant | 98% | 5110 / 7110 | Multi-tenant auth, JWT issuer, Participant Identity, Platform Identity, Register Invitations |
-| Validator | 95% | internal / 7004 | Consensus, chain integrity |
-| Peer | 70% | 5002 / 7002 | P2P network, gRPC |
+| Tenant | 98% | 5450 / 7110 | Multi-tenant auth, JWT issuer, Participant Identity, Platform Identity, Register Invitations |
+| Validator | 95% | 5800 / 7004 | Consensus, chain integrity |
+| Peer | 70% | 50051 / 7002 | P2P network, gRPC |
+| UI Web | 100% | 5400 / — | Blazor WASM host (Sorcha.UI.Web) |
 | API Gateway | 95% | 80 / 7082 | YARP reverse proxy |
+
+Docker exposes additional ports: Redis `16379`, Postgres `5432`, MongoDB `27017`, Aspire dashboard `19888`, OTLP gRPC `4317`, OTLP HTTP `4318`. All port values honour env-var overrides (see `docker-compose.yml`).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ dotnet restore && dotnet build && dotnet test
 | Databases | PostgreSQL / MongoDB / Redis | Relational, document, cache |
 | Auth | JWT Bearer | Service-to-service and user authentication |
 | Crypto | NBitcoin + Sorcha.Cryptography | HD wallets (BIP32/39/44), ED25519, P-256, RSA-4096 |
-| Testing | xUnit + FluentAssertions + Moq | 1,200+ tests across 30 projects |
+| Testing | xUnit + FluentAssertions + Moq | 8,500+ tests across 47 test projects |
 
 ---
 
@@ -404,7 +404,7 @@ await personaService.SetAutofillEnabledAsync(false);
 
 ```
 src/
-├── Apps/
+├── Apps/                            # 8 application projects
 │   ├── Sorcha.AppHost/              # .NET Aspire orchestrator
 │   ├── Sorcha.Admin/                # Blazor WASM admin UI (host)
 │   │   └── Sorcha.Admin.Client/     # Admin UI client components
@@ -412,10 +412,12 @@ src/
 │   ├── Sorcha.Cli/                  # Administrative CLI tool
 │   ├── Sorcha.Demo/                 # Demo application
 │   ├── Sorcha.McpServer/            # MCP Server for AI assistants (Claude Desktop, etc.)
+│   ├── Sorcha.PeerRouter/           # Standalone P2P relay router (not in docker-compose/Aspire)
 │   └── Sorcha.UI/                   # Main UI application
 │       ├── Sorcha.UI.Core/          # Shared UI components
 │       ├── Sorcha.UI.Web/           # Web host
-│       └── Sorcha.UI.Web.Client/    # Web client (Blazor WASM)
+│       ├── Sorcha.UI.Web.Client/    # Web client (Blazor WASM)
+│       └── tests/                   # UI-specific test projects (Core.Tests, Integration.Tests)
 ├── Common/
 │   ├── Sorcha.Blueprint.Models/     # Domain models with JSON-LD
 │   ├── Sorcha.Cryptography/         # Multi-algorithm crypto (ED25519, P-256, RSA)
@@ -438,11 +440,15 @@ src/
 │   ├── Sorcha.Blueprint.Engine/     # Portable execution (WASM-compatible)
 │   ├── Sorcha.Blueprint.Fluent/     # Fluent API for blueprint construction
 │   ├── Sorcha.Blueprint.Schemas/    # Schema management with caching
+│   ├── Sorcha.Blueprint.Schemas.Client/ # Client-side schema resolution
 │   ├── Sorcha.Register.Core/        # Ledger business logic
-│   └── Sorcha.Register.Storage.*/   # Register-specific storage (3 projects)
+│   └── Sorcha.Register.Storage.*/   # Register-specific storage (4 projects)
 │       ├── Sorcha.Register.Storage/ # Storage abstractions
 │       ├── InMemory/                # In-memory implementation
-│       └── MongoDB/                 # MongoDB implementation
+│       ├── MongoDB/                 # MongoDB implementation
+│       └── Redis/                   # Redis implementation
+├── Providers/                       # Pluggable provider implementations
+│   └── Sorcha.Wallet.Providers.Azure/ # Azure Key Vault seed protection provider
 └── Services/                        # 7 microservices
     ├── Sorcha.ApiGateway/           # YARP reverse proxy
     ├── Sorcha.Blueprint.Service/    # Workflow management
@@ -452,14 +458,15 @@ src/
     ├── Sorcha.Validator.Service/    # Blockchain validation
     └── Sorcha.Wallet.Service/       # Crypto wallet management
 
-tests/                               # 30 test projects
+tests/                               # 47 test projects
 ├── *.Tests/                         # Unit tests per component
 ├── *.IntegrationTests/              # Integration tests
-├── *.PerformanceTests/              # Performance/load tests
+├── *.Benchmarks/                    # BenchmarkDotNet performance projects
+├── Sorcha.Performance.Tests/        # Load/throughput tests
 └── Sorcha.UI.E2E.Tests/             # End-to-end Playwright tests
 ```
 
-**Project Count:** 42 source projects, 31 test projects
+**Project Count:** 42 source projects, 47 test projects (~8,500 test methods)
 
 ---
 
@@ -761,7 +768,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 ---
 
-**Version:** 2.6 | **Updated:** 2026-03-16 | Built with .NET 10 and .NET Aspire
+**Version:** 2.7 | **Updated:** 2026-04-08 | Built with .NET 10 and .NET Aspire
 
 
 ## Skill Usage Guide


### PR DESCRIPTION
- Update tech stack: 1,200+ tests across 30 projects -> 8,500+ across 47
- Add Sorcha.PeerRouter app (standalone P2P relay, not in compose/Aspire)
- Add src/Providers/ folder with Sorcha.Wallet.Providers.Azure
- Add Sorcha.Blueprint.Schemas.Client and Sorcha.Register.Storage.Redis
- Note UI-local tests under src/Apps/Sorcha.UI/tests/
- Update test project count 31 -> 47, note ~8,500 test methods
- Replace stale *.PerformanceTests entry with Benchmarks + Performance.Tests
- Bump version 2.6 -> 2.7

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
