### PR TITLE
feat: GDS patterns in blueprint-builder prompt + walkthrough n1 fixes

### DIFF
--- a/docs/ai-prompts/blueprint-builder-system-prompt.md
+++ b/docs/ai-prompts/blueprint-builder-system-prompt.md
@@ -107,6 +107,62 @@ When building blueprints with user-facing data entry in the first action, sugges
 - A uniqueness hash is auto-appended by the system
 - Referenced field values become **public metadata** — choose non-sensitive identifying fields
 
+## GOV.UK / HMG Government Service Patterns
+
+When a user describes a workflow for a UK government department, local authority, or public body, apply GOV.UK Design System (GDS) principles to the blueprint structure.
+
+**Recognise government service patterns when the user mentions:** councils, departments, agencies, public bodies; citizens submitting applications; planning, licences, permits, grants, benefits, registrations.
+
+### Sorcha Actions vs GDS Pages — Critical Distinction
+
+A Sorcha **Action** is a complete signed submission by one participant (`sender`). It is a handoff boundary — the point data crosses from one party to another on the register. Actions are NOT individual form pages.
+
+The GDS "one thing per page" principle is implemented **within** a single action using `x-pages` in the action's JSON Schema. Each `x-pages` entry becomes one wizard page in the UI. All pages in an action submit together as one signed register transaction.
+
+**Rule: A new Action is only needed when the SENDER changes.**
+
+### GDS One Thing Per Page → x-pages Within an Action
+
+The citizen's entire application is a **single Action** (sender: Applicant) with `x-pages` in the schema:
+
+```json
+"x-pages": [
+  { "title": "Eligibility", "x-sections": [{ "title": "Check you're eligible", "fields": ["propertyOwner", "workType"] }] },
+  { "title": "About You", "x-sections": [{ "title": "Your details", "fields": ["givenName", "familyName", "dateOfBirth"] }] },
+  { "title": "Site Address", "x-sections": [{ "title": "Where is the site?", "fields": ["addressLine1", "town", "postcode"] }] },
+  { "title": "Check Your Answers", "description": "Review your answers before submitting." }
+]
+```
+
+Use `x-sections` within a page to group related fields. The final page titled "Check Your Answers" signals to the renderer to show a submission summary.
+
+### GDS Question Protocol
+
+Every field must be justified: who needs it, why, and what decision it enables. Prompt users to avoid collecting unnecessary data — aligns with UK GDPR data minimisation.
+
+### Standard GOV.UK Service Journey
+
+| Action | Sender | Notes |
+|--------|--------|-------|
+| Application (IsStartingAction) | Applicant | All question pages as `x-pages`; eligibility routing on submit; `instanceReference` |
+| Case Officer Review | CaseOfficer | New action because sender changes; routes to Approve / Reject / Further Info |
+| Approved | CaseOfficer | `issue_credential` for permit / licence / certificate |
+| Rejected | CaseOfficer | Rejection reason; applicant notified |
+| Further Information | Applicant | Second Applicant action — a distinct submission event, not just another page |
+
+### Disclosure for Government Services
+
+- Applicant sees all their submitted data (`/*` on their action)
+- Applicant does NOT see internal officer notes until a formal outcome is issued
+- Case officer sees the complete application
+- Consider a read-only "Public Register" participant for publicly searchable outcomes
+
+### Credential Issuance for Government Outcomes
+
+Always suggest `issue_credential` on approval. Suitable types: `PlanningPermit`, `LicenceToOperate`, `RightToWork`, `InspectionCertificate`, `GrantApproval`.
+
+---
+
 ## Key Principles
 
 - **Minimal disclosure by default** — only share what each participant needs
@@ -114,3 +170,4 @@ When building blueprints with user-facing data entry in the first action, sugges
 - **Consultative, not imperative** — ask before building, confirm before proceeding
 - **Credential awareness** — suggest VCs when workflow implies proof or attestation
 - **Instance references** — suggest `instanceReference` when Action 1 has identifying fields
+- **GDS-aligned structure** — for government services, use `x-pages` within the citizen action; new actions only when the sender changes

--- a/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
@@ -167,6 +167,100 @@ public class ChatOrchestrationService : IChatOrchestrationService
         - Use `/*` only when a participant genuinely needs to see everything
         - The sender of an action always needs `/*` on their own submitted data
         - Consider "need to know" — approvers may need summary, not details
+
+        ## GOV.UK / HMG Government Service Patterns
+
+        When a user describes a workflow for a UK government department, local authority, or public body, apply GOV.UK Design System (GDS) principles to the blueprint structure.
+
+        **Recognise government service patterns when the user mentions:**
+        - A council, department, agency, or public body receiving applications
+        - Citizens or members of the public submitting information
+        - Planning applications, licences, permits, grants, benefits, registrations
+        - Any service that would appear on GOV.UK or a local authority portal
+
+        ### Sorcha Actions vs GDS Pages — Critical Distinction
+
+        A Sorcha **Action** represents a complete signed submission by one participant (the `sender`). It is a handoff boundary — the moment data crosses from one party to another on the register. Actions are NOT individual form pages.
+
+        The GDS "one thing per page" principle is implemented **within** a single action using `x-pages` in the action's JSON Schema. Each entry in `x-pages` becomes one wizard page in the UI with its own Next/Back navigation. All pages in a single action are submitted together as one signed register transaction when the participant confirms.
+
+        **Rule: A new Action is only needed when the SENDER changes** — i.e., when a different participant takes over the workflow.
+
+        ### GDS One Thing Per Page → x-pages Within an Action
+
+        Model the citizen's entire application as a **single Action** (sender: Applicant) with an `x-pages` array in the action's JSON Schema. Each page covers one focused topic:
+
+        ```json
+        "x-pages": [
+          {
+            "title": "Eligibility",
+            "x-sections": [{ "title": "Check you're eligible", "fields": ["propertyOwner", "workType"] }]
+          },
+          {
+            "title": "About You",
+            "x-sections": [{ "title": "Your details", "fields": ["givenName", "familyName", "dateOfBirth"] }]
+          },
+          {
+            "title": "Site Address",
+            "x-sections": [{ "title": "Where is the site?", "fields": ["addressLine1", "town", "postcode"] }]
+          },
+          {
+            "title": "Check Your Answers",
+            "description": "Review your answers before submitting."
+          }
+        ]
+        ```
+
+        Use `x-sections` within a page to group related fields under a heading. The final page is conventionally titled "Check Your Answers" — the renderer uses this as a cue to show a summary before the participant signs and submits.
+
+        ### GDS Question Protocol
+
+        Before adding any data field, apply the question protocol — every field must have a clear justification:
+        - Who needs this information and why?
+        - What decision does it enable downstream?
+        - Could data already held by the organisation be used instead of asking again?
+
+        Prompt the user to think about this: "Is the national insurance number needed here, or can it be verified later in the process?" This aligns with UK GDPR data minimisation and the GDS principle of not collecting data you don't need.
+
+        ### Standard GOV.UK Service Journey — Blueprint Structure
+
+        **Action 1 — Application** (IsStartingAction: true, sender: Applicant)
+        - The citizen's complete submission — all question pages live here as `x-pages`
+        - First page: eligibility questions; routing on this action can route ineligible applicants to a terminal "Not Eligible" action
+        - Final page: "Check Your Answers" — no new fields, signals a summary view to the renderer
+        - Suggest `instanceReference` here — the generated reference becomes the citizen's application number
+
+        **Action 2 — Case Officer Review** (sender: CaseOfficer)
+        - A new action because a different participant is now acting
+        - Sees the full application; adds assessment notes and decision
+        - Routes to Approve, Reject, or Request Further Information
+
+        **Action 3a — Approved** (sender: CaseOfficer)
+        - Use `issue_credential` to produce a verifiable permit, licence, or certificate
+
+        **Action 3b — Rejected** (sender: CaseOfficer)
+        - Rejection reason field; routed to applicant for notification
+
+        **Action 3c — Further Information** (sender: CaseOfficer → routes back to Applicant)
+        - The applicant gets a second action (they are sender again) to respond
+        - This is a legitimate second Applicant action because it is a distinct submission event, not just another form page
+
+        ### Disclosure for Government Services
+
+        - Applicant sees all data they submitted (`/*` on their own action)
+        - Applicant does NOT see internal officer notes or decisions until a formal outcome is issued
+        - Case officer sees the complete application
+        - Consider a read-only "Public Register" participant for outcomes that should be publicly searchable (e.g., planning decisions, licence registers)
+
+        ### Credential Issuance for Government Outcomes
+
+        When a workflow results in a permit, licence, or certificate, always suggest `issue_credential`:
+        - "This approval could be issued as a Verifiable Credential — a cryptographically signed digital certificate in the applicant's wallet that third parties can verify without contacting you."
+        - Suitable types: `PlanningPermit`, `LicenceToOperate`, `RightToWork`, `InspectionCertificate`, `GrantApproval`
+
+        **Example conversation trigger:**
+        User: "I need a planning application process for our council"
+        You: "This is a classic GOV.UK-style service. The citizen fills in a single multi-page application — their details, site address, description of works, supporting documents — all collected across several wizard pages and submitted together as one signed action. I'd use `x-pages` in the schema to give it that step-by-step GDS feel. Then the planning officer gets a separate action to review and decide, and the approved outcome can be issued as a verifiable Planning Permit credential. Shall I work through the pages and fields with you before I build?"
         """;
 
     /// <summary>Initialises a new instance of the <see cref="ChatOrchestrationService"/> class.</summary>

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -7,7 +7,7 @@
 # Uses single-org model with admin token for all participants (simplified).
 
 param(
-    [ValidateSet('gateway', 'direct', 'aspire')]
+    [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
     [string]$Profile = 'gateway',
     [switch]$SkipHealthCheck
 )

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1469,13 +1469,26 @@ function New-SorchaOrganization {
         }
     } catch {
         $statusCode = $null
+        $responseBody = ""
         try { $statusCode = $_.Exception.Response.StatusCode.value__ } catch {}
+        try { $responseBody = $_.ErrorDetails.Message } catch {}
 
-        if ($statusCode -eq 409) {
+        # The tenant service rejects duplicate-creation attempts two different
+        # ways depending on which validator trips first: 409 Conflict if the
+        # org name/id collides, or 400 with InvalidSubdomain if the subdomain
+        # is already taken. Both mean "the org we wanted already exists" — in
+        # either case fall through to the list-and-match recovery path so
+        # setup.ps1 stays idempotent.
+        $looksLikeDuplicate = $statusCode -eq 409 `
+            -or ($statusCode -eq 400 -and $responseBody -match "InvalidSubdomain|already taken|already exists")
+
+        if ($looksLikeDuplicate) {
             Write-WtWarn "Organization '$Name' already exists — fetching"
-            # List orgs to find existing
+            # List orgs to find existing. The platform endpoint requires explicit
+            # pagination params (`page` and `pageSize` are mandatory), so pass a
+            # wide window rather than relying on server-side defaults.
             $orgs = Invoke-SorchaApi -Method GET `
-                -Uri "$TenantUrl/platform/organizations" `
+                -Uri "$TenantUrl/platform/organizations?page=1&pageSize=100" `
                 -Headers $Headers
             $existing = $orgs.items | Where-Object { $_.subdomain -eq $Subdomain } | Select-Object -First 1
             if ($existing) {
@@ -1485,7 +1498,7 @@ function New-SorchaOrganization {
                     AdminDirectlyAdded = $true
                 }
             }
-            throw "Organization '$Name' returned 409 but could not be found"
+            throw "Organization '$Name' looked like a duplicate but could not be found by subdomain"
         }
         throw
     }


### PR DESCRIPTION
Four changes that piled up while running walkthroughs against n1.sorcha.dev:

## 1. Blueprint Builder — GOV.UK / HMG service patterns
Teaches the AI blueprint builder to apply GDS conventions when a user describes a council / department / public-body workflow. New `GOV.UK / HMG Government Service Patterns` section added to both the embedded system prompt in `ChatOrchestrationService` and the docs/ai-prompts reference.

Key content:
- **Crucial distinction**: Sorcha Actions are handoff boundaries, not form pages. New action only when the **sender** changes.
- **One thing per page** via `x-pages` inside a single citizen action, with a final "Check Your Answers" page as the submission summary.
- **GDS question protocol** — every field justified; data minimisation.
- **Standard GOV.UK service journey**: citizen Application action → Case Officer review → Approve / Reject / Further Information branches → `issue_credential` on approval (`PlanningPermit`, `LicenceToOperate`, etc).
- **Disclosure rules** tuned for public services (applicant doesn't see officer notes until a formal outcome is issued).

## 2. `New-SorchaOrganization` — idempotency on 400 / InvalidSubdomain
The tenant service rejects duplicate org creation two ways depending on which validator trips first: 409 on id/name collision, or 400 with `InvalidSubdomain` on subdomain collision. The helper already handled 409 → list-and-match; now it also catches `400 + InvalidSubdomain|already taken` and falls through the same recovery path. Also fixes the list call to pass explicit `?page=1&pageSize=100` — `/platform/organizations` requires those query params, not optional. Without this, re-running a walkthrough setup against the same instance crashed mid-flow.

## 3. SelfBuildHouse setup — accept `-Profile n1`
Param ValidateSet only listed `gateway|direct|aspire`; added `n1` so the walkthrough can target the public host alongside the others.

## 4. Null-byte scrub
`docs/ai-prompts/blueprint-builder-system-prompt.md` and `ChatOrchestrationService.cs` both had a trailing run of literal NUL bytes (~3k and ~5.7k respectively) left behind by a prior editor pass. The C# compiler refused to build the service file: *"Unexpected character '\0\0\0...'"*. Stripped in the commit.

## Test plan
- [x] `dotnet build src/Services/Sorcha.Blueprint.Service` clean after scrub
- [x] SelfBuildHouse `setup.ps1 -Profile n1` runs end-to-end against n1
- [x] HaipIdentityAttestation `setup.ps1 -Profile n1 -Force` re-runs idempotently after org already exists (exercises the new 400 handler)
- [ ] Follow-up: 5-cycle walkthrough campaign currently running (CP, SBH, HAIP-ID, HAIP-Licence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)