### PR TITLE
chore: weekly-review 2026-04-20 fixes

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1548,20 +1548,16 @@ app.MapPost("/api/registers/{registerId}/blueprints/publish", async (
         }
     }
 
-    // Publish to system register (global catalog) — idempotent: skip if already exists
-    var blueprintElement = System.Text.Json.JsonDocument.Parse(request.BlueprintJson).RootElement;
-    long systemVersion = 0;
+    // Per-register blueprint publish — intentionally does NOT propagate to the System
+    // Register (issue #297). The SSR is a curated catalog for blueprints marked as
+    // system (e.g. `join-private-register-v1`) and those are published directly via
+    // SystemRegisterBootstrapper / the POST /api/system-register/blueprints endpoint.
+    // Walkthrough and tenant-owned blueprints stay on their target register only.
+    //
+    // We still probe the SSR read-only so the response carries a meaningful `version`
+    // for system-catalogued blueprints; walkthrough blueprints return version 1.
     var existingEntry = await systemRegister.GetBlueprintAsync(request.BlueprintId);
-    if (existingEntry is null)
-    {
-        var entry = await systemRegister.PublishBlueprintAsync(
-            request.BlueprintId, blueprintElement, request.PublishedBy);
-        systemVersion = entry.Version;
-    }
-    else
-    {
-        systemVersion = existingEntry.Version;
-    }
+    long systemVersion = existingEntry?.Version ?? 1;
 
     // Submit a Control transaction to the validator for validation and docket creation.
     // All transactions must go through the validator — never write directly to the register.

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.AspNetCore.Mvc;
+using Sorcha.ServiceDefaults;
 using Sorcha.Tenant.Service.Trust;
 
 namespace Sorcha.Tenant.Service.Endpoints;
@@ -85,6 +86,10 @@ public static class TrustEndpoints
                 "this endpoint during chain validation.")
             .Produces(StatusCodes.Status200OK, contentType: "application/pkix-crl")
             .Produces(StatusCodes.Status404NotFound)
+            // Public but rate-limited (SEC-002): the CRL is embedded as a CDP URL in every
+            // org cert so any verifier may fetch it. The Api policy keeps abusive clients
+            // off the CA signing path.
+            .RequireRateLimiting(RateLimitPolicies.Api)
             .AllowAnonymous();
     }
 

--- a/src/Services/Sorcha.Tenant.Service/Trust/InternalCaTrustProvider.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/InternalCaTrustProvider.cs
@@ -243,7 +243,7 @@ public class InternalCaTrustProvider : ITrustProvider
 
         var crlNumber = _crlCounters.AddOrUpdate(tenantId, 1, (_, prev) => prev + 1);
         var (crlDer, nextUpdate) = TenantCrlBuilder.Build(
-            rootCa.CertificateDer, rootPrivateKey, revoked, crlNumber, _crlRefreshHours);
+            rootCa.CertificateDer, rootPrivateKey, revoked, crlNumber, _crlRefreshHours, rootCa.Algorithm);
 
         var crl = new TenantCrl
         {

--- a/src/Services/Sorcha.Tenant.Service/Trust/TenantCrlBuilder.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/TenantCrlBuilder.cs
@@ -26,19 +26,33 @@ public static class TenantCrlBuilder
     /// <param name="revokedEntries">Serial-hex + revocation time pairs.</param>
     /// <param name="crlNumber">Monotonic CRL version — must strictly increase across publications.</param>
     /// <param name="validityHours">Hours until <c>nextUpdate</c>. Default 24.</param>
+    /// <param name="algorithm">Signing algorithm identifier from the tenant trust config (e.g. "ES256"). Only ES256 is supported today.</param>
     /// <returns>DER-encoded CRL bytes plus the effective <c>nextUpdate</c>.</returns>
+    /// <exception cref="NotSupportedException">Thrown when <paramref name="algorithm"/> is not ES256 — RSA and EdDSA are deferred until keys are managed under PKCS#8 with an explicit discriminator.</exception>
     public static (byte[] CrlDer, DateTimeOffset NextUpdate) Build(
         byte[] rootCertDer,
         byte[] rootPrivateKey,
         IEnumerable<(string SerialHex, DateTimeOffset RevokedAt)> revokedEntries,
         long crlNumber,
-        int validityHours = 24)
+        int validityHours = 24,
+        string algorithm = "ES256")
     {
         ArgumentNullException.ThrowIfNull(rootCertDer);
         ArgumentNullException.ThrowIfNull(rootPrivateKey);
         ArgumentNullException.ThrowIfNull(revokedEntries);
         if (validityHours < 1)
             throw new ArgumentOutOfRangeException(nameof(validityHours));
+
+        // Guard the latent runtime crash flagged on PR #316: raw ImportECPrivateKey
+        // silently throws CryptographicException when a tenant CA is provisioned with
+        // RSA (or a future EdDSA). Fail loudly at the callsite instead so operators
+        // see a clear "not supported" error at config time, not a cryptic stack later.
+        if (!string.Equals(algorithm, "ES256", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException(
+                $"CRL signing for algorithm '{algorithm}' is not yet implemented. " +
+                "Only ES256 (NIST P-256) is supported today; see spec 096 persistent-storage follow-up for RSA / EdDSA.");
+        }
 
         using var rootCert = X509CertificateLoader.LoadCertificate(rootCertDer);
         using var rootEcdsa = ECDsa.Create();

--- a/walkthroughs/PropertyInspection/property-inspection-template.json
+++ b/walkthroughs/PropertyInspection/property-inspection-template.json
@@ -466,7 +466,7 @@
             { "claimName": "jobReference", "sourceField": "/instanceReference" },
             { "claimName": "propertyAddress", "sourceField": "/propertyAddress" },
             { "claimName": "category", "sourceField": "/category" },
-            { "claimName": "completionDate", "sourceField": "/completionDate" },
+            { "claimName": "completionDate", "sourceField": "/targetCompletionDate" },
             { "claimName": "satisfactionRating", "sourceField": "/rating" },
             { "claimName": "contractorName", "sourceField": "/assignedOperativeName" }
           ],


### PR DESCRIPTION
Bundles four independent fixes surfaced during the 2026-04-20 weekly review pass.

## 1. PR #264 follow-up — null `completionDate` credential claim

`walkthroughs/PropertyInspection/property-inspection-template.json`. `ServiceCompletionCredential` mapped `sourceField: "/completionDate"` which no action schema declares — silently emitted a null claim. Remapped to `/targetCompletionDate` (Action 1 "Triage Request"). Closes the bug flagged at PR #264 review but unaddressed at merge.

## 2. PR #316 follow-up — CRL signing algorithm guard

`Sorcha.Tenant.Service/Trust/TenantCrlBuilder.cs` now takes an `algorithm` parameter and throws `NotSupportedException` on anything other than ES256. Replaces the latent `CryptographicException` that raw `ImportECPrivateKey` would have produced against a tenant CA provisioned with RSA. Caller (`InternalCaTrustProvider`) threads `rootCa.Algorithm`.

## 3. PR #316 follow-up — CRL endpoint rate limit

`Sorcha.Tenant.Service/Endpoints/TrustEndpoints.cs`. Public `GET /api/v1/trust/tenants/{id}/crl` now attaches `.RequireRateLimiting(RateLimitPolicies.Api)` per SEC-002. Still `.AllowAnonymous` (verifiers embed CDP URLs and fetch the CRL unauthenticated); rate limit keeps abusive clients off the CA signing path.

## 4. Issue #297 — walkthrough blueprints on SSR

`Sorcha.Register.Service/Program.cs`. `POST /api/registers/{registerId}/blueprints/publish` no longer side-effects `systemRegister.PublishBlueprintAsync`. Walkthrough and tenant-owned blueprints land only on their target register. Read probe retained so the response's `version` field still reflects the SSR catalog for blueprints explicitly published there (via `SystemRegisterBootstrapper` or the dedicated `/api/system-register/blueprints` endpoint).

## Test plan

- [x] Full solution builds clean (0 errors).
- [x] 32 trust tests pass (`Sorcha.Tenant.Service.Tests` with Trust filter).
- [x] 33 blueprint/publish tests pass (`Sorcha.Register.Service.Tests`).

## Related

Closes #297 (#298 already closed by PR #324). Raised #326 (SEC-001 CORS policy call) and #327 (VAL-001 DTO validation chore) from the same review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)