### PR TITLE
fix: exclude soft-deleted wallets from the owner list query

### DIFF
--- a/src/Core/Sorcha.Wallet.Core/Repositories/EfCoreWalletRepository.cs
+++ b/src/Core/Sorcha.Wallet.Core/Repositories/EfCoreWalletRepository.cs
@@ -140,9 +140,15 @@ public class EfCoreWalletRepository : IWalletRepository
 
         _logger.LogDebug("Getting wallets for owner {Owner} in tenant {Tenant}", owner, tenant);
 
+        // Exclude soft-deleted wallets from the owner listing — DeleteWalletAsync
+        // flips Status to Deleted but the row is kept for audit. Including it
+        // here leaks tombstones into every wallet UI indefinitely. If an admin
+        // ever needs to see deleted wallets for forensics, add a separate
+        // flag-gated query rather than expanding this default view.
         var wallets = await _context.Wallets
             .AsNoTracking()
-            .Where(w => w.Owner == owner && w.Tenant == tenant)
+            .Where(w => w.Owner == owner && w.Tenant == tenant
+                && w.Status != Domain.WalletStatus.Deleted)
             .OrderByDescending(w => w.CreatedAt)
             .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
`DeleteWalletAsync` flips `Status = Deleted` and keeps the row for audit. The owner-list query at the repo layer didn't filter on status, so every wallet UI, CLI listing, and `/api/wallet/wallets` call showed deleted wallets mixed in with live ones forever.

Spotted during n1 cleanup after the SelfBuildHouse multi-org fix — seven orphan wallets from earlier single-admin SBH runs had been DELETE'd successfully (status = Deleted in the database) but kept appearing at the top of the sysadmin's wallet list.

Single-line fix in `EfCoreWalletRepository.GetByOwnerAsync`: add `&& w.Status != Domain.WalletStatus.Deleted`. If an admin ever needs to see deleted wallets for forensics, add a separate flag-gated query rather than expanding this default view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)