### PR TITLE
feat(103): wave 7 — PostcodeLookup dispatch + HAIP claim mapping fix

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ControlDispatcher.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ControlDispatcher.razor
@@ -62,6 +62,10 @@
             <FileRenderer Control="Control" IsDisabled="_isDisabled" />
             break;
 
+        case ControlTypes.PostcodeLookup:
+            <PostcodeLookupRenderer Control="Control" IsDisabled="_isDisabled" />
+            break;
+
         default:
             <UnsupportedControlRenderer Control="Control" />
             break;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -175,8 +175,12 @@
         // For ValidateOnly mode we additionally call the lookup API on blur
         // to populate the sibling town/region fields. FullAddress mode waits
         // for the explicit "Find address" button so we don't hit the upstream
-        // API on every keystroke.
-        if (_mode == LookupMode.ValidateOnly && !string.IsNullOrWhiteSpace(_value))
+        // API on every keystroke. Skip the call entirely when schema
+        // validation has already rejected the postcode — the API round-trip
+        // would be wasted.
+        if (_mode == LookupMode.ValidateOnly
+            && !string.IsNullOrWhiteSpace(_value)
+            && errors.Count == 0)
         {
             await LookupAsync();
         }
@@ -196,6 +200,7 @@
             if (!response.IsSuccessStatusCode)
             {
                 Logger.LogDebug("Address lookup returned {Status}", (int)response.StatusCode);
+                _candidates = null;
                 return;
             }
 
@@ -203,6 +208,7 @@
             if (result is null || !result.IsValid)
             {
                 _metadataHint = "Postcode not recognised — enter your address manually.";
+                _candidates = null;
                 return;
             }
 
@@ -223,6 +229,7 @@
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Address lookup request failed");
+            _candidates = null;
         }
     }
 
@@ -330,7 +337,7 @@
         public double? Longitude { get; set; }
     }
 
-    public sealed class AddressCandidate
+    private sealed class AddressCandidate
     {
         public string Line1 { get; set; } = string.Empty;
         public string? Line2 { get; set; }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -289,24 +289,38 @@
         if (FormContext is null) return;
 
         var parentScope = GetParentScope(Control.Scope);
-        FormContext.SetValue($"{parentScope}line1", candidate.Line1);
+        SetSiblingValue($"{parentScope}line1", candidate.Line1);
         if (!string.IsNullOrEmpty(candidate.Line2))
         {
-            FormContext.SetValue($"{parentScope}line2", candidate.Line2);
+            SetSiblingValue($"{parentScope}line2", candidate.Line2);
         }
-        FormContext.SetValue($"{parentScope}town", candidate.Town);
+        SetSiblingValue($"{parentScope}town", candidate.Town);
         if (!string.IsNullOrEmpty(candidate.Region))
         {
-            FormContext.SetValue($"{parentScope}region", candidate.Region);
+            SetSiblingValue($"{parentScope}region", candidate.Region);
         }
-        FormContext.SetValue($"{parentScope}postcode", candidate.Postcode);
-        FormContext.SetValue($"{parentScope}country", candidate.Country);
+        SetSiblingValue($"{parentScope}postcode", candidate.Postcode);
+        SetSiblingValue($"{parentScope}country", candidate.Country);
 
         _value = candidate.Postcode;
         _candidates = null;
         _metadataHint = $"Selected: {candidate.DisplayLabel}";
         _adornmentIcon = Icons.Material.Filled.CheckCircle;
         _adornmentColor = Color.Success;
+    }
+
+    /// <summary>
+    /// Writes a value to a sibling field and re-runs schema validation so
+    /// any prior "required but empty" errors are cleared. Without this the
+    /// sibling controls stay in their old error state until the user
+    /// manually focuses and blurs each field.
+    /// </summary>
+    private void SetSiblingValue(string scope, string value)
+    {
+        if (FormContext is null) return;
+        FormContext.SetValue(scope, value);
+        var errors = SchemaService.ValidateField(FormContext.DataSchema, scope, value);
+        FormContext.SetErrors(scope, errors);
     }
 
     private void AutofillMetadata(LookupMetadata metadata)
@@ -317,15 +331,15 @@
 
         if (!string.IsNullOrEmpty(metadata.Town))
         {
-            FormContext.SetValue($"{parentScope}town", metadata.Town);
+            SetSiblingValue($"{parentScope}town", metadata.Town);
         }
         if (!string.IsNullOrEmpty(metadata.Region))
         {
-            FormContext.SetValue($"{parentScope}region", metadata.Region);
+            SetSiblingValue($"{parentScope}region", metadata.Region);
         }
         if (!string.IsNullOrEmpty(metadata.Country))
         {
-            FormContext.SetValue($"{parentScope}country", metadata.Country);
+            SetSiblingValue($"{parentScope}country", metadata.Country);
         }
     }
 
@@ -384,8 +398,6 @@
         public string? Town { get; set; }
         public string? Region { get; set; }
         public string? Country { get; set; }
-        public double? Latitude { get; set; }
-        public double? Longitude { get; set; }
     }
 
     private sealed class AddressCandidate

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -175,7 +175,11 @@
 
     public void Dispose()
     {
-        try { _cts.Cancel(); } catch { /* ignored */ }
+        // CancellationTokenSource.Cancel() throws ObjectDisposedException
+        // if Dispose() was called concurrently from another path. Narrow
+        // the catch so unrelated bugs aren't swallowed.
+        try { _cts.Cancel(); }
+        catch (ObjectDisposedException) { /* already disposed */ }
         _cts.Dispose();
     }
 
@@ -234,6 +238,7 @@
             {
                 Logger.LogDebug("Address lookup returned {Status}", (int)response.StatusCode);
                 _candidates = null;
+                _metadataHint = null;
                 return;
             }
 
@@ -265,11 +270,13 @@
         {
             // Component disposed mid-flight — no-op.
             _candidates = null;
+            _metadataHint = null;
         }
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Address lookup request failed");
             _candidates = null;
+            _metadataHint = null;
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -1,0 +1,343 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using System.Net.Http.Json
+@using System.Text.Json
+@using System.Text.Json.Serialization
+@using Microsoft.Extensions.Logging
+@using Sorcha.Blueprint.Models
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Forms
+
+@inject HttpClient Http
+@inject IFormSchemaService SchemaService
+@inject ILogger<PostcodeLookupRenderer> Logger
+
+@*
+    Feature 103 US3 (T070 + T072)
+
+    Renders a postcode field with address lookup, dispatched by
+    FormSchemaService when a string property carries x-address-lookup: true.
+
+    Three runtime states:
+      * No provider  — renders as plain text (graceful degradation)
+      * ValidateOnly — enter postcode, on blur call /api/address-lookup/postcode;
+                       show a tick on valid postcode, autofill sibling
+                       town/region/country fields from the metadata
+      * FullAddress  — enter postcode, "Find address" button triggers the
+                       lookup and shows a picker; on selection, autofill all
+                       sibling address fields
+
+    The renderer locates sibling fields by computing the parent scope from
+    its own Control.Scope (e.g. /address/postcode → parent /address/) and
+    writing to /address/line1, /address/town, etc via FormContext.SetValue.
+*@
+
+<div @onfocusin="OnFocusIn" @onfocusout="OnFocusOut" class="postcode-lookup">
+    <MudTextField T="string"
+                  data-testid="postcode-input"
+                  Label="@Control.Title"
+                  Value="@_value"
+                  ValueChanged="OnValueChanged"
+                  Disabled="@(IsDisabled || FormContext?.IsReadOnly == true)"
+                  Required="@_isRequired"
+                  ErrorText="@_errorText"
+                  Error="@(!string.IsNullOrEmpty(_errorText))"
+                  Adornment="Adornment.End"
+                  AdornmentIcon="@_adornmentIcon"
+                  AdornmentColor="@_adornmentColor"
+                  Immediate="false"
+                  Variant="Variant.Outlined"
+                  Margin="Margin.Dense"
+                  DebounceInterval="300"
+                  OnBlur="OnBlurAsync" />
+
+    @if (_mode == LookupMode.FullAddress)
+    {
+        <MudButton data-testid="postcode-find-address-button"
+                   Variant="Variant.Text"
+                   Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Search"
+                   Disabled="@(IsDisabled || FormContext?.IsReadOnly == true || string.IsNullOrWhiteSpace(_value))"
+                   OnClick="OnFindAddressClickedAsync"
+                   Class="mt-1">
+            Find address
+        </MudButton>
+    }
+
+    @if (_candidates is { Count: > 0 })
+    {
+        <MudPaper data-testid="postcode-candidate-modal" Elevation="2" Class="pa-2 mt-2">
+            <MudText Typo="Typo.caption" Class="mb-1">Select your address</MudText>
+            <MudList T="AddressCandidate" Dense="true">
+                @for (var i = 0; i < _candidates.Count; i++)
+                {
+                    var candidate = _candidates[i];
+                    var idx = i;
+                    <MudListItem T="AddressCandidate"
+                                 data-testid="@($"postcode-candidate-{idx}")"
+                                 Value="candidate"
+                                 OnClick="@(() => OnCandidateSelected(candidate))">
+                        @candidate.DisplayLabel
+                    </MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    }
+    else if (!string.IsNullOrEmpty(_metadataHint))
+    {
+        <MudText Typo="Typo.caption" Class="mt-1 mud-text-secondary">
+            @_metadataHint
+        </MudText>
+    }
+</div>
+
+@code {
+    [CascadingParameter] public FormContext? FormContext { get; set; }
+    [Parameter, EditorRequired] public Control Control { get; set; } = new();
+    [Parameter] public bool IsDisabled { get; set; }
+
+    private enum LookupMode { NoProvider, ValidateOnly, FullAddress }
+
+    private string _value = string.Empty;
+    private string _errorText = string.Empty;
+    private bool _isRequired;
+    private LookupMode _mode = LookupMode.NoProvider;
+    private string _adornmentIcon = string.Empty;
+    private Color _adornmentColor = Color.Default;
+    private string? _metadataHint;
+    private List<AddressCandidate>? _candidates;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    protected override void OnParametersSet()
+    {
+        _value = FormContext?.GetValue<string>(Control.Scope) ?? string.Empty;
+        _isRequired = SchemaService.IsRequired(FormContext?.DataSchema, Control.Scope);
+        UpdateErrors();
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Detect provider capability once. When the endpoint is unreachable
+        // (auth, network, gateway) we fall through to NoProvider mode so the
+        // field still works as a plain text input.
+        try
+        {
+            var providers = await Http.GetFromJsonAsync<List<ProviderInfo>>(
+                "/api/address-lookup/providers", JsonOptions);
+
+            if (providers is not null && providers.Count > 0)
+            {
+                // Prefer FullAddress over ValidateOnly. Only consider available providers.
+                var available = providers.Where(p => p.Available).ToList();
+                if (available.Any(p => p.Capability == "FullAddress"))
+                {
+                    _mode = LookupMode.FullAddress;
+                }
+                else if (available.Any(p => p.Capability == "ValidateOnly"))
+                {
+                    _mode = LookupMode.ValidateOnly;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Address lookup provider discovery failed; falling back to plain text");
+            _mode = LookupMode.NoProvider;
+        }
+    }
+
+    private void OnValueChanged(string newValue)
+    {
+        _value = newValue;
+        FormContext?.SetValue(Control.Scope, newValue);
+        // Clear stale adornment + hints when the user edits the postcode.
+        _adornmentIcon = string.Empty;
+        _metadataHint = null;
+        _candidates = null;
+    }
+
+    private async Task OnBlurAsync()
+    {
+        if (FormContext is null) return;
+
+        // Schema-level validation (required, pattern etc.) runs on every blur
+        // regardless of provider mode.
+        var errors = SchemaService.ValidateField(FormContext.DataSchema, Control.Scope, _value);
+        FormContext.SetErrors(Control.Scope, errors);
+        UpdateErrors();
+
+        // For ValidateOnly mode we additionally call the lookup API on blur
+        // to populate the sibling town/region fields. FullAddress mode waits
+        // for the explicit "Find address" button so we don't hit the upstream
+        // API on every keystroke.
+        if (_mode == LookupMode.ValidateOnly && !string.IsNullOrWhiteSpace(_value))
+        {
+            await LookupAsync();
+        }
+    }
+
+    private Task OnFindAddressClickedAsync() => LookupAsync();
+
+    private async Task LookupAsync()
+    {
+        try
+        {
+            var response = await Http.PostAsJsonAsync(
+                "/api/address-lookup/postcode",
+                new { postcode = _value },
+                JsonOptions);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Logger.LogDebug("Address lookup returned {Status}", (int)response.StatusCode);
+                return;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<LookupResult>(JsonOptions);
+            if (result is null || !result.IsValid)
+            {
+                _metadataHint = "Postcode not recognised — enter your address manually.";
+                return;
+            }
+
+            _adornmentIcon = Icons.Material.Filled.CheckCircle;
+            _adornmentColor = Color.Success;
+
+            if (result.Capability == "FullAddress" && result.Candidates is { Count: > 0 })
+            {
+                _candidates = result.Candidates;
+                _metadataHint = $"{result.Candidates.Count} address{(result.Candidates.Count == 1 ? string.Empty : "es")} found — select one below.";
+            }
+            else if (result.Capability == "ValidateOnly" && result.Metadata is not null)
+            {
+                AutofillMetadata(result.Metadata);
+                _metadataHint = $"{result.Metadata.Town}{(string.IsNullOrEmpty(result.Metadata.Region) ? string.Empty : $", {result.Metadata.Region}")}";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Address lookup request failed");
+        }
+    }
+
+    private void OnCandidateSelected(AddressCandidate candidate)
+    {
+        if (FormContext is null) return;
+
+        var parentScope = GetParentScope(Control.Scope);
+        FormContext.SetValue($"{parentScope}line1", candidate.Line1);
+        if (!string.IsNullOrEmpty(candidate.Line2))
+        {
+            FormContext.SetValue($"{parentScope}line2", candidate.Line2);
+        }
+        FormContext.SetValue($"{parentScope}town", candidate.Town);
+        if (!string.IsNullOrEmpty(candidate.Region))
+        {
+            FormContext.SetValue($"{parentScope}region", candidate.Region);
+        }
+        FormContext.SetValue($"{parentScope}postcode", candidate.Postcode);
+        FormContext.SetValue($"{parentScope}country", candidate.Country);
+
+        _value = candidate.Postcode;
+        _candidates = null;
+        _metadataHint = $"Selected: {candidate.DisplayLabel}";
+        _adornmentIcon = Icons.Material.Filled.CheckCircle;
+        _adornmentColor = Color.Success;
+    }
+
+    private void AutofillMetadata(LookupMetadata metadata)
+    {
+        if (FormContext is null) return;
+
+        var parentScope = GetParentScope(Control.Scope);
+
+        if (!string.IsNullOrEmpty(metadata.Town))
+        {
+            FormContext.SetValue($"{parentScope}town", metadata.Town);
+        }
+        if (!string.IsNullOrEmpty(metadata.Region))
+        {
+            FormContext.SetValue($"{parentScope}region", metadata.Region);
+        }
+        if (!string.IsNullOrEmpty(metadata.Country))
+        {
+            FormContext.SetValue($"{parentScope}country", metadata.Country);
+        }
+    }
+
+    /// <summary>
+    /// Given a JSON Pointer-style scope like <c>/address/postcode</c>, returns
+    /// the parent prefix with a trailing slash (<c>/address/</c>) so sibling
+    /// writes can be composed by concatenation. For a root-level scope
+    /// (<c>/postcode</c>) the parent is <c>/</c>.
+    /// </summary>
+    internal static string GetParentScope(string scope)
+    {
+        if (string.IsNullOrEmpty(scope)) return "/";
+        var lastSlash = scope.LastIndexOf('/');
+        if (lastSlash <= 0) return "/";
+        return scope.Substring(0, lastSlash + 1);
+    }
+
+    private void UpdateErrors()
+    {
+        var errors = FormContext?.GetErrors(Control.Scope) ?? [];
+        _errorText = errors.Count > 0 ? string.Join("; ", errors) : string.Empty;
+    }
+
+    private void OnFocusIn() => FormContext?.SetFocusedField(Control.Scope);
+
+    private void OnFocusOut()
+    {
+        if (FormContext?.FocusedFieldScope == Control.Scope)
+        {
+            FormContext.SetFocusedField(null);
+        }
+    }
+
+    // ----- wire DTOs -----
+
+    private sealed class ProviderInfo
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Capability { get; set; } = string.Empty;
+        public List<string> SupportedCountries { get; set; } = new();
+        public bool Available { get; set; }
+    }
+
+    private sealed class LookupResult
+    {
+        public string Postcode { get; set; } = string.Empty;
+        public bool IsValid { get; set; }
+        public string Provider { get; set; } = string.Empty;
+        public string Capability { get; set; } = string.Empty;
+        public LookupMetadata? Metadata { get; set; }
+        public List<AddressCandidate>? Candidates { get; set; }
+    }
+
+    private sealed class LookupMetadata
+    {
+        public string? Town { get; set; }
+        public string? Region { get; set; }
+        public string? Country { get; set; }
+        public double? Latitude { get; set; }
+        public double? Longitude { get; set; }
+    }
+
+    public sealed class AddressCandidate
+    {
+        public string Line1 { get; set; } = string.Empty;
+        public string? Line2 { get; set; }
+        public string Town { get; set; } = string.Empty;
+        public string? Region { get; set; }
+        public string Postcode { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+        public string DisplayLabel { get; set; } = string.Empty;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -9,6 +9,7 @@
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.UI.Core.Services.Forms
 
+@implements IDisposable
 @inject HttpClient Http
 @inject IFormSchemaService SchemaService
 @inject ILogger<PostcodeLookupRenderer> Logger
@@ -58,10 +59,10 @@
                    Variant="Variant.Text"
                    Color="Color.Primary"
                    StartIcon="@Icons.Material.Filled.Search"
-                   Disabled="@(IsDisabled || FormContext?.IsReadOnly == true || string.IsNullOrWhiteSpace(_value))"
+                   Disabled="@(IsDisabled || FormContext?.IsReadOnly == true || string.IsNullOrWhiteSpace(_value) || _isLookingUp)"
                    OnClick="OnFindAddressClickedAsync"
                    Class="mt-1">
-            Find address
+            @(_isLookingUp ? "Searching..." : "Find address")
         </MudButton>
     }
 
@@ -82,6 +83,14 @@
                     </MudListItem>
                 }
             </MudList>
+            <MudButton data-testid="postcode-dismiss-candidates"
+                       Variant="Variant.Text"
+                       Size="Size.Small"
+                       Color="Color.Default"
+                       OnClick="@(() => _candidates = null)"
+                       Class="mt-1">
+                Enter manually instead
+            </MudButton>
         </MudPaper>
     }
     else if (!string.IsNullOrEmpty(_metadataHint))
@@ -99,6 +108,12 @@
 
     private enum LookupMode { NoProvider, ValidateOnly, FullAddress }
 
+    // Capability constants — match the server-side AddressLookupCapability
+    // values exactly. Comparisons are case-insensitive to defend against
+    // minor wire-shape drift.
+    private const string CapabilityFullAddress = "FullAddress";
+    private const string CapabilityValidateOnly = "ValidateOnly";
+
     private string _value = string.Empty;
     private string _errorText = string.Empty;
     private bool _isRequired;
@@ -107,6 +122,8 @@
     private Color _adornmentColor = Color.Default;
     private string? _metadataHint;
     private List<AddressCandidate>? _candidates;
+    private bool _isLookingUp;
+    private readonly CancellationTokenSource _cts = new();
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -129,27 +146,37 @@
         try
         {
             var providers = await Http.GetFromJsonAsync<List<ProviderInfo>>(
-                "/api/address-lookup/providers", JsonOptions);
+                "/api/address-lookup/providers", JsonOptions, _cts.Token);
 
             if (providers is not null && providers.Count > 0)
             {
                 // Prefer FullAddress over ValidateOnly. Only consider available providers.
                 var available = providers.Where(p => p.Available).ToList();
-                if (available.Any(p => p.Capability == "FullAddress"))
+                if (available.Any(p => string.Equals(p.Capability, CapabilityFullAddress, StringComparison.OrdinalIgnoreCase)))
                 {
                     _mode = LookupMode.FullAddress;
                 }
-                else if (available.Any(p => p.Capability == "ValidateOnly"))
+                else if (available.Any(p => string.Equals(p.Capability, CapabilityValidateOnly, StringComparison.OrdinalIgnoreCase)))
                 {
                     _mode = LookupMode.ValidateOnly;
                 }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            // Component disposed before provider discovery finished — no-op.
         }
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Address lookup provider discovery failed; falling back to plain text");
             _mode = LookupMode.NoProvider;
         }
+    }
+
+    public void Dispose()
+    {
+        try { _cts.Cancel(); } catch { /* ignored */ }
+        _cts.Dispose();
     }
 
     private void OnValueChanged(string newValue)
@@ -190,12 +217,18 @@
 
     private async Task LookupAsync()
     {
+        // Concurrent-request guard: rapid clicks on "Find address" would
+        // otherwise race, and the last response to arrive (not the last
+        // request sent) could win — producing a stale candidate list.
+        if (_isLookingUp) return;
+        _isLookingUp = true;
         try
         {
             var response = await Http.PostAsJsonAsync(
                 "/api/address-lookup/postcode",
                 new { postcode = _value },
-                JsonOptions);
+                JsonOptions,
+                _cts.Token);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -204,7 +237,7 @@
                 return;
             }
 
-            var result = await response.Content.ReadFromJsonAsync<LookupResult>(JsonOptions);
+            var result = await response.Content.ReadFromJsonAsync<LookupResult>(JsonOptions, _cts.Token);
             if (result is null || !result.IsValid)
             {
                 _metadataHint = "Postcode not recognised — enter your address manually.";
@@ -215,21 +248,32 @@
             _adornmentIcon = Icons.Material.Filled.CheckCircle;
             _adornmentColor = Color.Success;
 
-            if (result.Capability == "FullAddress" && result.Candidates is { Count: > 0 })
+            if (string.Equals(result.Capability, CapabilityFullAddress, StringComparison.OrdinalIgnoreCase)
+                && result.Candidates is { Count: > 0 })
             {
                 _candidates = result.Candidates;
                 _metadataHint = $"{result.Candidates.Count} address{(result.Candidates.Count == 1 ? string.Empty : "es")} found — select one below.";
             }
-            else if (result.Capability == "ValidateOnly" && result.Metadata is not null)
+            else if (string.Equals(result.Capability, CapabilityValidateOnly, StringComparison.OrdinalIgnoreCase)
+                && result.Metadata is not null)
             {
                 AutofillMetadata(result.Metadata);
                 _metadataHint = $"{result.Metadata.Town}{(string.IsNullOrEmpty(result.Metadata.Region) ? string.Empty : $", {result.Metadata.Region}")}";
             }
         }
+        catch (OperationCanceledException)
+        {
+            // Component disposed mid-flight — no-op.
+            _candidates = null;
+        }
         catch (Exception ex)
         {
             Logger.LogDebug(ex, "Address lookup request failed");
             _candidates = null;
+        }
+        finally
+        {
+            _isLookingUp = false;
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FormSchemaService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FormSchemaService.cs
@@ -248,11 +248,23 @@ public class FormSchemaService : IFormSchemaService
         var hasEnum = schema.TryGetProperty("enum", out _);
         var format = schema.TryGetProperty("format", out var formatEl) ? formatEl.GetString() : null;
 
+        // Feature 103 US3: a string field carrying `x-address-lookup: true`
+        // dispatches to the postcode lookup control regardless of format /
+        // maxLength. The control falls back to plain text at runtime when no
+        // provider is configured, so we can route unconditionally here.
+        var hasAddressLookup =
+            schema.TryGetProperty("x-address-lookup", out var lookupEl) &&
+            lookupEl.ValueKind == JsonValueKind.True;
+
         ControlTypes controlType;
 
         if (hasEnum)
         {
             controlType = ControlTypes.Selection;
+        }
+        else if (hasAddressLookup && type == "string")
+        {
+            controlType = ControlTypes.PostcodeLookup;
         }
         else if (format is "date" or "date-time")
         {

--- a/src/Common/Sorcha.Blueprint.Models/Control.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Control.cs
@@ -181,5 +181,15 @@ public enum ControlTypes
     /// Dropdown selection list for choosing from predefined options
     /// </summary>
     [DataAnnotations.Display(Name = "Selection")]
-    Selection
+    Selection,
+
+    /// <summary>
+    /// Postcode input with address lookup. Dispatched when a string field
+    /// carries <c>x-address-lookup: true</c>. The renderer calls the Tenant
+    /// Service address lookup endpoints and autofills sibling address fields
+    /// from the selected provider. Falls back to plain text when no provider
+    /// is configured. Feature 103 US3.
+    /// </summary>
+    [DataAnnotations.Display(Name = "Postcode Lookup")]
+    PostcodeLookup
 }

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1286,29 +1286,18 @@ public class ActionExecutionService : IActionExecutionService
     }
 
     /// <summary>
-    /// Resolves a JSON Pointer (<c>/foo/bar/baz</c>) against a root dictionary
-    /// built from the action payload. Walks nested <see cref="Dictionary{TKey,TValue}"/>,
-    /// <see cref="IDictionary{TKey,TValue}"/>, and <see cref="JsonElement"/> nodes.
-    /// Returns <c>false</c> on any missing segment.
-    /// </summary>
-    /// <remarks>
-    /// Used by the claim-mapping extractor so that primitive-nested payloads
-    /// (e.g. <c>/name/givenName</c> for a PersonName/v1-backed submission)
-    /// resolve correctly. Flat paths (<c>/givenName</c>) continue to work
-    /// because the pointer walk of a single segment degenerates to a
-    /// top-level lookup. Feature 103 US2/US4.
-    /// </remarks>
-    /// <summary>
     /// Applies the credential issuance <c>ClaimMappings</c> list against the
     /// action's merged data, walking JSON Pointer <c>SourceField</c> paths so
     /// nested primitive values (Feature 103) resolve correctly. Shared by
     /// both the internal issuance path and the HAIP external-wallet path.
+    /// Missing mappings are logged at Warning level because a dropped claim
+    /// silently produces a credential with fewer attributes than expected.
     /// </summary>
-    private Dictionary<string, object> BuildClaimsFromMappings(
+    private Dictionary<string, object?> BuildClaimsFromMappings(
         IEnumerable<Sorcha.Blueprint.Models.Credentials.ClaimMapping>? mappings,
-        IReadOnlyDictionary<string, object> mergedData)
+        IReadOnlyDictionary<string, object?> mergedData)
     {
-        var claims = new Dictionary<string, object>();
+        var claims = new Dictionary<string, object?>();
         if (mappings is null) return claims;
 
         foreach (var mapping in mappings)
@@ -1319,28 +1308,49 @@ public class ActionExecutionService : IActionExecutionService
             }
             else
             {
-                _logger.LogDebug(
-                    "Claim mapping source '{SourceField}' not found in action data; skipping claim '{ClaimName}'",
+                _logger.LogWarning(
+                    "Claim mapping source '{SourceField}' not found in action data; dropping claim '{ClaimName}' from credential",
                     mapping.SourceField, mapping.ClaimName);
             }
         }
         return claims;
     }
 
+    /// <summary>
+    /// Resolves a JSON Pointer (<c>/foo/bar/baz</c>) against a root dictionary
+    /// built from the action payload. Walks nested <see cref="Dictionary{TKey,TValue}"/>,
+    /// <see cref="IDictionary{TKey,TValue}"/>, and <see cref="JsonElement"/> nodes.
+    /// Returns <c>false</c> on any missing segment.
+    /// </summary>
+    /// <remarks>
+    /// Used by the claim-mapping extractor so that primitive-nested payloads
+    /// (e.g. <c>/name/givenName</c> for a PersonName/v1-backed submission)
+    /// resolve correctly. Flat paths (<c>/givenName</c>) continue to work
+    /// because the pointer walk of a single segment degenerates to a
+    /// top-level lookup. RFC 6901 escape sequences (<c>~1</c> → <c>/</c>,
+    /// <c>~0</c> → <c>~</c>) are unescaped per segment. Feature 103 US2/US4.
+    /// </remarks>
     internal static bool TryResolveJsonPointer(
-        IReadOnlyDictionary<string, object> root,
+        IReadOnlyDictionary<string, object?> root,
         string jsonPointer,
-        out object value)
+        out object? value)
     {
-        value = null!;
+        value = null;
         if (string.IsNullOrEmpty(jsonPointer) || jsonPointer == "/")
         {
             return false;
         }
 
+        // RFC 6901: ~1 decodes to /, ~0 decodes to ~. Order matters:
+        // ~1 must be handled BEFORE ~0 to avoid double-unescape.
         var segments = jsonPointer
             .TrimStart('/')
             .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i < segments.Length; i++)
+        {
+            segments[i] = segments[i].Replace("~1", "/").Replace("~0", "~");
+        }
 
         if (segments.Length == 0) return false;
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -619,18 +619,20 @@ public class ActionExecutionService : IActionExecutionService
                 // landed in the credential as the nested objects themselves.
                 var haipClaims = BuildClaimsFromMappings(
                     actionDef.CredentialIssuanceConfig.ClaimMappings,
-                    mergedData);
+                    mergedData!);
+                // HAIP client expects non-nullable values; flatten before sending.
+                var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
                 _logger.LogInformation(
                     "Routing credential issuance to HAIP service for external wallet: type={Type}, claims=[{ClaimNames}]",
                     actionDef.CredentialIssuanceConfig.CredentialType,
-                    string.Join(", ", haipClaims.Keys));
+                    string.Join(", ", haipClaimsForWire.Keys));
 
                 haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
                     request.SenderWallet,
                     instance.RegisterId,
                     actionDef.CredentialIssuanceConfig.CredentialType,
-                    haipClaims,
+                    haipClaimsForWire,
                     actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
                     cancellationToken);
 
@@ -1296,6 +1298,17 @@ public class ActionExecutionService : IActionExecutionService
     private Dictionary<string, object?> BuildClaimsFromMappings(
         IEnumerable<Sorcha.Blueprint.Models.Credentials.ClaimMapping>? mappings,
         IReadOnlyDictionary<string, object?> mergedData)
+        => BuildClaimsFromMappings(mappings, mergedData, _logger);
+
+    /// <summary>
+    /// Static logger-injected overload used by unit tests so the helper can
+    /// be exercised without needing the full <see cref="ActionExecutionService"/>
+    /// constructor graph.
+    /// </summary>
+    internal static Dictionary<string, object?> BuildClaimsFromMappings(
+        IEnumerable<Sorcha.Blueprint.Models.Credentials.ClaimMapping>? mappings,
+        IReadOnlyDictionary<string, object?> mergedData,
+        ILogger logger)
     {
         var claims = new Dictionary<string, object?>();
         if (mappings is null) return claims;
@@ -1308,7 +1321,7 @@ public class ActionExecutionService : IActionExecutionService
             }
             else
             {
-                _logger.LogWarning(
+                logger.LogWarning(
                     "Claim mapping source '{SourceField}' not found in action data; dropping claim '{ClaimName}' from credential",
                     mapping.SourceField, mapping.ClaimName);
             }
@@ -1406,7 +1419,12 @@ public class ActionExecutionService : IActionExecutionService
         // extraction walks the pointer segment-by-segment through nested
         // dictionaries and JsonElement objects. Missing segments log a
         // warning and skip the claim rather than failing the whole issue.
-        var claims = BuildClaimsFromMappings(config.ClaimMappings, mergedData);
+        var claims = BuildClaimsFromMappings(config.ClaimMappings, mergedData!);
+        // Wallet client expects non-nullable values; the mapper preserves
+        // null only when the source field is itself null, which never
+        // happens in the issuance path because TryResolveJsonPointer drops
+        // null segments.
+        var claimsForWallet = claims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
         // Resolve recipient wallet address from participant ID
         var recipientWallet = senderWallet; // Default: issuer is also recipient
@@ -1487,7 +1505,7 @@ public class ActionExecutionService : IActionExecutionService
             var result = await _walletClient.IssueCredentialAsync(
                 issuerWalletAddress: senderWallet,
                 credentialType: config.CredentialType,
-                claims: claims,
+                claims: claimsForWallet,
                 recipientWallet: recipientWallet,
                 expiryDuration: config.ExpiryDuration,
                 disclosableClaims: config.Disclosable?.ToList(),

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1321,8 +1321,14 @@ public class ActionExecutionService : IActionExecutionService
             }
             else
             {
+                // Note: the walker treats both "key missing" and "key present
+                // with null value" as unresolvable. The log message uses the
+                // neutral "no value at" phrasing so it's accurate for both
+                // cases. A null optional field (e.g. middleName) will produce
+                // this warning and a credential without that claim, which is
+                // the correct behaviour for issuance.
                 logger.LogWarning(
-                    "Claim mapping source '{SourceField}' not found in action data; dropping claim '{ClaimName}' from credential",
+                    "Claim mapping source '{SourceField}' has no value in action data; dropping claim '{ClaimName}' from credential",
                     mapping.SourceField, mapping.ClaimName);
             }
         }
@@ -1342,6 +1348,14 @@ public class ActionExecutionService : IActionExecutionService
     /// because the pointer walk of a single segment degenerates to a
     /// top-level lookup. RFC 6901 escape sequences (<c>~1</c> → <c>/</c>,
     /// <c>~0</c> → <c>~</c>) are unescaped per segment. Feature 103 US2/US4.
+    ///
+    /// <para><b>Deviations from RFC 6901:</b> the empty pointer <c>""</c>
+    /// (whole document) and the single-slash pointer <c>"/"</c> (key
+    /// <c>""</c>) are both treated as unresolvable and return <c>false</c>.
+    /// Neither has a use case for credential claim mapping, and conflating
+    /// them is the simpler contract for the call sites. Explicit-null
+    /// values are also treated as unresolvable so the issuance path drops
+    /// the claim rather than emitting a credential with a null attribute.</para>
     /// </remarks>
     internal static bool TryResolveJsonPointer(
         IReadOnlyDictionary<string, object?> root,

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -613,15 +613,24 @@ public class ActionExecutionService : IActionExecutionService
             if (actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet
                 && _haipClient != null)
             {
+                // Feature 103: apply ClaimMappings here too. The HAIP path was
+                // previously passing mergedData unchanged, so nested primitive
+                // values (e.g. /name/givenName from a PersonName/v1 reference)
+                // landed in the credential as the nested objects themselves.
+                var haipClaims = BuildClaimsFromMappings(
+                    actionDef.CredentialIssuanceConfig.ClaimMappings,
+                    mergedData);
+
                 _logger.LogInformation(
-                    "Routing credential issuance to HAIP service for external wallet: type={Type}",
-                    actionDef.CredentialIssuanceConfig.CredentialType);
+                    "Routing credential issuance to HAIP service for external wallet: type={Type}, claims=[{ClaimNames}]",
+                    actionDef.CredentialIssuanceConfig.CredentialType,
+                    string.Join(", ", haipClaims.Keys));
 
                 haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
                     request.SenderWallet,
                     instance.RegisterId,
                     actionDef.CredentialIssuanceConfig.CredentialType,
-                    mergedData,
+                    haipClaims,
                     actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
                     cancellationToken);
 
@@ -1276,6 +1285,100 @@ public class ActionExecutionService : IActionExecutionService
             $"Transaction {txId} was not confirmed within {_confirmationOptions.Timeout.TotalSeconds}s for register {registerId}");
     }
 
+    /// <summary>
+    /// Resolves a JSON Pointer (<c>/foo/bar/baz</c>) against a root dictionary
+    /// built from the action payload. Walks nested <see cref="Dictionary{TKey,TValue}"/>,
+    /// <see cref="IDictionary{TKey,TValue}"/>, and <see cref="JsonElement"/> nodes.
+    /// Returns <c>false</c> on any missing segment.
+    /// </summary>
+    /// <remarks>
+    /// Used by the claim-mapping extractor so that primitive-nested payloads
+    /// (e.g. <c>/name/givenName</c> for a PersonName/v1-backed submission)
+    /// resolve correctly. Flat paths (<c>/givenName</c>) continue to work
+    /// because the pointer walk of a single segment degenerates to a
+    /// top-level lookup. Feature 103 US2/US4.
+    /// </remarks>
+    /// <summary>
+    /// Applies the credential issuance <c>ClaimMappings</c> list against the
+    /// action's merged data, walking JSON Pointer <c>SourceField</c> paths so
+    /// nested primitive values (Feature 103) resolve correctly. Shared by
+    /// both the internal issuance path and the HAIP external-wallet path.
+    /// </summary>
+    private Dictionary<string, object> BuildClaimsFromMappings(
+        IEnumerable<Sorcha.Blueprint.Models.Credentials.ClaimMapping>? mappings,
+        IReadOnlyDictionary<string, object> mergedData)
+    {
+        var claims = new Dictionary<string, object>();
+        if (mappings is null) return claims;
+
+        foreach (var mapping in mappings)
+        {
+            if (TryResolveJsonPointer(mergedData, mapping.SourceField, out var value))
+            {
+                claims[mapping.ClaimName] = value;
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Claim mapping source '{SourceField}' not found in action data; skipping claim '{ClaimName}'",
+                    mapping.SourceField, mapping.ClaimName);
+            }
+        }
+        return claims;
+    }
+
+    internal static bool TryResolveJsonPointer(
+        IReadOnlyDictionary<string, object> root,
+        string jsonPointer,
+        out object value)
+    {
+        value = null!;
+        if (string.IsNullOrEmpty(jsonPointer) || jsonPointer == "/")
+        {
+            return false;
+        }
+
+        var segments = jsonPointer
+            .TrimStart('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length == 0) return false;
+
+        // First segment: look up in the root dictionary.
+        if (!root.TryGetValue(segments[0], out var current) || current is null)
+        {
+            return false;
+        }
+
+        // Subsequent segments: descend through nested structures.
+        for (var i = 1; i < segments.Length; i++)
+        {
+            current = DescendOneLevel(current, segments[i]);
+            if (current is null) return false;
+        }
+
+        value = current;
+        return true;
+    }
+
+    private static object? DescendOneLevel(object parent, string key)
+    {
+        switch (parent)
+        {
+            case IDictionary<string, object?> nullableDict:
+                return nullableDict.TryGetValue(key, out var v1) ? v1 : null;
+
+            case System.Collections.IDictionary plainDict:
+                return plainDict.Contains(key) ? plainDict[key] : null;
+
+            case JsonElement element when element.ValueKind == JsonValueKind.Object:
+                return element.TryGetProperty(key, out var child) ? (object)child : null;
+
+            default:
+                return null;
+        }
+    }
+
     private async Task<CredentialIssuanceResult?> IssueCredentialFromActionAsync(
         ActionModel actionDef,
         Dictionary<string, object> mergedData,
@@ -1285,19 +1388,15 @@ public class ActionExecutionService : IActionExecutionService
     {
         var config = actionDef.CredentialIssuanceConfig!;
 
-        // Map claims from action data using ClaimMappings
-        var claims = new Dictionary<string, object>();
-        if (config.ClaimMappings != null)
-        {
-            foreach (var mapping in config.ClaimMappings)
-            {
-                var sourceKey = mapping.SourceField.TrimStart('/');
-                if (mergedData.TryGetValue(sourceKey, out var value))
-                {
-                    claims[mapping.ClaimName] = value;
-                }
-            }
-        }
+        // Map claims from action data using ClaimMappings.
+        //
+        // Feature 103: sourceField is a JSON Pointer, so it may be either
+        // flat ("/givenName") or nested into a primitive value object
+        // ("/name/givenName" where name is a PersonName/v1 reference). The
+        // extraction walks the pointer segment-by-segment through nested
+        // dictionaries and JsonElement objects. Missing segments log a
+        // warning and skip the claim rather than failing the whole issue.
+        var claims = BuildClaimsFromMappings(config.ClaimMappings, mergedData);
 
         // Resolve recipient wallet address from participant ID
         var recipientWallet = senderWallet; // Default: issuer is also recipient
@@ -1371,6 +1470,10 @@ public class ActionExecutionService : IActionExecutionService
 
         try
         {
+            _logger.LogDebug(
+                "Issuing {CredentialType} with {ClaimCount} claims: [{ClaimNames}]",
+                config.CredentialType, claims.Count, string.Join(", ", claims.Keys));
+
             var result = await _walletClient.IssueCredentialAsync(
                 issuerWalletAddress: senderWallet,
                 credentialType: config.CredentialType,

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -620,7 +620,13 @@ public class ActionExecutionService : IActionExecutionService
                 var haipClaims = BuildClaimsFromMappings(
                     actionDef.CredentialIssuanceConfig.ClaimMappings,
                     mergedData!);
-                // HAIP client expects non-nullable values; flatten before sending.
+                // HAIP client expects non-nullable values. The null-forgiving
+                // operator below is safe because TryResolveJsonPointer returns
+                // false for null-valued segments, so BuildClaimsFromMappings
+                // never produces a null value. If that invariant is ever
+                // relaxed (e.g. to support explicitly-null optional fields),
+                // this projection must be updated to filter or coerce nulls
+                // before the wire call.
                 var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
                 _logger.LogInformation(
@@ -1434,10 +1440,11 @@ public class ActionExecutionService : IActionExecutionService
         // dictionaries and JsonElement objects. Missing segments log a
         // warning and skip the claim rather than failing the whole issue.
         var claims = BuildClaimsFromMappings(config.ClaimMappings, mergedData!);
-        // Wallet client expects non-nullable values; the mapper preserves
-        // null only when the source field is itself null, which never
-        // happens in the issuance path because TryResolveJsonPointer drops
-        // null segments.
+        // Wallet client expects non-nullable values. Safe because
+        // TryResolveJsonPointer returns false on null-valued segments —
+        // BuildClaimsFromMappings never produces a null value. If that
+        // invariant is ever relaxed, this projection must filter or
+        // coerce nulls before the wire call.
         var claimsForWallet = claims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
         // Resolve recipient wallet address from participant ID

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsTests.cs
@@ -101,7 +101,7 @@ public class BuildClaimsFromMappingsTests
             x => x.Log(
                 LogLevel.Warning,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("/notThere") && v.ToString()!.Contains("missing")),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("/notThere") && v.ToString()!.Contains("missing") && v.ToString()!.Contains("no value")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsTests.cs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Blueprint.Service.Services.Implementation;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ActionExecutionService.BuildClaimsFromMappings"/> — the
+/// shared claim-mapping extractor used by both the internal issuance path
+/// and the HAIP external-wallet path. Feature 103 US4 round 2 review item 8.
+/// </summary>
+public class BuildClaimsFromMappingsTests
+{
+    private readonly Mock<ILogger> _logger = new();
+
+    [Fact]
+    public void NullMappings_ReturnsEmptyClaims()
+    {
+        var data = new Dictionary<string, object?> { ["givenName"] = "Alice" };
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(null, data, NullLogger.Instance);
+
+        claims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EmptyMappings_ReturnsEmptyClaims()
+    {
+        var data = new Dictionary<string, object?> { ["givenName"] = "Alice" };
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            Array.Empty<ClaimMapping>(), data, NullLogger.Instance);
+
+        claims.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FlatMapping_PopulatesClaim()
+    {
+        var data = new Dictionary<string, object?> { ["givenName"] = "Alice" };
+        var mappings = new[]
+        {
+            new ClaimMapping { ClaimName = "givenName", SourceField = "/givenName" }
+        };
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(mappings, data, NullLogger.Instance);
+
+        claims.Should().ContainKey("givenName");
+        claims["givenName"].Should().Be("Alice");
+    }
+
+    [Fact]
+    public void NestedMapping_WalksJsonPointer()
+    {
+        // Feature 103: nested PersonName/v1 reference resolves via /name/givenName
+        var data = new Dictionary<string, object?>
+        {
+            ["name"] = new Dictionary<string, object?>
+            {
+                ["givenName"] = "Alice",
+                ["familyName"] = "O'Brien"
+            }
+        };
+        var mappings = new[]
+        {
+            new ClaimMapping { ClaimName = "givenName", SourceField = "/name/givenName" },
+            new ClaimMapping { ClaimName = "familyName", SourceField = "/name/familyName" }
+        };
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(mappings, data, NullLogger.Instance);
+
+        claims.Should().HaveCount(2);
+        claims["givenName"].Should().Be("Alice");
+        claims["familyName"].Should().Be("O'Brien");
+    }
+
+    [Fact]
+    public void MissingSource_DropsClaimAndLogsWarning()
+    {
+        var data = new Dictionary<string, object?> { ["givenName"] = "Alice" };
+        var mappings = new[]
+        {
+            new ClaimMapping { ClaimName = "givenName", SourceField = "/givenName" },
+            new ClaimMapping { ClaimName = "missing", SourceField = "/notThere" }
+        };
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(mappings, data, _logger.Object);
+
+        claims.Should().ContainKey("givenName");
+        claims.Should().NotContainKey("missing");
+
+        // Verify the warning was emitted — silently dropped claims would
+        // produce a credential with fewer attributes than the action
+        // promised, so the log is a critical diagnostic anchor.
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("/notThere") && v.ToString()!.Contains("missing")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ObjectSubtreeSource_ReturnsWholeSubtree()
+    {
+        // /address should return the full address object so the credential
+        // carries a structured 'address' claim (e.g. for vCard-style payloads).
+        var address = new Dictionary<string, object?>
+        {
+            ["line1"] = "42 Grafton Street",
+            ["town"] = "Dublin"
+        };
+        var data = new Dictionary<string, object?> { ["address"] = address };
+        var mappings = new[]
+        {
+            new ClaimMapping { ClaimName = "address", SourceField = "/address" }
+        };
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(mappings, data, NullLogger.Instance);
+
+        claims["address"].Should().BeSameAs(address);
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/JsonPointerResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/JsonPointerResolverTests.cs
@@ -24,10 +24,28 @@ public class JsonPointerResolverTests
             ["familyName"] = "O'Brien"
         };
 
-        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/givenName", out var v);
+        var ok = ActionExecutionService.TryResolveJsonPointer(root, "/givenName", out var v);
 
         ok.Should().BeTrue();
         v.Should().Be("Alice");
+    }
+
+    [Fact]
+    public void TryResolve_Rfc6901EscapeSequences_DecodedBeforeLookup()
+    {
+        // "/a/b" as a raw property name is written as "a~1b" per RFC 6901.
+        // The walker must unescape ~1 → / and ~0 → ~ before dictionary lookup.
+        var root = new Dictionary<string, object?>
+        {
+            ["weird/key"] = "slash-value",
+            ["tilde~key"] = "tilde-value"
+        };
+
+        ActionExecutionService.TryResolveJsonPointer(root, "/weird~1key", out var slashValue).Should().BeTrue();
+        slashValue.Should().Be("slash-value");
+
+        ActionExecutionService.TryResolveJsonPointer(root, "/tilde~0key", out var tildeValue).Should().BeTrue();
+        tildeValue.Should().Be("tilde-value");
     }
 
     [Fact]
@@ -43,10 +61,10 @@ public class JsonPointerResolverTests
             }
         };
 
-        ActionExecutionService.TryResolveJsonPointer(root!, "/name/givenName", out var given).Should().BeTrue();
+        ActionExecutionService.TryResolveJsonPointer(root, "/name/givenName", out var given).Should().BeTrue();
         given.Should().Be("Alice");
 
-        ActionExecutionService.TryResolveJsonPointer(root!, "/name/middleName", out var middle).Should().BeTrue();
+        ActionExecutionService.TryResolveJsonPointer(root, "/name/middleName", out var middle).Should().BeTrue();
         middle.Should().Be("Maeve");
     }
 
@@ -55,7 +73,7 @@ public class JsonPointerResolverTests
     {
         var root = new Dictionary<string, object?> { ["foo"] = "bar" };
 
-        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/missing", out var _);
+        var ok = ActionExecutionService.TryResolveJsonPointer(root, "/missing", out var _);
 
         ok.Should().BeFalse();
     }
@@ -68,7 +86,7 @@ public class JsonPointerResolverTests
             ["name"] = new Dictionary<string, object?> { ["givenName"] = "Alice" }
         };
 
-        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/name/missing", out var _);
+        var ok = ActionExecutionService.TryResolveJsonPointer(root, "/name/missing", out var _);
 
         ok.Should().BeFalse();
     }
@@ -78,8 +96,8 @@ public class JsonPointerResolverTests
     {
         // "/" is the whole-document pointer — no use case for claim mapping.
         var root = new Dictionary<string, object?> { ["x"] = 1 };
-        ActionExecutionService.TryResolveJsonPointer(root!, "/", out _).Should().BeFalse();
-        ActionExecutionService.TryResolveJsonPointer(root!, string.Empty, out _).Should().BeFalse();
+        ActionExecutionService.TryResolveJsonPointer(root, "/", out _).Should().BeFalse();
+        ActionExecutionService.TryResolveJsonPointer(root, string.Empty, out _).Should().BeFalse();
     }
 
     [Fact]
@@ -94,7 +112,7 @@ public class JsonPointerResolverTests
         };
         var root = new Dictionary<string, object?> { ["address"] = address };
 
-        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/address", out var value);
+        var ok = ActionExecutionService.TryResolveJsonPointer(root, "/address", out var value);
 
         ok.Should().BeTrue();
         value.Should().BeSameAs(address);
@@ -114,10 +132,10 @@ public class JsonPointerResolverTests
             ["name"] = doc.RootElement.GetProperty("name")
         };
 
-        ActionExecutionService.TryResolveJsonPointer(root!, "/name/givenName", out var given).Should().BeTrue();
+        ActionExecutionService.TryResolveJsonPointer(root, "/name/givenName", out var given).Should().BeTrue();
         ((JsonElement)given!).GetString().Should().Be("Alice");
 
-        ActionExecutionService.TryResolveJsonPointer(root!, "/name/middleName", out var middle).Should().BeTrue();
+        ActionExecutionService.TryResolveJsonPointer(root, "/name/middleName", out var middle).Should().BeTrue();
         ((JsonElement)middle!).GetString().Should().Be("Maeve");
     }
 
@@ -135,7 +153,7 @@ public class JsonPointerResolverTests
             }
         };
 
-        ActionExecutionService.TryResolveJsonPointer(root!, "/a/b/c", out var value).Should().BeTrue();
+        ActionExecutionService.TryResolveJsonPointer(root, "/a/b/c", out var value).Should().BeTrue();
         value.Should().Be("deep");
     }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/JsonPointerResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/JsonPointerResolverTests.cs
@@ -92,9 +92,13 @@ public class JsonPointerResolverTests
     }
 
     [Fact]
-    public void TryResolve_RootPointer_ReturnsFalse()
+    public void TryResolve_RootAndEmptyPointer_ReturnFalse()
     {
-        // "/" is the whole-document pointer — no use case for claim mapping.
+        // RFC 6901 strictly defines "" as the whole-document pointer and
+        // "/" as the single empty-string key. Neither has a use case for
+        // claim mapping, so the walker treats both as "no resolution" and
+        // returns false. This test pins the simplification so a future
+        // change doesn't accidentally start returning the root document.
         var root = new Dictionary<string, object?> { ["x"] = 1 };
         ActionExecutionService.TryResolveJsonPointer(root, "/", out _).Should().BeFalse();
         ActionExecutionService.TryResolveJsonPointer(root, string.Empty, out _).Should().BeFalse();

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/JsonPointerResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/JsonPointerResolverTests.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Sorcha.Blueprint.Service.Services.Implementation;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ActionExecutionService.TryResolveJsonPointer"/> — the
+/// JSON Pointer walker used by the credential claim mapper. Feature 103 US4
+/// exposed the need for nested-path resolution when the action payload nests
+/// primitive values (e.g. <c>/name/givenName</c> for a PersonName/v1-backed
+/// submission).
+/// </summary>
+public class JsonPointerResolverTests
+{
+    [Fact]
+    public void TryResolve_FlatPath_ReturnsValue()
+    {
+        var root = new Dictionary<string, object?>
+        {
+            ["givenName"] = "Alice",
+            ["familyName"] = "O'Brien"
+        };
+
+        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/givenName", out var v);
+
+        ok.Should().BeTrue();
+        v.Should().Be("Alice");
+    }
+
+    [Fact]
+    public void TryResolve_NestedPath_ReturnsInnerValue()
+    {
+        var root = new Dictionary<string, object?>
+        {
+            ["name"] = new Dictionary<string, object?>
+            {
+                ["givenName"] = "Alice",
+                ["middleName"] = "Maeve",
+                ["familyName"] = "O'Brien"
+            }
+        };
+
+        ActionExecutionService.TryResolveJsonPointer(root!, "/name/givenName", out var given).Should().BeTrue();
+        given.Should().Be("Alice");
+
+        ActionExecutionService.TryResolveJsonPointer(root!, "/name/middleName", out var middle).Should().BeTrue();
+        middle.Should().Be("Maeve");
+    }
+
+    [Fact]
+    public void TryResolve_MissingTopLevel_ReturnsFalse()
+    {
+        var root = new Dictionary<string, object?> { ["foo"] = "bar" };
+
+        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/missing", out var _);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryResolve_MissingNestedSegment_ReturnsFalse()
+    {
+        var root = new Dictionary<string, object?>
+        {
+            ["name"] = new Dictionary<string, object?> { ["givenName"] = "Alice" }
+        };
+
+        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/name/missing", out var _);
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryResolve_RootPointer_ReturnsFalse()
+    {
+        // "/" is the whole-document pointer — no use case for claim mapping.
+        var root = new Dictionary<string, object?> { ["x"] = 1 };
+        ActionExecutionService.TryResolveJsonPointer(root!, "/", out _).Should().BeFalse();
+        ActionExecutionService.TryResolveJsonPointer(root!, string.Empty, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryResolve_ReturnsWholeSubtreeOnObjectSourceField()
+    {
+        // Feature 103 credential mapping: `/address` should return the full
+        // address object, not a per-property drill-down.
+        var address = new Dictionary<string, object?>
+        {
+            ["line1"] = "42 Grafton Street",
+            ["town"] = "Dublin"
+        };
+        var root = new Dictionary<string, object?> { ["address"] = address };
+
+        var ok = ActionExecutionService.TryResolveJsonPointer(root!, "/address", out var value);
+
+        ok.Should().BeTrue();
+        value.Should().BeSameAs(address);
+    }
+
+    [Fact]
+    public void TryResolve_JsonElementValues_WalksJsonStructure()
+    {
+        // When the payload was deserialised via System.Text.Json, the nested
+        // values are JsonElement instances. The walker must descend through
+        // them transparently.
+        var doc = JsonDocument.Parse("""
+            { "name": { "givenName": "Alice", "middleName": "Maeve" } }
+            """);
+        var root = new Dictionary<string, object?>
+        {
+            ["name"] = doc.RootElement.GetProperty("name")
+        };
+
+        ActionExecutionService.TryResolveJsonPointer(root!, "/name/givenName", out var given).Should().BeTrue();
+        ((JsonElement)given!).GetString().Should().Be("Alice");
+
+        ActionExecutionService.TryResolveJsonPointer(root!, "/name/middleName", out var middle).Should().BeTrue();
+        ((JsonElement)middle!).GetString().Should().Be("Maeve");
+    }
+
+    [Fact]
+    public void TryResolve_DeeperNesting_WalksAllSegments()
+    {
+        var root = new Dictionary<string, object?>
+        {
+            ["a"] = new Dictionary<string, object?>
+            {
+                ["b"] = new Dictionary<string, object?>
+                {
+                    ["c"] = "deep"
+                }
+            }
+        };
+
+        ActionExecutionService.TryResolveJsonPointer(root!, "/a/b/c", out var value).Should().BeTrue();
+        value.Should().Be("deep");
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
@@ -175,6 +175,53 @@ public class FormSchemaServiceTests
     // --- x-rule parsing (Feature 091) ---
 
     [Fact]
+    public void AutoGenerateForm_StringWithXAddressLookup_DispatchesToPostcodeLookup()
+    {
+        // Feature 103 US3: a string field carrying `x-address-lookup: true`
+        // should be routed to the PostcodeLookup control type regardless of
+        // format / maxLength. Siblings without the marker stay on TextLine.
+        var schema = JsonDocument.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "line1":    { "type": "string", "title": "Address line 1" },
+                "town":     { "type": "string", "title": "Town" },
+                "postcode": { "type": "string", "title": "Postcode", "x-address-lookup": true },
+                "country":  { "type": "string", "title": "Country" }
+            }
+        }
+        """);
+
+        var form = _sut.AutoGenerateForm(new[] { schema });
+
+        var postcode = form.Elements.FirstOrDefault(e => e.Scope == "/postcode");
+        postcode.Should().NotBeNull();
+        postcode!.ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.PostcodeLookup);
+
+        form.Elements.First(e => e.Scope == "/line1").ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.TextLine);
+        form.Elements.First(e => e.Scope == "/town").ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.TextLine);
+        form.Elements.First(e => e.Scope == "/country").ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.TextLine);
+    }
+
+    [Fact]
+    public void AutoGenerateForm_XAddressLookupFalse_RemainsTextLine()
+    {
+        // Explicit `x-address-lookup: false` should NOT dispatch to postcode lookup.
+        var schema = JsonDocument.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "postcode": { "type": "string", "x-address-lookup": false }
+            }
+        }
+        """);
+
+        var form = _sut.AutoGenerateForm(new[] { schema });
+        form.Elements.First(e => e.Scope == "/postcode").ControlType
+            .Should().Be(Sorcha.Blueprint.Models.ControlTypes.TextLine);
+    }
+
+    [Fact]
     public void AutoGenerateForm_PropertyWithXRule_PopulatesControlRule()
     {
         var schema = JsonDocument.Parse("""

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/PostcodeLookupRendererTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/PostcodeLookupRendererTests.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.UI.Core.Components.Forms.Controls;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Tests for <see cref="PostcodeLookupRenderer.GetParentScope"/> — the helper
+/// that computes the sibling-field prefix for autofill writes. Feature 103 US3.
+/// </summary>
+public class PostcodeLookupRendererTests
+{
+    [Fact]
+    public void GetParentScope_OneDeepScope_ReturnsParentWithTrailingSlash()
+    {
+        PostcodeLookupRenderer.GetParentScope("/address/postcode")
+            .Should().Be("/address/");
+    }
+
+    [Fact]
+    public void GetParentScope_RootLevelScope_ReturnsRootSlash()
+    {
+        PostcodeLookupRenderer.GetParentScope("/postcode")
+            .Should().Be("/");
+    }
+
+    [Fact]
+    public void GetParentScope_EmptyScope_ReturnsRootSlash()
+    {
+        PostcodeLookupRenderer.GetParentScope(string.Empty)
+            .Should().Be("/");
+    }
+
+    [Fact]
+    public void GetParentScope_DeeplyNestedScope_ReturnsImmediateParent()
+    {
+        PostcodeLookupRenderer.GetParentScope("/applicant/address/postcode")
+            .Should().Be("/applicant/address/");
+    }
+}


### PR DESCRIPTION
## Summary

Wave 7 of Feature 103 (Verified Citizen v2). Two things bundled because they were discovered together during integration:

1. **UI dispatch for `x-address-lookup` (US3)** — string fields carrying `x-address-lookup: true` now render as a new `PostcodeLookup` control with three runtime modes (NoProvider / ValidateOnly / FullAddress). Sibling address fields autofill via `FormContext.SetValue` on the parent scope.
2. **HAIP claim-mapping fix (US4)** — `ActionExecutionService` used a flat top-level lookup for `ClaimMapping.SourceField`, so nested primitive payloads (e.g. `/name/givenName` from a `PersonName/v1` reference) resolved to null and the claim was dropped. Credentials ended up carrying the nested `name` object instead of flat `givenName`/`familyName`/etc. The HAIP external-wallet path bypassed the claim mapper entirely, passing `mergedData` straight through.

## Changes

**UI dispatch**
- `ControlTypes.PostcodeLookup` enum value
- `FormSchemaService` routes `x-address-lookup: true` string fields
- `ControlDispatcher.razor` case wiring
- **New** `PostcodeLookupRenderer.razor` (~280 lines) — discovers provider capability via `/api/address-lookup/providers`, calls `/api/address-lookup/postcode` on blur (validate-only) or via explicit button (full-address), and writes sibling address fields on candidate selection
- `data-testid` attributes on all interactive elements for E2E testing

**Claim mapping**
- New `TryResolveJsonPointer` static walker — descends through nested `Dictionary<string, object?>` and `JsonElement` objects segment by segment
- New `BuildClaimsFromMappings` helper shared between the internal issuance path and the HAIP external-wallet path
- Both paths now correctly extract nested values

## Test plan

- [x] 8 new `JsonPointerResolverTests` (flat, nested, missing, root, whole-subtree, JsonElement, deeper nesting)
- [x] 2 new `FormSchemaServiceTests` covering `x-address-lookup: true` and `false`
- [x] Full `Sorcha.Blueprint.Service.Tests` JsonPointer filter pass (8/8 green)
- [x] Full `Sorcha.UI.Core.Tests` FormSchemaService filter pass (26/26 green)
- [x] End-to-end: `HaipVerifiedCitizen` walkthrough against rebuilt containers — credential now exposes flat disclosures (`givenName`, `middleName`, `familyName`, `fullName`, `dateOfBirth`, `email`, plus address components)
- [x] End-to-end: `HaipDrivingLicence` chained walkthrough — successfully presents identity credential and issues downstream `DrivingLicenceCredential`

🤖 Generated with [Claude Code](https://claude.com/claude-code)