### PR TITLE
fix: submission spinner stuck due to JSON case-sensitivity

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WorkflowService.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Models.Common;
 using Sorcha.UI.Core.Models.Workflows;
 
@@ -39,7 +40,7 @@ public class WorkflowService : IWorkflowService
                 return new PaginatedList<WorkflowInstanceViewModel>();
             }
 
-            var result = await response.Content.ReadFromJsonAsync<PaginatedList<WorkflowInstanceViewModel>>(cancellationToken: cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<PaginatedList<WorkflowInstanceViewModel>>(JsonDefaults.Api, cancellationToken: cancellationToken);
             return result ?? new PaginatedList<WorkflowInstanceViewModel>();
         }
         catch (Exception ex)
@@ -77,7 +78,7 @@ public class WorkflowService : IWorkflowService
                 return [];
             }
 
-            var result = await response.Content.ReadFromJsonAsync<PendingActionsResponse>(cancellationToken: cancellationToken);
+            var result = await response.Content.ReadFromJsonAsync<PendingActionsResponse>(JsonDefaults.Api, cancellationToken: cancellationToken);
             if (result?.Items is null || result.Items.Count == 0) return [];
 
             return result.Items.Select(s => new PendingActionViewModel
@@ -161,7 +162,7 @@ public class WorkflowService : IWorkflowService
                 return null;
             }
 
-            return await response.Content.ReadFromJsonAsync<WorkflowInstanceViewModel>(cancellationToken: cancellationToken);
+            return await response.Content.ReadFromJsonAsync<WorkflowInstanceViewModel>(JsonDefaults.Api, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {
@@ -232,7 +233,7 @@ public class WorkflowService : IWorkflowService
                 };
             }
 
-            return await response.Content.ReadFromJsonAsync<ActionSubmissionResultViewModel>(cancellationToken: cancellationToken);
+            return await response.Content.ReadFromJsonAsync<ActionSubmissionResultViewModel>(JsonDefaults.Api, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- `WorkflowService.ReadFromJsonAsync` calls didn't pass `JsonDefaults.Api` (which has `PropertyNameCaseInsensitive=true`)
- Server returns camelCase (`transactionId`, `isComplete`), ViewModel uses PascalCase — all properties deserialized as defaults
- Result: `IsComplete=false`, `InstanceId=""`, submission appeared stuck on "Submitting..." overlay
- Fix: pass `JsonDefaults.Api` to all 4 `ReadFromJsonAsync` calls in WorkflowService

## Found via
DevTools E2E test of AssuredPerson SorchaLocalWallet flow on n1.sorcha.dev

## Test plan
- [x] UI.Core builds clean
- [ ] Submit AssuredPerson on n1 — should navigate to my-actions after submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)