### PR TITLE
fix: Blueprint snapshot HasDefaultValue mismatch blocks fresh deploy

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Data/Migrations/BlueprintDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Data/Migrations/BlueprintDbContextModelSnapshot.cs
@@ -257,9 +257,7 @@ namespace Sorcha.Blueprint.Service.Data.Migrations
                         .HasColumnType("text");
 
                     b.Property<bool>("IsReadOnlyMirror")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(false);
+                        .HasColumnType("boolean");
 
                     b.Property<string>("LastTransactionId")
                         .HasColumnType("text");


### PR DESCRIPTION
## Summary
- PR #301 fixed the Designer and InitialCreate files but missed the snapshot
- The snapshot still had `HasDefaultValue(false)` causing `PendingModelChangesWarning` on n1

## Test plan
- [x] `dotnet ef migrations has-pending-model-changes` returns "No changes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)