### PR TITLE
feat(validator): Tier 3 chain-derived participant binding

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -1111,11 +1111,15 @@ public class ValidationEngine : IValidationEngine
                             {
                                 // SEC-AUDIT 4.8: no Tier 1/2 record AND no Tier 3 chain
                                 // binding — nothing on-ledger authorises this submitter.
+                                // NB: if ResolveChainBoundWalletAsync logged a prior
+                                // warning (transient register-service failure), the error
+                                // message hint below flags the degraded-query case so an
+                                // operator can correlate the two logs.
                                 _logger.LogWarning(
                                     "Participant {ParticipantId} has no wallet, no published record, and no prior in-instance binding on register {RegisterId} — rejecting transaction for action {ActionId}",
                                     action.Sender, transaction.RegisterId, actionIdInt);
                                 errors.Add(CreateError("VAL_BP_002",
-                                    $"Cannot verify sender authorization: participant '{action.Sender}' has no wallet address and no published record on register '{transaction.RegisterId}'",
+                                    $"Cannot verify sender authorization: participant '{action.Sender}' has no wallet address, no published record on register '{transaction.RegisterId}', and no prior in-instance binding. (Chain lookup degraded? See preceding validator warnings.)",
                                     ValidationErrorCategory.Permission, "Signatures"));
                             }
                         }
@@ -1996,10 +2000,10 @@ public class ValidationEngine : IValidationEngine
             .ThenBy(t => t.TxId, StringComparer.Ordinal)
             .FirstOrDefault(t =>
             {
-                // Widen the comparison so a uint ActionId >= int.MaxValue never
-                // accidentally matches a negative blueprint Id.
+                // `a.Id >= 0` guard makes the cast intent obvious to readers: a uint
+                // ActionId >= int.MaxValue must never match a negative blueprint Id.
                 var action = blueprint.Actions.FirstOrDefault(a =>
-                    (uint)a.Id == t.MetaData!.ActionId!.Value);
+                    a.Id >= 0 && (uint)a.Id == t.MetaData!.ActionId!.Value);
                 return action != null
                     && string.Equals(action.Sender, participantId, StringComparison.OrdinalIgnoreCase);
             });

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -1961,6 +1961,13 @@ public class ValidationEngine : IValidationEngine
             priorTxs = await _registerClient.GetTransactionsByInstanceIdAsync(
                 currentTx.RegisterId, instanceId, ct);
         }
+        // Deliberate caller cancellation (shutdown, request timeout) must propagate —
+        // falling through to VAL_BP_002 on a cancelled request would mislead callers
+        // into thinking the chain authoritatively lacked a binding.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException
                                       or TaskCanceledException
                                       or TimeoutException
@@ -1977,14 +1984,22 @@ public class ValidationEngine : IValidationEngine
             return null;
         }
 
-        // Oldest first — the earliest matching tx is the binding authority.
+        // Oldest first — the earliest matching tx is the binding authority. TxId
+        // secondary sort is a deterministic tie-breaker for equal TimeStamps.
+        // TODO: Tier 3 currently fetches all in-instance txs. For long-running instances
+        // (100+ actions) a purpose-built "first tx by participant role" register query
+        // would let the DB short-circuit. Fine at MVD scale; revisit when workflows grow.
         var match = priorTxs
             .Where(t => !string.Equals(t.TxId, currentTx.TransactionId, StringComparison.OrdinalIgnoreCase))
             .Where(t => t.MetaData?.ActionId is not null)
             .OrderBy(t => t.TimeStamp)
+            .ThenBy(t => t.TxId, StringComparer.Ordinal)
             .FirstOrDefault(t =>
             {
-                var action = blueprint.Actions.FirstOrDefault(a => a.Id == (int)t.MetaData!.ActionId!.Value);
+                // Widen the comparison so a uint ActionId >= int.MaxValue never
+                // accidentally matches a negative blueprint Id.
+                var action = blueprint.Actions.FirstOrDefault(a =>
+                    (uint)a.Id == t.MetaData!.ActionId!.Value);
                 return action != null
                     && string.Equals(action.Sender, participantId, StringComparison.OrdinalIgnoreCase);
             });

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -1080,14 +1080,44 @@ public class ValidationEngine : IValidationEngine
                         }
                         else
                         {
-                            // SEC-AUDIT 4.8: Fail hard when participant cannot be resolved
-                            // rather than silently skipping sender authorization
-                            _logger.LogWarning(
-                                "Participant {ParticipantId} has no wallet and no published record on register {RegisterId} — rejecting transaction for action {ActionId}",
-                                action.Sender, transaction.RegisterId, actionIdInt);
-                            errors.Add(CreateError("VAL_BP_002",
-                                $"Cannot verify sender authorization: participant '{action.Sender}' has no wallet address and no published record on register '{transaction.RegisterId}'",
-                                ValidationErrorCategory.Permission, "Signatures"));
+                            // Tier 3: chain-derived late-binding. Before failing hard, walk
+                            // the in-instance transaction chain. If an earlier tx in this
+                            // instance was signed for the same participant role, its signing
+                            // wallet IS the late-binding — authoritative because it's
+                            // on-ledger and signed. This keeps "open participant" blueprints
+                            // (public citizen, applicant, procurement-mgr on its own flow)
+                            // working without an auto-publish side-effect on late-bind.
+                            var chainWallet = await ResolveChainBoundWalletAsync(
+                                transaction, action.Sender, blueprint, ct);
+
+                            if (chainWallet != null)
+                            {
+                                if (string.Equals(chainWallet, derivedWallet, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    _logger.LogDebug(
+                                        "Participant {ParticipantId} chain-bound to wallet {Wallet} from prior in-instance tx — matches current signer",
+                                        action.Sender, derivedWallet);
+                                }
+                                else
+                                {
+                                    // Immutable-binding violation (FR-004): a prior in-instance tx
+                                    // bound this participant role to a different wallet.
+                                    errors.Add(CreateError("VAL_BP_002",
+                                        $"Signer wallet {derivedWallet} does not match chain-derived binding {chainWallet} for participant '{action.Sender}' (late-bound on an earlier action in this instance)",
+                                        ValidationErrorCategory.Permission, "Signatures"));
+                                }
+                            }
+                            else
+                            {
+                                // SEC-AUDIT 4.8: no Tier 1/2 record AND no Tier 3 chain
+                                // binding — nothing on-ledger authorises this submitter.
+                                _logger.LogWarning(
+                                    "Participant {ParticipantId} has no wallet, no published record, and no prior in-instance binding on register {RegisterId} — rejecting transaction for action {ActionId}",
+                                    action.Sender, transaction.RegisterId, actionIdInt);
+                                errors.Add(CreateError("VAL_BP_002",
+                                    $"Cannot verify sender authorization: participant '{action.Sender}' has no wallet address and no published record on register '{transaction.RegisterId}'",
+                                    ValidationErrorCategory.Permission, "Signatures"));
+                            }
                         }
                     }
                 }
@@ -1903,4 +1933,67 @@ public class ValidationEngine : IValidationEngine
         return null;
     }
 
+    /// <summary>
+    /// Tier 3 sender-authorisation fallback. Walks the in-instance transaction chain on the
+    /// register, finds the earliest prior transaction whose action <c>Sender</c> matches
+    /// <paramref name="participantId"/>, and returns that transaction's signing wallet.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the on-ledger derivation of the late-binding contract: once an open
+    /// participant is bound by a signed action, the signature IS the proof. Any later
+    /// transaction purporting to act as the same participant must re-sign with the same
+    /// wallet (FR-004 immutable binding).
+    /// </para>
+    /// <para>
+    /// Returns null when no in-instance history exists for this participant (cold start)
+    /// or when the transaction has no instance id in metadata. Either case keeps the
+    /// existing fail-closed VAL_BP_002 path.
+    /// </para>
+    /// </remarks>
+    private async Task<string?> ResolveChainBoundWalletAsync(
+        Transaction currentTx,
+        string participantId,
+        BlueprintModel blueprint,
+        CancellationToken ct)
+    {
+        if (!currentTx.Metadata.TryGetValue("instanceId", out var instanceId)
+            || string.IsNullOrWhiteSpace(instanceId))
+        {
+            return null;
+        }
+
+        List<Sorcha.Register.Models.TransactionModel> priorTxs;
+        try
+        {
+            priorTxs = await _registerClient.GetTransactionsByInstanceIdAsync(
+                currentTx.RegisterId, instanceId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Chain-binding lookup failed for instance {InstanceId} on register {RegisterId} — treating as no binding",
+                instanceId, currentTx.RegisterId);
+            return null;
+        }
+
+        if (priorTxs.Count == 0)
+        {
+            return null;
+        }
+
+        // Oldest first — the earliest matching tx is the binding authority.
+        var match = priorTxs
+            .Where(t => !string.Equals(t.TxId, currentTx.TransactionId, StringComparison.OrdinalIgnoreCase))
+            .Where(t => t.MetaData?.ActionId is not null)
+            .OrderBy(t => t.TimeStamp)
+            .FirstOrDefault(t =>
+            {
+                var action = blueprint.Actions.FirstOrDefault(a => a.Id == (int)t.MetaData!.ActionId!.Value);
+                return action != null
+                    && string.Equals(action.Sender, participantId, StringComparison.OrdinalIgnoreCase);
+            });
+
+        return !string.IsNullOrWhiteSpace(match?.SenderWallet) ? match.SenderWallet : null;
+    }
 }

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -1933,23 +1933,15 @@ public class ValidationEngine : IValidationEngine
         return null;
     }
 
-    /// <summary>
-    /// Tier 3 sender-authorisation fallback. Walks the in-instance transaction chain on the
-    /// register, finds the earliest prior transaction whose action <c>Sender</c> matches
-    /// <paramref name="participantId"/>, and returns that transaction's signing wallet.
-    /// </summary>
+    /// <summary>Tier 3 sender-authorisation fallback — derives a late-binding from the earliest prior in-instance transaction signed for the same participant role.</summary>
     /// <remarks>
-    /// <para>
-    /// This is the on-ledger derivation of the late-binding contract: once an open
-    /// participant is bound by a signed action, the signature IS the proof. Any later
-    /// transaction purporting to act as the same participant must re-sign with the same
-    /// wallet (FR-004 immutable binding).
-    /// </para>
-    /// <para>
-    /// Returns null when no in-instance history exists for this participant (cold start)
-    /// or when the transaction has no instance id in metadata. Either case keeps the
-    /// existing fail-closed VAL_BP_002 path.
-    /// </para>
+    /// Trust invariant: <c>TransactionModel.SenderWallet</c> on a sealed transaction is
+    /// populated by the validator at docket-sealing time (see
+    /// <c>DocketSerializer.GetSenderWallet</c>) from the Wallet Service's verified
+    /// <c>Signature.SignedBy</c>. Any transaction that reaches the chain-walk below has
+    /// already passed signature verification and (for non-starting actions) Tier 1/2 sender
+    /// checks, so <c>SenderWallet</c> is the cryptographically-bound wallet, not
+    /// submitter-supplied metadata.
     /// </remarks>
     private async Task<string?> ResolveChainBoundWalletAsync(
         Transaction currentTx,
@@ -1969,7 +1961,10 @@ public class ValidationEngine : IValidationEngine
             priorTxs = await _registerClient.GetTransactionsByInstanceIdAsync(
                 currentTx.RegisterId, instanceId, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is HttpRequestException
+                                      or TaskCanceledException
+                                      or TimeoutException
+                                      or IOException)
         {
             _logger.LogWarning(ex,
                 "Chain-binding lookup failed for instance {InstanceId} on register {RegisterId} — treating as no binding",

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineChainBindingTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineChainBindingTests.cs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+using Sorcha.Cryptography.Enums;
+using Sorcha.Cryptography.Interfaces;
+using Sorcha.Register.Models;
+using Sorcha.ServiceClients.Register;
+using Sorcha.ServiceClients.Register.Models;
+using Sorcha.Validator.Service.Configuration;
+using Sorcha.Validator.Service.Models;
+using Sorcha.Validator.Service.Services;
+using Sorcha.Validator.Service.Services.Interfaces;
+
+using Xunit;
+
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+using ActionModel = Sorcha.Blueprint.Models.Action;
+using ParticipantModel = Sorcha.Blueprint.Models.Participant;
+using RouteModel = Sorcha.Blueprint.Models.Route;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Tier 3 fallback for sender authorisation: when a participant has no hardcoded wallet on
+/// the blueprint AND no published participant record on the register, the validator falls
+/// back to walking the in-instance transaction chain to derive the late-binding from the
+/// earliest prior transaction submitted by that participant. The signature on that earlier
+/// transaction is the on-ledger proof of binding — no external state required.
+/// Closes the gap that broke TradeFinance Action 6 on master after Feature 083 + SEC-AUDIT 4.8.
+/// </summary>
+public class ValidationEngineChainBindingTests
+{
+    private const string RegisterId = "reg-test";
+    private const string BlueprintId = "bp-test";
+    private const string InstanceId = "inst-test-0001";
+    private const string ProcurementMgr = "procurement-mgr";
+    private const string BoundWallet = "ws11q-procurement-bound-wallet";
+
+    private readonly Mock<IBlueprintCache> _blueprintCacheMock = new();
+    private readonly Mock<IHashProvider> _hashProviderMock = new();
+    private readonly Mock<ICryptoModule> _cryptoModuleMock = new();
+    private readonly Mock<IRegisterServiceClient> _registerClientMock = new();
+    private readonly Mock<IRightsEnforcementService> _rightsEnforcementMock = new();
+    private readonly Mock<IWalletUtilities> _walletUtilitiesMock = new();
+    private readonly Mock<ILogger<ValidationEngine>> _loggerMock = new();
+    private readonly ValidationEngine _engine;
+
+    public ValidationEngineChainBindingTests()
+    {
+        _registerClientMock.Setup(r => r.GetTransactionsByPrevTxIdAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TransactionPage { Page = 1, PageSize = 1 });
+
+        _rightsEnforcementMock.Setup(r => r.ValidateGovernanceRightsAsync(
+                It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Transaction tx, CancellationToken _) =>
+                ValidationEngineResult.Success(tx.TransactionId, tx.RegisterId, TimeSpan.Zero));
+
+        // Tier 1 + Tier 2 must both fail to reach Tier 3.
+        _registerClientMock.Setup(r => r.ResolveParticipantAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PublishedParticipantRecord?)null);
+
+        var config = new ValidationEngineConfiguration
+        {
+            EnableSchemaValidation = false,
+            EnableSignatureVerification = false,
+            EnableChainValidation = false,
+            EnableBlueprintConformance = true,
+            EnableParallelValidation = false,
+            MaxClockSkew = TimeSpan.FromMinutes(5),
+            MaxTransactionAge = TimeSpan.FromHours(1)
+        };
+
+        _engine = new ValidationEngine(
+            Options.Create(config),
+            _blueprintCacheMock.Object,
+            _hashProviderMock.Object,
+            _cryptoModuleMock.Object,
+            _walletUtilitiesMock.Object,
+            _registerClientMock.Object,
+            _rightsEnforcementMock.Object,
+            _loggerMock.Object);
+
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(BlueprintId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildBlueprint());
+
+        SetupHashValidation();
+    }
+
+    [Fact]
+    public async Task Tier3_PriorInstanceTxFromSameParticipant_AcceptsMatchingWallet()
+    {
+        // The walkthrough scenario: procurement-mgr is the open participant on Action 1
+        // (starting action — validator skips strict check; binding happens via signature on
+        // the recorded tx). Action 6 has procurement-mgr again. Tier 1 (no blueprint wallet)
+        // and Tier 2 (no published record) both fail by design. Tier 3 walks the in-instance
+        // chain, finds Action 1's tx with senderWallet == BoundWallet, and accepts the
+        // matching wallet on Action 6.
+        _registerClientMock.Setup(r => r.GetTransactionsByInstanceIdAsync(
+                RegisterId, InstanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                BuildPriorTx(actionId: 1, senderWallet: BoundWallet, timestamp: DateTime.UtcNow.AddMinutes(-5))
+            ]);
+
+        _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
+            .Returns(BoundWallet);
+
+        var tx = BuildAction6Tx(senderWallet: BoundWallet);
+
+        var result = await _engine.ValidateBlueprintConformanceAsync(tx);
+
+        result.Errors.Should().NotContain(e => e.Code == "VAL_BP_002",
+            "Tier 3 chain-derived binding should accept Action 6 when the wallet matches the earlier in-instance tx");
+    }
+
+    [Fact]
+    public async Task Tier3_PriorInstanceTxWithDifferentWallet_RejectsAsImmutableBindingViolation()
+    {
+        // Late-binding is immutable per FR-004. If procurement-mgr's earlier tx was signed by
+        // wallet A, a later tx by procurement-mgr signed by wallet B must be rejected — even
+        // when neither wallet is on the blueprint or in published records.
+        _registerClientMock.Setup(r => r.GetTransactionsByInstanceIdAsync(
+                RegisterId, InstanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                BuildPriorTx(actionId: 1, senderWallet: BoundWallet, timestamp: DateTime.UtcNow.AddMinutes(-5))
+            ]);
+
+        _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
+            .Returns("ws11q-attacker-wallet");
+
+        var tx = BuildAction6Tx(senderWallet: "ws11q-attacker-wallet");
+
+        var result = await _engine.ValidateBlueprintConformanceAsync(tx);
+
+        result.Errors.Should().Contain(e => e.Code == "VAL_BP_002",
+            "a different wallet for an already-bound late-bound participant must reject as immutable-binding violation");
+    }
+
+    [Fact]
+    public async Task Tier3_NoPriorInstanceTxFromParticipant_FallsThroughToVAL_BP_002()
+    {
+        // Cold-start scenario: this is the first time procurement-mgr appears in the instance
+        // chain. Tier 3 cannot derive a binding from no history; the existing fail-closed
+        // VAL_BP_002 from SEC-AUDIT 4.8 still fires.
+        _registerClientMock.Setup(r => r.GetTransactionsByInstanceIdAsync(
+                RegisterId, InstanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TransactionModel>());
+
+        _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
+            .Returns(BoundWallet);
+
+        var tx = BuildAction6Tx(senderWallet: BoundWallet);
+
+        var result = await _engine.ValidateBlueprintConformanceAsync(tx);
+
+        result.Errors.Should().Contain(e => e.Code == "VAL_BP_002",
+            "no prior chain binding means Tier 3 has nothing to authorise against");
+    }
+
+    [Fact]
+    public async Task Tier3_MissingInstanceIdMetadata_FallsThroughToVAL_BP_002()
+    {
+        // Defensive: if the submission lacks an instanceId in metadata, Tier 3 has no chain
+        // to consult and must keep the fail-closed behaviour.
+        _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
+            .Returns(BoundWallet);
+
+        var tx = BuildAction6Tx(senderWallet: BoundWallet, withInstanceId: false);
+
+        var result = await _engine.ValidateBlueprintConformanceAsync(tx);
+
+        result.Errors.Should().Contain(e => e.Code == "VAL_BP_002");
+        _registerClientMock.Verify(r => r.GetTransactionsByInstanceIdAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "Tier 3 must not call the register when no instance id is available");
+    }
+
+    // ---------------- helpers ----------------
+
+    private void SetupHashValidation()
+    {
+        _hashProviderMock.Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(Convert.FromHexString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    }
+
+    private static BlueprintModel BuildBlueprint() => new()
+    {
+        Id = BlueprintId,
+        Title = "Procurement (open participant)",
+        Participants =
+        [
+            // Open participant — no walletAddress; binding deferred to first submitter.
+            new ParticipantModel { Id = ProcurementMgr, Name = "Procurement Manager" },
+        ],
+        Actions =
+        [
+            new ActionModel
+            {
+                Id = 1,
+                Title = "Raise PO",
+                Sender = ProcurementMgr,
+                IsStartingAction = true,
+                Routes = [new RouteModel { NextActionIds = [6] }]
+            },
+            new ActionModel
+            {
+                Id = 6,
+                Title = "Approve Invoice",
+                Sender = ProcurementMgr,
+            }
+        ]
+    };
+
+    private static Transaction BuildAction6Tx(string senderWallet, bool withInstanceId = true)
+    {
+        var metadata = new Dictionary<string, string>();
+        if (withInstanceId)
+        {
+            metadata["instanceId"] = InstanceId;
+        }
+        return new Transaction
+        {
+            TransactionId = $"tx-{Guid.NewGuid():N}",
+            RegisterId = RegisterId,
+            BlueprintId = BlueprintId,
+            ActionId = "6",
+            Payload = JsonSerializer.Deserialize<JsonElement>("{}"),
+            PayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            CreatedAt = DateTimeOffset.UtcNow,
+            PreviousTransactionId = "tx-prev-action-5",
+            Metadata = metadata,
+            Signatures =
+            [
+                new Signature
+                {
+                    PublicKey = new byte[32],
+                    SignatureValue = new byte[64],
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow,
+                    SignedBy = senderWallet,
+                }
+            ]
+        };
+    }
+
+    private static TransactionModel BuildPriorTx(uint actionId, string senderWallet, DateTime timestamp) => new()
+    {
+        TxId = $"tx-prior-{actionId:0000}-{Guid.NewGuid():N}",
+        RegisterId = RegisterId,
+        SenderWallet = senderWallet,
+        TimeStamp = timestamp,
+        MetaData = new TransactionMetaData
+        {
+            BlueprintId = BlueprintId,
+            InstanceId = InstanceId,
+            ActionId = actionId,
+        },
+        Signature = "stubbed-not-used-by-tier3"
+    };
+}

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineChainBindingTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineChainBindingTests.cs
@@ -154,7 +154,7 @@ public class ValidationEngineChainBindingTests
         // VAL_BP_002 from SEC-AUDIT 4.8 still fires.
         _registerClientMock.Setup(r => r.GetTransactionsByInstanceIdAsync(
                 RegisterId, InstanceId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<TransactionModel>());
+            .ReturnsAsync([]);
 
         _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
             .Returns(BoundWallet);
@@ -184,6 +184,76 @@ public class ValidationEngineChainBindingTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never,
             "Tier 3 must not call the register when no instance id is available");
+    }
+
+    [Fact]
+    public async Task Tier3_RegisterClientThrows_FallsThroughToVAL_BP_002_NotSilentPass()
+    {
+        // Security-relevant: a transient network blip in the chain-walk must NOT silently
+        // admit a transaction that no Tier 1/2 record authorises. The catch returns null;
+        // the caller falls through to the existing fail-closed VAL_BP_002.
+        _registerClientMock.Setup(r => r.GetTransactionsByInstanceIdAsync(
+                RegisterId, InstanceId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("register-service unreachable"));
+
+        _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
+            .Returns(BoundWallet);
+
+        var tx = BuildAction6Tx(senderWallet: BoundWallet);
+
+        var result = await _engine.ValidateBlueprintConformanceAsync(tx);
+
+        result.Errors.Should().Contain(e => e.Code == "VAL_BP_002");
+    }
+
+    [Fact]
+    public async Task Tier3_ParticipantRoleFilter_DoesNotLeakBindingAcrossParticipants()
+    {
+        // Participant A has prior history; participant B (also on the blueprint) has not
+        // yet acted. A Tier 3 resolution for participant B must not accidentally return
+        // participant A's wallet just because they share an instance.
+        //
+        // Here the current tx is Action 6 for procurement-mgr (B), but the only prior
+        // in-instance tx is for sales-mgr (A). Tier 3 must find no match and fall through.
+        var blueprint = new BlueprintModel
+        {
+            Id = BlueprintId,
+            Title = "Two open participants",
+            Participants =
+            [
+                new ParticipantModel { Id = ProcurementMgr, Name = "Procurement Manager" },
+                new ParticipantModel { Id = "sales-mgr", Name = "Sales Manager" },
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Id = 1, Title = "Start", Sender = "sales-mgr", IsStartingAction = true,
+                    Routes = [new RouteModel { NextActionIds = [6] }]
+                },
+                new ActionModel { Id = 6, Title = "Approve", Sender = ProcurementMgr }
+            ]
+        };
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(BlueprintId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+
+        _registerClientMock.Setup(r => r.GetTransactionsByInstanceIdAsync(
+                RegisterId, InstanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                // Prior history exists — but for a DIFFERENT participant.
+                BuildPriorTx(actionId: 1, senderWallet: "ws11q-sales-bound", timestamp: DateTime.UtcNow.AddMinutes(-5))
+            ]);
+
+        _walletUtilitiesMock.Setup(w => w.PublicKeyToWallet(It.IsAny<byte[]>(), It.IsAny<byte>()))
+            .Returns(BoundWallet);
+
+        var tx = BuildAction6Tx(senderWallet: BoundWallet);
+
+        var result = await _engine.ValidateBlueprintConformanceAsync(tx);
+
+        result.Errors.Should().Contain(e => e.Code == "VAL_BP_002",
+            "procurement-mgr has no prior in-instance tx of their own — sales-mgr's binding must not leak");
     }
 
     // ---------------- helpers ----------------


### PR DESCRIPTION
## Summary

Fixes the late-binding regression that broke TradeFinance Action 6 (and every walkthrough where the same open participant submits more than once).

Before: validator sender auth had **Tier 1** (blueprint hardcoded wallet) and **Tier 2** (published participant record). Both fail for an *open* participant — no hardcoded wallet (guardrail `VAL_BP_010` requires null) and no published record (they're public citizens / applicants / one-shot roles). `SEC-AUDIT 4.8` fail-closed then rejects every later action from that participant.

After: **Tier 3** walks the in-instance transaction chain. The earliest prior tx whose action `Sender` matches the current participant carries the binding authority — its `SenderWallet` is the signed, on-ledger proof. Matching current wallet → pass. Different wallet → `VAL_BP_002` (immutable-binding violation, FR-004). No chain history → keep the existing fail-closed behaviour.

## Why this is the right design

Open participants should not need to be auto-published anywhere — they're anonymous by design, authentic by signature. The ledger is already the source of truth for *who acted as what role*; Tier 3 simply consults it. Multi-node safe (every node sees the same chain), no new Redis/DB writes, no `SEC-AUDIT 4.8` violation.

Enables the same chain-walk to become the canonical ``participantId → wallet`` map for recipient resolution, notification routing, and future variable hydration (e.g. ``\${initiator.wallet}``) — follow-up work.

## Test plan

- [x] 4 new `ValidationEngineChainBindingTests` cases: accept, immutable-binding reject, cold-start fall-through, missing-instanceId guard.
- [x] Pre-existing 12 ValidationEngine test failures on master baseline unchanged (unrelated to this path).
- [x] To verify on n1 after merge: rerun TradeFinance walkthrough — Action 6 that currently rejects with `VAL_BP_002` should complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)