### PR TITLE
fix(094,097,098): SD-JWT array disclosure + HAIP endpoint hardening

### DIFF
--- a/src/Common/Sorcha.Cryptography/SdJwt/NestedDisclosure.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/NestedDisclosure.cs
@@ -94,50 +94,55 @@ public static class NestedDisclosure
             }
         }
 
-        // Process each parent object, inserting _sd arrays at the correct depth
+        // Process each parent container. The container may be an object (nested
+        // field disclosure → _sd array) or an array (element disclosure → each
+        // requested index is replaced with a {"...": digest} placeholder).
         foreach (var (parentPath, leafEntries) in pathsByParent)
         {
             var parentSegments = ParsePointer(parentPath);
-            // Navigate INTO the parent object (all segments, not to the parent-of-parent)
-            var parentObj = NavigateInto(processedClaims, parentSegments);
-            if (parentObj == null)
+            var parentContainer = NavigateIntoContainer(processedClaims, parentSegments);
+            if (parentContainer is null)
                 continue;
 
-            var nestedSdDigests = new List<string>();
-
-            foreach (var (leafSegment, fullPath) in leafEntries)
+            if (parentContainer is Dictionary<string, object> parentDict)
             {
-                // Check if this is an array index
-                if (int.TryParse(leafSegment, out var arrayIndex) &&
-                    parentObj.TryGetValue(leafSegment, out var arrayValue) &&
-                    arrayValue is List<object> array &&
-                    arrayIndex >= 0 && arrayIndex < array.Count)
+                // Object container: extract named fields into a local _sd array.
+                var nestedSdDigests = new List<string>();
+                foreach (var (leafSegment, _) in leafEntries)
                 {
-                    // Array element disclosure — two-element format per SD-JWT §5.2.4
-                    var disclosure = CreateArrayElementDisclosure(array[arrayIndex]);
-                    disclosures.Add(disclosure);
-                    nestedSdDigests.Add(ComputeDigest(disclosure));
-                }
-                else if (parentObj.TryGetValue(leafSegment, out var leafValue))
-                {
-                    // Object property disclosure
+                    if (!parentDict.TryGetValue(leafSegment, out var leafValue))
+                        continue;
                     var disclosure = CreateDisclosure(leafSegment, leafValue);
                     disclosures.Add(disclosure);
                     nestedSdDigests.Add(ComputeDigest(disclosure));
-                    parentObj.Remove(leafSegment);
+                    parentDict.Remove(leafSegment);
+                }
+
+                if (nestedSdDigests.Count > 0)
+                {
+                    if (parentDict.TryGetValue("_sd", out var existingSd) && existingSd is List<string> existing)
+                        existing.AddRange(nestedSdDigests);
+                    else
+                        parentDict["_sd"] = nestedSdDigests;
                 }
             }
-
-            if (nestedSdDigests.Count > 0)
+            else if (parentContainer is List<object> parentArray)
             {
-                // Merge with any existing _sd array at this level
-                if (parentObj.TryGetValue("_sd", out var existingSd) && existingSd is List<string> existingList)
+                // Array container: replace each requested index with a placeholder
+                // {"...": digest} object and emit a 2-element [salt, value] disclosure.
+                // Per SD-JWT §5.2.4 — preserves the array length for non-disclosed
+                // elements while hiding the disclosable ones cryptographically.
+                foreach (var (leafSegment, _) in leafEntries)
                 {
-                    existingList.AddRange(nestedSdDigests);
-                }
-                else
-                {
-                    parentObj["_sd"] = nestedSdDigests;
+                    if (!int.TryParse(leafSegment, out var idx))
+                        continue;
+                    if (idx < 0 || idx >= parentArray.Count)
+                        continue;
+
+                    var disclosure = CreateArrayElementDisclosure(parentArray[idx]);
+                    disclosures.Add(disclosure);
+                    var digest = ComputeDigest(disclosure);
+                    parentArray[idx] = new Dictionary<string, object> { ["..."] = digest };
                 }
             }
         }
@@ -188,7 +193,12 @@ public static class NestedDisclosure
 
     // --- Private helpers ---
 
-    private static string[] ParsePointer(string pointer)
+    /// <summary>
+    /// Parses an RFC 6901 JSON Pointer into its unescaped segments. Exposed
+    /// internally so <see cref="SdJwtService"/> can reuse the same parser
+    /// when correlating array-element paths to placeholder digests.
+    /// </summary>
+    internal static string[] ParsePointer(string pointer)
     {
         if (string.IsNullOrEmpty(pointer) || pointer == "/")
             return [];
@@ -198,6 +208,64 @@ public static class NestedDisclosure
         return pointer.Split('/').Where(s => s.Length > 0)
             .Select(s => s.Replace("~1", "/").Replace("~0", "~"))
             .ToArray();
+    }
+
+    /// <summary>
+    /// Navigates into the claim tree following all segments. Returns either a
+    /// <see cref="Dictionary{TKey, TValue}"/> (object container) or a
+    /// <see cref="List{T}"/> of <see cref="object"/> (array container) at the
+    /// final depth, or null if the path does not resolve. Arrays cause
+    /// <see cref="NavigateInto"/> to return null; this helper exists so array
+    /// disclosures (<c>/qualifications/1</c>) can resolve to the backing list.
+    /// </summary>
+    private static object? NavigateIntoContainer(Dictionary<string, object> root, string[] segments)
+    {
+        object current = root;
+        foreach (var segment in segments)
+        {
+            if (current is Dictionary<string, object> dict)
+            {
+                if (!dict.TryGetValue(segment, out var child))
+                    return null;
+                var materialised = MaterialiseJsonElement(child);
+                if (materialised is null)
+                    return null;
+                current = materialised;
+            }
+            else if (current is List<object> list)
+            {
+                if (!int.TryParse(segment, out var idx))
+                    return null;
+                if (idx < 0 || idx >= list.Count)
+                    return null;
+                var materialised = MaterialiseJsonElement(list[idx]);
+                if (materialised is null)
+                    return null;
+                current = materialised;
+            }
+            else
+            {
+                return null;
+            }
+        }
+        return current;
+    }
+
+    /// <summary>
+    /// Lazily materialises a JsonElement container into Dictionary/List so
+    /// subsequent navigation can mutate it. Non-container values are returned
+    /// unchanged.
+    /// </summary>
+    private static object? MaterialiseJsonElement(object value)
+    {
+        if (value is JsonElement elem)
+        {
+            if (elem.ValueKind == JsonValueKind.Object)
+                return JsonElementToDict(elem);
+            if (elem.ValueKind == JsonValueKind.Array)
+                return elem.EnumerateArray().Select(e => (object)ConvertJsonElementToObject(e)).ToList();
+        }
+        return value;
     }
 
     /// <summary>

--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -300,7 +300,7 @@ public class SdJwtService : ISdJwtService
         var jwtPart = parts[0];
         var allDisclosures = parts.Length > 1 ? parts[1..] : Array.Empty<string>();
 
-        var selectedDisclosures = SelectDisclosures(allDisclosures, claimsToDisclose);
+        var selectedDisclosures = SelectDisclosures(jwtPart, allDisclosures, claimsToDisclose);
 
         // Build presentation: jwt~selected_disclosure1~selected_disclosure2~[kb-jwt]
         var presentationParts = new List<string> { jwtPart };
@@ -357,7 +357,7 @@ public class SdJwtService : ISdJwtService
         var jwtPart = parts[0];
         var allDisclosures = parts.Length > 1 ? parts[1..] : Array.Empty<string>();
 
-        var selectedDisclosures = SelectDisclosures(allDisclosures, claimsToDisclose);
+        var selectedDisclosures = SelectDisclosures(jwtPart, allDisclosures, claimsToDisclose);
 
         // Build the presentation prefix (everything before the KB-JWT)
         var presentationParts = new List<string> { jwtPart };
@@ -558,26 +558,81 @@ public class SdJwtService : ISdJwtService
 
     /// <summary>
     /// Selects disclosures that match the caller's disclosure request.
-    /// Handles both top-level claim names and JSON Pointer paths by extracting
-    /// the leaf segment from each pointer path.
+    /// Handles three shapes:
+    /// <list type="bullet">
+    ///   <item>Top-level names like <c>name</c> → match against the claim-name
+    ///   field of 3-element disclosures.</item>
+    ///   <item>Nested object JSON Pointers like <c>/address/locality</c> →
+    ///   match leaf segment against 3-element disclosure names.</item>
+    ///   <item>Array-element JSON Pointers like <c>/qualifications/1</c> →
+    ///   navigate the JWT payload to the placeholder slot, extract the digest,
+    ///   then select the single 2-element disclosure whose hash matches. This
+    ///   closes the TODO(094) that previously dumped every array-element
+    ///   disclosure into the presentation (full-array disclosure by accident).</item>
+    /// </list>
     /// </summary>
-    private static List<string> SelectDisclosures(string[] allDisclosures, IEnumerable<string> claimsToDisclose)
+    private static List<string> SelectDisclosures(
+        string jwtPart,
+        string[] allDisclosures,
+        IEnumerable<string> claimsToDisclose)
     {
-        // Build a set of names to match against disclosure name fields.
-        // For JSON Pointer paths like "/address/locality", extract the leaf "locality".
-        // For top-level names like "name", use as-is.
-        var matchNames = new HashSet<string>();
+        // Split the requests into those that refer to object fields (by name or
+        // nested pointer) and those that refer to array elements (trailing numeric
+        // segment pointing at an array slot). We can't just inspect the leaf
+        // segment — an object key could be numeric ("2024" as a property name) —
+        // so we resolve each path against the JWT payload below.
+        var objectFieldNames = new HashSet<string>(StringComparer.Ordinal);
+        var pointerPaths = new List<string>();
         foreach (var entry in claimsToDisclose)
         {
+            if (string.IsNullOrWhiteSpace(entry))
+                continue;
             if (entry.StartsWith('/'))
-            {
-                var lastSlash = entry.LastIndexOf('/');
-                if (lastSlash >= 0 && lastSlash < entry.Length - 1)
-                    matchNames.Add(entry[(lastSlash + 1)..]);
-            }
+                pointerPaths.Add(entry);
             else
+                objectFieldNames.Add(entry);
+        }
+
+        // Hash every disclosure once so we can look up by digest without
+        // rehashing per request. Two-element disclosures need this to correlate
+        // with array placeholders; three-element ones fall through to the name
+        // path but still benefit from the pre-computed hash when the caller
+        // passes the same path in multiple forms.
+        var digestToDisclosure = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var disclosure in allDisclosures)
+        {
+            if (string.IsNullOrWhiteSpace(disclosure))
+                continue;
+            var digest = ComputeDisclosureDigest(disclosure);
+            digestToDisclosure.TryAdd(digest, disclosure);
+        }
+
+        // Resolve every pointer path against the JWT payload. If it lands on an
+        // array-element placeholder, record the digest; if it lands on an object
+        // field, fall back to leaf-name matching (for 3-element disclosures).
+        var arrayDigestRequests = new HashSet<string>(StringComparer.Ordinal);
+        if (pointerPaths.Count > 0)
+        {
+            var payloadRoot = TryExtractPayloadRoot(jwtPart);
+            foreach (var path in pointerPaths)
             {
-                matchNames.Add(entry);
+                var segments = NestedDisclosure.ParsePointer(path);
+                if (segments.Length == 0)
+                    continue;
+
+                var placeholderDigest = payloadRoot.HasValue
+                    ? ResolveArrayPlaceholderDigest(payloadRoot.Value, segments)
+                    : null;
+                if (placeholderDigest is not null)
+                {
+                    arrayDigestRequests.Add(placeholderDigest);
+                }
+                else
+                {
+                    // Object-field disclosure — match by leaf name against
+                    // 3-element [salt, name, value] disclosures below.
+                    objectFieldNames.Add(segments[^1]);
+                }
             }
         }
 
@@ -592,21 +647,20 @@ public class SdJwtService : ISdJwtService
                 var disclosureJson = Base64UrlDecode(disclosure);
                 var disclosureArray = JsonSerializer.Deserialize<JsonElement[]>(disclosureJson);
 
-                // Three-element disclosure: [salt, name, value]
                 if (disclosureArray is { Length: 3 })
                 {
+                    // Object-field disclosure [salt, name, value].
                     var claimName = disclosureArray[1].GetString();
-                    if (claimName != null && matchNames.Contains(claimName))
+                    if (claimName is not null && objectFieldNames.Contains(claimName))
                         selected.Add(disclosure);
                 }
-                // Two-element disclosure: [salt, value] — array element.
-                // TODO(094): Array element selection currently includes all array disclosures.
-                // When array-element disclosure is wired end-to-end (spec 097/098),
-                // correlate requested indices against {"...": digest} placeholders
-                // in the parent array to select only the requested elements.
                 else if (disclosureArray is { Length: 2 })
                 {
-                    selected.Add(disclosure);
+                    // Array-element disclosure [salt, value]. Only include if the
+                    // caller explicitly asked for this element's placeholder slot.
+                    var digest = ComputeDisclosureDigest(disclosure);
+                    if (arrayDigestRequests.Contains(digest))
+                        selected.Add(disclosure);
                 }
             }
             catch
@@ -616,6 +670,95 @@ public class SdJwtService : ISdJwtService
         }
 
         return selected;
+    }
+
+    /// <summary>
+    /// Decodes the JWT payload segment from a compact-serialised JWT prefix.
+    /// Returns null on any parse failure — callers fall back to name-only
+    /// disclosure matching when the payload is unreadable.
+    /// </summary>
+    private static JsonElement? TryExtractPayloadRoot(string jwtPart)
+    {
+        try
+        {
+            var segments = jwtPart.Split('.');
+            if (segments.Length < 2)
+                return null;
+            var payloadBytes = Base64UrlDecode(segments[1]);
+            var doc = JsonDocument.Parse(payloadBytes);
+            return doc.RootElement.Clone();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Walks the payload following <paramref name="segments"/>. Returns the
+    /// <c>"..."</c> digest if the final step lands on an array element that
+    /// is an SD-JWT placeholder object <c>{"...": "&lt;digest&gt;"}</c>. Returns
+    /// null for any other terminal shape (object field, scalar, missing path).
+    /// </summary>
+    private static string? ResolveArrayPlaceholderDigest(JsonElement root, string[] segments)
+    {
+        var current = root;
+        for (var i = 0; i < segments.Length; i++)
+        {
+            if (current.ValueKind == JsonValueKind.Object)
+            {
+                if (!current.TryGetProperty(segments[i], out var next))
+                    return null;
+                current = next;
+            }
+            else if (current.ValueKind == JsonValueKind.Array)
+            {
+                if (!int.TryParse(segments[i], System.Globalization.NumberStyles.None,
+                        System.Globalization.CultureInfo.InvariantCulture, out var idx))
+                    return null;
+                var length = current.GetArrayLength();
+                if (idx < 0 || idx >= length)
+                    return null;
+                // Navigate to the indexed element.
+                var arrIdx = 0;
+                JsonElement? child = null;
+                foreach (var item in current.EnumerateArray())
+                {
+                    if (arrIdx == idx)
+                    {
+                        child = item;
+                        break;
+                    }
+                    arrIdx++;
+                }
+                if (child is null)
+                    return null;
+                current = child.Value;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        if (current.ValueKind != JsonValueKind.Object)
+            return null;
+
+        // Exactly one property named "..." whose value is a string digest.
+        string? digest = null;
+        var propertyCount = 0;
+        foreach (var prop in current.EnumerateObject())
+        {
+            propertyCount++;
+            if (propertyCount > 1)
+                return null;
+            if (prop.Name != "...")
+                return null;
+            if (prop.Value.ValueKind != JsonValueKind.String)
+                return null;
+            digest = prop.Value.GetString();
+        }
+        return string.IsNullOrEmpty(digest) ? null : digest;
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
@@ -28,13 +28,13 @@ public static class CredentialEndpoints
             .WithTags("HAIP Credential")
             .WithSummary("Issue a credential to an external HAIP wallet")
             .WithDescription(
-                "Accepts a JWT proof of possession from the wallet, validates it against the c_nonce, " +
-                "mints an SD-JWT VC with cnf binding to the wallet's holder key, and returns it.")
+                "Accepts a Bearer access token (correlating to a credential offer), a JWT proof of " +
+                "possession from the wallet, and returns a minted SD-JWT VC bound to the wallet's " +
+                "holder key via cnf.")
             .Produces<object>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces(StatusCodes.Status501NotImplemented)
-            .AllowAnonymous(); // TODO(097): require Bearer token once token store is wired
+            .AllowAnonymous(); // Bearer token is required; validated inline so we can return OAuth-style error bodies rather than a blank 401 from the auth middleware.
     }
 
     private static async Task<IResult> IssueCredential(
@@ -50,15 +50,64 @@ public static class CredentialEndpoints
     {
         var logger = loggerFactory.CreateLogger("Sorcha.Haip.Service.Endpoints.CredentialEndpoints");
 
+        // Require a Bearer access token and correlate it to a credential offer.
+        // OpenID4VCI §7.2: the credential endpoint MUST reject requests without a
+        // valid access token. The fallback-to-defaults behaviour we had before
+        // would silently issue a "SorchaCredential" to any caller — security gap.
+        var authHeader = httpContext.Request.Headers.Authorization.ToString();
+        if (string.IsNullOrWhiteSpace(authHeader) ||
+            !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.Json(new
+            {
+                error = "invalid_token",
+                error_description = "Bearer access token is required",
+            }, statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var bearerToken = authHeader["Bearer ".Length..].Trim();
+        var offerId = await tokenStore.LookupAsync(bearerToken, ct);
+        if (!offerId.HasValue)
+        {
+            return Results.Json(new
+            {
+                error = "invalid_token",
+                error_description = "Access token is invalid or expired",
+            }, statusCode: StatusCodes.Status401Unauthorized);
+        }
+
+        var offer = offerService.GetOffer(offerId.Value);
+        if (offer is null)
+        {
+            // Token is valid but the offer has been evicted from the store —
+            // treat as an expired token rather than silently issuing.
+            return Results.Json(new
+            {
+                error = "invalid_token",
+                error_description = "Offer for this access token has expired",
+            }, statusCode: StatusCodes.Status401Unauthorized);
+        }
+
         // Validate format
-        // TODO: Validate request.Vct against credentials_supported when offer → token
-        // correlation is wired (requires AccessTokenStore.LookupAsync integration).
         if (request.Format != "vc+sd-jwt")
         {
             return Results.BadRequest(new
             {
                 error = "unsupported_credential_format",
                 error_description = $"Format '{request.Format}' is not supported. Use 'vc+sd-jwt'."
+            });
+        }
+
+        // Validate vct (credential type) matches the offer. The wallet must request
+        // exactly the credential type that was offered — issuing a different type
+        // would break the trust chain from the offer → token → minted credential.
+        if (!string.IsNullOrWhiteSpace(request.Vct)
+            && !string.Equals(request.Vct, offer.CredentialType, StringComparison.Ordinal))
+        {
+            return Results.BadRequest(new
+            {
+                error = "unsupported_credential_type",
+                error_description = $"Requested vct '{request.Vct}' does not match the offer ('{offer.CredentialType}')",
             });
         }
 
@@ -257,42 +306,14 @@ public static class CredentialEndpoints
         var issuerUrl = configuration.GetValue<string>("Haip:IssuerUrl")
             ?? "https://sorcha.example/haip";
 
-        // Look up the offer via the access token to get real claims
-        var bearerToken = httpContext.Request.Headers.Authorization.ToString().Replace("Bearer ", "");
-        var offerId = !string.IsNullOrEmpty(bearerToken)
-            ? await tokenStore.LookupAsync(bearerToken, ct)
-            : null;
-
-        Dictionary<string, object> claims;
-        List<string> disclosablePaths;
-        string credentialType;
-
-        if (offerId.HasValue)
-        {
-            var offer = offerService.GetOffer(offerId.Value);
-            if (offer != null)
-            {
-                claims = offer.Claims;
-                disclosablePaths = offer.DisclosablePaths;
-                credentialType = offer.CredentialType;
-                logger.LogInformation("Resolved offer {OfferId}: type={Type}, claims={Count}",
-                    offerId, credentialType, claims.Count);
-            }
-            else
-            {
-                claims = new Dictionary<string, object> { ["type"] = "SorchaCredential" };
-                disclosablePaths = new List<string>();
-                credentialType = "SorchaCredential";
-                logger.LogWarning("Offer {OfferId} not found in store — using default claims", offerId);
-            }
-        }
-        else
-        {
-            claims = new Dictionary<string, object> { ["type"] = "SorchaCredential" };
-            disclosablePaths = new List<string>();
-            credentialType = "SorchaCredential";
-            logger.LogWarning("No bearer token or offer correlation — using default claims");
-        }
+        // Use the offer resolved above — every branch below is guaranteed to have
+        // a valid offer because the Bearer / lookup gates already rejected the
+        // unauthenticated and expired-token cases.
+        var claims = offer.Claims;
+        var disclosablePaths = offer.DisclosablePaths;
+        var credentialType = offer.CredentialType;
+        logger.LogInformation("Resolved offer {OfferId}: type={Type}, claims={Count}",
+            offerId, credentialType, claims.Count);
 
         try
         {

--- a/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
@@ -105,7 +105,7 @@ public static class VerifierEndpoints
     private static async Task<IResult> GetRequestObject(
         Guid requestId,
         PresentationRequestStore store,
-        IConfiguration configuration,
+        RequestObjectSigner signer,
         CancellationToken ct)
     {
         var request = await store.GetAsync(requestId, ct);
@@ -115,10 +115,17 @@ public static class VerifierEndpoints
         if (request.ExpiresAt < DateTimeOffset.UtcNow)
             return Results.Json(new { error = "Presentation request has expired" }, statusCode: 410);
 
-        // Build the Request Object payload per OpenID4VP
-        // TODO(098): Sign this as a JWT with the verifier's key for production HAIP compliance
-        var requestObject = new Dictionary<string, object>
+        // Build the Request Object payload per OpenID4VP.
+        // iat is mandatory for signed Request Objects (RFC 9101 §10.8 — CSRF window).
+        // iss is the verifier's identifier — same value as client_id for now; spec 096
+        // will swap this to the verifier's DID / x509_san_uri.
+        var nowSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var requestObjectPayload = new Dictionary<string, object>
         {
+            ["iss"] = request.ClientId,
+            ["aud"] = "https://self-issued.me/v2",
+            ["iat"] = nowSeconds,
+            ["exp"] = request.ExpiresAt.ToUnixTimeSeconds(),
             ["response_type"] = "vp_token",
             ["response_mode"] = "direct_post",
             ["response_uri"] = request.ResponseUri,
@@ -153,7 +160,13 @@ public static class VerifierEndpoints
             }
         };
 
-        return Results.Json(requestObject);
+        // HAIP 1.0 §6.1 and RFC 9101 §4 require the Request Object to be a signed JWT
+        // with typ="oauth-authz-req+jwt". Wallets refuse to act on an unsigned JSON body.
+        var requestObjectJwt = signer.Sign(requestObjectPayload);
+
+        // Content type per RFC 9101 §4: application/oauth-authz-req+jwt. Wallets use this
+        // to distinguish a signed Request Object from an unsigned JSON request.
+        return Results.Text(requestObjectJwt, contentType: "application/oauth-authz-req+jwt");
     }
 
     private static async Task<IResult> HandleDirectPost(

--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddSingleton<HaipCredentialMinter>();
 // Feature 098: HAIP verifier services
 builder.Services.AddSingleton<PresentationRequestStore>();
 builder.Services.AddSingleton<HaipPresentationVerifier>();
+builder.Services.AddSingleton<RequestObjectSigner>();
 
 var app = builder.Build();
 

--- a/src/Services/Sorcha.Haip.Service/Services/AccessTokenStore.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/AccessTokenStore.cs
@@ -15,8 +15,6 @@ namespace Sorcha.Haip.Service.Services;
 /// TODO: Hash the access token (SHA-256) before using it as the Redis key
 /// to prevent token exposure via key enumeration (SCAN).
 /// TODO: Implement IDisposable to dispose the MemoryCache fallback (CA2213).
-/// TODO: Wire LookupAsync in CredentialEndpoints to correlate Bearer tokens
-/// to offer IDs for claim/type resolution.
 /// </remarks>
 public class AccessTokenStore
 {

--- a/src/Services/Sorcha.Haip.Service/Services/RequestObjectSigner.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/RequestObjectSigner.cs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Sorcha.Haip.Service.Services;
+
+/// <summary>
+/// Signs OpenID4VP Request Objects as compact-serialised JWTs per RFC 9101
+/// (JWT-Secured Authorization Request, JAR) with typ="oauth-authz-req+jwt".
+/// HAIP 1.0 §6.1 mandates a signed Request Object — wallets refuse to act on
+/// unsigned JSON bodies.
+/// </summary>
+/// <remarks>
+/// Supports ES256 (P-256) and EdDSA (Ed25519). The verifier's public key is
+/// embedded as a <c>jwk</c> header so wallets can self-resolve the signing key
+/// without a DID or x5c lookup. When spec 096 (x.509 Org Trust) ships this can
+/// be replaced by an <c>x5c</c> chain without changing the request shape.
+/// </remarks>
+public sealed class RequestObjectSigner
+{
+    private readonly string? _signingKeyBase64;
+    private readonly string _algorithm;
+    private readonly ILogger<RequestObjectSigner> _logger;
+
+    public RequestObjectSigner(IConfiguration configuration, ILogger<RequestObjectSigner> logger)
+    {
+        _signingKeyBase64 = configuration.GetValue<string>("Haip:IssuerSigningKey");
+        var configuredAlg = configuration.GetValue<string>("Haip:IssuerSigningAlgorithm") ?? "ES256";
+        _algorithm = NormaliseAlgorithm(configuredAlg);
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Signs <paramref name="payload"/> with the configured issuer key and
+    /// returns a compact-serialised JWT ready to be served as
+    /// <c>application/oauth-authz-req+jwt</c>.
+    /// </summary>
+    public string Sign(Dictionary<string, object> payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        var header = new Dictionary<string, object>
+        {
+            ["alg"] = _algorithm,
+            ["typ"] = "oauth-authz-req+jwt",
+        };
+
+        if (_algorithm == "ES256")
+        {
+            using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+            if (!string.IsNullOrWhiteSpace(_signingKeyBase64))
+            {
+                ecdsa.ImportECPrivateKey(Convert.FromBase64String(_signingKeyBase64), out _);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Request Object signing using ephemeral ES256 key — set Haip:IssuerSigningKey for production");
+            }
+
+            var parameters = ecdsa.ExportParameters(includePrivateParameters: false);
+            header["jwk"] = new Dictionary<string, string>
+            {
+                ["kty"] = "EC",
+                ["crv"] = "P-256",
+                ["x"] = Base64Url.EncodeToString(parameters.Q.X!),
+                ["y"] = Base64Url.EncodeToString(parameters.Q.Y!),
+            };
+
+            var (signingInput, h, p) = BuildSigningInput(header, payload);
+            var signature = ecdsa.SignData(
+                signingInput, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+            return $"{h}.{p}.{Base64Url.EncodeToString(signature)}";
+        }
+
+        // EdDSA / Ed25519
+        byte[] edPrivateKey;
+        byte[] edPublicKey;
+        if (!string.IsNullOrWhiteSpace(_signingKeyBase64))
+        {
+            var seedOrPrivate = Convert.FromBase64String(_signingKeyBase64);
+            if (seedOrPrivate.Length == 32)
+            {
+                var kp = Sodium.PublicKeyAuth.GenerateKeyPair(seedOrPrivate);
+                edPrivateKey = kp.PrivateKey;
+                edPublicKey = kp.PublicKey;
+            }
+            else if (seedOrPrivate.Length == 64)
+            {
+                edPrivateKey = seedOrPrivate;
+                edPublicKey = Sodium.PublicKeyAuth.ExtractEd25519PublicKeyFromEd25519SecretKey(seedOrPrivate);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Haip:IssuerSigningKey for EdDSA must be a 32-byte seed or 64-byte secret key (got {seedOrPrivate.Length})");
+            }
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Request Object signing using ephemeral EdDSA key — set Haip:IssuerSigningKey for production");
+            var kp = Sodium.PublicKeyAuth.GenerateKeyPair();
+            edPrivateKey = kp.PrivateKey;
+            edPublicKey = kp.PublicKey;
+        }
+
+        header["jwk"] = new Dictionary<string, string>
+        {
+            ["kty"] = "OKP",
+            ["crv"] = "Ed25519",
+            ["x"] = Base64Url.EncodeToString(edPublicKey),
+        };
+
+        var (signingInputEd, hEd, pEd) = BuildSigningInput(header, payload);
+        var signatureEd = Sodium.PublicKeyAuth.SignDetached(signingInputEd, edPrivateKey);
+        return $"{hEd}.{pEd}.{Base64Url.EncodeToString(signatureEd)}";
+    }
+
+    private static string NormaliseAlgorithm(string raw) => raw.ToUpperInvariant() switch
+    {
+        "ES256" or "P-256" or "P256" => "ES256",
+        "EDDSA" or "ED25519" => "EdDSA",
+        _ => "ES256",
+    };
+
+    private static (byte[] SigningInput, string HeaderB64, string PayloadB64) BuildSigningInput(
+        Dictionary<string, object> header,
+        Dictionary<string, object> payload)
+    {
+        var headerJson = JsonSerializer.SerializeToUtf8Bytes(header);
+        var payloadJson = JsonSerializer.SerializeToUtf8Bytes(payload);
+        var headerB64 = Base64Url.EncodeToString(headerJson);
+        var payloadB64 = Base64Url.EncodeToString(payloadJson);
+        var signingInput = Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
+        return (signingInput, headerB64, payloadB64);
+    }
+}

--- a/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtNestedDisclosureTests.cs
+++ b/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtNestedDisclosureTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Buffers.Text;
 using System.Security.Cryptography;
 using System.Text.Json;
 using FluentAssertions;
@@ -159,6 +160,128 @@ public class SdJwtNestedDisclosureTests
         var fullResult = await _service.VerifyTokenAsync(token.RawToken, publicKey, "ES256");
         fullResult.IsValid.Should().BeTrue();
         fullResult.Claims.Should().ContainKey("name");
+    }
+
+    [Fact]
+    public async Task ArrayElementDisclosure_SelectsOnlyRequestedIndex()
+    {
+        // Feature 094 TODO(094) regression test: requesting /qualifications/1 must
+        // select only the disclosure whose digest appears at that placeholder slot.
+        // Prior behaviour dumped every 2-element disclosure into the presentation,
+        // silently leaking elements the holder did not intend to disclose.
+        var (privateKey, publicKey) = GenerateP256KeyPair();
+
+        var claims = new Dictionary<string, object>
+        {
+            ["name"] = "Alice",
+            ["qualifications"] = new List<object>
+            {
+                new Dictionary<string, object> { ["type"] = "Plumbing" },
+                new Dictionary<string, object> { ["type"] = "Engineering" },
+                new Dictionary<string, object> { ["type"] = "Medicine" },
+            },
+        };
+
+        var token = await _service.CreateTokenAsync(
+            claims,
+            disclosableClaims: ["/qualifications/0", "/qualifications/1", "/qualifications/2"],
+            issuer: "did:sorcha:org:gov",
+            subject: "did:sorcha:w:alice",
+            signingKey: privateKey,
+            algorithm: "ES256");
+
+        // Disclose ONLY index 1.
+        var presentation = await _service.CreatePresentationAsync(
+            token.RawToken,
+            claimsToDisclose: ["/qualifications/1"]);
+
+        presentation.SelectedDisclosures.Should().HaveCount(1,
+            "only the single requested array-element disclosure must be selected");
+
+        // Decode the one disclosure and confirm it carries the Engineering element.
+        var raw = presentation.SelectedDisclosures[0];
+        var decoded = JsonSerializer.Deserialize<JsonElement[]>(
+            Base64Url.DecodeFromChars(raw));
+        decoded.Should().NotBeNull();
+        decoded!.Should().HaveCount(2, "array-element disclosures are [salt, value]");
+        var value = decoded[1];
+        value.GetProperty("type").GetString().Should().Be("Engineering");
+
+        // Verifying the presentation end-to-end must still succeed.
+        var verified = await _service.VerifyPresentationAsync(
+            presentation.RawPresentation, publicKey, "ES256");
+        verified.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ArrayElementDisclosure_RequestingNoElements_YieldsEmptyDisclosureList()
+    {
+        // The caller may legitimately want to present only public fields; no array
+        // elements disclosed means the selected list must be empty — NOT every
+        // 2-element disclosure in the token (the prior bug).
+        var (privateKey, _) = GenerateP256KeyPair();
+
+        var claims = new Dictionary<string, object>
+        {
+            ["publicField"] = "always-visible",
+            ["qualifications"] = new List<object>
+            {
+                new Dictionary<string, object> { ["type"] = "Plumbing" },
+                new Dictionary<string, object> { ["type"] = "Engineering" },
+            },
+        };
+
+        var token = await _service.CreateTokenAsync(
+            claims,
+            disclosableClaims: ["/qualifications/0", "/qualifications/1"],
+            issuer: "did:sorcha:org:gov",
+            subject: "did:sorcha:w:alice",
+            signingKey: privateKey,
+            algorithm: "ES256");
+
+        var presentation = await _service.CreatePresentationAsync(
+            token.RawToken,
+            claimsToDisclose: Array.Empty<string>());
+
+        presentation.SelectedDisclosures.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ArrayElementDisclosure_MixedWithTopLevelNameRequest_SelectsBoth()
+    {
+        // Top-level "name" + /qualifications/1 in one presentation. Both disclosures
+        // must be selected, nothing else.
+        var (privateKey, publicKey) = GenerateP256KeyPair();
+
+        var claims = new Dictionary<string, object>
+        {
+            ["name"] = "Alice",
+            ["qualifications"] = new List<object>
+            {
+                new Dictionary<string, object> { ["type"] = "Plumbing" },
+                new Dictionary<string, object> { ["type"] = "Engineering" },
+            },
+        };
+
+        var token = await _service.CreateTokenAsync(
+            claims,
+            disclosableClaims: ["name", "/qualifications/0", "/qualifications/1"],
+            issuer: "did:sorcha:org:gov",
+            subject: "did:sorcha:w:alice",
+            signingKey: privateKey,
+            algorithm: "ES256");
+
+        var presentation = await _service.CreatePresentationAsync(
+            token.RawToken,
+            claimsToDisclose: ["name", "/qualifications/1"]);
+
+        presentation.SelectedDisclosures.Should().HaveCount(2);
+
+        var verified = await _service.VerifyPresentationAsync(
+            presentation.RawPresentation, publicKey, "ES256");
+        verified.IsValid.Should().BeTrue();
+        verified.Claims.Should().ContainKey("name");
+        verified.Claims["name"].Should().Be("Alice");
     }
 
     [Fact]

--- a/tests/Sorcha.Haip.Service.Tests/Services/RequestObjectSignerTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/RequestObjectSignerTests.cs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Sorcha.Haip.Service.Services;
+
+using Xunit;
+
+namespace Sorcha.Haip.Service.Tests.Services;
+
+/// <summary>
+/// Feature 094/098 follow-up — verifies that <see cref="RequestObjectSigner"/>
+/// produces a compact JWT matching the RFC 9101 contract for JWT-Secured
+/// Authorization Requests.
+/// </summary>
+public class RequestObjectSignerTests
+{
+    [Fact]
+    public void Sign_ES256_ProducesJwtWithRfc9101TypAndVerifiableSignature()
+    {
+        // Arrange: a configured P-256 signing key and a sample Request Object payload.
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var keyBase64 = Convert.ToBase64String(ecdsa.ExportECPrivateKey());
+        var signer = BuildSigner(new()
+        {
+            ["Haip:IssuerSigningKey"] = keyBase64,
+            ["Haip:IssuerSigningAlgorithm"] = "ES256",
+        });
+
+        var payload = new Dictionary<string, object>
+        {
+            ["iss"] = "https://verifier.example/haip",
+            ["aud"] = "https://self-issued.me/v2",
+            ["response_type"] = "vp_token",
+            ["nonce"] = "n-0S6_WzA2Mj",
+            ["state"] = Guid.NewGuid().ToString(),
+        };
+
+        // Act
+        var jwt = signer.Sign(payload);
+
+        // Assert: shape
+        var parts = jwt.Split('.');
+        parts.Should().HaveCount(3, "compact JWS has 3 segments");
+
+        // Header MUST carry typ=oauth-authz-req+jwt and alg=ES256 per RFC 9101 §4.
+        var headerJson = Base64Url.DecodeFromChars(parts[0]);
+        using var header = JsonDocument.Parse(headerJson);
+        header.RootElement.GetProperty("typ").GetString().Should().Be("oauth-authz-req+jwt");
+        header.RootElement.GetProperty("alg").GetString().Should().Be("ES256");
+
+        // JWK embedded so wallets can self-resolve the verifier key pre-x5c (spec 096).
+        header.RootElement.TryGetProperty("jwk", out var jwk).Should().BeTrue();
+        jwk.GetProperty("kty").GetString().Should().Be("EC");
+        jwk.GetProperty("crv").GetString().Should().Be("P-256");
+
+        // Signature must verify against the configured public key.
+        using var verify = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        verify.ImportECPrivateKey(Convert.FromBase64String(keyBase64), out _);
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64Url.DecodeFromChars(parts[2]);
+        verify.VerifyData(
+            signingInput, signature,
+            HashAlgorithmName.SHA256,
+            DSASignatureFormat.IeeeP1363FixedFieldConcatenation)
+            .Should().BeTrue("the JWT must verify under its own embedded public key");
+    }
+
+    [Fact]
+    public void Sign_ES256_NoConfiguredKey_UsesEphemeralKeyStillVerifiesUnderEmbeddedJwk()
+    {
+        // When Haip:IssuerSigningKey is absent the signer falls back to an ephemeral key.
+        // Dev convenience only, but the signature MUST still verify under the jwk it embeds.
+        var signer = BuildSigner(new() { ["Haip:IssuerSigningAlgorithm"] = "ES256" });
+
+        var jwt = signer.Sign(new Dictionary<string, object>
+        {
+            ["nonce"] = "ephemeral-key-test",
+        });
+
+        var parts = jwt.Split('.');
+        var headerJson = Base64Url.DecodeFromChars(parts[0]);
+        using var header = JsonDocument.Parse(headerJson);
+        var jwk = header.RootElement.GetProperty("jwk");
+
+        using var verify = ECDsa.Create(new ECParameters
+        {
+            Curve = ECCurve.NamedCurves.nistP256,
+            Q = new ECPoint
+            {
+                X = Base64Url.DecodeFromChars(jwk.GetProperty("x").GetString()!),
+                Y = Base64Url.DecodeFromChars(jwk.GetProperty("y").GetString()!),
+            },
+        });
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64Url.DecodeFromChars(parts[2]);
+        verify.VerifyData(
+            signingInput, signature,
+            HashAlgorithmName.SHA256,
+            DSASignatureFormat.IeeeP1363FixedFieldConcatenation)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Sign_EdDSA_ProducesJwtWithOkpJwkAndVerifiableSignature()
+    {
+        var keyPair = Sodium.PublicKeyAuth.GenerateKeyPair();
+        var signer = BuildSigner(new()
+        {
+            ["Haip:IssuerSigningKey"] = Convert.ToBase64String(keyPair.PrivateKey),
+            ["Haip:IssuerSigningAlgorithm"] = "EdDSA",
+        });
+
+        var jwt = signer.Sign(new Dictionary<string, object> { ["nonce"] = "ed-test" });
+
+        var parts = jwt.Split('.');
+        var headerJson = Base64Url.DecodeFromChars(parts[0]);
+        using var header = JsonDocument.Parse(headerJson);
+        header.RootElement.GetProperty("alg").GetString().Should().Be("EdDSA");
+        header.RootElement.GetProperty("typ").GetString().Should().Be("oauth-authz-req+jwt");
+
+        var jwk = header.RootElement.GetProperty("jwk");
+        jwk.GetProperty("kty").GetString().Should().Be("OKP");
+        jwk.GetProperty("crv").GetString().Should().Be("Ed25519");
+
+        var publicKey = Base64Url.DecodeFromChars(jwk.GetProperty("x").GetString()!);
+        publicKey.Should().BeEquivalentTo(keyPair.PublicKey);
+
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64Url.DecodeFromChars(parts[2]);
+        Sodium.PublicKeyAuth.VerifyDetached(signature, signingInput, publicKey)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Sign_PayloadRoundTripsThroughBase64UrlDecoding()
+    {
+        var signer = BuildSigner(new());
+
+        var claims = new Dictionary<string, object>
+        {
+            ["nonce"] = "roundtrip-payload",
+            ["response_type"] = "vp_token",
+            ["state"] = "abc-123",
+        };
+
+        var jwt = signer.Sign(claims);
+        var parts = jwt.Split('.');
+
+        var payloadJson = Base64Url.DecodeFromChars(parts[1]);
+        using var doc = JsonDocument.Parse(payloadJson);
+        doc.RootElement.GetProperty("nonce").GetString().Should().Be("roundtrip-payload");
+        doc.RootElement.GetProperty("response_type").GetString().Should().Be("vp_token");
+        doc.RootElement.GetProperty("state").GetString().Should().Be("abc-123");
+    }
+
+    [Fact]
+    public void Sign_EdDSA_RejectsWrongKeyLength()
+    {
+        // 16 bytes is neither a valid Ed25519 seed (32B) nor a secret key (64B).
+        var signer = BuildSigner(new()
+        {
+            ["Haip:IssuerSigningKey"] = Convert.ToBase64String(new byte[16]),
+            ["Haip:IssuerSigningAlgorithm"] = "EdDSA",
+        });
+
+        var act = () => signer.Sign(new Dictionary<string, object> { ["nonce"] = "bad" });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*32-byte seed or 64-byte secret key*");
+    }
+
+    private static RequestObjectSigner BuildSigner(Dictionary<string, string?> values)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        return new RequestObjectSigner(config, NullLogger<RequestObjectSigner>.Instance);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the remaining reachable Category 1 TODOs from the platform completion plan. **1c (status list fetch) is deferred** — it depends on spec 095 (IETF Token Status List) shipping the public endpoint first.

## Changes

### 1b — SD-JWT array-element disclosure correctness (`NestedDisclosure` + `SdJwtService`)

**Issuer side (`Translate`)**: previously bailed when the parent of a JSON-Pointer path was an array. Now navigates into arrays too, replacing each requested index with an SD-JWT §5.2.4 placeholder `{\"...\": digest}` and emitting the 2-element `[salt, value]` disclosure. `NavigateInto` gains a container-aware sibling `NavigateIntoContainer`.

**Selector side (`SelectDisclosures`)**: previously dumped every 2-element disclosure into the presentation whenever ANY array element was requested — a silent full-array disclosure bug. Now parses the JWT payload, walks the pointer path to the `{\"...\": digest}` placeholder slot, and selects only the disclosure whose hash matches. Legacy top-level and nested-object paths keep working.

`ParsePointer` is promoted to `internal` so `SdJwtService` can reuse the RFC 6901 parser.

### 1d — Signed Request Object (`VerifierEndpoints` + `RequestObjectSigner`)

`GET /api/v1/verifier/requests/{id}/request-object` now returns a compact JWS per RFC 9101 with `typ=oauth-authz-req+jwt`, signed using `Haip:IssuerSigningKey`. Supports ES256 and EdDSA. Embeds the verifier JWK in the header so wallets can self-resolve the key until spec 096 x5c chains ship. `iat`/`exp`/`iss`/`aud` claims added. Content type set to `application/oauth-authz-req+jwt`. Signing logic extracted to `RequestObjectSigner` service for testability.

### 1e — Bearer/offer gating (`CredentialEndpoints`)

`/credential` now **rejects unauthenticated requests (401 `invalid_token`)** instead of falling back to a default `SorchaCredential` for any caller — a real security gap. Bearer token is required and looked up in `AccessTokenStore`; expired-offer and missing-offer cases also return 401. Requested `vct` is validated against the offer's `CredentialType`; mismatch returns 400 `unsupported_credential_type`. Stale \"TODO: wire LookupAsync\" comment removed from `AccessTokenStore`.

## Tests

8 new unit tests:

| File | Tests | Coverage |
|------|-------|----------|
| `SdJwtNestedDisclosureTests` | 3 | `/qualifications/1` selects only index 1; empty disclosure list; mixed top-level + array |
| `RequestObjectSignerTests` | 5 | ES256 signs & verifies; ephemeral fallback still verifiable; EdDSA signs & verifies; payload round-trip; wrong-key-length rejected |

## Test plan

- [x] `dotnet build Sorcha.sln` clean (0 errors)
- [x] 362/362 `Sorcha.Cryptography.Tests` pass (+3)
- [x] 40/40 `Sorcha.Haip.Service.Tests` pass (+5)
- [x] Full solution builds with 72 pre-existing warnings only

## Deferred

**1c** — `HaipPresentationVerifier.CheckStatus` currently returns `Active` for all credentials carrying a status claim. Implementing the IETF Token Status List fetch+decompress requires the publisher endpoint from spec 095; that work is scheduled as part of Category 2 (Token Status List) per the completion plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)