### PR TITLE
fix: attach bearer to GetTransactionsByInstanceIdAsync (unblocks validator Tier 3)

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
@@ -614,6 +614,11 @@ public class RegisterServiceClient : IRegisterServiceClient
                 "Getting transactions for instance {InstanceId} from register {RegisterId}",
                 instanceId, registerId);
 
+            // Query endpoints are gated by CanReadTransactions. Without the service
+            // bearer the call falls back to 401 and Tier 3 validator lookup sees an
+            // empty chain, causing VAL_BP_002 on every late-bound participant reuse.
+            await SetAuthHeaderAsync(cancellationToken);
+
             var response = await _httpClient.GetAsync(
                 $"api/query/instance/{Uri.EscapeDataString(instanceId)}/transactions/{Uri.EscapeDataString(registerId)}",
                 cancellationToken);

--- a/tests/Sorcha.ServiceClients.Tests/Register/RegisterServiceClientInstanceTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Register/RegisterServiceClientInstanceTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+using Sorcha.Register.Models;
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Register;
+
+using Xunit;
+
+namespace Sorcha.ServiceClients.Tests.Register;
+
+/// <summary>
+/// Pins the service-auth contract for <see cref="RegisterServiceClient.GetTransactionsByInstanceIdAsync"/>.
+/// The Register Service's <c>/api/query</c> group is gated by <c>CanReadTransactions</c>, so the
+/// client must attach a service bearer; without it the call hits 401, the client silently returns
+/// an empty list, and the validator's Tier 3 chain-binding lookup misfires VAL_BP_002 on every
+/// late-bound participant reuse. Regression guard for that incident on n1 (2026-04-20).
+/// </summary>
+public class RegisterServiceClientInstanceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Fact]
+    public async Task GetTransactionsByInstanceIdAsync_AttachesBearerTokenBeforeQuery()
+    {
+        var serviceAuth = new Mock<IServiceAuthClient>();
+        serviceAuth.Setup(a => a.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("test-service-bearer");
+
+        AuthenticationHeaderValue? capturedAuth = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                capturedAuth = req.Headers.Authorization;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                });
+            });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ServiceClients:RegisterService:Address"] = "http://localhost:5290"
+            })
+            .Build();
+
+        var client = new RegisterServiceClient(
+            new HttpClient(handler.Object),
+            serviceAuth.Object,
+            config,
+            Mock.Of<ILogger<RegisterServiceClient>>());
+
+        await client.GetTransactionsByInstanceIdAsync(
+            registerId: "reg-abc",
+            instanceId: "inst-xyz");
+
+        capturedAuth.Should().NotBeNull(
+            "Tier 3 chain-binding lookup goes through /api/query which requires CanReadTransactions auth");
+        capturedAuth!.Scheme.Should().Be("Bearer");
+        capturedAuth.Parameter.Should().Be("test-service-bearer");
+        serviceAuth.Verify(a => a.GetTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Root cause

Validator Tier 3 chain-binding (PR #324) landed cleanly but TradeFinance Action 6 still reliably hits \`VAL_BP_002\` on n1. The Tier 3 code IS executing — the new error message suffix "and no prior in-instance binding" confirms it. But Tier 3 calls \`IRegisterServiceClient.GetTransactionsByInstanceIdAsync\`, which was the only \`/api/query\` method on the client that never called \`SetAuthHeaderAsync\`.

Server-side \`app.MapGroup("/api/query").RequireAuthorization("CanReadTransactions")\`. Anonymous request → 401 → client returns empty list (fail-safe) → Tier 3 sees no prior history → VAL_BP_002.

## Fix

One-line `await SetAuthHeaderAsync(cancellationToken);` in `GetTransactionsByInstanceIdAsync` to match every other method on the client.

## Test

Added `RegisterServiceClientInstanceTests.GetTransactionsByInstanceIdAsync_AttachesBearerTokenBeforeQuery` — pins the contract so the regression can't recur silently.

## Evidence from n1

\`\`\`
VAL_BP_002: Cannot verify sender authorization: participant 'procurement-mgr' has
no wallet address, no published record on register '...', and no prior in-instance
binding. (Chain lookup degraded? See preceding validator warnings.)
\`\`\`

The "see preceding warnings" hint (added in PR #328) is accurate — the preceding warning would have been the 401 from the register client, which is what this PR stops.

## Deploy plan

Post-merge: pull \`sorchadev/validator-service:latest\` on n1 and rerun TradeFinance — Action 6 should clear on all three scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)