### PR TITLE
fix(103): assemble form submissions into nested payloads for v2 blueprints

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FormPayloadBuilder.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FormPayloadBuilder.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Converts the flat JSON-Pointer-keyed dictionary produced by
+/// <see cref="Sorcha.UI.Core.Models.Forms.FormContext"/> into a nested
+/// <see cref="Dictionary{TKey, TValue}"/> tree suitable for submission
+/// as an <c>ActionExecuteRequest.PayloadData</c>.
+/// <para>
+/// The form renderer stores every control's value keyed by its JSON Pointer
+/// scope (e.g. <c>"/name/givenName"</c>, <c>"/address/line1"</c>). Prior to
+/// Feature 103 wave 6 (<c>SchemaRefResolver</c>), action schemas were flat
+/// and the submission path could get away with stripping the leading slash
+/// and sending the dictionary as-is. Once core identity primitives
+/// (<c>PersonName</c>, <c>DateOfBirth</c>, <c>EmailAddress</c>,
+/// <c>PostalAddress</c>) started being flattened into action schemas as
+/// nested objects, that shortcut started producing payloads that failed
+/// validator schema validation with <c>VAL_SCHEMA_004</c>:
+/// <c>Required properties ["name","dob","email","address"] are not present</c>.
+/// </para>
+/// <para>
+/// This helper assembles a nested tree by walking each pointer and creating
+/// intermediate <see cref="Dictionary{TKey, TValue}"/> nodes as needed. The
+/// final dictionary serialises to JSON with the correct nesting:
+/// </para>
+/// <code>
+///   flat:   { "/name/givenName": "Alice", "/name/familyName": "Smith",
+///             "/dob/dateOfBirth": "1990-01-01" }
+///   nested: { "name": { "givenName": "Alice", "familyName": "Smith" },
+///             "dob":  { "dateOfBirth": "1990-01-01" } }
+/// </code>
+/// <para>
+/// Arrays (pointers with numeric segments such as <c>/emails/0/value</c>)
+/// are not currently supported — they would produce a dictionary keyed by
+/// the string "0" rather than a real JSON array. None of the in-flight
+/// v2 blueprints use array-valued primitives, but this is a known limitation
+/// if future primitives (e.g. <c>EmailAddressList/v1</c>) are adopted.
+/// </para>
+/// </summary>
+public static class FormPayloadBuilder
+{
+    /// <summary>
+    /// Builds a nested dictionary from a flat JSON-Pointer-keyed dictionary.
+    /// Leading slashes on keys are tolerated. Empty keys and <c>"/"</c>
+    /// are ignored. Null values are coerced to <see cref="string.Empty"/>
+    /// to mirror the pre-fix submission shape and satisfy the non-nullable
+    /// value type on <c>ActionExecuteRequest.PayloadData</c>. Values at
+    /// conflicting paths (e.g. a scalar at <c>/name</c> plus a nested value
+    /// at <c>/name/givenName</c>) are resolved by the nested value winning
+    /// — the later write replaces the earlier one.
+    /// </summary>
+    public static Dictionary<string, object> BuildNested(
+        IReadOnlyDictionary<string, object?> flatPointerKeyed)
+    {
+        ArgumentNullException.ThrowIfNull(flatPointerKeyed);
+
+        var root = new Dictionary<string, object>();
+        foreach (var kvp in flatPointerKeyed)
+        {
+            SetPointer(root, kvp.Key, kvp.Value ?? string.Empty);
+        }
+        return root;
+    }
+
+    private static void SetPointer(Dictionary<string, object> root, string pointer, object value)
+    {
+        if (string.IsNullOrEmpty(pointer)) return;
+
+        var trimmed = pointer.TrimStart('/');
+        if (string.IsNullOrEmpty(trimmed)) return;
+
+        var segments = trimmed.Split('/');
+        if (segments.Length == 0) return;
+
+        var current = root;
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            var key = UnescapePointerSegment(segments[i]);
+            if (current.TryGetValue(key, out var existing) && existing is Dictionary<string, object> existingDict)
+            {
+                current = existingDict;
+            }
+            else
+            {
+                var next = new Dictionary<string, object>();
+                current[key] = next;
+                current = next;
+            }
+        }
+
+        var leafKey = UnescapePointerSegment(segments[^1]);
+        current[leafKey] = value;
+    }
+
+    /// <summary>
+    /// Decodes the RFC 6901 pointer segment escapes (<c>~1</c> → <c>/</c>,
+    /// <c>~0</c> → <c>~</c>). Order matters — <c>~0</c> is decoded after
+    /// <c>~1</c> so a literal <c>~1</c> in the original segment survives.
+    /// </summary>
+    private static string UnescapePointerSegment(string segment)
+    {
+        return segment.Replace("~1", "/").Replace("~0", "~");
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FormPayloadBuilder.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FormPayloadBuilder.cs
@@ -72,7 +72,6 @@ public static class FormPayloadBuilder
         if (string.IsNullOrEmpty(trimmed)) return;
 
         var segments = trimmed.Split('/');
-        if (segments.Length == 0) return;
 
         var current = root;
         for (var i = 0; i < segments.Length - 1; i++)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -429,7 +429,7 @@
             {
                 ActionId = action.ActionId,
                 InstanceId = action.InstanceId,
-                Data = Sorcha.UI.Core.Services.Forms.FormPayloadBuilder.BuildNested(cardSubmission.Data)
+                Data = FormPayloadBuilder.BuildNested(cardSubmission.Data)
             };
             result = DialogResult.Ok(adapted);
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -421,13 +421,15 @@
         // matching ActionForm's own convention.
         if (result is { Canceled: false, Data: FormSubmission cardSubmission })
         {
+            // Assemble the flat JSON-Pointer-keyed FormContext data into a
+            // nested dictionary so v2 blueprints that flatten core primitives
+            // (PersonName, DateOfBirth, EmailAddress, PostalAddress) pass
+            // validator schema validation. See FormPayloadBuilder.
             var adapted = new ActionSubmissionViewModel
             {
                 ActionId = action.ActionId,
                 InstanceId = action.InstanceId,
-                Data = cardSubmission.Data.ToDictionary(
-                    kvp => kvp.Key.TrimStart('/'),
-                    kvp => kvp.Value ?? (object)string.Empty)
+                Data = Sorcha.UI.Core.Services.Forms.FormPayloadBuilder.BuildNested(cardSubmission.Data)
             };
             result = DialogResult.Ok(adapted);
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
@@ -11,6 +11,7 @@
 @using Sorcha.UI.Core.Models.Wallet
 @using Sorcha.UI.Core.Models.Workflows
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Forms
 @using Sorcha.UI.Core.Services.Wallet
 @inject NavigationStateService NavState
 @inject IBlueprintApiService BlueprintApiService
@@ -158,10 +159,13 @@
                 return;
             }
 
-            // Step 2: Execute starting action
-            var payloadData = submission.Data.ToDictionary(
-                kvp => kvp.Key.TrimStart('/'),
-                kvp => kvp.Value ?? (object)string.Empty);
+            // Step 2: Execute starting action.
+            // FormContext stores values keyed by JSON Pointer scopes like
+            // "/name/givenName". Assemble them into a nested dictionary via
+            // FormPayloadBuilder so the validator sees the correct nested
+            // shape for v2 blueprints that flatten core identity primitives
+            // (PersonName, DateOfBirth, EmailAddress, PostalAddress).
+            var payloadData = FormPayloadBuilder.BuildNested(submission.Data);
 
             var request = new ActionExecuteRequest
             {

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FormPayloadBuilderTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FormPayloadBuilderTests.cs
@@ -129,6 +129,15 @@ public class FormPayloadBuilderTests
     }
 
     [Fact]
+    public void BuildNested_NullInput_ThrowsArgumentNullException()
+    {
+        var act = () => FormPayloadBuilder.BuildNested(null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("flatPointerKeyed");
+    }
+
+    [Fact]
     public void BuildNested_MultipleWritesToSameObject_BothSurvive()
     {
         var flat = new Dictionary<string, object?>

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FormPayloadBuilderTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FormPayloadBuilderTests.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Regression coverage for the Feature 103 v2 nested-payload bug:
+/// <c>FormContext</c> stores values keyed by JSON Pointer scopes, and
+/// both <c>NewSubmissionWorkspace</c> and <c>MyActions</c> used to submit
+/// the flat pointer-keyed dictionary by just stripping the leading slash.
+/// Once <c>SchemaRefResolver</c> started flattening core identity
+/// primitives (PersonName, DateOfBirth, EmailAddress, PostalAddress) into
+/// action schemas as nested objects, that shortcut produced payloads that
+/// failed validator schema validation with
+/// <c>VAL_SCHEMA_004: Required properties ["name","dob","email","address"] are not present</c>.
+/// <see cref="FormPayloadBuilder"/> reconstructs the nested tree so the
+/// validator sees the correct shape.
+/// </summary>
+public class FormPayloadBuilderTests
+{
+    [Fact]
+    public void BuildNested_FlatPointerKeyedDictionary_AssemblesNestedObjects()
+    {
+        var flat = new Dictionary<string, object?>
+        {
+            ["/name/givenName"] = "Alice",
+            ["/name/familyName"] = "Smith",
+            ["/dob/dateOfBirth"] = "1990-03-15",
+            ["/email/email"] = "alice@example.com",
+            ["/address/line1"] = "42 Grafton Street",
+            ["/address/town"] = "Dublin",
+            ["/address/country"] = "IE"
+        };
+
+        var nested = FormPayloadBuilder.BuildNested(flat);
+
+        nested.Should().ContainKey("name");
+        var name = nested["name"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        name["givenName"].Should().Be("Alice");
+        name["familyName"].Should().Be("Smith");
+
+        var dob = nested["dob"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        dob["dateOfBirth"].Should().Be("1990-03-15");
+
+        var email = nested["email"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        email["email"].Should().Be("alice@example.com");
+
+        var address = nested["address"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        address["line1"].Should().Be("42 Grafton Street");
+        address["town"].Should().Be("Dublin");
+        address["country"].Should().Be("IE");
+    }
+
+    [Fact]
+    public void BuildNested_TopLevelScalarValues_AreStoredUnderRoot()
+    {
+        var flat = new Dictionary<string, object?>
+        {
+            ["/reference"] = "REF-001",
+            ["/count"] = 7
+        };
+
+        var nested = FormPayloadBuilder.BuildNested(flat);
+
+        nested["reference"].Should().Be("REF-001");
+        nested["count"].Should().Be(7);
+    }
+
+    [Fact]
+    public void BuildNested_NullValues_AreCoercedToEmptyString()
+    {
+        // Matches the pre-fix behaviour of `kvp.Value ?? (object)string.Empty`
+        // in the submission call sites. Required so the non-nullable
+        // Dictionary<string, object> on ActionExecuteRequest.PayloadData
+        // can hold every entry.
+        var flat = new Dictionary<string, object?>
+        {
+            ["/name/middleName"] = null,
+            ["/address/line2"] = null
+        };
+
+        var nested = FormPayloadBuilder.BuildNested(flat);
+
+        var name = nested["name"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        name["middleName"].Should().Be(string.Empty);
+
+        var address = nested["address"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        address["line2"].Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void BuildNested_EmptyKeyAndSlashOnly_AreIgnored()
+    {
+        var flat = new Dictionary<string, object?>
+        {
+            [""] = "skip-me",
+            ["/"] = "also-skip",
+            ["/kept"] = "alive"
+        };
+
+        var nested = FormPayloadBuilder.BuildNested(flat);
+
+        nested.Should().HaveCount(1);
+        nested["kept"].Should().Be("alive");
+    }
+
+    [Fact]
+    public void BuildNested_EscapedPointerSegments_AreUnescapedPerRfc6901()
+    {
+        // RFC 6901 defines ~1 → / and ~0 → ~ in pointer segments. Order
+        // matters: ~0 is decoded AFTER ~1 so literal ~1 in the original
+        // segment survives the decode.
+        var flat = new Dictionary<string, object?>
+        {
+            ["/weird~1key/inner"] = "value1",
+            ["/tilde~0field"] = "value2"
+        };
+
+        var nested = FormPayloadBuilder.BuildNested(flat);
+
+        var weird = nested["weird/key"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        weird["inner"].Should().Be("value1");
+
+        nested["tilde~field"].Should().Be("value2");
+    }
+
+    [Fact]
+    public void BuildNested_MultipleWritesToSameObject_BothSurvive()
+    {
+        var flat = new Dictionary<string, object?>
+        {
+            ["/name/givenName"] = "A",
+            ["/name/familyName"] = "B"
+        };
+
+        var nested = FormPayloadBuilder.BuildNested(flat);
+
+        var name = nested["name"].Should().BeOfType<Dictionary<string, object>>().Subject;
+        name.Should().HaveCount(2);
+        name["givenName"].Should().Be("A");
+        name["familyName"].Should().Be("B");
+    }
+}


### PR DESCRIPTION
## Summary

Third fix in the Feature 103 wave 14 live-testing chain. Once #285 (validator schema cache) and #286 (address-lookup auth client) were deployed, a public user submitting the Verified Citizen form on n1 hit a new validator rejection:

\`\`\`
[18:03:19 WRN] Sorcha.Validator.Service.Services.ValidationEngineService
Transaction 370f6835... failed validation:
VAL_SCHEMA_004: Schema violation at '':
Required properties ["name","dob","email","address"] are not present
\`\`\`

## Root cause

\`FormContext\` stores form values keyed by JSON Pointer scopes like \`"/name/givenName"\`, \`"/dob/dateOfBirth"\`, \`"/email/email"\`, \`"/address/line1"\`. Before Feature 103 wave 6 (\`SchemaRefResolver\`), action schemas were flat and both \`NewSubmissionWorkspace.razor\` and \`MyActions.razor\` could get away with:

\`\`\`csharp
submission.Data.ToDictionary(
    kvp => kvp.Key.TrimStart('/'),
    kvp => kvp.Value ?? (object)string.Empty)
\`\`\`

Once the resolver started flattening core identity primitives (\`PersonName\`, \`DateOfBirth\`, \`EmailAddress\`, \`PostalAddress\`) into blueprint action schemas as nested object properties, that shortcut started producing payloads like:

\`\`\`json
{ "name/givenName": "Alice", "name/familyName": "Smith",
  "dob/dateOfBirth": "1990-03-15", "email/email": "alice@example.com",
  "address/line1": "42 Grafton Street", ... }
\`\`\`

The validator checks the schema's \`required: ["name","dob","email","address"]\` against top-level property names, sees none of them present, and rejects with \`VAL_SCHEMA_004\`. \`ActionExecutionService.WaitForTransactionConfirmationAsync\` times out waiting for the rejected tx to land in a docket and surfaces it as a 400 to the browser.

**Why this didn't trip earlier:**

- The walkthrough's ConstructionPermit/Alice Action 1 build payloads in PowerShell and submit directly via the API — they never go through the form renderer
- Wave 10 T087 n1 verification used the walkthrough, not a browser submission
- Before #285 merged, every browser submission failed at the schema-registry layer before it could surface this shape mismatch. Fixing the first layer exposed the next

## Fix

New helper \`Sorcha.UI.Core.Services.Forms.FormPayloadBuilder\` with a single entry point \`BuildNested(flatPointerKeyed)\` that:

- Walks each JSON Pointer segment-by-segment and creates intermediate \`Dictionary<string, object>\` nodes as needed
- Handles RFC 6901 segment escapes (\`~1\` → \`/\`, \`~0\` → \`~\`)
- Coerces null values to \`string.Empty\` to mirror the pre-fix behaviour and satisfy the non-nullable value type on \`ActionExecuteRequest.PayloadData\`
- Ignores empty keys and the literal \`"/"\`

Both submission call sites (\`NewSubmissionWorkspace.razor\` and \`MyActions.razor\`) now route through \`FormPayloadBuilder.BuildNested\` instead of the flat \`ToDictionary\` pattern.

**Known limitation:** pointers with numeric segments (\`/emails/0/value\`) produce dictionary keys like \`"0"\` rather than real JSON arrays. None of the in-flight v2 blueprints reference array-valued primitives, but \`EmailAddressList/v1\` and future list primitives would need array support added here.

## Tests

\`FormPayloadBuilderTests\` covers:

1. Happy path for v2 identity primitives (PersonName + DateOfBirth + EmailAddress + PostalAddress fields all assemble into correct nested objects)
2. Top-level scalars stored under root
3. Null coercion to empty string
4. Empty-key and slash-only filtering
5. RFC 6901 escape handling
6. Multiple writes to the same parent object

**6/6 green locally.** \`Sorcha.UI.Core.Tests\` builds and runs cleanly.

## Deploy plan

- [ ] Merge
- [ ] Docker Publish rebuilds \`sorchadev/ui-web:latest\`
- [ ] Pull on n1 and restart \`sorcha-ui-web\` container
- [ ] Retest the public-user Verified Citizen submission — Action 1 should now make it past schema validation and land in a docket within the 60s window

## Related

- #285 — validator schema cache (merged, deployed)
- #286 — address-lookup auth HttpClient (merged, deployed)
- Persona 401 — deferred for consumer onboarding spec (Feature 105 TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)