### PR TITLE
fix(TradeFinance): accept pending credential before presenting

### DIFF
--- a/walkthroughs/TradeFinance/run.ps1
+++ b/walkthroughs/TradeFinance/run.ps1
@@ -425,6 +425,21 @@ foreach ($sid in $scenariosToRun) {
 
         Write-WtInfo "  Fetching credentials from sales-mgr wallet ($salesMgrWallet)..."
         try {
+            # Feature 106 Wave C: register-native credential delivery persists as
+            # Status=PendingAcceptance. The holder (sales-mgr) must accept before it
+            # becomes Active and usable for presentation. Do that here.
+            $pending = Invoke-SorchaApi -Method GET `
+                -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials?status=PendingAcceptance" `
+                -Headers $credHeaders
+
+            foreach ($p in ($pending | Where-Object { $_.type -eq "VerifiedInvoiceCredential" })) {
+                Write-WtInfo "  Accepting pending credential $($p.id)..."
+                $null = Invoke-SorchaApi -Method PATCH `
+                    -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials/$($p.id)" `
+                    -Body @{ status = "Active" } `
+                    -Headers $credHeaders
+            }
+
             $creds = Invoke-SorchaApi -Method GET `
                 -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials" `
                 -Headers $credHeaders


### PR DESCRIPTION
## Summary
Walkthrough now runs the Feature 106 Wave-C holder accept step between Action 6 and the credential presentation for Invoice Finance Action 1.

## Why
Register-native credential delivery persists to the recipient wallet as \`Status=PendingAcceptance\`. The default \`GET /credentials\` filters to Active-only for backward compatibility, so the walkthrough's \"find the VerifiedInvoiceCredential\" step was returning empty and Action 1 failed 400 on the missing credential requirement.

## What changed
Between the procurement phase and the finance phase the walkthrough now:
1. Queries \`?status=PendingAcceptance\` for the sales-mgr wallet
2. PATCHes each matching VerifiedInvoiceCredential to \`Active\` (the Wave-C endpoint)
3. Continues with the existing Active fetch → export → present path

## Test plan
Verified on n1 against DevMode=true registers (see PR #332):
- [x] golden-path: Procurement 6/6, Finance 4/4 (PASS)
- [x] declined: Procurement 6/6, Finance declined 4/4 (PASS)
- [ ] disputed: separate Action 5 resubmit issue, investigating