### PR TITLE
fix(094): reconstruct nested SD-JWT disclosures at correct tree depth

### DIFF
--- a/src/Common/Sorcha.Cryptography/SdJwt/NestedDisclosure.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/NestedDisclosure.cs
@@ -146,44 +146,285 @@ public static class NestedDisclosure
     }
 
     /// <summary>
-    /// Reconstructs disclosed claims from a mix of top-level and nested disclosures,
-    /// merging them into a unified claims dictionary.
+    /// Reconstructs the disclosed claims tree from an SD-JWT payload and the
+    /// raw disclosures carried in the presentation. Implements the verifier
+    /// algorithm from IETF SD-JWT §7.1:
+    /// <list type="number">
+    ///   <item>Hash each raw disclosure to build a digest → disclosed-value map.</item>
+    ///   <item>Walk the payload tree. At every object, replace each digest in the
+    ///   local <c>_sd</c> array with its matching object-field disclosure and merge
+    ///   at the SAME depth (so <c>/address/locality</c> lands inside <c>address</c>,
+    ///   not at the root).</item>
+    ///   <item>At every array, replace <c>{"...": digest}</c> placeholders with the
+    ///   matching array-element disclosure value. Placeholders with no matching
+    ///   disclosure are dropped (cryptographically hidden).</item>
+    ///   <item>Strip <c>_sd</c> and <c>_sd_alg</c> from the output. JWT-standard
+    ///   claims (<c>iss</c>, <c>sub</c>, <c>iat</c>, <c>exp</c>, <c>cnf</c>) are
+    ///   dropped — callers extract those from <c>basePayload</c> directly.</item>
+    /// </list>
     /// </summary>
-    /// <remarks>
-    /// WARNING: This method currently places nested disclosures at the top level
-    /// (e.g., "locality" instead of "address.locality"). It does not walk nested
-    /// _sd digests to inject values at the correct depth. This is a known gap
-    /// from PR #226 review item #2. The method is not called from any production
-    /// path — SdJwtService.VerifyTokenAsync uses its own disclosure parsing.
-    /// Fix required before nested selective disclosure is used end-to-end.
-    /// </remarks>
-    /// <param name="basePayload">The JWT payload (may contain nested _sd arrays).</param>
-    /// <param name="disclosures">Decoded disclosure arrays.</param>
-    /// <returns>Merged claims dictionary.</returns>
+    /// <param name="basePayload">The JWT payload (may contain nested <c>_sd</c> arrays).</param>
+    /// <param name="rawDisclosures">
+    /// Base64url-encoded disclosure strings exactly as they appear in the tilde-
+    /// separated presentation (no padding, no JWT signature suffix). Both the
+    /// 3-element object-field form <c>[salt, name, value]</c> and the 2-element
+    /// array-element form <c>[salt, value]</c> are supported. Malformed entries
+    /// are silently skipped; they cannot cause a throw.
+    /// </param>
+    /// <returns>
+    /// Merged claims dictionary at the correct tree depth. Objects become
+    /// <see cref="Dictionary{TKey, TValue}"/>, arrays become <see cref="List{T}"/>,
+    /// scalars are converted to their CLR equivalent.
+    /// </returns>
     public static Dictionary<string, object> Reconstruct(
         Dictionary<string, JsonElement> basePayload,
-        List<(string salt, string name, object value)> disclosures)
+        IEnumerable<string> rawDisclosures)
     {
-        var result = new Dictionary<string, object>();
-        var reservedClaims = new HashSet<string> { "iss", "sub", "iat", "exp", "_sd", "_sd_alg", "cnf" };
+        ArgumentNullException.ThrowIfNull(basePayload);
+        ArgumentNullException.ThrowIfNull(rawDisclosures);
 
-        // Add non-reserved, non-_sd claims from payload
-        foreach (var (key, value) in basePayload)
+        var digestMap = new Dictionary<string, DecodedDisclosure>(StringComparer.Ordinal);
+        foreach (var raw in rawDisclosures)
         {
-            if (reservedClaims.Contains(key))
+            if (string.IsNullOrWhiteSpace(raw))
                 continue;
-
-            result[key] = ConvertAndMergeDisclosures(value, disclosures);
+            if (!TryDecodeDisclosure(raw, out var decoded))
+                continue;
+            var digest = ComputeDigest(raw);
+            // Duplicate digests would indicate a malformed presentation; keep the first.
+            digestMap.TryAdd(digest, decoded);
         }
 
-        // Add top-level disclosures
-        foreach (var (_, name, value) in disclosures)
+        // JWT-standard claims belong to the envelope, not the application claims.
+        // Callers who need them read them directly off basePayload.
+        var envelopeClaims = new HashSet<string>(StringComparer.Ordinal)
         {
-            if (!result.ContainsKey(name))
-                result[name] = value;
+            "iss", "sub", "iat", "exp", "cnf", "_sd", "_sd_alg",
+        };
+
+        var result = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        // Walk application-level properties, recursing through the tree.
+        foreach (var (key, value) in basePayload)
+        {
+            if (envelopeClaims.Contains(key))
+                continue;
+
+            var processed = ProcessElement(value, digestMap);
+            if (processed is not null)
+                result[key] = processed;
+        }
+
+        // Resolve top-level _sd digests INTO the result (same depth = root).
+        if (basePayload.TryGetValue("_sd", out var topLevelSd)
+            && topLevelSd.ValueKind == JsonValueKind.Array)
+        {
+            ApplyObjectSdDigests(result, topLevelSd, digestMap);
         }
 
         return result;
+    }
+
+    // --- Reconstruct tree walk ---
+
+    /// <summary>
+    /// Recursively walks a single JSON element, resolving nested <c>_sd</c>
+    /// digests and array-element disclosure placeholders against
+    /// <paramref name="digestMap"/>. Returns the reconstructed subtree as a
+    /// CLR object (Dictionary / List / primitive).
+    /// </summary>
+    private static object? ProcessElement(
+        JsonElement element,
+        IReadOnlyDictionary<string, DecodedDisclosure> digestMap)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+            {
+                var dict = new Dictionary<string, object>(StringComparer.Ordinal);
+
+                // First pass: copy through all non-envelope properties.
+                foreach (var prop in element.EnumerateObject())
+                {
+                    if (prop.Name is "_sd" or "_sd_alg")
+                        continue;
+                    var child = ProcessElement(prop.Value, digestMap);
+                    if (child is not null)
+                        dict[prop.Name] = child;
+                }
+
+                // Second pass: resolve this object's _sd array AT this depth.
+                if (element.TryGetProperty("_sd", out var sdArray)
+                    && sdArray.ValueKind == JsonValueKind.Array)
+                {
+                    ApplyObjectSdDigests(dict, sdArray, digestMap);
+                }
+
+                return dict;
+            }
+
+            case JsonValueKind.Array:
+            {
+                var list = new List<object?>();
+                foreach (var item in element.EnumerateArray())
+                {
+                    // Array-element placeholder: { "...": "<digest>" }.
+                    // Per SD-JWT §5.2.4 the key is the literal three-dot string.
+                    if (TryReadArrayPlaceholder(item, out var placeholderDigest))
+                    {
+                        if (digestMap.TryGetValue(placeholderDigest, out var disclosed)
+                            && disclosed.Name is null)
+                        {
+                            // 2-element [salt, value] disclosure — inject the value at
+                            // this index, recursing so an object value with further
+                            // nested _sd also resolves.
+                            list.Add(ProcessDisclosedValue(disclosed.Value, digestMap));
+                        }
+                        // else: placeholder remains hidden — drop it from output.
+                        continue;
+                    }
+
+                    list.Add(ProcessElement(item, digestMap));
+                }
+                return list;
+            }
+
+            case JsonValueKind.String:
+                return element.GetString() ?? string.Empty;
+            case JsonValueKind.Number:
+                return element.TryGetInt64(out var l) ? l : element.GetDouble();
+            case JsonValueKind.True:
+                return true;
+            case JsonValueKind.False:
+                return false;
+            case JsonValueKind.Null:
+                return null;
+            default:
+                return element.GetRawText();
+        }
+    }
+
+    /// <summary>
+    /// Injects object-field disclosures whose digests appear in the supplied
+    /// <c>_sd</c> array into <paramref name="target"/> at this depth.
+    /// Two-element array disclosures are ignored here — they only make sense
+    /// inside arrays, not object <c>_sd</c> slots.
+    /// </summary>
+    private static void ApplyObjectSdDigests(
+        Dictionary<string, object> target,
+        JsonElement sdArray,
+        IReadOnlyDictionary<string, DecodedDisclosure> digestMap)
+    {
+        foreach (var digestEl in sdArray.EnumerateArray())
+        {
+            if (digestEl.ValueKind != JsonValueKind.String)
+                continue;
+            var digest = digestEl.GetString();
+            if (string.IsNullOrEmpty(digest))
+                continue;
+            if (!digestMap.TryGetValue(digest, out var disclosed))
+                continue;
+            if (disclosed.Name is null)
+                continue; // array-element disclosure in an object slot — malformed
+
+            var processed = ProcessDisclosedValue(disclosed.Value, digestMap);
+            if (processed is not null)
+                target[disclosed.Name] = processed;
+        }
+    }
+
+    /// <summary>
+    /// Recursively resolves any further <c>_sd</c> or array placeholders that
+    /// live inside the disclosed value itself. This covers the "entire address
+    /// is disclosable and contains its own nested _sd" shape where one
+    /// disclosure transitively unlocks more.
+    /// </summary>
+    private static object? ProcessDisclosedValue(
+        JsonElement? value,
+        IReadOnlyDictionary<string, DecodedDisclosure> digestMap)
+    {
+        if (value is null)
+            return null;
+        return ProcessElement(value.Value, digestMap);
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="element"/> is an SD-JWT array-element
+    /// placeholder object with exactly one property keyed <c>"..."</c> whose
+    /// value is a digest string.
+    /// </summary>
+    private static bool TryReadArrayPlaceholder(JsonElement element, out string digest)
+    {
+        digest = string.Empty;
+        if (element.ValueKind != JsonValueKind.Object)
+            return false;
+
+        string? found = null;
+        var propertyCount = 0;
+        foreach (var prop in element.EnumerateObject())
+        {
+            propertyCount++;
+            if (propertyCount > 1)
+                return false;
+            if (prop.Name != "...")
+                return false;
+            if (prop.Value.ValueKind != JsonValueKind.String)
+                return false;
+            found = prop.Value.GetString();
+        }
+
+        if (propertyCount == 1 && !string.IsNullOrEmpty(found))
+        {
+            digest = found;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Decoded disclosure shape. <see cref="Name"/> is null for the 2-element
+    /// array-element form; set for the 3-element object-field form.
+    /// </summary>
+    private sealed record DecodedDisclosure(string Salt, string? Name, JsonElement? Value);
+
+    /// <summary>
+    /// Decodes a base64url disclosure string into the (salt, name, value)
+    /// tuple. Returns false on any parse error — disclosures that fail to
+    /// decode are silently skipped, matching the spec's guidance that the
+    /// verifier must never throw on attacker-controlled input.
+    /// </summary>
+    private static bool TryDecodeDisclosure(string raw, out DecodedDisclosure decoded)
+    {
+        decoded = null!;
+        try
+        {
+            var bytes = Base64Url.DecodeFromChars(raw);
+            using var doc = JsonDocument.Parse(bytes);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return false;
+
+            var items = doc.RootElement;
+            var len = items.GetArrayLength();
+            if (len == 3)
+            {
+                var salt = items[0].GetString() ?? string.Empty;
+                var name = items[1].GetString();
+                decoded = new DecodedDisclosure(salt, name, items[2].Clone());
+                return true;
+            }
+            if (len == 2)
+            {
+                var salt = items[0].GetString() ?? string.Empty;
+                decoded = new DecodedDisclosure(salt, null, items[1].Clone());
+                return true;
+            }
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     // --- Private helpers ---
@@ -253,25 +494,6 @@ public static class NestedDisclosure
             JsonValueKind.Array => element.EnumerateArray().Select(ConvertJsonElementToObject).ToList(),
             _ => element.GetRawText()
         };
-    }
-
-    private static object ConvertAndMergeDisclosures(JsonElement value,
-        List<(string salt, string name, object value)> disclosures)
-    {
-        if (value.ValueKind == JsonValueKind.Object)
-        {
-            var dict = new Dictionary<string, object>();
-            foreach (var prop in value.EnumerateObject())
-            {
-                if (prop.Name == "_sd")
-                    continue; // Skip _sd arrays in nested objects — disclosures handle these
-
-                dict[prop.Name] = ConvertAndMergeDisclosures(prop.Value, disclosures);
-            }
-            return dict;
-        }
-
-        return ConvertJsonElementToObject(value);
     }
 
     private static string CreateDisclosure(string claimName, object claimValue)

--- a/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtNestedDisclosureTests.cs
+++ b/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtNestedDisclosureTests.cs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Buffers.Text;
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Sorcha.Cryptography.SdJwt;
@@ -159,6 +161,273 @@ public class SdJwtNestedDisclosureTests
         var fullResult = await _service.VerifyTokenAsync(token.RawToken, publicKey, "ES256");
         fullResult.IsValid.Should().BeTrue();
         fullResult.Claims.Should().ContainKey("name");
+    }
+
+    // -----------------------------------------------------------------------
+    // Reconstruct tests — verifier-side tree walk per SD-JWT §7.1.
+    // These tests lock in the fix for PR #226 review item #2: nested disclosures
+    // must land at the correct tree depth, not at the root.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Reconstruct_NestedObjectField_PlacesAtCorrectDepth()
+    {
+        // Build a payload where /address/locality is disclosable via a nested _sd
+        // array inside the address object. The expected result has address.locality
+        // INSIDE address — NOT a flat "locality" at the root.
+        var localityDisclosure = EncodeDisclosure("salt-locality", "locality", "Edinburgh");
+        var localityDigest = ComputeDigest(localityDisclosure);
+
+        var payloadJson = $$"""
+        {
+          "iss": "did:sorcha:org:gov",
+          "sub": "did:sorcha:w:alice",
+          "iat": 1700000000,
+          "address": {
+            "street": "123 Main St",
+            "country": "UK",
+            "_sd": ["{{localityDigest}}"]
+          },
+          "_sd_alg": "sha-256"
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var result = NestedDisclosure.Reconstruct(payload, [localityDisclosure]);
+
+        result.Should().ContainKey("address");
+        result.Should().NotContainKey("locality",
+            "the disclosed value MUST land inside its parent object, not at the root");
+
+        var address = result["address"].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        address["locality"].Should().Be("Edinburgh");
+        address["street"].Should().Be("123 Main St");
+        address["country"].Should().Be("UK");
+        address.Should().NotContainKey("_sd", "_sd slots must be stripped from the output");
+    }
+
+    [Fact]
+    public void Reconstruct_NestedDisclosureNotPresented_StaysHidden()
+    {
+        // Same payload, but the holder does NOT disclose locality. The verifier
+        // must not see any trace of the undisclosed field.
+        var localityDisclosure = EncodeDisclosure("salt-locality", "locality", "Edinburgh");
+        var localityDigest = ComputeDigest(localityDisclosure);
+
+        var payloadJson = $$"""
+        {
+          "address": {
+            "street": "123 Main St",
+            "_sd": ["{{localityDigest}}"]
+          },
+          "_sd_alg": "sha-256"
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var result = NestedDisclosure.Reconstruct(payload, []);
+
+        var address = result["address"].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        address.Should().NotContainKey("locality");
+        address["street"].Should().Be("123 Main St");
+    }
+
+    [Fact]
+    public void Reconstruct_MixedTopLevelAndNested_BothResolveCorrectly()
+    {
+        // Top-level "name" disclosure + nested /address/locality disclosure in one
+        // presentation. Both must land at their correct depth.
+        var nameDisclosure = EncodeDisclosure("salt-name", "name", "Alice");
+        var nameDigest = ComputeDigest(nameDisclosure);
+        var localityDisclosure = EncodeDisclosure("salt-locality", "locality", "Edinburgh");
+        var localityDigest = ComputeDigest(localityDisclosure);
+
+        var payloadJson = $$"""
+        {
+          "_sd": ["{{nameDigest}}"],
+          "address": {
+            "country": "UK",
+            "_sd": ["{{localityDigest}}"]
+          }
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var result = NestedDisclosure.Reconstruct(payload, [nameDisclosure, localityDisclosure]);
+
+        result["name"].Should().Be("Alice");
+        var address = result["address"].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        address["locality"].Should().Be("Edinburgh");
+        address["country"].Should().Be("UK");
+    }
+
+    [Fact]
+    public void Reconstruct_ArrayElementDisclosure_RestoresAtIndex()
+    {
+        // /qualifications/1 disclosable — only element at index 1 is revealed.
+        // Element 0 is plaintext (non-disclosable), elements 2 is a placeholder
+        // whose disclosure is absent from the presentation → must stay hidden.
+        var qualOne = EncodeArrayDisclosure("salt-q1", new { type = "Engineering" });
+        var qualOneDigest = ComputeDigest(qualOne);
+        var qualTwo = EncodeArrayDisclosure("salt-q2", new { type = "Medicine" });
+        var qualTwoDigest = ComputeDigest(qualTwo);
+
+        var payloadJson = $$"""
+        {
+          "qualifications": [
+            { "type": "Plumbing" },
+            { "...": "{{qualOneDigest}}" },
+            { "...": "{{qualTwoDigest}}" }
+          ]
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        // Only disclose element 1.
+        var result = NestedDisclosure.Reconstruct(payload, [qualOne]);
+
+        var quals = result["qualifications"].Should().BeAssignableTo<List<object?>>().Subject;
+        quals.Should().HaveCount(2, "plumbing stays (plaintext), q1 is disclosed, q2 is hidden and dropped");
+
+        // Plumbing still at index 0.
+        var q0 = quals[0].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        q0["type"].Should().Be("Plumbing");
+
+        // Engineering was at placeholder index 1 → now at index 1 in output.
+        var q1 = quals[1].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        q1["type"].Should().Be("Engineering");
+    }
+
+    [Fact]
+    public void Reconstruct_EnvelopeClaims_AreStripped()
+    {
+        // iss/sub/iat/exp/cnf belong to the JWT envelope, not the application
+        // claims surface. Callers pull those off basePayload directly.
+        var payloadJson = """
+        {
+          "iss": "did:sorcha:org:gov",
+          "sub": "did:sorcha:w:alice",
+          "iat": 1700000000,
+          "exp": 1800000000,
+          "cnf": { "jwk": { "kty": "EC" } },
+          "publicField": "visible"
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var result = NestedDisclosure.Reconstruct(payload, []);
+
+        result.Should().ContainKey("publicField");
+        result.Keys.Should().NotContain(["iss", "sub", "iat", "exp", "cnf", "_sd", "_sd_alg"]);
+    }
+
+    [Fact]
+    public void Reconstruct_MalformedDisclosure_SilentlySkipped()
+    {
+        // Verifier MUST NOT throw on attacker-controlled disclosure strings.
+        // Malformed entries are simply ignored (their digests won't match anything).
+        var validDisclosure = EncodeDisclosure("salt-name", "name", "Alice");
+        var validDigest = ComputeDigest(validDisclosure);
+
+        var payloadJson = $$"""
+        {
+          "_sd": ["{{validDigest}}"]
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var act = () => NestedDisclosure.Reconstruct(payload, [
+            validDisclosure,
+            "!!not-base64!!",
+            "",
+            "   ",
+            Base64Url.EncodeToString(Encoding.UTF8.GetBytes("not-an-array")),
+        ]);
+
+        var result = act.Should().NotThrow().Which;
+        result["name"].Should().Be("Alice");
+    }
+
+    [Fact]
+    public void Reconstruct_DisclosedValueWithNestedSd_ResolvesTransitively()
+    {
+        // An entire "address" object is disclosable, and the disclosed value
+        // itself contains a further _sd with "locality" hidden inside. When both
+        // disclosures are presented, the verifier must recurse into the disclosed
+        // value and resolve the inner _sd digest too.
+        var localityDisclosure = EncodeDisclosure("salt-locality", "locality", "Edinburgh");
+        var localityDigest = ComputeDigest(localityDisclosure);
+
+        // The address value carries its own _sd array.
+        var addressValueJson = $$"""
+        {
+          "country": "UK",
+          "_sd": ["{{localityDigest}}"]
+        }
+        """;
+        var addressValue = JsonSerializer.Deserialize<JsonElement>(addressValueJson);
+
+        // Build the address disclosure with that nested structure as the value.
+        var addressDisclosureRaw = $"[\"salt-addr\",\"address\",{addressValue.GetRawText()}]";
+        var addressDisclosure = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(addressDisclosureRaw));
+        var addressDigest = ComputeDigest(addressDisclosure);
+
+        var payloadJson = $$"""
+        {
+          "_sd": ["{{addressDigest}}"]
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var result = NestedDisclosure.Reconstruct(payload, [addressDisclosure, localityDisclosure]);
+
+        var address = result["address"].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        address["country"].Should().Be("UK");
+        address["locality"].Should().Be("Edinburgh",
+            "a disclosed value carrying its own _sd must recurse and resolve inner digests");
+        address.Should().NotContainKey("_sd");
+    }
+
+    [Fact]
+    public void Reconstruct_DigestPresentNoMatchingDisclosure_IsDropped()
+    {
+        // The _sd array references a digest we don't have the disclosure for
+        // (holder didn't present it). The digest must NOT appear in the output.
+        var payloadJson = """
+        {
+          "address": {
+            "street": "123 Main St",
+            "_sd": ["ZF53bOHwmAdEWLmBh4QItUv6tQZKRw6iYxdqjOErXt8"]
+          }
+        }
+        """;
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(payloadJson)!;
+
+        var result = NestedDisclosure.Reconstruct(payload, []);
+
+        var address = result["address"].Should().BeAssignableTo<Dictionary<string, object>>().Subject;
+        address.Keys.Should().OnlyContain(k => k == "street");
+    }
+
+    // --- Test helpers (mirror the encoding used by Translate / the SD-JWT spec) ---
+
+    private static string EncodeDisclosure(string salt, string name, object value)
+    {
+        var json = JsonSerializer.Serialize(new object[] { salt, name, value });
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(json));
+    }
+
+    private static string EncodeArrayDisclosure(string salt, object value)
+    {
+        var json = JsonSerializer.Serialize(new object[] { salt, value });
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(json));
+    }
+
+    private static string ComputeDigest(string disclosure)
+    {
+        var bytes = Encoding.ASCII.GetBytes(disclosure);
+        var hash = SHA256.HashData(bytes);
+        return Base64Url.EncodeToString(hash);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes Category 1a from the completion plan. `NestedDisclosure.Reconstruct` previously placed every disclosed field at the top level — disclosing `/address/locality` surfaced as `locality: \"Edinburgh\"` at the root instead of `address: { locality: \"Edinburgh\" }`. Array-element disclosures had the same problem: revealed elements never made it back into their parent array at the correct index.

Rewritten to the canonical IETF SD-JWT §7.1 verifier algorithm.

## Algorithm

1. Hash each raw disclosure string to build a `digest → disclosed-value` map.
2. Walk the payload tree:
   - **Objects**: resolve the local `_sd` array into disclosed fields merged at THAT depth.
   - **Arrays**: replace `{\"...\": digest}` placeholders with matching array-element disclosures; drop unmatched placeholders (hidden).
3. Recurse into disclosed values so further nested `_sd` within a disclosure resolves transitively.
4. Strip `_sd` / `_sd_alg` from output; JWT envelope claims (`iss`/`sub`/`iat`/`exp`/`cnf`) are left for the caller.

## API change

`Reconstruct` now takes raw base64url-encoded disclosure strings (symmetric with `Translate`'s output) instead of pre-decoded tuples. Both 2-element (array-element) and 3-element (object-field) disclosure forms are handled internally. **No production callers** — safe to change shape. `SdJwtService.VerifyTokenAsync` currently uses its own inline parsing (same bug); wiring `Reconstruct` into the verifier is spec 094 task T022 and left for a follow-up PR.

## Tests

8 new unit tests:

| Test | Lock |
|------|------|
| `Reconstruct_NestedObjectField_PlacesAtCorrectDepth` | `/address/locality` lands inside `address`, not at the root |
| `Reconstruct_NestedDisclosureNotPresented_StaysHidden` | Undisclosed fields leave no trace |
| `Reconstruct_MixedTopLevelAndNested_BothResolveCorrectly` | `_sd` at root + nested `_sd` both resolved in one pass |
| `Reconstruct_ArrayElementDisclosure_RestoresAtIndex` | Array `{\"...\": digest}` → value; non-disclosed placeholders dropped |
| `Reconstruct_EnvelopeClaims_AreStripped` | `iss`/`sub`/`iat`/`exp`/`cnf` filtered |
| `Reconstruct_MalformedDisclosure_SilentlySkipped` | Verifier never throws on attacker input |
| `Reconstruct_DisclosedValueWithNestedSd_ResolvesTransitively` | Disclosure value carrying further `_sd` recurses |
| `Reconstruct_DigestPresentNoMatchingDisclosure_IsDropped` | `_sd` entry without a disclosure leaves no artefact |

## Test plan

- [x] `dotnet build Sorcha.Cryptography` clean (0 warnings, 0 errors)
- [x] 367/367 `Sorcha.Cryptography.Tests` pass (up from 359 — 8 new)
- [x] Spec reference: `specs/094-sdjwt-haip-hardening/spec.md` FR-015 through FR-021

🤖 Generated with [Claude Code](https://claude.com/claude-code)