### PR TITLE
fix(register): add GET /api/query/instance/{id}/transactions/{register} (completes validator Tier 3)

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
@@ -614,6 +614,11 @@ public class RegisterServiceClient : IRegisterServiceClient
                 "Getting transactions for instance {InstanceId} from register {RegisterId}",
                 instanceId, registerId);
 
+            // Query endpoints are gated by CanReadTransactions. Without the service
+            // bearer the call falls back to 401 and Tier 3 validator lookup sees an
+            // empty chain, causing VAL_BP_002 on every late-bound participant reuse.
+            await SetAuthHeaderAsync(cancellationToken);
+
             var response = await _httpClient.GetAsync(
                 $"api/query/instance/{Uri.EscapeDataString(instanceId)}/transactions/{Uri.EscapeDataString(registerId)}",
                 cancellationToken);

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1218,6 +1218,34 @@ queryGroup.MapGet("/previous/{prevTxId}/transactions", async (
 .Produces(StatusCodes.Status400BadRequest)
 .Produces(StatusCodes.Status401Unauthorized);
 
+// <summary>
+// Query transactions by workflow instance ID. Used by the Validator's Tier 3
+// chain-derived participant binding (PR #324) to find the earliest prior in-instance
+// tx for a participant role. Ordered by TimeStamp ascending so the caller can
+// short-circuit on the first match.
+// </summary>
+queryGroup.MapGet("/instance/{instanceId}/transactions/{registerId}", async (
+    TransactionManager manager,
+    string instanceId,
+    string registerId) =>
+{
+    if (string.IsNullOrWhiteSpace(instanceId))
+        return Results.BadRequest(new { error = "instanceId is required" });
+    if (string.IsNullOrWhiteSpace(registerId))
+        return Results.BadRequest(new { error = "registerId is required" });
+
+    var txs = (await manager.GetTransactionsByInstanceAsync(registerId, instanceId))
+        .OrderBy(t => t.TimeStamp)
+        .ToList();
+    return Results.Ok(txs);
+})
+.WithName("GetTransactionsByInstanceId")
+.WithSummary("Query transactions by workflow instance ID")
+.WithDescription("Returns all transactions for a workflow instance on the given register, ordered by timestamp. Powers the Validator's chain-derived participant binding.")
+.Produces<List<Sorcha.Register.Models.TransactionModel>>(StatusCodes.Status200OK)
+.Produces(StatusCodes.Status400BadRequest)
+.Produces(StatusCodes.Status401Unauthorized);
+
 // ===========================
 // Docket Management API
 // ===========================

--- a/tests/Sorcha.ServiceClients.Tests/Register/RegisterServiceClientInstanceTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Register/RegisterServiceClientInstanceTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+using Sorcha.Register.Models;
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Register;
+
+using Xunit;
+
+namespace Sorcha.ServiceClients.Tests.Register;
+
+/// <summary>
+/// Pins the service-auth contract for <see cref="RegisterServiceClient.GetTransactionsByInstanceIdAsync"/>.
+/// The Register Service's <c>/api/query</c> group is gated by <c>CanReadTransactions</c>, so the
+/// client must attach a service bearer; without it the call hits 401, the client silently returns
+/// an empty list, and the validator's Tier 3 chain-binding lookup misfires VAL_BP_002 on every
+/// late-bound participant reuse. Regression guard for that incident on n1 (2026-04-20).
+/// </summary>
+public class RegisterServiceClientInstanceTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    [Fact]
+    public async Task GetTransactionsByInstanceIdAsync_AttachesBearerTokenBeforeQuery()
+    {
+        var serviceAuth = new Mock<IServiceAuthClient>();
+        serviceAuth.Setup(a => a.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("test-service-bearer");
+
+        AuthenticationHeaderValue? capturedAuth = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                capturedAuth = req.Headers.Authorization;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", System.Text.Encoding.UTF8, "application/json")
+                });
+            });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ServiceClients:RegisterService:Address"] = "http://localhost:5290"
+            })
+            .Build();
+
+        var client = new RegisterServiceClient(
+            new HttpClient(handler.Object),
+            serviceAuth.Object,
+            config,
+            Mock.Of<ILogger<RegisterServiceClient>>());
+
+        await client.GetTransactionsByInstanceIdAsync(
+            registerId: "reg-abc",
+            instanceId: "inst-xyz");
+
+        capturedAuth.Should().NotBeNull(
+            "Tier 3 chain-binding lookup goes through /api/query which requires CanReadTransactions auth");
+        capturedAuth!.Scheme.Should().Be("Bearer");
+        capturedAuth.Parameter.Should().Be("test-service-bearer");
+        serviceAuth.Verify(a => a.GetTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Root cause (third hop)

The "validator Tier 3 chain-binding" incident turns out to be three stacked gaps:

1. **PR #324** added Tier 3 logic in \`ValidationEngine\` + the client call to \`GetTransactionsByInstanceIdAsync\`.
2. **PR #329** added the missing \`SetAuthHeaderAsync\` on that client call.
3. **This PR** adds the server endpoint the client was calling. It was never registered in \`Program.cs\` — only the service-layer method (\`TransactionManager.GetTransactionsByInstanceAsync\`) existed.

n1 evidence (2026-04-20 10:51 UTC, post-PR329 deploy):

\`\`\`
GET /api/query/instance/0a6d21d0-.../transactions/e1b50bbb... → 404 Not Found
\`\`\`

No 401 (auth fix worked); just 404. Client returns empty list, Tier 3 sees no history, VAL_BP_002 fires.

## Fix

\`\`\`csharp
queryGroup.MapGet("/instance/{instanceId}/transactions/{registerId}", ...)
\`\`\`

Inside the existing \`queryGroup\` (auto-inherits \`CanReadTransactions\` auth). Delegates to the existing \`TransactionManager.GetTransactionsByInstanceAsync\` service method. Orders by \`TimeStamp\` ascending so the validator's \`FirstOrDefault\` short-circuits on first match.

## Deploy

Post-merge + Docker Publish: pull \`sorchadev/register-service:latest\` on n1 and rerun TradeFinance. Expected: Action 6 clears on all three scenarios, VAL_BP_002 disappears from validator logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)