### PR TITLE
fix(103): wave 11 — My Activity consumer UI polish

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Help.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Help.razor
@@ -172,7 +172,7 @@
                 <MudGrid>
                     <MudItem xs="12" md="3">
                         <MudText Typo="Typo.subtitle2" Class="mb-2">GitHub</MudText>
-                        <MudLink Href="https://github.com/StuartF303/Sorcha" Target="_blank" Typo="Typo.body2">
+                        <MudLink Href="https://github.com/Sorcha-Platform/Sorcha" Target="_blank" Typo="Typo.body2">
                             Source Code & Issues
                         </MudLink>
                         <MudText Typo="Typo.caption" Color="Color.Secondary">

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
@@ -169,8 +169,16 @@ else
         </Authorized>
     </AuthorizeView>
 
-    @* Alerts Panel *@
-    <AlertsPanel Alerts="@_visibleAlerts" OnRefresh="RefreshAlertsAsync" />
+    @* Alerts Panel — operational alerts (peer health, validator quorum,
+       service degradation) are surfaced only to users who can act on
+       them. Citizens have no agency over infrastructure health, so
+       showing them a "Peer network health is 0.0%" warning on the
+       welcome page is misleading and adds anxiety for nothing. *@
+    <AuthorizeView Roles="Administrator,SystemAdmin,OrganizationAdmin">
+        <Authorized Context="alertsAuthContext">
+            <AlertsPanel Alerts="@_visibleAlerts" OnRefresh="RefreshAlertsAsync" />
+        </Authorized>
+    </AuthorizeView>
 
     @if (_isRefreshing)
     {
@@ -180,7 +188,7 @@ else
     @* Quick Actions *@
     <MudText Typo="Typo.h6" Class="mb-2">@Loc.T("dashboard.quickActions")</MudText>
     <MudStack Row="true" Spacing="2" Class="mb-6">
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="my-workflows"
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="new-submissions"
                    StartIcon="@Icons.Material.Filled.PostAdd">
             @Loc.T("nav.newSubmission")
         </MudButton>
@@ -206,8 +214,10 @@ else
         </AuthorizeView>
     </MudStack>
 
-    @* Error State Display *@
-    @if (!_stats.IsLoaded && !_isLoading)
+    @* Error State Display — only for admin viewers who actually request
+       the stats. Citizens never load the stats endpoint, so "stats not
+       loaded" for them is not an error, just a not-applicable state. *@
+    @if (_canSeeAdminDashboard && !_stats.IsLoaded && !_isLoading)
     {
         <MudAlert Severity="Severity.Warning" Class="mb-4">
             @Loc.T("dashboard.statsError") <a href="wallets" class="mud-alert-link">@Loc.T("dashboard.viewWallets")</a>
@@ -228,6 +238,7 @@ else
     private bool _isLoading = true;
     private bool _isRefreshing;
     private bool _hasDefaultWallet;
+    private bool _canSeeAdminDashboard;
     private string _displayName = string.Empty;
     private System.Timers.Timer? _refreshTimer;
     private bool _disposed;
@@ -239,13 +250,23 @@ else
         // Get display name from auth state (already verified by [Authorize] + AuthorizeRouteView)
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         _displayName = GetDisplayName(authState.User);
+        // Operational alerts + admin-scoped dashboard stats are only
+        // fetched for users in admin roles — citizens don't see the
+        // AlertsPanel or the admin stat grid, so polling those endpoints
+        // for them just produces 401 noise in the console.
+        _canSeeAdminDashboard = authState.User.IsInRole("Administrator")
+                                || authState.User.IsInRole("SystemAdmin")
+                                || authState.User.IsInRole("OrganizationAdmin");
 
         var wallets = await WalletApi.GetWalletsAsync();
         var defaultWallet = await WalletPreferences.GetSmartDefaultAsync(wallets);
         _hasDefaultWallet = defaultWallet is not null;
 
-        _stats = await DashboardService.GetDashboardStatsAsync();
-        await LoadAlertsAsync();
+        if (_canSeeAdminDashboard)
+        {
+            _stats = await DashboardService.GetDashboardStatsAsync();
+            await LoadAlertsAsync();
+        }
         _isLoading = false;
 
         StartAutoRefresh();
@@ -262,6 +283,8 @@ else
     private async Task RefreshDashboardAsync()
     {
         if (_disposed) return;
+        if (!_canSeeAdminDashboard) return;
+
         _isRefreshing = true;
         StateHasChanged();
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor
@@ -173,12 +173,14 @@ else
        service degradation) are surfaced only to users who can act on
        them. Citizens have no agency over infrastructure health, so
        showing them a "Peer network health is 0.0%" warning on the
-       welcome page is misleading and adds anxiety for nothing. *@
-    <AuthorizeView Roles="Administrator,SystemAdmin,OrganizationAdmin">
-        <Authorized Context="alertsAuthContext">
-            <AlertsPanel Alerts="@_visibleAlerts" OnRefresh="RefreshAlertsAsync" />
-        </Authorized>
-    </AuthorizeView>
+       welcome page is misleading and adds anxiety for nothing. We
+       drive visibility from _canSeeAdminDashboard instead of wrapping
+       in an AuthorizeView so the role check lives in one place
+       (OnInitializedAsync). *@
+    @if (_canSeeAdminDashboard)
+    {
+        <AlertsPanel Alerts="@_visibleAlerts" OnRefresh="RefreshAlertsAsync" />
+    }
 
     @if (_isRefreshing)
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
@@ -74,19 +74,14 @@
     {
         <MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true" Class="mb-4">
 
-            @* Pending tab *@
-            <MudTabPanel Icon="@Icons.Material.Filled.HourglassEmpty"
+            @* Pending tab — Text drives the accessible name; the
+               BadgeData shows the count on the Pending pill. Previously
+               a <TabContent> override rendered the label inline, which
+               left the tab with no accessible name for screen readers. *@
+            <MudTabPanel Text="Pending"
+                         Icon="@Icons.Material.Filled.HourglassEmpty"
                          BadgeData="@(_pendingCredentials.Count > 0 ? _pendingCredentials.Count.ToString() : null)"
                          BadgeColor="Color.Warning">
-                <TabContent>
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                        <MudText>Pending</MudText>
-                        @if (_pendingCredentials.Count > 0)
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Warning" Size="MudBlazor.Size.Small" Style="font-size: 10px;" />
-                        }
-                    </MudStack>
-                </TabContent>
                 <ChildContent>
                     @if (_pendingCredentials.Count > 0)
                     {
@@ -138,7 +133,8 @@
             </MudTabPanel>
 
             @* Presentation Inbox tab *@
-            <MudTabPanel Icon="@Icons.Material.Filled.Inbox"
+            <MudTabPanel Text="Inbox"
+                         Icon="@Icons.Material.Filled.Inbox"
                          BadgeData="@(_pendingRequests.Count > 0 ? _pendingRequests.Count.ToString() : null)"
                          BadgeColor="Color.Error">
                 <ChildContent>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissions.razor
@@ -331,6 +331,19 @@
                             StartingActionDescription = startingAction?.Description
                         };
                     })
+                    // Feature 103 wave 11: collapse duplicate blueprint versions
+                    // by Title. Re-running the walkthrough setup publishes a
+                    // fresh blueprint with a timestamped id (e.g.
+                    // haip-verified-citizen-20260413232917), so the catalogue
+                    // previously showed the same "HAIP Verified Citizen" card
+                    // twice — or N times for N re-runs. Group by Title and
+                    // keep the highest Version; break ties by BlueprintId
+                    // (timestamp suffix sorts newest last lexicographically).
+                    .GroupBy(s => s.Title, StringComparer.OrdinalIgnoreCase)
+                    .Select(g => g
+                        .OrderByDescending(s => s.Version)
+                        .ThenByDescending(s => s.BlueprintId, StringComparer.Ordinal)
+                        .First())
                     .ToList();
 
                 if (startables.Count > 0)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissions.razor
@@ -338,7 +338,14 @@
                     // previously showed the same "HAIP Verified Citizen" card
                     // twice — or N times for N re-runs. Group by Title and
                     // keep the highest Version; break ties by BlueprintId
-                    // (timestamp suffix sorts newest last lexicographically).
+                    // descending so the newest timestamp (lexicographically
+                    // largest) wins.
+                    //
+                    // TODO: this is a client-side workaround. The real fix
+                    // is server-side — either the Blueprint Service should
+                    // expose a "latest version per title" query, or the
+                    // publish path should supersede prior versions on the
+                    // same title. Tracking as a follow-up.
                     .GroupBy(s => s.Title, StringComparer.OrdinalIgnoreCase)
                     .Select(g => g
                         .OrderByDescending(s => s.Version)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletList.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletList.razor
@@ -73,7 +73,12 @@
     {
         try
         {
-            defaultWalletAddress = await WalletPreferenceService.GetDefaultWalletAsync();
+            // Use GetSmartDefaultAsync so the default star is always
+            // visible — if the user has never explicitly set a default,
+            // the service falls back to the first wallet in the list.
+            // This matches the Dashboard wallet resolution and stops the
+            // "10 wallets, no default" confusion from wave 11 audit.
+            defaultWalletAddress = await WalletPreferenceService.GetSmartDefaultAsync(wallets);
         }
         catch
         {


### PR DESCRIPTION
## Summary

Six targeted UI polish fixes from the wave 10 consumer UI audit. Each addresses a distinct medium or low severity issue that showed up when walking the citizen user story through the Blazor UI as \`alice.obrien@haip-walkthrough.local\`. All verified end-to-end via chrome-devtools-mcp walk-through.

## What's in this PR

| # | Page | Before | After |
|---|------|--------|-------|
| 1 | **Dashboard** | \"Peer Service: Peer network health is 0.0%\" alert shown to citizens | Alerts panel gated on admin roles + the fetch is skipped for non-admins |
| 2 | **Dashboard** | NEW SUBMISSION Quick Action → \`/my-workflows\` (redirect stub) | Direct link to \`/new-submissions\` |
| 3 | **New Submission** | \"HAIP Verified Citizen\" listed twice (or 10 times after re-runs) | Each register shows one card per title; latest version wins |
| 4 | **My Wallet** | 10 cards, all showing \"Set as Default\", no indication which one is actually active | First wallet shows filled star + \"Default Wallet\" button via \`GetSmartDefaultAsync\` fallback |
| 5 | **My Credentials** | First tab (\"Pending\") had no accessible name — reported as \`tab selectable selected\` with zero label | All five tabs labelled: PENDING / ACTIVE / EXPIRED / REVOKED / Inbox |
| 6 | **Help & Support** | GitHub link → \`github.com/StuartF303/Sorcha\` (personal fork) | \`github.com/Sorcha-Platform/Sorcha\` (org) |

## Side benefits

- Dashboard alerts fetch is completely skipped for non-admin users, removing a portion of the \"401 Unauthorized\" console noise that was showing up on the dashboard.
- \`RefreshDashboardAsync\` now short-circuits for non-admins so the 30-second auto-refresh timer stops polling admin endpoints for citizen users.

## Not in this PR (tracked for follow-up)

| Severity | Issue | Why deferred |
|---|---|---|
| MED | Help content is designer-oriented (\"Design a Blueprint\" step, Ctrl+S Save Blueprint shortcut) | Content rewrite — wants a proper citizen-path draft |
| LOW | My Credentials needs an explainer card for HAIP-delivered vs native credentials | UX decision for the content |
| LOW | Remaining 401 console noise from non-dashboard pages | Deep trace per endpoint; separate wave |

## Test plan

- [x] Rebuilt \`sorcha-ui-web\` docker image
- [x] Drove Dashboard / New Submission / My Wallet / My Credentials / Help end-to-end via chrome-devtools-mcp
- [x] Verified dashboard alerts card is absent for citizen user
- [x] Verified no duplicate blueprint cards on New Submission
- [x] Verified one wallet card shows \"Default Wallet\" button disabled
- [x] Verified all 5 credential tabs have accessible names in a11y tree
- [x] Verified Help GitHub link renders with the correct URL
- [x] \`dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Sorcha.UI.Web.Client.csproj\` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)