### PR TITLE
feat(invitations): Blazor UI for private register invitations (T058-T062)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
@@ -158,7 +158,7 @@
             _submitError = ex.StatusCode switch
             {
                 HttpStatusCode.Conflict => "Your organisation is already subscribed to this register.",
-                HttpStatusCode.BadRequest => ex.Message,
+                HttpStatusCode.BadRequest => $"The invitation token is invalid or expired: {ex.Message}",
                 _ => ex.Message,
             };
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
@@ -1,0 +1,177 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using System.Net
+@using Microsoft.AspNetCore.Components.Authorization
+@using Sorcha.ServiceClients.Invitation
+
+@inject IRegisterInvitationServiceClient InvitationClient
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject NavigationManager Navigation
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.MarkEmailRead" Class="mr-2" />
+            Accept Invitation
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+            @if (_result is null)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    Paste the invitation token shared with your organisation. Accepting
+                    creates an Invited subscription to the register and cannot be undone —
+                    an accepted invitation's nonce is consumed.
+                </MudText>
+
+                <MudTextField T="string"
+                              Label="Invitation token"
+                              @bind-Value="_token"
+                              Placeholder="eyJ2IjoxLCJzaWciOiIuLi4iLCJlbmMiOi..."
+                              Required="true"
+                              Lines="4"
+                              Variant="Variant.Outlined"
+                              Error="_tokenError is not null"
+                              ErrorText="@_tokenError"
+                              data-testid="accept-token-field" />
+
+                @if (_submitError is not null)
+                {
+                    <MudAlert Severity="Severity.Error" data-testid="accept-submit-error">
+                        @_submitError
+                    </MudAlert>
+                }
+            }
+            else
+            {
+                <MudAlert Severity="Severity.Success" data-testid="accept-success">
+                    Accepted. Your organisation is now subscribed to the register.
+                </MudAlert>
+
+                <MudSimpleTable Dense="true" Bordered="false" Striped="false">
+                    <tbody>
+                        <tr>
+                            <td><MudText Typo="Typo.caption" Color="Color.Secondary">Register</MudText></td>
+                            <td><strong>@(_result.RegisterName ?? _result.RegisterId)</strong></td>
+                        </tr>
+                        <tr>
+                            <td><MudText Typo="Typo.caption" Color="Color.Secondary">Invited by</MudText></td>
+                            <td>@(_result.SourceOrgName ?? _result.SourceOrgDid)</td>
+                        </tr>
+                        <tr>
+                            <td><MudText Typo="Typo.caption" Color="Color.Secondary">Subscription</MudText></td>
+                            <td>
+                                <MudChip T="string" Size="Size.Small" Color="Color.Success">
+                                    @_result.SubscriptionStatus
+                                </MudChip>
+                            </td>
+                        </tr>
+                    </tbody>
+                </MudSimpleTable>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        @if (_result is null)
+        {
+            <MudButton OnClick="Cancel" data-testid="accept-cancel">Cancel</MudButton>
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       OnClick="SubmitAsync"
+                       Disabled="_isSubmitting"
+                       data-testid="accept-submit">
+                @if (_isSubmitting)
+                {
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                }
+                Accept
+            </MudButton>
+        }
+        else
+        {
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       OnClick="Close"
+                       data-testid="accept-done">
+                Done
+            </MudButton>
+        }
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    /// <summary>
+    /// Optional pre-populated token — set by the magic-link handler page so the dialog opens
+    /// with the token already pasted. Manual dialog openings leave this null.
+    /// </summary>
+    [Parameter] public string? InitialToken { get; set; }
+
+    private string _token = string.Empty;
+    private string? _tokenError;
+    private string? _submitError;
+    private bool _isSubmitting;
+    private InvitationAcceptedResponse? _result;
+
+    protected override void OnInitialized()
+    {
+        if (!string.IsNullOrWhiteSpace(InitialToken))
+        {
+            _token = InitialToken.Trim();
+        }
+    }
+
+    private async Task SubmitAsync()
+    {
+        _submitError = null;
+        _tokenError = null;
+
+        if (string.IsNullOrWhiteSpace(_token))
+        {
+            _tokenError = "Paste the invitation token.";
+            return;
+        }
+
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var orgClaim = authState.User.FindFirst("org_id")?.Value;
+        if (!Guid.TryParse(orgClaim, out var orgId))
+        {
+            _submitError = "Current organisation could not be identified. Sign in again or switch organisation.";
+            return;
+        }
+
+        _isSubmitting = true;
+        try
+        {
+            _result = await InvitationClient.AcceptAsync(orgId, new AcceptInvitationRequest
+            {
+                InvitationToken = _token.Trim(),
+            });
+            Snackbar.Add($"Joined register {_result.RegisterName ?? _result.RegisterId}", Severity.Success);
+        }
+        catch (InvitationApiException ex)
+        {
+            _submitError = ex.StatusCode switch
+            {
+                HttpStatusCode.Conflict => "Your organisation is already subscribed to this register.",
+                HttpStatusCode.BadRequest => ex.Message,
+                _ => ex.Message,
+            };
+        }
+        catch (Exception ex)
+        {
+            _submitError = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+    private void Close() => MudDialog.Close(DialogResult.Ok(_result));
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
@@ -1,0 +1,264 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using System.Net
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.JSInterop
+@using Sorcha.ServiceClients.Invitation
+
+@inject IRegisterInvitationServiceClient InvitationClient
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IDialogService DialogService
+@inject IJSRuntime JS
+@inject ISnackbar Snackbar
+
+<MudExpansionPanel MaxHeight="480"
+                   Expanded="@Expanded"
+                   ExpandedChanged="OnExpandedChanged"
+                   data-testid="invitations-panel">
+    <TitleContent>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.MailOutline" />
+            <MudText Typo="Typo.h6">Register Invitations</MudText>
+            @if (_totalPending > 0)
+            {
+                <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled">
+                    @_totalPending pending
+                </MudChip>
+            }
+        </MudStack>
+    </TitleContent>
+    <ChildContent>
+        <MudStack Spacing="3">
+            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                <MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true"
+                         ActivePanelIndex="_tabIndex"
+                         ActivePanelIndexChanged="OnTabChanged">
+                    <MudTabPanel Text="All" />
+                    <MudTabPanel Text="Sent" />
+                    <MudTabPanel Text="Received" />
+                </MudTabs>
+                <MudStack Row="true" Spacing="1">
+                    <MudIconButton Icon="@Icons.Material.Filled.Refresh"
+                                   Size="Size.Small"
+                                   OnClick="LoadAsync"
+                                   Disabled="_isLoading"
+                                   aria-label="Refresh invitations" />
+                    <MudButton Variant="Variant.Outlined"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.MarkEmailRead"
+                               OnClick="OpenAcceptDialogAsync"
+                               data-testid="invitations-accept-button">
+                        Accept invitation
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+
+            @if (_isLoading)
+            {
+                <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+            }
+            else if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error" data-testid="invitations-error">
+                    @_error
+                    <MudButton Variant="Variant.Text" Color="Color.Error" Size="Size.Small"
+                               OnClick="LoadAsync" Class="ml-2">Retry</MudButton>
+                </MudAlert>
+            }
+            else if (_invitations.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center" Class="py-4">
+                    No invitations in this view.
+                </MudText>
+            }
+            else
+            {
+                <MudTable Items="@_invitations" Dense="true" Hover="true" Striped="true"
+                          data-testid="invitations-table">
+                    <HeaderContent>
+                        <MudTh>Register</MudTh>
+                        <MudTh>Direction</MudTh>
+                        <MudTh>Counterparty</MudTh>
+                        <MudTh>Status</MudTh>
+                        <MudTh>Expires</MudTh>
+                        <MudTh Style="width:1%">Actions</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Register">
+                            <MudText Typo="Typo.body2">@(context.RegisterName ?? context.RegisterId)</MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Direction">
+                            <MudChip T="string" Size="Size.Small"
+                                     Color="@(context.Direction == "sent" ? Color.Info : Color.Secondary)"
+                                     Variant="Variant.Outlined">
+                                @context.Direction
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="Counterparty">
+                            <MudText Typo="Typo.caption">
+                                @(context.Direction == "sent"
+                                    ? (context.TargetOrgName ?? context.TargetOrgDid)
+                                    : (context.SourceOrgName ?? context.SourceOrgDid))
+                            </MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Status">
+                            <MudChip T="string" Size="Size.Small" Color="@StatusColour(context.Status)">
+                                @context.Status
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="Expires">@context.ExpiresAt.ToString("yyyy-MM-dd")</MudTd>
+                        <MudTd DataLabel="Actions">
+                            @if (context.Direction == "sent"
+                                 && string.Equals(context.Status, "Pending", StringComparison.OrdinalIgnoreCase))
+                            {
+                                <MudStack Row="true" Spacing="1">
+                                    <MudIconButton Icon="@Icons.Material.Filled.Cancel"
+                                                   Size="Size.Small"
+                                                   Color="Color.Error"
+                                                   OnClick="@(() => RevokeAsync(context))"
+                                                   Disabled="_busyInvitationId == context.InvitationId"
+                                                   aria-label="Revoke invitation" />
+                                </MudStack>
+                            }
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            }
+        </MudStack>
+    </ChildContent>
+</MudExpansionPanel>
+
+@code {
+    [Parameter] public bool Expanded { get; set; }
+    [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
+
+    /// <summary>
+    /// Raised after the user accepts an invitation — the parent Registers page uses this
+    /// to refresh its subscribed-register list.
+    /// </summary>
+    [Parameter] public EventCallback OnSubscriptionChanged { get; set; }
+
+    private List<InvitationSummary> _invitations = [];
+    private bool _isLoading;
+    private string? _error;
+    private int _tabIndex;
+    private int _totalPending;
+    private string? _busyInvitationId;
+    private Guid _orgId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        Guid.TryParse(authState.User.FindFirst("org_id")?.Value, out _orgId);
+        if (Expanded)
+        {
+            await LoadAsync();
+        }
+    }
+
+    private async Task OnExpandedChanged(bool expanded)
+    {
+        await ExpandedChanged.InvokeAsync(expanded);
+        if (expanded && _invitations.Count == 0 && _error is null && !_isLoading)
+        {
+            await LoadAsync();
+        }
+    }
+
+    private async Task OnTabChanged(int index)
+    {
+        _tabIndex = index;
+        await LoadAsync();
+    }
+
+    private string DirectionFilter => _tabIndex switch
+    {
+        1 => "sent",
+        2 => "received",
+        _ => "all",
+    };
+
+    private async Task LoadAsync()
+    {
+        if (_orgId == Guid.Empty)
+        {
+            _error = "Could not determine your organisation.";
+            return;
+        }
+
+        _isLoading = true;
+        _error = null;
+        try
+        {
+            var page = await InvitationClient.ListAsync(_orgId, DirectionFilter);
+            _invitations = page.Invitations.ToList();
+            _totalPending = _invitations.Count(i =>
+                string.Equals(i.Status, "Pending", StringComparison.OrdinalIgnoreCase));
+        }
+        catch (InvitationApiException ex)
+        {
+            _error = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to load invitations: {ex.Message}";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task OpenAcceptDialogAsync()
+    {
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<AcceptInvitationDialog>("Accept Invitation", options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: InvitationAcceptedResponse })
+        {
+            await LoadAsync();
+            await OnSubscriptionChanged.InvokeAsync();
+        }
+    }
+
+    private async Task RevokeAsync(InvitationSummary invitation)
+    {
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Revoke invitation?",
+            $"The token for {invitation.TargetOrgName ?? invitation.TargetOrgDid} will stop working immediately. This cannot be undone.",
+            yesText: "Revoke",
+            cancelText: "Cancel");
+
+        if (confirmed != true) return;
+
+        _busyInvitationId = invitation.InvitationId;
+        try
+        {
+            await InvitationClient.RevokeAsync(_orgId, invitation.InvitationId);
+            Snackbar.Add("Invitation revoked", Severity.Success);
+            await LoadAsync();
+        }
+        catch (InvitationApiException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Unexpected error: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _busyInvitationId = null;
+        }
+    }
+
+    private static Color StatusColour(string status) => status?.ToLowerInvariant() switch
+    {
+        "pending" => Color.Warning,
+        "accepted" => Color.Success,
+        "revoked" => Color.Default,
+        "expired" => Color.Default,
+        _ => Color.Default,
+    };
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
@@ -107,7 +107,7 @@
                                 @context.Status
                             </MudChip>
                         </MudTd>
-                        <MudTd DataLabel="Expires">@context.ExpiresAt.ToString("yyyy-MM-dd")</MudTd>
+                        <MudTd DataLabel="Expires">@context.ExpiresAt.UtcDateTime.ToString("yyyy-MM-dd") UTC</MudTd>
                         <MudTd DataLabel="Actions">
                             @if (context.Direction == "sent"
                                  && string.Equals(context.Status, "Pending", StringComparison.OrdinalIgnoreCase))
@@ -248,6 +248,13 @@
             await InvitationClient.RevokeAsync(_orgId, invitation.InvitationId);
             Snackbar.Add("Invitation revoked", Severity.Success);
             await LoadAsync();
+            // Badge tracks the cross-tab pending count. After a mutation we need a fresh
+            // "all" snapshot — otherwise the chip stays at the pre-revoke value until the
+            // user manually switches to the All tab.
+            if (!string.Equals(DirectionFilter, "all", StringComparison.Ordinal))
+            {
+                await RefreshBadgeAsync();
+            }
         }
         catch (InvitationApiException ex)
         {
@@ -260,6 +267,21 @@
         finally
         {
             _busyInvitationId = null;
+        }
+    }
+
+    private async Task RefreshBadgeAsync()
+    {
+        try
+        {
+            var all = await InvitationClient.ListAsync(_orgId, "all");
+            _totalPending = all.Invitations.Count(i =>
+                string.Equals(i.Status, "Pending", StringComparison.OrdinalIgnoreCase));
+        }
+        catch
+        {
+            // Badge refresh is best-effort; the snackbar from the mutation already
+            // tells the user the operation succeeded.
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
@@ -141,6 +141,7 @@
 
     private List<InvitationSummary> _invitations = [];
     private bool _isLoading;
+    private bool _hasLoaded;
     private string? _error;
     private int _tabIndex;
     private int _totalPending;
@@ -160,7 +161,9 @@
     private async Task OnExpandedChanged(bool expanded)
     {
         await ExpandedChanged.InvokeAsync(expanded);
-        if (expanded && _invitations.Count == 0 && _error is null && !_isLoading)
+        // Load only on the first expand. A successful load that returned zero rows
+        // sets _hasLoaded so collapse + re-expand doesn't re-fetch pointlessly.
+        if (expanded && !_hasLoaded && !_isLoading)
         {
             await LoadAsync();
         }
@@ -193,8 +196,15 @@
         {
             var page = await InvitationClient.ListAsync(_orgId, DirectionFilter);
             _invitations = page.Invitations.ToList();
-            _totalPending = _invitations.Count(i =>
-                string.Equals(i.Status, "Pending", StringComparison.OrdinalIgnoreCase));
+            // Badge count reflects the total across both directions, not the filtered
+            // tab. Only refresh it when we loaded the "all" view; on a filtered tab the
+            // previously cached value is kept so the badge doesn't under-report.
+            if (string.Equals(DirectionFilter, "all", StringComparison.Ordinal))
+            {
+                _totalPending = _invitations.Count(i =>
+                    string.Equals(i.Status, "Pending", StringComparison.OrdinalIgnoreCase));
+            }
+            _hasLoaded = true;
         }
         catch (InvitationApiException ex)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
@@ -103,7 +103,7 @@
     <DialogActions>
         @if (_result is null)
         {
-            <MudButton OnClick="Close" data-testid="invite-cancel">Cancel</MudButton>
+            <MudButton OnClick="Cancel" data-testid="invite-cancel">Cancel</MudButton>
             <MudButton Color="Color.Primary"
                        Variant="Variant.Filled"
                        OnClick="SubmitAsync"
@@ -144,7 +144,8 @@
     // A validated-orgs directory picker is future work — see US10 discussion.
     // did:sorcha:org:{walletAddress}  where walletAddress starts with ws1q / ws11q / ws12q etc.
     private static readonly System.Text.RegularExpressions.Regex DidRegex =
-        new(@"^did:sorcha:org:ws[0-9]+[a-z0-9]+$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        new(@"^did:sorcha:org:ws[0-9]+[a-z0-9]+$",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
 
     private string MagicLink
     {
@@ -221,5 +222,6 @@
         Snackbar.Add("Magic link copied to clipboard", Severity.Success);
     }
 
+    private void Cancel() => MudDialog.Cancel();
     private void Close() => MudDialog.Close(DialogResult.Ok(_result));
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
@@ -1,0 +1,225 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using System.Net
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.JSInterop
+@using Sorcha.ServiceClients.Invitation
+@using Sorcha.UI.Core.Models.Registers
+
+@inject IRegisterInvitationServiceClient InvitationClient
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.GroupAdd" Class="mr-2" />
+            Invite Organisation
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3">
+            <MudText Typo="Typo.body2" Color="Color.Secondary">
+                Generate a cryptographic invitation token for another organisation to join
+                the register <strong>@Register?.Name</strong>. Share the token or magic link
+                with the target organisation over any channel — they accept it inside their
+                own Sorcha tenant.
+            </MudText>
+
+            @if (_result is null)
+            {
+                <MudTextField T="string"
+                              Label="Target organisation DID"
+                              @bind-Value="_targetDid"
+                              Placeholder="did:sorcha:org:ws1q..."
+                              Required="true"
+                              Error="_didError is not null"
+                              ErrorText="@_didError"
+                              data-testid="invite-target-did" />
+
+                <MudNumericField T="int"
+                                 Label="Expires in (days)"
+                                 @bind-Value="_expiresInDays"
+                                 Min="1"
+                                 Max="90"
+                                 HelperText="Recipients must accept before this window closes." />
+
+                @if (_submitError is not null)
+                {
+                    <MudAlert Severity="Severity.Error" data-testid="invite-submit-error">
+                        @_submitError
+                    </MudAlert>
+                }
+            }
+            else
+            {
+                <MudAlert Severity="Severity.Success" data-testid="invite-success">
+                    Invitation created. Share either the token or the magic link with the
+                    target organisation.
+                </MudAlert>
+
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.subtitle2">Token</MudText>
+                    <MudTextField T="string"
+                                  Value="@_result.InvitationToken"
+                                  ReadOnly="true"
+                                  Lines="3"
+                                  Variant="Variant.Outlined"
+                                  data-testid="invite-token-field" />
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.ContentCopy"
+                               OnClick="CopyTokenAsync"
+                               data-testid="invite-copy-token">
+                        Copy token
+                    </MudButton>
+                </MudStack>
+
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.subtitle2">Magic link</MudText>
+                    <MudTextField T="string"
+                                  Value="@MagicLink"
+                                  ReadOnly="true"
+                                  Variant="Variant.Outlined"
+                                  data-testid="invite-magic-link-field" />
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Link"
+                               OnClick="CopyLinkAsync"
+                               data-testid="invite-copy-link">
+                        Copy link
+                    </MudButton>
+                </MudStack>
+
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    Expires @_result.ExpiresAt.ToString("yyyy-MM-dd HH:mm") UTC
+                </MudText>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        @if (_result is null)
+        {
+            <MudButton OnClick="Close" data-testid="invite-cancel">Cancel</MudButton>
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       OnClick="SubmitAsync"
+                       Disabled="_isSubmitting"
+                       data-testid="invite-submit">
+                @if (_isSubmitting)
+                {
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                }
+                Generate invitation
+            </MudButton>
+        }
+        else
+        {
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Filled"
+                       OnClick="Close"
+                       data-testid="invite-done">
+                Done
+            </MudButton>
+        }
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public RegisterViewModel? Register { get; set; }
+
+    private string _targetDid = string.Empty;
+    private int _expiresInDays = 7;
+    private string? _didError;
+    private string? _submitError;
+    private bool _isSubmitting;
+    private InvitationCreatedResponse? _result;
+
+    // Raw-DID input per the product decision: v1 asks admins to paste the target org DID.
+    // A validated-orgs directory picker is future work — see US10 discussion.
+    // did:sorcha:org:{walletAddress}  where walletAddress starts with ws1q / ws11q / ws12q etc.
+    private static readonly System.Text.RegularExpressions.Regex DidRegex =
+        new(@"^did:sorcha:org:ws[0-9]+[a-z0-9]+$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+    private string MagicLink
+    {
+        get
+        {
+            if (_result is null) return string.Empty;
+            // Uri.EscapeDataString keeps the base64url token safe as a query parameter.
+            var basePath = Navigation.BaseUri.TrimEnd('/');
+            return $"{basePath}/accept-invitation?token={Uri.EscapeDataString(_result.InvitationToken)}";
+        }
+    }
+
+    private async Task SubmitAsync()
+    {
+        _submitError = null;
+        _didError = null;
+
+        if (string.IsNullOrWhiteSpace(_targetDid) || !DidRegex.IsMatch(_targetDid.Trim()))
+        {
+            _didError = "Enter the target organisation's DID (did:sorcha:org:{walletAddress}).";
+            return;
+        }
+        if (Register is null || string.IsNullOrWhiteSpace(Register.Id))
+        {
+            _submitError = "No register selected.";
+            return;
+        }
+
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var orgClaim = authState.User.FindFirst("org_id")?.Value;
+        if (!Guid.TryParse(orgClaim, out var orgId))
+        {
+            _submitError = "Current organisation could not be identified. Sign in again or switch organisation.";
+            return;
+        }
+
+        _isSubmitting = true;
+        try
+        {
+            _result = await InvitationClient.CreateAsync(orgId, new CreateInvitationRequest
+            {
+                RegisterId = Register.Id,
+                TargetOrgDid = _targetDid.Trim(),
+                ExpiresInDays = _expiresInDays,
+            });
+        }
+        catch (InvitationApiException ex)
+        {
+            _submitError = ex.StatusCode == HttpStatusCode.TooManyRequests
+                ? "Rate limit reached — try again in an hour."
+                : ex.Message;
+        }
+        catch (Exception ex)
+        {
+            _submitError = $"Unexpected error: {ex.Message}";
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+    }
+
+    private async Task CopyTokenAsync()
+    {
+        if (_result is null) return;
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", _result.InvitationToken);
+        Snackbar.Add("Token copied to clipboard", Severity.Success);
+    }
+
+    private async Task CopyLinkAsync()
+    {
+        if (_result is null) return;
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", MagicLink);
+        Snackbar.Add("Magic link copied to clipboard", Severity.Success);
+    }
+
+    private void Close() => MudDialog.Close(DialogResult.Ok(_result));
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
@@ -143,9 +143,11 @@
     // Raw-DID input per the product decision: v1 asks admins to paste the target org DID.
     // A validated-orgs directory picker is future work — see US10 discussion.
     // did:sorcha:org:{walletAddress}  where walletAddress starts with ws1q / ws11q / ws12q etc.
+    // Sorcha DIDs are Bech32 — canonically lowercase. Reject mixed-case client-side so
+    // the user gets a clear error before the server round-trip rejects it anyway.
     private static readonly System.Text.RegularExpressions.Regex DidRegex =
         new(@"^did:sorcha:org:ws[0-9]+[a-z0-9]+$",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
+            System.Text.RegularExpressions.RegexOptions.Compiled);
 
     private string MagicLink
     {
@@ -211,15 +213,29 @@
     private async Task CopyTokenAsync()
     {
         if (_result is null) return;
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", _result.InvitationToken);
-        Snackbar.Add("Token copied to clipboard", Severity.Success);
+        await CopyToClipboardAsync(_result.InvitationToken, "Token copied to clipboard");
     }
 
     private async Task CopyLinkAsync()
     {
         if (_result is null) return;
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", MagicLink);
-        Snackbar.Add("Magic link copied to clipboard", Severity.Success);
+        await CopyToClipboardAsync(MagicLink, "Magic link copied to clipboard");
+    }
+
+    // navigator.clipboard throws when the page isn't served over HTTPS or the user denies
+    // the permission prompt. Silently failing leaves the admin thinking the token was
+    // copied when it wasn't — surface the failure with instructions to copy manually.
+    private async Task CopyToClipboardAsync(string value, string successMessage)
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", value);
+            Snackbar.Add(successMessage, Severity.Success);
+        }
+        catch
+        {
+            Snackbar.Add("Clipboard unavailable — select the field above and copy manually.", Severity.Warning);
+        }
     }
 
     private void Cancel() => MudDialog.Cancel();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -703,6 +704,19 @@ public static class ServiceCollectionExtensions
             var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
             var logger = sp.GetRequiredService<ILogger<InvitationClientService>>();
             return new InvitationClientService(httpClient, logger);
+        });
+
+        // Register invitation client (private-register invitation envelopes — US10).
+        // Uses the same bearer-attaching handler so calls reach the Tenant Service
+        // as the signed-in user (endpoint is RequireAdministrator-gated).
+        services.AddScoped<Sorcha.ServiceClients.Invitation.IRegisterInvitationServiceClient>(sp =>
+        {
+            var handler = sp.GetRequiredService<AuthenticatedHttpMessageHandler>();
+            handler.InnerHandler = new HttpClientHandler();
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
+            var config = sp.GetRequiredService<IConfiguration>();
+            var logger = sp.GetRequiredService<ILogger<Sorcha.ServiceClients.Invitation.RegisterInvitationServiceClient>>();
+            return new Sorcha.ServiceClients.Invitation.RegisterInvitationServiceClient(httpClient, config, logger);
         });
 
         // Domain Restriction Client Service (054 - authenticated)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Sorcha.UI.Core.csproj
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Sorcha.UI.Core.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common\Sorcha.Blueprint.Models\Sorcha.Blueprint.Models.csproj" />
     <ProjectReference Include="..\..\..\Common\Sorcha.Register.Models\Sorcha.Register.Models.csproj" />
+    <ProjectReference Include="..\..\..\Common\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
     <ProjectReference Include="..\..\..\Common\Sorcha.Tenant.Models\Sorcha.Tenant.Models.csproj" />
     <ProjectReference Include="..\..\..\Core\Sorcha.Blueprint.Schemas.Client\Sorcha.Blueprint.Schemas.Client.csproj" />
   </ItemGroup>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/AcceptInvitation.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/AcceptInvitation.razor
@@ -1,0 +1,61 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@page "/accept-invitation"
+@using Microsoft.AspNetCore.Authorization
+@using Sorcha.ServiceClients.Invitation
+@using Sorcha.UI.Core.Components.Registers
+@attribute [Authorize(Roles = "Administrator,SystemAdmin")]
+
+@inject NavigationManager Navigation
+@inject IDialogService DialogService
+
+<PageTitle>Accept Invitation - Sorcha</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="py-8">
+    <MudPaper Elevation="2" Class="pa-6 text-center">
+        <MudIcon Icon="@Icons.Material.Filled.MarkEmailRead" Size="Size.Large" Color="Color.Primary" />
+        <MudText Typo="Typo.h5" Class="mt-4">Accept Invitation</MudText>
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mt-2">
+            @if (_token is null)
+            {
+                <text>No invitation token in the URL. Paste one manually from the Registers page.</text>
+            }
+            else
+            {
+                <text>Review the invitation details and accept to join the register.</text>
+            }
+        </MudText>
+    </MudPaper>
+</MudContainer>
+
+@code {
+    private string? _token;
+    private bool _opened;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || _opened) return;
+
+        // Parse ?token=... from the URI. Avoid Microsoft.AspNetCore.WebUtilities (not
+        // referenced in the WASM Client project) and use the plain .NET parser.
+        var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
+        var parsed = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        _token = parsed["token"];
+
+        if (string.IsNullOrWhiteSpace(_token)) return;
+
+        _opened = true;
+        var parameters = new DialogParameters<AcceptInvitationDialog>
+        {
+            { x => x.InitialToken, _token }
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<AcceptInvitationDialog>("Accept Invitation", parameters, options);
+        var result = await dialog.Result;
+
+        // Whether accepted or cancelled, return the user to the Registers page.
+        // The panel there picks up the new subscription on its next load.
+        Navigation.NavigateTo("/registers");
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
@@ -64,6 +64,16 @@
         </MudStack>
     </MudStack>
 
+    @* Invitations panel — visible to all admins; collapsed by default to stay out of the way. *@
+    @if (_isAdmin)
+    {
+        <MudExpansionPanels Elevation="0" Class="mb-3">
+            <InvitationsPanel Expanded="@_invitationsExpanded"
+                              ExpandedChanged="@(e => _invitationsExpanded = e)"
+                              OnSubscriptionChanged="RefreshRegistersAsync" />
+        </MudExpansionPanels>
+    }
+
     @* Search and filter bar *@
     @if (!_isLoading && _registers.Count > 0)
     {
@@ -220,6 +230,16 @@
                                         </MudStack>
                                     }
                                     <RegisterStatusBadge Status="@register.Status" />
+                                    @if (_isAdmin && string.Equals(subscriptionType, "Owner", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.GroupAdd"
+                                                       Size="Size.Small"
+                                                       Color="Color.Primary"
+                                                       OnClick="@(() => OpenInviteDialog(register))"
+                                                       OnClick:stopPropagation="true"
+                                                       Title="Invite organisation to this register"
+                                                       data-testid="invite-organisation-button" />
+                                    }
                                     @if (_isAdmin && !string.Equals(subscriptionType, "Owner", StringComparison.OrdinalIgnoreCase))
                                     {
                                         <MudIconButton Icon="@Icons.Material.Filled.LinkOff"
@@ -246,6 +266,7 @@
     private bool _isLoading = true;
     private string? _errorMessage;
     private bool _isAdmin;
+    private bool _invitationsExpanded;
     private Guid _orgId;
     private RegisterFilterState _filterState = new();
 
@@ -411,6 +432,28 @@
     private void NavigateToRegister(RegisterViewModel register)
     {
         Navigation.NavigateTo($"registers/{register.Id}");
+    }
+
+    private async Task OpenInviteDialog(RegisterViewModel register)
+    {
+        var parameters = new DialogParameters<InviteOrganisationDialog>
+        {
+            { x => x.Register, register }
+        };
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true
+        };
+        var dialog = await DialogService.ShowAsync<InviteOrganisationDialog>(
+            $"Invite organisation — {register.Name}", parameters, options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: Sorcha.ServiceClients.Invitation.InvitationCreatedResponse })
+        {
+            // Reveal the invitations panel so the newly-sent invitation is visible.
+            _invitationsExpanded = true;
+        }
     }
 
     private async Task OpenCreateRegisterDialog()

--- a/src/Common/Sorcha.ServiceClients.Http/Invitation/IRegisterInvitationServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Invitation/IRegisterInvitationServiceClient.cs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Serialization;
+
+namespace Sorcha.ServiceClients.Invitation;
+
+/// <summary>
+/// HTTP client interface for the Tenant Service's private register invitation endpoints.
+/// Used by the Blazor UI (and future callers) to create, accept, list, and revoke
+/// cryptographic invitation envelopes that bring organisations onto a private register.
+/// </summary>
+/// <remarks>
+/// The interface surface mirrors the Tenant Service endpoints one-for-one. Auth is
+/// expected to be attached by the caller's <c>HttpClient</c> pipeline (for the Blazor
+/// UI this is the logged-in user's access token). All 4xx responses surface as
+/// <see cref="InvitationApiException"/> so dialogs can render the server message
+/// without parsing the body themselves.
+/// </remarks>
+public interface IRegisterInvitationServiceClient
+{
+    /// <summary>Create a private register invitation for a target organisation.</summary>
+    Task<InvitationCreatedResponse> CreateAsync(
+        Guid sourceOrgId,
+        CreateInvitationRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Accept an invitation token as the target organisation.</summary>
+    Task<InvitationAcceptedResponse> AcceptAsync(
+        Guid targetOrgId,
+        AcceptInvitationRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>List invitations for an organisation (direction: sent / received / all).</summary>
+    Task<InvitationListResponse> ListAsync(
+        Guid orgId,
+        string direction = "all",
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Revoke a pending invitation created by this organisation.</summary>
+    Task RevokeAsync(
+        Guid sourceOrgId,
+        string invitationId,
+        CancellationToken cancellationToken = default);
+}
+
+// ---- Request / response DTOs (wire-compatible with Sorcha.Tenant.Service.Models.Dtos) ----
+
+/// <summary>Request to create a register invitation.</summary>
+public record CreateInvitationRequest
+{
+    [JsonPropertyName("register_id")]
+    public required string RegisterId { get; init; }
+
+    [JsonPropertyName("target_org_did")]
+    public required string TargetOrgDid { get; init; }
+
+    [JsonPropertyName("expires_in_days")]
+    public int ExpiresInDays { get; init; } = 7;
+}
+
+/// <summary>Response returned after creating a register invitation.</summary>
+public record InvitationCreatedResponse
+{
+    [JsonPropertyName("invitation_id")]
+    public required string InvitationId { get; init; }
+
+    [JsonPropertyName("invitation_token")]
+    public required string InvitationToken { get; init; }
+
+    [JsonPropertyName("register_id")]
+    public required string RegisterId { get; init; }
+
+    [JsonPropertyName("target_org_did")]
+    public required string TargetOrgDid { get; init; }
+
+    [JsonPropertyName("expires_at")]
+    public required DateTimeOffset ExpiresAt { get; init; }
+
+    [JsonPropertyName("created_at")]
+    public required DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>Request to accept an invitation.</summary>
+public record AcceptInvitationRequest
+{
+    [JsonPropertyName("invitation_token")]
+    public required string InvitationToken { get; init; }
+}
+
+/// <summary>Response returned after accepting an invitation.</summary>
+public record InvitationAcceptedResponse
+{
+    [JsonPropertyName("subscription_id")]
+    public required Guid SubscriptionId { get; init; }
+
+    [JsonPropertyName("register_id")]
+    public required string RegisterId { get; init; }
+
+    [JsonPropertyName("register_name")]
+    public string? RegisterName { get; init; }
+
+    [JsonPropertyName("source_org_did")]
+    public required string SourceOrgDid { get; init; }
+
+    [JsonPropertyName("source_org_name")]
+    public string? SourceOrgName { get; init; }
+
+    [JsonPropertyName("subscription_status")]
+    public required string SubscriptionStatus { get; init; }
+
+    [JsonPropertyName("accepted_at")]
+    public required DateTimeOffset AcceptedAt { get; init; }
+}
+
+/// <summary>Summary of an invitation for listing.</summary>
+public record InvitationSummary
+{
+    [JsonPropertyName("invitation_id")]
+    public required string InvitationId { get; init; }
+
+    [JsonPropertyName("register_id")]
+    public required string RegisterId { get; init; }
+
+    [JsonPropertyName("register_name")]
+    public string? RegisterName { get; init; }
+
+    [JsonPropertyName("source_org_did")]
+    public required string SourceOrgDid { get; init; }
+
+    [JsonPropertyName("source_org_name")]
+    public string? SourceOrgName { get; init; }
+
+    [JsonPropertyName("target_org_did")]
+    public required string TargetOrgDid { get; init; }
+
+    [JsonPropertyName("target_org_name")]
+    public string? TargetOrgName { get; init; }
+
+    [JsonPropertyName("direction")]
+    public required string Direction { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("expires_at")]
+    public required DateTimeOffset ExpiresAt { get; init; }
+
+    [JsonPropertyName("created_at")]
+    public required DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>Response containing a list of invitations.</summary>
+public record InvitationListResponse
+{
+    [JsonPropertyName("invitations")]
+    public required IReadOnlyList<InvitationSummary> Invitations { get; init; }
+
+    [JsonPropertyName("total_count")]
+    public required int TotalCount { get; init; }
+}
+
+/// <summary>
+/// Raised when the Tenant Service returns a 4xx response for an invitation call.
+/// Carries the server's message so the UI can surface it directly without reparsing.
+/// </summary>
+public sealed class InvitationApiException : Exception
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+
+    public InvitationApiException(System.Net.HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/src/Common/Sorcha.ServiceClients.Http/Invitation/RegisterInvitationServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Invitation/RegisterInvitationServiceClient.cs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.ServiceClients.Invitation;
+
+/// <summary>
+/// HTTP client for the Tenant Service's private register invitation endpoints.
+/// Auth is expected on the supplied <see cref="HttpClient"/>; construct via
+/// <c>IHttpClientFactory</c> with a bearer-attaching DelegatingHandler (Blazor UI)
+/// or with a pre-authorised client for server-side callers.
+/// </summary>
+public sealed class RegisterInvitationServiceClient : IRegisterInvitationServiceClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<RegisterInvitationServiceClient> _logger;
+
+    public RegisterInvitationServiceClient(
+        HttpClient httpClient,
+        IConfiguration configuration,
+        ILogger<RegisterInvitationServiceClient> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        if (_httpClient.BaseAddress is null)
+        {
+            var baseAddress = configuration["ServiceClients:TenantService:Address"]
+                ?? configuration["Services:TenantService:BaseAddress"]
+                ?? throw new InvalidOperationException(
+                    "No ServiceClients:TenantService:Address configured for RegisterInvitationServiceClient.");
+            _httpClient.BaseAddress = new Uri(baseAddress.TrimEnd('/') + "/");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<InvitationCreatedResponse> CreateAsync(
+        Guid sourceOrgId,
+        CreateInvitationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var response = await _httpClient.PostAsJsonAsync(
+            $"api/organizations/{sourceOrgId}/register-invitations",
+            request,
+            JsonOptions,
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await BuildApiExceptionAsync(response, "create invitation", cancellationToken);
+        }
+
+        return (await response.Content.ReadFromJsonAsync<InvitationCreatedResponse>(
+                   JsonOptions, cancellationToken))
+               ?? throw new InvalidOperationException("Empty body on create-invitation success.");
+    }
+
+    /// <inheritdoc />
+    public async Task<InvitationAcceptedResponse> AcceptAsync(
+        Guid targetOrgId,
+        AcceptInvitationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var response = await _httpClient.PostAsJsonAsync(
+            $"api/organizations/{targetOrgId}/register-invitations/accept",
+            request,
+            JsonOptions,
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await BuildApiExceptionAsync(response, "accept invitation", cancellationToken);
+        }
+
+        return (await response.Content.ReadFromJsonAsync<InvitationAcceptedResponse>(
+                   JsonOptions, cancellationToken))
+               ?? throw new InvalidOperationException("Empty body on accept-invitation success.");
+    }
+
+    /// <inheritdoc />
+    public async Task<InvitationListResponse> ListAsync(
+        Guid orgId,
+        string direction = "all",
+        CancellationToken cancellationToken = default)
+    {
+        var path = $"api/organizations/{orgId}/register-invitations?direction={Uri.EscapeDataString(direction)}";
+        var response = await _httpClient.GetAsync(path, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await BuildApiExceptionAsync(response, "list invitations", cancellationToken);
+        }
+
+        return (await response.Content.ReadFromJsonAsync<InvitationListResponse>(
+                   JsonOptions, cancellationToken))
+               ?? new InvitationListResponse { Invitations = Array.Empty<InvitationSummary>(), TotalCount = 0 };
+    }
+
+    /// <inheritdoc />
+    public async Task RevokeAsync(
+        Guid sourceOrgId,
+        string invitationId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(invitationId);
+
+        var response = await _httpClient.DeleteAsync(
+            $"api/organizations/{sourceOrgId}/register-invitations/{Uri.EscapeDataString(invitationId)}",
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await BuildApiExceptionAsync(response, "revoke invitation", cancellationToken);
+        }
+    }
+
+    private async Task<InvitationApiException> BuildApiExceptionAsync(
+        HttpResponseMessage response,
+        string action,
+        CancellationToken ct)
+    {
+        string message;
+        try
+        {
+            // Server uses { "error": "<message>" } on failures. Falls back to status reason.
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+            message = doc.RootElement.TryGetProperty("error", out var err) && err.ValueKind == JsonValueKind.String
+                ? err.GetString()!
+                : response.ReasonPhrase ?? response.StatusCode.ToString();
+        }
+        catch
+        {
+            message = response.ReasonPhrase ?? response.StatusCode.ToString();
+        }
+
+        _logger.LogWarning(
+            "Failed to {Action}: {StatusCode} — {Message}",
+            action, (int)response.StatusCode, message);
+
+        return new InvitationApiException(response.StatusCode, message);
+    }
+}

--- a/tests/Sorcha.ServiceClients.Tests/Invitation/RegisterInvitationServiceClientTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Invitation/RegisterInvitationServiceClientTests.cs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+using Sorcha.ServiceClients.Invitation;
+
+using Xunit;
+
+namespace Sorcha.ServiceClients.Tests.Invitation;
+
+/// <summary>
+/// Wire-shape + error-mapping tests for <see cref="RegisterInvitationServiceClient"/>. The client
+/// must round-trip snake_case DTOs with the Tenant Service endpoints and surface 4xx
+/// responses as <see cref="InvitationApiException"/> carrying the server's error message.
+/// </summary>
+public class RegisterRegisterInvitationServiceClientTests
+{
+    private static readonly Guid OrgId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private const string InvitationId = "inv-abc-123";
+
+    [Fact]
+    public async Task CreateAsync_SendsSnakeCaseBody_AndParsesResponse()
+    {
+        HttpRequestMessage? captured = null;
+        var responseBody = """
+            {
+              "invitation_id": "inv-abc-123",
+              "invitation_token": "base64url-token",
+              "register_id": "aebf26362e079087571ac0932d4db973",
+              "target_org_did": "did:sorcha:org:ws1qtarget",
+              "expires_at": "2026-04-30T00:00:00Z",
+              "created_at": "2026-04-20T00:00:00Z"
+            }
+            """;
+        var client = Build(HttpStatusCode.Created, responseBody, req => captured = req);
+
+        var result = await client.CreateAsync(OrgId, new CreateInvitationRequest
+        {
+            RegisterId = "aebf26362e079087571ac0932d4db973",
+            TargetOrgDid = "did:sorcha:org:ws1qtarget",
+            ExpiresInDays = 14,
+        });
+
+        captured.Should().NotBeNull();
+        captured!.Method.Should().Be(HttpMethod.Post);
+        captured.RequestUri!.AbsolutePath
+            .Should().Be($"/api/organizations/{OrgId}/register-invitations");
+
+        var sentBody = await captured.Content!.ReadAsStringAsync();
+        // Snake-case on the wire is what the Tenant endpoints expect.
+        sentBody.Should().Contain("\"register_id\":\"aebf26362e079087571ac0932d4db973\"");
+        sentBody.Should().Contain("\"target_org_did\":\"did:sorcha:org:ws1qtarget\"");
+        sentBody.Should().Contain("\"expires_in_days\":14");
+
+        result.InvitationId.Should().Be("inv-abc-123");
+        result.InvitationToken.Should().Be("base64url-token");
+    }
+
+    [Fact]
+    public async Task AcceptAsync_Returns409Conflict_AsInvitationApiException()
+    {
+        const string body = """{ "error": "Organization is already subscribed to this register." }""";
+        var client = Build(HttpStatusCode.Conflict, body);
+
+        var act = async () => await client.AcceptAsync(OrgId, new AcceptInvitationRequest
+        {
+            InvitationToken = "token",
+        });
+
+        var ex = (await act.Should().ThrowAsync<InvitationApiException>()).Which;
+        ex.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        ex.Message.Should().Contain("already subscribed");
+    }
+
+    [Fact]
+    public async Task CreateAsync_Returns429_AsInvitationApiException()
+    {
+        const string body = """{ "error": "Rate limit exceeded. Maximum 10 invitations per hour." }""";
+        var client = Build(HttpStatusCode.TooManyRequests, body);
+
+        var act = async () => await client.CreateAsync(OrgId, new CreateInvitationRequest
+        {
+            RegisterId = "r".PadRight(32, 'e'),
+            TargetOrgDid = "did:sorcha:org:ws1qtarget",
+        });
+
+        var ex = (await act.Should().ThrowAsync<InvitationApiException>()).Which;
+        ex.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+        ex.Message.Should().Contain("Rate limit");
+    }
+
+    [Fact]
+    public async Task ListAsync_BuildsDirectionQuery_AndParsesArrayResponse()
+    {
+        HttpRequestMessage? captured = null;
+        const string body = """
+            {
+              "invitations": [
+                {
+                  "invitation_id": "inv-1",
+                  "register_id": "aebf26362e079087571ac0932d4db973",
+                  "register_name": "Procurement",
+                  "source_org_did": "did:sorcha:org:ws1qsource",
+                  "source_org_name": "Cairngorm",
+                  "target_org_did": "did:sorcha:org:ws1qtarget",
+                  "target_org_name": "Highland",
+                  "direction": "sent",
+                  "status": "Pending",
+                  "expires_at": "2026-04-30T00:00:00Z",
+                  "created_at": "2026-04-20T00:00:00Z"
+                }
+              ],
+              "total_count": 1
+            }
+            """;
+        var client = Build(HttpStatusCode.OK, body, req => captured = req);
+
+        var result = await client.ListAsync(OrgId, "sent");
+
+        captured!.RequestUri!.Query.Should().Contain("direction=sent");
+        result.TotalCount.Should().Be(1);
+        result.Invitations.Should().HaveCount(1);
+        result.Invitations[0].InvitationId.Should().Be("inv-1");
+        result.Invitations[0].Direction.Should().Be("sent");
+    }
+
+    [Fact]
+    public async Task RevokeAsync_Returns204_NoBodyExpected()
+    {
+        HttpRequestMessage? captured = null;
+        var client = Build(HttpStatusCode.NoContent, "", req => captured = req);
+
+        await client.RevokeAsync(OrgId, InvitationId);
+
+        captured!.Method.Should().Be(HttpMethod.Delete);
+        captured.RequestUri!.AbsolutePath
+            .Should().Be($"/api/organizations/{OrgId}/register-invitations/{InvitationId}");
+    }
+
+    [Fact]
+    public async Task RevokeAsync_404_AsInvitationApiException()
+    {
+        const string body = """{ "error": "Invitation not found" }""";
+        var client = Build(HttpStatusCode.NotFound, body);
+
+        var act = async () => await client.RevokeAsync(OrgId, InvitationId);
+
+        var ex = (await act.Should().ThrowAsync<InvitationApiException>()).Which;
+        ex.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ---- test helper ----
+
+    private static RegisterInvitationServiceClient Build(
+        HttpStatusCode status,
+        string body,
+        Action<HttpRequestMessage>? onRequest = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                // Buffer body so tests can inspect it after the call completes.
+                if (req.Content is not null)
+                {
+                    await req.Content.LoadIntoBufferAsync();
+                }
+                onRequest?.Invoke(req);
+                return new HttpResponseMessage(status)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                };
+            });
+
+        var http = new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("http://tenant.test/"),
+        };
+        var config = new ConfigurationBuilder().Build();
+        return new RegisterInvitationServiceClient(http, config, Mock.Of<ILogger<RegisterInvitationServiceClient>>());
+    }
+}

--- a/tests/Sorcha.ServiceClients.Tests/Invitation/RegisterInvitationServiceClientTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Invitation/RegisterInvitationServiceClientTests.cs
@@ -22,7 +22,7 @@ namespace Sorcha.ServiceClients.Tests.Invitation;
 /// must round-trip snake_case DTOs with the Tenant Service endpoints and surface 4xx
 /// responses as <see cref="InvitationApiException"/> carrying the server's error message.
 /// </summary>
-public class RegisterRegisterInvitationServiceClientTests
+public class RegisterInvitationServiceClientTests
 {
     private static readonly Guid OrgId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private const string InvitationId = "inv-abc-123";
@@ -63,6 +63,54 @@ public class RegisterRegisterInvitationServiceClientTests
 
         result.InvitationId.Should().Be("inv-abc-123");
         result.InvitationToken.Should().Be("base64url-token");
+    }
+
+    [Fact]
+    public async Task AcceptAsync_HappyPath_ReturnsSubscriptionSummary()
+    {
+        const string body = """
+            {
+              "subscription_id": "88888888-8888-8888-8888-888888888888",
+              "register_id": "aebf26362e079087571ac0932d4db973",
+              "register_name": "Shared Register",
+              "source_org_did": "did:sorcha:org:ws1qsource",
+              "source_org_name": "Cairngorm",
+              "subscription_status": "Active",
+              "accepted_at": "2026-04-20T10:00:00Z"
+            }
+            """;
+        HttpRequestMessage? captured = null;
+        var client = Build(HttpStatusCode.OK, body, req => captured = req);
+
+        var result = await client.AcceptAsync(OrgId, new AcceptInvitationRequest
+        {
+            InvitationToken = "token-xyz",
+        });
+
+        captured!.Method.Should().Be(HttpMethod.Post);
+        captured.RequestUri!.AbsolutePath
+            .Should().Be($"/api/organizations/{OrgId}/register-invitations/accept");
+        var sentBody = await captured.Content!.ReadAsStringAsync();
+        sentBody.Should().Contain("\"invitation_token\":\"token-xyz\"");
+
+        result.SubscriptionStatus.Should().Be("Active");
+        result.RegisterName.Should().Be("Shared Register");
+        result.SourceOrgName.Should().Be("Cairngorm");
+    }
+
+    [Fact]
+    public async Task ListAsync_EmptyArray_ParsesCleanly()
+    {
+        // Exercises the "no invitations" wire shape that the server returns when the org
+        // has never sent or received one. Keeps the null-coalescence fallback in the
+        // client in the tested path rather than dead code.
+        const string body = """{ "invitations": [], "total_count": 0 }""";
+        var client = Build(HttpStatusCode.OK, body);
+
+        var result = await client.ListAsync(OrgId);
+
+        result.TotalCount.Should().Be(0);
+        result.Invitations.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes US10 Wave 1. Admins on owned registers can invite other organisations by DID; invited orgs accept via paste or magic link; a sent/received panel lives on the Registers page.

### Design decisions locked in with the product owner

| # | Decision |
|---|---|
| 1 | Shared HTTP client in `Sorcha.ServiceClients.Http/Invitation/` (not a UI-only variant — no Blazor coupling in the client surface). |
| 2 | DID paste + format validation for v1. A future validated-orgs directory drives a picker. |
| 3 | Copy token **and** magic link `/accept-invitation?token=...`. |
| 4 | Accept is decrypt + commit in one call — no preview step, the user has already explicitly pasted the token. |
| 5 | No SignalR. Manual refresh button + panel reload on accept. |

### What landed

- **HTTP client** (`IRegisterInvitationServiceClient` + `RegisterInvitationServiceClient`) with snake_case DTOs matching Tenant Service endpoints 1:1. 4xx → `InvitationApiException` so dialogs render the server message without re-parsing.
- **Dialogs** (`InviteOrganisationDialog`, `AcceptInvitationDialog`) under `Sorcha.UI.Core/Components/Registers/`.
- **Panel** (`InvitationsPanel`) with All / Sent / Received tabs, status chips, revoke on pending-sent rows.
- **Pages/Registers/Index.razor** integration: Invite icon button on Owner cards, panel mounted above the filter bar for admins.
- **Magic-link route** `/accept-invitation?token=...` auto-opens the accept dialog with the token pre-filled.

### Explicitly out of scope

- On-ledger audit trail for invitations (T055/T066, P1 #3). UI uses the existing endpoints; audit can wire in transparently.
- SignalR real-time updates (deferred per product decision).
- Org Settings page with wallet/DID display (T063, separate follow-up).

## Test plan

- [x] 6 wire-shape + error-mapping tests for the HTTP client (`RegisterInvitationServiceClientTests`).
- [x] Full UI solution builds clean.
- [ ] E2E: awaiting a fresh n1 deploy carrying this branch to click through the full invite → accept flow across two orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)