### PR TITLE
fix(103): cache validator action schemas to survive multi-submitter flows

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -576,7 +576,7 @@ public class ValidationEngine : IValidationEngine
                     // strict about unknown keywords and throws "Unknown keywords (x-pages)
                     // are disallowed for this dialect" when they appear at the schema root.
                     var schemaText = StripCustomExtensionKeywords(schemaDoc.RootElement);
-                    jsonSchema = JsonSchema.FromText(schemaText);
+                    jsonSchema = GetOrParseActionSchema(schemaText);
                 }
                 catch (Exception ex)
                 {
@@ -1389,6 +1389,39 @@ public class ValidationEngine : IValidationEngine
 
     private static Json.Schema.JsonSchema? _participantSchema;
     private static readonly object _schemaLock = new();
+
+    /// <summary>
+    /// Content-addressed cache of parsed blueprint action data schemas.
+    /// <para>
+    /// JsonSchema.Net's <see cref="Json.Schema.JsonSchema.FromText(string)"/> eagerly
+    /// registers any sub-schema with an <c>$id</c> in the process-global
+    /// <c>SchemaRegistry.Global</c>. Feature 103 wave 6's <c>SchemaRefResolver</c> flattens
+    /// the core identity primitives (<c>PersonName.v1</c>, <c>DateOfBirth.v1</c>,
+    /// <c>EmailAddress.v1</c>, <c>PostalAddress.v1</c>) into action schemas, and those
+    /// primitives carry stable <c>$id</c> URIs. Parsing the same flattened schema twice
+    /// from two different transactions therefore trips the library's
+    /// "Overwriting registered schemas is not permitted" error.
+    /// </para>
+    /// <para>
+    /// This cache guarantees <see cref="Json.Schema.JsonSchema.FromText(string)"/> is called
+    /// exactly once per unique schema text within a validator process lifetime. The key is
+    /// a SHA-256 of the stripped schema text, so republishes with changed content
+    /// naturally miss the cache and get a fresh parse. The value is wrapped in
+    /// <see cref="Lazy{T}"/> with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>
+    /// to guarantee exactly-once parsing even under concurrent transaction validation.
+    /// </para>
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Lazy<Json.Schema.JsonSchema>> _actionSchemaCache = new();
+
+    private static Json.Schema.JsonSchema GetOrParseActionSchema(string schemaText)
+    {
+        var hashBytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(schemaText));
+        var key = Convert.ToHexString(hashBytes);
+        var lazy = _actionSchemaCache.GetOrAdd(key, _ => new Lazy<Json.Schema.JsonSchema>(
+            () => Json.Schema.JsonSchema.FromText(schemaText),
+            LazyThreadSafetyMode.ExecutionAndPublication));
+        return lazy.Value;
+    }
 
     private static Json.Schema.JsonSchema GetParticipantSchema()
     {

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -1410,12 +1411,18 @@ public class ValidationEngine : IValidationEngine
     /// <see cref="Lazy{T}"/> with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>
     /// to guarantee exactly-once parsing even under concurrent transaction validation.
     /// </para>
+    /// <para>
+    /// The cache is intentionally unbounded. In practice the number of distinct action
+    /// schemas in any validator process is bounded by the set of live blueprint versions,
+    /// which is small and finite. If this ever becomes a memory concern, add a size cap
+    /// with LRU eviction keyed by last-access time.
+    /// </para>
     /// </summary>
     private static readonly ConcurrentDictionary<string, Lazy<Json.Schema.JsonSchema>> _actionSchemaCache = new();
 
-    private static Json.Schema.JsonSchema GetOrParseActionSchema(string schemaText)
+    internal static Json.Schema.JsonSchema GetOrParseActionSchema(string schemaText)
     {
-        var hashBytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(schemaText));
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(schemaText));
         var key = Convert.ToHexString(hashBytes);
         var lazy = _actionSchemaCache.GetOrAdd(key, _ => new Lazy<Json.Schema.JsonSchema>(
             () => Json.Schema.JsonSchema.FromText(schemaText),

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineSchemaCacheTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineSchemaCacheTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using FluentAssertions;
+using Json.Schema;
+using Sorcha.Validator.Service.Services;
+using Xunit;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Regression coverage for the "Overwriting registered schemas is not permitted"
+/// failure first observed in Feature 103 wave 13 follow-up when a second citizen
+/// attempted to submit the Verified Citizen Action 1 against a validator that had
+/// already processed Alice's transaction.
+/// <para>
+/// The root cause: <c>SchemaRefResolver</c> flattens core identity primitives with
+/// stable <c>$id</c> URIs into blueprint action schemas. JsonSchema.Net's
+/// <see cref="JsonSchema.FromText(string)"/> eagerly registers any sub-schema with an
+/// <c>$id</c> in the process-global <c>SchemaRegistry.Global</c>, so the second parse
+/// of the same flattened schema throws.
+/// </para>
+/// <para>
+/// <see cref="ValidationEngine"/> now routes action schema parsing through an internal
+/// content-addressed cache (<c>GetOrParseActionSchema</c>) so <see cref="JsonSchema.FromText(string)"/>
+/// is called exactly once per unique schema text within a validator process lifetime.
+/// </para>
+/// </summary>
+public class ValidationEngineSchemaCacheTests
+{
+    /// <summary>
+    /// Uses a unique <c>$id</c> per test run so repeat runs of the same test in the
+    /// same process don't collide with each other's global registry entries.
+    /// </summary>
+    private static string MakeFlattenedSchemaWithIdPrimitive(string uniqueId)
+    {
+        // Mirrors the shape produced by SchemaRefResolver: a wrapper object schema
+        // that inlines a core primitive carrying a stable $id.
+        return $$"""
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "$id": "https://schemas.sorcha.dev/test/{{uniqueId}}",
+              "type": "object",
+              "properties": {
+                "givenName": { "type": "string" },
+                "familyName": { "type": "string" }
+              },
+              "required": ["givenName", "familyName"]
+            }
+          },
+          "required": ["name"]
+        }
+        """;
+    }
+
+    private static JsonSchema InvokeGetOrParseActionSchema(string schemaText)
+    {
+        var method = typeof(ValidationEngine).GetMethod(
+            "GetOrParseActionSchema",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("GetOrParseActionSchema not found");
+        return (JsonSchema)method.Invoke(null, new object[] { schemaText })!;
+    }
+
+    [Fact]
+    public void JsonSchemaFromText_CalledTwiceWithSameIdSchema_ThrowsOnSecondCall_RegressionProof()
+    {
+        // This test PROVES the underlying JsonSchema.Net behaviour the cache exists
+        // to work around. If this test ever starts failing because FromText becomes
+        // idempotent, the cache could potentially be simplified — but the cache still
+        // saves re-parsing cost, so it stays.
+        var unique = Guid.NewGuid().ToString("N");
+        var schemaText = MakeFlattenedSchemaWithIdPrimitive(unique);
+
+        var firstParse = () => JsonSchema.FromText(schemaText);
+        var secondParse = () => JsonSchema.FromText(schemaText);
+
+        firstParse.Should().NotThrow("the first parse seeds the global SchemaRegistry");
+        secondParse.Should().Throw<Exception>()
+            .Where(ex => ex.Message.Contains("Overwriting registered schemas is not permitted"),
+                "JsonSchema.Net rejects duplicate registrations by design");
+    }
+
+    [Fact]
+    public void GetOrParseActionSchema_CalledTwiceWithSameSchemaText_ReturnsCachedInstanceWithoutThrowing()
+    {
+        // The cache's primary job: calling FromText exactly once per unique schema
+        // text so Feature 103 v2 blueprints (which flatten core primitives with $ids)
+        // survive repeated validation across multiple submitters.
+        var unique = Guid.NewGuid().ToString("N");
+        var schemaText = MakeFlattenedSchemaWithIdPrimitive(unique);
+
+        var first = InvokeGetOrParseActionSchema(schemaText);
+        var second = InvokeGetOrParseActionSchema(schemaText);
+
+        first.Should().NotBeNull();
+        second.Should().BeSameAs(first,
+            "cache should return the identical parsed instance on repeat calls");
+    }
+
+    [Fact]
+    public void GetOrParseActionSchema_DifferentSchemaText_GetsFreshParse()
+    {
+        var unique1 = Guid.NewGuid().ToString("N");
+        var unique2 = Guid.NewGuid().ToString("N");
+        var schemaA = MakeFlattenedSchemaWithIdPrimitive(unique1);
+        var schemaB = MakeFlattenedSchemaWithIdPrimitive(unique2);
+
+        var parsedA = InvokeGetOrParseActionSchema(schemaA);
+        var parsedB = InvokeGetOrParseActionSchema(schemaB);
+
+        parsedA.Should().NotBeSameAs(parsedB,
+            "different schema text must yield a fresh cache entry so blueprint republishes with changed content get reparsed");
+    }
+}

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineSchemaCacheTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineSchemaCacheTests.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Reflection;
 using FluentAssertions;
 using Json.Schema;
 using Sorcha.Validator.Service.Services;
@@ -56,15 +55,6 @@ public class ValidationEngineSchemaCacheTests
         """;
     }
 
-    private static JsonSchema InvokeGetOrParseActionSchema(string schemaText)
-    {
-        var method = typeof(ValidationEngine).GetMethod(
-            "GetOrParseActionSchema",
-            BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new InvalidOperationException("GetOrParseActionSchema not found");
-        return (JsonSchema)method.Invoke(null, new object[] { schemaText })!;
-    }
-
     [Fact]
     public void JsonSchemaFromText_CalledTwiceWithSameIdSchema_ThrowsOnSecondCall_RegressionProof()
     {
@@ -93,8 +83,8 @@ public class ValidationEngineSchemaCacheTests
         var unique = Guid.NewGuid().ToString("N");
         var schemaText = MakeFlattenedSchemaWithIdPrimitive(unique);
 
-        var first = InvokeGetOrParseActionSchema(schemaText);
-        var second = InvokeGetOrParseActionSchema(schemaText);
+        var first = ValidationEngine.GetOrParseActionSchema(schemaText);
+        var second = ValidationEngine.GetOrParseActionSchema(schemaText);
 
         first.Should().NotBeNull();
         second.Should().BeSameAs(first,
@@ -109,8 +99,8 @@ public class ValidationEngineSchemaCacheTests
         var schemaA = MakeFlattenedSchemaWithIdPrimitive(unique1);
         var schemaB = MakeFlattenedSchemaWithIdPrimitive(unique2);
 
-        var parsedA = InvokeGetOrParseActionSchema(schemaA);
-        var parsedB = InvokeGetOrParseActionSchema(schemaB);
+        var parsedA = ValidationEngine.GetOrParseActionSchema(schemaA);
+        var parsedB = ValidationEngine.GetOrParseActionSchema(schemaB);
 
         parsedA.Should().NotBeSameAs(parsedB,
             "different schema text must yield a fresh cache entry so blueprint republishes with changed content get reparsed");


### PR DESCRIPTION
## Summary

Root cause fix for the 400 error hit by the second citizen trying to submit the Verified Citizen v2 Action 1 against a live validator.

**Symptom observed on n1:** user creates public-org account, opens the Verified Citizen form, submits → \`Instance created (9a9f4c9f...) but action execution was rejected (400): An error occurred processing the request.\`

## Root Cause

Validator logs from n1:

\`\`\`
[16:27:05 WRN] ValidationEngineService
Transaction 1de61a0606644d6856d3a4bc224069a7602b79a1dee11f56fd067e3f9e3dfd09 failed validation:
VAL_SCHEMA_005: Malformed JSON schema in blueprint 'haip-verified-citizen-20260414172456' action 1:
Overwriting registered schemas is not permitted.
\`\`\`

Feature 103 wave 6 (#273) added \`SchemaRefResolver\` which flattens core identity primitives (\`PersonName.v1\`, \`DateOfBirth.v1\`, \`EmailAddress.v1\`, \`PostalAddress.v1\`) into blueprint action schemas at publish time. Each primitive carries a stable \`\$id\` URI.

JsonSchema.Net's \`JsonSchema.FromText\` eagerly registers any sub-schema with an \`\$id\` in the process-global \`SchemaRegistry\`. The **first** transaction for an action seeds the registry. Every **subsequent** transaction for the same action throws \`"Overwriting registered schemas is not permitted"\`.

The validator surfaces this as a transaction rejection. Blueprint service's \`WaitForTransactionConfirmationAsync\` times out waiting for the tx to land in a docket and returns 400 to the browser.

**Why this was never caught:**

- Wave 10 T087 n1 verification ran **one** citizen per validator process lifetime
- Walkthroughs are single-actor by design
- Wave 6 (PR #273) introduced the SchemaRefResolver flattening that makes \$id collisions possible
- Mongo inspection on n1 confirmed the second citizen's tx (\`1de61a06...\`) never made it into any docket, while the first citizen's tx (\`8b7f24e9...\` from Alice) landed in docket 2

## Fix

Route \`ValidationEngine\`'s action-schema parsing through a new content-addressed cache in \`ValidationEngine.cs\`:

- \`static ConcurrentDictionary<string, Lazy<JsonSchema>>\` keyed by SHA-256 of the stripped schema text
- \`Lazy<T>\` with \`LazyThreadSafetyMode.ExecutionAndPublication\` so concurrent transactions serialise cleanly
- \`FromText\` runs exactly once per unique schema text within a validator process lifetime
- Republishes with changed schema content get a fresh cache entry naturally

Same pattern already used by \`_participantSchema\` at \`ValidationEngine.cs:1393\`.

## Tests

\`ValidationEngineSchemaCacheTests\` covers three cases:

1. **Regression proof** against bare \`JsonSchema.FromText\` — shows the second call throws, confirming the library behaviour this cache exists to work around
2. **Happy path** — cache returns the identical instance on repeat calls, no throw
3. **Republish path** — different schema text produces a different cache entry

⚠️ \`Sorcha.Validator.Service.Tests\` has 30 pre-existing compile errors on master (stale mocks missing logger ctor args, missing \`TenantId\` properties on \`RegisterControlRecord\`/\`Register\`). The new test file is correct C# and will compile once the project is repaired. E2E verification for this fix runs against n1 after merge.

## Verification plan

- [x] \`Sorcha.Validator.Service.csproj\` builds clean (validated)
- [ ] Docker publish workflow rebuilds validator-service image
- [ ] Pull latest on n1, restart validator-service
- [ ] Retest: second public-user submission of Verified Citizen Action 1 should succeed end-to-end
- [ ] Credential mint (Action 2) should still complete

## Out of scope / follow-ups

Two unrelated 401s observed during the same browser session will be addressed separately:

1. **\`/api/address-lookup/providers\` 401** — \`PostcodeLookupRenderer.razor\` injects the default \`HttpClient\` at line 13, which is registered at \`ServiceCollectionExtensions.cs:45\` as a bare \`HttpClient\` without \`AuthenticatedHttpMessageHandler\`. Deterministic auth handler mis-wiring.
2. **\`/api/me/persona\` 401** — observed to proxy through YARP and get rejected by \`PersonaEndpoints.GetMyPersona\` when \`context.User.FindFirst("platform_user_id")\` returns empty. Needs a token claim trace; design discussion ongoing about capturing persona at first-time consumer login rather than chasing the claim issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)