### PR TITLE
feat(096): org cert chain HTTP client (IOrgCertChainProvider)

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Trust/IOrgCertChainProvider.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Trust/IOrgCertChainProvider.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.ServiceClients.Trust;
+
+/// <summary>
+/// Feature 096 US3 consumer client — fetches an organisation's X.509
+/// certificate chain (leaf + tenant root) from the Tenant Service for use as
+/// the <c>x5c</c> JWS header when issuing HAIP credentials. Return value
+/// order matches the JWS <c>x5c</c> conventions (leaf first, root last).
+/// </summary>
+public interface IOrgCertChainProvider
+{
+    /// <summary>
+    /// Returns the cert chain for <paramref name="orgWalletAddress"/> under
+    /// <paramref name="tenantId"/>. Null when the Tenant Service has no
+    /// active enrolment (404) or the request failed transiently.
+    /// </summary>
+    Task<OrgCertChain?> GetChainForAsync(
+        string tenantId,
+        string orgWalletAddress,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// DER-encoded certificate pair. <see cref="OrgCertDer"/> is the leaf cert
+/// bound to the org's HAIP classical co-key; <see cref="RootCertDer"/> is
+/// the tenant root CA. The <see cref="AsJwsChain"/> helper returns both in
+/// the order the JWS spec expects (leaf first).
+/// </summary>
+public sealed record OrgCertChain(byte[] OrgCertDer, byte[] RootCertDer)
+{
+    /// <summary>
+    /// Returns the chain as a list ready for <c>ISdJwtService.CreateTokenAsync(..., x5cChain: ...)</c>.
+    /// Leaf first, root last — matches RFC 7515 §4.1.6.
+    /// </summary>
+    public IReadOnlyList<byte[]> AsJwsChain() => new[] { OrgCertDer, RootCertDer };
+}

--- a/src/Common/Sorcha.ServiceClients.Http/Trust/TrustServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Trust/TrustServiceClient.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.ServiceClients.Trust;
+
+/// <summary>
+/// HTTP client for the Tenant Service's X.509 trust endpoints. Today only
+/// implements <see cref="IOrgCertChainProvider"/>; future trust surfaces
+/// (CRL fetch, trust-anchor download, revocation submission) compose into
+/// this client as separate interfaces.
+/// </summary>
+/// <remarks>
+/// Org certs rotate rarely (yearly at most in typical production). An in-
+/// memory TTL cache of 5 minutes prevents a chain fetch per credential
+/// issuance while still letting a freshly-rotated cert propagate quickly
+/// after the cache expires. Cache is best-effort — service restarts drop
+/// it; there is no cross-node consistency requirement.
+/// </remarks>
+public sealed class TrustServiceClient : IOrgCertChainProvider
+{
+    private static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromMinutes(5);
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<TrustServiceClient> _logger;
+    private readonly TimeSpan _cacheTtl;
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
+
+    public TrustServiceClient(
+        HttpClient httpClient,
+        ILogger<TrustServiceClient> logger,
+        TimeSpan? cacheTtl = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+    }
+
+    /// <inheritdoc />
+    public async Task<OrgCertChain?> GetChainForAsync(
+        string tenantId,
+        string orgWalletAddress,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(orgWalletAddress);
+
+        var cacheKey = $"{tenantId}:{orgWalletAddress}";
+        if (_cache.TryGetValue(cacheKey, out var cached) && cached.ExpiresAt > DateTimeOffset.UtcNow)
+        {
+            return cached.Chain;
+        }
+
+        var path = $"/api/v1/trust/tenants/{Uri.EscapeDataString(tenantId)}/orgs/{Uri.EscapeDataString(orgWalletAddress)}/cert-chain";
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _httpClient.GetAsync(path, ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex,
+                "Cert chain fetch failed for tenant {TenantId} org {OrgWallet} — returning null",
+                tenantId, orgWalletAddress);
+            return null;
+        }
+
+        try
+        {
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogDebug(
+                    "No active cert chain for tenant {TenantId} org {OrgWallet} (404 from Tenant Service)",
+                    tenantId, orgWalletAddress);
+                // Cache the miss for a short window so a tight-loop caller
+                // doesn't hammer the Tenant Service when enrolment is pending.
+                _cache[cacheKey] = new CacheEntry(null, DateTimeOffset.UtcNow.AddSeconds(30));
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Cert chain fetch returned {StatusCode} for tenant {TenantId} org {OrgWallet}",
+                    (int)response.StatusCode, tenantId, orgWalletAddress);
+                return null;
+            }
+
+            JsonElement body;
+            try
+            {
+                body = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Malformed cert chain response for tenant {TenantId} org {OrgWallet}",
+                    tenantId, orgWalletAddress);
+                return null;
+            }
+
+            var orgB64 = body.TryGetProperty("orgCertBase64", out var orgEl) ? orgEl.GetString() : null;
+            var rootB64 = body.TryGetProperty("rootCertBase64", out var rootEl) ? rootEl.GetString() : null;
+            if (string.IsNullOrWhiteSpace(orgB64) || string.IsNullOrWhiteSpace(rootB64))
+            {
+                _logger.LogWarning(
+                    "Cert chain response missing orgCertBase64 / rootCertBase64 for tenant {TenantId} org {OrgWallet}",
+                    tenantId, orgWalletAddress);
+                return null;
+            }
+
+            byte[] orgDer;
+            byte[] rootDer;
+            try
+            {
+                orgDer = Convert.FromBase64String(orgB64);
+                rootDer = Convert.FromBase64String(rootB64);
+            }
+            catch (FormatException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Cert chain response contained non-base64 certificate bytes for tenant {TenantId} org {OrgWallet}",
+                    tenantId, orgWalletAddress);
+                return null;
+            }
+
+            var chain = new OrgCertChain(orgDer, rootDer);
+            _cache[cacheKey] = new CacheEntry(chain, DateTimeOffset.UtcNow + _cacheTtl);
+            return chain;
+        }
+        finally
+        {
+            response.Dispose();
+        }
+    }
+
+    private sealed record CacheEntry(OrgCertChain? Chain, DateTimeOffset ExpiresAt);
+}

--- a/tests/Sorcha.ServiceClients.Tests/Trust/TrustServiceClientTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Trust/TrustServiceClientTests.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Sorcha.ServiceClients.Trust;
+
+using Xunit;
+
+namespace Sorcha.ServiceClients.Tests.Trust;
+
+/// <summary>
+/// Feature 096 US3 consumer — round-trips the Tenant Service's cert-chain
+/// endpoint through <see cref="TrustServiceClient"/>. A fake HTTP handler
+/// lets the test assert the exact path + parse the response body without a
+/// running Tenant Service, while also verifying the 5-minute cache behaviour.
+/// </summary>
+public class TrustServiceClientTests
+{
+    private const string TenantId = "tenant-test-1";
+    private const string OrgWallet = "ws1qtestorg";
+
+    [Fact]
+    public async Task GetChainForAsync_OkResponse_DecodesBothCerts()
+    {
+        var handler = new RecordingHandler(BuildOkResponse(orgCertAscii: "ORG_CERT", rootCertAscii: "ROOT_CERT"));
+        var sut = Build(handler);
+
+        var chain = await sut.GetChainForAsync(TenantId, OrgWallet);
+
+        chain.Should().NotBeNull();
+        System.Text.Encoding.UTF8.GetString(chain!.OrgCertDer).Should().Be("ORG_CERT");
+        System.Text.Encoding.UTF8.GetString(chain.RootCertDer).Should().Be("ROOT_CERT");
+
+        handler.Requests.Should().HaveCount(1);
+        handler.Requests[0].RequestUri!.AbsolutePath
+            .Should().Be($"/api/v1/trust/tenants/{TenantId}/orgs/{OrgWallet}/cert-chain");
+    }
+
+    [Fact]
+    public async Task GetChainForAsync_NotFound_ReturnsNull()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.NotFound));
+        var sut = Build(handler);
+
+        var chain = await sut.GetChainForAsync(TenantId, OrgWallet);
+
+        chain.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetChainForAsync_MalformedBase64_ReturnsNull_NoThrow()
+    {
+        // Attacker-controlled Tenant Service response must not crash the Wallet.
+        var body = new { orgCertBase64 = "!!!not-base64!!!", rootCertBase64 = "!!!also-bad!!!" };
+        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"),
+        };
+        var handler = new RecordingHandler(resp);
+        var sut = Build(handler);
+
+        var chain = await sut.GetChainForAsync(TenantId, OrgWallet);
+
+        chain.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetChainForAsync_CachesWithinTtl_SkipsSecondHttpCall()
+    {
+        // First call: real HTTP round-trip. Second call within TTL: served
+        // from cache. The cert rotation cadence (yearly) means a 5-minute TTL
+        // is safe and prevents per-issuance chain fetches.
+        var handler = new RecordingHandler(() => BuildOkResponse("A", "B"));
+        var sut = Build(handler, cacheTtl: TimeSpan.FromMinutes(5));
+
+        var first = await sut.GetChainForAsync(TenantId, OrgWallet);
+        var second = await sut.GetChainForAsync(TenantId, OrgWallet);
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        handler.Requests.Should().HaveCount(1, "second call within TTL must be served from cache");
+    }
+
+    [Fact]
+    public async Task GetChainForAsync_NotFoundIsCached_AvoidsHammeringTenantService()
+    {
+        // When enrolment is pending, the caller may retry tightly — the short
+        // miss cache keeps that from hammering the Tenant Service.
+        var handler = new RecordingHandler(() => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var sut = Build(handler);
+
+        var first = await sut.GetChainForAsync(TenantId, OrgWallet);
+        var second = await sut.GetChainForAsync(TenantId, OrgWallet);
+
+        first.Should().BeNull();
+        second.Should().BeNull();
+        handler.Requests.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetChainForAsync_TransientHttpError_ReturnsNull()
+    {
+        var handler = new RecordingHandler(_ => throw new HttpRequestException("dns-fail"));
+        var sut = Build(handler);
+
+        var chain = await sut.GetChainForAsync(TenantId, OrgWallet);
+
+        chain.Should().BeNull();
+    }
+
+    [Fact]
+    public void AsJwsChain_OrdersLeafThenRoot()
+    {
+        // RFC 7515 §4.1.6: x5c is leaf-first. The helper must preserve that
+        // order or the verifier will treat the root as the issuer key.
+        var chain = new OrgCertChain(new byte[] { 1, 2 }, new byte[] { 9, 9 });
+        var jws = chain.AsJwsChain();
+        jws[0].Should().BeEquivalentTo(new byte[] { 1, 2 });
+        jws[1].Should().BeEquivalentTo(new byte[] { 9, 9 });
+    }
+
+    // --- helpers ---
+
+    private static TrustServiceClient Build(HttpMessageHandler handler, TimeSpan? cacheTtl = null)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://tenant.test/") };
+        return new TrustServiceClient(http, NullLogger<TrustServiceClient>.Instance, cacheTtl);
+    }
+
+    private static HttpResponseMessage BuildOkResponse(string orgCertAscii, string rootCertAscii)
+    {
+        var body = new
+        {
+            orgCertBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(orgCertAscii)),
+            rootCertBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(rootCertAscii)),
+        };
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _producer;
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        public RecordingHandler(HttpResponseMessage fixedResponse)
+            : this(_ => fixedResponse) { }
+
+        public RecordingHandler(Func<HttpResponseMessage> factory)
+            : this(_ => factory()) { }
+
+        public RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> producer)
+        {
+            _producer = producer;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_producer(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last deferred **Category 3 US3** piece from the platform brief. Downstream callers (Wallet Service HAIP-path issuance, primarily) can now fetch an org's cert chain from the Tenant Service and pass it into \`ISdJwtService.CreateTokenAsync\`'s \`x5cChain\` parameter without reimplementing the HTTP shape per caller.

## Changes

- **\`IOrgCertChainProvider\` + \`OrgCertChain\` record** in \`Sorcha.ServiceClients.Http/Trust/\`. \`AsJwsChain()\` helper returns leaf-first to match RFC 7515 §4.1.6 so callers don't accidentally invert the \`x5c\` order (which would cause verifiers to treat the root as the issuer key).
- **\`TrustServiceClient\`** implements the provider against \`/api/v1/trust/tenants/{tenantId}/orgs/{wallet}/cert-chain\`:
  - 5-minute in-memory TTL cache — cert rotation is yearly so per-issuance fetches are pure waste
  - 30-second negative cache on 404 so a tight-loop caller waiting for enrolment doesn't hammer the Tenant Service
  - \`HttpRequestException\` / malformed base64 / missing fields all collapse to \`null\` (never throw) so the Wallet Service can decide to skip \`x5c\` embedding gracefully

## Tests

7 \`TrustServiceClientTests\`:
- OK response decodes both certs and hits the right path
- 404 returns null
- Malformed base64 returns null without throwing (attacker-controlled response safety)
- Cached second call within TTL skips HTTP
- Negative cache survives short retry loops
- Transient \`HttpRequestException\` returns null
- \`AsJwsChain\` preserves leaf-first order

## Test plan

- [x] 159/159 \`Sorcha.ServiceClients.Tests\` (+7)
- [x] \`dotnet build Sorcha.sln\` clean

## Deferred

- **DI registration + Wallet Service wiring** — \`CredentialEndpoints.IssueCredential\` needs \`tenantId\` context (not currently threaded through the issuance request) before it can call \`GetChainForAsync\` and pass the result into \`CreateTokenAsync\`. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)