### PR TITLE
fix(103): wave 13 review — IsPreHashed + cleanup

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Credentials/HaipLocalReceiveService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Credentials/HaipLocalReceiveService.cs
@@ -143,15 +143,19 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
             var signingInput = Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
 
             // The Wallet Service /sign endpoint takes base64 transaction
-            // data and produces a base64 signature. IsPreHashed=false means
-            // the service will hash the input internally and sign the hash;
-            // for raw JWS we need raw-data signing (no extra hash). Sorcha
-            // wallets sign the raw bytes with PublicKeyAuth.SignDetached
-            // when IsPreHashed=false on a non-hashed payload.
+            // data and produces a base64 signature. IsPreHashed=true tells
+            // the wallet to sign the transactionData bytes directly without
+            // applying an additional SHA-256 pre-hash (see
+            // TransactionService.SignTransactionAsync lines 53-56). Ed25519's
+            // internal hashing (SHA-512 inside EdDSA) handles the raw JWS
+            // signing input correctly, and the HAIP verifier uses
+            // Sodium.PublicKeyAuth.VerifyDetached against the raw bytes — so
+            // we MUST skip the wallet's extra SHA-256 to produce a signature
+            // that verifies.
             var signRequest = new SignRequest
             {
                 TransactionData = Convert.ToBase64String(signingInput),
-                IsPreHashed = false
+                IsPreHashed = true
             };
             var signResponse = await _httpClient.PostAsJsonAsync(
                 $"/api/v1/wallets/{walletAddress}/sign", signRequest, JsonOptions, ct);
@@ -268,7 +272,7 @@ public sealed class HaipLocalReceiveService : IHaipLocalReceiveService
         if (!offer.TryGetProperty("grants", out var grants)) return null;
         foreach (var grant in grants.EnumerateObject())
         {
-            if (grant.Name.Contains("pre-authorized_code", StringComparison.Ordinal) &&
+            if (grant.Name == "urn:ietf:params:oauth:grant-type:pre-authorized_code" &&
                 grant.Value.TryGetProperty("pre-authorized_code", out var code))
             {
                 return code.GetString();

--- a/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
@@ -81,9 +81,14 @@ public static class CredentialEndpoints
             });
         }
 
-        // Parse the JWT proof to extract the c_nonce and holder key
+        // Parse the JWT proof to extract the c_nonce, holder key, signing
+        // input, and signature bytes. Everything that depends on the JWT
+        // structure is computed here, under a single length guard, so later
+        // code can access segments without reparsing.
         JsonElement proofPayload;
         JsonElement? holderJwk;
+        byte[] signingInput;
+        byte[] signature;
         try
         {
             var proofParts = request.Proof.Jwt.Split('.');
@@ -100,6 +105,10 @@ public static class CredentialEndpoints
             // Parse payload for nonce
             var payloadBytes = Base64Url.DecodeFromChars(proofParts[1]);
             proofPayload = JsonSerializer.Deserialize<JsonElement>(payloadBytes);
+
+            // Compute the signing input + decoded signature for later verification.
+            signingInput = Encoding.ASCII.GetBytes($"{proofParts[0]}.{proofParts[1]}");
+            signature = Base64Url.DecodeFromChars(proofParts[2]);
         }
         catch (Exception ex)
         {
@@ -118,10 +127,6 @@ public static class CredentialEndpoints
             var jwk = holderJwk.Value;
             var kty = jwk.TryGetProperty("kty", out var ktyProp) ? ktyProp.GetString() : null;
             var crv = jwk.TryGetProperty("crv", out var crvProp) ? crvProp.GetString() : null;
-
-            var proofParts2 = request.Proof.Jwt.Split('.');
-            var signingInput = Encoding.ASCII.GetBytes($"{proofParts2[0]}.{proofParts2[1]}");
-            var signature = Base64Url.DecodeFromChars(proofParts2[2]);
 
             if (kty == "EC" && crv == "P-256"
                 && jwk.TryGetProperty("x", out var xProp) && jwk.TryGetProperty("y", out var yProp))


### PR DESCRIPTION
## Summary

Wave 11 audit + wave 12 conversation flagged that HAIP-issued credentials only land in the external wallet that scans the QR — they never reach the user's own Sorcha wallet, so they can't be presented again from the same account. This PR adds the alternative path: a **\"Receive on this device\"** button alongside the QR that drives the OpenID4VCI pre-authorized-code flow with the user's existing Sorcha wallet acting as the holder.

The credential ends up in the local credential store on the user's wallet, surfaces in **My Credentials**, and is bound to the wallet's signing key (cnf claim) so it can be presented from the same account.

## Architecture

The walkthrough's \`sorcha-agent\` CLI already implements the full OpenID4VCI flow with a fresh P-256 holder key. Wave 13 ports that flow into a Blazor service and binds to the user's actual Sorcha wallet so the credential is held by a key the user already controls.

Three coordinated changes:

### 1. HAIP issuer — extend proof verification to accept EdDSA / Ed25519

Sorcha citizen wallets default to ED25519, so the holder JWK from the local wallet is OKP/Ed25519. The existing HAIP credential endpoint only accepted EC P-256 JWKs and refused everything else. Added a new branch that:
- Reads the OKP/Ed25519 JWK shape (\`kty=OKP\`, \`crv=Ed25519\`, \`x=<base64url public key>\`)
- Verifies the signature with \`Sodium.PublicKeyAuth.VerifyDetached\` (already a transitive dep via Sorcha.Cryptography)
- Falls through to a clearer error message for unsupported JWK shapes

The EC P-256 path is unchanged so the existing sorcha-agent flow keeps working.

### 2. Sorcha.UI.Core — \`IHaipLocalReceiveService\` + impl

New file: \`Services/Credentials/HaipLocalReceiveService.cs\`. The \`ReceiveLocallyAsync(credentialOfferUri, walletAddress)\` method:

1. Parses the \`openid-credential-offer://\` URI to extract \`credential_issuer\` + \`pre-authorized_code\`
2. Fetches \`GET /api/v1/wallets/{address}\` to read the wallet's ED25519 public key + algorithm (refuses non-ED25519 wallets with a clear error)
3. Fetches the issuer metadata for token + credential endpoints
4. POSTs the token endpoint with the pre-auth grant
5. Builds the JWT proof header (\`alg=EdDSA\`, \`typ=openid4vci-proof+jwt\`, \`jwk={kty=OKP, crv=Ed25519, x=...}\`) and payload (\`aud\`, \`iat\`, \`nonce\`)
6. POSTs \`/api/v1/wallets/{address}/sign\` with the JWT signing input bytes (\`IsPreHashed=false\`) to get an Ed25519 signature
7. Assembles the compact JWS and POSTs the credential endpoint
8. POSTs the resulting SD-JWT VC to \`/api/v1/wallets/{address}/credentials\` so it lands in the existing local credential store (which feeds \`MyCredentials.razor\`)

Returns a \`HaipLocalReceiveResult\` record (Success/Fail) so the caller can show snackbar feedback. Errors at any step capture an \`ErrorCode\` (e.g. \`token_exchange_failed\`, \`wallet_sign_failed\`, \`credential_request_failed\`, \`local_store_failed\`) plus a human-readable message.

### 3. \`CredentialOfferQrCard\` — new \"Receive on this device\" button

New optional \`LocalWalletAddress\` parameter. When supplied, renders a button below the QR with a divider + \"or\" label. Click handler:
- Disables itself + shows \"Receiving...\" with a spinner
- Calls \`IHaipLocalReceiveService.ReceiveLocallyAsync\`
- On success: snackbar success, transitions card to Exchanged state (so polling stops), fires \`OnLocalReceived\` callback so consumers can refresh
- On failure: snackbar error with the issuer's error message

\`CredentialOfferQrDialog\` passes the parameter through. Both call sites (\`NewSubmissionWorkspace\` + \`MyActions\`) pass the action submitter's signing wallet.

## Tests

\`Sorcha.UI.Core.Tests/Credentials/HaipLocalReceiveServiceParseTests.cs\` — 6 pure-parser unit tests:

- Valid \`credential_offer\` URI returns decoded JSON
- Trailing query params stop at \`&\`
- Missing marker returns null
- Pre-auth code extraction with valid grants
- No grants → null
- Grants without pre-authorized branch → null

**6/6 green.** Full receive flow verification will run as the wave 13 walkthrough re-run after merge.

## Out of scope (tracked for wave 14)

- **Recipient inbox.** The QR dialog currently appears for the action SENDER (the assessor in HaipVerifiedCitizen), not the credential RECIPIENT (the citizen). Clicking \"Receive on this device\" therefore stores the credential in the assessor's wallet, which works mechanically but is semantically backwards. The proper fix is a notification + inbox flow on the recipient side: the citizen sees pending credential offers in My Credentials → Inbox and can claim them there.
- **NISTP256 wallets.** The HAIP issuer now accepts EdDSA + ES256 but not NISTP256. Adding NISTP256 support is straightforward (same EC code path with a different curve hint) but out of scope here.
- **Per-endpoint rate limit.** The local receive endpoint inherits the standard \`RateLimitPolicies.Api\` via the HttpClient handler chain but doesn't have a dedicated bucket.

## Test plan

- [x] HAIP service builds clean
- [x] Sorcha.UI.Core builds clean
- [x] Sorcha.UI.Web.Client builds clean
- [x] 6/6 HaipLocalReceiveServiceParseTests green
- [x] sorcha-ui-web + haip-service docker images rebuilt locally
- [ ] End-to-end: walkthrough run → click \"Receive on this device\" on the QR dialog → SD-JWT lands in local credential store, surfaces in My Credentials (will run after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)