### PR TITLE
feat: [096] X.509 organisation trust integration

### DIFF
--- a/specs/096-x509-org-trust/checklists/requirements.md
+++ b/specs/096-x509-org-trust/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Specification Quality Checklist: X.509 Organisation Trust Integration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain *(intentional — see Notes below)*
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Two architectural clarifications are intentionally left in the spec's Clarifications section rather than collapsed to defaults:
+  - **Q4.1**: CA signing key in the wallet domain vs a new first-class entity. Spec draft defaults to Option B (new first-class entity) but the Sorcha tradition of BIP32 purpose consolidation pulls toward Option A. User ruling required.
+  - **Q4.2**: EKU OID set for HAIP credential issuer Org Certs. Spec draft defaults to Option D (no EKU, defer to HAIP 1.1). User ruling required — specifically influenced by whether a named partner (GOV.UK Wallet, EUDI Wallet) has a concrete EKU requirement.
+- Five user stories cover: external HAIP wallet trusts a Sorcha credential via X.509 (US1), tenant PKI provisioning (US2), DID ↔ X.509 identity binding (US3), org cert revocation via CRL (US4), pluggable trust provider swap (US5). Priorities P1/P1/P1/P2/P2.
+- Inline decisions made (not flagged as architectural clarifications):
+  - Two-level chain (Tenant Root → Org Cert). Three-level is an out-of-scope extension.
+  - CRL only, no OCSP. OCSP deferred.
+  - SAN URI carries the `did:sorcha:org:{walletAddress}` identifier, linking the X.509 and DID identities.
+  - Subject CN carries the org's human-readable display name.
+  - `x5c` header in JWS is the wire carrier for the chain, per RFC 7515 §4.1.6 and HAIP 1.0.
+  - Default CA validity 10 years; default Org Cert validity 2 years; default CRL refresh 24 hours. All configurable.
+  - Internal-path credentials do NOT carry `x5c`. The two trust stacks run genuinely in parallel on different credentials.
+- Inline decision on org cert issuance triggering: enrolment requires `HaipIssuer` capability from spec 094 to already be set. No auto-enrolment; operator action is required.
+- The "No [NEEDS CLARIFICATION] markers" checklist item is intentionally unchecked. Q4.1 and Q4.2 are genuine architectural questions that affect planning shape. Closing them requires a user ruling, not a planner's best guess.
+- Items requiring updates before `/speckit.plan`: Q4.1 and Q4.2 rulings must be captured.

--- a/specs/096-x509-org-trust/checklists/requirements.md
+++ b/specs/096-x509-org-trust/checklists/requirements.md
@@ -13,7 +13,7 @@
 
 ## Requirement Completeness
 
-- [ ] No [NEEDS CLARIFICATION] markers remain *(intentional — see Notes below)*
+- [x] No [NEEDS CLARIFICATION] markers remain *(Q4.1 and Q4.2 resolved by user ruling — see Notes)*
 - [x] Requirements are testable and unambiguous
 - [x] Success criteria are measurable
 - [x] Success criteria are technology-agnostic (no implementation details)
@@ -31,9 +31,9 @@
 
 ## Notes
 
-- Two architectural clarifications are intentionally left in the spec's Clarifications section rather than collapsed to defaults:
-  - **Q4.1**: CA signing key in the wallet domain vs a new first-class entity. Spec draft defaults to Option B (new first-class entity) but the Sorcha tradition of BIP32 purpose consolidation pulls toward Option A. User ruling required.
-  - **Q4.2**: EKU OID set for HAIP credential issuer Org Certs. Spec draft defaults to Option D (no EKU, defer to HAIP 1.1). User ruling required — specifically influenced by whether a named partner (GOV.UK Wallet, EUDI Wallet) has a concrete EKU requirement.
+- Two architectural clarifications were raised during drafting and **have been resolved by user ruling**:
+  - **Q4.1** → **Option B** (new first-class Tenant CA entity with its own key storage). Rationale: end goal is to support importing signing keys from external sources (HSMs, eIDAS QTSPs), which requires storage independent of wallet HD derivation. Internally generated CA keys can still be derived under `sorcha:tenant-ca-signing` from a recovery seed for deterministic recovery.
+  - **Q4.2** → **Option D** (no EKU extension on Org Certs; defer to HAIP 1.1 or named partner requirement). A follow-up operational spec will add a configurable EKU per trust provider when needed.
 - Five user stories cover: external HAIP wallet trusts a Sorcha credential via X.509 (US1), tenant PKI provisioning (US2), DID ↔ X.509 identity binding (US3), org cert revocation via CRL (US4), pluggable trust provider swap (US5). Priorities P1/P1/P1/P2/P2.
 - Inline decisions made (not flagged as architectural clarifications):
   - Two-level chain (Tenant Root → Org Cert). Three-level is an out-of-scope extension.
@@ -44,5 +44,4 @@
   - Default CA validity 10 years; default Org Cert validity 2 years; default CRL refresh 24 hours. All configurable.
   - Internal-path credentials do NOT carry `x5c`. The two trust stacks run genuinely in parallel on different credentials.
 - Inline decision on org cert issuance triggering: enrolment requires `HaipIssuer` capability from spec 094 to already be set. No auto-enrolment; operator action is required.
-- The "No [NEEDS CLARIFICATION] markers" checklist item is intentionally unchecked. Q4.1 and Q4.2 are genuine architectural questions that affect planning shape. Closing them requires a user ruling, not a planner's best guess.
-- Items requiring updates before `/speckit.plan`: Q4.1 and Q4.2 rulings must be captured.
+- All checklist items pass as of this iteration. Q4.1 and Q4.2 rulings are captured in the spec's Clarifications section, in FR-002, FR-012, and in the Assumptions section.

--- a/specs/096-x509-org-trust/contracts/README.md
+++ b/specs/096-x509-org-trust/contracts/README.md
@@ -1,0 +1,102 @@
+# Phase 1 Contracts: X.509 Organisation Trust Integration
+
+**Feature**: 096-x509-org-trust
+
+## Public HTTP endpoints
+
+### `POST /api/v1/trust/tenants/{tenantId}/provision`
+
+**Auth**: Tenant admin
+**Body**:
+```json
+{
+  "algorithm": "Ed25519",
+  "validityYears": 10,
+  "signingMode": "Local",
+  "externalCertDer": null
+}
+```
+**Behaviour**: idempotent — running twice on the same tenant returns the existing root without regenerating
+**200 Response**: `TenantRootCa` record (cert in base64 DER, public key, validity)
+
+### `GET /api/v1/trust/tenants/{tenantId}/trust-anchor`
+
+**Auth**: Anonymous (public, cacheable)
+**Cache-Control**: `public, max-age=3600`
+**200 Response**: Tenant Root CA certificate in DER-encoded base64
+
+### `GET /api/v1/trust/tenants/{tenantId}/crl`
+
+**Auth**: Anonymous (public, cacheable)
+**Cache-Control**: `public, max-age=3600`
+**Content-Type**: `application/pkix-crl`
+**200 Response**: DER-encoded CRL signed by the tenant root
+
+### `POST /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/enrol`
+
+**Auth**: Tenant admin
+**Preconditions**: org wallet must carry `HaipIssuer` capability (spec 094)
+**Body**:
+```json
+{
+  "displayName": "ACME Ltd",
+  "validityYears": 2
+}
+```
+**200 Response**: `OrgCertEnrolment` record with serial, cert DER, validity
+**400**: wallet lacks `HaipIssuer` capability — points at spec 094
+
+### `POST /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/revoke`
+
+**Auth**: Tenant admin
+**Body**: `{ "reason": "keyCompromise" | "superseded" | "unspecified" }`
+**200 Response**: updated `TenantCrl`
+
+## Internal service contracts
+
+### `ITrustProvider` — pluggable interface
+
+```csharp
+public interface ITrustProvider
+{
+    Task<TenantRootCa> ProvisionTrustAnchorAsync(string tenantId, ProvisionOptions options, CancellationToken ct);
+    Task<OrgCertEnrolment> IssueOrgCertAsync(string tenantId, string orgWalletAddress, IssueOptions options, CancellationToken ct);
+    Task<TenantCrl> RevokeOrgCertAsync(string tenantId, string serialNumber, string reason, CancellationToken ct);
+    Task<TenantCrl> PublishCrlAsync(string tenantId, CancellationToken ct);
+    Task<TenantRootCa?> FetchTrustAnchorAsync(string tenantId, CancellationToken ct);
+}
+```
+
+### `ICaKeyProtection` — CA key storage adapter
+
+```csharp
+public interface ICaKeyProtection
+{
+    Task<string> StoreAsync(byte[] privateKeyDer, string tenantId, CancellationToken ct);
+    Task<byte[]> RetrieveAsync(string keyRef, CancellationToken ct);
+    Task DeleteAsync(string keyRef, CancellationToken ct);
+}
+```
+
+Two implementations: `LocalCaKeyProtection` (wraps the existing local encryption provider) and `KmsResidentCaKeyProtection` (wraps the existing KMS integration).
+
+### Wallet Service / issuer integration
+
+`CredentialEndpoints.IssueCredential` gains a new branch: when the request indicates HAIP-path issuance (via the new `StatusClaimForm: IetfTokenStatusList` from spec 095 or an explicit `IncludeX5c: true` flag), the handler:
+1. Fetches the Org Cert chain via a new `IOrgCertChainProvider.GetChainForAsync(walletAddress, ct)` that calls the Tenant Service's trust endpoints
+2. Passes the chain into `ISdJwtService.CreateTokenAsync` as a new optional `x5cChain` parameter
+3. `SdJwtService` embeds the chain in the JWS header before signing
+
+### Verifier integration
+
+The verifier (`PresentationRequestService` per spec 093, and the new HAIP verifier per spec 098) gains:
+- `ITrustStore` — holds accepted root certs for chain validation
+- On presentation verify, if the token's JWS header contains `x5c`, walk the chain against the trust store; fall back to DID-based trust if no chain is present
+
+## Wire format impacts
+
+- **New public endpoints** under `/api/v1/trust/tenants/{tenantId}/...`
+- **HAIP-path SD-JWT VC JWS header** gains `x5c` array with DER-encoded base64 certs
+- **Internal-path SD-JWT VC JWS header** unchanged (no `x5c`)
+- **`CertificateRevocationListDistributionPoints`** extension on Org Certs points at the tenant CRL URL
+- **`SubjectAlternativeName`** URI entry on Org Certs carries the `did:sorcha:org:` DID

--- a/specs/096-x509-org-trust/data-model.md
+++ b/specs/096-x509-org-trust/data-model.md
@@ -1,0 +1,105 @@
+# Phase 1 Data Model: X.509 Organisation Trust Integration
+
+**Feature**: 096-x509-org-trust
+
+## Entities
+
+### 1. `TenantRootCa` (new, first-class domain entity per Q4.1 Option B)
+
+Represents the Tenant Root CA for a Sorcha tenant. One per tenant.
+
+**Fields:**
+- `TenantId` (PK) — the tenant identifier
+- `Subject` — X.500 distinguished name (CN = tenant name, O = Sorcha)
+- `SerialNumber` — base16
+- `NotBefore`, `NotAfter` — validity period (default 10 years)
+- `Algorithm` — classical only (Ed25519, ES256, RS256)
+- `PublicKeyDer` — DER-encoded SubjectPublicKeyInfo
+- `CertDer` — DER-encoded certificate
+- `PrivateKeyProtectionMode` — `Local` | `KmsResident` | `ExternallyImported`
+- `PrivateKeyRef` — for `Local`/`KmsResident`, the reference into the key-protection provider; for `ExternallyImported`, null
+- `DerivationSeedIndex` — optional, non-null when the key was internally generated from a tenant CA recovery seed under `sorcha:tenant-ca-signing`
+- `CreatedAt`, `UpdatedAt`
+
+**Semantics:**
+- Not part of the wallet HD hierarchy (Q4.1 Option B)
+- Storage reuses the wallet KMS integration via a thin `ICaKeyProtection` adapter
+- Tenant can swap `PrivateKeyProtectionMode` at provisioning time but cannot change it after the root is generated (rotation is out of scope)
+
+### 2. `OrgCertEnrolment` (new)
+
+Represents a per-organisation cert issued by the Tenant Root CA.
+
+**Fields:**
+- `Id` (PK) — surrogate
+- `TenantId` — foreign key to tenant
+- `OrgWalletAddress` — the Sorcha org wallet whose classical HAIP issuer signing key is bound
+- `SerialNumber` — unique per Tenant Root CA
+- `Subject` — CN = org display name, O = tenant name
+- `SubjectAltName` — URI = `did:sorcha:org:{orgWalletAddress}`
+- `Algorithm` — classical, matches the org wallet's HAIP issuer signing key (ES256 default)
+- `PublicKeyDer` — matches the org wallet's `HaipIssuerCoKey.PublicKey`
+- `CertDer` — DER-encoded certificate
+- `NotBefore`, `NotAfter` — validity period (default 2 years)
+- `RevokedAt` — null when active, set when revoked
+- `RevocationReason` — RFC 5280 reason code, null when active
+- `CrlDistributionPoint` — URL of the tenant CRL
+- `CreatedAt`
+
+**Semantics:**
+- Bound to the existing classical HAIP issuer signing key — the key is not generated at enrolment time
+- Attempting to enrol for a wallet that lacks the `HaipIssuer` capability fails with a clear prerequisite error pointing at spec 094
+- Revocation is permanent; a new enrolment generates a new cert with a new serial number
+- After revocation, the Wallet Service refuses HAIP-path issuance from the underlying wallet until a fresh Org Cert is enrolled
+
+### 3. `TenantCrl` (new)
+
+Represents the current CRL state for a tenant.
+
+**Fields:**
+- `TenantId` (PK)
+- `ThisUpdate` — CRL generation time
+- `NextUpdate` — scheduled refresh time (24 hours default)
+- `CrlDer` — DER-encoded CRL signed by the Tenant Root CA
+- `RevokedSerialNumbers` — list of (serial, revokedAt, reason) tuples, mirrors the CRL content for querying
+- `Version` — monotonic counter
+
+**Semantics:**
+- Regenerated on every revocation and on the scheduled refresh interval
+- Serves via the `/api/v1/trust/tenants/{tenantId}/crl` endpoint with `Cache-Control: public, max-age=3600`
+- Tenant Root CA key signs each version
+
+### 4. `ITrustProvider` (new pluggable interface)
+
+Contract for swapping between internal CA and externally-rooted trust providers.
+
+**Methods:**
+- `ProvisionTrustAnchor(tenantId, options, ct)` → `TenantRootCa`
+- `IssueOrgCert(tenantId, orgWalletAddress, options, ct)` → `OrgCertEnrolment`
+- `RevokeOrgCert(tenantId, serialNumber, reason, ct)` → `TenantCrl`
+- `PublishCrl(tenantId, ct)` → current `TenantCrl` (may regenerate)
+- `FetchTrustAnchor(tenantId, ct)` → `TenantRootCa`
+
+**Default implementation**: `InternalCaTrustProvider` — generates a self-signed root using BCL primitives. Custom implementations can swap in externally-rooted chains.
+
+### 5. `Wallet` capability check (no field change)
+
+No change to `Wallet` entity itself — the `HaipIssuer` flag is defined by spec 094. Spec 096 reads this flag as a precondition at enrolment time.
+
+## Validation rules
+
+- Tenant Root CA validity period must be ≥ 1 year and ≤ 20 years
+- Org Cert validity period must be ≤ Tenant Root CA validity period remaining
+- Org Cert's public key MUST match the wallet's `HaipIssuerCoKey.PublicKey` at enrolment time
+- Revocation requires the caller to have tenant-admin scope (enforced by JWT claim check)
+- CRL serial number list MUST be ordered by serial value per RFC 5280
+
+## Migration notes
+
+New EF migration for `TenantRootCa`, `OrgCertEnrolment`, `TenantCrl` tables. Folded into the pre-release consolidated migration per user guidance (`feedback_migration_squash` memory note). No runtime migration needed since nothing exists in production for these tables yet.
+
+## On-wire format impacts
+
+- **HAIP-path SD-JWT VC outer JWS header**: gains an `x5c` array with Org Cert (leaf) and Tenant Root CA (root) as DER-encoded base64 entries
+- **Internal-path SD-JWT VC**: unchanged — no `x5c`, DID-based trust only
+- **New public endpoints**: trust anchor publication, CRL publication, enrolment/revocation admin endpoints

--- a/specs/096-x509-org-trust/plan.md
+++ b/specs/096-x509-org-trust/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: X.509 Organisation Trust Integration
+
+**Branch**: `096-x509-org-trust` | **Date**: 2026-04-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/096-x509-org-trust/spec.md`
+
+## Summary
+
+Stand up an X.509 trust anchor stack so Sorcha-issued credentials can be verified by HAIP wallets that expect PKI chains. Per Phase 2 D4 Option B with Q4.1 → Option B and Q4.2 → Option D rulings captured in spec.md:
+
+- **Tenant Root CA** is a new first-class domain entity (not a wallet HD sub-key), with its own key storage. Internally generated CA keys MAY be derived from a tenant CA recovery seed under `sorcha:tenant-ca-signing` for deterministic recovery; externally imported CA keys (HSMs, eIDAS QTSPs) carry no derivation history.
+- **Two-level chain**: Tenant Root → Org Cert. Org Cert's Subject Public Key Info encodes the existing classical HAIP issuer signing key (from spec 094). `did:sorcha:org:{walletAddress}` goes into a Subject Alternative Name URI entry.
+- **`x5c` chain** on the outer JWS header of HAIP-path SD-JWT VCs, per RFC 7515 §4.1.6.
+- **CRLs** only (no OCSP) — tenant CRL signed by the root, 24-hour default refresh, no delta CRLs.
+- **Pluggable trust provider** interface so a deployment can swap the default internal CA for an externally-rooted chain without touching the HAIP plumbing.
+- **No EKU** on the Org Cert (Q4.2 Option D) — defer to HAIP 1.1 or a named partner requirement.
+
+Depends on spec 094 (classical HAIP issuer co-key). Independent of spec 095. Required by specs 097 and 098.
+
+## Technical Context
+
+**Language/Version**: C# 13, .NET 10
+**Primary Dependencies**: `System.Security.Cryptography.X509Certificates` (BCL — full cert issuance, CRL generation, chain validation for classical algorithms), `System.Formats.Asn1` (BCL, for ASN.1 DER serialisation), `Sorcha.Cryptography` for the BIP32 purpose derivation when generating CA keys internally. No new NuGet packages.
+**Storage**: PostgreSQL — new `TenantRootCa` table (tenant ID, cert bytes, creation/validity, signing mode) and `OrgCertEnrolment` table (org wallet address, serial number, cert bytes, issued/expires, revoked flag). New EF migration folded into the pre-release consolidated migration per user guidance.
+**Testing**: xUnit, FluentAssertions, Moq. Unit tests for cert issuance, chain walk, CRL generation/consumption. Integration tests with round-trip enrol→issue→verify→revoke→re-enrol.
+**Target Platform**: Linux server (Docker), net10.0
+**Project Type**: Multi-service monorepo. **No new services** (trust provider lives in `Sorcha.Tenant.Service` because tenant-level identity fits the tenant domain). New domain entities under `Sorcha.Tenant.Models`.
+**Performance Goals**: Cert issuance < 100 ms P95. Chain validation < 10 ms P95 (classical cryptographic signatures). CRL fetch < 200 ms P95 under cache.
+**Constraints**: Internal Sorcha credentials MUST NOT carry `x5c` (FR-020). DID-based trust path for internal credentials MUST remain unchanged (FR-040). CA signing algorithm MUST be classical only (FR-005 — HAIP 1.0 is classical at the trust boundary). Spec 094 must be merged before the Org Cert binding-key step can be implemented.
+**Scale/Scope**: New first-class domain entity (Tenant Root CA). ~10 source files, ~5 test files. New HTTP endpoints for trust anchor publication, CRL publication, org enrolment, cert revocation.
+
+## Constitution Check
+
+| Principle | Assessment |
+|---|---|
+| **I. Microservices-First Architecture** | PASS. Tenant Root CA lives in the Tenant Service (tenant-scoped identity is a natural fit). No new services. Blueprint, Wallet, Register services unchanged beyond consuming the new chain at issue/verify time. |
+| **II. Security First** | PASS — this spec is a trust layer hardening. CA private keys live under the same `signingMode` abstraction (`Local`, `KmsResident`) that wallet keys use. No secrets in source control. Input validation on all enrolment endpoints via FluentValidation. |
+| **III. API Documentation** | PASS. New endpoints documented via Scalar. XML doc comments on all new public APIs. |
+| **IV. Testing Requirements** | PASS. FR-038 mandates unit + integration coverage. |
+| **V. Code Quality** | PASS. Nullable enabled. Standard C# conventions. |
+| **VI. Blueprint Creation Standards** | N/A. No blueprint changes. |
+| **VII. Domain-Driven Design** | PASS. New domain terms: `TenantRootCa`, `OrgCert`, `TenantCrl`, `TrustProvider`, `EnrolmentRecord`. Distinct from wallet domain concepts per Q4.1 ruling. |
+| **VIII. Observability by Default** | PASS. Structured log events on cert issuance, CRL generation, chain validation failures, trust provider switching. |
+
+**Constitution gate: PASS.**
+
+## Project Structure
+
+```text
+specs/096-x509-org-trust/
+├── spec.md              # (complete, Q4.1+Q4.2 resolved)
+├── plan.md              # This file
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md
+
+src/
+├── Common/
+│   └── Sorcha.Tenant.Models/
+│       ├── Trust/
+│       │   ├── TenantRootCa.cs                    # NEW — domain entity
+│       │   ├── OrgCertEnrolment.cs                # NEW — per-org cert record
+│       │   ├── TenantCrl.cs                       # NEW — CRL state/version
+│       │   └── TrustProviderMode.cs               # NEW — enum (InternalCa | External)
+│       └── Credentials/
+│           └── (unchanged)
+└── Services/
+    └── Sorcha.Tenant.Service/
+        ├── Trust/
+        │   ├── ITrustProvider.cs                  # NEW — pluggable interface
+        │   ├── InternalCaTrustProvider.cs         # NEW — default implementation
+        │   ├── X509CertificateBuilder.cs          # NEW — builds Org Certs bound to the classical signing key
+        │   ├── TenantCrlBuilder.cs                # NEW — generates signed CRLs
+        │   └── TrustProviderRegistry.cs           # NEW — resolves provider per tenant
+        ├── Endpoints/
+        │   └── TrustEndpoints.cs                  # NEW — provisioning, enrolment, revocation, trust anchor GET, CRL GET
+        └── Services/
+            ├── Interfaces/
+            │   └── ITrustAnchorService.cs         # NEW — tenant-facing facade
+            └── Implementation/
+                └── TrustAnchorService.cs          # NEW
+
+src/Services/Sorcha.Wallet.Service/
+└── Endpoints/
+    └── CredentialEndpoints.cs                     # CHANGE — when HAIP-path issuance, fetch Org Cert chain and embed in x5c JWS header
+
+src/Services/Sorcha.Blueprint.Service/  (or Haip service when spec 097 lands)
+└── (presentation verifier extended to walk x5c chains — may land here or in Wallet Service verifier)
+
+tests/
+├── Sorcha.Tenant.Service.Tests/
+│   └── Trust/
+│       ├── X509CertificateBuilderTests.cs         # NEW
+│       ├── TenantCrlBuilderTests.cs               # NEW
+│       ├── InternalCaTrustProviderTests.cs        # NEW
+│       └── TrustAnchorServiceTests.cs             # NEW
+└── Sorcha.Tenant.Service.IntegrationTests/
+    └── TrustRoundTripTests.cs                     # NEW — provision → enrol → issue → verify → revoke → re-enrol
+```
+
+**Structure Decision**: Existing monorepo. CA stack lives in `Sorcha.Tenant.Service` (not Wallet — the CA is not a wallet key per Q4.1 Option B). New `Trust/` namespace inside the Tenant Service holds the provider interface, default implementation, cert/CRL builders, and registry. Domain entities under `Sorcha.Tenant.Models/Trust/`. HTTP endpoints exposed via a new `TrustEndpoints.cs`.
+
+## Complexity Tracking
+
+*No Constitution violations — this section intentionally empty.*

--- a/specs/096-x509-org-trust/quickstart.md
+++ b/specs/096-x509-org-trust/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: Verifying X.509 Organisation Trust Locally
+
+**Feature**: 096-x509-org-trust
+
+## Prerequisites
+
+- Specs 093 and 094 merged to master
+- .NET 10 SDK, Docker Desktop
+
+## 1. Provision a Tenant Root CA
+
+### Steps
+
+1. Provision:
+   ```bash
+   curl -X POST http://localhost/api/v1/trust/tenants/{tenantId}/provision \
+     -H "Authorization: Bearer $ADMIN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"algorithm":"Ed25519","validityYears":10,"signingMode":"Local"}'
+   ```
+2. Fetch the trust anchor:
+   ```bash
+   curl http://localhost/api/v1/trust/tenants/{tenantId}/trust-anchor > root.cer
+   ```
+3. Inspect with OpenSSL:
+   ```bash
+   openssl x509 -inform DER -in root.cer -text -noout
+   ```
+
+### Expected
+
+- Self-signed root with `CN=tenant display name`, 10-year validity, Ed25519 public key.
+
+## 2. Enrol an organisation
+
+### Steps
+
+1. Create a wallet with `HaipIssuer` capability (spec 094).
+2. Enrol the wallet as an org issuer:
+   ```bash
+   curl -X POST http://localhost/api/v1/trust/tenants/{tenantId}/orgs/{walletAddress}/enrol \
+     -H "Authorization: Bearer $ADMIN_TOKEN" \
+     -d '{"displayName":"ACME Ltd","validityYears":2}'
+   ```
+3. Fetch the org cert and inspect:
+   ```bash
+   # Response body contains `certDer` field in base64
+   echo "{certDerBase64}" | base64 -d > org.cer
+   openssl x509 -inform DER -in org.cer -text -noout
+   ```
+
+### Expected
+
+- Subject CN = "ACME Ltd"
+- SAN URI = `did:sorcha:org:{walletAddress}`
+- CRL Distribution Points = tenant CRL URL
+- Subject Public Key Info matches the wallet's `HaipIssuerCoKey.PublicKey`
+- No EKU extension (Q4.2 ruling)
+- Issued by the Tenant Root CA
+
+## 3. Issue a HAIP-path credential with x5c
+
+### Steps
+
+1. Issue a credential from the enrolled wallet via the Blueprint or direct HTTP path with the HAIP flag set.
+2. Extract the `rawToken` and decode its JWS header:
+   ```bash
+   echo "{headerBase64}" | base64 -d | jq
+   ```
+
+### Expected
+
+Header contains `x5c` array with two entries (leaf = Org Cert, root = Tenant Root CA), both DER-encoded base64.
+
+## 4. Verify externally
+
+### Steps
+
+1. Build the chain from the token's `x5c`.
+2. Walk against the tenant root fetched at step 1:
+   ```bash
+   openssl verify -CAfile root.cer org.cer
+   ```
+3. Verify the token signature against the Org Cert's public key.
+
+### Expected
+
+Chain valid, signature valid.
+
+## 5. Revoke and observe propagation
+
+### Steps
+
+1. Revoke the Org Cert:
+   ```bash
+   curl -X POST http://localhost/api/v1/trust/tenants/{tenantId}/orgs/{walletAddress}/revoke \
+     -H "Authorization: Bearer $ADMIN_TOKEN" \
+     -d '{"reason":"keyCompromise"}'
+   ```
+2. Refetch the CRL after the cache TTL elapses:
+   ```bash
+   curl http://localhost/api/v1/trust/tenants/{tenantId}/crl > crl.der
+   openssl crl -inform DER -in crl.der -text -noout
+   ```
+
+### Expected
+
+CRL contains the Org Cert's serial number with the `keyCompromise` reason code. Subsequent HAIP-path issuance attempts from the same wallet fail until a fresh Org Cert is enrolled.
+
+## 6. Swap to external trust provider
+
+### Steps
+
+1. Configure a custom `ITrustProvider` implementation via DI that returns a pre-generated externally-rooted chain.
+2. Run provisioning on a fresh tenant.
+3. Confirm the trust anchor endpoint returns the externally-rooted cert, and org enrolment uses the external provider for signing.
+
+## Sign-off criteria
+
+- [ ] Tenant Root CA provisioning is idempotent
+- [ ] Org Cert enrolment fails for wallets without `HaipIssuer` capability
+- [ ] Issued credential JWS header contains valid `x5c` chain
+- [ ] External OpenSSL `verify` confirms the chain
+- [ ] Revocation propagates to the CRL after cache TTL
+- [ ] Internal-path credentials (no `x5c`) continue to verify unchanged (spec 093 regression)
+- [ ] DID-based verification path still works for credentials without `x5c` (spec 039 regression)
+- [ ] External trust provider swap produces a deployment where the HAIP boundary works with no Sorcha code change

--- a/specs/096-x509-org-trust/research.md
+++ b/specs/096-x509-org-trust/research.md
@@ -1,0 +1,134 @@
+# Phase 0 Research: X.509 Organisation Trust Integration
+
+**Feature**: 096-x509-org-trust
+**Date**: 2026-04-09
+
+## Research items
+
+1. BCL capability check — can `System.Security.Cryptography.X509Certificates` build a self-signed root, issue end-entity certs, and generate CRLs without third-party libraries?
+2. CA private key storage — which existing Sorcha signingMode abstraction to reuse
+3. SAN URI encoding for `did:sorcha:org:` identifiers
+4. Org Cert Subject Public Key Info — how to bind the classical HAIP issuer signing key from spec 094
+5. CRL publication URL and cache strategy
+6. Trust provider switch at runtime — how a deployment selects internal vs external provider
+7. Chain walk on the verifier side — where the trust store lives and how verifiers are configured
+
+---
+
+## R1. BCL X.509 capability
+
+### Findings
+
+.NET 10 `System.Security.Cryptography.X509Certificates`:
+- `CertificateRequest` builds a certificate signing request with subject, public key, extensions
+- `CertificateRequest.CreateSelfSigned` builds a self-signed root
+- `CertificateRequest.Create(issuer, signatureGenerator, notBefore, notAfter, serialNumber)` signs an end-entity cert with a root
+- `X509Certificate2.CopyWithPrivateKey` associates a private key with a cert for storage
+- CRL generation: `CertificateRevocationListBuilder` (added in .NET 7+) produces RFC 5280 CRLs signed by the issuer
+
+All classical algorithms (Ed25519, ECDsa P-256, RSA) are supported. Ed25519 cert signing is supported in .NET 10 via the `EdDsaOpenSsl` integration.
+
+### Decision: use the BCL for everything, no third-party cert library
+
+**Rationale.** BCL coverage is complete for classical algorithms. `BouncyCastle` would add bloat and overlap. The `CertificateRevocationListBuilder` ships CRL generation in-the-box.
+
+**Consequence.** All cert and CRL work lives in new helper classes (`X509CertificateBuilder`, `TenantCrlBuilder`) under `Sorcha.Tenant.Service/Trust/`. No new NuGet dependencies.
+
+---
+
+## R2. CA private key storage
+
+### Findings
+
+The wallet domain has `signingMode: "Local" | "KmsResident"` per spec 094. The KMS integration pattern (Azure Key Vault, AWS KMS) is available for wallet keys. The same abstraction can be reused for CA keys — the key itself is just bytes, and the storage backend doesn't care whether it's a wallet signing key or a CA signing key.
+
+### Decision: introduce a parallel `CaKeyStorage` abstraction that delegates to the same KMS / local providers the wallet layer uses
+
+**Rationale.** Q4.1 Option B (new first-class entity) says CA keys are distinct from wallet keys. But the *storage mechanism* can still reuse the wallet's KMS integration — only the logical ownership and lifecycle differ. The `CaKeyStorage` is a thin adapter that wraps the existing key protection providers with a CA-scoped key identifier naming scheme.
+
+**Consequence.** New `ICaKeyProtection` interface in `Sorcha.Tenant.Service/Trust/`. Two implementations: `LocalCaKeyProtection` (using existing local encryption provider) and `KmsResidentCaKeyProtection` (using existing KMS integration). Tenant configures which one at provisioning time.
+
+**Alternative rejected.** Reusing `IWalletRepository` or `IKeyManagementService` directly. Rejected because it would blur the wallet/CA domain boundary that Q4.1 ruled against.
+
+---
+
+## R3. SAN URI encoding for `did:sorcha:org`
+
+### Findings
+
+RFC 5280 Subject Alternative Name supports a `uniformResourceIdentifier` field carrying any URI. `did:sorcha:org:{walletAddress}` is a valid URI (colon-separated, scheme is `did`).
+
+`CertificateRequest` exposes `X509Extension` builders; `X509SubjectAlternativeNameBuilder.AddUri(Uri)` adds a URI-type SAN entry.
+
+### Decision: use `AddUri(new Uri("did:sorcha:org:..."))`
+
+**Rationale.** Standard, interoperable, already well-supported in the BCL.
+
+**Consequence.** `X509CertificateBuilder.BuildOrgCert(...)` method takes a `did:sorcha:org:` DID string and adds it as a SAN URI alongside the CN.
+
+---
+
+## R4. Org Cert Subject Public Key Info
+
+### Decision: bind the classical HAIP issuer signing key from spec 094
+
+**Rationale.** Per FR-008, the Org Cert's Subject Public Key Info encodes the existing classical HAIP issuer signing key. No new key is generated at enrolment time. The key comes from `IHaipIssuerCoKeyService.GetSigningKeyForHaipIssuanceAsync(walletAddress)` (spec 094).
+
+**Consequence.** The enrolment flow:
+1. Verify the target wallet carries the `HaipIssuer` capability (spec 094 precondition)
+2. Call `IHaipIssuerCoKeyService.GetSigningKeyForHaipIssuanceAsync(walletAddress)` to get the classical `(privateKey, algorithm, publicJwk)` tuple
+3. Build a `CertificateRequest` using the public key from step 2
+4. Sign with the Tenant Root CA's private key
+5. Persist the resulting cert as an `OrgCertEnrolment` record
+
+**Key rotation note**: if the underlying classical co-key is rotated (spec 094 derives a new key at a new index), the Org Cert must be re-issued. Spec 094 marks rotation as out of scope, so this spec matches that scope — rotation is a follow-up.
+
+---
+
+## R5. CRL publication URL and cache
+
+### Decision: one CRL per tenant at `/api/v1/trust/tenants/{tenantId}/crl`
+
+**Rationale.** Tenant-scoped is the simplest unit. The CRL's CRLDP extension on each Org Cert points at this URL. Cache-Control: `public, max-age=3600` (1 hour — shorter than the 24-hour refresh interval so clients don't serve stale CRLs too long).
+
+Refresh interval is configurable. Default 24 hours. Refresh happens on every revocation AND on a scheduled background task.
+
+**Consequence.** New endpoint handler `GetTenantCrl` in `TrustEndpoints.cs`. Uses the same `CachedResult` wrapper used by the status list endpoint.
+
+---
+
+## R6. Trust provider switch
+
+### Decision: `ITrustProvider` interface resolved from tenant config at service startup
+
+**Rationale.** Per spec FR-031–FR-035. The interface surfaces `ProvisionTrustAnchor`, `IssueOrgCert`, `RevokeOrgCert`, `PublishCrl`, `FetchTrustAnchor`. Default implementation is `InternalCaTrustProvider` (self-signed root). A deployment can register a custom implementation in DI before the default is registered; the registry picks the first registered implementation per tenant.
+
+**Consequence.** `TrustProviderRegistry.GetProviderForTenant(tenantId)` returns the configured provider. Tenants can override by setting `Trust:Provider` in config.
+
+---
+
+## R7. Chain walk on the verifier side
+
+### Decision: the verifier's trust store is deployment configuration
+
+**Rationale.** Per FR-029 the trust store is configurable per deployment. For Sorcha-internal verification, the trust store contains the tenant's own root cert (added at provisioning time). For external verifiers (HAIP wallets), trust store population is out of Sorcha's control.
+
+**Consequence.** A new `ITrustStore` service in the verifier side holds the configured roots. `PresentationRequestService` (or the new HAIP verifier service in spec 098) walks the `x5c` chain against this store during credential verification.
+
+Internal credentials (no `x5c`) continue to use DID-based trust per spec 093/039.
+
+---
+
+## Summary
+
+All seven research items resolved. Key decisions:
+
+1. BCL only — no new cert libraries
+2. CA key storage reuses wallet KMS integration via a thin `ICaKeyProtection` adapter
+3. `did:sorcha:org:{addr}` goes into a URI-type SAN on the Org Cert
+4. Org Cert binds the spec 094 classical HAIP issuer signing key
+5. One tenant CRL at `/api/v1/trust/tenants/{tenantId}/crl`, 1-hour cache, 24-hour refresh
+6. `ITrustProvider` interface with `InternalCaTrustProvider` default; deployments override in DI
+7. Verifier trust store is per-deployment config; `x5c` walks match against it
+
+Ready for Phase 1.

--- a/specs/096-x509-org-trust/spec.md
+++ b/specs/096-x509-org-trust/spec.md
@@ -1,0 +1,288 @@
+# Feature Specification: X.509 Organisation Trust Integration
+
+**Feature Branch**: `096-x509-org-trust`
+**Created**: 2026-04-09
+**Status**: Draft
+**Input**: User description: "Internal Sorcha CA per tenant issuing X.509 org certs for HAIP issuer identity, pluggable trust provider, x5c chain in SD-JWT VC JWS header"
+
+## Context
+
+HAIP 1.0 external verifiers — GOV.UK Wallet, EUDI Wallet, registered Digital Verification Services, generic HAIP-conformant test harnesses — validate issuer identity against **X.509 certificate chains rooted in trust lists**, not against the DID-based trust model Sorcha uses internally. Phase 1 confirmed that Sorcha has zero X.509 integration on master: no certificate handling, no CA, no `x5c` headers on issued SD-JWT VCs, no CRL publication. Without this, any Sorcha-issued credential reaching a HAIP wallet is architecturally unverifiable at the trust layer regardless of how conformant the rest of the credential format is.
+
+Phase 2 D4 chose **internal Sorcha CA per tenant** as the default trust model, sitting behind a **pluggable trust provider interface** so a real-world deployment can later swap in a publicly-rooted chain (eIDAS QTSP, HMG DVS-accepted CA) without changing the credential format or the rest of the HAIP spec set. D4 also scoped this first spec to **org-level** certificates only; tenant-level and register-level scopes are explicitly deferred.
+
+This spec stands up the PKI stack, wires it into the HAIP credential issuance path introduced by spec 097, and publishes the chain on the wire via the standard JOSE `x5c` header on the SD-JWT VC's outer JWS. Internal Sorcha credential issuance and verification paths continue to use DID-based trust unchanged — the two trust stacks run in parallel on the same credentials.
+
+**Related specs.**
+- **Depends on** spec 094 (`sdjwt-haip-hardening`) — the Org Cert's subject public key is the classical signing key that 094 derives under `sorcha:haip-issuer-signing`.
+- **Runs in parallel to** spec 095 (`ietf-token-status-list`) — no dependency in either direction. The IETF Token Status List JWT signing key can be verified via this spec's X.509 chain for HAIP-facing scenarios, but neither spec blocks the other.
+- **Required by** spec 097 (`openid4vci-issuer`) — the HAIP issuer endpoint cannot emit credentials acceptable to HAIP wallets without an X.509 chain in `x5c`.
+- **Required by** spec 098 (`openid4vp-verifier`) — the HAIP verifier endpoint needs to validate incoming credentials' `x5c` chains against its trust store.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A HAIP external wallet trusts a Sorcha-issued credential via X.509 chain (Priority: P1)
+
+A Sorcha-using authority (a council, a regulator, a professional body) issues a licence credential via the HAIP path. The signed SD-JWT VC carries an `x5c` header containing a two-element certificate chain: the Org Cert for the issuing authority and the Tenant Root CA that signed it. A HAIP wallet receives the credential, walks the chain, checks the Tenant Root against whatever trust store it holds, verifies the credential signature using the public key from the Org Cert's Subject Public Key Info, and accepts the credential without needing any Sorcha-specific knowledge.
+
+After this spec ships, the X.509 pieces work end to end for the Sorcha-internal CA case. A deployment that wants real-world trust (EUDI Wallet enrolment, HMG DVS) swaps the pluggable trust provider for a publicly-rooted one without touching the credential format or the HAIP spec set.
+
+**Why this priority**: This is the hard prerequisite for HAIP external wallet interop at the trust layer. Spec 097 can emit HAIP-shaped credentials, but without a valid trust chain in `x5c` no real HAIP wallet will accept them. This story is also what the "Sorcha is the workflow layer above GOV.UK Wallet" positioning stands or falls on once a demo progresses past credential-format validation.
+
+**Independent Test**: Provision a tenant root CA, issue an org cert for a test authority, issue a credential through a test HAIP path with the `x5c` header populated, then verify the credential with a generic third-party HAIP client that has the test tenant root in its trust store. Confirm the client accepts the credential. Remove the tenant root from the client's trust store and confirm the client rejects it with a trust anchor error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provisioned tenant root CA and an issued org cert for a HAIP issuer wallet, **When** the wallet issues a credential via the HAIP path, **Then** the signed SD-JWT VC's JWS header contains an `x5c` member carrying the Org Cert and the Tenant Root CA in DER-encoded base64 form, leaf first.
+2. **Given** a credential with a valid two-element `x5c` chain, **When** a generic HAIP client walks the chain and finds the Tenant Root in its trust store, **Then** chain validation succeeds, the credential signature is verified against the Org Cert's Subject Public Key Info, and the credential is accepted.
+3. **Given** the same credential, **When** the Tenant Root is not in the HAIP client's trust store, **Then** chain validation fails with a trust anchor error and the credential is rejected before any claim is considered.
+4. **Given** a credential whose Org Cert has expired, **When** the HAIP client walks the chain, **Then** validation fails with a certificate expiry error naming the offending cert.
+5. **Given** a credential whose Org Cert has been revoked (CRL listing), **When** the HAIP client fetches the CRL and checks the Org Cert's serial number, **Then** validation fails with a revoked certificate error.
+6. **Given** a credential whose issuer identifier embedded in the SD-JWT `iss` claim does not match the Org Cert's Subject Alternative Name URI, **When** the HAIP client validates consistency, **Then** validation fails with an issuer mismatch error.
+
+---
+
+### User Story 2 - A Sorcha tenant provisions a fresh PKI stack with a single operation (Priority: P1)
+
+A new Sorcha deployment needs X.509-capable HAIP issuance. The tenant operator runs a provisioning operation that creates the Tenant Root CA, publishes its public trust anchor information, and initialises the CRL distribution point. From that point forward, org certs can be issued on demand whenever an organisation in the tenant registers as a HAIP issuer.
+
+After this spec ships, provisioning is a single tenant-scoped operation with idempotent semantics. The Tenant Root CA key material is held in the same key-management mode as the tenant's other high-sensitivity keys (local or KMS-resident, following the existing `signingMode` pattern from spec 094). Trust anchor publication uses a stable URL so external verifiers can fetch and cache it.
+
+**Why this priority**: This is the setup story. Every other User Story in this spec assumes a provisioned tenant CA. Without a clean provisioning model, the whole spec becomes an ops-heavy collection of manual steps.
+
+**Independent Test**: Run the provisioning operation on an empty tenant and confirm a Tenant Root CA exists, its trust anchor URL resolves to a valid document, and the CRL distribution URL resolves to a valid empty CRL. Run the provisioning operation a second time on the same tenant and confirm it is idempotent (no second root is created).
+
+**Acceptance Scenarios**:
+
+1. **Given** a tenant with no existing PKI, **When** the tenant provisioning operation runs, **Then** a Tenant Root CA is created, its private key is stored according to the tenant's declared signing mode (local or KMS-resident), and its public trust anchor is published at a stable URL.
+2. **Given** a provisioned tenant, **When** the provisioning operation runs a second time, **Then** the operation is a no-op and the existing Tenant Root CA is unchanged.
+3. **Given** a provisioned tenant, **When** the trust anchor URL is fetched, **Then** the response contains the Tenant Root CA certificate in DER-encoded base64 form and metadata identifying the tenant.
+4. **Given** a provisioned tenant, **When** the CRL distribution URL is fetched, **Then** the response contains a valid CRL signed by the Tenant Root CA, initially listing zero revoked certificates, with a defined `nextUpdate` for refresh.
+5. **Given** a tenant where the configured signing mode is `KmsResident`, **When** the root CA is created, **Then** the private key is generated inside the configured KMS and never extracted.
+6. **Given** a deployment that swaps the pluggable trust provider from the default internal CA to an externally-rooted provider, **When** the provisioning operation runs, **Then** the externally-rooted chain is installed in place of a newly generated internal root, and the credential format and HAIP plumbing are unchanged.
+
+---
+
+### User Story 3 - An organisation's X.509 identity is bound to its existing DID identity (Priority: P1)
+
+An organisation in a Sorcha tenant already has a `did:sorcha:org:{walletAddress}` identifier and a wallet holding its classical HAIP issuer co-key (from spec 094). When the organisation is enrolled as a HAIP issuer, the tenant CA issues an Org Cert whose subject public key is the existing classical co-key, whose Subject CN is the human-readable org name, and whose Subject Alternative Name includes the `did:sorcha:org:{walletAddress}` as a URI SAN. After enrolment, the same classical signing key has two identities: its Sorcha DID verification method entry and its X.509 cert. HAIP external verifiers pick the X.509 path; Sorcha-internal verifiers continue to use the DID path. The underlying signatures are identical regardless of which trust stack the verifier walks.
+
+**Why this priority**: This is the binding story. Without it, a Sorcha organisation would have to generate a new key when enrolling for HAIP, splitting its identity across two keys and two trust stacks and creating a correlation nightmare. The whole point of the two-path design is that the classical key is shared; only the trust wrapping differs.
+
+**Independent Test**: Take an organisation with an existing HAIP-issuer wallet. Enrol it for X.509 trust. Confirm the resulting Org Cert's Subject Public Key Info matches the wallet's classical co-key, the Subject CN matches the org name, and the Subject Alternative Name contains the `did:sorcha:org:{walletAddress}` URI. Sign a credential with the wallet and confirm the signature verifies both via the DID path (resolve the DID, extract the verification method, check signature) and via the X.509 path (walk the `x5c` chain, extract the Subject Public Key Info, check signature) and yields the same result.
+
+**Acceptance Scenarios**:
+
+1. **Given** an organisation with an existing `did:sorcha:org:{walletAddress}` and a wallet holding a classical HAIP issuer co-key, **When** the org is enrolled as a HAIP issuer, **Then** the tenant CA issues an Org Cert whose Subject Public Key Info encodes the same classical public key as the wallet holds.
+2. **Given** an Org Cert issued for a Sorcha org, **When** the cert is inspected, **Then** its Subject CN is the org's human-readable name, its Subject Alternative Name includes a URI entry naming the org's `did:sorcha:org:{walletAddress}`, and its CRL Distribution Points extension points at the tenant's CRL URL.
+3. **Given** a HAIP-issued credential signed by the org's classical co-key, **When** the credential is verified via the DID path (Sorcha-internal verifier), **Then** signature verification succeeds using the DID's verification method.
+4. **Given** the same credential, **When** it is verified via the X.509 path (HAIP external verifier), **Then** signature verification succeeds using the Org Cert's Subject Public Key Info and returns the same result as the DID path.
+5. **Given** an org whose primary wallet key is PQC and that has not yet been upgraded for HAIP issuance, **When** enrolment for X.509 trust is attempted, **Then** the enrolment fails with a clear prerequisite error pointing at the missing classical co-key (spec 094 `HaipIssuer` capability not set).
+6. **Given** an existing Org Cert whose underlying wallet classical co-key is rotated via spec 094's derivation path, **When** the rotation completes, **Then** the Org Cert must be re-issued by the tenant CA to bind the new public key; outstanding credentials signed by the old key continue to verify against the old Org Cert until that cert's validity period expires.
+
+---
+
+### User Story 4 - A tenant operator revokes an org cert and downstream HAIP verifiers stop trusting the issuer within the CRL refresh window (Priority: P2)
+
+A tenant operator needs to disable an organisation's ability to issue new HAIP credentials — for example, after a security incident, policy violation, or organisation closure. They add the org's cert serial number to the tenant CRL. The updated CRL is republished at the distribution point. HAIP verifiers that refresh the CRL within its `nextUpdate` window see the revocation and start rejecting any credential signed by that Org Cert on the next verification attempt.
+
+**Why this priority**: Revocation is the standard PKI counterpart to issuance. It is non-optional for any production deployment but the mechanism is simple enough (CRL only, no OCSP) that it does not carry the risks that a full OCSP stack would at this scope.
+
+**Independent Test**: Issue a credential, confirm it verifies, revoke the Org Cert that signed it, republish the CRL, and confirm that a HAIP verifier fetching the CRL after the refresh window rejects the credential with a revoked-certificate error. Also confirm that credentials signed by the Org Cert *before* revocation continue to verify in a "validity was correct at signing time" mode if the verifier is configured for that posture (standard PKI behaviour).
+
+**Acceptance Scenarios**:
+
+1. **Given** a tenant with an issued and active Org Cert, **When** the operator issues a revoke operation against the Org Cert's serial number, **Then** the cert is added to the tenant CRL, the CRL is re-signed by the Tenant Root CA, and the updated CRL is published at the distribution point.
+2. **Given** a published CRL with a revoked Org Cert entry, **When** a HAIP verifier fetches the CRL after its cached copy's `nextUpdate` elapses, **Then** the verifier sees the revocation and rejects any credential signed by the revoked Org Cert.
+3. **Given** a HAIP verifier in default strict mode, **When** it encounters a credential signed by a revoked Org Cert, **Then** it returns a revoked-certificate error regardless of whether the credential was issued before or after the revocation timestamp.
+4. **Given** a revoked Org Cert, **When** the operator attempts to use the same wallet to issue a new HAIP credential, **Then** the credential issuance endpoint refuses because the Org Cert that would sign the chain is no longer valid, and the operator must enrol for a fresh Org Cert before further issuance.
+5. **Given** a CRL that grows past a configurable threshold, **When** the refresh interval elapses, **Then** the CRL is published using standard CRL delta mechanisms or is allowed to grow, according to deployment configuration. Default is allow to grow; delta CRLs are a future concern.
+
+---
+
+### User Story 5 - A deployment swaps the internal CA for a publicly-rooted chain without changing anything else (Priority: P2)
+
+A specific Sorcha deployment — for example, a Scottish council partner that wants to participate in a HMG DVS pilot — needs credentials that chain to a publicly-accepted CA rather than a self-signed Sorcha tenant root. They configure a trust provider that returns an externally-issued Tenant Root Cert from an eIDAS QTSP or equivalent. The rest of the Sorcha HAIP stack is unchanged: spec 097 still emits credentials with `x5c` chains, spec 098 still verifies incoming chains, and nothing in the Blueprint authoring path, the Wallet Service, or the presentation flow is touched.
+
+**Why this priority**: This is the escape hatch that makes the default internal CA acceptable to ship. Without a clean swap mechanism, every deployment that needs real-world trust would have to fork Sorcha. With the swap mechanism, the default is "works out of the box for walkthroughs and internal demos" and the production path is "configure a different trust provider and continue".
+
+**Independent Test**: Implement a mock external trust provider that returns a pre-generated Tenant Root Cert signed by a test CA. Configure a Sorcha tenant to use the mock provider. Run the provisioning operation. Confirm the tenant's trust anchor URL returns the externally-signed Tenant Root Cert rather than a freshly generated self-signed one. Issue a credential and confirm its `x5c` chain ends at the externally-signed Tenant Root.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tenant configured with a custom trust provider, **When** tenant provisioning runs, **Then** the provider's `ProvisionTrustAnchor` operation is called and the returned Tenant Root Cert replaces the default self-signed cert.
+2. **Given** a tenant using a custom trust provider, **When** an org cert is requested, **Then** the provider's `IssueOrgCert` operation is called and the returned Org Cert is used in credential `x5c` chains.
+3. **Given** a tenant using a custom trust provider whose `IssueOrgCert` operation returns an error, **When** org enrolment is attempted, **Then** the enrolment fails with the provider's error surfaced to the operator without leaking sensitive details.
+4. **Given** a custom trust provider that publishes its own CRL at an external URL, **When** a HAIP verifier fetches credentials signed via that chain, **Then** the CRL Distribution Points extension on the Org Cert points at the external URL, not at a Sorcha-hosted one.
+5. **Given** a tenant swapped from the default internal CA to a custom trust provider mid-life, **When** the swap completes, **Then** credentials issued before the swap continue to validate against the old Tenant Root for the remainder of their Org Cert's validity period, and credentials issued after the swap validate against the new provider's chain.
+
+---
+
+### Edge Cases
+
+- What happens when a HAIP verifier receives a credential whose `x5c` chain references a Tenant Root the verifier does not know? Chain validation fails with a trust anchor error. This is the correct behaviour — trust anchor management is deployment configuration.
+- What happens when an Org Cert's validity period is shorter than a credential's validity period it signed? The credential becomes unverifiable once the Org Cert expires, per standard PKI behaviour. Operators should set Org Cert lifetimes at or beyond expected credential lifetimes.
+- What happens when a tenant operator tries to revoke the Tenant Root CA itself? Revocation of the root is not supported via the CRL mechanism (the root signs the CRL; a root cannot revoke itself). Tenant root rotation is a separate operational ceremony, out of scope for this spec and deferred.
+- What happens when a Sorcha-internal verifier encounters a credential whose `x5c` chain is malformed? The internal verifier falls back to the DID-based verification path, because internal verification does not require the X.509 path. A warning is logged for operator visibility.
+- What happens when a classical co-key is rotated (spec 094) but the Org Cert is not re-issued? New credentials signed with the new key fail `x5c` signature verification because the Org Cert still binds the old key. The operator must re-issue the Org Cert after rotation, per User Story 3 AC-6.
+- What happens when the tenant CA's own signing key is compromised? This is a tenant-wide incident. All issued Org Certs must be revoked via CRL, and the tenant root is rotated via a ceremony that is out of scope for this spec. All outstanding credentials signed under the compromised root are untrusted.
+- What happens when the CRL fetch fails at verification time? Behaviour depends on the HAIP verifier's configured revocation check policy. Default is fail-closed; deployments can choose fail-open with an audit warning, matching the existing `RevocationCheckPolicy` pattern in the status list consumer.
+- What happens when an Org Cert's Subject Alternative Name URI (the `did:sorcha:org:...`) does not resolve because the referenced wallet no longer exists? The DID resolution path fails gracefully; the X.509 verification path continues to work independently because it does not depend on DID resolution. The two trust stacks are genuinely independent.
+- What happens when a deployment wants to issue credentials under multiple public trust anchors (for example, one chain for UK HMG DVS and another for EUDI Wallet)? This spec covers one trust provider per tenant. Multi-provider support is a future extension; a deployment that needs both can run two tenants or wait for the extension.
+- What happens when a credential is issued by a HAIP issuer wallet whose classical co-key was derived for a different tenant? The Org Cert is tenant-scoped; attempting to cross-sign across tenants is rejected at enrolment.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Tenant Root CA provisioning:**
+- **FR-001**: The system MUST provide a tenant-scoped provisioning operation that creates a Tenant Root CA if one does not already exist. The operation MUST be idempotent.
+- **FR-002**: The Tenant Root CA's private key MUST be stored according to the tenant's declared signing mode. `KmsResident` mode MUST honour the same KMS integration Sorcha already uses for wallet keys (spec 094 FR-028 surfaces the same pattern).
+- **FR-003**: The Tenant Root CA's public trust anchor MUST be published at a stable tenant-scoped URL so external verifiers can fetch and cache it.
+- **FR-004**: The Tenant Root CA MUST sign a tenant CRL that is published at a stable tenant-scoped URL with a configurable refresh interval (default 24 hours).
+- **FR-005**: The Tenant Root CA certificate MUST use a classical signing algorithm (ES256 default, matching spec 094 FR-030). PQC algorithms MUST NOT be used for the CA chain because HAIP 1.0 is classical-only at the trust boundary.
+- **FR-006**: The Tenant Root CA certificate's validity period MUST be configurable at provisioning time, with a sensible default (10 years for internal CAs).
+
+**Org Cert issuance:**
+- **FR-007**: The system MUST issue an Org Cert on demand when an organisation is enrolled as a HAIP issuer. Enrolment MUST require that the organisation's wallet already carries the `HaipIssuer` capability (spec 094 FR-028).
+- **FR-008**: The Org Cert's Subject Public Key Info MUST encode the organisation's existing classical HAIP issuer signing key (spec 094's `sorcha:haip-issuer-signing` derivation). A new key MUST NOT be generated; the existing key is reused.
+- **FR-009**: The Org Cert's Subject CN MUST be the organisation's human-readable display name.
+- **FR-010**: The Org Cert's Subject Alternative Name extension MUST contain a URI entry whose value is the organisation's `did:sorcha:org:{walletAddress}` identifier.
+- **FR-011**: The Org Cert's CRL Distribution Points extension MUST reference the tenant's CRL URL from FR-004.
+- **FR-012**: The Org Cert's Extended Key Usage extension MUST declare the extended key usages appropriate for a HAIP SD-JWT VC credential issuer. The exact EKU OID set is an architectural clarification flagged below — see Clarifications section.
+- **FR-013**: The Org Cert MUST be issued with a validity period configurable at issuance time, with a sensible default (2 years).
+- **FR-014**: The Org Cert MUST be signed by the Tenant Root CA using the default signing algorithm declared at provisioning time.
+- **FR-015**: Attempting to issue an Org Cert for a wallet that does not carry the `HaipIssuer` capability MUST fail with a clear prerequisite error pointing at spec 094.
+- **FR-016**: Attempting to issue a second Org Cert for the same wallet without first revoking the existing one MUST fail with a clear "cert already active" error.
+
+**x5c embedding in SD-JWT VC:**
+- **FR-017**: When an SD-JWT VC is signed via the HAIP issuance path (spec 097), its outer JWS header MUST contain an `x5c` member.
+- **FR-018**: The `x5c` array MUST contain the Org Cert as the first (leaf) element and the Tenant Root CA as the last element, each in DER-encoded base64 form, matching RFC 7515 §4.1.6.
+- **FR-019**: The SD-JWT VC's `iss` claim MUST be consistent with the Org Cert's identity. Specifically, the `iss` value MUST match either the Org Cert's Subject Alternative Name URI or a derived form of the Subject CN agreed with HAIP 1.0.
+- **FR-020**: Credentials issued via the Sorcha-internal path MUST NOT carry an `x5c` header. Internal-path credentials continue to use DID-based trust exclusively.
+
+**CRL publication and consumption:**
+- **FR-021**: The system MUST expose a public, anonymous, cacheable HTTP endpoint that serves the tenant's CRL in DER-encoded base64 form.
+- **FR-022**: The CRL MUST be re-signed and republished whenever an Org Cert is revoked or at the scheduled refresh interval, whichever is sooner.
+- **FR-023**: The CRL's `nextUpdate` field MUST match the configured refresh interval so verifiers know when to refresh their cached copy.
+- **FR-024**: Revoking an Org Cert MUST add the cert's serial number to the CRL and set its revocation reason per RFC 5280.
+- **FR-025**: After an Org Cert is revoked, the HAIP credential issuance endpoint (spec 097) MUST refuse to issue new credentials signed by the underlying wallet until a fresh Org Cert is enrolled.
+
+**HAIP verifier chain validation (spec 098 substrate):**
+- **FR-026**: The HAIP verifier (spec 098) MUST extract the `x5c` chain from an incoming credential's JWS header and walk it to a trusted root in its configured trust store.
+- **FR-027**: Chain validation MUST check each certificate's validity period, signature, and the CRL Distribution Points extension (fetching and checking the CRL per FR-021).
+- **FR-028**: If `x5c` chain validation fails for any reason (trust anchor missing, expiry, revocation, signature mismatch, malformed chain), the verifier MUST fail the credential with a specific error identifying the failure cause.
+- **FR-029**: The HAIP verifier's trust store MUST be configurable per deployment — a set of accepted Tenant Root CAs, external public roots, or both.
+- **FR-030**: The HAIP verifier's revocation check policy MUST be configurable (fail-closed, fail-open-with-warning) matching the existing status list consumer's policy model.
+
+**Pluggable trust provider:**
+- **FR-031**: The system MUST define a trust provider interface with operations for: provisioning a tenant trust anchor, issuing an org cert, revoking an org cert, publishing the CRL, and fetching the trust anchor.
+- **FR-032**: The default trust provider MUST implement the interface using an internal self-signed Tenant Root CA.
+- **FR-033**: A deployment MUST be able to configure a custom trust provider implementation at tenant provisioning time, replacing the default internal CA with an externally-rooted chain without changing the credential format or any other spec in the HAIP spec set.
+- **FR-034**: A custom trust provider's `IssueOrgCert` operation MUST return certificates that satisfy FR-008 through FR-013 (subject key, SAN URI, CRL distribution points, EKU, validity period) so the rest of the HAIP stack is unchanged regardless of trust provider choice.
+- **FR-035**: A custom trust provider MAY host the CRL externally; in that case the Org Cert's CRL Distribution Points extension MUST reference the external URL.
+
+**Scope restrictions:**
+- **FR-036**: This spec introduces org-scoped certificates only. Tenant-scoped identity certificates and register-scoped certificates are out of scope and deferred to follow-up specs.
+- **FR-037**: This spec introduces only the default two-level chain (Tenant Root → Org Cert). Three-level chains (Tenant Root → Org → Per-Wallet or Per-Credential) are out of scope and deferred.
+
+**Cross-cutting:**
+- **FR-038**: All new behaviour MUST be covered by automated tests at unit and integration level, including round-trip tests from provisioning through issuance, signing, verification and revocation.
+- **FR-039**: The spec MUST not regress any acceptance scenario from specs 039, 093, 094, or 095.
+- **FR-040**: The spec MUST not change the DID-based verification path for Sorcha-internal credentials. Both trust stacks run in parallel.
+
+### Key Entities *(include if feature involves data)*
+
+- **Tenant Root CA** (new): A self-signed (default) or externally-rooted (via custom trust provider) certificate authority, one per Sorcha tenant. Signs Org Certs and the tenant CRL. Private key stored according to the tenant's signing mode. Public trust anchor published at a stable URL. Validity period default 10 years.
+- **Org Cert** (new): An X.509 certificate issued by the Tenant Root CA for a specific HAIP issuer organisation. Subject CN is the org's display name. Subject Public Key Info is the org wallet's classical HAIP issuer signing key (from spec 094). Subject Alternative Name contains the URI form of the org's `did:sorcha:org:{walletAddress}`. CRL Distribution Points references the tenant CRL. EKU declares credential issuer usage. Validity period default 2 years.
+- **Tenant CRL** (new): An X.509 Certificate Revocation List signed by the Tenant Root CA, listing revoked Org Cert serial numbers. Published at a stable public URL. Refreshed on every revocation and at a configurable interval (default 24 hours).
+- **Trust provider interface** (new): A pluggable contract with operations `ProvisionTrustAnchor`, `IssueOrgCert`, `RevokeOrgCert`, `PublishCrl`, `FetchTrustAnchor`. The default implementation uses the internal self-signed CA; custom implementations can swap in external roots.
+- **HAIP issuer enrolment record** (new, conceptual): Tracks which organisations in a tenant have been enrolled for HAIP issuance, their current Org Cert serial number, and the enrolment state. Used by spec 097 to gate credential issuance.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A generic HAIP client with a configured trust store containing a Sorcha tenant root successfully validates a Sorcha-issued credential's `x5c` chain and accepts the credential in 100 % of conforming test cases.
+- **SC-002**: The same client rejects credentials whose Tenant Root is not in its trust store, whose Org Cert has expired, or whose Org Cert has been revoked via CRL, in 100 % of those negative test cases.
+- **SC-003**: Tenant provisioning is idempotent — running it twice on the same tenant produces the same Tenant Root CA and does not mint a second one.
+- **SC-004**: Org Cert issuance binds the correct classical signing key in 100 % of enrolments; no cert is ever issued whose Subject Public Key Info does not match the underlying wallet's `sorcha:haip-issuer-signing` key.
+- **SC-005**: Revoking an Org Cert propagates to HAIP verifiers within the CRL refresh window (default 24 hours, configurable down to 1 hour for test deployments).
+- **SC-006**: After revoking an Org Cert, the HAIP credential issuance endpoint refuses to mint new credentials signed by the underlying wallet until a fresh Org Cert is enrolled.
+- **SC-007**: A deployment that swaps the default trust provider for a custom externally-rooted provider continues to issue and verify credentials without any change to the credential format or the rest of the HAIP spec set, confirmed by an end-to-end swap test using a mock external provider.
+- **SC-008**: Sorcha-internal credential verification (DID-based path) continues to work unchanged for credentials that do not carry `x5c`, and falls back gracefully for credentials that do carry `x5c` but are presented to an internal verifier.
+- **SC-009**: A credential whose `x5c` chain validates is the same credential that the DID-based path would also have accepted, confirmed by a parallel-verification regression test that runs both paths over every credential in a corpus.
+- **SC-010**: No acceptance scenario from specs 039, 093, 094, or 095 regresses after this spec ships.
+
+## Out of Scope
+
+The following are explicitly deferred to later specs or later phases:
+
+- Tenant-level and register-level certificate scopes. This spec covers org-level only. A future spec may add tenant-scoped certs (representing the whole Sorcha deployment as an identity) and register-scoped certs (representing a specific Sorcha register as an identity).
+- Three-level certificate chains (Tenant Root → Org → Per-Wallet or Per-Credential). Default is two-level.
+- OCSP revocation. CRLs only in this spec.
+- Delta CRLs. CRLs grow without delta support; deployments that need delta CRLs can configure shorter refresh intervals.
+- Tenant Root CA rotation ceremonies. Out of scope; operational concern.
+- Cross-signing with publicly-accepted CAs for trust list enrolment (EUDI Wallet trust list, HMG DVS acceptance). This is a deployment operations concern; this spec provides the pluggable interface, not the enrolment ceremony itself.
+- Multi-provider tenants (one tenant issuing credentials under two different trust anchors simultaneously). Future extension.
+- Trust lists and "known good" Tenant Root directories. A HAIP verifier's trust store is configured per deployment; a shared Sorcha-wide trust list is a future operational concern.
+- Certificate Transparency log submission. Future extension if needed for public trust interop.
+- PQC-signed CA certificates. HAIP 1.0 is classical-only; this spec tracks HAIP 1.0.
+
+## Assumptions
+
+- The Sorcha wallet domain can hold a CA signing key via its existing key storage and signing mode abstractions. This assumption is flagged as an architectural clarification in the Clarifications section because it may require a new wallet purpose or a new "CA key" concept distinct from the `HaipIssuer` wallets.
+- The existing `signingMode: KmsResident` model in spec 094 is sufficient to secure the Tenant Root CA key without requiring new KMS-specific plumbing.
+- A suitable .NET X.509 library is available (`System.Security.Cryptography.X509Certificates` is part of the BCL and covers certificate issuance, CRL generation, and chain validation for classical algorithms).
+- HAIP 1.0's use of `x5c` as the carrier for the issuer chain is stable and will not change between HAIP 1.0 and HAIP 1.1.
+- RFC 5280 CRL semantics (including CRL Distribution Points extension, nextUpdate, revocation reasons) are stable and directly usable.
+- The tenant CRL will remain small enough in practical deployments that ordinary (non-delta) CRLs are viable for at least the first several years of operation.
+- The `did:sorcha:org:{walletAddress}` identifier format is stable and suitable for embedding in an X.509 SAN URI field.
+- The classical HAIP issuer co-key derived under `sorcha:haip-issuer-signing` is the correct binding target for the Org Cert. If spec 094's derivation is later revised, this spec's Org Cert issuance path must be revised in lockstep.
+- A mock external trust provider implementation is sufficient for User Story 5's test — the interface need not be stress-tested against a real eIDAS QTSP in this spec.
+
+## Clarifications
+
+These architectural questions arose during drafting and need a ruling before `/speckit.plan`:
+
+### Q4.1 — CA signing key in the wallet domain: new purpose, new entity, or existing HAIP issuer co-key?
+
+The Tenant Root CA's private signing key needs a home in the Sorcha key-management story. Three options:
+
+| Option | Description | Implication |
+|---|---|---|
+| A | Derive the Tenant Root CA key under a new BIP32 purpose `sorcha:tenant-ca-signing`, treating it as a wallet key under a dedicated tenant-scoped wallet. | Consistent with spec 094 patterns (`sorcha:docket-signing`, `sorcha:persona-vault`, `sorcha:haip-issuer-signing`). Recoverable from mnemonic. But mixes CA keys with wallet keys conceptually. |
+| B | Introduce a new first-class entity "Tenant CA" in the domain, with its own key management independent of the wallet model. Key held in the same storage backends (local / KmsResident) but not part of the wallet HD hierarchy. | Cleaner separation. A CA key is not a wallet key. But adds a new domain entity and new plumbing parallel to the wallet domain. |
+| C | Reuse the tenant's existing system wallet (validators, system register bootstrapping) and add a CA key derivation under a new purpose on that wallet. | Minimises new entities. But the system wallet already carries several distinct responsibilities and adding another may overload it. |
+
+My default in the spec draft is **B**. A CA key conceptually is not a wallet key — it has its own lifecycle, its own rotation cadence, and its own trust posture. Treating it as a wallet key (Option A or C) risks confusion later. But I am flagging this because the Sorcha tradition (per your CLAUDE.md and memory notes) is to consolidate key derivation under BIP32 purposes, which would pull toward Option A.
+
+### Q4.2 — Extended Key Usage OID set for HAIP credential issuer Org Certs
+
+FR-012 requires the Org Cert to declare EKUs appropriate for a HAIP SD-JWT VC credential issuer. HAIP 1.0 does not name a specific EKU OID for this purpose. Three options:
+
+| Option | Description | Implication |
+|---|---|---|
+| A | Use no EKU extension at all — leave the Org Cert general-purpose. | Simplest. Works with any HAIP verifier that does not check EKU. May fail with strict verifiers that expect an explicit EKU constraint. |
+| B | Use `id-kp-emailProtection` or `id-kp-codeSigning` as a placeholder until HAIP names a dedicated OID. | Works with strict verifiers that check *some* EKU but is semantically wrong. Misleading. |
+| C | Use a Sorcha-private EKU OID under the Sorcha organisation's OID arc (or a private experimental arc) with a published meaning. | Semantically correct for internal verifiers that know the OID. Opaque to external verifiers unless they learn it. Establishes a pattern that can be retired once HAIP names an OID. |
+| D | Do not set EKU, and defer this question to HAIP 1.1. Flag as a known gap. | Pragmatic. Most HAIP verifiers do not enforce EKU today. |
+
+My default in the spec draft is **D** (do not set EKU, defer to HAIP 1.1). I am flagging this because the right answer is a deployment-ops question — if a specific partner (EUDI Wallet, GOV.UK Wallet) requires a specific EKU, we should use it.
+
+## Dependencies
+
+- **Depends on spec 094** (`sdjwt-haip-hardening`) — hard dependency. The Org Cert's Subject Public Key Info is the classical HAIP issuer co-key derived there. Without 094, there is no classical key to bind.
+- **Independent of spec 095** (`ietf-token-status-list`) — 095 and 096 can run in parallel branches.
+- **Required by spec 097** (`openid4vci-issuer`) — the HAIP issuer endpoint cannot emit credentials acceptable to HAIP wallets without a valid `x5c` chain.
+- **Required by spec 098** (`openid4vp-verifier`) — the HAIP verifier endpoint needs `x5c` chain validation to accept external HAIP wallet presentations.
+- **Independent of spec 093** (`vc-security-fixes`) — 093 is a prerequisite for the HAIP spec set as a whole but 096 does not specifically depend on 093's content beyond "the verifier works".
+
+## Amendment note on earlier specs
+
+This spec does not supersede any earlier spec. It amends:
+
+- `specs/039-verifiable-presentations` FR-019 (DID resolution) — X.509 chain validation is added as a parallel trust path for HAIP-facing credentials. DID resolution continues to be the only trust path for Sorcha-internal credentials.
+- No requirement from spec 039 is retired by this spec.
+
+All existing trust model behaviour for internal credentials is unchanged.

--- a/specs/096-x509-org-trust/spec.md
+++ b/specs/096-x509-org-trust/spec.md
@@ -137,7 +137,7 @@ A specific Sorcha deployment — for example, a Scottish council partner that wa
 
 **Tenant Root CA provisioning:**
 - **FR-001**: The system MUST provide a tenant-scoped provisioning operation that creates a Tenant Root CA if one does not already exist. The operation MUST be idempotent.
-- **FR-002**: The Tenant Root CA's private key MUST be stored according to the tenant's declared signing mode. `KmsResident` mode MUST honour the same KMS integration Sorcha already uses for wallet keys (spec 094 FR-028 surfaces the same pattern).
+- **FR-002**: The Tenant Root CA is a first-class domain entity with its own key storage, independent of the wallet HD hierarchy (see Clarifications Q4.1 ruling). Its private key MUST be stored in one of three modes: (a) generated internally and optionally derivable from a tenant CA recovery seed under the purpose `sorcha:tenant-ca-signing` for deterministic recovery, (b) imported from an external source such as an HSM, eIDAS QTSP-issued signer, or an existing PKI signing key, in which case no derivation is performed, or (c) `KmsResident` mode honouring the same KMS integration Sorcha already uses for wallet keys. The tenant picks the mode at provisioning time.
 - **FR-003**: The Tenant Root CA's public trust anchor MUST be published at a stable tenant-scoped URL so external verifiers can fetch and cache it.
 - **FR-004**: The Tenant Root CA MUST sign a tenant CRL that is published at a stable tenant-scoped URL with a configurable refresh interval (default 24 hours).
 - **FR-005**: The Tenant Root CA certificate MUST use a classical signing algorithm (ES256 default, matching spec 094 FR-030). PQC algorithms MUST NOT be used for the CA chain because HAIP 1.0 is classical-only at the trust boundary.
@@ -149,7 +149,7 @@ A specific Sorcha deployment — for example, a Scottish council partner that wa
 - **FR-009**: The Org Cert's Subject CN MUST be the organisation's human-readable display name.
 - **FR-010**: The Org Cert's Subject Alternative Name extension MUST contain a URI entry whose value is the organisation's `did:sorcha:org:{walletAddress}` identifier.
 - **FR-011**: The Org Cert's CRL Distribution Points extension MUST reference the tenant's CRL URL from FR-004.
-- **FR-012**: The Org Cert's Extended Key Usage extension MUST declare the extended key usages appropriate for a HAIP SD-JWT VC credential issuer. The exact EKU OID set is an architectural clarification flagged below — see Clarifications section.
+- **FR-012**: The Org Cert MUST NOT set an Extended Key Usage extension in this spec. HAIP 1.0 does not name a dedicated EKU OID for SD-JWT VC credential issuance and most HAIP verifiers do not enforce EKU. This is a known gap that will be revisited when HAIP 1.1 names an OID or when a named deployment partner (for example GOV.UK Wallet or EUDI Wallet) requires a specific EKU (see Clarifications Q4.2 ruling). A follow-up operational spec may later add a configurable EKU set per trust provider without changing the rest of this spec.
 - **FR-013**: The Org Cert MUST be issued with a validity period configurable at issuance time, with a sensible default (2 years).
 - **FR-014**: The Org Cert MUST be signed by the Tenant Root CA using the default signing algorithm declared at provisioning time.
 - **FR-015**: Attempting to issue an Org Cert for a wallet that does not carry the `HaipIssuer` capability MUST fail with a clear prerequisite error pointing at spec 094.
@@ -231,7 +231,7 @@ The following are explicitly deferred to later specs or later phases:
 
 ## Assumptions
 
-- The Sorcha wallet domain can hold a CA signing key via its existing key storage and signing mode abstractions. This assumption is flagged as an architectural clarification in the Clarifications section because it may require a new wallet purpose or a new "CA key" concept distinct from the `HaipIssuer` wallets.
+- The Tenant Root CA is a new first-class domain entity with its own key storage and lifecycle, parallel to the wallet domain rather than embedded in it (Q4.1 Option B ruled by the user). Internally generated CA keys MAY be derived from a tenant CA recovery seed under purpose `sorcha:tenant-ca-signing` for deterministic recovery; externally imported CA keys carry no derivation history. The long-term intent is to support importing signing keys from external sources (HSMs, eIDAS QTSPs, existing PKI), which motivates the separate-storage choice.
 - The existing `signingMode: KmsResident` model in spec 094 is sufficient to secure the Tenant Root CA key without requiring new KMS-specific plumbing.
 - A suitable .NET X.509 library is available (`System.Security.Cryptography.X509Certificates` is part of the BCL and covers certificate issuance, CRL generation, and chain validation for classical algorithms).
 - HAIP 1.0's use of `x5c` as the carrier for the issuer chain is stable and will not change between HAIP 1.0 and HAIP 1.1.
@@ -243,32 +243,15 @@ The following are explicitly deferred to later specs or later phases:
 
 ## Clarifications
 
-These architectural questions arose during drafting and need a ruling before `/speckit.plan`:
+These architectural questions arose during drafting and have been resolved by user ruling. Retained here for traceability.
 
 ### Q4.1 — CA signing key in the wallet domain: new purpose, new entity, or existing HAIP issuer co-key?
 
-The Tenant Root CA's private signing key needs a home in the Sorcha key-management story. Three options:
-
-| Option | Description | Implication |
-|---|---|---|
-| A | Derive the Tenant Root CA key under a new BIP32 purpose `sorcha:tenant-ca-signing`, treating it as a wallet key under a dedicated tenant-scoped wallet. | Consistent with spec 094 patterns (`sorcha:docket-signing`, `sorcha:persona-vault`, `sorcha:haip-issuer-signing`). Recoverable from mnemonic. But mixes CA keys with wallet keys conceptually. |
-| B | Introduce a new first-class entity "Tenant CA" in the domain, with its own key management independent of the wallet model. Key held in the same storage backends (local / KmsResident) but not part of the wallet HD hierarchy. | Cleaner separation. A CA key is not a wallet key. But adds a new domain entity and new plumbing parallel to the wallet domain. |
-| C | Reuse the tenant's existing system wallet (validators, system register bootstrapping) and add a CA key derivation under a new purpose on that wallet. | Minimises new entities. But the system wallet already carries several distinct responsibilities and adding another may overload it. |
-
-My default in the spec draft is **B**. A CA key conceptually is not a wallet key — it has its own lifecycle, its own rotation cadence, and its own trust posture. Treating it as a wallet key (Option A or C) risks confusion later. But I am flagging this because the Sorcha tradition (per your CLAUDE.md and memory notes) is to consolidate key derivation under BIP32 purposes, which would pull toward Option A.
+**Ruling: Option B (new first-class Tenant CA entity).** The Tenant Root CA is a domain entity separate from the wallet HD hierarchy, with its own key storage and lifecycle. User rationale: the end goal is to support importing signing keys from external sources (HSMs, eIDAS QTSPs, existing PKI), which requires storage independent of the wallet-derivation model. When a deployment generates the CA key internally, it can still be derived under purpose `sorcha:tenant-ca-signing` from a tenant CA recovery seed for deterministic recovery — so recoverability is preserved without forcing the CA key into the wallet HD hierarchy. Reflected in FR-002 and in Assumptions.
 
 ### Q4.2 — Extended Key Usage OID set for HAIP credential issuer Org Certs
 
-FR-012 requires the Org Cert to declare EKUs appropriate for a HAIP SD-JWT VC credential issuer. HAIP 1.0 does not name a specific EKU OID for this purpose. Three options:
-
-| Option | Description | Implication |
-|---|---|---|
-| A | Use no EKU extension at all — leave the Org Cert general-purpose. | Simplest. Works with any HAIP verifier that does not check EKU. May fail with strict verifiers that expect an explicit EKU constraint. |
-| B | Use `id-kp-emailProtection` or `id-kp-codeSigning` as a placeholder until HAIP names a dedicated OID. | Works with strict verifiers that check *some* EKU but is semantically wrong. Misleading. |
-| C | Use a Sorcha-private EKU OID under the Sorcha organisation's OID arc (or a private experimental arc) with a published meaning. | Semantically correct for internal verifiers that know the OID. Opaque to external verifiers unless they learn it. Establishes a pattern that can be retired once HAIP names an OID. |
-| D | Do not set EKU, and defer this question to HAIP 1.1. Flag as a known gap. | Pragmatic. Most HAIP verifiers do not enforce EKU today. |
-
-My default in the spec draft is **D** (do not set EKU, defer to HAIP 1.1). I am flagging this because the right answer is a deployment-ops question — if a specific partner (EUDI Wallet, GOV.UK Wallet) requires a specific EKU, we should use it.
+**Ruling: Option D (do not set EKU; defer to HAIP 1.1 or a named partner requirement).** The Org Cert does not set an EKU extension in this spec. HAIP 1.0 does not name a dedicated EKU OID for SD-JWT VC credential issuance and most HAIP verifiers do not enforce EKU. When HAIP 1.1 names an OID, or when a deployment partner such as GOV.UK Wallet or EUDI Wallet requires a specific EKU, a follow-up operational spec will add a configurable EKU set per trust provider. Reflected in FR-012.
 
 ## Dependencies
 

--- a/specs/096-x509-org-trust/tasks.md
+++ b/specs/096-x509-org-trust/tasks.md
@@ -1,0 +1,158 @@
+---
+
+description: "Task list for spec 096: X.509 Organisation Trust Integration"
+---
+
+# Tasks: X.509 Organisation Trust Integration
+
+**Input**: Design documents from `specs/096-x509-org-trust/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/README.md
+
+**Tests**: Included — spec FR-038 mandates unit + integration coverage.
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm `096-x509-org-trust` branch is rebased onto master. Spec 093 must be merged; spec 094 must be merged because Org Cert binding needs `IHaipIssuerCoKeyService`
+- [ ] T002 Verify BCL `System.Security.Cryptography.X509Certificates.CertificateRequest` and `CertificateRevocationListBuilder` are available in .NET 10 target
+- [ ] T003 [P] Add config keys `Trust:BaseUrl`, `Trust:DefaultCaAlgorithm`, `Trust:DefaultCaValidityYears`, `Trust:DefaultOrgCertValidityYears`, `Trust:CrlRefreshHours` to `src/Services/Sorcha.Tenant.Service/appsettings.json`
+- [ ] T004 [P] Add new purpose constant `sorcha:tenant-ca-signing` to the shared constants file from spec 094 T003
+
+## Phase 2: Foundational
+
+- [ ] T005 Baseline: run `dotnet test tests/Sorcha.Tenant.Service.Tests` to confirm the branch builds and pre-change tests pass
+- [ ] T006 Create EF migration skeleton for `TenantRootCa`, `OrgCertEnrolment`, `TenantCrl` tables in `src/Services/Sorcha.Tenant.Service/Data/Migrations/`. Folded into the pre-release consolidated migration per user guidance — no runtime migration created
+
+## Phase 3: User Story 1 - Tenant Root CA provisioning (Priority: P1) 🎯 MVP
+
+### Tests for US1
+
+- [ ] T007 [P] [US1] Write failing unit test `BuildSelfSignedRoot_Ed25519_ValidCertDerOutput` in `tests/Sorcha.Tenant.Service.Tests/Trust/X509CertificateBuilderTests.cs`
+- [ ] T008 [P] [US1] Write failing unit test `BuildSelfSignedRoot_Es256_ValidCertDerOutput` in the same file
+- [ ] T009 [P] [US1] Write failing unit test `BuildSelfSignedRoot_ValidityPeriod_RespectsInput` in the same file
+- [ ] T010 [P] [US1] Write failing unit test `Provision_IsIdempotent_ReturnsExistingRoot` in `tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs`
+- [ ] T011 [P] [US1] Write failing unit test `Provision_LocalSigningMode_StoresKeyLocally` in the same file
+- [ ] T012 [P] [US1] Write failing unit test `Provision_KmsResidentSigningMode_DelegatesToKmsProvider` in the same file
+
+### Implementation
+
+- [ ] T013 [US1] Create `TenantRootCa`, `OrgCertEnrolment`, `TenantCrl`, `TrustProviderMode` domain entities in `src/Common/Sorcha.Tenant.Models/Trust/`
+- [ ] T014 [US1] Create `ICaKeyProtection` interface and `LocalCaKeyProtection`, `KmsResidentCaKeyProtection` implementations in `src/Services/Sorcha.Tenant.Service/Trust/`
+- [ ] T015 [US1] Create `X509CertificateBuilder.cs` with `BuildSelfSignedRoot(algorithm, subject, validityYears)` method using BCL `CertificateRequest.CreateSelfSigned`
+- [ ] T016 [US1] Create `ITrustProvider` interface per contracts/README.md
+- [ ] T017 [US1] Create `InternalCaTrustProvider` implementing `ProvisionTrustAnchorAsync` — stores the resulting `TenantRootCa` via EF Core, stores the private key via `ICaKeyProtection`
+- [ ] T018 [US1] Create `TrustProviderRegistry` for resolving a provider per tenant (default `InternalCaTrustProvider`)
+- [ ] T019 [US1] Create `TrustEndpoints.cs` in `src/Services/Sorcha.Tenant.Service/Endpoints/` with `POST /api/v1/trust/tenants/{tenantId}/provision` and `GET /api/v1/trust/tenants/{tenantId}/trust-anchor`
+- [ ] T020 [US1] Wire `ITrustProvider`, `TrustProviderRegistry`, `X509CertificateBuilder`, `ICaKeyProtection` in the Tenant Service DI container
+- [ ] T021 [US1] Map the new endpoints in `Program.cs`
+
+**Checkpoint**: US1 done. Tenants can provision a self-signed root. Trust anchor URL returns valid DER-encoded cert.
+
+## Phase 4: User Story 2 - Organisation cert enrolment (Priority: P1)
+
+### Tests for US2
+
+- [ ] T022 [P] [US2] Write failing unit test `BuildOrgCert_BindsClassicalHaipIssuerCoKey` in `tests/Sorcha.Tenant.Service.Tests/Trust/X509CertificateBuilderTests.cs`
+- [ ] T023 [P] [US2] Write failing unit test `BuildOrgCert_EmbedsSanUri_WithDidSorchaOrgPrefix` in the same file
+- [ ] T024 [P] [US2] Write failing unit test `BuildOrgCert_CrlDistributionPoints_PointsAtTenantCrl` in the same file
+- [ ] T025 [P] [US2] Write failing unit test `BuildOrgCert_NoEkuExtension_Q42RulingD` in the same file
+- [ ] T026 [P] [US2] Write failing unit test `IssueOrgCert_WalletLacksHaipIssuerCapability_FailsWithPrereqError` in `tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs`
+- [ ] T027 [P] [US2] Write failing integration test `EnrolOrgCert_RoundTrip_FromProvisionToIssue` in `tests/Sorcha.Tenant.Service.IntegrationTests/TrustRoundTripTests.cs`
+
+### Implementation
+
+- [ ] T028 [US2] Extend `X509CertificateBuilder` with `BuildOrgCert(rootCa, rootPrivateKey, publicKey, subject, sanUri, crlDp, validityYears)`
+- [ ] T029 [US2] Extend `InternalCaTrustProvider.IssueOrgCertAsync`: check `HaipIssuer` capability, call `IHaipIssuerCoKeyService.GetSigningKeyForHaipIssuanceAsync`, build cert, persist `OrgCertEnrolment`
+- [ ] T030 [US2] Add enrolment endpoint `POST /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/enrol` in `TrustEndpoints.cs`
+- [ ] T031 [US2] Add `IOrgCertChainProvider` service in `src/Common/Sorcha.ServiceClients.Http/` that fetches the chain (leaf + root) for a given org wallet — used by Wallet Service during HAIP-path issuance
+
+## Phase 5: User Story 3 - x5c embedding on HAIP-path issuance (Priority: P1)
+
+### Tests for US3
+
+- [ ] T032 [P] [US3] Write failing unit test `CreateTokenAsync_WithX5cChain_EmbedsChainInJwsHeader` in `tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtX5cHeaderTests.cs`
+- [ ] T033 [P] [US3] Write failing unit test `IssueCredential_HaipPath_FetchesOrgCertChain_AndPassesToSdJwt` in `tests/Sorcha.Wallet.Service.Tests/Endpoints/CredentialEndpointsX5cTests.cs`
+- [ ] T034 [P] [US3] Write failing integration test `HaipCredential_X5cChain_VerifiableAgainstTenantRoot` in `tests/Sorcha.Tenant.Service.IntegrationTests/TrustRoundTripTests.cs`
+
+### Implementation
+
+- [ ] T035 [US3] Extend `ISdJwtService.CreateTokenAsync` with a new optional `x5cChain` parameter accepting a list of DER-encoded cert bytes. When present, the chain is serialised into the JWS header's `x5c` array (base64-encoded DER per RFC 7515 §4.1.6)
+- [ ] T036 [US3] In `CredentialEndpoints.IssueCredential`, when HAIP-path issuance is in effect, call `IOrgCertChainProvider.GetChainForAsync(walletAddress)` and pass the chain into the SD-JWT service call
+- [ ] T037 [US3] Update `IWalletServiceClient.IssueCredentialAsync` and its implementation to forward a new `x5cChain` parameter (or derive it server-side from the wallet address + HAIP flag — planner picks during task execution)
+
+## Phase 6: User Story 4 - CRL publication and revocation (Priority: P1)
+
+### Tests for US4
+
+- [ ] T038 [P] [US4] Write failing unit test `BuildTenantCrl_SignedByRootCa` in `tests/Sorcha.Tenant.Service.Tests/Trust/TenantCrlBuilderTests.cs`
+- [ ] T039 [P] [US4] Write failing unit test `BuildTenantCrl_IncludesRevokedSerialNumbers` in the same file
+- [ ] T040 [P] [US4] Write failing unit test `RevokeOrgCert_RegeneratesCrl_IncludesNewSerial` in `tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs`
+- [ ] T041 [P] [US4] Write failing integration test `CrlFetch_AfterRevocation_ReturnsUpdatedCrl_WithinCacheTtl` in `tests/Sorcha.Tenant.Service.IntegrationTests/TrustRoundTripTests.cs`
+
+### Implementation
+
+- [ ] T042 [US4] Create `TenantCrlBuilder.cs` using BCL `CertificateRevocationListBuilder`
+- [ ] T043 [US4] Extend `InternalCaTrustProvider.RevokeOrgCertAsync`: mark `OrgCertEnrolment.RevokedAt`, regenerate CRL, persist new version
+- [ ] T044 [US4] Extend `InternalCaTrustProvider.PublishCrlAsync`: return the current `TenantCrl` or regenerate if stale
+- [ ] T045 [US4] Add endpoints `POST /api/v1/trust/tenants/{tenantId}/orgs/{orgWalletAddress}/revoke` and `GET /api/v1/trust/tenants/{tenantId}/crl` in `TrustEndpoints.cs`. CRL endpoint uses `CachedResult` wrapper with 1-hour TTL
+- [ ] T046 [US4] After revocation, the Wallet Service must refuse HAIP-path issuance until re-enrolment. Add a check in `CredentialEndpoints.IssueCredential` (or the chain provider) that calls the Tenant Service to verify the Org Cert is still active
+
+## Phase 7: User Story 5 - Pluggable trust provider swap (Priority: P2)
+
+### Tests for US5
+
+- [ ] T047 [P] [US5] Write failing unit test `MockExternalProvider_IsResolvedByRegistry_WhenRegistered` in `tests/Sorcha.Tenant.Service.Tests/Trust/TrustProviderRegistryTests.cs`
+- [ ] T048 [P] [US5] Write failing integration test `ProvisionWithExternalProvider_ReturnsExternallyRootedCert` in `tests/Sorcha.Tenant.Service.IntegrationTests/TrustRoundTripTests.cs`
+
+### Implementation
+
+- [ ] T049 [US5] Verify `TrustProviderRegistry` correctly resolves custom providers from DI when registered before the default
+- [ ] T050 [US5] Document the swap mechanism in `src/Services/Sorcha.Tenant.Service/README.md`
+
+## Phase 8: Verifier chain-walk integration (Priority: P1)
+
+### Tests for US6
+
+- [ ] T051 [P] [US6] Write failing unit test `Verifier_WalksX5cChain_AgainstTrustStore_AcceptsValidChain` in `tests/Sorcha.Wallet.Service.Tests/Presentations/PresentationRequestVerificationTests.cs` (extend existing file)
+- [ ] T052 [P] [US6] Write failing unit test `Verifier_X5cChain_RootNotInTrustStore_Fails` in the same file
+- [ ] T053 [P] [US6] Write failing unit test `Verifier_X5cChain_RevokedOrgCert_Fails_AfterCrlCheck` in the same file
+- [ ] T054 [P] [US6] Write failing unit test `Verifier_NoX5c_FallsBackToDidBasedTrust_Unchanged_Spec093Regression` in the same file
+
+### Implementation
+
+- [ ] T055 [US6] Add `ITrustStore` service in `src/Services/Sorcha.Wallet.Service/Services/Interfaces/`
+- [ ] T056 [US6] Implement `ConfigurableTrustStore` reading accepted root certs from deployment config
+- [ ] T057 [US6] Extend `PresentationRequestService.VerifyPresentationAsync` to detect `x5c` in the JWS header, walk the chain against the trust store, check the CRL for each cert in the chain, and fall back to DID-based trust when no `x5c` is present
+
+## Phase 9: Polish
+
+- [ ] T058 Run `dotnet test tests/Sorcha.Tenant.Service.Tests`
+- [ ] T059 Run `dotnet test tests/Sorcha.Tenant.Service.IntegrationTests`
+- [ ] T060 Run `dotnet test tests/Sorcha.Wallet.Service.Tests` and confirm spec 093 verifier tests still pass
+- [ ] T061 Walk the quickstart.md manual verification procedure
+- [ ] T062 [P] Update `src/Services/Sorcha.Tenant.Service/README.md` with the trust anchor and CRL endpoints
+- [ ] T063 [P] Update `docs/reference/API-DOCUMENTATION.md` with the new `/api/v1/trust/*` endpoints
+
+## Dependencies
+
+- Phase 1 → Phase 2 → Phase 3 (US1 MVP — provisioning) → Phase 4 (US2 — enrolment) → Phase 5 (US3 — x5c embed) → Phase 6 (US4 — revocation) → Phase 7 (US5 — pluggable) → Phase 8 (US6 — verifier)
+- US3 depends on US2 (needs Org Cert to embed)
+- US4 depends on US2 (revokes Org Certs)
+- US5 can run in parallel with US2-US4 once US1 completes
+- US6 depends on US3 (needs `x5c` to be embedded before the verifier has anything to walk)
+
+## Task summary
+
+| Phase | Tasks | Count |
+|---|---|---|
+| Phase 1 Setup | T001-T004 | 4 |
+| Phase 2 Foundational | T005-T006 | 2 |
+| Phase 3 US1 provisioning (MVP) | T007-T021 | 15 |
+| Phase 4 US2 org enrolment | T022-T031 | 10 |
+| Phase 5 US3 x5c embed | T032-T037 | 6 |
+| Phase 6 US4 CRL + revocation | T038-T046 | 9 |
+| Phase 7 US5 pluggable provider | T047-T050 | 4 |
+| Phase 8 US6 verifier chain walk | T051-T057 | 7 |
+| Phase 9 Polish | T058-T063 | 6 |
+| **Total** | | **63** |
+
+**Suggested MVP**: Phase 1 + 2 + 3 + 4 + 5 = 37 tasks. Ships provisioning, enrolment, and x5c embedding. Revocation, pluggable swap, and verifier chain-walk can follow as separate increments.

--- a/src/Common/Sorcha.Tenant.Models/Trust/TrustModels.cs
+++ b/src/Common/Sorcha.Tenant.Models/Trust/TrustModels.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Tenant.Models.Trust;
+
+/// <summary>
+/// Represents a tenant-level self-signed root CA certificate.
+/// One per tenant — acts as the trust anchor for all organisation certificates
+/// issued under that tenant.
+/// </summary>
+public class TenantRootCa
+{
+    /// <summary>Primary key.</summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Tenant that owns this root CA.</summary>
+    public required string TenantId { get; set; }
+
+    /// <summary>DER-encoded self-signed root certificate.</summary>
+    public required byte[] CertificateDer { get; set; }
+
+    /// <summary>Certificate serial number (hex string).</summary>
+    public required string SerialNumber { get; set; }
+
+    /// <summary>X.500 subject distinguished name.</summary>
+    public required string SubjectDn { get; set; }
+
+    /// <summary>Signing algorithm used (e.g., "ES256", "EdDSA").</summary>
+    public required string Algorithm { get; set; }
+
+    /// <summary>Certificate validity start.</summary>
+    public DateTimeOffset NotBefore { get; set; }
+
+    /// <summary>Certificate validity end.</summary>
+    public DateTimeOffset NotAfter { get; set; }
+
+    /// <summary>When the root CA was provisioned.</summary>
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>How the private key is protected.</summary>
+    public TrustProviderMode KeyProtectionMode { get; set; } = TrustProviderMode.Local;
+}
+
+/// <summary>
+/// Represents an organisation certificate issued by the tenant root CA.
+/// Binds the organisation's HAIP classical co-key to an X.509 identity.
+/// </summary>
+public class OrgCertEnrolment
+{
+    /// <summary>Primary key.</summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Tenant that issued the cert.</summary>
+    public required string TenantId { get; set; }
+
+    /// <summary>Organisation wallet address.</summary>
+    public required string OrgWalletAddress { get; set; }
+
+    /// <summary>DER-encoded organisation certificate.</summary>
+    public required byte[] CertificateDer { get; set; }
+
+    /// <summary>Certificate serial number (hex string).</summary>
+    public required string SerialNumber { get; set; }
+
+    /// <summary>X.500 subject distinguished name.</summary>
+    public required string SubjectDn { get; set; }
+
+    /// <summary>SAN URI (e.g., "did:sorcha:org:{walletAddress}").</summary>
+    public required string SanUri { get; set; }
+
+    /// <summary>Certificate validity start.</summary>
+    public DateTimeOffset NotBefore { get; set; }
+
+    /// <summary>Certificate validity end.</summary>
+    public DateTimeOffset NotAfter { get; set; }
+
+    /// <summary>When the cert was issued.</summary>
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>When the cert was revoked (null if active).</summary>
+    public DateTimeOffset? RevokedAt { get; set; }
+
+    /// <summary>Revocation reason (null if active).</summary>
+    public string? RevocationReason { get; set; }
+}
+
+/// <summary>
+/// Represents the tenant's Certificate Revocation List (CRL).
+/// Regenerated whenever an org cert is revoked.
+/// </summary>
+public class TenantCrl
+{
+    /// <summary>Primary key.</summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>Tenant that owns this CRL.</summary>
+    public required string TenantId { get; set; }
+
+    /// <summary>DER-encoded CRL.</summary>
+    public required byte[] CrlDer { get; set; }
+
+    /// <summary>CRL version (incremented on each regeneration).</summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>When the CRL was last regenerated.</summary>
+    public DateTimeOffset LastUpdated { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>When the CRL expires (next scheduled regeneration).</summary>
+    public DateTimeOffset NextUpdate { get; set; }
+}
+
+/// <summary>
+/// How the trust anchor's private key is managed.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TrustProviderMode
+{
+    /// <summary>Key stored locally (encrypted by the Tenant Service key protection).</summary>
+    Local = 0,
+
+    /// <summary>Key managed by a cloud KMS (Azure Key Vault, AWS KMS, etc.).</summary>
+    KmsResident = 1,
+
+    /// <summary>Trust anchor imported from an external CA — no local key.</summary>
+    External = 2
+}

--- a/src/Core/Sorcha.Wallet.Portable/Constants/SorchaDerivationPaths.cs
+++ b/src/Core/Sorcha.Wallet.Portable/Constants/SorchaDerivationPaths.cs
@@ -143,6 +143,21 @@ public static class SorchaDerivationPaths
     public const string HaipIssuerSigningPath = "m/44'/0'/0'/0/106";
 
     /// <summary>
+    /// Derivation path for tenant-level CA signing key
+    /// </summary>
+    /// <remarks>
+    /// Used by the Tenant Service to derive a key for signing the tenant's
+    /// self-signed root CA certificate and organisation certificates.
+    /// Maps to: m/44'/0'/0'/0/107
+    /// </remarks>
+    public const string TenantCaSigning = "sorcha:tenant-ca-signing";
+
+    /// <summary>
+    /// BIP44 path for tenant CA signing key
+    /// </summary>
+    public const string TenantCaSigningPath = "m/44'/0'/0'/0/107";
+
+    /// <summary>
     /// Resolves a Sorcha system path to its corresponding BIP44 path
     /// </summary>
     /// <param name="systemPath">Sorcha system path (e.g., "sorcha:register-attestation")</param>
@@ -167,6 +182,7 @@ public static class SorchaDerivationPaths
             PersonaVault => PersonaVaultPath,
             CredentialHolderBinding => CredentialHolderBindingPath,
             HaipIssuerSigning => HaipIssuerSigningPath,
+            TenantCaSigning => TenantCaSigningPath,
             _ => throw new ArgumentException($"Unknown Sorcha system path: {systemPath}", nameof(systemPath))
         };
     }

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs
@@ -27,7 +27,7 @@ public static class TrustEndpoints
                 "Creates a self-signed X.509 root CA certificate for the tenant. " +
                 "Idempotent — returns the existing root if already provisioned.")
             .Produces<TrustAnchorResponse>(StatusCodes.Status200OK)
-            .RequireAuthorization();
+            .RequireAuthorization("RequireAdministrator");
 
         // Trust anchor — public (verifiers need to fetch the root cert)
         group.MapGet("/tenants/{tenantId}/trust-anchor", GetTrustAnchor)
@@ -49,7 +49,7 @@ public static class TrustEndpoints
                 "signed by the tenant's root CA. Binds the org's DID to the certificate via SAN URI.")
             .Produces<OrgCertEnrolmentResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
-            .RequireAuthorization();
+            .RequireAuthorization("RequireAdministrator");
 
         // Org cert chain — public
         group.MapGet("/tenants/{tenantId}/orgs/{orgWalletAddress}/cert-chain", GetOrgCertChain)

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Mvc;
+using Sorcha.Tenant.Service.Trust;
+
+namespace Sorcha.Tenant.Service.Endpoints;
+
+/// <summary>
+/// REST endpoints for X.509 trust anchor and organisation certificate management.
+/// </summary>
+public static class TrustEndpoints
+{
+    /// <summary>
+    /// Maps trust endpoints under /api/v1/trust.
+    /// </summary>
+    public static void MapTrustEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v1/trust")
+            .WithTags("Trust");
+
+        // Provisioning — requires SystemAdmin or TenantAdmin
+        group.MapPost("/tenants/{tenantId}/provision", ProvisionTrustAnchor)
+            .WithName("ProvisionTrustAnchor")
+            .WithSummary("Provision a self-signed root CA for a tenant")
+            .WithDescription(
+                "Creates a self-signed X.509 root CA certificate for the tenant. " +
+                "Idempotent — returns the existing root if already provisioned.")
+            .Produces<TrustAnchorResponse>(StatusCodes.Status200OK)
+            .RequireAuthorization();
+
+        // Trust anchor — public (verifiers need to fetch the root cert)
+        group.MapGet("/tenants/{tenantId}/trust-anchor", GetTrustAnchor)
+            .WithName("GetTrustAnchor")
+            .WithSummary("Get the tenant's trust anchor certificate (DER)")
+            .WithDescription(
+                "Returns the DER-encoded self-signed root CA certificate. " +
+                "Public endpoint — verifiers use it to validate organisation certificate chains.")
+            .Produces(StatusCodes.Status200OK, contentType: "application/pkix-cert")
+            .Produces(StatusCodes.Status404NotFound)
+            .AllowAnonymous();
+
+        // Org cert enrolment — requires auth
+        group.MapPost("/tenants/{tenantId}/orgs/{orgWalletAddress}/enrol", EnrolOrgCert)
+            .WithName("EnrolOrgCert")
+            .WithSummary("Issue an organisation certificate signed by the tenant root CA")
+            .WithDescription(
+                "Issues an X.509 certificate for the organisation's HAIP classical co-key, " +
+                "signed by the tenant's root CA. Binds the org's DID to the certificate via SAN URI.")
+            .Produces<OrgCertEnrolmentResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .RequireAuthorization();
+
+        // Org cert chain — public
+        group.MapGet("/tenants/{tenantId}/orgs/{orgWalletAddress}/cert-chain", GetOrgCertChain)
+            .WithName("GetOrgCertChain")
+            .WithSummary("Get the organisation's certificate chain (leaf + root)")
+            .WithDescription(
+                "Returns the organisation certificate and the tenant root CA as base64-encoded DER. " +
+                "Used by the Wallet Service to populate the x5c JWS header on HAIP-path credentials.")
+            .Produces<CertChainResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound)
+            .AllowAnonymous();
+    }
+
+    private static async Task<IResult> ProvisionTrustAnchor(
+        string tenantId,
+        ITrustProvider trustProvider,
+        CancellationToken ct)
+    {
+        var root = await trustProvider.ProvisionTrustAnchorAsync(tenantId, ct: ct);
+
+        return Results.Ok(new TrustAnchorResponse
+        {
+            TenantId = root.TenantId,
+            SerialNumber = root.SerialNumber,
+            SubjectDn = root.SubjectDn,
+            Algorithm = root.Algorithm,
+            NotBefore = root.NotBefore,
+            NotAfter = root.NotAfter,
+            CertificateBase64 = Convert.ToBase64String(root.CertificateDer)
+        });
+    }
+
+    private static async Task<IResult> GetTrustAnchor(
+        string tenantId,
+        ITrustProvider trustProvider,
+        CancellationToken ct)
+    {
+        var root = await trustProvider.GetTrustAnchorAsync(tenantId, ct);
+        if (root == null)
+            return Results.NotFound(new { error = $"No trust anchor provisioned for tenant '{tenantId}'" });
+
+        return Results.Bytes(root.CertificateDer, "application/pkix-cert");
+    }
+
+    private static async Task<IResult> EnrolOrgCert(
+        string tenantId,
+        string orgWalletAddress,
+        [FromBody] EnrolOrgCertRequest request,
+        ITrustProvider trustProvider,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.OrgPublicKeyBase64))
+            return Results.BadRequest(new { error = "OrgPublicKeyBase64 is required" });
+        if (string.IsNullOrWhiteSpace(request.OrgDisplayName))
+            return Results.BadRequest(new { error = "OrgDisplayName is required" });
+
+        byte[] orgPublicKey;
+        try
+        {
+            orgPublicKey = Convert.FromBase64String(request.OrgPublicKeyBase64);
+        }
+        catch (FormatException)
+        {
+            return Results.BadRequest(new { error = "OrgPublicKeyBase64 is not valid Base64" });
+        }
+
+        try
+        {
+            var enrolment = await trustProvider.IssueOrgCertAsync(
+                tenantId, orgWalletAddress, orgPublicKey, request.OrgDisplayName, ct);
+
+            return Results.Ok(new OrgCertEnrolmentResponse
+            {
+                OrgWalletAddress = enrolment.OrgWalletAddress,
+                SerialNumber = enrolment.SerialNumber,
+                SubjectDn = enrolment.SubjectDn,
+                SanUri = enrolment.SanUri,
+                NotBefore = enrolment.NotBefore,
+                NotAfter = enrolment.NotAfter,
+                CertificateBase64 = Convert.ToBase64String(enrolment.CertificateDer)
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+
+    private static async Task<IResult> GetOrgCertChain(
+        string tenantId,
+        string orgWalletAddress,
+        ITrustProvider trustProvider,
+        CancellationToken ct)
+    {
+        var chain = await trustProvider.GetOrgCertChainAsync(tenantId, orgWalletAddress, ct);
+        if (chain == null)
+            return Results.NotFound(new { error = $"No active cert for org '{orgWalletAddress}' under tenant '{tenantId}'" });
+
+        return Results.Ok(new CertChainResponse
+        {
+            OrgCertBase64 = Convert.ToBase64String(chain.Value.OrgCertDer),
+            RootCertBase64 = Convert.ToBase64String(chain.Value.RootCertDer)
+        });
+    }
+}
+
+/// <summary>Response for trust anchor provisioning.</summary>
+public class TrustAnchorResponse
+{
+    public required string TenantId { get; init; }
+    public required string SerialNumber { get; init; }
+    public required string SubjectDn { get; init; }
+    public required string Algorithm { get; init; }
+    public DateTimeOffset NotBefore { get; init; }
+    public DateTimeOffset NotAfter { get; init; }
+    public required string CertificateBase64 { get; init; }
+}
+
+/// <summary>Request to enrol an organisation certificate.</summary>
+public class EnrolOrgCertRequest
+{
+    public required string OrgPublicKeyBase64 { get; init; }
+    public required string OrgDisplayName { get; init; }
+}
+
+/// <summary>Response for org cert enrolment.</summary>
+public class OrgCertEnrolmentResponse
+{
+    public required string OrgWalletAddress { get; init; }
+    public required string SerialNumber { get; init; }
+    public required string SubjectDn { get; init; }
+    public required string SanUri { get; init; }
+    public DateTimeOffset NotBefore { get; init; }
+    public DateTimeOffset NotAfter { get; init; }
+    public required string CertificateBase64 { get; init; }
+}
+
+/// <summary>Response for cert chain retrieval.</summary>
+public class CertChainResponse
+{
+    public required string OrgCertBase64 { get; init; }
+    public required string RootCertBase64 { get; init; }
+}

--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -93,6 +93,10 @@ builder.Services.AddScoped<Sorcha.Tenant.Service.Services.Interfaces.IEventServi
     Sorcha.Tenant.Service.Services.EventService>();
 builder.Services.AddHostedService<Sorcha.Tenant.Service.Services.EventCleanupService>();
 
+// Feature 096: X.509 Organisation Trust — trust anchor provisioning and org cert enrolment
+builder.Services.AddSingleton<Sorcha.Tenant.Service.Trust.ITrustProvider,
+    Sorcha.Tenant.Service.Trust.InternalCaTrustProvider>();
+
 // Feature 092: Consumer persona — orchestrator + typed HttpClient to Wallet Service
 builder.Services.AddScoped<Sorcha.Tenant.Service.Services.IPersonaService,
     Sorcha.Tenant.Service.Services.PersonaService>();
@@ -184,6 +188,7 @@ app.MapPushSubscriptionEndpoints();
 app.MapEventEndpoints();
 app.MapRegisterSubscriptionEndpoints();
 app.MapRegisterInvitationEndpoints();
+app.MapTrustEndpoints();
 app.MapRazorPages();
 
 // Health check is provided by MapDefaultEndpoints() which maps /health and /alive

--- a/src/Services/Sorcha.Tenant.Service/Trust/ITrustProvider.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/ITrustProvider.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Tenant.Models.Trust;
+
+namespace Sorcha.Tenant.Service.Trust;
+
+/// <summary>
+/// Provisions and manages X.509 trust anchors and organisation certificates.
+/// </summary>
+public interface ITrustProvider
+{
+    /// <summary>
+    /// Provisions a self-signed root CA for a tenant. Idempotent — returns
+    /// the existing root if one is already provisioned.
+    /// </summary>
+    Task<TenantRootCa> ProvisionTrustAnchorAsync(
+        string tenantId,
+        string? subjectDn = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the trust anchor for a tenant, or null if not provisioned.
+    /// </summary>
+    Task<TenantRootCa?> GetTrustAnchorAsync(
+        string tenantId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Issues an organisation certificate signed by the tenant root CA.
+    /// </summary>
+    Task<OrgCertEnrolment> IssueOrgCertAsync(
+        string tenantId,
+        string orgWalletAddress,
+        byte[] orgPublicKey,
+        string orgDisplayName,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the cert chain (leaf + root) for a given org wallet.
+    /// </summary>
+    Task<(byte[] OrgCertDer, byte[] RootCertDer)?> GetOrgCertChainAsync(
+        string tenantId,
+        string orgWalletAddress,
+        CancellationToken ct = default);
+}

--- a/src/Services/Sorcha.Tenant.Service/Trust/InternalCaTrustProvider.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/InternalCaTrustProvider.cs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Sorcha.Tenant.Models.Trust;
+
+namespace Sorcha.Tenant.Service.Trust;
+
+/// <summary>
+/// In-memory trust provider that provisions self-signed root CAs and
+/// issues organisation certificates. Production would persist to PostgreSQL.
+/// </summary>
+public class InternalCaTrustProvider : ITrustProvider
+{
+    private readonly ConcurrentDictionary<string, TenantRootCa> _roots = new();
+    private readonly ConcurrentDictionary<string, byte[]> _rootPrivateKeys = new();
+    private readonly ConcurrentDictionary<string, OrgCertEnrolment> _orgCerts = new();
+    private readonly ILogger<InternalCaTrustProvider> _logger;
+    private readonly string _defaultAlgorithm;
+    private readonly int _defaultCaValidityYears;
+    private readonly int _defaultOrgCertValidityYears;
+    private readonly string _trustBaseUrl;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="InternalCaTrustProvider"/> class.
+    /// </summary>
+    public InternalCaTrustProvider(
+        ILogger<InternalCaTrustProvider> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _defaultAlgorithm = configuration.GetValue<string>("Trust:DefaultCaAlgorithm") ?? "ES256";
+        _defaultCaValidityYears = configuration.GetValue<int>("Trust:DefaultCaValidityYears", 10);
+        _defaultOrgCertValidityYears = configuration.GetValue<int>("Trust:DefaultOrgCertValidityYears", 3);
+        _trustBaseUrl = configuration.GetValue<string>("Trust:BaseUrl")
+            ?? "https://sorcha.example/api/v1/trust";
+    }
+
+    /// <inheritdoc />
+    public Task<TenantRootCa> ProvisionTrustAnchorAsync(
+        string tenantId,
+        string? subjectDn = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        // Idempotent — return existing root if provisioned
+        if (_roots.TryGetValue(tenantId, out var existing))
+        {
+            _logger.LogInformation(
+                "Trust anchor already provisioned for tenant {TenantId}, returning existing",
+                tenantId);
+            return Task.FromResult(existing);
+        }
+
+        var dn = subjectDn ?? $"CN=Sorcha Tenant {tenantId} Root CA, O=Sorcha, C=IE";
+
+        var (certDer, privateKey, serialNumber) = X509CertificateBuilder.BuildSelfSignedRoot(
+            _defaultAlgorithm, dn, _defaultCaValidityYears);
+
+        var rootCa = new TenantRootCa
+        {
+            TenantId = tenantId,
+            CertificateDer = certDer,
+            SerialNumber = serialNumber,
+            SubjectDn = dn,
+            Algorithm = _defaultAlgorithm,
+            NotBefore = DateTimeOffset.UtcNow,
+            NotAfter = DateTimeOffset.UtcNow.AddYears(_defaultCaValidityYears),
+            KeyProtectionMode = TrustProviderMode.Local
+        };
+
+        if (_roots.TryAdd(tenantId, rootCa))
+        {
+            _rootPrivateKeys[tenantId] = privateKey;
+
+            _logger.LogInformation(
+                "Provisioned trust anchor for tenant {TenantId}: serial={Serial}, algorithm={Algorithm}, valid until {NotAfter}",
+                tenantId, serialNumber, _defaultAlgorithm, rootCa.NotAfter);
+        }
+        else
+        {
+            // Race — another thread provisioned first
+            rootCa = _roots[tenantId];
+        }
+
+        return Task.FromResult(rootCa);
+    }
+
+    /// <inheritdoc />
+    public Task<TenantRootCa?> GetTrustAnchorAsync(string tenantId, CancellationToken ct = default)
+    {
+        _roots.TryGetValue(tenantId, out var root);
+        return Task.FromResult(root);
+    }
+
+    /// <inheritdoc />
+    public Task<OrgCertEnrolment> IssueOrgCertAsync(
+        string tenantId,
+        string orgWalletAddress,
+        byte[] orgPublicKey,
+        string orgDisplayName,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(orgWalletAddress);
+        ArgumentNullException.ThrowIfNull(orgPublicKey);
+
+        if (!_roots.TryGetValue(tenantId, out var rootCa))
+            throw new InvalidOperationException(
+                $"Tenant {tenantId} has no provisioned trust anchor. Call ProvisionTrustAnchorAsync first.");
+
+        if (!_rootPrivateKeys.TryGetValue(tenantId, out var rootPrivateKey))
+            throw new InvalidOperationException(
+                $"Root CA private key not available for tenant {tenantId}.");
+
+        var key = $"{tenantId}:{orgWalletAddress}";
+        if (_orgCerts.TryGetValue(key, out var existing) && existing.RevokedAt == null)
+        {
+            _logger.LogInformation(
+                "Org cert already issued for {OrgWallet} under tenant {TenantId}",
+                orgWalletAddress, tenantId);
+            return Task.FromResult(existing);
+        }
+
+        var subjectDn = $"CN={orgDisplayName}, O=Sorcha Org, C=IE";
+        var sanUri = $"did:sorcha:org:{orgWalletAddress}";
+        var crlDp = $"{_trustBaseUrl}/tenants/{tenantId}/crl";
+
+        var (certDer, serialNumber) = X509CertificateBuilder.BuildOrgCert(
+            rootCa.CertificateDer, rootPrivateKey, orgPublicKey,
+            subjectDn, sanUri, crlDp, _defaultOrgCertValidityYears);
+
+        var enrolment = new OrgCertEnrolment
+        {
+            TenantId = tenantId,
+            OrgWalletAddress = orgWalletAddress,
+            CertificateDer = certDer,
+            SerialNumber = serialNumber,
+            SubjectDn = subjectDn,
+            SanUri = sanUri,
+            NotBefore = DateTimeOffset.UtcNow,
+            NotAfter = DateTimeOffset.UtcNow.AddYears(_defaultOrgCertValidityYears)
+        };
+
+        _orgCerts[key] = enrolment;
+
+        _logger.LogInformation(
+            "Issued org cert for {OrgWallet} under tenant {TenantId}: serial={Serial}",
+            orgWalletAddress, tenantId, serialNumber);
+
+        return Task.FromResult(enrolment);
+    }
+
+    /// <inheritdoc />
+    public Task<(byte[] OrgCertDer, byte[] RootCertDer)?> GetOrgCertChainAsync(
+        string tenantId,
+        string orgWalletAddress,
+        CancellationToken ct = default)
+    {
+        var key = $"{tenantId}:{orgWalletAddress}";
+        if (!_orgCerts.TryGetValue(key, out var enrolment) || enrolment.RevokedAt != null)
+            return Task.FromResult<(byte[], byte[])?>(null);
+
+        if (!_roots.TryGetValue(tenantId, out var rootCa))
+            return Task.FromResult<(byte[], byte[])?>(null);
+
+        return Task.FromResult<(byte[], byte[])?>(
+            (enrolment.CertificateDer, rootCa.CertificateDer));
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Trust/X509CertificateBuilder.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/X509CertificateBuilder.cs
@@ -8,7 +8,8 @@ namespace Sorcha.Tenant.Service.Trust;
 
 /// <summary>
 /// Builds X.509 certificates using the .NET BCL <see cref="CertificateRequest"/> API.
-/// Supports ES256 (P-256) and EdDSA (Ed25519 via exportable key) root CA and org certificates.
+/// Currently supports ES256 (P-256) for root CA and org certificates.
+/// EdDSA (Ed25519) support deferred — BCL CertificateRequest requires an asymmetric algorithm adapter.
 /// </summary>
 public static class X509CertificateBuilder
 {

--- a/src/Services/Sorcha.Tenant.Service/Trust/X509CertificateBuilder.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/X509CertificateBuilder.cs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Sorcha.Tenant.Service.Trust;
+
+/// <summary>
+/// Builds X.509 certificates using the .NET BCL <see cref="CertificateRequest"/> API.
+/// Supports ES256 (P-256) and EdDSA (Ed25519 via exportable key) root CA and org certificates.
+/// </summary>
+public static class X509CertificateBuilder
+{
+    /// <summary>
+    /// Builds a self-signed root CA certificate.
+    /// </summary>
+    /// <param name="algorithm">Signing algorithm ("ES256" or "EdDSA").</param>
+    /// <param name="subjectDn">X.500 subject distinguished name (e.g., "CN=Sorcha Tenant Root CA").</param>
+    /// <param name="validityYears">Certificate validity period in years.</param>
+    /// <returns>Tuple of (DER-encoded certificate bytes, private key bytes, serial number hex).</returns>
+    public static (byte[] CertificateDer, byte[] PrivateKey, string SerialNumber) BuildSelfSignedRoot(
+        string algorithm,
+        string subjectDn,
+        int validityYears = 10)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(algorithm);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectDn);
+        if (validityYears < 1) throw new ArgumentOutOfRangeException(nameof(validityYears));
+
+        var alg = algorithm.ToUpperInvariant();
+
+        if (alg is "ES256" or "P-256" or "P256")
+        {
+            return BuildSelfSignedRootP256(subjectDn, validityYears);
+        }
+
+        throw new NotSupportedException(
+            $"Unsupported CA algorithm: {algorithm}. Supported: ES256.");
+    }
+
+    /// <summary>
+    /// Builds an organisation certificate signed by the root CA.
+    /// </summary>
+    /// <param name="rootCertDer">DER-encoded root CA certificate.</param>
+    /// <param name="rootPrivateKey">Root CA private key bytes.</param>
+    /// <param name="orgPublicKey">Organisation's public key (SPKI-encoded).</param>
+    /// <param name="subjectDn">X.500 subject distinguished name.</param>
+    /// <param name="sanUri">Subject Alternative Name URI (e.g., "did:sorcha:org:ws1q...").</param>
+    /// <param name="crlDistributionPoint">URL of the CRL endpoint.</param>
+    /// <param name="validityYears">Certificate validity period in years.</param>
+    /// <returns>Tuple of (DER-encoded certificate bytes, serial number hex).</returns>
+    public static (byte[] CertificateDer, string SerialNumber) BuildOrgCert(
+        byte[] rootCertDer,
+        byte[] rootPrivateKey,
+        byte[] orgPublicKey,
+        string subjectDn,
+        string sanUri,
+        string? crlDistributionPoint = null,
+        int validityYears = 3)
+    {
+        ArgumentNullException.ThrowIfNull(rootCertDer);
+        ArgumentNullException.ThrowIfNull(rootPrivateKey);
+        ArgumentNullException.ThrowIfNull(orgPublicKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subjectDn);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sanUri);
+
+        using var rootCert = X509CertificateLoader.LoadCertificate(rootCertDer);
+
+        // Extract root CA private key for signing
+        using var rootEcdsa = ECDsa.Create();
+        rootEcdsa.ImportECPrivateKey(rootPrivateKey, out _);
+
+        // Import the org's public key
+        using var orgEcdsa = ECDsa.Create();
+        orgEcdsa.ImportSubjectPublicKeyInfo(orgPublicKey, out _);
+
+        var request = new CertificateRequest(
+            new X500DistinguishedName(subjectDn),
+            orgEcdsa,
+            HashAlgorithmName.SHA256);
+
+        // Basic constraints: NOT a CA
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(false, false, 0, true));
+
+        // Key usage: Digital Signature only
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true));
+
+        // Subject Alternative Name with URI
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddUri(new Uri(sanUri));
+        request.CertificateExtensions.Add(sanBuilder.Build());
+
+        // Subject Key Identifier
+        request.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        // Serial number
+        var serialBytes = RandomNumberGenerator.GetBytes(16);
+        serialBytes[0] &= 0x7F; // Ensure positive
+
+        var now = DateTimeOffset.UtcNow;
+        using var signedCert = request.Create(
+            rootCert.SubjectName,
+            X509SignatureGenerator.CreateForECDsa(rootEcdsa),
+            now,
+            now.AddYears(validityYears),
+            serialBytes);
+
+        var serialHex = Convert.ToHexString(serialBytes);
+        return (signedCert.RawData, serialHex);
+    }
+
+    private static (byte[] CertificateDer, byte[] PrivateKey, string SerialNumber) BuildSelfSignedRootP256(
+        string subjectDn,
+        int validityYears)
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var request = new CertificateRequest(
+            new X500DistinguishedName(subjectDn),
+            ecdsa,
+            HashAlgorithmName.SHA256);
+
+        // Basic constraints: IS a CA
+        request.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(true, true, 1, true));
+
+        // Key usage: Certificate Signing, CRL Signing
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                true));
+
+        // Subject Key Identifier
+        request.CertificateExtensions.Add(
+            new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        var now = DateTimeOffset.UtcNow;
+        using var cert = request.CreateSelfSigned(now, now.AddYears(validityYears));
+
+        var privateKey = ecdsa.ExportECPrivateKey();
+        var serialHex = cert.SerialNumber;
+
+        return (cert.RawData, privateKey, serialHex);
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/appsettings.json
+++ b/src/Services/Sorcha.Tenant.Service/appsettings.json
@@ -66,5 +66,13 @@
   "RateLimiting": {
     "TotpPermitLimit": 5,
     "PlatformAuthPermitLimit": 5
+  },
+
+  "Trust": {
+    "BaseUrl": "https://sorcha.example/api/v1/trust",
+    "DefaultCaAlgorithm": "ES256",
+    "DefaultCaValidityYears": 10,
+    "DefaultOrgCertValidityYears": 3,
+    "CrlRefreshHours": 24
   }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs
@@ -83,6 +83,23 @@ public class InternalCaTrustProviderTests
     }
 
     [Fact]
+    public async Task IssueOrgCert_IsIdempotent_ReturnsExistingCert()
+    {
+        await _provider.ProvisionTrustAnchorAsync("tenant-1");
+
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        var cert1 = await _provider.IssueOrgCertAsync(
+            "tenant-1", "ws1qorg123", orgPublicKey, "Test Organisation");
+        var cert2 = await _provider.IssueOrgCertAsync(
+            "tenant-1", "ws1qorg123", orgPublicKey, "Test Organisation");
+
+        cert1.Id.Should().Be(cert2.Id);
+        cert1.SerialNumber.Should().Be(cert2.SerialNumber);
+    }
+
+    [Fact]
     public async Task IssueOrgCert_WithoutProvisionedRoot_Throws()
     {
         using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);

--- a/tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Trust/InternalCaTrustProviderTests.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Sorcha.Tenant.Service.Trust;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Trust;
+
+/// <summary>
+/// Tests for InternalCaTrustProvider — provisioning, enrolment, idempotency.
+/// </summary>
+public class InternalCaTrustProviderTests
+{
+    private readonly InternalCaTrustProvider _provider;
+
+    public InternalCaTrustProviderTests()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Trust:DefaultCaAlgorithm"] = "ES256",
+                ["Trust:DefaultCaValidityYears"] = "10",
+                ["Trust:DefaultOrgCertValidityYears"] = "3",
+                ["Trust:BaseUrl"] = "https://test.example/api/v1/trust"
+            })
+            .Build();
+
+        _provider = new InternalCaTrustProvider(
+            Mock.Of<ILogger<InternalCaTrustProvider>>(),
+            config);
+    }
+
+    [Fact]
+    public async Task Provision_CreatesNewRootCa()
+    {
+        var root = await _provider.ProvisionTrustAnchorAsync("tenant-1");
+
+        root.Should().NotBeNull();
+        root.TenantId.Should().Be("tenant-1");
+        root.CertificateDer.Should().NotBeEmpty();
+        root.SerialNumber.Should().NotBeNullOrWhiteSpace();
+        root.Algorithm.Should().Be("ES256");
+        root.NotAfter.Should().BeAfter(DateTimeOffset.UtcNow.AddYears(9));
+    }
+
+    [Fact]
+    public async Task Provision_IsIdempotent_ReturnsExistingRoot()
+    {
+        var root1 = await _provider.ProvisionTrustAnchorAsync("tenant-1");
+        var root2 = await _provider.ProvisionTrustAnchorAsync("tenant-1");
+
+        root1.Id.Should().Be(root2.Id);
+        root1.SerialNumber.Should().Be(root2.SerialNumber);
+    }
+
+    [Fact]
+    public async Task GetTrustAnchor_NotProvisioned_ReturnsNull()
+    {
+        var root = await _provider.GetTrustAnchorAsync("nonexistent");
+        root.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task IssueOrgCert_WithProvisionedRoot_Succeeds()
+    {
+        await _provider.ProvisionTrustAnchorAsync("tenant-1");
+
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        var enrolment = await _provider.IssueOrgCertAsync(
+            "tenant-1", "ws1qorg123", orgPublicKey, "Test Organisation");
+
+        enrolment.Should().NotBeNull();
+        enrolment.OrgWalletAddress.Should().Be("ws1qorg123");
+        enrolment.SanUri.Should().Be("did:sorcha:org:ws1qorg123");
+        enrolment.CertificateDer.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task IssueOrgCert_WithoutProvisionedRoot_Throws()
+    {
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        var act = () => _provider.IssueOrgCertAsync(
+            "tenant-1", "ws1qorg123", orgPublicKey, "Test Organisation");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no provisioned trust anchor*");
+    }
+
+    [Fact]
+    public async Task GetOrgCertChain_AfterEnrolment_ReturnsBothCerts()
+    {
+        await _provider.ProvisionTrustAnchorAsync("tenant-1");
+
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        await _provider.IssueOrgCertAsync("tenant-1", "ws1qorg123", orgPublicKey, "Test Org");
+
+        var chain = await _provider.GetOrgCertChainAsync("tenant-1", "ws1qorg123");
+
+        chain.Should().NotBeNull();
+        chain!.Value.OrgCertDer.Should().NotBeEmpty();
+        chain.Value.RootCertDer.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetOrgCertChain_NotEnrolled_ReturnsNull()
+    {
+        await _provider.ProvisionTrustAnchorAsync("tenant-1");
+
+        var chain = await _provider.GetOrgCertChainAsync("tenant-1", "ws1qnonexistent");
+        chain.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Trust/X509CertificateBuilderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Trust/X509CertificateBuilderTests.cs
@@ -39,7 +39,7 @@ public class X509CertificateBuilderTests
         using var cert = X509CertificateLoader.LoadCertificate(certDer);
         var expectedExpiry = DateTimeOffset.UtcNow.AddYears(5);
 
-        // Allow 2 hours of clock skew (UTC vs local time conversion)
+        // Allow 5 minutes tolerance for UTC/local time conversion and test execution time
         cert.NotAfter.ToUniversalTime().Should().BeCloseTo(expectedExpiry.UtcDateTime, TimeSpan.FromMinutes(5));
     }
 
@@ -137,9 +137,13 @@ public class X509CertificateBuilderTests
 
         using var orgCert = X509CertificateLoader.LoadCertificate(orgCertDer);
 
-        // Check SAN extension exists
+        // Check SAN extension exists and contains the DID URI
         var san = orgCert.Extensions.OfType<X509SubjectAlternativeNameExtension>().FirstOrDefault();
         san.Should().NotBeNull("org cert must have SAN extension");
+        // The SAN extension's formatted string should contain the DID URI
+        var sanFormatted = san!.Format(true);
+        sanFormatted.Should().Contain("did:sorcha:org:ws1qtest123",
+            because: "SAN URI should contain the org's DID");
     }
 
     [Fact]

--- a/tests/Sorcha.Tenant.Service.Tests/Trust/X509CertificateBuilderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Trust/X509CertificateBuilderTests.cs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FluentAssertions;
+using Sorcha.Tenant.Service.Trust;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Trust;
+
+/// <summary>
+/// Tests for X509CertificateBuilder — self-signed root CA and org cert generation.
+/// </summary>
+public class X509CertificateBuilderTests
+{
+    [Fact]
+    public void BuildSelfSignedRoot_Es256_ValidCertDerOutput()
+    {
+        var (certDer, privateKey, serialNumber) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA, O=Sorcha, C=IE");
+
+        certDer.Should().NotBeEmpty();
+        privateKey.Should().NotBeEmpty();
+        serialNumber.Should().NotBeNullOrWhiteSpace();
+
+        // Parse the DER to validate it's a real X.509 cert
+        using var cert = X509CertificateLoader.LoadCertificate(certDer);
+        cert.Subject.Should().Contain("CN=Test Root CA");
+        cert.Issuer.Should().Contain("CN=Test Root CA"); // self-signed
+    }
+
+    [Fact]
+    public void BuildSelfSignedRoot_ValidityPeriod_RespectsInput()
+    {
+        var (certDer, _, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA", validityYears: 5);
+
+        using var cert = X509CertificateLoader.LoadCertificate(certDer);
+        var expectedExpiry = DateTimeOffset.UtcNow.AddYears(5);
+
+        // Allow 2 hours of clock skew (UTC vs local time conversion)
+        cert.NotAfter.ToUniversalTime().Should().BeCloseTo(expectedExpiry.UtcDateTime, TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public void BuildSelfSignedRoot_HasCaBasicConstraints()
+    {
+        var (certDer, _, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA");
+
+        using var cert = X509CertificateLoader.LoadCertificate(certDer);
+
+        var basicConstraints = cert.Extensions.OfType<X509BasicConstraintsExtension>().FirstOrDefault();
+        basicConstraints.Should().NotBeNull();
+        basicConstraints!.CertificateAuthority.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildSelfSignedRoot_HasKeyUsageCertSignAndCrlSign()
+    {
+        var (certDer, _, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA");
+
+        using var cert = X509CertificateLoader.LoadCertificate(certDer);
+
+        var keyUsage = cert.Extensions.OfType<X509KeyUsageExtension>().FirstOrDefault();
+        keyUsage.Should().NotBeNull();
+        keyUsage!.KeyUsages.Should().HaveFlag(X509KeyUsageFlags.KeyCertSign);
+        keyUsage.KeyUsages.Should().HaveFlag(X509KeyUsageFlags.CrlSign);
+    }
+
+    [Fact]
+    public void BuildSelfSignedRoot_UnsupportedAlgorithm_Throws()
+    {
+        var act = () => X509CertificateBuilder.BuildSelfSignedRoot(
+            "ML-DSA-65", "CN=Test Root CA");
+
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("*Unsupported CA algorithm*");
+    }
+
+    [Fact]
+    public void BuildOrgCert_SignedByRootCa()
+    {
+        // Create root CA
+        var (rootCertDer, rootPrivateKey, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA");
+
+        // Generate an org key
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        // Issue org cert
+        var (orgCertDer, orgSerial) = X509CertificateBuilder.BuildOrgCert(
+            rootCertDer, rootPrivateKey, orgPublicKey,
+            "CN=Test Org, O=Sorcha Org, C=IE",
+            "did:sorcha:org:ws1qtest123");
+
+        orgCertDer.Should().NotBeEmpty();
+        orgSerial.Should().NotBeNullOrWhiteSpace();
+
+        using var orgCert = X509CertificateLoader.LoadCertificate(orgCertDer);
+        orgCert.Subject.Should().Contain("CN=Test Org");
+        orgCert.Issuer.Should().Contain("CN=Test Root CA"); // signed by root
+    }
+
+    [Fact]
+    public void BuildOrgCert_IsNotCA()
+    {
+        var (rootCertDer, rootPrivateKey, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA");
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        var (orgCertDer, _) = X509CertificateBuilder.BuildOrgCert(
+            rootCertDer, rootPrivateKey, orgPublicKey,
+            "CN=Test Org", "did:sorcha:org:ws1qtest123");
+
+        using var orgCert = X509CertificateLoader.LoadCertificate(orgCertDer);
+        var bc = orgCert.Extensions.OfType<X509BasicConstraintsExtension>().FirstOrDefault();
+        bc.Should().NotBeNull();
+        bc!.CertificateAuthority.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildOrgCert_EmbedsSanUri_WithDidSorchaOrgPrefix()
+    {
+        var (rootCertDer, rootPrivateKey, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA");
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        var (orgCertDer, _) = X509CertificateBuilder.BuildOrgCert(
+            rootCertDer, rootPrivateKey, orgPublicKey,
+            "CN=Test Org", "did:sorcha:org:ws1qtest123");
+
+        using var orgCert = X509CertificateLoader.LoadCertificate(orgCertDer);
+
+        // Check SAN extension exists
+        var san = orgCert.Extensions.OfType<X509SubjectAlternativeNameExtension>().FirstOrDefault();
+        san.Should().NotBeNull("org cert must have SAN extension");
+    }
+
+    [Fact]
+    public void BuildOrgCert_ChainVerifiesAgainstRoot()
+    {
+        var (rootCertDer, rootPrivateKey, _) = X509CertificateBuilder.BuildSelfSignedRoot(
+            "ES256", "CN=Test Root CA");
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgPublicKey = orgEcdsa.ExportSubjectPublicKeyInfo();
+
+        var (orgCertDer, _) = X509CertificateBuilder.BuildOrgCert(
+            rootCertDer, rootPrivateKey, orgPublicKey,
+            "CN=Test Org", "did:sorcha:org:ws1qtest123");
+
+        using var rootCert = X509CertificateLoader.LoadCertificate(rootCertDer);
+        using var orgCert = X509CertificateLoader.LoadCertificate(orgCertDer);
+
+        // Build a chain with the root as trusted
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+
+        var isValid = chain.Build(orgCert);
+        isValid.Should().BeTrue("org cert should verify against the root CA");
+    }
+}


### PR DESCRIPTION
## Summary

X.509 trust anchor provisioning and organisation certificate enrolment for HAIP-compliant credential issuance. Each tenant gets a self-signed root CA; organisations enrol their HAIP classical co-key to receive an X.509 certificate signed by the tenant root. The cert chain (leaf + root) will be embedded in the `x5c` JWS header on HAIP-path credentials (wiring in spec 097).

- **Root CA provisioning**: self-signed P-256 root with CA=true, KeyCertSign+CrlSign
- **Org cert enrolment**: signed by tenant root, CA=false, DigitalSignature only, SAN URI = `did:sorcha:org:{wallet}`
- **Chain verification**: X509Chain validates org cert against root with CustomRootTrust
- **Trust endpoints**: provision, trust-anchor (public DER), enrol, cert-chain (public)

## Files changed

### Domain models
- `Sorcha.Tenant.Models/Trust/TrustModels.cs` — NEW: TenantRootCa, OrgCertEnrolment, TenantCrl, TrustProviderMode

### Tenant Service
- `Trust/X509CertificateBuilder.cs` — NEW: BCL CertificateRequest-based cert builder
- `Trust/ITrustProvider.cs` — NEW: trust provider interface
- `Trust/InternalCaTrustProvider.cs` — NEW: in-memory implementation
- `Endpoints/TrustEndpoints.cs` — NEW: 4 endpoints under /api/v1/trust
- `Program.cs` — DI registration + endpoint mapping
- `appsettings.json` — Trust config section

### Shared
- `SorchaDerivationPaths.cs` — `sorcha:tenant-ca-signing` (index 107)

## Test results

| Suite | Total | New | Passed | Failed |
|-------|-------|-----|--------|--------|
| Trust tests | 16 | 16 | 16 | 0 |
| Tenant Service (full) | 713 | 16 | 702 | 3 (pre-existing TOTP) |

## Deferred (Push 2+)
- x5c embedding in SD-JWT JWS header (Phase 5 US3) — extends ISdJwtService
- CRL publication and revocation (Phase 6 US4)
- Pluggable trust provider swap (Phase 7 US5)
- Verifier chain-walk integration (Phase 8 US6)

## Test plan

- [x] 9 X509CertificateBuilder tests — root CA generation, constraints, key usage, org cert signing, chain verification
- [x] 7 InternalCaTrustProvider tests — provisioning, idempotency, enrolment, chain retrieval
- [x] 0 regressions in existing 702 Tenant Service tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)