### PR TITLE
fix: walkthroughs auto-subscribe Public Org and repair SelfBuildHouse setup

### DIFF
--- a/walkthroughs/ConstructionPermit/setup.ps1
+++ b/walkthroughs/ConstructionPermit/setup.ps1
@@ -324,6 +324,7 @@ $meridianSession = $sessionCache["$($secrets.contractorEmail)|$($orgs.meridian)"
 $register = New-SorchaRegister `
     -RegisterUrl $env.RegisterUrl `
     -WalletUrl $env.WalletUrl `
+    -TenantUrl $env.TenantUrl `
     -Name "Construction Permit Register" `
     -Description "Multi-org construction permit approval register" `
     -TenantId $orgs.meridian `

--- a/walkthroughs/SelfBuildHouse/run-agents.ps1
+++ b/walkthroughs/SelfBuildHouse/run-agents.ps1
@@ -54,7 +54,7 @@ $headers = @{ Authorization = "Bearer $($state.adminToken)" }
 
 # Planning instance
 Write-Host "  Creating planning permission instance..."
-$planningInstance = Invoke-SorchaApi -Method POST -Url "$blueprintUrl/instances/" `
+$planningInstance = Invoke-SorchaApi -Method POST -Uri "$blueprintUrl/instances/" `
     -Headers $headers -Body @{
         blueprintId  = $state.planningBlueprintId
         registerId   = $state.planningRegisterId
@@ -65,7 +65,7 @@ Write-Host "  Planning instance: $($planningInstance.id)" -ForegroundColor Cyan
 
 # Building warrant instance
 Write-Host "  Creating building warrant instance..."
-$warrantInstance = Invoke-SorchaApi -Method POST -Url "$blueprintUrl/instances/" `
+$warrantInstance = Invoke-SorchaApi -Method POST -Uri "$blueprintUrl/instances/" `
     -Headers $headers -Body @{
         blueprintId  = $state.warrantBlueprintId
         registerId   = $state.buildingRegisterId
@@ -79,10 +79,20 @@ Write-Host "  Warrant instance: $($warrantInstance.id)" -ForegroundColor Cyan
 [Environment]::SetEnvironmentVariable("ADMIN_PASSWORD", $secrets.adminPassword)
 
 # --- Launch Agents ---
-$agentProject = Join-Path $walkthroughDir ".." ".." "src" "Apps" "Sorcha.Agent" "Sorcha.Agent.csproj"
-if (-not (Test-Path $agentProject)) {
-    Write-Error "Cannot find Sorcha.Agent project."
-    exit 1
+# Prefer the installed `sorcha-agent` global tool (single binary, no per-agent
+# build race). Fall back to `dotnet run --project` only if the tool is missing.
+$agentCommand = (Get-Command sorcha-agent -ErrorAction SilentlyContinue)
+if ($agentCommand) {
+    $useGlobalTool = $true
+    Write-Host "  Using installed sorcha-agent ($($agentCommand.Source))" -ForegroundColor DarkGray
+} else {
+    $useGlobalTool = $false
+    $agentProject = Join-Path $walkthroughDir ".." ".." "src" "Apps" "Sorcha.Agent" "Sorcha.Agent.csproj"
+    if (-not (Test-Path $agentProject)) {
+        Write-Error "sorcha-agent is not installed and Sorcha.Agent.csproj was not found. Install with: dotnet tool install --global Sorcha.Agent"
+        exit 1
+    }
+    Write-Warning "sorcha-agent global tool not found — falling back to 'dotnet run' (slower, parallel build races possible). Install with: dotnet tool install --global Sorcha.Agent"
 }
 
 $actorFiles = @(
@@ -109,10 +119,17 @@ foreach ($file in $actorFiles) {
     }
 
     $logFile = Join-Path $logsDir "$($file -replace '\.json$', '.log')"
-    $args = @("run", "--project", (Resolve-Path $agentProject).Path, "--", "run", "--config", $configPath, "--state", $StatePath)
+
+    if ($useGlobalTool) {
+        $exe = "sorcha-agent"
+        $args = @("run", "--config", $configPath, "--state", $StatePath)
+    } else {
+        $exe = "dotnet"
+        $args = @("run", "--project", (Resolve-Path $agentProject).Path, "--", "run", "--config", $configPath, "--state", $StatePath)
+    }
 
     Write-Host "  Starting $file..."
-    $proc = Start-Process -FilePath "dotnet" -ArgumentList $args `
+    $proc = Start-Process -FilePath $exe -ArgumentList $args `
         -RedirectStandardOutput $logFile -RedirectStandardError "$logFile.err" `
         -PassThru -NoNewWindow
 

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -65,7 +65,7 @@ Write-WtStep "Step 4: Create Registers (2)"
 
 Write-WtInfo "  Creating Highland Planning Register..."
 $planningRegister = New-SorchaRegister `
-    -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl `
+    -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl -TenantUrl $env.TenantUrl `
     -Name "Highland Planning Register" `
     -Description "Planning applications, consultations, and decisions for the Highland Council area" `
     -TenantId $admin.OrganizationId `
@@ -77,7 +77,7 @@ Write-WtSuccess "  Planning Register: $($planningRegister.RegisterId)"
 
 Write-WtInfo "  Creating Highland Building Standards Register..."
 $buildingRegister = New-SorchaRegister `
-    -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl `
+    -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl -TenantUrl $env.TenantUrl `
     -Name "Highland Building Standards Register" `
     -Description "Building warrants, staged inspections, and completion certificates for the Highland Council area" `
     -TenantId $admin.OrganizationId `
@@ -98,7 +98,7 @@ $planningBlueprint = Publish-SorchaBlueprint `
     -WalletMap $wallets `
     -Headers $admin.Headers `
     -IdPrefix "self-build-planning" `
-    -RegisterId $register.RegisterId
+    -RegisterId $planningRegister.RegisterId
 Write-WtSuccess "  Planning Blueprint: $($planningBlueprint.BlueprintId)"
 
 Write-WtInfo "  Publishing Building Warrant blueprint..."
@@ -108,7 +108,7 @@ $warrantBlueprint = Publish-SorchaBlueprint `
     -WalletMap $wallets `
     -Headers $admin.Headers `
     -IdPrefix "self-build-warrant" `
-    -RegisterId $register.RegisterId
+    -RegisterId $buildingRegister.RegisterId
 Write-WtSuccess "  Warrant Blueprint: $($warrantBlueprint.BlueprintId)"
 
 # Save state

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -122,9 +122,12 @@ $secrets = [ordered]@{
         receiverName   = "Receiver"
     }
     "self-build-house" = @{
-        adminEmail    = $platformEmail
-        adminPassword = $platformPassword
-        adminName     = $platformName
+        adminEmail             = $platformEmail
+        adminPassword          = $platformPassword
+        adminName              = $platformName
+        # First-org admin alias (Highland Construction is the bootstrap org, doubles as platform admin)
+        highlandAdminEmail     = $platformEmail
+        highlandAdminPassword  = $platformPassword
     }
     "trade-finance" = @{
         adminEmail    = $platformEmail

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -313,6 +313,11 @@ function Initialize-SorchaEnvironment {
     Write-WtInfo "  Register:  $($env.RegisterUrl)"
     Write-WtInfo "  Wallet:    $($env.WalletUrl)"
 
+    # Cache at module scope so downstream helpers (e.g. New-SorchaRegister's
+    # auto public-org subscription) can find TenantUrl without requiring every
+    # caller to pass it explicitly.
+    $script:LastEnvironment = $env
+
     return $env
 }
 
@@ -956,7 +961,13 @@ function New-SorchaRegister {
         [Parameter(Mandatory)][string]$OwnerUserId,
         [Parameter(Mandatory)][string]$OwnerWalletAddress,
         [Parameter(Mandatory)][hashtable]$Headers,
-        [hashtable]$Metadata = @{}
+        [hashtable]$Metadata = @{},
+        # Optional: tenant URL used to auto-subscribe the Sorcha Public Org
+        # (well-known ID 00000000-0000-0000-0000-000000000002). When provided,
+        # the Public Org is subscribed as "Public" immediately after finalize
+        # so consumer-persona and public-discovery flows have access by default.
+        [string]$TenantUrl,
+        [switch]$SkipPublicOrgSubscription
     )
 
     # Phase 1: Initiate
@@ -1033,6 +1044,32 @@ function New-SorchaRegister {
         -Headers $Headers
 
     Write-WtSuccess "Register '$Name' created: $registerId"
+
+    # Auto-subscribe Sorcha Public Org (well-known ID) so consumer-persona
+    # and public-discovery flows can access the register by default.
+    # TenantUrl resolution order: explicit parameter → cached environment.
+    if (-not $SkipPublicOrgSubscription) {
+        $resolvedTenantUrl = if ($TenantUrl) { $TenantUrl } `
+                             elseif ($script:LastEnvironment) { $script:LastEnvironment.TenantUrl } `
+                             else { $null }
+
+        if ($resolvedTenantUrl) {
+            $publicOrgId = "00000000-0000-0000-0000-000000000002"
+            try {
+                $null = New-SorchaRegisterSubscription `
+                    -TenantUrl $resolvedTenantUrl `
+                    -OrganizationId $publicOrgId `
+                    -RegisterId $registerId `
+                    -RegisterName $Name `
+                    -SubscriptionType "Public" `
+                    -Headers $Headers
+            } catch {
+                Write-WtWarn "  Public org auto-subscribe failed for register '$Name': $($_.Exception.Message)"
+            }
+        } else {
+            Write-WtWarn "  Skipping public org subscription for '$Name' — no TenantUrl available (pass -TenantUrl or call Initialize-SorchaEnvironment first)"
+        }
+    }
 
     return @{
         RegisterId           = $registerId


### PR DESCRIPTION
Wires the Sorcha Public Org (well-known ID 00000000-0000-0000-0000-000000000002)
into every register created via the New-SorchaRegister helper. Consumer
persona and public discovery flows now have default access to any register
a walkthrough creates.

Module changes (walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1)
 - Initialize-SorchaEnvironment caches the resolved URLs in $script:LastEnvironment
   so downstream helpers can look up TenantUrl without every caller passing it.
 - New-SorchaRegister accepts optional -TenantUrl and -SkipPublicOrgSubscription.
   After finalize, it subscribes the Public Org as "Public" using (in order):
   explicit -TenantUrl, then the cached environment, then a warning if neither
   is available. Subscription failures are logged as warnings so the walkthrough
   is not blocked by public-discovery infrastructure issues.

ConstructionPermit & SelfBuildHouse setup scripts
 - Pass -TenantUrl $env.TenantUrl explicitly at each New-SorchaRegister call
   so intent is visible at the call site even though the module would fall
   back to the cached environment.

SelfBuildHouse bug fixes uncovered while validating the new path
 - setup.ps1 line 101/111: $register.RegisterId was undefined. Fixed to use
   $planningRegister.RegisterId and $buildingRegister.RegisterId respectively.
   This call was broken since the feature 089 actor migration.
 - initialize-secrets.ps1: self-build-house section was missing highlandAdminEmail
   and highlandAdminPassword that setup.ps1 requires.
 - run-agents.ps1: two -Url arguments to Invoke-SorchaApi fixed to -Uri
   (matches module signature); launcher now prefers the installed sorcha-agent
   global tool when available (avoids parallel dotnet run build races) and
   falls back to dotnet run --project with a clear install hint.

Validation
 - ConstructionPermit: verified inline — a test register created via
   New-SorchaRegister shows status=Active subscription_type=Public on the
   Public Org.
 - ConstructionPermit scenarios A/B/C all still pass end-to-end (104s).
 - SelfBuildHouse run.ps1 Planning phase passes; cross-register Warrant phase
   still fails because run.ps1 does not collect and present the issued
   PlanningPermissionCredential. The actor-based run-agents.ps1 is the
   canonical path for that walkthrough — left as a separate follow-up.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
