### PR TITLE
feat(106): bloom filter register-create fan-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ build/
 walkthroughs/*/wallet/
 walkthroughs/*/state.json
 .claude/scheduled_tasks.lock
+verify-feature-106.ps1

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -202,6 +202,8 @@ builder.Services.AddSingleton<Sorcha.Register.Service.Services.Interfaces.ILocal
     Sorcha.Register.Service.Services.Implementation.RedisBloomFilterAddressIndex>();
 builder.Services.AddSingleton<Sorcha.Register.Service.Services.Interfaces.IInboundTransactionRouter,
     Sorcha.Register.Service.Services.Implementation.InboundTransactionRouter>();
+builder.Services.AddSingleton<Sorcha.Register.Service.Services.Interfaces.IBloomFilterRebuilder,
+    Sorcha.Register.Service.Services.Implementation.BloomFilterRebuilder>();
 
 // Feature 106 startup-rebuild: reconcile bloom filters on boot in case Redis was wiped
 // or hooks failed during normal wallet creation. Non-blocking — runs as a hosted service

--- a/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterRebuilder.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterRebuilder.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Sorcha.Register.Service.Services.Interfaces;
+using Sorcha.ServiceClients.Grpc;
+using Sorcha.Wallet.Service.Grpc;
+
+namespace Sorcha.Register.Service.Services.Implementation;
+
+/// <inheritdoc />
+public sealed class BloomFilterRebuilder : IBloomFilterRebuilder
+{
+    private readonly ILocalAddressIndex _addressIndex;
+    private readonly IWalletNotificationClient _walletClient;
+    private readonly ILogger<BloomFilterRebuilder> _logger;
+
+    public BloomFilterRebuilder(
+        ILocalAddressIndex addressIndex,
+        IWalletNotificationClient walletClient,
+        ILogger<BloomFilterRebuilder> logger)
+    {
+        _addressIndex = addressIndex ?? throw new ArgumentNullException(nameof(addressIndex));
+        _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<BloomFilterStats> RebuildAsync(string registerId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(registerId)) throw new ArgumentException("registerId required", nameof(registerId));
+
+        var addresses = _walletClient.GetAllLocalAddressesAsync(
+            registerId, activeOnly: true, cancellationToken);
+
+        var stats = await _addressIndex.RebuildAsync(
+            registerId, ExtractAddresses(addresses), cancellationToken);
+
+        _logger.LogInformation(
+            "Bloom rebuild for register {RegisterId}: {AddressCount} addresses indexed.",
+            registerId, stats.AddressCount);
+
+        return stats;
+    }
+
+    private static async IAsyncEnumerable<string> ExtractAddresses(IAsyncEnumerable<LocalAddressEntry> entries)
+    {
+        await foreach (var entry in entries)
+        {
+            if (!string.IsNullOrEmpty(entry.Address))
+            {
+                yield return entry.Address;
+            }
+        }
+    }
+}

--- a/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterRebuilder.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterRebuilder.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Runtime.CompilerServices;
+
 using Microsoft.Extensions.Logging;
 using Sorcha.Register.Service.Services.Interfaces;
 using Sorcha.ServiceClients.Grpc;
@@ -34,7 +36,7 @@ public sealed class BloomFilterRebuilder : IBloomFilterRebuilder
             registerId, activeOnly: true, cancellationToken);
 
         var stats = await _addressIndex.RebuildAsync(
-            registerId, ExtractAddresses(addresses), cancellationToken);
+            registerId, ExtractAddresses(addresses, cancellationToken), cancellationToken);
 
         _logger.LogInformation(
             "Bloom rebuild for register {RegisterId}: {AddressCount} addresses indexed.",
@@ -43,9 +45,11 @@ public sealed class BloomFilterRebuilder : IBloomFilterRebuilder
         return stats;
     }
 
-    private static async IAsyncEnumerable<string> ExtractAddresses(IAsyncEnumerable<LocalAddressEntry> entries)
+    private static async IAsyncEnumerable<string> ExtractAddresses(
+        IAsyncEnumerable<LocalAddressEntry> entries,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        await foreach (var entry in entries)
+        await foreach (var entry in entries.WithCancellation(cancellationToken))
         {
             if (!string.IsNullOrEmpty(entry.Address))
             {

--- a/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterStartupRebuildService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterStartupRebuildService.cs
@@ -5,16 +5,14 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Sorcha.Register.Core.Managers;
 using Sorcha.Register.Service.Services.Interfaces;
-using Sorcha.ServiceClients.Grpc;
-using Sorcha.Wallet.Service.Grpc;
 
 namespace Sorcha.Register.Service.Services.Implementation;
 
 /// <summary>
 /// Background service that runs once on startup to ensure each register's bloom
 /// filter has at least one address indexed. If the params hash for a register is
-/// missing or has <c>address_count == 0</c>, the service rebuilds it from the
-/// peer Wallet Service via the existing <c>GetAllLocalAddresses</c> gRPC stream.
+/// missing or has <c>address_count == 0</c>, the service rebuilds it via
+/// <see cref="IBloomFilterRebuilder"/>.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -33,9 +31,7 @@ namespace Sorcha.Register.Service.Services.Implementation;
 ///   <item>Iterates every register known to <see cref="RegisterManager"/>.</item>
 ///   <item>Skips registers whose bloom already reports a non-zero
 ///         <c>address_count</c> in <see cref="ILocalAddressIndex.GetStatsAsync"/>.</item>
-///   <item>For empty/missing blooms, calls
-///         <see cref="ILocalAddressIndex.RebuildAsync"/> with the address stream
-///         from the Wallet Service.</item>
+///   <item>For empty/missing blooms, delegates to <see cref="IBloomFilterRebuilder"/>.</item>
 ///   <item>Failures are logged and skipped — the service does not throw on
 ///         individual register failures and never blocks ASP.NET startup.</item>
 /// </list>
@@ -75,7 +71,7 @@ public sealed class BloomFilterStartupRebuildService : BackgroundService
         await using var scope = _services.CreateAsyncScope();
         var registerManager = scope.ServiceProvider.GetRequiredService<RegisterManager>();
         var addressIndex = scope.ServiceProvider.GetRequiredService<ILocalAddressIndex>();
-        var walletClient = scope.ServiceProvider.GetRequiredService<IWalletNotificationClient>();
+        var rebuilder = scope.ServiceProvider.GetRequiredService<IBloomFilterRebuilder>();
 
         IReadOnlyList<Sorcha.Register.Models.Register> registers;
         try
@@ -124,11 +120,7 @@ public sealed class BloomFilterStartupRebuildService : BackgroundService
                     "Bloom startup-rebuild: rebuilding register {RegisterId} (current={Count})",
                     registerId, stats?.AddressCount ?? 0);
 
-                var addresses = walletClient.GetAllLocalAddressesAsync(
-                    registerId, activeOnly: true, stoppingToken);
-
-                var newStats = await addressIndex.RebuildAsync(
-                    registerId, ExtractAddresses(addresses), stoppingToken);
+                var newStats = await rebuilder.RebuildAsync(registerId, stoppingToken);
 
                 rebuilt++;
                 _logger.LogInformation(
@@ -147,17 +139,5 @@ public sealed class BloomFilterStartupRebuildService : BackgroundService
         _logger.LogInformation(
             "Bloom startup-rebuild complete: {Rebuilt} rebuilt, {Skipped} already populated, {Failed} failed (of {Total}).",
             rebuilt, skipped, failed, registers.Count);
-    }
-
-    private static async IAsyncEnumerable<string> ExtractAddresses(
-        IAsyncEnumerable<LocalAddressEntry> entries)
-    {
-        await foreach (var entry in entries)
-        {
-            if (!string.IsNullOrEmpty(entry.Address))
-            {
-                yield return entry.Address;
-            }
-        }
     }
 }

--- a/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterStartupRebuildService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Implementation/BloomFilterStartupRebuildService.cs
@@ -40,17 +40,25 @@ namespace Sorcha.Register.Service.Services.Implementation;
 public sealed class BloomFilterStartupRebuildService : BackgroundService
 {
     private readonly IServiceProvider _services;
+    private readonly IBloomFilterRebuilder _rebuilder;
     private readonly ILogger<BloomFilterStartupRebuildService> _logger;
     private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Initialises a new instance of <see cref="BloomFilterStartupRebuildService"/>.
     /// </summary>
+    /// <remarks>
+    /// <see cref="IBloomFilterRebuilder"/> is a singleton and constructor-injected.
+    /// <see cref="IServiceProvider"/> stays for resolving scoped dependencies
+    /// (<c>RegisterManager</c>, <see cref="ILocalAddressIndex"/>) inside the rebuild loop.
+    /// </remarks>
     public BloomFilterStartupRebuildService(
         IServiceProvider services,
+        IBloomFilterRebuilder rebuilder,
         ILogger<BloomFilterStartupRebuildService> logger)
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
+        _rebuilder = rebuilder ?? throw new ArgumentNullException(nameof(rebuilder));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -71,7 +79,6 @@ public sealed class BloomFilterStartupRebuildService : BackgroundService
         await using var scope = _services.CreateAsyncScope();
         var registerManager = scope.ServiceProvider.GetRequiredService<RegisterManager>();
         var addressIndex = scope.ServiceProvider.GetRequiredService<ILocalAddressIndex>();
-        var rebuilder = scope.ServiceProvider.GetRequiredService<IBloomFilterRebuilder>();
 
         IReadOnlyList<Sorcha.Register.Models.Register> registers;
         try
@@ -120,7 +127,7 @@ public sealed class BloomFilterStartupRebuildService : BackgroundService
                     "Bloom startup-rebuild: rebuilding register {RegisterId} (current={Count})",
                     registerId, stats?.AddressCount ?? 0);
 
-                var newStats = await rebuilder.RebuildAsync(registerId, stoppingToken);
+                var newStats = await _rebuilder.RebuildAsync(registerId, stoppingToken);
 
                 rebuilt++;
                 _logger.LogInformation(

--- a/src/Services/Sorcha.Register.Service/Services/Interfaces/IBloomFilterRebuilder.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Interfaces/IBloomFilterRebuilder.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Register.Service.Services.Interfaces;
+
+/// <summary>
+/// Per-register bloom filter rebuild operation. Rebuilds the local-address index for
+/// a single register by streaming addresses from the Wallet Service and atomically
+/// swapping the rebuilt filter into Redis.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Centralises the rebuild flow so it can be triggered from multiple call sites:
+/// startup reconciliation (<see cref="Implementation.BloomFilterStartupRebuildService"/>),
+/// admin endpoint (<c>POST /admin/rebuild-index</c>), and register-creation fan-in
+/// (<see cref="RegisterCreationOrchestrator.FinalizeAsync"/>).
+/// </para>
+/// </remarks>
+public interface IBloomFilterRebuilder
+{
+    /// <summary>
+    /// Rebuild the bloom filter for a single register. Streams addresses from the
+    /// Wallet Service and atomically swaps the rebuilt filter into Redis.
+    /// </summary>
+    /// <param name="registerId">The register whose bloom filter should be rebuilt.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Statistics about the rebuilt index.</returns>
+    Task<BloomFilterStats> RebuildAsync(string registerId, CancellationToken cancellationToken = default);
+}

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -10,6 +10,7 @@ using Sorcha.Register.Core.Managers;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Constants;
 using Sorcha.Register.Models.Enums;
+using Sorcha.Register.Service.Services.Interfaces;
 using Sorcha.ServiceClients.Wallet;
 using Sorcha.ServiceClients.Peer;
 using Sorcha.ServiceClients.SystemWallet;
@@ -33,6 +34,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
     private readonly IPendingRegistrationStore _pendingStore;
     private readonly IPeerServiceClient _peerClient;
     private readonly ITenantSubscriptionClient _tenantSubscriptionClient;
+    private readonly IBloomFilterRebuilder _bloomFilterRebuilder;
 
     private readonly TimeSpan _pendingExpirationTime = TimeSpan.FromMinutes(5);
     private readonly JsonSerializerOptions _canonicalJsonOptions;
@@ -48,7 +50,8 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         ISystemWalletSigningService signingService,
         IPendingRegistrationStore pendingStore,
         IPeerServiceClient peerClient,
-        ITenantSubscriptionClient tenantSubscriptionClient)
+        ITenantSubscriptionClient tenantSubscriptionClient,
+        IBloomFilterRebuilder bloomFilterRebuilder)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _registerManager = registerManager ?? throw new ArgumentNullException(nameof(registerManager));
@@ -61,6 +64,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         _pendingStore = pendingStore ?? throw new ArgumentNullException(nameof(pendingStore));
         _peerClient = peerClient ?? throw new ArgumentNullException(nameof(peerClient));
         _tenantSubscriptionClient = tenantSubscriptionClient ?? throw new ArgumentNullException(nameof(tenantSubscriptionClient));
+        _bloomFilterRebuilder = bloomFilterRebuilder ?? throw new ArgumentNullException(nameof(bloomFilterRebuilder));
 
         // Configure JSON serialization for canonical form
         // UnsafeRelaxedJsonEscaping ensures characters like '+' in DateTimeOffset and base64
@@ -464,6 +468,26 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         register = await _registerManager.UpdateRegisterStatusAsync(register.Id, RegisterStatus.Online, cancellationToken);
 
         _logger.LogInformation("Register {RegisterId} set to Online", register.Id);
+
+        // Feature 106: Initialise the bloom filter for this register so any pre-existing
+        // local wallets are immediately routable on inbound transactions. Without this
+        // fan-in, addresses created before the register existed stay invisible to the
+        // InboundTransactionRouter until the next BloomFilterStartupRebuildService pass
+        // (i.e. the next service restart). Failures are non-fatal — the next startup
+        // pass or admin /rebuild-index will reconcile.
+        try
+        {
+            var bloomStats = await _bloomFilterRebuilder.RebuildAsync(register.Id, cancellationToken);
+            _logger.LogInformation(
+                "Initialised bloom filter for new register {RegisterId} with {AddressCount} addresses.",
+                register.Id, bloomStats.AddressCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to initialise bloom filter for new register {RegisterId}; reconciliation deferred to next startup-rebuild or admin /rebuild-index.",
+                register.Id);
+        }
 
         // Notify Peer Service to advertise register if requested (fire-and-forget)
         if (pending.Advertise)

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -469,16 +469,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
 
         _logger.LogInformation("Register {RegisterId} set to Online", register.Id);
 
-        // Without this rebuild, addresses provisioned before register creation
-        // stay invisible to InboundTransactionRouter until the next
-        // BloomFilterStartupRebuildService pass (i.e. the next service restart).
-        // Failures are non-fatal — startup-rebuild or /rebuild-index reconciles.
-        //
-        // Bounded wait: a slow Wallet Service must not stall the FinalizeAsync
-        // response indefinitely. 10s is generous for the streaming address load
-        // (typical case: 0–10 wallets at register creation time) while still
-        // keeping the worst-case latency tight. The catch swallows the resulting
-        // TaskCanceledException so finalize still succeeds.
+        // Best-effort fan-in; 10s timeout caps wallet-svc latency.
         using var bloomCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         bloomCts.CancelAfter(TimeSpan.FromSeconds(10));
         try
@@ -488,7 +479,11 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
                 "Initialised bloom filter for new register {RegisterId} with {AddressCount} addresses.",
                 register.Id, bloomStats.AddressCount);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is OperationCanceledException
+                                      or global::Grpc.Core.RpcException
+                                      or IOException
+                                      or InvalidOperationException
+                                      or TimeoutException)
         {
             _logger.LogWarning(ex,
                 "Failed to initialise bloom filter for new register {RegisterId}; reconciliation deferred to next startup-rebuild or admin /rebuild-index.",

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -473,9 +473,17 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         // stay invisible to InboundTransactionRouter until the next
         // BloomFilterStartupRebuildService pass (i.e. the next service restart).
         // Failures are non-fatal — startup-rebuild or /rebuild-index reconciles.
+        //
+        // Bounded wait: a slow Wallet Service must not stall the FinalizeAsync
+        // response indefinitely. 10s is generous for the streaming address load
+        // (typical case: 0–10 wallets at register creation time) while still
+        // keeping the worst-case latency tight. The catch swallows the resulting
+        // TaskCanceledException so finalize still succeeds.
+        using var bloomCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        bloomCts.CancelAfter(TimeSpan.FromSeconds(10));
         try
         {
-            var bloomStats = await _bloomFilterRebuilder.RebuildAsync(register.Id, cancellationToken);
+            var bloomStats = await _bloomFilterRebuilder.RebuildAsync(register.Id, bloomCts.Token);
             _logger.LogInformation(
                 "Initialised bloom filter for new register {RegisterId} with {AddressCount} addresses.",
                 register.Id, bloomStats.AddressCount);

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -469,12 +469,10 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
 
         _logger.LogInformation("Register {RegisterId} set to Online", register.Id);
 
-        // Feature 106: Initialise the bloom filter for this register so any pre-existing
-        // local wallets are immediately routable on inbound transactions. Without this
-        // fan-in, addresses created before the register existed stay invisible to the
-        // InboundTransactionRouter until the next BloomFilterStartupRebuildService pass
-        // (i.e. the next service restart). Failures are non-fatal — the next startup
-        // pass or admin /rebuild-index will reconcile.
+        // Without this rebuild, addresses provisioned before register creation
+        // stay invisible to InboundTransactionRouter until the next
+        // BloomFilterStartupRebuildService pass (i.e. the next service restart).
+        // Failures are non-fatal — startup-rebuild or /rebuild-index reconciles.
         try
         {
             var bloomStats = await _bloomFilterRebuilder.RebuildAsync(register.Id, cancellationToken);

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
@@ -12,6 +12,7 @@ using Sorcha.Register.Core.Managers;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Enums;
 using Sorcha.Register.Service.Services;
+using Sorcha.Register.Service.Services.Interfaces;
 using Sorcha.ServiceClients.Peer;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.ServiceClients.Validator;
@@ -36,6 +37,7 @@ public class RegisterCreationOrchestratorTests
     private readonly Mock<IPendingRegistrationStore> _mockPendingStore;
     private readonly Mock<IPeerServiceClient> _mockPeerClient;
     private readonly Mock<ITenantSubscriptionClient> _mockTenantSubscriptionClient;
+    private readonly Mock<IBloomFilterRebuilder> _mockBloomFilterRebuilder;
     private readonly RegisterCreationOrchestrator _orchestrator;
 
     public RegisterCreationOrchestratorTests()
@@ -127,6 +129,11 @@ public class RegisterCreationOrchestratorTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
+        _mockBloomFilterRebuilder = new Mock<IBloomFilterRebuilder>();
+        _mockBloomFilterRebuilder
+            .Setup(b => b.RebuildAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BloomFilterStats(0, 1024, 3, DateTimeOffset.UtcNow));
+
         _orchestrator = new RegisterCreationOrchestrator(
             _mockLogger.Object,
             _mockRegisterManager.Object,
@@ -138,7 +145,8 @@ public class RegisterCreationOrchestratorTests
             _mockSigningService.Object,
             _mockPendingStore.Object,
             _mockPeerClient.Object,
-            _mockTenantSubscriptionClient.Object);
+            _mockTenantSubscriptionClient.Object,
+            _mockBloomFilterRebuilder.Object);
     }
 
     #region InitiateAsync Tests
@@ -637,6 +645,138 @@ public class RegisterCreationOrchestratorTests
         var act = async () => await _orchestrator.FinalizeAsync(finalizeRequest);
         await act.Should().ThrowAsync<UnauthorizedAccessException>()
             .WithMessage("*Invalid signature*");
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_ShouldRebuildBloomFilterForNewRegister()
+    {
+        // Wallet-create fans out to existing registers via hooks A/B/C, but a fresh
+        // register has no fan-in path — without an explicit rebuild here, any wallet
+        // that existed before the register is created stays invisible to the
+        // InboundTransactionRouter until the next service restart triggers
+        // BloomFilterStartupRebuildService. This test pins the contract: every
+        // successful register creation MUST trigger a rebuild for the new register.
+        var initiateRequest = new InitiateRegisterCreationRequest
+        {
+            Name = "Bloom Fan-In Register",
+            Owners = new List<OwnerInfo>
+            {
+                new() { UserId = "user-001", WalletId = "wallet-001" }
+            }
+        };
+
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(new byte[32]);
+
+        var initiateResponse = await _orchestrator.InitiateAsync(initiateRequest);
+
+        var signedAttestations = initiateResponse.AttestationsToSign.Select(a => new SignedAttestation
+        {
+            AttestationData = a.AttestationData,
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            Signature = Convert.ToBase64String(new byte[64]),
+            Algorithm = SignatureAlgorithm.ED25519
+        }).ToList();
+
+        var finalizeRequest = new FinalizeRegisterCreationRequest
+        {
+            RegisterId = initiateResponse.RegisterId,
+            Nonce = initiateResponse.Nonce,
+            SignedAttestations = signedAttestations
+        };
+
+        _mockCryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CryptoStatus.Success);
+
+        _mockRegisterManager
+            .Setup(m => m.CreateRegisterAsync(
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = initiateResponse.RegisterId,
+                Name = "Bloom Fan-In Register",
+                CreatedAt = DateTime.UtcNow
+            });
+
+        await _orchestrator.FinalizeAsync(finalizeRequest);
+
+        _mockBloomFilterRebuilder.Verify(
+            b => b.RebuildAsync(initiateResponse.RegisterId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task FinalizeAsync_BloomRebuildFailure_ShouldNotFailFinalize()
+    {
+        // Bloom rebuild is a best-effort initialisation — a failure (Redis down,
+        // wallet service unreachable, transient gRPC error) MUST not roll back a
+        // successful register creation. The next BloomFilterStartupRebuildService
+        // pass or admin /rebuild-index call will reconcile.
+        var initiateRequest = new InitiateRegisterCreationRequest
+        {
+            Name = "Bloom Resilience Register",
+            Owners = new List<OwnerInfo>
+            {
+                new() { UserId = "user-001", WalletId = "wallet-001" }
+            }
+        };
+
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(new byte[32]);
+
+        var initiateResponse = await _orchestrator.InitiateAsync(initiateRequest);
+
+        var signedAttestations = initiateResponse.AttestationsToSign.Select(a => new SignedAttestation
+        {
+            AttestationData = a.AttestationData,
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            Signature = Convert.ToBase64String(new byte[64]),
+            Algorithm = SignatureAlgorithm.ED25519
+        }).ToList();
+
+        var finalizeRequest = new FinalizeRegisterCreationRequest
+        {
+            RegisterId = initiateResponse.RegisterId,
+            Nonce = initiateResponse.Nonce,
+            SignedAttestations = signedAttestations
+        };
+
+        _mockCryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CryptoStatus.Success);
+
+        _mockRegisterManager
+            .Setup(m => m.CreateRegisterAsync(
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = initiateResponse.RegisterId,
+                Name = "Bloom Resilience Register",
+                CreatedAt = DateTime.UtcNow
+            });
+
+        _mockBloomFilterRebuilder
+            .Setup(b => b.RebuildAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var act = async () => await _orchestrator.FinalizeAsync(finalizeRequest);
+
+        var response = await act.Should().NotThrowAsync();
+        response.Subject.RegisterId.Should().Be(initiateResponse.RegisterId);
+        response.Subject.Status.Should().Be("created");
     }
 
     #endregion

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
@@ -11,6 +11,7 @@ using Sorcha.Cryptography.Interfaces;
 using Sorcha.Register.Core.Managers;
 using Sorcha.Register.Models;
 using Sorcha.Register.Service.Services;
+using Sorcha.Register.Service.Services.Interfaces;
 using Sorcha.ServiceClients.Peer;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.ServiceClients.Validator;
@@ -76,7 +77,8 @@ public class RegisterCreationPolicyTests
             mockSigningService.Object,
             _mockPendingStore.Object,
             mockPeerClient.Object,
-            Mock.Of<ITenantSubscriptionClient>());
+            Mock.Of<ITenantSubscriptionClient>(),
+            Mock.Of<IBloomFilterRebuilder>());
     }
 
     [Fact]

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
@@ -51,6 +51,14 @@ public class RegisterCreationPolicyTests
         var mockSigningService = new Mock<ISystemWalletSigningService>();
         _mockPendingStore = new Mock<IPendingRegistrationStore>();
         var mockPeerClient = new Mock<IPeerServiceClient>();
+        // Explicit Setup so a policy test that reaches FinalizeAsync sees a real
+        // BloomFilterStats. Without it Mock.Of returns null Task and the
+        // orchestrator's catch-all swallows the resulting NullReferenceException
+        // — passing tests would mask broken setup.
+        var mockBloomRebuilder = new Mock<IBloomFilterRebuilder>();
+        mockBloomRebuilder
+            .Setup(b => b.RebuildAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BloomFilterStats(0, 1024, 3, DateTimeOffset.UtcNow));
 
         // Default hash provider returns deterministic bytes
         _mockHashProvider
@@ -78,7 +86,7 @@ public class RegisterCreationPolicyTests
             _mockPendingStore.Object,
             mockPeerClient.Object,
             Mock.Of<ITenantSubscriptionClient>(),
-            Mock.Of<IBloomFilterRebuilder>());
+            mockBloomRebuilder.Object);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Introduces `IBloomFilterRebuilder` and wires it into `RegisterCreationOrchestrator.FinalizeAsync` so newly created registers immediately fan in any pre-existing local wallet addresses.
- Removes the operational footgun where a fresh register stayed invisible to `InboundTransactionRouter` until `BloomFilterStartupRebuildService` next fired (i.e. a service restart) — the same fault that forced the manual register-service restart after every `n1-reset.ps1` run.
- Refactors `BloomFilterStartupRebuildService` to delegate to the new rebuilder, eliminating duplicate stream-extraction code.

## Why

Wallet-create already fans out to all existing registers via hooks A/B/C. The reverse (register-create fan-in) was only handled at startup, so any wallet provisioned before a register existed silently dropped inbound transactions until the next reboot.

## Test plan

- [x] `FinalizeAsync_ShouldRebuildBloomFilterForNewRegister` — pinned RED with the rebuild call removed (`No invocations performed`), GREEN with it in place.
- [x] `FinalizeAsync_BloomRebuildFailure_ShouldNotFailFinalize` — confirms a Redis/wallet-svc hiccup cannot roll back a sealed register.
- [x] All 19 orchestrator + policy tests pass (`dotnet test --filter FullyQualifiedName~RegisterCreationOrchestratorTests|FullyQualifiedName~RegisterCreationPolicyTests`).
- [x] Pre-existing failures (8 RegisterApiTests / SystemRegisterBootstrapper) confirmed identical on master baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)