### PR TITLE
feat(104): wave 14b credential claim card + blueprint updates

### DIFF
--- a/.claude/skills/blueprint-builder/SKILL.md
+++ b/.claude/skills/blueprint-builder/SKILL.md
@@ -307,6 +307,37 @@ If your blueprint asks the user for a name, date of birth, email, or postal addr
 }
 ```
 
+### Route with OutputMapping (Payload Carry-Forward) — Feature 104
+
+A route MAY carry data from the current action's execution result into the next action's **prepopulated payload** via `outputMapping`. This is a general-purpose primitive — any blueprint can use it to hand data off between actions without the recipient re-entering it.
+
+```json
+{
+  "id": "approved-to-claim",
+  "nextActionIds": [3],
+  "condition": { "==": [{ "var": "verificationDecision" }, "approved"] },
+  "outputMapping": {
+    "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+    "/haip/credential_type":      "/credentialOffer/credential_type",
+    "/haip/expires_at":           "/credentialOffer/expires_at"
+  }
+}
+```
+
+**How it works:**
+- Keys are JSON Pointers into the **source document** produced by the current action's execution. Available sub-trees:
+  - `/payload/*` — the submitted action payload
+  - `/calculations/*` — values produced by the engine's calculate step
+  - `/haip/*` — HAIP credential offer output (`credential_offer_uri`, `offer_id`, `expires_at`, `credential_type`) when the current action declared `credentialIssuanceConfig.targetAudience = HaipExternalWallet`
+- Values are JSON Pointers into the **target** — the next action's prepopulated starting payload. Intermediate object nodes are created as needed.
+- Absent source paths are **silently skipped** (not an error) — authors can map optional fields without adding conditionals.
+- The seed is merged with the recipient's submission on execute — submitted fields win on key collision.
+- Seed persists across page reloads and is cleared atomically when the action resolves (complete, reject, or expire).
+
+**Publish-time validation:**
+- `VAL_BP_011` — every target JSON Pointer's top-level field MUST exist in at least one `DataSchema` of at least one next action. Writing to fields that aren't declared on the receiving action is a publish error.
+- Both source and target pointers MUST begin with `/` (RFC 6901).
+
 ## Route Precedence
 
 Route-based routing (via `Action.Routes`) takes precedence over legacy condition-based routing (via `Action.Participants`). Always use `routes` for new blueprints.
@@ -332,6 +363,127 @@ Route-based routing (via `Action.Routes`) takes precedence over legacy condition
 ```json
 { "type": "number", "minimum": 0, "title": "Amount" }
 ```
+
+## Credential Claim Actions (Feature 104 — wave 14b)
+
+When a blueprint **issues a HAIP credential**, the credential offer must reach the **recipient**, not the issuing action sender. The correct pattern is a three-action shape:
+
+```
+Action 1: Applicant submits data        (sender: applicant — open, late-bound)
+Action 2: Issuer reviews, mints offer    (sender: issuer; declares credentialIssuanceConfig)
+          → route.outputMapping carries /haip/* into action 3's payload seed
+Action 3: Applicant claims credential    (sender: applicant; same participant as action 1)
+          → uses x-credential-offer schema extension
+```
+
+The claim action renders as a **CredentialClaimCard** in the applicant's *My Actions* queue with Claim / Scan-with-external-wallet / Decline buttons. Clicking Claim calls `HaipLocalReceiveService` to redeem the pre-authorized code against the citizen's local Sorcha wallet. Scan-QR reveals an embedded QR for external HAIP wallets. Decline seals an `InstanceState.Rejected` transaction via `RejectionConfig.IsTerminal = true`.
+
+**Why this shape** (not the wave 13 assessor-side QR dialog):
+- Cryptographic correctness: the OpenID4VCI `pre_authorized_code` is a bearer token; whoever redeems it binds the credential to *their* key via the `cnf` claim. Landing the code in the assessor's browser binds the credential to the wrong wallet. Routing it through the claim action via `outputMapping` + participant late-binding ensures only the applicant's wallet can redeem.
+- Recipient-locked for free: action 3's sender is the same open participant as action 1, already late-bound to the citizen's wallet. No extra authz logic required.
+- Durable and auditable: the offer persists as seeded payload state; the claim is sealed to the register as a normal action transaction with a `claimed_at` timestamp.
+- Reuses existing infrastructure: My Actions queue, open-participant late-binding, rejection config — no new notification channel.
+
+### Action 3 schema — `x-credential-offer` extension
+
+Mark a top-level **object** field with `"x-credential-offer": true`. The UI renderer detects the extension on a pending action and swaps in the credential claim card instead of the default form. The blueprint declares the shape; the previous action's `outputMapping` seeds the values.
+
+```json
+{
+  "id": 3,
+  "title": "Claim your Verified Citizen credential",
+  "description": "Your credential is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP wallet.",
+  "sender": "citizen",
+  "requiredPriorActions": [2],
+  "dataSchemas": [
+    {
+      "type": "object",
+      "properties": {
+        "credentialOffer": {
+          "type": "object",
+          "title": "Credential Offer",
+          "x-credential-offer": true,
+          "properties": {
+            "credential_offer_uri": {
+              "type": "string",
+              "format": "uri",
+              "description": "Canonical OpenID4VCI offer URI"
+            },
+            "credential_type": { "type": "string" },
+            "expires_at":      { "type": "string", "format": "date-time" },
+            "offer_id":        { "type": "string" }
+          },
+          "required": ["credential_offer_uri"]
+        },
+        "claimed_at": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Claimed at",
+          "description": "Set by the client when the citizen clicks Claim"
+        }
+      },
+      "required": ["credentialOffer"]
+    }
+  ],
+  "rejectionConfig": {
+    "targetActionId": 0,
+    "isTerminal": true,
+    "requireReason": false
+  },
+  "disclosures": [
+    { "participantAddress": "citizen", "dataPointers": ["/*"] }
+  ],
+  "routes": [
+    {
+      "id": "claimed-terminal",
+      "nextActionIds": [],
+      "isDefault": true,
+      "description": "Credential claimed — workflow complete"
+    }
+  ]
+}
+```
+
+### Action 2 — route mapping
+
+The issuing action (action 2) must route **conditionally** to the claim action on approval and terminate on rejection. Declare both routes and include `outputMapping` only on the approval route:
+
+```json
+"routes": [
+  {
+    "id": "approved-to-claim",
+    "nextActionIds": [3],
+    "condition": { "==": [{ "var": "verificationDecision" }, "approved"] },
+    "description": "Approved — hand the minted credential to the applicant",
+    "outputMapping": {
+      "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+      "/haip/credential_type":      "/credentialOffer/credential_type",
+      "/haip/expires_at":           "/credentialOffer/expires_at",
+      "/haip/offer_id":             "/credentialOffer/offer_id"
+    }
+  },
+  {
+    "id": "rejected-terminal",
+    "nextActionIds": [],
+    "isDefault": true,
+    "description": "Rejected — workflow ends with no credential issued"
+  }
+]
+```
+
+Action 2 still declares `credentialIssuanceConfig` with `targetAudience: HaipExternalWallet` exactly as before — the engine mints the offer pre-routing and exposes it under `/haip/*` in the routing source document so the mapping can pick it up.
+
+### Publish-time validation for claim actions
+
+- **VAL_BP_012** (error): `x-credential-offer: true` may only appear on **object**-typed schema fields. Scalar or array fields are rejected.
+- **WARN_BP_006** (non-blocking warning): an `x-credential-offer` object should declare `credential_offer_uri` in its `required` list — the claim card cannot render without the URI, so declaring it required fails fast at publish time.
+
+### Foot-guns
+
+- **Don't pre-bake a wallet on the claim action's sender participant** — action 3's sender must be the same open-participant as action 1 (the applicant). If the blueprint pre-binds a wallet to that participant, the late-binding mechanism breaks and `VAL_BP_010` fires at publish time.
+- **Don't forget the conditional on action 2's approval route** — if action 2 unconditionally routes to the claim action even on rejection, the citizen gets a claim card for a credential that was never approved.
+- **Display strings are the blueprint author's job, not the engine's** — the engine only exposes protocol fields (`credential_offer_uri`, `credential_type`, `expires_at`, `offer_id`) under `/haip/*`. Title / subtitle / issuer name come from the action's `title`, the blueprint's participants, and the `credential_type` value. Localise them in the blueprint JSON.
+- **The claim card is the whole action surface** — don't mix other form fields at the top level of action 3's schema. Keep the schema to `credentialOffer` (object, `x-credential-offer: true`) and an optional `claimed_at`. Additional fields would render as a normal form beneath the card, which is almost always wrong.
 
 ## Template Wrapper
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Workflows/WorkflowInstanceViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Workflows/WorkflowInstanceViewModel.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Sorcha.UI.Core.Models.Workflows;
@@ -40,6 +41,13 @@ public record PendingActionViewModel
     public DateTimeOffset AssignedAt { get; init; }
     public DateTimeOffset? DueAt { get; init; }
     public System.Text.Json.JsonElement? DataSchema { get; init; }
+
+    /// <summary>
+    /// Prepopulated payload seeded by a previous action's Route.OutputMapping
+    /// (Feature 104 wave 14a). Null when no seed is attached. For credential
+    /// claim actions this carries the minted HAIP offer data.
+    /// </summary>
+    public JsonObject? PrepopulatedPayload { get; init; }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/CredentialOfferSchemaResolver.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/CredentialOfferSchemaResolver.cs
@@ -59,7 +59,15 @@ public static class CredentialOfferSchemaResolver
             if (!prepopulatedPayload.TryGetPropertyValue(prop.Name, out var seededNode)) continue;
             if (seededNode is not JsonObject seededObj) continue;
 
-            var offerUri = seededObj["credential_offer_uri"]?.GetValue<string>();
+            // JsonNode.GetValue<string>() throws InvalidOperationException when
+            // the node's runtime type doesn't match — e.g. a malformed seed
+            // where credential_offer_uri arrives as a number or object. The
+            // seed comes from an external HAIP service via Route.OutputMapping,
+            // so we can't assume it's well-typed. Use the value-type gate
+            // instead so a malformed node surfaces as a skipped field (and the
+            // caller falls through to the default renderer) rather than an
+            // uncaught exception on the citizen's screen.
+            var offerUri = TryGetString(seededObj, "credential_offer_uri");
             if (string.IsNullOrWhiteSpace(offerUri))
             {
                 // FR-022 prerequisite — no point rendering the card without a URI.
@@ -68,10 +76,10 @@ public static class CredentialOfferSchemaResolver
                 continue;
             }
 
-            var credentialType = seededObj["credential_type"]?.GetValue<string>();
-            var offerId = seededObj["offer_id"]?.GetValue<string>();
+            var credentialType = TryGetString(seededObj, "credential_type");
+            var offerId = TryGetString(seededObj, "offer_id");
             DateTimeOffset? expiresAt = null;
-            var expiresAtRaw = seededObj["expires_at"]?.GetValue<string>();
+            var expiresAtRaw = TryGetString(seededObj, "expires_at");
             if (!string.IsNullOrWhiteSpace(expiresAtRaw) &&
                 DateTimeOffset.TryParse(expiresAtRaw, out var parsed))
             {
@@ -87,6 +95,25 @@ public static class CredentialOfferSchemaResolver
                 RawCredentialOffer: seededObj);
         }
 
+        return null;
+    }
+
+    /// <summary>
+    /// Type-safe string extraction from a <see cref="JsonObject"/> property.
+    /// Returns null if the property is absent, null, or not a string-typed
+    /// <see cref="JsonValue"/>. Never throws on a type mismatch — callers
+    /// depend on this for defensive seed parsing.
+    /// </summary>
+    private static string? TryGetString(JsonObject obj, string propertyName)
+    {
+        if (!obj.TryGetPropertyValue(propertyName, out var node) || node is null)
+        {
+            return null;
+        }
+        if (node is JsonValue value && value.TryGetValue(out string? s))
+        {
+            return s;
+        }
         return null;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/CredentialOfferSchemaResolver.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/CredentialOfferSchemaResolver.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Detects the <c>x-credential-offer</c> schema extension on a blueprint action's
+/// data schema and extracts the seeded credential offer payload. Feature 104 wave 14b.
+/// </summary>
+/// <remarks>
+/// The claim-action pattern in Feature 104 is:
+/// <list type="number">
+///   <item>A previous action's <c>Route.OutputMapping</c> seeds the claim action's
+///     prepopulated payload with a <c>credentialOffer</c> object.</item>
+///   <item>The pending-actions listing surfaces that object on
+///     <see cref="Sorcha.UI.Core.Models.Workflows.PendingActionViewModel.PrepopulatedPayload"/>.</item>
+///   <item>This resolver inspects the action's schema for a property marked
+///     <c>x-credential-offer: true</c> and, if found, extracts the corresponding
+///     object from the prepopulated payload so the UI can render the claim card.</item>
+/// </list>
+/// Returns <c>null</c> when the action is not a claim action, is not seeded, or
+/// the seeded payload is missing the offer URI — the caller falls back to the
+/// default form renderer in all three cases.
+/// </remarks>
+public static class CredentialOfferSchemaResolver
+{
+    /// <summary>
+    /// Inspects the action's data schema and returns a <see cref="CredentialOfferInfo"/>
+    /// when the action carries an <c>x-credential-offer: true</c> object field that
+    /// is populated in the prepopulated payload. Returns <c>null</c> otherwise.
+    /// </summary>
+    public static CredentialOfferInfo? TryResolve(JsonElement? dataSchema, JsonObject? prepopulatedPayload)
+    {
+        if (dataSchema is null || !dataSchema.HasValue) return null;
+        if (prepopulatedPayload is null || prepopulatedPayload.Count == 0) return null;
+
+        var schemaRoot = dataSchema.Value;
+        if (schemaRoot.ValueKind != JsonValueKind.Object) return null;
+        if (!schemaRoot.TryGetProperty("properties", out var props)) return null;
+        if (props.ValueKind != JsonValueKind.Object) return null;
+
+        foreach (var prop in props.EnumerateObject())
+        {
+            if (prop.Value.ValueKind != JsonValueKind.Object) continue;
+
+            if (!prop.Value.TryGetProperty("x-credential-offer", out var marker)) continue;
+            if (marker.ValueKind != JsonValueKind.True) continue;
+
+            // Found a claim field. Must be object-typed per VAL_BP_012.
+            var isObject = prop.Value.TryGetProperty("type", out var typeEl) &&
+                           typeEl.ValueKind == JsonValueKind.String &&
+                           typeEl.GetString() == "object";
+            if (!isObject) continue;
+
+            // Look up the seeded value in the prepopulated payload.
+            if (!prepopulatedPayload.TryGetPropertyValue(prop.Name, out var seededNode)) continue;
+            if (seededNode is not JsonObject seededObj) continue;
+
+            var offerUri = seededObj["credential_offer_uri"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(offerUri))
+            {
+                // FR-022 prerequisite — no point rendering the card without a URI.
+                // Fall through and let the caller degrade to the default renderer,
+                // which will fail validation at submit time per VAL_BP_011 rules.
+                continue;
+            }
+
+            var credentialType = seededObj["credential_type"]?.GetValue<string>();
+            var offerId = seededObj["offer_id"]?.GetValue<string>();
+            DateTimeOffset? expiresAt = null;
+            var expiresAtRaw = seededObj["expires_at"]?.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(expiresAtRaw) &&
+                DateTimeOffset.TryParse(expiresAtRaw, out var parsed))
+            {
+                expiresAt = parsed;
+            }
+
+            return new CredentialOfferInfo(
+                FieldName: prop.Name,
+                CredentialOfferUri: offerUri!,
+                CredentialType: credentialType,
+                OfferId: offerId,
+                ExpiresAt: expiresAt,
+                RawCredentialOffer: seededObj);
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Parsed credential offer extracted from a claim action's prepopulated payload.
+/// Feature 104 wave 14b.
+/// </summary>
+/// <param name="FieldName">
+/// Name of the schema property that carries <c>x-credential-offer</c>. The claim
+/// card uses this when assembling the confirmation payload on submit so it sits
+/// under the same key the engine validated.
+/// </param>
+/// <param name="CredentialOfferUri">OpenID4VCI offer URI (required).</param>
+/// <param name="CredentialType">Credential type advertised by the issuer, when known.</param>
+/// <param name="OfferId">HAIP offer identifier for status polling, when known.</param>
+/// <param name="ExpiresAt">Parsed expiry timestamp, when the payload carried one.</param>
+/// <param name="RawCredentialOffer">
+/// The full credentialOffer object from the seed. The claim card echoes this
+/// back in the submission payload so the engine-side schema validation passes
+/// and the audit trail records the offer as claimed.
+/// </param>
+public record CredentialOfferInfo(
+    string FieldName,
+    string CredentialOfferUri,
+    string? CredentialType,
+    string? OfferId,
+    DateTimeOffset? ExpiresAt,
+    JsonObject RawCredentialOffer);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Sorcha.UI.Core.Models.Common;
 using Sorcha.UI.Core.Models.Workflows;
@@ -131,7 +132,7 @@ public class WorkflowService : IWorkflowService
         /// Prepopulated payload seeded by a previous action's Route.OutputMapping.
         /// Feature 104 wave 14a.
         /// </summary>
-        public System.Text.Json.Nodes.JsonObject? PrepopulatedPayload { get; init; }
+        public JsonObject? PrepopulatedPayload { get; init; }
     }
 
     public async Task<WorkflowInstanceViewModel?> CreateInstanceAsync(string blueprintId, string registerId, CancellationToken cancellationToken = default)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
@@ -91,7 +91,8 @@ public class WorkflowService : IWorkflowService
                 Description = s.Summary ?? string.Empty,
                 Priority = s.Urgency ?? "normal",
                 AssignedAt = s.ReceivedAt,
-                DueAt = s.Deadline
+                DueAt = s.Deadline,
+                PrepopulatedPayload = s.PrepopulatedPayload
             }).ToList();
         }
         catch (Exception ex)
@@ -125,6 +126,12 @@ public class WorkflowService : IWorkflowService
         public DateTimeOffset? Deadline { get; init; }
         public string RegisterId { get; init; } = string.Empty;
         public DateTimeOffset ReceivedAt { get; init; }
+
+        /// <summary>
+        /// Prepopulated payload seeded by a previous action's Route.OutputMapping.
+        /// Feature 104 wave 14a.
+        /// </summary>
+        public System.Text.Json.Nodes.JsonObject? PrepopulatedPayload { get; init; }
     }
 
     public async Task<WorkflowInstanceViewModel?> CreateInstanceAsync(string blueprintId, string registerId, CancellationToken cancellationToken = default)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
@@ -196,7 +196,10 @@
     /// </summary>
     [Parameter] public EventCallback<string> OnReject { get; set; }
 
-    private enum State { Ready, Claiming, Claimed, Expired }
+    // Claiming progress is tracked by _isClaiming rather than a State value
+    // so the card can disable the button without transitioning away from Ready
+    // (which would also hide the rest of the UI).
+    private enum State { Ready, Claimed, Expired }
     private State _state = State.Ready;
     private bool _isClaiming;
     private bool _isDeclining;
@@ -254,6 +257,22 @@
         if (string.IsNullOrWhiteSpace(LocalWalletAddress))
         {
             Snackbar.Add("No wallet address available. Please sign in again.", Severity.Error);
+            return;
+        }
+
+        // Defence in depth: the offer URI arrives from a server-seeded payload,
+        // but we still validate the scheme before handing it to the HAIP receive
+        // flow. A compromised seed could otherwise redirect the claim to an
+        // attacker-controlled issuer. Accept the canonical openid-credential-offer
+        // scheme plus https for HTTP-based OpenID4VCI metadata fetches.
+        if (!IsAcceptableOfferUri(Offer.CredentialOfferUri))
+        {
+            Logger.LogWarning(
+                "Rejecting credential offer URI with unexpected scheme: {Prefix}",
+                Offer.CredentialOfferUri.Length > 32
+                    ? Offer.CredentialOfferUri[..32] + "..."
+                    : Offer.CredentialOfferUri);
+            Snackbar.Add("Could not claim credential. The offer is malformed.", Severity.Error);
             return;
         }
 
@@ -330,6 +349,21 @@
             _isDeclining = false;
             SafeStateHasChanged();
         }
+    }
+
+    /// <summary>
+    /// Validates that an offer URI uses one of the schemes we're willing to
+    /// hand to <see cref="IHaipLocalReceiveService"/>. Defence in depth against
+    /// a compromised action seed redirecting the claim to an attacker.
+    /// </summary>
+    private static bool IsAcceptableOfferUri(string uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+        {
+            return false;
+        }
+        return uri.StartsWith("openid-credential-offer://", StringComparison.OrdinalIgnoreCase)
+            || uri.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
@@ -5,6 +5,7 @@
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.UI.Core.Services.Credentials
 @using Sorcha.UI.Core.Services.Forms
+@implements IDisposable
 @inject IHaipLocalReceiveService LocalReceive
 @inject ISnackbar Snackbar
 @inject ILogger<CredentialClaimCard> Logger
@@ -86,13 +87,6 @@
                             <td><MudText Typo="Typo.body2">@Offer.CredentialType</MudText></td>
                         </tr>
                     }
-                    @if (!string.IsNullOrWhiteSpace(IssuerName))
-                    {
-                        <tr>
-                            <td><MudText Typo="Typo.body2" Color="Color.Secondary">Issuer</MudText></td>
-                            <td><MudText Typo="Typo.body2">@IssuerName</MudText></td>
-                        </tr>
-                    }
                     @if (Offer.ExpiresAt.HasValue)
                     {
                         <tr>
@@ -106,10 +100,13 @@
             @if (_showQr)
             {
                 <div class="mb-4">
+                    @* Guid.Empty is safe here — CredentialOfferQrCard guards
+                       against it and skips polling, so missing offer_id in
+                       the seed just means the QR is static rather than
+                       actively tracked. *@
                     <CredentialOfferQrCard CredentialOfferUri="@Offer.CredentialOfferUri"
                                            OfferId="@(_parsedOfferId ?? Guid.Empty)"
                                            CredentialType="@(Offer.CredentialType ?? string.Empty)"
-                                           IssuerName="@IssuerName"
                                            ExpiresAt="@Offer.ExpiresAt" />
                     <MudButton Variant="Variant.Text"
                                StartIcon="@Icons.Material.Filled.ArrowBack"
@@ -157,6 +154,7 @@
             <MudButton data-testid="credential-claim-decline-btn"
                        Variant="Variant.Text"
                        Color="Color.Error"
+                       Disabled="@_isDeclining"
                        OnClick="OnDeclineClicked">
                 Decline
             </MudButton>
@@ -176,9 +174,6 @@
 
     /// <summary>Optional action description shown under the header.</summary>
     [Parameter] public string? Description { get; set; }
-
-    /// <summary>Issuer display name (derived from the blueprint by the host).</summary>
-    [Parameter] public string? IssuerName { get; set; }
 
     /// <summary>
     /// The citizen's local wallet address, used when claiming into the Sorcha
@@ -204,7 +199,9 @@
     private enum State { Ready, Claiming, Claimed, Expired }
     private State _state = State.Ready;
     private bool _isClaiming;
+    private bool _isDeclining;
     private bool _showQr;
+    private bool _disposed;
     private Guid? _parsedOfferId;
 
     protected override void OnParametersSet()
@@ -216,13 +213,23 @@
             return;
         }
 
-        if (Offer.ExpiresAt.HasValue && Offer.ExpiresAt.Value <= DateTimeOffset.UtcNow)
+        // Never stomp a terminal state (Claimed) back to Expired — if a
+        // successful claim has landed, Blazor reconciliation on a parent
+        // re-render must not revert the UI to an expired warning.
+        // TODO(T028): when the server-side claim-expired endpoint lands,
+        // expiry will be authoritative via action state transitions
+        // rather than client clock comparisons, removing the clock-skew
+        // edge case entirely.
+        if (_state != State.Claimed)
         {
-            _state = State.Expired;
-        }
-        else if (_state != State.Claimed)
-        {
-            _state = State.Ready;
+            if (Offer.ExpiresAt.HasValue && Offer.ExpiresAt.Value <= DateTimeOffset.UtcNow)
+            {
+                _state = State.Expired;
+            }
+            else
+            {
+                _state = State.Ready;
+            }
         }
 
         _parsedOfferId = Guid.TryParse(Offer.OfferId, out var g) ? g : null;
@@ -258,9 +265,13 @@
             if (!result.Success)
             {
                 // Retry-friendly failure — action stays pending, button re-enables.
-                var detail = result.ErrorMessage ?? "Unknown error";
-                Logger.LogWarning("Local receive failed: code={Code} message={Message}", result.ErrorCode, detail);
-                Snackbar.Add($"Could not claim credential: {detail}", Severity.Error);
+                // Log the raw error for diagnostics but show a generic message
+                // in the UI to avoid leaking internal details.
+                Logger.LogWarning(
+                    "Local receive failed: code={Code} message={Message}",
+                    result.ErrorCode,
+                    result.ErrorMessage ?? "Unknown error");
+                Snackbar.Add("Could not claim credential. Please try again.", Severity.Error);
                 return;
             }
 
@@ -269,7 +280,7 @@
                 Severity.Success);
 
             _state = State.Claimed;
-            StateHasChanged();
+            SafeStateHasChanged();
 
             // Echo the seeded offer back in the submission so the engine-side
             // schema validation passes (credentialOffer is required), then add
@@ -282,24 +293,61 @@
             };
             var submission = new FormSubmission { Data = submissionData };
             await OnSubmit.InvokeAsync(submission);
+            // OnSubmit closes the hosting dialog; don't StateHasChanged after this.
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Credential claim threw an unexpected error");
-            Snackbar.Add($"Could not claim credential: {ex.Message}", Severity.Error);
+            Snackbar.Add("Could not claim credential. Please try again.", Severity.Error);
         }
         finally
         {
             _isClaiming = false;
-            StateHasChanged();
+            // Only re-render while the component is still mounted. After a
+            // successful claim the dialog has closed (OnSubmit above) and the
+            // component is disposed — rendering here would throw in debug
+            // builds and is noise in release builds.
+            SafeStateHasChanged();
         }
     }
 
     private async Task OnDeclineClicked()
     {
-        if (OnReject.HasDelegate)
+        if (_isDeclining || !OnReject.HasDelegate)
+        {
+            return;
+        }
+        _isDeclining = true;
+        SafeStateHasChanged();
+        try
         {
             await OnReject.InvokeAsync("declined");
         }
+        finally
+        {
+            // OnReject closes the dialog synchronously in the happy path; this
+            // only matters if the host doesn't close (unlikely but defensive).
+            _isDeclining = false;
+            SafeStateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Calls <c>StateHasChanged</c> only when the component is still mounted.
+    /// Prevents noisy re-renders (and <c>ObjectDisposedException</c> in edge
+    /// cases) after the hosting dialog has closed the component.
+    /// </summary>
+    private void SafeStateHasChanged()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
@@ -1,0 +1,305 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using Microsoft.Extensions.Logging
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Services.Forms
+@inject IHaipLocalReceiveService LocalReceive
+@inject ISnackbar Snackbar
+@inject ILogger<CredentialClaimCard> Logger
+
+@*
+    Feature 104 wave 14b — credential claim card.
+
+    Renders a pending claim action that was seeded with a HAIP credential
+    offer via Route.OutputMapping on the previous action. The citizen can:
+      - Claim the credential into their local Sorcha wallet (primary action)
+      - Reveal a QR code to load it into an external HAIP wallet
+      - Decline (sealed to the register as a terminal rejection)
+      - Retry on transient failure (card stays interactive on error)
+      - See an expired state and Claim is disabled when past expires_at
+
+    On successful claim the card echoes the seeded credentialOffer object
+    back into the submission payload plus a claimed_at timestamp, so the
+    engine-side schema validation passes and the sealed transaction
+    records the claim.
+*@
+
+<MudCard Elevation="3" Class="credential-claim-card pa-4">
+    <MudCardHeader>
+        <CardHeaderAvatar>
+            @if (_state == State.Claimed)
+            {
+                <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Large" />
+            }
+            else if (_state == State.Expired)
+            {
+                <MudIcon Icon="@Icons.Material.Filled.Error" Color="Color.Warning" Size="Size.Large" />
+            }
+            else
+            {
+                <MudIcon Icon="@Icons.Material.Filled.CardGiftcard" Color="Color.Primary" Size="Size.Large" />
+            }
+        </CardHeaderAvatar>
+        <CardHeaderContent>
+            <MudText Typo="Typo.h6">@Title</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                @(Offer?.CredentialType ?? "Verifiable Credential")
+            </MudText>
+        </CardHeaderContent>
+    </MudCardHeader>
+
+    <MudCardContent>
+        @if (Offer is null)
+        {
+            <MudAlert Severity="Severity.Error">
+                No credential offer was attached to this action. The workflow may be misconfigured.
+            </MudAlert>
+        }
+        else if (_state == State.Claimed)
+        {
+            <MudAlert Severity="Severity.Success" Variant="Variant.Filled" Class="mb-4">
+                Credential stored in your wallet.
+            </MudAlert>
+        }
+        else if (_state == State.Expired)
+        {
+            <MudAlert Severity="Severity.Warning" Class="mb-4">
+                This credential offer expired on @(Offer.ExpiresAt?.LocalDateTime.ToString("dd MMM HH:mm") ?? "an earlier date")
+                and can no longer be claimed. You can start a new application.
+            </MudAlert>
+        }
+        else
+        {
+            @if (!string.IsNullOrWhiteSpace(Description))
+            {
+                <MudText Typo="Typo.body2" Class="mb-3">@Description</MudText>
+            }
+
+            <MudSimpleTable Dense="true" Bordered="false" Class="mb-4" Style="max-width: 520px;">
+                <tbody>
+                    @if (!string.IsNullOrWhiteSpace(Offer.CredentialType))
+                    {
+                        <tr>
+                            <td><MudText Typo="Typo.body2" Color="Color.Secondary">Credential</MudText></td>
+                            <td><MudText Typo="Typo.body2">@Offer.CredentialType</MudText></td>
+                        </tr>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(IssuerName))
+                    {
+                        <tr>
+                            <td><MudText Typo="Typo.body2" Color="Color.Secondary">Issuer</MudText></td>
+                            <td><MudText Typo="Typo.body2">@IssuerName</MudText></td>
+                        </tr>
+                    }
+                    @if (Offer.ExpiresAt.HasValue)
+                    {
+                        <tr>
+                            <td><MudText Typo="Typo.body2" Color="Color.Secondary">Expires</MudText></td>
+                            <td><MudText Typo="Typo.body2">@Offer.ExpiresAt.Value.LocalDateTime.ToString("dd MMM HH:mm")</MudText></td>
+                        </tr>
+                    }
+                </tbody>
+            </MudSimpleTable>
+
+            @if (_showQr)
+            {
+                <div class="mb-4">
+                    <CredentialOfferQrCard CredentialOfferUri="@Offer.CredentialOfferUri"
+                                           OfferId="@(_parsedOfferId ?? Guid.Empty)"
+                                           CredentialType="@(Offer.CredentialType ?? string.Empty)"
+                                           IssuerName="@IssuerName"
+                                           ExpiresAt="@Offer.ExpiresAt" />
+                    <MudButton Variant="Variant.Text"
+                               StartIcon="@Icons.Material.Filled.ArrowBack"
+                               Class="mt-2"
+                               OnClick="HideQr">
+                        Back to claim options
+                    </MudButton>
+                </div>
+            }
+        }
+    </MudCardContent>
+
+    @if (Offer is not null && _state == State.Ready)
+    {
+        <MudCardActions>
+            <MudButton data-testid="credential-claim-btn"
+                       Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Download"
+                       Disabled="@_isClaiming"
+                       OnClick="OnClaimClicked">
+                @if (_isClaiming)
+                {
+                    <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                    @:Claiming...
+                }
+                else
+                {
+                    @:Claim credential
+                }
+            </MudButton>
+
+            @if (!_showQr)
+            {
+                <MudButton data-testid="credential-claim-external-btn"
+                           Variant="Variant.Text"
+                           StartIcon="@Icons.Material.Filled.QrCode2"
+                           OnClick="ShowQr">
+                    Scan with external wallet
+                </MudButton>
+            }
+
+            <MudSpacer />
+
+            <MudButton data-testid="credential-claim-decline-btn"
+                       Variant="Variant.Text"
+                       Color="Color.Error"
+                       OnClick="OnDeclineClicked">
+                Decline
+            </MudButton>
+        </MudCardActions>
+    }
+</MudCard>
+
+@code {
+    /// <summary>
+    /// The parsed credential offer extracted from the action's prepopulated
+    /// payload by <see cref="CredentialOfferSchemaResolver"/>.
+    /// </summary>
+    [Parameter, EditorRequired] public CredentialOfferInfo? Offer { get; set; }
+
+    /// <summary>Action title shown as the card header.</summary>
+    [Parameter] public string Title { get; set; } = "Claim credential";
+
+    /// <summary>Optional action description shown under the header.</summary>
+    [Parameter] public string? Description { get; set; }
+
+    /// <summary>Issuer display name (derived from the blueprint by the host).</summary>
+    [Parameter] public string? IssuerName { get; set; }
+
+    /// <summary>
+    /// The citizen's local wallet address, used when claiming into the Sorcha
+    /// wallet via <see cref="IHaipLocalReceiveService"/>. Must come from the
+    /// authenticated session — never from the payload.
+    /// </summary>
+    [Parameter, EditorRequired] public string LocalWalletAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Fires with the claim confirmation payload on a successful claim. The
+    /// host (ActionForm dialog) closes the dialog with this payload so the
+    /// normal action-submission flow seals the completion to the register.
+    /// </summary>
+    [Parameter] public EventCallback<FormSubmission> OnSubmit { get; set; }
+
+    /// <summary>
+    /// Fires when the citizen clicks Decline. The host closes the dialog with
+    /// the reject signal so <see cref="Sorcha.Blueprint.Models.RejectionConfig"/>
+    /// terminates the instance.
+    /// </summary>
+    [Parameter] public EventCallback<string> OnReject { get; set; }
+
+    private enum State { Ready, Claiming, Claimed, Expired }
+    private State _state = State.Ready;
+    private bool _isClaiming;
+    private bool _showQr;
+    private Guid? _parsedOfferId;
+
+    protected override void OnParametersSet()
+    {
+        if (Offer is null)
+        {
+            _state = State.Ready;
+            _parsedOfferId = null;
+            return;
+        }
+
+        if (Offer.ExpiresAt.HasValue && Offer.ExpiresAt.Value <= DateTimeOffset.UtcNow)
+        {
+            _state = State.Expired;
+        }
+        else if (_state != State.Claimed)
+        {
+            _state = State.Ready;
+        }
+
+        _parsedOfferId = Guid.TryParse(Offer.OfferId, out var g) ? g : null;
+    }
+
+    private void ShowQr()
+    {
+        _showQr = true;
+    }
+
+    private void HideQr()
+    {
+        _showQr = false;
+    }
+
+    private async Task OnClaimClicked()
+    {
+        if (_isClaiming || Offer is null || _state != State.Ready)
+        {
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(LocalWalletAddress))
+        {
+            Snackbar.Add("No wallet address available. Please sign in again.", Severity.Error);
+            return;
+        }
+
+        _isClaiming = true;
+        StateHasChanged();
+        try
+        {
+            var result = await LocalReceive.ReceiveLocallyAsync(Offer.CredentialOfferUri, LocalWalletAddress);
+            if (!result.Success)
+            {
+                // Retry-friendly failure — action stays pending, button re-enables.
+                var detail = result.ErrorMessage ?? "Unknown error";
+                Logger.LogWarning("Local receive failed: code={Code} message={Message}", result.ErrorCode, detail);
+                Snackbar.Add($"Could not claim credential: {detail}", Severity.Error);
+                return;
+            }
+
+            Snackbar.Add(
+                $"{result.CredentialType ?? Offer.CredentialType ?? "Credential"} stored in your wallet",
+                Severity.Success);
+
+            _state = State.Claimed;
+            StateHasChanged();
+
+            // Echo the seeded offer back in the submission so the engine-side
+            // schema validation passes (credentialOffer is required), then add
+            // the claimed_at confirmation so the audit trail carries the
+            // moment of claim.
+            var submissionData = new Dictionary<string, object?>
+            {
+                [$"/{Offer.FieldName}"] = Offer.RawCredentialOffer,
+                ["/claimed_at"] = DateTimeOffset.UtcNow.ToString("O")
+            };
+            var submission = new FormSubmission { Data = submissionData };
+            await OnSubmit.InvokeAsync(submission);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Credential claim threw an unexpected error");
+            Snackbar.Add($"Could not claim credential: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isClaiming = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnDeclineClicked()
+    {
+        if (OnReject.HasDelegate)
+        {
+            await OnReject.InvokeAsync("declined");
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimDialog.razor
@@ -12,20 +12,19 @@
     pending action. The dialog echoes the card's OnSubmit (claim) / OnReject
     (decline) callbacks back through DialogResult so the caller runs them
     through the normal action execution / rejection pipeline.
+
+    The dialog title comes from the MudDialog shell argument passed by
+    DialogService.ShowAsync — do NOT also render a <TitleContent>, or the
+    title will appear twice (once in the shell, once in the overlay). The
+    card inside still renders its own header (the action title) as the
+    primary content label.
 *@
 
 <MudDialog>
-    <TitleContent>
-        <MudText Typo="Typo.h6">
-            <MudIcon Icon="@Icons.Material.Filled.CardGiftcard" Class="mr-2" />
-            @Title
-        </MudText>
-    </TitleContent>
     <DialogContent>
         <CredentialClaimCard Offer="@Offer"
                              Title="@Title"
                              Description="@Description"
-                             IssuerName="@IssuerName"
                              LocalWalletAddress="@LocalWalletAddress"
                              OnSubmit="HandleCardSubmit"
                              OnReject="HandleCardReject" />
@@ -36,12 +35,20 @@
 </MudDialog>
 
 @code {
+    /// <summary>
+    /// Magic value returned in <see cref="DialogResult.Data"/> when the
+    /// citizen clicks Decline. <c>MyActions.TakeAction</c> matches against
+    /// this constant to route the outcome through
+    /// <c>IWorkflowService.RejectActionAsync</c>. Kept as a single source of
+    /// truth so the dialog and its caller cannot drift.
+    /// </summary>
+    public const string RejectResult = "reject";
+
     [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
 
     [Parameter, EditorRequired] public CredentialOfferInfo? Offer { get; set; }
     [Parameter] public string Title { get; set; } = "Claim credential";
     [Parameter] public string? Description { get; set; }
-    [Parameter] public string? IssuerName { get; set; }
     [Parameter, EditorRequired] public string LocalWalletAddress { get; set; } = string.Empty;
 
     private Task HandleCardSubmit(FormSubmission submission)
@@ -56,8 +63,8 @@
     private Task HandleCardReject(string reason)
     {
         // Match ActionForm's reject contract so MyActions handles both dialogs
-        // uniformly — it detects a "reject" string and fires the reject path.
-        MudDialog.Close(DialogResult.Ok("reject"));
+        // uniformly — it detects RejectResult and fires the reject path.
+        MudDialog.Close(DialogResult.Ok(RejectResult));
         return Task.CompletedTask;
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimDialog.razor
@@ -1,0 +1,65 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Forms
+
+@*
+    Feature 104 wave 14b — MudBlazor dialog host for the credential claim card.
+
+    MyActions.razor opens this dialog (instead of the default ActionForm) when
+    CredentialOfferSchemaResolver detects an x-credential-offer field on the
+    pending action. The dialog echoes the card's OnSubmit (claim) / OnReject
+    (decline) callbacks back through DialogResult so the caller runs them
+    through the normal action execution / rejection pipeline.
+*@
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.CardGiftcard" Class="mr-2" />
+            @Title
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <CredentialClaimCard Offer="@Offer"
+                             Title="@Title"
+                             Description="@Description"
+                             IssuerName="@IssuerName"
+                             LocalWalletAddress="@LocalWalletAddress"
+                             OnSubmit="HandleCardSubmit"
+                             OnReject="HandleCardReject" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Variant="Variant.Text">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter, EditorRequired] public CredentialOfferInfo? Offer { get; set; }
+    [Parameter] public string Title { get; set; } = "Claim credential";
+    [Parameter] public string? Description { get; set; }
+    [Parameter] public string? IssuerName { get; set; }
+    [Parameter, EditorRequired] public string LocalWalletAddress { get; set; } = string.Empty;
+
+    private Task HandleCardSubmit(FormSubmission submission)
+    {
+        // Dialog caller consumes the FormSubmission the same way it consumes
+        // an ActionForm submission (stripping the leading slash and executing
+        // the action), so we can reuse the normal TakeAction pipeline.
+        MudDialog.Close(DialogResult.Ok(submission));
+        return Task.CompletedTask;
+    }
+
+    private Task HandleCardReject(string reason)
+    {
+        // Match ActionForm's reject contract so MyActions handles both dialogs
+        // uniformly — it detects a "reject" string and fires the reject path.
+        MudDialog.Close(DialogResult.Ok("reject"));
+        return Task.CompletedTask;
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -15,7 +15,9 @@
 @using Sorcha.UI.Core.Components.Workflows
 @using Sorcha.UI.Core.Models.Credentials
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Forms
 @using Sorcha.UI.Core.Services.Wallet
+@using Sorcha.UI.Core.Models.Forms
 @inject IWorkflowService WorkflowService
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferenceService
@@ -370,14 +372,80 @@
             }
         }
 
-        var parameters = new DialogParameters
+        // Feature 104 wave 14b — if this pending action carries a prepopulated
+        // credential offer payload (via Route.OutputMapping on the previous
+        // action), render the CredentialClaimCard dialog instead of the
+        // default form. Falls through to the form for all non-claim actions.
+        var offerInfo = CredentialOfferSchemaResolver.TryResolve(action.DataSchema, action.PrepopulatedPayload);
+
+        IDialogReference dialog;
+        if (offerInfo is not null)
         {
-            ["Action"] = action,
-            ["WalletAddress"] = walletAddress
-        };
-        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
-        var dialog = await DialogService.ShowAsync<ActionForm>("Execute Action", parameters, options);
+            var claimParams = new DialogParameters<Components.Credentials.CredentialClaimDialog>
+            {
+                { x => x.Offer, offerInfo },
+                { x => x.Title, action.ActionName },
+                { x => x.Description, action.Description },
+                { x => x.LocalWalletAddress, walletAddress }
+            };
+            var claimOptions = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseOnEscapeKey = true };
+            dialog = await DialogService.ShowAsync<Components.Credentials.CredentialClaimDialog>(
+                "Claim credential", claimParams, claimOptions);
+        }
+        else
+        {
+            var parameters = new DialogParameters
+            {
+                ["Action"] = action,
+                ["WalletAddress"] = walletAddress
+            };
+            var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+            dialog = await DialogService.ShowAsync<ActionForm>("Execute Action", parameters, options);
+        }
         var result = await dialog.Result;
+
+        // Handle the CredentialClaimDialog FormSubmission shape — convert it to
+        // the ActionSubmissionViewModel the existing execution path expects.
+        // The card's FormSubmission.Data uses leading-slash JSON Pointer keys,
+        // matching ActionForm's own convention.
+        if (result is { Canceled: false, Data: FormSubmission cardSubmission })
+        {
+            var adapted = new ActionSubmissionViewModel
+            {
+                ActionId = action.ActionId,
+                InstanceId = action.InstanceId,
+                Data = cardSubmission.Data.ToDictionary(
+                    kvp => kvp.Key.TrimStart('/'),
+                    kvp => kvp.Value ?? (object)string.Empty)
+            };
+            result = DialogResult.Ok(adapted);
+        }
+        else if (result is { Canceled: false, Data: string decision } && decision == "reject")
+        {
+            // Decline path from either dialog — fire the reject endpoint and remove the action.
+            try
+            {
+                var rejected = await WorkflowService.RejectActionAsync(
+                    action.InstanceId, action.ActionId, "declined");
+                if (rejected)
+                {
+                    Snackbar.Add("Action declined", Severity.Info);
+                    _actions.Remove(action);
+                    RebuildGroups();
+                    StateHasChanged();
+                }
+                else
+                {
+                    Snackbar.Add("Failed to decline action. Please try again.", Severity.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error rejecting action {ActionId}", action.ActionId);
+                Snackbar.Add("An error occurred while declining the action.", Severity.Error);
+            }
+            return;
+        }
 
         if (result is { Canceled: false, Data: ActionSubmissionViewModel submission })
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -389,8 +389,12 @@
                 { x => x.LocalWalletAddress, walletAddress }
             };
             var claimOptions = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true, CloseOnEscapeKey = true };
+            // Use the action name as the dialog shell title — the dialog
+            // no longer renders its own <TitleContent>, so this is shown
+            // once in the overlay chrome. The card inside renders the same
+            // name as its primary header for the citizen.
             dialog = await DialogService.ShowAsync<Components.Credentials.CredentialClaimDialog>(
-                "Claim credential", claimParams, claimOptions);
+                action.ActionName, claimParams, claimOptions);
         }
         else
         {
@@ -420,7 +424,8 @@
             };
             result = DialogResult.Ok(adapted);
         }
-        else if (result is { Canceled: false, Data: string decision } && decision == "reject")
+        else if (result is { Canceled: false, Data: string decision }
+                 && decision == Components.Credentials.CredentialClaimDialog.RejectResult)
         {
             // Decline path from either dialog — fire the reject endpoint and remove the action.
             try

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -2806,7 +2806,80 @@ public class PublishService(
         // declared on at least one of the route's next actions. This prevents
         // blueprint authors from writing mappings to fields that don't exist on
         // the receiving action.
+        //
+        // Rule 7b (Feature 104, VAL_BP_012 / WARN_BP_006): x-credential-offer
+        // extension rules — it may only appear on object-typed schema fields,
+        // and when present the object should declare credential_offer_uri as
+        // required (warning, not error).
         const string OutputMappingTargetCode = "VAL_BP_011";
+        const string CredentialOfferTypeCode = "VAL_BP_012";
+        const string CredentialOfferRequiredWarning = "WARN_BP_006";
+
+        // Walk every schema on every action looking for x-credential-offer
+        foreach (var action in blueprint.Actions)
+        {
+            if (action.DataSchemas is null) continue;
+            foreach (var schemaDoc in action.DataSchemas)
+            {
+                try
+                {
+                    var root = schemaDoc.RootElement;
+                    if (root.ValueKind != System.Text.Json.JsonValueKind.Object) continue;
+                    if (!root.TryGetProperty("properties", out var propsEl) ||
+                        propsEl.ValueKind != System.Text.Json.JsonValueKind.Object) continue;
+
+                    foreach (var prop in propsEl.EnumerateObject())
+                    {
+                        if (prop.Value.ValueKind != System.Text.Json.JsonValueKind.Object) continue;
+
+                        // Skip properties that don't carry the extension
+                        if (!prop.Value.TryGetProperty("x-credential-offer", out var coEl)) continue;
+                        if (coEl.ValueKind != System.Text.Json.JsonValueKind.True) continue;
+
+                        // VAL_BP_012: must be on an object-typed field
+                        var typeStr = prop.Value.TryGetProperty("type", out var typeEl) &&
+                                      typeEl.ValueKind == System.Text.Json.JsonValueKind.String
+                            ? typeEl.GetString()
+                            : null;
+                        if (typeStr != "object")
+                        {
+                            errors.Add(
+                                $"[{CredentialOfferTypeCode}] Action {action.Id} ('{action.Title}'): Field '{prop.Name}' " +
+                                $"carries 'x-credential-offer: true' but is not an object-typed field (found type: '{typeStr ?? "(missing)"}'). " +
+                                $"The credential-offer renderer requires an object field with credential_offer_uri inside.");
+                            continue;
+                        }
+
+                        // WARN_BP_006: credential_offer_uri should be required
+                        var hasRequiredUri = false;
+                        if (prop.Value.TryGetProperty("required", out var requiredEl) &&
+                            requiredEl.ValueKind == System.Text.Json.JsonValueKind.Array)
+                        {
+                            foreach (var reqItem in requiredEl.EnumerateArray())
+                            {
+                                if (reqItem.ValueKind == System.Text.Json.JsonValueKind.String &&
+                                    reqItem.GetString() == "credential_offer_uri")
+                                {
+                                    hasRequiredUri = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!hasRequiredUri)
+                        {
+                            warnings.Add(
+                                $"[{CredentialOfferRequiredWarning}] Action {action.Id} ('{action.Title}'): Field '{prop.Name}' " +
+                                $"is marked 'x-credential-offer: true' but does not declare 'credential_offer_uri' in its required list. " +
+                                $"The credential claim card cannot render without the offer URI — add it to required to fail fast at publish time.");
+                        }
+                    }
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    // Malformed schema — other rules will surface this
+                }
+            }
+        }
 
         foreach (var action in blueprint.Actions)
         {

--- a/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
@@ -105,11 +105,11 @@ public class ChatOrchestrationService : IChatOrchestrationService
 
         **Privacy & Routing:**
         - `set_disclosure` — Control who sees what data (JSON Pointer paths)
-        - `add_routing` — Add conditional routing logic
+        - `add_routing` — Add conditional routing logic (supports `outputMapping` for carrying data from one action's execution result into the next action's prepopulated payload — required for the credential claim pattern in Feature 104)
 
         **Credentials:**
         - `require_credential` — Require a Verified Credential to perform an action
-        - `issue_credential` — Issue a Verified Credential on action completion
+        - `issue_credential` — Issue a Verified Credential on action completion. When `targetAudience` is `HaipExternalWallet`, ALWAYS add a dedicated Claim action after the issuing action using `x-credential-offer` — see the "Credential Claim Actions" section below. Never rely on the issuing action's sender to display the offer.
 
         **Validation:**
         - `validate_blueprint` — Check blueprint validity (always call this at the end)
@@ -270,6 +270,120 @@ public class ChatOrchestrationService : IChatOrchestrationService
         **Example conversation trigger:**
         User: "I need a planning application process for our council"
         You: "This is a classic GOV.UK-style service. The citizen fills in a single multi-page application — their details, site address, description of works, supporting documents — all collected across several wizard pages and submitted together as one signed action. I'd use `x-pages` in the schema to give it that step-by-step GDS feel. Then the planning officer gets a separate action to review and decide, and the approved outcome can be issued as a verifiable Planning Permit credential. Shall I work through the pages and fields with you before I build?"
+
+        ## Credential Claim Actions (Feature 104 — recommended pattern for HAIP issuance)
+
+        When a blueprint **issues a HAIP credential** to an applicant (via `targetAudience: HaipExternalWallet`), the credential offer must reach the **recipient** — not the issuing action sender. Do NOT rely on the assessor's browser to display a QR for the citizen to scan; this is both a UX and cryptographic mistake (the `pre_authorized_code` is a bearer token and whoever redeems it binds the credential to *their* wallet key).
+
+        **Correct pattern — three actions:**
+
+        ```
+        Action 1: Applicant submits data           (sender: applicant — open, late-bound)
+        Action 2: Issuer reviews, mints the offer  (sender: issuer; credentialIssuanceConfig)
+                  → route.outputMapping carries /haip/* into action 3's seed
+        Action 3: Applicant claims the credential  (sender: applicant — same participant as action 1)
+                  → uses x-credential-offer schema extension + rejectionConfig.isTerminal
+        ```
+
+        The claim action appears in the applicant's My Actions queue as "Claim your ... credential". Clicking Claim stores the credential in their local Sorcha wallet; Scan-with-external-wallet reveals a QR for external HAIP wallets; Decline seals an `InstanceState.Rejected` transaction.
+
+        ### Why this shape (and not wave 13's dialog on the assessor)
+
+        - **Cryptographic correctness:** the pre-auth code must land in the recipient's session so their key is bound to the credential via the `cnf` claim.
+        - **Recipient-locked for free:** action 3's sender is the same open participant as action 1 (already late-bound to the citizen's wallet). No extra authz logic required.
+        - **Durable and auditable:** the offer persists in the instance as seeded payload state. The claim seals as a normal action transaction with a `claimed_at` timestamp — full audit trail on the register.
+        - **Offline-safe:** a citizen can approve on Monday and claim on Wednesday. The offer waits in their My Actions.
+        - **No new subsystem:** reuses My Actions, late-binding, rejection config.
+
+        ### Action 3 schema shape
+
+        Mark a top-level **object** field with `"x-credential-offer": true`. The UI renderer swaps in the CredentialClaimCard component for that field. The previous action's `outputMapping` seeds the values:
+
+        ```json
+        {
+          "id": 3,
+          "title": "Claim your Verified Citizen credential",
+          "description": "Your credential is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP wallet.",
+          "sender": "citizen",
+          "dataSchemas": [{
+            "type": "object",
+            "properties": {
+              "credentialOffer": {
+                "type": "object",
+                "x-credential-offer": true,
+                "properties": {
+                  "credential_offer_uri": { "type": "string", "format": "uri" },
+                  "credential_type":      { "type": "string" },
+                  "expires_at":           { "type": "string", "format": "date-time" },
+                  "offer_id":             { "type": "string" }
+                },
+                "required": ["credential_offer_uri"]
+              },
+              "claimed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["credentialOffer"]
+          }],
+          "rejectionConfig": { "targetActionId": 0, "isTerminal": true, "requireReason": false },
+          "routes": [
+            { "id": "claimed-terminal", "nextActionIds": [], "isDefault": true }
+          ]
+        }
+        ```
+
+        ### Action 2 routing — conditional OutputMapping
+
+        Action 2 still declares `credentialIssuanceConfig` with `targetAudience: HaipExternalWallet` exactly as before. The engine mints the offer **before** routing and exposes it under `/haip/*` in the routing source document. Declare two routes: one approves and carries forward, the other terminates on rejection.
+
+        ```json
+        "routes": [
+          {
+            "id": "approved-to-claim",
+            "nextActionIds": [3],
+            "condition": { "==": [{ "var": "verificationDecision" }, "approved"] },
+            "description": "Approved — hand the minted credential to the applicant",
+            "outputMapping": {
+              "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+              "/haip/credential_type":      "/credentialOffer/credential_type",
+              "/haip/expires_at":           "/credentialOffer/expires_at",
+              "/haip/offer_id":             "/credentialOffer/offer_id"
+            }
+          },
+          {
+            "id": "rejected-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Rejected — workflow ends with no credential issued"
+          }
+        ]
+        ```
+
+        ### Source document available to `outputMapping`
+
+        Keys in `outputMapping` are JSON Pointers into a source document with these sub-trees:
+        - `/payload/*` — the submitted action payload
+        - `/calculations/*` — values produced by the engine's calculate step
+        - `/haip/*` — HAIP mint output (`credential_offer_uri`, `offer_id`, `expires_at`, `credential_type`) when the current action minted an offer
+        - Absent source paths are **silently skipped** (not an error).
+
+        Target pointers must reference schema fields declared on at least one next action (publish-time check `VAL_BP_011`).
+
+        ### Publish-time validation rules for claim actions
+
+        - **VAL_BP_011** — every `outputMapping` target pointer's top-level field must exist on at least one next action's schema.
+        - **VAL_BP_012** — `x-credential-offer: true` may only appear on object-typed schema fields.
+        - **WARN_BP_006** (non-blocking) — an `x-credential-offer` object should declare `credential_offer_uri` in its `required` list.
+
+        ### Common foot-guns
+
+        - Don't pre-bake a wallet on the claim action's sender participant — it must be the same open participant as action 1 (the applicant). Pre-binding breaks late-binding and triggers `VAL_BP_010` at publish time.
+        - Don't forget the conditional on action 2's approval route — if action 2 unconditionally routes to claim even on rejection, the citizen sees a claim card for a credential that was never approved.
+        - Don't mix other form fields at the top level of action 3's schema — the claim card is the whole action surface. Keep it to `credentialOffer` (object, `x-credential-offer: true`) and an optional `claimed_at`. Any additional field would render as a normal form beneath the card, which is almost always wrong.
+        - Display strings (title / subtitle / issuer name) are the blueprint author's job — the engine only exposes protocol fields (`credential_offer_uri`, `credential_type`, `expires_at`, `offer_id`) under `/haip/*`. The card derives title from `action.title`, subtitle from `credential_type`, and description from `action.description`. Set those on the claim action in the blueprint JSON.
+
+        ### Example conversation trigger
+
+        User: "I want to issue a driving licence as a verifiable credential to the applicant"
+        You: "Great — the right pattern here is a three-action shape. Action 1 is the applicant's submission, action 2 is the council's review and licence minting, and action 3 is a dedicated Claim action that appears in the applicant's My Actions queue. When the council approves on action 2, the route's `outputMapping` carries the minted offer forward into action 3's payload seed, and the applicant sees a credential claim card where they can click Claim to store it in their Sorcha wallet or scan a QR to load it into an external HAIP wallet. This way the credential always ends up in the applicant's hands, not the council's browser. Shall I build this shape?"
         """;
 
     /// <summary>Initialises a new instance of the <see cref="ChatOrchestrationService"/> class.</summary>

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -467,32 +467,30 @@ public class ActionExecutionService : IActionExecutionService
                     "default form renderer. Check service registration.",
                     actionDef.Id, blueprint.Id);
             }
-        }
-        if (actionDef.CredentialIssuanceConfig != null
-            && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet
-            && _haipClient != null)
-        {
-            var haipClaims = BuildClaimsFromMappings(
-                actionDef.CredentialIssuanceConfig.ClaimMappings,
-                mergedData!);
-            var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
+            else
+            {
+                var haipClaims = BuildClaimsFromMappings(
+                    actionDef.CredentialIssuanceConfig.ClaimMappings,
+                    mergedData!);
+                var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
-            _logger.LogInformation(
-                "Routing credential issuance to HAIP service for external wallet: type={Type}, claims=[{ClaimNames}]",
-                actionDef.CredentialIssuanceConfig.CredentialType,
-                string.Join(", ", haipClaimsForWire.Keys));
+                _logger.LogInformation(
+                    "Routing credential issuance to HAIP service for external wallet: type={Type}, claims=[{ClaimNames}]",
+                    actionDef.CredentialIssuanceConfig.CredentialType,
+                    string.Join(", ", haipClaimsForWire.Keys));
 
-            haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
-                request.SenderWallet,
-                instance.RegisterId,
-                actionDef.CredentialIssuanceConfig.CredentialType,
-                haipClaimsForWire,
-                actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
-                cancellationToken);
+                haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
+                    request.SenderWallet,
+                    instance.RegisterId,
+                    actionDef.CredentialIssuanceConfig.CredentialType,
+                    haipClaimsForWire,
+                    actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
+                    cancellationToken);
 
-            _logger.LogInformation(
-                "HAIP credential offer created: offerId={OfferId}, expiresAt={ExpiresAt}",
-                haipOfferResult.OfferId, haipOfferResult.ExpiresAt);
+                _logger.LogInformation(
+                    "HAIP credential offer created: offerId={OfferId}, expiresAt={ExpiresAt}",
+                    haipOfferResult.OfferId, haipOfferResult.ExpiresAt);
+            }
         }
 
         // 9. Evaluate routing conditions to determine next action(s).

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -444,11 +444,44 @@ public class ActionExecutionService : IActionExecutionService
             }
         }
 
+        // 8b. HAIP credential mint (Feature 097 + Feature 104 wave 14b).
+        //     Moved to run BEFORE routing so the minted offer data can be
+        //     carried forward to the claim action via Route.OutputMapping.
+        //     Internal Sorcha issuance (issuedCredential) still runs later at
+        //     step 9d because it depends on the built transaction context.
+        CreateOfferResult? haipOfferResult = null;
+        if (actionDef.CredentialIssuanceConfig != null
+            && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet
+            && _haipClient != null)
+        {
+            var haipClaims = BuildClaimsFromMappings(
+                actionDef.CredentialIssuanceConfig.ClaimMappings,
+                mergedData!);
+            var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
+
+            _logger.LogInformation(
+                "Routing credential issuance to HAIP service for external wallet: type={Type}, claims=[{ClaimNames}]",
+                actionDef.CredentialIssuanceConfig.CredentialType,
+                string.Join(", ", haipClaimsForWire.Keys));
+
+            haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
+                request.SenderWallet,
+                instance.RegisterId,
+                actionDef.CredentialIssuanceConfig.CredentialType,
+                haipClaimsForWire,
+                actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
+                cancellationToken);
+
+            _logger.LogInformation(
+                "HAIP credential offer created: offerId={OfferId}, expiresAt={ExpiresAt}",
+                haipOfferResult.OfferId, haipOfferResult.ExpiresAt);
+        }
+
         // 9. Evaluate routing conditions to determine next action(s).
         //    Build the output source document for Route.OutputMapping evaluation
-        //    (Feature 104 wave 14a). Payload and calculations are always present;
-        //    HAIP mint output is attached in wave 14b when it runs.
-        var outputSource = BuildOutputMappingSource(request.PayloadData, calculations);
+        //    (Feature 104 wave 14a). Payload, calculations, and (when present)
+        //    HAIP mint output are exposed under /payload, /calculations, /haip.
+        var outputSource = BuildOutputMappingSource(request.PayloadData, calculations, haipOfferResult, actionDef);
         var routingResult = await EvaluateRoutingAsync(blueprint, actionDef, mergedData, outputSource, cancellationToken);
 
         // 9a. Build payload that includes calculated values so they persist in the transaction
@@ -645,54 +678,18 @@ public class ActionExecutionService : IActionExecutionService
             }
         }
 
-        // 9d. Issue credential if action has issuance configuration
+        // 9d. Issue internal Sorcha credential if configured (non-HAIP path).
+        //     The HAIP path has already run at step 8b (moved before routing in
+        //     Feature 104 wave 14b so Route.OutputMapping can carry offer data
+        //     forward to a claim action). The internal path remains here
+        //     because it builds a register transaction from the merged state.
         CredentialIssuanceResult? issuedCredential = null;
-        CreateOfferResult? haipOfferResult = null;
-        if (actionDef.CredentialIssuanceConfig != null)
+        if (actionDef.CredentialIssuanceConfig != null
+            && actionDef.CredentialIssuanceConfig.TargetAudience != TargetAudience.HaipExternalWallet)
         {
-            // Feature 097: Route HAIP-path issuance through the HAIP service
-            if (actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet
-                && _haipClient != null)
-            {
-                // Feature 103: apply ClaimMappings here too. The HAIP path was
-                // previously passing mergedData unchanged, so nested primitive
-                // values (e.g. /name/givenName from a PersonName/v1 reference)
-                // landed in the credential as the nested objects themselves.
-                var haipClaims = BuildClaimsFromMappings(
-                    actionDef.CredentialIssuanceConfig.ClaimMappings,
-                    mergedData!);
-                // HAIP client expects non-nullable values. The null-forgiving
-                // operator below is safe because TryResolveJsonPointer returns
-                // false for null-valued segments, so BuildClaimsFromMappings
-                // never produces a null value. If that invariant is ever
-                // relaxed (e.g. to support explicitly-null optional fields),
-                // this projection must be updated to filter or coerce nulls
-                // before the wire call.
-                var haipClaimsForWire = haipClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
-
-                _logger.LogInformation(
-                    "Routing credential issuance to HAIP service for external wallet: type={Type}, claims=[{ClaimNames}]",
-                    actionDef.CredentialIssuanceConfig.CredentialType,
-                    string.Join(", ", haipClaimsForWire.Keys));
-
-                haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
-                    request.SenderWallet,
-                    instance.RegisterId,
-                    actionDef.CredentialIssuanceConfig.CredentialType,
-                    haipClaimsForWire,
-                    actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
-                    cancellationToken);
-
-                _logger.LogInformation(
-                    "HAIP credential offer created: offerId={OfferId}, expiresAt={ExpiresAt}",
-                    haipOfferResult.OfferId, haipOfferResult.ExpiresAt);
-            }
-            else
-            {
-                // Internal Sorcha issuance path (existing behaviour)
-                issuedCredential = await IssueCredentialFromActionAsync(
-                    actionDef, mergedData, request.SenderWallet, instance, cancellationToken);
-            }
+            // Internal Sorcha issuance path (existing behaviour)
+            issuedCredential = await IssueCredentialFromActionAsync(
+                actionDef, mergedData, request.SenderWallet, instance, cancellationToken);
         }
 
         // 10. Build transaction
@@ -1096,13 +1093,15 @@ public class ActionExecutionService : IActionExecutionService
 
     /// <summary>
     /// Builds the output source JsonObject for <see cref="Sorcha.Blueprint.Models.Route.OutputMapping"/>
-    /// evaluation. Shape: <c>{ "payload": {...}, "calculations": {...} }</c>.
-    /// HAIP mint output (when present) is attached by the caller before routing
-    /// under the <c>haip</c> key — not yet wired in wave 14a. Feature 104.
+    /// evaluation. Shape: <c>{ "payload": {...}, "calculations": {...}, "haip": {...}? }</c>.
+    /// The <c>haip</c> key is present only when the current action minted an
+    /// OpenID4VCI credential offer via the HAIP service (Feature 104 wave 14b).
     /// </summary>
     private static JsonObject BuildOutputMappingSource(
         IReadOnlyDictionary<string, object> payloadData,
-        IReadOnlyDictionary<string, object>? calculations)
+        IReadOnlyDictionary<string, object>? calculations,
+        CreateOfferResult? haipOfferResult = null,
+        ActionModel? actionDef = null)
     {
         var source = new JsonObject();
 
@@ -1110,6 +1109,37 @@ public class ActionExecutionService : IActionExecutionService
         // consistently get JsonNode values regardless of the input object types.
         source["payload"] = ConvertToJsonNode(payloadData) ?? new JsonObject();
         source["calculations"] = ConvertToJsonNode(calculations ?? new Dictionary<string, object>()) ?? new JsonObject();
+
+        if (haipOfferResult is not null)
+        {
+            // Expose the HAIP mint output under /haip/* so the Verified Citizen v2
+            // blueprint can declare routes like
+            //   "outputMapping": {
+            //     "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+            //     "/haip/credential_type":      "/credentialOffer/credential_type",
+            //     "/haip/expires_at":           "/credentialOffer/expires_at"
+            //   }
+            // and carry the offer into the claim action's prepopulated payload.
+            //
+            // Human-readable display strings (title / subtitle / description /
+            // issuer name) are the blueprint author's responsibility — they ship
+            // as literals on the claim action's schema defaults so they can be
+            // localised per blueprint. The service only emits protocol fields.
+            var haipNode = new JsonObject
+            {
+                ["credential_offer_uri"] = haipOfferResult.CredentialOfferUri,
+                ["offer_id"] = haipOfferResult.OfferId.ToString(),
+                ["expires_at"] = haipOfferResult.ExpiresAt.ToString("O")
+            };
+
+            var issuanceConfig = actionDef?.CredentialIssuanceConfig;
+            if (issuanceConfig is not null)
+            {
+                haipNode["credential_type"] = issuanceConfig.CredentialType;
+            }
+
+            source["haip"] = haipNode;
+        }
 
         return source;
     }

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -451,6 +451,24 @@ public class ActionExecutionService : IActionExecutionService
         //     step 9d because it depends on the built transaction context.
         CreateOfferResult? haipOfferResult = null;
         if (actionDef.CredentialIssuanceConfig != null
+            && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet)
+        {
+            if (_haipClient is null)
+            {
+                // HAIP-targeted issuance without a registered HAIP client is a
+                // misconfiguration: the action expects an external-wallet offer
+                // but no service is available to mint one. Surface this in
+                // observability so deployment-time gaps don't silently produce
+                // empty claim actions downstream.
+                _logger.LogError(
+                    "Action {ActionId} on blueprint {BlueprintId} declares TargetAudience=HaipExternalWallet " +
+                    "but no IHaipClient is registered. HAIP offer will not be minted; downstream claim " +
+                    "action (if any) will have an empty credentialOffer seed and will fall back to the " +
+                    "default form renderer. Check service registration.",
+                    actionDef.Id, blueprint.Id);
+            }
+        }
+        if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet
             && _haipClient != null)
         {
@@ -1125,6 +1143,20 @@ public class ActionExecutionService : IActionExecutionService
             // issuer name) are the blueprint author's responsibility — they ship
             // as literals on the claim action's schema defaults so they can be
             // localised per blueprint. The service only emits protocol fields.
+            //
+            // Defensive: if the HAIP service returned a result with an empty
+            // credential_offer_uri, that's a contract violation — the downstream
+            // claim action would silently fall through to the default form
+            // renderer (via the resolver's IsNullOrWhiteSpace guard) with no
+            // user-facing error. Throw loudly instead.
+            if (string.IsNullOrWhiteSpace(haipOfferResult.CredentialOfferUri))
+            {
+                throw new InvalidOperationException(
+                    "HAIP service returned a credential offer with an empty CredentialOfferUri. " +
+                    "This indicates a contract violation in the HAIP service — downstream claim " +
+                    "actions cannot render without the offer URI.");
+            }
+
             var haipNode = new JsonObject
             {
                 ["credential_offer_uri"] = haipOfferResult.CredentialOfferUri,

--- a/tests/Sorcha.UI.Core.Tests/Services/CredentialOfferSchemaResolverTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/CredentialOfferSchemaResolverTests.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="CredentialOfferSchemaResolver"/>. Feature 104 wave 14b.
+/// </summary>
+public class CredentialOfferSchemaResolverTests
+{
+    private static JsonElement ClaimActionSchema() =>
+        JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "credentialOffer": {
+              "type": "object",
+              "x-credential-offer": true,
+              "properties": {
+                "credential_offer_uri": { "type": "string" },
+                "credential_type":      { "type": "string" },
+                "expires_at":           { "type": "string", "format": "date-time" },
+                "offer_id":             { "type": "string" }
+              },
+              "required": ["credential_offer_uri"]
+            },
+            "claimed_at": { "type": "string", "format": "date-time" }
+          },
+          "required": ["credentialOffer"]
+        }
+        """);
+
+    private static JsonObject FullSeededPayload() => new()
+    {
+        ["credentialOffer"] = new JsonObject
+        {
+            ["credential_offer_uri"] = "openid-credential-offer://?credential_offer=abc",
+            ["credential_type"] = "VerifiedCitizenCredential",
+            ["expires_at"] = "2026-04-15T12:00:00Z",
+            ["offer_id"] = "11111111-1111-1111-1111-111111111111"
+        }
+    };
+
+    [Fact]
+    public void TryResolve_FullyPopulatedSeed_ReturnsInfo()
+    {
+        var info = CredentialOfferSchemaResolver.TryResolve(ClaimActionSchema(), FullSeededPayload());
+
+        info.Should().NotBeNull();
+        info!.FieldName.Should().Be("credentialOffer");
+        info.CredentialOfferUri.Should().Be("openid-credential-offer://?credential_offer=abc");
+        info.CredentialType.Should().Be("VerifiedCitizenCredential");
+        info.OfferId.Should().Be("11111111-1111-1111-1111-111111111111");
+        info.ExpiresAt.Should().NotBeNull();
+        info.ExpiresAt!.Value.Year.Should().Be(2026);
+        info.RawCredentialOffer.Should().NotBeNull();
+        info.RawCredentialOffer["credential_offer_uri"]!.GetValue<string>()
+            .Should().Be("openid-credential-offer://?credential_offer=abc");
+    }
+
+    [Fact]
+    public void TryResolve_NullSchema_ReturnsNull()
+    {
+        CredentialOfferSchemaResolver.TryResolve(null, FullSeededPayload()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_NullPrepopulatedPayload_ReturnsNull()
+    {
+        CredentialOfferSchemaResolver.TryResolve(ClaimActionSchema(), null).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_EmptyPrepopulatedPayload_ReturnsNull()
+    {
+        CredentialOfferSchemaResolver.TryResolve(ClaimActionSchema(), new JsonObject()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_SchemaWithoutCredentialOfferExtension_ReturnsNull()
+    {
+        var plainSchema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "note": { "type": "string" }
+          }
+        }
+        """);
+        var seed = new JsonObject { ["note"] = "hello" };
+
+        CredentialOfferSchemaResolver.TryResolve(plainSchema, seed).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_CredentialOfferMarkerOnNonObjectField_ReturnsNull()
+    {
+        // VAL_BP_012 would block this at publish time but the resolver is also
+        // defensive — if a malformed schema reaches the client, we bail rather
+        // than attempt to render a claim card on a scalar field.
+        var schema = JsonSerializer.Deserialize<JsonElement>("""
+        {
+          "type": "object",
+          "properties": {
+            "credentialOffer": {
+              "type": "string",
+              "x-credential-offer": true
+            }
+          }
+        }
+        """);
+        var seed = new JsonObject { ["credentialOffer"] = "not an object" };
+
+        CredentialOfferSchemaResolver.TryResolve(schema, seed).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_SeedMissingOfferUri_ReturnsNull()
+    {
+        var seed = new JsonObject
+        {
+            ["credentialOffer"] = new JsonObject
+            {
+                ["credential_type"] = "VerifiedCitizenCredential"
+                // no credential_offer_uri
+            }
+        };
+
+        CredentialOfferSchemaResolver.TryResolve(ClaimActionSchema(), seed).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_MinimalSeedWithOnlyUri_ReturnsInfoWithNullOptionals()
+    {
+        var seed = new JsonObject
+        {
+            ["credentialOffer"] = new JsonObject
+            {
+                ["credential_offer_uri"] = "openid-credential-offer://?credential_offer=minimal"
+            }
+        };
+
+        var info = CredentialOfferSchemaResolver.TryResolve(ClaimActionSchema(), seed);
+
+        info.Should().NotBeNull();
+        info!.CredentialOfferUri.Should().Be("openid-credential-offer://?credential_offer=minimal");
+        info.CredentialType.Should().BeNull();
+        info.OfferId.Should().BeNull();
+        info.ExpiresAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_MalformedExpiresAt_ReturnsInfoWithNullExpiresAt()
+    {
+        var seed = new JsonObject
+        {
+            ["credentialOffer"] = new JsonObject
+            {
+                ["credential_offer_uri"] = "openid-credential-offer://?credential_offer=bad",
+                ["expires_at"] = "not-a-date"
+            }
+        };
+
+        var info = CredentialOfferSchemaResolver.TryResolve(ClaimActionSchema(), seed);
+
+        info.Should().NotBeNull();
+        info!.ExpiresAt.Should().BeNull();
+    }
+}

--- a/walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json
+++ b/walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json
@@ -1,21 +1,21 @@
 {
   "id": "haip-driving-licence-v2",
   "title": "Driving Licence Application",
-  "description": "Citizen submits a driving licence application. Council verifies identity by requesting the applicant's VerifiedCitizenCredential via HAIP presentation (QR), then issues a DrivingLicenceCredential to the applicant's external HAIP wallet via HAIP credential offer (QR). Three-action workflow: applicant submits, council verifies, council issues.",
-  "version": 2,
+  "description": "Citizen submits a driving licence application. Council verifies identity by requesting the applicant's VerifiedCitizenCredential via HAIP presentation (QR), then issues a DrivingLicenceCredential. From v3 the credential is delivered back to the applicant as a dedicated Claim Credential action in their My Actions queue — the citizen clicks Claim to land the credential in their local wallet, or scans the QR to load it into an external HAIP wallet. Four-action workflow: applicant submits, council verifies, council issues, applicant claims.",
+  "version": 3,
   "category": "licensing",
-  "tags": ["haip", "driving-licence", "oid4vci", "oid4vp", "verifiable-credential", "external-wallet", "citizen-application"],
+  "tags": ["haip", "driving-licence", "oid4vci", "oid4vp", "verifiable-credential", "credential-claim", "citizen-application"],
   "author": "Sorcha Team",
   "published": true,
   "template": {
     "id": "haip-driving-licence",
     "title": "Driving Licence Application",
-    "description": "Citizen submits a driving licence application. Council verifies identity via HAIP and issues the licence.",
-    "version": 2,
+    "description": "Citizen submits a driving licence application, council verifies identity via HAIP and issues the licence, applicant claims the licence via a dedicated pending action.",
+    "version": 3,
     "metadata": {
       "category": "Licensing & Permits",
       "complexity": "Standard",
-      "actions": "3",
+      "actions": "4",
       "features": "HAIP, OpenID4VCI, OpenID4VP, External Wallet, Verifiable Credential, Citizen Application",
       "sector": "Government"
     },
@@ -226,10 +226,82 @@
         ],
         "routes": [
           {
-            "id": "complete",
+            "id": "to-claim",
+            "nextActionIds": [4],
+            "isDefault": true,
+            "description": "Licence issued — hand off to applicant for claim",
+            "outputMapping": {
+              "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+              "/haip/credential_type":      "/credentialOffer/credential_type",
+              "/haip/expires_at":           "/credentialOffer/expires_at",
+              "/haip/offer_id":             "/credentialOffer/offer_id"
+            }
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Claim your Driving Licence",
+        "description": "Your driving licence credential is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP-compatible wallet. Declining will cancel the claim and no credential will be issued.",
+        "sender": "applicant",
+        "requiredPriorActions": [3],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "credentialOffer": {
+                "type": "object",
+                "title": "Credential Offer",
+                "x-credential-offer": true,
+                "properties": {
+                  "credential_offer_uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Canonical OpenID4VCI offer URI (openid-credential-offer://...)"
+                  },
+                  "credential_type": {
+                    "type": "string",
+                    "description": "The credential type to be issued"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the credential offer expires and can no longer be claimed"
+                  },
+                  "offer_id": {
+                    "type": "string",
+                    "description": "HAIP offer identifier for status polling"
+                  }
+                },
+                "required": ["credential_offer_uri"]
+              },
+              "claimed_at": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Claimed at",
+                "description": "Set by the client when the citizen clicks Claim"
+              }
+            },
+            "required": ["credentialOffer"]
+          }
+        ],
+        "rejectionConfig": {
+          "targetActionId": 0,
+          "isTerminal": true,
+          "requireReason": false
+        },
+        "disclosures": [
+          {
+            "participantAddress": "applicant",
+            "dataPointers": ["/*"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "claimed-terminal",
             "nextActionIds": [],
             "isDefault": true,
-            "description": "Workflow complete after licence issued"
+            "description": "Licence claimed — workflow complete"
           }
         ]
       }

--- a/walkthroughs/HaipVerifiedCitizen/blueprints/verified-citizen.json
+++ b/walkthroughs/HaipVerifiedCitizen/blueprints/verified-citizen.json
@@ -1,22 +1,22 @@
 {
   "id": "haip-verified-citizen-v2",
   "title": "HAIP Verified Citizen",
-  "description": "A citizen submits a verified-citizen application using the Sorcha core identity primitive library (PersonName, DateOfBirth, EmailAddress, PostalAddress). A government assessor reviews the application, then issues a VerifiedCitizenCredential to the citizen's external HAIP wallet via the OpenID4VCI pre-authorized code flow (delivered as a QR code). v2 introduced in Feature 103.",
-  "version": 2,
+  "description": "A citizen submits a verified-citizen application using the Sorcha core identity primitive library (PersonName, DateOfBirth, EmailAddress, PostalAddress). A government assessor reviews the application, then issues a VerifiedCitizenCredential. From v3 the credential is delivered back to the citizen as a dedicated Claim Credential action in their My Actions queue — the citizen clicks Claim to land the credential in their local wallet, or scans the QR to load it into an external HAIP wallet. v2 introduced in Feature 103; three-action claim flow added in Feature 104 wave 14b.",
+  "version": 3,
   "category": "identity",
-  "tags": ["haip", "verified-citizen", "identity", "oid4vci", "verifiable-credential", "external-wallet", "citizen-application", "core-primitives"],
+  "tags": ["haip", "verified-citizen", "identity", "oid4vci", "verifiable-credential", "credential-claim", "citizen-application", "core-primitives"],
   "author": "Sorcha Team",
   "published": true,
   "template": {
     "id": "haip-verified-citizen",
     "title": "HAIP Verified Citizen",
-    "description": "Citizen submits identity details using shared core primitives, government assessor reviews and issues a Verified Citizen credential to the citizen's external HAIP wallet.",
-    "version": 2,
+    "description": "Citizen submits identity details using shared core primitives, government assessor reviews and issues a Verified Citizen credential, and the citizen claims the credential via a dedicated pending action.",
+    "version": 3,
     "metadata": {
       "category": "Identity & Credentials",
       "complexity": "Simple",
-      "actions": "2",
-      "features": "HAIP, OpenID4VCI, External Wallet, Verifiable Credential, Citizen Application, Core Primitives",
+      "actions": "3",
+      "features": "HAIP, OpenID4VCI, External Wallet, Verifiable Credential, Citizen Claim Action, Core Primitives",
       "sector": "Government"
     },
     "participants": [
@@ -24,7 +24,7 @@
         "id": "citizen",
         "name": "Citizen",
         "organisation": "Public",
-        "description": "Submits a verified-citizen application and receives the Verified Citizen credential via their external HAIP wallet"
+        "description": "Submits a verified-citizen application and claims the Verified Citizen credential into their local or external HAIP wallet"
       },
       {
         "id": "government-assessor",
@@ -43,7 +43,7 @@
         "dataSchemas": [
           {
             "type": "object",
-            "x-introduction": "Submit your personal details so a government assessor can verify your identity. After review, the Verified Citizen credential will be delivered to the wallet you scan the QR code with.",
+            "x-introduction": "Submit your personal details so a government assessor can verify your identity. After review, the Verified Citizen credential will appear in your My Actions queue for you to claim.",
             "x-pages": [
               {
                 "title": "Your Name",
@@ -109,13 +109,13 @@
       {
         "id": 2,
         "title": "Review & Issue Verified Citizen Credential",
-        "description": "Government assessor reviews the citizen's submitted application. On approval, a VerifiedCitizenCredential is issued and delivered to the citizen's external HAIP wallet via a QR code (OpenID4VCI pre-authorized code flow). Claims are sourced from the v2 nested submission structure.",
+        "description": "Government assessor reviews the citizen's submitted application. On approval, a VerifiedCitizenCredential is minted via the HAIP service and routed forward to action 3 (the citizen's Claim Credential action) via Route.OutputMapping. Claims are sourced from the v2 nested submission structure.",
         "sender": "government-assessor",
         "requiredPriorActions": [1],
         "dataSchemas": [
           {
             "type": "object",
-            "x-introduction": "Review the citizen's submitted personal details against your records and approve or reject the application. On approval the Verified Citizen credential is minted and offered to the citizen's external wallet.",
+            "x-introduction": "Review the citizen's submitted personal details against your records and approve or reject the application. On approval the Verified Citizen credential is minted and made available to the citizen as a Claim Credential action in their My Actions queue.",
             "x-sections": [
               {
                 "title": "Decision",
@@ -170,10 +170,88 @@
         ],
         "routes": [
           {
-            "id": "complete",
+            "id": "approved-to-claim",
+            "nextActionIds": [3],
+            "condition": { "==": [{ "var": "verificationDecision" }, "approved"] },
+            "description": "Approved — deliver the minted credential to the citizen's Claim Credential pending action",
+            "outputMapping": {
+              "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+              "/haip/credential_type":      "/credentialOffer/credential_type",
+              "/haip/expires_at":           "/credentialOffer/expires_at",
+              "/haip/offer_id":             "/credentialOffer/offer_id"
+            }
+          },
+          {
+            "id": "rejected-terminal",
             "nextActionIds": [],
             "isDefault": true,
-            "description": "Workflow complete after credential issued"
+            "description": "Rejected — workflow ends with no credential issued"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Claim your Verified Citizen credential",
+        "description": "Your Verified Citizen credential is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP-compatible wallet. Declining will cancel the claim and no credential will be issued.",
+        "sender": "citizen",
+        "requiredPriorActions": [2],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "credentialOffer": {
+                "type": "object",
+                "title": "Credential Offer",
+                "x-credential-offer": true,
+                "properties": {
+                  "credential_offer_uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Canonical OpenID4VCI offer URI (openid-credential-offer://...)"
+                  },
+                  "credential_type": {
+                    "type": "string",
+                    "description": "The credential type to be issued"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the credential offer expires and can no longer be claimed"
+                  },
+                  "offer_id": {
+                    "type": "string",
+                    "description": "HAIP offer identifier for status polling"
+                  }
+                },
+                "required": ["credential_offer_uri"]
+              },
+              "claimed_at": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Claimed at",
+                "description": "Set by the client when the citizen clicks Claim"
+              }
+            },
+            "required": ["credentialOffer"]
+          }
+        ],
+        "rejectionConfig": {
+          "targetActionId": 0,
+          "isTerminal": true,
+          "requireReason": false
+        },
+        "disclosures": [
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/*"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "claimed-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Credential claimed — workflow complete"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Wave 14b of Feature 103 (Verified Citizen v2) — the user-facing feature on top of wave 14a's engine primitive. Delivers HAIP credential offers to the **recipient** (citizen) via a dedicated pending \"Claim credential\" action in My Actions, with Claim / Scan-QR / Decline / retry paths. Fixes the wave 13 semantic bug where the offer surfaced in the assessor's browser.

Wave 14a (engine primitive) shipped as PR #282 ✅

## Server

- **\`ActionExecutionService\`**: HAIP mint moved to run **before** routing so \`Route.OutputMapping\` can carry the offer forward to the claim action. Internal (non-HAIP) issuance stays post-transaction-build.
- **\`BuildOutputMappingSource\`**: emits \`/haip/{credential_offer_uri, offer_id, expires_at, credential_type}\` when a HAIP offer was minted in this execution.
- **\`ValidateBlueprint\`**: adds \`VAL_BP_012\` (x-credential-offer only on object fields) and \`WARN_BP_006\` (non-blocking: credential_offer_uri should be required).

## UI

- **\`CredentialOfferSchemaResolver\`** (Core, service): detects \`x-credential-offer: true\` on a schema object field and extracts the seed payload. Defensive — returns null for malformed seeds so callers fall back to the default form.
- **\`CredentialClaimCard.razor\`** (Web.Client, component): header + Claim + Scan-with-external-wallet + Decline + retry-friendly failure handling + client-side Expired detection. Reuses wave 13's \`CredentialOfferQrCard\` and \`IHaipLocalReceiveService\` verbatim.
- **\`CredentialClaimDialog.razor\`** (Web.Client): thin MudBlazor wrapper so \`MyActions.TakeAction\` can show the card via \`DialogService.ShowAsync\`.
- **\`MyActions.razor\`**: branches on the resolver — claim actions open the new dialog, everything else routes through \`ActionForm\` unchanged. Declines go through \`IWorkflowService.RejectActionAsync\` and seal via \`RejectionConfig.IsTerminal\`.
- **\`PendingActionViewModel.PrepopulatedPayload\`** + \`WorkflowService\` deserialisation: surfaces the wave 14a server-side seed through to the client view model.

## Blueprint updates

- **Verified Citizen v2 → v3**: adds action 3 (citizen claim). Action 2 routes conditionally — \`verificationDecision == \"approved\"\` carries \`/haip/*\` forward into \`/credentialOffer/*\` on action 3; rejected goes terminal with no credential.
- **HAIP Driving Licence → v3**: same pattern layered on top, adds action 4 (applicant claim) after council issuance.

## Test plan

- [x] \`Blueprint.Engine.Tests\`: **460 pass** (no regressions)
- [x] \`UI.Core.Tests\`: **1072 pass / 1 fail** — single failure is the pre-existing \`WorkflowServiceAsyncTests.SubmitActionExecuteAsync_ServerError_ReturnsNull\` documented in MEMORY.md, unchanged by this PR
- [x] \`CredentialOfferSchemaResolverTests\`: 9 new green tests
- [x] Full solution build: 0 errors, 35 warnings all pre-existing
- [ ] Playwright E2E for the full P1 claim flow — deferred; manual walkthrough exercise coming in the n1 redeployment PR
- [ ] \`HaipVerifiedCitizen\` / \`HaipDrivingLicence\` walkthrough run.ps1 script updates — deferred; blueprints ship here, script updates in the n1 redeployment PR
- [ ] POST \`/claim-expired\` server endpoint (T028, P3 scope) — deferred. Card detects expiry client-side and disables Claim; server-side state transition is a separate concern.

## Backward compatibility

Purely additive. Blueprints without \`x-credential-offer\` fields route through the existing \`ActionForm\` → \`SorchaFormRenderer\` pipeline unchanged. The pre-routing HAIP mint re-ordering is observable only to blueprints that declare \`Route.OutputMapping\` referencing \`/haip/*\`; existing HAIP-issuance blueprints still receive the offer in their response payload for display via \`CredentialOfferQrDialog\` exactly as today.

## Next

- Playwright E2E + walkthrough script updates in a follow-up PR.
- Server-side claim-expired endpoint when P3 becomes relevant.
- n1 redeployment + re-run HaipVerifiedCitizen / HaipDrivingLicence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)