### PR TITLE
fix(106): SorchaLocalWallet credentials must go through PendingAcceptance

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
@@ -160,6 +160,7 @@ public interface IWalletServiceClient
         string? statusListUrl = null,
         int? statusListIndex = null,
         string? statusListPurpose = null,
+        bool skipRecipientStore = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -294,6 +294,7 @@ public class WalletServiceClient : IWalletServiceClient
         string? statusListUrl = null,
         int? statusListIndex = null,
         string? statusListPurpose = null,
+        bool skipRecipientStore = false,
         CancellationToken cancellationToken = default)
     {
         try
@@ -314,7 +315,8 @@ public class WalletServiceClient : IWalletServiceClient
                 issuanceBlueprintId,
                 statusListUrl,
                 statusListIndex,
-                statusListPurpose
+                statusListPurpose,
+                skipRecipientStore
             };
 
             var response = await _httpClient.PostAsJsonAsync(

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1821,6 +1821,7 @@ public class ActionExecutionService : IActionExecutionService
                 statusListUrl: preAllocatedStatusListUrl,
                 statusListIndex: preAllocatedStatusListIndex,
                 statusListPurpose: preAllocatedStatusListUrl != null ? "revocation" : null,
+                skipRecipientStore: config.TargetAudience == TargetAudience.SorchaLocalWallet,
                 cancellationToken: cancellationToken);
 
             return result;

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -610,8 +610,11 @@ public static class CredentialEndpoints
         };
         await store.StoreAsync(issuerEntity, cancellationToken);
 
-        // 7. Store copy in recipient's wallet (if different and exists)
-        if (!string.Equals(walletAddress, request.RecipientWallet, StringComparison.OrdinalIgnoreCase))
+        // 7. Store copy in recipient's wallet (if different and exists).
+        //    Feature 106: Skip for SorchaLocalWallet — the credential arrives via the
+        //    register disclosure and InboundCredentialDetector as PendingAcceptance.
+        if (!request.SkipRecipientStore
+            && !string.Equals(walletAddress, request.RecipientWallet, StringComparison.OrdinalIgnoreCase))
         {
             var recipientWallet = await walletRepository.GetByAddressAsync(
                 request.RecipientWallet, cancellationToken: cancellationToken);
@@ -713,6 +716,14 @@ public class IssueCredentialRequest
     /// are provided and this field is left null.
     /// </summary>
     public string? StatusListPurpose { get; init; }
+
+    /// <summary>
+    /// Feature 106: When true, the credential is stored only in the issuer's wallet — not
+    /// in the recipient's. Used for SorchaLocalWallet delivery where the credential should
+    /// arrive via the register disclosure (InboundCredentialDetector) as PendingAcceptance,
+    /// not be pre-stored as Active on the same node.
+    /// </summary>
+    public bool SkipRecipientStore { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- On single-node, `IssueCredentialAsync` stored credentials directly in the recipient wallet as Active
- This bypassed `InboundCredentialDetector` and the PendingAcceptance → Accept flow entirely
- Credential appeared in ACTIVE tab immediately, skipping the holder consent ceremony

## Fix
- Add `SkipRecipientStore` flag to `IssueCredentialRequest`
- `ActionExecutionService` sets it when `targetAudience == SorchaLocalWallet`
- Credential is only stored in issuer's wallet; recipient gets it via register disclosure → `InboundCredentialDetector` as `PendingAcceptance`
- Works identically on single-node and multi-node

## Found via
DevTools E2E test — credential went straight to ACTIVE tab, PENDING tab was empty

## Test plan
- [x] All affected projects build clean
- [ ] Deploy to n1, submit AssuredPerson — credential should appear in PENDING tab (not ACTIVE)
- [ ] Accept credential — transitions to ACTIVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)