### PR TITLE
feat: [101] HAIP walkthroughs — agent commands + identity + driving licence

### DIFF
--- a/specs/101-haip-walkthroughs/checklists/requirements.md
+++ b/specs/101-haip-walkthroughs/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: HAIP Walkthroughs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.
+- FR-001 through FR-010 cover the agent extension; FR-011 through FR-021 cover the walkthroughs.
+- No clarification markers — all decisions were resolved during the brainstorming session.

--- a/specs/101-haip-walkthroughs/contracts/README.md
+++ b/specs/101-haip-walkthroughs/contracts/README.md
@@ -1,0 +1,134 @@
+# Contracts: HAIP Walkthroughs
+
+**Feature**: 101-haip-walkthroughs
+
+This spec does not add HTTP endpoints. It extends the `sorcha-agent` CLI with
+HAIP holder commands and creates walkthrough scripts that exercise the OpenID4VCI
+issuer (097) and OpenID4VP verifier (098) infrastructure end-to-end.
+
+---
+
+## CLI Commands (sorcha-agent)
+
+### `sorcha-agent haip receive`
+
+Receives a Verifiable Credential via the OpenID4VCI pre-authorized code flow.
+
+```
+sorcha-agent haip receive --offer-uri <uri> [--key-file <path>] [--wallet-dir <dir>]
+```
+
+**Arguments**:
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--offer-uri` | Yes | -- | `openid-credential-offer://` URI from QR code or deep link |
+| `--key-file` | No | `./wallet/holder-key.pem` | Path to the holder's private key (PEM, ES256) |
+| `--wallet-dir` | No | `./wallet/` | Directory for storing received credentials |
+
+**Behaviour**:
+
+1. Resolves the Credential Offer from the URI
+2. Exchanges the pre-authorized code at the token endpoint
+3. Requests a fresh `c_nonce` from the nonce endpoint
+4. Builds a key-bound JWT proof using the holder key
+5. Submits the credential request to the credential endpoint
+6. Stores the received SD-JWT VC to `{wallet-dir}/credentials/{vct-short-name}.sdjwt`
+7. Prints a summary to stdout: credential type, issuer, claims, `cnf` binding present
+
+**Output** (stdout):
+
+```
+Credential received:
+  Type:    urn:sorcha:credential:verified-identity
+  Issuer:  did:sorcha:org:sorcha1abc123
+  Claims:  givenName, familyName, dateOfBirth
+  Bound:   yes (ES256)
+  Stored:  ./wallet/credentials/VerifiedIdentityCredential.sdjwt
+```
+
+**Exit codes**:
+
+| Code | Condition |
+|------|-----------|
+| 0 | Credential received and stored successfully |
+| 1 | Invalid or malformed offer URI |
+| 2 | Token exchange failed (expired code, invalid grant) |
+| 3 | Key proof rejected by issuer (nonce mismatch, unsupported algorithm) |
+| 4 | Network error (issuer unreachable, timeout) |
+
+---
+
+### `sorcha-agent haip present`
+
+Presents a Verifiable Credential via the OpenID4VP authorization response flow.
+
+```
+sorcha-agent haip present --request-uri <uri> --credential <type> --disclose <claims> [--key-file <path>] [--wallet-dir <dir>]
+```
+
+**Arguments**:
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--request-uri` | Yes | -- | `openid4vp://` request URI from verifier |
+| `--credential` | Yes | -- | Credential type to present (short name or full VCT) |
+| `--disclose` | Yes | -- | Comma-separated list of claims to selectively disclose |
+| `--key-file` | No | `./wallet/holder-key.pem` | Path to the holder's private key (PEM, ES256) |
+| `--wallet-dir` | No | `./wallet/` | Directory containing stored credentials |
+
+**Behaviour**:
+
+1. Resolves the Authorization Request from the request URI
+2. Locates the matching credential in `{wallet-dir}/credentials/`
+3. Validates the credential has not expired
+4. Builds a VP Token with selective disclosure (only the requested claims)
+5. Signs the key-binding JWT with the holder key
+6. Submits the Authorization Response to the verifier's `response_uri`
+7. Prints the submission result to stdout
+
+**Output** (stdout):
+
+```
+Presentation submitted:
+  Verifier:   https://verifier.example.com
+  Credential: DrivingLicenceCredential
+  Disclosed:  licenceNumber, category
+  Result:     accepted
+```
+
+**Exit codes**:
+
+| Code | Condition |
+|------|-----------|
+| 0 | Presentation accepted by verifier |
+| 1 | Credential not found in wallet directory |
+| 2 | Authorization request expired or invalid |
+| 3 | Verification failed (signature invalid, key binding mismatch) |
+| 4 | Network error (verifier unreachable, timeout) |
+
+---
+
+## Actor Definition Extension
+
+Walkthrough actor definitions include a `haip` block that configures the holder
+wallet for HAIP operations:
+
+```json
+{
+  "name": "CitizenHolder",
+  "role": "holder",
+  "haip": {
+    "holderKeyAlgorithm": "ES256",
+    "walletDir": "./wallet"
+  }
+}
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `holderKeyAlgorithm` | No | `ES256` | Algorithm for the holder key (`ES256`, `EdDSA`) |
+| `walletDir` | No | `./wallet` | Working directory for credentials and keys |
+
+When an actor has a `haip` block, the launcher generates a holder key at
+`{walletDir}/holder-key.pem` during setup if one does not already exist.

--- a/specs/101-haip-walkthroughs/data-model.md
+++ b/specs/101-haip-walkthroughs/data-model.md
@@ -1,0 +1,309 @@
+# Phase 1 Data Model: HAIP Walkthroughs
+
+**Feature**: 101-haip-walkthroughs
+**Date**: 2026-04-11
+
+## Entities and value objects
+
+### 1. `HolderKeyPair` (new, `Sorcha.Agent/Haip/HolderKeyManager.cs`)
+
+**Shape**: P-256 (secp256r1) EC key pair managed by `HolderKeyManager`. Persisted as two files in the wallet directory.
+
+**Private key file** (`holder_key.pem`):
+```
+-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIBkg2yGz...base64...
+-----END EC PRIVATE KEY-----
+```
+
+**Public key file** (`holder_key.jwk.json`):
+```json
+{
+  "kty": "EC",
+  "crv": "P-256",
+  "x": "base64url-encoded-x-coordinate",
+  "y": "base64url-encoded-y-coordinate"
+}
+```
+
+**Properties:**
+- `privateKeyPem` — `string`, PEM-encoded EC private key (PKCS#8), persisted to `holder_key.pem`
+- `publicKeyJwk` — `JsonElement`, JWK representation of the public key, persisted to `holder_key.jwk.json`
+- `algorithm` — `string`, always `"ES256"` for HAIP 1.0
+- `walletDir` — `string`, absolute path to the wallet directory containing both key files
+
+**Lifecycle:**
+- Created on first `haip receive` invocation if no PEM file exists (FR-002)
+- Loaded from PEM on subsequent invocations — JWK is regenerated from PEM to ensure consistency
+- One key pair per agent identity, reused across all credentials
+- Never transmitted — only the public key (as JWK) appears in JWT proof headers and `cnf` claims
+
+**Public interface:**
+```csharp
+public class HolderKeyManager
+{
+    /// <summary>Loads existing key pair or generates a new P-256 pair.</summary>
+    public ECDsa GetOrCreateKey(string walletDir);
+
+    /// <summary>Returns the public key as a JWK JsonElement for embedding in JWT headers and cnf claims.</summary>
+    public JsonElement GetPublicKeyJwk(ECDsa key);
+
+    /// <summary>Returns true if a holder key already exists in the wallet directory.</summary>
+    public bool KeyExists(string walletDir);
+}
+```
+
+### 2. `CredentialWallet` (new, `Sorcha.Agent/Haip/CredentialWallet.cs`)
+
+**Shape**: File-based storage of SD-JWT VC tokens. Each credential is stored as a raw SD-JWT compact serialisation file, named by the credential type extracted from the `vct` claim.
+
+**Directory layout:**
+```
+wallets/citizen/credentials/
+├── VerifiedIdentityCredential.sdjwt
+└── DrivingLicenceCredential.sdjwt
+```
+
+**Properties:**
+- `walletDir` — `string`, absolute path to the wallet directory (parent of `credentials/`)
+- `credentials` — `Dictionary<string, string>`, credential type → absolute file path (populated lazily from directory scan)
+
+**File contents**: Raw SD-JWT compact serialisation as a single line of text. Example:
+```
+eyJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJWZXJpZmllZElkZW50aXR5Q3JlZGVudGlhbCIsIl9zZCI6Wy4uLl19.sig~WyJzYWx0IiwiZ2l2ZW5OYW1lIiwiQWxpY2UiXQ~WyJzYWx0IiwiZmFtaWx5TmFtZSIsIlNtaXRoIl0~
+```
+
+**Credential type extraction**: The `vct` claim is read from the SD-JWT issuer JWT payload (second segment, base64url-decoded JSON). If `vct` is absent, the credential type falls back to `unknown_{sha256_prefix}`.
+
+**Public interface:**
+```csharp
+public class CredentialWallet
+{
+    /// <summary>Saves an SD-JWT VC to disk. Extracts vct to determine filename.</summary>
+    public async Task<string> SaveAsync(string walletDir, string rawSdJwt);
+
+    /// <summary>Loads a credential by type. Returns null if not found.</summary>
+    public async Task<string?> LoadAsync(string walletDir, string credentialType);
+
+    /// <summary>Lists all credential types stored in the wallet.</summary>
+    public IReadOnlyList<string> ListTypes(string walletDir);
+
+    /// <summary>Returns true if the wallet contains a credential of the given type.</summary>
+    public bool Exists(string walletDir, string credentialType);
+}
+```
+
+### 3. `WalkthroughState` (`state.json`)
+
+**Shape**: JSON file persisted between setup.ps1 and run.ps1 scripts. Contains all IDs and references needed to run the walkthrough without re-provisioning.
+
+**HaipIdentityAttestation state.json:**
+```json
+{
+  "tenantId": "guid",
+  "orgIds": {
+    "governmentAuthority": "guid"
+  },
+  "walletAddresses": {
+    "governmentAuthority": "sorcha1abc..."
+  },
+  "userCredentials": {
+    "citizen": {
+      "email": "alice.citizen@example.com",
+      "password": "$env:CITIZEN_PASSWORD"
+    }
+  },
+  "credentialPaths": {
+    "VerifiedIdentityCredential": "wallets/citizen/credentials/VerifiedIdentityCredential.sdjwt"
+  },
+  "offerUris": {
+    "VerifiedIdentityCredential": "openid-credential-offer://?credential_offer_uri=http://localhost/api/haip/offers/guid"
+  },
+  "holderWalletDir": "wallets/citizen",
+  "registerId": "guid"
+}
+```
+
+**HaipDrivingLicence state.json** (extends identity attestation state):
+```json
+{
+  "tenantId": "guid",
+  "orgIds": {
+    "governmentAuthority": "guid",
+    "councilAuthority": "guid"
+  },
+  "walletAddresses": {
+    "governmentAuthority": "sorcha1abc...",
+    "councilAuthority": "sorcha1def..."
+  },
+  "userCredentials": {
+    "citizen": {
+      "email": "alice.citizen@example.com",
+      "password": "$env:CITIZEN_PASSWORD"
+    }
+  },
+  "credentialPaths": {
+    "VerifiedIdentityCredential": "wallets/citizen/credentials/VerifiedIdentityCredential.sdjwt",
+    "DrivingLicenceCredential": "wallets/citizen/credentials/DrivingLicenceCredential.sdjwt"
+  },
+  "offerUris": {
+    "VerifiedIdentityCredential": "openid-credential-offer://?credential_offer_uri=...",
+    "DrivingLicenceCredential": "openid-credential-offer://?credential_offer_uri=..."
+  },
+  "holderWalletDir": "wallets/citizen",
+  "registerId": "guid",
+  "blueprintId": "guid",
+  "identityAttestationStateRef": "../HaipIdentityAttestation/state.json"
+}
+```
+
+**Properties:**
+- `tenantId` — `string` (GUID), the platform tenant used for provisioning
+- `orgIds` — `Dictionary<string, string>`, role name → organisation GUID
+- `walletAddresses` — `Dictionary<string, string>`, role name → Sorcha wallet address (bech32)
+- `userCredentials` — `Dictionary<string, object>`, role name → `{email, password}` object. Passwords reference environment variables via `$env:` prefix
+- `credentialPaths` — `Dictionary<string, string>`, credential type → relative file path to the stored SD-JWT
+- `offerUris` — `Dictionary<string, string>`, credential type → OID4VCI credential offer URI
+- `holderWalletDir` — `string`, relative path to the citizen's wallet directory
+- `registerId` — `string` (GUID), the register used for the walkthrough (driving licence only)
+- `blueprintId` — `string` (GUID), optional, the published blueprint ID (driving licence only)
+- `identityAttestationStateRef` — `string`, optional, relative path to the upstream walkthrough's state.json (driving licence only)
+
+### 4. `ActorDefinition` extension (existing `actors/*.json`)
+
+**Shape**: The existing actor definition JSON gains an optional `haip` section for HAIP wallet configuration. Existing fields (`actor`, `connection`, `inbox`, `mode`, `rules`) are unchanged.
+
+**Extended actor definition** (`citizen.json`):
+```json
+{
+  "actor": {
+    "name": "citizen",
+    "description": "External HAIP wallet holder — receives and presents credentials"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost"
+  },
+  "haip": {
+    "holderKeyAlgorithm": "ES256",
+    "walletDir": "wallets/citizen"
+  }
+}
+```
+
+**New fields in `haip` section:**
+- `holderKeyAlgorithm` — `string`, the algorithm for the holder key pair. Always `"ES256"` for HAIP 1.0. Included for forward-compatibility with future algorithms.
+- `walletDir` — `string`, relative or absolute path to the wallet directory. Contains `holder_key.pem`, `holder_key.jwk.json`, and `credentials/` subdirectory.
+
+**Semantics:**
+- The `haip` section is optional. Existing actor definitions without it continue to work unchanged.
+- The `connection` section is simplified for HAIP actors — only `gatewayUrl` is required (no `registerId`, `credentials`, or `walletAddress`). The HAIP commands handle authentication via the OID4VCI/OID4VP protocols, not via Sorcha JWT auth.
+- The `inbox`, `mode`, and `rules` sections are not used by `haip receive` and `haip present` commands.
+
+### 5. `JwtProofBuilder` output (transient, `Sorcha.Agent/Haip/JwtProofBuilder.cs`)
+
+**Shape**: OID4VCI JWT proof of possession. Compact JWT string built for a single credential request. Not persisted.
+
+**Header:**
+```json
+{
+  "typ": "openid4vci-proof+jwt",
+  "alg": "ES256",
+  "jwk": {
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "base64url-x",
+    "y": "base64url-y"
+  }
+}
+```
+
+**Payload:**
+```json
+{
+  "iss": "sorcha-agent",
+  "aud": "http://localhost/api/haip",
+  "iat": 1712700000,
+  "nonce": "c_nonce_from_token_response"
+}
+```
+
+**Wire format**: `base64url(header).base64url(payload).base64url(es256_signature)`
+
+**Properties:**
+- `iss` — `string`, fixed identifier for the agent (`"sorcha-agent"`)
+- `aud` — `string`, the credential issuer URL (from issuer metadata)
+- `iat` — `long`, Unix timestamp (seconds) of proof creation
+- `nonce` — `string`, the `c_nonce` value from the token endpoint response
+
+**Public interface:**
+```csharp
+public class JwtProofBuilder
+{
+    /// <summary>Builds a JWT proof of possession for OID4VCI credential requests.</summary>
+    public string Build(ECDsa holderKey, JsonElement publicKeyJwk, string issuerUrl, string cNonce);
+}
+```
+
+### 6. `KbJwtBuilder` output (transient, `Sorcha.Agent/Haip/KbJwtBuilder.cs`)
+
+**Shape**: SD-JWT Key Binding JWT for OID4VP presentations. Compact JWT string appended to the SD-JWT presentation. Not persisted.
+
+**Header:**
+```json
+{
+  "typ": "kb+jwt",
+  "alg": "ES256"
+}
+```
+
+**Payload:**
+```json
+{
+  "aud": "http://localhost/api/haip/verify",
+  "nonce": "verifier_nonce_from_request_object",
+  "iat": 1712700000,
+  "sd_hash": "base64url-sha256-of-presentation-prefix"
+}
+```
+
+**Wire format**: The KB-JWT is appended after the last disclosure `~` in the SD-JWT presentation:
+```
+eyJ...<issuer-jwt>...~WyJ...disclosure1...~WyJ...disclosure2...~eyJ...<kb-jwt>...
+```
+
+**Properties:**
+- `aud` — `string`, the verifier's audience URL (from the presentation request object)
+- `nonce` — `string`, the verifier's nonce (from the presentation request object)
+- `iat` — `long`, Unix timestamp (seconds) of KB-JWT creation
+- `sd_hash` — `string`, `base64url(sha256(presentation_bytes_without_kb_jwt))` where the presentation bytes include the issuer JWT, all selected disclosures, and the trailing `~`
+
+**Public interface:**
+```csharp
+public class KbJwtBuilder
+{
+    /// <summary>Builds a Key Binding JWT for SD-JWT presentations.</summary>
+    /// <param name="holderKey">The holder's P-256 private key.</param>
+    /// <param name="presentationPrefix">The serialised presentation up to and including the final ~.</param>
+    /// <param name="audience">The verifier's audience URL.</param>
+    /// <param name="nonce">The verifier's nonce.</param>
+    public string Build(ECDsa holderKey, string presentationPrefix, string audience, string nonce);
+}
+```
+
+## Validation rules
+
+- `HolderKeyManager.GetOrCreateKey` MUST generate a P-256 key pair. Other curves are not supported for HAIP 1.0.
+- `HolderKeyManager.GetPublicKeyJwk` MUST produce a JWK with `kty: "EC"`, `crv: "P-256"`, and both `x` and `y` coordinates base64url-encoded without padding.
+- `CredentialWallet.SaveAsync` MUST extract the `vct` claim from the SD-JWT payload and reject tokens without a `vct` claim (unless fallback naming is used).
+- `JwtProofBuilder.Build` MUST include the holder's public key JWK in the JWT header (not the payload).
+- `JwtProofBuilder.Build` MUST set `typ` to `"openid4vci-proof+jwt"` per the OID4VCI specification.
+- `KbJwtBuilder.Build` MUST compute `sd_hash` as `base64url(sha256(presentationPrefix))` where `presentationPrefix` includes the trailing `~`.
+- `KbJwtBuilder.Build` MUST set `typ` to `"kb+jwt"` per the SD-JWT specification.
+- `KbJwtBuilder.Build` MUST set `iat` to the current Unix timestamp in seconds.
+- Both builders MUST sign with ES256 (ECDSA using P-256 and SHA-256).
+- The `haip` section in actor definitions MUST be optional — missing it does not prevent parsing of existing actor definitions.
+- `WalkthroughState.credentialPaths` values MUST be valid relative paths that resolve to existing `.sdjwt` files after the walkthrough completes.
+
+## Migration notes
+
+None required. This feature adds only local filesystem storage (PEM/JWK/SDJWT files) and walkthrough scripts. No database entities, no EF migrations, no service-level schema changes.

--- a/specs/101-haip-walkthroughs/plan.md
+++ b/specs/101-haip-walkthroughs/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: HAIP Walkthroughs
+
+**Branch**: `101-haip-walkthroughs` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/101-haip-walkthroughs/spec.md`
+
+## Summary
+
+Extend the existing `Sorcha.Agent` CLI with two new commands (`haip receive` and `haip present`) that act as a minimal HAIP external wallet, then create two end-to-end walkthroughs proving the HAIP issuance and verification pipelines work against the Docker stack.
+
+- **`haip receive`** completes the OID4VCI pre-authorized code flow: fetches issuer metadata, exchanges a pre-auth code for an access token + c_nonce, constructs a JWT proof of possession binding a locally-generated P-256 holder key, submits it to the credential endpoint, and stores the returned SD-JWT VC to disk.
+- **`haip present`** completes the OID4VP direct_post flow: fetches a signed request object, selects disclosures from a stored credential, builds a Key Binding JWT (aud, nonce, iat, sd_hash), and submits the VP token via direct_post.
+- **HaipIdentityAttestation** walkthrough provisions a Government Identity Authority org that issues a VerifiedIdentityCredential to a citizen via HAIP.
+- **HaipDrivingLicence** walkthrough chains off the identity attestation, requiring the citizen to present their identity credential to a Council licensing authority before receiving a DrivingLicenceCredential — exercising both HAIP verification and issuance in a single Blueprint workflow.
+
+## Technical Context
+
+**Language/Version**: C# 13, .NET 10
+**Primary Dependencies**: `System.CommandLine` 2.0.2 (existing Sorcha.Agent CLI framework), `Sorcha.Cryptography.SdJwt` (SD-JWT parsing, disclosure selection, KB-JWT hash computation), `System.Security.Cryptography.ECDsa` (P-256 key generation and signing), `System.Text.Json` (JWK/JWT payload construction), `System.Net.Http` (OID4VCI/OID4VP HTTP flows).
+**Storage**: Local filesystem only. PEM file for holder private key, JWK JSON for public key, raw SD-JWT files for credentials. No database. State persisted via `state.json` in walkthrough directories.
+**Testing**: xUnit, FluentAssertions, Moq. Unit tests for `HolderKeyManager`, `CredentialWallet`, `JwtProofBuilder`, `KbJwtBuilder`. No integration tests required — the walkthroughs themselves serve as E2E validation.
+**Target Platform**: net10.0, Docker (walkthroughs run against Docker stack via `http://localhost`).
+**Project Type**: Existing multi-service monorepo. Extends `Sorcha.Agent` (existing CLI app). Two new walkthrough directories with PowerShell scripts.
+**Performance Goals**: Agent commands complete in < 5 seconds against a healthy Docker stack. Walkthroughs complete in < 2 minutes each.
+**Constraints**: Must follow existing walkthrough patterns (setup.ps1 + run.ps1 + state.json + SorchaWalkthrough module). Must reuse existing `System.CommandLine` patterns from `RunCommand.cs` and `ValidateCommand.cs`. No external JWT library — uses `Sorcha.Cryptography` primitives and `ECDsa` directly.
+**Scale/Scope**: ~6 new C# files in Sorcha.Agent, ~2 new walkthrough directories with ~3 scripts each, ~4 unit test files.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|---|---|
+| **I. Microservices-First Architecture** | PASS. No new services. Extends an existing CLI application (`Sorcha.Agent`) with two new commands. Walkthrough scripts orchestrate existing services via HTTP. |
+| **II. Security First** | PASS. Holder private keys are stored as PEM files in a local wallet directory with no network exposure. The agent never sends the private key over the wire — only the public key (as JWK in proofs) and signatures. |
+| **III. API Documentation** | PASS. New commands are self-documenting via `System.CommandLine` descriptions. Walkthrough READMEs document setup and usage. XML comments on all public classes. |
+| **IV. Testing Requirements** | PASS. Unit tests for all new HAIP wallet logic (key management, JWT construction, credential storage). The walkthroughs themselves are the integration/E2E test layer. |
+| **V. Code Quality** | PASS. Standard C# conventions, nullable enabled, license headers. Follows existing `Sorcha.Agent` patterns. |
+| **VI. Blueprint Creation Standards** | PASS. The driving licence Blueprint is created as a JSON file (`driving-licence.json`), following the primary creation policy. |
+| **VII. Domain-Driven Design** | PASS. Clean separation: `HolderKeyManager` (key lifecycle), `CredentialWallet` (storage), `JwtProofBuilder` (OID4VCI proofs), `KbJwtBuilder` (OID4VP KB-JWTs). |
+| **VIII. Observability by Default** | PASS. Commands use `ILogger` via the existing Sorcha.Agent logging pipeline. Structured log events for key generation, token exchange, credential receipt, and presentation submission. |
+
+**Constitution gate: PASS.** No violations. `Complexity Tracking` section empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/101-haip-walkthroughs/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+Existing Sorcha multi-service monorepo. Paths touched by this spec:
+
+```text
+src/
+└── Apps/
+    └── Sorcha.Agent/
+        ├── Commands/
+        │   ├── HaipReceiveCommand.cs          # NEW — `haip receive` command (OID4VCI pre-auth flow)
+        │   └── HaipPresentCommand.cs          # NEW — `haip present` command (OID4VP direct_post flow)
+        ├── Haip/
+        │   ├── HolderKeyManager.cs            # NEW — P-256 key pair generation, PEM/JWK persistence, loading
+        │   ├── CredentialWallet.cs             # NEW — file-based SD-JWT VC storage (save, load, list by type)
+        │   ├── JwtProofBuilder.cs             # NEW — OID4VCI JWT proof of possession (header + payload + ES256 sign)
+        │   └── KbJwtBuilder.cs                # NEW — OID4VP Key Binding JWT (aud, nonce, iat, sd_hash + ES256 sign)
+        └── Program.cs                         # CHANGE — register haip receive and haip present commands
+
+walkthroughs/
+├── HaipIdentityAttestation/
+│   ├── setup.ps1                              # NEW — provision Government org, citizen user, persona, credential offer
+│   ├── run.ps1                                # NEW — invoke `sorcha-agent haip receive`, verify credential
+│   └── actors/
+│       └── citizen.json                       # NEW — actor definition with haip wallet config
+├── HaipDrivingLicence/
+│   ├── setup.ps1                              # NEW — check identity credential, provision Council org, publish blueprint
+│   ├── run.ps1                                # NEW — present identity, receive licence credential
+│   ├── actors/
+│   │   └── citizen.json                       # NEW — actor definition referencing identity + licence credentials
+│   └── blueprints/
+│       └── driving-licence.json               # NEW — Blueprint with presentation requirement + credential issuance
+
+tests/
+└── Sorcha.Agent.Tests/
+    └── Haip/
+        ├── HolderKeyManagerTests.cs           # NEW — key generation, PEM round-trip, JWK serialisation
+        ├── CredentialWalletTests.cs            # NEW — save, load, list, missing-file handling
+        ├── JwtProofBuilderTests.cs            # NEW — proof structure, c_nonce binding, ES256 signature verification
+        └── KbJwtBuilderTests.cs               # NEW — KB-JWT structure, sd_hash computation, signature verification
+```
+
+**Structure Decision**: Existing monorepo. New code is concentrated in a `Haip/` subdirectory under `Sorcha.Agent` for the wallet logic, with two new command files in the existing `Commands/` directory. Walkthrough scripts follow the established pattern (setup.ps1 + run.ps1 + actors/ + state.json). Unit tests mirror the source structure under the existing `Sorcha.Agent.Tests` project. No new projects, no new service boundaries.
+
+## Complexity Tracking
+
+*No Constitution violations — this section intentionally empty.*

--- a/specs/101-haip-walkthroughs/quickstart.md
+++ b/specs/101-haip-walkthroughs/quickstart.md
@@ -1,0 +1,88 @@
+# Quickstart: HAIP Walkthroughs
+
+Manual verification procedure for the HAIP walkthrough scenarios.
+
+## Prerequisites
+
+- Docker Desktop running
+- .NET 10 SDK installed
+- PowerShell 7+ (`pwsh`)
+- Solution built: `dotnet build`
+
+## Step 1 -- Start the Docker stack
+
+```bash
+docker-compose up -d
+```
+
+Wait for all services to become healthy. Confirm with:
+
+```bash
+docker-compose ps
+```
+
+All services should show `healthy` or `running` status.
+
+## Step 2 -- Run the HaipIdentityAttestation walkthrough
+
+```bash
+pwsh walkthroughs/HaipIdentityAttestation/setup.ps1
+pwsh walkthroughs/HaipIdentityAttestation/run.ps1
+```
+
+The setup script provisions the issuer organisation, enrols it as a HAIP issuer
+for the `VerifiedIdentityCredential` type, and generates a holder key. The run
+script executes the full OpenID4VCI pre-authorized code flow.
+
+### Verify
+
+Confirm the credential was received and stored:
+
+```bash
+ls wallet/credentials/VerifiedIdentityCredential.sdjwt
+```
+
+The file should exist and contain a valid SD-JWT VC (three tilde-separated segments).
+
+## Step 3 -- Run the HaipDrivingLicence walkthrough
+
+```bash
+pwsh walkthroughs/HaipDrivingLicence/setup.ps1
+pwsh walkthroughs/HaipDrivingLicence/run.ps1
+```
+
+This walkthrough issues a driving licence credential that chains from the
+verified identity established in Step 2.
+
+### Verify
+
+Confirm the credential was received and stored:
+
+```bash
+ls wallet/credentials/DrivingLicenceCredential.sdjwt
+```
+
+## Step 4 -- Verify both credentials
+
+Check the wallet directory contains both credentials:
+
+```bash
+ls wallet/credentials/
+```
+
+Expected output:
+
+```
+DrivingLicenceCredential.sdjwt
+VerifiedIdentityCredential.sdjwt
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `setup.ps1` fails with connection error | Services not ready | Wait 30s, retry; check `docker-compose logs haip-service` |
+| Exit code 2 from `run.ps1` | Pre-authorized code expired | Re-run `setup.ps1` to generate a fresh offer, then `run.ps1` |
+| Exit code 3 from `run.ps1` | Holder key mismatch | Delete `wallet/holder-key.pem` and re-run `setup.ps1` |
+| Exit code 4 from `run.ps1` | Network timeout | Check `docker-compose ps` for crashed containers |
+| Credential file missing after successful run | Wrong working directory | Run scripts from the walkthrough root directory |

--- a/specs/101-haip-walkthroughs/research.md
+++ b/specs/101-haip-walkthroughs/research.md
@@ -1,0 +1,157 @@
+# Phase 0 Research: HAIP Walkthroughs
+
+**Feature**: 101-haip-walkthroughs
+**Date**: 2026-04-11
+
+## Research items
+
+1. Extend Sorcha.Agent vs standalone tool for HAIP wallet commands?
+2. P-256 key storage format for the holder key pair?
+3. Credential storage strategy for received SD-JWT VCs?
+4. PowerShell orchestration pattern for the walkthroughs?
+5. Walkthrough chaining — how does HaipDrivingLicence depend on HaipIdentityAttestation?
+6. JWT proof construction — which libraries and primitives to use?
+
+---
+
+## R1. Extend Sorcha.Agent vs standalone tool
+
+### Current state
+
+`Sorcha.Agent` is an existing CLI application (`src/Apps/Sorcha.Agent/`) built on `System.CommandLine` 2.0.2. It currently has two commands: `run` (long-running autonomous actor) and `validate` (actor definition validation). The project already has authentication infrastructure (`Auth/`), configuration management (`Configuration/`), and HTTP client setup for communicating with Sorcha services.
+
+A standalone tool would require duplicating the auth pipeline, HTTP client configuration, and actor definition parsing. It would also require a separate build, separate Docker image, and separate documentation.
+
+### Decision: extend Sorcha.Agent with `haip receive` and `haip present` commands
+
+**Rationale.** The agent already has the auth and HTTP infrastructure. Adding two new commands follows the existing `System.CommandLine` pattern established by `RunCommand.cs` and `ValidateCommand.cs`. The HAIP wallet logic is self-contained in a `Haip/` subdirectory, keeping it cleanly separated from the existing actor-agent logic. The actor definition JSON format can be extended with a `haip` section for holder key configuration without breaking existing definitions.
+
+**Consequence.** Two new command classes in `Commands/`, four new support classes in `Haip/`, one change to `Program.cs` to register the commands. The existing `run` and `validate` commands are unaffected.
+
+**Alternative rejected.** Standalone `sorcha-haip-wallet` CLI tool. Rejected because it would duplicate auth infrastructure, require a separate Docker image, and fragment the tooling story. The agent is already the "external actor" tool — HAIP wallet behaviour is a natural extension of that role.
+
+---
+
+## R2. P-256 key storage — PEM file for private key, JWK JSON for public key
+
+### Current state
+
+The agent currently has no local key storage. All signing operations go through the Wallet Service. For the HAIP external wallet scenario, the agent acts as an independent holder with its own key pair, outside the Sorcha wallet infrastructure.
+
+P-256 (secp256r1) is the HAIP 1.0 mandatory-to-implement algorithm for holder keys. .NET's `ECDsa` class natively supports P-256 key generation, PEM export/import (`ExportECPrivateKey`/`ImportECPrivateKey`), and signing.
+
+### Decision: PEM file for private key, JWK JSON for public key
+
+**Rationale.** PEM is the standard interchange format for EC private keys and .NET has first-class support via `ECDsa.ImportFromPem()` and `ECDsa.ExportECPrivateKeyPem()`. JWK is the format required by the `cnf` claim and the JWT proof `jwk` header — storing the public key as JWK avoids re-serialisation on every use. Both files are human-readable and inspectable, which aids walkthrough debugging.
+
+**File layout:**
+```
+wallets/citizen/
+├── holder_key.pem          # EC private key (PKCS#8 PEM)
+├── holder_key.jwk.json     # EC public key (JWK format)
+└── credentials/
+    ├── VerifiedIdentityCredential.sdjwt
+    └── DrivingLicenceCredential.sdjwt
+```
+
+**Consequence.** `HolderKeyManager` handles generation (if no PEM exists), loading (if PEM exists), and JWK serialisation. The JWK file is regenerated from the PEM on load to ensure consistency. Key pair generation is idempotent — existing keys are reused (FR-002).
+
+**Alternative rejected.** PKCS#12 (.pfx) container for both keys. Rejected because it requires a password, is binary (not inspectable), and adds complexity for no security benefit in a walkthrough scenario. Also rejected: storing raw key bytes — not portable, not human-readable.
+
+---
+
+## R3. Credential storage — one SD-JWT file per credential type
+
+### Current state
+
+There is no existing credential storage in the agent. The Wallet Service stores credentials in PostgreSQL, but the HAIP external wallet operates independently.
+
+### Decision: one SD-JWT file per credential type in the wallet directory
+
+**Rationale.** The walkthrough scenario has a small number of credential types (2: VerifiedIdentityCredential, DrivingLicenceCredential). File-based storage is the simplest approach that supports the requirement to persist credentials between `haip receive` and `haip present` invocations. The raw SD-JWT compact serialisation is stored as-is — no wrapping, no metadata envelope. The credential type is extracted from the `vct` claim in the SD-JWT payload and used as the filename.
+
+**Consequence.** `CredentialWallet` provides `SaveAsync(rawSdJwt)`, `LoadAsync(credentialType)`, `ListTypes()`, and `ExistsAsync(credentialType)`. The file name is `{credentialType}.sdjwt`. The wallet directory is configurable via the actor definition's `haip.walletDir` field or the `--wallet-dir` command option.
+
+**Alternative rejected.** SQLite database for credential storage. Rejected as over-engineering for a walkthrough tool that manages 2-3 credentials. Also rejected: JSON envelope wrapping the SD-JWT with metadata — the SD-JWT itself contains all metadata (type, claims, issuer) and can be parsed to extract it.
+
+---
+
+## R4. PowerShell orchestration — follows existing walkthrough pattern
+
+### Current state
+
+All existing walkthroughs follow a consistent pattern:
+- `setup.ps1` — provisions infrastructure (orgs, users, wallets, registers, blueprints) via the API Gateway
+- `run.ps1` — executes the scenario (starts agent processes, waits for completion)
+- `actors/*.json` — actor definitions for `sorcha-agent run`
+- `state.json` — persisted state between setup and run (IDs, addresses, credentials)
+- `SorchaWalkthrough` module (`walkthroughs/modules/`) — shared functions for auth, API calls, health checks, banner output
+
+The module provides `Initialize-SorchaEnvironment`, `Get-SorchaSecrets`, `Write-WtBanner`, `Invoke-SorchaApi`, and profile-based URL resolution (gateway/direct/aspire/n1).
+
+### Decision: follow the existing pattern exactly
+
+**Rationale.** Consistency with ConstructionPermit, SelfBuildHouse, and other walkthroughs. The `setup.ps1` → `state.json` → `run.ps1` flow is well-established and understood by developers. The SorchaWalkthrough module provides all the HTTP plumbing needed for provisioning.
+
+**Consequence.** Two new walkthrough directories following the exact same structure. The `haip receive` and `haip present` commands are invoked from `run.ps1` as `dotnet run --project src/Apps/Sorcha.Agent -- haip receive ...` (or via a built binary). State is passed via `state.json` and command-line arguments.
+
+**Alternative rejected.** Docker Compose-based orchestration for walkthroughs. Rejected because existing walkthroughs run from the host against the Docker stack — changing the pattern would create inconsistency and require the agent to run inside Docker.
+
+---
+
+## R5. Walkthrough chaining — HaipDrivingLicence checks for state.json from HaipIdentityAttestation
+
+### Current state
+
+The existing walkthroughs are independent — each has its own setup.ps1 that provisions everything from scratch. There is no precedent for walkthrough chaining.
+
+### Decision: HaipDrivingLicence setup.ps1 checks for the identity attestation state.json and runs the identity flow inline if missing
+
+**Rationale.** The driving licence walkthrough requires a VerifiedIdentityCredential in the agent's wallet. Rather than duplicating the identity provisioning logic, the setup script checks:
+1. Does `walkthroughs/HaipIdentityAttestation/state.json` exist?
+2. Does the credential file referenced in that state exist in the wallet directory?
+
+If both checks pass, the driving licence setup reuses the existing citizen identity and wallet. If either check fails, it invokes the HaipIdentityAttestation setup.ps1 and run.ps1 inline.
+
+**Consequence.** The `state.json` format must include `credentialPaths` (a dictionary of credential type to file path) so the downstream walkthrough can verify the credential exists. The identity attestation walkthrough is fully self-contained and can run independently. The driving licence walkthrough has a soft dependency that is resolved automatically.
+
+**Alternative rejected.** Making both walkthroughs completely independent by duplicating the identity issuance in the driving licence setup. Rejected because it would issue a second identity credential (wasting resources) and not exercise the chaining scenario that demonstrates real-world HAIP usage.
+
+---
+
+## R6. JWT proof construction — uses Sorcha.Cryptography primitives, no external JWT library
+
+### Current state
+
+The codebase does not use any external JWT library (e.g., `System.IdentityModel.Tokens.Jwt` or `jose-jwt`). JWT construction in existing code uses manual header + payload + signature assembly with `System.Text.Json` for payload serialisation and `Sorcha.Cryptography` for signing.
+
+The SD-JWT library (`Sorcha.Cryptography.SdJwt`) already handles JWT parsing and base64url encoding/decoding. `ECDsa` in .NET provides `SignData` with `HashAlgorithmName.SHA256` for ES256 signatures.
+
+### Decision: build JWT proofs manually using ECDsa + System.Text.Json, no external JWT library
+
+**Rationale.** Two JWT structures need to be built:
+
+1. **JWT proof of possession** (OID4VCI): header `{"typ":"openid4vci-proof+jwt", "alg":"ES256", "jwk":{...}}`, payload `{"iss":"...", "aud":"...", "iat":..., "nonce":"..."}`. Signed with the holder's P-256 private key.
+
+2. **Key Binding JWT** (OID4VP/SD-JWT): header `{"typ":"kb+jwt", "alg":"ES256"}`, payload `{"aud":"...", "nonce":"...", "iat":..., "sd_hash":"..."}`. Signed with the same holder key.
+
+Both are straightforward: serialise header and payload as JSON, base64url-encode each, concatenate with `.`, sign the result with `ECDsa.SignData()`, base64url-encode the signature, append after the second `.`.
+
+**Consequence.** Two builder classes: `JwtProofBuilder` (for OID4VCI proofs) and `KbJwtBuilder` (for KB-JWTs). Each takes the relevant parameters and the `ECDsa` instance, returns the compact JWT string. The base64url encoding can use `Sorcha.Cryptography`'s existing utilities or `Microsoft.IdentityModel.Tokens.Base64UrlEncoder` if already referenced.
+
+**Alternative rejected.** Adding `System.IdentityModel.Tokens.Jwt` as a dependency. Rejected because it pulls in a large dependency tree for constructing two simple JWTs. The manual approach is ~30 lines of code per builder and keeps the agent lightweight.
+
+---
+
+## Summary
+
+All six research items resolved. No `NEEDS CLARIFICATION` markers remain. Key decisions:
+
+1. **Extend Sorcha.Agent** with `haip receive` and `haip present` commands — reuses auth, CLI framework, and actor definitions.
+2. **PEM + JWK files** for P-256 holder key storage — human-readable, portable, .NET-native.
+3. **One SD-JWT file per credential type** — simple filesystem storage, credential type from `vct` claim used as filename.
+4. **Follow existing walkthrough pattern** — setup.ps1 + run.ps1 + state.json + SorchaWalkthrough module.
+5. **Walkthrough chaining via state.json** — HaipDrivingLicence checks for identity credential and runs identity flow inline if missing.
+6. **Manual JWT construction** with ECDsa + System.Text.Json — no external JWT library, ~30 lines per builder.
+
+Ready for Phase 1.

--- a/specs/101-haip-walkthroughs/spec.md
+++ b/specs/101-haip-walkthroughs/spec.md
@@ -1,0 +1,167 @@
+# Feature Specification: HAIP Walkthroughs
+
+**Feature Branch**: `101-haip-walkthroughs`
+**Created**: 2026-04-11
+**Status**: Draft
+**Input**: User description: "HAIP walkthroughs: extend Sorcha.Agent with HAIP wallet commands (haip receive, haip present) and create HaipIdentityAttestation + HaipDrivingLicence walkthroughs"
+
+## Context
+
+The HAIP spec set (093-098) is fully implemented and deployed. The Docker stack runs all services including the new Sorcha.Haip.Service. However, there are no end-to-end tests or walkthroughs that exercise the HAIP issuance and verification flows. The existing walkthroughs (ConstructionPermit, SelfBuildHouse, etc.) use the Sorcha-internal credential path — none exercises the external HAIP wallet path.
+
+This spec extends the existing `Sorcha.Agent` CLI tool with HAIP wallet capabilities and creates two walkthroughs that prove the HAIP pipeline works end-to-end against the Docker stack using real-world credential scenarios.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Sorcha.Agent receives a credential via HAIP issuance (Priority: P1)
+
+A Government Identity Authority issues a verified identity credential to a citizen. The citizen's `sorcha-agent` acts as a HAIP wallet: it generates a holder key pair, exchanges a pre-authorized code for an access token, constructs a JWT proof of possession binding the holder key and c_nonce, submits the proof to the credential endpoint, and receives an SD-JWT VC with cnf holder key binding. The credential contains the citizen's persona data (name, email, date of birth, address) with each field selectively disclosable.
+
+**Why this priority**: This is the foundational HAIP wallet capability. Without a tool that can receive credentials via the HAIP protocol, no walkthrough or E2E test can exercise the issuance pipeline. Every other story depends on this.
+
+**Independent Test**: Run `sorcha-agent haip receive --offer-uri <uri>` against a running Docker stack with a valid credential offer. Verify the agent completes the pre-auth code flow, receives a credential, stores it locally, and the credential has a valid cnf claim matching the agent's holder key.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh agent with no existing keys, **When** `haip receive` is invoked with a valid offer URI, **Then** the agent generates a P-256 holder key pair and persists it to the wallet directory.
+2. **Given** a credential offer with a pre-authorized code, **When** the agent exchanges the code at the token endpoint, **Then** it receives an access token and a c_nonce.
+3. **Given** a valid access token and c_nonce, **When** the agent constructs and submits a JWT proof to the credential endpoint, **Then** the proof contains the holder's public key in the header, the c_nonce in the payload, and the credential issuer URL as the audience.
+4. **Given** a successful credential response, **When** the agent parses the SD-JWT VC, **Then** the credential's cnf.jwk matches the agent's holder public key and all expected claims are present.
+5. **Given** a received credential, **When** the agent stores it locally, **Then** the credential file can be loaded in a subsequent session and its type and claims are retrievable.
+6. **Given** an expired pre-authorized code, **When** the agent attempts to exchange it, **Then** the agent reports a clear error indicating the code has expired.
+7. **Given** an agent that already has a holder key pair from a previous run, **When** `haip receive` is invoked again, **Then** the agent reuses the existing key pair rather than generating a new one.
+
+---
+
+### User Story 2 — Sorcha.Agent presents a credential via HAIP verification (Priority: P1)
+
+A citizen holds a verified identity credential in their agent's wallet. A Council licensing authority creates a presentation request requiring the identity credential with specific claims disclosed. The agent fetches the signed request object, selects the requested disclosures from the stored credential, constructs a Key Binding JWT proving possession of the holder key (bound to the verifier's nonce and audience), and submits the VP token via direct_post. The verifier validates the presentation and accepts the disclosed claims.
+
+**Why this priority**: Presentation is the second half of the HAIP wallet capability. Without it, the agent can receive credentials but never use them. The driving licence walkthrough depends on this.
+
+**Independent Test**: Run `sorcha-agent haip present --request-uri <uri> --credential VerifiedIdentityCredential --disclose "givenName,familyName"` against a running Docker stack with a valid presentation request. Verify the agent submits a valid VP token, the KB-JWT binds the correct nonce and audience, and the verifier accepts the presentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent with a stored credential and a presentation request URI, **When** `haip present` is invoked, **Then** the agent fetches the request object and extracts the nonce, audience, and required claims.
+2. **Given** a credential with selectively disclosable claims, **When** the agent selects disclosures matching the `--disclose` parameter, **Then** only the specified claims are included in the presentation.
+3. **Given** the selected disclosures and the request's nonce, **When** the agent constructs a KB-JWT, **Then** the KB-JWT payload contains the correct aud (verifier audience), nonce (from request), iat (current time), and sd_hash (hash of the presentation prefix).
+4. **Given** a complete VP token, **When** the agent submits it via direct_post with the state parameter, **Then** the verifier returns a success response.
+5. **Given** a credential that does not match the requested type, **When** the agent searches its wallet, **Then** it reports a clear error that no matching credential was found.
+6. **Given** a presentation request that has expired, **When** the agent fetches the request object, **Then** it reports a clear error indicating the request has expired.
+
+---
+
+### User Story 3 — HaipIdentityAttestation walkthrough (Priority: P1)
+
+A DevOps engineer or QA tester runs the HaipIdentityAttestation walkthrough against the Docker stack to verify that the HAIP issuance pipeline works end-to-end. The walkthrough provisions the infrastructure (tenant, trust anchor, Government org), creates a credential offer from a citizen's persona data, and invokes the agent to receive the credential. At the end, the walkthrough reports success with a summary of the credential contents.
+
+**Why this priority**: This is the simplest complete walkthrough — it proves issuance works without the complexity of presentation. It's the first thing a new developer or QA engineer would run to verify the HAIP stack.
+
+**Independent Test**: Run `pwsh walkthroughs/HaipIdentityAttestation/setup.ps1` followed by `pwsh walkthroughs/HaipIdentityAttestation/run.ps1` against a fresh Docker stack. Verify the walkthrough completes without errors and the credential is stored in the agent's wallet.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running Docker stack with all services healthy, **When** setup.ps1 is run, **Then** it creates a tenant, provisions a trust anchor, creates and enrols a Government org as a HAIP issuer, and creates a citizen user with persona data.
+2. **Given** setup.ps1 has completed, **When** run.ps1 is executed, **Then** it creates a credential offer from the citizen's persona (givenName, familyName, email, dateOfBirth, address), invokes `sorcha-agent haip receive`, and the agent receives a VerifiedIdentityCredential.
+3. **Given** the walkthrough has completed, **When** the credential is inspected, **Then** it contains all persona claims, has a valid cnf, and each address field is independently disclosable via JSON Pointer paths.
+4. **Given** the walkthrough has already been run, **When** setup.ps1 is run again, **Then** it is idempotent — it reuses existing resources rather than creating duplicates.
+5. **Given** a Docker stack where the HAIP service is unhealthy, **When** setup.ps1 runs, **Then** it reports a clear error about the service being unreachable.
+
+---
+
+### User Story 4 — HaipDrivingLicence walkthrough (Priority: P2)
+
+A DevOps engineer runs the HaipDrivingLicence walkthrough which exercises both HAIP verification and issuance in a single Blueprint workflow. A Council licensing authority requires the citizen to present their identity credential, verifies it, and then issues a driving licence credential. The walkthrough checks for the identity credential from the previous walkthrough (and runs it inline if missing), then executes the full round-trip.
+
+**Why this priority**: This is the complex walkthrough that proves the complete HAIP story — present a credential to unlock a workflow action, then receive a new credential as the output. It depends on US1-US3 being implemented first.
+
+**Independent Test**: Run `pwsh walkthroughs/HaipDrivingLicence/setup.ps1` followed by `pwsh walkthroughs/HaipDrivingLicence/run.ps1`. Verify the agent presents the identity credential via direct_post, the Blueprint action resumes, and the agent receives a DrivingLicenceCredential.
+
+**Acceptance Scenarios**:
+
+1. **Given** the HaipIdentityAttestation walkthrough has been completed, **When** HaipDrivingLicence setup.ps1 runs, **Then** it detects the existing identity credential and citizen wallet, creates a Council org, and enrols it as a HAIP issuer.
+2. **Given** the HaipIdentityAttestation walkthrough has NOT been run, **When** HaipDrivingLicence setup.ps1 runs, **Then** it runs the identity attestation flow inline before proceeding with its own setup.
+3. **Given** setup is complete, **When** run.ps1 starts a Blueprint instance, **Then** Action 1 creates a presentation request requiring a VerifiedIdentityCredential with specific claims.
+4. **Given** a presentation request, **When** the agent presents the identity credential with selective disclosure (givenName, familyName, dateOfBirth, address.locality), **Then** the verifier accepts the presentation and the Blueprint action resumes with the verified claims.
+5. **Given** the identity verification passes, **When** Action 2 fires, **Then** a credential offer is created for a DrivingLicenceCredential containing licenceNumber, vehicleClass, issuedDate, expiryDate, and the holder's verified name and address.
+6. **Given** the licence credential offer, **When** the agent receives the credential, **Then** the DrivingLicenceCredential has nested address disclosure (e.g., `/address/locality` is independently disclosable) and the licence number is present.
+7. **Given** the walkthrough completes, **When** the agent's wallet is inspected, **Then** it contains both the VerifiedIdentityCredential and the DrivingLicenceCredential.
+
+---
+
+### Edge Cases
+
+- What happens when the Docker stack is not running? Setup scripts check service health and fail with a clear message.
+- What happens when the agent's wallet directory doesn't exist? It is created automatically on first key generation.
+- What happens when a credential offer has already been redeemed? The token endpoint returns an error and the agent reports it clearly.
+- What happens when the agent tries to present a credential it doesn't have? The agent searches the wallet, finds no match, and reports the available credential types.
+- What happens when the network is intermittent during the flow? The agent uses standard HTTP retry logic and reports the failure point.
+- What happens when the presentation's nonce has expired? The KB-JWT verification fails with a clock-skew error and the agent reports it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Sorcha.Agent HAIP wallet commands:**
+- **FR-001**: The agent MUST support a `haip receive` command that accepts a credential offer URI and completes the OID4VCI pre-authorized code flow.
+- **FR-002**: The agent MUST generate and persist a P-256 holder key pair on first use, and reuse it on subsequent invocations.
+- **FR-003**: The agent MUST construct a JWT proof of possession per OpenID4VCI, binding the holder public key and the c_nonce from the token response.
+- **FR-004**: The agent MUST store received SD-JWT VC credentials as files in a local wallet directory, organised by credential type.
+- **FR-005**: The agent MUST support a `haip present` command that accepts a presentation request URI, a credential type, and a list of claims to disclose.
+- **FR-006**: The agent MUST construct a Key Binding JWT per the SD-JWT spec, binding the verifier's nonce and audience, and compute the correct sd_hash.
+- **FR-007**: The agent MUST submit the VP token via direct_post with the state parameter from the presentation request.
+- **FR-008**: The agent MUST select only the specified disclosures from the stored credential when building the presentation.
+- **FR-009**: Both commands MUST report clear, structured errors when any step fails (expired code, invalid nonce, missing credential, service unreachable).
+- **FR-010**: The agent MUST fetch issuer metadata from `.well-known/openid-credential-issuer` as part of the receive flow.
+
+**HaipIdentityAttestation walkthrough:**
+- **FR-011**: The walkthrough MUST provision a complete trust infrastructure (tenant, trust anchor, HAIP issuer org) via setup.ps1.
+- **FR-012**: The walkthrough MUST create a credential offer containing persona-sourced claims (givenName, familyName, email, dateOfBirth, address with street, locality, region, postcode, country).
+- **FR-013**: The walkthrough MUST invoke `sorcha-agent haip receive` and verify the credential was received and stored.
+- **FR-014**: Setup.ps1 MUST be idempotent — running it twice produces the same result.
+- **FR-015**: The walkthrough MUST save state to state.json for use by downstream walkthroughs.
+
+**HaipDrivingLicence walkthrough:**
+- **FR-016**: Setup.ps1 MUST check for the identity credential from HaipIdentityAttestation and run it inline if missing.
+- **FR-017**: The walkthrough MUST create a Blueprint with a presentation requirement (PresentationSource: HaipExternalWallet) and a credential issuance (TargetAudience: HaipExternalWallet).
+- **FR-018**: The walkthrough MUST invoke `sorcha-agent haip present` for the identity verification step.
+- **FR-019**: The walkthrough MUST invoke `sorcha-agent haip receive` for the licence issuance step.
+- **FR-020**: The walkthrough MUST verify that both credentials exist in the agent's wallet at completion.
+- **FR-021**: The driving licence credential MUST have nested address disclosure (at least `/address/locality` independently disclosable).
+
+### Key Entities *(include if feature involves data)*
+
+**HolderKeyPair**: P-256 EC key pair persisted as PEM (private) and JWK (public) in the wallet directory. One per agent identity, reused across all credentials.
+
+**CredentialWallet**: Local file-based storage of SD-JWT VC tokens. One file per credential, named by type. Contains the raw SD-JWT compact serialisation.
+
+**WalkthroughState** (state.json): Persisted between setup and run scripts. Contains tenant ID, org IDs, wallet addresses, user credentials, credential offer URIs, and paths to stored credentials.
+
+**ActorDefinition**: Existing Sorcha.Agent JSON configuration extended with a `haip` section containing holder key algorithm preference and wallet directory path.
+
+## Success Criteria
+
+- Both walkthroughs complete against the Docker stack in under 2 minutes each
+- The agent's `haip receive` command completes the full OID4VCI pre-auth code flow without manual intervention
+- The agent's `haip present` command submits a valid VP token that the HAIP verifier accepts
+- A new developer can run `pwsh walkthroughs/HaipIdentityAttestation/setup.ps1 && pwsh walkthroughs/HaipIdentityAttestation/run.ps1` with no prior knowledge beyond the README
+- The driving licence walkthrough produces two distinct credentials in the agent's wallet, each verifiable independently
+- Running `walkthroughs/run-all.ps1` includes the HAIP walkthroughs alongside existing ones
+
+## Dependencies
+
+- Docker stack running with all services healthy (including Sorcha.Haip.Service)
+- Specs 093-098 merged to master (confirmed)
+- Sorcha.Agent CLI tool (`src/Apps/Sorcha.Agent/`)
+- `Sorcha.Cryptography.SdJwt` for SD-JWT operations
+- `SorchaWalkthrough` PowerShell module (`walkthroughs/modules/`)
+- Consumer Persona API (spec 092) for identity claim sourcing
+
+## Assumptions
+
+- The HAIP service uses ephemeral signing keys in Docker mode (acceptable for walkthroughs; production key wiring is out of scope)
+- The agent's wallet directory is local to the filesystem (no Redis or database persistence needed for walkthrough scenarios)
+- Blueprint creation for the driving licence walkthrough uses the existing JSON file approach, not the Fluent API
+- The walkthroughs target the Docker stack via `http://localhost` (API Gateway port 80)
+- Persona data for the identity credential is hardcoded in the walkthrough scripts (not fetched from the Persona API at runtime — the API writes are done in setup.ps1)

--- a/specs/101-haip-walkthroughs/tasks.md
+++ b/specs/101-haip-walkthroughs/tasks.md
@@ -1,0 +1,122 @@
+---
+
+description: "Task list for spec 101: HAIP Walkthroughs"
+---
+
+# Tasks: HAIP Walkthroughs
+
+**Input**: Design documents from `specs/101-haip-walkthroughs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/README.md
+
+**Tests**: Included — FR-009 mandates clear error reporting, agent commands need unit coverage.
+
+## Phase 1: Setup
+
+- [ ] T001 Verify `101-haip-walkthroughs` branch is rebased onto master with all HAIP specs (093-098) and infrastructure (#237-248) merged
+- [ ] T002 Verify Sorcha.Agent project builds: `dotnet build src/Apps/Sorcha.Agent/Sorcha.Agent.csproj`
+- [ ] T003 Add project reference to `Sorcha.Cryptography` in `src/Apps/Sorcha.Agent/Sorcha.Agent.csproj` (needed for SdJwtService, ECDsa operations)
+- [ ] T004 [P] Create directory structure: `src/Apps/Sorcha.Agent/Haip/` for new HAIP wallet files
+
+## Phase 2: Foundational — Holder Key Manager + Credential Wallet
+
+- [ ] T005 Create `src/Apps/Sorcha.Agent/Haip/HolderKeyManager.cs` — P-256 key pair generation, PEM persistence (`holder-key.pem`), JWK export (`holder-key.jwk.json`), load-or-create pattern per FR-002
+- [ ] T006 [P] Create `src/Apps/Sorcha.Agent/Haip/CredentialWallet.cs` — file-based SD-JWT storage per FR-004: `StoreAsync(type, rawSdJwt)`, `LoadAsync(type)`, `ListTypes()`, organised in `wallet/credentials/` directory
+- [ ] T007 [P] Write failing test `HolderKeyManager_GenerateOrLoad_ReturnsDeterministicKey` in `tests/Sorcha.Agent.Tests/Haip/HolderKeyManagerTests.cs`
+- [ ] T008 [P] Write failing test `CredentialWallet_StoreAndLoad_RoundTrips` in `tests/Sorcha.Agent.Tests/Haip/CredentialWalletTests.cs`
+- [ ] T009 Write failing test `HolderKeyManager_ExportJwk_ValidP256Format` in the same file as T007
+- [ ] T010 Write failing test `CredentialWallet_ListTypes_ReturnsStoredTypes` in the same file as T008
+
+## Phase 3: User Story 1 — `haip receive` command (Priority: P1) 🎯 MVP
+
+**Goal**: Agent can receive a credential via the OID4VCI pre-authorized code flow.
+
+### Tests for US1
+
+- [ ] T011 [P] [US1] Write failing test `JwtProofBuilder_Build_ContainsRequiredClaims` in `tests/Sorcha.Agent.Tests/Haip/JwtProofBuilderTests.cs`
+- [ ] T012 [P] [US1] Write failing test `JwtProofBuilder_Build_SignatureVerifies` in the same file
+- [ ] T013 [P] [US1] Write failing test `JwtProofBuilder_Build_BindsCNonce` in the same file
+
+### Implementation
+
+- [ ] T014 [US1] Create `src/Apps/Sorcha.Agent/Haip/JwtProofBuilder.cs` — builds JWT proof of possession per OpenID4VCI: header with `alg`, `typ: openid4vci-proof+jwt`, `jwk` (holder public key); payload with `iss`, `aud` (credential_issuer), `iat`, `nonce` (c_nonce). Signs with holder's ECDsa private key per FR-003
+- [ ] T015 [US1] Create `src/Apps/Sorcha.Agent/Commands/HaipReceiveCommand.cs` using System.CommandLine with `--offer-uri`, `--key-file`, `--wallet-dir` options per contracts/README.md
+- [ ] T016 [US1] Implement the receive flow in HaipReceiveCommand: parse offer URI → fetch issuer metadata from `.well-known/openid-credential-issuer` (FR-010) → extract pre-auth code → POST /token (exchange code, FR-001) → POST /nonce (get c_nonce) → build JWT proof (FR-003) → POST /credential → parse response → store credential (FR-004) → print summary
+- [ ] T017 [US1] Register `haip receive` as a subcommand in `src/Apps/Sorcha.Agent/Program.cs`
+- [ ] T018 [US1] Handle error cases per FR-009: expired code (exit 2), proof rejected (exit 3), network error (exit 4), invalid offer URI (exit 1)
+
+## Phase 4: User Story 2 — `haip present` command (Priority: P1)
+
+**Goal**: Agent can present a stored credential via the OID4VP direct_post flow.
+
+### Tests for US2
+
+- [ ] T019 [P] [US2] Write failing test `KbJwtBuilder_Build_ContainsAudNonceSdHash` in `tests/Sorcha.Agent.Tests/Haip/KbJwtBuilderTests.cs`
+- [ ] T020 [P] [US2] Write failing test `KbJwtBuilder_Build_SignatureVerifies` in the same file
+- [ ] T021 [P] [US2] Write failing test `KbJwtBuilder_Build_SdHashMatchesPresentationPrefix` in the same file
+
+### Implementation
+
+- [ ] T022 [US2] Create `src/Apps/Sorcha.Agent/Haip/KbJwtBuilder.cs` — builds Key Binding JWT per SD-JWT spec: header with `alg`, `typ: kb+jwt`; payload with `aud`, `nonce`, `iat`, `sd_hash`. Signs with holder's ECDsa private key per FR-006
+- [ ] T023 [US2] Create `src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs` using System.CommandLine with `--request-uri`, `--credential`, `--disclose`, `--key-file`, `--wallet-dir` options per contracts/README.md
+- [ ] T024 [US2] Implement the present flow: load credential from wallet (FR-005) → fetch request object from request_uri → extract nonce, audience, required claims → select disclosures matching `--disclose` (FR-008) → build presentation with selected disclosures → build KB-JWT (FR-006) → POST direct_post with vp_token + state (FR-007) → print result
+- [ ] T025 [US2] Register `haip present` as a subcommand in `src/Apps/Sorcha.Agent/Program.cs`
+- [ ] T026 [US2] Handle error cases per FR-009: credential not found (exit 1), request expired (exit 2), verification failed (exit 3), network error (exit 4)
+
+## Phase 5: User Story 3 — HaipIdentityAttestation walkthrough (Priority: P1)
+
+**Goal**: A complete walkthrough issues a verified identity credential to a citizen.
+
+- [ ] T027 [US3] Create `walkthroughs/HaipIdentityAttestation/actors/citizen.json` — actor definition with `haip` section: `holderKeyAlgorithm: ES256`, `walletDir: ./wallet`
+- [ ] T028 [US3] Create `walkthroughs/HaipIdentityAttestation/setup.ps1` — idempotent setup per FR-011/FR-014: check service health, authenticate as platform admin, create tenant (or reuse), provision trust anchor, create Government Identity Authority org, enrol as HAIP issuer, create citizen user with persona data (givenName: Alice, familyName: O'Brien, email: alice@example.com, dateOfBirth: 1990-03-15, address: 42 Grafton St, Dublin, Leinster, D02 Y1K8, Ireland). Save state.json per FR-015
+- [ ] T029 [US3] Create `walkthroughs/HaipIdentityAttestation/run.ps1` — execution per FR-012/FR-013: load state.json, create credential offer via HAIP service internal API (POST /api/v1/offers with persona claims, disclosable paths for all fields + nested `/address/*`), invoke `sorcha-agent haip receive --offer-uri <uri> --wallet-dir ./wallet`, verify credential file exists, print summary banner
+- [ ] T030 [US3] Update `walkthroughs/run-all.ps1` to include HaipIdentityAttestation
+- [ ] T031 [US3] Update `walkthroughs/README.md` with HaipIdentityAttestation entry in the walkthrough table
+
+## Phase 6: User Story 4 — HaipDrivingLicence walkthrough (Priority: P2)
+
+**Goal**: A complete walkthrough verifies an identity credential then issues a driving licence.
+
+- [ ] T032 [US4] Create `walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json` — Blueprint with 2 actions: Action 1 requires VerifiedIdentityCredential (PresentationSource: HaipExternalWallet, requiredClaims: givenName, familyName, dateOfBirth, address.locality), Action 2 issues DrivingLicenceCredential (TargetAudience: HaipExternalWallet, claims: licenceNumber, vehicleClass, issuedDate, expiryDate, holder name + address, disclosable: all + `/address/locality`) per FR-017/FR-021
+- [ ] T033 [US4] Create `walkthroughs/HaipDrivingLicence/actors/citizen.json` — actor definition reusing wallet keys from HaipIdentityAttestation
+- [ ] T034 [US4] Create `walkthroughs/HaipDrivingLicence/setup.ps1` — per FR-016: check for HaipIdentityAttestation/state.json (run it inline if missing), create Council Licensing Authority org, enrol as HAIP issuer, publish driving-licence.json Blueprint. Save state.json
+- [ ] T035 [US4] Create `walkthroughs/HaipDrivingLicence/run.ps1` — per FR-018/FR-019/FR-020: load state, start Blueprint instance, Action 1 creates presentation request → invoke `sorcha-agent haip present --request-uri <uri> --credential VerifiedIdentityCredential --disclose "givenName,familyName,dateOfBirth,address.locality"` → verify acceptance, Action 2 creates credential offer → invoke `sorcha-agent haip receive --offer-uri <uri>` → verify both credentials in wallet → print summary banner
+- [ ] T036 [US4] Update `walkthroughs/run-all.ps1` to include HaipDrivingLicence (after HaipIdentityAttestation)
+- [ ] T037 [US4] Update `walkthroughs/README.md` with HaipDrivingLicence entry
+
+## Phase 7: Polish
+
+- [ ] T038 Run `dotnet test tests/Sorcha.Agent.Tests` — confirm all new tests pass
+- [ ] T039 Run `dotnet build src/Apps/Sorcha.Agent/` — confirm clean build
+- [ ] T040 Run HaipIdentityAttestation against Docker stack and verify credential
+- [ ] T041 Run HaipDrivingLicence against Docker stack and verify both credentials
+- [ ] T042 [P] Update `src/Apps/Sorcha.Agent/README.md` with HAIP commands documentation
+- [ ] T043 [P] Update `walkthroughs/ORGANIZATION-SUMMARY.md` if it tracks walkthrough metadata
+
+## Dependencies
+
+- Phase 1 → Phase 2 → Phase 3 (US1 receive) → Phase 4 (US2 present) → Phase 5 (US3 identity walkthrough) → Phase 6 (US4 licence walkthrough) → Phase 7
+- US1 and US2 share foundational code (Phase 2) but are otherwise independent
+- US3 depends on US1 (needs `haip receive` command)
+- US4 depends on US1 + US2 + US3 (needs both commands + identity credential)
+
+## Parallel opportunities
+
+- Phase 2: T006, T007, T008 parallel (different files)
+- Phase 3: T011-T013 parallel (test files)
+- Phase 4: T019-T021 parallel (test files)
+- Phase 7: T042-T043 parallel (doc files)
+
+## Task summary
+
+| Phase | Tasks | Count |
+|---|---|---|
+| Phase 1 Setup | T001-T004 | 4 |
+| Phase 2 Foundational | T005-T010 | 6 |
+| Phase 3 US1 haip receive | T011-T018 | 8 |
+| Phase 4 US2 haip present | T019-T026 | 8 |
+| Phase 5 US3 Identity walkthrough | T027-T031 | 5 |
+| Phase 6 US4 Licence walkthrough | T032-T037 | 6 |
+| Phase 7 Polish | T038-T043 | 6 |
+| **Total** | | **43** |
+
+**Suggested MVP**: Phase 1 + 2 + 3 = 18 tasks. Ships `haip receive` with holder key management, JWT proof construction, and credential storage. Can be verified against the Docker stack immediately.

--- a/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.CommandLine;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Sorcha.Agent.Haip;
+using Sorcha.Cryptography.SdJwt;
+
+namespace Sorcha.Agent.Commands;
+
+/// <summary>
+/// The "haip present" command — presents a stored credential via the OID4VP direct_post flow.
+/// </summary>
+public class HaipPresentCommand : Command
+{
+    public HaipPresentCommand() : base("present", "Present a credential to a HAIP verifier via direct_post")
+    {
+        var requestUriOption = new Option<string>("--request-uri")
+        {
+            Description = "OpenID4VP Authorization Request URI",
+            Required = true
+        };
+        var credentialOption = new Option<string>("--credential")
+        {
+            Description = "Credential type to present (e.g., VerifiedIdentityCredential)",
+            Required = true
+        };
+        var discloseOption = new Option<string>("--disclose")
+        {
+            Description = "Comma-separated claim names to disclose",
+            Required = true
+        };
+        var walletDirOption = new Option<string>("--wallet-dir")
+        {
+            Description = "Wallet directory for keys and credentials",
+            DefaultValueFactory = _ => "./wallet"
+        };
+
+        Options.Add(requestUriOption);
+        Options.Add(credentialOption);
+        Options.Add(discloseOption);
+        Options.Add(walletDirOption);
+
+        this.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var requestUri = parseResult.GetValue(requestUriOption)!;
+            var credentialType = parseResult.GetValue(credentialOption)!;
+            var disclose = parseResult.GetValue(discloseOption)!;
+            var walletDir = parseResult.GetValue(walletDirOption) ?? "./wallet";
+
+            return await ExecuteAsync(requestUri, credentialType, disclose, walletDir, cancellationToken);
+        });
+    }
+
+    private static async Task<int> ExecuteAsync(
+        string requestUri, string credentialType, string disclose,
+        string walletDir, CancellationToken ct)
+    {
+        try
+        {
+            Console.WriteLine($"[haip present] Wallet dir: {walletDir}");
+            Console.WriteLine($"[haip present] Credential: {credentialType}");
+            Console.WriteLine($"[haip present] Disclosing: {disclose}");
+
+            // Step 1: Load credential from wallet
+            var wallet = new CredentialWallet(walletDir);
+            var rawCredential = await wallet.LoadAsync(credentialType);
+            if (rawCredential == null)
+            {
+                Console.Error.WriteLine($"[ERROR] Credential '{credentialType}' not found in wallet");
+                Console.Error.WriteLine($"  Available: {string.Join(", ", wallet.ListTypes())}");
+                return 1;
+            }
+
+            // Step 2: Load holder key
+            var keyManager = new HolderKeyManager(walletDir);
+            var holderKey = keyManager.GetOrCreateKey();
+            Console.WriteLine("[haip present] Holder key loaded");
+
+            using var httpClient = new HttpClient();
+
+            // Step 3: Fetch the request object
+            Console.WriteLine($"[haip present] Fetching request object from {requestUri}");
+            JsonElement requestObject;
+            try
+            {
+                requestObject = await httpClient.GetFromJsonAsync<JsonElement>(requestUri, ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ERROR] Failed to fetch request object: {ex.Message}");
+                return 2;
+            }
+
+            var nonce = requestObject.GetProperty("nonce").GetString()!;
+            var audience = requestObject.GetProperty("client_id").GetString()!;
+            var responseUri = requestObject.GetProperty("response_uri").GetString()!;
+            var state = requestObject.GetProperty("state").GetString()!;
+
+            Console.WriteLine($"[haip present] Nonce: {nonce[..8]}..., Audience: {audience}");
+
+            // Step 4: Build presentation with selective disclosure
+            var claimsToDisclose = disclose.Split(',', StringSplitOptions.TrimEntries);
+            var sdJwtService = new SdJwtService();
+
+            // Create presentation with KB-JWT
+            var presentation = await sdJwtService.CreatePresentationAsync(
+                rawCredential,
+                claimsToDisclose,
+                kbJwtSigner: (data, _) =>
+                {
+                    var sig = holderKey.SignData(data, System.Security.Cryptography.HashAlgorithmName.SHA256);
+                    return Task.FromResult(sig);
+                },
+                holderAlgorithm: "ES256",
+                audience: audience,
+                nonce: nonce);
+
+            Console.WriteLine($"[haip present] Presentation built, {presentation.SelectedDisclosures.Count} disclosures, KB-JWT present");
+
+            // Step 5: Submit via direct_post
+            var formContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("vp_token", presentation.RawPresentation),
+                new KeyValuePair<string, string>("state", state),
+                new KeyValuePair<string, string>("presentation_submission", JsonSerializer.Serialize(new
+                {
+                    id = Guid.NewGuid().ToString(),
+                    definition_id = $"pd-{state}",
+                    descriptor_map = new[]
+                    {
+                        new { id = credentialType, format = "vc+sd-jwt", path = "$" }
+                    }
+                }))
+            });
+
+            Console.WriteLine($"[haip present] Submitting via direct_post to {responseUri}");
+            var response = await httpClient.PostAsync(responseUri, formContent, ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                Console.WriteLine();
+                Console.WriteLine("=== Presentation Accepted ===");
+                Console.WriteLine($"  Credential: {credentialType}");
+                Console.WriteLine($"  Disclosed:  {disclose}");
+                Console.WriteLine($"  Verifier:   {audience}");
+                Console.WriteLine("=============================");
+                return 0;
+            }
+            else
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(ct);
+                Console.Error.WriteLine($"[ERROR] Presentation rejected ({response.StatusCode}): {errorBody}");
+                return 3;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine($"[ERROR] Network error: {ex.Message}");
+            return 4;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ERROR] Unexpected error: {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Agent/Commands/HaipReceiveCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/HaipReceiveCommand.cs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.CommandLine;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Sorcha.Agent.Haip;
+
+namespace Sorcha.Agent.Commands;
+
+/// <summary>
+/// The "haip receive" command — receives a credential via the OID4VCI pre-authorized code flow.
+/// </summary>
+public class HaipReceiveCommand : Command
+{
+    public HaipReceiveCommand() : base("receive", "Receive a credential from a HAIP issuer via pre-authorized code flow")
+    {
+        var offerUriOption = new Option<string>("--offer-uri")
+        {
+            Description = "OpenID4VCI Credential Offer URI",
+            Required = true
+        };
+        var keyFileOption = new Option<string?>("--key-file")
+        {
+            Description = "Path to holder key PEM file (default: ./wallet/holder-key.pem)"
+        };
+        var walletDirOption = new Option<string>("--wallet-dir")
+        {
+            Description = "Wallet directory for keys and credentials",
+            DefaultValueFactory = _ => "./wallet"
+        };
+
+        Options.Add(offerUriOption);
+        Options.Add(keyFileOption);
+        Options.Add(walletDirOption);
+
+        this.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var offerUri = parseResult.GetValue(offerUriOption)!;
+            var walletDir = parseResult.GetValue(walletDirOption) ?? "./wallet";
+
+            return await ExecuteAsync(offerUri, walletDir, cancellationToken);
+        });
+    }
+
+    private static async Task<int> ExecuteAsync(string offerUri, string walletDir, CancellationToken ct)
+    {
+        try
+        {
+            Console.WriteLine($"[haip receive] Wallet dir: {walletDir}");
+
+            // Step 1: Parse the credential offer URI
+            var offerJson = ExtractOfferJson(offerUri);
+            if (offerJson == null)
+            {
+                Console.Error.WriteLine("[ERROR] Invalid credential offer URI");
+                return 1;
+            }
+
+            var offer = JsonSerializer.Deserialize<JsonElement>(offerJson);
+            var issuerUrl = offer.GetProperty("credential_issuer").GetString()!;
+            Console.WriteLine($"[haip receive] Issuer: {issuerUrl}");
+
+            // Extract pre-authorized code from grants
+            string? preAuthCode = null;
+            if (offer.TryGetProperty("grants", out var grants))
+            {
+                foreach (var grant in grants.EnumerateObject())
+                {
+                    if (grant.Name.Contains("pre-authorized_code") &&
+                        grant.Value.TryGetProperty("pre-authorized_code", out var code))
+                    {
+                        preAuthCode = code.GetString();
+                        break;
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(preAuthCode))
+            {
+                Console.Error.WriteLine("[ERROR] No pre-authorized code found in offer");
+                return 1;
+            }
+
+            // Step 2: Generate or load holder key
+            var keyManager = new HolderKeyManager(walletDir);
+            var holderKey = keyManager.GetOrCreateKey();
+            var holderJwk = keyManager.GetPublicJwk();
+            Console.WriteLine("[haip receive] Holder key ready");
+
+            using var httpClient = new HttpClient();
+
+            // Step 3: Fetch issuer metadata
+            var metadataUrl = $"{issuerUrl}/.well-known/openid-credential-issuer";
+            Console.WriteLine($"[haip receive] Fetching metadata from {metadataUrl}");
+
+            JsonElement metadata;
+            try
+            {
+                metadata = await httpClient.GetFromJsonAsync<JsonElement>(metadataUrl, ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ERROR] Failed to fetch issuer metadata: {ex.Message}");
+                return 4;
+            }
+
+            var tokenEndpoint = metadata.GetProperty("token_endpoint").GetString()!;
+
+            // Step 4: Exchange pre-authorized code for access token
+            Console.WriteLine("[haip receive] Exchanging pre-authorized code...");
+            var tokenContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", "urn:ietf:params:oauth:grant-type:pre-authorized_code"),
+                new KeyValuePair<string, string>("pre-authorized_code", preAuthCode)
+            });
+
+            var tokenResponse = await httpClient.PostAsync(tokenEndpoint, tokenContent, ct);
+            if (!tokenResponse.IsSuccessStatusCode)
+            {
+                var errorBody = await tokenResponse.Content.ReadAsStringAsync(ct);
+                Console.Error.WriteLine($"[ERROR] Token exchange failed ({tokenResponse.StatusCode}): {errorBody}");
+                return 2;
+            }
+
+            var tokenResult = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(ct);
+            var accessToken = tokenResult.GetProperty("access_token").GetString()!;
+            var cNonce = tokenResult.GetProperty("c_nonce").GetString()!;
+            Console.WriteLine("[haip receive] Access token received");
+
+            // Step 5: Build JWT proof of possession
+            var credentialIssuer = metadata.GetProperty("credential_issuer").GetString()!;
+            var jwtProof = JwtProofBuilder.Build(holderKey, holderJwk, credentialIssuer, cNonce);
+            Console.WriteLine("[haip receive] JWT proof constructed");
+
+            // Step 6: Request credential
+            var credentialEndpoint = metadata.GetProperty("credential_endpoint").GetString()!;
+            var credentialRequest = new
+            {
+                format = "vc+sd-jwt",
+                proof = new
+                {
+                    proof_type = "jwt",
+                    jwt = jwtProof
+                }
+            };
+
+            httpClient.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", accessToken);
+
+            var credentialResponse = await httpClient.PostAsJsonAsync(credentialEndpoint, credentialRequest, ct);
+            if (!credentialResponse.IsSuccessStatusCode)
+            {
+                var errorBody = await credentialResponse.Content.ReadAsStringAsync(ct);
+                Console.Error.WriteLine($"[ERROR] Credential request failed ({credentialResponse.StatusCode}): {errorBody}");
+                return 3;
+            }
+
+            var credResult = await credentialResponse.Content.ReadFromJsonAsync<JsonElement>(ct);
+            var credential = credResult.GetProperty("credential").GetString()!;
+
+            // Step 7: Store credential
+            var credentialType = "SorchaCredential"; // Default; could be extracted from vct
+            if (offer.TryGetProperty("credentials", out var creds) &&
+                creds.GetArrayLength() > 0)
+            {
+                credentialType = creds[0].GetString() ?? credentialType;
+            }
+
+            var wallet = new CredentialWallet(walletDir);
+            await wallet.StoreAsync(credentialType, credential);
+
+            // Print summary
+            Console.WriteLine();
+            Console.WriteLine("=== Credential Received ===");
+            Console.WriteLine($"  Type:      {credentialType}");
+            Console.WriteLine($"  Issuer:    {credentialIssuer}");
+            Console.WriteLine($"  Stored:    {walletDir}/credentials/{credentialType}.sdjwt");
+            Console.WriteLine($"  Token len: {credential.Length} chars");
+
+            // Check for cnf
+            var parts = credential.TrimEnd('~').Split('~');
+            var jwtParts = parts[0].Split('.');
+            if (jwtParts.Length >= 2)
+            {
+                var payloadBytes = System.Buffers.Text.Base64Url.DecodeFromChars(jwtParts[1]);
+                var payload = JsonSerializer.Deserialize<JsonElement>(payloadBytes);
+                var hasCnf = payload.TryGetProperty("cnf", out _);
+                Console.WriteLine($"  cnf:       {(hasCnf ? "present" : "absent")}");
+            }
+
+            Console.WriteLine("===========================");
+            return 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine($"[ERROR] Network error: {ex.Message}");
+            return 4;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ERROR] Unexpected error: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static string? ExtractOfferJson(string offerUri)
+    {
+        // Parse openid-credential-offer://?credential_offer=<json>
+        // or openid-credential-offer://?credential_offer_uri=<url>
+        if (offerUri.Contains("credential_offer="))
+        {
+            var start = offerUri.IndexOf("credential_offer=") + "credential_offer=".Length;
+            var encoded = offerUri[start..];
+            // Remove credential_offer_uri if it follows
+            var ampersand = encoded.IndexOf('&');
+            if (ampersand >= 0) encoded = encoded[..ampersand];
+            return Uri.UnescapeDataString(encoded);
+        }
+
+        return null;
+    }
+}

--- a/src/Apps/Sorcha.Agent/Haip/CredentialWallet.cs
+++ b/src/Apps/Sorcha.Agent/Haip/CredentialWallet.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Agent.Haip;
+
+/// <summary>
+/// File-based storage for SD-JWT VC credentials. One file per credential type,
+/// stored as raw SD-JWT compact serialisation in the wallet directory.
+/// </summary>
+public class CredentialWallet
+{
+    private readonly string _credentialDir;
+
+    public CredentialWallet(string walletDir)
+    {
+        _credentialDir = Path.Combine(walletDir, "credentials");
+        Directory.CreateDirectory(_credentialDir);
+    }
+
+    /// <summary>
+    /// Stores a credential by type. Overwrites if the type already exists.
+    /// </summary>
+    public async Task StoreAsync(string credentialType, string rawSdJwt)
+    {
+        var path = GetPath(credentialType);
+        await File.WriteAllTextAsync(path, rawSdJwt);
+    }
+
+    /// <summary>
+    /// Loads a credential by type. Returns null if not found.
+    /// </summary>
+    public async Task<string?> LoadAsync(string credentialType)
+    {
+        var path = GetPath(credentialType);
+        return File.Exists(path) ? await File.ReadAllTextAsync(path) : null;
+    }
+
+    /// <summary>
+    /// Lists all stored credential types.
+    /// </summary>
+    public IEnumerable<string> ListTypes()
+    {
+        if (!Directory.Exists(_credentialDir))
+            return [];
+
+        return Directory.GetFiles(_credentialDir, "*.sdjwt")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => n != null)
+            .Cast<string>();
+    }
+
+    /// <summary>
+    /// Checks whether a credential of the given type exists.
+    /// </summary>
+    public bool HasCredential(string credentialType) =>
+        File.Exists(GetPath(credentialType));
+
+    private string GetPath(string credentialType) =>
+        Path.Combine(_credentialDir, $"{credentialType}.sdjwt");
+}

--- a/src/Apps/Sorcha.Agent/Haip/HolderKeyManager.cs
+++ b/src/Apps/Sorcha.Agent/Haip/HolderKeyManager.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Sorcha.Agent.Haip;
+
+/// <summary>
+/// Manages the holder's P-256 key pair for HAIP credential binding.
+/// Generates on first use, persists as PEM (private) and JWK (public),
+/// and reuses on subsequent invocations.
+/// </summary>
+public class HolderKeyManager
+{
+    private readonly string _keyDir;
+    private ECDsa? _ecdsa;
+
+    public HolderKeyManager(string walletDir)
+    {
+        _keyDir = walletDir;
+        Directory.CreateDirectory(_keyDir);
+    }
+
+    /// <summary>
+    /// Loads the existing key pair or generates a new one.
+    /// </summary>
+    public ECDsa GetOrCreateKey()
+    {
+        if (_ecdsa != null) return _ecdsa;
+
+        var pemPath = Path.Combine(_keyDir, "holder-key.pem");
+
+        if (File.Exists(pemPath))
+        {
+            _ecdsa = ECDsa.Create();
+            _ecdsa.ImportFromPem(File.ReadAllText(pemPath));
+        }
+        else
+        {
+            _ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            var pem = _ecdsa.ExportECPrivateKeyPem();
+            File.WriteAllText(pemPath, pem);
+
+            // Also write the public JWK for reference
+            var jwk = ExportPublicJwk(_ecdsa);
+            File.WriteAllText(Path.Combine(_keyDir, "holder-key.jwk.json"),
+                JsonSerializer.Serialize(jwk, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        return _ecdsa;
+    }
+
+    /// <summary>
+    /// Exports the holder's public key as a JWK JsonElement.
+    /// </summary>
+    public JsonElement GetPublicJwk()
+    {
+        var key = GetOrCreateKey();
+        var jwk = ExportPublicJwk(key);
+        return JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(jwk));
+    }
+
+    private static Dictionary<string, string> ExportPublicJwk(ECDsa key)
+    {
+        var parameters = key.ExportParameters(includePrivateParameters: false);
+        return new Dictionary<string, string>
+        {
+            ["kty"] = "EC",
+            ["crv"] = "P-256",
+            ["x"] = Base64Url.EncodeToString(parameters.Q.X!),
+            ["y"] = Base64Url.EncodeToString(parameters.Q.Y!)
+        };
+    }
+}

--- a/src/Apps/Sorcha.Agent/Haip/JwtProofBuilder.cs
+++ b/src/Apps/Sorcha.Agent/Haip/JwtProofBuilder.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Sorcha.Agent.Haip;
+
+/// <summary>
+/// Builds a JWT proof of possession per OpenID4VCI for the credential endpoint.
+/// The proof binds the holder's public key and the c_nonce from the token response.
+/// </summary>
+public static class JwtProofBuilder
+{
+    /// <summary>
+    /// Builds and signs a JWT proof of possession.
+    /// </summary>
+    /// <param name="holderKey">The holder's ECDsa key pair.</param>
+    /// <param name="holderJwk">The holder's public key in JWK form (for the header).</param>
+    /// <param name="credentialIssuer">The credential_issuer URL (aud claim).</param>
+    /// <param name="cNonce">The c_nonce from the token response.</param>
+    /// <returns>The compact JWS string.</returns>
+    public static string Build(ECDsa holderKey, JsonElement holderJwk, string credentialIssuer, string cNonce)
+    {
+        var header = new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = "openid4vci-proof+jwt",
+            ["jwk"] = holderJwk
+        };
+
+        var payload = new Dictionary<string, object>
+        {
+            ["aud"] = credentialIssuer,
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["nonce"] = cNonce
+        };
+
+        var headerB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.UTF8.GetBytes($"{headerB64}.{payloadB64}");
+        var signature = holderKey.SignData(signingInput, HashAlgorithmName.SHA256);
+        var signatureB64 = Base64Url.EncodeToString(signature);
+
+        return $"{headerB64}.{payloadB64}.{signatureB64}";
+    }
+}

--- a/src/Apps/Sorcha.Agent/Haip/KbJwtBuilder.cs
+++ b/src/Apps/Sorcha.Agent/Haip/KbJwtBuilder.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Sorcha.Agent.Haip;
+
+/// <summary>
+/// Builds a Key Binding JWT per the SD-JWT spec for credential presentations.
+/// The KB-JWT proves the presenter holds the key named in the credential's cnf claim.
+/// </summary>
+public static class KbJwtBuilder
+{
+    /// <summary>
+    /// Builds and signs a Key Binding JWT.
+    /// </summary>
+    /// <param name="holderKey">The holder's ECDsa key pair (must match cnf.jwk).</param>
+    /// <param name="audience">The verifier's audience URI.</param>
+    /// <param name="nonce">The verifier's nonce from the presentation request.</param>
+    /// <param name="presentationPrefix">The SD-JWT presentation prefix (everything before the KB-JWT) for sd_hash computation.</param>
+    /// <returns>The compact JWS string.</returns>
+    public static string Build(ECDsa holderKey, string audience, string nonce, string presentationPrefix)
+    {
+        var sdHash = Base64Url.EncodeToString(
+            SHA256.HashData(Encoding.ASCII.GetBytes(presentationPrefix)));
+
+        var header = new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = "kb+jwt"
+        };
+
+        var payload = new Dictionary<string, object>
+        {
+            ["aud"] = audience,
+            ["nonce"] = nonce,
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["sd_hash"] = sdHash
+        };
+
+        var headerB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.UTF8.GetBytes($"{headerB64}.{payloadB64}");
+        var signature = holderKey.SignData(signingInput, HashAlgorithmName.SHA256);
+        var signatureB64 = Base64Url.EncodeToString(signature);
+
+        return $"{headerB64}.{payloadB64}.{signatureB64}";
+    }
+}

--- a/src/Apps/Sorcha.Agent/Program.cs
+++ b/src/Apps/Sorcha.Agent/Program.cs
@@ -15,6 +15,12 @@ internal class Program
             rootCommand.Subcommands.Add(new RunCommand());
             rootCommand.Subcommands.Add(new ValidateCommand());
 
+            // HAIP wallet commands (spec 101)
+            var haipCommand = new Command("haip", "HAIP wallet operations — receive and present credentials");
+            haipCommand.Subcommands.Add(new HaipReceiveCommand());
+            haipCommand.Subcommands.Add(new HaipPresentCommand());
+            rootCommand.Subcommands.Add(haipCommand);
+
             return await rootCommand.Parse(args).InvokeAsync();
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.Agent/Sorcha.Agent.csproj
+++ b/src/Apps/Sorcha.Agent/Sorcha.Agent.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup>
     <!-- Sorcha Libraries -->
+    <ProjectReference Include="..\..\Common\Sorcha.Cryptography\Sorcha.Cryptography.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.Blueprint.Models\Sorcha.Blueprint.Models.csproj" />
     <ProjectReference Include="..\..\Core\Sorcha.Blueprint.Engine\Sorcha.Blueprint.Engine.csproj" />

--- a/walkthroughs/HaipDrivingLicence/actors/citizen.json
+++ b/walkthroughs/HaipDrivingLicence/actors/citizen.json
@@ -1,0 +1,10 @@
+{
+  "actor": {
+    "name": "citizen-wallet",
+    "description": "Simulated HAIP wallet presenting identity and receiving driving licence"
+  },
+  "haip": {
+    "holderKeyAlgorithm": "ES256",
+    "walletDir": "../HaipIdentityAttestation/wallet"
+  }
+}

--- a/walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json
+++ b/walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json
@@ -1,0 +1,79 @@
+{
+  "title": "Driving Licence Application",
+  "description": "Citizen presents verified identity, Council issues driving licence via HAIP",
+  "participants": [
+    {
+      "id": "applicant",
+      "name": "Licence Applicant",
+      "description": "Citizen applying for a driving licence"
+    },
+    {
+      "id": "council",
+      "name": "Council Licensing Authority",
+      "description": "Issues driving licences after identity verification"
+    }
+  ],
+  "actions": [
+    {
+      "id": "verify-identity",
+      "title": "Verify Applicant Identity",
+      "description": "Council requests identity credential from applicant",
+      "participant": "applicant",
+      "credentialRequirements": [
+        {
+          "type": "VerifiedIdentityCredential",
+          "presentationSource": "HaipExternalWallet",
+          "requiredClaims": [
+            { "claimName": "givenName" },
+            { "claimName": "familyName" },
+            { "claimName": "dateOfBirth" }
+          ],
+          "revocationCheckPolicy": "FailClosed",
+          "description": "Government-issued identity credential"
+        }
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "confirmed": { "type": "boolean" }
+        }
+      }
+    },
+    {
+      "id": "issue-licence",
+      "title": "Issue Driving Licence",
+      "description": "Council issues driving licence credential to applicant",
+      "participant": "council",
+      "credentialIssuance": {
+        "credentialType": "DrivingLicenceCredential",
+        "targetAudience": "HaipExternalWallet",
+        "recipientParticipantId": "applicant",
+        "claimMappings": [
+          { "claimName": "licenceNumber", "sourceField": "/licenceNumber" },
+          { "claimName": "vehicleClass", "sourceField": "/vehicleClass" },
+          { "claimName": "issuedDate", "sourceField": "/issuedDate" },
+          { "claimName": "expiryDate", "sourceField": "/expiryDate" },
+          { "claimName": "holderName", "sourceField": "/holderName" }
+        ],
+        "disclosable": [
+          "licenceNumber", "vehicleClass", "issuedDate", "expiryDate", "holderName"
+        ],
+        "expiryDuration": "P10Y"
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "licenceNumber": { "type": "string" },
+          "vehicleClass": { "type": "string" },
+          "issuedDate": { "type": "string", "format": "date" },
+          "expiryDate": { "type": "string", "format": "date" },
+          "holderName": { "type": "string" }
+        },
+        "required": ["licenceNumber", "vehicleClass"]
+      },
+      "routes": [
+        { "condition": "true", "target": null }
+      ]
+    }
+  ]
+}

--- a/walkthroughs/HaipDrivingLicence/run.ps1
+++ b/walkthroughs/HaipDrivingLicence/run.ps1
@@ -1,0 +1,148 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# HaipDrivingLicence — Run
+# Presents identity credential → receives driving licence credential.
+# Exercises both HAIP verification (spec 098) and issuance (spec 097).
+
+param(
+    [switch]$ShowJson
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "HaipDrivingLicence — Run"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+if (-not (Test-Path $stateFile)) { Write-WtFail "No state.json. Run setup.ps1 first."; exit 1 }
+$state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+
+$walletDir = $state.walletDir
+$agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
+
+# --- Step 1: Authenticate ---
+Write-WtStep 1 "Authenticating as Council admin"
+$secrets = Get-SorchaSecrets -WalkthroughName "haip-licence"
+$councilToken = Connect-SorchaUser -BaseUrl $state.baseUrl `
+    -Email "council-admin@haip-walkthrough.local" -Password $secrets.DefaultPassword `
+    -OrganizationId $state.councilOrgId
+
+# --- Step 2: Create presentation request for identity credential ---
+Write-WtStep 2 "Creating presentation request for VerifiedIdentityCredential"
+
+$presRequestBody = @{
+    credentialType = "VerifiedIdentityCredential"
+    requiredClaims = @("givenName", "familyName", "dateOfBirth")
+    acceptedIssuers = $null
+}
+
+try {
+    $presRequest = Invoke-SorchaApi -BaseUrl $state.baseUrl -Token $councilToken `
+        -Method POST -Path "/api/v1/verifier/requests" -Body $presRequestBody
+
+    $requestUri = $presRequest.requestUri
+    Write-WtSuccess "Presentation request created: $($presRequest.requestId)"
+    if ($ShowJson) { $presRequest | ConvertTo-Json -Depth 5 | Write-Host }
+} catch {
+    Write-WtFail "Failed to create presentation request: $_"
+    exit 1
+}
+
+# --- Step 3: Present identity credential via sorcha-agent ---
+Write-WtStep 3 "Presenting VerifiedIdentityCredential"
+Write-WtInfo "Disclosing: givenName, familyName, dateOfBirth"
+
+try {
+    & dotnet run --project $agentProject -- haip present `
+        --request-uri $requestUri `
+        --credential "VerifiedIdentityCredential" `
+        --disclose "givenName,familyName,dateOfBirth" `
+        --wallet-dir $walletDir
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-WtFail "Presentation failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+    Write-WtSuccess "Identity credential presented and verified"
+} catch {
+    Write-WtFail "Presentation threw an exception: $_"
+    exit 1
+}
+
+# --- Step 4: Create credential offer for driving licence ---
+Write-WtStep 4 "Creating credential offer for DrivingLicenceCredential"
+
+$today = (Get-Date).ToString("yyyy-MM-dd")
+$expiry = (Get-Date).AddYears(10).ToString("yyyy-MM-dd")
+
+$licenceOfferBody = @{
+    issuerWalletAddress = $state.councilWalletAddress
+    tenantId = $state.tenantId
+    credentialType = "DrivingLicenceCredential"
+    claims = @{
+        licenceNumber = "DL-$(Get-Random -Maximum 99999)"
+        vehicleClass = "B"
+        issuedDate = $today
+        expiryDate = $expiry
+        holderName = "Alice O'Brien"
+    }
+    disclosablePaths = @(
+        "licenceNumber", "vehicleClass", "issuedDate", "expiryDate", "holderName"
+    )
+}
+
+try {
+    $licenceOffer = Invoke-SorchaApi -BaseUrl $state.baseUrl -Token $councilToken `
+        -Method POST -Path "/api/v1/offers" -Body $licenceOfferBody
+
+    Write-WtSuccess "Licence offer created: $($licenceOffer.offerId)"
+    if ($ShowJson) { $licenceOffer | ConvertTo-Json -Depth 5 | Write-Host }
+} catch {
+    Write-WtFail "Failed to create licence offer: $_"
+    exit 1
+}
+
+# --- Step 5: Receive driving licence credential ---
+Write-WtStep 5 "Receiving DrivingLicenceCredential"
+
+try {
+    & dotnet run --project $agentProject -- haip receive `
+        --offer-uri $licenceOffer.credentialOfferUri `
+        --wallet-dir $walletDir
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-WtFail "Credential receive failed with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+    Write-WtSuccess "Driving licence credential received"
+} catch {
+    Write-WtFail "Credential receive threw an exception: $_"
+    exit 1
+}
+
+# --- Step 6: Verify both credentials in wallet ---
+Write-WtStep 6 "Verifying wallet contents"
+
+$identityCred = Join-Path $walletDir "credentials/VerifiedIdentityCredential.sdjwt"
+$licenceCred = Join-Path $walletDir "credentials/DrivingLicenceCredential.sdjwt"
+
+$identityOk = Test-Path $identityCred
+$licenceOk = Test-Path $licenceCred
+
+if ($identityOk -and $licenceOk) {
+    Write-WtSuccess "Both credentials present in wallet:"
+    Write-WtInfo "  VerifiedIdentityCredential: $((Get-Item $identityCred).Length) bytes"
+    Write-WtInfo "  DrivingLicenceCredential:   $((Get-Item $licenceCred).Length) bytes"
+} else {
+    if (-not $identityOk) { Write-WtFail "Missing: VerifiedIdentityCredential" }
+    if (-not $licenceOk)  { Write-WtFail "Missing: DrivingLicenceCredential" }
+    exit 1
+}
+
+Write-WtBanner "HaipDrivingLicence — Complete"
+Write-WtSuccess "Full HAIP round-trip: present identity → verify → issue licence"

--- a/walkthroughs/HaipDrivingLicence/setup.ps1
+++ b/walkthroughs/HaipDrivingLicence/setup.ps1
@@ -1,0 +1,119 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# HaipDrivingLicence — Setup
+# Creates a Council Licensing Authority org and publishes the driving licence blueprint.
+# Checks for HaipIdentityAttestation and runs it if missing.
+
+param(
+    [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
+    [string]$Profile = 'gateway',
+    [switch]$SkipHealthCheck,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "HaipDrivingLicence — Setup"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+$identityDir = Join-Path (Split-Path -Parent $scriptDir) "HaipIdentityAttestation"
+$identityState = Join-Path $identityDir "state.json"
+
+# Check if already set up
+if ((Test-Path $stateFile) -and -not $Force) {
+    Write-WtInfo "state.json already exists. Use -Force to re-run setup."
+    return
+}
+
+# --- Step 1: Ensure identity attestation is complete ---
+Write-WtStep 1 "Checking for identity credential"
+if (-not (Test-Path $identityState)) {
+    Write-WtWarn "HaipIdentityAttestation not run — running it now"
+    & (Join-Path $identityDir "setup.ps1") -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
+    & (Join-Path $identityDir "run.ps1")
+}
+
+$idState = Get-Content -Path $identityState -Raw | ConvertFrom-Json
+Write-WtSuccess "Identity credential available from $identityDir"
+
+$secrets = Get-SorchaSecrets -WalkthroughName "haip-licence"
+$env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
+
+# --- Step 2: Connect as system admin ---
+Write-WtStep 2 "Connecting as system admin"
+$adminToken = Connect-SorchaAdmin -BaseUrl $env.BaseUrl -Secrets $secrets
+
+# --- Step 3: Create Council Licensing Authority ---
+Write-WtStep 3 "Creating Council Licensing Authority"
+$councilOrg = Get-OrCreateOrganization -BaseUrl $env.BaseUrl -Token $adminToken `
+    -Name "Council Licensing Authority" `
+    -AdminEmail "council-admin@haip-walkthrough.local" `
+    -AdminPassword $secrets.DefaultPassword
+
+$councilOrgId = $councilOrg.id
+Write-WtSuccess "Council org: $councilOrgId"
+
+# --- Step 4: Create Council wallet ---
+Write-WtStep 4 "Creating Council wallet"
+$councilToken = Connect-SorchaUser -BaseUrl $env.BaseUrl `
+    -Email "council-admin@haip-walkthrough.local" -Password $secrets.DefaultPassword `
+    -OrganizationId $councilOrgId
+
+$councilWallet = New-SorchaWallet -BaseUrl $env.BaseUrl -Token $councilToken `
+    -Name "Council Licence Issuer" -Algorithm "ES256"
+
+Write-WtSuccess "Council wallet: $($councilWallet.address)"
+
+# --- Step 5: Enrol Council as HAIP issuer ---
+Write-WtStep 5 "Enrolling Council as HAIP issuer"
+try {
+    $enrolResult = Invoke-SorchaApi -BaseUrl $env.BaseUrl -Token $adminToken `
+        -Method POST `
+        -Path "/api/v1/trust/tenants/$($env.TenantId)/orgs/$($councilWallet.address)/enrol" `
+        -Body @{
+            orgPublicKeyBase64 = $councilWallet.publicKey
+            orgDisplayName = "Council Licensing Authority"
+        }
+    Write-WtSuccess "Council cert enrolled"
+} catch {
+    Write-WtWarn "Enrolment may already exist: $_"
+}
+
+# --- Step 6: Publish driving licence blueprint ---
+Write-WtStep 6 "Publishing driving licence blueprint"
+$blueprintPath = Join-Path $scriptDir "blueprints/driving-licence.json"
+$blueprint = Get-Content -Path $blueprintPath -Raw | ConvertFrom-Json
+
+# Create a register for the blueprint
+$register = New-SorchaRegister -BaseUrl $env.BaseUrl -Token $councilToken `
+    -Name "Driving Licence Register" -Description "HAIP walkthrough register"
+
+$publishedBlueprint = Publish-SorchaBlueprint -BaseUrl $env.BaseUrl -Token $councilToken `
+    -Blueprint $blueprint -RegisterId $register.id
+
+Write-WtSuccess "Blueprint published: $($publishedBlueprint.id)"
+
+# --- Save state ---
+$state = @{
+    tenantId = $env.TenantId
+    councilOrgId = $councilOrgId
+    councilOrgName = "Council Licensing Authority"
+    councilWalletAddress = $councilWallet.address
+    registerId = $register.id
+    blueprintId = $publishedBlueprint.id
+    identityStateFile = $identityState
+    citizenEmail = $idState.citizenEmail
+    citizenPassword = $idState.citizenPassword
+    walletDir = $idState.walletDir
+    baseUrl = $env.BaseUrl
+}
+
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
+Write-WtSuccess "State saved to $stateFile"
+Write-WtBanner "HaipDrivingLicence — Setup Complete"

--- a/walkthroughs/HaipIdentityAttestation/actors/citizen.json
+++ b/walkthroughs/HaipIdentityAttestation/actors/citizen.json
@@ -1,0 +1,10 @@
+{
+  "actor": {
+    "name": "citizen-wallet",
+    "description": "Simulated HAIP wallet for a citizen receiving identity credentials"
+  },
+  "haip": {
+    "holderKeyAlgorithm": "ES256",
+    "walletDir": "./wallet"
+  }
+}

--- a/walkthroughs/HaipIdentityAttestation/run.ps1
+++ b/walkthroughs/HaipIdentityAttestation/run.ps1
@@ -1,0 +1,111 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# HaipIdentityAttestation — Run
+# Issues a VerifiedIdentityCredential to the citizen via the HAIP OID4VCI flow.
+# Uses sorcha-agent haip receive to simulate a HAIP wallet.
+
+param(
+    [switch]$ShowJson
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "HaipIdentityAttestation — Run"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+if (-not (Test-Path $stateFile)) { Write-WtFail "No state.json. Run setup.ps1 first."; exit 1 }
+$state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+
+$walletDir = Join-Path $scriptDir "wallet"
+
+# --- Step 1: Authenticate as Government admin ---
+Write-WtStep 1 "Authenticating as Government admin"
+$adminToken = Connect-SorchaAdmin -BaseUrl $state.baseUrl -Secrets (Get-SorchaSecrets -WalkthroughName "haip-identity")
+
+# --- Step 2: Create credential offer ---
+Write-WtStep 2 "Creating credential offer for VerifiedIdentityCredential"
+
+$persona = $state.persona
+$offerClaims = @{
+    givenName = $persona.givenName
+    familyName = $persona.familyName
+    fullName = $persona.fullName
+    dateOfBirth = $persona.dateOfBirth
+    email = $persona.defaultEmail
+    address = @{
+        street = $persona.defaultAddress.street
+        locality = $persona.defaultAddress.locality
+        region = $persona.defaultAddress.region
+        postcode = $persona.defaultAddress.postcode
+        country = $persona.defaultAddress.country
+    }
+}
+
+$offerBody = @{
+    issuerWalletAddress = $state.govWalletAddress
+    tenantId = $state.tenantId
+    credentialType = "VerifiedIdentityCredential"
+    claims = $offerClaims
+    disclosablePaths = @(
+        "givenName", "familyName", "fullName", "dateOfBirth", "email",
+        "/address/street", "/address/locality", "/address/region",
+        "/address/postcode", "/address/country"
+    )
+}
+
+try {
+    $offerResult = Invoke-SorchaApi -BaseUrl $state.baseUrl -Token $adminToken `
+        -Method POST -Path "/api/v1/offers" -Body $offerBody
+
+    $offerUri = $offerResult.credentialOfferUri
+    Write-WtSuccess "Credential offer created: $($offerResult.offerId)"
+    if ($ShowJson) { $offerResult | ConvertTo-Json -Depth 5 | Write-Host }
+} catch {
+    Write-WtFail "Failed to create credential offer: $_"
+    exit 1
+}
+
+# --- Step 3: Run sorcha-agent haip receive ---
+Write-WtStep 3 "Invoking sorcha-agent haip receive"
+Write-WtInfo "Offer URI: $($offerUri.Substring(0, [Math]::Min(80, $offerUri.Length)))..."
+
+$agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
+
+$agentExitCode = 0
+try {
+    & dotnet run --project $agentProject -- haip receive --offer-uri $offerUri --wallet-dir $walletDir
+    $agentExitCode = $LASTEXITCODE
+} catch {
+    Write-WtFail "Agent threw an exception: $_"
+    exit 1
+}
+
+if ($agentExitCode -ne 0) {
+    Write-WtFail "sorcha-agent haip receive failed with exit code $agentExitCode"
+    exit $agentExitCode
+}
+
+# --- Step 4: Verify credential stored ---
+Write-WtStep 4 "Verifying credential stored"
+$credFile = Join-Path $walletDir "credentials/VerifiedIdentityCredential.sdjwt"
+if (Test-Path $credFile) {
+    $credSize = (Get-Item $credFile).Length
+    Write-WtSuccess "Credential stored: $credFile ($credSize bytes)"
+} else {
+    Write-WtFail "Credential file not found at $credFile"
+    exit 1
+}
+
+# --- Update state with credential path ---
+$state | Add-Member -NotePropertyName "credentialPath" -NotePropertyValue $credFile -Force
+$state | Add-Member -NotePropertyName "walletDir" -NotePropertyValue $walletDir -Force
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
+
+Write-WtBanner "HaipIdentityAttestation — Complete"
+Write-WtSuccess "VerifiedIdentityCredential issued to citizen wallet"

--- a/walkthroughs/HaipIdentityAttestation/setup.ps1
+++ b/walkthroughs/HaipIdentityAttestation/setup.ps1
@@ -1,0 +1,132 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# HaipIdentityAttestation — Setup
+# Creates a Government Identity Authority and a citizen user with persona data.
+# Provisions trust anchor and enrols the Government org as a HAIP issuer.
+#
+# Idempotent — safe to run multiple times.
+
+param(
+    [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
+    [string]$Profile = 'gateway',
+    [switch]$SkipHealthCheck,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "HaipIdentityAttestation — Setup"
+
+$secrets = Get-SorchaSecrets -WalkthroughName "haip-identity"
+$env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+
+# Check if already set up (idempotent)
+if ((Test-Path $stateFile) -and -not $Force) {
+    Write-WtInfo "state.json already exists. Use -Force to re-run setup."
+    $state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+    Write-WtSuccess "Setup already complete. Org: $($state.govOrgName)"
+    return
+}
+
+# --- Step 1: Connect as system admin ---
+Write-WtStep 1 "Connecting as system admin"
+$adminToken = Connect-SorchaAdmin -BaseUrl $env.BaseUrl -Secrets $secrets
+
+# --- Step 2: Create Government Identity Authority org ---
+Write-WtStep 2 "Creating Government Identity Authority"
+$govOrg = Get-OrCreateOrganization -BaseUrl $env.BaseUrl -Token $adminToken `
+    -Name "Government Identity Authority" `
+    -AdminEmail "gov-admin@haip-walkthrough.local" `
+    -AdminPassword $secrets.DefaultPassword
+
+$govOrgId = $govOrg.id
+Write-WtSuccess "Government org: $govOrgId"
+
+# --- Step 3: Create citizen user on public org ---
+Write-WtStep 3 "Creating citizen user"
+$citizenEmail = "alice.obrien@haip-walkthrough.local"
+$citizenPassword = $secrets.DefaultPassword
+
+$citizen = Register-SorchaPublicUser -BaseUrl $env.BaseUrl `
+    -Email $citizenEmail -Password $citizenPassword -DisplayName "Alice O'Brien"
+Confirm-SorchaUserEmail -BaseUrl $env.BaseUrl -Token $adminToken -Email $citizenEmail
+
+Write-WtSuccess "Citizen user: $citizenEmail"
+
+# --- Step 4: Create wallet for Government org ---
+Write-WtStep 4 "Creating Government wallet"
+$govAdminToken = Connect-SorchaUser -BaseUrl $env.BaseUrl `
+    -Email "gov-admin@haip-walkthrough.local" -Password $secrets.DefaultPassword `
+    -OrganizationId $govOrgId
+
+$govWallet = New-SorchaWallet -BaseUrl $env.BaseUrl -Token $govAdminToken `
+    -Name "Government Identity Issuer" -Algorithm "ES256"
+
+Write-WtSuccess "Government wallet: $($govWallet.address)"
+
+# --- Step 5: Provision trust anchor ---
+Write-WtStep 5 "Provisioning trust anchor for tenant"
+try {
+    $trustResult = Invoke-SorchaApi -BaseUrl $env.BaseUrl -Token $adminToken `
+        -Method POST -Path "/api/v1/trust/tenants/$($env.TenantId)/provision" `
+        -Body @{}
+    Write-WtSuccess "Trust anchor provisioned: $($trustResult.serialNumber)"
+} catch {
+    Write-WtWarn "Trust anchor may already exist: $_"
+}
+
+# --- Step 6: Enrol Government org as HAIP issuer ---
+Write-WtStep 6 "Enrolling Government org as HAIP issuer"
+try {
+    $enrolResult = Invoke-SorchaApi -BaseUrl $env.BaseUrl -Token $adminToken `
+        -Method POST `
+        -Path "/api/v1/trust/tenants/$($env.TenantId)/orgs/$($govWallet.address)/enrol" `
+        -Body @{
+            orgPublicKeyBase64 = $govWallet.publicKey
+            orgDisplayName = "Government Identity Authority"
+        }
+    Write-WtSuccess "Org cert enrolled: $($enrolResult.serialNumber)"
+} catch {
+    Write-WtWarn "Enrolment may already exist: $_"
+}
+
+# --- Save state ---
+$state = @{
+    tenantId = $env.TenantId
+    govOrgId = $govOrgId
+    govOrgName = "Government Identity Authority"
+    govWalletAddress = $govWallet.address
+    citizenEmail = $citizenEmail
+    citizenPassword = $citizenPassword
+    citizenName = @{
+        givenName = "Alice"
+        familyName = "O'Brien"
+    }
+    persona = @{
+        givenName = "Alice"
+        familyName = "O'Brien"
+        fullName = "Alice O'Brien"
+        dateOfBirth = "1990-03-15"
+        defaultEmail = $citizenEmail
+        defaultAddress = @{
+            street = "42 Grafton Street"
+            locality = "Dublin"
+            region = "Leinster"
+            postcode = "D02 Y1K8"
+            country = "Ireland"
+        }
+    }
+    baseUrl = $env.BaseUrl
+}
+
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
+Write-WtSuccess "State saved to $stateFile"
+Write-WtBanner "HaipIdentityAttestation — Setup Complete"

--- a/walkthroughs/README.md
+++ b/walkthroughs/README.md
@@ -60,6 +60,15 @@ AI agent-operated walkthroughs using MCP Server connections for autonomous execu
 |-------------|--------------|
 | [TradeFinance](./TradeFinance/) | **Agent-driven multi-register workflow.** 4 organisations, 6 participants, **2 registers** with a procurement-to-pay blueprint (6 actions) and an invoice finance blueprint (4 actions). Exercises cross-register verifiable credentials (VerifiedInvoiceCredential required on Register 2), credential chains, selective disclosure under field-level encryption, AI agent coordination via MCP Server (2 Claude Code sessions on separate machines), scripted and persona execution modes, DevMode-to-FLE transition, and 5 JSON Logic calculations. Three scenarios: golden path (approved), disputed invoice (rejection + resubmission), and declined financing (low credit score). |
 
+### HAIP (External Wallet)
+
+Credential issuance and verification with external HAIP wallets via OpenID4VCI/OpenID4VP.
+
+| Walkthrough | What It Tests |
+|-------------|--------------|
+| [HaipIdentityAttestation](./HaipIdentityAttestation/) | Government issues a VerifiedIdentityCredential to a citizen via the HAIP OID4VCI pre-authorized code flow. Tests trust anchor provisioning, org cert enrolment, credential offer creation, pre-auth code exchange, JWT proof of possession, SD-JWT VC issuance with cnf holder key binding and nested address disclosure. Uses `sorcha-agent haip receive`. |
+| [HaipDrivingLicence](./HaipDrivingLicence/) | Council verifies the citizen's identity credential via OID4VP direct_post, then issues a driving licence credential via OID4VCI. Tests the full HAIP round-trip: present credential with KB-JWT and selective disclosure → verify → issue new credential. Chains from HaipIdentityAttestation. Uses `sorcha-agent haip present` and `haip receive`. |
+
 ### Advanced
 
 Specialized infrastructure scenarios requiring additional setup beyond `docker-compose up -d`.

--- a/walkthroughs/run-all.ps1
+++ b/walkthroughs/run-all.ps1
@@ -47,6 +47,10 @@ $walkthroughs = @(
     # Multi-Org
     @{ Name = "ConstructionPermit"; Category = "Multi-Org"; HasSetupRun = $true }
     @{ Name = "SelfBuildHouse"; Category = "Multi-Org"; HasSetupRun = $true }
+
+    # HAIP (External Wallet) — must run in order (licence depends on identity)
+    @{ Name = "HaipIdentityAttestation"; Category = "HAIP"; HasSetupRun = $true }
+    @{ Name = "HaipDrivingLicence"; Category = "HAIP"; HasSetupRun = $true }
 )
 
 if (-not $SkipAdvanced) {


### PR DESCRIPTION
## Summary

Extends `sorcha-agent` with HAIP wallet capabilities and creates two end-to-end walkthroughs exercising the full HAIP spec set (093-098).

### Agent Commands
- `sorcha-agent haip receive --offer-uri <uri>` — OID4VCI pre-authorized code flow
- `sorcha-agent haip present --request-uri <uri> --credential <type> --disclose <claims>` — OID4VP direct_post

### Walkthroughs
- **HaipIdentityAttestation**: Government issues VerifiedIdentityCredential to citizen
- **HaipDrivingLicence**: Council verifies identity → issues DrivingLicenceCredential

### New Files
- 6 agent source files (HolderKeyManager, CredentialWallet, JwtProofBuilder, KbJwtBuilder, HaipReceiveCommand, HaipPresentCommand)
- 7 walkthrough files (2x setup.ps1, 2x run.ps1, 2x actor JSON, 1 Blueprint JSON)
- Spec, plan, research, data-model, contracts, tasks artifacts

## Test plan
- [x] Agent builds clean
- [x] `sorcha-agent haip --help` shows receive + present commands
- [ ] HaipIdentityAttestation runs against Docker stack
- [ ] HaipDrivingLicence runs against Docker stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)