### PR TITLE
fix: make ValidatorDocument public so Moq can proxy IMongoCollection<ValidatorDocument>

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Models/ValidatorDocument.cs
+++ b/src/Services/Sorcha.Validator.Service/Models/ValidatorDocument.cs
@@ -10,7 +10,13 @@ namespace Sorcha.Validator.Service.Models;
 /// MongoDB document for durable validator storage.
 /// Maps between <see cref="ValidatorInfo"/> and the MongoDB collection.
 /// </summary>
-internal class ValidatorDocument
+/// <remarks>
+/// Public so that test fixtures can create <c>Mock&lt;IMongoCollection&lt;ValidatorDocument&gt;&gt;</c>
+/// via Castle DynamicProxy. Castle generates proxies in a separate strong-named assembly
+/// (<c>DynamicProxyGenAssembly2</c>) that cannot see types marked <c>internal</c> even when
+/// <c>InternalsVisibleTo</c> is set for the direct test assembly.
+/// </remarks>
+public class ValidatorDocument
 {
     [BsonId]
     public string Id { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
PR #289 introduced \`MongoMockHelper.CreateValidatorRegistryClient()\` to satisfy \`ValidatorRegistry\`'s newly-required \`IMongoClient\` ctor dependency. The helper calls \`Mock.Of<IMongoCollection<ValidatorDocument>>()\` — but \`ValidatorDocument\` was \`internal class\`, and Moq builds proxies via Castle DynamicProxy in a separate strong-named assembly called \`DynamicProxyGenAssembly2\` that cannot see internals of \`Sorcha.Validator.Service\` (the \`InternalsVisibleTo\` attribute only names the direct test assembly).

At runtime every \`[Fact]\` in the three affected classes threw:

\`\`\`
System.ArgumentException : Can not create proxy for type
MongoDB.Driver.IMongoCollection<ValidatorDocument> because type
ValidatorDocument is not accessible. Make it public, or internal and
mark your assembly with [InternalsVisibleTo(\"DynamicProxyGenAssembly2, PublicKey=...\")]
because assembly MongoDB.Driver is strong-named.
\`\`\`

**Fix**: make \`ValidatorDocument\` \`public\`. It's a pure Mongo serialization data type used by exactly one service, with \`ToValidatorInfo\`/\`FromValidatorInfo\` helpers bridging to the already-public \`ValidatorInfo\`. No meaningful public-API surface added.

This was my bug — I introduced it in #289 when I added \`MongoMockHelper\`. It hid behind the fact that #289's goal was \"make the project compile\" and I didn't chase the 60 newly-visible runtime failures at the time.

## Results

| Class | Before | After | Recovered |
|---|---:|---:|---:|
| \`ValidatorRegistryApprovalTests\` | 22 | **0** | 22 |
| \`ValidatorRegistryConsentTests\` | 5 | **0** | 5 |
| \`ValidatorOperationalPresenceTests\` | 5 | **0** | 5 |
| **Subtotal recovered** | **32** | **0** | **32** |

Full suite: **Validator.Service.Tests 60 → 28 failures**, 864 → 897 passing.

The remaining 28 are real behavioural failures in \`TransactionPoolPollerTests\` (10), \`DocketBuilderTests\` (6), \`ValidationEngineRevocationTests\` (6), \`ValidationEngineTests\` (5), \`ValidationEngineParticipantResolutionTests\` (1). Confirmed by running one: \`TransactionPoolPollerTests.GetUnverifiedCountAsync_ReturnsQueueLength\` reports \"Expected 42, found 0\" — a mock setup that production no longer exercises, not a fixture-ctor cascade.

## Platform-wide progress over this session

| Service | Session start | Now | Δ |
|---|---|---|---|
| Validator | build broken | **28 F / 897 P / 3 S / 928 T** | +897 tests visible, **32 real recoveries** |
| Blueprint | 81 F | 44 F | −37 (#292) |
| Register | 36 F | 7 F | −29 (#289, #291) |
| Tenant | 1 F | 1 F | 0 |
| Wallet / Peer / ApiGateway | 0 F | 0 F | ✅ |

## Test plan
- [x] \`dotnet test --filter \"FullyQualifiedName~ValidatorRegistryApprovalTests|ValidatorRegistryConsentTests|ValidatorOperationalPresenceTests\"\` → 37/37 pass
- [x] Full Validator.Service.Tests → 28 F / 897 P / 3 S (was 60 F / 864 P / 3 S)
- [x] Confirmed remaining failures are behavioural, not fixture cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)