### PR TITLE
fix(106): detect plaintext /credential on DevMode registers

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
@@ -129,55 +129,33 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
                 return null;
             }
 
-            // 3. Only encrypted transactions carry recipient-addressed disclosure groups.
-            //    Dev-mode/plaintext transactions never seal Feature 106 credentials.
+            // 3. Fork on payload shape:
+            //    - `contentEncoding == "encrypted"`: walk encryptedPayloads → decrypt our group → find /credential
+            //    - otherwise: only parse when the register is DevMode=true, then walk
+            //      payloads[walletAddress] → find /credential. Plaintext on a non-DevMode
+            //      register is a security signal (encryption skipped because recipient keys
+            //      couldn't be resolved) and we must NOT parse such transactions.
             var contentEncoding = txJson.TryGetProperty("contentEncoding", out var ceEl)
                 ? ceEl.GetString()
                 : null;
-            if (!string.Equals(contentEncoding, "encrypted", StringComparison.OrdinalIgnoreCase))
+            var isEncrypted = string.Equals(contentEncoding, "encrypted", StringComparison.OrdinalIgnoreCase);
+
+            JsonElement? credentialField;
+            if (isEncrypted)
             {
-                _metrics.RecordSkippedNoRecipientDisclosure();
-                return null;
+                credentialField = await TryFindEncryptedCredentialAsync(
+                    walletAddress, txJson, transactionId, cancellationToken);
+            }
+            else
+            {
+                credentialField = await TryFindDevModePlaintextCredentialAsync(
+                    walletAddress, registerId, txJson, transactionId, cancellationToken);
             }
 
-            // 4. Walk the encrypted payload groups looking for one whose wrappedKeys contains
-            //    our wallet address. This matches the FileReassemblyService pattern exactly.
-            if (!txJson.TryGetProperty("encryptedPayloads", out var groupsEl)
-                || groupsEl.ValueKind != JsonValueKind.Array)
-            {
-                _metrics.RecordSkippedNoRecipientDisclosure();
-                return null;
-            }
-
-            JsonElement? decryptedPayload = null;
-            foreach (var group in groupsEl.EnumerateArray())
-            {
-                var decrypted = await TryDecryptGroupForWalletAsync(
-                    walletAddress, group, transactionId, cancellationToken);
-                if (decrypted is not null)
-                {
-                    decryptedPayload = decrypted;
-                    break;
-                }
-            }
-
-            if (decryptedPayload is null)
-            {
-                // Either none of the groups target us, OR every group we tried failed to decrypt.
-                // The distinction matters for metrics — TryDecryptGroupForWalletAsync counts
-                // decrypt failures internally; a bare null here means no group targeted us.
-                _metrics.RecordSkippedNoRecipientDisclosure();
-                return null;
-            }
-
-            // 5. Look for the Feature 106 `/credential` shape in the decrypted payload.
-            //    The writer at ActionExecutionService step 9b-bis puts the credential under
-            //    a literal "/credential" field. camelCase fallback isn't required because
-            //    the JSON is serialised with the literal pointer key.
-            var credentialField = FindCredentialField(decryptedPayload.Value);
             if (credentialField is null)
             {
-                _metrics.RecordSkippedNoRecipientDisclosure();
+                // All skip counters are recorded inside the Try* helpers; a null return here
+                // is already accounted for. Nothing more to do.
                 return null;
             }
 
@@ -252,6 +230,99 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
             sw.Stop();
             _metrics.RecordExtractionLatency(sw.Elapsed.TotalMilliseconds);
         }
+    }
+
+    /// <summary>
+    /// Encrypted path: walks the transaction's <c>encryptedPayloads</c> array, finds
+    /// the first group that targets <paramref name="walletAddress"/> (via
+    /// <see cref="TryDecryptGroupForWalletAsync"/>), and extracts the <c>/credential</c>
+    /// field from the decrypted payload. Records the appropriate skip counters on miss.
+    /// </summary>
+    private async Task<JsonElement?> TryFindEncryptedCredentialAsync(
+        string walletAddress,
+        JsonElement txJson,
+        string transactionId,
+        CancellationToken cancellationToken)
+    {
+        if (!txJson.TryGetProperty("encryptedPayloads", out var groupsEl)
+            || groupsEl.ValueKind != JsonValueKind.Array)
+        {
+            _metrics.RecordSkippedNoRecipientDisclosure();
+            return null;
+        }
+
+        foreach (var group in groupsEl.EnumerateArray())
+        {
+            var decrypted = await TryDecryptGroupForWalletAsync(
+                walletAddress, group, transactionId, cancellationToken);
+            if (decrypted is null)
+            {
+                continue;
+            }
+
+            var field = FindCredentialField(decrypted.Value);
+            if (field is not null)
+            {
+                return field;
+            }
+        }
+
+        // Either no group targeted us, every targeted group failed to decrypt (those
+        // increment SkippedDecryptFailed internally), or a group decrypted but carried
+        // no /credential shape. All three collapse to "no recipient disclosure" for us.
+        _metrics.RecordSkippedNoRecipientDisclosure();
+        return null;
+    }
+
+    /// <summary>
+    /// Plaintext path (Feature 106 DevMode): when the register is in DevMode the
+    /// writer emits payloads as a flat <c>{ "payloads": { walletAddress: { ... } } }</c>
+    /// dictionary — see the plaintext branch of
+    /// <c>ITransactionBuilderService.BuildActionTransactionAsync</c>. This helper looks
+    /// up our wallet's entry and extracts the <c>/credential</c> shape.
+    /// <para>
+    /// SECURITY: plaintext transactions on non-DevMode registers are dropped. Such
+    /// transactions only occur when the encryption pipeline could not resolve recipient
+    /// keys (Feature 083 publishing gap or similar) — treating them as credentials would
+    /// silently downgrade the DAD guarantee. Returning null on that path is intentional.
+    /// </para>
+    /// </summary>
+    private async Task<JsonElement?> TryFindDevModePlaintextCredentialAsync(
+        string walletAddress,
+        string registerId,
+        JsonElement txJson,
+        string transactionId,
+        CancellationToken cancellationToken)
+    {
+        bool registerDevMode;
+        try
+        {
+            var register = await _registerClient.GetRegisterAsync(registerId, cancellationToken);
+            registerDevMode = register?.DevMode ?? false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "InboundCredentialDetector: failed to resolve register {RegisterId} DevMode flag for plaintext tx {TxId} — skipping",
+                registerId, transactionId);
+            _metrics.RecordSkippedNoRecipientDisclosure();
+            return null;
+        }
+
+        if (!registerDevMode)
+        {
+            _metrics.RecordSkippedNoRecipientDisclosure();
+            return null;
+        }
+
+        var field = FindPlaintextCredentialForWallet(txJson, walletAddress);
+        if (field is null)
+        {
+            _metrics.RecordSkippedNoRecipientDisclosure();
+            return null;
+        }
+
+        return field;
     }
 
     /// <summary>
@@ -343,6 +414,39 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
                 _metrics.RecordSkippedDecryptFailed();
                 return null;
             }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// DevMode plaintext shape: the writer emits a top-level
+    /// <c>"payloads": { walletAddress: { "/credential": { ... } } }</c> dictionary
+    /// (see <c>ITransactionBuilderService.BuildActionTransactionAsync</c> non-encrypted
+    /// branch). Look up our wallet's entry, case-insensitively, and delegate to
+    /// <see cref="FindCredentialField"/> for the actual shape match.
+    /// </summary>
+    internal static JsonElement? FindPlaintextCredentialForWallet(JsonElement txJson, string walletAddress)
+    {
+        if (!txJson.TryGetProperty("payloads", out var payloadsEl)
+            || payloadsEl.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var prop in payloadsEl.EnumerateObject())
+        {
+            if (!string.Equals(prop.Name, walletAddress, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (prop.Value.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            return FindCredentialField(prop.Value);
         }
 
         return null;

--- a/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorDevModeTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorDevModeTests.cs
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Cryptography.Interfaces;
+using Sorcha.Register.Models;
+using Sorcha.ServiceClients.Register;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Encryption.Providers;
+using Sorcha.Wallet.Core.Events.Publishers;
+using Sorcha.Wallet.Core.Repositories.Implementation;
+using Sorcha.Wallet.Core.Services.Implementation;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Tests.Helpers;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Feature 106 Wave F follow-up — end-to-end <see cref="InboundCredentialDetector.TryExtractAsync"/>
+/// tests that exercise the DevMode plaintext path introduced for the HaipVerifiedCitizen
+/// walkthrough. The citizen applicant is anonymous/late-bound and cannot have their key
+/// published, so the encryption pipeline falls through to plaintext. The detector must
+/// parse that plaintext shape ONLY when the register is in DevMode — a production register
+/// emitting plaintext is a security signal (encryption expected but recipient keys missing)
+/// and we must never persist credentials off it.
+/// </summary>
+public class InboundCredentialDetectorDevModeTests
+{
+    private const string WalletAddress = "ws11qcitizen";
+    private const string RegisterId = "af7b1040-register-devmode";
+    private const string TransactionId = "tx-devmode-plaintext-1";
+
+    private const string PlaintextTxBody = /*lang=json,strict*/ """
+    {
+      "type": "action",
+      "blueprintId": "haip-verified-citizen-v2-1.0.0",
+      "actionId": "2",
+      "instanceId": "instance-devmode-round-trip",
+      "previousTxId": "prev-tx-id",
+      "timestamp": "2026-04-19T12:00:00+00:00",
+      "payloads": {
+        "ws11qcitizen": {
+          "/credential": {
+            "credentialId": "urn:uuid:feature-106-devmode-test-1",
+            "credentialType": "VerifiedCitizenCredential",
+            "issuerDid": "did:sorcha:org:ws11qgovernment",
+            "issuerOrgName": "Government Identity Authority",
+            "subjectDid": "did:sorcha:wallet:ws11qcitizen",
+            "issuedAt": "2026-04-15T10:30:00+00:00",
+            "expiresAt": "2027-04-15T10:30:00+00:00",
+            "rawToken": "eyJhbGciOiJFZERTQSJ9.devmode.token",
+            "issuanceBlueprintId": "haip-verified-citizen-v2-1.0.0",
+            "issuanceInstanceId": "instance-devmode-round-trip",
+            "issuanceActionId": "2",
+            "claimActionId": "3",
+            "registerId": "af7b1040-register-devmode"
+          }
+        }
+      }
+    }
+    """;
+
+    [Fact]
+    public async Task TryExtractAsync_DevMode_PlaintextPayload_PersistsPendingCredential()
+    {
+        var fixture = new Fixture();
+        fixture.ArrangePlaintextTransaction(PlaintextTxBody);
+        fixture.ArrangeRegisterDevMode(true);
+
+        var extract = await fixture.Sut.TryExtractAsync(
+            WalletAddress, TransactionId, RegisterId, CancellationToken.None);
+
+        extract.Should().NotBeNull("DevMode register + plaintext /credential payload → detector must extract");
+        extract!.CredentialId.Should().Be("urn:uuid:feature-106-devmode-test-1");
+        extract.RawToken.Should().Be("eyJhbGciOiJFZERTQSJ9.devmode.token");
+
+        fixture.CredentialStoreMock.Verify(
+            s => s.StoreAsync(It.Is<CredentialEntity>(e =>
+                e.Id == "urn:uuid:feature-106-devmode-test-1"
+                && e.Status == CredentialStatus.PendingAcceptance
+                && e.WalletAddress == WalletAddress),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryExtractAsync_NonDevMode_PlaintextPayload_Skips()
+    {
+        // Security posture: plaintext on a non-DevMode register only happens when the
+        // encryption pipeline couldn't resolve recipient keys (Feature 083 gap). Persisting
+        // such a credential would silently downgrade the DAD guarantee — must skip.
+        var fixture = new Fixture();
+        fixture.ArrangePlaintextTransaction(PlaintextTxBody);
+        fixture.ArrangeRegisterDevMode(false);
+
+        var extract = await fixture.Sut.TryExtractAsync(
+            WalletAddress, TransactionId, RegisterId, CancellationToken.None);
+
+        extract.Should().BeNull();
+        fixture.CredentialStoreMock.Verify(
+            s => s.StoreAsync(It.IsAny<CredentialEntity>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "non-DevMode plaintext must never persist a credential");
+    }
+
+    [Fact]
+    public async Task TryExtractAsync_RegisterLookupThrows_Skips()
+    {
+        // Transient Register Service failure while resolving DevMode flag → safer to
+        // skip than persist. The bloom-filter hit will eventually retry once the
+        // Register Service recovers.
+        var fixture = new Fixture();
+        fixture.ArrangePlaintextTransaction(PlaintextTxBody);
+        fixture.RegisterClientMock
+            .Setup(c => c.GetRegisterAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("register service transient fault"));
+
+        var extract = await fixture.Sut.TryExtractAsync(
+            WalletAddress, TransactionId, RegisterId, CancellationToken.None);
+
+        extract.Should().BeNull();
+        fixture.CredentialStoreMock.Verify(
+            s => s.StoreAsync(It.IsAny<CredentialEntity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryExtractAsync_DevMode_PlaintextForOtherWallet_Skips()
+    {
+        // The transaction targets ws11qcitizen but our detector is running for a
+        // different wallet — there should be no match and nothing persisted.
+        var fixture = new Fixture();
+        fixture.ArrangePlaintextTransaction(PlaintextTxBody);
+        fixture.ArrangeRegisterDevMode(true);
+
+        var extract = await fixture.Sut.TryExtractAsync(
+            "ws11qdifferent-wallet", TransactionId, RegisterId, CancellationToken.None);
+
+        extract.Should().BeNull();
+        fixture.CredentialStoreMock.Verify(
+            s => s.StoreAsync(It.IsAny<CredentialEntity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task TryExtractAsync_DevMode_Duplicate_Skips()
+    {
+        // Idempotency invariant INV-1: a credential id that already exists in the
+        // local store is a duplicate arrival; do not re-persist.
+        var fixture = new Fixture();
+        fixture.ArrangePlaintextTransaction(PlaintextTxBody);
+        fixture.ArrangeRegisterDevMode(true);
+        fixture.CredentialStoreMock
+            .Setup(s => s.GetByIdAsync("urn:uuid:feature-106-devmode-test-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CredentialEntity
+            {
+                Id = "urn:uuid:feature-106-devmode-test-1",
+                Type = "VerifiedCitizenCredential",
+                IssuerDid = "did:sorcha:org:ws11qgovernment",
+                SubjectDid = "did:sorcha:wallet:ws11qcitizen",
+                ClaimsJson = "{}",
+                RawToken = "eyJhbGciOiJFZERTQSJ9.devmode.token",
+                IssuedAt = DateTimeOffset.UtcNow,
+                Status = CredentialStatus.PendingAcceptance,
+                IssuanceTxId = TransactionId,
+                WalletAddress = WalletAddress,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+        var extract = await fixture.Sut.TryExtractAsync(
+            WalletAddress, TransactionId, RegisterId, CancellationToken.None);
+
+        extract.Should().BeNull();
+        fixture.CredentialStoreMock.Verify(
+            s => s.StoreAsync(It.IsAny<CredentialEntity>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // -----------------------------------------------------------------------
+    // Fixture: minimal detector wiring — only the Register Service client and
+    // credential store behaviours matter on the plaintext path; the WalletManager
+    // and ISymmetricCrypto are never invoked but are required by the constructor.
+    // -----------------------------------------------------------------------
+
+    private sealed class Fixture
+    {
+        public Mock<IRegisterServiceClient> RegisterClientMock { get; }
+        public Mock<ICredentialStore> CredentialStoreMock { get; }
+        public InboundCredentialDetector Sut { get; }
+
+        public Fixture()
+        {
+            RegisterClientMock = new Mock<IRegisterServiceClient>();
+            CredentialStoreMock = new Mock<ICredentialStore>();
+            var symmetricCryptoMock = new Mock<ISymmetricCrypto>();
+
+            // WalletManager is constructor-required but unreachable on the plaintext
+            // path — build a stub with in-memory repository + noop dependencies.
+            var walletRepository = new InMemoryWalletRepository();
+            var encryptionProvider = new LocalEncryptionProvider(NullLogger<LocalEncryptionProvider>.Instance);
+            var eventPublisher = new InMemoryEventPublisher(NullLogger<InMemoryEventPublisher>.Instance);
+            var keyManagement = new KeyManagementService(
+                encryptionProvider,
+                Mock.Of<ICryptoModule>(),
+                Mock.Of<IWalletUtilities>(),
+                NullLogger<KeyManagementService>.Instance);
+            var transactionService = new TransactionService(
+                Mock.Of<ICryptoModule>(),
+                Mock.Of<IHashProvider>(),
+                NullLogger<TransactionService>.Instance);
+            var delegationService = new DelegationService(
+                walletRepository,
+                NullLogger<DelegationService>.Instance);
+            var walletManager = new WalletManager(
+                keyManagement,
+                transactionService,
+                delegationService,
+                walletRepository,
+                eventPublisher,
+                NullLogger<WalletManager>.Instance,
+                Mock.Of<IRecoveryKeyService>());
+
+            var metrics = new InboundCredentialDetectorMetrics(new TestMeterFactory());
+
+            Sut = new InboundCredentialDetector(
+                RegisterClientMock.Object,
+                walletManager,
+                symmetricCryptoMock.Object,
+                CredentialStoreMock.Object,
+                metrics,
+                NullLogger<InboundCredentialDetector>.Instance);
+        }
+
+        public void ArrangePlaintextTransaction(string canonicalJson)
+        {
+            var data = Convert.ToBase64String(Encoding.UTF8.GetBytes(canonicalJson));
+            var tx = new TransactionModel
+            {
+                Id = TransactionId,
+                Payloads = [new PayloadModel { Data = data }],
+            };
+
+            RegisterClientMock
+                .Setup(c => c.GetTransactionAsync(RegisterId, TransactionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(tx);
+        }
+
+        public void ArrangeRegisterDevMode(bool devMode)
+        {
+            RegisterClientMock
+                .Setup(c => c.GetRegisterAsync(RegisterId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Sorcha.Register.Models.Register
+                {
+                    Id = RegisterId,
+                    Name = "HAIP Verified Citizen Register",
+                    DevMode = devMode,
+                });
+        }
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorShapeTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorShapeTests.cs
@@ -155,6 +155,123 @@ public class InboundCredentialDetectorShapeTests
         extract.Should().BeNull("missing credentialId, rawToken → parser returns null");
     }
 
+    /// <summary>
+    /// Exact JSON shape produced by the plaintext (DevMode) branch of
+    /// <c>ITransactionBuilderService.BuildActionTransactionAsync</c>: the writer emits
+    /// <c>{ "payloads": { walletAddress: { "/credential": { ... } } } }</c> with no
+    /// <c>contentEncoding</c> property. Wave F update: Feature 106 requires this shape
+    /// to be detectable on DevMode registers so anonymous/late-bound recipients
+    /// (e.g. HaipVerifiedCitizen) can still receive credentials.
+    /// </summary>
+    private const string DevModePlaintextTxJson = /*lang=json,strict*/ """
+    {
+      "type": "action",
+      "blueprintId": "haip-verified-citizen-v2-1.0.0",
+      "actionId": "2",
+      "instanceId": "instance-devmode-round-trip",
+      "previousTxId": "prev-tx-id",
+      "timestamp": "2026-04-19T12:00:00+00:00",
+      "payloads": {
+        "ws11qcitizen": {
+          "/credential": {
+            "credentialId": "urn:uuid:feature-106-devmode-test-1",
+            "credentialType": "VerifiedCitizenCredential",
+            "issuerDid": "did:sorcha:org:ws11qgovernment",
+            "issuerOrgName": "Government Identity Authority",
+            "subjectDid": "did:sorcha:wallet:ws11qcitizen",
+            "issuedAt": "2026-04-15T10:30:00+00:00",
+            "expiresAt": "2027-04-15T10:30:00+00:00",
+            "rawToken": "eyJhbGciOiJFZERTQSJ9.devmode.token",
+            "issuanceBlueprintId": "haip-verified-citizen-v2-1.0.0",
+            "issuanceInstanceId": "instance-devmode-round-trip",
+            "issuanceActionId": "2",
+            "claimActionId": "3",
+            "registerId": "af7b1040-register-devmode"
+          }
+        }
+      }
+    }
+    """;
+
+    [Fact]
+    public void PlaintextShape_FindsCredentialForMatchingWallet()
+    {
+        var doc = JsonSerializer.Deserialize<JsonElement>(DevModePlaintextTxJson);
+
+        var field = InboundCredentialDetector.FindPlaintextCredentialForWallet(doc, "ws11qcitizen");
+
+        field.Should().NotBeNull(
+            "DevMode plaintext writer produces payloads[walletAddress][/credential] — reader must find it");
+
+        var extract = InboundCredentialDetector.TryParseExtract(field!.Value, "tx-devmode");
+        extract.Should().NotBeNull();
+        extract!.CredentialId.Should().Be("urn:uuid:feature-106-devmode-test-1");
+        extract.RawToken.Should().Be("eyJhbGciOiJFZERTQSJ9.devmode.token");
+    }
+
+    [Fact]
+    public void PlaintextShape_IsCaseInsensitiveOnWalletAddress()
+    {
+        // Wallet addresses round-trip through HTTP and Redis where case preservation
+        // is not guaranteed. The encrypted path already compares case-insensitively
+        // (see TryDecryptGroupForWalletAsync); the plaintext path must match.
+        var doc = JsonSerializer.Deserialize<JsonElement>(DevModePlaintextTxJson);
+
+        var field = InboundCredentialDetector.FindPlaintextCredentialForWallet(doc, "WS11QCITIZEN");
+
+        field.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PlaintextShape_ReturnsNull_WhenWalletAddressNotInPayloads()
+    {
+        var doc = JsonSerializer.Deserialize<JsonElement>(DevModePlaintextTxJson);
+
+        var field = InboundCredentialDetector.FindPlaintextCredentialForWallet(doc, "ws11qsomeoneelse");
+
+        field.Should().BeNull("wallet address not among the recipient keys — nothing to extract");
+    }
+
+    [Fact]
+    public void PlaintextShape_ReturnsNull_WhenPayloadsPropertyAbsent()
+    {
+        // Encrypted transactions carry encryptedPayloads, not payloads — the plaintext
+        // helper must safely return null rather than misinterpret.
+        const string EncryptedShapeJson = /*lang=json,strict*/ """
+        {
+          "type": "action",
+          "contentEncoding": "encrypted",
+          "encryptedPayloads": []
+        }
+        """;
+
+        var doc = JsonSerializer.Deserialize<JsonElement>(EncryptedShapeJson);
+
+        var field = InboundCredentialDetector.FindPlaintextCredentialForWallet(doc, "ws11qcitizen");
+
+        field.Should().BeNull();
+    }
+
+    [Fact]
+    public void PlaintextShape_ReturnsNull_WhenRecipientEntryIsNotAnObject()
+    {
+        // Defensive — future writer drift that emits an array or scalar under the
+        // wallet key must not throw; the helper must return null.
+        const string MalformedJson = /*lang=json,strict*/ """
+        {
+          "payloads": {
+            "ws11qcitizen": []
+          }
+        }
+        """;
+
+        var doc = JsonSerializer.Deserialize<JsonElement>(MalformedJson);
+
+        var field = InboundCredentialDetector.FindPlaintextCredentialForWallet(doc, "ws11qcitizen");
+
+        field.Should().BeNull();
+    }
+
     [Fact]
     public void OptionalFields_Absent_StillParses()
     {

--- a/walkthroughs/HaipVerifiedCitizen/setup.ps1
+++ b/walkthroughs/HaipVerifiedCitizen/setup.ps1
@@ -214,6 +214,13 @@ try {
 # ============================================================================
 Write-WtStep "Step 7: Create Register"
 
+# DevMode: the citizen applicant is an open/late-bound participant and is
+# deliberately NOT published to the register (anonymous by design). That means
+# Action 2 has no resolvable recipient key for the citizen wallet, so the
+# encryption pipeline would drop to plaintext regardless. Making DevMode
+# explicit declares this intent to the runtime and to InboundCredentialDetector,
+# which only parses plaintext /credential shapes on DevMode registers as a
+# security posture (plaintext on a prod register is a signal to drop, not read).
 $register = New-SorchaRegister `
     -RegisterUrl $sorchaEnv.RegisterUrl `
     -WalletUrl $sorchaEnv.WalletUrl `
@@ -223,9 +230,29 @@ $register = New-SorchaRegister `
     -OwnerUserId $govSession.UserId `
     -OwnerWalletAddress $govWallet.Address `
     -Headers $govSession.Headers `
-    -TenantUrl $sorchaEnv.TenantUrl
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -DevMode
 
 Write-WtSuccess "Register: $($register.RegisterId)"
+
+# Publish the government assessor participant record to the register so its
+# public key is resolvable for any non-citizen encryption flows (Feature 083).
+# The citizen applicant is intentionally omitted — they remain anonymous and
+# are late-bound at Action 1 submission. Action 2's credential issuance to the
+# citizen rides the DevMode plaintext path.
+try {
+    $null = Publish-SorchaParticipant `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $govOrgId `
+        -RegisterId $register.RegisterId `
+        -ParticipantName "Government Assessor" `
+        -OrganizationName "Government Identity Authority" `
+        -WalletAddress $govWallet.Address `
+        -PublicKey $govWallet.PublicKey `
+        -Headers $govSession.Headers
+} catch {
+    Write-WtWarn "Government participant publish failed: $($_.Exception.Message)"
+}
 
 # Subscribe the public org so the citizen can see the register and submit
 # Action 1 from their own session. Owner subscription for the gov org is

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -998,6 +998,12 @@ function New-SorchaRegister {
         Authorization headers.
     .PARAMETER Metadata
         Optional metadata hashtable.
+    .PARAMETER DevMode
+        When set, creates the register with devMode=true so payloads are stored as
+        plaintext with disclosure filtering applied at read time. Use for flows
+        that have anonymous/late-bound recipients whose keys cannot be published
+        (e.g. the HaipVerifiedCitizen walkthrough). Dev mode is a one-way switch —
+        it can be disabled via the DisableDevMode endpoint but never re-enabled.
     .RETURNS
         Hashtable with RegisterId, GenesisTransactionId.
     #>
@@ -1016,7 +1022,8 @@ function New-SorchaRegister {
         # the Public Org is subscribed as "Public" immediately after finalize
         # so consumer-persona and public-discovery flows have access by default.
         [string]$TenantUrl,
-        [switch]$SkipPublicOrgSubscription
+        [switch]$SkipPublicOrgSubscription,
+        [switch]$DevMode
     )
 
     # Idempotency short-circuit: if the caller's current identity is already
@@ -1068,6 +1075,11 @@ function New-SorchaRegister {
             }
         )
         metadata = $defaultMeta
+    }
+
+    if ($DevMode) {
+        $initiateBody.devMode = $true
+        Write-WtInfo "  DevMode: enabled (payloads stored plaintext)"
     }
 
     $initiateResponse = Invoke-SorchaApi -Method POST `


### PR DESCRIPTION
## Summary

Closes the final Feature 106 blocker: on the HaipVerifiedCitizen walkthrough, the citizen applicant is an anonymous late-bound participant whose key is never published to the register. Action 2 therefore fell through to the plaintext path and `InboundCredentialDetector` silently bailed at `contentEncoding != "encrypted"`, leaving holders without their issued credentials.

## Changes

- **Walkthrough (`HaipVerifiedCitizen/setup.ps1`)** — creates the HAIP register with `DevMode=true` (explicit declaration of intent) and publishes the government assessor participant record. Citizen stays unpublished by design.
- **Module (`SorchaWalkthrough.psm1`)** — new `-DevMode` switch on `New-SorchaRegister` threads `devMode=true` into the initiate body.
- **Detector (`InboundCredentialDetector.cs`)** — refactored into `TryFindEncryptedCredentialAsync` and `TryFindDevModePlaintextCredentialAsync`. Encrypted path unchanged. Plaintext path fetches the register via `IRegisterServiceClient.GetRegisterAsync` and only extracts when `DevMode=true`. A non-DevMode register emitting plaintext is treated as a security signal (encryption expected but recipients unresolvable) and skipped — preserving the DAD guarantee.
- **Tests** — 10 new unit tests:
  - 5 parser-shape tests in `InboundCredentialDetectorShapeTests` for `FindPlaintextCredentialForWallet` (matching wallet, case-insensitive, missing wallet, absent `payloads`, non-object recipient entry).
  - 5 end-to-end `TryExtractAsync` tests in new `InboundCredentialDetectorDevModeTests` covering DevMode happy path, non-DevMode skip, register lookup failure, wrong-wallet skip, and duplicate-credential dedup.

## Security posture

Only DevMode registers can deliver plaintext credentials to holders. In production, a plaintext transaction on a non-DevMode register indicates the encryption pipeline could not resolve recipient keys — silently accepting such credentials would downgrade the disclosure guarantee. The detector treats that case as a drop, not a parse.

## Test plan

- [x] `dotnet build Sorcha.sln` clean (0 errors, 57 pre-existing warnings)
- [x] `dotnet test tests/Sorcha.Wallet.Service.Tests` — 617/617 pass (15 InboundCredentialDetector tests including the 10 new ones)
- [x] PowerShell module + setup script parse cleanly via `[ScriptBlock]::Create`
- [ ] Deploy to n1 and verify MyCredentials PENDING tab populates after running HaipVerifiedCitizen walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)