### PR TITLE
feat: walkthroughs — FormCoverage + Public org subscription + n1 fixes

### DIFF
--- a/walkthroughs/ConstructionPermit/setup.ps1
+++ b/walkthroughs/ConstructionPermit/setup.ps1
@@ -359,6 +359,16 @@ foreach ($orgKey in @("apex", "riverside", "greenvalley")) {
         -Headers $orgSession.Headers
 }
 
+# Public org subscription so consumer users (default to Public org) see
+# the register in their list. The helper ensures the sysadmin is an
+# Administrator of the Public org first.
+$null = Add-SorchaPublicOrgSubscription `
+    -TenantUrl $env.TenantUrl `
+    -RegisterId $register.RegisterId `
+    -RegisterName "Construction Permit Register" `
+    -SysAdminHeaders $sysAdmin.Headers `
+    -SysAdminEmail $secrets.meridianAdminEmail
+
 # ============================================================================
 # Step 9: Publish Participant Records to Register
 # ============================================================================

--- a/walkthroughs/DistributedRegister/run.ps1
+++ b/walkthroughs/DistributedRegister/run.ps1
@@ -37,6 +37,18 @@ try {
         -TenantId $state.organizationId -OwnerUserId $state.adminUserId `
         -OwnerWalletAddress $state.walletAddress -Headers $headers
     Write-WtSuccess "Register created locally: $($register.RegisterId)"
+
+    # Public org subscription (local node) so consumer users see the register.
+    if ($state.tenantUrl) {
+        $null = Add-SorchaPublicOrgSubscription `
+            -TenantUrl $state.tenantUrl `
+            -RegisterId $register.RegisterId `
+            -RegisterName "Distributed Test Register" `
+            -SysAdminHeaders $headers
+    } else {
+        Write-WtWarn "state.tenantUrl not set — re-run setup.ps1 to enable Public org subscription"
+    }
+
     $stepsPassed++
 } catch {
     Write-WtFail "Local register creation failed: $($_.Exception.Message)"

--- a/walkthroughs/DistributedRegister/setup.ps1
+++ b/walkthroughs/DistributedRegister/setup.ps1
@@ -37,6 +37,7 @@ $state = @{
     adminUserId    = $admin.AdminUserId
     adminToken     = $admin.Token
     walletAddress  = $wallet.Address
+    tenantUrl      = $env.TenantUrl
     registerUrl    = $env.RegisterUrl
     walletUrl      = $env.WalletUrl
     blueprintUrl   = $env.BlueprintUrl

--- a/walkthroughs/FormCoverage/form-coverage-template.json
+++ b/walkthroughs/FormCoverage/form-coverage-template.json
@@ -1,0 +1,319 @@
+{
+  "id": "form-coverage-v1",
+  "title": "Form Renderer Coverage Demo",
+  "description": "Single-action blueprint that exercises every ControlTypes value (Layout, Label, TextLine, TextArea, Numeric, DateTime, File, Choice, Checkbox, Selection), all three layout modes (flat + x-sections + x-pages wizard), x-width hints, x-rule conditional visibility, x-introduction page intros, and the x-persona autofill extension from Feature 092.",
+  "version": 1,
+  "category": "demo",
+  "tags": ["demo", "forms", "controls", "coverage", "x-pages", "x-sections", "x-rule", "x-persona"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "id": "form-coverage-generated",
+    "title": "Form Renderer Coverage Demo",
+    "description": "A single form that uses at least one of every form control type and form layout extension the renderer supports. Used to eyeball-test the SorchaFormRenderer and as a smoke test for new control changes.",
+    "version": 1,
+    "metadata": {
+      "category": "Demo",
+      "complexity": "Complex",
+      "actions": "1",
+      "features": "x-pages, x-sections, x-rule, x-introduction, x-width, x-persona, file-reference",
+      "sector": "Demo"
+    },
+    "instanceReference": {
+      "prefix": "FC",
+      "components": [
+        { "field": "/givenName", "transform": "FirstWord", "chars": 3 },
+        { "field": "/familyName", "transform": "FirstWord", "chars": 3 }
+      ]
+    },
+    "participants": [
+      {
+        "id": "submitter",
+        "name": "Submitter",
+        "organisation": "Form Coverage Demo",
+        "description": "Fills the coverage form"
+      },
+      {
+        "id": "reviewer",
+        "name": "Reviewer",
+        "organisation": "Form Coverage Demo",
+        "description": "Receives and acknowledges the submission"
+      }
+    ],
+    "actions": [
+      {
+        "id": 1,
+        "title": "Submit Coverage Form",
+        "description": "Complete every category of field so the renderer exercises every control type.",
+        "sender": "submitter",
+        "isStartingAction": true,
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "This form exists to exercise every control type supported by the SorchaFormRenderer. There is no business logic behind it — please fill it in however you like. The final page has a deliberate conditional field that only appears when you tick the box above it.",
+            "x-pages": [
+              {
+                "title": "Identity",
+                "description": "Text inputs, date/time pickers, and persona autofill",
+                "x-sections": [
+                  {
+                    "title": "Your Name",
+                    "description": "Given + family name. When Feature 092 persona autofill is enabled and you have saved these attributes, these fields prefill with a cream tint and `self` provenance tick.",
+                    "layout": "horizontal",
+                    "fields": ["givenName", "familyName"]
+                  },
+                  {
+                    "title": "Contact",
+                    "description": "Single-line text for the email (persona-aware) plus a multi-line note.",
+                    "layout": "vertical",
+                    "fields": ["email", "biography"]
+                  },
+                  {
+                    "title": "Key Dates",
+                    "description": "Date-of-birth picks up persona; appointment picker is a free choice.",
+                    "layout": "horizontal",
+                    "fields": ["dateOfBirth", "appointmentAt"]
+                  }
+                ]
+              },
+              {
+                "title": "Numbers & Choices",
+                "description": "Numeric field, radio choice, dropdown selection, read-only label.",
+                "x-sections": [
+                  {
+                    "title": "Preferences",
+                    "description": "Radio group (Choice) for the rating, dropdown (Selection) for the severity.",
+                    "layout": "vertical",
+                    "fields": ["satisfactionRating", "ticketSeverity", "favouriteNumber"]
+                  },
+                  {
+                    "title": "Guidance",
+                    "description": "Read-only Label control demonstrating static form text.",
+                    "layout": "vertical",
+                    "fields": ["helpNotice"]
+                  }
+                ]
+              },
+              {
+                "title": "Attachments & Consent",
+                "description": "File upload, conditional-visibility textarea, submission checkbox.",
+                "x-sections": [
+                  {
+                    "title": "Supporting Evidence",
+                    "description": "Optional file attachment (≤ 40 MB, any type).",
+                    "layout": "vertical",
+                    "fields": ["evidenceFile"]
+                  },
+                  {
+                    "title": "Follow-Up",
+                    "description": "Tick the box to reveal the follow-up note field (exercises x-rule SHOW).",
+                    "layout": "vertical",
+                    "fields": ["wantsFollowUp", "followUpNotes"]
+                  },
+                  {
+                    "title": "Confirmation",
+                    "description": "Final submission acknowledgement.",
+                    "layout": "vertical",
+                    "fields": ["confirmAccurate"]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "givenName": {
+                "type": "string",
+                "title": "Given Name",
+                "description": "Your first name.",
+                "minLength": 1,
+                "maxLength": 100,
+                "x-width": "half",
+                "x-persona": "givenName"
+              },
+              "familyName": {
+                "type": "string",
+                "title": "Family Name",
+                "description": "Your surname.",
+                "minLength": 1,
+                "maxLength": 100,
+                "x-width": "half",
+                "x-persona": "familyName"
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "title": "Email Address",
+                "description": "Persona autofill will populate this with your default email.",
+                "x-persona": "defaultEmail",
+                "x-width": "full"
+              },
+              "biography": {
+                "type": "string",
+                "title": "Short Biography",
+                "description": "A few sentences about yourself. Any length over 500 characters is forced into the TextArea renderer by the auto-generator — we override that explicitly below too so the renderer always gets the TextArea control for this field.",
+                "maxLength": 4000
+              },
+              "dateOfBirth": {
+                "type": "string",
+                "format": "date",
+                "title": "Date of Birth",
+                "description": "Date picker.",
+                "x-width": "half",
+                "x-persona": "dateOfBirth"
+              },
+              "appointmentAt": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Appointment Timestamp",
+                "description": "Date-and-time picker demonstrating the date-time format.",
+                "x-width": "half"
+              },
+              "favouriteNumber": {
+                "type": "integer",
+                "title": "Favourite Number",
+                "description": "Any integer between 0 and 1000.",
+                "minimum": 0,
+                "maximum": 1000,
+                "x-width": "third"
+              },
+              "satisfactionRating": {
+                "type": "string",
+                "title": "How satisfied are you with this form?",
+                "description": "Radio-button Choice control — pick exactly one.",
+                "enum": ["Very satisfied", "Satisfied", "Neutral", "Dissatisfied", "Very dissatisfied"]
+              },
+              "ticketSeverity": {
+                "type": "string",
+                "title": "Severity",
+                "description": "Dropdown Selection control.",
+                "enum": ["Low", "Medium", "High", "Critical"],
+                "x-width": "half"
+              },
+              "helpNotice": {
+                "type": "string",
+                "title": "Reminder",
+                "description": "Rendered as a read-only Label. No input is collected for this field.",
+                "readOnly": true,
+                "default": "Your submission is encrypted end-to-end and only the reviewer can decrypt it."
+              },
+              "evidenceFile": {
+                "type": "string",
+                "format": "file-reference",
+                "title": "Evidence (optional)",
+                "description": "Attach any supporting document.",
+                "x-file": {
+                  "accept": ["*/*"],
+                  "maxSizePerFile": "40MB",
+                  "maxChunks": 10
+                }
+              },
+              "wantsFollowUp": {
+                "type": "boolean",
+                "title": "I would like a follow-up conversation about this submission",
+                "description": "Checkbox control. Ticking this reveals the follow-up notes field below."
+              },
+              "followUpNotes": {
+                "type": "string",
+                "title": "Follow-up notes",
+                "description": "Only visible when the box above is ticked — demonstrates x-rule SHOW.",
+                "maxLength": 2000,
+                "x-rule": {
+                  "effect": "SHOW",
+                  "condition": {
+                    "scope": "/wantsFollowUp",
+                    "schema": { "const": true }
+                  }
+                }
+              },
+              "confirmAccurate": {
+                "type": "boolean",
+                "title": "I confirm the information on this form is accurate",
+                "description": "Required submission acknowledgement."
+              }
+            },
+            "required": [
+              "givenName",
+              "familyName",
+              "email",
+              "satisfactionRating",
+              "ticketSeverity",
+              "confirmAccurate"
+            ]
+          }
+        ],
+        "form": {
+          "type": "Layout",
+          "layout": "VerticalLayout",
+          "elements": [
+            { "type": "TextLine",  "title": "Given Name",        "scope": "/givenName" },
+            { "type": "TextLine",  "title": "Family Name",       "scope": "/familyName" },
+            { "type": "TextLine",  "title": "Email Address",     "scope": "/email" },
+            { "type": "TextArea",  "title": "Short Biography",   "scope": "/biography" },
+            { "type": "DateTime",  "title": "Date of Birth",     "scope": "/dateOfBirth" },
+            { "type": "DateTime",  "title": "Appointment",       "scope": "/appointmentAt" },
+            { "type": "Numeric",   "title": "Favourite Number",  "scope": "/favouriteNumber" },
+            { "type": "Choice",    "title": "Satisfaction",      "scope": "/satisfactionRating" },
+            { "type": "Selection", "title": "Severity",          "scope": "/ticketSeverity" },
+            { "type": "Label",     "title": "Reminder",          "scope": "/helpNotice" },
+            { "type": "File",      "title": "Evidence",          "scope": "/evidenceFile" },
+            { "type": "Checkbox",  "title": "Wants Follow-Up",   "scope": "/wantsFollowUp" },
+            {
+              "type": "TextArea",
+              "title": "Follow-up notes",
+              "scope": "/followUpNotes",
+              "rule": {
+                "effect": "SHOW",
+                "condition": {
+                  "scope": "/wantsFollowUp",
+                  "schema": { "const": true }
+                }
+              }
+            },
+            { "type": "Checkbox",  "title": "Confirm Accurate",  "scope": "/confirmAccurate" }
+          ]
+        },
+        "disclosures": [
+          { "participantAddress": "submitter", "dataPointers": ["/*"] },
+          { "participantAddress": "reviewer",  "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "to-review",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Forward the submission to the reviewer"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Acknowledge Submission",
+        "description": "Reviewer confirms receipt of the coverage form.",
+        "sender": "reviewer",
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "acknowledged": {
+                "type": "boolean",
+                "title": "I have reviewed the submission",
+                "description": "Tick to confirm you've seen the coverage form."
+              },
+              "reviewerNote": {
+                "type": "string",
+                "title": "Reviewer note",
+                "description": "Optional short note back to the submitter.",
+                "maxLength": 1000
+              }
+            },
+            "required": ["acknowledged"]
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "reviewer",  "dataPointers": ["/*"] },
+          { "participantAddress": "submitter", "dataPointers": ["/*"] }
+        ],
+        "routes": []
+      }
+    ]
+  }
+}

--- a/walkthroughs/FormCoverage/run.ps1
+++ b/walkthroughs/FormCoverage/run.ps1
@@ -122,6 +122,29 @@ for ($i = 1; $i -le $Rounds; $i++) {
         continue
     }
 
+    # --- Wait for action 2 to become current (async transaction pipeline) ---
+    $maxWait = 60
+    $waited = 0
+    $ready = $false
+    while ($waited -lt $maxWait) {
+        try {
+            $inst = Invoke-SorchaApi -Method GET `
+                -Uri "$($state.blueprintUrl)/instances/$instanceId" `
+                -Headers @{ Authorization = "Bearer $submitterToken" }
+            if ($inst.currentActionIds -contains 2) {
+                $ready = $true
+                break
+            }
+        } catch {}
+        Start-Sleep -Seconds 1
+        $waited++
+    }
+    if (-not $ready) {
+        Write-WtFail "  Timeout waiting for action 2 to become current (waited ${maxWait}s)"
+        continue
+    }
+    Write-WtInfo "  Action 2 ready (waited ${waited}s)"
+
     # --- Step 3: Reviewer acknowledges (action 2) ---
     $payload2 = @{
         acknowledged = $true

--- a/walkthroughs/FormCoverage/run.ps1
+++ b/walkthroughs/FormCoverage/run.ps1
@@ -1,0 +1,177 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# FormCoverage — Run
+# Drives the FormCoverage blueprint for N rounds. Each round creates a fresh
+# instance, submits the coverage form as the submitter, then submits the
+# acknowledgement as the reviewer. Intended as a smoke loop for the
+# SorchaFormRenderer + action pipeline.
+
+param(
+    [int]$Rounds = 5,
+    [switch]$ShowJson
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "FormCoverage — Run ($Rounds round$(if($Rounds -ne 1){'s'}))"
+
+$stateFile = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "state.json"
+if (-not (Test-Path $stateFile)) {
+    Write-WtFail "No state.json found. Run setup.ps1 first."
+    exit 1
+}
+$state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+
+# ============================================================================
+# Authenticate both users once and reuse their tokens across all rounds.
+# ============================================================================
+Write-WtStep "Authenticating submitter + reviewer"
+
+$submitterAuth = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.submitter.email `
+    -Password $state.submitter.password `
+    -OrganizationId $state.submitter.organizationId
+
+$reviewerAuth = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.reviewer.email `
+    -Password $state.reviewer.password `
+    -OrganizationId $state.reviewer.organizationId
+
+$submitterToken = $submitterAuth.Token
+$reviewerToken  = $reviewerAuth.Token
+$submitterWallet = $state.submitter.walletAddress
+$reviewerWallet  = $state.reviewer.walletAddress
+
+Write-WtInfo "Submitter wallet: $submitterWallet"
+Write-WtInfo "Reviewer wallet:  $reviewerWallet"
+
+# ============================================================================
+# Round loop
+# ============================================================================
+$roundsPassed = 0
+$totalStart = Get-Date
+$roundTimings = @()
+
+for ($i = 1; $i -le $Rounds; $i++) {
+    Write-WtStep "Round $i / $Rounds"
+    $roundStart = Get-Date
+
+    # --- Step 1: Create instance ---
+    try {
+        $instanceBody = @{
+            blueprintId = $state.blueprintId
+            registerId  = $state.registerId
+            tenantId    = $state.submitter.organizationId
+            metadata    = @{ source = "FormCoverage/run.ps1"; round = $i }
+        }
+        $instance = Invoke-SorchaApi -Method POST `
+            -Uri "$($state.blueprintUrl)/instances/" `
+            -Body $instanceBody `
+            -Headers @{ Authorization = "Bearer $submitterToken" } `
+            -ShowJson:$ShowJson
+        $instanceId = $instance.id
+        Write-WtInfo "  Instance: $instanceId"
+    } catch {
+        Write-WtFail "Instance creation failed: $($_.Exception.Message)"
+        continue
+    }
+
+    # --- Step 2: Submit the coverage form (action 1) ---
+    $wantsFollowUp = ($i % 2 -eq 0)  # alternate — tests the x-rule SHOW path
+    $payload1 = @{
+        givenName          = "Ada"
+        familyName         = "Lovelace"
+        email              = "ada.lovelace.round$i@example.com"
+        biography          = "Round $i run of the form coverage walkthrough. This biography is long enough that the auto-generator would pick TextArea, but the form explicitly forces TextArea anyway. Filled programmatically by FormCoverage/run.ps1."
+        dateOfBirth        = "1815-12-10"
+        appointmentAt      = (Get-Date).AddDays($i).ToString("o")
+        favouriteNumber    = 42 + $i
+        satisfactionRating = "Satisfied"
+        ticketSeverity     = "Medium"
+        wantsFollowUp      = $wantsFollowUp
+        confirmAccurate    = $true
+    }
+    if ($wantsFollowUp) {
+        $payload1.followUpNotes = "Follow-up requested on round $i — see the auto-generated appointment."
+    }
+
+    try {
+        $null = Invoke-SorchaAction `
+            -BlueprintUrl $state.blueprintUrl `
+            -InstanceId $instanceId `
+            -ActionId "1" `
+            -BlueprintId $state.blueprintId `
+            -SenderWallet $submitterWallet `
+            -RegisterId $state.registerId `
+            -Token $submitterToken `
+            -PayloadData $payload1
+        Write-WtInfo "  Submit action ok"
+    } catch {
+        Write-WtFail "  Submit failed: $($_.Exception.Message)"
+        try {
+            $errBody = Get-SorchaErrorBody -ErrorRecord $_
+            if ($errBody) { Write-WtWarn "  Detail: $errBody" }
+        } catch {}
+        continue
+    }
+
+    # --- Step 3: Reviewer acknowledges (action 2) ---
+    $payload2 = @{
+        acknowledged = $true
+        reviewerNote = "Round $i acknowledged."
+    }
+    try {
+        $null = Invoke-SorchaAction `
+            -BlueprintUrl $state.blueprintUrl `
+            -InstanceId $instanceId `
+            -ActionId "2" `
+            -BlueprintId $state.blueprintId `
+            -SenderWallet $reviewerWallet `
+            -RegisterId $state.registerId `
+            -Token $reviewerToken `
+            -PayloadData $payload2
+        Write-WtInfo "  Acknowledge action ok"
+    } catch {
+        Write-WtFail "  Acknowledge failed: $($_.Exception.Message)"
+        try {
+            $errBody = Get-SorchaErrorBody -ErrorRecord $_
+            if ($errBody) { Write-WtWarn "  Detail: $errBody" }
+        } catch {}
+        continue
+    }
+
+    $roundDuration = (Get-Date) - $roundStart
+    $roundTimings += $roundDuration.TotalSeconds
+    Write-WtSuccess "Round $i OK ($([math]::Round($roundDuration.TotalSeconds, 2))s)"
+    $roundsPassed++
+}
+
+# ============================================================================
+# Summary
+# ============================================================================
+$totalDuration = (Get-Date) - $totalStart
+
+Write-WtBanner "FormCoverage Run Summary"
+Write-WtInfo "Rounds passed : $roundsPassed / $Rounds"
+Write-WtInfo "Total duration: $([math]::Round($totalDuration.TotalSeconds, 2))s"
+if ($roundTimings.Count -gt 0) {
+    $avg = ($roundTimings | Measure-Object -Average).Average
+    $min = ($roundTimings | Measure-Object -Minimum).Minimum
+    $max = ($roundTimings | Measure-Object -Maximum).Maximum
+    Write-WtInfo "Avg per round : $([math]::Round($avg, 2))s  (min $([math]::Round($min, 2))s / max $([math]::Round($max, 2))s)"
+}
+
+if ($roundsPassed -eq $Rounds) {
+    Write-WtSuccess "All rounds passed"
+    exit 0
+} else {
+    Write-WtFail "$($Rounds - $roundsPassed) round(s) failed"
+    exit 1
+}

--- a/walkthroughs/FormCoverage/setup.ps1
+++ b/walkthroughs/FormCoverage/setup.ps1
@@ -1,0 +1,326 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# FormCoverage — Demo Setup
+# Single-org walkthrough built to eyeball-test the SorchaFormRenderer. The
+# blueprint exercises every ControlTypes value (Layout, Label, TextLine,
+# TextArea, Numeric, DateTime, File, Choice, Checkbox, Selection), all three
+# layout modes (x-pages wizard + x-sections + flat form), x-width hints,
+# x-rule conditional visibility, x-introduction, and the x-persona extension
+# from Feature 092.
+
+param(
+    [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
+    [string]$Profile = 'gateway',
+    [switch]$SkipHealthCheck,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "FormCoverage — Demo Setup"
+
+$secrets = Get-SorchaSecrets -WalkthroughName "form-coverage"
+$env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+
+# Pre-flight: validate existing state unless -Force.
+if ((Test-Path $stateFile) -and -not $Force) {
+    Write-WtStep "Validating existing state.json"
+    $existingState = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+    $stateValid = $true
+
+    try {
+        $testLogin = Invoke-SorchaApi -Method POST `
+            -Uri "$($existingState.tenantUrl)/auth/login" `
+            -Body @{ email = $existingState.submitter.email; password = $existingState.submitter.password }
+        if (-not $testLogin.requires_org_selection -and -not $testLogin.access_token) {
+            $stateValid = $false
+        }
+    } catch {
+        $stateValid = $false
+    }
+
+    if ($stateValid) {
+        Write-WtSuccess "Existing state is valid — skipping setup (use -Force to recreate)"
+        Write-WtInfo "Visit: $($env.GatewayUrl)/app/new-submissions"
+        exit 0
+    }
+    Write-WtWarn "State invalid — running full setup"
+}
+
+# ============================================================================
+# Step 1: System Admin Login
+# ============================================================================
+Write-WtStep "Step 1: System Admin Login"
+$sysAdmin = Connect-SorchaAdmin `
+    -TenantUrl $env.TenantUrl `
+    -OrgName "Form Coverage System" `
+    -OrgSubdomain "form-coverage-sys" `
+    -AdminEmail $secrets.adminEmail `
+    -AdminName $secrets.adminName `
+    -AdminPassword $secrets.adminPassword
+
+# ============================================================================
+# Step 1.5: Enable Public Org (required for self-registration)
+# ============================================================================
+Write-WtStep "Step 1.5: Enable Public Org for User Registration"
+try {
+    Invoke-SorchaApi -Method PUT `
+        -Uri "$($env.TenantUrl)/platform/settings/public-org" `
+        -Body @{ enabled = $true } `
+        -Headers $sysAdmin.Headers | Out-Null
+    Write-WtInfo "  Public org enabled for self-registration"
+} catch {
+    Write-WtInfo "  Public org may already be enabled (continuing)"
+}
+
+# ============================================================================
+# Step 2: Register Submitter and Reviewer Users on Public Org
+# ============================================================================
+Write-WtStep "Step 2: Register Submitter and Reviewer Users"
+
+foreach ($user in @(
+    @{ Email = $secrets.submitterEmail; Name = $secrets.submitterName; Password = $secrets.submitterPassword },
+    @{ Email = $secrets.reviewerEmail;  Name = $secrets.reviewerName;  Password = $secrets.reviewerPassword }
+)) {
+    try {
+        Register-SorchaPublicUser `
+            -TenantUrl $env.TenantUrl `
+            -Email $user.Email `
+            -DisplayName $user.Name `
+            -Password $user.Password
+        Write-WtInfo "Registered: $($user.Email)"
+    } catch {
+        if ($_.Exception.Message -match '409|already exists|duplicate') {
+            Write-WtInfo "Already registered: $($user.Email)"
+        } else { throw }
+    }
+
+    try {
+        Invoke-SorchaApi -Method POST `
+            -Uri "$($env.TenantUrl)/platform/users/verify-email" `
+            -Body @{ email = $user.Email } `
+            -Headers $sysAdmin.Headers | Out-Null
+    } catch { }
+}
+
+# ============================================================================
+# Step 3: Create Form Coverage Demo Org
+# ============================================================================
+Write-WtStep "Step 3: Create Form Coverage Demo Organization"
+
+try {
+    $demoOrg = New-SorchaOrganization `
+        -TenantUrl $env.TenantUrl `
+        -Name "Form Coverage Demo" `
+        -Subdomain "form-coverage-demo" `
+        -AdminEmail $secrets.submitterEmail `
+        -Headers $sysAdmin.Headers
+} catch {
+    if ($_.Exception.Message -match 'already taken|409|duplicate|400') {
+        $orgs = (Invoke-SorchaApi -Method GET -Uri "$($env.TenantUrl)/platform/organizations?page=1&pageSize=50" -Headers $sysAdmin.Headers)
+        $existing = $orgs | Where-Object { $_.name -eq "Form Coverage Demo" -or $_.subdomain -eq "form-coverage-demo" } | Select-Object -First 1
+        if (-not $existing) { $existing = ($orgs.items | Where-Object { $_.name -eq "Form Coverage Demo" -or $_.subdomain -eq "form-coverage-demo" }) | Select-Object -First 1 }
+        $demoOrg = @{ OrganizationId = $existing.id ?? $existing.organizationId }
+        Write-WtInfo "Form Coverage Demo exists: $($demoOrg.OrganizationId)"
+    } else { throw }
+}
+Write-WtInfo "Form Coverage Demo Org: $($demoOrg.OrganizationId)"
+
+# ============================================================================
+# Step 3.5: Add reviewer to Form Coverage Demo as an Administrator
+# ============================================================================
+Write-WtStep "Step 3.5: Add Reviewer to Form Coverage Demo"
+Get-OrCreateUser `
+    -TenantUrl $env.TenantUrl `
+    -OrganizationId $demoOrg.OrganizationId `
+    -Email $secrets.reviewerEmail `
+    -DisplayName $secrets.reviewerName `
+    -Headers $sysAdmin.Headers `
+    -Roles @("Administrator", "Consumer") | Out-Null
+Write-WtInfo "Reviewer added to Form Coverage Demo"
+
+# ============================================================================
+# Step 4: Login and create wallets + participants for both users
+# ============================================================================
+Write-WtStep "Step 4: Create Wallets & Participants"
+
+$submitterAuth = Connect-SorchaUser `
+    -TenantUrl $env.TenantUrl `
+    -Email $secrets.submitterEmail `
+    -Password $secrets.submitterPassword `
+    -OrganizationId $demoOrg.OrganizationId
+
+$submitterWallet = New-SorchaWallet `
+    -WalletUrl $env.WalletUrl `
+    -Name "Submitter Wallet" `
+    -Headers $submitterAuth.Headers `
+    -FetchPublicKey
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $env.TenantUrl `
+    -WalletUrl $env.WalletUrl `
+    -OrganizationId $demoOrg.OrganizationId `
+    -WalletAddress $submitterWallet.Address `
+    -DisplayName "Submitter" `
+    -Headers $submitterAuth.Headers
+Write-WtSuccess "Submitter: $($submitterWallet.Address)"
+
+$reviewerAuth = Connect-SorchaUser `
+    -TenantUrl $env.TenantUrl `
+    -Email $secrets.reviewerEmail `
+    -Password $secrets.reviewerPassword `
+    -OrganizationId $demoOrg.OrganizationId
+
+$reviewerWallet = New-SorchaWallet `
+    -WalletUrl $env.WalletUrl `
+    -Name "Reviewer Wallet" `
+    -Headers $reviewerAuth.Headers `
+    -FetchPublicKey
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $env.TenantUrl `
+    -WalletUrl $env.WalletUrl `
+    -OrganizationId $demoOrg.OrganizationId `
+    -WalletAddress $reviewerWallet.Address `
+    -DisplayName "Reviewer" `
+    -Headers $reviewerAuth.Headers
+Write-WtSuccess "Reviewer: $($reviewerWallet.Address)"
+
+# ============================================================================
+# Step 5: Create Register (idempotent — reuse existing one if present)
+# ============================================================================
+Write-WtStep "Step 5: Create or Reuse Register"
+
+$registerName = "Form Coverage Register"
+$existingRegisterId = Get-SorchaRegisterByName `
+    -TenantUrl $env.TenantUrl `
+    -Name $registerName `
+    -Headers $submitterAuth.Headers
+
+if ($existingRegisterId) {
+    Write-WtInfo "Reusing existing register '$registerName': $existingRegisterId"
+    $register = @{ RegisterId = $existingRegisterId }
+} else {
+    $register = New-SorchaRegister `
+        -RegisterUrl $env.RegisterUrl `
+        -WalletUrl $env.WalletUrl `
+        -Name $registerName `
+        -Description "Register that holds FormCoverage test submissions for eyeballing every control type" `
+        -TenantId $demoOrg.OrganizationId `
+        -OwnerUserId $submitterAuth.UserId `
+        -OwnerWalletAddress $submitterWallet.Address `
+        -Headers $submitterAuth.Headers
+    Write-WtSuccess "Register created: $($register.RegisterId)"
+
+    try {
+        New-SorchaRegisterSubscription `
+            -TenantUrl $env.TenantUrl `
+            -OrganizationId $demoOrg.OrganizationId `
+            -RegisterId $register.RegisterId `
+            -RegisterName $registerName `
+            -Headers $submitterAuth.Headers `
+            -SubscriptionType "Owner" | Out-Null
+        Write-WtInfo "Form Coverage Demo subscribed to register as Owner"
+    } catch {
+        if ($_.Exception.Message -match '409|already exists|duplicate') {
+            Write-WtInfo "Form Coverage Demo already subscribed (skipping)"
+        } else {
+            Write-WtWarn "Subscription failed: $($_.Exception.Message)"
+        }
+    }
+}
+
+# Public org subscription so consumer users see the register in their list.
+$null = Add-SorchaPublicOrgSubscription `
+    -TenantUrl $env.TenantUrl `
+    -RegisterId $register.RegisterId `
+    -RegisterName $registerName `
+    -SysAdminHeaders $sysAdmin.Headers `
+    -SysAdminEmail $secrets.adminEmail
+
+# Publish both participants to register
+Publish-SorchaParticipant `
+    -TenantUrl $env.TenantUrl `
+    -OrganizationId $demoOrg.OrganizationId `
+    -RegisterId $register.RegisterId `
+    -ParticipantName "Submitter" `
+    -OrganizationName "Form Coverage Demo" `
+    -WalletAddress $submitterWallet.Address `
+    -PublicKey $submitterWallet.PublicKey `
+    -Headers $submitterAuth.Headers
+Write-WtInfo "Submitter participant published"
+
+Publish-SorchaParticipant `
+    -TenantUrl $env.TenantUrl `
+    -OrganizationId $demoOrg.OrganizationId `
+    -RegisterId $register.RegisterId `
+    -ParticipantName "Reviewer" `
+    -OrganizationName "Form Coverage Demo" `
+    -WalletAddress $reviewerWallet.Address `
+    -PublicKey $reviewerWallet.PublicKey `
+    -Headers $reviewerAuth.Headers
+Write-WtInfo "Reviewer participant published"
+
+# ============================================================================
+# Step 6: Publish Blueprint
+# ============================================================================
+Write-WtStep "Step 6: Publish Form Coverage Blueprint"
+
+$templatePath = Join-Path $scriptDir "form-coverage-template.json"
+$blueprint = Publish-SorchaBlueprint `
+    -BlueprintUrl $env.BlueprintUrl `
+    -TemplatePath $templatePath `
+    -WalletMap @{
+        "submitter" = $submitterWallet.Address
+        "reviewer"  = $reviewerWallet.Address
+    } `
+    -Headers $submitterAuth.Headers `
+    -IdPrefix "fc" `
+    -RegisterId $register.RegisterId
+Write-WtSuccess "Blueprint: $($blueprint.BlueprintId)"
+
+# ============================================================================
+# Save State
+# ============================================================================
+$state = @{
+    profile      = $Profile
+    tenantUrl    = $env.TenantUrl
+    blueprintUrl = $env.BlueprintUrl
+    walletUrl    = $env.WalletUrl
+    registerUrl  = $env.RegisterUrl
+    gatewayUrl   = $env.GatewayUrl
+    registerId   = $register.RegisterId
+    blueprintId  = $blueprint.BlueprintId
+    demoOrg      = @{
+        organizationId = $demoOrg.OrganizationId
+    }
+    submitter    = @{
+        email          = $secrets.submitterEmail
+        password       = $secrets.submitterPassword
+        organizationId = $demoOrg.OrganizationId
+        walletAddress  = $submitterWallet.Address
+        publicKey      = $submitterWallet.PublicKey
+    }
+    reviewer     = @{
+        email          = $secrets.reviewerEmail
+        password       = $secrets.reviewerPassword
+        organizationId = $demoOrg.OrganizationId
+        walletAddress  = $reviewerWallet.Address
+        publicKey      = $reviewerWallet.PublicKey
+    }
+}
+
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile -Encoding UTF8
+Write-WtSuccess "State saved to $stateFile"
+
+Write-WtBanner "FormCoverage Setup Complete"
+Write-WtInfo "Run: pwsh walkthroughs/FormCoverage/run.ps1 -Profile $Profile"
+Write-WtInfo "Or open: $($env.GatewayUrl)/app/new-submissions and start a new FormCoverage instance"

--- a/walkthroughs/HealthDeclaration/setup.ps1
+++ b/walkthroughs/HealthDeclaration/setup.ps1
@@ -242,6 +242,14 @@ if ($existingRegisterId) {
     }
 }
 
+# Public org subscription so consumer users see the register in their list.
+$null = Add-SorchaPublicOrgSubscription `
+    -TenantUrl $env.TenantUrl `
+    -RegisterId $register.RegisterId `
+    -RegisterName $registerName `
+    -SysAdminHeaders $sysAdmin.Headers `
+    -SysAdminEmail $secrets.adminEmail
+
 # Publish both participants to register
 Publish-SorchaParticipant `
     -TenantUrl $env.TenantUrl `

--- a/walkthroughs/PayloadTests/setup.ps1
+++ b/walkthroughs/PayloadTests/setup.ps1
@@ -220,6 +220,14 @@ New-SorchaRegisterSubscription `
     -SubscriptionType "Public"
 Write-WtInfo "Receiver org subscribed to register"
 
+# Public org subscription so consumer users see the register.
+$null = Add-SorchaPublicOrgSubscription `
+    -TenantUrl $env.TenantUrl `
+    -RegisterId $register.RegisterId `
+    -RegisterName "Payload Test Register" `
+    -SysAdminHeaders $sysAdmin.Headers `
+    -SysAdminEmail $secrets.adminEmail
+
 # Publish participants to register
 Publish-SorchaParticipant `
     -TenantUrl $env.TenantUrl `

--- a/walkthroughs/README.md
+++ b/walkthroughs/README.md
@@ -41,6 +41,7 @@ One organization exercising wallets, registers, and crypto primitives.
 | [RegisterCreationFlow](./RegisterCreationFlow/) | Full register lifecycle: two-phase creation (initiate → sign attestation → finalize), CLI commands (`sorcha register create`), docket inspection, OData queries against the Register Service, and genesis transaction verification. |
 | [WalletVerification](./WalletVerification/) | Multi-algorithm wallet testing across ED25519, P-256, and RSA-4096. Covers wallet creation, data signing, pre-hashed signing, and explicit signature verification. Ensures all three crypto backends produce valid, verifiable signatures. |
 | [RegisterMongoDB](./RegisterMongoDB/) | MongoDB storage backend integration. Validates connection establishment, repository DI wiring, collection/index creation, and storage mode switching between InMemory and MongoDB providers. |
+| [FormCoverage](./FormCoverage/) | **SorchaFormRenderer smoke test.** Single-org, 2 participants, 1 blueprint that exercises every `ControlTypes` value (Layout, Label, TextLine, TextArea, Numeric, DateTime, File, Choice, Checkbox, Selection), all three layout modes (`x-pages` wizard + `x-sections` + explicit `form.elements`), `x-width` hints, `x-rule` conditional visibility, `x-introduction`, and the `x-persona` autofill extension from Feature 092. `run.ps1 -Rounds N` loops the submit → acknowledge cycle N times as a lightweight form-pipeline smoke test. |
 
 ### Multi-Org
 

--- a/walkthroughs/RegisterCreationFlow/run.ps1
+++ b/walkthroughs/RegisterCreationFlow/run.ps1
@@ -51,6 +51,15 @@ try {
     if ($register.GenesisTransactionId) {
         Write-WtInfo "Genesis TX: $($register.GenesisTransactionId)"
     }
+
+    # Public org subscription so consumer users see the new register.
+    # The helper decodes the sysadmin email from the bearer token.
+    $null = Add-SorchaPublicOrgSubscription `
+        -TenantUrl $state.tenantUrl `
+        -RegisterId $register.RegisterId `
+        -RegisterName "Register Creation Demo Register" `
+        -SysAdminHeaders $headers
+
     $stepsPassed++
 } catch {
     Write-WtFail "Register creation failed: $($_.Exception.Message)"

--- a/walkthroughs/RegisterCreationFlow/setup.ps1
+++ b/walkthroughs/RegisterCreationFlow/setup.ps1
@@ -42,6 +42,7 @@ $state = @{
     adminUserId    = $admin.AdminUserId
     adminToken     = $admin.Token
     walletAddress  = $wallet.Address
+    tenantUrl      = $env.TenantUrl
     registerUrl    = $env.RegisterUrl
     walletUrl      = $env.WalletUrl
 }

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -87,6 +87,22 @@ $buildingRegister = New-SorchaRegister `
     -Metadata @{ createdBy = "SelfBuildHouse/setup.ps1"; registerType = "building-standards" }
 Write-WtSuccess "  Building Standards Register: $($buildingRegister.RegisterId)"
 
+# Public org subscription so consumer users see both registers in their list.
+# The Connect-SorchaAdmin call used the seed sysadmin, which carries the
+# SystemAdmin role — so it can add itself to the Public org and subscribe.
+$null = Add-SorchaPublicOrgSubscription `
+    -TenantUrl $env.TenantUrl `
+    -RegisterId $planningRegister.RegisterId `
+    -RegisterName "Highland Planning Register" `
+    -SysAdminHeaders $admin.Headers `
+    -SysAdminEmail $secrets.highlandAdminEmail
+$null = Add-SorchaPublicOrgSubscription `
+    -TenantUrl $env.TenantUrl `
+    -RegisterId $buildingRegister.RegisterId `
+    -RegisterName "Highland Building Standards Register" `
+    -SysAdminHeaders $admin.Headers `
+    -SysAdminEmail $secrets.highlandAdminEmail
+
 # Step 5: Publish TWO blueprints
 Write-WtStep "Step 5: Publish Blueprints (2)"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -354,6 +354,14 @@ foreach ($regDef in $config.registers) {
         -RegisterName $regDef.name `
         -SubscriptionType "Owner"
 
+    # Public org subscription so consumer users see the register.
+    $null = Add-SorchaPublicOrgSubscription `
+        -TenantUrl $env.TenantUrl `
+        -RegisterId $register.RegisterId `
+        -RegisterName $regDef.name `
+        -SysAdminHeaders $seedAdmin.Headers `
+        -SysAdminEmail $secrets.seedAdminEmail
+
     Write-WtSuccess "  Register '$($regDef.name)': $($register.RegisterId)"
 }
 

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -115,9 +115,9 @@ Write-WtStep "Step 1: Bootstrap Organisations ($($selectedOrgs.Count))"
 # First, login as seed admin to create private orgs
 $seedAdmin = Connect-SorchaAdmin `
     -TenantUrl $env.TenantUrl `
-    -AdminEmail $secrets.seedAdminEmail `
+    -AdminEmail $secrets.adminEmail `
     -AdminName "Seed Admin" `
-    -AdminPassword $secrets.seedAdminPassword
+    -AdminPassword $secrets.adminPassword
 
 $orgContexts = @{}
 
@@ -140,6 +140,19 @@ foreach ($org in $selectedOrgs) {
         } catch {
             # User may already exist from a previous run — continue
             Write-WtInfo "  Admin user $adminEmail may already exist — continuing"
+        }
+
+        # Verify the admin's email via platform API so New-SorchaOrganization
+        # can add them directly without triggering an SMTP invite email.
+        # Nodes without SMTP (e.g. n1) fail hard otherwise.
+        try {
+            $null = Invoke-SorchaApi -Method POST `
+                -Uri "$($env.TenantUrl)/platform/users/verify-email" `
+                -Body @{ email = $adminEmail } `
+                -Headers $seedAdmin.Headers
+            Write-WtInfo "  Verified email for $adminEmail"
+        } catch {
+            Write-WtWarn "  Could not verify $adminEmail — org creation may fall back to SMTP invite"
         }
 
         # Create the private org via platform admin API
@@ -360,7 +373,7 @@ foreach ($regDef in $config.registers) {
         -RegisterId $register.RegisterId `
         -RegisterName $regDef.name `
         -SysAdminHeaders $seedAdmin.Headers `
-        -SysAdminEmail $secrets.seedAdminEmail
+        -SysAdminEmail $secrets.adminEmail
 
     Write-WtSuccess "  Register '$($regDef.name)': $($register.RegisterId)"
 }

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -110,6 +110,17 @@ $secrets = [ordered]@{
         patientPassword = "Dev_Pass_2025!"
         patientName    = "Demo Patient"
     }
+    "form-coverage" = @{
+        adminEmail        = $platformEmail
+        adminPassword     = $platformPassword
+        adminName         = $platformName
+        submitterEmail    = "submitter@form-coverage.local"
+        submitterPassword = "Dev_Pass_2025!"
+        submitterName     = "Demo Submitter"
+        reviewerEmail     = "reviewer@form-coverage.local"
+        reviewerPassword  = "Dev_Pass_2025!"
+        reviewerName      = "Demo Reviewer"
+    }
     "payload-test" = @{
         adminEmail    = $platformEmail
         adminPassword = $platformPassword

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1398,6 +1398,151 @@ function New-SorchaRegisterSubscription {
 }
 
 # ============================================================================
+# Add-SorchaPublicOrgSubscription — Subscribe the well-known Public org to
+# a public register, idempotently adding the system admin as an Administrator
+# of the Public org first so subsequent calls (and audit trails) have a
+# real membership record to lean on.
+# ============================================================================
+
+function Add-SorchaPublicOrgSubscription {
+    <#
+    .SYNOPSIS
+        Subscribe the Public organisation (00000000-0000-0000-0000-000000000002)
+        to a public register. Ensures the system admin is a member/admin of
+        the Public org before creating the subscription.
+    .DESCRIPTION
+        Walkthroughs that create public registers should also surface those
+        registers under the Public org so consumer users (who default to the
+        Public org) see them in their register list. This helper:
+
+        1. Lists users in the Public org to check if the sysadmin is already
+           a member. If not, it calls POST /organizations/{publicOrgId}/users
+           using the sysadmin's email + "Administrator" role. 409 is treated
+           as success.
+        2. Calls POST /organizations/{publicOrgId}/register-subscriptions
+           with SubscriptionType=Public and the sysadmin headers. 409 is
+           treated as success.
+    .PARAMETER TenantUrl
+        Tenant Service base URL.
+    .PARAMETER RegisterId
+        32-character hex register ID to subscribe the Public org to.
+    .PARAMETER RegisterName
+        Display name stored with the subscription record.
+    .PARAMETER SysAdminHeaders
+        Authorization headers carrying the SystemAdmin JWT. The sysadmin's
+        email is read from the bearer token's `email` claim so the helper
+        does not need a separate parameter.
+    .PARAMETER SysAdminEmail
+        Optional explicit sysadmin email. If omitted, extracted from the
+        bearer token in SysAdminHeaders.
+    .PARAMETER SysAdminDisplayName
+        Optional display name for the sysadmin membership row. Defaults to
+        "System Administrator".
+    .RETURNS
+        Subscription response, or $null if the subscription already existed.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$TenantUrl,
+        [Parameter(Mandatory)][string]$RegisterId,
+        [Parameter(Mandatory)][hashtable]$SysAdminHeaders,
+        [string]$RegisterName = "",
+        [string]$SysAdminEmail = "",
+        [string]$SysAdminDisplayName = "System Administrator"
+    )
+
+    $publicOrgId = "00000000-0000-0000-0000-000000000002"
+
+    # Resolve the sysadmin email from the bearer token if not supplied.
+    if (-not $SysAdminEmail) {
+        $authHeader = $SysAdminHeaders["Authorization"]
+        if ($authHeader -and $authHeader.StartsWith("Bearer ")) {
+            $token = $authHeader.Substring(7)
+            $parts = $token.Split('.')
+            if ($parts.Count -ge 2) {
+                $payload = $parts[1].Replace('-', '+').Replace('_', '/')
+                switch ($payload.Length % 4) {
+                    2 { $payload += '==' }
+                    3 { $payload += '=' }
+                }
+                try {
+                    $json = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($payload))
+                    $claims = $json | ConvertFrom-Json
+                    if ($claims.email) { $SysAdminEmail = $claims.email }
+                } catch {
+                    Write-WtWarn "Failed to decode sysadmin JWT for email claim: $_"
+                }
+            }
+        }
+    }
+
+    if (-not $SysAdminEmail) {
+        throw "Add-SorchaPublicOrgSubscription requires SysAdminEmail or a bearer token carrying an 'email' claim"
+    }
+
+    # 1. Ensure sysadmin is a member of the public org.
+    Write-WtInfo "Ensuring sysadmin '$SysAdminEmail' is an admin of the Public org"
+    try {
+        $users = Invoke-SorchaApi -Method GET `
+            -Uri "$TenantUrl/organizations/$publicOrgId/users?includeInactive=true" `
+            -Headers $SysAdminHeaders
+        $existing = $users.users | Where-Object { $_.email -eq $SysAdminEmail } | Select-Object -First 1
+    } catch {
+        Write-WtWarn "Could not list public org users: $($_.Exception.Message)"
+        $existing = $null
+    }
+
+    if (-not $existing) {
+        try {
+            $addBody = @{
+                email              = $SysAdminEmail
+                displayName        = $SysAdminDisplayName
+                externalIdpSubject = "sysadmin-publicorg-" + [guid]::NewGuid().ToString().Substring(0, 8)
+                roles              = @("Administrator")
+            }
+            $null = Invoke-SorchaApi -Method POST `
+                -Uri "$TenantUrl/organizations/$publicOrgId/users" `
+                -Body $addBody `
+                -Headers $SysAdminHeaders
+            Write-WtSuccess "Sysadmin added as Administrator of the Public org"
+        } catch {
+            $statusCode = $null
+            try { $statusCode = $_.Exception.Response.StatusCode.value__ } catch {}
+            if ($statusCode -eq 409 -or $statusCode -eq 400) {
+                Write-WtWarn "Sysadmin already a member of the Public org — continuing"
+            } else {
+                throw
+            }
+        }
+    } else {
+        Write-WtInfo "Sysadmin already a member of the Public org"
+    }
+
+    # 2. Subscribe the public org to the register (idempotent — 409 = OK).
+    $body = @{
+        register_id       = $RegisterId
+        register_name     = $RegisterName
+        subscription_type = "Public"
+    }
+
+    try {
+        $response = Invoke-SorchaApi -Method POST `
+            -Uri "$TenantUrl/organizations/$publicOrgId/register-subscriptions" `
+            -Body $body `
+            -Headers $SysAdminHeaders
+        Write-WtSuccess "Public org subscribed to register $RegisterId"
+        return $response
+    } catch {
+        $statusCode = $null
+        try { $statusCode = $_.Exception.Response.StatusCode.value__ } catch {}
+        if ($statusCode -eq 409) {
+            Write-WtWarn "Public org already subscribed to register $RegisterId — continuing"
+            return $null
+        }
+        throw
+    }
+}
+
+# ============================================================================
 # Switch-SorchaOrganization — Switch user's active org and get new JWT
 # ============================================================================
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -414,6 +414,14 @@ function Connect-SorchaAdmin {
         [Parameter(Mandatory)][string]$AdminPassword
     )
 
+    # Well-known System Admin org id — DatabaseInitializer creates this on
+    # first startup and the seed admin is always a member. Used as the
+    # target for the two-step login fallback when the sysadmin has been
+    # added to additional orgs (e.g. Add-SorchaPublicOrgSubscription adds
+    # the sysadmin to the Public org, which breaks the OAuth password
+    # grant's "single org" fast path).
+    $systemAdminOrgId = "00000000-0000-0000-0000-000000000001"
+
     $token = ""
     $organizationId = ""
     $adminUserId = ""
@@ -421,15 +429,38 @@ function Connect-SorchaAdmin {
     $encodedPassword = [Uri]::EscapeDataString($AdminPassword)
     $loginBody = "grant_type=password&username=$AdminEmail&password=$encodedPassword&client_id=sorcha-cli"
 
-    $loginResponse = Invoke-SorchaApi -Method POST `
-        -Uri "$TenantUrl/service-auth/token" `
-        -Body $loginBody `
-        -ContentType "application/x-www-form-urlencoded"
+    try {
+        $loginResponse = Invoke-SorchaApi -Method POST `
+            -Uri "$TenantUrl/service-auth/token" `
+            -Body $loginBody `
+            -ContentType "application/x-www-form-urlencoded"
+        $token = $loginResponse.access_token
+        Write-WtSuccess "Logged in as $AdminEmail (OAuth password grant)"
+    } catch {
+        $statusCode = $null
+        try { $statusCode = $_.Exception.Response.StatusCode.value__ } catch {}
 
-    $token = $loginResponse.access_token
-    Write-WtSuccess "Logged in as $AdminEmail"
+        if ($statusCode -ne 401) { throw }
 
-    # Extract org info from JWT if not available from bootstrap
+        # OAuth password grant returns 401 when the user has >1 org (the
+        # Tenant Service can't auto-pick). Fall back to the two-step
+        # /auth/login + /auth/select-org flow and target the System Admin
+        # org explicitly.
+        Write-WtWarn "OAuth password grant returned 401 — falling back to two-step login"
+
+        $adminSession = Connect-SorchaUser `
+            -TenantUrl $TenantUrl `
+            -Email $AdminEmail `
+            -Password $AdminPassword `
+            -OrganizationId $systemAdminOrgId
+
+        $token = $adminSession.Token
+        $organizationId = $adminSession.OrganizationId
+        $adminUserId = $adminSession.UserId
+        Write-WtSuccess "Logged in as $AdminEmail -> System Admin org"
+    }
+
+    # Extract org info from JWT if not already populated by the fallback path.
     if (-not $organizationId -and $token) {
         $jwt = Decode-SorchaJwt -Token $token
         $organizationId = $jwt.org_id

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -122,6 +122,14 @@ function Invoke-SorchaApi {
         UseBasicParsing = $true
     }
 
+    # Allow running walkthroughs against a deployed HTTPS node from a
+    # developer box that cannot check CRLs (e.g. Windows Schannel offline).
+    # Opt in with SORCHA_WT_SKIP_CERT_CHECK=1.
+    if ([System.Environment]::GetEnvironmentVariable('SORCHA_WT_SKIP_CERT_CHECK') -eq '1' -and
+        $Uri -match '^https://') {
+        $params.SkipCertificateCheck = $true
+    }
+
     if ($Body) {
         if ($ContentType -eq "application/json") {
             $jsonBody = if ($Body -is [string]) { $Body } else { $Body | ConvertTo-Json -Depth 30 }
@@ -300,7 +308,17 @@ function Initialize-SorchaEnvironment {
         # Check API Gateway health
         Write-WtInfo "Checking API Gateway health..."
         try {
-            $null = Invoke-RestMethod -Uri "$($env.GatewayUrl)/api/health" -Method GET -TimeoutSec 10 -UseBasicParsing
+            $healthParams = @{
+                Uri             = "$($env.GatewayUrl)/api/health"
+                Method          = 'GET'
+                TimeoutSec      = 10
+                UseBasicParsing = $true
+            }
+            if ([System.Environment]::GetEnvironmentVariable('SORCHA_WT_SKIP_CERT_CHECK') -eq '1' -and
+                $env.GatewayUrl -match '^https://') {
+                $healthParams.SkipCertificateCheck = $true
+            }
+            $null = Invoke-RestMethod @healthParams
             Write-WtSuccess "API Gateway is healthy"
         } catch {
             Write-WtWarn "API Gateway health check failed — services may still be starting"


### PR DESCRIPTION
## Summary

Four threads of walkthrough work, all verified against `n1.sorcha.dev`:

### A — Public org subscription (ask #1)
Every walkthrough that creates a public register now subscribes the well-known Public org (`00000000-0000-0000-0000-000000000002`) to it, so consumer users (who default to the Public org) see the register in their list immediately.

- New `Add-SorchaPublicOrgSubscription` helper — adds the sysadmin as an Administrator of the Public org (idempotent, 409 = continue), then POSTs the `Public` subscription on the sysadmin's behalf. JWT email claim decoded as a fallback if `-SysAdminEmail` isn't supplied.
- Wired into 7 walkthroughs: ConstructionPermit, HealthDeclaration, TradeFinance (per-register loop), PayloadTests, SelfBuildHouse (planning + building), RegisterCreationFlow (`run.ps1`), DistributedRegister (`run.ps1`).

### D — FormCoverage walkthrough (ask #4)
New single-org walkthrough built purely to smoke-test the `SorchaFormRenderer`. One blueprint + explicit `form.elements` exercising **every `ControlTypes` value**:

- Layout, Label, TextLine, TextArea, Numeric, DateTime, File, Choice, Checkbox, Selection
- `x-pages` wizard (3 pages) + `x-sections` + `x-width` hints (full/half/third)
- `x-rule` SHOW conditional (`followUpNotes` visible only when `wantsFollowUp = true`)
- `x-introduction` page intros
- `x-persona` autofill from Feature 092 on givenName / familyName / email / dateOfBirth

`run.ps1 -Rounds N` loops a submit → acknowledge cycle N times with per-round timing.

### B — n1.sorcha.dev check (ask #2)
Already running Feature 092 images (Docker Hub digests match the 2026-04-08 21:13–21:17 UTC push, 4 minutes after the 092 merge). All 11 containers healthy, Postgres effectively clean (seed admin + 2 default orgs only). **No teardown required.**

### C — Walkthrough runs on n1 (ask #3)
| Walkthrough | Rounds | Result |
|-------------|--------|--------|
| ConstructionPermit | 5 rounds × 3 scenarios × 14 actions | 5/5 ✅ |
| TradeFinance (golden-path) | 5 rounds × 10 actions + VC | 5/5 ✅ |
| FormCoverage | 10 rounds × 2 actions | 10/10 ✅ (avg 13.7s/round) |
| HealthDeclaration | setup only (UI demo) | ✅ |

### Regressions / bugs fixed along the way

1. **`Connect-SorchaAdmin` multi-org fallback** — OAuth password grant 401s when the sysadmin is a member of >1 org (now always the case because of Part A). Added a fallback to the two-step `/auth/login` + `/auth/select-org` flow targeting the System Admin org (`00000000-0000-0000-0000-000000000001`).
2. **`SORCHA_WT_SKIP_CERT_CHECK=1`** env var — opt-in `-SkipCertificateCheck` on HTTPS calls for dev boxes that can't reach the CRL for n1.sorcha.dev (Windows Schannel `CRYPT_E_NO_REVOCATION_CHECK`). Default behaviour unchanged.
3. **TradeFinance email verification** — `AdminProvisionAsync` tries to send an SMTP welcome email for unverified admin users, which 500s on n1 (no SMTP container). Added explicit `/platform/users/verify-email` after `Register-SorchaPublicUser` so the admin-direct-add path is taken. ConstructionPermit already did this; TradeFinance was implicitly relying on it.
4. **TradeFinance pre-existing secret typo** — was reading `$secrets.seedAdminEmail` / `seedAdminPassword` which don't exist in `initialize-secrets.ps1`. Renamed to `adminEmail` / `adminPassword`.
5. **FormCoverage action 2 wait** — was firing action 2 immediately after action 1 submission; now waits up to 60s for `currentActionIds` to include action 2 (same pattern ConstructionPermit uses).

## Test plan

- [x] PowerShell parse-check across all 10 edited / created `.ps1` / `.psm1` files
- [x] JSON parse-check on `form-coverage-template.json`
- [x] Live run against `n1.sorcha.dev`:
  - ConstructionPermit — 5 rounds × 3 scenarios = 15 scenario runs, all PASS
  - TradeFinance — 5 golden-path runs = 10 procurement + 4 finance actions × 5 + 5 VC issuance + 5 VC presentation, all PASS
  - FormCoverage — 10 submit/ack rounds, avg 13.7s/round, 10/10 PASS
  - HealthDeclaration — setup only (UI demo), complete