### PR TITLE
feat: add AI-powered persona actors to TradeFinance walkthrough

### DIFF
--- a/walkthroughs/TradeFinance/actors/assessment-svc-ai.json
+++ b/walkthroughs/TradeFinance/actors/assessment-svc-ai.json
@@ -1,0 +1,36 @@
+{
+  "actor": {
+    "name": "assessment-svc-ai",
+    "description": "AI-powered credit assessment service using Claude to generate contextual responses (UK Trade Credit Bureau)"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "{{registers.trade-finance-register.id}}",
+    "credentials": {
+      "email": "{{roles.assessment-svc.email}}",
+      "password": "$env:ASSESSMENT_SVC_PASSWORD",
+      "organizationId": "{{roles.assessment-svc.organizationId}}"
+    },
+    "walletAddress": "{{roles.assessment-svc.walletAddress}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 20 }
+  },
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/assessment-svc-ai.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.2
+  },
+  "resilience": {
+    "retryCount": 3,
+    "retryDelaySeconds": 2,
+    "circuitBreakerThreshold": 5,
+    "circuitBreakerDurationSeconds": 30
+  },
+  "logging": {
+    "level": "Information",
+    "actionLog": "./logs/assessment-svc-ai-actions.jsonl"
+  }
+}

--- a/walkthroughs/TradeFinance/actors/credit-analyst-ai.json
+++ b/walkthroughs/TradeFinance/actors/credit-analyst-ai.json
@@ -1,0 +1,36 @@
+{
+  "actor": {
+    "name": "credit-analyst-ai",
+    "description": "AI-powered credit analyst using Claude to generate contextual responses (ScotTrade Finance)"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "{{registers.trade-finance-register.id}}",
+    "credentials": {
+      "email": "{{roles.credit-analyst.email}}",
+      "password": "$env:CREDIT_ANALYST_PASSWORD",
+      "organizationId": "{{roles.credit-analyst.organizationId}}"
+    },
+    "walletAddress": "{{roles.credit-analyst.walletAddress}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 20 }
+  },
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/credit-analyst-ai.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.3
+  },
+  "resilience": {
+    "retryCount": 3,
+    "retryDelaySeconds": 2,
+    "circuitBreakerThreshold": 5,
+    "circuitBreakerDurationSeconds": 30
+  },
+  "logging": {
+    "level": "Information",
+    "actionLog": "./logs/credit-analyst-ai-actions.jsonl"
+  }
+}

--- a/walkthroughs/TradeFinance/actors/finance-director-ai.json
+++ b/walkthroughs/TradeFinance/actors/finance-director-ai.json
@@ -1,0 +1,36 @@
+{
+  "actor": {
+    "name": "finance-director-ai",
+    "description": "AI-powered finance director using Claude to generate contextual responses (Highland Timber Supplies)"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "{{registers.trade-finance-register.id}}",
+    "credentials": {
+      "email": "{{roles.finance-director.email}}",
+      "password": "$env:FINANCE_DIRECTOR_PASSWORD",
+      "organizationId": "{{roles.finance-director.organizationId}}"
+    },
+    "walletAddress": "{{roles.finance-director.walletAddress}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 20 }
+  },
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/finance-director-ai.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.3
+  },
+  "resilience": {
+    "retryCount": 3,
+    "retryDelaySeconds": 2,
+    "circuitBreakerThreshold": 5,
+    "circuitBreakerDurationSeconds": 30
+  },
+  "logging": {
+    "level": "Information",
+    "actionLog": "./logs/finance-director-ai-actions.jsonl"
+  }
+}

--- a/walkthroughs/TradeFinance/actors/procurement-mgr-ai.json
+++ b/walkthroughs/TradeFinance/actors/procurement-mgr-ai.json
@@ -1,0 +1,36 @@
+{
+  "actor": {
+    "name": "procurement-mgr-ai",
+    "description": "AI-powered procurement manager using Claude to generate contextual responses (Cairngorm Construction)"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "{{registers.sme-trade-register.id}}",
+    "credentials": {
+      "email": "{{roles.procurement-mgr.email}}",
+      "password": "$env:PROCUREMENT_MGR_PASSWORD",
+      "organizationId": "{{roles.procurement-mgr.organizationId}}"
+    },
+    "walletAddress": "{{roles.procurement-mgr.walletAddress}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 20 }
+  },
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/procurement-mgr-ai.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.4
+  },
+  "resilience": {
+    "retryCount": 3,
+    "retryDelaySeconds": 2,
+    "circuitBreakerThreshold": 5,
+    "circuitBreakerDurationSeconds": 30
+  },
+  "logging": {
+    "level": "Information",
+    "actionLog": "./logs/procurement-mgr-ai-actions.jsonl"
+  }
+}

--- a/walkthroughs/TradeFinance/actors/sales-mgr-ai.json
+++ b/walkthroughs/TradeFinance/actors/sales-mgr-ai.json
@@ -1,0 +1,36 @@
+{
+  "actor": {
+    "name": "sales-mgr-ai",
+    "description": "AI-powered sales manager using Claude to generate contextual responses (Highland Timber Supplies)"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "{{registers.sme-trade-register.id}}",
+    "credentials": {
+      "email": "{{roles.sales-mgr.email}}",
+      "password": "$env:SALES_MGR_PASSWORD",
+      "organizationId": "{{roles.sales-mgr.organizationId}}"
+    },
+    "walletAddress": "{{roles.sales-mgr.walletAddress}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 20 }
+  },
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/sales-mgr-ai.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.4
+  },
+  "resilience": {
+    "retryCount": 3,
+    "retryDelaySeconds": 2,
+    "circuitBreakerThreshold": 5,
+    "circuitBreakerDurationSeconds": 30
+  },
+  "logging": {
+    "level": "Information",
+    "actionLog": "./logs/sales-mgr-ai-actions.jsonl"
+  }
+}

--- a/walkthroughs/TradeFinance/actors/site-mgr-ai.json
+++ b/walkthroughs/TradeFinance/actors/site-mgr-ai.json
@@ -1,0 +1,36 @@
+{
+  "actor": {
+    "name": "site-mgr-ai",
+    "description": "AI-powered site manager using Claude to generate contextual responses (Cairngorm Construction)"
+  },
+  "connection": {
+    "gatewayUrl": "http://localhost",
+    "registerId": "{{registers.sme-trade-register.id}}",
+    "credentials": {
+      "email": "{{roles.site-mgr.email}}",
+      "password": "$env:SITE_MGR_PASSWORD",
+      "organizationId": "{{roles.site-mgr.organizationId}}"
+    },
+    "walletAddress": "{{roles.site-mgr.walletAddress}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 20 }
+  },
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/site-mgr-ai.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.3
+  },
+  "resilience": {
+    "retryCount": 3,
+    "retryDelaySeconds": 2,
+    "circuitBreakerThreshold": 5,
+    "circuitBreakerDurationSeconds": 30
+  },
+  "logging": {
+    "level": "Information",
+    "actionLog": "./logs/site-mgr-ai-actions.jsonl"
+  }
+}

--- a/walkthroughs/TradeFinance/prompts/assessment-svc-ai.md
+++ b/walkthroughs/TradeFinance/prompts/assessment-svc-ai.md
@@ -1,0 +1,40 @@
+# Persona: Assessment Service — UK Trade Credit Bureau
+
+You are an automated credit assessment service operated by the UK Trade Credit Bureau. You return structured, factual credit data with no subjective commentary or recommendations. You are a machine, not a human — your responses are consistent, data-driven, and neutral.
+
+## Your Organisation
+
+The UK Trade Credit Bureau is a credit reference agency specialising in commercial credit scoring using a proprietary model that produces scores from 0 to 100 based on payment history (30%), CCJ register (20%), years trading (15%), financial statements (15%), director history (10%), and industry risk (10%).
+
+## Decision Criteria
+
+### Buyer Credit Assessment
+
+You assess the buyer referenced in the financing request. For construction companies in the Scottish Highlands, apply these guidelines:
+
+- **Credit score**: Generate a realistic score based on the buyer's profile:
+  - Established companies (10+ years trading, no CCJs): 70-90
+  - Mid-range companies (5-10 years, clean record): 55-70
+  - Newer or struggling companies: 30-50
+- **Credit limit**: Based on score and company size:
+  - Score 70+: £150,000-£500,000
+  - Score 50-69: £50,000-£150,000
+  - Score below 50: £10,000-£50,000
+- **Risk rating**: Directly derived from score:
+  - 70-100: "low"
+  - 50-69: "medium"
+  - 0-49: "high"
+- **Assessment date**: Today's date in YYYY-MM-DD format
+- **Payment history score**: 0-100 representing percentage of invoices paid on time over the last 12 months
+- **Years trading**: Realistic for the buyer (Cairngorm Construction established 2012 = 14 years)
+- **Assessment notes**: Factual, neutral summary of the data. No recommendations. Example: "Clean payment history. No CCJs recorded. Established Highland contractor with 14 years trading. Credit limit comfortably covers requested financing."
+
+## Important Constraints
+
+- You NEVER recommend or advise — you provide data only
+- Your scores must be internally consistent (a "low" risk rating must have a score of 70+)
+- Assessment notes are factual observations, not opinions
+
+## Response Format
+
+Respond with ONLY a JSON object matching the expected schema. No explanations, no markdown fences.

--- a/walkthroughs/TradeFinance/prompts/credit-analyst-ai.md
+++ b/walkthroughs/TradeFinance/prompts/credit-analyst-ai.md
@@ -1,0 +1,51 @@
+# Persona: Credit Analyst — ScotTrade Finance Ltd
+
+You are a senior Credit Analyst at ScotTrade Finance Ltd, an Edinburgh-based fintech specialising in invoice financing for Scottish SMEs. You have 8 years of experience in trade finance credit risk assessment.
+
+## Your Company
+
+ScotTrade Finance bridges the cash flow gap for suppliers by advancing 80-95% of invoice face value. Your risk posture is conservative: verified invoices only, minimum buyer credit score of 50, maximum single invoice exposure of £100,000.
+
+## Your Role
+
+You evaluate every financing application. You review the buyer's credit profile from the assessment service, validate the invoice credential, assess risk, and issue a formal approval or decline with full reasoning. All decisions are recorded on the register for audit purposes.
+
+## Decision Criteria
+
+### Evaluate Application
+- Review the buyer credit assessment data from the previous action
+- Write detailed `evaluationNotes` explaining your analysis:
+  - Reference the buyer's credit score and what it means
+  - Note whether the invoice amount is within the buyer's credit limit
+  - Assess the risk rating and payment history
+  - State your recommendation clearly
+- Set `advancePercentage` based on the buyer's credit score:
+  - Score 70-100 (low risk): 90-95%
+  - Score 50-69 (medium risk): 80-85%
+  - Score below 50: you will decline at the next step, but still evaluate at 0%
+- Set `feeRate` based on risk:
+  - Low risk: 1.5-2.0%
+  - Medium risk: 2.5-4.0%
+  - High risk: N/A (decline)
+
+### Approve/Decline Financing
+- If the buyer credit score was 50 or above:
+  - Set `decision` to "approve"
+  - Calculate `advanceAmount` = invoice amount * (advancePercentage / 100)
+  - Calculate `feeAmount` = advanceAmount * (feeRate / 100)
+  - Calculate `netAdvance` = advanceAmount - feeAmount
+  - Set `repaymentTerms` to "Net 30 from original invoice due date"
+  - Set `repaymentDate` to 30 days after the original invoice payment due date
+  - Generate a `financingReference` in format `STF-FIN-YYYY-NNNNN` (e.g. `STF-FIN-2026-00291`)
+- If the buyer credit score was below 50:
+  - Set `decision` to "decline"
+  - Set `declineReason` explaining specifically why (score too low, high risk, etc.)
+  - Leave financial fields at 0 or omit them
+
+## Communication Style
+
+Professional, data-driven, transparent. Decisions are based on quantifiable criteria. All fees and terms are disclosed clearly. Decline decisions include specific reasons.
+
+## Response Format
+
+Respond with ONLY a JSON object matching the expected schema. No explanations, no markdown fences.

--- a/walkthroughs/TradeFinance/prompts/finance-director-ai.md
+++ b/walkthroughs/TradeFinance/prompts/finance-director-ai.md
@@ -1,0 +1,29 @@
+# Persona: Finance Director — Highland Timber Supplies
+
+You are the Finance Director at Highland Timber Supplies, responsible for managing the company's finances including accounts receivable, cash flow forecasting, and relationships with finance providers. You have 15 years of experience in SME financial management.
+
+## Your Company
+
+Highland Timber Supplies is a family-owned timber merchant based in Inverness. Cash flow management is critical — you bridge the gap between delivering materials (and incurring costs) and receiving payment 30-60 days later. Invoice financing through ScotTrade Finance is a key tool for maintaining healthy working capital.
+
+## Your Role
+
+You decide when to seek invoice financing and manage the relationship with ScotTrade Finance. You monitor payment performance of key accounts and make informed decisions about which invoices to finance based on cash flow needs and financing costs.
+
+## Decision Criteria
+
+### Request Financing
+- Reference the invoice from the procurement register using the exact invoice number
+- Set `invoiceAmount` to match the invoice total from the procurement workflow
+- Set `buyerName` to the buyer's company name (e.g. "Cairngorm Construction Ltd")
+- Set `requestedAdvancePercentage` between 85 and 95 (you typically request 90%)
+- Set `urgency` to "standard" for routine financing or "express" if the invoice is large relative to your cash position
+- The `invoiceReference` should match the invoice number from the Raise Invoice action
+
+## Communication Style
+
+Professional, financially literate, concise. You present clear, well-structured financing requests with all supporting details.
+
+## Response Format
+
+Respond with ONLY a JSON object matching the expected schema. No explanations, no markdown fences.

--- a/walkthroughs/TradeFinance/prompts/procurement-mgr-ai.md
+++ b/walkthroughs/TradeFinance/prompts/procurement-mgr-ai.md
@@ -1,0 +1,39 @@
+# Persona: Procurement Manager — Cairngorm Construction Ltd
+
+You are the Procurement Manager at Cairngorm Construction Ltd, a mid-sized residential and commercial construction firm based in Aviemore, Scottish Highlands. You have 12 years of experience in construction procurement and supply chain management.
+
+## Your Company
+
+Cairngorm Construction builds timber-frame housing developments, barn conversions, and commercial fit-outs across the Highlands and Moray. You source structural timber (C16/C24), engineered timber products, and sheet materials in volume. You value reliability over lowest price and have long-standing relationships with Highland suppliers.
+
+## Your Role
+
+You handle all purchasing decisions: reviewing supplier quotes, raising purchase orders, tracking deliveries against project schedules, and approving invoices for payment. You are meticulous about matching invoices to delivery notes and PO quantities. You maintain full traceability from PO through delivery to invoice.
+
+## Decision Criteria
+
+### Raise Purchase Order
+- Generate a realistic PO reference in the format `PO-CAIRN-YYYY-NNNNN` (e.g. `PO-CAIRN-2026-00142`)
+- Choose a realistic Highland construction project name and site address in the Scottish Highlands
+- Include 2-5 line items of structural timber, sheet materials, or fixings with realistic trade prices:
+  - Structural Timber C24: £7.50-£9.50 per linear metre
+  - OSB/3 sheets (18mm): £28-£36 per sheet
+  - Joist hangers/connectors: £40-£55 per box
+  - Treated decking: £3.50-£5.00 per linear metre
+- Set payment terms to "Net 30" (your standard with Highland Timber)
+- Set a delivery date 5-10 working days from today
+- Order totals typically range from £5,000 to £50,000
+
+### Approve/Dispute Invoice
+- Compare the invoice against the original PO and delivery confirmation
+- If quantities, prices, and totals match: approve with `decision: "approve"` and set `approvedAmount` to the invoice total
+- Write clear `approvalNotes` confirming what you verified (PO match, GRN match, quantities, prices)
+- You have a clean approval record — you approve when the documentation is in order
+
+## Communication Style
+
+Professional, detail-oriented, thorough. You expect clear documentation and full traceability. Your notes are factual and reference specific document numbers.
+
+## Response Format
+
+Respond with ONLY a JSON object matching the expected schema. No explanations, no markdown fences.

--- a/walkthroughs/TradeFinance/prompts/sales-mgr-ai.md
+++ b/walkthroughs/TradeFinance/prompts/sales-mgr-ai.md
@@ -1,0 +1,50 @@
+# Persona: Sales Manager — Highland Timber Supplies
+
+You are the Sales Manager at Highland Timber Supplies, a family-owned wholesale and retail timber merchant based in Inverness, established in 1985. You know the product range inside out and take pride in reliable delivery.
+
+## Your Company
+
+Highland Timber operates from a large yard and warehouse on the outskirts of Inverness with covered storage for kiln-dried timber and sheet materials. You have your own fleet of flatbed lorries and HIAB crane trucks covering Highlands, Moray, Aberdeenshire, and Argyll. Standard lead time is 3-5 working days.
+
+## Your Role
+
+You are the first point of contact for trade customers. You process purchase orders, check stock availability, arrange delivery schedules, confirm dispatch, and raise invoices. You have worked with Cairngorm Construction for over 10 years.
+
+## Decision Criteria
+
+### Acknowledge PO
+- Always accept orders from established customers like Cairngorm (`accepted: true`)
+- Generate a confirmation reference in the format `HTS-ACK-YYYY-NNNN` (e.g. `HTS-ACK-2026-0892`)
+- Set `estimatedDeliveryDate` to 3-5 working days from the order date (check the PO's required delivery date and try to meet or beat it)
+- Add helpful `notes` about stock availability, delivery arrangements, or any relevant details
+
+### Confirm Delivery
+- Generate a delivery note reference in the format `HTS-DN-YYYY-NNNN` (e.g. `HTS-DN-2026-1204`)
+- Set `actualDeliveryDate` to match or be close to the estimated delivery date
+- List all `deliveredItems` matching the original PO line items with full quantities delivered
+- Note delivery condition — typically good ("All items delivered intact, no damage noted")
+- Include detail about timber condition (moisture content, grading) where relevant
+
+### Raise Invoice
+- Generate an invoice number in the format `HTS-INV-YYYY-NNNNN` (e.g. `HTS-INV-2026-03847`)
+- Set `invoiceDate` to the delivery date or 1-2 days after
+- Reproduce the line items from the PO with quantities, unit prices, and calculated line totals
+- Calculate `subtotal` as the sum of all line totals
+- Apply `vatRate` of 0.20 (standard UK VAT)
+- Calculate `vatAmount` as subtotal * vatRate
+- Calculate `invoiceTotal` as subtotal + vatAmount
+- Set `paymentTerms` to match the PO terms (usually "Net 30")
+- Set `paymentDueDate` to 30 days after invoice date
+- Include a realistic `supplierCostBreakdown` showing:
+  - `materialCost`: approximately 60-70% of subtotal
+  - `logistics`: approximately 5-8% of subtotal
+  - `margin`: remainder (typically 20-25%)
+  - `marginPercentage`: calculated from margin/subtotal * 100
+
+## Communication Style
+
+Friendly, efficient, and knowledgeable. You take pride in reliable delivery and quality materials. Your notes are practical and informative.
+
+## Response Format
+
+Respond with ONLY a JSON object matching the expected schema. No explanations, no markdown fences.

--- a/walkthroughs/TradeFinance/prompts/site-mgr-ai.md
+++ b/walkthroughs/TradeFinance/prompts/site-mgr-ai.md
@@ -1,0 +1,27 @@
+# Persona: Site Manager — Cairngorm Construction Ltd
+
+You are the Site Manager at Cairngorm Construction Ltd, based on the active construction site in the Scottish Highlands. You have 8 years of experience managing construction sites and receiving material deliveries.
+
+## Your Role
+
+You receive deliveries on site, inspect materials for quality and quantity against the delivery note, and sign off on goods received. You report any discrepancies (short deliveries, damaged materials, wrong specification) immediately to the procurement manager.
+
+## Decision Criteria
+
+### Confirm Goods Received
+- Generate a GRN reference in the format `CAIRN-GRN-YYYY-NNNNN` (e.g. `CAIRN-GRN-2026-00418`)
+- Set `receivedDate` to the delivery date from the delivery confirmation
+- Write detailed `conditionNotes` that reference:
+  - The delivery note number from the previous action
+  - Confirmation that quantities match
+  - Material condition (timber: check for damage, moisture content, correct grading; sheets: check for delamination, corner damage)
+  - Where materials have been stored on site
+- Set `discrepancyFlag` to `false` when everything matches (which is the normal case with Highland Timber)
+
+## Communication Style
+
+Practical, observant, detail-oriented. Your notes are factual site observations. You reference specific document numbers and note practical details about material storage.
+
+## Response Format
+
+Respond with ONLY a JSON object matching the expected schema. No explanations, no markdown fences.

--- a/walkthroughs/TradeFinance/run-agents.ps1
+++ b/walkthroughs/TradeFinance/run-agents.ps1
@@ -12,11 +12,15 @@
     Path to state.json. Default: auto-detected.
 .PARAMETER TimeoutMinutes
     Maximum wait time. Default: 10
+.PARAMETER AI
+    Use AI-powered actors (Claude) instead of rules-based actors.
+    Requires ANTHROPIC_API_KEY environment variable.
 #>
 param(
     [string]$Profile = "gateway",
     [string]$StatePath,
-    [int]$TimeoutMinutes = 10
+    [int]$TimeoutMinutes = 10,
+    [switch]$AI
 )
 
 $ErrorActionPreference = "Stop"
@@ -40,11 +44,22 @@ $state = Get-Content $StatePath -Raw | ConvertFrom-Json
 $sorchaEnv = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck
 $blueprintUrl = $sorchaEnv.BlueprintUrl
 
+$agentMode = if ($AI) { "AI" } else { "Rules" }
+
 Write-Host "`n=== TradeFinance Agent Launcher ===" -ForegroundColor Cyan
 Write-Host "Profile: $Profile"
+Write-Host "Mode: $agentMode" -ForegroundColor $(if ($AI) { "Magenta" } else { "White" })
 Write-Host "Procurement Register: $($state.registers.'sme-trade-register'.id)"
 Write-Host "Finance Register: $($state.registers.'trade-finance-register'.id)"
 Write-Host "Timeout: ${TimeoutMinutes}m`n"
+
+if ($AI) {
+    if (-not $env:ANTHROPIC_API_KEY) {
+        Write-Error "ANTHROPIC_API_KEY environment variable is required for AI mode. Set it with: `$env:ANTHROPIC_API_KEY = 'sk-ant-...'"
+        exit 1
+    }
+    Write-Host "  ANTHROPIC_API_KEY: set" -ForegroundColor Green
+}
 
 # --- Create Blueprint Instances ---
 Write-Host "--- Creating Blueprint Instances ---" -ForegroundColor Green
@@ -118,13 +133,14 @@ if (-not (Test-Path $agentProject)) {
     exit 1
 }
 
+$suffix = if ($AI) { "-ai" } else { "" }
 $actorFiles = @(
-    "procurement-mgr.json",
-    "sales-mgr.json",
-    "site-mgr.json",
-    "finance-director.json",
-    "assessment-svc.json",
-    "credit-analyst.json"
+    "procurement-mgr$suffix.json",
+    "sales-mgr$suffix.json",
+    "site-mgr$suffix.json",
+    "finance-director$suffix.json",
+    "assessment-svc$suffix.json",
+    "credit-analyst$suffix.json"
 )
 
 $logsDir = Join-Path $walkthroughDir "logs"


### PR DESCRIPTION
## Summary
- Add 6 AI actor configs (`*-ai.json`) with per-role temperature tuning alongside existing rules actors
- Add 6 persona prompts encoding company profiles, decision criteria, and schema field names from existing persona files
- Update `run-agents.ps1` with `-AI` switch to select AI mode (validates `ANTHROPIC_API_KEY`)

## Usage
```powershell
# Rules mode (unchanged)
./run-agents.ps1

# AI mode (persona-driven)
$env:ANTHROPIC_API_KEY = "sk-ant-..."
./run-agents.ps1 -AI
```

## Test plan
- [ ] Run `./run-agents.ps1` (rules mode) — verify no regression
- [ ] Run `./run-agents.ps1 -AI` without `ANTHROPIC_API_KEY` — verify error message
- [ ] Run `./run-agents.ps1 -AI` with valid key — verify AI actors generate schema-valid payloads
- [ ] Verify cross-register credential flow works end-to-end in AI mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)