### PR TITLE
fix(validator): persist InstanceId on sealed transactions (completes Tier 3)

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -589,7 +589,16 @@ public class DocketBuildTriggerService : BackgroundService
                             RegisterId = t.RegisterId,
                             BlueprintId = t.BlueprintId,
                             ActionId = uint.TryParse(t.ActionId, out var actionId) ? actionId : null,
-                            TransactionType = txType
+                            TransactionType = txType,
+                            // Carry InstanceId through from the in-memory submission so the
+                            // Validator's Tier 3 chain-derived participant binding can walk
+                            // in-instance transactions on the register. Prior to this, sealed
+                            // txs were persisted with InstanceId=null and every Tier 3 lookup
+                            // returned an empty list.
+                            InstanceId = t.Metadata.TryGetValue("instanceId", out var iid)
+                                         && !string.IsNullOrWhiteSpace(iid)
+                                ? iid
+                                : null,
                         }
                     };
                 }).ToList(),


### PR DESCRIPTION
## Root cause (fourth hop)

The validator Tier 3 chain-binding incident has four stacked gaps:

1. **PR #324** — Tier 3 logic in \`ValidationEngine\`.
2. **PR #329** — missing \`SetAuthHeaderAsync\` on the client's chain query.
3. **PR #330** — missing server endpoint the client was calling.
4. **This PR** — server endpoint now returns 200 but every tx persisted with \`MetaData.InstanceId = null\`, so the filter matches nothing.

n1 evidence (2026-04-20 11:04 UTC):

\`\`\`
GET /api/query/instance/{id}/transactions/{register} → 200 OK []
\`\`\`

MongoDB sample on \`sorcha_register_e1b50bbbb2d04c82b955e165f7c72c53\`:
\`\`\`json
{ "MetaData": { "BlueprintId": "...", "ActionId": 1, "InstanceId": null } }
\`\`\`

\`DocketBuildTriggerService.cs:587\` built \`TransactionMetaData\` copying \`RegisterId\`, \`BlueprintId\`, \`ActionId\`, \`TransactionType\` — never \`InstanceId\`. The in-memory \`Transaction.Metadata\` dict (set by \`ValidationEndpoints\`) carries it fine, but the docket-seal projection dropped it.

## Fix

Copy \`Metadata["instanceId"]\` into \`TransactionMetaData.InstanceId\` at docket-seal time.

## Deploy

Post-merge + Docker Publish: pull \`sorchadev/validator-service:latest\` on n1 and rerun TradeFinance. This time Action 6 should actually clear because:
- Validator Tier 3 runs (PR #324) ✓
- Client call has auth (PR #329) ✓
- Endpoint exists and returns 200 (PR #330) ✓
- **Response carries an Action 1 tx with InstanceId populated** (this PR)
- \`SenderWallet\` field is already populated (verified independently)

## Lesson

Two PRs in sequence without end-to-end n1 verification between them surfaced two more layers of gaps. Cheap rule for future: a validator-pipeline change gets one \`curl\` probe of the actual HTTP endpoint on n1 before declaring the fix done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)