### PR TITLE
fix: HAIP quality wave 3 — medium correctness items

### DIFF
--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -240,7 +240,7 @@ public class SdJwtService : ISdJwtService
                 cnf.ValueKind == JsonValueKind.Object &&
                 cnf.TryGetProperty("jwk", out var jwk))
             {
-                result.CnfJwk = jwk;
+                result.CnfJwk = jwk.Clone();
             }
 
             // Extract non-SD claims
@@ -330,6 +330,12 @@ public class SdJwtService : ISdJwtService
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// This overload always builds a KB-JWT. The caller is responsible for not invoking
+    /// this method on legacy credentials that do not contain a <c>cnf</c> claim — a KB-JWT
+    /// appended to such a credential is harmless (verifiers ignore it per FR-006) but adds
+    /// unnecessary bytes and signing overhead.
+    /// </remarks>
     public async Task<SdJwtPresentation> CreatePresentationAsync(
         string rawToken,
         IEnumerable<string> claimsToDisclose,

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/StatusListEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/StatusListEndpoints.cs
@@ -130,6 +130,9 @@ public static class StatusListEndpoints
         var subUrl = $"{ietfBaseUrl}/{listId}";
 
         // Signing key: configurable for production, ephemeral fallback for dev.
+        // The ephemeral key fallback is intentional for pre-release — no startup validation
+        // is needed until the production deployment guide exists. The runtime warning below
+        // is sufficient to flag misconfiguration during development.
         // TODO(095): Wire real signing key from issuer wallet via IHaipIssuerCoKeyService
         var signingKeyBase64 = configuration.GetValue<string>("StatusList:IetfSigningKey");
         var algorithm = configuration.GetValue<string>("StatusList:IetfSigningAlgorithm") ?? "ES256";

--- a/src/Services/Sorcha.Haip.Service/Endpoints/OfferEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/OfferEndpoints.cs
@@ -26,7 +26,7 @@ public static class OfferEndpoints
             .WithDescription(
                 "Creates a Credential Offer with a pre-authorized code for an external HAIP wallet. " +
                 "Returns the offer details and a URI for QR code rendering.")
-            .Produces<object>(StatusCodes.Status200OK)
+            .Produces<object>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
             .RequireAuthorization("RequireService");
 
@@ -58,7 +58,7 @@ public static class OfferEndpoints
             request.DisclosablePaths,
             ct);
 
-        return Results.Ok(new
+        return Results.Created($"/api/v1/offers/{offer.Id}", new
         {
             offerId = offer.Id,
             credentialOfferUri = offerUri,

--- a/src/Services/Sorcha.Haip.Service/Models/HaipModels.cs
+++ b/src/Services/Sorcha.Haip.Service/Models/HaipModels.cs
@@ -78,6 +78,9 @@ public class CredentialRequest
     [JsonPropertyName("format")]
     public string Format { get; set; } = "vc+sd-jwt";
 
+    [JsonPropertyName("vct")]
+    public string? Vct { get; set; }
+
     [JsonPropertyName("proof")]
     public CredentialRequestProof? Proof { get; set; }
 }

--- a/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
+++ b/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
@@ -38,8 +38,8 @@ public enum PresentationRequestState
     Submitted = 1,
     Verified = 2,
     Denied = 3,
-    Cancelled = 4,
-    Expired = 5
+    Cancelled = 4, // TODO: wire cancellation endpoint when request timeout is implemented
+    Expired = 5    // Ordinal skips no values — Cancelled (4) added in wave 3
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
+++ b/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
@@ -23,8 +23,8 @@ public class PresentationRequest
     public PresentationRequestState State { get; set; } = PresentationRequestState.Pending;
 
     /// <summary>
-    /// Opaque state token for OID4VP state correlation.
-    /// Defaults to the request ID string on creation.
+    /// Opaque state token for OID4VP state correlation (CSRF protection).
+    /// Must be set explicitly by the store on creation — not auto-initialized.
     /// </summary>
     public string StateToken { get; set; } = string.Empty;
 
@@ -38,8 +38,8 @@ public enum PresentationRequestState
     Submitted = 1,
     Verified = 2,
     Denied = 3,
-    Cancelled = 4, // TODO: wire cancellation endpoint when request timeout is implemented
-    Expired = 5    // Ordinal skips no values — Cancelled (4) added in wave 3
+    Expired = 4,
+    Cancelled = 10 // Non-contiguous to avoid shifting Expired's ordinal (existing Redis data safety)
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
+++ b/src/Services/Sorcha.Haip.Service/Models/VerifierModels.cs
@@ -21,6 +21,13 @@ public class PresentationRequest
     public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset ExpiresAt { get; set; }
     public PresentationRequestState State { get; set; } = PresentationRequestState.Pending;
+
+    /// <summary>
+    /// Opaque state token for OID4VP state correlation.
+    /// Defaults to the request ID string on creation.
+    /// </summary>
+    public string StateToken { get; set; } = string.Empty;
+
     public VerificationResult? Result { get; set; }
 }
 
@@ -30,8 +37,9 @@ public enum PresentationRequestState
     Pending = 0,
     Submitted = 1,
     Verified = 2,
-    Failed = 3,
-    Expired = 4
+    Denied = 3,
+    Cancelled = 4,
+    Expired = 5
 }
 
 /// <summary>
@@ -42,9 +50,11 @@ public class VerificationResult
     [JsonPropertyName("isValid")]
     public bool IsValid { get; set; }
 
+    // TODO(098-#45): Key by input descriptor ID: Dictionary<string, Dictionary<string, object>>
     [JsonPropertyName("verifiedClaims")]
     public Dictionary<string, object> VerifiedClaims { get; set; } = new();
 
+    // TODO(098-#44): Migrate to structured VerificationError with Kind, Description, InputDescriptorId
     [JsonPropertyName("errors")]
     public List<string> Errors { get; set; } = new();
 

--- a/src/Services/Sorcha.Haip.Service/Services/CredentialOfferService.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/CredentialOfferService.cs
@@ -16,6 +16,7 @@ public class CredentialOfferService
     private readonly PreAuthCodeStore _codeStore;
     private readonly ILogger<CredentialOfferService> _logger;
     private readonly string _issuerUrl;
+    private readonly int _offerLifetimeSeconds;
 
     // In-memory offer store (production would use Redis or a database)
     private readonly ConcurrentDictionary<Guid, CredentialOffer> _offers = new();
@@ -29,6 +30,7 @@ public class CredentialOfferService
         _logger = logger;
         _issuerUrl = configuration.GetValue<string>("Haip:IssuerUrl")
             ?? "https://sorcha.example/haip";
+        _offerLifetimeSeconds = configuration.GetValue<int>("Haip:OfferLifetimeSeconds", 600);
     }
 
     /// <summary>
@@ -51,7 +53,7 @@ public class CredentialOfferService
             Claims = claims,
             DisclosablePaths = disclosablePaths ?? new(),
             PreAuthorizedCode = string.Empty, // Set below
-            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10)
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(_offerLifetimeSeconds)
         };
 
         // Generate and store the pre-authorized code

--- a/src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs
@@ -11,7 +11,7 @@ namespace Sorcha.Haip.Service.Services;
 
 /// <summary>
 /// Redis-backed store for HAIP presentation requests. Requests have TTL-based
-/// expiry and transition through Pending → Submitted → Verified/Failed states.
+/// expiry and transition through Pending → Submitted → Verified/Denied states.
 /// </summary>
 public class PresentationRequestStore
 {
@@ -56,7 +56,8 @@ public class PresentationRequestStore
             RequiredClaims = requiredClaims,
             AcceptedIssuers = acceptedIssuers,
             ResponseUri = $"{baseUrl}/api/v1/verifier/requests/{id}/direct-post",
-            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(_ttlSeconds)
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(_ttlSeconds),
+            StateToken = id.ToString()
         };
 
         if (_cache != null)
@@ -115,7 +116,7 @@ public class PresentationRequestStore
             if (json != null)
             {
                 var request = JsonSerializer.Deserialize<PresentationRequest>(json)!;
-                request.State = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Failed;
+                request.State = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Denied;
                 request.Result = result;
                 await _cache.SetStringAsync(key, JsonSerializer.Serialize(request),
                     new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_ttlSeconds) },
@@ -124,7 +125,7 @@ public class PresentationRequestStore
         }
         else if (_memoryStore.TryGetValue(requestId, out var request))
         {
-            request.State = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Failed;
+            request.State = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Denied;
             request.Result = result;
         }
     }

--- a/src/Services/Sorcha.Haip.Service/appsettings.json
+++ b/src/Services/Sorcha.Haip.Service/appsettings.json
@@ -11,6 +11,7 @@
     "IssuerUrl": "https://sorcha.example/haip",
     "TokenLifetimeSeconds": 300,
     "NonceLifetimeSeconds": 300,
-    "PreAuthCodeLifetimeSeconds": 300
+    "PreAuthCodeLifetimeSeconds": 300,
+    "OfferLifetimeSeconds": 600
   }
 }

--- a/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
@@ -47,6 +47,7 @@ public class PresentationRequestStoreTests
         request.CredentialType.Should().Be("LicenseCredential");
         request.RequiredClaims.Should().HaveCount(2);
         request.State.Should().Be(PresentationRequestState.Pending);
+        request.StateToken.Should().Be(request.Id.ToString());
         request.ResponseUri.Should().Contain(request.Id.ToString());
     }
 
@@ -96,7 +97,7 @@ public class PresentationRequestStoreTests
     }
 
     [Fact]
-    public async Task MarkCompletedAsync_FailedResult_SetsFailedState()
+    public async Task MarkCompletedAsync_DeniedResult_SetsDeniedState()
     {
         var created = await _store.CreateAsync(
             "https://test.example/haip", "TestCredential",

--- a/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
@@ -111,7 +111,7 @@ public class PresentationRequestStoreTests
         await _store.MarkCompletedAsync(created.Id, result);
 
         var updated = await _store.GetAsync(created.Id);
-        updated!.State.Should().Be(PresentationRequestState.Failed);
+        updated!.State.Should().Be(PresentationRequestState.Denied);
         updated.Result!.Errors.Should().Contain("KB-JWT signature invalid");
     }
 }


### PR DESCRIPTION
## Summary

Medium-severity correctness and schema fixes from the PR review audit.

## Fixed (8 items)
| # | Item |
|---|------|
| 2 | CnfJwk.Clone() for JsonElement lifetime safety |
| 3 | KB-JWT legacy credential doc |
| 29 | vct field on CredentialRequest |
| 30 | Offer ExpiresAt from config (was hardcoded) |
| 31 | CreateOffer → 201 Created |
| 42 | StateToken for OID4VP correlation |
| 43 | Failed → Denied + Cancelled enum |
| 9 | Ephemeral key documented as intentional |

## Tracked with TODOs (3 items)
- #44: Structured VerificationError
- #45: VerifiedClaims keyed by descriptor
- #4: Array element disclosure selection

## Deferred (4 items)
- #16: CRL/Revoke endpoints
- #17: Provision body params
- #28: CredentialOfferService Redis
- #46: MarkCompletedAsync TOCTOU

## Tests: SD-JWT 43/43, HAIP 35/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)