### PR TITLE
chore: set Haip__IssuerUrl to https://n1.sorcha.dev on n1

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -58,6 +58,16 @@ services:
     environment:
       <<: *jwt-env
 
+  haip-service:
+    image: sorchadev/haip-service:latest
+    environment:
+      <<: *jwt-env
+      # Credential offers embed this URL as the credential_issuer; the agent
+      # receiving the offer dereferences /.well-known/openid-credential-issuer
+      # against it, so it must be the public URL, not the internal 127.0.0.1
+      # default baked into docker-compose.yml.
+      Haip__IssuerUrl: https://n1.sorcha.dev
+
   sorcha-ui-web:
     image: sorchadev/ui-web:latest
 


### PR DESCRIPTION
Credential offers generated by the HAIP Service embed the `credential_issuer` URL; external wallets / the sorcha-agent dereference `/.well-known/openid-credential-issuer` against it. The base compose file defaults the URL to `http://127.0.0.1` for Docker-local dev, which was being inherited by n1, so agents calling n1.sorcha.dev were receiving offers that pointed at their own loopback interface.

Every `HaipIdentityAttestation` run against n1 in this session failed with `Pre-authorized code is invalid` for this exact reason — the agent was fetching metadata and exchanging codes against 127.0.0.1 instead of n1, hitting an empty offer store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)