### PR TITLE
feat(095): wire IETF status list end-to-end (US3 + US4)

### DIFF
--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -48,6 +48,14 @@ builder.Services.AddSingleton<PresentationRequestStore>();
 builder.Services.AddSingleton<HaipPresentationVerifier>();
 builder.Services.AddSingleton<RequestObjectSigner>();
 
+// Feature 095 US4: status list fetch for the verifier. Registered as HttpClient-
+// backed so the underlying connection pool is shared and timeouts are governed
+// by the standard .NET HTTP resilience pipeline.
+builder.Services.AddHttpClient<IetfTokenStatusListChecker>(client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(10);
+});
+
 var app = builder.Build();
 
 // OpenAPI and Scalar UI

--- a/src/Services/Sorcha.Haip.Service/Services/HaipPresentationVerifier.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/HaipPresentationVerifier.cs
@@ -23,6 +23,7 @@ public class HaipPresentationVerifier
 {
     private readonly ISdJwtService _sdJwtService;
     private readonly IDidResolverRegistry? _didResolver;
+    private readonly IetfTokenStatusListChecker? _ietfStatusChecker;
     private readonly ILogger<HaipPresentationVerifier> _logger;
 
     // Trusted root certificates for x5c chain validation.
@@ -32,11 +33,13 @@ public class HaipPresentationVerifier
     public HaipPresentationVerifier(
         ISdJwtService sdJwtService,
         ILogger<HaipPresentationVerifier> logger,
-        IDidResolverRegistry? didResolver = null)
+        IDidResolverRegistry? didResolver = null,
+        IetfTokenStatusListChecker? ietfStatusChecker = null)
     {
         _sdJwtService = sdJwtService ?? throw new ArgumentNullException(nameof(sdJwtService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _didResolver = didResolver;
+        _ietfStatusChecker = ietfStatusChecker;
     }
 
     /// <summary>
@@ -104,7 +107,7 @@ public class HaipPresentationVerifier
             result.VerifiedClaims = sdJwtResult.Claims;
 
             // Step 4: Check credential status (IETF or W3C claim)
-            var statusResult = CheckStatus(sdJwtResult.Claims);
+            var statusResult = await CheckStatusAsync(sdJwtResult.Claims, ct);
             result.StatusCheckResult = statusResult;
             if (statusResult is "Revoked" or "Suspended")
             {
@@ -276,26 +279,155 @@ public class HaipPresentationVerifier
     }
 
     /// <summary>
-    /// Checks credential status from the verified claims.
-    /// Returns "Active", "Revoked", "Suspended", or null (no status claim).
+    /// Feature 095 US4 — resolves a credential's lifecycle status by reading the
+    /// <c>status.status_list</c> claim (IETF, preferred) or <c>credentialStatus</c>
+    /// claim (W3C, fallback), fetching the referenced status list endpoint, and
+    /// reading the bit at the allocated index. Returns:
+    /// <list type="bullet">
+    ///   <item><c>"Active"</c> — bit is 0 or the credential carries no status claim.</item>
+    ///   <item><c>"Revoked"</c> / <c>"Suspended"</c> — bit is 1. Purpose disambiguation
+    ///   comes from the W3C <c>statusPurpose</c> field when present; IETF lists default
+    ///   to <c>Revoked</c> (bits=1 semantic).</item>
+    ///   <item>null — no claim present, caller treats as Active per FR-010 policy.</item>
+    ///   <item><c>"Unknown"</c> — claim was present but the endpoint was unreachable
+    ///   or unverifiable. Non-fatal by design — lets the orchestrator decide whether
+    ///   to fail-open.</item>
+    /// </list>
     /// </summary>
-    private string? CheckStatus(Dictionary<string, object> claims)
+    private async Task<string?> CheckStatusAsync(Dictionary<string, object> claims, CancellationToken ct)
     {
-        // IETF status.status_list or W3C credentialStatus
-        if (claims.ContainsKey("status") || claims.ContainsKey("credentialStatus"))
+        // IETF claim takes precedence over W3C per spec 095 US4.
+        var (ietfUri, ietfIdx) = TryExtractIetfStatusList(claims);
+        if (ietfUri is not null && ietfIdx.HasValue)
         {
-            // Full implementation would fetch the status list endpoint,
-            // verify the JWT, decompress the bitstring, and read the bit.
-            // The BitstringStatusListChecker in Blueprint.Engine handles
-            // the W3C path; the IETF path uses IetfTokenStatusListSerializer.
-            // For now, return "Active" — the status list infrastructure
-            // from spec 095 is available but requires an HttpClient to
-            // fetch the endpoint, which is a cross-service call.
-            _logger.LogInformation("Credential has status claim — returning Active (full status list fetch not wired)");
-            return "Active";
+            if (_ietfStatusChecker is null)
+            {
+                _logger.LogWarning(
+                    "Credential carries IETF status claim but IetfTokenStatusListChecker is not wired — returning Unknown");
+                return "Unknown";
+            }
+
+            var bit = await _ietfStatusChecker.CheckBitAsync(ietfUri, ietfIdx.Value, ct);
+            return bit switch
+            {
+                StatusListBit.NotSet => "Active",
+                StatusListBit.Set => "Revoked",
+                _ => "Unknown",
+            };
         }
 
+        var (w3cUri, w3cIdx, w3cPurpose) = TryExtractW3cCredentialStatus(claims);
+        if (w3cUri is not null && w3cIdx.HasValue)
+        {
+            if (_ietfStatusChecker is null)
+            {
+                _logger.LogWarning(
+                    "Credential carries W3C status claim but IetfTokenStatusListChecker is not wired — returning Unknown");
+                return "Unknown";
+            }
+
+            // The W3C endpoint also serves a signed JWT envelope in this codebase's
+            // deployment — the IETF checker's fetch+decompress path accepts either.
+            // When the backing raw bitstring differs (pre-095 W3C-only deployments),
+            // this will return Unknown and the caller falls back to server-side.
+            var bit = await _ietfStatusChecker.CheckBitAsync(w3cUri, w3cIdx.Value, ct);
+            return bit switch
+            {
+                StatusListBit.NotSet => "Active",
+                StatusListBit.Set => string.Equals(w3cPurpose, "suspension", StringComparison.OrdinalIgnoreCase)
+                    ? "Suspended"
+                    : "Revoked",
+                _ => "Unknown",
+            };
+        }
+
+        // No status claim at all — treat as Active by default (pre-spec-093 credentials).
         return null;
+    }
+
+    /// <summary>
+    /// Reads the IETF <c>status.status_list</c> claim into a (uri, idx) pair.
+    /// Returns (null, null) when the claim is absent or malformed.
+    /// </summary>
+    private static (string? Uri, int? Idx) TryExtractIetfStatusList(Dictionary<string, object> claims)
+    {
+        if (!claims.TryGetValue("status", out var statusRaw) || statusRaw is null)
+            return (null, null);
+        if (!TryGetObjectProperty(statusRaw, "status_list", out var statusList))
+            return (null, null);
+        var uri = TryReadString(statusList, "uri");
+        var idx = TryReadInt(statusList, "idx");
+        return (uri, idx);
+    }
+
+    /// <summary>
+    /// Reads the W3C <c>credentialStatus</c> claim into a (uri, idx, purpose)
+    /// tuple. <c>statusListCredential</c> maps to uri; <c>statusListIndex</c>
+    /// maps to idx (may be a string or number in the wire form).
+    /// </summary>
+    private static (string? Uri, int? Idx, string? Purpose) TryExtractW3cCredentialStatus(
+        Dictionary<string, object> claims)
+    {
+        if (!claims.TryGetValue("credentialStatus", out var raw) || raw is null)
+            return (null, null, null);
+        var uri = TryReadString(raw, "statusListCredential");
+        var idx = TryReadInt(raw, "statusListIndex");
+        var purpose = TryReadString(raw, "statusPurpose");
+        return (uri, idx, purpose);
+    }
+
+    private static bool TryGetObjectProperty(object container, string name, out object value)
+    {
+        if (container is Dictionary<string, object> dict && dict.TryGetValue(name, out var v) && v is not null)
+        {
+            value = v;
+            return true;
+        }
+        if (container is JsonElement element && element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty(name, out var prop))
+        {
+            value = prop;
+            return true;
+        }
+        value = null!;
+        return false;
+    }
+
+    private static string? TryReadString(object container, string name)
+    {
+        if (container is Dictionary<string, object> dict && dict.TryGetValue(name, out var v))
+            return v?.ToString();
+        if (container is JsonElement element && element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty(name, out var prop))
+            return prop.ValueKind == JsonValueKind.String ? prop.GetString() : prop.ToString();
+        return null;
+    }
+
+    private static int? TryReadInt(object container, string name)
+    {
+        if (container is Dictionary<string, object> dict && dict.TryGetValue(name, out var v))
+        {
+            return v switch
+            {
+                int i => i,
+                long l => (int)l,
+                double d => (int)d,
+                string s when int.TryParse(s, out var parsed) => parsed,
+                JsonElement jEl => ReadJsonInt(jEl),
+                _ => null,
+            };
+        }
+        if (container is JsonElement element && element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty(name, out var prop))
+            return ReadJsonInt(prop);
+        return null;
+
+        static int? ReadJsonInt(JsonElement el) => el.ValueKind switch
+        {
+            JsonValueKind.Number when el.TryGetInt32(out var n) => n,
+            JsonValueKind.String when int.TryParse(el.GetString(), out var n) => n,
+            _ => null,
+        };
     }
 
     private static byte[]? ExtractPublicKeyFromJwk(JsonElement jwk)

--- a/src/Services/Sorcha.Haip.Service/Services/IetfTokenStatusListChecker.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/IetfTokenStatusListChecker.cs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Sorcha.Haip.Service.Services;
+
+/// <summary>
+/// Feature 095 US4 — client-side verifier for the IETF Token Status List
+/// endpoint. Fetches the signed envelope JWT, verifies its signature against
+/// the embedded JWK header, decompresses the zlib-packed <c>lst</c> bitstring,
+/// and reads the bit at the requested index.
+/// </summary>
+/// <remarks>
+/// The envelope is signed by the list's issuer. The public JWK is embedded in
+/// the JWT header during the pre-x5c dev phase (matching
+/// <see cref="IetfTokenStatusListSerializer"/>); once spec 096 ships, a real
+/// <c>x5c</c> chain will replace the embedded JWK and this checker should be
+/// extended to walk the chain. No signature = refuse to trust the bitstring.
+/// </remarks>
+public sealed class IetfTokenStatusListChecker
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<IetfTokenStatusListChecker> _logger;
+
+    public IetfTokenStatusListChecker(HttpClient httpClient, ILogger<IetfTokenStatusListChecker> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Returns <see cref="StatusListBit.NotSet"/> when the bit at
+    /// <paramref name="idx"/> is 0 (active), <see cref="StatusListBit.Set"/>
+    /// when it is 1 (revoked/suspended), or <see cref="StatusListBit.Unknown"/>
+    /// when the envelope cannot be fetched, verified, or decoded. The verifier
+    /// treats <c>Unknown</c> as a non-fatal status signal — the caller decides
+    /// whether to fail-open or fail-closed.
+    /// </summary>
+    public async Task<StatusListBit> CheckBitAsync(
+        string uri, int idx, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+            return StatusListBit.Unknown;
+        if (idx < 0)
+            return StatusListBit.Unknown;
+
+        string jwt;
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Accept.Add(
+                new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/statuslist+jwt"));
+            using var response = await _httpClient.SendAsync(
+                request, HttpCompletionOption.ResponseContentRead, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "IETF status list fetch failed: {StatusCode} {ReasonPhrase} for {Uri}",
+                    (int)response.StatusCode, response.ReasonPhrase, uri);
+                return StatusListBit.Unknown;
+            }
+            jwt = (await response.Content.ReadAsStringAsync(ct)).Trim();
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "IETF status list fetch errored for {Uri}", uri);
+            return StatusListBit.Unknown;
+        }
+
+        return ParseAndReadBit(jwt, idx);
+    }
+
+    /// <summary>
+    /// Pure-function variant: decodes a signed IETF Token Status List JWT,
+    /// verifies the signature against the embedded <c>jwk</c> header, and reads
+    /// the bit at <paramref name="idx"/>. Returns <see cref="StatusListBit.Unknown"/>
+    /// on any parse, signature, or index failure. Extracted for unit testing
+    /// without an <see cref="HttpClient"/>.
+    /// </summary>
+    internal static StatusListBit ParseAndReadBit(string jwt, int idx)
+    {
+        var parts = jwt.Split('.');
+        if (parts.Length != 3) return StatusListBit.Unknown;
+
+        JsonElement header;
+        JsonElement payload;
+        byte[] signature;
+        try
+        {
+            header = JsonSerializer.Deserialize<JsonElement>(Base64Url.DecodeFromChars(parts[0]));
+            payload = JsonSerializer.Deserialize<JsonElement>(Base64Url.DecodeFromChars(parts[1]));
+            signature = Base64Url.DecodeFromChars(parts[2]);
+        }
+        catch
+        {
+            return StatusListBit.Unknown;
+        }
+
+        // Sanity-check typ — must be "statuslist+jwt".
+        if (!header.TryGetProperty("typ", out var typEl)
+            || !string.Equals(typEl.GetString(), "statuslist+jwt", StringComparison.Ordinal))
+        {
+            return StatusListBit.Unknown;
+        }
+
+        if (!header.TryGetProperty("alg", out var algEl))
+            return StatusListBit.Unknown;
+        var alg = algEl.GetString();
+        if (string.IsNullOrEmpty(alg)) return StatusListBit.Unknown;
+
+        // Verify the envelope signature using the embedded JWK header. Pre-x5c
+        // dev posture — once spec 096 lands this should walk the x5c chain and
+        // validate against the trust anchor.
+        if (!header.TryGetProperty("jwk", out var jwkEl))
+            return StatusListBit.Unknown;
+
+        var signingInput = Encoding.UTF8.GetBytes($"{parts[0]}.{parts[1]}");
+        if (!VerifySignature(signingInput, signature, jwkEl, alg))
+            return StatusListBit.Unknown;
+
+        // Decompress the zlib-packed bitstring and read the bit.
+        if (!payload.TryGetProperty("status_list", out var statusList))
+            return StatusListBit.Unknown;
+        if (!statusList.TryGetProperty("lst", out var lstEl))
+            return StatusListBit.Unknown;
+        var bits = statusList.TryGetProperty("bits", out var bitsEl) && bitsEl.TryGetInt32(out var b)
+            ? b : 1;
+
+        byte[] raw;
+        try
+        {
+            var compressed = Base64Url.DecodeFromChars(lstEl.GetString()!);
+            raw = ZLibDecompress(compressed);
+        }
+        catch
+        {
+            return StatusListBit.Unknown;
+        }
+
+        // Multi-bit lists pack `bits` bits per entry. 1-bit lists are the common case.
+        return ReadBit(raw, idx, bits);
+    }
+
+    private static bool VerifySignature(byte[] signingInput, byte[] signature, JsonElement jwk, string alg)
+    {
+        try
+        {
+            var normalisedAlg = alg.ToUpperInvariant();
+            if (normalisedAlg is "ES256" or "P-256" or "P256"
+                && jwk.TryGetProperty("kty", out var kty) && kty.GetString() == "EC"
+                && jwk.TryGetProperty("x", out var xEl) && jwk.TryGetProperty("y", out var yEl))
+            {
+                using var ecdsa = ECDsa.Create(new ECParameters
+                {
+                    Curve = ECCurve.NamedCurves.nistP256,
+                    Q = new ECPoint
+                    {
+                        X = Base64Url.DecodeFromChars(xEl.GetString()!),
+                        Y = Base64Url.DecodeFromChars(yEl.GetString()!),
+                    },
+                });
+                // IetfTokenStatusListSerializer signs with raw SignData → DER output
+                // by default. Accept both IEEE P1363 concatenated and DER forms.
+                return ecdsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256)
+                    || ecdsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256,
+                        DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+            }
+
+            if (normalisedAlg is "EDDSA" or "ED25519"
+                && jwk.TryGetProperty("kty", out var kty2) && kty2.GetString() == "OKP"
+                && jwk.TryGetProperty("x", out var okpXEl))
+            {
+                var publicKey = Base64Url.DecodeFromChars(okpXEl.GetString()!);
+                return Sodium.PublicKeyAuth.VerifyDetached(signature, signingInput, publicKey);
+            }
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static byte[] ZLibDecompress(byte[] compressed)
+    {
+        using var input = new MemoryStream(compressed);
+        using var zlib = new ZLibStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        zlib.CopyTo(output);
+        return output.ToArray();
+    }
+
+    /// <summary>
+    /// Reads the bit at entry index <paramref name="idx"/> from a bitstring where
+    /// each entry takes <paramref name="bitsPerEntry"/> bits. Returns
+    /// <see cref="StatusListBit.Set"/> if any bit in the entry is set; otherwise
+    /// <see cref="StatusListBit.NotSet"/>.
+    /// </summary>
+    internal static StatusListBit ReadBit(byte[] raw, int idx, int bitsPerEntry)
+    {
+        if (bitsPerEntry <= 0) return StatusListBit.Unknown;
+
+        var startBit = (long)idx * bitsPerEntry;
+        var endBit = startBit + bitsPerEntry;
+        if (endBit > (long)raw.Length * 8)
+            return StatusListBit.Unknown;
+
+        for (var bit = startBit; bit < endBit; bit++)
+        {
+            var byteIdx = (int)(bit / 8);
+            var bitIdx = (int)(bit % 8);
+            // IETF & W3C use MSB-first bit ordering within a byte.
+            if ((raw[byteIdx] & (1 << (7 - bitIdx))) != 0)
+                return StatusListBit.Set;
+        }
+        return StatusListBit.NotSet;
+    }
+}
+
+/// <summary>
+/// Result of reading a bit from a status list bitstring.
+/// </summary>
+public enum StatusListBit
+{
+    /// <summary>Bit read successfully and is 0 — credential is active.</summary>
+    NotSet = 0,
+    /// <summary>Bit read successfully and is 1 — credential is revoked or suspended.</summary>
+    Set = 1,
+    /// <summary>Status could not be resolved (fetch failed, signature invalid, etc.).</summary>
+    Unknown = 2,
+}

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -564,14 +564,32 @@ public static class CredentialEndpoints
                 ? "revocation"
                 : request.StatusListPurpose!;
 
-            claims["credentialStatus"] = new Dictionary<string, object>
+            // Feature 095 US3: HAIP-path callers select the IETF shape so external
+            // wallets can read status via IETF Token Status List semantics; internal
+            // callers keep the W3C shape to preserve spec 093 behaviour. Exactly one
+            // shape is embedded per credential — callers cannot opt into both.
+            if (request.StatusClaimForm == Sorcha.Wallet.Service.Models.StatusClaimForm.IetfTokenStatusList)
             {
-                ["id"] = $"{request.StatusListUrl}#{request.StatusListIndex.Value}",
-                ["type"] = "BitstringStatusListEntry",
-                ["statusPurpose"] = purpose,
-                ["statusListIndex"] = request.StatusListIndex.Value.ToString(),
-                ["statusListCredential"] = request.StatusListUrl!
-            };
+                claims["status"] = new Dictionary<string, object>
+                {
+                    ["status_list"] = new Dictionary<string, object>
+                    {
+                        ["uri"] = request.StatusListUrl!,
+                        ["idx"] = request.StatusListIndex.Value,
+                    },
+                };
+            }
+            else
+            {
+                claims["credentialStatus"] = new Dictionary<string, object>
+                {
+                    ["id"] = $"{request.StatusListUrl}#{request.StatusListIndex.Value}",
+                    ["type"] = "BitstringStatusListEntry",
+                    ["statusPurpose"] = purpose,
+                    ["statusListIndex"] = request.StatusListIndex.Value.ToString(),
+                    ["statusListCredential"] = request.StatusListUrl!
+                };
+            }
         }
 
         var token = await sdJwtService.CreateTokenAsync(
@@ -718,6 +736,18 @@ public class IssueCredentialRequest
     /// are provided and this field is left null.
     /// </summary>
     public string? StatusListPurpose { get; init; }
+
+    /// <summary>
+    /// Feature 095 US3 — selects which status-list claim shape to embed in the
+    /// signed SD-JWT payload. Defaults to the spec 093 W3C form; HAIP-path callers
+    /// set <see cref="Sorcha.Wallet.Service.Models.StatusClaimForm.IetfTokenStatusList"/>
+    /// so external wallets can read the status via IETF semantics
+    /// (<c>status.status_list.uri</c> + <c>idx</c>). Requires
+    /// <see cref="StatusListUrl"/> and <see cref="StatusListIndex"/> to be set;
+    /// when the allocation is absent this field is ignored (no claim embedded).
+    /// </summary>
+    public Sorcha.Wallet.Service.Models.StatusClaimForm StatusClaimForm { get; init; }
+        = Sorcha.Wallet.Service.Models.StatusClaimForm.W3cBitstringStatusListEntry;
 
     /// <summary>
     /// Feature 106: When true, the credential is stored only in the issuer's wallet — not

--- a/src/Services/Sorcha.Wallet.Service/Models/StatusClaimForm.cs
+++ b/src/Services/Sorcha.Wallet.Service/Models/StatusClaimForm.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Wallet.Service.Models;
+
+/// <summary>
+/// Feature 095 US3 — selector for which status-list claim shape a credential
+/// carries in its signed SD-JWT payload.
+/// </summary>
+/// <remarks>
+/// The default value is <see cref="W3cBitstringStatusListEntry"/>, which preserves
+/// the spec 093 behaviour for any caller that does not opt in. HAIP-path issuance
+/// explicitly selects <see cref="IetfTokenStatusList"/> so external wallets and
+/// verifiers can read the status via IETF Token Status List semantics.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum StatusClaimForm
+{
+    /// <summary>
+    /// Embed a W3C <c>credentialStatus</c> claim with a
+    /// <c>BitstringStatusListEntry</c>. Spec 093 behaviour.
+    /// </summary>
+    W3cBitstringStatusListEntry = 0,
+
+    /// <summary>
+    /// Embed an IETF <c>status.status_list</c> claim carrying <c>uri</c> and
+    /// <c>idx</c>. The issuer publishes the backing bitstring at the
+    /// <c>/api/v1/credentials/ietf-status-lists/{listId}</c> endpoint as a
+    /// signed JWT with <c>typ=statuslist+jwt</c>.
+    /// </summary>
+    IetfTokenStatusList = 1,
+}

--- a/tests/Sorcha.Haip.Service.Tests/Services/IetfTokenStatusListCheckerTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/IetfTokenStatusListCheckerTests.cs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Sorcha.Haip.Service.Services;
+
+using Xunit;
+
+namespace Sorcha.Haip.Service.Tests.Services;
+
+/// <summary>
+/// Feature 095 US4 — verifies <see cref="IetfTokenStatusListChecker"/> can round-
+/// trip a signed envelope produced by the issuer-side
+/// <see cref="Sorcha.Blueprint.Service.Services.IetfTokenStatusListSerializer"/>.
+/// The signature verification closes the real security boundary — malicious
+/// endpoints cannot fake a revocation state.
+/// </summary>
+public class IetfTokenStatusListCheckerTests
+{
+    [Fact]
+    public void ParseAndReadBit_NotSet_WhenBitAtIdxIsZero()
+    {
+        // Single-bit list of 128 bits, all zero — every index should read NotSet.
+        var jwt = BuildSignedEnvelope(new byte[16], bitsPerEntry: 1);
+
+        var bit = IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 42);
+
+        bit.Should().Be(StatusListBit.NotSet);
+    }
+
+    [Fact]
+    public void ParseAndReadBit_Set_WhenBitAtIdxIsOne()
+    {
+        // Set the bit at index 42 to 1. MSB-first within a byte: bit 42 → byte 5, bit 2.
+        var raw = new byte[16];
+        SetBit(raw, 42);
+        var jwt = BuildSignedEnvelope(raw, bitsPerEntry: 1);
+
+        var bit = IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 42);
+
+        bit.Should().Be(StatusListBit.Set);
+        IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 41).Should().Be(StatusListBit.NotSet);
+        IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 43).Should().Be(StatusListBit.NotSet);
+    }
+
+    [Fact]
+    public void ParseAndReadBit_Unknown_WhenSignatureInvalid()
+    {
+        var jwt = BuildSignedEnvelope(new byte[16], bitsPerEntry: 1);
+        // Flip the last byte of the signature segment to invalidate it.
+        var parts = jwt.Split('.');
+        var sigBytes = Base64Url.DecodeFromChars(parts[2]);
+        sigBytes[^1] ^= 0xFF;
+        var tamperedJwt = $"{parts[0]}.{parts[1]}.{Base64Url.EncodeToString(sigBytes)}";
+
+        var bit = IetfTokenStatusListChecker.ParseAndReadBit(tamperedJwt, idx: 0);
+
+        bit.Should().Be(StatusListBit.Unknown,
+            "a tampered signature MUST cause the status read to be treated as Unknown, never Active");
+    }
+
+    [Fact]
+    public void ParseAndReadBit_Unknown_WhenTypHeaderWrong()
+    {
+        // Rebuild an envelope with typ="jwt" instead of statuslist+jwt — verifier
+        // must refuse because it wasn't meant as a status list.
+        var jwt = BuildSignedEnvelope(new byte[16], bitsPerEntry: 1, typ: "jwt");
+
+        var bit = IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 0);
+
+        bit.Should().Be(StatusListBit.Unknown);
+    }
+
+    [Fact]
+    public void ParseAndReadBit_Unknown_WhenIdxOutOfRange()
+    {
+        var jwt = BuildSignedEnvelope(new byte[16], bitsPerEntry: 1);
+
+        IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 128).Should().Be(StatusListBit.Unknown);
+        IetfTokenStatusListChecker.ParseAndReadBit(jwt, idx: 10_000).Should().Be(StatusListBit.Unknown);
+    }
+
+    [Fact]
+    public void ReadBit_TwoBitList_ReadsAcrossBoundary()
+    {
+        // 2-bit list: entry 0 occupies bits 0-1, entry 1 occupies 2-3, etc.
+        // Set entry index 3 (bits 6-7) to 01 — any bit set → Set.
+        var raw = new byte[2];
+        raw[0] = 0b0000_0001;
+
+        IetfTokenStatusListChecker.ReadBit(raw, idx: 3, bitsPerEntry: 2)
+            .Should().Be(StatusListBit.Set);
+        IetfTokenStatusListChecker.ReadBit(raw, idx: 0, bitsPerEntry: 2)
+            .Should().Be(StatusListBit.NotSet);
+    }
+
+    // --- Test helpers ---
+
+    private static void SetBit(byte[] raw, int idx)
+    {
+        var byteIdx = idx / 8;
+        var bitIdx = idx % 8;
+        raw[byteIdx] |= (byte)(1 << (7 - bitIdx));
+    }
+
+    private static string BuildSignedEnvelope(byte[] rawBitstring, int bitsPerEntry, string typ = "statuslist+jwt")
+    {
+        // Mirror what IetfTokenStatusListSerializer produces: zlib-compress the raw
+        // bits, base64url, build header+payload, sign with ES256, embed the JWK so
+        // the checker can self-resolve the key (dev phase; pre-x5c).
+        var compressed = ZLibCompress(rawBitstring);
+        var lst = Base64Url.EncodeToString(compressed);
+
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var parameters = ecdsa.ExportParameters(includePrivateParameters: false);
+
+        var header = new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = typ,
+            ["jwk"] = new Dictionary<string, string>
+            {
+                ["kty"] = "EC",
+                ["crv"] = "P-256",
+                ["x"] = Base64Url.EncodeToString(parameters.Q.X!),
+                ["y"] = Base64Url.EncodeToString(parameters.Q.Y!),
+            },
+        };
+
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var payload = new Dictionary<string, object>
+        {
+            ["iss"] = "did:sorcha:test:issuer",
+            ["sub"] = "https://test/list/1",
+            ["iat"] = now,
+            ["exp"] = now + 3600,
+            ["status_list"] = new Dictionary<string, object>
+            {
+                ["bits"] = bitsPerEntry,
+                ["lst"] = lst,
+            },
+        };
+
+        var headerB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.UTF8.GetBytes($"{headerB64}.{payloadB64}");
+        var signature = ecdsa.SignData(signingInput, HashAlgorithmName.SHA256);
+        return $"{headerB64}.{payloadB64}.{Base64Url.EncodeToString(signature)}";
+    }
+
+    private static byte[] ZLibCompress(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, CompressionLevel.Optimal))
+        {
+            zlib.Write(data, 0, data.Length);
+        }
+        return output.ToArray();
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/StatusClaimFormTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/StatusClaimFormTests.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Sorcha.Wallet.Service.Models;
+
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Credentials;
+
+/// <summary>
+/// Feature 095 US3 — locks in the wire shape for the new
+/// <see cref="StatusClaimForm"/> enum so the Blueprint Service can set the HAIP
+/// form by string name over HTTP without this diverging silently.
+/// </summary>
+public class StatusClaimFormTests
+{
+    [Fact]
+    public void Enum_Default_IsW3cBitstringStatusListEntry()
+    {
+        // Default covers callers that haven't been migrated — spec 093 behaviour
+        // must continue to be the fallback shape.
+        default(StatusClaimForm).Should().Be(StatusClaimForm.W3cBitstringStatusListEntry);
+    }
+
+    [Fact]
+    public void Enum_SerializesAsString_NotInteger()
+    {
+        // The JsonStringEnumConverter annotation means requests carry the string
+        // names on the wire, not ordinal ints. Accidentally losing the converter
+        // would break every HAIP caller silently.
+        var payload = JsonSerializer.Serialize(StatusClaimForm.IetfTokenStatusList);
+
+        payload.Should().Be("\"IetfTokenStatusList\"");
+    }
+
+    [Fact]
+    public void Enum_RoundTripsFromWire()
+    {
+        var wire = "\"IetfTokenStatusList\"";
+        var parsed = JsonSerializer.Deserialize<StatusClaimForm>(wire);
+        parsed.Should().Be(StatusClaimForm.IetfTokenStatusList);
+
+        wire = "\"W3cBitstringStatusListEntry\"";
+        parsed = JsonSerializer.Deserialize<StatusClaimForm>(wire);
+        parsed.Should().Be(StatusClaimForm.W3cBitstringStatusListEntry);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the remaining user stories for spec 095 IETF Token Status List. Phases 1-4 (endpoint, serializer, dual-envelope byte-identity) were already on master from an earlier partial landing; this PR lands **US3 (claim-form issuance)** and **US4 (verifier consumer)**, which together close **Category 1c from the completion plan** — \`HaipPresentationVerifier\` now actually fetches, verifies, and reads status instead of returning a blind \`Active\`.

## Changes

### US3 — \`StatusClaimForm\` on issuance (Wallet Service)

- New \`StatusClaimForm\` enum (\`W3cBitstringStatusListEntry\` default / \`IetfTokenStatusList\` opt-in) with \`JsonStringEnumConverter\` so it round-trips as a string name on the wire.
- Added as an optional field on \`IssueCredentialRequest\`.
- \`CredentialEndpoints.IssueCredential\` branches on the form:
  - IETF: embeds \`status: { status_list: { uri, idx } }\`
  - W3C: keeps existing \`credentialStatus: { id, type, statusPurpose, statusListIndex, statusListCredential }\`
- Exactly one shape per credential. Spec 093 callers continue unchanged.

### US4 — Verifier fetches + verifies + decompresses (Haip Service)

New \`IetfTokenStatusListChecker\` service (\`HttpClient\`-backed, standard .NET connection pooling + 10s timeout):

1. Fetches the signed envelope JWT from the status list URI
2. Verifies \`typ=\"statuslist+jwt\"\` and the signature against the embedded JWK header (pre-x5c; spec 096 will replace the JWK with an x5c chain)
3. zlib-decompresses the \`lst\` field
4. Reads the bit at the requested index (MSB-first, supports 1-bit and 2-bit lists)

Returns an explicit \`StatusListBit { NotSet, Set, Unknown }\`.

\`HaipPresentationVerifier.CheckStatus\` is now \`CheckStatusAsync\` with deterministic precedence:

| Claim | Result |
|-------|--------|
| IETF \`status.status_list\` | Fetch + verify + read → \`Active\` / \`Revoked\` |
| W3C \`credentialStatus\` | Same checker (both point at signed JWT envelope) → \`Active\` / \`Revoked\` / \`Suspended\` (disambiguated by \`statusPurpose\`) |
| No claim | \`null\` — caller treats as Active |
| Fetch / signature failure | \`\"Unknown\"\` — non-fatal, caller decides fail-open policy |

**Security posture**: tampered signatures, wrong \`typ\` headers, out-of-range indices, and unreachable endpoints all fail closed to \`Unknown\` — never silently \`Active\`.

## Tests

| File | Tests | Coverage |
|------|-------|----------|
| \`IetfTokenStatusListCheckerTests\` | 6 | bit-read round trip at set / unset positions, tampered signature → Unknown, wrong \`typ\` → Unknown, out-of-range idx → Unknown, 2-bit list entry bounds |
| \`StatusClaimFormTests\` | 3 | default = W3C, serializes as string name (not ordinal int), round-trips from wire |

## Test plan

- [x] \`dotnet build Sorcha.sln\` clean (57 pre-existing warnings, 0 errors)
- [x] 620/620 \`Sorcha.Wallet.Service.Tests\` pass (+3)
- [x] 46/46 \`Sorcha.Haip.Service.Tests\` pass (+6)

## Deferred

- **Phase 7 docs polish** — low-value churn; defer to a sweep after Category 3 x5c lands (the JWK header shape will change)
- **TODO(095) on Blueprint Service signing key** — needs \`IHaipIssuerCoKeyService\` wiring; bundled with spec 094 production key work

🤖 Generated with [Claude Code](https://claude.com/claude-code)