### PR TITLE
fix: wire activity log real-time updates, remove toast

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -251,7 +251,7 @@
     <ActivityLogPanel @bind-IsOpen="_activityLogOpen" OnEventsRead="RefreshUnreadCount" />
     <OperationNotificationListener />
     <CryptoProgressPopover />
-    <PendingActionToast />
+    @* PendingActionToast removed — activity log panel now handles all notifications *@
     <PendingActionInbox @bind-IsOpen="_pendingInboxOpen" />
 </MudLayout>
 
@@ -332,7 +332,9 @@
 
     private void OnUnreadCountUpdated(int count)
     {
-        _unreadCount = count;
+        // -1 signals "increment by 1" (server doesn't know exact count in real-time)
+        // Any other value is an absolute count from a REST refresh
+        _unreadCount = count == -1 ? _unreadCount + 1 : count;
         InvokeAsync(StateHasChanged);
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -330,11 +330,11 @@
         InvokeAsync(StateHasChanged);
     }
 
+    private const int IncrementByOneSignal = -1;
+
     private void OnUnreadCountUpdated(int count)
     {
-        // -1 signals "increment by 1" (server doesn't know exact count in real-time)
-        // Any other value is an absolute count from a REST refresh
-        _unreadCount = count == -1 ? _unreadCount + 1 : count;
+        _unreadCount = count == IncrementByOneSignal ? _unreadCount + 1 : count;
         InvokeAsync(StateHasChanged);
     }
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EventsHubNotificationBridge.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EventsHubNotificationBridge.cs
@@ -122,7 +122,8 @@ public sealed class EventsHubNotificationBridge : IHostedService, IDisposable
             // Enrich and persist to Tenant Service activity feed (for pull-back)
             await EnrichAndPersistEventAsync(actionEvent);
 
-            // Send thin signal to user's SignalR group — client pulls detail from activity feed
+            // Send thin signal to user's SignalR group — consumed by PendingActionInbox
+            // and MainLayout for pending action count (separate from activity log)
             var userGroup = $"user:{actionEvent.UserId}";
             var signal = new Hubs.SignalNotification
             {
@@ -272,7 +273,6 @@ public sealed class EventsHubNotificationBridge : IHostedService, IDisposable
             _ => "Info"
         };
 
-        var eventId = Guid.NewGuid();
         var createdAt = DateTime.UtcNow;
         var userGroup = $"user:{actionEvent.UserId}";
 
@@ -306,12 +306,16 @@ public sealed class EventsHubNotificationBridge : IHostedService, IDisposable
                 actionEvent.UserId);
         }
 
-        // 2. Broadcast full event to activity panel via SignalR (real-time update)
+        // 2. Broadcast full event to activity panel via SignalR (real-time update).
+        // Shape matches Sorcha.UI.Core.Models.ActivityEventDto — coupled by JSON contract,
+        // not by project reference (Blueprint Service does not reference UI.Core).
+        // Id is omitted — the Tenant Service assigns the canonical ID on persist.
+        // The panel uses CreatedAt + EntityId for dedup when re-fetching from REST.
         try
         {
             var activityEvent = new
             {
-                Id = eventId,
+                Id = Guid.Empty,
                 EventType = "PendingAction",
                 Severity = severity,
                 Title = notification.ActionDescription ?? "New action available",
@@ -341,10 +345,11 @@ public sealed class EventsHubNotificationBridge : IHostedService, IDisposable
         // 3. Broadcast updated unread count
         try
         {
-            // Increment is approximate — the client can refresh the exact count on demand.
-            // We send -1 as a signal to increment the local counter by 1.
+            // Signal client to increment its local unread counter by 1.
+            // The client can refresh the exact count from REST on demand.
+            const int incrementByOne = -1;
             await _hubContext.Clients.Group(userGroup)
-                .SendAsync("UnreadCountUpdated", -1);
+                .SendAsync("UnreadCountUpdated", incrementByOne);
         }
         catch (Exception ex)
         {

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EventsHubNotificationBridge.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EventsHubNotificationBridge.cs
@@ -259,23 +259,28 @@ public sealed class EventsHubNotificationBridge : IHostedService, IDisposable
             GroupKey = groupKey
         };
 
-        // Persist as ActivityEvent via Tenant Service (best-effort, for pull-back)
-        await PersistActivityEventAsync(actionEvent, notification);
+        // Persist as ActivityEvent via Tenant Service and broadcast to activity panel
+        await PersistAndBroadcastActivityEventAsync(actionEvent, notification);
     }
 
-    private async Task PersistActivityEventAsync(InboundActionEvent actionEvent, InboundActionNotification notification)
+    private async Task PersistAndBroadcastActivityEventAsync(InboundActionEvent actionEvent, InboundActionNotification notification)
     {
+        var severity = notification.Urgency switch
+        {
+            "urgent" => "Error",
+            "warning" => "Warning",
+            _ => "Info"
+        };
+
+        var eventId = Guid.NewGuid();
+        var createdAt = DateTime.UtcNow;
+        var userGroup = $"user:{actionEvent.UserId}";
+
+        // 1. Persist to Tenant Service activity log (best-effort)
         try
         {
             using var scope = _scopeFactory.CreateScope();
             var eventClient = scope.ServiceProvider.GetRequiredService<IEventServiceClient>();
-
-            var severity = notification.Urgency switch
-            {
-                "urgent" => "Error",
-                "warning" => "Warning",
-                _ => "Info"
-            };
 
             var request = new CreateActivityEventRequest(
                 OrganizationId: Guid.TryParse(actionEvent.TenantId, out var tenantGuid) ? tenantGuid : Guid.Empty,
@@ -298,6 +303,53 @@ public sealed class EventsHubNotificationBridge : IHostedService, IDisposable
         {
             _logger.LogWarning(ex,
                 "Failed to persist PendingAction activity event for user {UserId}",
+                actionEvent.UserId);
+        }
+
+        // 2. Broadcast full event to activity panel via SignalR (real-time update)
+        try
+        {
+            var activityEvent = new
+            {
+                Id = eventId,
+                EventType = "PendingAction",
+                Severity = severity,
+                Title = notification.ActionDescription ?? "New action available",
+                Message = notification.Summary ?? "",
+                SourceService = "Blueprint",
+                EntityId = actionEvent.InstanceId,
+                EntityType = "BlueprintInstance",
+                IsRead = false,
+                CreatedAt = createdAt,
+                UserDisplayName = notification.SenderDisplayName
+            };
+
+            await _hubContext.Clients.Group(userGroup)
+                .SendAsync("EventReceived", activityEvent);
+
+            _logger.LogDebug(
+                "Broadcast EventReceived to group {Group} for instance {InstanceId}",
+                userGroup, actionEvent.InstanceId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to broadcast EventReceived for user {UserId}",
+                actionEvent.UserId);
+        }
+
+        // 3. Broadcast updated unread count
+        try
+        {
+            // Increment is approximate — the client can refresh the exact count on demand.
+            // We send -1 as a signal to increment the local counter by 1.
+            await _hubContext.Clients.Group(userGroup)
+                .SendAsync("UnreadCountUpdated", -1);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to broadcast UnreadCountUpdated for user {UserId}",
                 actionEvent.UserId);
         }
     }


### PR DESCRIPTION
## Summary

- Activity panel now receives real-time events via SignalR `EventReceived` broadcast (was never wired)
- Badge counter updates immediately via `UnreadCountUpdated` signal (was never sent)
- Removed `PendingActionToast` component (superseded by activity panel)

## Root Cause

`EventsHubNotificationBridge` persisted events to the Tenant DB but only sent `InboundActionReceived` (thin toast signal). It never broadcast the full `ActivityEventDto` via `EventReceived` or the `UnreadCountUpdated` count. Both were documented as expected client methods in `EventsHub.cs` but never implemented.

## Changes

| File | Change |
|------|--------|
| `EventsHubNotificationBridge.cs` | Added `EventReceived` + `UnreadCountUpdated` SignalR broadcasts after persist |
| `MainLayout.razor` | Handle `-1` unread count as increment, removed `PendingActionToast` |

## Test plan

- [x] Blueprint Service builds clean
- [ ] Start services, trigger a workflow action, verify activity panel shows event in real-time
- [ ] Verify badge counter increments on new events
- [ ] Verify no toast popups appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)