### PR TITLE
fix(103): self-healing wallet resolution for pending actions

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
@@ -246,6 +246,27 @@ public interface IWalletServiceClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Lists wallets owned by a specific user (service-to-service lookup).
+    /// </summary>
+    /// <remarks>
+    /// Resolves the caller's user id (the <c>Owner</c> field on wallets,
+    /// populated from <c>NameIdentifier</c> / <c>sub</c> on wallet creation)
+    /// without requiring the caller to hold a <c>wallet_address</c> JWT claim.
+    /// Used by the Blueprint Service's pending-actions query so that a
+    /// consumer whose token was issued before they created their first wallet
+    /// still sees their pending actions after the wallet exists. Calls
+    /// <c>GET /api/v1/wallets/by-owner/{ownerId}</c> and requires a service
+    /// principal token — the endpoint enforces the <c>RequireService</c>
+    /// authorisation policy.
+    /// </remarks>
+    /// <param name="ownerId">User id (the wallet's <c>Owner</c> value).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Zero or more wallets belonging to the owner.</returns>
+    Task<IReadOnlyList<WalletInfo>> GetWalletsByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates a new wallet
     /// </summary>
     /// <param name="name">Wallet name</param>

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -497,8 +497,11 @@ public class WalletServiceClient : IWalletServiceClient
                 JsonOptions, cancellationToken);
             return wallets ?? (IReadOnlyList<WalletInfo>)Array.Empty<WalletInfo>();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            // Cancellation is caller-initiated (tab close, request abort)
+            // and must propagate cleanly rather than be logged as an error
+            // and turned into a silent empty list.
             _logger.LogError(ex, "Failed to list wallets for owner {OwnerId}", ownerId);
             return Array.Empty<WalletInfo>();
         }

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -471,6 +471,39 @@ public class WalletServiceClient : IWalletServiceClient
         }
     }
 
+    public async Task<IReadOnlyList<WalletInfo>> GetWalletsByOwnerAsync(
+        string ownerId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(ownerId))
+            return Array.Empty<WalletInfo>();
+
+        try
+        {
+            _logger.LogDebug("Listing wallets for owner {OwnerId}", ownerId);
+
+            await SetAuthHeaderAsync(cancellationToken);
+
+            var response = await _httpClient.GetAsync(
+                $"/api/v1/wallets/by-owner/{Uri.EscapeDataString(ownerId)}", cancellationToken);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return Array.Empty<WalletInfo>();
+            }
+
+            response.EnsureSuccessStatusCode();
+            var wallets = await response.Content.ReadFromJsonAsync<List<WalletInfo>>(
+                JsonOptions, cancellationToken);
+            return wallets ?? (IReadOnlyList<WalletInfo>)Array.Empty<WalletInfo>();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list wallets for owner {OwnerId}", ownerId);
+            return Array.Empty<WalletInfo>();
+        }
+    }
+
     public async Task<WalletInfo> CreateWalletAsync(
         string name,
         string algorithm,

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
@@ -28,11 +28,10 @@ public static class ActionEndpoints
             HttpContext httpContext,
             IInstanceStore instanceStore,
             IWalletServiceClient walletClient,
-            ILoggerFactory loggerFactory,
+            ILogger<ActionEndpointsLogCategory> logger,
             int page = 1,
             int pageSize = 20) =>
         {
-            var logger = loggerFactory.CreateLogger("Sorcha.Blueprint.Service.Endpoints.ActionEndpoints");
             var walletAddresses = await ResolveUserWalletAddressesAsync(
                 httpContext, walletClient, logger, httpContext.RequestAborted);
 
@@ -49,6 +48,16 @@ public static class ActionEndpoints
             // allowed. We over-fetch each wallet up to pageUpperBound so
             // the final interleaved sort + skip + take yields a correct
             // page even if one wallet is ahead of another in the ordering.
+            //
+            // NOTE: The merged pagination is approximate for users with
+            // multiple wallets. If any single wallet has more than
+            // pageUpperBound items, items beyond that ceiling will never
+            // appear in the merged result on deeper pages. For the
+            // primary use case — consumers with a single wallet — this
+            // is exact. A proper multi-wallet query would fan out at
+            // the store layer and do server-side merge-sort; tracked
+            // for a future iteration when multi-wallet consumer flows
+            // become load-bearing.
             var mergedItems = new List<PendingActionSummary>();
             var totalCount = 0;
             foreach (var wallet in walletAddresses)
@@ -108,9 +117,8 @@ public static class ActionEndpoints
             HttpContext httpContext,
             IInstanceStore instanceStore,
             IWalletServiceClient walletClient,
-            ILoggerFactory loggerFactory) =>
+            ILogger<ActionEndpointsLogCategory> logger) =>
         {
-            var logger = loggerFactory.CreateLogger("Sorcha.Blueprint.Service.Endpoints.ActionEndpoints");
             var walletAddresses = await ResolveUserWalletAddressesAsync(
                 httpContext, walletClient, logger, httpContext.RequestAborted);
 
@@ -184,17 +192,28 @@ public static class ActionEndpoints
 
             return wallets.Select(w => w.Address).Where(a => !string.IsNullOrEmpty(a)).ToArray();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Non-fatal: surface an empty list so the endpoint still returns
             // a clean 200 rather than cascading a 500 to the user. The user
             // will see "no pending actions" which is the same visible
             // outcome as before this fix — the upside is that when the
             // wallet service IS reachable the list now populates correctly.
+            // Cancellation is explicitly NOT caught here — tab-close / abort
+            // must propagate cleanly so ASP.NET's request pipeline can short
+            // circuit without a bogus 200 response.
             logger.LogWarning(ex,
                 "Failed to resolve wallet addresses for user {UserId} via Wallet Service fallback; returning empty list",
                 userId);
             return Array.Empty<string>();
         }
     }
+
+    /// <summary>
+    /// Marker type for <see cref="ILogger{T}"/> categorisation. Kept internal
+    /// and purpose-only so the log category is stable and obvious in Serilog
+    /// output, and so the action endpoints don't need to resolve
+    /// <c>ILoggerFactory</c> just to create a named logger.
+    /// </summary>
+    internal sealed class ActionEndpointsLogCategory { }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
@@ -3,7 +3,10 @@
 
 #pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
 
+using System.Security.Claims;
+using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Storage;
+using Sorcha.ServiceClients.Wallet;
 
 namespace Sorcha.Blueprint.Service.Endpoints;
 
@@ -24,25 +27,48 @@ public static class ActionEndpoints
         group.MapGet("/pending", async (
             HttpContext httpContext,
             IInstanceStore instanceStore,
+            IWalletServiceClient walletClient,
+            ILoggerFactory loggerFactory,
             int page = 1,
             int pageSize = 20) =>
         {
-            var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
-            if (string.IsNullOrEmpty(walletAddress))
+            var logger = loggerFactory.CreateLogger("Sorcha.Blueprint.Service.Endpoints.ActionEndpoints");
+            var walletAddresses = await ResolveUserWalletAddressesAsync(
+                httpContext, walletClient, logger, httpContext.RequestAborted);
+
+            if (walletAddresses.Count == 0)
             {
                 return Results.Ok(new { items = Array.Empty<object>(), totalCount = 0, page, pageSize });
             }
 
             var skip = (page - 1) * pageSize;
-            var items = await instanceStore.GetPendingActionsByWalletAsync(
-                walletAddress, skip, pageSize);
+            var pageUpperBound = skip + pageSize;
 
-            var itemList = items.ToList();
-            var totalCount = await instanceStore.GetPendingActionCountByWalletAsync(walletAddress);
+            // Fan out across all of the user's wallets and merge. Consumer
+            // accounts usually have one wallet, but multi-wallet is
+            // allowed. We over-fetch each wallet up to pageUpperBound so
+            // the final interleaved sort + skip + take yields a correct
+            // page even if one wallet is ahead of another in the ordering.
+            var mergedItems = new List<PendingActionSummary>();
+            var totalCount = 0;
+            foreach (var wallet in walletAddresses)
+            {
+                var items = await instanceStore.GetPendingActionsByWalletAsync(
+                    wallet, skip: 0, take: pageUpperBound);
+                mergedItems.AddRange(items);
+
+                totalCount += await instanceStore.GetPendingActionCountByWalletAsync(wallet);
+            }
+
+            var paged = mergedItems
+                .OrderByDescending(s => s.ReceivedAt)
+                .Skip(skip)
+                .Take(pageSize)
+                .ToList();
 
             return Results.Ok(new
             {
-                items = itemList,
+                items = paged,
                 totalCount,
                 page,
                 pageSize
@@ -50,8 +76,11 @@ public static class ActionEndpoints
         })
         .WithName("GetPendingActions")
         .WithSummary("Get pending actions for the authenticated user")
-        .WithDescription("Returns all pending actions across blueprint instances for the user's wallet address. "
-            + "Supports pagination. Urgency and blueprint filtering will be added in a future iteration.")
+        .WithDescription("Returns all pending actions across blueprint instances for every wallet the user owns. "
+            + "Resolves the user's wallets from the `wallet_address` JWT claim when present (fast path), and "
+            + "falls back to a live Wallet Service lookup keyed by the user's `sub` claim when the claim is "
+            + "absent — this keeps the endpoint self-healing for users whose token was issued before their "
+            + "first wallet was created.")
         .WithOpenApi(operation =>
         {
             OpenApiExamples.SetResponseExample(operation, "200", """
@@ -77,24 +106,95 @@ public static class ActionEndpoints
 
         group.MapGet("/pending/count", async (
             HttpContext httpContext,
-            IInstanceStore instanceStore) =>
+            IInstanceStore instanceStore,
+            IWalletServiceClient walletClient,
+            ILoggerFactory loggerFactory) =>
         {
-            var walletAddress = httpContext.User.FindFirst("wallet_address")?.Value;
-            if (string.IsNullOrEmpty(walletAddress))
+            var logger = loggerFactory.CreateLogger("Sorcha.Blueprint.Service.Endpoints.ActionEndpoints");
+            var walletAddresses = await ResolveUserWalletAddressesAsync(
+                httpContext, walletClient, logger, httpContext.RequestAborted);
+
+            if (walletAddresses.Count == 0)
             {
                 return Results.Ok(new { count = 0, urgentCount = 0 });
             }
 
-            var count = await instanceStore.GetPendingActionCountByWalletAsync(walletAddress);
+            var total = 0;
+            foreach (var wallet in walletAddresses)
+            {
+                total += await instanceStore.GetPendingActionCountByWalletAsync(wallet);
+            }
 
             // TODO: urgentCount requires urgency-aware query — tracked for next iteration
-            return Results.Ok(new { count, urgentCount = 0 });
+            return Results.Ok(new { count = total, urgentCount = 0 });
         })
         .WithName("GetPendingActionCount")
         .WithSummary("Get pending action count for badge display")
-        .WithDescription("Returns the count of pending actions for the authenticated user's wallet address. "
-            + "urgentCount is currently always 0 — urgency-aware counting will be added in a future iteration.");
+        .WithDescription("Returns the count of pending actions across every wallet the authenticated user owns. "
+            + "Uses the same wallet resolution path as GetPendingActions. urgentCount is currently always 0 — "
+            + "urgency-aware counting will be added in a future iteration.");
 
         return routes;
+    }
+
+    /// <summary>
+    /// Resolves the set of wallet addresses the authenticated user owns, in
+    /// priority order:
+    /// <list type="number">
+    /// <item><description>The <c>wallet_address</c> JWT claim (fast path, zero-RTT).</description></item>
+    /// <item><description>Live lookup via <see cref="IWalletServiceClient.GetWalletsByOwnerAsync"/>
+    /// keyed on the <c>sub</c> / <see cref="ClaimTypes.NameIdentifier"/> claim,
+    /// used when the JWT claim is absent (e.g. because the token was issued
+    /// before the user created their first wallet and no refresh has happened
+    /// since).</description></item>
+    /// </list>
+    /// The fallback is what makes the pending-actions query self-healing —
+    /// without it, a consumer who signs up and then creates a wallet in the
+    /// same session would see an empty pending-actions list forever, even
+    /// though the server has the action and knows which wallet it belongs to.
+    /// Returns an empty list when neither path yields a wallet — the caller
+    /// should surface an empty result rather than a 401.
+    /// </summary>
+    private static async Task<IReadOnlyList<string>> ResolveUserWalletAddressesAsync(
+        HttpContext httpContext,
+        IWalletServiceClient walletClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var claim = httpContext.User.FindFirst("wallet_address")?.Value;
+        if (!string.IsNullOrEmpty(claim))
+        {
+            return new[] { claim };
+        }
+
+        var userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? httpContext.User.FindFirst("sub")?.Value;
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Array.Empty<string>();
+        }
+
+        try
+        {
+            var wallets = await walletClient.GetWalletsByOwnerAsync(userId, cancellationToken);
+            if (wallets.Count == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            return wallets.Select(w => w.Address).Where(a => !string.IsNullOrEmpty(a)).ToArray();
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: surface an empty list so the endpoint still returns
+            // a clean 200 rather than cascading a 500 to the user. The user
+            // will see "no pending actions" which is the same visible
+            // outcome as before this fix — the upside is that when the
+            // wallet service IS reachable the list now populates correctly.
+            logger.LogWarning(ex,
+                "Failed to resolve wallet addresses for user {UserId} via Wallet Service fallback; returning empty list",
+                userId);
+            return Array.Empty<string>();
+        }
     }
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -155,6 +155,25 @@ public static class WalletEndpoints
             .Produces<IEnumerable<WalletDto>>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized);
 
+        // GET /api/v1/wallets/by-owner/{ownerId} - List wallets owned by a specific user
+        // Service-to-service lookup used by Blueprint Service (and any other service that needs
+        // to resolve a user's wallets without depending on a stale wallet_address JWT claim).
+        // Requires a service principal token — never exposed to end users.
+        walletGroup.MapGet("/by-owner/{ownerId}", ListWalletsByOwner)
+            .WithName("ListWalletsByOwner")
+            .WithSummary("List wallets owned by a specific user (service only)")
+            .WithDescription(
+                "Returns all active wallets owned by the specified user id (the NameIdentifier / "
+                + "sub claim used as Owner on wallet creation). Intended for service-to-service lookups "
+                + "such as the Blueprint Service's pending-actions query, which must resolve a user's "
+                + "wallets without relying on the `wallet_address` JWT claim (that claim is populated at "
+                + "login/refresh time and can be stale or absent for users whose wallets were created "
+                + "after the current token was issued).")
+            .RequireAuthorization(Microsoft.Extensions.Hosting.AuthorizationPolicies.RequireService)
+            .Produces<IEnumerable<WalletDto>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden);
+
         // GET /api/v1/wallets/{address} - Get wallet by address
         walletGroup.MapGet("/{address}", GetWallet)
             .WithName("GetWallet")
@@ -560,6 +579,33 @@ public static class WalletEndpoints
 
         var wallets = await walletManager.GetWalletsByOwnerAsync(owner, tenant, cancellationToken);
 
+        return Results.Ok(wallets.Select(w => w.ToDto()));
+    }
+
+    /// <summary>
+    /// List wallets owned by a specific user id (service principal lookup).
+    /// </summary>
+    /// <remarks>
+    /// This is the service-to-service twin of <see cref="ListWallets"/>. Where
+    /// <see cref="ListWallets"/> reads the owner from the calling user's
+    /// <c>NameIdentifier</c> claim, this variant takes the owner as a route
+    /// parameter so a service principal can resolve any user's wallets —
+    /// required by Blueprint Service's pending-actions query, which must
+    /// operate even when the consumer's JWT has no <c>wallet_address</c> claim
+    /// (e.g. because the wallet was created after their current token was
+    /// issued and no refresh has happened since).
+    /// </remarks>
+    private static async Task<IResult> ListWalletsByOwner(
+        string ownerId,
+        HttpContext context,
+        WalletManager walletManager,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(ownerId))
+            return Results.BadRequest(new { error = "ownerId is required" });
+
+        var tenant = GetCurrentTenant(context);
+        var wallets = await walletManager.GetWalletsByOwnerAsync(ownerId, tenant, cancellationToken);
         return Results.Ok(wallets.Select(w => w.ToDto()));
     }
 


### PR DESCRIPTION
## Summary

Fixes the final blocker for public-user Verified Citizen flows observed during the live chrome-devtools-mcp walkthrough: a new consumer signs up, creates a wallet, submits Action 1, gets approved by the issuer — then their MyActions page stays at "All Caught Up!" forever despite the Action 3 being server-side and correctly assigned to their wallet.

## Root cause

\`/api/actions/pending\` and \`/pending/count\` in the Blueprint Service read the user's wallet from the \`wallet_address\` JWT claim and early-return an empty list when the claim is absent (\`ActionEndpoints.cs:31-34\`).

\`TokenService.AddWalletAddressClaimAsync\` only populates that claim for users who have a \`Participant\` record (assessor / government-org pattern), **and** only at login/refresh time. A consumer who signs up and then creates their first wallet in the same session never gets the claim — the refresh path at \`TokenService.cs:276-280\` only propagates the claim if it was already present on the refresh principal, so it stays missing forever.

**Smoking gun from blueprint-service logs on n1:**
\`\`\`
HTTP GET /api/actions/pending responded 200 in 0.25ms
\`\`\`
0.25ms is the \`walletAddress == null\` early-return path, not a real DB query. Confirmed by the live chrome-devtools-mcp trace of \"Debug Tester\", a fresh user created during debugging.

## Fix

Resolve the user's wallets at **request time** via a two-step lookup:

1. **Fast path** — \`wallet_address\` JWT claim if present (zero RTT, unchanged for all Participant-bound users and any consumer whose token got refreshed after wallet creation).
2. **Self-healing fallback** — live Wallet Service lookup by \`sub\` / \`ClaimTypes.NameIdentifier\`. Stale tokens auto-recover on the next request.

Supporting plumbing:

- **New Wallet Service endpoint:** \`GET /api/v1/wallets/by-owner/{ownerId}\`, protected by the \`RequireService\` authorisation policy so only other services can hit it. Returns \`WalletDto[]\` for wallets where \`Owner = ownerId\`.
- **New \`IWalletServiceClient.GetWalletsByOwnerAsync\`** that calls the new endpoint through \`SetAuthHeaderAsync\` (service principal token). Returns empty list on error so the caller degrades gracefully.
- **\`ActionEndpoints\` fans out** \`GetPendingActionsByWalletAsync\` across every wallet the user owns (usually one for consumers) and merges the results with server-side skip/take on the combined list. Pending-count does the same. Both endpoints stay at the same URLs — no breaking API changes.

## Why endpoint-level rather than patching \`AddWalletAddressClaimAsync\`

- **Self-healing at request time** — stale tokens auto-recover on the next request without requiring the client to detect wallet creation and trigger a refresh
- **No changes to the token pipeline, login flow, or refresh path**
- **Single source of truth** — wallet ownership lives in the Wallet Service; the Blueprint Service asks at request time instead of baking a point-in-time snapshot into the JWT
- **The AddWalletAddressClaimAsync path keeps working as the fast path** — no regression for users whose token already has the claim

## Verification plan

- [x] Sorcha.Wallet.Service + Sorcha.Blueprint.Service + Sorcha.ServiceClients.Http build clean locally
- [ ] Docker Publish rebuilds wallet-service + blueprint-service images
- [ ] Pull on n1 and restart both containers
- [ ] Debug Tester (the test account from the live debug trace) refreshes MyActions — should now show the pending Action 3 that's been stuck server-side
- [ ] Same flow from a fresh public-user signup on n1 — the Action 3 appears in MyActions without requiring a relogin

## Scope notes

This is **Fix A** of the two-part plan discussed earlier — the narrow tactical unblocker. **Feature 106 (register-native credential delivery)** is the structural follow-up that eliminates the three-action claim-card pattern entirely in favour of recipient-encrypted register transactions picked up by a Wallet Service inbound monitor. Fix A buys us a working state to test against while that design is specced and built.

## Related (separate follow-ups noted during the debug trace)

- **Signup.cshtml.cs:127** hardcodes \`orgSubdomain = \"default\"\` but the Public org is \`public\` on n1 — every email signup fails with a generic "Registration failed." error. Trivial 1-line fix, separate PR.
- **\`/api/me/persona\` 401** — known, deferred for the onboarding spec (Feature 105 TBD)
- **UX-007** — \"Administrator|SystemAdmin\" role authorization warning in console for public users, already tracked in MASTER-TASKS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)