### PR TITLE
fix(HAIP): citizen submits, government issues — both walkthroughs

### DIFF
--- a/walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json
+++ b/walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json
@@ -1,45 +1,144 @@
 {
-  "id": "haip-driving-licence-v1",
+  "id": "haip-driving-licence-v2",
   "title": "Driving Licence Application",
-  "description": "Council verifies citizen identity via HAIP presentation request, then issues a DrivingLicenceCredential via HAIP credential offer. Two-action workflow: verify identity (council-initiated QR), then issue licence.",
-  "version": 1,
+  "description": "Citizen submits a driving licence application. Council verifies identity by requesting the applicant's VerifiedIdentityCredential via HAIP presentation (QR), then issues a DrivingLicenceCredential to the applicant's external HAIP wallet via HAIP credential offer (QR). Three-action workflow: applicant submits, council verifies, council issues.",
+  "version": 2,
   "category": "licensing",
-  "tags": ["haip", "driving-licence", "oid4vci", "oid4vp", "verifiable-credential", "external-wallet"],
+  "tags": ["haip", "driving-licence", "oid4vci", "oid4vp", "verifiable-credential", "external-wallet", "citizen-application"],
   "author": "Sorcha Team",
   "published": true,
   "template": {
     "id": "haip-driving-licence",
     "title": "Driving Licence Application",
-    "description": "Citizen presents verified identity, Council issues driving licence via HAIP",
-    "version": 1,
+    "description": "Citizen submits a driving licence application. Council verifies identity via HAIP and issues the licence.",
+    "version": 2,
     "metadata": {
       "category": "Licensing & Permits",
       "complexity": "Standard",
-      "actions": "2",
-      "features": "HAIP, OpenID4VCI, OpenID4VP, External Wallet, Verifiable Credential",
+      "actions": "3",
+      "features": "HAIP, OpenID4VCI, OpenID4VP, External Wallet, Verifiable Credential, Citizen Application",
       "sector": "Government"
     },
     "participants": [
       {
+        "id": "applicant",
+        "name": "Licence Applicant",
+        "organisation": "Public",
+        "description": "Citizen applying for a driving licence — submits application and receives the licence credential via their external HAIP wallet"
+      },
+      {
         "id": "council",
         "name": "Council Licensing Officer",
         "organisation": "Council Licensing Authority",
-        "description": "Verifies citizen identity and issues driving licences"
-      },
-      {
-        "id": "applicant",
-        "name": "Licence Applicant",
-        "organisation": "Citizen",
-        "description": "Citizen applying for a driving licence"
+        "description": "Verifies the applicant's identity and issues driving licences"
       }
     ],
     "actions": [
       {
         "id": 1,
-        "title": "Verify Applicant Identity",
-        "description": "Council requests identity credential from the applicant's external HAIP wallet. A QR code is displayed for the citizen to scan and present their VerifiedIdentityCredential.",
-        "sender": "council",
+        "title": "Submit Driving Licence Application",
+        "description": "Citizen submits a driving licence application with their personal details and requested vehicle class. The council will then request identity verification and, on approval, issue the licence.",
+        "sender": "applicant",
         "isStartingAction": true,
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Apply for a driving licence. After you submit, the council will request your verified identity credential via QR code and, on approval, issue the licence to your external wallet.",
+            "x-pages": [
+              {
+                "title": "About You",
+                "description": "Your full legal name and date of birth.",
+                "x-sections": [
+                  {
+                    "title": "Name",
+                    "layout": "horizontal",
+                    "fields": ["givenName", "familyName"]
+                  },
+                  {
+                    "title": "Personal",
+                    "layout": "horizontal",
+                    "fields": ["dateOfBirth", "email"]
+                  }
+                ]
+              },
+              {
+                "title": "Licence Requested",
+                "description": "What vehicle class are you applying for?",
+                "x-sections": [
+                  {
+                    "title": "Vehicle Class",
+                    "layout": "vertical",
+                    "fields": ["vehicleClass", "applicantNotes"]
+                  }
+                ]
+              }
+            ],
+            "properties": {
+              "givenName": {
+                "type": "string",
+                "title": "Given Name",
+                "minLength": 1,
+                "maxLength": 100,
+                "x-persona": "givenName"
+              },
+              "familyName": {
+                "type": "string",
+                "title": "Family Name",
+                "minLength": 1,
+                "maxLength": 100,
+                "x-persona": "familyName"
+              },
+              "dateOfBirth": {
+                "type": "string",
+                "format": "date",
+                "title": "Date of Birth",
+                "x-persona": "dateOfBirth"
+              },
+              "email": {
+                "type": "string",
+                "format": "email",
+                "title": "Email Address",
+                "x-persona": "defaultEmail"
+              },
+              "vehicleClass": {
+                "type": "string",
+                "title": "Vehicle Class",
+                "enum": ["Car (B)", "Motorcycle (A)", "Lorry (C)", "Bus (D)"]
+              },
+              "applicantNotes": {
+                "type": "string",
+                "title": "Notes",
+                "maxLength": 500
+              }
+            },
+            "required": ["givenName", "familyName", "dateOfBirth", "vehicleClass"]
+          }
+        ],
+        "disclosures": [
+          {
+            "participantAddress": "applicant",
+            "dataPointers": ["/*"]
+          },
+          {
+            "participantAddress": "council",
+            "dataPointers": ["/*"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "to-verify",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Application submitted — pending identity verification"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Verify Applicant Identity",
+        "description": "Council requests the applicant's VerifiedIdentityCredential from their external HAIP wallet. A QR code is displayed for the citizen to scan and present.",
+        "sender": "council",
+        "requiredPriorActions": [1],
         "credentialRequirements": [
           {
             "type": "VerifiedIdentityCredential",
@@ -74,27 +173,28 @@
         "routes": [
           {
             "id": "to-issue-licence",
-            "nextActionIds": [2],
+            "nextActionIds": [3],
             "isDefault": true,
-            "description": "Route to licence issuance after identity verification"
+            "description": "Identity verified — route to licence issuance"
           }
         ]
       },
       {
-        "id": 2,
+        "id": 3,
         "title": "Issue Driving Licence",
-        "description": "Council issues a DrivingLicenceCredential to the applicant's external HAIP wallet via QR code.",
+        "description": "Council issues a DrivingLicenceCredential to the applicant's external HAIP wallet via QR code (OpenID4VCI pre-authorized code flow).",
         "sender": "council",
+        "requiredPriorActions": [2],
         "credentialIssuanceConfig": {
           "credentialType": "DrivingLicenceCredential",
           "targetAudience": "HaipExternalWallet",
           "recipientParticipantId": "applicant",
           "claimMappings": [
             { "claimName": "licenceNumber", "sourceField": "/licenceNumber" },
-            { "claimName": "vehicleClass", "sourceField": "/vehicleClass" },
-            { "claimName": "issuedDate", "sourceField": "/issuedDate" },
-            { "claimName": "expiryDate", "sourceField": "/expiryDate" },
-            { "claimName": "holderName", "sourceField": "/holderName" }
+            { "claimName": "vehicleClass",  "sourceField": "/vehicleClass" },
+            { "claimName": "issuedDate",    "sourceField": "/issuedDate" },
+            { "claimName": "expiryDate",    "sourceField": "/expiryDate" },
+            { "claimName": "holderName",    "sourceField": "/holderName" }
           ],
           "disclosable": [
             "licenceNumber", "vehicleClass", "issuedDate", "expiryDate", "holderName"
@@ -106,10 +206,10 @@
             "type": "object",
             "properties": {
               "licenceNumber": { "type": "string", "title": "Licence Number" },
-              "vehicleClass": { "type": "string", "title": "Vehicle Class" },
-              "issuedDate": { "type": "string", "format": "date", "title": "Issue Date" },
-              "expiryDate": { "type": "string", "format": "date", "title": "Expiry Date" },
-              "holderName": { "type": "string", "title": "Holder Name" }
+              "vehicleClass":  { "type": "string", "title": "Vehicle Class" },
+              "issuedDate":    { "type": "string", "format": "date", "title": "Issue Date" },
+              "expiryDate":    { "type": "string", "format": "date", "title": "Expiry Date" },
+              "holderName":    { "type": "string", "title": "Holder Name" }
             },
             "required": ["licenceNumber", "vehicleClass"]
           }
@@ -118,6 +218,10 @@
           {
             "participantAddress": "council",
             "dataPointers": ["/*"]
+          },
+          {
+            "participantAddress": "applicant",
+            "dataPointers": ["/licenceNumber", "/vehicleClass", "/issuedDate", "/expiryDate"]
           }
         ],
         "routes": [

--- a/walkthroughs/HaipDrivingLicence/run.ps1
+++ b/walkthroughs/HaipDrivingLicence/run.ps1
@@ -27,48 +27,83 @@ $walletDir = $state.walletDir
 $agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
 
 # ============================================================================
-# Step 1: Authenticate as Council Admin
+# Step 1: Authenticate as Applicant and Council
 # ============================================================================
-Write-WtStep "Step 1: Authenticate as Council Admin"
+# Two distinct identities:
+#   - The applicant submits Action 1 (their own licence application) under
+#     their own user token, in the public org.
+#   - The council submits Actions 2 and 3 (verify identity + issue licence)
+#     under the council admin token.
+Write-WtStep "Step 1: Authenticate as Applicant and Council"
+
+$applicantSession = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.roles.applicant.email `
+    -Password $state.roles.applicant.password `
+    -OrganizationId $state.roles.applicant.organizationId
+Write-WtSuccess "Authenticated as applicant ($($state.roles.applicant.email))"
 
 $councilSession = Connect-SorchaUser `
     -TenantUrl $state.tenantUrl `
     -Email $state.roles.councilAdmin.email `
     -Password $state.roles.councilAdmin.password `
     -OrganizationId $state.roles.councilAdmin.organizationId
-
-Write-WtSuccess "Authenticated"
+Write-WtSuccess "Authenticated as council"
 
 # ============================================================================
-# Step 2: Create Blueprint Instance
+# Step 2: Applicant Creates the Blueprint Instance
 # ============================================================================
-Write-WtStep "Step 2: Create Blueprint Instance"
+# Created under the applicant token because they're the starting-action
+# sender. Instance metadata is correctly attributed to them.
+Write-WtStep "Step 2: Applicant creates Blueprint Instance"
 
 $instanceBody = @{
     blueprintId = $state.blueprintId
     registerId  = $state.registerId
-    tenantId    = $state.councilOrgId
+    tenantId    = $state.roles.applicant.organizationId
     metadata    = @{ source = "walkthrough"; walkthrough = "HaipDrivingLicence" }
 }
 
 $instance = Invoke-SorchaApi -Method POST `
     -Uri "$($state.blueprintUrl)/instances/" `
     -Body $instanceBody `
-    -Headers $councilSession.Headers
+    -Headers $applicantSession.Headers
 
 $instanceId = $instance.id
 Write-WtSuccess "Instance: $instanceId"
 if ($ShowJson) { $instance | ConvertTo-Json -Depth 5 | Write-Host }
 
 # ============================================================================
-# Step 3: Execute "Verify Applicant Identity" (creates presentation request QR)
+# Step 3: Applicant Submits Driving Licence Application (Action 1)
 # ============================================================================
-Write-WtStep "Step 3: Verify Applicant Identity"
+Write-WtStep "Step 3: Applicant submits Driving Licence Application (Action 1)"
+
+$null = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "1" `
+    -BlueprintId $state.blueprintId `
+    -SenderWallet $state.applicantWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $applicantSession.Token `
+    -PayloadData @{
+        givenName    = "Alice"
+        familyName   = "O'Brien"
+        dateOfBirth  = "1990-03-15"
+        email        = $state.roles.applicant.email
+        vehicleClass = "Car (B)"
+        applicantNotes = "Standard car licence application"
+    }
+
+# ============================================================================
+# Step 4: Council Verifies Applicant Identity (Action 2 — HAIP presentation)
+# ============================================================================
+Write-WtStep "Step 4: Council verifies applicant identity (Action 2)"
 
 $verifyResponse = Invoke-SorchaAction `
     -BlueprintUrl $state.blueprintUrl `
     -InstanceId $instanceId `
-    -ActionId "1" `
+    -ActionId "2" `
     -BlueprintId $state.blueprintId `
     -SenderWallet $state.councilWalletAddress `
     -RegisterId $state.registerId `
@@ -89,9 +124,9 @@ Write-WtInfo "Credential type: $($presentationRequest.credentialType)"
 Write-WtInfo "Requested claims: $($presentationRequest.requestedClaims -join ', ')"
 
 # ============================================================================
-# Step 4: sorcha-agent haip present (citizen presents identity credential)
+# Step 5: sorcha-agent haip present (citizen presents identity credential)
 # ============================================================================
-Write-WtStep "Step 4: sorcha-agent haip present"
+Write-WtStep "Step 5: sorcha-agent haip present"
 Write-WtInfo "Disclosing: givenName, familyName, dateOfBirth"
 
 # The presentation request URI contains the request object URL
@@ -111,9 +146,9 @@ if ($LASTEXITCODE -ne 0) {
 Write-WtSuccess "Identity credential presented and verified"
 
 # ============================================================================
-# Step 5: Wait for Action 2 to become current
+# Step 6: Wait for Action 3 (Issue Licence) to become current
 # ============================================================================
-Write-WtStep "Step 5: Wait for Action 2"
+Write-WtStep "Step 6: Wait for Action 3"
 
 $maxWait = 60
 $waited = 0
@@ -122,7 +157,7 @@ while ($waited -lt $maxWait) {
     $inst = Invoke-SorchaApi -Method GET `
         -Uri "$($state.blueprintUrl)/instances/$instanceId" `
         -Headers $councilSession.Headers
-    if ($inst.currentActionIds -contains 2) {
+    if ($inst.currentActionIds -contains 3) {
         $ready = $true
         break
     }
@@ -130,15 +165,15 @@ while ($waited -lt $maxWait) {
     $waited++
 }
 if (-not $ready) {
-    Write-WtWarn "Action 2 not yet current after ${waited}s — proceeding anyway"
+    Write-WtWarn "Action 3 not yet current after ${waited}s — proceeding anyway"
 } else {
-    Write-WtInfo "Action 2 ready (waited ${waited}s)"
+    Write-WtInfo "Action 3 ready (waited ${waited}s)"
 }
 
 # ============================================================================
-# Step 6: Execute "Issue Driving Licence" (creates credential offer QR)
+# Step 7: Council Issues Driving Licence (Action 3 — HAIP credential offer)
 # ============================================================================
-Write-WtStep "Step 6: Issue Driving Licence"
+Write-WtStep "Step 7: Council issues Driving Licence (Action 3)"
 
 $today = (Get-Date).ToString("yyyy-MM-dd")
 $expiry = (Get-Date).AddYears(10).ToString("yyyy-MM-dd")
@@ -154,7 +189,7 @@ $licenceData = @{
 $licenceResponse = Invoke-SorchaAction `
     -BlueprintUrl $state.blueprintUrl `
     -InstanceId $instanceId `
-    -ActionId "2" `
+    -ActionId "3" `
     -BlueprintId $state.blueprintId `
     -SenderWallet $state.councilWalletAddress `
     -RegisterId $state.registerId `
@@ -173,9 +208,9 @@ if (-not $credentialOffer) {
 Write-WtSuccess "Licence offer: $($credentialOffer.offerId)"
 
 # ============================================================================
-# Step 7: sorcha-agent haip receive (citizen collects driving licence)
+# Step 8: sorcha-agent haip receive (citizen collects driving licence)
 # ============================================================================
-Write-WtStep "Step 7: sorcha-agent haip receive"
+Write-WtStep "Step 8: sorcha-agent haip receive"
 
 & dotnet run --project $agentProject -- haip receive `
     --offer-uri $credentialOffer.credentialOfferUri `
@@ -187,9 +222,9 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # ============================================================================
-# Step 8: Verify both credentials in wallet
+# Step 9: Verify both credentials in wallet
 # ============================================================================
-Write-WtStep "Step 8: Verify Wallet Contents"
+Write-WtStep "Step 9: Verify Wallet Contents"
 
 $identityCred = Join-Path $walletDir "credentials/VerifiedIdentityCredential.sdjwt"
 $licenceCred = Join-Path $walletDir "credentials/DrivingLicenceCredential.sdjwt"

--- a/walkthroughs/HaipDrivingLicence/setup.ps1
+++ b/walkthroughs/HaipDrivingLicence/setup.ps1
@@ -162,14 +162,40 @@ $register = New-SorchaRegister `
 
 Write-WtSuccess "Register: $($register.RegisterId)"
 
+# Subscribe the public org so the citizen applicant can submit Action 1
+# from their own session.
+try {
+    $publicOrgId = "00000000-0000-0000-0000-000000000002"
+    $null = New-SorchaRegisterSubscription `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $publicOrgId `
+        -RegisterId $register.RegisterId `
+        -RegisterName "HAIP Driving Licence Register" `
+        -SubscriptionType "Public" `
+        -Headers $sysAdmin.Headers
+} catch {
+    Write-WtWarn "Public org subscribe to licence register failed: $($_.Exception.Message)"
+}
+
 # ============================================================================
 # Step 7: Publish Blueprint
 # ============================================================================
 Write-WtStep "Step 7: Publish Blueprint"
 
+if (-not $idState.citizenWalletAddress) {
+    Write-WtFail "HaipIdentityAttestation state.json has no citizenWalletAddress — re-run that setup first."
+    exit 1
+}
+
 $walletMap = @{
     "council"   = $councilWallet.Address
-    "applicant" = $councilWallet.Address  # Placeholder — external wallet handles credential delivery
+    # The applicant is the same citizen from HaipIdentityAttestation. Using
+    # their actual wallet (not a placeholder of the council wallet) means
+    # Action 1 of the licence blueprint is correctly signed by the citizen
+    # under their own user token in run.ps1, and the in-platform audit trail
+    # ties the application back to the real applicant. The licence credential
+    # itself is still delivered to their EXTERNAL HAIP wallet via QR.
+    "applicant" = $idState.citizenWalletAddress
 }
 
 $blueprint = Publish-SorchaBlueprint `
@@ -194,6 +220,7 @@ $state = @{
     tenantId     = $tenantId
     councilOrgId = $councilOrgId
     councilWalletAddress = $councilWallet.Address
+    applicantWalletAddress = $idState.citizenWalletAddress
     registerId   = $register.RegisterId
     blueprintId  = $blueprint.BlueprintId
     identityStateFile = $identityState
@@ -204,6 +231,16 @@ $state = @{
             password = $councilAdminPassword
             organizationId = $councilOrgId
             walletAddress = $councilWallet.Address
+        }
+        # The applicant is the citizen from HaipIdentityAttestation. We
+        # reach back into that walkthrough's state to pull their credentials
+        # and org so run.ps1 can authenticate as them and sign Action 1
+        # under their own user token.
+        applicant = @{
+            email          = $idState.roles.citizen.email
+            password       = $idState.roles.citizen.password
+            organizationId = $idState.roles.citizen.organizationId
+            walletAddress  = $idState.citizenWalletAddress
         }
     }
 }

--- a/walkthroughs/HaipIdentityAttestation/blueprints/identity-attestation.json
+++ b/walkthroughs/HaipIdentityAttestation/blueprints/identity-attestation.json
@@ -1,86 +1,132 @@
 {
-  "id": "haip-identity-attestation-v1",
+  "id": "haip-identity-attestation-v2",
   "title": "HAIP Identity Attestation",
-  "description": "Government issues a VerifiedIdentityCredential to a citizen via the HAIP OpenID4VCI pre-authorized code flow. Single-action workflow where the government admin fills in citizen details and the credential is delivered to an external HAIP wallet via QR code.",
-  "version": 1,
+  "description": "A citizen submits an identity application. A government assessor reviews the application, then issues a VerifiedIdentityCredential to the citizen's external HAIP wallet via the OpenID4VCI pre-authorized code flow (delivered as a QR code).",
+  "version": 2,
   "category": "identity",
-  "tags": ["haip", "identity", "oid4vci", "verifiable-credential", "external-wallet"],
+  "tags": ["haip", "identity", "oid4vci", "verifiable-credential", "external-wallet", "citizen-application"],
   "author": "Sorcha Team",
   "published": true,
   "template": {
     "id": "haip-identity-attestation",
     "title": "HAIP Identity Attestation",
-    "description": "Issue a VerifiedIdentityCredential to a citizen's external HAIP wallet",
-    "version": 1,
+    "description": "Citizen submits identity details, government assessor reviews and issues a verifiable credential to the citizen's external HAIP wallet.",
+    "version": 2,
     "metadata": {
       "category": "Identity & Credentials",
       "complexity": "Simple",
-      "actions": "1",
-      "features": "HAIP, OpenID4VCI, External Wallet, Verifiable Credential",
+      "actions": "2",
+      "features": "HAIP, OpenID4VCI, External Wallet, Verifiable Credential, Citizen Application",
       "sector": "Government"
     },
     "participants": [
       {
-        "id": "government-admin",
-        "name": "Government Admin",
-        "organisation": "Government Identity Authority",
-        "description": "Issues verified identity credentials to citizens"
-      },
-      {
         "id": "citizen",
         "name": "Citizen",
         "organisation": "Public",
-        "description": "Receives verified identity credential via external HAIP wallet"
+        "description": "Submits an identity application and receives the verified identity credential via their external HAIP wallet"
+      },
+      {
+        "id": "government-assessor",
+        "name": "Government Assessor",
+        "organisation": "Government Identity Authority",
+        "description": "Reviews citizen identity applications and issues VerifiedIdentityCredential on approval"
       }
     ],
     "actions": [
       {
         "id": 1,
-        "title": "Issue Identity Credential",
-        "description": "Government admin enters citizen identity details. A VerifiedIdentityCredential is issued to the citizen's external HAIP wallet via a QR code.",
-        "sender": "government-admin",
+        "title": "Submit Identity Application",
+        "description": "Citizen submits their personal details for verification. The government assessor will review the application and, if approved, issue a VerifiedIdentityCredential.",
+        "sender": "citizen",
         "isStartingAction": true,
         "dataSchemas": [
           {
             "type": "object",
+            "x-introduction": "Submit your personal details so a government assessor can verify your identity. After review, the verified identity credential will be delivered to the wallet you scan the QR code with.",
+            "x-pages": [
+              {
+                "title": "Your Name",
+                "description": "Your full legal name as it appears on official documents.",
+                "x-sections": [
+                  {
+                    "title": "Name",
+                    "layout": "horizontal",
+                    "fields": ["givenName", "familyName"]
+                  },
+                  {
+                    "title": "Full Name",
+                    "layout": "vertical",
+                    "fields": ["fullName"]
+                  }
+                ]
+              },
+              {
+                "title": "Personal Details",
+                "description": "Date of birth and contact email.",
+                "x-sections": [
+                  {
+                    "title": "Personal",
+                    "layout": "horizontal",
+                    "fields": ["dateOfBirth", "email"]
+                  }
+                ]
+              },
+              {
+                "title": "Address",
+                "description": "Your current registered address.",
+                "x-sections": [
+                  {
+                    "title": "Address",
+                    "layout": "vertical",
+                    "fields": ["address"]
+                  }
+                ]
+              }
+            ],
             "properties": {
               "givenName": {
                 "type": "string",
                 "title": "Given Name",
                 "minLength": 1,
-                "maxLength": 100
+                "maxLength": 100,
+                "x-persona": "givenName"
               },
               "familyName": {
                 "type": "string",
                 "title": "Family Name",
                 "minLength": 1,
-                "maxLength": 100
+                "maxLength": 100,
+                "x-persona": "familyName"
               },
               "fullName": {
                 "type": "string",
                 "title": "Full Name",
                 "minLength": 1,
-                "maxLength": 200
+                "maxLength": 200,
+                "x-persona": "fullName"
               },
               "dateOfBirth": {
                 "type": "string",
                 "format": "date",
-                "title": "Date of Birth"
+                "title": "Date of Birth",
+                "x-persona": "dateOfBirth"
               },
               "email": {
                 "type": "string",
                 "format": "email",
-                "title": "Email Address"
+                "title": "Email Address",
+                "x-persona": "defaultEmail"
               },
               "address": {
                 "type": "object",
                 "title": "Address",
                 "properties": {
-                  "street": { "type": "string", "title": "Street" },
+                  "street":   { "type": "string", "title": "Street" },
                   "locality": { "type": "string", "title": "City/Town" },
-                  "region": { "type": "string", "title": "Region/State" },
+                  "region":   { "type": "string", "title": "Region/State" },
                   "postcode": { "type": "string", "title": "Postcode" },
-                  "country": { "type": "string", "title": "Country" }
+                  "country":  { "type": "string", "title": "Country" }
                 },
                 "required": ["street", "locality", "country"]
               }
@@ -88,17 +134,69 @@
             "required": ["givenName", "familyName", "fullName", "dateOfBirth"]
           }
         ],
+        "disclosures": [
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/*"]
+          },
+          {
+            "participantAddress": "government-assessor",
+            "dataPointers": ["/*"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "to-review",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Application submitted — pending assessor review"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Review & Issue Identity Credential",
+        "description": "Government assessor reviews the citizen's submitted application. On approval, a VerifiedIdentityCredential is issued and delivered to the citizen's external HAIP wallet via a QR code (OpenID4VCI pre-authorized code flow).",
+        "sender": "government-assessor",
+        "requiredPriorActions": [1],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Review the citizen's submitted personal details against your records and approve or reject the application. On approval the verified identity credential is minted and offered to the citizen's external wallet.",
+            "x-sections": [
+              {
+                "title": "Decision",
+                "description": "Approval state and supporting notes for the audit trail.",
+                "layout": "vertical",
+                "fields": ["verificationDecision", "reviewerNotes"]
+              }
+            ],
+            "properties": {
+              "verificationDecision": {
+                "type": "string",
+                "title": "Decision",
+                "enum": ["approved", "rejected"]
+              },
+              "reviewerNotes": {
+                "type": "string",
+                "title": "Reviewer Notes",
+                "maxLength": 500
+              }
+            },
+            "required": ["verificationDecision"]
+          }
+        ],
         "credentialIssuanceConfig": {
           "credentialType": "VerifiedIdentityCredential",
           "targetAudience": "HaipExternalWallet",
           "recipientParticipantId": "citizen",
           "claimMappings": [
-            { "claimName": "givenName", "sourceField": "/givenName" },
-            { "claimName": "familyName", "sourceField": "/familyName" },
-            { "claimName": "fullName", "sourceField": "/fullName" },
+            { "claimName": "givenName",   "sourceField": "/givenName" },
+            { "claimName": "familyName",  "sourceField": "/familyName" },
+            { "claimName": "fullName",    "sourceField": "/fullName" },
             { "claimName": "dateOfBirth", "sourceField": "/dateOfBirth" },
-            { "claimName": "email", "sourceField": "/email" },
-            { "claimName": "address", "sourceField": "/address" }
+            { "claimName": "email",       "sourceField": "/email" },
+            { "claimName": "address",     "sourceField": "/address" }
           ],
           "disclosable": [
             "givenName", "familyName", "fullName", "dateOfBirth", "email",
@@ -108,8 +206,12 @@
         },
         "disclosures": [
           {
-            "participantAddress": "government-admin",
+            "participantAddress": "government-assessor",
             "dataPointers": ["/*"]
+          },
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/verificationDecision", "/reviewerNotes"]
           }
         ],
         "routes": [

--- a/walkthroughs/HaipIdentityAttestation/run.ps1
+++ b/walkthroughs/HaipIdentityAttestation/run.ps1
@@ -26,43 +26,57 @@ $state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
 $walletDir = Join-Path $scriptDir "wallet"
 
 # ============================================================================
-# Step 1: Authenticate as Government Admin
+# Step 1: Authenticate as Citizen and Government Assessor
 # ============================================================================
-Write-WtStep "Step 1: Authenticate as Government Admin"
+# Two distinct identities are needed:
+#   - The citizen submits Action 1 (their own identity application) under
+#     their own user token, in the public org.
+#   - The government assessor submits Action 2 (review + issue VC) under the
+#     gov org admin token. Action 2 carries the credentialIssuanceConfig.
+Write-WtStep "Step 1: Authenticate as Citizen and Gov Assessor"
 
-$govSession = Connect-SorchaUser `
+$citizenSession = Connect-SorchaUser `
     -TenantUrl $state.tenantUrl `
-    -Email $state.roles.govAdmin.email `
-    -Password $state.roles.govAdmin.password `
-    -OrganizationId $state.roles.govAdmin.organizationId
+    -Email $state.roles.citizen.email `
+    -Password $state.roles.citizen.password `
+    -OrganizationId $state.roles.citizen.organizationId
+Write-WtSuccess "Authenticated as citizen ($($state.roles.citizen.email))"
 
-Write-WtSuccess "Authenticated as gov-admin"
+$assessorSession = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.roles.govAssessor.email `
+    -Password $state.roles.govAssessor.password `
+    -OrganizationId $state.roles.govAssessor.organizationId
+Write-WtSuccess "Authenticated as government-assessor"
 
 # ============================================================================
-# Step 2: Create Blueprint Instance
+# Step 2: Citizen Creates the Blueprint Instance
 # ============================================================================
-Write-WtStep "Step 2: Create Blueprint Instance"
+# The instance is created under the citizen's token because they're the
+# starting-action sender. tenantId reflects their org (public), so the
+# audit trail correctly attributes the application to them.
+Write-WtStep "Step 2: Citizen creates Blueprint Instance"
 
 $instanceBody = @{
     blueprintId = $state.blueprintId
     registerId  = $state.registerId
-    tenantId    = $state.govOrgId
+    tenantId    = $state.publicOrgId
     metadata    = @{ source = "walkthrough"; walkthrough = "HaipIdentityAttestation" }
 }
 
 $instance = Invoke-SorchaApi -Method POST `
     -Uri "$($state.blueprintUrl)/instances/" `
     -Body $instanceBody `
-    -Headers $govSession.Headers
+    -Headers $citizenSession.Headers
 
 $instanceId = $instance.id
 Write-WtSuccess "Instance created: $instanceId"
 if ($ShowJson) { $instance | ConvertTo-Json -Depth 5 | Write-Host }
 
 # ============================================================================
-# Step 3: Execute "Issue Identity Credential" Action
+# Step 3: Citizen Submits Identity Application (Action 1)
 # ============================================================================
-Write-WtStep "Step 3: Execute Issue Identity Credential Action"
+Write-WtStep "Step 3: Citizen submits Identity Application (Action 1)"
 
 $persona = $state.persona
 $payloadData = @{
@@ -80,22 +94,43 @@ $payloadData = @{
     }
 }
 
-$actionResponse = Invoke-SorchaAction `
+$null = Invoke-SorchaAction `
     -BlueprintUrl $state.blueprintUrl `
     -InstanceId $instanceId `
     -ActionId "1" `
     -BlueprintId $state.blueprintId `
+    -SenderWallet $state.citizenWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $citizenSession.Token `
+    -PayloadData $payloadData
+
+# ============================================================================
+# Step 4: Government Assessor Reviews and Issues Credential (Action 2)
+# ============================================================================
+# Action 2 carries the credentialIssuanceConfig — submitting it triggers the
+# HAIP credential offer (OpenID4VCI pre-authorized code flow) and returns
+# the offerUri the citizen will scan with their external HAIP wallet.
+Write-WtStep "Step 4: Gov Assessor reviews and issues credential (Action 2)"
+
+$actionResponse = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "2" `
+    -BlueprintId $state.blueprintId `
     -SenderWallet $state.govWalletAddress `
     -RegisterId $state.registerId `
-    -Token $govSession.Token `
-    -PayloadData $payloadData
+    -Token $assessorSession.Token `
+    -PayloadData @{
+        verificationDecision = "approved"
+        reviewerNotes        = "Identity verified against persona of record."
+    }
 
 if ($ShowJson) { $actionResponse | ConvertTo-Json -Depth 5 | Write-Host }
 
 # Extract credential offer URI from action response
 $credentialOffer = $actionResponse.credentialOffer
 if (-not $credentialOffer) {
-    Write-WtFail "Action response did not contain a credentialOffer. HAIP response pipeline may not be working."
+    Write-WtFail "Action 2 response did not contain a credentialOffer. HAIP response pipeline may not be working."
     exit 1
 }
 
@@ -108,9 +143,9 @@ $truncatedUri = $offerUri.Substring(0, [Math]::Min(80, $offerUri.Length))
 Write-WtInfo "Offer URI: $truncatedUri..."
 
 # ============================================================================
-# Step 4: sorcha-agent haip receive
+# Step 5: sorcha-agent haip receive (simulates citizen's external wallet)
 # ============================================================================
-Write-WtStep "Step 4: sorcha-agent haip receive"
+Write-WtStep "Step 5: sorcha-agent haip receive"
 
 $agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
 
@@ -121,9 +156,9 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # ============================================================================
-# Step 5: Verify Credential
+# Step 6: Verify Credential
 # ============================================================================
-Write-WtStep "Step 5: Verify Credential"
+Write-WtStep "Step 6: Verify Credential"
 
 $credFile = Join-Path $walletDir "credentials/VerifiedIdentityCredential.sdjwt"
 if (Test-Path $credFile) {

--- a/walkthroughs/HaipIdentityAttestation/setup.ps1
+++ b/walkthroughs/HaipIdentityAttestation/setup.ps1
@@ -145,9 +145,43 @@ $govParticipant = Register-SorchaParticipant `
     -WalletUrl $sorchaEnv.WalletUrl `
     -OrganizationId $govOrgId `
     -WalletAddress $govWallet.Address `
-    -DisplayName "Government Admin" `
+    -DisplayName "Government Assessor" `
     -Headers $govSession.Headers
-Write-WtInfo "Participant registered"
+Write-WtInfo "Government assessor participant registered"
+
+# ============================================================================
+# Step 5b: Citizen — Login on Public Org, Wallet, Participant
+# ============================================================================
+# The citizen submits Action 1 of the blueprint (their own identity application)
+# from inside the platform. They need their own wallet under their own user
+# token so the action is signed by them — not by the government assessor or
+# the system admin. The verifiable credential issued by Action 2 still goes
+# to their EXTERNAL HAIP wallet via QR; this in-platform wallet is only used
+# to sign the in-platform application submission.
+Write-WtStep "Step 5b: Citizen — Login, Wallet, Participant"
+
+$citizenSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $citizenEmail `
+    -Password $citizenPassword `
+    -OrganizationId $publicOrgId
+
+$citizenWallet = New-SorchaWallet `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Citizen Application Wallet" `
+    -Headers $citizenSession.Headers `
+    -FetchPublicKey
+
+Write-WtSuccess "Citizen wallet: $($citizenWallet.Address)"
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $publicOrgId `
+    -WalletAddress $citizenWallet.Address `
+    -DisplayName "Alice O'Brien" `
+    -Headers $citizenSession.Headers
+Write-WtInfo "Citizen participant registered in public org"
 
 # ============================================================================
 # Step 6: Provision Trust Anchor + Enrol as HAIP Issuer
@@ -193,13 +227,29 @@ $register = New-SorchaRegister `
 
 Write-WtSuccess "Register: $($register.RegisterId)"
 
+# Subscribe the public org so the citizen can see the register and submit
+# Action 1 from their own session. Owner subscription for the gov org is
+# created server-side by Register Service finalize (PR #258).
+try {
+    $null = New-SorchaRegisterSubscription `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $publicOrgId `
+        -RegisterId $register.RegisterId `
+        -RegisterName "HAIP Identity Register" `
+        -SubscriptionType "Public" `
+        -Headers $sysAdmin.Headers
+} catch {
+    Write-WtWarn "Public org subscribe to identity register failed: $($_.Exception.Message)"
+}
+
 # ============================================================================
 # Step 8: Publish Blueprint
 # ============================================================================
 Write-WtStep "Step 8: Publish Blueprint"
 
 $walletMap = @{
-    "government-admin" = $govWallet.Address
+    "government-assessor" = $govWallet.Address
+    "citizen"             = $citizenWallet.Address
 }
 
 $blueprint = Publish-SorchaBlueprint `
@@ -225,10 +275,23 @@ $state = @{
     govOrgId     = $govOrgId
     govWalletAddress = $govWallet.Address
     govWalletPublicKey = $govWallet.PublicKey
+    publicOrgId  = $publicOrgId
+    citizenWalletAddress = $citizenWallet.Address
     registerId   = $register.RegisterId
     blueprintId  = $blueprint.BlueprintId
+    # walletDir is captured here at setup time so downstream walkthroughs
+    # (HaipDrivingLicence) don't read a null when they pull in this state file.
+    walletDir    = (Join-Path $scriptDir "wallet")
     roles = @{
+        # govAdmin retained as an alias so older state.json consumers continue
+        # to load — this is the same record as govAssessor below.
         govAdmin = @{
+            email = $govAdminEmail
+            password = $govAdminPassword
+            organizationId = $govOrgId
+            walletAddress = $govWallet.Address
+        }
+        govAssessor = @{
             email = $govAdminEmail
             password = $govAdminPassword
             organizationId = $govOrgId
@@ -237,6 +300,8 @@ $state = @{
         citizen = @{
             email = $citizenEmail
             password = $citizenPassword
+            organizationId = $publicOrgId
+            walletAddress = $citizenWallet.Address
         }
     }
     persona = @{


### PR DESCRIPTION
## Problem
Both HAIP walkthroughs had the workflow inverted. Every action was `sender = government / council`, which meant the government admin was filling in the citizen's personal details on the citizen's behalf. That isn't how identity attestation or licence applications work — the citizen should fill in their own form and submit it **to** a government assessor.

This was also the root cause of the *"Sender wallet does not match designated participant wallet"* 400 error you'd see filling in HAIP Identity action 1 from the UI: the action was pinned to the gov wallet but the user filling in the form had their own wallet, so submission was correctly rejected.

## HAIP Identity Attestation — now 2 actions
| # | Title | Sender | Notes |
|---|---|---|---|
| 1 | Submit Identity Application | **citizen** | x-pages wizard with persona-aware field hints. Citizen submits name, DOB, email, address under their own user token in the public org. |
| 2 | Review & Issue Identity Credential | government-assessor | Approve/reject. On approval the existing `credentialIssuanceConfig` fires and the `VerifiedIdentityCredential` is delivered to the citizen's external HAIP wallet via QR. `claimMappings` reference the citizen-submitted fields from Action 1. |

Renamed participant `government-admin → government-assessor`. `setup.ps1` now creates the citizen's wallet under the citizen's own token in the public org, registers them as a participant, and subscribes the public org to the identity register. State.json gains `roles.citizen` and `roles.govAssessor` (`govAdmin` kept as an alias for compat).

## HAIP Driving Licence — now 3 actions
| # | Title | Sender | Notes |
|---|---|---|---|
| 1 | Submit Driving Licence Application | **applicant** | x-pages wizard. Applicant fills in name, DOB, vehicle class, notes under their own token in the public org. |
| 2 | Verify Applicant Identity | council | Council requests applicant's `VerifiedIdentityCredential` via HAIP presentation request (QR). |
| 3 | Issue Driving Licence | council | Council issues `DrivingLicenceCredential` to applicant's external HAIP wallet via credential offer (QR). |

`setup.ps1` now reads the citizen wallet from HaipIdentityAttestation's state.json (same person plays both walkthroughs) instead of using a placeholder of the council wallet. Subscribes the public org to the licence register. `roles.applicant` added to state.json.

## Run scripts
Both run scripts log in as **all** roles up-front, create the instance under the **starting-action sender's** token (citizen / applicant), and submit each action under the **sending role's own user token** — no shared admin token.

## Side-fix
`HaipIdentityAttestation/setup.ps1` now writes `walletDir` into state.json at setup time so `HaipDrivingLicence/setup.ps1` doesn't read a null on the first chained run (this caused the empty `--wallet-dir` failures earlier today).

## Verified
End-to-end on n1.sorcha.dev:
- **HAIP Identity** (Step 1-6 OK) — citizen submits Action 1 → assessor approves Action 2 → `VerifiedIdentityCredential` (2222 bytes) delivered to external wallet
- **HAIP Driving Licence** (Step 1-9 OK) — applicant submits Action 1 → council verifies via HAIP presentation Action 2 → council issues Action 3 → `DrivingLicenceCredential` (1712 bytes) delivered to external wallet, both credentials present in wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)