### PR TITLE
feat(096): configurable CRL revocation check in verifier (US6 completion)

### DIFF
--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -47,11 +47,19 @@ builder.Services.AddSingleton<HaipCredentialMinter>();
 builder.Services.AddSingleton<PresentationRequestStore>();
 builder.Services.AddSingleton<HaipPresentationVerifier>(sp =>
 {
+    // Feature 096 US6 — deployments with reachable CRL endpoints opt in with
+    // Haip:VerifyRevocation=true. Default off so the chain walk doesn't block
+    // on dead CDP URLs in test/dev environments.
+    var revocationMode = builder.Configuration.GetValue<bool>("Haip:VerifyRevocation")
+        ? System.Security.Cryptography.X509Certificates.X509RevocationMode.Online
+        : System.Security.Cryptography.X509Certificates.X509RevocationMode.NoCheck;
+
     var verifier = new HaipPresentationVerifier(
         sp.GetRequiredService<Sorcha.Cryptography.SdJwt.ISdJwtService>(),
         sp.GetRequiredService<ILogger<HaipPresentationVerifier>>(),
         sp.GetService<Sorcha.ServiceClients.Did.IDidResolverRegistry>(),
-        sp.GetService<IetfTokenStatusListChecker>());
+        sp.GetService<IetfTokenStatusListChecker>(),
+        revocationMode);
 
     // Feature 096 US6 — load trusted root CA certs from config. Deployments
     // list them under `Haip:TrustedRootCertificates` as base64-DER strings.

--- a/src/Services/Sorcha.Haip.Service/Services/HaipPresentationVerifier.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/HaipPresentationVerifier.cs
@@ -24,6 +24,7 @@ public class HaipPresentationVerifier
     private readonly ISdJwtService _sdJwtService;
     private readonly IDidResolverRegistry? _didResolver;
     private readonly IetfTokenStatusListChecker? _ietfStatusChecker;
+    private readonly X509RevocationMode _revocationMode;
     private readonly ILogger<HaipPresentationVerifier> _logger;
 
     // Trusted root certificates for x5c chain validation.
@@ -34,13 +35,20 @@ public class HaipPresentationVerifier
         ISdJwtService sdJwtService,
         ILogger<HaipPresentationVerifier> logger,
         IDidResolverRegistry? didResolver = null,
-        IetfTokenStatusListChecker? ietfStatusChecker = null)
+        IetfTokenStatusListChecker? ietfStatusChecker = null,
+        X509RevocationMode revocationMode = X509RevocationMode.NoCheck)
     {
         _sdJwtService = sdJwtService ?? throw new ArgumentNullException(nameof(sdJwtService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _didResolver = didResolver;
         _ietfStatusChecker = ietfStatusChecker;
+        _revocationMode = revocationMode;
     }
+
+    /// <summary>
+    /// Exposes the effective revocation mode — used by tests and diagnostics.
+    /// </summary>
+    internal X509RevocationMode RevocationMode => _revocationMode;
 
     /// <summary>
     /// Adds a trusted root certificate for x5c chain validation.
@@ -259,7 +267,20 @@ public class HaipPresentationVerifier
         if (certs.Count == 0) return false;
 
         using var chain = new X509Chain();
-        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        // Feature 096 US6 completion — revocation mode defaults to NoCheck for
+        // unit-test friendliness (CDP URLs in tests point at unreachable domains)
+        // but production deployments set Haip:VerifyRevocation=true at DI wiring
+        // time so chain.Build fetches CRLs from the CDP extension embedded in
+        // org certs by the Tenant Service. ExcludeRoot skips the self-signed
+        // tenant root — it has no CRL issuer and will always read as unknown.
+        chain.ChainPolicy.RevocationMode = _revocationMode;
+        if (_revocationMode != X509RevocationMode.NoCheck)
+        {
+            chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+            // 30s is generous enough for a single CDP fetch but tight enough
+            // that a slow CRL endpoint doesn't block the verifier indefinitely.
+            chain.ChainPolicy.UrlRetrievalTimeout = TimeSpan.FromSeconds(30);
+        }
         chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
 
         foreach (var root in _trustedRoots)

--- a/tests/Sorcha.Haip.Service.Tests/Services/HaipPresentationVerifierTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/HaipPresentationVerifierTests.cs
@@ -22,6 +22,35 @@ public class HaipPresentationVerifierTests
 {
     private readonly SdJwtService _sdJwtService = new();
 
+    // --- Feature 096 US6 — revocation mode configurability ---
+
+    [Fact]
+    public void Constructor_DefaultRevocationMode_IsNoCheck()
+    {
+        // Default preserves pre-096 behaviour — unit tests that use self-signed
+        // chains with unreachable CDP URLs must not fail on BCL CRL fetch.
+        var verifier = new HaipPresentationVerifier(
+            _sdJwtService, Mock.Of<ILogger<HaipPresentationVerifier>>());
+
+        verifier.RevocationMode.Should().Be(X509RevocationMode.NoCheck);
+    }
+
+    [Fact]
+    public void Constructor_RevocationModeOverride_IsApplied()
+    {
+        // Production deployments pass Online when Haip:VerifyRevocation=true at
+        // DI wiring time. The field-level value must round-trip from the ctor.
+        var verifier = new HaipPresentationVerifier(
+            _sdJwtService,
+            Mock.Of<ILogger<HaipPresentationVerifier>>(),
+            didResolver: null,
+            ietfStatusChecker: null,
+            revocationMode: X509RevocationMode.Online);
+
+        verifier.RevocationMode.Should().Be(X509RevocationMode.Online);
+    }
+
+
     private static (byte[] privateKey, byte[] publicKey) GenerateP256KeyPair()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);


### PR DESCRIPTION
## Summary

Completes the last spec 096 **US6** piece. \`HaipPresentationVerifier.ValidateX5cChain\` was hardcoded to \`X509RevocationMode.NoCheck\` — acceptable for the dev/pre-release posture that shipped with #317 but it silently skips the CRL check even when the CDP extension is present on org certs.

## Changes

- **\`HaipPresentationVerifier\` ctor** takes an optional \`X509RevocationMode\` parameter (default \`NoCheck\`). The field is exposed internally as \`RevocationMode\` for tests and diagnostics.
- When the mode is not \`NoCheck\`, \`ValidateX5cChain\` also sets \`RevocationFlag.ExcludeRoot\` (the self-signed tenant root has no CRL issuer and would always read as Unknown) and a 30s URL retrieval timeout so a slow CDP doesn't block the verifier.
- **\`Program.cs\`** reads \`Haip:VerifyRevocation\` (bool, default false) at startup and wires \`Online\` when true.

## Rationale

The BCL's \`X509Chain\` handles the CDP fetch + CRL verification for us — no need to re-implement. Keeping the default off preserves every existing test that uses self-signed chains with synthetic CDP URLs pointing at \`sorcha.example\` (unreachable). When the deployment's tenant root is reachable, flipping one config value closes the full X.509 trust+revocation story.

## Tests

2 shape tests:
- \`Constructor_DefaultRevocationMode_IsNoCheck\` — default matches prior behaviour
- \`Constructor_RevocationModeOverride_IsApplied\` — field round-trips from ctor

## Test plan

- [x] 48/48 \`Sorcha.Haip.Service.Tests\` (+2)
- [x] \`dotnet build Sorcha.sln\` clean (78 pre-existing warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)