### PR TITLE
fix(106): wire RecipientsWallets end-to-end + bloom hooks + gRPC port-split

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,11 @@ services:
       ServiceAuth__Scopes: "registers:write registers:read"
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__RegisterService__Address: http://register-service:8080
+      # Explicit gRPC address for IRegisterAddressClient (Feature 106 bloom hook fan-out).
+      # Port 5001 is the dedicated HTTP/2 gRPC endpoint; port 8080 is HTTP/1.1 REST only.
+      # h2c cleartext can't multiplex with HTTP/1.1 on a single Kestrel port because it
+      # requires ALPN which requires TLS.
+      ServiceClients__RegisterService__GrpcAddress: http://register-service:5001
       ServiceClients__BlueprintService__Address: http://blueprint-service:8080
       OrgKeyProtection__EncryptionKey: "dGhpcy1pcy1hLTMyLWJ5dGUtdGVzdC1rZXkh"
       # Encryption Provider Configuration
@@ -241,10 +246,17 @@ services:
       RegisterStorage__MongoDB__CreateIndexesOnStartup: "true"
       ServiceClients__WalletService__Address: http://sorcha-wallet-service:8080
       ServiceClients__WalletService__UseGrpc: "false"
+      # Explicit gRPC addresses (Feature 106). Port 5001 is HTTP/2-only for gRPC;
+      # port 8080 is HTTP/1.1 REST only. h2c cleartext can't share a Kestrel port
+      # with HTTP/1.1 without TLS/ALPN, so services bind two ports. The "https+http://"
+      # default from service-discovery isn't registered in this topology and would
+      # throw "No address resolver configured for the scheme 'https+http'" anyway.
+      ServiceClients__WalletService__GrpcAddress: http://sorcha-wallet-service:5001
       ServiceClients__ValidatorService__Address: http://sorcha-validator-service:8080
       ServiceClients__ValidatorService__UseGrpc: "false"
       ServiceClients__PeerService__Address: http://sorcha-peer-service:5000
       ServiceClients__PeerService__HttpAddress: http://sorcha-peer-service:8080
+      ServiceClients__PeerService__GrpcAddress: http://sorcha-peer-service:5000
       # System wallet signing (for blueprint publish, governance Control TXs)
       SystemWalletSigning__ValidatorId: docker-register-1
       # Service-to-service auth for Wallet Service calls

--- a/src/Common/Sorcha.ServiceClients/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Common/Sorcha.ServiceClients/Extensions/ServiceCollectionExtensions.cs
@@ -80,7 +80,7 @@ public static class ServiceCollectionExtensions
             o.Address = new Uri(
                 configuration["ServiceClients:RegisterService:GrpcAddress"]
                 ?? "https+http://register-service");
-        });
+        }).AddServiceDiscovery();
         services.AddSingleton<IRegisterAddressClient, RegisterAddressClient>();
 
         services.AddGrpcClient<WalletNotificationService.WalletNotificationServiceClient>(
@@ -89,7 +89,7 @@ public static class ServiceCollectionExtensions
             o.Address = new Uri(
                 configuration["ServiceClients:WalletService:GrpcAddress"]
                 ?? "https+http://wallet-service");
-        });
+        }).AddServiceDiscovery();
         services.AddSingleton<IWalletNotificationClient, WalletNotificationClient>();
 
         services.AddGrpcClient<DocketSyncService.DocketSyncServiceClient>(
@@ -98,7 +98,7 @@ public static class ServiceCollectionExtensions
             o.Address = new Uri(
                 configuration["ServiceClients:PeerService:GrpcAddress"]
                 ?? "https+http://peer-service");
-        });
+        }).AddServiceDiscovery();
         services.AddSingleton<IDocketSyncClient, DocketSyncClient>();
 
         return services;

--- a/src/Common/Sorcha.ServiceClients/Sorcha.ServiceClients.csproj
+++ b/src/Common/Sorcha.ServiceClients/Sorcha.ServiceClients.csproj
@@ -11,6 +11,10 @@
     <!-- gRPC dependencies (HTTP packages come transitively from ServiceClients.Http) -->
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.ClientFactory" />
+    <!-- Service discovery resolver for https+http:// URIs used by Aspire.
+         Without this, gRPC clients throw
+         "No address resolver configured for the scheme 'https+http'" at call time. -->
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
     <PackageReference Include="Grpc.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -26,8 +26,23 @@ using Sorcha.ServiceClients.Peer;
 using Sorcha.ServiceClients.Register;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.Validator.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Kestrel on plaintext HTTP can't multiplex HTTP/1.1 + HTTP/2 on one port
+// (h2c needs ALPN, which needs TLS). Bind REST on 8080 and gRPC on a
+// dedicated HTTP/2-only port for RegisterAddressGrpcService.
+{
+    var httpPort = int.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_HTTP_PORTS"), out var envHttpPort) ? envHttpPort : 8080;
+    var grpcPort = builder.Configuration.GetValue<int>("Kestrel:GrpcPort", 5001);
+    builder.WebHost.ConfigureKestrel(opts =>
+    {
+        opts.ListenAnyIP(httpPort, lo => lo.Protocols = HttpProtocols.Http1);
+        opts.ListenAnyIP(grpcPort, lo => lo.Protocols = HttpProtocols.Http2);
+    });
+    builder.WebHost.UseUrls();
+}
 
 // Add service defaults (OpenTelemetry, health checks, service discovery)
 builder.AddServiceDefaults();
@@ -187,6 +202,11 @@ builder.Services.AddSingleton<Sorcha.Register.Service.Services.Interfaces.ILocal
     Sorcha.Register.Service.Services.Implementation.RedisBloomFilterAddressIndex>();
 builder.Services.AddSingleton<Sorcha.Register.Service.Services.Interfaces.IInboundTransactionRouter,
     Sorcha.Register.Service.Services.Implementation.InboundTransactionRouter>();
+
+// Feature 106 startup-rebuild: reconcile bloom filters on boot in case Redis was wiped
+// or hooks failed during normal wallet creation. Non-blocking — runs as a hosted service
+// on a startup delay and never blocks ASP.NET startup.
+builder.Services.AddHostedService<Sorcha.Register.Service.Services.Implementation.BloomFilterStartupRebuildService>();
 
 // Feature 047: Inbound routing metrics (T047 — observability)
 builder.Services.AddSingleton<Sorcha.Register.Service.Services.Implementation.InboundRoutingMetrics>();

--- a/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterStartupRebuildService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterStartupRebuildService.cs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Sorcha.Register.Core.Managers;
+using Sorcha.Register.Service.Services.Interfaces;
+using Sorcha.ServiceClients.Grpc;
+using Sorcha.Wallet.Service.Grpc;
+
+namespace Sorcha.Register.Service.Services.Implementation;
+
+/// <summary>
+/// Background service that runs once on startup to ensure each register's bloom
+/// filter has at least one address indexed. If the params hash for a register is
+/// missing or has <c>address_count == 0</c>, the service rebuilds it from the
+/// peer Wallet Service via the existing <c>GetAllLocalAddresses</c> gRPC stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why this exists: bloom registration during normal wallet creation is fire-and-forget
+/// and can fail (peer down, transient network) without failing the wallet create.
+/// Redis volume wipes also lose bloom state. Without a startup reconciliation, a
+/// freshly booted Register Service would silently drop every inbound credential
+/// notification because <c>InboundTransactionRouter.MayContainAsync</c> returns
+/// false for everyone.
+/// </para>
+/// <para>
+/// Behaviour:
+/// <list type="bullet">
+///   <item>Runs once at startup, after a short delay so dependent services finish
+///         coming up (Redis, Wallet Service gRPC).</item>
+///   <item>Iterates every register known to <see cref="RegisterManager"/>.</item>
+///   <item>Skips registers whose bloom already reports a non-zero
+///         <c>address_count</c> in <see cref="ILocalAddressIndex.GetStatsAsync"/>.</item>
+///   <item>For empty/missing blooms, calls
+///         <see cref="ILocalAddressIndex.RebuildAsync"/> with the address stream
+///         from the Wallet Service.</item>
+///   <item>Failures are logged and skipped — the service does not throw on
+///         individual register failures and never blocks ASP.NET startup.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class BloomFilterStartupRebuildService : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<BloomFilterStartupRebuildService> _logger;
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="BloomFilterStartupRebuildService"/>.
+    /// </summary>
+    public BloomFilterStartupRebuildService(
+        IServiceProvider services,
+        ILogger<BloomFilterStartupRebuildService> logger)
+    {
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(StartupDelay, stoppingToken);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        if (stoppingToken.IsCancellationRequested) return;
+
+        await using var scope = _services.CreateAsyncScope();
+        var registerManager = scope.ServiceProvider.GetRequiredService<RegisterManager>();
+        var addressIndex = scope.ServiceProvider.GetRequiredService<ILocalAddressIndex>();
+        var walletClient = scope.ServiceProvider.GetRequiredService<IWalletNotificationClient>();
+
+        IReadOnlyList<Sorcha.Register.Models.Register> registers;
+        try
+        {
+            registers = (await registerManager.GetAllRegistersAsync(stoppingToken)).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Bloom startup-rebuild: failed to enumerate registers; skipping.");
+            return;
+        }
+
+        if (registers.Count == 0)
+        {
+            _logger.LogInformation("Bloom startup-rebuild: no registers found, nothing to reconcile.");
+            return;
+        }
+
+        var rebuilt = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        foreach (var register in registers)
+        {
+            if (stoppingToken.IsCancellationRequested) break;
+
+            var registerId = register.Id;
+            if (string.IsNullOrEmpty(registerId))
+            {
+                continue;
+            }
+
+            try
+            {
+                var stats = await addressIndex.GetStatsAsync(registerId, stoppingToken);
+                if (stats is { AddressCount: > 0 })
+                {
+                    skipped++;
+                    _logger.LogDebug(
+                        "Bloom startup-rebuild: register {RegisterId} already has {Count} addresses; skipping.",
+                        registerId, stats.AddressCount);
+                    continue;
+                }
+
+                _logger.LogInformation(
+                    "Bloom startup-rebuild: rebuilding register {RegisterId} (current={Count})",
+                    registerId, stats?.AddressCount ?? 0);
+
+                var addresses = walletClient.GetAllLocalAddressesAsync(
+                    registerId, activeOnly: true, stoppingToken);
+
+                var newStats = await addressIndex.RebuildAsync(
+                    registerId, ExtractAddresses(addresses), stoppingToken);
+
+                rebuilt++;
+                _logger.LogInformation(
+                    "Bloom startup-rebuild: register {RegisterId} rebuilt with {Count} addresses.",
+                    registerId, newStats.AddressCount);
+            }
+            catch (Exception ex)
+            {
+                failed++;
+                _logger.LogWarning(ex,
+                    "Bloom startup-rebuild: failed for register {RegisterId}; subsequent transactions on this register may miss inbound routing until next admin rebuild.",
+                    registerId);
+            }
+        }
+
+        _logger.LogInformation(
+            "Bloom startup-rebuild complete: {Rebuilt} rebuilt, {Skipped} already populated, {Failed} failed (of {Total}).",
+            rebuilt, skipped, failed, registers.Count);
+    }
+
+    private static async IAsyncEnumerable<string> ExtractAddresses(
+        IAsyncEnumerable<LocalAddressEntry> entries)
+    {
+        await foreach (var entry in entries)
+        {
+            if (!string.IsNullOrEmpty(entry.Address))
+            {
+                yield return entry.Address;
+            }
+        }
+    }
+}

--- a/src/Services/Sorcha.Validator.Service/Program.cs
+++ b/src/Services/Sorcha.Validator.Service/Program.cs
@@ -13,8 +13,23 @@ using Sorcha.Cryptography.Utilities;
 using Sorcha.ServiceClients.Extensions;
 using Sorcha.Register.Storage.MongoDB;
 using Sorcha.Register.Storage.Redis;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Kestrel on plaintext HTTP can't multiplex HTTP/1.1 + HTTP/2 on one port
+// (h2c needs ALPN, which needs TLS). Bind REST on 8080 and gRPC on a
+// dedicated HTTP/2-only port for ValidatorGrpcService.
+{
+    var httpPort = int.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_HTTP_PORTS"), out var envHttpPort) ? envHttpPort : 8080;
+    var grpcPort = builder.Configuration.GetValue<int>("Kestrel:GrpcPort", 5001);
+    builder.WebHost.ConfigureKestrel(opts =>
+    {
+        opts.ListenAnyIP(httpPort, lo => lo.Protocols = HttpProtocols.Http1);
+        opts.ListenAnyIP(grpcPort, lo => lo.Protocols = HttpProtocols.Http2);
+    });
+    builder.WebHost.UseUrls();
+}
 
 // Add service defaults (OpenTelemetry, health checks, service discovery)
 builder.AddServiceDefaults();

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -583,6 +583,7 @@ public class DocketBuildTriggerService : BackgroundService
                                 ContentEncoding = "base64url"
                             }
                         },
+                        RecipientsWallets = t.RecipientsWallets ?? new List<string>(),
                         MetaData = new Sorcha.Register.Models.TransactionMetaData
                         {
                             RegisterId = t.RegisterId,

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -18,6 +18,7 @@ using Sorcha.Wallet.Core.Domain.Entities;
 using Sorcha.Wallet.Core.Domain.Enums;
 using Sorcha.Wallet.Core.Domain.ValueObjects;
 using Sorcha.Wallet.Core.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
 using Sorcha.ServiceClients.Participant;
 using Sorcha.ServiceClients.Wallet.Models;
 using Sorcha.Wallet.Service.Mappers;
@@ -441,6 +442,23 @@ public static class WalletEndpoints
                 {
                     // Can't use scoped logger here if scope creation itself failed
                     Console.Error.WriteLine($"Auto-link failed for wallet {walletAddress}: {autoLinkEx.Message}");
+                }
+            });
+
+            // Feature 106 hook A: announce primary wallet address to all register bloom filters.
+            // Fire-and-forget via a fresh scope — bloom is a cache and its update must never
+            // fail the wallet create. Startup-rebuild on the Register Service reconciles gaps.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var scope = serviceScopeFactory.CreateAsyncScope();
+                    var svc = scope.ServiceProvider.GetRequiredService<IAddressRegistrationService>();
+                    await svc.NotifyLocalAddressCreatedAsync(walletAddress, CancellationToken.None);
+                }
+                catch (Exception bloomEx)
+                {
+                    Console.Error.WriteLine($"Bloom fan-out failed for wallet {walletAddress}: {bloomEx.Message}");
                 }
             });
 
@@ -1002,6 +1020,7 @@ public static class WalletEndpoints
         string address,
         [FromBody] RegisterDerivedAddressRequest request,
         WalletManager walletManager,
+        IServiceScopeFactory serviceScopeFactory,
         ILogger<Program> logger,
         CancellationToken cancellationToken = default)
     {
@@ -1027,6 +1046,23 @@ public static class WalletEndpoints
             logger.LogInformation(
                 "Successfully registered address {DerivedAddress} at path {Path}",
                 request.DerivedAddress, request.DerivationPath);
+
+            // Feature 106 hook B: announce BIP44-derived child address to all register bloom filters.
+            // Fire-and-forget via a fresh scope; startup-rebuild reconciles failures.
+            var derivedAddr = walletAddress.Address;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var scope = serviceScopeFactory.CreateAsyncScope();
+                    var svc = scope.ServiceProvider.GetRequiredService<IAddressRegistrationService>();
+                    await svc.NotifyLocalAddressCreatedAsync(derivedAddr, CancellationToken.None);
+                }
+                catch (Exception bloomEx)
+                {
+                    Console.Error.WriteLine($"Bloom fan-out failed for derived address {derivedAddr}: {bloomEx.Message}");
+                }
+            });
 
             return Results.Created($"/api/v1/wallets/{address}/addresses/{walletAddress.Id}", dto);
         }

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Sorcha.Wallet.Service.Extensions;
 using Sorcha.Wallet.Service.Endpoints;
 using Sorcha.Wallet.Service.GrpcServices;
@@ -8,6 +9,20 @@ using Sorcha.Wallet.Service.Services;
 using Sorcha.ServiceClients.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Kestrel on plaintext HTTP can't multiplex HTTP/1.1 + HTTP/2 on one port
+// because h2c needs ALPN which needs TLS. Bind REST on the main HTTP port and
+// gRPC on a dedicated HTTP/2-only port. Same pattern as Peer.Service.
+var httpPort = int.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_HTTP_PORTS"), out var envHttpPort) ? envHttpPort : 8080;
+var grpcPort = builder.Configuration.GetValue<int>("Kestrel:GrpcPort", 5001);
+builder.WebHost.ConfigureKestrel(opts =>
+{
+    opts.ListenAnyIP(httpPort, lo => lo.Protocols = HttpProtocols.Http1);
+    opts.ListenAnyIP(grpcPort, lo => lo.Protocols = HttpProtocols.Http2);
+});
+// Clear ASPNETCORE_URLS so our explicit Listen bindings aren't appended to
+// default HTTP/1.1 endpoints that would miss HTTP/2 entirely.
+builder.WebHost.UseUrls();
 
 // Add Aspire service defaults (health checks, OpenTelemetry, service discovery)
 builder.AddServiceDefaults();

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/AddressRegistrationService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/AddressRegistrationService.cs
@@ -4,6 +4,7 @@
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Sorcha.ServiceClients.Grpc;
+using Sorcha.ServiceClients.Register;
 using Sorcha.Wallet.Service.Services.Interfaces;
 
 namespace Sorcha.Wallet.Service.Services.Implementation;
@@ -15,18 +16,22 @@ namespace Sorcha.Wallet.Service.Services.Implementation;
 public class AddressRegistrationService : IAddressRegistrationService
 {
     private readonly IRegisterAddressClient _registerAddressClient;
+    private readonly IRegisterServiceClient _registerServiceClient;
     private readonly ILogger<AddressRegistrationService> _logger;
 
     /// <summary>
     /// Initializes a new instance of <see cref="AddressRegistrationService"/>.
     /// </summary>
     /// <param name="registerAddressClient">gRPC client for Register Service address operations.</param>
+    /// <param name="registerServiceClient">HTTP client used to enumerate registers for Option B fan-out.</param>
     /// <param name="logger">Logger instance.</param>
     public AddressRegistrationService(
         IRegisterAddressClient registerAddressClient,
+        IRegisterServiceClient registerServiceClient,
         ILogger<AddressRegistrationService> logger)
     {
         _registerAddressClient = registerAddressClient ?? throw new ArgumentNullException(nameof(registerAddressClient));
+        _registerServiceClient = registerServiceClient ?? throw new ArgumentNullException(nameof(registerServiceClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -92,5 +97,63 @@ public class AddressRegistrationService : IAddressRegistrationService
 
             return false;
         }
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyLocalAddressCreatedAsync(string address, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(address))
+        {
+            return;
+        }
+
+        List<InternalRegisterInfo> registers;
+        try
+        {
+            registers = await _registerServiceClient.GetInternalRegistersAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Bloom fan-out skipped for {Address}: failed to enumerate registers. Startup rebuild will reconcile.",
+                address);
+            return;
+        }
+
+        if (registers.Count == 0)
+        {
+            _logger.LogDebug(
+                "Bloom fan-out for {Address}: no registers known yet. Startup rebuild will reconcile once registers exist.",
+                address);
+            return;
+        }
+
+        var added = 0;
+        foreach (var register in registers)
+        {
+            if (string.IsNullOrEmpty(register.Id))
+            {
+                continue;
+            }
+
+            try
+            {
+                var ok = await RegisterAddressAsync(address, register.Id, cancellationToken);
+                if (ok)
+                {
+                    added++;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Bloom registration failed for address {Address} on register {RegisterId}; startup rebuild will reconcile.",
+                    address, register.Id);
+            }
+        }
+
+        _logger.LogInformation(
+            "Bloom fan-out complete for {Address}: added to {Added}/{Total} registers.",
+            address, added, registers.Count);
     }
 }

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/OrgKeyDerivationService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/OrgKeyDerivationService.cs
@@ -12,6 +12,7 @@ using Sorcha.Wallet.Core.Domain.Entities;
 using Sorcha.Wallet.Core.Domain.Enums;
 using Sorcha.Wallet.Core.Services.Interfaces;
 using Sorcha.Wallet.Portable;
+using Sorcha.Wallet.Service.Services.Interfaces;
 
 namespace Sorcha.Wallet.Service.Services.Implementation;
 
@@ -25,6 +26,7 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
     private readonly IOrgKeyProtectionProvider _protectionProvider;
     private readonly ICryptoModule _cryptoModule;
     private readonly IWalletUtilities _walletUtilities;
+    private readonly IAddressRegistrationService _addressRegistration;
     private readonly ILogger<OrgKeyDerivationService> _logger;
 
     /// <summary>
@@ -34,18 +36,21 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
     /// <param name="protectionProvider">Key protection provider for seed encryption.</param>
     /// <param name="cryptoModule">Cryptographic module for key generation.</param>
     /// <param name="walletUtilities">Wallet address utilities.</param>
+    /// <param name="addressRegistration">Bloom filter fan-out for newly created local addresses (Feature 106 hook C).</param>
     /// <param name="logger">Logger instance.</param>
     public OrgKeyDerivationService(
         WalletDbContext db,
         IOrgKeyProtectionProvider protectionProvider,
         ICryptoModule cryptoModule,
         IWalletUtilities walletUtilities,
+        IAddressRegistrationService addressRegistration,
         ILogger<OrgKeyDerivationService> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _protectionProvider = protectionProvider ?? throw new ArgumentNullException(nameof(protectionProvider));
         _cryptoModule = cryptoModule ?? throw new ArgumentNullException(nameof(cryptoModule));
         _walletUtilities = walletUtilities ?? throw new ArgumentNullException(nameof(walletUtilities));
+        _addressRegistration = addressRegistration ?? throw new ArgumentNullException(nameof(addressRegistration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -222,6 +227,24 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
                 "Derived {Usage} key for user {UserId} in organisation {OrganizationId} at path {Path}",
                 usage, userId, organizationId, path);
 
+            // Feature 106 hook C: announce the org-derived wallet address to all register bloom
+            // filters. Fire-and-forget — bloom is a cache and its update must never fail the key
+            // derivation transaction. Startup-rebuild reconciles any missed registrations.
+            var derivedWalletAddress = walletAddress;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await _addressRegistration.NotifyLocalAddressCreatedAsync(derivedWalletAddress, CancellationToken.None);
+                }
+                catch (Exception bloomEx)
+                {
+                    _logger.LogWarning(bloomEx,
+                        "Bloom fan-out failed for org-derived address {Address}; startup rebuild will reconcile.",
+                        derivedWalletAddress);
+                }
+            });
+
             return new DerivedKeyResult(
                 derivedKeyRecord.Id,
                 walletAddress,
@@ -373,6 +396,22 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
             _logger.LogInformation(
                 "Rotated {Usage} key for user {UserId} in organisation {OrganizationId} from index {OldIndex} to {NewIndex}",
                 oldRecord.KeyUsage, oldRecord.UserId, oldRecord.OrganizationId, oldRecord.KeyIndex, newKeyIndex);
+
+            // Feature 106 hook C: announce the new rotated address to all register bloom filters.
+            var rotatedWalletAddress = walletAddress;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await _addressRegistration.NotifyLocalAddressCreatedAsync(rotatedWalletAddress, CancellationToken.None);
+                }
+                catch (Exception bloomEx)
+                {
+                    _logger.LogWarning(bloomEx,
+                        "Bloom fan-out failed for rotated org-derived address {Address}; startup rebuild will reconcile.",
+                        rotatedWalletAddress);
+                }
+            });
 
             return new DerivedKeyResult(
                 newRecord.Id,

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IAddressRegistrationService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IAddressRegistrationService.cs
@@ -29,4 +29,22 @@ public interface IAddressRegistrationService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if removal/rebuild was triggered.</returns>
     Task<bool> RemoveAddressAsync(string address, string registerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Announces a newly created local wallet address to every register's bloom filter.
+    /// Called from wallet-create / address-derive / org-key-derive paths so the
+    /// Register Service's InboundTransactionRouter can match local recipients on
+    /// docket-sealed transactions.
+    /// </summary>
+    /// <remarks>
+    /// This method swallows all failures and logs them as warnings; bloom registration
+    /// is a best-effort cache update and must not fail the caller's wallet-create
+    /// operation. The Register Service's startup-rebuild hosted service reconciles
+    /// any addresses missed here by iterating <c>IWalletRepository.GetAllPagedAsync</c>.
+    /// Policy is <b>Option B</b>: the address is added to every register discovered
+    /// via <see cref="Sorcha.ServiceClients.Register.IRegisterServiceClient.GetInternalRegistersAsync"/>.
+    /// </remarks>
+    /// <param name="address">The newly created wallet address.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task NotifyLocalAddressCreatedAsync(string address, CancellationToken cancellationToken = default);
 }

--- a/tests/Sorcha.Wallet.Service.Tests/Services/AddressRegistrationServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/AddressRegistrationServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using ServiceClients::Sorcha.Register.Service.Grpc;
 using ServiceClients::Sorcha.ServiceClients.Grpc;
+using Sorcha.ServiceClients.Register;
 using Sorcha.Wallet.Service.Services.Implementation;
 using Xunit;
 using FluentAssertions;
@@ -17,6 +18,7 @@ namespace Sorcha.Wallet.Service.Tests.Services;
 public class AddressRegistrationServiceTests
 {
     private readonly Mock<IRegisterAddressClient> _mockClient;
+    private readonly Mock<IRegisterServiceClient> _mockRegisterServiceClient;
     private readonly Mock<ILogger<AddressRegistrationService>> _mockLogger;
     private readonly AddressRegistrationService _service;
 
@@ -26,10 +28,12 @@ public class AddressRegistrationServiceTests
     public AddressRegistrationServiceTests()
     {
         _mockClient = new Mock<IRegisterAddressClient>();
+        _mockRegisterServiceClient = new Mock<IRegisterServiceClient>();
         _mockLogger = new Mock<ILogger<AddressRegistrationService>>();
 
         _service = new AddressRegistrationService(
             _mockClient.Object,
+            _mockRegisterServiceClient.Object,
             _mockLogger.Object);
     }
 
@@ -40,14 +44,21 @@ public class AddressRegistrationServiceTests
     [Fact]
     public void Constructor_NullClient_ThrowsArgumentNullException()
     {
-        var act = () => new AddressRegistrationService(null!, _mockLogger.Object);
+        var act = () => new AddressRegistrationService(null!, _mockRegisterServiceClient.Object, _mockLogger.Object);
         act.Should().Throw<ArgumentNullException>().WithParameterName("registerAddressClient");
+    }
+
+    [Fact]
+    public void Constructor_NullRegisterServiceClient_ThrowsArgumentNullException()
+    {
+        var act = () => new AddressRegistrationService(_mockClient.Object, null!, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("registerServiceClient");
     }
 
     [Fact]
     public void Constructor_NullLogger_ThrowsArgumentNullException()
     {
-        var act = () => new AddressRegistrationService(_mockClient.Object, null!);
+        var act = () => new AddressRegistrationService(_mockClient.Object, _mockRegisterServiceClient.Object, null!);
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 

--- a/tests/Sorcha.Wallet.Service.Tests/Services/OrgKeyDerivationServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/OrgKeyDerivationServiceTests.cs
@@ -15,6 +15,7 @@ using Sorcha.Wallet.Core.Domain.Enums;
 using Sorcha.Wallet.Core.Services.Interfaces;
 using Sorcha.Wallet.Portable;
 using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
 using Xunit;
 using WalletEntity = Sorcha.Wallet.Core.Domain.Entities.Wallet;
 
@@ -26,6 +27,7 @@ public class OrgKeyDerivationServiceTests : IDisposable
     private readonly Mock<IOrgKeyProtectionProvider> _protectionProviderMock;
     private readonly Mock<ICryptoModule> _cryptoModuleMock;
     private readonly Mock<IWalletUtilities> _walletUtilitiesMock;
+    private readonly Mock<IAddressRegistrationService> _addressRegistrationMock;
     private readonly Mock<ILogger<OrgKeyDerivationService>> _loggerMock;
     private readonly OrgKeyDerivationService _sut;
 
@@ -42,6 +44,7 @@ public class OrgKeyDerivationServiceTests : IDisposable
         _protectionProviderMock = new Mock<IOrgKeyProtectionProvider>();
         _cryptoModuleMock = new Mock<ICryptoModule>();
         _walletUtilitiesMock = new Mock<IWalletUtilities>();
+        _addressRegistrationMock = new Mock<IAddressRegistrationService>();
         _loggerMock = new Mock<ILogger<OrgKeyDerivationService>>();
 
         // Setup default mocks
@@ -82,6 +85,7 @@ public class OrgKeyDerivationServiceTests : IDisposable
             _protectionProviderMock.Object,
             _cryptoModuleMock.Object,
             _walletUtilitiesMock.Object,
+            _addressRegistrationMock.Object,
             _loggerMock.Object);
     }
 

--- a/walkthroughs/HaipVerifiedCitizen/blueprints/assured-person.json
+++ b/walkthroughs/HaipVerifiedCitizen/blueprints/assured-person.json
@@ -1,0 +1,221 @@
+{
+  "id": "assured-person-v1",
+  "title": "Assured Person",
+  "description": "A citizen submits an identity application using core primitives (PersonName, DateOfBirth, EmailAddress, PostalAddress). A government assessor reviews and issues an AssuredPersonCredential delivered directly to the citizen's Sorcha wallet via register-native delivery (SorchaLocalWallet). The credential appears in the citizen's My Credentials PENDING tab — no QR code, no external wallet, no OpenID4VCI round-trip. Feature 106 register-native credential delivery.",
+  "version": 1,
+  "category": "identity",
+  "tags": ["identity", "assured-person", "sorcha-local-wallet", "register-native", "verifiable-credential", "citizen-application", "core-primitives", "feature-106"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "id": "assured-person",
+    "title": "Assured Person",
+    "description": "Citizen submits identity details, government assessor reviews and issues an AssuredPersonCredential delivered directly to the citizen's Sorcha wallet via the register. The citizen accepts or declines from their My Credentials page.",
+    "version": 1,
+    "metadata": {
+      "category": "Identity & Credentials",
+      "complexity": "Simple",
+      "actions": "3",
+      "features": "SorchaLocalWallet, Register-Native Delivery, Verifiable Credential, Core Primitives",
+      "sector": "Government"
+    },
+    "participants": [
+      {
+        "id": "citizen",
+        "name": "Citizen",
+        "organisation": "Public",
+        "description": "Submits an identity application. The issued credential is delivered directly to their Sorcha wallet — no external wallet or QR code needed."
+      },
+      {
+        "id": "government-assessor",
+        "name": "Government Assessor",
+        "organisation": "Government Identity Authority",
+        "description": "Reviews citizen identity applications and issues AssuredPersonCredential on approval"
+      }
+    ],
+    "actions": [
+      {
+        "id": 1,
+        "title": "Submit Identity Application",
+        "description": "Submit your personal details for verification. After review, the Assured Person credential will be delivered directly to your Sorcha wallet.",
+        "sender": "citizen",
+        "isStartingAction": true,
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Submit your personal details so a government assessor can verify your identity. After approval, the credential will appear in your My Credentials page for you to accept.",
+            "x-pages": [
+              {
+                "title": "Your Name",
+                "description": "Your full legal name as it appears on official documents.",
+                "x-sections": [
+                  { "fields": ["name"] }
+                ]
+              },
+              {
+                "title": "Date of Birth",
+                "description": "Your date of birth.",
+                "x-sections": [
+                  { "fields": ["dob"] }
+                ]
+              },
+              {
+                "title": "Contact",
+                "description": "We'll only use your email for correspondence about this application.",
+                "x-sections": [
+                  { "fields": ["email"] }
+                ]
+              },
+              {
+                "title": "Address",
+                "description": "Your current registered address.",
+                "x-sections": [
+                  { "fields": ["address"] }
+                ]
+              },
+              {
+                "title": "Check Your Answers",
+                "description": "Review the details before submitting. The government assessor will see exactly what you submit here."
+              }
+            ],
+            "properties": {
+              "name":    { "$ref": "https://schemas.sorcha.dev/core/PersonName/v1" },
+              "dob":     { "$ref": "https://schemas.sorcha.dev/core/DateOfBirth/v1" },
+              "email":   { "$ref": "https://schemas.sorcha.dev/core/EmailAddress/v1" },
+              "address": { "$ref": "https://schemas.sorcha.dev/core/PostalAddress/v1" }
+            },
+            "required": ["name", "dob", "email", "address"]
+          }
+        ],
+        "disclosures": [
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/*"]
+          },
+          {
+            "participantAddress": "government-assessor",
+            "dataPointers": ["/*"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "to-review",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Application submitted — pending assessor review"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Review & Issue Assured Person Credential",
+        "description": "Government assessor reviews the citizen's application. On approval, an AssuredPersonCredential is minted and sealed directly into the citizen's register-addressed disclosure group. The credential arrives in the citizen's wallet automatically via the InboundCredentialDetector — no OpenID4VCI, no QR code.",
+        "sender": "government-assessor",
+        "requiredPriorActions": [1],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Review the citizen's submitted personal details against your records and approve or reject the application. On approval the Assured Person credential is delivered directly to the citizen's Sorcha wallet.",
+            "x-sections": [
+              {
+                "title": "Decision",
+                "description": "Approval state and supporting notes for the audit trail.",
+                "layout": "vertical",
+                "fields": ["verificationDecision", "reviewerNotes"]
+              }
+            ],
+            "properties": {
+              "verificationDecision": {
+                "type": "string",
+                "title": "Decision",
+                "enum": ["approved", "rejected"]
+              },
+              "reviewerNotes": {
+                "type": "string",
+                "title": "Reviewer Notes",
+                "maxLength": 500
+              }
+            },
+            "required": ["verificationDecision"]
+          }
+        ],
+        "credentialIssuanceConfig": {
+          "credentialType": "AssuredPersonCredential",
+          "targetAudience": "SorchaLocalWallet",
+          "recipientParticipantId": "citizen",
+          "claimMappings": [
+            { "claimName": "givenName",   "sourceField": "/name/givenName" },
+            { "claimName": "middleName",  "sourceField": "/name/middleName" },
+            { "claimName": "familyName",  "sourceField": "/name/familyName" },
+            { "claimName": "fullName",    "sourceField": "/name/fullName" },
+            { "claimName": "dateOfBirth", "sourceField": "/dob/dateOfBirth" },
+            { "claimName": "email",       "sourceField": "/email/email" },
+            { "claimName": "address",     "sourceField": "/address" }
+          ],
+          "disclosable": [
+            "givenName", "middleName", "familyName", "fullName", "dateOfBirth", "email",
+            "/address/line1", "/address/line2", "/address/town", "/address/region",
+            "/address/postcode", "/address/country"
+          ]
+        },
+        "disclosures": [
+          {
+            "participantAddress": "government-assessor",
+            "dataPointers": ["/*"]
+          },
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/verificationDecision", "/reviewerNotes"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "approved-to-accept",
+            "nextActionIds": [3],
+            "condition": { "==": [{ "var": "verificationDecision" }, "approved"] },
+            "description": "Approved — credential sealed into register disclosure for citizen's wallet"
+          },
+          {
+            "id": "rejected-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Rejected — workflow ends with no credential issued"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Accept Assured Person Credential",
+        "description": "Your Assured Person credential has been delivered to your wallet. Accept to activate it, or decline to reject it. This action is executed automatically when you click Accept or Decline in your My Credentials page.",
+        "sender": "citizen",
+        "requiredPriorActions": [2],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          }
+        ],
+        "rejectionConfig": {
+          "targetActionId": 0,
+          "isTerminal": true,
+          "requireReason": false
+        },
+        "disclosures": [
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/*"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "accepted-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Credential accepted — workflow complete"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Feature 106 register-native credential delivery was silently broken in three stacked ways — this PR closes all three so a credential sealed into a docket actually reaches the holder's Wallet Service on n1.

- **Pipeline gap**: `DocketBuildTriggerService.WriteDocketAndTransactionsAsync` built `TransactionModel` inline and dropped `RecipientsWallets`. PR #306 only fixed the sibling `DocketSerializer.ToRegisterModel` path, which isn't the active runtime path. One-line fix restores the field end-to-end.
- **Bloom filter empty**: `IAddressRegistrationService` was in DI but had zero callers, so Redis `register:bloom:*` stayed empty and `InboundTransactionRouter.MayContainAsync` returned false for every address. Added three hook emission sites (primary wallet create, BIP44 derive, org-derived wallet create/rotate) that fan out to every known register, plus a startup-rebuild hosted service as safety net.
- **gRPC broken on plaintext**: `AddGrpcClient` defaults used Aspire `https+http://` URIs with no resolver registered, and Kestrel won't multiplex HTTP/1.1 + HTTP/2 on one plaintext port (h2c needs ALPN → needs TLS). Added `.AddServiceDiscovery()` to gRPC clients, switched config to plain `http://`, and split Kestrel to REST on 8080 / gRPC on 5001 across wallet, register, validator. Same pattern Peer.Service already uses.

## Verified on n1

- `Bloom startup-rebuild complete: 2 rebuilt, 0 already populated, 0 failed` — registers seeded with 9 addresses each on Register Service boot.
- `Bloom filter match for address ws11qqdg... routing notification` — `InboundTransactionRouter` correctly identifies Alice's wallet.
- `HTTP POST /sorcha.wallet.WalletNotificationService/NotifyInboundTransaction responded 200` — gRPC round-trip works on port 5001.

## Known follow-up (not in scope here)

`InboundCredentialDetector` short-circuits when `contentEncoding != "encrypted"`, and the test register is currently producing plaintext because `ResolveRecipientKeysAsync` returns zero recipients — Feature 083 participant-key publishing into the test register is the gap. Tracked separately.

## Test plan

- [x] Build & tests green locally (`dotnet build Sorcha.sln -c Release`)
- [x] Deployed to n1: bloom filter populates (9 addresses per register)
- [x] E2E: `Bloom filter match` + `NotifyInboundTransaction 200` on both gov and citizen wallets
- [ ] CI build & unit tests pass (watch `Docker Publish` + test workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)