### PR TITLE
fix: Blueprint migration PendingModelChangesWarning blocks fresh deploy

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260406203435_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260406203435_InitialCreate.Designer.cs
@@ -260,9 +260,7 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                         .HasColumnType("text");
 
                     b.Property<bool>("IsReadOnlyMirror")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(false);
+                        .HasColumnType("boolean");
 
                     b.Property<string>("LastTransactionId")
                         .HasColumnType("text");

--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260406203435_InitialCreate.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/20260406203435_InitialCreate.cs
@@ -97,7 +97,7 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                     CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     CompletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
-                    IsReadOnlyMirror = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                    IsReadOnlyMirror = table.Column<bool>(type: "boolean", nullable: false)
                 },
                 constraints: table =>
                 {


### PR DESCRIPTION
## Summary
- Remove `HasDefaultValue(false)` from `IsReadOnlyMirror` in Blueprint InitialCreate migration Designer
- Fixes `PendingModelChangesWarning` that blocks `MigrateAsync` on fresh databases
- Discovered during n1 clean reset: volumes deleted, containers restarted, but Blueprint DB stayed empty because the migration silently failed

## Test plan
- [x] `dotnet ef migrations has-pending-model-changes` returns "No changes"
- [ ] n1 clean deploy creates Blueprint DB tables successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)