### PR TITLE
fix: grant persona:crypto scope to tenant service principal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,10 @@ services:
       # Service-to-service auth for Wallet Service calls during wallet link verification
       ServiceAuth__ClientId: tenant-service
       ServiceAuth__ClientSecret: tenant-service-secret
+      # persona:crypto is required by the Wallet Service persona encrypt/decrypt
+      # endpoints that back the Consumer persona feature (092). wallets:sign and
+      # wallets:verify are retained for participant wallet link verification.
+      ServiceAuth__Scopes: "wallets:sign wallets:verify persona:crypto"
       ServiceClients__WalletService__Address: http://wallet-service:8080
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__RegisterService__Address: http://register-service:8080

--- a/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
@@ -421,7 +421,11 @@ public class DatabaseInitializer
                 "Tenant Service",
                 "tenant-service",
                 "tenant-service-secret",
-                new[] { "wallets:read", "wallets:sign", "wallets:verify" }
+                // persona:crypto grants access to the Wallet Service's
+                // /persona/encrypt|decrypt endpoints used by the Consumer
+                // persona feature (092). Only the Tenant Service is issued
+                // this scope.
+                new[] { "wallets:read", "wallets:sign", "wallets:verify", "persona:crypto" }
             )
         };
 


### PR DESCRIPTION
## Summary
- `PUT /api/me/persona` failed with 500 on n1 (`PersonaCryptoException: Persona encrypt failed: 403 Forbidden`).
- Root cause: Wallet Service's `/persona/encrypt` requires `persona:crypto` scope (`RequirePersonaCrypto` policy). Tenant Service principal wasn't granted it AND the ServiceAuth client didn't request it.

## Fix
- `DatabaseInitializer.cs`: add `persona:crypto` to the tenant-service principal's seeded scopes. Zero-migration — the existing seeder auto-updates scopes when they diverge.
- `docker-compose.yml`: add `ServiceAuth__Scopes: "wallets:sign wallets:verify persona:crypto"` to tenant-service env.

## Test plan
- [ ] Rebuild and redeploy tenant-service to n1
- [ ] Verify startup log shows scope update applied
- [ ] Public Consumer saves profile → 200, persona round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)