### PR TITLE
chore: loosen PlatformAuth rate limit on n1 for walkthrough bursts

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -43,6 +43,13 @@ services:
       Fido2__ServerDomain: n1.sorcha.dev
       Fido2__ServerName: Sorcha
       Fido2__Origins__0: https://n1.sorcha.dev
+      # n1 is the shared dev/demo node. Walkthrough setup scripts create
+      # bursts of users in one run — 7 for SelfBuildHouse, 5 for ConstructionPermit.
+      # The baked-in 10/min PlatformAuth limit is brute-force protection for
+      # production and is inappropriate here, so loosen it. Other policies
+      # (TOTP, Strict) keep their production defaults.
+      RateLimiting__PlatformAuthPermitLimit: 500
+      RateLimiting__PlatformAuthQueueLimit: 100
 
   peer-service:
     image: sorchadev/peer-service:latest


### PR DESCRIPTION
n1 is a dev/demo node and walkthrough setup scripts create bursts of users in a single run (SelfBuildHouse: 7, ConstructionPermit: 5). The baked-in 10/min `PlatformAuth` rate limit is brute-force protection meant for production — inappropriate for the demo node and blocking every fresh walkthrough setup past the first few users. Raises to 500/min with a 100-deep queue. TOTP and Strict policies keep their production defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)