### PR TITLE
fix: scoped DI for RegisterManager in genesis docket write

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1260,6 +1260,7 @@ docketsGroup.MapPost("/", async (
     IRegisterRepository repository,
     Sorcha.Register.Core.Events.IEventPublisher eventPublisher,
     Sorcha.Register.Service.Services.Interfaces.IInboundTransactionRouter transactionRouter,
+    Sorcha.Register.Core.Managers.RegisterManager registerManager,
     ILogger<Program> logger,
     string registerId,
     WriteDocketRequest request) =>
@@ -1272,7 +1273,6 @@ docketsGroup.MapPost("/", async (
             registerId == Sorcha.Register.Models.Constants.SystemRegisterConstants.SystemRegisterId)
         {
             logger.LogInformation("Auto-creating system register for genesis docket");
-            var registerManager = app.Services.GetRequiredService<Sorcha.Register.Core.Managers.RegisterManager>();
             register = await registerManager.CreateRegisterAsync(
                 Sorcha.Register.Models.Constants.SystemRegisterConstants.SystemRegisterName,
                 advertise: false,


### PR DESCRIPTION
## Summary
- Fix scoped service resolution error when auto-creating system register on genesis docket write
- RegisterManager is scoped (MongoDB deps), inject via endpoint parameter instead of root provider

## Test plan
- [x] `dotnet build` — clean
- [ ] CI passes  
- [ ] Genesis docket sealed on n1.sorcha.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)