### PR TITLE
fix(UI): surface real action-execution errors + restore Blazor scoped-CSS bundle under /app

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Workflows/NewSubmissionDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Workflows/NewSubmissionDialog.razor
@@ -164,11 +164,19 @@
             };
 
             var result = await WorkflowService.SubmitActionExecuteAsync(request);
-            if (result == null)
+            if (result is null || result.IsFailure)
             {
-                // Partial success: instance created but action failed
                 _submitting = false;
-                _loadError = $"Instance created ({instance.InstanceId[..Math.Min(8, instance.InstanceId.Length)]}...) but action execution failed. The action will appear in your Pending Actions.";
+                var instanceShort = instance.InstanceId[..Math.Min(8, instance.InstanceId.Length)];
+                if (result?.ErrorMessage is { Length: > 0 } message)
+                {
+                    var statusBit = result.ErrorStatusCode is > 0 ? $" ({result.ErrorStatusCode})" : string.Empty;
+                    _loadError = $"Instance created ({instanceShort}...) but action execution was rejected{statusBit}: {message}";
+                }
+                else
+                {
+                    _loadError = $"Instance created ({instanceShort}...) but action execution failed (no response from server).";
+                }
                 StateHasChanged();
                 return;
             }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Workflows/ActionSubmissionResultViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Workflows/ActionSubmissionResultViewModel.cs
@@ -5,7 +5,12 @@ namespace Sorcha.UI.Core.Models.Workflows;
 
 /// <summary>
 /// Result view model from submitting an action execution.
-/// Maps to ActionSubmissionResponse from the Blueprint Service.
+/// Maps to ActionSubmissionResponse from the Blueprint Service. When the
+/// blueprint service returns a non-success status code the WorkflowService
+/// returns an instance with <see cref="ErrorMessage"/> populated and
+/// <see cref="IsFailure"/> = true so the calling UI can show the actual
+/// server error rather than a generic "will appear in pending actions"
+/// message.
 /// </summary>
 public record ActionSubmissionResultViewModel
 {
@@ -14,6 +19,24 @@ public record ActionSubmissionResultViewModel
     public bool IsComplete { get; init; }
     public List<NextActionInfo>? NextActions { get; init; }
     public List<string>? Warnings { get; init; }
+
+    /// <summary>
+    /// Server-supplied error message when the submission was rejected with
+    /// a non-success status code. Null on success.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// HTTP status code returned by the blueprint service when submission
+    /// failed. Null on success.
+    /// </summary>
+    public int? ErrorStatusCode { get; init; }
+
+    /// <summary>
+    /// True when the blueprint service rejected the submission. Mutually
+    /// exclusive with a populated <see cref="TransactionId"/>.
+    /// </summary>
+    public bool IsFailure => ErrorMessage is not null;
 
     /// <summary>
     /// Operation ID for async encryption tracking. Null for synchronous operations.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
@@ -198,7 +198,19 @@ public class WorkflowService : IWorkflowService
             {
                 _logger.LogWarning("Failed to execute action {ActionId} on instance {InstanceId}: {StatusCode}",
                     request.ActionId, request.InstanceId, response.StatusCode);
-                return null;
+
+                // Read the body so the caller can show the real reason
+                // (sender wallet mismatch, schema validation, credential
+                // requirement not met, etc) rather than a generic "appears in
+                // pending actions" message that's almost always wrong for
+                // hard errors.
+                var errorMessage = await ReadServerErrorAsync(response, cancellationToken);
+                return new ActionSubmissionResultViewModel
+                {
+                    InstanceId = request.InstanceId,
+                    ErrorMessage = errorMessage,
+                    ErrorStatusCode = (int)response.StatusCode
+                };
             }
 
             return await response.Content.ReadFromJsonAsync<ActionSubmissionResultViewModel>(cancellationToken: cancellationToken);
@@ -206,7 +218,85 @@ public class WorkflowService : IWorkflowService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error executing action {ActionId} on instance {InstanceId}", request.ActionId, request.InstanceId);
-            return null;
+            return new ActionSubmissionResultViewModel
+            {
+                InstanceId = request.InstanceId,
+                ErrorMessage = ex.Message,
+                ErrorStatusCode = 0
+            };
+        }
+    }
+
+    /// <summary>
+    /// Best-effort extraction of a human-readable error from a non-success
+    /// response. Tries Problem Details first, then a generic { errors }
+    /// shape from FluentValidation, then the raw body.
+    /// </summary>
+    private static async Task<string> ReadServerErrorAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var raw = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}".Trim();
+            }
+
+            // RFC 7807 Problem Details
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(raw);
+                if (doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object)
+                {
+                    if (doc.RootElement.TryGetProperty("detail", out var detail) &&
+                        detail.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        var s = detail.GetString();
+                        if (!string.IsNullOrWhiteSpace(s)) return s!;
+                    }
+
+                    if (doc.RootElement.TryGetProperty("errors", out var errors) &&
+                        errors.ValueKind == System.Text.Json.JsonValueKind.Array &&
+                        errors.GetArrayLength() > 0)
+                    {
+                        var first = errors[0];
+                        if (first.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            return first.GetString() ?? raw;
+                        }
+                        if (first.TryGetProperty("message", out var msg) &&
+                            msg.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            return msg.GetString() ?? raw;
+                        }
+                    }
+
+                    if (doc.RootElement.TryGetProperty("error", out var err))
+                    {
+                        if (err.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            return err.GetString() ?? raw;
+                        }
+                    }
+
+                    if (doc.RootElement.TryGetProperty("title", out var title) &&
+                        title.ValueKind == System.Text.Json.JsonValueKind.String)
+                    {
+                        return title.GetString() ?? raw;
+                    }
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // Not JSON — fall through and return the raw body.
+            }
+
+            // Truncate very long bodies so the toast/banner stays readable.
+            return raw.Length > 600 ? raw.Substring(0, 600) + "…" : raw;
+        }
+        catch (Exception)
+        {
+            return $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}".Trim();
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
@@ -174,11 +174,20 @@
             };
 
             var result = await WorkflowService.SubmitActionExecuteAsync(request);
-            if (result is null)
+            if (result is null || result.IsFailure)
             {
-                _workspace?.SetError(
-                    $"Instance created ({instance.InstanceId[..Math.Min(8, instance.InstanceId.Length)]}...) " +
-                    "but action execution failed. The action will appear in your Pending Actions.");
+                var instanceShort = instance.InstanceId[..Math.Min(8, instance.InstanceId.Length)];
+                if (result?.ErrorMessage is { Length: > 0 } errorMessage)
+                {
+                    var statusBit = result.ErrorStatusCode is > 0 ? $" ({result.ErrorStatusCode})" : string.Empty;
+                    _workspace?.SetError(
+                        $"Instance created ({instanceShort}...) but action execution was rejected{statusBit}: {errorMessage}");
+                }
+                else
+                {
+                    _workspace?.SetError(
+                        $"Instance created ({instanceShort}...) but action execution failed (no response from server).");
+                }
                 return;
             }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/Program.cs
@@ -95,11 +95,20 @@ app.Use(async (context, next) =>
     await next();
 });
 
-// URL rewriting: map /app/* to root for static web assets
+// URL rewriting: map /app/* to root for static web assets.
+// The Blazor WASM client (Sorcha.UI.Web.Client) is served under /app/ while
+// the marketing landing page lives at /. Files like the framework bundle,
+// scoped-CSS bundles, and content assets all live in wwwroot/, but the
+// browser requests them with the /app/ prefix. Each rewrite maps a
+// browser-visible /app/<path> back to the on-disk wwwroot/<path>.
 var rewriteOptions = new RewriteOptions()
     .AddRewrite(@"^app/_framework/(.*)$", "_framework/$1", skipRemainingRules: true)
     .AddRewrite(@"^app/_content/(.*)$", "_content/$1", skipRemainingRules: true)
     .AddRewrite(@"^app/Sorcha\.UI\.Web\.styles\.css$", "Sorcha.UI.Web.styles.css", skipRemainingRules: true)
+    // Blazor scoped-CSS bundle. The file name embeds a build-time content
+    // hash (Sorcha.UI.Web.Client.<hash>.bundle.scp.css) that changes with
+    // every build, so the rule has to match the pattern, not a literal name.
+    .AddRewrite(@"^app/(Sorcha\.UI\.Web\.Client\.[^/]+\.bundle\.scp\.css)$", "$1", skipRemainingRules: true)
     .AddRewrite(@"^app/appsettings\.(.*)$", "appsettings.$1", skipRemainingRules: true)
     .AddRewrite(@"^app/i18n/(.*)$", "i18n/$1", skipRemainingRules: true);
 app.UseRewriter(rewriteOptions);


### PR DESCRIPTION
Two distinct UX bugs spotted while filling in HAIP Identity action 1 through the n1 web UI.

## 1. Misleading error banner on action failure
`POST /api/instances/{id}/actions/{aid}/execute` returning 400 (sender wallet doesn't match the designated participant, schema validation, missing credential) caused the UI to show:

> _Instance created (xxxxxxxx...) but action execution failed. The action will appear in your Pending Actions._

…which is wrong for hard errors. The action does **not** appear in Pending Actions because there's no retry queue for permanent rejections, and the user has no idea what actually went wrong. In today's session the actual server message was `Sender wallet ws11qp73… does not match designated participant wallet ws11qzt9… for action 1` — useful information that the UI was hiding.

**Fix**:
- `WorkflowService.SubmitActionExecuteAsync` reads the error body on `!IsSuccessStatusCode` and returns an `ActionSubmissionResultViewModel` with `ErrorMessage` + `ErrorStatusCode` populated. Body parser handles RFC 7807 ProblemDetails, FluentValidation `{errors:[…]}` arrays, and falls back to raw text.
- `ActionSubmissionResultViewModel` gains nullable `ErrorMessage`, `ErrorStatusCode`, and an `IsFailure` helper.
- `NewSubmissionDialog.razor` and `NewSubmissionWorkspace.razor` now render the actual server message:

> _Instance created (2929b36c...) but action execution was rejected (400): Sender wallet ws11qp73… does not match designated participant wallet ws11qzt9… for action 1_

## 2. Scoped-CSS bundle 404 under /app — served as text/html
Browser console:
> _Refused to apply style from 'https://n1.sorcha.dev/app/Sorcha.UI.Web.Client.&lt;hash&gt;.bundle.scp.css' because its MIME type ('text/html') is not a supported stylesheet_

The Blazor WASM client lives under `/app/`, but its scoped-CSS bundle has a build-time content hash in the filename. `Sorcha.UI.Web.Program.cs` had rewrite rules for `/app/_framework`, `/app/_content`, `/app/Sorcha.UI.Web.styles.css`, `/app/appsettings.*`, and `/app/i18n/` to map them back to wwwroot, but **no rule for the scoped-CSS bundle pattern**. The request fell through to the SPA fallback and `index.html` came back with `text/html`, breaking strict-MIME enforcement.

**Fix**: pattern-based regex rewrite `^app/Sorcha\.UI\.Web\.Client\.[^/]+\.bundle\.scp\.css$ → $1` — survives future content hash changes.

## Test plan
- [x] Solution builds clean
- [ ] After deploy: HAIP Identity submit with wrong wallet shows the real `Sender wallet … does not match …` message instead of the Pending Actions blurb
- [ ] After deploy: `/app/Sorcha.UI.Web.Client.<hash>.bundle.scp.css` returns 200 with `Content-Type: text/css`
- [ ] Browser console no longer reports a CSS MIME refusal on /app/* pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)