### PR TITLE
chore: add Sorcha.Haip.Service deployment infrastructure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,6 +489,35 @@ services:
     networks:
       - sorcha-network
 
+  haip-service:
+    build:
+      context: .
+      dockerfile: src/Services/Sorcha.Haip.Service/Dockerfile
+    image: sorchadev/haip-service:latest
+    container_name: sorcha-haip-service
+    restart: unless-stopped
+    # No ports published - accessed via API Gateway
+    environment:
+      <<: [*otel-env, *jwt-env]
+      OTEL_SERVICE_NAME: haip-service
+      ASPNETCORE_ENVIRONMENT: Docker
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__Redis: redis:6379
+      Haip__IssuerUrl: http://api-gateway:8080/haip
+    depends_on:
+      redis:
+        condition: service_healthy
+      aspire-dashboard:
+        condition: service_started
+    networks:
+      - sorcha-network
+    healthcheck:
+      test: ["CMD", "/bin/busybox", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+
   api-gateway:
     build:
       context: .
@@ -512,6 +541,7 @@ services:
       Services__Tenant__Url: http://tenant-service:8080
       Services__Peer__Url: http://peer-service:8080  # Use Docker DNS
       Services__Validator__Url: http://validator-service:8080
+      Services__Haip__Url: http://haip-service:8080
       Services__UI__Url: http://sorcha-ui-web:8080
       ConnectionStrings__Redis: redis:6379
       OpenApi__RequireAuth: ${OPENAPI_REQUIRE_AUTH:-true}
@@ -531,6 +561,8 @@ services:
       peer-service:
         condition: service_healthy
       validator-service:
+        condition: service_healthy
+      haip-service:
         condition: service_healthy
       sorcha-ui-web:
         condition: service_started

--- a/docs/getting-started/PORT-CONFIGURATION.md
+++ b/docs/getting-started/PORT-CONFIGURATION.md
@@ -28,6 +28,7 @@ Sorcha uses a standardized port configuration across all development and deploym
 | **Peer Service** | 5002 | 7002 | 5002 | 8080 |
 | **Tenant Service** | 5110 | 7110 | 5110 | 8080 |
 | **Register Service** | 5290 | 7290 | 5290 | 8080 |
+| **HAIP Service** | 5300 | 7300 | N/A | 8080 |
 | **API Gateway** | 8080 | 7082 | 8080 | 8080 |
 | **Admin UI** | 8081 | 7083 | N/A | N/A |
 

--- a/src/Apps/Sorcha.AppHost/AppHost.cs
+++ b/src/Apps/Sorcha.AppHost/AppHost.cs
@@ -102,6 +102,14 @@ var validatorService = builder.AddProject<Projects.Sorcha_Validator_Service>("va
     .WithEnvironment("ServiceAuth__Scopes", "registers:write registers:read")
     .WithExternalHttpEndpoints(); // Exposed for walkthrough testing
 
+// Add HAIP Service for external wallet credential issuance and verification (specs 097/098)
+var haipService = builder.AddProject<Projects.Sorcha_Haip_Service>("haip-service")
+    .WithReference(redis)
+    .WithEnvironment("JwtSettings__SigningKey", jwtSigningKey)
+    .WithEnvironment("JwtSettings__Issuer", "https://localhost:7110")
+    .WithEnvironment("JwtSettings__Audience", "https://sorcha.local")
+    .WithExternalHttpEndpoints(); // Exposed for HAIP wallet access
+
 // Add API Gateway as the API entry point for backend services
 var apiGateway = builder.AddProject<Projects.Sorcha_ApiGateway>("api-gateway")
     .WithReference(tenantService)
@@ -110,6 +118,7 @@ var apiGateway = builder.AddProject<Projects.Sorcha_ApiGateway>("api-gateway")
     .WithReference(registerService)
     .WithReference(peerService)
     .WithReference(validatorService)
+    .WithReference(haipService)
     .WithReference(redis)
     .WithExternalHttpEndpoints(); // Exposed for API calls from UI
 

--- a/src/Apps/Sorcha.AppHost/Sorcha.AppHost.csproj
+++ b/src/Apps/Sorcha.AppHost/Sorcha.AppHost.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\Sorcha.UI\Sorcha.UI.Web\Sorcha.UI.Web.csproj" />
     <ProjectReference Include="..\..\Services\Sorcha.Tenant.Service\Sorcha.Tenant.Service.csproj" />
     <ProjectReference Include="..\..\Services\Sorcha.Validator.Service\Sorcha.Validator.Service.csproj" />
+    <ProjectReference Include="..\..\Services\Sorcha.Haip.Service\Sorcha.Haip.Service.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -383,7 +383,15 @@
         "AuthorizationPolicy": "RequireAdministrator",
         "Match": { "Path": "/admin/dashboard/{**catch-all}" },
         "Transforms": [ { "PathRemovePrefix": "/admin/dashboard" } ]
-      }
+      },
+
+      "haip-well-known":     { "ClusterId": "haip-cluster", "Match": { "Path": "/.well-known/openid-credential-issuer" },           "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "haip-oauth-metadata": { "ClusterId": "haip-cluster", "Match": { "Path": "/.well-known/oauth-authorization-server" },         "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "haip-token":          { "ClusterId": "haip-cluster", "Match": { "Path": "/token" },                                          "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "haip-nonce":          { "ClusterId": "haip-cluster", "Match": { "Path": "/nonce" },                                          "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "haip-credential":     { "ClusterId": "haip-cluster", "Match": { "Path": "/credential" },                                     "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "haip-offers":         { "ClusterId": "haip-cluster", "Match": { "Path": "/api/v1/offers/{**catch-all}" },                     "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "haip-verifier":       { "ClusterId": "haip-cluster", "Match": { "Path": "/api/v1/verifier/{**catch-all}" },                   "Transforms": [ { "X-Forwarded": "Set" } ] }
     },
     "Clusters": {
       "admin-cluster": {
@@ -432,6 +440,13 @@
         "Destinations": {
           "destination1": {
             "Address": "http://validator-service:8080"
+          }
+        }
+      },
+      "haip-cluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://haip-service:8080"
           }
         }
       },

--- a/src/Services/Sorcha.Haip.Service/Dockerfile
+++ b/src/Services/Sorcha.Haip.Service/Dockerfile
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy build property files for central package management
+COPY ["Directory.Packages.props", "."]
+COPY ["src/Services/Directory.Build.props", "src/Services/"]
+COPY ["src/Common/Directory.Build.props", "src/Common/"]
+
+# Copy project files for restore
+COPY ["src/Services/Sorcha.Haip.Service/Sorcha.Haip.Service.csproj", "src/Services/Sorcha.Haip.Service/"]
+COPY ["src/Common/Sorcha.ServiceDefaults/Sorcha.ServiceDefaults.csproj", "src/Common/Sorcha.ServiceDefaults/"]
+COPY ["src/Common/Sorcha.ServiceClients/Sorcha.ServiceClients.csproj", "src/Common/Sorcha.ServiceClients/"]
+COPY ["src/Common/Sorcha.Cryptography/Sorcha.Cryptography.csproj", "src/Common/Sorcha.Cryptography/"]
+COPY ["src/Common/Sorcha.Blueprint.Models/Sorcha.Blueprint.Models.csproj", "src/Common/Sorcha.Blueprint.Models/"]
+COPY ["src/Common/Sorcha.Tenant.Models/Sorcha.Tenant.Models.csproj", "src/Common/Sorcha.Tenant.Models/"]
+
+# Restore dependencies
+RUN dotnet restore "src/Services/Sorcha.Haip.Service/Sorcha.Haip.Service.csproj"
+
+# Copy source code
+COPY src/ ./src/
+
+# Build the application
+WORKDIR "/src/src/Services/Sorcha.Haip.Service"
+RUN dotnet build "Sorcha.Haip.Service.csproj" -c Release -o /app/build
+
+# Publish stage
+FROM build AS publish
+RUN dotnet publish "Sorcha.Haip.Service.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+# Dependencies stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgssapi-krb5-2 \
+    busybox-static \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /home/app/.aspnet/DataProtection-Keys && \
+    chown -R 1654:1654 /home/app/.aspnet
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble AS final
+WORKDIR /app
+
+COPY --from=dependencies /bin/busybox /bin/busybox
+COPY --from=dependencies --chown=$APP_UID:$APP_UID /home/app/.aspnet /home/app/.aspnet
+
+EXPOSE 8080
+
+COPY --from=publish /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_HTTP_PORTS=8080
+
+USER $APP_UID
+
+ENTRYPOINT ["dotnet", "Sorcha.Haip.Service.dll"]


### PR DESCRIPTION
## Summary

Makes `Sorcha.Haip.Service` (specs 097/098) deployable in the full Sorcha stack — Dockerfile, Aspire AppHost, YARP routing, and docker-compose.

## Changes

- **Dockerfile**: multi-stage build, net10.0, busybox health check, non-root user
- **AppHost**: new `haip-service` Aspire resource with Redis + JWT config, API Gateway references it
- **YARP**: 7 routes covering all HAIP endpoints (metadata, token, nonce, credential, offers, verifier)
- **docker-compose**: new `haip-service` container, API Gateway `depends_on` updated
- **Port config**: HAIP Service at 5300/7300

## Test plan

- [x] AppHost builds clean (0 errors)
- [x] HAIP Service builds and 26 tests pass
- [x] YARP routes correctly map to haip-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)