### PR TITLE
feat(096): wallet HAIP x5c wiring (US3 end-to-end)

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
@@ -162,6 +162,7 @@ public interface IWalletServiceClient
         string? statusListPurpose = null,
         bool skipRecipientStore = false,
         string? issuerOrgName = null,
+        string? tenantId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -296,6 +296,7 @@ public class WalletServiceClient : IWalletServiceClient
         string? statusListPurpose = null,
         bool skipRecipientStore = false,
         string? issuerOrgName = null,
+        string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -318,7 +319,8 @@ public class WalletServiceClient : IWalletServiceClient
                 statusListIndex,
                 statusListPurpose,
                 skipRecipientStore,
-                issuerOrgName
+                issuerOrgName,
+                tenantId
             };
 
             var response = await _httpClient.PostAsJsonAsync(

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -510,8 +510,6 @@ public class ActionExecutionService : IActionExecutionService
         CredentialIssuanceResult? localWalletCredential = null;
         string? localWalletRecipient = null;
         var issuerOrgName = caller?.FindFirst("org_name")?.Value;
-        // Threaded to the Wallet Service for the x5c JWS header lookup. Null when
-        // the caller has no org context — preserves the Sorcha-internal default.
         var issuerTenantId = caller?.FindFirst("org_id")?.Value;
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience is TargetAudience.SorchaLocalWallet

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -510,6 +510,10 @@ public class ActionExecutionService : IActionExecutionService
         CredentialIssuanceResult? localWalletCredential = null;
         string? localWalletRecipient = null;
         var issuerOrgName = caller?.FindFirst("org_name")?.Value;
+        // Feature 096 US3: thread the caller's org_id (tenant id) through to the
+        // Wallet Service so it can fetch the org cert chain for the JWS x5c header.
+        // Null when the caller has no org context — keeps Sorcha-internal callers working.
+        var issuerTenantId = caller?.FindFirst("org_id")?.Value;
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience is TargetAudience.SorchaLocalWallet
                 or TargetAudience.SorchaInternal)
@@ -528,7 +532,7 @@ public class ActionExecutionService : IActionExecutionService
             try
             {
                 localWalletCredential = await IssueCredentialFromActionAsync(
-                    actionDef, mergedData, request.SenderWallet, instance, issuerOrgName, cancellationToken);
+                    actionDef, mergedData, request.SenderWallet, instance, issuerOrgName, issuerTenantId, cancellationToken);
             }
             catch (Exception ex) when (ex is not InvalidOperationException)
             {
@@ -1711,6 +1715,7 @@ public class ActionExecutionService : IActionExecutionService
         string senderWallet,
         Instance instance,
         string? issuerOrgName,
+        string? issuerTenantId,
         CancellationToken cancellationToken)
     {
         var config = actionDef.CredentialIssuanceConfig!;
@@ -1820,6 +1825,7 @@ public class ActionExecutionService : IActionExecutionService
                 statusListPurpose: preAllocatedStatusListUrl != null ? "revocation" : null,
                 skipRecipientStore: config.TargetAudience is TargetAudience.SorchaLocalWallet or TargetAudience.SorchaInternal,
                 issuerOrgName: issuerOrgName,
+                tenantId: issuerTenantId,
                 cancellationToken: cancellationToken);
 
             return result;

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -510,9 +510,8 @@ public class ActionExecutionService : IActionExecutionService
         CredentialIssuanceResult? localWalletCredential = null;
         string? localWalletRecipient = null;
         var issuerOrgName = caller?.FindFirst("org_name")?.Value;
-        // Feature 096 US3: thread the caller's org_id (tenant id) through to the
-        // Wallet Service so it can fetch the org cert chain for the JWS x5c header.
-        // Null when the caller has no org context — keeps Sorcha-internal callers working.
+        // Threaded to the Wallet Service for the x5c JWS header lookup. Null when
+        // the caller has no org context — preserves the Sorcha-internal default.
         var issuerTenantId = caller?.FindFirst("org_id")?.Value;
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience is TargetAudience.SorchaLocalWallet

--- a/src/Services/Sorcha.Wallet.Service/Credentials/IssueCredentialChainResolver.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/IssueCredentialChainResolver.cs
@@ -8,8 +8,8 @@ using Sorcha.ServiceClients.Trust;
 namespace Sorcha.Wallet.Service.Credentials;
 
 /// <summary>
-/// Feature 096 US3 — resolves the X.509 certificate chain for the JWS <c>x5c</c>
-/// header on HAIP-path credential issuance.
+/// Resolves the X.509 certificate chain for the JWS <c>x5c</c> header on
+/// HAIP-path credential issuance.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Services/Sorcha.Wallet.Service/Credentials/IssueCredentialChainResolver.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/IssueCredentialChainResolver.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+
+using Sorcha.ServiceClients.Trust;
+
+namespace Sorcha.Wallet.Service.Credentials;
+
+/// <summary>
+/// Feature 096 US3 — resolves the X.509 certificate chain for the JWS <c>x5c</c>
+/// header on HAIP-path credential issuance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted from <c>CredentialEndpoints.IssueCredential</c> so the chain-fetch
+/// decision rules (no provider → null, blank tenant → null, provider failure →
+/// null) can be tested in isolation and shared with future issuance paths.
+/// </para>
+/// <para>
+/// The endpoint must never fail credential issuance because the trust client
+/// failed — the absence of an <c>x5c</c> header degrades the credential to
+/// DID-only verifiability, which is the documented Sorcha-internal default. The
+/// resolver therefore swallows provider exceptions and returns null.
+/// </para>
+/// </remarks>
+public static class IssueCredentialChainResolver
+{
+    /// <summary>
+    /// Returns the leaf-first cert chain for <paramref name="issuerWallet"/> under
+    /// <paramref name="tenantId"/>, or null when the chain should not be embedded.
+    /// </summary>
+    public static async Task<IReadOnlyList<byte[]>?> ResolveChainAsync(
+        IOrgCertChainProvider? provider,
+        string? tenantId,
+        string issuerWallet,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (provider is null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return null;
+        }
+
+        try
+        {
+            var chain = await provider.GetChainForAsync(tenantId, issuerWallet, cancellationToken);
+            return chain?.AsJwsChain();
+        }
+        catch (Exception ex)
+        {
+            // Issuance must not fail because of a trust-service hiccup. The
+            // missing x5c header degrades the credential to DID-only verifiability.
+            logger.LogWarning(ex,
+                "Cert chain fetch failed for tenant {TenantId} issuer {IssuerWallet}; issuing credential without x5c header.",
+                tenantId, issuerWallet);
+            return null;
+        }
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Credentials/IssueCredentialChainResolver.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/IssueCredentialChainResolver.cs
@@ -8,22 +8,9 @@ using Sorcha.ServiceClients.Trust;
 namespace Sorcha.Wallet.Service.Credentials;
 
 /// <summary>
-/// Resolves the X.509 certificate chain for the JWS <c>x5c</c> header on
-/// HAIP-path credential issuance.
+/// Resolves the X.509 cert chain for the JWS <c>x5c</c> header on HAIP issuance;
+/// returns null on any provider failure (degrades to DID-only verifiability).
 /// </summary>
-/// <remarks>
-/// <para>
-/// Extracted from <c>CredentialEndpoints.IssueCredential</c> so the chain-fetch
-/// decision rules (no provider → null, blank tenant → null, provider failure →
-/// null) can be tested in isolation and shared with future issuance paths.
-/// </para>
-/// <para>
-/// The endpoint must never fail credential issuance because the trust client
-/// failed — the absence of an <c>x5c</c> header degrades the credential to
-/// DID-only verifiability, which is the documented Sorcha-internal default. The
-/// resolver therefore swallows provider exceptions and returns null.
-/// </para>
-/// </remarks>
 public static class IssueCredentialChainResolver
 {
     /// <summary>
@@ -52,10 +39,14 @@ public static class IssueCredentialChainResolver
             var chain = await provider.GetChainForAsync(tenantId, issuerWallet, cancellationToken);
             return chain?.AsJwsChain();
         }
+        catch (OperationCanceledException)
+        {
+            // Caller cancellation must propagate — never silently issue a
+            // credential without x5c when the request was abandoned.
+            throw;
+        }
         catch (Exception ex)
         {
-            // Issuance must not fail because of a trust-service hiccup. The
-            // missing x5c header degrades the credential to DID-only verifiability.
             logger.LogWarning(ex,
                 "Cert chain fetch failed for tenant {TenantId} issuer {IssuerWallet}; issuing credential without x5c header.",
                 tenantId, issuerWallet);

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -485,7 +485,8 @@ public static class CredentialEndpoints
         ISdJwtService sdJwtService,
         ICredentialStore store,
         ILoggerFactory loggerFactory,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        Sorcha.ServiceClients.Trust.IOrgCertChainProvider? orgCertChainProvider = null)
     {
         // 1. Get the issuer wallet
         var wallet = await walletRepository.GetByAddressAsync(walletAddress, cancellationToken: cancellationToken);
@@ -592,6 +593,17 @@ public static class CredentialEndpoints
             }
         }
 
+        // Feature 096 US3: when the caller supplies a tenant id and the wallet service
+        // has an IOrgCertChainProvider registered, embed the org cert chain in the JWS
+        // x5c header so external HAIP verifiers can validate against the tenant trust
+        // anchor. Failures degrade silently to DID-only verifiability.
+        var x5cChain = await Credentials.IssueCredentialChainResolver.ResolveChainAsync(
+            orgCertChainProvider,
+            request.TenantId,
+            walletAddress,
+            logger,
+            cancellationToken);
+
         var token = await sdJwtService.CreateTokenAsync(
             claims,
             request.DisclosableClaims,
@@ -600,7 +612,8 @@ public static class CredentialEndpoints
             privateKey,
             wallet.Algorithm,
             expiresAt,
-            cancellationToken);
+            cancellationToken,
+            x5cChain);
 
         // 5. Generate credential ID
         var credentialId = $"urn:uuid:{Guid.NewGuid()}";
@@ -762,6 +775,17 @@ public class IssueCredentialRequest
     /// JWT org_name claim at action execution time.
     /// </summary>
     public string? IssuerOrgName { get; init; }
+
+    /// <summary>
+    /// Feature 096 US3 — tenant id (org_id Guid as string) used to fetch the
+    /// issuer's X.509 certificate chain from the Tenant Service trust client. When
+    /// supplied AND the wallet service has an <c>IOrgCertChainProvider</c>
+    /// registered, the resulting chain is embedded in the JWS <c>x5c</c> header so
+    /// external HAIP verifiers can validate the issuer key against the tenant
+    /// trust anchor without DID resolution. Null falls back to DID-only
+    /// verifiability (the existing Sorcha-internal default).
+    /// </summary>
+    public string? TenantId { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using Sorcha.Blueprint.Models.Credentials;
 using Sorcha.Cryptography.SdJwt;
 using Sorcha.ServiceClients.Models;
+using Sorcha.ServiceClients.Trust;
 using Sorcha.Wallet.Core.Domain.Entities;
 using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Core.Services.Interfaces;
@@ -486,7 +487,7 @@ public static class CredentialEndpoints
         ICredentialStore store,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken = default,
-        Sorcha.ServiceClients.Trust.IOrgCertChainProvider? orgCertChainProvider = null)
+        IOrgCertChainProvider? orgCertChainProvider = null)
     {
         // 1. Get the issuer wallet
         var wallet = await walletRepository.GetByAddressAsync(walletAddress, cancellationToken: cancellationToken);
@@ -593,10 +594,9 @@ public static class CredentialEndpoints
             }
         }
 
-        // Feature 096 US3: when the caller supplies a tenant id and the wallet service
-        // has an IOrgCertChainProvider registered, embed the org cert chain in the JWS
-        // x5c header so external HAIP verifiers can validate against the tenant trust
-        // anchor. Failures degrade silently to DID-only verifiability.
+        // Embed the org cert chain in the JWS x5c header when the caller supplies
+        // a tenant id. Absence of either the provider or the tenant id falls back
+        // to DID-only verifiability — the existing Sorcha-internal default.
         var x5cChain = await Credentials.IssueCredentialChainResolver.ResolveChainAsync(
             orgCertChainProvider,
             request.TenantId,

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -486,8 +486,8 @@ public static class CredentialEndpoints
         ISdJwtService sdJwtService,
         ICredentialStore store,
         ILoggerFactory loggerFactory,
-        CancellationToken cancellationToken = default,
-        IOrgCertChainProvider? orgCertChainProvider = null)
+        IOrgCertChainProvider? orgCertChainProvider = null,
+        CancellationToken cancellationToken = default)
     {
         // 1. Get the issuer wallet
         var wallet = await walletRepository.GetByAddressAsync(walletAddress, cancellationToken: cancellationToken);
@@ -777,13 +777,13 @@ public class IssueCredentialRequest
     public string? IssuerOrgName { get; init; }
 
     /// <summary>
-    /// Feature 096 US3 — tenant id (org_id Guid as string) used to fetch the
-    /// issuer's X.509 certificate chain from the Tenant Service trust client. When
-    /// supplied AND the wallet service has an <c>IOrgCertChainProvider</c>
-    /// registered, the resulting chain is embedded in the JWS <c>x5c</c> header so
-    /// external HAIP verifiers can validate the issuer key against the tenant
-    /// trust anchor without DID resolution. Null falls back to DID-only
-    /// verifiability (the existing Sorcha-internal default).
+    /// Tenant id (org_id Guid as string) used to fetch the issuer's X.509
+    /// certificate chain from the Tenant Service trust client. When supplied AND
+    /// the wallet service has an <c>IOrgCertChainProvider</c> registered, the
+    /// resulting chain is embedded in the JWS <c>x5c</c> header so external HAIP
+    /// verifiers can validate the issuer key against the tenant trust anchor
+    /// without DID resolution. Null falls back to DID-only verifiability (the
+    /// existing Sorcha-internal default).
     /// </summary>
     public string? TenantId { get; init; }
 }

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -57,21 +57,9 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificationDeliveryService,
     Sorcha.Wallet.Service.Services.Implementation.NotificationDeliveryService>();
 
-// Org cert chain provider — fetched by the IssueCredential endpoint to embed
-// the issuer's X.509 chain in the JWS x5c header for HAIP-path credentials.
-//
-// Registered as a singleton: TrustServiceClient holds an internal 5-min cache;
-// transient registration would discard the cache between requests and turn every
-// issuance into a Tenant Service round-trip. The HttpClient is owned by the
-// IHttpClientFactory infrastructure (created via the named "trust-service"
-// binding below) so we keep the per-handler lifecycle while still pinning the
-// client+cache as a singleton.
-//
-// NOTE: the HttpClient is captured once at singleton creation, so mTLS cert
-// rotation on the Tenant Service end requires a Wallet Service restart to be
-// picked up. Acceptable today (cert rotation is operator-driven and rare);
-// revisit by injecting IHttpClientFactory into a thin wrapper if rotation
-// cadence becomes faster than restarts.
+// Singleton TrustServiceClient — its 5-min cert cache must survive across
+// requests, so the HttpClient is captured once. mTLS cert rotation on the
+// Tenant Service therefore requires a Wallet Service restart.
 builder.Services.AddHttpClient("trust-service", (sp, http) =>
 {
     var config = sp.GetRequiredService<IConfiguration>();

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -57,15 +57,19 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificationDeliveryService,
     Sorcha.Wallet.Service.Services.Implementation.NotificationDeliveryService>();
 
-// Singleton TrustServiceClient — its 5-min cert cache must survive across
-// requests, so the HttpClient is captured once. mTLS cert rotation on the
-// Tenant Service therefore requires a Wallet Service restart.
+// Singleton TrustServiceClient — 5-min cert cache must survive across requests,
+// so the HttpClient is captured once. PooledConnectionLifetime caps connection
+// age at 2 min so DNS / mTLS rotation lands via connection recycling.
 builder.Services.AddHttpClient("trust-service", (sp, http) =>
 {
     var config = sp.GetRequiredService<IConfiguration>();
     var address = config["ServiceClients:TenantService:Address"]
         ?? "https+http://tenant-service";
     http.BaseAddress = new Uri(address.TrimEnd('/') + "/");
+})
+.ConfigurePrimaryHttpMessageHandler(() => new System.Net.Http.SocketsHttpHandler
+{
+    PooledConnectionLifetime = TimeSpan.FromMinutes(2),
 });
 builder.Services.AddSingleton<Sorcha.ServiceClients.Trust.IOrgCertChainProvider>(sp =>
 {

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -57,6 +57,18 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificationDeliveryService,
     Sorcha.Wallet.Service.Services.Implementation.NotificationDeliveryService>();
 
+// Feature 096 US3: org cert chain provider — fetched by the IssueCredential endpoint
+// to embed the issuer's X.509 chain in the JWS x5c header for HAIP-path credentials.
+// Reads the Tenant Service address from ServiceClients:TenantService:Address (Aspire wiring).
+builder.Services.AddHttpClient<Sorcha.ServiceClients.Trust.IOrgCertChainProvider,
+    Sorcha.ServiceClients.Trust.TrustServiceClient>((sp, http) =>
+{
+    var config = sp.GetRequiredService<IConfiguration>();
+    var address = config["ServiceClients:TenantService:Address"]
+        ?? "https+http://tenant-service";
+    http.BaseAddress = new Uri(address.TrimEnd('/') + "/");
+});
+
 // Feature 060: Wallet recovery services
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IPasskeyRecoveryService,
     Sorcha.Wallet.Service.Services.Implementation.PasskeyRecoveryService>();

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -57,16 +57,28 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificationDeliveryService,
     Sorcha.Wallet.Service.Services.Implementation.NotificationDeliveryService>();
 
-// Feature 096 US3: org cert chain provider — fetched by the IssueCredential endpoint
-// to embed the issuer's X.509 chain in the JWS x5c header for HAIP-path credentials.
-// Reads the Tenant Service address from ServiceClients:TenantService:Address (Aspire wiring).
-builder.Services.AddHttpClient<Sorcha.ServiceClients.Trust.IOrgCertChainProvider,
-    Sorcha.ServiceClients.Trust.TrustServiceClient>((sp, http) =>
+// Org cert chain provider — fetched by the IssueCredential endpoint to embed
+// the issuer's X.509 chain in the JWS x5c header for HAIP-path credentials.
+//
+// Registered as a singleton: TrustServiceClient holds an internal 5-min cache;
+// transient registration would discard the cache between requests and turn every
+// issuance into a Tenant Service round-trip. The HttpClient is owned by the
+// IHttpClientFactory infrastructure (created via the named "trust-service"
+// binding below) so we keep the per-handler lifecycle while still pinning the
+// client+cache as a singleton.
+builder.Services.AddHttpClient("trust-service", (sp, http) =>
 {
     var config = sp.GetRequiredService<IConfiguration>();
     var address = config["ServiceClients:TenantService:Address"]
         ?? "https+http://tenant-service";
     http.BaseAddress = new Uri(address.TrimEnd('/') + "/");
+});
+builder.Services.AddSingleton<Sorcha.ServiceClients.Trust.IOrgCertChainProvider>(sp =>
+{
+    var factory = sp.GetRequiredService<IHttpClientFactory>();
+    var http = factory.CreateClient("trust-service");
+    var logger = sp.GetRequiredService<ILogger<Sorcha.ServiceClients.Trust.TrustServiceClient>>();
+    return new Sorcha.ServiceClients.Trust.TrustServiceClient(http, logger);
 });
 
 // Feature 060: Wallet recovery services

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -66,6 +66,12 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 // IHttpClientFactory infrastructure (created via the named "trust-service"
 // binding below) so we keep the per-handler lifecycle while still pinning the
 // client+cache as a singleton.
+//
+// NOTE: the HttpClient is captured once at singleton creation, so mTLS cert
+// rotation on the Tenant Service end requires a Wallet Service restart to be
+// picked up. Acceptable today (cert rotation is operator-driven and rare);
+// revisit by injecting IHttpClientFactory into a thin wrapper if rotation
+// cadence becomes faster than restarts.
 builder.Services.AddHttpClient("trust-service", (sp, http) =>
 {
     var config = sp.GetRequiredService<IConfiguration>();

--- a/tests/Sorcha.ServiceClients.Tests/Wallet/WalletServiceClientIssueCredentialTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Wallet/WalletServiceClientIssueCredentialTests.cs
@@ -87,6 +87,11 @@ public class WalletServiceClientIssueCredentialTests
         // Backward-compat: pre-096-US3 callers (and internal callers without a JWT
         // org context) MUST keep working; the field should be omitted entirely so the
         // server-side IssueCredentialRequest deserialiser leaves TenantId null.
+        //
+        // This guarantee depends on WalletServiceClient using
+        // JsonSerializerOptions { DefaultIgnoreCondition = WhenWritingNull } —
+        // verified at the static field declaration. If that ever changes, this
+        // assertion becomes the canary.
         string? capturedBody = null;
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()

--- a/tests/Sorcha.ServiceClients.Tests/Wallet/WalletServiceClientIssueCredentialTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Wallet/WalletServiceClientIssueCredentialTests.cs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text.Json;
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Wallet;
+
+using Xunit;
+
+namespace Sorcha.ServiceClients.Tests.Wallet;
+
+/// <summary>
+/// Wire-shape tests for <see cref="WalletServiceClient.IssueCredentialAsync"/>.
+/// Ensures the Blueprint Service-supplied tenant id reaches the Wallet Service in
+/// the request body so the HAIP issuer can fetch the org cert chain for the
+/// <c>x5c</c> JWS header (Feature 096 US3 end-to-end wiring).
+/// </summary>
+public class WalletServiceClientIssueCredentialTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact]
+    public async Task IssueCredentialAsync_WithTenantId_IncludesTenantIdInRequestBody()
+    {
+        // Arrange — capture the request body so we can assert tenantId is on the wire.
+        string? capturedBody = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync(ct);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        JsonSerializer.Serialize(new
+                        {
+                            credentialId = "urn:uuid:test",
+                            type = "TestCredential",
+                            issuerDid = "did:sorcha:w:issuer",
+                            subjectDid = "did:sorcha:w:recipient",
+                            claims = new Dictionary<string, object> { ["foo"] = "bar" },
+                            issuedAt = DateTimeOffset.UtcNow,
+                            rawToken = "eyJ.test.token",
+                        }, JsonOptions),
+                        System.Text.Encoding.UTF8,
+                        "application/json"),
+                };
+            });
+
+        var client = BuildClient(handler);
+
+        // Act
+        await client.IssueCredentialAsync(
+            issuerWalletAddress: "ws1qissuer",
+            credentialType: "TestCredential",
+            claims: new Dictionary<string, object> { ["foo"] = "bar" },
+            recipientWallet: "ws1qrecipient",
+            tenantId: "11111111-1111-1111-1111-111111111111");
+
+        // Assert
+        capturedBody.Should().NotBeNullOrEmpty();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        doc.RootElement.TryGetProperty("tenantId", out var tenantEl).Should().BeTrue(
+            "the Wallet endpoint relies on tenantId to fetch the issuer's org cert chain (096 US3)");
+        tenantEl.GetString().Should().Be("11111111-1111-1111-1111-111111111111");
+    }
+
+    [Fact]
+    public async Task IssueCredentialAsync_WithoutTenantId_OmitsTenantIdFromRequestBody()
+    {
+        // Backward-compat: pre-096-US3 callers (and internal callers without a JWT
+        // org context) MUST keep working; the field should be omitted entirely so the
+        // server-side IssueCredentialRequest deserialiser leaves TenantId null.
+        string? capturedBody = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+            {
+                capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync(ct);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        JsonSerializer.Serialize(new
+                        {
+                            credentialId = "urn:uuid:test",
+                            type = "TestCredential",
+                            issuerDid = "did:sorcha:w:issuer",
+                            subjectDid = "did:sorcha:w:recipient",
+                            claims = new Dictionary<string, object> { ["foo"] = "bar" },
+                            issuedAt = DateTimeOffset.UtcNow,
+                            rawToken = "eyJ.test.token",
+                        }, JsonOptions),
+                        System.Text.Encoding.UTF8,
+                        "application/json"),
+                };
+            });
+
+        var client = BuildClient(handler);
+
+        await client.IssueCredentialAsync(
+            issuerWalletAddress: "ws1qissuer",
+            credentialType: "TestCredential",
+            claims: new Dictionary<string, object> { ["foo"] = "bar" },
+            recipientWallet: "ws1qrecipient");
+
+        capturedBody.Should().NotBeNullOrEmpty();
+        using var doc = JsonDocument.Parse(capturedBody!);
+        doc.RootElement.TryGetProperty("tenantId", out _).Should().BeFalse();
+    }
+
+    private static WalletServiceClient BuildClient(Mock<HttpMessageHandler> handler)
+    {
+        var http = new HttpClient(handler.Object);
+        var auth = new Mock<IServiceAuthClient>();
+        auth.Setup(a => a.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("test-token");
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ServiceClients:WalletService:Address"] = "http://localhost:5001",
+            })
+            .Build();
+        var logger = Mock.Of<ILogger<WalletServiceClient>>();
+        return new WalletServiceClient(http, auth.Object, config, logger);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/IssueCredentialChainResolverTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/IssueCredentialChainResolverTests.cs
@@ -117,4 +117,27 @@ public class IssueCredentialChainResolverTests
 
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task ResolveChainAsync_ProviderThrowsOperationCanceled_Rethrows()
+    {
+        // OperationCanceledException must NOT be swallowed — silently issuing a
+        // credential without x5c when the caller has abandoned the request would
+        // produce an unverifiable artifact under timeout/disconnect scenarios.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var provider = new Mock<IOrgCertChainProvider>();
+        provider.Setup(p => p.GetChainForAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        var act = async () => await IssueCredentialChainResolver.ResolveChainAsync(
+            provider: provider.Object,
+            tenantId: TenantId,
+            issuerWallet: IssuerWallet,
+            logger: NullLogger.Instance,
+            cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/IssueCredentialChainResolverTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/IssueCredentialChainResolverTests.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http;
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+using Sorcha.ServiceClients.Trust;
+using Sorcha.Wallet.Service.Credentials;
+
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Credentials;
+
+/// <summary>
+/// Feature 096 US3 — pins the resolution rules between the IssueCredential endpoint
+/// and the Tenant Service trust client. The endpoint must:
+///   • skip the chain fetch entirely when no provider is registered (dev / opt-out),
+///   • skip when the caller (Blueprint Service) didn't supply a tenant id,
+///   • return null (no x5c) when the Tenant Service has no enrolment,
+///   • return leaf-first chain bytes ready for the JWS x5c header on success,
+///   • absorb provider exceptions so a Tenant Service hiccup never breaks issuance.
+/// </summary>
+public class IssueCredentialChainResolverTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string IssuerWallet = "ws1qissuer";
+
+    [Fact]
+    public async Task ResolveChainAsync_NullProvider_ReturnsNull()
+    {
+        var result = await IssueCredentialChainResolver.ResolveChainAsync(
+            provider: null,
+            tenantId: TenantId,
+            issuerWallet: IssuerWallet,
+            logger: NullLogger.Instance,
+            cancellationToken: default);
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ResolveChainAsync_BlankTenantId_ReturnsNull_WithoutCallingProvider(string? tenantId)
+    {
+        var provider = new Mock<IOrgCertChainProvider>(MockBehavior.Strict);
+
+        var result = await IssueCredentialChainResolver.ResolveChainAsync(
+            provider: provider.Object,
+            tenantId: tenantId,
+            issuerWallet: IssuerWallet,
+            logger: NullLogger.Instance,
+            cancellationToken: default);
+
+        result.Should().BeNull();
+        provider.Verify(p => p.GetChainForAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveChainAsync_ProviderReturnsNull_ReturnsNull()
+    {
+        var provider = new Mock<IOrgCertChainProvider>();
+        provider.Setup(p => p.GetChainForAsync(TenantId, IssuerWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OrgCertChain?)null);
+
+        var result = await IssueCredentialChainResolver.ResolveChainAsync(
+            provider: provider.Object,
+            tenantId: TenantId,
+            issuerWallet: IssuerWallet,
+            logger: NullLogger.Instance,
+            cancellationToken: default);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveChainAsync_ProviderReturnsChain_ReturnsLeafThenRoot()
+    {
+        var leafDer = new byte[] { 0x30, 0x82, 0x01, 0x01 };
+        var rootDer = new byte[] { 0x30, 0x82, 0x02, 0x02 };
+        var provider = new Mock<IOrgCertChainProvider>();
+        provider.Setup(p => p.GetChainForAsync(TenantId, IssuerWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrgCertChain(leafDer, rootDer));
+
+        var result = await IssueCredentialChainResolver.ResolveChainAsync(
+            provider: provider.Object,
+            tenantId: TenantId,
+            issuerWallet: IssuerWallet,
+            logger: NullLogger.Instance,
+            cancellationToken: default);
+
+        result.Should().NotBeNull();
+        result.Should().HaveCount(2);
+        result![0].Should().BeEquivalentTo(leafDer);
+        result[1].Should().BeEquivalentTo(rootDer);
+    }
+
+    [Fact]
+    public async Task ResolveChainAsync_ProviderThrows_ReturnsNull_NoRethrow()
+    {
+        var provider = new Mock<IOrgCertChainProvider>();
+        provider.Setup(p => p.GetChainForAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("tenant down"));
+
+        var result = await IssueCredentialChainResolver.ResolveChainAsync(
+            provider: provider.Object,
+            tenantId: TenantId,
+            issuerWallet: IssuerWallet,
+            logger: NullLogger.Instance,
+            cancellationToken: default);
+
+        result.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/IssueCredentialChainResolverTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/IssueCredentialChainResolverTests.cs
@@ -3,8 +3,9 @@
 
 using System.Net.Http;
 
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+
+using FluentAssertions;
 using Moq;
 
 using Sorcha.ServiceClients.Trust;


### PR DESCRIPTION
## Summary

- Threads tenant id from Blueprint Service `org_id` JWT claim through `WalletServiceClient.IssueCredentialAsync` into the Wallet Service `IssueCredential` endpoint.
- Wallet Service now fetches the org cert chain via `TrustServiceClient` (introduced PR #320) and embeds it in the JWS `x5c` header so external HAIP verifiers can validate against the tenant trust anchor.
- Extracts `IssueCredentialChainResolver` so the resolution decision matrix (null provider, blank tenant, provider null/throws/returns) is unit-tested in isolation.
- Failures degrade silently to DID-only verifiability — Tenant Service hiccups never break issuance.

## Why

PR #320 landed the trust client + cache but it was unused. This PR closes the loop end-to-end: Blueprint action → tenant id forwarded → Wallet fetches chain → x5c embedded in signed credential.

## Test plan

- [x] 7 `IssueCredentialChainResolverTests` (decision matrix).
- [x] 2 `WalletServiceClientIssueCredentialTests` (wire shape — `tenantId` present/absent).
- [x] Full ServiceClients suite (161 tests) green.
- [x] Full Wallet Service suite (627 tests) green.
- [x] Pre-existing 22 `Blueprint.Service.Tests.Services.ActionExecution*` failures confirmed identical on master baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)