### PR TITLE
feat(master-phase2): join-private-register audit-trail blueprint

### DIFF
--- a/blueprints/templates/join-private-register-v1.json
+++ b/blueprints/templates/join-private-register-v1.json
@@ -1,0 +1,92 @@
+{
+  "id": "join-private-register-v1",
+  "title": "Join Private Register",
+  "description": "Records the lifecycle of a private-register invitation on the system register: a source organisation creates an invitation for a target organisation, and the target records acceptance on-ledger so every node in the network can audit the subscription decision.",
+  "version": 1,
+  "category": "governance",
+  "tags": ["governance", "invitation", "private-register"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "@context": "https://sorcha.dev/blueprints/v1",
+    "id": "join-private-register-v1",
+    "title": "Join Private Register",
+    "description": "Records the lifecycle of a private-register invitation on the system register.",
+    "version": 1,
+    "participants": [
+      { "id": "sourceOrg", "name": "Inviting Organisation", "organisation": "Register Owner" },
+      { "id": "targetOrg", "name": "Target Organisation", "organisation": "Invitee" }
+    ],
+    "actions": [
+      {
+        "id": 0,
+        "title": "Create Invitation",
+        "sender": "sourceOrg",
+        "isStartingAction": true,
+        "schema": {
+          "type": "object",
+          "required": ["invitationId", "registerId", "sourceOrgDid", "targetOrgDid", "nonce", "expiresAt"],
+          "properties": {
+            "invitationId":  { "type": "string", "description": "UUID of this invitation." },
+            "registerId":    { "type": "string", "pattern": "^[a-f0-9]{32}$", "description": "32-char hex register ID being shared." },
+            "sourceOrgDid":  { "type": "string", "description": "did:sorcha:org:{walletAddress} of the inviting org." },
+            "targetOrgDid":  { "type": "string", "description": "did:sorcha:org:{walletAddress} of the target org." },
+            "registerName":  { "type": ["string", "null"], "description": "Display name at create time (audit)." },
+            "nonce":         { "type": "string", "description": "Single-use nonce that the acceptance action must reference." },
+            "expiresAt":     { "type": "string", "format": "date-time", "description": "ISO-8601 UTC expiry." }
+          }
+        },
+        "routes": [
+          { "id": "to-accept-or-expire", "nextActionIds": [1], "isDefault": true }
+        ]
+      },
+      {
+        "id": 1,
+        "title": "Accept Invitation",
+        "sender": "targetOrg",
+        "schema": {
+          "type": "object",
+          "required": ["invitationId", "registerId", "nonce"],
+          "properties": {
+            "invitationId":  { "type": "string", "description": "Must equal the invitationId recorded in Action 0." },
+            "registerId":    { "type": "string", "pattern": "^[a-f0-9]{32}$" },
+            "nonce":         { "type": "string", "description": "MUST match the nonce from Action 0; consumed here." },
+            "acceptedAt":    { "type": "string", "format": "date-time" }
+          }
+        },
+        "routes": []
+      }
+    ],
+    "metadata": {
+      "category": "governance",
+      "type": "join-private-register",
+      "isSystem": "true",
+      "hasCycles": "false"
+    }
+  },
+  "parameterSchema": null,
+  "defaultParameters": null,
+  "examples": [
+    {
+      "name": "Typical invitation flow",
+      "description": "Source org creates invitation, target org accepts within 14 days.",
+      "actionPayloads": {
+        "0": {
+          "invitationId": "00000000-0000-0000-0000-000000000001",
+          "registerId": "aebf26362e079087571ac0932d4db973",
+          "sourceOrgDid": "did:sorcha:org:ws1qsource",
+          "targetOrgDid": "did:sorcha:org:ws1qtarget",
+          "registerName": "Shared Procurement Register",
+          "nonce": "11111111-2222-3333-4444-555555555555",
+          "expiresAt": "2026-04-30T00:00:00Z"
+        },
+        "1": {
+          "invitationId": "00000000-0000-0000-0000-000000000001",
+          "registerId": "aebf26362e079087571ac0932d4db973",
+          "nonce": "11111111-2222-3333-4444-555555555555",
+          "acceptedAt": "2026-04-20T09:30:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
@@ -386,7 +386,16 @@ public class SystemRegisterBootstrapper : BackgroundService
         SystemRegisterService systemRegisterService,
         CancellationToken cancellationToken)
     {
-        var blueprints = new[] { "register-creation-v1", "register-governance-v1", "create-organisation-v1" };
+        var blueprints = new[]
+        {
+            "register-creation-v1",
+            "register-governance-v1",
+            "create-organisation-v1",
+            // Spec master Phase 2 US11 — audit-trail blueprint for private-register
+            // invitation lifecycle. Must be published before the first acceptance so
+            // RegisterInvitationService can submit an instance against it.
+            "join-private-register-v1",
+        };
 
         foreach (var blueprintId in blueprints)
         {

--- a/tests/Sorcha.Blueprint.Models.Tests/JoinPrivateRegisterBlueprintTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/JoinPrivateRegisterBlueprintTests.cs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace Sorcha.Blueprint.Models.Tests;
+
+/// <summary>
+/// Spec master Phase 2 US11 — shape contract for the join-private-register
+/// governance blueprint. Parses the JSON, confirms the on-ledger audit-trail
+/// actions exist with the right sender participants and required schema fields.
+/// The SystemRegisterBootstrapper seeds this blueprint at startup; if the shape
+/// drifts, acceptance invitations will fail to create instances against it.
+/// </summary>
+public class JoinPrivateRegisterBlueprintTests
+{
+    private const string BlueprintId = "join-private-register-v1";
+
+    private static JsonElement LoadTemplate()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var repoRoot = FindRepoRoot(baseDir);
+        var path = Path.Combine(repoRoot, "blueprints", "templates", $"{BlueprintId}.json");
+        File.Exists(path).Should().BeTrue($"blueprint catalog must carry {BlueprintId} at {path}");
+
+        var json = File.ReadAllText(path);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("template").Clone();
+    }
+
+    private static string FindRepoRoot(string startDir)
+    {
+        var dir = startDir;
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir, ".git"))
+                || Directory.Exists(Path.Combine(dir, "blueprints")))
+            {
+                return dir;
+            }
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        return Path.GetFullPath(Path.Combine(startDir, "..", "..", "..", "..", "..", ".."));
+    }
+
+    [Fact]
+    public void Template_IdentifiesAsJoinPrivateRegisterV1()
+    {
+        var template = LoadTemplate();
+        template.GetProperty("id").GetString().Should().Be(BlueprintId);
+        template.GetProperty("version").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public void Template_HasSourceAndTargetParticipants()
+    {
+        var template = LoadTemplate();
+        var participants = template.GetProperty("participants");
+        participants.GetArrayLength().Should().Be(2);
+
+        var ids = new HashSet<string>();
+        foreach (var p in participants.EnumerateArray())
+            ids.Add(p.GetProperty("id").GetString()!);
+
+        ids.Should().Contain("sourceOrg");
+        ids.Should().Contain("targetOrg");
+    }
+
+    [Fact]
+    public void Template_HasCreateAndAcceptActions()
+    {
+        var template = LoadTemplate();
+        var actions = template.GetProperty("actions");
+        actions.GetArrayLength().Should().Be(2);
+
+        var create = actions[0];
+        create.GetProperty("title").GetString().Should().Be("Create Invitation");
+        create.GetProperty("sender").GetString().Should().Be("sourceOrg");
+        create.GetProperty("isStartingAction").GetBoolean().Should().BeTrue();
+
+        var accept = actions[1];
+        accept.GetProperty("title").GetString().Should().Be("Accept Invitation");
+        accept.GetProperty("sender").GetString().Should().Be("targetOrg");
+    }
+
+    [Fact]
+    public void CreateAction_Schema_RequiresAuditFields()
+    {
+        var template = LoadTemplate();
+        var create = template.GetProperty("actions")[0];
+        var required = create.GetProperty("schema").GetProperty("required");
+
+        var requiredFields = new HashSet<string>();
+        foreach (var r in required.EnumerateArray())
+            requiredFields.Add(r.GetString()!);
+
+        requiredFields.Should().Contain("invitationId",
+            "acceptance must be correlatable to a specific invitation record");
+        requiredFields.Should().Contain("registerId");
+        requiredFields.Should().Contain("sourceOrgDid");
+        requiredFields.Should().Contain("targetOrgDid");
+        requiredFields.Should().Contain("nonce",
+            "nonce must be recorded on-ledger so replay detection spans nodes");
+        requiredFields.Should().Contain("expiresAt");
+    }
+
+    [Fact]
+    public void AcceptAction_Schema_ReferencesOriginalNonce()
+    {
+        var template = LoadTemplate();
+        var accept = template.GetProperty("actions")[1];
+        var required = accept.GetProperty("schema").GetProperty("required");
+
+        var requiredFields = new HashSet<string>();
+        foreach (var r in required.EnumerateArray())
+            requiredFields.Add(r.GetString()!);
+
+        requiredFields.Should().Contain("invitationId");
+        requiredFields.Should().Contain("nonce",
+            "acceptance MUST echo the nonce so a replay attempt is detectable on-chain");
+    }
+
+    [Fact]
+    public void Template_RegisterIdPattern_Matches32HexChars()
+    {
+        // Both actions constrain registerId to 32-char lowercase hex, matching
+        // Sorcha's canonical register ID format. A tighter pattern guards
+        // against accidental cross-register transactions.
+        var template = LoadTemplate();
+        foreach (var action in template.GetProperty("actions").EnumerateArray())
+        {
+            var props = action.GetProperty("schema").GetProperty("properties");
+            props.TryGetProperty("registerId", out var registerIdProp).Should().BeTrue();
+            registerIdProp.GetProperty("pattern").GetString()
+                .Should().Be("^[a-f0-9]{32}$");
+        }
+    }
+
+    [Fact]
+    public void Template_Metadata_MarksAsSystemGovernance()
+    {
+        // isSystem=true + category=governance are read by the bootstrapper to
+        // decide publishing privileges. If these drift the blueprint ends up
+        // in the non-privileged catalog and can't be seeded to the system register.
+        var template = LoadTemplate();
+        var metadata = template.GetProperty("metadata");
+        metadata.GetProperty("category").GetString().Should().Be("governance");
+        metadata.GetProperty("type").GetString().Should().Be("join-private-register");
+        metadata.GetProperty("isSystem").GetString().Should().Be("true");
+    }
+}


### PR DESCRIPTION
## Summary

Spec master Phase 2 **US11** — ships the governance blueprint that records private-register invitation lifecycle on the system register. Closes **T064** (template), **T065** (bootstrap seed), **T067** (shape test).

Backend for Phase 2 is substantially complete already (T037–T057): org DID resolver, \`RegisterInvitationService.CreateAsync\`/\`AcceptAsync\`, \`InvitationNonce\` replay protection, endpoints, tests. What was missing was the on-ledger audit-trail scaffold — without a blueprint published to the system register, the acceptance record was local-only and couldn't be cross-node-audited.

## Changes

- **\`blueprints/templates/join-private-register-v1.json\`** — two-action governance blueprint:
  - Action 0 \"Create Invitation\" (sourceOrg, starting action) — schema requires \`invitationId\`, \`registerId\`, \`sourceOrgDid\`, \`targetOrgDid\`, \`nonce\`, \`expiresAt\`
  - Action 1 \"Accept Invitation\" (targetOrg) — echoes \`invitationId\` and \`nonce\` so replay detection spans nodes
  - 32-char lowercase-hex \`registerId\` pattern matches Sorcha's canonical form
- **\`SystemRegisterBootstrapper.SeedBlueprintsIfMissingAsync\`** — seed array extended to include the new blueprint alongside the existing three. Idempotent.
- **\`JoinPrivateRegisterBlueprintTests\`** — 6 shape tests (id/version, participants, actions, required-field sets, registerId pattern, metadata flags). Drift surfaces at unit-test time rather than as a bootstrap failure.

The Register Service Dockerfile already \`COPY blueprints/templates/\` — no csproj changes needed.

## Test plan

- [x] 393/393 \`Sorcha.Blueprint.Models.Tests\` (+6)
- [x] \`dotnet build Sorcha.sln\` clean

## Deferred

- **T055 / T066** — wire \`RegisterInvitationService.AcceptAsync\` to submit a blueprint instance against this blueprint when an invitation is accepted. Needs a Blueprint Service client injection. Separate PR.
- **T058–T063** — Blazor UI dialogs (\`InviteOrganisationDialog\`, \`AcceptInvitationDialog\`). Separate PR — needs visual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)