### PR TITLE
test: pass all RegisterManager ctor args in Moq proxy construction

### DIFF
--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
@@ -41,9 +41,16 @@ public class RegisterCreationOrchestratorTests
     public RegisterCreationOrchestratorTests()
     {
         _mockLogger = new Mock<ILogger<RegisterCreationOrchestrator>>();
+        // RegisterManager's ctor takes two required and two optional parameters
+        // (ISubscriptionServiceClient?, ILogger<RegisterManager>?). Default parameter
+        // values are a compile-time feature — Moq uses reflection via Castle DynamicProxy,
+        // which requires every parameter to be supplied explicitly. Passing nulls for the
+        // optionals matches the production default behaviour.
         _mockRegisterManager = new Mock<RegisterManager>(
             Mock.Of<Sorcha.Register.Core.Storage.IRegisterRepository>(),
-            Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>());
+            Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>(),
+            null!,
+            null!);
         _mockTransactionManager = new Mock<TransactionManager>(
             Mock.Of<Sorcha.Register.Core.Storage.IRegisterRepository>(),
             Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>());

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
@@ -33,9 +33,13 @@ public class RegisterCreationPolicyTests
     public RegisterCreationPolicyTests()
     {
         _mockLogger = new Mock<ILogger<RegisterCreationOrchestrator>>();
+        // See RegisterCreationOrchestratorTests for why all four ctor args are passed:
+        // Moq's reflection-based proxy construction cannot use C# default parameter values.
         var mockRegisterManager = new Mock<RegisterManager>(
             Mock.Of<Sorcha.Register.Core.Storage.IRegisterRepository>(),
-            Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>());
+            Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>(),
+            null!,
+            null!);
         var mockTransactionManager = new Mock<TransactionManager>(
             Mock.Of<Sorcha.Register.Core.Storage.IRegisterRepository>(),
             Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>());


### PR DESCRIPTION
## Summary
`RegisterCreationOrchestratorTests` and `RegisterCreationPolicyTests` built a `Mock<RegisterManager>` with only two constructor args, relying on the ctor's two **optional** parameters (`ISubscriptionServiceClient?`, `ILogger<RegisterManager>?`) to default to null. **C# default parameter values are compile-time sugar** — at runtime the ctor has 4 parameters, and Moq's reflection-based Castle DynamicProxy cannot use the defaults. Both fixture constructors threw:

```
System.ArgumentException : Can not instantiate proxy of class: Sorcha.Register.Core.Managers.RegisterManager.
Could not find a constructor that would match given arguments:
Castle.Proxies.IRegisterRepositoryProxy
Castle.Proxies.IEventPublisherProxy
---- System.MissingMethodException : Constructor on type 'Castle.Proxies.RegisterManagerProxy' not found.
```

Every `[Fact]` in both classes cascaded to FAIL because the fixture ctor failed.

**Fix**: pass all four args explicitly, with `null!` for the optionals (matches production default behaviour). One short comment added to each fixture explaining the reflection trap for future readers.

The optional params were added in Feature 067 (#122) and the tests were never updated — classic drift.

## Results

| Metric | Before | After | Δ |
|---|---|---|---|
| Register.Service.Tests failed | 24 | 7 | **−17** |
| Register.Service.Tests passed | 272 | 289 | +17 |
| Total | 296 | 296 | 0 |

Recovers exactly the 17 failures in the Moq bucket (all tests in `RegisterCreationOrchestratorTests` + `RegisterCreationPolicyTests` + `SystemRegisterBootstrapTests` that consume the shared mock).

The remaining 7 Register failures are all in `RegisterApiTests.GetAllRegisters_*` / `DeleteRegister_*` — a **behavioural** failure: `GET /api/registers` (`src/Services/Sorcha.Register.Service/Program.cs:519`) now filters by `org_id` claim, `Guid.TryParse`s it, and returns only `Purpose == System` registers if the parse fails. `RegisterServiceWebApplicationFactory.TestAuthHandler` sets `org_id = \"test-org-001\"` — not a Guid — so the parse fails. Fixing it requires a real Guid org_id plus a test subscription wiring the created register to that org. Out of scope for this mechanical-fix PR; diagnostic notes are in #289's discussion.

## Test plan
- [x] `dotnet test --filter \"FullyQualifiedName~RegisterCreationOrchestratorTests|FullyQualifiedName~RegisterCreationPolicyTests\"` → 17/17 pass
- [x] Full Register.Service.Tests suite → 289 pass / 7 fail (was 272 / 24)
- [ ] Follow-up PR to fix the `TestAuthHandler` org_id Guid claim + subscription wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)