### PR TITLE
test: use real IConfiguration in ActionExecutionService fixtures

### DIFF
--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionDevModeTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionDevModeTests.cs
@@ -95,7 +95,7 @@ public class ActionExecutionDevModeTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>(),
+            new ConfigurationBuilder().Build(),
             credentialVerifier: null,
             confirmationOptions: null,
             statusListManager: null,

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionEncryptionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionEncryptionTests.cs
@@ -95,7 +95,7 @@ public class ActionExecutionEncryptionTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>(),
+            new ConfigurationBuilder().Build(),
             credentialVerifier: null,
             confirmationOptions: null,
             statusListManager: null,

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceEncryptionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceEncryptionTests.cs
@@ -94,7 +94,7 @@ public class ActionExecutionServiceEncryptionTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>(),
+            new ConfigurationBuilder().Build(),
             credentialVerifier: null,
             confirmationOptions: null,
             statusListManager: null,
@@ -116,7 +116,7 @@ public class ActionExecutionServiceEncryptionTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>());
+            new ConfigurationBuilder().Build());
     }
 
     #region Encryption Pipeline Integration Tests

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
@@ -73,7 +73,7 @@ public class ActionExecutionServiceTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>());
+            new ConfigurationBuilder().Build());
     }
 
     #region Constructor Tests
@@ -95,7 +95,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -195,7 +195,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -215,7 +215,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -255,7 +255,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -275,7 +275,7 @@ public class ActionExecutionServiceTests
                 null!,
                 _mockExecutionEngine.Object,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -295,7 +295,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 null!,
                 _mockLogger.Object,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     [Fact]
@@ -315,7 +315,7 @@ public class ActionExecutionServiceTests
                 _mockActionStore.Object,
                 _mockExecutionEngine.Object,
                 null!,
-                Mock.Of<IConfiguration>()));
+                new ConfigurationBuilder().Build()));
     }
 
     #endregion
@@ -454,7 +454,7 @@ public class ActionExecutionServiceTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>());
+            new ConfigurationBuilder().Build());
 
         Assert.NotNull(service);
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionStartingActionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionStartingActionTests.cs
@@ -74,7 +74,7 @@ public class ActionExecutionStartingActionTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>());
+            new ConfigurationBuilder().Build());
     }
 
     [Fact]

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/PublicKeyResolutionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/PublicKeyResolutionTests.cs
@@ -81,7 +81,7 @@ public class PublicKeyResolutionTests
             _mockActionStore.Object,
             _mockExecutionEngine.Object,
             _mockLogger.Object,
-            Mock.Of<IConfiguration>(),
+            new ConfigurationBuilder().Build(),
             credentialVerifier: null,
             confirmationOptions: null,
             statusListManager: null,


### PR DESCRIPTION
## Summary
Six Blueprint.Service.Tests fixtures passed \`Mock.Of<IConfiguration>()\` into \`ActionExecutionService\`. The service's ctor (line 122) reads a feature flag via \`ConfigurationBinder.GetValue<T>\`:

\`\`\`csharp
_credentialStatusEmbeddingEnabled =
    configuration?.GetValue<bool?>(\"CredentialStatus:EnableEmbedding\") ?? true;
\`\`\`

\`Mock.Of<T>()\` returns an implementation whose methods all return default values (null). \`ConfigurationBinder.GetValue<T>\` internally calls \`configuration.GetSection(key)\`, gets null back, and NREs before returning — so every fixture constructor threw \`NullReferenceException\`, cascading dozens of \`[Fact]\`s to FAIL for reasons that had nothing to do with the test body. This affected every test in these classes including trivial \`Constructor_WithNullX_Throws\` cases, which is why the original diagnosis first looked like ctor-drift.

**Fix**: replace \`Mock.Of<IConfiguration>()\` with \`new ConfigurationBuilder().Build()\` — an empty but fully-functional \`IConfiguration\` that \`GetSection\` / \`GetValue\` walk without NRE. All six files already import \`Microsoft.Extensions.Configuration\`, so no new usings needed. 20 replacements across 6 files, one string.

## Results

| Class | Before | After | Recovered |
|---|---:|---:|---:|
| \`ActionExecutionServiceTests\` | 38 | 7 | **31** |
| \`ActionExecutionStartingActionTests\` | 4 | 0 | **4** |
| \`ActionExecutionServiceEncryptionTests\` | 9 | 7 | 2 |
| \`ActionExecutionEncryptionTests\` | 4 | 4 | 0 |
| \`ActionExecutionDevModeTests\` | 4 | 4 | 0 |
| \`PublicKeyResolutionTests\` | 5 | 5 | 0 |
| \`BlueprintRecoveryServiceTests\` | 12 | 12 | 0 |
| \`EncryptionBackgroundServiceTests\` | 3 | 3 | 0 |
| Other (1+1) | 2 | 2 | 0 |
| **Total** | **81** | **44** | **−37** |

The remaining 44 are **no longer fixture-ctor cascades** — they split between:
- **Real behavioural failures** surfaced underneath the fixture fix (the 7 remaining \`ActionExecutionServiceTests\` are all \`ExecuteAsync_*\` scenarios with real issues, not \`Constructor_WithNull*\` cascades).
- **Separate test rot** in \`BlueprintRecoveryService\`, \`PublicKeyResolution\`, \`EncryptionBackgroundService\`, \`ChatOrchestration\`, \`BlueprintToolExecutor\` — these share a file namespace but exercise different services and need individual investigation.

## Platform-wide progress over this session

| Service | Session start | Now | Δ |
|---|---|---|---|
| Validator | build broken, 0 signal | 60 F / 864 P / 3 S / 927 T | +864 tests visible |
| Blueprint | 81 F | **44 F** | **−37** |
| Register | 36 F | 7 F | **−29** (#289 + #291) |
| Tenant | 1 F | 1 F | 0 |
| Wallet / Peer / ApiGateway | 0 F | 0 F | ✅ |

## Test plan
- [x] \`dotnet test tests/Sorcha.Blueprint.Service.Tests/...\` → 44 F / 535 P (was 81 F / 498 P)
- [x] Spot-check confirms remaining 7 \`ActionExecutionServiceTests\` failures are all \`ExecuteAsync_*\` behavioural tests, not \`Constructor_WithNull*\` cascades
- [ ] Follow-up PRs to tackle behavioural failures and unrelated test rot

🤖 Generated with [Claude Code](https://claude.com/claude-code)