### PR TITLE
fix(TradeFinance): create registers in DevMode so credentials flow

### DIFF
--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -381,6 +381,7 @@ foreach ($regDef in $config.registers) {
         -OwnerUserId $ctx.AdminUserId `
         -OwnerWalletAddress $ownerWalletAddress `
         -Headers $ctx.Headers `
+        -DevMode `
         -Metadata @{ createdBy = "TradeFinance/setup.ps1"; registerType = $regDef.ownerOrg }
 
     $state.registers[$regShortName] = @{


### PR DESCRIPTION
## Summary
- TradeFinance `setup.ps1` now passes `-DevMode` to `New-SorchaRegister` for both the trade and finance registers.
- Aligns with the walkthrough's documented starting state ("Registers are created in DevMode by default" — `docs/Trade-Finance-Walkthrough.md`) and lets the existing `-DisableDevMode` / `-VerifyFLE` mid-run toggle demo continue to work both ways.

## Why
On n1 the last walkthrough run showed Action 6 issuing `VerifiedInvoiceCredential` into the trade register as a plaintext payload (`ContentEncoding: "base64url"`, `WalletAccess: []`). The register was created with `DevMode: false`, so `InboundCredentialDetector` correctly dropped the plaintext tx as a DAD-integrity signal (see `InboundCredentialDetector.cs:283-293`) and no row ever landed under sales-mgr's wallet. Invoice Finance Action 1 then failed 400 on the missing `VerifiedInvoiceCredential` requirement.

The upstream bug — the transaction builder emitting plaintext on a DevMode=false register — is real and tracked separately. Flipping the walkthrough default to DevMode unblocks the current demo while preserving the authored mid-run transition path.

## Test plan
- [ ] Clean volume reset on n1 (`n1-reset.ps1 -ResourceGroup sorcha-n1-uk -UpdateCompose -Yes`)
- [ ] Run TradeFinance setup — confirm both registers report `DevMode: true` in `sorcha_register_registry.registers`
- [ ] Run `run.ps1 -Scenario golden-path` — Action 6 succeeds AND sales-mgr's wallet now has a VerifiedInvoiceCredential row
- [ ] Run `run.ps1 -Scenario golden-path -DisableDevMode -VerifyFLE` — DevMode→FLE transition still works