### PR TITLE
test: first-pass test-rot repair — unblock Validator build, drop dead SignalR tests

### DIFF
--- a/tests/Sorcha.Register.Service.Tests/SignalRHubTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/SignalRHubTests.cs
@@ -82,96 +82,13 @@ public class SignalRHubTests : IClassFixture<RegisterServiceWebApplicationFactor
         exception.Should().BeNull();
     }
 
-    [Fact]
-    public async Task SubscribeToTenant_ShouldAllowSubscription()
-    {
-        // Arrange
-        var tenantId = "test-tenant-123";
-
-        // Act
-        var exception = await Record.ExceptionAsync(async () =>
-            await _hubConnection!.InvokeAsync("SubscribeToTenant", tenantId));
-
-        // Assert
-        exception.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task UnsubscribeFromTenant_ShouldAllowUnsubscription()
-    {
-        // Arrange
-        var tenantId = "test-tenant-123";
-        await _hubConnection!.InvokeAsync("SubscribeToTenant", tenantId);
-
-        // Act
-        var exception = await Record.ExceptionAsync(async () =>
-            await _hubConnection.InvokeAsync("UnsubscribeFromTenant", tenantId));
-
-        // Assert
-        exception.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task RegisterCreated_ShouldReceiveEvent()
-    {
-        // Arrange
-        var tenantId = "signalr-test-tenant";
-        var registerCreatedReceived = false;
-        string? receivedRegisterId = null;
-        string? receivedName = null;
-
-        _hubConnection!.On<string, string>("RegisterCreated", (registerId, name) =>
-        {
-            registerCreatedReceived = true;
-            receivedRegisterId = registerId;
-            receivedName = name;
-        });
-
-        await _hubConnection.InvokeAsync("SubscribeToTenant", tenantId);
-
-        // Act — create register via service layer (POST /api/registers was removed)
-        var register = await _factory.CreateTestRegisterAsync("SignalR Test Register", tenantId);
-
-        // Wait for event
-        await Task.Delay(1000);
-
-        // Assert
-        registerCreatedReceived.Should().BeTrue();
-        receivedRegisterId.Should().Be(register.Id);
-        receivedName.Should().Be("SignalR Test Register");
-    }
-
-    [Fact]
-    public async Task RegisterDeleted_ShouldReceiveEvent()
-    {
-        // Arrange
-        var tenantId = "signalr-delete-tenant";
-        var registerDeletedReceived = false;
-        string? receivedRegisterId = null;
-
-        _hubConnection!.On<string>("RegisterDeleted", (registerId) =>
-        {
-            registerDeletedReceived = true;
-            receivedRegisterId = registerId;
-        });
-
-        await _hubConnection.InvokeAsync("SubscribeToTenant", tenantId);
-
-        // Create a register via service layer (POST /api/registers was removed)
-        var register = await _factory.CreateTestRegisterAsync("To Delete", tenantId);
-
-        await Task.Delay(500); // Allow create event to process
-
-        // Act
-        await _client.DeleteAsync($"/api/registers/{register.Id}?tenantId={tenantId}");
-
-        // Wait for event
-        await Task.Delay(1000);
-
-        // Assert
-        registerDeletedReceived.Should().BeTrue();
-        receivedRegisterId.Should().Be(register.Id);
-    }
+    // Removed: SubscribeToTenant / UnsubscribeFromTenant hub methods were deleted
+    // when notifications moved from tenant-scoped groups to register-scoped groups
+    // (see src/Services/Sorcha.Register.Service/README.md). Tests for tenant-scoped
+    // RegisterCreated / RegisterDeleted / MultipleClients notifications exercised the
+    // removed behaviour and are no longer applicable. Register-scoped equivalents are
+    // covered by SubscribeToRegister_*, TransactionConfirmed_ShouldReceiveEvent, and
+    // RegisterSubscription_ShouldOnlyReceiveRegisterSpecificEvents below.
 
     [Fact]
     public async Task TransactionConfirmed_ShouldReceiveEvent()
@@ -205,45 +122,6 @@ public class SignalRHubTests : IClassFixture<RegisterServiceWebApplicationFactor
         transactionConfirmedReceived.Should().BeTrue();
         receivedRegisterId.Should().Be(register.Id);
         receivedTransactionId.Should().Be(submittedTx!.TxId);
-    }
-
-    [Fact]
-    public async Task MultipleClients_ShouldReceiveSameEvent()
-    {
-        // Arrange
-        var tenantId = "multi-client-tenant";
-
-        // Create second hub connection
-        var hubUrl = _factory.Server.BaseAddress + "hubs/register";
-        var hubConnection2 = new HubConnectionBuilder()
-            .WithUrl(hubUrl, options =>
-            {
-                options.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler();
-            })
-            .Build();
-        await hubConnection2.StartAsync();
-
-        var client1Received = false;
-        var client2Received = false;
-
-        _hubConnection!.On<string, string>("RegisterCreated", (_, _) => client1Received = true);
-        hubConnection2.On<string, string>("RegisterCreated", (_, _) => client2Received = true);
-
-        await _hubConnection.InvokeAsync("SubscribeToTenant", tenantId);
-        await hubConnection2.InvokeAsync("SubscribeToTenant", tenantId);
-
-        // Act — create register via service layer (POST /api/registers was removed)
-        await _factory.CreateTestRegisterAsync("Multi-Client Test", tenantId);
-
-        // Wait for events
-        await Task.Delay(1000);
-
-        // Assert
-        client1Received.Should().BeTrue();
-        client2Received.Should().BeTrue();
-
-        // Cleanup
-        await hubConnection2.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Sorcha.Validator.Service.Tests/Helpers/MongoMockHelper.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Helpers/MongoMockHelper.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using MongoDB.Driver;
+using Moq;
+using Sorcha.Validator.Service.Models;
+
+namespace Sorcha.Validator.Service.Tests.Helpers;
+
+/// <summary>
+/// Builds a minimally-wired <see cref="IMongoClient"/> mock whose
+/// <c>GetDatabase</c> and <c>GetCollection&lt;T&gt;</c> calls return mock
+/// instances sufficient for <c>ValidatorRegistry</c> construction. The
+/// returned collections are non-functional — tests that exercise Mongo
+/// behaviour should configure additional setups.
+/// </summary>
+internal static class MongoMockHelper
+{
+    public static Mock<IMongoClient> CreateValidatorRegistryClient()
+    {
+        var databaseMock = new Mock<IMongoDatabase>();
+        databaseMock
+            .Setup(d => d.GetCollection<ValidatorDocument>(It.IsAny<string>(), It.IsAny<MongoCollectionSettings>()))
+            .Returns(Mock.Of<IMongoCollection<ValidatorDocument>>());
+        databaseMock
+            .Setup(d => d.GetCollection<ValidatorAuditEntry>(It.IsAny<string>(), It.IsAny<MongoCollectionSettings>()))
+            .Returns(Mock.Of<IMongoCollection<ValidatorAuditEntry>>());
+
+        var clientMock = new Mock<IMongoClient>();
+        clientMock
+            .Setup(c => c.GetDatabase(It.IsAny<string>(), It.IsAny<MongoDatabaseSettings>()))
+            .Returns(databaseMock.Object);
+
+        return clientMock;
+    }
+}

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketDistributorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketDistributorTests.cs
@@ -78,6 +78,20 @@ public class DocketDistributorTests
     }
 
     [Fact]
+    public void Constructor_NullReceiptGenerator_ThrowsArgumentNullException()
+    {
+        var act = () => new DocketDistributor(
+            _peerClientMock.Object,
+            _registerClientMock.Object,
+            null!,
+            _configMock.Object,
+            _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("receiptGenerator");
+    }
+
+    [Fact]
     public void Constructor_NullLogger_ThrowsArgumentNullException()
     {
         var act = () => new DocketDistributor(

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketDistributorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketDistributorTests.cs
@@ -17,6 +17,7 @@ public class DocketDistributorTests
 {
     private readonly Mock<IPeerServiceClient> _peerClientMock;
     private readonly Mock<IRegisterServiceClient> _registerClientMock;
+    private readonly Mock<IReceiptGenerator> _receiptGeneratorMock;
     private readonly Mock<IOptions<DocketDistributorConfiguration>> _configMock;
     private readonly Mock<ILogger<DocketDistributor>> _loggerMock;
     private readonly DocketDistributorConfiguration _config;
@@ -33,6 +34,7 @@ public class DocketDistributorTests
 
         _peerClientMock = new Mock<IPeerServiceClient>();
         _registerClientMock = new Mock<IRegisterServiceClient>();
+        _receiptGeneratorMock = new Mock<IReceiptGenerator>();
         _configMock = new Mock<IOptions<DocketDistributorConfiguration>>();
         _configMock.Setup(x => x.Value).Returns(_config);
         _loggerMock = new Mock<ILogger<DocketDistributor>>();
@@ -40,6 +42,7 @@ public class DocketDistributorTests
         _distributor = new DocketDistributor(
             _peerClientMock.Object,
             _registerClientMock.Object,
+            _receiptGeneratorMock.Object,
             _configMock.Object,
             _loggerMock.Object);
     }
@@ -52,6 +55,7 @@ public class DocketDistributorTests
         var act = () => new DocketDistributor(
             null!,
             _registerClientMock.Object,
+            _receiptGeneratorMock.Object,
             _configMock.Object,
             _loggerMock.Object);
 
@@ -65,6 +69,7 @@ public class DocketDistributorTests
         var act = () => new DocketDistributor(
             _peerClientMock.Object,
             null!,
+            _receiptGeneratorMock.Object,
             _configMock.Object,
             _loggerMock.Object);
 
@@ -78,6 +83,7 @@ public class DocketDistributorTests
         var act = () => new DocketDistributor(
             _peerClientMock.Object,
             _registerClientMock.Object,
+            _receiptGeneratorMock.Object,
             _configMock.Object,
             null!);
 
@@ -96,6 +102,7 @@ public class DocketDistributorTests
         var act = () => new DocketDistributor(
             _peerClientMock.Object,
             _registerClientMock.Object,
+            _receiptGeneratorMock.Object,
             nullConfigMock.Object,
             _loggerMock.Object);
 

--- a/tests/Sorcha.Validator.Service.Tests/Services/GenesisConfigFallbackTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/GenesisConfigFallbackTests.cs
@@ -77,7 +77,6 @@ public class GenesisConfigFallbackTests
         {
             RegisterId = registerId,
             Name = "PolicyTest",
-            TenantId = "tenant-1",
             RegisterPolicy = new RegisterPolicy
             {
                 Version = 1,
@@ -138,7 +137,6 @@ public class GenesisConfigFallbackTests
         {
             RegisterId = registerId,
             Name = "LegacyRegister",
-            TenantId = "tenant-1",
             // RegisterPolicy is null (pre-Feature 048 register)
             Attestations = new List<RegisterAttestation>()
         };
@@ -209,7 +207,6 @@ public class GenesisConfigFallbackTests
         {
             RegisterId = registerId,
             Name = "EnumTest",
-            TenantId = "tenant-1",
             RegisterPolicy = new RegisterPolicy
             {
                 Version = 2,
@@ -240,8 +237,7 @@ public class GenesisConfigFallbackTests
         var register = new Sorcha.Register.Models.Register
         {
             Id = registerId,
-            Name = controlRecord.Name,
-            TenantId = controlRecord.TenantId
+            Name = controlRecord.Name
         };
 
         _registerClientMock

--- a/tests/Sorcha.Validator.Service.Tests/Services/RightsEnforcementServiceTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/RightsEnforcementServiceTests.cs
@@ -40,7 +40,6 @@ public class RightsEnforcementServiceTests
             {
                 RegisterId = "test-register",
                 Name = "Test",
-                TenantId = "t1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = members.Select(m => new RegisterAttestation
                 {
@@ -68,7 +67,6 @@ public class RightsEnforcementServiceTests
             {
                 RegisterId = "test-register",
                 Name = "Test",
-                TenantId = "t1",
                 CreatedAt = DateTimeOffset.UtcNow,
                 Attestations = []
             },

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidatorOperationalPresenceTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidatorOperationalPresenceTests.cs
@@ -10,6 +10,7 @@ using Sorcha.ServiceClients.Register;
 using Sorcha.Validator.Service.Configuration;
 using Sorcha.Validator.Service.Services;
 using Sorcha.Validator.Service.Services.Interfaces;
+using Sorcha.Validator.Service.Tests.Helpers;
 using StackExchange.Redis;
 using Xunit;
 
@@ -271,6 +272,7 @@ public class ValidatorOperationalPresenceTests
 
         var registry = new ValidatorRegistry(
             mockRedis.Object,
+            MongoMockHelper.CreateValidatorRegistryClient().Object,
             mockClient.Object,
             mockGenesis.Object,
             config,

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidatorRegistryApprovalTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidatorRegistryApprovalTests.cs
@@ -12,6 +12,7 @@ using Sorcha.ServiceClients.Register;
 using Sorcha.Validator.Service.Configuration;
 using Sorcha.Validator.Service.Services;
 using Sorcha.Validator.Service.Services.Interfaces;
+using Sorcha.Validator.Service.Tests.Helpers;
 using ValidatorStatus = Sorcha.Validator.Service.Services.Interfaces.ValidatorStatus;
 
 namespace Sorcha.Validator.Service.Tests.Services;
@@ -73,6 +74,7 @@ public class ValidatorRegistryApprovalTests
 
         _registry = new ValidatorRegistry(
             _redisMock.Object,
+            MongoMockHelper.CreateValidatorRegistryClient().Object,
             _registerClientMock.Object,
             _genesisConfigMock.Object,
             Options.Create(_config),

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidatorRegistryConsentTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidatorRegistryConsentTests.cs
@@ -13,6 +13,7 @@ using Sorcha.ServiceClients.Register;
 using Sorcha.Validator.Service.Configuration;
 using Sorcha.Validator.Service.Services;
 using Sorcha.Validator.Service.Services.Interfaces;
+using Sorcha.Validator.Service.Tests.Helpers;
 
 namespace Sorcha.Validator.Service.Tests.Services;
 
@@ -99,6 +100,7 @@ public class ValidatorRegistryConsentTests
 
         _registry = new ValidatorRegistry(
             _redisMock.Object,
+            MongoMockHelper.CreateValidatorRegistryClient().Object,
             _registerClientMock.Object,
             _genesisConfigMock.Object,
             Options.Create(_config),


### PR DESCRIPTION
## Summary
- **Validator test project** no longer compiled; three classes of drift fixed: `ValidatorRegistry` ctor gained `IMongoClient` + `ILogger`, `DocketDistributor` ctor gained `IReceiptGenerator`, and six stale `RegisterControlRecord.TenantId` references (field removed in feature 067).
- **Register SignalR hub tests** still called `SubscribeToTenant`/`UnsubscribeFromTenant` hub methods that were removed when notifications moved from tenant-scoped to register-scoped groups (see `src/Services/Sorcha.Register.Service/README.md:390`). Five dead tests deleted.
- Added `tests/Sorcha.Validator.Service.Tests/Helpers/MongoMockHelper.cs` to build a minimally-wired `IMongoClient` mock reusable across the three `ValidatorRegistry` test classes.

## Results

| Service | Before | After | Δ |
|---|---|---|---|
| Validator | build broken, 0 signal | 60 fail / 864 pass / 3 skip / 927 total | **+864 passing tests now visible** |
| Register | 36 fail / 265 pass / 301 total | 24 fail / 272 pass / 296 total | **−12 failures** |

The Register delta is larger than the 5 deleted tests because removing them also stabilised 7 previously-flaky tests that were sharing polluted hub state with them.

## Not addressed (deliberately deferred)
- **Blueprint 81 failures** in `ActionExecutionService*` — initially hypothesised as ctor drift but the fixture args already line up with the production 13 required parameters; root cause needs per-test diagnosis, not mechanical fix.
- **Register 24 remaining failures** — `RegisterManager` Moq proxy failures need a design decision (sealing/virtual-ness of the class under test), and `RegisterApiTests.GetAllRegisters_*` turns out to be a behavioural "expected ≥2 registers, found 0" failure, not the config gap I first assumed (`RegisterServiceWebApplicationFactory` already sets `SystemWalletSigning__ValidatorId`).

## Test plan
- [x] `dotnet build tests/Sorcha.Validator.Service.Tests/…` compiles (was previously broken)
- [x] `dotnet test tests/Sorcha.Validator.Service.Tests/…` → 60 fail / 864 pass / 3 skip (new baseline)
- [x] `dotnet test tests/Sorcha.Register.Service.Tests/…` → 24 fail / 272 pass (down from 36 / 265)
- [ ] Follow-up PR(s) to tackle Blueprint `ActionExecutionService*` diagnosis and Register behavioural failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)