### PR TITLE
feat(096): x5c embedding + config-driven trust anchors (US3 + US6)

### DIFF
--- a/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
@@ -25,6 +25,13 @@ public interface ISdJwtService
     /// <param name="signingKey">Private key bytes for signing (algorithm determined by key type).</param>
     /// <param name="algorithm">Signing algorithm (e.g., "EdDSA", "ES256", "RS256").</param>
     /// <param name="expiresAt">Optional expiration timestamp.</param>
+    /// <param name="x5cChain">
+    /// Feature 096 US3 — optional X.509 certificate chain (leaf first) to embed
+    /// in the JWS header's <c>x5c</c> array per RFC 7515 §4.1.6. When supplied,
+    /// verifiers can validate the issuer key against a trust anchor without DID
+    /// resolution. Each entry is raw DER bytes; the header encodes them as
+    /// base64 (not base64url).
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The created SD-JWT token with all disclosures.</returns>
     Task<SdJwtToken> CreateTokenAsync(
@@ -35,7 +42,8 @@ public interface ISdJwtService
         byte[] signingKey,
         string algorithm,
         DateTimeOffset? expiresAt = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<byte[]>? x5cChain = null);
 
     /// <summary>
     /// Creates a new SD-JWT VC token with selective disclosure and holder key binding (cnf).
@@ -48,6 +56,7 @@ public interface ISdJwtService
     /// <param name="algorithm">Signing algorithm (e.g., "EdDSA", "ES256", "RS256").</param>
     /// <param name="holderJwk">Holder's public key in JWK form, embedded as the <c>cnf.jwk</c> claim.</param>
     /// <param name="expiresAt">Optional expiration timestamp.</param>
+    /// <param name="x5cChain">Feature 096 US3 — optional X.509 chain for the JWS header.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The created SD-JWT token with cnf claim and all disclosures.</returns>
     Task<SdJwtToken> CreateTokenAsync(
@@ -59,7 +68,8 @@ public interface ISdJwtService
         string algorithm,
         JsonElement holderJwk,
         DateTimeOffset? expiresAt = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<byte[]>? x5cChain = null);
 
     /// <summary>
     /// Verifies an SD-JWT token's signature, structure, and extracts all disclosed claims.

--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -34,10 +34,11 @@ public class SdJwtService : ISdJwtService
         byte[] signingKey,
         string algorithm,
         DateTimeOffset? expiresAt = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<byte[]>? x5cChain = null)
     {
         return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject, signingKey,
-            algorithm, holderJwk: null, expiresAt, cancellationToken);
+            algorithm, holderJwk: null, expiresAt, x5cChain, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -50,10 +51,11 @@ public class SdJwtService : ISdJwtService
         string algorithm,
         JsonElement holderJwk,
         DateTimeOffset? expiresAt = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<byte[]>? x5cChain = null)
     {
         return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject, signingKey,
-            algorithm, holderJwk, expiresAt, cancellationToken);
+            algorithm, holderJwk, expiresAt, x5cChain, cancellationToken);
     }
 
     private Task<SdJwtToken> CreateTokenCoreAsync(
@@ -65,6 +67,7 @@ public class SdJwtService : ISdJwtService
         string algorithm,
         JsonElement? holderJwk,
         DateTimeOffset? expiresAt,
+        IReadOnlyList<byte[]>? x5cChain,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(claims);
@@ -154,6 +157,13 @@ public class SdJwtService : ISdJwtService
             ["alg"] = MapAlgorithm(algorithm),
             ["typ"] = "vc+sd-jwt"
         };
+
+        // Feature 096 US3 — x5c chain, if the caller supplied one. RFC 7515 §4.1.6
+        // mandates base64 (NOT base64url) encoding for x5c entries.
+        if (x5cChain is { Count: > 0 })
+        {
+            header["x5c"] = x5cChain.Select(Convert.ToBase64String).ToArray();
+        }
 
         // Sign the JWT
         var headerB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(header));

--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -45,7 +45,42 @@ builder.Services.AddSingleton<HaipCredentialMinter>();
 
 // Feature 098: HAIP verifier services
 builder.Services.AddSingleton<PresentationRequestStore>();
-builder.Services.AddSingleton<HaipPresentationVerifier>();
+builder.Services.AddSingleton<HaipPresentationVerifier>(sp =>
+{
+    var verifier = new HaipPresentationVerifier(
+        sp.GetRequiredService<Sorcha.Cryptography.SdJwt.ISdJwtService>(),
+        sp.GetRequiredService<ILogger<HaipPresentationVerifier>>(),
+        sp.GetService<Sorcha.ServiceClients.Did.IDidResolverRegistry>(),
+        sp.GetService<IetfTokenStatusListChecker>());
+
+    // Feature 096 US6 — load trusted root CA certs from config. Deployments
+    // list them under `Haip:TrustedRootCertificates` as base64-DER strings.
+    // Without at least one root, x5c chain validation will reject every cert.
+    var configuredRoots = builder.Configuration
+        .GetSection("Haip:TrustedRootCertificates")
+        .Get<string[]>() ?? Array.Empty<string>();
+    var logger = sp.GetRequiredService<ILogger<HaipPresentationVerifier>>();
+    foreach (var rootBase64 in configuredRoots)
+    {
+        if (string.IsNullOrWhiteSpace(rootBase64))
+            continue;
+        try
+        {
+            var der = Convert.FromBase64String(rootBase64);
+            var cert = System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadCertificate(der);
+            verifier.AddTrustedRoot(cert);
+            logger.LogInformation(
+                "Loaded trusted root CA into HAIP verifier: {Subject} (NotAfter={NotAfter})",
+                cert.Subject, cert.NotAfter);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Failed to load a Haip:TrustedRootCertificates entry — skipping and continuing");
+        }
+    }
+    return verifier;
+});
 builder.Services.AddSingleton<RequestObjectSigner>();
 
 // Feature 095 US4: status list fetch for the verifier. Registered as HttpClient-

--- a/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtX5cHeaderTests.cs
+++ b/tests/Sorcha.Cryptography.Tests/SdJwt/SdJwtX5cHeaderTests.cs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Sorcha.Cryptography.SdJwt;
+
+using Xunit;
+
+namespace Sorcha.Cryptography.Tests.SdJwt;
+
+/// <summary>
+/// Feature 096 US3 — verifies <see cref="SdJwtService.CreateTokenAsync"/>
+/// embeds the supplied X.509 chain in the JWS header's <c>x5c</c> array per
+/// RFC 7515 §4.1.6. Downstream verifiers (HaipPresentationVerifier) walk this
+/// chain against a trust anchor to resolve the issuer key without DID lookup.
+/// </summary>
+public class SdJwtX5cHeaderTests
+{
+    private readonly SdJwtService _service = new();
+
+    [Fact]
+    public async Task CreateTokenAsync_WithX5cChain_EmbedsChainInJwsHeader()
+    {
+        var (chain, signingKey) = BuildOrgChain();
+
+        var token = await _service.CreateTokenAsync(
+            claims: new Dictionary<string, object> { ["name"] = "Alice" },
+            disclosableClaims: null,
+            issuer: "did:sorcha:org:ws1qtest",
+            subject: "did:sorcha:w:alice",
+            signingKey: signingKey,
+            algorithm: "ES256",
+            expiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            cancellationToken: default,
+            x5cChain: chain);
+
+        // Decode the header segment and assert x5c is an array of base64-encoded DER.
+        var headerB64 = token.RawToken.Split('.')[0];
+        var headerJson = Base64Url.DecodeFromChars(headerB64);
+        using var doc = JsonDocument.Parse(headerJson);
+
+        doc.RootElement.TryGetProperty("x5c", out var x5c).Should().BeTrue(
+            "x5c header MUST be present when chain supplied");
+        x5c.ValueKind.Should().Be(JsonValueKind.Array);
+        x5c.GetArrayLength().Should().Be(chain.Count);
+
+        // First entry must be the leaf cert (DER matches).
+        var leafFromHeader = Convert.FromBase64String(x5c[0].GetString()!);
+        leafFromHeader.Should().BeEquivalentTo(chain[0],
+            "leaf cert in x5c must be byte-identical to the one passed in");
+
+        // Header still carries the standard JWT claims.
+        doc.RootElement.GetProperty("alg").GetString().Should().Be("ES256");
+        doc.RootElement.GetProperty("typ").GetString().Should().Be("vc+sd-jwt");
+    }
+
+    [Fact]
+    public async Task CreateTokenAsync_NullX5cChain_OmitsHeader()
+    {
+        // Default behaviour (pre-096) — no x5c header — MUST continue to hold so
+        // issuer flows that don't have a cert chain yet keep working.
+        var (_, signingKey) = BuildOrgChain();
+
+        var token = await _service.CreateTokenAsync(
+            claims: new Dictionary<string, object> { ["name"] = "Alice" },
+            disclosableClaims: null,
+            issuer: "did:sorcha:org:ws1qtest",
+            subject: "did:sorcha:w:alice",
+            signingKey: signingKey,
+            algorithm: "ES256");
+
+        var headerJson = Base64Url.DecodeFromChars(token.RawToken.Split('.')[0]);
+        using var doc = JsonDocument.Parse(headerJson);
+        doc.RootElement.TryGetProperty("x5c", out _).Should().BeFalse(
+            "x5c header MUST be absent when no chain supplied (spec 096 backward-compat)");
+    }
+
+    [Fact]
+    public async Task CreateTokenAsync_EmptyX5cChain_OmitsHeader()
+    {
+        var (_, signingKey) = BuildOrgChain();
+
+        var token = await _service.CreateTokenAsync(
+            claims: new Dictionary<string, object> { ["name"] = "Alice" },
+            disclosableClaims: null,
+            issuer: "did:sorcha:org:ws1qtest",
+            subject: "did:sorcha:w:alice",
+            signingKey: signingKey,
+            algorithm: "ES256",
+            expiresAt: null,
+            cancellationToken: default,
+            x5cChain: Array.Empty<byte[]>());
+
+        var headerJson = Base64Url.DecodeFromChars(token.RawToken.Split('.')[0]);
+        using var doc = JsonDocument.Parse(headerJson);
+        doc.RootElement.TryGetProperty("x5c", out _).Should().BeFalse(
+            "empty chain treated as 'no chain' — don't emit an empty array");
+    }
+
+    // --- helpers ---
+
+    /// <summary>
+    /// Builds a minimal two-cert chain: self-signed root CA + org leaf signed
+    /// by it. Returns the chain (leaf first, root last) plus the org's signing
+    /// key bytes so the test can create a token signed by the leaf.
+    /// </summary>
+    private static (IReadOnlyList<byte[]> Chain, byte[] SigningKey) BuildOrgChain()
+    {
+        using var rootEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var rootRequest = new CertificateRequest(
+            new X500DistinguishedName("CN=Test Root CA"),
+            rootEcdsa,
+            HashAlgorithmName.SHA256);
+        rootRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(true, true, 1, true));
+        rootRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, true));
+
+        var now = DateTimeOffset.UtcNow;
+        using var rootCert = rootRequest.CreateSelfSigned(now, now.AddYears(5));
+
+        using var orgEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var orgRequest = new CertificateRequest(
+            new X500DistinguishedName("CN=Test Org Leaf"),
+            orgEcdsa,
+            HashAlgorithmName.SHA256);
+        orgRequest.CertificateExtensions.Add(
+            new X509BasicConstraintsExtension(false, false, 0, true));
+        orgRequest.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true));
+
+        var serial = RandomNumberGenerator.GetBytes(16);
+        serial[0] &= 0x7F;
+        using var orgCert = orgRequest.Create(
+            rootCert.SubjectName,
+            X509SignatureGenerator.CreateForECDsa(rootEcdsa),
+            now, now.AddYears(2), serial);
+
+        var chain = new List<byte[]> { orgCert.RawData, rootCert.RawData };
+        return (chain, orgEcdsa.ExportECPrivateKey());
+    }
+}


### PR DESCRIPTION
## Summary

Completes spec 096 **User Story 3** (x5c embedding on HAIP-path issuance) and the config-binding half of **US6** (verifier trust anchors loaded from deployment config). Chain-walk validation against \`_trustedRoots\` already existed in \`HaipPresentationVerifier.ValidateX5cChain\` — this PR supplies the inputs it needs from both ends.

## Changes

### Issuer side (US3)

\`ISdJwtService.CreateTokenAsync\` gains an optional \`IReadOnlyList<byte[]> x5cChain\` on both overloads. When supplied, the JWS header includes \`x5c\` with each cert base64-encoded per RFC 7515 §4.1.6 (base64, **not** base64url).

Parameter placed after \`cancellationToken\` so every existing positional caller (CredentialIssuer, CredentialEndpoints, HaipCredentialMinter, and every test passing \`ct\` positionally) compiles unchanged. Unusual but preferable to breaking every caller.

Null or empty chain → no header key emitted → byte-identical output for every pre-096 caller.

### Verifier side (US6 half)

\`Program.cs\` reads \`Haip:TrustedRootCertificates\` (array of base64-DER) from config at startup and calls \`AddTrustedRoot\` for each valid entry. Invalid entries are logged and skipped. Without at least one trusted root the chain walk rejects every x5c presentation — the safe default.

## Tests

\`SdJwtX5cHeaderTests\` (3):
- Chain supplied → \`x5c\` header present, base64-DER matches input
- No chain → no \`x5c\` key (backward compat with pre-096 callers)
- Empty chain → no \`x5c\` key (empty treated as absent)

Existing \`HaipPresentationVerifier\` chain-walk tests cover the verifier side via \`AddTrustedRoot\`.

## Test plan

- [x] 373/373 \`Sorcha.Cryptography.Tests\` (+3)
- [x] 46/46 \`Sorcha.Haip.Service.Tests\`
- [x] 461 \`Sorcha.Blueprint.Engine.Tests\`
- [x] 620 \`Sorcha.Wallet.Service.Tests\`
- [x] \`dotnet build Sorcha.sln\` clean (64 pre-existing warnings)

## Deferred

- **Wallet Service HAIP-path chain fetch** — Wallet Service needs to call Tenant Service \`/cert-chain\` and pass the chain into \`CreateTokenAsync\`. Last US3 piece — separate PR, bundled with the Wallet↔Tenant service client.
- **CRL revocation check during chain walk** (\`X509RevocationMode.Online\`). Chain-walk uses \`NoCheck\` today; full US6 adds CRL fetch during verification. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)