### PR TITLE
chore: docker-compose.seed.yml for network seed nodes

### DIFF
--- a/.claude/skills/network-bootstrap/SKILL.md
+++ b/.claude/skills/network-bootstrap/SKILL.md
@@ -87,24 +87,36 @@ REPO_RAW="https://raw.githubusercontent.com/Sorcha-Platform/Sorcha/master"
 curl -sL "$REPO_RAW/docker-compose.yml" -o docker-compose.yml
 curl -sL "$REPO_RAW/docker-compose.n1.yml" -o docker-compose.n1.yml
 curl -sL "$REPO_RAW/docker-compose.ports.yml" -o docker-compose.ports.yml
+curl -sL "$REPO_RAW/docker-compose.seed.yml" -o docker-compose.seed.yml
 curl -sL "$REPO_RAW/docker/postgres-init.sql" -o docker/postgres-init.sql
 curl -sL "$REPO_RAW/scripts/n1-setup-remote.sh" -o n1-setup-remote.sh
 chmod +x n1-setup-remote.sh
 '
 ```
 
-**Pull images and start:**
+**Pull images and start (seed mode for a fresh network):**
+
+`docker-compose.n1.yml` defaults to `SystemRegister__BootstrapMode: SyncOnly`,
+which is correct for replica nodes but will leave the seed waiting forever
+for a peer that doesn't exist. For the very first node of a new network,
+stack `docker-compose.seed.yml` on top — it flips the register service to
+`GenesisFile` so it ingests the embedded trust anchor and bootstraps the
+governance blueprints. Drop the seed override on subsequent restarts
+(local storage will find the system register before either path runs).
 
 ```bash
 az vm run-command invoke --resource-group sorcha-n1-uk --name sorcha-n1-vm \
   --command-id RunShellScript --scripts '
 cd /opt/sorcha
-docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml pull
+COMPOSE_FILES="-f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.seed.yml -f docker-compose.ports.yml"
+docker compose $COMPOSE_FILES pull
 docker volume create sorcha_wallet-encryption-keys 2>/dev/null || true
 docker run --rm -v sorcha_wallet-encryption-keys:/data alpine chown -R 1654:1654 /data
-docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml up -d
+docker compose $COMPOSE_FILES up -d
 '
 ```
+
+Replica nodes and routine n1 restarts omit `-f docker-compose.seed.yml`.
 
 ### Step 4: Bootstrap Platform
 

--- a/docker-compose.seed.yml
+++ b/docker-compose.seed.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Docker Compose override for the seed node of a fresh network.
+#
+# Usage (typically on top of n1.yml):
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.n1.yml \
+#     -f docker-compose.seed.yml \
+#     -f docker-compose.ports.yml \
+#     up -d
+#
+# Use this ONLY for the very first node of a brand-new network, when there
+# are no peers to sync the system register from. It switches the register
+# service from SyncOnly (wait for a peer) to GenesisFile (ingest the embedded
+# genesis block, then bootstrap the governance blueprints).
+#
+# Once the seed has the system register persisted on disk, subsequent restarts
+# can drop this override — the local copy will be discovered before either
+# the sync path or the genesis path is attempted.
+#
+# Secondary / replica nodes must NOT use this override. They should pull the
+# system register from the seed via the peer network.
+
+services:
+  register-service:
+    environment:
+      SystemRegister__BootstrapMode: GenesisFile


### PR DESCRIPTION
## Summary
Adds an explicit override for the very first node of a fresh network, switching `register-service` to `SystemRegister__BootstrapMode: GenesisFile`. Replica nodes keep the safer `SyncOnly` default baked into `docker-compose.n1.yml`.

## Why
During today's n1.sorcha.dev re-initialisation after PR #255 (fresh genesis), the register service sat in `SyncOnly` mode waiting for a peer that didn't exist. I had to `sed` the mode on the VM mid-bootstrap. That workaround is not reproducible by someone following the skill, so this PR bakes the correct behaviour into source.

## Usage
**Seed a fresh network:**
```bash
docker compose \
  -f docker-compose.yml \
  -f docker-compose.n1.yml \
  -f docker-compose.seed.yml \
  -f docker-compose.ports.yml up -d
```

**Replica or routine restart:**
```bash
docker compose \
  -f docker-compose.yml \
  -f docker-compose.n1.yml \
  -f docker-compose.ports.yml up -d
```

Drop the seed override on subsequent restarts — the local copy of the system register is discovered before either the sync or genesis path runs.

## Also updated
- `network-bootstrap` skill Step 3 documents stacking `-f docker-compose.seed.yml` for fresh bootstraps and the replica case explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)