### PR TITLE
fix(SelfBuildHouse): rewrite as multi-org so wallets belong to their users

### DIFF
--- a/walkthroughs/SelfBuildHouse/run.ps1
+++ b/walkthroughs/SelfBuildHouse/run.ps1
@@ -30,6 +30,35 @@ $state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
 $wallets = @{}
 foreach ($prop in $state.wallets.PSObject.Properties) { $wallets[$prop.Name] = $prop.Value }
 
+# Convert roles PSObject to hashtable
+$roles = @{}
+foreach ($prop in $state.roles.PSObject.Properties) {
+    $r = $prop.Value
+    $roles[$prop.Name] = @{
+        email          = $r.email
+        password       = $r.password
+        organizationId = $r.organizationId
+        orgKey         = $r.orgKey
+        walletAddress  = $r.walletAddress
+    }
+}
+
+# Login each role up-front and cache per-role tokens. Every subsequent action
+# submission goes out under the sending role's own user token — NOT a shared
+# admin token — so the audit trail ties every transaction back to the real
+# user who performed it.
+Write-WtStep "Authenticating (per-role login)"
+$roleTokenCache = @{}
+foreach ($role in $roles.Keys) {
+    $r = $roles[$role]
+    $session = Connect-SorchaUser `
+        -TenantUrl $state.tenantUrl `
+        -Email $r.email `
+        -Password $r.password `
+        -OrganizationId $r.organizationId
+    $roleTokenCache[$role] = $session.Token
+}
+
 # Action-to-sender mapping for PLANNING PERMISSION blueprint
 $planningSenderMap = @{
     1 = "self-builder"
@@ -78,14 +107,20 @@ function Invoke-BlueprintScenario {
 
     Write-WtInfo "  Phase: $Phase (Blueprint: $BlueprintId)"
 
-    # Create instance
+    # Create the instance under the token of the first-action sender (the
+    # self-builder in both phases). That user's org becomes the tenant on
+    # the instance, and instance metadata reflects them — not the sysadmin.
+    $starterRole = $SenderMap[[int]$ExpectedPath[0]]
+    $starterToken = $roleTokenCache[$starterRole]
+    $starterOrgId = $roles[$starterRole].organizationId
+
     $instanceBody = @{
         blueprintId = $BlueprintId; registerId = $RegisterId
-        tenantId = $state.organizationId
+        tenantId = $starterOrgId
         metadata = @{ source = "walkthrough"; phase = $Phase }
     }
     $ir = Invoke-SorchaApi -Method POST -Uri "$($state.blueprintUrl)/instances/" -Body $instanceBody `
-        -Headers @{ Authorization = "Bearer $($state.adminToken)" } -ShowJson:$ShowJson
+        -Headers @{ Authorization = "Bearer $starterToken" } -ShowJson:$ShowJson
     $instanceId = $ir.id
     Write-WtSuccess "  Instance: $instanceId"
 
@@ -108,13 +143,18 @@ function Invoke-BlueprintScenario {
         $isLastAction = ($actionId -eq $ExpectedPath[-1])
         $isRejectionAction = $IsRejection -and $isLastAction
 
+        # Use the sender's own token — their user JWT — for this action so
+        # the signed submission matches the participant identity on the
+        # register.
+        $senderToken = $roleTokenCache[$sender]
+
         try {
             if ($isRejectionAction) {
                 $null = Invoke-SorchaAction `
                     -BlueprintUrl $state.blueprintUrl -InstanceId $instanceId `
                     -ActionId $actionIdStr -BlueprintId $BlueprintId `
                     -SenderWallet $senderWallet -RegisterId $RegisterId `
-                    -Token $state.adminToken `
+                    -Token $senderToken `
                     -Reject -RejectionReason $RejectionReason
                 Write-WtWarn "    Action $actionIdStr ($sender) -> REJECTED"
             } else {
@@ -128,7 +168,7 @@ function Invoke-BlueprintScenario {
                     -BlueprintUrl $state.blueprintUrl -InstanceId $instanceId `
                     -ActionId $actionIdStr -BlueprintId $BlueprintId `
                     -SenderWallet $senderWallet -RegisterId $RegisterId `
-                    -Token $state.adminToken -PayloadData $payloadData `
+                    -Token $senderToken -PayloadData $payloadData `
                     -CredentialPresentations $presentations
 
                 Write-WtSuccess "    Action $actionIdStr ($sender) -> OK"
@@ -182,13 +222,17 @@ foreach ($sid in $scenariosToRun) {
     if ($planningResult.Passed -and -not $isRejection -and $scenarioData.expectedWarrantPath) {
         $warrantPath = @($scenarioData.expectedWarrantPath)
 
-        # Lazy credential fetcher: pulls the correct VC just-in-time per action.
-        # Action 1 needs PlanningPermissionCredential; actions 5-7 (staged inspections)
-        # need BuildingWarrantCredential, which isn't issued until warrant action 4
-        # completes — so fetch-on-demand instead of up-front.
+        # Lazy credential fetcher: pulls the correct VC just-in-time per
+        # action. Action 1 needs PlanningPermissionCredential; actions 5-7
+        # (staged inspections) need BuildingWarrantCredential, which isn't
+        # issued until warrant action 4 completes — so fetch on demand
+        # rather than up-front.
+        # The credentials are held in the self-builder's wallet, so we hit
+        # the wallet API with the self-builder's own token rather than a
+        # shared admin token. Authorisation stays scoped to the holder.
         $selfBuilderWallet = $wallets["self-builder"]
         $walletUrl = $state.walletUrl
-        $adminToken = $state.adminToken
+        $selfBuilderToken = $roleTokenCache["self-builder"]
         $warrantFetcher = {
             param($actionId)
             $aid = [int]$actionId
@@ -196,13 +240,13 @@ foreach ($sid in $scenariosToRun) {
                 $p = Get-SorchaCredentialPresentation -WalletUrl $walletUrl `
                     -WalletAddress $selfBuilderWallet `
                     -CredentialType "PlanningPermissionCredential" `
-                    -Token $adminToken
+                    -Token $selfBuilderToken
                 if ($p) { return @($p) }
             } elseif ($aid -ge 5) {
                 $p = Get-SorchaCredentialPresentation -WalletUrl $walletUrl `
                     -WalletAddress $selfBuilderWallet `
                     -CredentialType "BuildingWarrantCredential" `
-                    -Token $adminToken
+                    -Token $selfBuilderToken
                 if ($p) { return @($p) }
             }
             return $null

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -1,15 +1,32 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
-# SelfBuildHouse — Setup
-# Bootstrap org, create 7 wallets, 2 registers, publish 2 blueprints.
-# Uses single-org model with admin token for all participants (simplified).
+# SelfBuildHouse — Setup (Multi-Org)
+# Creates 5 private orgs + 1 public-org citizen, 7 users, 7 wallets,
+# 2 registers, and publishes the planning permission + building warrant
+# blueprints.
+#
+# Each role's wallet is created under that role's own user token, so the
+# wallets belong to the people they represent — nothing pollutes the
+# sysadmin's wallet list.
+#
+# Organisations (5 private + public):
+#   1. (Public Org)                          — self-builder (citizen)
+#   2. Highland Council — Planning           — planning-officer (admin)
+#   3. Highland Council — Building Standards — building-standards-officer (admin)
+#                                            + building-inspector (team)
+#   4. Scottish Water                         — utilities-officer (admin)
+#   5. MacGregor Structural Engineers         — structural-engineer (admin)
+#   6. Glen Ecology Consultants               — ecologist (admin)
+#
+# Follows the ConstructionPermit multi-org setup pattern exactly.
 
 param(
     [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
     [string]$Profile = 'gateway',
-    [switch]$SkipHealthCheck
+    [switch]$SkipHealthCheck,
+    [switch]$Force
 )
 
 $ErrorActionPreference = "Stop"
@@ -17,102 +34,291 @@ $ErrorActionPreference = "Stop"
 $modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
 Import-Module $modulePath -Force
 
-Write-WtBanner "SelfBuildHouse — Setup"
+Write-WtBanner "SelfBuildHouse — Multi-Org Setup"
 
 $secrets = Get-SorchaSecrets -WalkthroughName "self-build-house"
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
-# Step 1: Bootstrap primary org
-Write-WtStep "Step 1: Bootstrap Organisation"
-$admin = Connect-SorchaAdmin `
-    -TenantUrl $env.TenantUrl `
-    -OrgName "Highland Council" `
-    -OrgSubdomain "highland-council" `
-    -AdminEmail $secrets.highlandAdminEmail `
-    -AdminName "Planning Admin" `
-    -AdminPassword $secrets.highlandAdminPassword
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
 
-# Step 2: Create wallets for all 7 participants across 6 organisations
-Write-WtStep "Step 2: Create Wallets (7 participants)"
-$wallets = @{}
-$participantDefs = @(
-    @{ id = "self-builder"; name = "Self-Builder Wallet" }
-    @{ id = "structural-engineer"; name = "Structural Engineer Wallet" }
-    @{ id = "ecologist"; name = "Ecologist Wallet" }
-    @{ id = "utilities-officer"; name = "Scottish Water Wallet" }
-    @{ id = "planning-officer"; name = "Planning Officer Wallet" }
-    @{ id = "building-standards-officer"; name = "Building Standards Officer Wallet" }
-    @{ id = "building-inspector"; name = "Building Inspector Wallet" }
+# Well-known public org ID (created by DatabaseInitializer)
+$publicOrgId = "00000000-0000-0000-0000-000000000002"
+
+# ============================================================================
+# Definitions
+# ============================================================================
+
+$orgDefs = @(
+    @{ name = "Highland Council — Planning";           subdomain = "highland-planning"; desc = "Planning authority";                      adminRole = "planning-officer" }
+    @{ name = "Highland Council — Building Standards"; subdomain = "highland-bs";       desc = "Building control & standards";            adminRole = "building-standards-officer" }
+    @{ name = "Scottish Water";                         subdomain = "scottish-water";   desc = "Water & drainage consultee";              adminRole = "utilities-officer" }
+    @{ name = "MacGregor Structural Engineers";         subdomain = "macgregor";        desc = "Structural engineering consultancy";       adminRole = "structural-engineer" }
+    @{ name = "Glen Ecology Consultants";               subdomain = "glen-ecology";     desc = "Ecology, habitat, and species surveys";    adminRole = "ecologist" }
 )
 
-foreach ($p in $participantDefs) {
-    $w = New-SorchaWallet -WalletUrl $env.WalletUrl -Name $p.name -Headers $admin.Headers -FetchPublicKey
-    $wallets[$p.id] = $w.Address
-    Write-WtInfo "  $($p.id) -> $($w.Address)"
+$userDefs = @(
+    # Self-builder is a citizen — lives in the Public Org, not a private org admin.
+    @{ role = "self-builder";               org = "public";          email = $secrets.selfBuilderEmail;      password = $secrets.selfBuilderPassword;      name = $secrets.selfBuilderName;         isOrgAdmin = $false; isCitizen = $true }
+    @{ role = "planning-officer";           org = "highland-planning"; email = $secrets.planningEmail;       password = $secrets.planningPassword;         name = $secrets.planningName;            isOrgAdmin = $true }
+    @{ role = "building-standards-officer"; org = "highland-bs";     email = $secrets.buildingStandardsEmail; password = $secrets.buildingStandardsPassword; name = $secrets.buildingStandardsName;  isOrgAdmin = $true }
+    @{ role = "building-inspector";         org = "highland-bs";     email = $secrets.buildingInspectorEmail; password = $secrets.buildingInspectorPassword; name = $secrets.buildingInspectorName;  isOrgAdmin = $false }
+    @{ role = "utilities-officer";          org = "scottish-water";  email = $secrets.utilitiesEmail;        password = $secrets.utilitiesPassword;        name = $secrets.utilitiesName;           isOrgAdmin = $true }
+    @{ role = "structural-engineer";        org = "macgregor";       email = $secrets.structuralEmail;       password = $secrets.structuralPassword;       name = $secrets.structuralName;          isOrgAdmin = $true }
+    @{ role = "ecologist";                  org = "glen-ecology";    email = $secrets.ecologistEmail;        password = $secrets.ecologistPassword;        name = $secrets.ecologistName;           isOrgAdmin = $true }
+)
+
+# ============================================================================
+# Step 1: Login as System Admin
+# ============================================================================
+Write-WtStep "Step 1: Login as System Admin"
+$sysAdmin = Connect-SorchaAdmin `
+    -TenantUrl $env.TenantUrl `
+    -AdminEmail $secrets.adminEmail `
+    -AdminPassword $secrets.adminPassword
+
+# ============================================================================
+# Step 2: Enable Public Org (required for user self-registration)
+# ============================================================================
+Write-WtStep "Step 2: Enable Public Org"
+Invoke-SorchaApi -Method PUT `
+    -Uri "$($env.TenantUrl)/platform/settings/public-org" `
+    -Body @{ enabled = $true } `
+    -Headers $sysAdmin.Headers
+Write-WtInfo "  Public org enabled for self-registration"
+
+# ============================================================================
+# Step 3: Register ALL users on the public org (creates PlatformUser records)
+# ============================================================================
+Write-WtStep "Step 3: Register Users (public org — creates PlatformUser records)"
+
+foreach ($u in $userDefs) {
+    Register-SorchaPublicUser `
+        -TenantUrl $env.TenantUrl `
+        -Email $u.email `
+        -Password $u.password `
+        -DisplayName $u.name | Out-Null
+    Write-WtInfo "  $($u.role) -> $($u.email)"
 }
 
-# Step 3: Register participant + link primary wallet
-Write-WtStep "Step 3: Register Participant"
-$participant = Register-SorchaParticipant `
-    -TenantUrl $env.TenantUrl -WalletUrl $env.WalletUrl `
-    -OrganizationId $admin.OrganizationId `
-    -WalletAddress $wallets["self-builder"] `
-    -DisplayName "Self-Builder" `
-    -Headers $admin.Headers
+# ============================================================================
+# Step 4: Verify Everyone's Email (admin override — bypasses SMTP)
+# ============================================================================
+Write-WtStep "Step 4: Verify User Emails (admin override)"
 
-# Step 4: Create TWO registers (planning + building standards)
-Write-WtStep "Step 4: Create Registers (2)"
+$publicUsers = Invoke-SorchaApi -Method GET `
+    -Uri "$($env.TenantUrl)/organizations/$publicOrgId/users?includeInactive=true" `
+    -Headers $sysAdmin.Headers
+
+foreach ($u in $userDefs) {
+    $publicUser = $publicUsers.users | Where-Object { $_.email -eq $u.email } | Select-Object -First 1
+    if ($publicUser) {
+        Confirm-SorchaUserEmail `
+            -TenantUrl $env.TenantUrl `
+            -OrganizationId $publicOrgId `
+            -UserId $publicUser.id `
+            -Headers $sysAdmin.Headers
+    } else {
+        Write-WtWarn "  User $($u.email) not found in public org"
+    }
+}
+
+# ============================================================================
+# Step 5: Create 5 Private Organizations (with verified org-admin emails)
+# ============================================================================
+Write-WtStep "Step 5: Create Organizations (5)"
+
+$orgs = @{}
+foreach ($def in $orgDefs) {
+    $adminUser = $userDefs | Where-Object { $_.role -eq $def.adminRole } | Select-Object -First 1
+    $result = New-SorchaOrganization `
+        -TenantUrl $env.TenantUrl `
+        -Name $def.name `
+        -Subdomain $def.subdomain `
+        -AdminEmail $adminUser.email `
+        -Headers $sysAdmin.Headers `
+        -Description $def.desc
+    $orgs[$def.subdomain] = $result.OrganizationId
+    Write-WtInfo "  $($def.subdomain): $($result.OrganizationId) (admin: $($adminUser.email))"
+}
+
+# Self-builder lives on the public org — its org id is the well-known public one.
+$orgs["public"] = $publicOrgId
+
+# ============================================================================
+# Step 6: Add Team Members (non-admin users) to Their Target Orgs
+# ============================================================================
+Write-WtStep "Step 6: Add Team Members"
+
+# Non-admin, non-citizen users need to be added to their target private org by
+# the sysadmin. Today that's just the building-inspector sharing Highland BS.
+$teamMembers = $userDefs | Where-Object { -not $_.isOrgAdmin -and -not $_.isCitizen }
+foreach ($u in $teamMembers) {
+    $orgId = $orgs[$u.org]
+    Get-OrCreateUser `
+        -TenantUrl $env.TenantUrl `
+        -OrganizationId $orgId `
+        -Email $u.email `
+        -DisplayName $u.name `
+        -Headers $sysAdmin.Headers `
+        -Roles @("Administrator", "Consumer") | Out-Null
+    Write-WtInfo "  $($u.role) ($($u.email)) -> $($u.org)"
+}
+
+# ============================================================================
+# Step 7: Per-Role Setup (login, wallet, participant, wallet-link)
+# ============================================================================
+Write-WtStep "Step 7: Per-Role Setup (each user creates their own wallet)"
+
+$users = @{}   # role -> { email, password, organizationId, walletAddress, orgKey }
+$wallets = @{} # role -> wallet address
+$sessionCache = @{}
+
+foreach ($u in $userDefs) {
+    $orgKey = $u.org
+    $orgId = $orgs[$orgKey]
+    Write-WtInfo "--- $($u.role) ($($u.name)) in $orgKey ---"
+
+    # Login as this user and select their target org (two-step auth flow).
+    $cacheKey = "$($u.email)|$orgId"
+    if ($sessionCache.ContainsKey($cacheKey)) {
+        $userSession = $sessionCache[$cacheKey]
+        Write-WtInfo "  (cached session)"
+    } else {
+        $userSession = Connect-SorchaUser `
+            -TenantUrl $env.TenantUrl `
+            -Email $u.email `
+            -Password $u.password `
+            -OrganizationId $orgId
+        $sessionCache[$cacheKey] = $userSession
+    }
+
+    # Create wallet under THIS user's token — wallet ownership is scoped to
+    # the caller, so creating it here puts it in this user's wallet list.
+    $wallet = New-SorchaWallet `
+        -WalletUrl $env.WalletUrl `
+        -Name "$($u.name) Wallet" `
+        -Headers $userSession.Headers `
+        -FetchPublicKey
+    $wallets[$u.role] = $wallet.Address
+    Write-WtInfo "  wallet: $($wallet.Address)"
+
+    # Register participant + link wallet in the user's org.
+    $null = Register-SorchaParticipant `
+        -TenantUrl $env.TenantUrl `
+        -WalletUrl $env.WalletUrl `
+        -OrganizationId $orgId `
+        -WalletAddress $wallet.Address `
+        -DisplayName $u.name `
+        -Headers $userSession.Headers
+
+    $users[$u.role] = @{
+        email          = $u.email
+        password       = $u.password
+        organizationId = $orgId
+        orgKey         = $orgKey
+        walletAddress  = $wallet.Address
+    }
+}
+
+# ============================================================================
+# Step 8: Create Registers (2) — owned by the appropriate council officers
+# ============================================================================
+Write-WtStep "Step 8: Create Registers (2)"
+
+# Planning register is owned by Highland Council — Planning (planning-officer).
+# Build the headers/user-id/wallet from the planning-officer's session so the
+# register is created under that user and their org is subscribed as Owner.
+$planningSession = $sessionCache["$($users['planning-officer'].email)|$($users['planning-officer'].organizationId)"]
+$planningOfficerJwt = Decode-SorchaJwt -Token $planningSession.Token
+$planningOwnerUserId = $planningOfficerJwt.sub
 
 Write-WtInfo "  Creating Highland Planning Register..."
 $planningRegister = New-SorchaRegister `
     -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl -TenantUrl $env.TenantUrl `
     -Name "Highland Planning Register" `
     -Description "Planning applications, consultations, and decisions for the Highland Council area" `
-    -TenantId $admin.OrganizationId `
-    -OwnerUserId $admin.AdminUserId `
-    -OwnerWalletAddress $wallets["planning-officer"] `
-    -Headers $admin.Headers `
+    -TenantId $users["planning-officer"].organizationId `
+    -OwnerUserId $planningOwnerUserId `
+    -OwnerWalletAddress $users["planning-officer"].walletAddress `
+    -Headers $planningSession.Headers `
     -Metadata @{ createdBy = "SelfBuildHouse/setup.ps1"; registerType = "planning" }
 Write-WtSuccess "  Planning Register: $($planningRegister.RegisterId)"
+
+# Building Standards register is owned by Highland Council — Building Standards
+# (building-standards-officer).
+$bsSession = $sessionCache["$($users['building-standards-officer'].email)|$($users['building-standards-officer'].organizationId)"]
+$bsOfficerJwt = Decode-SorchaJwt -Token $bsSession.Token
+$bsOwnerUserId = $bsOfficerJwt.sub
 
 Write-WtInfo "  Creating Highland Building Standards Register..."
 $buildingRegister = New-SorchaRegister `
     -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl -TenantUrl $env.TenantUrl `
     -Name "Highland Building Standards Register" `
     -Description "Building warrants, staged inspections, and completion certificates for the Highland Council area" `
-    -TenantId $admin.OrganizationId `
-    -OwnerUserId $admin.AdminUserId `
-    -OwnerWalletAddress $wallets["building-standards-officer"] `
-    -Headers $admin.Headers `
+    -TenantId $users["building-standards-officer"].organizationId `
+    -OwnerUserId $bsOwnerUserId `
+    -OwnerWalletAddress $users["building-standards-officer"].walletAddress `
+    -Headers $bsSession.Headers `
     -Metadata @{ createdBy = "SelfBuildHouse/setup.ps1"; registerType = "building-standards" }
 Write-WtSuccess "  Building Standards Register: $($buildingRegister.RegisterId)"
 
-# Public org subscription so consumer users see both registers in their list.
-# The Connect-SorchaAdmin call used the seed sysadmin, which carries the
-# SystemAdmin role — so it can add itself to the Public org and subscribe.
-$null = Add-SorchaPublicOrgSubscription `
-    -TenantUrl $env.TenantUrl `
-    -RegisterId $planningRegister.RegisterId `
-    -RegisterName "Highland Planning Register" `
-    -SysAdminHeaders $admin.Headers `
-    -SysAdminEmail $secrets.highlandAdminEmail
-$null = Add-SorchaPublicOrgSubscription `
-    -TenantUrl $env.TenantUrl `
-    -RegisterId $buildingRegister.RegisterId `
-    -RegisterName "Highland Building Standards Register" `
-    -SysAdminHeaders $admin.Headers `
-    -SysAdminEmail $secrets.highlandAdminEmail
+# ============================================================================
+# Step 9: Cross-Org Subscriptions — every org that participates in either
+# workflow must be subscribed to both registers so their members can see
+# the transactions they're expected to act on.
+# ============================================================================
+Write-WtStep "Step 9: Subscribe Participating Orgs to Both Registers"
 
-# Step 5: Publish TWO blueprints
-Write-WtStep "Step 5: Publish Blueprints (2)"
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$privateOrgKeys = $orgDefs | ForEach-Object { $_.subdomain }
+
+foreach ($orgKey in $privateOrgKeys) {
+    $orgId = $orgs[$orgKey]
+
+    # Skip owners — they already have Owner subscriptions from finalize.
+    $isPlanningOwner = ($orgKey -eq "highland-planning")
+    $isBuildingOwner = ($orgKey -eq "highland-bs")
+
+    if (-not $isPlanningOwner) {
+        try {
+            $null = New-SorchaRegisterSubscription `
+                -TenantUrl $env.TenantUrl `
+                -OrganizationId $orgId `
+                -RegisterId $planningRegister.RegisterId `
+                -RegisterName "Highland Planning Register" `
+                -SubscriptionType "Public" `
+                -Headers $sysAdmin.Headers
+        } catch {
+            Write-WtWarn "  $orgKey -> Planning Register subscribe failed: $($_.Exception.Message)"
+        }
+    }
+
+    if (-not $isBuildingOwner) {
+        try {
+            $null = New-SorchaRegisterSubscription `
+                -TenantUrl $env.TenantUrl `
+                -OrganizationId $orgId `
+                -RegisterId $buildingRegister.RegisterId `
+                -RegisterName "Highland Building Standards Register" `
+                -SubscriptionType "Public" `
+                -Headers $sysAdmin.Headers
+        } catch {
+            Write-WtWarn "  $orgKey -> Building Register subscribe failed: $($_.Exception.Message)"
+        }
+    }
+}
+
+# ============================================================================
+# Step 10: Publish Blueprints (planning + warrant)
+# ============================================================================
+Write-WtStep "Step 10: Publish Blueprints (2)"
 
 Write-WtInfo "  Publishing Planning Permission blueprint..."
 $planningBlueprint = Publish-SorchaBlueprint `
     -BlueprintUrl $env.BlueprintUrl `
     -TemplatePath (Join-Path $scriptDir "planning-permission-template.json") `
     -WalletMap $wallets `
-    -Headers $admin.Headers `
+    -Headers $planningSession.Headers `
     -IdPrefix "self-build-planning" `
     -RegisterId $planningRegister.RegisterId
 Write-WtSuccess "  Planning Blueprint: $($planningBlueprint.BlueprintId)"
@@ -122,27 +328,30 @@ $warrantBlueprint = Publish-SorchaBlueprint `
     -BlueprintUrl $env.BlueprintUrl `
     -TemplatePath (Join-Path $scriptDir "building-warrant-template.json") `
     -WalletMap $wallets `
-    -Headers $admin.Headers `
+    -Headers $bsSession.Headers `
     -IdPrefix "self-build-warrant" `
     -RegisterId $buildingRegister.RegisterId
 Write-WtSuccess "  Warrant Blueprint: $($warrantBlueprint.BlueprintId)"
 
-# Save state
+# ============================================================================
+# Save State
+# ============================================================================
 $state = @{
-    profile                = $Profile
-    organizationId         = $admin.OrganizationId
-    adminToken             = $admin.Token
-    wallets                = $wallets
-    planningRegisterId     = $planningRegister.RegisterId
-    buildingRegisterId     = $buildingRegister.RegisterId
-    planningBlueprintId    = $planningBlueprint.BlueprintId
-    warrantBlueprintId     = $warrantBlueprint.BlueprintId
-    blueprintUrl           = $env.BlueprintUrl
-    walletUrl              = $env.WalletUrl
+    profile             = $Profile
+    tenantUrl           = $env.TenantUrl
+    blueprintUrl        = $env.BlueprintUrl
+    registerUrl         = $env.RegisterUrl
+    walletUrl           = $env.WalletUrl
+    organizations       = $orgs
+    roles               = $users
+    wallets             = $wallets
+    planningRegisterId  = $planningRegister.RegisterId
+    buildingRegisterId  = $buildingRegister.RegisterId
+    planningBlueprintId = $planningBlueprint.BlueprintId
+    warrantBlueprintId  = $warrantBlueprint.BlueprintId
 }
 
-$stateFile = Join-Path $scriptDir "state.json"
 $state | ConvertTo-Json -Depth 5 | Set-Content -Path $stateFile -Encoding UTF8
 
-Write-WtSuccess "Setup complete — 7 wallets, 2 registers, 2 blueprints published"
+Write-WtSuccess "Setup complete — 5 private orgs + public org, 7 users, 7 wallets, 2 registers, 2 blueprints"
 Write-WtInfo "Run: pwsh walkthroughs/SelfBuildHouse/run.ps1"


### PR DESCRIPTION
## Problem
Logging into n1 as sysadmin and opening the wallet list returned seven wallets that should belong to seven different people: Self-Builder, Planning Officer, Ecologist, Structural Engineer, Utilities Officer, Building Standards Officer, Building Inspector.

SelfBuildHouse was the only walkthrough using "single-org delegation" — a comment in its old setup.ps1 read _"single-org model with admin token for all participants (simplified)"_. Every wallet creation call, register creation, blueprint publish, and action submission used the sysadmin token. The register audit trail pointed all transactions back to the sysadmin as well.

ConstructionPermit, HAIP Identity, and HAIP Driving Licence were already multi-org-correct — only SBH had this pattern.

## Fix
Rewrite `setup.ps1` and `run.ps1` to mirror the ConstructionPermit multi-org pattern.

### setup.ps1 — new 10-step flow
1. Login as sysadmin
2. Enable public org
3. Register 7 users on the public org (creates PlatformUser records)
4. Admin-confirm every email (bypass SMTP)
5. Create 5 private orgs with verified org-admin emails:
   - **Highland Council — Planning** (planning-officer)
   - **Highland Council — Building Standards** (building-standards-officer)
   - **Scottish Water** (utilities-officer)
   - **MacGregor Structural Engineers** (structural-engineer)
   - **Glen Ecology Consultants** (ecologist)
   - Self-builder stays a citizen on the Public Org
6. Add building-inspector as a team member of Highland BS (shared org)
7. **Per-role: log in as that user, create their wallet under THEIR token**, register participant + link wallet in their org
8. Create Planning + Building Standards registers under the appropriate council officers — registers now actually owned by the teams that administer them
9. Cross-subscribe every participating private org to both registers so team members can see the transactions they need to act on
10. Publish planning + warrant blueprints under the appropriate officer tokens

### run.ps1 — per-role tokens
- Cache a per-role token at the top (one `Connect-SorchaUser` per role)
- Instance creation uses the first-action sender's token (self-builder)
- **Every action submission uses the sending role's own user token**, not a shared admin token
- Credential-fetch closure hits the wallet API with the self-builder's own token (they're the holder)

## Visible behaviour change
Logging in as sysadmin on n1 and opening the wallet list no longer shows seven walkthrough wallets. Each participant now holds their own wallet.

## Test plan
- [ ] `setup.ps1 -Profile n1` creates 7 users across 5 private orgs + public org, with wallets correctly scoped
- [ ] Sysadmin's wallet list on n1 is clean
- [ ] Each role's wallet list shows exactly their role wallet
- [ ] 5-cycle campaign: A/B/C scenarios all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)