### PR TITLE
feat: server-side owner subscription on register finalize

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -128,6 +128,20 @@ builder.Services.AddScoped<ICryptoModule, Sorcha.Cryptography.Core.CryptoModule>
 // Register wallet service client
 builder.Services.AddServiceClients(builder.Configuration);
 
+// Tenant Service internal subscription client. After finalising a register, the
+// Register Service immediately subscribes the owning organisation via a
+// service-to-service call — this removes the old client-side admin-gated hop
+// that blocked service-principal callers from seeing their own registers.
+builder.Services.AddHttpClient<
+    Sorcha.Register.Service.Services.ITenantSubscriptionClient,
+    Sorcha.Register.Service.Services.TenantSubscriptionClient>(client =>
+{
+    var tenantBase = builder.Configuration["ServiceClients:TenantService:Address"]
+        ?? builder.Configuration["TenantService:Endpoint"]
+        ?? "http://tenant-service";
+    client.BaseAddress = new Uri(tenantBase);
+});
+
 // Register system wallet signing service (opt-in — used for genesis + blueprint publish)
 builder.Services.AddSystemWalletSigning(builder.Configuration);
 
@@ -772,11 +786,29 @@ The pending registration expires after 5 minutes. The client must finalize withi
 registerCreationGroup.MapPost("/finalize", async (
     IRegisterCreationOrchestrator orchestrator,
     FinalizeRegisterCreationRequest request,
+    HttpContext httpContext,
     CancellationToken cancellationToken) =>
 {
     try
     {
-        var response = await orchestrator.FinalizeAsync(request, cancellationToken);
+        // Pull the caller's org_id and sub claims so the orchestrator can
+        // create an owner subscription via the Tenant Service internal
+        // endpoint. These are read from the JWT, NEVER from the request body —
+        // that's the whole point: the caller doesn't get to pick whose org
+        // becomes the owner.
+        var orgIdClaim = httpContext.User.FindFirst("org_id")?.Value
+            ?? httpContext.User.FindFirst("organization_id")?.Value;
+        var userIdClaim = httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? httpContext.User.FindFirst("sub")?.Value;
+
+        Guid.TryParse(orgIdClaim, out var callerOrgId);
+        Guid.TryParse(userIdClaim, out var callerUserId);
+
+        var response = await orchestrator.FinalizeAsync(
+            request,
+            callerOrgId,
+            callerUserId,
+            cancellationToken);
         return Results.Created($"/api/registers/{response.RegisterId}", response);
     }
     catch (InvalidOperationException ex) when (ex.Message.Contains("expired"))

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -32,6 +32,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
     private readonly ISystemWalletSigningService _signingService;
     private readonly IPendingRegistrationStore _pendingStore;
     private readonly IPeerServiceClient _peerClient;
+    private readonly ITenantSubscriptionClient _tenantSubscriptionClient;
 
     private readonly TimeSpan _pendingExpirationTime = TimeSpan.FromMinutes(5);
     private readonly JsonSerializerOptions _canonicalJsonOptions;
@@ -46,7 +47,8 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         IValidatorServiceClient validatorClient,
         ISystemWalletSigningService signingService,
         IPendingRegistrationStore pendingStore,
-        IPeerServiceClient peerClient)
+        IPeerServiceClient peerClient,
+        ITenantSubscriptionClient tenantSubscriptionClient)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _registerManager = registerManager ?? throw new ArgumentNullException(nameof(registerManager));
@@ -58,6 +60,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         _signingService = signingService ?? throw new ArgumentNullException(nameof(signingService));
         _pendingStore = pendingStore ?? throw new ArgumentNullException(nameof(pendingStore));
         _peerClient = peerClient ?? throw new ArgumentNullException(nameof(peerClient));
+        _tenantSubscriptionClient = tenantSubscriptionClient ?? throw new ArgumentNullException(nameof(tenantSubscriptionClient));
 
         // Configure JSON serialization for canonical form
         // UnsafeRelaxedJsonEscaping ensures characters like '+' in DateTimeOffset and base64
@@ -229,10 +232,17 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
     }
 
     /// <summary>
-    /// Finalizes register creation (Phase 2): verifies signatures and creates register
+    /// Finalizes register creation (Phase 2): verifies signatures and creates register.
+    /// When <paramref name="callerOrganizationId"/> is non-empty, the owning
+    /// organisation is immediately subscribed via a service-to-service call to
+    /// the Tenant Service's internal endpoint. Failures there are logged but do
+    /// NOT fail finalisation — the register has already been sealed and can be
+    /// subscribed manually later.
     /// </summary>
     public async Task<FinalizeRegisterCreationResponse> FinalizeAsync(
         FinalizeRegisterCreationRequest request,
+        Guid callerOrganizationId = default,
+        Guid callerUserId = default,
         CancellationToken cancellationToken = default)
     {
         _logger.LogInformation(
@@ -481,8 +491,36 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         // It will be written to Register Service database after docket creation
         // Validator Service handles the write after successful docket build
 
-        // Owner subscription is created by the UI's CreateRegisterWizard after finalization
-        // via POST /api/organizations/{orgId}/register-subscriptions with subscription_type=Owner.
+        // Create the owner subscription via a service-to-service call to the
+        // Tenant Service. Attestation signatures have already been verified above,
+        // so the Register Service is in a position to vouch for ownership without
+        // the admin role check that gates the public subscribe endpoint. Failure
+        // here is logged but non-fatal — the register itself is already sealed
+        // and a manual subscribe will reconcile it.
+        if (callerOrganizationId != Guid.Empty)
+        {
+            try
+            {
+                await _tenantSubscriptionClient.CreateOwnerSubscriptionAsync(
+                    callerOrganizationId,
+                    register.Id,
+                    controlRecord.Name,
+                    callerUserId,
+                    cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Owner subscription call failed for register {RegisterId} (org {OrgId}). Register was created successfully; subscribe manually to reconcile.",
+                    register.Id, callerOrganizationId);
+            }
+        }
+        else
+        {
+            _logger.LogDebug(
+                "Register {RegisterId} finalised without a caller org_id — owner subscription skipped (e.g. system bootstrap path).",
+                register.Id);
+        }
 
         return new FinalizeRegisterCreationResponse
         {
@@ -716,9 +754,16 @@ public interface IRegisterCreationOrchestrator
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Finalizes register creation (Phase 2): verifies signatures and creates register
+    /// Finalizes register creation (Phase 2): verifies signatures and creates register.
+    /// After successful persistence, the orchestrator calls the Tenant Service's
+    /// internal owner-subscription endpoint using <paramref name="callerOrganizationId"/>
+    /// and <paramref name="callerUserId"/> (both resolved from the authenticated
+    /// caller's JWT claims). Pass <see cref="Guid.Empty"/> for either value to skip
+    /// the subscription step (e.g. bootstrapper contexts with no user identity).
     /// </summary>
     Task<FinalizeRegisterCreationResponse> FinalizeAsync(
         FinalizeRegisterCreationRequest request,
+        Guid callerOrganizationId = default,
+        Guid callerUserId = default,
         CancellationToken cancellationToken = default);
 }

--- a/src/Services/Sorcha.Register.Service/Services/TenantSubscriptionClient.cs
+++ b/src/Services/Sorcha.Register.Service/Services/TenantSubscriptionClient.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Sorcha.ServiceClients.Auth;
+
+namespace Sorcha.Register.Service.Services;
+
+/// <summary>
+/// Minimal service-to-service client for the Tenant Service's internal
+/// owner-subscription endpoint. Called from <c>RegisterCreationOrchestrator.FinalizeAsync</c>
+/// after owner attestations have been cryptographically verified.
+/// </summary>
+public interface ITenantSubscriptionClient
+{
+    /// <summary>
+    /// Create an owner subscription for the supplied organisation. Idempotent —
+    /// a 409 response from the tenant service is treated as success.
+    /// </summary>
+    Task<bool> CreateOwnerSubscriptionAsync(
+        Guid organizationId,
+        string registerId,
+        string? registerName,
+        Guid ownerUserId,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// HttpClient-backed implementation. Uses the shared
+/// <see cref="IServiceAuthClient"/> to acquire a service JWT (register-service
+/// client credentials are seeded into the Tenant Service database by
+/// <c>DatabaseInitializer</c>, so no deploy-time provisioning is required).
+/// </summary>
+public class TenantSubscriptionClient : ITenantSubscriptionClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IServiceAuthClient _serviceAuth;
+    private readonly ILogger<TenantSubscriptionClient> _logger;
+
+    public TenantSubscriptionClient(
+        HttpClient httpClient,
+        IServiceAuthClient serviceAuth,
+        ILogger<TenantSubscriptionClient> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _serviceAuth = serviceAuth ?? throw new ArgumentNullException(nameof(serviceAuth));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> CreateOwnerSubscriptionAsync(
+        Guid organizationId,
+        string registerId,
+        string? registerName,
+        Guid ownerUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (organizationId == Guid.Empty)
+        {
+            _logger.LogDebug(
+                "Skipping owner subscription for register {RegisterId}: no organizationId (caller had no org_id claim).",
+                registerId);
+            return false;
+        }
+
+        var token = await _serviceAuth.GetTokenAsync(cancellationToken);
+        if (string.IsNullOrEmpty(token))
+        {
+            _logger.LogWarning(
+                "Could not acquire service token for owner subscription on register {RegisterId} — subscription skipped.",
+                registerId);
+            return false;
+        }
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/api/internal/register-owner-subscriptions")
+        {
+            Content = JsonContent.Create(new InternalOwnerSubscriptionRequestBody
+            {
+                OrganizationId = organizationId,
+                RegisterId = registerId,
+                RegisterName = registerName,
+                OwnerUserId = ownerUserId
+            })
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation(
+                    "Owner subscription created for org {OrgId} on register {RegisterId}",
+                    organizationId, registerId);
+                return true;
+            }
+
+            // 409 means somebody already subscribed this org (e.g. retry) — treat as success.
+            if (response.StatusCode == HttpStatusCode.Conflict)
+            {
+                _logger.LogInformation(
+                    "Owner subscription for org {OrgId} on register {RegisterId} already exists — treating as success.",
+                    organizationId, registerId);
+                return true;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogWarning(
+                "Owner subscription call failed for org {OrgId} on register {RegisterId}: HTTP {StatusCode} — {Body}",
+                organizationId, registerId, (int)response.StatusCode, body);
+            return false;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex,
+                "Owner subscription call threw HttpRequestException for org {OrgId} on register {RegisterId}",
+                organizationId, registerId);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Wire-level shape matching Tenant Service's InternalOwnerSubscriptionRequest.
+    /// Kept as a private DTO to avoid cross-service coupling on tenant-service types.
+    /// </summary>
+    private sealed record InternalOwnerSubscriptionRequestBody
+    {
+        [JsonPropertyName("organizationId")]
+        public required Guid OrganizationId { get; init; }
+
+        [JsonPropertyName("registerId")]
+        public required string RegisterId { get; init; }
+
+        [JsonPropertyName("registerName")]
+        public string? RegisterName { get; init; }
+
+        [JsonPropertyName("ownerUserId")]
+        public required Guid OwnerUserId { get; init; }
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/RegisterSubscriptionEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/RegisterSubscriptionEndpoints.cs
@@ -81,6 +81,31 @@ public static class RegisterSubscriptionEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .RequireAuthorization();
 
+        // Service-to-service endpoint: Register Service calls this right after
+        // it finalises a register so that the owning organisation is subscribed
+        // without the client needing to make a second admin-gated call. The
+        // Register Service has already cryptographically verified the owner
+        // attestations, so the admin role check that gates the public endpoint
+        // above is redundant here — we trust the caller by virtue of it holding
+        // a valid service token (RequireService policy).
+        app.MapPost("/api/internal/register-owner-subscriptions", CreateInternalOwnerSubscription)
+            .WithName("CreateInternalOwnerSubscription")
+            .WithSummary("Internal: create an owner register subscription (service-to-service)")
+            .WithDescription(
+                "Creates an Owner subscription for the supplied organization. Requires a service "
+                + "token. The caller is expected to have already established that the supplied "
+                + "organization is the rightful owner of the register (e.g. via signed owner "
+                + "attestations during register finalisation). Returns 409 if a subscription "
+                + "already exists. Idempotent — treating 409 as success is safe.")
+            .WithTags("Register Subscriptions")
+            .Produces<RegisterSubscriptionResponse>(StatusCodes.Status201Created)
+            .Produces<ProblemDetails>(StatusCodes.Status409Conflict)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .RequireAuthorization("RequireService")
+            .ExcludeFromDescription();
+
         return app;
     }
 
@@ -223,6 +248,60 @@ public static class RegisterSubscriptionEndpoints
 
         var subscriptions = await subscriptionService.GetSubscribedRegistersForOrgAsync(orgId, cancellationToken);
         return TypedResults.Ok(subscriptions);
+    }
+
+    /// <summary>
+    /// POST /api/internal/register-owner-subscriptions — service-to-service handler that
+    /// creates an owner subscription without the RequireAdministrator gate used by the
+    /// public subscribe endpoint.
+    /// </summary>
+    private static async Task<IResult> CreateInternalOwnerSubscription(
+        InternalOwnerSubscriptionRequest request,
+        IRegisterSubscriptionService subscriptionService,
+        ILogger<Program> logger,
+        CancellationToken cancellationToken)
+    {
+        if (request is null
+            || request.OrganizationId == Guid.Empty
+            || string.IsNullOrWhiteSpace(request.RegisterId))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["request"] = ["organizationId and registerId are required"]
+            });
+        }
+
+        try
+        {
+            var subscription = await subscriptionService.CreateOwnerSubscriptionAsync(
+                request.OrganizationId,
+                request.RegisterId,
+                request.RegisterName,
+                request.OwnerUserId,
+                cancellationToken);
+
+            logger.LogInformation(
+                "Internal owner subscription created for org {OrgId} on register {RegisterId}",
+                request.OrganizationId, request.RegisterId);
+
+            return TypedResults.Created(
+                $"/api/organizations/{request.OrganizationId}/register-subscriptions/{request.RegisterId}",
+                subscription);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already has a subscription"))
+        {
+            // Idempotent: caller may retry after a transient failure. Returning 409 lets
+            // callers distinguish "already done" from "newly created" without breaking.
+            logger.LogInformation(
+                "Owner subscription already exists for org {OrgId} on register {RegisterId}",
+                request.OrganizationId, request.RegisterId);
+            return TypedResults.Conflict(new ProblemDetails
+            {
+                Title = "Duplicate Subscription",
+                Detail = ex.Message,
+                Status = StatusCodes.Status409Conflict
+            });
+        }
     }
 
     private static Guid GetUserId(ClaimsPrincipal user)

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/RegisterSubscriptionDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/RegisterSubscriptionDtos.cs
@@ -6,6 +6,44 @@ using System.Text.Json.Serialization;
 namespace Sorcha.Tenant.Service.Models.Dtos;
 
 /// <summary>
+/// Service-to-service request body for <c>POST /api/internal/register-owner-subscriptions</c>.
+/// Sent by the Register Service immediately after finalising a register so that the
+/// owning organisation is subscribed without the client having to make a second
+/// admin-gated call. The Register Service has already verified owner attestations
+/// cryptographically, so the admin role check on the public subscribe endpoint is
+/// redundant here — trust is established by the service-to-service token instead.
+/// </summary>
+public record InternalOwnerSubscriptionRequest
+{
+    /// <summary>
+    /// Owning organisation ID — resolved from the authenticated caller's JWT claims
+    /// by the Register Service finalize endpoint, never accepted from an untrusted
+    /// request body.
+    /// </summary>
+    [JsonPropertyName("organizationId")]
+    public required Guid OrganizationId { get; init; }
+
+    /// <summary>
+    /// Register identifier (32-character hex string).
+    /// </summary>
+    [JsonPropertyName("registerId")]
+    public required string RegisterId { get; init; }
+
+    /// <summary>
+    /// Human-readable register name (cached on the subscription row for display).
+    /// </summary>
+    [JsonPropertyName("registerName")]
+    public string? RegisterName { get; init; }
+
+    /// <summary>
+    /// User ID recorded as the creator of the subscription. Resolved from the
+    /// authenticated caller's <c>sub</c> claim by the Register Service.
+    /// </summary>
+    [JsonPropertyName("ownerUserId")]
+    public required Guid OwnerUserId { get; init; }
+}
+
+/// <summary>
 /// Request to subscribe an organization to a register.
 /// </summary>
 public record SubscribeRequest

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
@@ -35,6 +35,7 @@ public class RegisterCreationOrchestratorTests
     private readonly Mock<ISystemWalletSigningService> _mockSigningService;
     private readonly Mock<IPendingRegistrationStore> _mockPendingStore;
     private readonly Mock<IPeerServiceClient> _mockPeerClient;
+    private readonly Mock<ITenantSubscriptionClient> _mockTenantSubscriptionClient;
     private readonly RegisterCreationOrchestrator _orchestrator;
 
     public RegisterCreationOrchestratorTests()
@@ -109,6 +110,16 @@ public class RegisterCreationOrchestratorTests
                 return false;
             });
 
+        _mockTenantSubscriptionClient = new Mock<ITenantSubscriptionClient>();
+        _mockTenantSubscriptionClient
+            .Setup(c => c.CreateOwnerSubscriptionAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         _orchestrator = new RegisterCreationOrchestrator(
             _mockLogger.Object,
             _mockRegisterManager.Object,
@@ -119,7 +130,8 @@ public class RegisterCreationOrchestratorTests
             _mockValidatorClient.Object,
             _mockSigningService.Object,
             _mockPendingStore.Object,
-            _mockPeerClient.Object);
+            _mockPeerClient.Object,
+            _mockTenantSubscriptionClient.Object);
     }
 
     #region InitiateAsync Tests
@@ -367,6 +379,157 @@ public class RegisterCreationOrchestratorTests
                 It.IsAny<CancellationToken>()),
             Times.Once);
 
+        // Default call (no caller claims) should NOT subscribe — we only
+        // create owner subscriptions when the caller identity is known.
+        _mockTenantSubscriptionClient.Verify(
+            c => c.CreateOwnerSubscriptionAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_WithCallerClaims_ShouldCreateOwnerSubscription()
+    {
+        // Arrange — same shape as the happy-path test, but pass caller org/user ids
+        // so the orchestrator can invoke the tenant service internal endpoint.
+        var callerOrgId = Guid.NewGuid();
+        var callerUserId = Guid.NewGuid();
+
+        var initiateRequest = new InitiateRegisterCreationRequest
+        {
+            Name = "Smoke Register",
+            Owners = new List<OwnerInfo>
+            {
+                new() { UserId = "user-001", WalletId = "wallet-001" }
+            }
+        };
+
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(new byte[32]);
+
+        var initiateResponse = await _orchestrator.InitiateAsync(initiateRequest);
+
+        var signedAttestations = initiateResponse.AttestationsToSign.Select(a => new SignedAttestation
+        {
+            AttestationData = a.AttestationData,
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            Signature = Convert.ToBase64String(new byte[64]),
+            Algorithm = SignatureAlgorithm.ED25519
+        }).ToList();
+
+        var finalizeRequest = new FinalizeRegisterCreationRequest
+        {
+            RegisterId = initiateResponse.RegisterId,
+            Nonce = initiateResponse.Nonce,
+            SignedAttestations = signedAttestations
+        };
+
+        _mockCryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CryptoStatus.Success);
+
+        _mockRegisterManager
+            .Setup(m => m.CreateRegisterAsync(
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = initiateResponse.RegisterId,
+                Name = "Smoke Register",
+                CreatedAt = DateTime.UtcNow
+            });
+
+        // Act
+        await _orchestrator.FinalizeAsync(finalizeRequest, callerOrgId, callerUserId);
+
+        // Assert — the tenant subscription client was called exactly once with
+        // the caller's org/user ids and the register id/name from the pending
+        // control record (NOT from anything the caller could have spoofed).
+        _mockTenantSubscriptionClient.Verify(
+            c => c.CreateOwnerSubscriptionAsync(
+                callerOrgId,
+                initiateResponse.RegisterId,
+                "Smoke Register",
+                callerUserId,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_WithEmptyCallerOrg_ShouldNotCreateOwnerSubscription()
+    {
+        // Arrange — bootstrap-style call where no user identity exists.
+        var initiateRequest = new InitiateRegisterCreationRequest
+        {
+            Name = "Bootstrap Register",
+            Owners = new List<OwnerInfo>
+            {
+                new() { UserId = "user-001", WalletId = "wallet-001" }
+            }
+        };
+
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(new byte[32]);
+
+        var initiateResponse = await _orchestrator.InitiateAsync(initiateRequest);
+
+        var signedAttestations = initiateResponse.AttestationsToSign.Select(a => new SignedAttestation
+        {
+            AttestationData = a.AttestationData,
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            Signature = Convert.ToBase64String(new byte[64]),
+            Algorithm = SignatureAlgorithm.ED25519
+        }).ToList();
+
+        var finalizeRequest = new FinalizeRegisterCreationRequest
+        {
+            RegisterId = initiateResponse.RegisterId,
+            Nonce = initiateResponse.Nonce,
+            SignedAttestations = signedAttestations
+        };
+
+        _mockCryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CryptoStatus.Success);
+
+        _mockRegisterManager
+            .Setup(m => m.CreateRegisterAsync(
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = initiateResponse.RegisterId,
+                Name = "Bootstrap Register",
+                CreatedAt = DateTime.UtcNow
+            });
+
+        // Act — explicit Guid.Empty for caller org means "bootstrap context,
+        // skip the subscription hop". The register itself still gets created.
+        await _orchestrator.FinalizeAsync(finalizeRequest, Guid.Empty, Guid.Empty);
+
+        // Assert
+        _mockTenantSubscriptionClient.Verify(
+            c => c.CreateOwnerSubscriptionAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
@@ -71,7 +71,8 @@ public class RegisterCreationPolicyTests
             mockValidatorClient.Object,
             mockSigningService.Object,
             _mockPendingStore.Object,
-            mockPeerClient.Object);
+            mockPeerClient.Object,
+            Mock.Of<ITenantSubscriptionClient>());
     }
 
     [Fact]

--- a/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBootstrapTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/SystemRegisterBootstrapTests.cs
@@ -222,7 +222,11 @@ public class SystemRegisterBootstrapTests
 
         // Finalize returns success
         _mockOrchestrator
-            .Setup(o => o.FinalizeAsync(It.IsAny<FinalizeRegisterCreationRequest>(), It.IsAny<CancellationToken>()))
+            .Setup(o => o.FinalizeAsync(
+                It.IsAny<FinalizeRegisterCreationRequest>(),
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FinalizeRegisterCreationResponse
             {
                 RegisterId = SystemRegisterConstants.SystemRegisterId,
@@ -265,10 +269,13 @@ public class SystemRegisterBootstrapTests
                 r.Name == SystemRegisterConstants.SystemRegisterName),
             It.IsAny<CancellationToken>()), Times.Once);
 
-        // Finalization was called
+        // Finalization was called — bootstrapper runs with no caller identity
+        // (system path), so orgId / userId should be Guid.Empty.
         _mockOrchestrator.Verify(o => o.FinalizeAsync(
             It.Is<FinalizeRegisterCreationRequest>(r =>
                 r.RegisterId == SystemRegisterConstants.SystemRegisterId),
+            It.IsAny<Guid>(),
+            It.IsAny<Guid>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1124,27 +1124,11 @@ function New-SorchaRegister {
 
     Write-WtSuccess "Register '$Name' created: $registerId"
 
-    # Subscribe the owner org to its own register so idempotent name-lookups
-    # (via /me/subscribed-registers) find it on subsequent setup runs. Without
-    # this, subscriptions and ownership diverge — the owner can create a
-    # register but never see it listed. Uses SubscriptionType "Owner".
-    $ownerSubTenantUrl = if ($TenantUrl) { $TenantUrl } `
-                         elseif ($script:LastEnvironment) { $script:LastEnvironment.TenantUrl } `
-                         else { $null }
-
-    if ($ownerSubTenantUrl) {
-        try {
-            $null = New-SorchaRegisterSubscription `
-                -TenantUrl $ownerSubTenantUrl `
-                -OrganizationId $TenantId `
-                -RegisterId $registerId `
-                -RegisterName $Name `
-                -SubscriptionType "Owner" `
-                -Headers $Headers
-        } catch {
-            Write-WtWarn "  Owner org auto-subscribe failed for register '$Name': $($_.Exception.Message)"
-        }
-    }
+    # Owner subscription is now created server-side by the Register Service's
+    # finalize endpoint via a service-to-service call to the Tenant Service
+    # internal subscription endpoint. No client-side subscribe call is needed
+    # or even possible for service-principal callers (they don't have the
+    # Administrator role required by the public subscribe endpoint).
 
     # Auto-subscribe Sorcha Public Org (well-known ID) so consumer-persona
     # and public-discovery flows can access the register by default.


### PR DESCRIPTION
## Summary
Removes the second admin-gated round trip after \`POST /api/registers/finalize\`. The Register Service now creates the owner subscription itself via a service-to-service call to a new Tenant Service internal endpoint, immediately after owner attestations are cryptographically verified.

## Why
Every register-creation flow previously had to POST to \`/api/organizations/{orgId}/register-subscriptions\` after finalize. That endpoint is gated by \`RequireAdministrator\`, so **service principals cannot create their own subscriptions** — they finalise a register successfully but the follow-up subscribe returns 403, leaving the register orphaned (sealed in MongoDB but invisible to the owning org's subscription listing).

Hit live this session during the n1 smoke test: \`n1-smoke-test-register\` was created cleanly but the module's auto-subscribe returned 403 from the service-principal token.

## Authority chain — is this a privilege bypass?
The admin role check on the public subscribe endpoint was a coarse proxy for *"is this caller authorised to mark org X as owner of register Y?"*. The **real** authority is the owner attestation signatures in the control record, which \`/finalize\` already verifies cryptographically before sealing the register. Once signature verification passes, the Register Service is in a position to vouch for ownership directly — so we trust it with one narrow internal endpoint instead of duplicating the role check.

**Technically**: yes, this bypasses \`RequireAdministrator\` on \`POST /organizations/{orgId}/register-subscriptions\` for this one code path.
**Conceptually**: no new authority is being granted. The authority that already existed (valid owner attestations + caller JWT with an \`org_id\` claim) is now sufficient to produce both the register *and* the subscription, whereas before it only produced the register.

Key invariant, preserved: the **orgId for the subscription is read from the authenticated caller's JWT**, never from a request body. A caller cannot subscribe someone else's org.

## Changes
- **NEW** \`POST /api/internal/register-owner-subscriptions\` on Tenant Service. \`RequireService\` policy. Delegates to the existing \`CreateOwnerSubscriptionAsync\` method. Idempotent — 409 on duplicate is treated as success by callers.
- **NEW** \`TenantSubscriptionClient\` in Register Service. Typed \`HttpClient\` + existing \`IServiceAuthClient\` for the token. The \`register-service\` SP is already seeded by \`DatabaseInitializer\` with the right scopes, so no deploy-time provisioning is needed.
- **MOD** \`RegisterCreationOrchestrator.FinalizeAsync\` gains optional \`callerOrganizationId\` and \`callerUserId\` \`Guid\` parameters. When non-empty, the orchestrator calls the new subscription client after register persistence succeeds. Failures are logged but non-fatal.
- **MOD** The \`/api/registers/finalize\` endpoint reads \`org_id\` and \`sub\` claims from \`HttpContext\` and passes them through. Nothing comes from the request body.
- **MOD** Walkthrough module's \`New-SorchaRegister\` drops its own client-side auto-subscribe call — server handles it now. Public-org subscribe is unchanged.

## The public endpoint is unchanged
\`POST /api/organizations/{orgId}/register-subscriptions\` keeps its \`RequireAdministrator\` gate — still the right path for *"subscribe my org to someone else's register"*.

## Regression tests
- \`FinalizeAsync_WithCallerClaims_ShouldCreateOwnerSubscription\` — subscription is created with exactly the caller's orgId/userId and the register name from the *pending control record* (not from the request).
- \`FinalizeAsync_WithEmptyCallerOrg_ShouldNotCreateOwnerSubscription\` — \`Guid.Empty\` caller (bootstrapper path) skips the subscription call entirely.
- Happy-path orchestrator test now asserts default-overload does NOT call the subscription client.
- \`SystemRegisterBootstrapTests\` Mock setup updated for the new 4-arg signature.

## Test plan
- [x] Register + Tenant services build clean
- [x] Orchestrator & policy unit tests compile (two pre-existing test-infra failures on \`master\` are unrelated — \`Mock<RegisterManager>\` constructor proxy issue and \`SystemRegisterBootstrapperTests\` \`InitiatesAndFinalizes\`)
- [x] Tenant service tests: 704 pass, 2 pre-existing passkey failures on \`master\`
- [ ] n1 deploy exercise with SP: finalize → subscribe → \`/me/subscribed-registers\` returns the new register without any client-side subscribe call (follow-up after merge + image build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)