### PR TITLE
fix: key persona on platform_user_id and resolve wallet from claim

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PersonaEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PersonaEndpoints.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Security.Claims;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Sorcha.ServiceDefaults;
@@ -97,9 +96,11 @@ public static class PersonaEndpoints
         var userId = GetUserId(context);
         if (userId == Guid.Empty) return TypedResults.Unauthorized();
 
+        var walletAddress = context.User.FindFirst("wallet_address")?.Value;
+
         try
         {
-            var result = await personaService.ReplaceAsync(userId, body, ct);
+            var result = await personaService.ReplaceAsync(userId, walletAddress, body, ct);
             return TypedResults.Ok(result);
         }
         catch (PersonaValidationException ex)
@@ -128,10 +129,17 @@ public static class PersonaEndpoints
         return TypedResults.NoContent();
     }
 
+    /// <summary>
+    /// Resolves the caller's <see cref="PlatformUser"/> id from the
+    /// <c>platform_user_id</c> claim. The <c>sub</c> claim carries the
+    /// org-scoped <c>UserIdentity.Id</c>, not the cross-org PlatformUser id,
+    /// so it cannot be used as the key for the <c>PlatformUserPersonas</c>
+    /// table (FK violation). See <c>TokenService.GenerateUserTokenAsync</c>
+    /// for where the <c>platform_user_id</c> claim is emitted.
+    /// </summary>
     private static Guid GetUserId(HttpContext context)
     {
-        var sub = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? context.User.FindFirst("sub")?.Value;
-        return Guid.TryParse(sub, out var id) ? id : Guid.Empty;
+        var platformUserId = context.User.FindFirst("platform_user_id")?.Value;
+        return Guid.TryParse(platformUserId, out var id) ? id : Guid.Empty;
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/IPersonaService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IPersonaService.cs
@@ -25,15 +25,28 @@ public interface IPersonaService
 
     /// <summary>
     /// Replaces the persona for a platform user with the supplied plaintext.
-    /// Validates invariants, encrypts via the Wallet Service, upserts the row
-    /// and writes an activity log entry.
+    /// Validates invariants, encrypts via the Wallet Service using
+    /// <paramref name="walletAddress"/>, upserts the row and writes an
+    /// activity log entry.
     /// </summary>
+    /// <param name="platformUserId">The cross-org <see cref="PlatformUser"/> id
+    /// that owns the persona row (FK target). This is the <c>platform_user_id</c>
+    /// claim on the caller's JWT, not <c>sub</c> — <c>sub</c> carries the
+    /// org-scoped <c>UserIdentity.Id</c>.</param>
+    /// <param name="walletAddress">Wallet address used to derive the content
+    /// key via the Wallet Service. Stored in <c>WrappedKeyRef</c> so reads
+    /// can re-derive the same key on decrypt. Passed in from the caller's
+    /// <c>wallet_address</c> JWT claim; <see cref="PersonaWalletNotProvisionedException"/>
+    /// is thrown if null or empty.</param>
+    /// <param name="plaintext">The persona attributes to encrypt and persist.</param>
+    /// <param name="ct">Cancellation token.</param>
     /// <exception cref="PersonaValidationException">Invariant violation — invalid
     /// email / phone / country code, multiple defaults, or list cap exceeded.</exception>
-    /// <exception cref="PersonaWalletNotProvisionedException">User has no primary
-    /// wallet provisioned — cannot encrypt.</exception>
+    /// <exception cref="PersonaWalletNotProvisionedException">No wallet address
+    /// supplied — cannot encrypt.</exception>
     Task<PersonaReadModelV1> ReplaceAsync(
         Guid platformUserId,
+        string? walletAddress,
         PersonaAttributesV1 plaintext,
         CancellationToken ct = default);
 

--- a/src/Services/Sorcha.Tenant.Service/Services/PersonaService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PersonaService.cs
@@ -85,12 +85,16 @@ public sealed partial class PersonaService : IPersonaService
             return new PersonaReadModelV1();
         }
 
-        // Fetch the user's default wallet address so we can decrypt.
-        var walletAddress = await ResolvePrimaryWalletAsync(platformUserId, ct);
-        if (walletAddress is null)
+        // WrappedKeyRef stores the wallet address that was used to derive the
+        // content key on encrypt (see data-model.md §1). Using it directly
+        // means reads never depend on the caller's currently active wallet or
+        // on any org-scoped preferences row — the persona is cross-org, and
+        // so is its key material reference.
+        var walletAddress = row.WrappedKeyRef;
+        if (string.IsNullOrEmpty(walletAddress))
         {
             _logger.LogWarning(
-                "Persona row exists for user {PlatformUserId} but no primary wallet is set — returning empty.",
+                "Persona row for user {PlatformUserId} has no WrappedKeyRef — returning empty.",
                 platformUserId);
             return new PersonaReadModelV1();
         }
@@ -166,6 +170,7 @@ public sealed partial class PersonaService : IPersonaService
     /// <inheritdoc />
     public async Task<PersonaReadModelV1> ReplaceAsync(
         Guid platformUserId,
+        string? walletAddress,
         PersonaAttributesV1 plaintext,
         CancellationToken ct = default)
     {
@@ -174,9 +179,16 @@ public sealed partial class PersonaService : IPersonaService
         // 1. Validate invariants.
         var normalised = ValidateAndNormalise(plaintext);
 
-        // 2. Resolve the user's primary wallet — required for encryption.
-        var walletAddress = await ResolvePrimaryWalletAsync(platformUserId, ct)
-            ?? throw new PersonaWalletNotProvisionedException();
+        // 2. The caller-supplied wallet address is the content-key derivation
+        // input and is stored with the row as WrappedKeyRef so future reads
+        // can derive the same key. Persona is a cross-org attribute on the
+        // PlatformUser, so it is keyed by platform_user_id — the previous
+        // implementation's UserPreferences lookup was org-scoped and
+        // produced a foreign-key violation against PlatformUserPersonas.
+        if (string.IsNullOrEmpty(walletAddress))
+        {
+            throw new PersonaWalletNotProvisionedException();
+        }
 
         // 3. Encrypt via Wallet Service.
         var bytes = JsonSerializer.SerializeToUtf8Bytes(normalised, JsonOptions);
@@ -294,20 +306,6 @@ public sealed partial class PersonaService : IPersonaService
     }
 
     // -------- private helpers --------
-
-    /// <summary>
-    /// Resolves the user's primary wallet address from their
-    /// <see cref="UserPreferences.DefaultWalletAddress"/>. Returns null if
-    /// no default wallet is set. In v1 this is the sole mechanism —
-    /// richer resolution (latest active wallet, etc.) is a follow-up.
-    /// </summary>
-    private async Task<string?> ResolvePrimaryWalletAsync(Guid platformUserId, CancellationToken ct)
-    {
-        return await _db.UserPreferences
-            .Where(p => p.UserId == platformUserId)
-            .Select(p => p.DefaultWalletAddress)
-            .FirstOrDefaultAsync(ct);
-    }
 
     /// <summary>
     /// Validates invariants I-1 through I-5 from data-model.md §2 and

--- a/tests/Sorcha.Tenant.Service.Tests/Services/PersonaServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/PersonaServiceTests.cs
@@ -110,7 +110,7 @@ public sealed class PersonaServiceTests : IDisposable
             Emails = [new PersonaEmail("ada@example.com", true)],
         };
 
-        var result = await _sut.ReplaceAsync(_userId, payload);
+        var result = await _sut.ReplaceAsync(_userId, WalletAddress, payload);
 
         result.GivenName!.Value.Should().Be("Ada");
         result.DefaultEmail!.Value.Value.Should().Be("ada@example.com");
@@ -129,12 +129,15 @@ public sealed class PersonaServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ReplaceAsync_NoPrimaryWallet_Throws409WalletNotProvisioned()
+    public async Task ReplaceAsync_NoWalletAddress_Throws409WalletNotProvisioned()
     {
-        var otherUserId = Guid.NewGuid();
-
+        // Passing a null or empty wallet address — the endpoint does this
+        // when the caller's JWT carries no wallet_address claim — must fail
+        // fast with PersonaWalletNotProvisionedException so the UI can
+        // surface a "provision a wallet first" recovery prompt.
         var act = async () => await _sut.ReplaceAsync(
-            otherUserId,
+            _userId,
+            walletAddress: null,
             new PersonaAttributesV1 { GivenName = "Grace" });
 
         await act.Should().ThrowAsync<PersonaWalletNotProvisionedException>();
@@ -149,7 +152,7 @@ public sealed class PersonaServiceTests : IDisposable
             .Select(i => new PersonaEmail($"a{i}@example.com", i == 0))
             .ToList();
 
-        var act = async () => await _sut.ReplaceAsync(_userId, new PersonaAttributesV1 { Emails = emails });
+        var act = async () => await _sut.ReplaceAsync(_userId, WalletAddress, new PersonaAttributesV1 { Emails = emails });
 
         var ex = await act.Should().ThrowAsync<PersonaValidationException>();
         ex.Which.Errors.Should().ContainKey("emails");
@@ -168,7 +171,7 @@ public sealed class PersonaServiceTests : IDisposable
             ]
         };
 
-        var act = async () => await _sut.ReplaceAsync(_userId, payload);
+        var act = async () => await _sut.ReplaceAsync(_userId, WalletAddress, payload);
 
         var ex = await act.Should().ThrowAsync<PersonaValidationException>();
         ex.Which.Errors["emails"].Should().Contain("multiple_defaults");
@@ -186,7 +189,7 @@ public sealed class PersonaServiceTests : IDisposable
             Emails = [new PersonaEmail(bad, true)]
         };
 
-        var act = async () => await _sut.ReplaceAsync(_userId, payload);
+        var act = async () => await _sut.ReplaceAsync(_userId, WalletAddress, payload);
 
         var ex = await act.Should().ThrowAsync<PersonaValidationException>();
         ex.Which.Errors.Should().ContainKey("emails[0].value");
@@ -201,7 +204,7 @@ public sealed class PersonaServiceTests : IDisposable
             Phones = [new PersonaPhone("not-e164", true)]
         };
 
-        var act = async () => await _sut.ReplaceAsync(_userId, payload);
+        var act = async () => await _sut.ReplaceAsync(_userId, WalletAddress, payload);
 
         var ex = await act.Should().ThrowAsync<PersonaValidationException>();
         ex.Which.Errors["phones[0].value"].Should().Contain("invalid_phone");
@@ -230,7 +233,7 @@ public sealed class PersonaServiceTests : IDisposable
             ]
         };
 
-        var result = await _sut.ReplaceAsync(_userId, payload);
+        var result = await _sut.ReplaceAsync(_userId, WalletAddress, payload);
 
         result.DefaultAddress!.Value.Country.Should().Be("GB");
     }


### PR DESCRIPTION
## Summary
- `PUT /api/me/persona` failed with FK violation on n1: `PlatformUserPersonas.PlatformUserId` is a FK to `PlatformUsers`, but `PersonaEndpoints.GetUserId` returned the `sub` claim which carries `UserIdentity.Id` (org-scoped), not `PlatformUser.Id`.
- Fixing that alone would break wallet resolution because `ResolvePrimaryWalletAsync` queried `UserPreferences.UserId`, which is keyed by `UserIdentity.Id`.

## Fix
- `PersonaEndpoints`: read `platform_user_id` claim for the row key, pass the `wallet_address` claim into `ReplaceAsync`.
- `PersonaService.ReplaceAsync`: accept `walletAddress` as a parameter; fail fast with `PersonaWalletNotProvisionedException` if null/empty.
- `PersonaService.GetAsync`: use `row.WrappedKeyRef` for decryption (it's the address captured at encrypt time) — no current-session lookup.
- Removed dead `ResolvePrimaryWalletAsync`.
- Tests updated; all 14 PersonaService tests pass locally.

## Test plan
- [X] `dotnet test --filter PersonaService` — 14 passed
- [ ] Deploy tenant-service to n1 and save persona as public Consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)