### PR TITLE
fix(106): wallet-scoped credential dedup + composite PK (n1 verification)

### DIFF
--- a/src/Core/Sorcha.Wallet.Core/Data/WalletDbContext.cs
+++ b/src/Core/Sorcha.Wallet.Core/Data/WalletDbContext.cs
@@ -467,7 +467,13 @@ public class WalletDbContext : DbContext
         {
             entity.ToTable("Credentials");
 
-            entity.HasKey(e => e.Id);
+            // Feature 106 fix — composite PK (Id, WalletAddress). A single credential
+            // lives in BOTH issuer and recipient wallets (issuer: audit/Active; recipient:
+            // PendingAcceptance → Active/Declined). On single-node deployments both rows
+            // land in the same DB; the prior Id-only PK blocked the detector's recipient
+            // insert with a PK conflict and the `already stored` dedup short-circuit
+            // masked the failure.
+            entity.HasKey(e => new { e.Id, e.WalletAddress });
 
             entity.Property(e => e.Id)
                 .HasMaxLength(500);

--- a/src/Core/Sorcha.Wallet.Core/Migrations/20260410214038_InitialCreate.Designer.cs
+++ b/src/Core/Sorcha.Wallet.Core/Migrations/20260410214038_InitialCreate.Designer.cs
@@ -126,7 +126,7 @@ namespace Sorcha.Wallet.Core.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
-                    b.HasKey("Id");
+                    b.HasKey("Id", "WalletAddress");
 
                     b.HasIndex("IssuerDid")
                         .HasDatabaseName("IX_Credentials_IssuerDid");

--- a/src/Core/Sorcha.Wallet.Core/Migrations/20260410214038_InitialCreate.cs
+++ b/src/Core/Sorcha.Wallet.Core/Migrations/20260410214038_InitialCreate.cs
@@ -47,7 +47,7 @@ namespace Sorcha.Wallet.Core.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_Credentials", x => x.Id);
+                    table.PrimaryKey("PK_Credentials", x => new { x.Id, x.WalletAddress });
                 });
 
             migrationBuilder.CreateTable(

--- a/src/Core/Sorcha.Wallet.Core/Migrations/WalletDbContextModelSnapshot.cs
+++ b/src/Core/Sorcha.Wallet.Core/Migrations/WalletDbContextModelSnapshot.cs
@@ -123,7 +123,7 @@ namespace Sorcha.Wallet.Core.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("character varying(200)");
 
-                    b.HasKey("Id");
+                    b.HasKey("Id", "WalletAddress");
 
                     b.HasIndex("IssuerDid")
                         .HasDatabaseName("IX_Credentials_IssuerDid");

--- a/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
@@ -60,12 +60,39 @@ public class CredentialStore : ICredentialStore
     }
 
     /// <inheritdoc />
+    public async Task<CredentialEntity?> GetByIdForWalletAsync(
+        string credentialId, string walletAddress, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(credentialId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
+        var credential = await _db.Credentials
+            .FirstOrDefaultAsync(
+                c => c.Id == credentialId && c.WalletAddress == walletAddress, ct);
+
+        if (credential != null)
+        {
+            await ExpireStaleCredentialsAsync([credential], ct);
+        }
+
+        return credential;
+    }
+
+    /// <inheritdoc />
     public async Task StoreAsync(CredentialEntity credential, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(credential);
 
+        // Feature 106 fix — use composite (Id, WalletAddress) lookup. Two rows with
+        // the same credential id are legitimate when the issuer audit row and the
+        // recipient PendingAcceptance row live in the same DB (single-node dev or
+        // co-located issuer/recipient wallets). Prior Id-only lookup would SetValues
+        // over the issuer's row when storing the recipient's copy — silently
+        // corrupting the audit trail.
         var existing = await _db.Credentials
-            .FirstOrDefaultAsync(c => c.Id == credential.Id, ct);
+            .FirstOrDefaultAsync(
+                c => c.Id == credential.Id && c.WalletAddress == credential.WalletAddress,
+                ct);
 
         if (existing != null)
         {

--- a/src/Services/Sorcha.Wallet.Service/Credentials/ICredentialStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/ICredentialStore.cs
@@ -16,9 +16,21 @@ public interface ICredentialStore
     Task<IReadOnlyList<CredentialEntity>> GetByWalletAsync(string walletAddress, CancellationToken ct = default);
 
     /// <summary>
-    /// Gets a credential by its ID.
+    /// Gets a credential by its ID. Returns the first match across wallets — use
+    /// <see cref="GetByIdForWalletAsync"/> when a specific wallet's copy is required
+    /// (e.g. Feature 106 InboundCredentialDetector dedup, where both issuer and
+    /// recipient hold rows with the same credential id on single-node deployments).
     /// </summary>
     Task<CredentialEntity?> GetByIdAsync(string credentialId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Feature 106 — returns the row keyed on <c>(credentialId, walletAddress)</c>,
+    /// or null if this wallet has no copy of the credential yet. Used by the
+    /// InboundCredentialDetector to dedup against its own prior inserts without
+    /// tripping on the issuer's audit row.
+    /// </summary>
+    Task<CredentialEntity?> GetByIdForWalletAsync(
+        string credentialId, string walletAddress, CancellationToken ct = default);
 
     /// <summary>
     /// Stores a new credential.

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
@@ -170,13 +170,18 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
                 return null;
             }
 
-            // 7. Dedup by credential id (INV-1) — persisting is idempotent on replay.
-            var existing = await _credentialStore.GetByIdAsync(extract.CredentialId, cancellationToken);
+            // 7. Dedup by (credentialId, walletAddress) (INV-1) — persisting is idempotent on
+            //    replay. MUST be wallet-scoped: on single-node deployments the issuer audit
+            //    row lives under the issuer wallet with the same credential id, and the
+            //    prior Id-only dedup would skip the recipient-side insert entirely (the
+            //    n1 Feature 106 bug surfaced at deploy time).
+            var existing = await _credentialStore.GetByIdForWalletAsync(
+                extract.CredentialId, walletAddress, cancellationToken);
             if (existing is not null)
             {
                 _logger.LogDebug(
-                    "InboundCredentialDetector: credential {CredentialId} already stored — skipping duplicate",
-                    extract.CredentialId);
+                    "InboundCredentialDetector: credential {CredentialId} already stored for wallet {Wallet} — skipping duplicate",
+                    extract.CredentialId, walletAddress);
                 _metrics.RecordSkippedDuplicate();
                 return null;
             }

--- a/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorDevModeTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorDevModeTests.cs
@@ -161,7 +161,8 @@ public class InboundCredentialDetectorDevModeTests
         fixture.ArrangePlaintextTransaction(PlaintextTxBody);
         fixture.ArrangeRegisterDevMode(true);
         fixture.CredentialStoreMock
-            .Setup(s => s.GetByIdAsync("urn:uuid:feature-106-devmode-test-1", It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetByIdForWalletAsync(
+                "urn:uuid:feature-106-devmode-test-1", WalletAddress, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CredentialEntity
             {
                 Id = "urn:uuid:feature-106-devmode-test-1",


### PR DESCRIPTION
## Summary

End-to-end verification of Feature 106 on n1 exposed a **single-node PK collision** that silently short-circuited the \`InboundCredentialDetector\`. Diagnosed, fixed, tested.

## Root cause

\`CredentialEntity.Id\` was the sole PK. On a single-node deployment the issuer's audit row (\`Status=Active\`, \`WalletAddress=issuer\`) and the recipient's \`PendingAcceptance\` row (\`WalletAddress=recipient\`) share the same credential id. The detector's dedup used \`GetByIdAsync(credentialId)\`, found the issuer's row, and skipped the recipient-side insert with a cheerful \"already stored — skipping duplicate\" log.

\`CredentialStore.StoreAsync\` had the same shape: its Id-only existence check would have \`SetValues\` overwritten the issuer's row with the recipient's values.

Multi-node deployments hid this because the two rows live in separate databases. n1 exposed it on first real test.

## Changes

- **\`WalletDbContext\`** — \`Credentials\` primary key is now composite \`(Id, WalletAddress)\`. Migration, designer, and model snapshot updated in-place per the pre-release \"squash new migrations into initial\" rule.
- **\`ICredentialStore.GetByIdForWalletAsync(credentialId, walletAddress)\`** — new method for dedup that must exclude other wallets' rows. \`GetByIdAsync\` keeps its cross-wallet \"first match\" semantics.
- **\`CredentialStore.StoreAsync\`** — existence check uses composite key so the issuer's row is never overwritten by a recipient-side upsert.
- **\`InboundCredentialDetector\`** — dedup uses \`GetByIdForWalletAsync\`. Log/metric message now names the wallet.

## Tests

- Existing \`TryExtractAsync_DevMode_Duplicate_Skips\` updated to mock \`GetByIdForWalletAsync\` with \`(credentialId, walletAddress)\`.
- 620/620 \`Sorcha.Wallet.Service.Tests\` pass.
- Solution builds clean.

## n1 verification

With this fix deployed, the AssuredPerson walkthrough flows end-to-end:

1. Gov approves Action 2 → credential minted, sealed into citizen's plaintext disclosure group (DevMode register)
2. Docket seals → \`InboundTransactionRouter\` matches citizen's address in the bloom filter → \`NotifyInboundTransaction\` gRPC fires
3. \`NotificationDeliveryService\` calls the detector; detector finds \`/credential\` in \`payloads[citizenWallet]\`, dedup correctly sees no recipient-side row exists, stores as \`PendingAcceptance\`
4. Citizen's \`MyCredentials\` PENDING tab shows the credential

🤖 Generated with [Claude Code](https://claude.com/claude-code)