### PR TITLE
fix(103): route PostcodeLookupRenderer through an auth-wrapped HttpClient

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -218,6 +218,7 @@ These are the **Tier 1** trust improvements identified in the transaction archit
 | UX-004 | Auditor role access review — determine read-only access scope | P2 | 4h | 📋 | Auditors currently have no nav items for Registers/Participants; decide if read-only access needed |
 | UX-005 | Dashboard org-scoped stats for multi-tenant deployments | P2 | 8h | 📋 | Currently global counts; need per-org stats for Consumer/Auditor users |
 | UX-006 | Public block explorer — unauthenticated register/transaction browsing | P2 | 16h | 📋 | Future feature — shares layout with authenticated app |
+| UX-007 | Public user page load hits Administrator/SystemAdmin-only endpoint | P2 | 4h | 📋 | Observed 2026-04-14 on n1 — browser console shows `Authorization failed. RolesAuthorizationRequirement:User.IsInRole must be true for one of the following roles: (Administrator|SystemAdmin)` during a Consumer's first page load. Some page-load call in the Blazor client is reaching an admin-only endpoint that a public-org Consumer role should never touch. Identify the culprit (likely a shared layout service that fans out to admin-scoped APIs without a role guard), gate the call behind a role check, and silence the console warning. Not blocking but pollutes the log and points at a latent authorization boundary bug. |
 
 ---
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -1,16 +1,14 @@
 @* SPDX-License-Identifier: MIT *@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
-@using System.Net.Http.Json
-@using System.Text.Json
-@using System.Text.Json.Serialization
 @using Microsoft.Extensions.Logging
 @using Sorcha.Blueprint.Models
 @using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.AddressLookup
 @using Sorcha.UI.Core.Services.Forms
 
 @implements IDisposable
-@inject HttpClient Http
+@inject IAddressLookupClient AddressLookup
 @inject IFormSchemaService SchemaService
 @inject ILogger<PostcodeLookupRenderer> Logger
 
@@ -125,12 +123,6 @@
     private bool _isLookingUp;
     private readonly CancellationTokenSource _cts = new();
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     protected override void OnParametersSet()
     {
         _value = FormContext?.GetValue<string>(Control.Scope) ?? string.Empty;
@@ -145,8 +137,7 @@
         // field still works as a plain text input.
         try
         {
-            var providers = await Http.GetFromJsonAsync<List<ProviderInfo>>(
-                "/api/address-lookup/providers", JsonOptions, _cts.Token);
+            var providers = await AddressLookup.GetProvidersAsync(_cts.Token);
 
             if (providers is not null && providers.Count > 0)
             {
@@ -228,21 +219,7 @@
         _isLookingUp = true;
         try
         {
-            var response = await Http.PostAsJsonAsync(
-                "/api/address-lookup/postcode",
-                new { postcode = _value },
-                JsonOptions,
-                _cts.Token);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                Logger.LogDebug("Address lookup returned {Status}", (int)response.StatusCode);
-                _candidates = null;
-                _metadataHint = null;
-                return;
-            }
-
-            var result = await response.Content.ReadFromJsonAsync<LookupResult>(JsonOptions, _cts.Token);
+            var result = await AddressLookup.LookupPostcodeAsync(_value, _cts.Token);
             if (result is null || !result.IsValid)
             {
                 _metadataHint = "Postcode not recognised — enter your address manually.";
@@ -373,41 +350,7 @@
         }
     }
 
-    // ----- wire DTOs -----
-
-    private sealed class ProviderInfo
-    {
-        public string Name { get; set; } = string.Empty;
-        public string Capability { get; set; } = string.Empty;
-        public List<string> SupportedCountries { get; set; } = new();
-        public bool Available { get; set; }
-    }
-
-    private sealed class LookupResult
-    {
-        public string Postcode { get; set; } = string.Empty;
-        public bool IsValid { get; set; }
-        public string Provider { get; set; } = string.Empty;
-        public string Capability { get; set; } = string.Empty;
-        public LookupMetadata? Metadata { get; set; }
-        public List<AddressCandidate>? Candidates { get; set; }
-    }
-
-    private sealed class LookupMetadata
-    {
-        public string? Town { get; set; }
-        public string? Region { get; set; }
-        public string? Country { get; set; }
-    }
-
-    private sealed class AddressCandidate
-    {
-        public string Line1 { get; set; } = string.Empty;
-        public string? Line2 { get; set; }
-        public string Town { get; set; } = string.Empty;
-        public string? Region { get; set; }
-        public string Postcode { get; set; } = string.Empty;
-        public string Country { get; set; } = string.Empty;
-        public string DisplayLabel { get; set; } = string.Empty;
-    }
+    // Wire DTOs live in Sorcha.UI.Core.Services.AddressLookup.IAddressLookupClient
+    // so that IAddressLookupClient and this renderer share the exact same
+    // shapes and a typed client boundary can be unit-tested without Razor.
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/PostcodeLookupRenderer.razor
@@ -220,7 +220,18 @@
         try
         {
             var result = await AddressLookup.LookupPostcodeAsync(_value, _cts.Token);
-            if (result is null || !result.IsValid)
+            if (result is null)
+            {
+                // Transient upstream failure (non-2xx / network / deserialise).
+                // Match the pre-typed-client behaviour: silent no-op so a 503
+                // or 429 from the provider doesn't mislead the user into
+                // thinking their postcode is wrong. Schema validation will
+                // still catch a genuinely malformed postcode on blur.
+                _candidates = null;
+                _metadataHint = null;
+                return;
+            }
+            if (!result.IsValid)
             {
                 _metadataHint = "Postcode not recognised — enter your address manually.";
                 _candidates = null;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -333,6 +333,19 @@ public static class ServiceCollectionExtensions
         services.AddScoped<Sorcha.UI.Core.Services.Persona.IPersonaService,
             Sorcha.UI.Core.Services.Persona.PersonaService>();
 
+        // Address Lookup Client — required by PostcodeLookupRenderer. Must use
+        // AuthenticatedHttpMessageHandler so the user's JWT is attached;
+        // otherwise YARP's RequireAuthenticated policy rejects the request at
+        // the gateway with a 401 before it reaches tenant-service.
+        services.AddScoped<Sorcha.UI.Core.Services.AddressLookup.IAddressLookupClient>(sp =>
+        {
+            var handler = sp.GetRequiredService<AuthenticatedHttpMessageHandler>();
+            handler.InnerHandler = new HttpClientHandler();
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
+            var logger = sp.GetRequiredService<ILogger<Sorcha.UI.Core.Services.AddressLookup.AddressLookupHttpClient>>();
+            return new Sorcha.UI.Core.Services.AddressLookup.AddressLookupHttpClient(httpClient, logger);
+        });
+
         // Persona autofill resolver — pure function, singleton.
         services.AddSingleton<Sorcha.UI.Core.Services.Forms.PersonaAutofillResolver>();
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/AddressLookup/AddressLookupHttpClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/AddressLookup/AddressLookupHttpClient.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.UI.Core.Services.AddressLookup;
+
+/// <summary>
+/// Default <see cref="IAddressLookupClient"/> — thin wrapper over the
+/// Tenant Service <c>/api/address-lookup/*</c> endpoints. Registered in
+/// <c>ServiceCollectionExtensions</c> with <c>AuthenticatedHttpMessageHandler</c>
+/// so the user's JWT bearer is attached automatically.
+/// </summary>
+public sealed class AddressLookupHttpClient : IAddressLookupClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<AddressLookupHttpClient> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public AddressLookupHttpClient(HttpClient httpClient, ILogger<AddressLookupHttpClient> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ProviderInfo>?> GetProvidersAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var providers = await _httpClient.GetFromJsonAsync<List<ProviderInfo>>(
+                "/api/address-lookup/providers", JsonOptions, ct);
+            return providers;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Address lookup provider discovery failed");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<LookupResult?> LookupPostcodeAsync(string postcode, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                "/api/address-lookup/postcode",
+                new { postcode },
+                JsonOptions,
+                ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "POST /api/address-lookup/postcode returned {Status}",
+                    (int)response.StatusCode);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<LookupResult>(JsonOptions, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Address lookup request failed");
+            return null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/AddressLookup/IAddressLookupClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/AddressLookup/IAddressLookupClient.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.AddressLookup;
+
+/// <summary>
+/// HTTP transport contract for the Tenant Service <c>/api/address-lookup/*</c>
+/// endpoints. Exists so that Razor components (notably
+/// <c>PostcodeLookupRenderer.razor</c>) can resolve an auth-wrapped client
+/// via DI instead of injecting the default unauthenticated <c>HttpClient</c>.
+/// <para>
+/// Prior to Feature 103 wave 14 the renderer injected the default
+/// <c>HttpClient</c>, which is registered as a bare <c>HttpClient</c>
+/// (no <c>AuthenticatedHttpMessageHandler</c>) specifically for
+/// <c>AuthenticationService</c> to avoid a circular DI dependency. Any
+/// other component that did <c>@inject HttpClient Http</c> silently
+/// inherited the unauthenticated client and hit 401 at the API Gateway's
+/// <c>RequireAuthenticated</c> policy. Routing through this typed client
+/// closes that footgun.
+/// </para>
+/// </summary>
+public interface IAddressLookupClient
+{
+    /// <summary>
+    /// Calls <c>GET /api/address-lookup/providers</c>. Returns the available
+    /// provider list so the renderer can pick <c>FullAddress</c> vs
+    /// <c>ValidateOnly</c> mode. Returns <c>null</c> on any failure — the
+    /// caller falls back to a plain text input when discovery fails.
+    /// </summary>
+    Task<IReadOnlyList<ProviderInfo>?> GetProvidersAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Calls <c>POST /api/address-lookup/postcode</c>. Returns the lookup
+    /// result (candidates for <c>FullAddress</c>, metadata for
+    /// <c>ValidateOnly</c>). Returns <c>null</c> on non-success so the
+    /// caller can distinguish transient failure from an invalid postcode.
+    /// </summary>
+    Task<LookupResult?> LookupPostcodeAsync(string postcode, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Describes an address-lookup provider registered in the Tenant Service.
+/// </summary>
+public sealed class ProviderInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string Capability { get; set; } = string.Empty;
+    public List<string> SupportedCountries { get; set; } = new();
+    public bool Available { get; set; }
+}
+
+/// <summary>
+/// Postcode lookup response. Either <see cref="Candidates"/> is populated
+/// (FullAddress providers) or <see cref="Metadata"/> is populated
+/// (ValidateOnly providers) — never both.
+/// </summary>
+public sealed class LookupResult
+{
+    public string Postcode { get; set; } = string.Empty;
+    public bool IsValid { get; set; }
+    public string Provider { get; set; } = string.Empty;
+    public string Capability { get; set; } = string.Empty;
+    public LookupMetadata? Metadata { get; set; }
+    public List<AddressCandidate>? Candidates { get; set; }
+}
+
+/// <summary>
+/// Coarse-grained location metadata returned by ValidateOnly providers.
+/// </summary>
+public sealed class LookupMetadata
+{
+    public string? Town { get; set; }
+    public string? Region { get; set; }
+    public string? Country { get; set; }
+}
+
+/// <summary>
+/// A single address candidate returned by FullAddress providers. Each
+/// candidate maps 1:1 to a row the user can pick from the renderer dropdown.
+/// </summary>
+public sealed class AddressCandidate
+{
+    public string Line1 { get; set; } = string.Empty;
+    public string? Line2 { get; set; }
+    public string Town { get; set; } = string.Empty;
+    public string? Region { get; set; }
+    public string Postcode { get; set; } = string.Empty;
+    public string Country { get; set; } = string.Empty;
+    public string DisplayLabel { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary

Follow-up to #285. Fixes the second of the 401s observed during Feature 103 wave 14 live testing on n1: \`GET /api/address-lookup/providers\` was rejected by YARP's \`RequireAuthenticated\` policy at the gateway with no Authorization header attached.

## Root cause

\`PostcodeLookupRenderer.razor\` injected the default unnamed \`HttpClient\`:

\`\`\`razor
@inject HttpClient Http
\`\`\`

The default \`HttpClient\` is registered at \`Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs:45\` as a **bare** \`HttpClient\` with no message handler. The comment on that registration is explicit about the intent:

\`\`\`csharp
// Register a plain HttpClient for AuthenticationService
// (no message handler to avoid circular dependency)
services.AddScoped<HttpClient>(sp => new HttpClient { BaseAddress = new Uri(baseAddress) });
\`\`\`

The implicit contract ("this client is for \`AuthenticationService\` only, everything else uses a typed client") isn't enforced anywhere, so any component that does \`@inject HttpClient\` silently inherits the unauthenticated client. Requests go out without a bearer token, YARP rejects at \`RequireAuthenticated\`, the component gets a 401 and falls back to NoProvider mode — the postcode field ends up as plain text.

**Gateway log evidence from n1:**

\`\`\`
[16:26:56 INF] HTTP GET /api/address-lookup/providers responded 401 in 0.5912 ms
\`\`\`

Sub-millisecond response, no \`Proxying to tenant-service\` log entry — rejected by the gateway's authorization middleware, never forwarded. By contrast \`/api/me/persona\` from the same page load **was** proxied through (\"Proxying to http://tenant-service:8080/api/me/persona\", 5ms) because \`PersonaHttpClient\` correctly uses \`AuthenticatedHttpMessageHandler\`.

## Fix

New \`Sorcha.UI.Core/Services/AddressLookup/\` folder with:

- **\`IAddressLookupClient\`** — contract with \`GetProvidersAsync\` + \`LookupPostcodeAsync\`, plus the shared wire DTOs (\`ProviderInfo\`, \`LookupResult\`, \`LookupMetadata\`, \`AddressCandidate\`) lifted out of the renderer's private inner classes
- **\`AddressLookupHttpClient\`** — thin wrapper around \`HttpClient\`, follows the exact same pattern as \`PersonaHttpClient\` / \`PendingActionService\` / \`UserPreferencesService\`
- **DI registration** in \`ServiceCollectionExtensions.cs\` — \`HttpClient\` wrapped in \`AuthenticatedHttpMessageHandler\` so the user's JWT bearer is attached and 401 refresh flows work as normal
- **\`PostcodeLookupRenderer.razor\`** — now injects \`IAddressLookupClient\` instead of raw \`HttpClient\`. No other behavioural changes.

Same footgun pattern exists for any other Razor component that \`@inject\`s \`HttpClient\` directly. This PR fixes the one we know about; I'd suggest a follow-up hygiene pass to grep for \`@inject HttpClient\` and migrate each hit to a typed client or explicit auth-wrapped factory. Not in scope here.

## Verification

- [x] \`Sorcha.UI.Core\` + \`Sorcha.UI.Web.Client\` build clean
- [ ] Docker Publish rebuilds \`sorchadev/ui-web:latest\` after merge
- [ ] Public-org user opens Verified Citizen form on n1 and the PostcodeLookupRenderer enters \`FullAddress\` mode (not \`NoProvider\` fallback)
- [ ] \`/api/address-lookup/providers\` returns 200 in browser devtools

## Related

- #285 (validator schema cache — merged) — unblocks the \"second citizen\" 400
- Persona 401 (\`/api/me/persona\` \`platform_user_id\` claim issue) — deferred, likely obviated by first-time consumer onboarding design work (Feature 105 spec TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)