### PR TITLE
chore(106): deprecate SorchaInternal — all credentials go through register

### DIFF
--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
@@ -98,7 +98,13 @@ public class CredentialIssuanceConfig
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TargetAudience
 {
-    /// <summary>Internal Sorcha participant — credential written to Sorcha wallet.</summary>
+    /// <summary>
+    /// Deprecated: maps to <see cref="SorchaLocalWallet"/> at runtime. Originally wrote
+    /// the credential directly to the recipient's wallet on the same node, bypassing the
+    /// register — which breaks on multi-node deployments. Use <see cref="SorchaLocalWallet"/>
+    /// for all on-platform credential delivery.
+    /// </summary>
+    [Obsolete("Use SorchaLocalWallet instead. SorchaInternal bypasses the register and breaks on multi-node.")]
     SorchaInternal = 0,
 
     /// <summary>External HAIP wallet — credential issued via OpenID4VCI pre-authorized code flow.</summary>

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -2907,7 +2907,19 @@ public class PublishService(
         {
             var issuance = action.CredentialIssuanceConfig;
             if (issuance is null) continue;
-            if (issuance.TargetAudience != Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaLocalWallet)
+
+            // SorchaInternal is deprecated — warn blueprint authors to migrate
+            if (issuance.TargetAudience == Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaInternal)
+            {
+                warnings.Add(
+                    $"[WARN_BP_CRED_DEPRECATED] Action {action.Id} ('{action.Title}'): " +
+                    $"targetAudience 'SorchaInternal' is deprecated and will be removed in a future release. " +
+                    $"Use 'SorchaLocalWallet' instead. SorchaInternal is treated as SorchaLocalWallet at runtime.");
+            }
+
+            // Apply SorchaLocalWallet validation to both SorchaLocalWallet and deprecated SorchaInternal
+            if (issuance.TargetAudience is not (Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaLocalWallet
+                or Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaInternal))
                 continue;
 
             // VAL_BP_CRED_001 — recipientParticipantId must resolve

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -493,11 +493,13 @@ public class ActionExecutionService : IActionExecutionService
             }
         }
 
-        // 8c. Feature 106 — mint a register-native credential for SorchaLocalWallet
-        //     target audience BEFORE routing and disclosure. The freshly minted credential
-        //     is sealed into the recipient-addressed disclosure group at step 9b so it
-        //     rides the existing encryption pipeline and peer-replicates to the holder's
-        //     Wallet Service (which extracts it via Wave B inbound credential detection).
+        // 8c. Feature 106 — mint a register-native credential for on-platform wallets
+        //     (SorchaLocalWallet or deprecated SorchaInternal) BEFORE routing and disclosure.
+        //     The freshly minted credential is sealed into the recipient-addressed disclosure
+        //     group at step 9b so it rides the existing encryption pipeline and peer-replicates
+        //     to the holder's Wallet Service (which extracts it via Wave B inbound credential
+        //     detection). This is the ONLY delivery path for on-platform credentials — direct
+        //     wallet writes are never used because they break on multi-node deployments.
         //
         //     Runtime error codes:
         //       VAL_RUNTIME_CRED_001 — recipient wallet not resolvable (late-binding not yet run)
@@ -508,7 +510,8 @@ public class ActionExecutionService : IActionExecutionService
         CredentialIssuanceResult? localWalletCredential = null;
         string? localWalletRecipient = null;
         if (actionDef.CredentialIssuanceConfig != null
-            && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.SorchaLocalWallet)
+            && actionDef.CredentialIssuanceConfig.TargetAudience is TargetAudience.SorchaLocalWallet
+                or TargetAudience.SorchaInternal)
         {
             var recipientId = actionDef.CredentialIssuanceConfig.RecipientParticipantId;
             if (string.IsNullOrWhiteSpace(recipientId)
@@ -791,19 +794,10 @@ public class ActionExecutionService : IActionExecutionService
         // 9d. Issue internal Sorcha credential if configured (non-HAIP path).
         //     The HAIP path has already run at step 8b (moved before routing in
         //     Feature 104 wave 14b so Route.OutputMapping can carry offer data
-        //     forward to a claim action). The SorchaLocalWallet path has already run
-        //     at step 8c (Feature 106) so the credential could be sealed into a
-        //     recipient-addressed disclosure. The internal SorchaInternal path
-        //     remains here because it builds a register transaction from the merged
-        //     state alongside the legacy direct-write behaviour.
+        //     forward to a claim action). Step 8c now handles both SorchaLocalWallet
+        //     AND the deprecated SorchaInternal — all on-platform credentials go
+        //     through the register disclosure path for multi-node correctness.
         CredentialIssuanceResult? issuedCredential = localWalletCredential;
-        if (actionDef.CredentialIssuanceConfig != null
-            && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.SorchaInternal)
-        {
-            // Internal Sorcha issuance path (existing behaviour)
-            issuedCredential = await IssueCredentialFromActionAsync(
-                actionDef, mergedData, request.SenderWallet, instance, cancellationToken);
-        }
 
         // 10. Build transaction
         BuiltTransaction transaction;


### PR DESCRIPTION
## Summary
- Mark `TargetAudience.SorchaInternal` as `[Obsolete]` — it bypasses the register, breaking multi-node
- Route `SorchaInternal` through the same register-native disclosure path as `SorchaLocalWallet`
- Remove the legacy direct-write block
- Add `WARN_BP_CRED_DEPRECATED` publish-time warning
- Existing blueprints with default `targetAudience` (=SorchaInternal=0) continue to work

## Test plan
- [x] Blueprint.Models + Blueprint.Service build clean
- [ ] Publish a blueprint with no targetAudience — should get WARN_BP_CRED_DEPRECATED warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)