### PR TITLE
fix: remove dead specs/001-tenant-auth links and /openapi root path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Set up your account using passkeys or social login.
 
 ### Developers
 Build on the Sorcha platform.
-- **[API Documentation](/openapi)** — Interactive Scalar API explorer
+- **API Documentation** — Interactive Scalar API explorer at `http://localhost/openapi` (when running locally)
 - **[Getting Started](#getting-started)** — Development environment setup
 - **[Guides](#guides)** — Feature-specific integration guides
 - **[Reference](#reference)** — Architecture, status, and specifications

--- a/src/Services/Sorcha.Tenant.Service/README.md
+++ b/src/Services/Sorcha.Tenant.Service/README.md
@@ -150,7 +150,7 @@ dotnet user-secrets set "JwtSettings:SigningKey" "$(cat jwt_private.pem)" --proj
 dotnet user-secrets set "ConnectionStrings:Password" "dev_password123" --project src/Services/Sorcha.Tenant.Service
 ```
 
-For detailed secrets management guide, see [specs/001-tenant-auth/secrets-setup.md](../../../specs/001-tenant-auth/secrets-setup.md).
+For detailed secrets management, see the Authentication Setup guide in `docs/guides/AUTHENTICATION-SETUP.md`.
 
 ### 3. Start Dependencies
 
@@ -860,13 +860,9 @@ redis-cli ping  # Should return: PONG
 
 ## Resources
 
-- **Original Specification**: [specs/001-tenant-auth/spec.md](../../../specs/001-tenant-auth/spec.md)
-- **Org Identity Admin Spec (054)**: [specs/054-org-identity-admin/spec.md](../../../specs/054-org-identity-admin/spec.md)
-- **054 Design Document**: [docs/plans/2026-03-08-org-identity-admin-design.md](../../../docs/plans/2026-03-08-org-identity-admin-design.md)
-- **Implementation Plan**: [specs/001-tenant-auth/plan.md](../../../specs/001-tenant-auth/plan.md)
-- **Secrets Setup**: [specs/001-tenant-auth/secrets-setup.md](../../../specs/001-tenant-auth/secrets-setup.md)
-- **Quickstart Guide**: [specs/001-tenant-auth/quickstart.md](../../../specs/001-tenant-auth/quickstart.md)
-- **API Contracts**: [specs/001-tenant-auth/contracts/](../../../specs/001-tenant-auth/contracts/)
+- **Authentication Setup**: [docs/guides/AUTHENTICATION-SETUP.md](../../../docs/guides/AUTHENTICATION-SETUP.md)
+- **Architecture**: [docs/reference/architecture.md](../../../docs/reference/architecture.md)
+- **Development Status**: [docs/reference/development-status.md](../../../docs/reference/development-status.md)
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #295 — fixes the remaining 6 link-check errors:

- Remove dead `specs/001-tenant-auth/*` references from Tenant Service README (directory was deleted)
- Convert `/openapi` root-relative link to inline text (lychee can't resolve root-relative paths)

## Test plan

- [ ] Check Markdown Links workflow passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)