### PR TITLE
fix: wire RecipientsWallets through entire transaction pipeline

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Validator/IValidatorServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Validator/IValidatorServiceClient.cs
@@ -54,6 +54,12 @@ public record TransactionSubmission
     /// Must equal sender's last sequence number + 1 on the target register.
     /// </summary>
     public long SequenceNumber { get; init; }
+
+    /// <summary>
+    /// Recipient wallet addresses. Populated from disclosure group recipients so the
+    /// Register Service can route docket-sealed transactions to recipient Wallet Services.
+    /// </summary>
+    public List<string>? RecipientsWallets { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
@@ -186,13 +186,22 @@ public static class TransactionBuilderServiceExtensions
         // with deterministic options. The Validator re-canonicalizes with the same options to verify.
         var payloadHash = txId;
 
+        // Extract recipient wallet addresses from the disclosed payloads dictionary.
+        // In dev-mode (plaintext), the dictionary keys are the wallet addresses
+        // that each payload is disclosed to.
+        var recipients = disclosedPayloads.Keys
+            .Where(w => !string.IsNullOrEmpty(w))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
         return Task.FromResult(new BuiltTransaction
         {
             TransactionData = transactionData,
             TxId = txId,
             PayloadHash = payloadHash,
             RegisterId = instance.RegisterId,
-            Metadata = metadata
+            Metadata = metadata,
+            RecipientsWallets = recipients
         });
     }
 
@@ -264,13 +273,25 @@ public static class TransactionBuilderServiceExtensions
         // with deterministic options. The Validator re-canonicalizes with the same options to verify.
         var payloadHash = txId;
 
+        // Extract recipient wallet addresses from the encrypted disclosure groups.
+        // Each wrappedKey entry is a wallet that can decrypt the group — these are
+        // the transaction's recipients and must be set so the Register Service's
+        // InboundTransactionRouter can notify their Wallet Services on docket seal.
+        var recipients = encryptedGroups
+            .SelectMany(g => g.WrappedKeys)
+            .Select(wk => wk.WalletAddress)
+            .Where(w => !string.IsNullOrEmpty(w))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
         return Task.FromResult(new BuiltTransaction
         {
             TransactionData = transactionData,
             TxId = txId,
             PayloadHash = payloadHash,
             RegisterId = instance.RegisterId,
-            Metadata = metadata
+            Metadata = metadata,
+            RecipientsWallets = recipients
         });
     }
 
@@ -371,6 +392,13 @@ public class BuiltTransaction
     public string SenderWallet { get; set; } = string.Empty;
 
     /// <summary>
+    /// Recipient wallet addresses extracted from disclosure groups. Used by the
+    /// Register Service's InboundTransactionRouter to notify recipient Wallet
+    /// Services when the transaction is sealed in a docket.
+    /// </summary>
+    public List<string> RecipientsWallets { get; set; } = [];
+
+    /// <summary>
     /// The signature (populated after signing)
     /// </summary>
     public byte[]? Signature { get; set; }
@@ -412,6 +440,7 @@ public class BuiltTransaction
             CreatedAt = DateTimeOffset.UtcNow,
             PreviousTransactionId = Metadata.GetValueOrDefault("previousTxId")?.ToString(),
             SequenceNumber = sequenceNumber,
+            RecipientsWallets = RecipientsWallets.Count > 0 ? RecipientsWallets : null,
             Metadata = new Dictionary<string, string>
             {
                 ["instanceId"] = Metadata.GetValueOrDefault("instanceId")?.ToString() ?? string.Empty,

--- a/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
@@ -77,7 +77,8 @@ public static class ValidationEndpoints
                 SequenceNumber = (ulong)request.SequenceNumber,
                 PreviousTransactionId = request.PreviousTransactionId,
                 Priority = request.Priority,
-                Metadata = request.Metadata ?? new Dictionary<string, string>()
+                Metadata = request.Metadata ?? new Dictionary<string, string>(),
+                RecipientsWallets = request.RecipientsWallets
             };
 
             // Participant transactions have no blueprint/action context — use a sentinel
@@ -224,6 +225,13 @@ public record ValidateTransactionRequest
     /// Must equal sender's last sequence number + 1 on the target register.
     /// </summary>
     public long SequenceNumber { get; init; }
+
+    /// <summary>
+    /// Recipient wallet addresses extracted from disclosure groups at transaction
+    /// build time. Passed through to the Register Service so docket-sealed
+    /// transactions can be routed to recipient Wallet Services.
+    /// </summary>
+    public List<string>? RecipientsWallets { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Validator.Service/Models/Transaction.cs
+++ b/src/Services/Sorcha.Validator.Service/Models/Transaction.cs
@@ -100,6 +100,14 @@ public class Transaction
     /// </summary>
     public string? PreviousTransactionId { get; init; }
 
+    // Recipients
+    /// <summary>
+    /// Wallet addresses of transaction recipients. Extracted from disclosure group
+    /// wrappedKeys at transaction build time. Used by the Register Service to route
+    /// docket-sealed transactions to recipient Wallet Services for inbound detection.
+    /// </summary>
+    public List<string>? RecipientsWallets { get; init; }
+
     // Metadata
     /// <summary>
     /// Extensible key-value metadata

--- a/src/Services/Sorcha.Validator.Service/Services/DocketSerializer.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketSerializer.cs
@@ -103,6 +103,7 @@ public static class DocketSerializer
                             PayloadSize = (ulong)(tx.PayloadJson?.Length ?? 0),
                             ContentEncoding = "base64url"
                         }],
+                    RecipientsWallets = tx.RecipientsWallets ?? [],
                     MetaData = new Sorcha.Register.Models.TransactionMetaData
                     {
                         RegisterId = tx.RegisterId,

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/TransactionBuilderExtensionsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/TransactionBuilderExtensionsTests.cs
@@ -201,4 +201,41 @@ public class TransactionBuilderExtensionsTests
         result.ActionId.Should().BeEmpty();
         result.Metadata!["instanceId"].Should().BeEmpty();
     }
+
+    [Fact]
+    public void ToTransactionSubmission_WithRecipientsWallets_MapsToSubmission()
+    {
+        var tx = CreateTestTransaction();
+        tx.RecipientsWallets = ["ws11qalice", "ws11qbob"];
+        var signResult = CreateTestSignResult();
+
+        var result = tx.ToTransactionSubmission(signResult);
+
+        result.RecipientsWallets.Should().NotBeNull();
+        result.RecipientsWallets.Should().BeEquivalentTo(["ws11qalice", "ws11qbob"]);
+    }
+
+    [Fact]
+    public void ToTransactionSubmission_WithEmptyRecipientsWallets_MapsToNull()
+    {
+        var tx = CreateTestTransaction();
+        tx.RecipientsWallets = [];
+        var signResult = CreateTestSignResult();
+
+        var result = tx.ToTransactionSubmission(signResult);
+
+        result.RecipientsWallets.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToTransactionSubmission_DefaultRecipientsWallets_MapsToNull()
+    {
+        var tx = CreateTestTransaction();
+        // RecipientsWallets defaults to empty list
+        var signResult = CreateTestSignResult();
+
+        var result = tx.ToTransactionSubmission(signResult);
+
+        result.RecipientsWallets.Should().BeNull();
+    }
 }

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketSerializerTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketSerializerTests.cs
@@ -170,6 +170,50 @@ public class DocketSerializerTests
         model.Transactions[1].TxId.Should().Be("tx-2");
     }
 
+    [Fact]
+    public void ToRegisterModel_MapsRecipientsWallets()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        var tx = CreateTransaction("tx-with-recipients");
+        tx = new Transaction
+        {
+            TransactionId = tx.TransactionId,
+            RegisterId = tx.RegisterId,
+            BlueprintId = tx.BlueprintId,
+            ActionId = tx.ActionId,
+            Payload = tx.Payload,
+            PayloadHash = tx.PayloadHash,
+            CreatedAt = tx.CreatedAt,
+            Signatures = tx.Signatures,
+            Metadata = tx.Metadata,
+            RecipientsWallets = ["ws11qalice", "ws11qbob"]
+        };
+        docket.Transactions.Add(tx);
+
+        // Act
+        var model = DocketSerializer.ToRegisterModel(docket);
+
+        // Assert
+        model.Transactions.Should().HaveCount(1);
+        model.Transactions[0].RecipientsWallets.Should().BeEquivalentTo(["ws11qalice", "ws11qbob"]);
+    }
+
+    [Fact]
+    public void ToRegisterModel_NullRecipientsWallets_MapsToEmptyList()
+    {
+        // Arrange — CreateTransaction does not set RecipientsWallets (defaults to null)
+        var docket = CreateDocketWithTransactions();
+
+        // Act
+        var model = DocketSerializer.ToRegisterModel(docket);
+
+        // Assert
+        model.Transactions.Should().HaveCount(2);
+        model.Transactions[0].RecipientsWallets.Should().BeEmpty();
+        model.Transactions[1].RecipientsWallets.Should().BeEmpty();
+    }
+
     #endregion
 
     #region Round Trip Tests


### PR DESCRIPTION
## Summary
`RecipientsWallets` existed on the Register's `TransactionModel` but was never populated anywhere in the pipeline. Every action transaction ever submitted had empty recipients, so the Register Service's `InboundTransactionRouter` never fired — blocking multi-node notifications and Feature 106's `InboundCredentialDetector`.

## Pipeline fix
| Stage | File | Change |
|-------|------|--------|
| Build | `ITransactionBuilderService.cs` | Extract recipients from `wrappedKeys` (encrypted) or disclosure keys (plaintext) |
| Submit | `ITransactionBuilderService.cs` | Map to `TransactionSubmission.RecipientsWallets` |
| Receive | `IValidatorServiceClient.cs` | Add `RecipientsWallets` to `TransactionSubmission` |
| Validate | `ValidationEndpoints.cs` | Add to `ValidateTransactionRequest`, map into `Transaction` |
| Model | `Transaction.cs` | Add `RecipientsWallets` property |
| Serialize | `DocketSerializer.cs` | Map into Register `TransactionModel` |

## Tests (5 new)
- `TransactionBuilderExtensionsTests`: 3 tests for recipients mapping through `ToTransactionSubmission`
- `DocketSerializerTests`: 2 tests for recipients mapping through `ToRegisterModel`

## Impact
This is a foundational fix — all action transactions on all blueprints now carry recipient addresses. The Register Service can route docket-sealed transactions to recipient Wallet Services, enabling:
- Feature 106 `InboundCredentialDetector` on single-node
- Multi-node transaction notifications (future)
- Multi-node credential delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)