### PR TITLE
fix(walkthroughs): council walkthroughs use DevMode + auto-accept pending VCs

### DIFF
--- a/walkthroughs/ConstructionPermit/setup.ps1
+++ b/walkthroughs/ConstructionPermit/setup.ps1
@@ -331,6 +331,7 @@ $register = New-SorchaRegister `
     -OwnerUserId $meridianSession.UserId `
     -OwnerWalletAddress $users["contractor"].WalletAddress `
     -Headers $meridianSession.Headers `
+    -DevMode `
     -Metadata @{ createdBy = "ConstructionPermit/setup.ps1"; multiOrg = "true" }
 
 # ============================================================================

--- a/walkthroughs/PropertyInspection/setup.ps1
+++ b/walkthroughs/PropertyInspection/setup.ps1
@@ -95,6 +95,7 @@ $register = New-SorchaRegister `
     -OwnerUserId $housingSession.UserId `
     -OwnerWalletAddress $housingRole.walletAddress `
     -Headers $housingSession.Headers `
+    -DevMode `
     -Metadata @{ createdBy = "PropertyInspection walkthrough" }
 
 Write-WtInfo "Register → $($register.RegisterId)"

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -242,6 +242,7 @@ $planningRegister = New-SorchaRegister `
     -OwnerUserId $planningOwnerUserId `
     -OwnerWalletAddress $users["planning-officer"].walletAddress `
     -Headers $planningSession.Headers `
+    -DevMode `
     -Metadata @{ createdBy = "SelfBuildHouse/setup.ps1"; registerType = "planning" }
 Write-WtSuccess "  Planning Register: $($planningRegister.RegisterId)"
 
@@ -260,6 +261,7 @@ $buildingRegister = New-SorchaRegister `
     -OwnerUserId $bsOwnerUserId `
     -OwnerWalletAddress $users["building-standards-officer"].walletAddress `
     -Headers $bsSession.Headers `
+    -DevMode `
     -Metadata @{ createdBy = "SelfBuildHouse/setup.ps1"; registerType = "building-standards" }
 Write-WtSuccess "  Building Standards Register: $($buildingRegister.RegisterId)"
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1406,6 +1406,28 @@ function Get-SorchaCredentialPresentation {
 
     $headers = @{ Authorization = "Bearer $Token" }
 
+    # Feature 106 Wave C: register-native credential delivery lands as
+    # Status=PendingAcceptance. The default /credentials list filters to Active
+    # only, so pending credentials are invisible to the presentation flow until
+    # the holder accepts. Walkthroughs are single-actor-per-role and don't have
+    # a separate "inbox triage" step, so auto-accept pending credentials of the
+    # requested type here before the Active fetch.
+    try {
+        $pending = Invoke-SorchaApi -Method GET `
+            -Uri "$WalletUrl/v1/wallets/$WalletAddress/credentials/?status=PendingAcceptance" `
+            -Headers $headers
+        foreach ($p in ($pending | Where-Object { $_.type -eq $CredentialType })) {
+            $null = Invoke-SorchaApi -Method PATCH `
+                -Uri "$WalletUrl/v1/wallets/$WalletAddress/credentials/$($p.id)" `
+                -Body @{ status = "Active" } `
+                -Headers $headers
+        }
+    } catch {
+        # Non-fatal: pending accept is best-effort. If the helper is being used
+        # against a wallet that has no pending credentials, the fetch below will
+        # return the already-active ones and the caller sees no difference.
+    }
+
     $credentials = Invoke-SorchaApi -Method GET `
         -Uri "$WalletUrl/v1/wallets/$WalletAddress/credentials/" `
         -Headers $headers


### PR DESCRIPTION
## Summary
Batch fix for the credential-delivery gap across the three council-universe walkthroughs (ConstructionPermit, SelfBuildHouse, PropertyInspection) — same root causes as TradeFinance (#332 + #333).

### Changes
1. **`-DevMode` on every `New-SorchaRegister`** in the three setup scripts so register-native credentials are accepted by `InboundCredentialDetector` (non-DevMode registers correctly drop plaintext payloads to preserve the DAD invariant — issuance emits plaintext; separate server-side bug).
2. **`Get-SorchaCredentialPresentation` auto-accepts pending credentials** in the shared `SorchaWalkthrough.psm1` module — queries `?status=PendingAcceptance`, PATCHes matching credentials of the requested type to Active, then does the existing Active fetch. All walkthroughs using this helper benefit immediately.

### Why module-level for accept, but per-walkthrough for DevMode
- Accept is a uniform wallet-API pattern — single helper change covers all callers.
- DevMode is a per-register authoring decision — keeping it explicit at the `New-SorchaRegister` call matches the TradeFinance change in #332 and stays visible to walkthrough authors rather than hiding in a default.

### Test plan
- [ ] Clean `state.json` files, run ConstructionPermit setup + scenarios on n1 (primary smoke)
- [ ] Run SelfBuildHouse setup + scenarios on n1 (stresses the shared helper across two registers with two different credential types)
- [ ] Run PropertyInspection setup + scenarios on n1
- [ ] Verify n1 MongoDB `sorcha_register_registry.registers` shows `DevMode: true` for all created registers

No server-side code changes — Docker Publish not required.