### PR TITLE
feat(107): Assured Identity v1 — PR 1 (US1) renderer polish + credential + walkthrough

### DIFF
--- a/specs/107-assured-identity-v1/checklists/requirements.md
+++ b/specs/107-assured-identity-v1/checklists/requirements.md
@@ -1,0 +1,71 @@
+# Specification Quality Checklist: Assured Identity v1
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Notes
+
+### Iteration 1 — passed with two minor fixes applied inline
+
+**Initial issues caught and fixed:**
+
+1. **Protocol-name leak in FR-016** — original wording referenced "OpenID4VCI pre-authorised code flow" in a parenthetical after "external HAIP wallet". The protocol name is implementation detail that adds nothing to the user-facing requirement (the outcome — holder chooses at claim time — is what the FR asserts). Rephrased to just "external HAIP wallet" with the parenthetical removed. The protocol specifics remain in Assumptions, which is the appropriate place.
+
+2. **Framework-name leak in SC-012** — original wording was "zero new Blazor components". "Blazor" is a specific UI framework and leaks implementation detail into a success criterion. Rephrased to "zero new bespoke UI components". The metric stays measurable (count of new components added for this screen) without naming the framework.
+
+**Domain language retained intentionally:**
+
+- **"Wallet"**, **"Verifiable Credential"**, **"external HAIP wallet"**, **"persona profile"** — all inherited as user-facing Sorcha terminology from the Feature 103 spec's resolution of the same question. Stakeholders reading this spec will have encountered them in Feature 103 already; replacing them would fragment the platform's vocabulary.
+- **"SD-JWT VC"**, **"OpenID4VCI"**, **"OpenID4VP `direct_post`"**, **"KB-JWT"** — appear only in Assumptions (where 103's spec also admits them) to document the prior-feature platform substrate this spec depends on. They do not appear in FRs or SCs.
+- **"sorcha-agent"** — the autonomous actor framework name, user-visible in walkthrough authoring documentation. Retained.
+- **"register-native delivery"** — user-facing Sorcha capability name from Feature 106. Retained.
+
+**Coverage check:**
+
+| Workstream | User Story | Functional Requirements | Success Criteria |
+|---|---|---|---|
+| 1 — Renderer polish | US-1 (enables) | FR-001 to FR-012 | SC-003, SC-004, SC-005, SC-007, SC-012 |
+| 2 — Assured Identity credential + blueprint | US-1 | FR-013 to FR-021 | SC-001, SC-003 |
+| 3 — Driving Licence | US-2 | FR-022 to FR-026 | SC-002, SC-005, SC-006 |
+| 4 — Unattended assessor | US-3 | FR-027 to FR-030 | SC-008 |
+| 5 — Consolidated walkthrough | US-1, US-2 | FR-031 to FR-035 | SC-001, SC-002, SC-011 |
+| 6 — Cross-peer smoke | US-4 | FR-036 to FR-040 | SC-009, SC-013 |
+| 7 — Consolidation & cleanup | US-5 | FR-041 to FR-044 | SC-010, SC-011, SC-014 |
+
+Every functional requirement maps to at least one user story's acceptance scenarios; every success criterion maps to at least one workstream. No orphans.
+
+**Assumption traceability:**
+
+Every assumption in the Assumptions section either (a) names the prior feature it depends on (Features 098, 101, 102, 103, 104, 106, 092) or (b) cites an external industry standard (ISO/IEC 19794-5, ISO 18013-5, ICAO Doc 9303). No "we decided" assumptions without a cite.
+
+## Notes
+
+- All checklist items pass after one validation iteration. Spec is ready for `/speckit.clarify` (likely no-op given prior brainstorming produced the design doc this spec was derived from) or directly for `/speckit.plan`.
+- The feature is intentionally split into seven phases that map user stories to sequenced platform deliverables. This phasing is *informative* in the spec and will be made *operative* by the planning phase.
+- The design doc at `docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md` is the authoritative rationale source; the spec is the implementation contract derived from it. They should stay in sync — any change to the spec's scope that is not already represented in the design doc should be back-propagated to the design doc in the same commit.

--- a/specs/107-assured-identity-v1/contracts/assured-identity-credential.md
+++ b/specs/107-assured-identity-v1/contracts/assured-identity-credential.md
@@ -1,0 +1,95 @@
+# Contract: AssuredIdentityCredential
+
+**Feature**: 107-assured-identity-v1
+**Format**: SD-JWT VC (W3C Verifiable Credentials 2.0, SD-JWT VC profile)
+
+## Identity
+
+| Property | Value |
+|---|---|
+| `vct` (verifiable credential type) | `AssuredIdentityCredential` |
+| Issuer DID | `did:sorcha:org:<wallet-of-issuing-org>` |
+| Holder binding | `cnf` claim with the holder's wallet public key (per HAIP) |
+| Expiry (`exp`) | None — identity credentials do not expire in v1; revocation via Feature 079 |
+| Issued at (`iat`) | Issuance timestamp |
+
+## Claim schema
+
+All claims are selectively disclosable.
+
+```jsonc
+{
+  "vct": "AssuredIdentityCredential",
+  "iss": "did:sorcha:org:wsXXX...",
+  "iat": 1740000000,
+  "cnf": { "jwk": { /* holder pubkey */ } },
+
+  "givenName": "Aisling",
+  "middleName": "Marie",          // optional
+  "familyName": "O'Brien",
+  "fullName": "Aisling Marie O'Brien",
+  "dateOfBirth": "1986-08-12",
+  "email": "aisling@example.com",
+  "address": {
+    "line1": "14 Princes Street",
+    "line2": null,
+    "town": "Edinburgh",
+    "region": null,
+    "postcode": "EH1 2NG",
+    "country": "GB"
+  },
+  "portrait": "/9j/4AAQSkZJ..."   // optional, base64 JPEG ≤27KB
+}
+```
+
+### Required vs optional claims
+
+| Claim | Required at issuance? | Notes |
+|---|---|---|
+| `givenName` | Yes | From submission `/name/givenName` |
+| `middleName` | No | Omitted if blank |
+| `familyName` | Yes | From submission `/name/familyName` |
+| `fullName` | Yes | Renderer-derived |
+| `dateOfBirth` | Yes | Server-side `formatMaximum: today` enforced |
+| `email` | Yes | RFC 5322 format |
+| `address` | Yes | Whole object disclosed/withheld as a unit in v1 |
+| `portrait` | No | Included only if citizen provided a photo and the client-side token is within size bounds |
+
+## Selective disclosure
+
+Each claim is its own SD claim (per SD-JWT VC convention). The holder may withhold any claim during a presentation. The `address` object is a single SD claim — sub-field selective disclosure (e.g. disclose town but withhold street) is out of scope in v1.
+
+## Issuance flows
+
+### Register-native (Feature 106)
+
+1. Citizen submits Page 5 of the wizard
+2. Assessor (agent or human) approves
+3. `ActionExecutionService` mints the credential, encrypts it via `EncryptionPipelineService` for the holder's wallet, seals it as a recipient-addressed disclosure on the register
+4. Holder's peer's `InboundCredentialDetector` picks it up via the bloom-filter notification path
+5. Credential lands in the holder's MyCredentials PENDING tab on the holder's peer
+6. Holder accepts → transitions to Active
+
+### HAIP external (Feature 097 + 104)
+
+1. Citizen submits Page 5 of the wizard
+2. Assessor approves
+3. `ActionExecutionService` mints the credential offer via the HAIP issuer, exposes the OpenID4VCI pre-authorised code
+4. The next action is a Wave 14b claim card (per `x-credential-offer` extension), surfaced to the citizen in My Actions
+5. Citizen clicks Claim (in-platform redemption via `HaipLocalReceiveService` into the local Sorcha wallet) OR Scan (QR for external HAIP wallet)
+6. Credential lands in the chosen wallet
+
+The blueprint declares both paths via the existing dual-path Wave 14b card; the holder picks at claim time.
+
+## Revocation
+
+- Mechanism: existing Feature 079 revocation transactions
+- Reasons supported: Superseded, Erroneous, Compromised, Expired (n/a here), Withdrawn, Regulatory
+- Verifier check: per credentialRequirements `revocationCheckPolicy: FailClosed`
+
+## Replaces
+
+- `VerifiedCitizenCredential` (from `walkthroughs/HaipVerifiedCitizen/blueprints/verified-citizen.json`)
+- `AssuredPersonCredential` (from `walkthroughs/HaipVerifiedCitizen/blueprints/assured-person.json`)
+
+Both are removed in Phase 7. No back-compat shim or aliasing.

--- a/specs/107-assured-identity-v1/contracts/cross-peer-findings-format.md
+++ b/specs/107-assured-identity-v1/contracts/cross-peer-findings-format.md
@@ -1,0 +1,94 @@
+# Contract: Cross-peer smoke test findings document
+
+**Feature**: 107-assured-identity-v1
+**Produced by**: `walkthroughs/AssuredIdentity/run-multi-peer.ps1`
+**Location**: `walkthroughs/AssuredIdentity/multi-peer-findings.md` (committed baseline) + per-run rolling files (gitignored)
+
+## Purpose
+
+The smoke test produces a structured markdown document on every run regardless of outcome. The document is the only output that matters — pass / fail / anomaly are all equally informative.
+
+## Document shape
+
+```markdown
+---
+run_timestamp: 2026-04-22T14:30:00Z
+peer_a_version: <git sha or version tag of peer A's image>
+peer_b_version: <git sha or version tag of peer B's image>
+outcome: pass | degraded-pass | fail | env-failure
+total_duration_ms: 23847
+---
+
+# Cross-peer smoke test — <date>
+
+## Summary
+
+<one or two sentences: what happened, what to take away>
+
+## Topology
+
+- Peer A: <hostname / container name> · <role: issuer>
+- Peer B: <hostname / container name> · <role: holder>
+- Shared register: <register id>
+- Government org DID: <did:sorcha:org:...>
+- Citizen wallet: <wallet address>
+
+## Timings
+
+| Milestone | Wall-clock (ms from start) |
+|---|---|
+| `setup.ps1` complete | 0 |
+| Phase 1 submit on peer A | <ms> |
+| Assessor approval (agent) on peer A | <ms> |
+| Credential minted, sealed disclosure on register | <ms> |
+| `InboundCredentialDetector` fires on peer B | <ms> |
+| MyCredentials PENDING surfaces on peer B | <ms> |
+| Holder Accept transaction signed on peer B | <ms> |
+| Accept transaction observed on peer A | <ms> |
+| Total | <ms> |
+
+## Anomalies
+
+<one entry per observed anomaly; bullet list when none>
+
+- [SEVERITY] <description> — <reproduction note>
+
+Severities: BLOCKER (test failed) · MAJOR (degraded pass) · MINOR (worth investigating later) · INFO (observation)
+
+## Reproduction notes
+
+- Commands run, in order
+- Environment variables / config that mattered
+- Any manual intervention performed
+- Versions of any external dependencies (Docker, PowerShell, .NET SDK)
+
+## Outcome rationale
+
+<for fail / env-failure outcomes: paragraph explaining why the outcome was assigned>
+```
+
+## Outcome semantics
+
+| Outcome | Meaning | Blocks release? |
+|---|---|---|
+| `pass` | All milestones hit within targeted latency, no anomalies | No (it passed) |
+| `degraded-pass` | All milestones eventually hit but at least one exceeded latency budget | No — flag for follow-up |
+| `fail` | A required milestone did not occur (e.g., credential never reached peer B) | **No** — feature ships, fix routed to peer-replication owner |
+| `env-failure` | Test could not run (docker-compose failure, port conflict, etc.) | No — flag for environment fix |
+
+The smoke test is **measurement-not-gating** by design (per spec assumption). Failures become findings.
+
+## Latency targets
+
+Per spec SC-009: full delivery (Phase 1 submit → MyCredentials PENDING on peer B) MUST complete in **≤ 30 seconds** under normal conditions to count as `pass`. Up to 60 seconds counts as `degraded-pass`. Above 60 seconds OR not arriving counts as `fail`.
+
+## File handling
+
+- **Committed baseline**: `walkthroughs/AssuredIdentity/multi-peer-findings.md` — the latest known-good representative run, committed to the feature branch and updated on each release that runs the smoke test
+- **Rolling per-run**: `walkthroughs/AssuredIdentity/multi-peer-findings/<run_timestamp>.md` — gitignored, useful for local debugging
+
+## Acceptance
+
+- A run of `run-multi-peer.ps1` produces a findings document with frontmatter and all sections populated, regardless of outcome
+- The committed baseline reflects the latest run on a release-cut commit
+- The `outcome` value is computable from the timings (no human judgement needed for pass / degraded-pass; fail and env-failure require explicit script-detected error conditions)

--- a/specs/107-assured-identity-v1/contracts/docker-compose-federation.md
+++ b/specs/107-assured-identity-v1/contracts/docker-compose-federation.md
@@ -1,0 +1,116 @@
+# Contract: docker-compose.federation.yml topology
+
+**Feature**: 107-assured-identity-v1
+**File location**: repository root, alongside existing `docker-compose.yml`
+
+## Purpose
+
+A two-peer Sorcha federation that supports `walkthroughs/AssuredIdentity/run-multi-peer.ps1` exercising the cross-peer credential delivery path of Feature 106. Two complete peer stacks subscribed to a shared register.
+
+## Topology
+
+```
+┌─────────────────────────────┐         ┌─────────────────────────────┐
+│         Peer A              │         │         Peer B              │
+│  ─────────────────          │         │  ─────────────────          │
+│  api-gateway-a (port 8081)  │         │  api-gateway-b (port 8082)  │
+│  blueprint-svc-a            │         │  blueprint-svc-b            │
+│  register-svc-a             │  ◄───►  │  register-svc-b             │
+│  validator-svc-a            │ peer-svc│  validator-svc-b            │
+│  wallet-svc-a               │  gRPC   │  wallet-svc-b               │
+│  tenant-svc-a               │         │  tenant-svc-b               │
+│  haip-svc-a                 │         │  haip-svc-b                 │
+│  peer-svc-a                 │         │  peer-svc-b                 │
+│  postgres-a (per service)   │         │  postgres-b (per service)   │
+│  mongo-a                    │         │  mongo-b                    │
+│  redis-a                    │         │  redis-b                    │
+└─────────────────────────────┘         └─────────────────────────────┘
+                  │                                    │
+                  └────────── shared docker network ───┘
+                              (sorcha-federation)
+```
+
+Both peers run identical service images. The only differences:
+- Hostnames are suffixed `-a` / `-b`
+- API gateway ports differ (8081 / 8082) so a host browser can hit either
+- Each peer has its own database stack (no shared DBs)
+- Each peer's `Peer:Seeds` configuration includes the other peer's `peer-svc` endpoint, so peer discovery is bootstrapped at startup
+
+## Service composition
+
+The compose file imports the existing `docker-compose.yml` service definitions where possible (via `extends:`) and parameterises hostnames and ports per peer. New compose-only resources:
+
+- `sorcha-federation` Docker network (bridge)
+- Per-peer named volumes for postgres / mongo data (so peer state persists across `docker compose down` for forensics)
+- Per-peer environment overrides for `Peer:Seeds`, `Peer:NodeId`, ports
+
+## Configuration overrides
+
+Each peer's `appsettings` overrides include:
+
+```jsonc
+{
+  "Peer": {
+    "NodeId": "peer-a",                      // or peer-b
+    "Seeds": [ "peer-svc-b:5002" ]           // or peer-svc-a:5002
+  },
+  "Cluster": {
+    "FederationMode": true                   // enables cross-peer replication paths
+  }
+}
+```
+
+## Setup behaviour
+
+`run-multi-peer.ps1` performs setup in this order:
+
+1. `docker compose -f docker-compose.federation.yml down -v` (clean slate)
+2. `docker compose -f docker-compose.federation.yml up -d` (start both peers)
+3. Wait for both API gateways to report healthy (poll `/health` endpoints)
+4. Provision the Government org on **peer A only** (the issuer)
+5. Provision the citizen public-org account on **peer B** (the holder)
+6. Citizen subscribes to peer A's Assured Identity register (using existing peer-discovery + register-subscription path)
+7. Wait for peer B to confirm subscription is replicated (poll register subscription state)
+8. Run Phase 1 submission on peer B (citizen submits to their own peer)
+9. Wait for the action to replicate to peer A (via existing register replication)
+10. Government agent on peer A picks up the assessor action, approves
+11. Credential is sealed as a recipient-addressed disclosure (Feature 106 register-native delivery)
+12. Wait for peer B's `InboundCredentialDetector` to surface the credential in the holder's MyCredentials PENDING tab
+13. Holder Accepts on peer B
+14. Accept transaction is observed on peer A (closes the loop)
+15. All milestones recorded; findings document written
+
+## Resource budget
+
+Two full Sorcha stacks. Each stack carries roughly the same resource cost as `docker-compose.yml`:
+
+- ~16 service containers per peer (32 total)
+- ~3 databases per peer (6 total: 2 postgres, 2 mongo, 2 redis)
+- Memory: estimate ~6–8 GB total under load
+- Startup time: ~60–90 seconds for both peers to be healthy
+
+This is a smoke test, not a continuous environment. Brought up for a single run, torn down after.
+
+## Cleanup
+
+`run-multi-peer.ps1` ends with:
+
+```powershell
+if (-not $KeepRunning) {
+  docker compose -f docker-compose.federation.yml down -v
+}
+```
+
+The `-KeepRunning` switch leaves both peers up so a developer can inspect them after a failed run.
+
+## Compatibility with existing docker-compose.yml
+
+The existing `docker-compose.yml` is unchanged. Single-peer demo (`run.ps1`) uses the existing compose file. Only `run-multi-peer.ps1` uses the new federation compose file. The two are mutually exclusive (you would not run both at the same time on one host).
+
+## Acceptance
+
+- `docker compose -f docker-compose.federation.yml up -d` brings both peer stacks healthy within ~90 seconds on reference hardware
+- Both peers' API gateways respond at distinct host ports (8081 / 8082)
+- A register created on peer A is observable via subscription on peer B within ~30 seconds
+- A credential issued on peer A reaches peer B's MyCredentials PENDING tab within the SC-009 latency budget under normal conditions
+- `down -v` cleanly removes all containers, volumes, and the federation network

--- a/specs/107-assured-identity-v1/contracts/driving-licence-credential.md
+++ b/specs/107-assured-identity-v1/contracts/driving-licence-credential.md
@@ -1,0 +1,86 @@
+# Contract: DrivingLicenceCredential
+
+**Feature**: 107-assured-identity-v1
+**Format**: SD-JWT VC
+
+## Identity
+
+| Property | Value |
+|---|---|
+| `vct` | `DrivingLicenceCredential` |
+| Issuer DID | `did:sorcha:org:<wallet-of-dla-org>` |
+| Holder binding | `cnf` (same wallet that holds the AssuredIdentityCredential — verified at presentation time) |
+| Expiry | 10 years (`exp = iat + P10Y`) |
+
+## Claim schema
+
+```jsonc
+{
+  "vct": "DrivingLicenceCredential",
+  "iss": "did:sorcha:org:wsYYY...",
+  "iat": 1740000000,
+  "exp": 2055000000,
+  "cnf": { "jwk": { /* holder pubkey */ } },
+
+  "licenceNumber": "DLA-2026-A7K3-001",
+  "vehicleClass": "Car (B)",
+  "issuedDate": "2026-04-20",
+  "expiryDate": "2036-04-20",
+  "holderName": "Aisling O'Brien",
+  "holderDateOfBirth": "1986-08-12",
+  "holderPortrait": "/9j/4AAQSkZJ..."   // optional, carried forward from presented identity if disclosed
+}
+```
+
+### Required vs optional claims
+
+| Claim | Required | Source |
+|---|---|---|
+| `licenceNumber` | Yes | DLA-side generated at approval (format: `DLA-{year}-{instance-suffix}-{class}`) |
+| `vehicleClass` | Yes | Submission `/vehicleClass` (enum) |
+| `issuedDate` | Yes | Today at approval |
+| `expiryDate` | Yes | `issuedDate + P10Y` |
+| `holderName` | Yes | Concatenated from presented `givenName + " " + familyName` |
+| `holderDateOfBirth` | Yes | Presented `dateOfBirth` |
+| `holderPortrait` | No | Presented `portrait` (only if the citizen elected to include their portrait in the AssuredIdentityCredential AND elected to disclose it during presentation) |
+
+## Phase 2 verification step (presentation requirement)
+
+The Driving Licence blueprint's verification action declares:
+
+```jsonc
+{
+  "credentialRequirements": [
+    {
+      "type": "AssuredIdentityCredential",
+      "presentationSource": "HaipExternalWallet",
+      "requiredClaims": [
+        { "claimName": "givenName" },
+        { "claimName": "familyName" },
+        { "claimName": "dateOfBirth" }
+      ],
+      "optionalClaims": [
+        { "claimName": "portrait" }
+      ],
+      "revocationCheckPolicy": "FailClosed",
+      "description": "Government-issued AssuredIdentityCredential — name, DoB, and optional portrait carried forward to the licence"
+    }
+  ]
+}
+```
+
+**Not requested**: `email`, `middleName`, `fullName`, `address`. These remain in the citizen's wallet and never reach the DLA.
+
+The presentation uses OpenID4VP `direct_post` with KB-JWT key binding (existing Feature 098 pipeline).
+
+## Issuance + claim flow
+
+1. Citizen submits Phase 2 starting action (open, late-bound to same wallet that holds AssuredIdentity)
+2. DLA presentation request issued; citizen consents and presents (selectively disclosing the requested claims + optional portrait)
+3. DLA officer (agent or human) reviews the **two stacked id-cards** (presented identity above, licence-to-be below) and approves
+4. Licence credential minted via HAIP OpenID4VCI; offer routed to citizen's My Actions via `outputMapping`
+5. Citizen claims via Wave 14b claim card (same dual-path as Phase 1)
+
+## Replaces
+
+`DrivingLicenceCredential` (from `walkthroughs/HaipDrivingLicence/blueprints/driving-licence.json`). The blueprint file moves to `walkthroughs/AssuredIdentity/blueprints/driving-licence.json` with the consolidated claim shape (adds `holderDateOfBirth`, `holderPortrait`).

--- a/specs/107-assured-identity-v1/contracts/portrait-claim-format.md
+++ b/specs/107-assured-identity-v1/contracts/portrait-claim-format.md
@@ -1,0 +1,86 @@
+# Contract: Portrait claim format
+
+**Feature**: 107-assured-identity-v1
+**Standards alignment**: ISO/IEC 19794-5 (token image), ISO 18013-5 (mDL portrait), ICAO Doc 9303 (composition guidance)
+
+## Token image (embedded in credential)
+
+| Property | Value |
+|---|---|
+| Dimensions | 240 × 320 pixels |
+| Aspect ratio | 3:4 (portrait orientation) |
+| Format | JPEG, sRGB colour |
+| Target raw size | ≤ 20KB |
+| Base64-encoded size | ≤ ~27KB (raw × 1.37 base64 overhead) |
+| Quality (JPEG q-factor) | Variable; resizer reduces until size target met |
+| Embedding | Base64 string as the `portrait` claim value in the SD-JWT VC |
+
+Rationale: matches ISO/IEC 19794-5 token image dimensions and the mDL precedent of embedding portraits directly in the credential rather than referencing them by URL. Offline verification works without a network round-trip.
+
+## Full-resolution original (kept on register, not embedded)
+
+| Property | Value |
+|---|---|
+| Minimum dimensions | 480 × 640 (ISO 19794-5 full frontal image floor) |
+| Maximum size | 5MB (per existing `x-file.maxSizePerFile`) |
+| Format | JPEG or PNG (per existing `x-file.accept`) |
+| Storage | Existing Feature 085 chunked-file pipeline (XChaCha20-Poly1305 encrypted at rest) |
+| Disclosure | Visible to the assessor on the review screen; not embedded in the credential |
+| Future use | Available for a real backend identity-validator service to consume for biometric matching |
+
+## Composition guidance (advisory, not enforced in v1)
+
+Rendered as a sibling panel next to the capture control when `x-file.embedAs: "image-token-jpeg-240x320"` is set:
+
+- Plain light background
+- Face centred, fills 70-80% of frame
+- Neutral expression
+- Eyes open, looking at camera
+- No sunglasses
+- No head covering (except religious)
+- Even lighting, no shadows
+
+Automated composition checking (face detection, background uniformity, quality scoring) is **deferred**. The assessor (human or agent) rejects bad photos in v1.
+
+## Resize algorithm (client-side)
+
+`PhotoTokenResizer` runs in the browser via Blazor JS interop using `<canvas>`:
+
+1. Read source file as `HTMLImageElement`
+2. Compute scale factor to fit 240×320 (cover-style: scale to fill, then centre-crop)
+3. Draw on a 240×320 `<canvas>`
+4. Export as JPEG at quality 0.85
+5. If output > 20KB raw, re-export at quality 0.75; if still > 20KB, quality 0.65; etc.
+6. Return base64 string
+
+Quality floor: 0.5. If 240×320 at quality 0.5 still exceeds 20KB (very unusual for a photo), the resizer surfaces a "photo too detailed for token" error; the citizen is prompted to retake; the credential can still be issued without the portrait if they skip.
+
+## Server-side validation (issuance)
+
+Per `ActionExecutionService`'s claim builder:
+
+- Read `/portrait/tokenImageBase64` from action payload
+- If absent → omit `portrait` claim from credential (valid)
+- If present and ≤ 27KB base64 → include claim
+- If present and > 27KB base64 → omit claim, log warning `WARN_CRED_PORTRAIT_OVERSIZE_001`, surface to citizen, credential still issued
+
+Server does not re-resize. Client is authoritative; server is the size gate.
+
+## Why a token, not the original
+
+| Concern | Token (240×320, ~20KB) | Original (480×640+, MBs) |
+|---|---|---|
+| Credential size | Stays under ~50KB total — fits comfortably in QR codes for HAIP presentation | 100KB+; QR codes become unwieldy |
+| Offline verification | Works | Works |
+| Biometric matching (future) | Sufficient for face matching at desk-check resolution | Better, but not embedded |
+| Holder selective disclosure | Single SD claim, easy to withhold | Same |
+| Privacy | Token image deliberately small — recognisable but not high-resolution; reduces re-identification risk if leaked | More privacy risk |
+
+The original on the register is what a future automated identity-validator service consumes — that service then writes its decision to the credential, not the photo.
+
+## Acceptance
+
+- A captured photo lands in the action payload as both `fullOriginalChunkIds` (chunked-file pipeline) and `tokenImageBase64` (≤27KB)
+- The issued credential's `portrait` claim contains the base64 token, no larger than the bound
+- Citizens who skip the photo receive a credential without the `portrait` claim
+- Photos that fail client-side resize (resizer floor reached) prompt the citizen to retake or skip

--- a/specs/107-assured-identity-v1/contracts/x-file-capture-extension.md
+++ b/specs/107-assured-identity-v1/contracts/x-file-capture-extension.md
@@ -1,0 +1,105 @@
+# Contract: `x-file` capture + token-resize extension
+
+**Feature**: 107-assured-identity-v1
+**Status**: Extension to existing Feature 085 schema extension
+
+## Purpose
+
+Extend the existing Feature 085 `x-file` schema extension with two new fields that let a blueprint declare a portrait-capture intent: `capture` (advise device camera) and `embedAs` (advise client-side resize for credential embedding).
+
+## Schema delta
+
+Existing `x-file` schema (Feature 085):
+
+```jsonc
+{
+  "x-file": {
+    "accept": ["image/jpeg", "image/png"],
+    "maxSizePerFile": "5MB",
+    "maxChunks": 1
+  }
+}
+```
+
+New fields added in v1:
+
+```jsonc
+{
+  "x-file": {
+    "accept": ["image/jpeg"],
+    "maxSizePerFile": "5MB",
+    "maxChunks": 1,
+    "capture": "user",
+    "embedAs": "image-token-jpeg-240x320"
+  }
+}
+```
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `capture` | enum: `user` \| `environment` \| null | no | null | `user` = front-facing (selfie), `environment` = rear. Renders `capture` HTML attribute on `<InputFile>` for mobile camera access. Null = legacy behaviour (no capture hint). |
+| `embedAs` | enum: `image-token-jpeg-240x320` \| null | no | null | When set, the renderer produces a resized token JPEG client-side alongside the full original. The token lands in the action payload as a base64 string at `<field>/tokenImageBase64`. The full original lands via the existing chunked-file pipeline. |
+
+Unknown values for either field produce a publish-time warning; the renderer falls back to legacy behaviour (no capture hint, no resize).
+
+## Renderer changes (FileRenderer.razor)
+
+When `capture` is non-null:
+- The rendered `<InputFile>` element gets a `capture` HTML attribute matching the value (`capture="user"` or `capture="environment"`)
+- On mobile devices, the device camera opens with the requested facing
+- On desktop, the file picker opens normally (capture attribute is mobile-only per HTML spec)
+
+When `embedAs` is set:
+- After the citizen picks/captures a file, the renderer invokes `PhotoTokenResizer.ResizeAsync(file, targetDimensions, qualityHint)` via Blazor JS interop
+- The resizer runs on the browser's `<canvas>` element: draws the source image, resizes proportionally to fit 240×320 (cover-style), exports as JPEG with progressive quality reduction until the result is ≤ 20KB
+- The resized token is added to the form payload at `<field>/tokenImageBase64` as a base64 string
+- The full original is uploaded via the existing chunked-file pipeline; the resulting `chunkTransactionIds` land at `<field>/fullOriginalChunkIds`
+- ICAO composition advice is rendered in a sibling panel (only when `embedAs` is set, since composition guidance is portrait-specific)
+
+## Action payload shape (after submission)
+
+Action payload field for the portrait:
+
+```jsonc
+{
+  "portrait": {
+    "fullOriginalChunkIds": ["tx-abc...", "tx-def..."],
+    "tokenImageBase64": "/9j/4AAQSkZJ...",  // ≤ 20KB raw, ≤ 27KB base64
+    "contentType": "image/jpeg",
+    "hash": "a1b2c3..."  // SHA-256 hex over the full original
+  }
+}
+```
+
+When the citizen does not provide a photo, the entire `portrait` field is absent from the payload (not present-but-empty).
+
+## Issuance-time behaviour (ActionExecutionService)
+
+The credential's `claimMappings` references the token by JSON pointer:
+
+```jsonc
+{
+  "claimName": "portrait",
+  "sourceField": "/portrait/tokenImageBase64"
+}
+```
+
+Validation at issuance time:
+- If `/portrait/tokenImageBase64` is absent: `portrait` claim is omitted from the credential (credential issued without portrait — valid v1 behaviour)
+- If `/portrait/tokenImageBase64` is present and ≤ 27KB base64: claim included
+- If `/portrait/tokenImageBase64` is present but > 27KB: claim omitted, warning surfaced (`WARN_CRED_PORTRAIT_OVERSIZE_001`); credential issued without portrait
+
+Server-side does not re-resize the image — the client is authoritative for the token. The server is the size gate.
+
+## Acceptance
+
+- A blueprint declaring `x-file: { capture: "user", embedAs: "image-token-jpeg-240x320", ... }` on a portrait field causes the renderer to default to the front-facing camera on mobile and to produce a token-image alongside the full original on submission.
+- The credential issuance path embeds `portrait` from `/portrait/tokenImageBase64` when present and within size bounds.
+- Citizens with no camera (desktop without webcam) get the file picker fallback and can still upload a photo.
+- Citizens who skip the photo entirely receive a credential without the `portrait` claim — credential is still valid.
+
+## Test surface
+
+- `FileRendererCaptureTests` — `capture` attribute propagated to `<InputFile>` correctly
+- `PhotoTokenResizerTests` — produces ≤20KB JPEG at 240×320; quality scaling logic
+- Issuance unit tests in `BuildClaimsFromMappingsTests` — token included when present + valid; omitted when absent; omitted with warning when oversize

--- a/specs/107-assured-identity-v1/contracts/x-review-extension.md
+++ b/specs/107-assured-identity-v1/contracts/x-review-extension.md
@@ -1,0 +1,163 @@
+# Contract: `x-review` schema extension + IdCardLayout
+
+**Feature**: 107-assured-identity-v1
+**Status**: Specification (implementation owned by Phase 1)
+
+## Purpose
+
+A blueprint schema extension that marks a wizard page as a **read-only review summary** of prior pages' submitted values. Renders via a parameterised layout component. Used identically for citizen-side draft review, assessor-side pending review, and (with `editable: false`) the issued credential's wallet detail view.
+
+## Schema shape
+
+Placement: as a sibling extension on a `type: object` page within a blueprint's `x-pages` list, alongside the existing `x-sections`, `x-introduction`, `x-width` extensions.
+
+```jsonc
+{
+  "type": "object",
+  "x-pages": [
+    /* ... earlier wizard pages ... */
+    {
+      "title": "Review your details",
+      "description": "What you'll receive once issued.",
+      "x-review": {
+        "layout": "id-card",
+        "editable": true,
+        "header": {
+          "issuerName": "Government of Scotland",
+          "credentialName": "Assured Identity",
+          "colourTheme": "identity-navy"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Field schema
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `layout` | enum | yes | — | One of `id-card`, `passport-page`, `tabular`, `receipt`. v1 implements only `id-card`. Unknown values produce a publish-time warning and the renderer falls back to a tabular minimal display. |
+| `editable` | bool | no | `true` | When true, the renderer generates an Edit button per detected section (sourced from prior pages' `x-sections` titles or page titles). |
+| `header.issuerName` | string | yes | — | Rendered as "Issued by &lt;issuerName&gt;" in the card header |
+| `header.credentialName` | string | yes | — | Rendered as the card type label |
+| `header.colourTheme` | enum | no | `identity-navy` | Visual variant. v1 ships `identity-navy` (Assured Identity) and `licence-pink` (Driving Licence). |
+
+## Parser changes (Sorcha.Blueprint.Models)
+
+`SchemaLayoutParser` extended to recognise `x-review` on a page and emit `XReviewExtension`:
+
+```csharp
+public sealed record XReviewExtension(
+    XReviewLayoutVariant Layout,
+    bool Editable,
+    XReviewHeader Header);
+
+public sealed record XReviewHeader(
+    string IssuerName,
+    string CredentialName,
+    XReviewColourTheme ColourTheme);
+
+public enum XReviewLayoutVariant { IdCard, PassportPage, Tabular, Receipt }
+public enum XReviewColourTheme { IdentityNavy, LicencePink }
+```
+
+Validation at parse time:
+- `header.issuerName` and `header.credentialName` must be present and non-empty
+- Unknown `layout` values logged at publish time as warning `WARN_BP_REVIEW_001` (no fail), renderer falls back
+
+## Renderer dispatch (Sorcha.UI.Core)
+
+`ControlDispatcher.razor` extended: if a page has `XReviewExtension` set, dispatch to `ReviewSummaryRenderer.razor` instead of the default form-page render path.
+
+`ReviewSummaryRenderer.razor`:
+- Reads the `XReviewExtension` from the page
+- Builds an `IdCardLayoutConfig` (see below) by pulling all submitted values from `FormContext.FormData` for fields declared on prior pages
+- Dispatches by `Layout` enum to the matching component (`IdCardLayout.razor` for `IdCard`)
+- Generates Edit-X buttons (when `Editable: true`) wired to `Wizard.NavigateToPage(pageIndex)` while preserving form state
+
+`IdCardLayout.razor` parameters:
+
+```csharp
+[Parameter] public required IdCardLayoutConfig Config { get; init; }
+[Parameter] public EventCallback<int> OnEditSection { get; set; }
+[Parameter] public RenderFragment? FooterActions { get; set; }
+```
+
+`IdCardLayoutConfig`:
+
+```csharp
+public sealed record IdCardLayoutConfig(
+    string IssuerName,
+    string CredentialName,
+    XReviewColourTheme ColourTheme,
+    IdCardWatermark Watermark,
+    IReadOnlyDictionary<string, object?> FieldValues,
+    IReadOnlyList<IdCardSection> Sections,
+    bool Editable);
+
+public enum IdCardWatermark { None, Draft, Pending, Issued }
+
+public sealed record IdCardSection(
+    string Title,
+    int OriginatingPageIndex,
+    IReadOnlyList<string> FieldPointers);
+```
+
+## State / context derivation
+
+`Watermark` is **not** specified by the extension; it is derived by the renderer from the hosting action's runtime state:
+
+| Action context | Watermark | Footer actions |
+|---|---|---|
+| Citizen on their own pre-submission review | `Draft` | Edit (per section) + Submit |
+| Assessor on a pending application | `Pending` | Approve + Reject |
+| Citizen viewing an issued credential in My Credentials | `Issued` | (none — read-only) |
+| Citizen viewing a not-yet-issued credential offer | `None` | (none — preview only) |
+
+Footer actions come from the hosting action's `routes` (existing blueprint pattern) — the extension does not redeclare them.
+
+## Two-card stacked variant
+
+For credential-chain workflows (e.g. DLA review of presented identity + licence-to-be), a single `x-review` extension on a single page can produce two stacked cards. The renderer detects this when the page also declares a `credentialRequirements` block (presented credential) AND a `credentialIssuanceConfig` block (credential-to-be):
+
+- Top card: presented credential (claims pulled from the verified presentation context, withheld claims rendered as faded "— — —" with explanatory caption)
+- Bottom card: credential-to-be (claims pulled from the action payload + the action's `credentialIssuanceConfig.claimMappings`)
+- Each card uses its own `IdCardLayoutConfig`. Top card's theme defaults to `identity-navy` (verified state badge); bottom card uses the theme declared in `header.colourTheme` (e.g. `licence-pink` for the licence).
+
+## CSS theming
+
+Each `colourTheme` is a CSS custom-property set applied to the `IdCardLayout` root:
+
+```css
+.id-card[data-theme="identity-navy"] {
+  --card-bg-start: #0b2545;
+  --card-bg-mid: #13315c;
+  --card-bg-end: #1b4b7a;
+  --card-accent: #d4a017;
+  --card-label: #a8c5e6;
+}
+.id-card[data-theme="licence-pink"] {
+  --card-bg-start: #6d1b3c;
+  --card-bg-mid: #8e2350;
+  --card-bg-end: #ad2c63;
+  --card-accent: #ffe5b4;
+  --card-label: #f5c2d6;
+}
+```
+
+Adding a new theme = adding one CSS block + one enum value.
+
+## Acceptance
+
+- A blueprint declaring `x-review: { layout: "id-card", editable: true, header: {...} }` on a page renders that page as a read-only ID card with all prior pages' values populated.
+- Edit buttons (when `editable: true`) navigate to the originating page with form state intact.
+- Same component renders Citizen draft (Draft watermark + Edit/Submit), Assessor pending (Pending watermark + Approve/Reject), and Wallet detail (Issued/no watermark + no actions).
+- Two-card stacked variant produces presented + credential-to-be on a single review page when the action declares both `credentialRequirements` and `credentialIssuanceConfig`.
+
+## Test surface
+
+- `XReviewExtensionParserTests` — parses valid extensions; warns on unknown layout; rejects missing required fields
+- `ReviewSummaryRendererTests` — dispatches by layout; pulls correct values; Edit buttons fire correct page index
+- `IdCardLayoutTests` — applies correct CSS theme by enum; renders watermark per state; renders footer actions
+- `ReviewSummaryDataSourceTests` — pulls field values from FormContext for prior-page fields only

--- a/specs/107-assured-identity-v1/data-model.md
+++ b/specs/107-assured-identity-v1/data-model.md
@@ -1,0 +1,173 @@
+# Data Model: Assured Identity v1
+
+**Feature**: 107-assured-identity-v1
+**Date**: 2026-04-20
+
+## Scope
+
+This document defines the entities, fields, relationships, validation rules, and state transitions introduced or modified by this feature. Entities that already exist in the platform (Blueprint, Action, Participant, Instance, Wallet, Persona) are referenced rather than redefined.
+
+## Credential types
+
+### AssuredIdentityCredential
+
+The canonical person-identity credential issued by a government (or equivalent) organisation to a late-bound citizen applicant.
+
+| Claim | Type | Required | Selectively disclosable | Source on issue |
+|---|---|---|---|---|
+| `givenName` | string | Yes | Yes | Submission payload `/name/givenName` |
+| `middleName` | string | No | Yes | Submission payload `/name/middleName` |
+| `familyName` | string | Yes | Yes | Submission payload `/name/familyName` |
+| `fullName` | string | Yes (derived) | Yes | Renderer-derived from given + middle + family; included in payload |
+| `dateOfBirth` | string (ISO 8601 date) | Yes | Yes | Submission payload `/dateOfBirth` |
+| `email` | string (RFC 5322) | Yes | Yes | Submission payload `/email` |
+| `address` | object (see below) | Yes | Yes (whole object) | Submission payload `/address` |
+| `portrait` | string (base64 JPEG) | No | Yes | Submission payload `/portrait/tokenImageBase64` (only if citizen provided a photo and token size ≤ 20KB) |
+
+**Address sub-object shape**:
+
+| Field | Type | Required | Selectively disclosable within address |
+|---|---|---|---|
+| `line1` | string | Yes | — |
+| `line2` | string | No | — |
+| `town` | string | Yes | — |
+| `region` | string | No | — |
+| `postcode` | string | Yes | — |
+| `country` | string (ISO 3166-1 alpha-2) | Yes | — |
+
+The address is disclosed or withheld as a unit in v1. Sub-field selective disclosure is out of scope (noted in spec).
+
+**Issuer**: `did:sorcha:org:<wallet-of-issuing-org>` (existing DID scheme).
+**Expiry**: None. Identity credentials do not expire in v1; revocation uses the existing Feature 079 revocation-transaction pipeline.
+**Format**: SD-JWT VC.
+**Key binding**: Holder's wallet key (`cnf` claim), per standard HAIP pattern.
+
+**State transitions** (per existing credential lifecycle; this feature adds no new states):
+- Issued → Active (on holder accept, per Feature 106 for register-native or standard OpenID4VCI for HAIP external)
+- Active → Revoked (via Feature 079 revocation transaction)
+
+**Replaces**: `VerifiedCitizenCredential` (schema-first type from `walkthroughs/HaipVerifiedCitizen/blueprints/verified-citizen.json`) and `AssuredPersonCredential` (from `walkthroughs/HaipVerifiedCitizen/blueprints/assured-person.json`). Both are removed in Phase 7.
+
+### DrivingLicenceCredential
+
+Issued by the Driver Licensing Authority (DLA) after verification of a presented `AssuredIdentityCredential`.
+
+| Claim | Type | Required | Selectively disclosable | Source on issue |
+|---|---|---|---|---|
+| `licenceNumber` | string | Yes | Yes | Issuing-side generated at approval time |
+| `vehicleClass` | string (enum: `Car (B)`, `Motorcycle (A)`, `Lorry (C)`, `Bus (D)`) | Yes | Yes | Submission payload `/vehicleClass` |
+| `issuedDate` | string (ISO 8601 date) | Yes | Yes | Issuing-side generated (today at approval) |
+| `expiryDate` | string (ISO 8601 date) | Yes | Yes | `issuedDate` + 10 years |
+| `holderName` | string | Yes | Yes | Carried forward from presented Assured Identity claim `givenName + familyName` |
+| `holderDateOfBirth` | string | Yes | Yes | Carried forward from presented Assured Identity claim `dateOfBirth` |
+| `holderPortrait` | string (base64 JPEG, ≤20KB) | No | Yes | Carried forward from presented Assured Identity `portrait` claim (if the citizen elected to disclose it) |
+
+**Issuer**: `did:sorcha:org:<wallet-of-dla-org>`.
+**Expiry**: 10 years (`P10Y` on the credential).
+**Format**: SD-JWT VC.
+**Key binding**: Holder's wallet key (same wallet that presented the Assured Identity).
+
+**Presentation requirement on Phase 2's verification action**:
+- Credential type: `AssuredIdentityCredential`
+- Required claims: `givenName`, `familyName`, `dateOfBirth`, `portrait` (if the citizen chose to include it in their Assured Identity)
+- Not requested: `email`, `address`, `middleName`, `fullName`
+- Revocation check policy: `FailClosed`
+
+## Schema extensions
+
+### XReviewExtension
+
+A new blueprint schema extension marking a wizard page as a read-only review summary of prior pages' values.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `layout` | enum: `id-card` \| `passport-page` \| `tabular` \| `receipt` | Yes | v1 implements only `id-card`; other values are reserved enum placeholders. Unknown values surface as a publish-time warning, renderer falls back to tabular minimal rendering. |
+| `editable` | bool | No (default `true`) | When `true`, the renderer generates Edit-X buttons per section. When `false`, the review page is pure display (useful for issued-credential detail views). |
+| `header` | object | Yes | Card header config |
+| `header.issuerName` | string | Yes | e.g. "Government of Scotland" |
+| `header.credentialName` | string | Yes | e.g. "Assured Identity" |
+| `header.colourTheme` | enum: `identity-navy` \| `licence-pink` \| custom | No (default `identity-navy`) | Drives the CSS custom-property set on the card root |
+
+**Placement**: on a `type: object` page within a blueprint's `x-pages` list, alongside `x-sections` / `x-introduction` / `x-width`.
+
+**Parsed by**: `Sorcha.Blueprint.Models.SchemaLayoutParser` (existing parser, extended to recognise `x-review`).
+
+**Rendered by**: `Sorcha.UI.Core.Components.Forms.ReviewSummaryRenderer` (new) which dispatches by `layout` to the matching layout component (`IdCardLayout.razor` in v1).
+
+**Semantics**:
+- Page is read-only — no form state mutation
+- Field values sourced from the bound `FormContext.FormData` keyed by pointer
+- When `editable: true`, clicking an Edit-X button navigates the wizard back to the originating page with all prior data preserved (bound model intact)
+- Rendered identically for citizen-side draft review and issuer-side pending review; action set (Submit/Edit vs Approve/Reject) derived from the hosting action's routes, not from the extension
+
+### XFileCaptureConfig (extension to existing XFileExtension)
+
+Adds camera-capture and token-resize fields to the existing Feature 085 `x-file` schema extension.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `capture` | enum: `user` \| `environment` \| null | No | Advises the renderer to default the device camera on mobile. `user` = front-facing (selfie), `environment` = rear. null = legacy (plain file picker). |
+| `embedAs` | enum: `image-token-jpeg-240x320` \| null | No | Advises the renderer to produce a resized token JPEG client-side alongside the full original. null = no resize; legacy behaviour. |
+
+**Existing fields unchanged**: `accept`, `maxSizePerFile`, `maxChunks`.
+
+## Runtime entities (UI-side)
+
+### IdCardLayoutConfig
+
+Runtime record passed to `IdCardLayout.razor`. Built by `ReviewSummaryRenderer` from the parsed `XReviewExtension` plus the form context.
+
+| Field | Type | Source |
+|---|---|---|
+| `IssuerName` | string | `XReviewExtension.Header.IssuerName` |
+| `CredentialName` | string | `XReviewExtension.Header.CredentialName` |
+| `ColourTheme` | enum | `XReviewExtension.Header.ColourTheme` (default `identity-navy`) |
+| `Watermark` | enum: `Draft` \| `Pending` \| `Issued` \| null | Derived from action state (Draft on citizen's pre-submit review; Pending on assessor's review; Issued or null on wallet detail view) |
+| `FieldValues` | `IDictionary<string, object?>` | Pulled from `FormContext.FormData` for fields referenced across prior pages |
+| `Editable` | bool | `XReviewExtension.Editable` |
+| `EditJumpTargets` | `IDictionary<string, int>` | Map of section label → originating page index (for Edit-X button navigation) |
+
+### Portrait (payload field value)
+
+The runtime representation of a captured photo in the action payload.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `FullOriginalChunkIds` | `IReadOnlyList<string>` | Yes (if photo provided) | Transaction IDs from the existing Feature 085 chunked-file upload pipeline; carries the original-resolution JPEG |
+| `TokenImageBase64` | string | Yes (if photo provided) | Client-side-resized 240×320 JPEG, base64-encoded. Must be ≤ ~20KB. |
+| `ContentType` | string | Yes (if photo provided) | `image/jpeg` in v1 |
+| `Hash` | string (hex SHA-256) | Yes (if photo provided) | Computed client-side over the full original; propagated with chunk metadata for integrity |
+
+**Validation rules**:
+- `TokenImageBase64` length MUST be ≤ ~27KB (20KB raw × 1.37 base64 overhead)
+- If `TokenImageBase64` exceeds the bound, the issuance-time claim builder refuses to include `portrait` in the credential and surfaces a warning; the credential is still issued without the portrait claim
+- The full original MUST pass the existing Feature 085 file-chunks pipeline validations (accept list, size, encryption)
+
+## Cross-peer smoke-test artefact
+
+### CrossPeerFindings
+
+The markdown document produced by `run-multi-peer.ps1` on every run.
+
+| Section | Content |
+|---|---|
+| Frontmatter (YAML) | `run_timestamp`, `peer_a_version`, `peer_b_version`, `outcome` (enum: `pass` \| `degraded-pass` \| `fail` \| `env-failure`) |
+| Topology | Description of the two-peer configuration used, register id, org DIDs |
+| Timings | Per-step milestone timings: issue on peer A → docket seal → peer-B inbound detection → peer-B MyCredentials PENDING → holder Accept |
+| Anomalies | Any unexpected behaviour observed (slow detection, partial replication, UI inconsistencies) |
+| Reproduction notes | Commands used, environment variables, any manual intervention needed |
+
+**Storage**: one committed baseline document `walkthroughs/AssuredIdentity/multi-peer-findings.md` representing the latest known-good run; a rolling per-run set gitignored in the same directory.
+
+## Persistent data changes
+
+**None at the persistence layer.** This feature adds no new database entities, no new tables, no new collections, no new Redis keys. Every piece of data flows through existing persistence (Feature 085 file chunks, Feature 106 sealed disclosures, Feature 103 schema index, Feature 092 persona profile).
+
+## Deletions
+
+Deleted in Phase 7:
+
+- `walkthroughs/HaipVerifiedCitizen/` — entire directory
+- `walkthroughs/HaipDrivingLicence/` — entire directory
+- `VerifiedCitizenCredential` (credential type name) — no live references in code; schema-first type, removed by deleting the blueprints that declared it
+- `AssuredPersonCredential` (credential type name) — same as above

--- a/specs/107-assured-identity-v1/plan.md
+++ b/specs/107-assured-identity-v1/plan.md
@@ -1,0 +1,283 @@
+# Implementation Plan: Assured Identity v1
+
+**Branch**: `107-assured-identity-v1` | **Date**: 2026-04-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/107-assured-identity-v1/spec.md`
+**Design**: [`docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md`](../../docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md)
+
+## Summary
+
+Deliver a single feature in **seven sequenced phases** that consolidate the platform's "verified person" story into one canonical `AssuredIdentityCredential` and one canonical `walkthroughs/AssuredIdentity/`, remove the `VerifiedCitizenCredential` / `AssuredPersonCredential` / `HaipVerifiedCitizen` / `HaipDrivingLicence` duplication, and substantially polish the citizen-facing form experience.
+
+The feature is **mostly new blueprint JSON, a new Blazor renderer extension, and walkthrough plumbing** — not new platform services. The renderer sits inside `Sorcha.UI.Core` and adds three reusable capabilities (DoB future-block via existing `SorchaDateTokenResolver`, photo capture dispatch with client-side token-image resize, the new `x-review` schema extension with a parameterised id-card layout). The two new blueprints consume Feature 103's shared identity primitives via `$ref` and Feature 104's Wave 14b credential claim action. The two new walkthroughs are a single consolidated walkthrough with phase scripts. The cross-peer smoke test is a new `docker-compose.federation.yml` plus a PowerShell driver that runs Phase 1 across two peer stacks and writes a findings markdown.
+
+**No new microservice, no new database technology, no new schema registry.** Every new piece sits inside an existing platform pattern: the `x-review` extension mirrors the existing `x-credential-offer` Wave 14b extension shape; the id-card component is a MudBlazor Razor component like every other in `Sorcha.UI.Core/Components`; the walkthrough structure mirrors `HaipVerifiedCitizen/` and `HaipDrivingLicence/` (which it replaces). The legacy artefacts are deleted in the final phase so that earlier phases can continue to build against them until they are superseded.
+
+## Technical Context
+
+**Language/Version**: C# 13 / .NET 10; Razor for Blazor WASM UI; JSON for blueprint and schema authoring; PowerShell 7.5+ for walkthrough scripts
+**Primary Dependencies**: .NET Aspire 13.0, ASP.NET Core, MudBlazor, JsonSchema.Net 7.4, `Sorcha.Cryptography` (XChaCha20-Poly1305 + HKDF for file chunks), NBitcoin (HD wallet), StackExchange.Redis (SignalR backplane + inbound notifications), OpenTelemetry 1.12; browser `MediaDevices.getUserMedia` via Blazor JS interop for camera capture; `<canvas>` via Blazor JS interop for client-side image resize
+**Storage**: Existing only — PostgreSQL (Tenant Service persona), MongoDB (Blueprint Service instance store, sealed disclosures), Redis (SignalR backplane, inbound credential detection). Photo evidence is stored via the existing Feature 085 file-chunks path (no new storage). No schema registry beyond Feature 103's `blueprints/schemas/sorcha-core/`
+**Testing**: xUnit + FluentAssertions + Moq for unit & integration; walkthrough scripts themselves are the primary E2E proof (Playwright E2E deferred per spec assumption)
+**Target Platform**: Linux containers via Docker Compose (single-peer and two-peer variants); Blazor WASM client in modern browsers with camera access; Windows / Linux / macOS dev hosts; n1.sorcha.dev reference deployment
+**Project Type**: Web — multi-service backend (microservices + API Gateway via YARP) plus Blazor WASM frontend. This feature does not add or remove a microservice
+**Performance Goals**:
+- Citizen form completion end-to-end: under 3 minutes with populated persona (SC-001)
+- Photo client-side resize to 240×320 token: under 2 seconds on a modest mobile device
+- Review summary card render: under 500ms after navigation to page 5
+- Agent-based assessor approval: under 30 seconds from submission to approved (SC-008)
+- Cross-peer credential delivery: under 30 seconds from issue on peer A to pending-acceptance on peer B (SC-009)
+- Driving Licence phase end-to-end: under 2 minutes from first form view to claim notification (SC-002)
+**Constraints**:
+- Photo size embedded in credential MUST stay within the token-image target (~20KB) regardless of the captured original's size — client-side resize is authoritative and the server-side issuance path MUST reject claim inclusion if the token exceeds the target
+- Citizen participant on both blueprints' starting actions MUST remain `walletAddress: null` at publish time; the Feature 103 `VAL_BP_010` guardrail MUST continue to enforce this and MUST NOT be weakened
+- The `x-review` extension MUST produce a read-only presentation — no form state mutation on the review page
+- Both walkthroughs MUST complete without requiring a human to open any assessor UI (agent-driven), but the human-facing assessor UI MUST remain functional for manual override
+- Cross-peer smoke test MUST NOT block release on any replication failure it surfaces; failures become findings, not gates
+- Legacy deletion (Phase 7) MUST land last so that Phases 1–6 can validate against the existing walkthroughs until their replacement is proven
+**Scale/Scope**:
+- 3 modified / new renderer components (`DateTimeRenderer`, `FileRenderer`, `ReviewSummaryRenderer`) plus `IdCardLayout.razor` — ~600 LOC total
+- 2 new blueprint JSON files (`assured-identity.json`, `driving-licence.json`) — ~400 LOC combined
+- 3 new actor JSON files + 5 walkthrough PowerShell scripts — ~800 LOC
+- 1 new `docker-compose.federation.yml` — ~200 LOC
+- 2 deleted walkthrough directories (`HaipVerifiedCitizen/` and `HaipDrivingLicence/`) — ~3000 LOC removed
+- ~1400 LOC unit / integration / walkthrough-functional tests across the feature
+- 7 pull requests (one per phase)
+- Touches: `Sorcha.UI.Core` (renderer), `Sorcha.Blueprint.Models` (extension parser), `walkthroughs/` (new + deletes), root (docker-compose.federation.yml)
+
+## Constitution Check
+
+Evaluating this plan against `.specify/memory/constitution.md`. Re-evaluation after Phase 1 design at the bottom of this section.
+
+| Principle | Status | Notes |
+|---|---|---|
+| **I. Microservices-First** | ✅ Pass | No new microservice. All renderer changes in `Sorcha.UI.Core`. Extension parser in `Sorcha.Blueprint.Models`. Walkthrough artefacts are not services. No upward dependencies introduced (UI → Blueprint Models is already the existing dependency direction). |
+| **II. Security First** | ✅ Pass with notes | Photo upload is a new class of user input — mitigated by (a) client-side size bounds, (b) server-side size validation in the existing file-chunks pipeline, (c) content-type validation via the existing `x-file.accept` schema extension, (d) the photo full-original lives inside the existing sealed-disclosure file-chunks path (encrypted at rest via Feature 085 XChaCha20-Poly1305). Cross-peer smoke test does not weaken any existing security posture. Open citizen submission uses the public-org JWT floor (Feature 103 contract preserved). `VAL_BP_010` publish guardrail preserved. No secrets introduced in any walkthrough script. |
+| **III. API Documentation** | ✅ Pass | **No new HTTP endpoints in this feature.** All platform interaction reuses existing documented endpoints: action execution (Feature 018), file chunks (Feature 085), HAIP offers (Feature 097), HAIP presentations (Feature 098), credential claim (Feature 104), sealed disclosures (Feature 106). The `x-review` and `x-file` schema extensions are documented in `contracts/` as schema-level contracts. |
+| **IV. Testing Requirements** | ✅ Pass | Each phase ships with unit tests for new renderer components (xUnit + FluentAssertions + Moq), extension parser tests, schema validation tests, and walkthrough-functional tests (PowerShell scripts asserting state transitions). Coverage target ≥ 85% for new UI code (constitution baseline 80%). Playwright screenshots deferred per explicit spec assumption (user will add "when I need them"). |
+| **V. Code Quality** | ✅ Pass | All new C# targets net10.0 with nullable reference types enabled. Async/await for all I/O. DI for all injected services. License header on every new file. No compiler warnings. |
+| **VI. Blueprint Creation Standards** | ✅ Pass | Both blueprints ship as JSON files. Identity primitives consumed via `$ref` from Feature 103's `blueprints/schemas/sorcha-core/`. The `x-review` extension is declared in blueprint JSON, not in C# code. No fluent-API additions. |
+| **VII. Domain-Driven Design** | ✅ Pass | Uses the established vocabulary: Blueprint, Action, Participant, Disclosure, Claim, Credential, Presentation, Issuance. Adds three new ubiquitous terms, all user-facing and all aligned with existing language: **Assured Identity** (the credential and the workflow), **Review Summary** / **ID Card Layout** (the new review pattern), **Validator Agent** (the sorcha-agent role filling the assessor seat). |
+| **VIII. Observability by Default** | ✅ Pass | Renderer changes emit client-side telemetry via the existing Blazor telemetry pipeline (no new instrumentation surface). Photo resize + upload reuses the Feature 085 file-chunks path which already emits OpenTelemetry spans. Walkthrough scripts emit structured log lines via the shared module. Cross-peer smoke test's findings document is itself a form of machine-readable observability record. |
+
+**No constitution violations.** No entries in the Complexity Tracking section.
+
+### Re-evaluation after Phase 1 design
+
+Phase 1 design produces no new architectural surfaces. The `x-review` extension mirrors the `x-credential-offer` Wave 14b extension exactly in shape and dispatch model. The id-card component is a parameterised MudBlazor component like every other in `Sorcha.UI.Core/Components`. The cross-peer smoke test is a new docker-compose file and a PowerShell driver — neither introduces a new subsystem. Constitution check confirmed unchanged. ✅
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/107-assured-identity-v1/
+├── plan.md                         # This file
+├── spec.md                         # Feature specification (committed)
+├── research.md                     # Phase 0 — design decisions distilled (links to design spec)
+├── data-model.md                   # Phase 1 — entities and shapes
+├── quickstart.md                   # Phase 1 — developer onboarding
+├── contracts/                      # Phase 1 — schema-extension and file-format contracts
+│   ├── x-review-extension.md       # New schema extension format
+│   ├── x-file-capture-extension.md # Camera-capture + token-resize schema extension
+│   ├── id-card-layout-config.md    # Colour theme / header / palette parameters
+│   ├── assured-identity-credential.md   # Claim list and SD-JWT shape
+│   ├── driving-licence-credential.md    # Claim list and SD-JWT shape
+│   ├── portrait-claim-format.md    # Token-image dimensions, JPEG bounds, ISO 19794-5 alignment
+│   ├── cross-peer-findings-format.md    # Multi-peer smoke test findings document shape
+│   └── docker-compose-federation.md     # Two-peer stack topology
+└── checklists/
+    └── requirements.md             # Spec quality checklist (committed)
+```
+
+### Source Code (repository root)
+
+This feature touches **existing UI, Blueprint Models, and walkthroughs**. No new top-level projects. Concrete paths:
+
+```text
+src/
+├── Apps/
+│   └── Sorcha.UI/
+│       └── Sorcha.UI.Core/
+│           ├── Components/Forms/
+│           │   ├── DateTimeRenderer.razor                    # MOD: wire SorchaDateTokenResolver for formatMin/Max client-side
+│           │   ├── FileRenderer.razor                        # MOD: capture attr, front-camera default, client-side token-image resize
+│           │   ├── ReviewSummaryRenderer.razor               # NEW: dispatch by x-review.layout; iterate prior-page values
+│           │   ├── Layouts/
+│           │   │   └── IdCardLayout.razor                    # NEW: styled credential-card layout, parameterised theme
+│           │   ├── ControlDispatcher.razor                   # MOD: dispatch x-review pages to ReviewSummaryRenderer
+│           │   └── SorchaFormRenderer.razor                  # MOD: treat x-review pages as read-only; wire Edit-X navigation
+│           └── Services/Forms/
+│               ├── PhotoTokenResizer.cs                      # NEW: client-side resize via JS interop, returns token-sized JPEG
+│               └── ReviewSummaryDataSource.cs                # NEW: reads prior-page values from FormContext for review render
+│
+├── Common/
+│   ├── Sorcha.Blueprint.Models/
+│   │   ├── SchemaLayoutParser.cs                             # MOD: parse x-review extension alongside x-pages/x-sections
+│   │   ├── XReviewExtension.cs                               # NEW: model for { layout, editable, header }
+│   │   ├── XFileExtension.cs                                 # MOD: add capture + embedAs fields
+│   │   └── XReviewLayoutVariant.cs                           # NEW: enum { IdCard, Tabular?, PassportPage? } — only IdCard implemented in v1
+│   └── Sorcha.Validator.Core/
+│       └── Tokens/
+│           └── SorchaDateTokenResolver.cs                    # (already exists from Feature 103 — unchanged here; wired by DateTimeRenderer in this feature)
+
+blueprints/
+└── schemas/
+    └── sorcha-core/                                           # (already exists from Feature 103 — unchanged here)
+        ├── PersonName.v1.json
+        ├── DateOfBirth.v1.json
+        ├── EmailAddress.v1.json
+        └── PostalAddress.v1.json
+
+walkthroughs/
+├── AssuredIdentity/                                           # NEW consolidated walkthrough directory
+│   ├── README.md
+│   ├── setup.ps1                                             # Provisions Gov + DLA orgs, citizen wallet, both blueprints (idempotent)
+│   ├── run.ps1                                               # Runs Phase 1 + Phase 2 end-to-end (single peer, HAIP delivery path)
+│   ├── run-phase1-identity.ps1                               # Just Phase 1 (citizen → AssuredIdentity)
+│   ├── run-phase2-licence.ps1                                # Just Phase 2 (citizen → DLA → DrivingLicence)
+│   ├── run-multi-peer.ps1                                    # Phase 1 across two peers, register-native delivery, findings-writing smoke test
+│   ├── blueprints/
+│   │   ├── assured-identity.json                             # Replaces verified-citizen.json + assured-person.json
+│   │   └── driving-licence.json                              # Replaces HaipDrivingLicence/blueprints/driving-licence.json
+│   ├── actors/
+│   │   ├── citizen.json                                      # Filesystem HAIP wallet-dir; receives + presents
+│   │   ├── gov-assessor.json                                 # Rules-mode, approves identity
+│   │   └── dla-officer.json                                  # Rules-mode, approves licence
+│   ├── data/
+│   │   └── sample-portrait.jpg                               # ICAO-compliant test photo
+│   └── multi-peer-findings.md                                # Produced per run of run-multi-peer.ps1 (gitignored; one committed baseline)
+├── HaipVerifiedCitizen/                                       # DELETED entirely in Phase 7
+├── HaipDrivingLicence/                                        # DELETED entirely in Phase 7
+└── HaipIdentityAttestation/                                   # KEPT — different scope (proves bare CLI)
+
+docker-compose.federation.yml                                  # NEW: two-peer compose for run-multi-peer.ps1 (peer-a, peer-b, shared docker network)
+
+tests/
+├── Sorcha.UI.Core.Tests/
+│   ├── Components/Forms/
+│   │   ├── DateTimeRendererFutureBlockTests.cs               # NEW: formatMaximum: "today" blocks future dates
+│   │   ├── FileRendererCaptureTests.cs                       # NEW: capture attr propagation, resize invocation
+│   │   ├── PhotoTokenResizerTests.cs                         # NEW: resize produces ≤20KB JPEG at 240×320
+│   │   └── ReviewSummaryRendererTests.cs                     # NEW: reads FormContext, renders id-card, Edit-X buttons nav correctly
+│   └── Services/Forms/
+│       └── ReviewSummaryDataSourceTests.cs                   # NEW: pulls correct values from prior pages
+├── Sorcha.Blueprint.Models.Tests/
+│   └── XReviewExtensionParserTests.cs                        # NEW: x-review schema extension parses with layout, editable, header
+└── walkthroughs/AssuredIdentity/
+    └── tests/                                                 # (Functional assertions live inside the walkthrough scripts themselves, as in TradeFinance/SelfBuildHouse)
+```
+
+**Structure Decision**: No new top-level applications, no new microservices, no new database technologies. The feature fits entirely inside existing patterns: the renderer changes live in `Sorcha.UI.Core`, schema extensions in `Sorcha.Blueprint.Models`, blueprints and walkthroughs under `walkthroughs/AssuredIdentity/`, and the cross-peer topology as `docker-compose.federation.yml` at the repository root alongside the existing `docker-compose.yml`. Legacy walkthrough directories `HaipVerifiedCitizen/` and `HaipDrivingLicence/` are deleted in Phase 7 after Phases 1–6 have been proven against them.
+
+## Phase 0: Outline & Research
+
+### Why this is light
+
+Every design unknown was resolved in the brainstorming session and is documented in [`docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md`](../../docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md) with rationale and rejected alternatives. Phase 0 of this plan is an *index* into that resolution work, not a fresh research pass.
+
+The full research artifact is generated as `research.md` and contains:
+- The seven design decisions (credential type naming, delivery mode, photo-as-embedded-claim, 5-page GDS wizard, id-card review pattern, validator-hook-as-agent, cross-peer measure-not-gate), each in the standard Decision / Rationale / Alternatives format
+- File:line citations from the existing codebase that prove the substrate is present (`SorchaDateTokenResolver.cs:37-120`, `FileReferenceField.razor:36-56`, `PersonaAutofillResolver.cs:42-359`, `ActionExecutionService.cs:496-617` for the sealed-disclosure path, `InboundCredentialDetector.cs` for the peer-B receive path)
+- The pattern each new piece mirrors (`x-credential-offer` Wave 14b → `x-review`; existing MudBlazor components → `IdCardLayout`; existing walkthrough scripts → consolidated `AssuredIdentity/` scripts)
+- The two open planning questions resolved by informed-default (which delivery path `run.ps1` exercises — HAIP external, because Phase 2 needs a filesystem wallet; whether photo quality checks are automated — no, deferred to future validator integration)
+
+### NEEDS CLARIFICATION markers
+
+**None.** All design questions resolved during brainstorming. Tactical questions resolved during specification authoring (which delivery path the primary walkthrough uses; whether the x-review extension supports multiple layout variants in v1; whether photo composition is auto-checked) are captured as informed defaults in the spec's Assumptions section, with rationale in `research.md`.
+
+## Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete (this section produces it alongside `data-model.md`, `contracts/`, `quickstart.md`).
+
+### Contracts (in `contracts/`)
+
+1. **`x-review-extension.md`** — The new schema extension format:
+   - Placement: on a `type: object` page within a schema's `x-pages` list, as a sibling extension alongside `x-sections` / `x-introduction` / `x-width`
+   - Shape: `{ layout: "id-card", editable: bool, header: { issuerName: string, credentialName: string } }`
+   - Semantics: the page is rendered read-only; field values come from prior pages in the same action's submission model; when `editable: true`, the renderer generates per-section Edit-X buttons that navigate back to the originating page with data preserved
+   - Future variants reserved: `layout: "passport-page" | "tabular" | "receipt"` — not implemented in v1
+
+2. **`x-file-capture-extension.md`** — Extension to the existing `x-file` schema extension (from Feature 085):
+   - New optional field: `capture: "user" | "environment" | null` — advises front-facing camera (user) or rear-facing (environment) on mobile; null is legacy behaviour (plain file picker)
+   - New optional field: `embedAs: "image-token-jpeg-240x320" | null` — advises the renderer to produce a resized token alongside the full original; null disables resize
+   - Semantics: the form submission carries both the full-resolution file (via the existing chunked-file pipeline) and the small token as a separate base64 field on the action payload; the credential claim mapping references the token field by JSON pointer
+
+3. **`id-card-layout-config.md`** — Parameters for `IdCardLayout.razor`:
+   - `issuerName: string` — rendered in the card header ("Issued by …")
+   - `credentialName: string` — rendered as the card's displayed credential type
+   - `colourTheme: "identity-navy" | "licence-pink" | custom` — CSS custom property set; v1 ships two themes
+   - `watermark: "draft" | "pending" | "issued" | null` — drives the watermark rendering and the accent colour
+   - `actions: enum` — derived from the hosting action's routes (Submit / Edit / Approve / Reject); not specified in the extension itself
+
+4. **`assured-identity-credential.md`** — Claim list and SD-JWT VC profile:
+   - Credential type: `AssuredIdentityCredential`
+   - Claims: `givenName`, `middleName?`, `familyName`, `fullName` (derived), `dateOfBirth`, `email`, `address` (structured: `line1`, `line2?`, `town`, `region?`, `postcode`, `country`), `portrait?`
+   - Every claim selectively disclosable
+   - Issuer: `did:sorcha:org:<wallet-of-issuing-org>` (per existing DID scheme)
+   - Expiry: none (identity credentials do not expire in v1; revocation via the existing Feature 079 revocation transactions)
+
+5. **`driving-licence-credential.md`** — Claim list and SD-JWT VC profile:
+   - Credential type: `DrivingLicenceCredential`
+   - Claims: `licenceNumber`, `vehicleClass`, `issuedDate`, `expiryDate`, `holderName`, `holderDateOfBirth`, `holderPortrait?`
+   - Every claim selectively disclosable
+   - Issuer: `did:sorcha:org:<wallet-of-dla-org>`
+   - Expiry: 10 years (`P10Y`)
+   - Presentation requirement on Phase 2's verification action: `AssuredIdentityCredential` disclosing `givenName`, `familyName`, `dateOfBirth`, `portrait`
+
+6. **`portrait-claim-format.md`** — Portrait claim technical shape:
+   - Token-image dimensions: 240×320 (aligned with ISO/IEC 19794-5 token image)
+   - Format: JPEG, sRGB colour, quality tuned for ≤20KB final size
+   - Embedding: base64 string value of the claim (per SD-JWT convention for binary)
+   - Full-resolution original: stored via existing file-chunks pipeline, linked from the action payload, NOT embedded in the credential
+   - Issuance path: the issuance step reads the token from the action payload, validates size bounds, base64-encodes into the claim; rejects claim inclusion if the token exceeds bounds (credential issued without portrait)
+
+7. **`cross-peer-findings-format.md`** — The markdown shape of `multi-peer-findings.md`:
+   - YAML frontmatter: `run_timestamp`, `peer_a_version`, `peer_b_version`, `outcome: pass | degraded-pass | fail | env-failure`
+   - Body sections: Topology, Timings (issue → docket seal → peer-B detection → peer-B MyCredentials PENDING tab → holder Accept), Anomalies, Reproduction notes
+   - Convention: one committed baseline representing the latest known-good state, plus a gitignored rolling set produced per run
+
+8. **`docker-compose-federation.md`** — Topology for the two-peer stack:
+   - Two full Sorcha stacks (peer-a and peer-b), each with its own Blueprint / Register / Validator / Wallet / Tenant / Peer / API Gateway / DB set
+   - Shared Docker network; peers discover each other via static seed configuration
+   - Single shared test register subscribed by both peers at setup time
+   - No cross-peer auth shortcuts; both peers use their own trust anchors
+
+### Data Model (in `data-model.md`)
+
+Entities, fields, relationships, and (where applicable) state transitions:
+
+- **AssuredIdentityCredential** — SD-JWT VC; claims listed above; issuer is the government org's DID; holder is the citizen's wallet (bound by Phase 1's open starting action's late-binding); disclosure envelope follows the Feature 106 register-native pattern when delivery is register-native, or the Feature 097 OpenID4VCI pre-auth code pattern when delivery is HAIP external
+- **DrivingLicenceCredential** — SD-JWT VC; claims listed above; issuer is the DLA org's DID; holder is the citizen's wallet (same wallet as the identity)
+- **XReviewExtension** — blueprint-model-side record of the parsed extension: `Layout` (enum), `Editable` (bool), `Header` (IssuerName, CredentialName). Attached to a `SchemaPage` alongside the existing `XSections` / `XIntroduction` / `XWidth` fields
+- **XFileCaptureConfig** — fields added to the existing `XFileExtension`: `Capture` (nullable enum `User | Environment`), `EmbedAs` (nullable enum: only `ImageTokenJpeg240x320` in v1)
+- **IdCardLayoutConfig** — runtime record passed to `IdCardLayout.razor`: `IssuerName`, `CredentialName`, `ColourTheme`, `Watermark`, `FieldValues` (dictionary of pointer → value read from the form context)
+- **Portrait** — a field value representing a captured photo: `FullOriginalChunkIds` (array of transaction ids from the file-chunks pipeline), `TokenImageBase64` (string, ≤20KB), `Hash` (SHA-256 of original), `ContentType` (`image/jpeg`)
+- **CrossPeerFindings** — the markdown document produced by `run-multi-peer.ps1`: frontmatter outcome, timings, anomalies, reproduction notes (see contract)
+
+### Quickstart (in `quickstart.md`)
+
+A developer onboarding doc covering:
+
+- **Running the walkthrough locally** — `setup.ps1 -Profile gateway` then `run.ps1`; expected output; how to verify the credential lands in the HAIP wallet-dir
+- **Running the multi-peer smoke test** — `docker compose -f docker-compose.federation.yml up -d`, then `run-multi-peer.ps1`; where the findings document lands; what anomalies to look for
+- **Adding a new review-summary layout variant** — where the variant enum lives, where the Razor component goes, which CSS custom properties to wire
+- **Adjusting the id-card colour theme for a new credential type** — extending the theme enum, adding the CSS, referencing it from a blueprint's `x-review` extension
+- **Swapping the assessor agent from rules-mode to AI-mode** — how the actor definition changes, what environment variables are needed (deferred in v1; quickstart documents the extension point)
+- **Debugging a photo that fails to embed in the credential** — where the size check happens, how the renderer surfaces the warning, what the action payload looks like with and without the portrait
+- **Migrating a downstream consumer from `VerifiedCitizenCredential` / `AssuredPersonCredential` to `AssuredIdentityCredential`** — search-and-replace guide; what to update in `credentialRequirements` presentation requests
+
+### Agent context update
+
+After Phase 1 artifacts are written, run the agent context update script to refresh `CLAUDE.md` and agent-specific files with new technology mentions and patterns introduced by this feature (the `x-review` extension, the photo-capture extension, the id-card layout component).
+
+## Phase 2 (out of scope — `/speckit.tasks` produces tasks.md)
+
+Task generation is **not** part of `/speckit.plan`. After this plan is written and reviewed, run `/speckit.tasks` to produce `tasks.md` with dependency-ordered work items grouped by phase, following the seven-phase mapping declared in the spec.
+
+## Complexity Tracking
+
+No constitution violations. No entries.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _none_ | _none_ | _none_ |

--- a/specs/107-assured-identity-v1/quickstart.md
+++ b/specs/107-assured-identity-v1/quickstart.md
@@ -1,0 +1,216 @@
+# Quickstart: Assured Identity v1
+
+**Feature**: 107-assured-identity-v1
+**Audience**: developers implementing or extending this feature
+
+## Run the walkthrough end-to-end (single peer)
+
+```bash
+# Bring up Sorcha (existing compose file)
+docker compose up -d
+
+# Set up Government org, DLA org, citizen public account, both blueprints
+pwsh walkthroughs/AssuredIdentity/setup.ps1
+
+# Run Phase 1 (Assured Identity issuance) + Phase 2 (Driving Licence chain) end-to-end
+pwsh walkthroughs/AssuredIdentity/run.ps1
+```
+
+Expected output: two credentials in the citizen's HAIP wallet directory, both verifiable via `sorcha-agent haip verify`.
+
+## Run only one phase
+
+```bash
+pwsh walkthroughs/AssuredIdentity/run-phase1-identity.ps1   # Phase 1 only
+pwsh walkthroughs/AssuredIdentity/run-phase2-licence.ps1    # Phase 2 only (requires Phase 1 to have run)
+```
+
+## Run the cross-peer smoke test
+
+```bash
+# Different compose file — two peer stacks
+docker compose -f docker-compose.federation.yml up -d
+
+# Wait for both peers healthy (~90s)
+docker compose -f docker-compose.federation.yml ps
+
+# Run the smoke test
+pwsh walkthroughs/AssuredIdentity/run-multi-peer.ps1
+
+# Inspect findings
+cat walkthroughs/AssuredIdentity/multi-peer-findings.md
+
+# Tear down
+docker compose -f docker-compose.federation.yml down -v
+```
+
+The findings document records pass / degraded-pass / fail / env-failure with timings and any anomalies. **Failures do not block release** — they become tickets for the peer-replication subsystem owner.
+
+## Add a new credential preview using `x-review`
+
+To produce an ID-card-style review screen for any future credential issuance blueprint:
+
+1. Add a final page to your blueprint's `x-pages` list with `x-review` declared:
+
+```jsonc
+{
+  "title": "Review your application",
+  "x-review": {
+    "layout": "id-card",
+    "editable": true,
+    "header": {
+      "issuerName": "Your Issuing Organisation",
+      "credentialName": "Your Credential Type",
+      "colourTheme": "identity-navy"
+    }
+  }
+}
+```
+
+2. The renderer pulls all submitted values from prior pages automatically. You don't list them manually.
+
+3. To use a new colour theme, add a CSS block in `Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor.css`:
+
+```css
+.id-card[data-theme="your-theme"] {
+  --card-bg-start: #...;
+  --card-bg-mid: #...;
+  --card-bg-end: #...;
+  --card-accent: #...;
+  --card-label: #...;
+}
+```
+
+4. Add the enum value to `XReviewColourTheme` in `Sorcha.Blueprint.Models`. Done.
+
+## Add an optional photo field to a blueprint
+
+```jsonc
+{
+  "portrait": {
+    "type": "string",
+    "format": "file-reference",
+    "x-file": {
+      "accept": ["image/jpeg"],
+      "maxSizePerFile": "5MB",
+      "maxChunks": 1,
+      "capture": "user",
+      "embedAs": "image-token-jpeg-240x320"
+    }
+  }
+}
+```
+
+In the credential's `claimMappings`:
+
+```jsonc
+{ "claimName": "portrait", "sourceField": "/portrait/tokenImageBase64" }
+```
+
+The renderer handles capture, ICAO advisory tips, client-side resize. The issuance step validates size and embeds the token. If the citizen skips the photo, the credential is issued without the `portrait` claim.
+
+## Switch the assessor from rules-mode to AI-mode (deferred to v1.1)
+
+Today the assessor actor uses rules mode:
+
+```jsonc
+{
+  "mode": "rules",
+  "rules": [
+    {
+      "actionName": "Verify Assured Identity Application",
+      "decision": "approve"
+    }
+  ]
+}
+```
+
+When AI-mode lands (v1.1), swap to:
+
+```jsonc
+{
+  "mode": "ai",
+  "ai": {
+    "promptFile": "./prompts/identity-assessor.md",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.3
+  }
+}
+```
+
+The rest of the walkthrough is unchanged. The blueprint, the form, the assessor UI, the citizen experience all stay the same. **No platform or blueprint changes** — the agent framework already supports this.
+
+## Debug: photo not embedded in issued credential
+
+Symptom: Citizen submitted with a photo, the credential lacks the `portrait` claim.
+
+Causes (in priority order):
+
+1. **Token oversize** — check the issuance log for `WARN_CRED_PORTRAIT_OVERSIZE_001`. The client-side resize should keep the token ≤27KB base64; if a citizen's photo trips this (very rare), the credential is intentionally issued without portrait.
+2. **Resize bypassed** — programmatic submission (test fixture, browser extension) might skip the client-side resize. Check the action payload at `/portrait/tokenImageBase64`. If absent, the client never wrote the token. If present but oversize, see (1).
+3. **Schema mapping wrong** — confirm `claimMappings` references `/portrait/tokenImageBase64`, not `/portrait` or `/portrait/fullOriginalChunkIds`.
+
+Log location: `dotnet logs sorcha-blueprint-svc | grep -i portrait`
+
+## Debug: cross-peer credential never arrives on peer B
+
+Symptom: `run-multi-peer.ps1` times out waiting for the credential to land in peer B's MyCredentials PENDING.
+
+Steps:
+
+1. Check the findings document — outcome should be `fail` with anomalies populated
+2. Confirm peer B is subscribed to the register: `docker exec peer-b-register-svc curl localhost/api/registers/<id>/subscriptions`
+3. Confirm the docket sealed on peer A: `docker exec peer-a-register-svc curl localhost/api/registers/<id>/dockets`
+4. Confirm peer-to-peer replication is healthy: check `peer-svc-a` and `peer-svc-b` logs for sync errors
+5. Confirm `InboundCredentialDetector` is running on peer B: it subscribes to `docket:confirmed` on Redis; check `wallet-svc-b` logs
+
+If the docket sealed but never replicated, the issue is in the peer subsystem — file an issue, do not block release.
+
+## Migrate a downstream consumer from `VerifiedCitizenCredential` to `AssuredIdentityCredential`
+
+Old:
+
+```jsonc
+{
+  "credentialRequirements": [
+    {
+      "type": "VerifiedCitizenCredential",
+      "presentationSource": "HaipExternalWallet",
+      "requiredClaims": [
+        { "claimName": "givenName" },
+        { "claimName": "familyName" },
+        { "claimName": "dateOfBirth" }
+      ]
+    }
+  ]
+}
+```
+
+New (drop-in replacement):
+
+```jsonc
+{
+  "credentialRequirements": [
+    {
+      "type": "AssuredIdentityCredential",
+      "presentationSource": "HaipExternalWallet",
+      "requiredClaims": [
+        { "claimName": "givenName" },
+        { "claimName": "familyName" },
+        { "claimName": "dateOfBirth" }
+      ]
+    }
+  ]
+}
+```
+
+Same claim names, same shapes, same optional disclosure semantics. Only the credential type name changes. Search-and-replace across blueprint JSON files; re-publish blueprints that reference the old name.
+
+## Reference
+
+- Spec: [`spec.md`](spec.md)
+- Plan: [`plan.md`](plan.md)
+- Design rationale: [`../../docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md`](../../docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md)
+- Contracts: [`contracts/`](contracts/)
+- Data model: [`data-model.md`](data-model.md)
+- Research: [`research.md`](research.md)

--- a/specs/107-assured-identity-v1/research.md
+++ b/specs/107-assured-identity-v1/research.md
@@ -1,0 +1,113 @@
+# Research: Assured Identity v1
+
+**Feature**: 107-assured-identity-v1
+**Date**: 2026-04-20
+**Status**: Complete — all decisions resolved during brainstorming; no open `NEEDS CLARIFICATION` items
+
+## Scope note
+
+This research document is an *index* into the brainstorming design artefact at [`docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md`](../../docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md). Every design decision in this feature was made in that session with rejected alternatives captured. This document summarises each decision in the standard Decision / Rationale / Alternatives format with file-path citations to the existing codebase where the substrate is already present.
+
+## Decisions
+
+### 1. Credential type name: `AssuredIdentityCredential`
+
+- **Decision**: Name the canonical person-identity credential `AssuredIdentityCredential`. Delete the existing `VerifiedCitizenCredential` and `AssuredPersonCredential` variants.
+- **Rationale**: Both existing names mislead. "Verified Citizen" implies civic-status verification (which the platform does not perform). "Assured Person" is closer but was positioned as a delivery variant rather than a canonical type. "Assured Identity" describes the semantic precisely — an identity record asserted true within an issuer's assurance frame — and generalises equally to government citizen identity, employer workforce identity, and any other public → issuer → credential pattern.
+- **Alternatives considered**:
+  - Keep `VerifiedCitizenCredential` and add a delivery field — preserves the downstream DLA chain but bakes in the misleading name.
+  - Keep `AssuredPersonCredential` and rebrand around it — keeps the chain at the cost of clarity; "Person" is less general than "Identity".
+
+### 2. Delivery mode: both register-native and HAIP external, holder chooses at claim time
+
+- **Decision**: Both delivery modes. The holder picks at claim time via the existing Feature 104 Wave 14b credential claim card.
+- **Rationale**: Register-native (Feature 106) is the simpler UX for Sorcha-native users. HAIP external is required for any verifier outside Sorcha and is necessary to prove OpenID4VP capability for Phase 2. The Wave 14b claim card already supports both paths in code — no new platform work needed. Existing implementation: `CredentialClaimCard.razor` + `HaipLocalReceiveService.cs`.
+- **Alternatives considered**:
+  - HAIP-external-only — simpler to build but loses register-native investment from Feature 106.
+  - Register-native-only — simpler still but cannot prove OpenID4VP for Phase 2.
+
+### 3. Photo embedded as selectively-disclosable `portrait` claim
+
+- **Decision**: Optional photo. Capture at 480×640+, keep full-resolution original on the register as evidence, embed a 240×320 token-image JPEG (~20KB) as a selectively-disclosable `portrait` claim in the credential.
+- **Rationale**: Industry precedent — ICAO e-passport chips and ISO 18013-5 mDLs both embed portraits directly as JPEGs of roughly token-image size, not by URL reference. Offline verification matters. Selective disclosure lets the holder withhold the portrait where it's not needed (age gates) and reveal it where it is (DLA roadside check).
+- **Alternatives considered**:
+  - Evidence-only (no claim) — smaller credential, but verifiers can't confirm the holder visually later, kills DLA-style downstream.
+  - Full-resolution as claim — credential bloat to 100KB+ for marginal benefit.
+
+### 4. Form layout: GDS 5-page wizard with review-as-id-card
+
+- **Decision**: Five-page wizard. Page 1 Name + DoB (two `x-sections`), Page 2 Address (postcode lookup), Page 3 Email, Page 4 Photo (optional, skippable), Page 5 Review (new `x-review` extension with `id-card` layout).
+- **Rationale**: GDS one-thing-per-page pattern is the established citizen-service UX standard. The ID-card review pattern lets the citizen see what they'll hold before submitting, and the same component renders the issued credential detail view later — one component, three states (draft / pending / issued).
+- **Alternatives considered**:
+  - Single-page sectioned form — desktop-friendly but overwhelming for citizen-facing flow.
+  - 3-page wizard (collapses fields) — loses the one-thing-per-page focus.
+  - 4-page wizard (no review) — misses the GDS-standard review-before-submit.
+
+### 5. Review screen architecture: `x-review` schema extension with parameterised `id-card` layout
+
+- **Decision**: New blueprint schema extension `x-review: { layout, editable, header }` parsed by `SchemaLayoutParser` and rendered by a new `ReviewSummaryRenderer.razor` that dispatches to a layout variant. `id-card` is the v1 variant; `passport-page`, `tabular`, `receipt` are reserved enum values.
+- **Rationale**: Mirrors the existing `x-credential-offer` Wave 14b extension pattern exactly. Parameterised colour theme + header lets Phase 2's driving-licence review reuse the same component with a pink theme — no bespoke per-credential component. Same component serves citizen Page 5 (draft watermark, Edit+Submit), assessor pending review (pending watermark, Approve+Reject), and wallet credential detail view (issued, no watermark).
+- **Alternatives considered**:
+  - Bespoke Blazor component referenced by `x-component: "name"` — works for one flow, accumulates component debt across credentials.
+  - Tabular summary — functional but loses the "see what you'll hold" UX win.
+  - Leave review screen out of blueprint, hard-code in Razor — locks the layout per credential type, defeats reuse.
+
+### 6. Validator hook: `sorcha-agent` actor in rules mode (not a new platform surface)
+
+- **Decision**: The assessor role is filled by a background `sorcha-agent` process in `rules` mode (approve if the submission is well-formed). Future validator-API integration plugs in as either an `external` agent mode or an HTTP call inside the agent's rules — no platform or blueprint changes required when that arrives.
+- **Rationale**: The actor framework already exists (`src/Apps/Sorcha.Agent/`). The blueprint's assessor action stays a normal decision action; the agent is just an unattended human. AI-mode (Claude vision) is a natural v1.1 extension — same code path, different agent mode. No new gate type or hook field on the Action model.
+- **Alternatives considered**:
+  - New `validatorHook` block on Action — adds platform surface for something the agent framework already handles.
+  - Blueprint-declared validator URL — couples the blueprint to a specific vendor; defeats pluggability.
+
+### 7. Cross-peer testing: measure-and-document, not block-and-fix
+
+- **Decision**: Bundle a single cross-peer smoke test (`run-multi-peer.ps1` + `docker-compose.federation.yml`) that exercises Feature 106 register-native delivery end-to-end. Produces a findings document on every run regardless of outcome. **Does not block the feature's release** on any replication issue it surfaces — those become findings for whoever owns peer replication.
+- **Rationale**: Feature 106's cross-peer path has never been exercised end-to-end (`DEFERRED-E2E.md` T047/T048 explicitly pending; `MASTER-TASKS.md` Theme 6 open). Fixing it is out of this feature's scope; measuring it is not. Bundling the smoke test retires the largest untested architectural assumption without coupling this feature's ship date to a separate subsystem's bug-fix cadence.
+- **Alternatives considered**:
+  - Block v1 on cross-peer correctness — couples ship date to a separate subsystem's reliability.
+  - Defer cross-peer entirely — leaves the largest architectural assumption unchecked indefinitely.
+
+## Substrate already present in the codebase
+
+Citations that prove each new piece sits inside an existing pattern:
+
+| New piece | Existing substrate | Citation |
+|---|---|---|
+| DOB client-side future-block | `SorchaDateTokenResolver` already implements token vocabulary server-side | `src/Common/Sorcha.Validator.Core/Tokens/SorchaDateTokenResolver.cs:37-120` |
+| Photo capture control | Legacy `FileReferenceField` in `Sorcha.UI.Web.Client` uses `<InputFile capture="environment">` | `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceField.razor:36-56` — needs promotion to core `FileRenderer.razor` |
+| Photo chunked upload pipeline | Feature 085 file-chunks path, XChaCha20-Poly1305 encrypted | `src/Services/Sorcha.Blueprint.Service/Endpoints/FileChunkEndpoints.cs`; `docs/reference/API-DOCUMENTATION.md` under "File Chunk Submission" |
+| `x-review` schema extension pattern | `x-credential-offer` Wave 14b extension | `src/Common/Sorcha.Blueprint.Models/` — existing `XCredentialOfferExtension` or equivalent; dispatched by `ControlDispatcher.razor` in the core UI |
+| Review summary dispatch | `SchemaLayoutParser` already parses `x-pages`, `x-sections`, etc. | `src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs:64-91` |
+| Persona autofill that reaches JWT | `PersonaAutofillResolver` writes to `_formContext.FormData` which flows through `BuildClaimsFromMappings` | `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Persona/PersonaAutofillResolver.cs`; `src/Services/Sorcha.Blueprint.Service/Services/.../ActionExecutionService.cs:1598-1626`; `BuildClaimsFromMappingsTests.cs` (single-unit regression guard) |
+| Credential claim card with dual-path | Feature 104 Wave 14b | `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Credentials/CredentialClaimCard.razor`; `HaipLocalReceiveService.cs` |
+| Register-native credential delivery | Feature 106 | `src/Services/Sorcha.Wallet.Service/Services/InboundCredentialDetector.cs`; `src/Services/Sorcha.Blueprint.Service/Services/InstanceMirrorReconstructor.cs`; `ActionExecutionService.cs:496-617` (sealed disclosure branch) |
+| HAIP OpenID4VCI / OpenID4VP | Features 097 + 098 | `src/Services/Sorcha.Haip.Service/` |
+| Open starting action + late binding | Feature 103 | `src/Services/Sorcha.Blueprint.Service/Services/.../ActionExecutionService.cs:309-332`; `ValidationEngine.cs:1027`; `VAL_BP_010` guardrail |
+| Shared identity schema primitives | Feature 103 | `blueprints/schemas/sorcha-core/{PersonName,DateOfBirth,EmailAddress,PostalAddress}.v1.json`; `CoreSchemaSeedService.cs` |
+| Agent framework with rules + AI modes | Feature 087 | `src/Apps/Sorcha.Agent/` |
+| Walkthrough structure | `walkthroughs/HaipVerifiedCitizen/` and `HaipDrivingLicence/` | both deleted in Phase 7 after the new consolidated walkthrough proves out |
+
+## Resolved-by-informed-default questions
+
+The following tactical questions were resolved during specification authoring with the rationale captured here:
+
+1. **Which delivery path does `run.ps1` exercise?** HAIP external wallet-dir. Reason: Phase 2's OpenID4VP presentation requires a filesystem-resident holder wallet (`sorcha-agent haip present --wallet-dir <dir>`). The register-native path is exercised separately by `run-multi-peer.ps1`. Together the two scripts prove both modes.
+2. **Does v1 ship multiple `x-review` layout variants?** No — only `id-card`. The enum reserves `passport-page`, `tabular`, `receipt` as forward-compatibility placeholders but the renderer only implements `id-card` in v1.
+3. **Is photo composition auto-checked?** No. ICAO composition guidance is rendered as advisory tips in the capture UI. Automated face-detection, background uniformity, quality scoring are all deferred to a future validator API integration. The assessor (human or agent) rejects bad photos in v1.
+4. **What happens if the client-side photo resize fails or is bypassed?** The server-side issuance step validates token-image size bounds and refuses to include the portrait claim if the token exceeds ~20KB. A warning is surfaced; the credential is still issued, without the portrait claim.
+5. **Does the DLA Phase 2 walkthrough use the same wallet as Phase 1?** Yes — the citizen actor's wallet-dir is the single source of identity across both phases; no script-level state ferrying.
+
+## Out of scope (explicitly deferred)
+
+These are not researched here because they are deliberately not in v1. Each is natural v1.1+ work:
+
+- Liveness detection on the selfie
+- Automated document verification
+- Real backend identity-validator service integration
+- AI-mode agent with Claude vision
+- Additional `x-review` layout variants beyond `id-card`
+- Nationality, phone, and social-profile claims
+- Per-issuer custom branding (logos, bespoke palettes)
+- Bridge from Sorcha in-platform wallet to filesystem HAIP wallet-dir
+- Playwright UI screenshot tests (deferred "until needed" per user)

--- a/specs/107-assured-identity-v1/spec.md
+++ b/specs/107-assured-identity-v1/spec.md
@@ -1,0 +1,286 @@
+# Feature Specification: Assured Identity v1
+
+**Feature Branch**: `107-assured-identity-v1`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: User description: "Assured Identity v1 — consolidate the platform's 'verified person' story into a single canonical credential and walkthrough."
+**Design Spec**: [`docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md`](../../docs/superpowers/specs/2026-04-20-assured-identity-v1-design.md)
+
+## Background
+
+The platform's "verified person" story is currently split across two co-located blueprints in the same walkthrough, producing competing `VerifiedCitizenCredential` and `AssuredPersonCredential` variants that share the same shape and the same seven claims but differ only in their delivery pipe (external HAIP wallet versus register-native sealed disclosure). A second walkthrough, `HaipDrivingLicence`, chains off the HAIP variant to prove a downstream credential-consumer flow. The resulting duplication means there is no single canonical credential for citizen identity, the holder's choice of where to keep the credential is presented as a publisher-side decision rather than a claim-time preference, and the citizen-facing form is functional but unpolished — future-dated birthdays are not blocked in the picker, no photo capture is wired into the core renderer, and no review-before-submit step exists.
+
+Separately, the platform has never exercised Feature 106 (register-native credential delivery) across two peers end-to-end. The architectural design is sound and the single-node code paths are unit-tested, but the cross-peer credential-delivery path — the primary reason Feature 106 exists — has not been verified in practice.
+
+This feature delivers one canonical Assured Identity workflow that replaces both existing person-identity blueprints and the chained driving-licence walkthrough; makes the citizen-facing form substantially more polished by fixing three renderer gaps (future-date block on date-of-birth, photo capture dispatch, a new review-as-id-card schema extension); and bundles a cross-peer smoke test of register-native delivery so the largest untested architectural assumption in the platform's credential story is finally measured. The design also preserves a clean seam for replacing the human assessor role with a real backend identity-validator service at a later date, without any blueprint or platform changes required when that arrives.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Citizen obtains a canonical Assured Identity credential with a polished form experience (Priority: P1)
+
+A member of the public lands on the Assured Identity service, signs up for a public account, and fills in their details across a short wizard. Their persona profile pre-populates most fields; the date-of-birth field prevents them from picking a future date; the address field autofills from their postcode; the optional photo field lets them take a selfie directly from their device camera with passport-style composition guidance on screen. Before submission, they see a summary page styled like the credential they will receive — their name, date of birth, email, address, and photo laid out as an ID card — and can jump back to any section to correct mistakes. After they submit, the issuer (government) approves, and the citizen claims the credential into either their in-platform wallet or an external HAIP wallet via a single click.
+
+**Why this priority**: This is the headline user experience the entire feature exists to deliver. Without it, none of the platform polish is visible, no credential is issued, and no downstream consumer has anything to consume. The form polish is specifically what transforms the current "functional but unpolished" experience into a showcase example of what the platform can do.
+
+**Independent Test**: Fresh public account on a fresh deployment. Run through the Assured Identity application end-to-end. Verify the credential lands in the holder's chosen wallet with all entered claims, the photo is embedded as a selectively-disclosable claim sized for offline verification, and future dates are never pickable on the date-of-birth field. Testable without any downstream consumer (driving licence).
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh public account with no persona profile, **When** the citizen opens the Assured Identity application, **Then** they see a five-page wizard presenting one topic per page (about you, address, contact, photo, review) with a progress indicator across the top.
+2. **Given** a public account with a saved persona profile that has name, date of birth, email, and address set, **When** the citizen opens the Assured Identity application, **Then** at least those four fields are pre-populated before the citizen touches any field, and each pre-populated field is visually marked as filled from the citizen's profile with a clear "self" provenance label.
+3. **Given** the citizen is on the date-of-birth page, **When** they open the date picker, **Then** the picker will not allow any date after today to be selected.
+4. **Given** the citizen is on the address page, **When** they type a valid UK postcode and a full-address lookup provider is configured, **Then** they are presented with address candidates and picking one fills all sibling address fields.
+5. **Given** the citizen is on the photo page on a mobile device, **When** they tap the take-photo control, **Then** the device's front-facing camera opens and ICAO composition guidance (plain background, centred face, neutral expression, no sunglasses) is visible on screen.
+6. **Given** the citizen does not want to provide a photo, **When** they are on the photo page, **Then** a clearly-labelled skip control lets them proceed to the review page without providing an image.
+7. **Given** the citizen has completed pages 1–4, **When** they reach the review page, **Then** they see all their entered details rendered as a stylised credential card ("ID card layout") with a "draft" watermark indicating it is not yet issued, an "Edit" control for each section, and a primary submit control.
+8. **Given** the citizen clicks Edit on a section from the review page, **When** they arrive back at the corresponding wizard page, **Then** every value they previously entered is still present and editable.
+9. **Given** the citizen has submitted their application, **When** the issuer approves it, **Then** the citizen receives a claim notification and a single-click choice to land the credential in either their in-platform wallet or an external HAIP wallet.
+10. **Given** the citizen has claimed the credential, **When** they open the credential's detail view in their wallet, **Then** they see the same ID card layout with the draft watermark replaced by an "issued" state showing the issue date and issuer name.
+11. **Given** the citizen provided a photo, **When** the credential is inspected in their wallet, **Then** the photo is present as a selectively-disclosable claim at a size consistent with offline biometric verification (token-image resolution, per established portrait standards).
+12. **Given** the citizen declined to provide a photo, **When** the credential is inspected in their wallet, **Then** it is still valid and usable for downstream services, with the portrait claim absent rather than empty.
+
+---
+
+### User Story 2 — Downstream service chain-consumes the Assured Identity credential (Priority: P2)
+
+A citizen who already holds an Assured Identity credential applies to the Driver Licensing Authority (DLA) for a driving licence. They pick a vehicle class and review the licence-to-be on a second stylised card. When the DLA officer (or the unattended agent standing in for them) opens the application, they see both the identity the citizen presented (selectively disclosed — only given name, family name, date of birth, and portrait) and the licence-to-be as two stacked cards, and approve. A `DrivingLicenceCredential` is minted carrying the licence number, vehicle class, issue and expiry dates, the citizen's name and date-of-birth, and the citizen's portrait carried forward from the presented identity. The citizen claims the licence using the same claim-card mechanism as the identity credential.
+
+**Why this priority**: Proves the identity credential is *useful* for the platform, not just mintable. Exercises the full credential chain including selective disclosure (address and email are withheld; the DLA has no business reason for them), key-binding proof (the holder of the identity must also sign the licence application), and cross-organisation trust (government and DLA are distinct issuers under one trust anchor). Without this story, the Assured Identity credential is a one-shot artefact with no validation that it can be consumed elsewhere.
+
+**Independent Test**: Starting from a clean state, run user story 1 to receive an AssuredIdentityCredential into a HAIP-compatible wallet. Then run the driving-licence flow. Verify: the DLA review screen renders both stacked cards (presented identity with withheld claims faded, licence-to-be preview); the citizen receives a signed driving licence credential; the licence's holder identity matches the identity that was presented. Independently testable from any other downstream consumer: if we never add another consumer, story 2 still proves the credential is chainable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a citizen holding an `AssuredIdentityCredential` in a HAIP-compatible wallet, **When** they open the driving licence application, **Then** they see a short wizard asking for vehicle class and presenting a licence-to-be review card on the final page.
+2. **Given** the citizen has submitted the licence application, **When** the DLA requests identity verification, **Then** the citizen is prompted to present the specific claims the DLA has requested (given name, family name, date of birth, portrait), with the request clearly listing each claim.
+3. **Given** the citizen consents to the presentation, **When** the platform presents the credential, **Then** only the requested claims are disclosed — the email and address claims are withheld from the DLA.
+4. **Given** the DLA officer opens the pending licence application, **When** the review screen renders, **Then** it shows two stacked credential cards: the presented identity on top (with disclosed claims populated and withheld claims shown as faded placeholders with an explanatory label) and the licence-to-be below (in a distinct colour theme signalling the different credential type, with a "pending" watermark).
+5. **Given** the DLA officer approves, **When** the licence credential is minted, **Then** the credential carries the licence number, vehicle class, issue date, expiry date, holder name, holder date of birth, and holder portrait (if the citizen chose to present a portrait).
+6. **Given** the licence credential has been minted, **When** the citizen opens their My Actions queue, **Then** a claim card for the driving licence is pending and claiming it lands the credential in the same wallet as the identity.
+7. **Given** the citizen has claimed the licence, **When** they open its detail view, **Then** it renders in the same ID card layout with a credential-type-appropriate colour theme distinct from the Assured Identity card.
+8. **Given** the citizen did not provide a portrait for their Assured Identity, **When** the DLA issues their licence, **Then** the licence is still issued and the portrait claim on the licence is also absent.
+
+---
+
+### User Story 3 — Unattended assessment by a background agent (Priority: P3)
+
+When the Assured Identity (or Driving Licence) workflow runs in a demo or walkthrough setting, a background process stands in for the human assessor. It picks up pending applications from its inbox, applies pre-declared rules (for the demo: approve if all required fields are present and the date-of-birth is plausible) or — for a future AI-mode variant — uses a vision model to examine the submitted photo, and posts the approval or rejection decision without a human opening the assessor UI. When a real backend identity-validation service becomes available later, it plugs in through the same agent mechanism as either an external agent mode or an HTTP call inside a rule, with no blueprint or platform changes required.
+
+**Why this priority**: Makes the walkthrough demonstrable end-to-end without a human in the loop, which is required for autonomous CI-style walkthrough runs and for demos where the presenter doesn't want to mime being a government officer. Also locks in the design-seam for real automated identity validation: the blueprint's decision action is shape-stable against either a human or an automated reviewer, so whoever picks up validator integration next does not need to change the blueprint or the platform.
+
+**Independent Test**: Run the Assured Identity walkthrough with only the citizen actor interactive and the assessor provided as a background agent. Verify: the application moves from submission to approval without any human opening the assessor UI; the approval transaction is cryptographically signed by the agent's wallet; the same assessor UI still renders correctly if a human opens it during the pending window. Independently testable from the other user stories: swap a rules-mode agent for a human-facing assessor and the other stories all still work.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Assured Identity application has been submitted, **When** the assessor role is filled by a background agent running in rules mode, **Then** the agent picks the pending application from its inbox within a small number of seconds and posts the approval decision.
+2. **Given** a Driving Licence application has reached the licensing-officer review step, **When** that role is filled by a background agent in rules mode, **Then** the agent posts the approval decision and the licence credential is minted.
+3. **Given** the same Assured Identity application, **When** a human opens the assessor UI during the pending window, **Then** they see the standard approve/reject review screen with all submitted details.
+4. **Given** a future validator-integration build where the agent's rule calls out to an HTTP endpoint for automated ID verification, **When** the endpoint returns a decision, **Then** the agent posts that decision to the platform in the exact same shape as the rules-mode decision — no blueprint or platform change is required.
+5. **Given** a future AI-mode agent variant that uses a vision model to examine the submitted photo against the form data, **When** the agent is run in AI mode, **Then** its decision flows through the same pipeline as the rules-mode decision.
+
+---
+
+### User Story 4 — Cross-peer delivery smoke test of register-native credentials (Priority: P4)
+
+A Sorcha operator needs to know whether the register-native credential delivery path (Feature 106) actually works when the issuing peer and the holding peer are different machines, not just when they are both on one node. The feature bundles a two-peer smoke test that issues an Assured Identity credential from peer A and verifies it lands in the holder's in-platform wallet on peer B within a small number of seconds. The test produces a findings document on every run — pass, fail, or anomaly — and does not block the feature from shipping if it surfaces replication issues, because those issues are scoped to whoever owns peer replication, not this feature.
+
+**Why this priority**: Retires the largest untested architectural assumption in the platform's credential-delivery story without coupling the ship date of this feature to the remediation of any bugs that surface. Documented, measurable, and timeboxed. Once it exists, every release can run it cheaply.
+
+**Independent Test**: Bring up a two-peer federation (both peers subscribed to the same register). Run the smoke script. Verify: the findings document is produced regardless of pass or fail; on pass, the credential exists in the holder's pending-acceptance list on peer B within the target latency; on acceptance, the accept transaction is cryptographically signed by the holder's key; any replication anomaly is recorded with a clear description.
+
+**Acceptance Scenarios**:
+
+1. **Given** a two-peer federation is running with both peers subscribed to the same Assured Identity register, **When** the smoke script issues a credential on peer A, **Then** the credential appears in the holder's pending-acceptance list on peer B within the configured latency budget.
+2. **Given** the credential is pending on peer B, **When** the holder accepts it on peer B, **Then** the accept transaction is signed by the holder's key (not by peer A's key) and the credential transitions to active.
+3. **Given** any cross-peer run (pass or fail), **When** the smoke script finishes, **Then** a findings document is written to a known location recording the outcome, the latency, and any anomalies observed.
+4. **Given** the smoke script surfaces a replication bug, **When** the operator inspects the findings, **Then** the bug is clearly described with sufficient context for a peer-replication engineer to reproduce it, and the bug does not cause the feature's release to be blocked.
+5. **Given** the smoke script passes consistently across multiple runs, **When** the release is cut, **Then** the findings history establishes baseline latency for future regression comparisons.
+
+---
+
+### User Story 5 — Consolidation of legacy walkthroughs and credential types (Priority: P5)
+
+A platform user looking at the walkthroughs directory today sees two separate HAIP walkthroughs for citizen identity (`HaipVerifiedCitizen` and `HaipDrivingLicence`) and two separate credential type names (`VerifiedCitizenCredential` and `AssuredPersonCredential`) for the same semantic. After this feature, they see one canonical Assured Identity walkthrough with both phases inside it, and one credential type name. The legacy folders and type names are gone; no back-compat shims remain.
+
+**Why this priority**: Delivers the "single canonical" promise of the feature. Without it, the consolidation is cosmetic — the old and new coexist indefinitely and the platform keeps carrying the duplication debt.
+
+**Independent Test**: Fresh clone of the repository. Verify: `walkthroughs/AssuredIdentity/` exists and runs end-to-end; `walkthroughs/HaipVerifiedCitizen/` and `walkthroughs/HaipDrivingLicence/` no longer exist; no source file references `VerifiedCitizenCredential` or `AssuredPersonCredential` as a credential type name; the `HaipIdentityAttestation` walkthrough (different scope — proves the bare CLI) still exists and still runs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh repository checkout, **When** the walkthroughs directory is listed, **Then** `AssuredIdentity/` is present and `HaipVerifiedCitizen/` and `HaipDrivingLicence/` are both absent.
+2. **Given** a code search for `VerifiedCitizenCredential` across the repository, **When** it completes, **Then** there are no live references outside historical design documents and past spec directories.
+3. **Given** a code search for `AssuredPersonCredential` across the repository, **When** it completes, **Then** there are no live references outside historical design documents and past spec directories.
+4. **Given** the `HaipIdentityAttestation` walkthrough, **When** it is run, **Then** it still passes end-to-end (it proves the bare `sorcha-agent haip receive` CLI and is not dependent on this feature).
+5. **Given** the historical spec directories (`specs/103-verified-citizen-v2/`, `specs/104-credential-claim-action/`, `specs/106-register-native-credentials/`), **When** inspected, **Then** they are still present as historical context, and this spec links to them.
+
+---
+
+### Edge Cases
+
+- **Citizen changes their mind mid-wizard.** They navigate back using the browser back button or the in-wizard Back control. All previously-entered values are preserved; navigating forward again does not reset them.
+- **Citizen's persona profile has stale data.** They edit a persona-filled field. The "self" provenance label drops from that specific field; other persona-filled fields retain their labels. On submission, the edited value is what reaches the credential — not the original persona value.
+- **Citizen declines the optional photo.** The credential is still issued. The portrait claim is absent, not empty. Any downstream service that *required* a portrait (via its presentation request) would reject the citizen's credential; services that only *request* it with "required: false" accept it.
+- **Citizen takes a poor-quality photo (blurry, no face visible).** The platform does not automatically reject it — no automated composition checking in v1. The assessor (human or agent) rejects the application in their review step and the citizen is informed.
+- **Citizen submits with a future date of birth because the client-side bound was bypassed** (e.g. programmatic submission, browser extension, schema-evasion attack). The server-side validator rejects the submission. The client-side block is convenience; the server-side constraint is authoritative.
+- **Credential claim action times out.** If the citizen never claims within the Wave 14b credential offer's expiry window, the claim card expires and the application workflow is recorded as failed-to-claim. Re-submitting the application is the path forward; there is no "re-mint the credential" escape hatch.
+- **Citizen picks "Scan with external wallet" on the claim card but their external wallet rejects the credential** (unsupported type, incompatible format). The claim falls back to the in-platform wallet path; the credential is still delivered to the citizen's Sorcha-held wallet.
+- **Cross-peer smoke test detects a replication delay above the latency budget but the credential eventually arrives.** The findings document records both the delay and the eventual arrival. The test is marked as a degraded pass with a specific anomaly note; the feature does not fail to ship on degraded performance.
+- **Cross-peer smoke test cannot even bring up the two-peer federation** (docker-compose failure, port conflicts). The smoke test is marked as "environment failure — not exercised this run" in the findings document; the feature still ships if the single-peer primary walkthrough passes.
+- **DLA officer tries to approve a licence application where no AssuredIdentityCredential was presented** (presentation step skipped or failed). The licence-issue action refuses to proceed because its credential-presentation prerequisite is unmet; the officer sees a clear "no identity presented" message rather than a blank review card.
+- **Portrait in the Assured Identity credential is above the size target** (e.g. the client-side resize failed or was bypassed). The issuer rejects the portrait claim rather than including an oversized image in the credential; a warning is surfaced to the citizen and the credential is issued without the portrait claim or the citizen is asked to re-submit the photo.
+- **A walkthrough contributor who did not read this spec publishes a new blueprint with a participant pre-bound to the citizen wallet for an open starting action.** The publish-time guardrail from Feature 103 (VAL_BP_010) rejects the publish attempt with a clear message; this feature does not weaken that guardrail.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Renderer polish (Workstream 1)
+
+- **FR-001**: The date-picker form control MUST prevent the citizen from selecting a date that violates a standard past-only constraint declared on the schema (expressed via the Sorcha date token vocabulary, e.g. not after `today`).
+- **FR-002**: The date-picker form control MUST continue to prevent violations of future-only and bounded-range constraints (e.g. `today+N years`, `today-N years`) consistently with past-only.
+- **FR-003**: When a schema field declares a file-reference intent with capture advisory (user-facing camera), the form renderer MUST present a camera capture control on mobile devices that defaults to the front-facing camera, alongside an upload control on any device.
+- **FR-004**: When a schema field declares a file-reference intent for an identity portrait with a target token size, the form renderer MUST produce a resized token-image (within the declared size target) on the client side before submission, alongside the original full-resolution image for issuer review.
+- **FR-005**: The form renderer MUST present advisory composition guidance (e.g. ICAO portrait composition rules) alongside the capture control when the schema declares a portrait intent, without enforcing the guidance automatically.
+- **FR-006**: The form renderer MUST support a new schema extension that marks a wizard page as a read-only review summary of prior pages' values, with a named layout variant.
+- **FR-007**: The review-summary extension MUST support at minimum a credential-card layout ("id-card") that renders the collected data in a styled card resembling the credential to be issued, with a draft watermark indicating it is not yet issued.
+- **FR-008**: The review-summary layout MUST be parameterisable by a per-use colour theme and per-use header (issuer name, credential display name) so that different credential types in the same workflow render with distinct visual identity without new per-credential components.
+- **FR-009**: The review-summary extension MUST generate per-section edit controls (when declared editable) that navigate the wizard back to the originating page with all previously-entered data intact.
+- **FR-010**: The review-summary component MUST render on both the citizen-side (draft state, Edit + Submit controls) and the issuer-side (pending state, Approve + Reject controls), with the action set derived from the blueprint's routes and the state signalled by a per-state watermark and colour treatment.
+- **FR-011**: The review-summary layout MUST be capable of rendering two cards stacked in a single review context (for credential-chain workflows: presented credential above, credential-to-be below), with withheld claims rendered as visibly faded placeholders with an explanatory label.
+- **FR-012**: The review-summary component in its card layout MUST be reusable for rendering an already-issued credential's detail view in the wallet (with the draft watermark removed and the state set to "issued"), so that the citizen sees the same visual both when previewing before submission and when holding the credential afterwards.
+
+#### Assured Identity credential and blueprint (Workstream 2)
+
+- **FR-013**: The platform MUST provide a single canonical Assured Identity workflow that accepts an open citizen submission, routes it through an assessor approval, and issues a credential to the citizen's chosen wallet.
+- **FR-014**: The Assured Identity credential MUST carry claims for given name, middle name (optional), family name, full name (derived), date of birth, email, and structured postal address (line 1, optional line 2, town, optional region, postcode, country), with every claim selectively disclosable.
+- **FR-015**: The Assured Identity credential MUST optionally carry a portrait claim when the citizen provided a photo, with the portrait embedded at a token-image resolution consistent with offline biometric verification standards, and the claim selectively disclosable.
+- **FR-016**: The Assured Identity workflow MUST allow the holder to choose, at claim time, whether to land the credential in their in-platform Sorcha wallet (register-native delivery) or in an external HAIP wallet.
+- **FR-017**: The Assured Identity workflow's submission action MUST be an open starting action with the citizen participant late-bound to the first submitter (per the Feature 103 open-participant contract).
+- **FR-018**: The Assured Identity workflow's submission form MUST use the citizen-facing persona profile for autofill on every field that has a corresponding persona attribute, following the Feature 103 explicit persona binding rules.
+- **FR-019**: The Assured Identity workflow's submission form MUST use the Feature 103 shared identity primitives (personal name, date of birth, email, postal address) via standard schema reference — no inline duplicate schemas.
+- **FR-020**: The Assured Identity workflow's submission form MUST present as a multi-page wizard with one concept per page (name and date of birth, address, contact, photo, review) in that order.
+- **FR-021**: The Assured Identity workflow's review page MUST use the new review-summary extension with the id-card layout variant and declare the credential type's display name and issuer name for the card header.
+
+#### Driving Licence credential and blueprint (Workstream 3)
+
+- **FR-022**: The platform MUST provide a Driving Licence issuance workflow that requires the citizen to present an Assured Identity credential as a prerequisite, issues a DrivingLicenceCredential on approval, and uses the same claim-card delivery mechanism as the Assured Identity workflow.
+- **FR-023**: The Driving Licence workflow's identity-presentation step MUST request only given name, family name, date of birth, and portrait from the Assured Identity credential — it MUST NOT request email or address.
+- **FR-024**: The Driving Licence credential MUST carry claims for licence number, vehicle class, issue date, expiry date, holder name, holder date of birth, and holder portrait (carried forward from the presented identity when present), with a ten-year validity period.
+- **FR-025**: The Driving Licence workflow's submission action MUST also be an open starting action with the citizen participant late-bound, so that the same wallet that holds the Assured Identity credential is the one that submits the licence application.
+- **FR-026**: The Driving Licence workflow's approve-and-issue review screen MUST use the new review-summary extension with two stacked cards: the presented Assured Identity above (verified state, disclosed claims filled, withheld claims faded) and the licence-to-be below (pending state, in a distinct colour theme appropriate to the credential type).
+
+#### Unattended assessor via background agent (Workstream 4)
+
+- **FR-027**: The Assured Identity and Driving Licence workflows' assessor review actions MUST be shaped so that a background `sorcha-agent` process in rules mode can fill them without blueprint or platform modifications.
+- **FR-028**: The actor definitions for the walkthrough MUST include rules-mode configurations for the government-assessor and DLA-officer roles that stamp approve on valid applications.
+- **FR-029**: The assessor review action's decision schema MUST be shape-stable against a future agent mode that calls out to an external identity-validation service, so that introducing the external mode later is purely additive to the agent and does not require blueprint or platform changes.
+- **FR-030**: The assessor human-facing UI MUST remain fully functional when a human opens the pending application during the window between submission and agent pickup, so that humans can still override or audit the agent's decisions.
+
+#### Consolidated walkthrough (Workstream 5)
+
+- **FR-031**: The repository MUST contain a single walkthrough directory (`walkthroughs/AssuredIdentity/`) that hosts both the Assured Identity issuance phase and the Driving Licence chain phase, with shared actors and shared state between phases.
+- **FR-032**: The walkthrough MUST provide scripts to run each phase independently and to run both phases end-to-end, so that individual-phase testing and full-lifecycle demonstration are both supported.
+- **FR-033**: The walkthrough setup MUST provision all organisations, wallets, participants, and credentials-or-registers required for both phases in a single idempotent setup invocation.
+- **FR-034**: The walkthrough's primary (single-peer) run MUST exercise the HAIP external wallet-dir delivery path, because the Driving Licence phase's OpenID4VP presentation requires a filesystem-resident holder wallet.
+- **FR-035**: The walkthrough's citizen actor definition MUST be reused across both phases without script-level state ferrying — the credential received in phase 1 is presented in phase 2 directly from the same actor's wallet directory.
+
+#### Cross-peer smoke test (Workstream 6)
+
+- **FR-036**: The repository MUST contain a two-peer federation composition definition sufficient to stand up two Sorcha node stacks subscribed to the same register.
+- **FR-037**: The repository MUST contain a smoke-test script that runs the Assured Identity phase 1 workflow with the issuer on one peer and the holder on the other peer, using register-native delivery specifically (so the cross-peer replication path is actually exercised).
+- **FR-038**: The smoke-test script MUST produce a findings document on every run (pass, fail, or environment failure) recording the outcome, observed latency, and any anomalies.
+- **FR-039**: The smoke test MUST NOT block the feature's release on a failure or anomaly — its purpose is measurement, not gating.
+- **FR-040**: The smoke test MUST verify that the holder's accept-or-decline action on the remote peer is cryptographically signed by the holder's own key (not by the issuing peer's key).
+
+#### Consolidation and cleanup (Workstream 7)
+
+- **FR-041**: The repository MUST delete `walkthroughs/HaipVerifiedCitizen/` and `walkthroughs/HaipDrivingLicence/` in full as part of this feature, leaving no residual files or blueprint definitions from those walkthroughs.
+- **FR-042**: The repository MUST retain `walkthroughs/HaipIdentityAttestation/` — it proves the bare HAIP CLI path and is not part of the consolidation.
+- **FR-043**: No live source code or configuration outside historical design or spec documents MUST reference the credential type names `VerifiedCitizenCredential` or `AssuredPersonCredential` after this feature ships.
+- **FR-044**: The repository MUST retain the historical spec directories for Features 103, 104, and 106 as context, and this feature's spec MUST link back to them.
+
+### Key Entities
+
+- **Citizen** — A member of the public who holds a Sorcha public-org account and may submit citizen-facing applications. Identified by a wallet under the public organisation. Carries a persona profile for autofill across services.
+- **Government Assessor** — A staff role within the Assured Identity issuing organisation who reviews citizen applications and approves credential issuance. May be filled by a human user or a background agent in rules or AI mode.
+- **DLA Officer** — A staff role within the Driver Licensing Authority. Verifies the citizen's presented identity and approves driving licence issuance. Same agent/human duality as the government assessor.
+- **Service Designer** — A human or AI assistant who authors blueprint definitions. For this feature they consume the Feature 103 identity primitives and the new review-summary extension.
+- **Assured Identity Credential** — A Verifiable Credential asserting that a citizen's name, date of birth, email, address, and optional portrait have been verified by the issuing government organisation to its assurance standard. Selectively disclosable. Replaces the prior `VerifiedCitizenCredential` and `AssuredPersonCredential` types.
+- **Driving Licence Credential** — A Verifiable Credential issued by the DLA asserting the citizen's right to drive a specified vehicle class until a specified expiry date. Carries the citizen's portrait when the Assured Identity's portrait was presented.
+- **Review Summary (ID Card Layout)** — A new schema-extension-driven UI pattern that renders a read-only summary of a multi-page wizard's collected data as a styled credential card. Parameterised by issuer name, credential display name, colour theme, and edit-enable flag. Reused for citizen-side pre-submission review, issuer-side pending review, and wallet-side issued credential detail view.
+- **Portrait** — An optional citizen-provided photograph, captured via camera or uploaded, resized to a token-image resolution for embedding in the credential as a selectively-disclosable claim. Full original kept on the register as evidence.
+- **Validator Agent** — A `sorcha-agent` background process filling the assessor role in a walkthrough. Runs in rules mode for the v1 demo; designed for a future AI mode (vision-based review) and a future external mode (integration with a real identity-validation service).
+- **Cross-Peer Smoke Test** — A measurement artefact, not a gate, that exercises Feature 106 register-native credential delivery across two Sorcha peers and documents findings.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A citizen with a populated persona profile can complete the Assured Identity application end-to-end — from first form view to receiving the claim notification — in **under 3 minutes**.
+- **SC-002**: A citizen who holds an Assured Identity credential can complete the Driving Licence application — from first form view to receiving the licence claim notification — in **under 2 minutes**.
+- **SC-003**: When the Assured Identity form is first rendered for a citizen with a complete persona profile, **at least 90% of auto-fillable fields are pre-populated** before the citizen touches any field.
+- **SC-004**: The date-of-birth picker **rejects 100% of future-date selection attempts** in its client-side UI, with the server-side constraint continuing to reject any future date that bypasses the client.
+- **SC-005**: When a citizen provides a photo, the embedded portrait claim in the issued credential **is within the token-image size target** (approximately 20KB or less) and meets the declared resolution requirements.
+- **SC-006**: A citizen on the driving-licence flow sees **exactly the four claims** (given name, family name, date of birth, portrait) on their consent-to-present screen, and those are the exact four claims disclosed — email and address **do not** leave the citizen's wallet.
+- **SC-007**: When the review-summary id-card layout renders, a **first-time user can identify the "Edit" control for a given section within 5 seconds** and editing that section returns to the corresponding wizard page with all prior data intact.
+- **SC-008**: When the assessor role is filled by a background agent in rules mode, the application transitions from submitted to approved **within 30 seconds** of submission under normal demo conditions.
+- **SC-009**: The cross-peer smoke test, when it passes, completes credential delivery from issuing peer to holding peer **within 30 seconds** across 5 consecutive runs on the reference hardware.
+- **SC-010**: After this feature ships, the repository contains **zero live code references** to `VerifiedCitizenCredential` or `AssuredPersonCredential` outside historical design documents and archived spec directories.
+- **SC-011**: The consolidated `walkthroughs/AssuredIdentity/` directory **reduces total file count** versus the sum of `walkthroughs/HaipVerifiedCitizen/` and `walkthroughs/HaipDrivingLicence/` before consolidation, with no loss of tested scenarios.
+- **SC-012**: A walkthrough author who adds a new credential-issuance blueprint using the review-summary extension **produces the review screen with zero new bespoke UI components** — parameters alone (colour, issuer name, layout variant) suffice.
+- **SC-013**: The cross-peer smoke test produces a findings document on **100% of runs** regardless of pass, fail, or environment-failure outcome.
+- **SC-014**: An administrator who deletes the `HaipVerifiedCitizen` and `HaipDrivingLicence` folders on the feature branch **finds no failing test, broken reference, or orphaned file** elsewhere in the repository as a result.
+
+## Assumptions
+
+The following defaults were chosen during specification authoring rather than asked as clarifications:
+
+- **Identity floor**: a citizen using Assured Identity is already authenticated to a public-org account (email/password or social login). The public-org account flow is the floor; fully anonymous entry is out of scope.
+- **HAIP pipeline is in place**: OpenID4VCI pre-authorised code flow, OpenID4VP `direct_post` presentation, KB-JWT key binding, and the Wave 14b credential-claim-action pattern are assumed to be fully implemented from Features 098, 101, 102, and 104.
+- **Register-native delivery is in place**: Feature 106's sealed-disclosure credential delivery, inbound detection, instance mirror reconstruction, and claim-card dual-path (in-platform vs external) are assumed present on single-peer. This feature is the first to measure the cross-peer path end-to-end.
+- **Identity primitive library is in place**: Feature 103's shared schema components (`PersonName/v1`, `DateOfBirth/v1`, `EmailAddress/v1`, `PostalAddress/v1`) and their server-side `$ref` resolution are assumed present. This feature consumes them, does not extend or alter them.
+- **Open starting action contract is in place**: Feature 103's late-binding, `VAL_BP_010` publish-time guardrail, and walkthrough-module auto-skip of open-participant wallet patching are assumed present. This feature does not weaken or modify them.
+- **Agent framework is sufficient**: the existing `sorcha-agent` rules-mode capability is sufficient for the v1 assessor automation. AI-mode is deferred; external-API mode is deferred (both are natural v1.1 additions).
+- **Photo embedding follows established biometric portrait standards**: the embedded portrait claim uses a token image consistent with ISO/IEC 19794-5 token image dimensions (~240×320) and mDL (ISO 18013-5) portrait embedding practice (~15-30KB JPEG). No bespoke biometric format is introduced.
+- **Cross-peer testing cadence**: the smoke test runs once per release cycle. Automatic per-commit execution is out of scope.
+- **Walkthrough single-peer primary path uses HAIP delivery**: because the Driving Licence OpenID4VP presentation currently requires a filesystem-resident wallet, the primary walkthrough uses HAIP delivery for phase 1 so that phase 2 works end-to-end. Register-native delivery is proven separately via the cross-peer smoke test.
+- **No back-compat shims**: the old credential type names and the old walkthrough directories are removed outright. Any external repository or script depending on the old names is the responsibility of that external consumer; there is no canary migration period.
+- **ICAO composition guidance is advisory, not enforced**: no face detection, no background uniformity check, no quality-score gate in v1. Automated composition checking is deferred to a future validator integration.
+- **Credential validity period for the driving licence**: ten years, matching standard real-world conventions. Renewal flow is out of scope.
+
+## Out of Scope
+
+The following are deliberately deferred:
+
+- **Liveness detection on the selfie** (face movement, blink challenge, anti-spoofing).
+- **Automated document verification** (scanning an existing ID, OCR, cross-reference against authoritative records).
+- **Real backend identity-validator service integration** (vendor selection, contract, integration plumbing).
+- **AI-mode agent for assessment** (Claude vision reading the submitted photo and making a contextual decision).
+- **Additional review-summary layout variants** beyond the id-card: passport-page, receipt, tabular, timeline, and others are reserved for future features as needs arise.
+- **Nationality, phone, and social-profile claims** on the Assured Identity credential. The v1 claim set is exactly the consolidated superset of what the prior credentials carried, plus portrait.
+- **Issuer-organisation custom branding**: per-org logos, bespoke colour palettes, custom seal designs on the id-card layout. The v1 colour theming is per-credential-type, not per-issuer-org.
+- **Bridge from Sorcha in-platform wallet to filesystem HAIP wallet-dir**: so that a register-native-delivered credential could be used directly in an OpenID4VP presentation without an external HAIP wallet. Natural v1.1.
+- **Per-issuer credential-template overrides**: custom card layouts or label text per issuing organisation beyond the parameterised colour / name / variant. Natural v1.1.
+- **Bulk-issuance flows**: employer-side workforce identity issuance, school-side student identity, etc.
+- **Renewal flows** for either the Assured Identity credential or the Driving Licence credential.
+- **Revocation UX for citizens**: how a citizen sees that their Assured Identity has been revoked by the issuer. Revocation transactions themselves exist under Feature 079; citizen-facing UX is deferred.
+- **Multi-country address lookup providers**: UK-only, inheriting Feature 103's initial scope. Non-UK providers plug in through the existing abstraction when needed.
+- **Playwright UI screenshot tests**: deferred until explicitly needed.
+- **Cross-peer federation automation**: the cross-peer smoke test is manual-per-release. Automated per-commit cross-peer testing is a separate investment.
+
+## Phase Mapping (informative)
+
+This feature is delivered in **seven sequential phases**, grouped into three shippable units. Each phase delivers a discrete, reviewable increment. Phases 1–2 ship the platform polish (Cluster A + identity blueprint); phases 3–4 ship the chain-consumption proof (DLA + cross-peer); phases 5–7 consolidate and clean up.
+
+| Phase | Workstream(s) | Primary User Story | Independently Shippable? |
+|---|---|---|---|
+| 1 | Renderer polish (WS1) | Enables US-1 | Partially — DOB block and review-summary extension ship cleanly; photo capture depends on downstream form referencing it |
+| 2 | Assured Identity credential + blueprint (WS2) | US-1 | Yes once Phase 1 is in; closes the headline citizen experience |
+| 3 | Driving Licence credential + blueprint (WS3) | US-2 | Yes — depends on Phases 1+2 |
+| 4 | Unattended assessor agent (WS4) | US-3 | Yes — depends on Phase 2 (at minimum); enhances Phases 2 and 3 |
+| 5 | Consolidated walkthrough (WS5) | US-1, US-2 (end-to-end validation) | Yes once Phases 2+3+4 are in |
+| 6 | Cross-peer smoke test (WS6) | US-4 | Yes — depends on Phases 2 and 5; runs in parallel with Phase 5 |
+| 7 | Consolidation and cleanup (WS7) | US-5 | Yes — depends on Phase 5 complete; must be last to avoid breaking incremental phase validation |
+
+Detailed implementation routes for each phase, including task-level breakdowns, dependency graphs, and acceptance gates, will be produced by `/speckit.plan` after this specification is reviewed.

--- a/specs/107-assured-identity-v1/tasks.md
+++ b/specs/107-assured-identity-v1/tasks.md
@@ -1,0 +1,361 @@
+# Tasks: Assured Identity v1
+
+**Input**: Design documents from `/specs/107-assured-identity-v1/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓, quickstart.md ✓
+**Tests**: Included per Sorcha constitution Principle IV (≥85% coverage on new code)
+**Organization**: Tasks are grouped by user story so each phase ships as an independent PR.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Different files, no incomplete dependencies — safe to run in parallel
+- **[Story]**: Maps to a user story (US1–US5)
+- All file paths are absolute from repo root `C:\Projects\Sorcha`
+
+## Path Conventions
+
+Web app (microservices backend + Blazor WASM frontend):
+- Frontend renderer: `src/Apps/Sorcha.UI/Sorcha.UI.Core/`
+- Blueprint models: `src/Common/Sorcha.Blueprint.Models/`
+- Validator core: `src/Common/Sorcha.Validator.Core/`
+- Backend services: `src/Services/Sorcha.{Service}.Service/`
+- Walkthroughs: `walkthroughs/{Name}/`
+- Tests: `tests/Sorcha.{Project}.Tests/`
+- Repo-root files: `docker-compose.federation.yml`, `CLAUDE.md`, `.gitignore`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Per-feature workspace prep. The repository, tooling, and CI are already configured.
+
+- [ ] T001 Verify local Sorcha dev environment is healthy by running `docker-compose up -d` and confirming Blueprint, Validator, Tenant, Wallet, Register, Haip, and UI services all reach Healthy state. Baseline for the rest of this feature.
+- [ ] T002 [P] Confirm `dotnet build` of the entire solution from `C:\Projects\Sorcha` completes with no warnings on a clean checkout of branch `107-assured-identity-v1`. Cold-start baseline.
+- [ ] T003 [P] Confirm `dotnet test --filter "Category=Smoke"` passes against the Docker stack so we know the existing test infrastructure is green before any new tests land.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Cross-cutting prerequisites that block multiple user stories.
+
+**⚠️ CRITICAL**: This phase is intentionally minimal — Sorcha already has the cross-cutting infrastructure (DI, EF Core, MongoDB, Redis, OpenTelemetry, JWT, rate limiting, Scalar OpenAPI, the file-chunks pipeline, Wave 14b claim card, register-native delivery, HAIP issuance, schema $ref resolution). Reserve the new validator warning codes so downstream guardrail and issuance work has a stable contract from day one.
+
+- [ ] T004 Reserve two new validator warning codes in `src/Services/Sorcha.Validator.Service/Models/ValidationErrorCodes.cs` (or wherever publish-time codes are constants today): `WARN_BP_REVIEW_001` (unknown x-review layout variant — surfaces a publish-time warning, not error, renderer falls back to tabular) and `WARN_CRED_PORTRAIT_OVERSIZE_001` (portrait token exceeded ~27KB base64 size bound at issuance — claim omitted, credential still issued). Add XML doc summaries referencing `specs/107-assured-identity-v1/contracts/x-review-extension.md` and `contracts/portrait-claim-format.md` respectively. No behaviour wiring yet — that lands in T026 and T024.
+
+**Checkpoint**: Foundation ready — all five user-story phases can now begin.
+
+---
+
+## Phase 3: User Story 1 — Citizen obtains a canonical Assured Identity credential with a polished form experience (Priority: P1) 🎯 MVP
+
+**Goal**: A public-org citizen runs the 5-page Assured Identity wizard end-to-end (name+DoB → address → email → optional photo → ID-card review) and receives a `AssuredIdentityCredential` in their chosen wallet. Includes the renderer polish (DOB future-block, photo capture dispatch, x-review extension with id-card layout) plus the AssuredIdentity blueprint, plus a single-phase walkthrough to prove it.
+
+**Independent Test**: Fresh public account on a fresh deployment. Run `walkthroughs/AssuredIdentity/run-phase1-identity.ps1`. Verify: the credential lands in the holder's wallet with all expected claims; the photo (when provided) is embedded as a 240×320 token in the `portrait` claim; the date-of-birth picker prevented future dates client-side; the review screen rendered as an ID card with edit-jump navigation.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE**: Write these tests FIRST, ensure they FAIL, then implement.
+
+- [ ] T005 [P] [US1] Write `DateTimeRendererFutureBlockTests` in `tests/Sorcha.UI.Core.Tests/Components/Forms/DateTimeRendererFutureBlockTests.cs` covering: `formatMaximum: "today"` blocks all future dates in the picker; `formatMaximum: "today-18Y"` blocks anyone under 18; `formatMinimum: "today"` blocks past dates; tokens parse via `SorchaDateTokenResolver`; absent constraints render the standard picker without bounds. Tests MUST fail before T013.
+- [ ] T006 [P] [US1] Write `XFileExtensionParserTests` in `tests/Sorcha.Blueprint.Models.Tests/XFileExtensionParserTests.cs` covering: existing fields still parse; new `capture` field parses (`user`, `environment`, null); new `embedAs` field parses (`image-token-jpeg-240x320`, null); unknown values produce a publish warning, not an error. Tests MUST fail before T014.
+- [ ] T007 [P] [US1] Write `FileRendererCaptureTests` in `tests/Sorcha.UI.Core.Tests/Components/Forms/FileRendererCaptureTests.cs` covering: `capture: "user"` propagates to the `<InputFile>` `capture` HTML attribute; `capture: "environment"` propagates correctly; null disables the attribute (legacy behaviour); `embedAs` non-null triggers the resize pipeline (mock `IPhotoTokenResizer`); `embedAs` null skips resize. Tests MUST fail before T015 + T017.
+- [ ] T008 [P] [US1] Write `PhotoTokenResizerTests` in `tests/Sorcha.UI.Core.Tests/Services/Forms/PhotoTokenResizerTests.cs` covering: input image at 1920×1080 resizes to 240×320 (cover-style centre crop); output is JPEG; output base64 is ≤27KB; resizer steps quality from 0.85 down to floor 0.5 until size target met; resizer surfaces a "too detailed" error if floor reached without meeting target. Mock the JS interop layer to return canonical fixture bytes. Tests MUST fail before T016.
+- [ ] T009 [P] [US1] Write `XReviewExtensionParserTests` in `tests/Sorcha.Blueprint.Models.Tests/XReviewExtensionParserTests.cs` covering: valid extension with all fields parses correctly; missing `header.issuerName` is a publish error; missing `header.credentialName` is a publish error; unknown `layout` value emits `WARN_BP_REVIEW_001` (warning, not error); `editable` defaults to true when absent; unknown `colourTheme` falls back to default. Tests MUST fail before T020.
+- [ ] T010 [P] [US1] Write `ReviewSummaryDataSourceTests` in `tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs` covering: data source pulls field values from `FormContext.FormData` keyed by JSON pointer; iterates fields declared on prior pages only (not the review page itself); handles nested object pointers (e.g. `/address/town`); returns null for fields the citizen left unfilled. Tests MUST fail before T021.
+- [ ] T011 [P] [US1] Write `ReviewSummaryRendererTests` in `tests/Sorcha.UI.Core.Tests/Components/Forms/ReviewSummaryRendererTests.cs` covering: dispatches to `IdCardLayout` for `layout: "id-card"`; falls back to tabular minimal for unknown layouts; passes `IdCardLayoutConfig` with correct watermark per action context (Draft / Pending / Issued); generates Edit-X buttons when `editable: true`; Edit-X buttons fire `OnEditSection(pageIndex)` with the correct originating page index. Tests MUST fail before T023.
+- [ ] T012 [P] [US1] Write `BuildClaimsFromMappingsPortraitTests` in `tests/Sorcha.Blueprint.Service.Tests/BuildClaimsFromMappingsPortraitTests.cs` covering: `portrait` claim included when `/portrait/tokenImageBase64` present and ≤27KB; claim omitted when absent (citizen skipped photo); claim omitted with `WARN_CRED_PORTRAIT_OVERSIZE_001` log when present and >27KB; existing claim mappings still resolve correctly. Tests MUST fail before T026.
+
+### Implementation for User Story 1
+
+#### 1a. DOB future-block
+
+- [ ] T013 [US1] Wire `SorchaDateTokenResolver` into `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/DateTimeRenderer.razor`. On the bound `MudDatePicker`, set `MaxDate` from `formatMaximum` and `MinDate` from `formatMinimum` after token resolution. Both client-side bounds graceful-fall-back to no bound when constraints absent. Server-side validator continues to be authoritative — this is convenience.
+
+#### 1b. Photo capture dispatch
+
+- [ ] T014 [P] [US1] Extend `src/Common/Sorcha.Blueprint.Models/Schema/XFileExtension.cs` (or equivalent) with two new optional fields: `Capture` (nullable enum `User | Environment`) and `EmbedAs` (nullable enum, v1 only `ImageTokenJpeg240x320`). Update the parser to read them from JSON without breaking existing `x-file` consumers. Surface unknown enum values via the publish warning channel.
+- [ ] T015 [P] [US1] Modify `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/FileRenderer.razor` to read `XFileCaptureConfig.Capture` from the schema and propagate to the rendered `<InputFile>` element's `capture` HTML attribute when non-null. Desktop browsers ignore the attribute by HTML spec; on mobile this opens the device camera with the requested facing.
+- [ ] T016 [P] [US1] Implement `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/PhotoTokenResizer.cs` and the matching JS module `wwwroot/js/photo-token-resizer.js`. Public method `Task<string> ResizeAsync(IBrowserFile file, ImageTokenSpec spec)`. JS side: load file into a `<canvas>`, scale + centre-crop to spec dimensions, export as JPEG with progressive quality reduction (0.85 → 0.5 floor) until size target met, return base64. Expose via Blazor JS interop.
+- [ ] T017 [US1] Wire `PhotoTokenResizer` into `FileRenderer.razor` (depends on T015 + T016). When `XFileCaptureConfig.EmbedAs == ImageTokenJpeg240x320`, after the citizen picks/captures a file: invoke the resizer, store the base64 token at `<bound-pointer>/tokenImageBase64` in `_formContext.FormData`, continue with the existing chunked-upload flow for the original. When EmbedAs is null, behaviour identical to today.
+- [ ] T018 [US1] Add ICAO composition guidance panel to `FileRenderer.razor` rendered as a sibling of the capture control, only when `XFileCaptureConfig.EmbedAs == ImageTokenJpeg240x320`. Static markup; tips listed in `contracts/portrait-claim-format.md` § Composition guidance. Localisable via existing resource pattern.
+
+#### 1c. `x-review` extension and ID card layout
+
+- [ ] T019 [P] [US1] Add `XReviewExtension` record + `XReviewLayoutVariant` enum + `XReviewColourTheme` enum + `XReviewHeader` record to `src/Common/Sorcha.Blueprint.Models/Schema/`. See `contracts/x-review-extension.md` § Parser changes for the exact shape.
+- [ ] T020 [P] [US1] Extend `src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs` to recognise `x-review` on a page and emit `XReviewExtension`. Validate at parse time: required header fields present; unknown `layout` produces `WARN_BP_REVIEW_001`; `editable` defaults true; pages with `x-review` MUST NOT declare `properties` (warning).
+- [ ] T021 [US1] Implement `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs` (depends on T019). Method `IdCardLayoutConfig BuildConfig(XReviewExtension extension, FormContext formContext, ActionRuntimeState runtimeState)`. Pull values from `formContext.FormData` for fields declared on prior pages; build `IdCardSection` list mapping section titles back to originating page indices; derive watermark from runtimeState.
+- [ ] T022 [US1] Implement `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor` + `IdCardLayout.razor.css`. Parameters: `IdCardLayoutConfig Config`, `EventCallback<int> OnEditSection`, `RenderFragment? FooterActions`. CSS provides `identity-navy` theme as the v1 baseline (DLA `licence-pink` lands in T036). Watermark rendered per `Config.Watermark` enum. Photo slot on the left, name + structured details on the right, header with issuer + credential name + accent dot, footer with SD-JWT tagline + state.
+- [ ] T023 [US1] Implement `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor`. Reads `XReviewExtension` from the current page, calls `ReviewSummaryDataSource.BuildConfig(...)`, dispatches by `Layout` enum (v1: `IdCard` → `IdCardLayout`; other variants log a warning + render minimal tabular fallback). Wires Edit-X event up to `Wizard.NavigateToPage(pageIndex)` with form state preserved.
+- [ ] T024 [US1] Modify `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ControlDispatcher.razor` to detect a page with `XReviewExtension` and dispatch to `ReviewSummaryRenderer.razor` instead of the default field-rendering loop.
+- [ ] T025 [US1] Modify `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor` to: treat `x-review` pages as read-only (no validation pass on bound model for that page); ensure the page's footer action set comes from the hosting action's routes (Submit/Edit on citizen-side draft, Approve/Reject on assessor-side pending).
+
+#### 1d. Server-side portrait size gate
+
+- [ ] T026 [US1] Modify `BuildClaimsFromMappings` in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs` (or wherever the claim builder lives) to validate `tokenImageBase64` source-field length ≤27_000 chars before claim inclusion. On overrun: omit the claim, emit `WARN_CRED_PORTRAIT_OVERSIZE_001` structured log, surface to citizen's submission response. Credential issuance proceeds without the portrait claim.
+
+#### 1e. AssuredIdentity blueprint
+
+- [ ] T027 [US1] Author `walkthroughs/AssuredIdentity/blueprints/assured-identity.json`. Three actions: 1) open citizen submission with 5-page wizard (Page 1 Name+DoB via `x-sections`, Page 2 Address with postcode lookup, Page 3 Email, Page 4 optional Photo with `x-file.capture: "user"` + `x-file.embedAs: "image-token-jpeg-240x320"`, Page 5 review via `x-review`); 2) assessor approve/reject (decision schema, agent-friendly shape); 3) citizen claim (existing `x-credential-offer` Wave 14b card with dual-path). Reference core schema `$ref` for `PersonName/v1`, `DateOfBirth/v1` (with `formatMaximum: "today"`), `EmailAddress/v1`, `PostalAddress/v1`. Citizen participant has `walletAddress: null` (open). Government assessor participant has a known wallet (filled by setup). Credential type `AssuredIdentityCredential` with claim mappings per `contracts/assured-identity-credential.md`. Both delivery modes declared (register-native + HAIP external).
+
+#### 1f. Walkthrough scaffolding (Phase 1 only)
+
+- [ ] T028 [US1] Create the `walkthroughs/AssuredIdentity/` directory tree: `README.md` (overview, prereqs, run instructions), `blueprints/`, `actors/`, `data/`. Add `data/sample-portrait.jpg` (an ICAO-compliant 480×640 JPEG suitable for the demo citizen).
+- [ ] T029 [US1] Implement `walkthroughs/AssuredIdentity/setup.ps1`. Idempotent. Provisions: Government org (`gov-scotland` subdomain), Government admin user, Government wallet (ED25519), Government-as-HAIP-issuer trust enrolment, Citizen public-org account with persona profile pre-populated for the demo, AssuredIdentity register, blueprint publish via `Publish-SorchaBlueprint` (citizen omitted from `$walletMap` per Feature 103 contract). Save state to `state.json`.
+- [ ] T030 [US1] Implement `walkthroughs/AssuredIdentity/run-phase1-identity.ps1`. Reads `state.json`. Creates a blueprint instance. Calls action 1 as the citizen with a payload that includes the photo (chunked-uploaded + token). Polls for the assessor approval. Polls for the credential offer. Claims into the citizen's HAIP wallet-dir via `sorcha-agent haip receive`. Asserts the credential exists in the wallet-dir with all expected claims including `portrait`. Logs each step.
+- [ ] T031 [US1] Add a `assured-identity` entry to `walkthroughs/.secrets/passwords.json` template with the demo passwords (gov-admin, citizen). Update `walkthroughs/initialize-secrets.ps1` if needed. Document in the README.
+
+#### 1g. Validation pass
+
+- [ ] T032 [US1] Run all renderer test suites (T005–T012) and verify they now pass. Specifically: `dotnet test tests/Sorcha.UI.Core.Tests --filter "Class=DateTimeRendererFutureBlockTests|FileRendererCaptureTests|PhotoTokenResizerTests|ReviewSummaryRendererTests|ReviewSummaryDataSourceTests"` and `dotnet test tests/Sorcha.Blueprint.Models.Tests --filter "Class=XFileExtensionParserTests|XReviewExtensionParserTests"` and `dotnet test tests/Sorcha.Blueprint.Service.Tests --filter "Class=BuildClaimsFromMappingsPortraitTests"`.
+- [ ] T033 [US1] Run `walkthroughs/AssuredIdentity/run-phase1-identity.ps1` end-to-end against the local Docker stack. Verify: citizen submits wizard with photo; agent approves (manually or via Phase 5 actor); citizen claims credential; credential exists in `walkthroughs/AssuredIdentity/wallet/credentials/AssuredIdentityCredential.sdjwt` with all claims including `portrait`. Capture output in PR description.
+
+**Checkpoint**: User Story 1 is fully functional and shippable as PR 1. The Assured Identity workflow runs end-to-end. The renderer polish (DOB block, photo capture, ID card review) lands as reusable platform capability.
+
+---
+
+## Phase 4: User Story 2 — Downstream service chain-consumes the Assured Identity credential (Priority: P2)
+
+**Goal**: A citizen who already holds an `AssuredIdentityCredential` applies for a Driving Licence. DLA verifies identity via OpenID4VP presentation, issues a `DrivingLicenceCredential` with the citizen's portrait carried forward (when present), and the citizen claims the licence into the same wallet.
+
+**Independent Test**: Starting from a clean state, run Phase 1 (US1) to receive an AssuredIdentityCredential. Then run `walkthroughs/AssuredIdentity/run-phase2-licence.ps1`. Verify: the DLA review screen renders both stacked id-cards; the citizen presents only `givenName`, `familyName`, `dateOfBirth`, `portrait` (email and address withheld); the licence credential is signed and lands in the citizen's wallet; the licence's portrait matches the identity's portrait.
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T034 [P] [US2] Write `BuildClaimsFromMappingsCarryForwardTests` in `tests/Sorcha.Blueprint.Service.Tests/BuildClaimsFromMappingsCarryForwardTests.cs` covering: claim mappings sourced from `/presentedClaims/*` resolve correctly when an action has a verified-presentation context; `holderPortrait` carries forward when the citizen disclosed `portrait` from their identity; `holderPortrait` is omitted when the citizen withheld `portrait` (still a valid licence). Tests MUST fail before T035.
+
+### Implementation for User Story 2
+
+- [ ] T035 [US2] Author `walkthroughs/AssuredIdentity/blueprints/driving-licence.json`. Four actions: 1) open citizen submission with 2-page wizard (vehicle class + review via `x-review` with `licence-pink` theme); 2) DLA verification action with `credentialRequirements` referencing `AssuredIdentityCredential` (required claims: `givenName`, `familyName`, `dateOfBirth`; optional claims: `portrait`); 3) DLA approve+issue action with stacked-cards review (presented identity + licence-to-be) and `credentialIssuanceConfig.claimMappings` carrying forward from `/presentedClaims/*`; 4) citizen claim card. Citizen participant has `walletAddress: null` (open). DLA officer participant has known wallet (filled by setup). Credential type `DrivingLicenceCredential` with claims per `contracts/driving-licence-credential.md`. 10-year expiry.
+- [ ] T036 [US2] Add `licence-pink` colour theme to `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor.css` per `contracts/x-review-extension.md` § CSS theming. Add `LicencePink` enum value to `XReviewColourTheme` (depends on T019). UK driving licence pink convention.
+- [ ] T037 [US2] Extend `ReviewSummaryRenderer.razor` (T023) to render two stacked cards on a review page when the hosting action declares both `credentialRequirements` (presented credential) AND `credentialIssuanceConfig` (credential-to-be). Top card pulls disclosed claims from the verified-presentation context, renders withheld claims as faded "— — —" with explanatory caption. Bottom card pulls from the action payload + claim mappings. Each card uses its own `IdCardLayoutConfig`.
+- [ ] T038 [US2] Extend `walkthroughs/AssuredIdentity/setup.ps1` to additionally provision: DLA org (`dla-scotland` subdomain), DLA admin user, DLA wallet, DLA-as-HAIP-issuer trust enrolment, Driving Licence register (or reuse the AssuredIdentity register — per design simplicity), publish `driving-licence.json` blueprint. Idempotent.
+- [ ] T039 [US2] Implement `walkthroughs/AssuredIdentity/run-phase2-licence.ps1`. Reads `state.json`. Verifies the citizen holds an `AssuredIdentityCredential` in the wallet-dir (Phase 1 prerequisite). Creates the licence blueprint instance. Submits action 1 with `vehicleClass: "Car (B)"`. Calls `sorcha-agent haip present` to disclose the requested claims to action 2. Polls for DLA approval (action 3). Claims the licence credential. Asserts the licence exists in the wallet-dir with `portrait` carried forward.
+- [ ] T040 [US2] Implement `walkthroughs/AssuredIdentity/run.ps1`. Runs `setup.ps1` (idempotent), `run-phase1-identity.ps1`, `run-phase2-licence.ps1` in sequence. Asserts both credentials in the wallet-dir at the end. Logs total elapsed time for the SC-001 + SC-002 budget check.
+
+### Validation pass
+
+- [ ] T041 [US2] Run `BuildClaimsFromMappingsCarryForwardTests` (T034) and verify all cases pass.
+- [ ] T042 [US2] Run `walkthroughs/AssuredIdentity/run.ps1` end-to-end against local Docker stack. Verify: both credentials in the wallet; the licence's `holderPortrait` claim matches the identity's `portrait` claim byte-for-byte; the DLA review screen showed both stacked id-cards (visual confirmation); the citizen's email and address never reached the DLA (verified by inspecting the action 2 payload). Capture output in PR description.
+
+**Checkpoint**: User Story 2 is fully functional and shippable as PR 2. The credential chain is proven; the DLA exercises the full HAIP round-trip including selective disclosure and KB-JWT.
+
+---
+
+## Phase 5: User Story 3 — Unattended assessment by a background agent (Priority: P3)
+
+**Goal**: Both walkthrough phases run without a human opening any assessor UI. `sorcha-agent` actors in rules mode pick up pending applications from their inboxes and post approve decisions automatically.
+
+**Independent Test**: Run `walkthroughs/AssuredIdentity/run.ps1` with the actors started in the background by the script. Verify: no human intervention required between submission and approval; both credentials issued; the human assessor UI still renders correctly if a developer opens it during the pending window (manual check).
+
+### Implementation for User Story 3
+
+- [ ] T043 [P] [US3] Author `walkthroughs/AssuredIdentity/actors/citizen.json`. HAIP wallet-dir at `walkthroughs/AssuredIdentity/wallet/`. Polling mode with SignalR fallback. No rules — citizen actor is interactive (driven by `run-phase1-identity.ps1` and `run-phase2-licence.ps1` directly), this config is for `sorcha-agent validate` and reference only.
+- [ ] T044 [P] [US3] Author `walkthroughs/AssuredIdentity/actors/gov-assessor.json`. Rules-mode. Single rule that approves the "Verify Assured Identity Application" action (action name from blueprint), with payload `{ "decision": "approved", "verificationNotes": "Auto-approved by demo agent" }`. SignalR + polling enabled. Logging to `walkthroughs/AssuredIdentity/logs/gov-assessor-actions.jsonl`.
+- [ ] T045 [P] [US3] Author `walkthroughs/AssuredIdentity/actors/dla-officer.json`. Rules-mode. Two rules: one approves the verification action (action 2); one approves the issuance action (action 3) with payload generating the licence number, dates, holder name. SignalR + polling enabled. Logging.
+- [ ] T046 [US3] Update `walkthroughs/AssuredIdentity/run.ps1`, `run-phase1-identity.ps1`, and `run-phase2-licence.ps1` to start `sorcha-agent` background processes for the gov-assessor and dla-officer actors before submitting actions, and to clean them up on exit (success or failure). Use the same pattern as `walkthroughs/ConstructionPermit/run-agents.ps1` for process management. Pass passwords via env vars from `state.json`.
+- [ ] T047 [US3] Run `walkthroughs/AssuredIdentity/run.ps1` end-to-end with NO human in the loop. Verify: both credentials issued within the SC-008 budget (assessor approval ≤ 30s after submission); no script-level state ferrying needed between phases; the citizen actor's wallet-dir contains both credentials at the end. Confirm a developer can still open the gov-assessor UI during the pending window and see the standard review screen (the agent simply gets there first).
+
+**Checkpoint**: User Story 3 is fully functional and shippable as PR 3. The walkthrough is demo-runnable without any human intervention. The agent-based design preserves the seam for future AI-mode and external-API-mode integrations.
+
+---
+
+## Phase 6: User Story 4 — Cross-peer delivery smoke test (Priority: P4)
+
+**Goal**: A two-peer Sorcha federation can be brought up locally; an `AssuredIdentityCredential` issued on peer A reaches the citizen's in-platform wallet on peer B via register-native delivery within the SC-009 latency budget; findings are documented on every run regardless of outcome.
+
+**Independent Test**: `docker compose -f docker-compose.federation.yml up -d` brings both peers healthy. `walkthroughs/AssuredIdentity/run-multi-peer.ps1` produces a findings document. The committed baseline shows a recent pass (or documents the anomaly if the smoke surfaces a replication issue).
+
+### Implementation for User Story 4
+
+- [ ] T048 [US4] Author `docker-compose.federation.yml` at the repo root. Two peer stacks (peer-a, peer-b), each with the full set of services (api-gateway, blueprint, register, validator, wallet, tenant, haip, peer) and per-peer DBs (postgres, mongo, redis). Shared docker network `sorcha-federation`. Per-peer environment overrides for `Peer:NodeId`, `Peer:Seeds`, gateway port (8081 / 8082). Per `contracts/docker-compose-federation.md`. Use `extends:` against the existing `docker-compose.yml` service definitions where possible to avoid duplication.
+- [ ] T049 [US4] Implement `walkthroughs/AssuredIdentity/run-multi-peer.ps1`. Sequence per `contracts/docker-compose-federation.md` § Setup behaviour: `down -v`, `up -d`, wait for both peers healthy, provision Government on peer A only, provision citizen on peer B, subscribe peer B to peer A's register, run Phase 1 with citizen on peer B and assessor agent on peer A, **using register-native delivery** (the citizen claims to in-platform Sorcha wallet via the Wave 14b card's "Store in my Sorcha wallet" path, not the HAIP external path). Assert the credential surfaces in the citizen's MyCredentials PENDING tab on peer B. Citizen accepts; verify the accept transaction is signed by the holder's key (FR-040). Record all milestones with timings.
+- [ ] T050 [US4] Implement findings document generation in `run-multi-peer.ps1` per `contracts/cross-peer-findings-format.md`. YAML frontmatter (timestamp, peer versions, outcome enum, latencies). Five fixed sections (Topology, Timings, Anomalies, Reproduction, Outcome rationale). Outcome computed automatically: pass if all milestones within budget; degraded-pass if any milestone exceeds budget but credential eventually arrives; fail if milestone never reached within 60s; env-failure if docker-compose fails. Writes to `walkthroughs/AssuredIdentity/multi-peer-findings/<timestamp>.md` (per-run, gitignored).
+- [ ] T051 [US4] Add `walkthroughs/AssuredIdentity/multi-peer-findings/` to `.gitignore` (the per-run rolling files). The committed `walkthroughs/AssuredIdentity/multi-peer-findings.md` (singular, no subdirectory) remains tracked as the latest known-good baseline.
+- [ ] T052 [US4] Run the smoke test on the local Docker host. Curate the resulting findings document into a `walkthroughs/AssuredIdentity/multi-peer-findings.md` (committed baseline). Record in the PR description what passed, what was slow, what was anomalous. **If the smoke surfaces a Feature 106 cross-peer replication bug, file a separate issue against the peer-replication subsystem owner; this PR still ships.**
+
+**Checkpoint**: User Story 4 is fully functional and shippable as PR 4. The cross-peer architectural assumption is now measured. Subsequent releases can re-run the smoke and compare findings.
+
+---
+
+## Phase 7: User Story 5 — Consolidation of legacy walkthroughs and credential types (Priority: P5)
+
+**Goal**: After this feature, the repository contains exactly one canonical Assured Identity walkthrough and one canonical credential type for citizen identity. The legacy `HaipVerifiedCitizen/` and `HaipDrivingLicence/` directories are gone; the legacy credential type names no longer appear in live code.
+
+**Independent Test**: Fresh clone of the feature branch. Verify `walkthroughs/AssuredIdentity/` exists and runs end-to-end; `walkthroughs/HaipVerifiedCitizen/` and `walkthroughs/HaipDrivingLicence/` no longer exist; no live source code references `VerifiedCitizenCredential` or `AssuredPersonCredential` outside historical specs and design docs; the `HaipIdentityAttestation/` walkthrough still exists and still runs.
+
+### Implementation for User Story 5
+
+- [ ] T053 [US5] Run a code-search across the repository for live references to `VerifiedCitizenCredential` and `AssuredPersonCredential`. Use `Grep -r "VerifiedCitizenCredential" -- '!specs/**/spec.md' '!specs/**/*.md' '!docs/**/*.md'` and equivalent for `AssuredPersonCredential`. Document any live references found, then update them to `AssuredIdentityCredential` or remove them as appropriate. Re-run until both searches return only historical-document hits.
+- [ ] T054 [US5] Delete `walkthroughs/HaipVerifiedCitizen/` entirely. `git rm -r walkthroughs/HaipVerifiedCitizen/`.
+- [ ] T055 [US5] Delete `walkthroughs/HaipDrivingLicence/` entirely. `git rm -r walkthroughs/HaipDrivingLicence/`.
+- [ ] T056 [US5] Run the full test suite (`dotnet test`) and the smoke test (`dotnet test --filter "Category=Smoke"`) to verify no broken references after deletion. Run `walkthroughs/HaipIdentityAttestation/run.ps1` to verify it still works (different scope — proves bare `sorcha-agent haip receive`).
+- [ ] T057 [US5] Update `walkthroughs/README.md` to remove `HaipVerifiedCitizen` and `HaipDrivingLicence` entries from the walkthroughs table. Add `AssuredIdentity` entry with status, actors, actions, registers, and key features columns matching the existing pattern.
+
+**Checkpoint**: User Story 5 is shippable as PR 5 (final PR for the feature). The platform has a single canonical citizen-identity story.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and skill updates that make the new patterns discoverable to future contributors.
+
+- [ ] T058 [P] Update `CLAUDE.md` with a new "Critical Patterns" section titled "Review Summary (`x-review`)" — about 15 lines, summarising the extension shape, the dispatch model, the two-card stacked variant, and pointing to `specs/107-assured-identity-v1/contracts/x-review-extension.md` for the full contract. Place after the existing "Open Participants & Late Binding" section to keep related patterns adjacent.
+- [ ] T059 [P] Update `.claude/skills/blueprint-builder/SKILL.md` with documentation for the `x-review` extension, the new `x-file.capture` and `x-file.embedAs` fields, and a worked example of the two-card stacked review pattern. Cross-reference the contracts directory.
+- [ ] T060 [P] Update `.claude/skills/walkthrough-builder/SKILL.md` to add `AssuredIdentity` to the existing walkthroughs reference table (and remove `HaipVerifiedCitizen` / `HaipDrivingLicence` from that table after Phase 7 lands). Document the multi-peer smoke-test pattern as a reusable shape for future federation testing.
+- [ ] T061 [P] Update `docs/reference/development-status.md` to note Feature 107 completion: AssuredIdentityCredential as the canonical citizen identity credential, the consolidated walkthrough, the cross-peer smoke test as the standing measurement of Feature 106's cross-peer correctness.
+- [ ] T062 [P] Update `.specify/MASTER-TASKS.md` to mark Theme 6 ("Cross-node verification") status: subsumed by Feature 107 phase 6; baseline cross-peer findings live in `walkthroughs/AssuredIdentity/multi-peer-findings.md`; future regression checks via re-running the smoke.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)** → **Phase 2 (Foundational)** → **Phases 3–7 (User Stories)** → **Phase 8 (Polish)**
+- Phase 2 has only one task (T004) and is intentionally minimal because the platform substrate is already in place.
+
+### User Story Dependencies
+
+- **US1 (P1, MVP)** is independent — it depends only on Phase 2 and on Feature 103's already-shipped substrate (open starting actions, schema $ref, persona autofill).
+- **US2 (P2)** depends on **US1** — it consumes the AssuredIdentityCredential issued by Phase 1 and re-uses the `x-review` extension and `IdCardLayout` from US1.
+- **US3 (P3)** depends on **US1 + US2** — it provides the actor configs that automate both. US1 and US2 can be tested with a human assessor before US3 lands.
+- **US4 (P4)** depends on **US1** only — the cross-peer smoke exercises Phase 1's register-native delivery path. Independent of US2 and US3.
+- **US5 (P5)** depends on **US1 + US2 + US3 + US4** — the consolidation deletion lands last so previous phases can validate against the existing walkthroughs until their replacement is proven.
+
+### Within Each User Story
+
+- Tests (T005–T012, T034) ⚠️ before implementation, fail before implementation lands.
+- Within implementation: model changes (`XReviewExtension`, `XFileCaptureConfig`) before parser updates; parser before renderer dispatch; renderer dispatch before SchemaFormRenderer wiring; everything before the validation pass.
+- Walkthrough scaffolding can land in parallel with renderer implementation (different file trees).
+
+### Parallel Opportunities
+
+**Within US1**:
+- T005–T012: All tests can be written in parallel (different files, no dependencies).
+- T013, T014, T016, T019, T020, T022 (CSS): All implementation pieces touch different files and can land in parallel up to the point of cross-wiring (T017, T021, T023, T024, T025).
+
+**Within US2**:
+- T035 (blueprint), T036 (CSS theme), T037 (renderer extension) all touch different files.
+
+**Within US3**: T043, T044, T045 are three separate JSON files — fully parallel.
+
+**Within US8 (Polish)**: T058–T062 all touch different files — fully parallel.
+
+### Cross-Story Parallelism
+
+- US3 (T043–T046) and US4 (T048–T051) can be developed in parallel after US1 ships, since they touch different file trees (`actors/` vs `docker-compose.federation.yml` + `run-multi-peer.ps1`).
+
+---
+
+## Parallel Examples
+
+### Example: US1 test wave (write all eight tests before any implementation)
+
+```bash
+# All seven test files can be written in parallel:
+T005 tests/Sorcha.UI.Core.Tests/Components/Forms/DateTimeRendererFutureBlockTests.cs
+T006 tests/Sorcha.Blueprint.Models.Tests/XFileExtensionParserTests.cs
+T007 tests/Sorcha.UI.Core.Tests/Components/Forms/FileRendererCaptureTests.cs
+T008 tests/Sorcha.UI.Core.Tests/Services/Forms/PhotoTokenResizerTests.cs
+T009 tests/Sorcha.Blueprint.Models.Tests/XReviewExtensionParserTests.cs
+T010 tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
+T011 tests/Sorcha.UI.Core.Tests/Components/Forms/ReviewSummaryRendererTests.cs
+T012 tests/Sorcha.Blueprint.Service.Tests/BuildClaimsFromMappingsPortraitTests.cs
+
+# Run them and confirm all fail:
+dotnet test --filter "Class~DateTimeRendererFutureBlockTests|Class~XFileExtensionParserTests|Class~FileRendererCaptureTests|Class~PhotoTokenResizerTests|Class~XReviewExtensionParserTests|Class~ReviewSummaryDataSourceTests|Class~ReviewSummaryRendererTests|Class~BuildClaimsFromMappingsPortraitTests"
+```
+
+### Example: US1 model + parser wave
+
+```bash
+# After tests fail, implement model and parser pieces in parallel:
+T014 src/Common/Sorcha.Blueprint.Models/Schema/XFileExtension.cs
+T019 src/Common/Sorcha.Blueprint.Models/Schema/XReviewExtension.cs
+T020 src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs
+
+# Parser tests should now pass (T006 + T009).
+```
+
+### Example: US3 actor file wave
+
+```bash
+# All three actor JSON files in parallel:
+T043 walkthroughs/AssuredIdentity/actors/citizen.json
+T044 walkthroughs/AssuredIdentity/actors/gov-assessor.json
+T045 walkthroughs/AssuredIdentity/actors/dla-officer.json
+```
+
+### Example: Polish wave (after Phase 7)
+
+```bash
+T058 CLAUDE.md
+T059 .claude/skills/blueprint-builder/SKILL.md
+T060 .claude/skills/walkthrough-builder/SKILL.md
+T061 docs/reference/development-status.md
+T062 .specify/MASTER-TASKS.md
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+US1 alone delivers a substantive, demonstrable improvement: the canonical Assured Identity credential issued via a polished GDS-style citizen wizard with the new `x-review` ID-card review pattern. Even without DLA chain (US2), unattended assessment (US3), cross-peer smoke (US4), or legacy cleanup (US5), the platform has a credible "issue an identity credential" story that could be demoed.
+
+**Suggested MVP scope**: T001–T033 (Setup + Foundational + US1).
+
+### Incremental Delivery
+
+| PR | Phases | Ship | What it adds |
+|---|---|---|---|
+| PR 1 | 1–3 (US1) | Core | Renderer polish + Assured Identity credential + Phase 1 walkthrough (manual assessor OK) |
+| PR 2 | 4 (US2) | Chain | Driving Licence credential + Phase 2 walkthrough proving credential chain |
+| PR 3 | 5 (US3) | Automation | Unattended walkthrough via background agents |
+| PR 4 | 6 (US4) | Measurement | Cross-peer smoke + findings baseline |
+| PR 5 | 7 + 8 (US5 + Polish) | Consolidation | Legacy deletion + documentation updates |
+
+Five PRs sequenced over the duration of the feature. Each PR is independently reviewable and ships a testable increment.
+
+### Parallel Team Strategy
+
+If multiple contributors are available:
+- Contributor A: PR 1 (US1 — the bulk of the work)
+- Contributor B: PR 4 (US4 — independent infra) can start immediately after US1 lands, in parallel with PR 2/3
+- Contributor C: PR 3 (US3) can start in parallel with PR 2 since the actor configs are isolated from the blueprint changes
+
+Recommended single-contributor cadence: PR 1 → PR 2 → PR 3 → PR 4 → PR 5 sequentially, ~1 week per PR for a feature this size.
+
+---
+
+## Notes
+
+- **Tests are mandatory** per Sorcha constitution Principle IV (≥85% coverage on new code). Test tasks (T005–T012, T034) are listed before implementation in each user story phase. Sorcha's TDD-leaning practice: write the tests, watch them fail, implement until they pass.
+- **No database migrations** in this feature. All credentials, sealed disclosures, file chunks, and persona data flow through existing persistence.
+- **No new HTTP endpoints**. All platform interaction reuses existing documented endpoints.
+- **Photo capture requires a browser with `<canvas>` and `MediaDevices.getUserMedia`** for the resize pipeline. Older browsers fall back to plain file picker without resize — credential is issued without `portrait`.
+- **The cross-peer smoke test is non-blocking**. If T052 surfaces a Feature 106 cross-peer bug, file an issue and ship PR 4 with the findings documented; do not block this feature on a different subsystem's bug fix.
+- **Phase 7 (cleanup) MUST be last**. Earlier phases need the existing walkthroughs as references and as comparison test fixtures; deleting them too early breaks intermediate validation.
+
+---
+
+## Task count summary
+
+| Phase | Tasks | User Story | Independently Shippable PR? |
+|---|---|---|---|
+| 1 — Setup | 3 (T001–T003) | — | No (prerequisite) |
+| 2 — Foundational | 1 (T004) | — | No (prerequisite) |
+| 3 — US1 (P1) 🎯 MVP | 29 (T005–T033) | Citizen flow + renderer polish | Yes — PR 1 |
+| 4 — US2 (P2) | 9 (T034–T042) | DLA chain | Yes — PR 2 |
+| 5 — US3 (P3) | 5 (T043–T047) | Unattended assessor | Yes — PR 3 |
+| 6 — US4 (P4) | 5 (T048–T052) | Cross-peer smoke | Yes — PR 4 |
+| 7 — US5 (P5) | 5 (T053–T057) | Consolidation cleanup | Yes — PR 5 |
+| 8 — Polish | 5 (T058–T062) | — | Bundled with PR 5 |
+| **Total** | **62** | 5 user stories, 5 PRs | |
+
+**Parallel opportunities identified**:
+- 8 test tasks in parallel within US1 (T005–T012)
+- 3 actor JSON tasks in parallel within US3 (T043–T045)
+- 5 polish tasks in parallel (T058–T062)
+- US3 (T043–T046) and US4 (T048–T051) can be developed in parallel after US1 ships

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/DateTimeRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/DateTimeRenderer.razor
@@ -61,7 +61,11 @@
         var propertySchema = SchemaService.GetSchemaForScope(FormContext.DataSchema, Control.Scope);
         if (propertySchema is null) return;
 
-        var today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+        // Use the user's local date for the client-side bound so a citizen
+        // near midnight doesn't see "today" as a blocked date because the
+        // UTC clock has rolled forward. The server-side validator remains
+        // authoritative; the picker bound is UX convenience only.
+        var today = DateOnly.FromDateTime(DateTime.Now.Date);
 
         if (DateTimeFieldBoundResolver.TryResolveBound(propertySchema.Value, "formatMinimum", today, out var minBound)
             && minBound is { } min)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/DateTimeRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/DateTimeRenderer.razor
@@ -17,6 +17,8 @@
                Error="@(!string.IsNullOrEmpty(_errorText))"
                Variant="Variant.Outlined"
                Margin="Margin.Dense"
+               MinDate="@_minDate"
+               MaxDate="@_maxDate"
                DateFormat="yyyy-MM-dd" />
 
 @code {
@@ -25,6 +27,8 @@
     [Parameter] public bool IsDisabled { get; set; }
 
     private DateTime? _dateValue;
+    private DateTime? _minDate;
+    private DateTime? _maxDate;
     private string _errorText = string.Empty;
     private bool _isRequired;
 
@@ -38,7 +42,38 @@
             _dateValue = dt;
         }
 
+        // Feature 107 — resolve formatMinimum / formatMaximum Sorcha date
+        // tokens into concrete client-side bounds so the picker cannot
+        // select past a DoB cutoff. Server-side validator remains the
+        // authoritative gate; this is a UX convenience.
+        ResolvePickerBounds();
+
         UpdateErrors();
+    }
+
+    private void ResolvePickerBounds()
+    {
+        _minDate = null;
+        _maxDate = null;
+
+        if (FormContext?.DataSchema is null) return;
+
+        var propertySchema = SchemaService.GetSchemaForScope(FormContext.DataSchema, Control.Scope);
+        if (propertySchema is null) return;
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow.Date);
+
+        if (DateTimeFieldBoundResolver.TryResolveBound(propertySchema.Value, "formatMinimum", today, out var minBound)
+            && minBound is { } min)
+        {
+            _minDate = min.ToDateTime(TimeOnly.MinValue);
+        }
+
+        if (DateTimeFieldBoundResolver.TryResolveBound(propertySchema.Value, "formatMaximum", today, out var maxBound)
+            && maxBound is { } max)
+        {
+            _maxDate = max.ToDateTime(TimeOnly.MinValue);
+        }
     }
 
     private void OnDateChanged(DateTime? newDate)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/FileRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/FileRenderer.razor
@@ -74,11 +74,41 @@
     private string? _acceptAttribute;
     private bool _showPortraitTips;
 
-    private const long MaxFileSize = 40L * 1024 * 1024; // 40 MB platform ceiling
+    // Platform ceiling — acts as the fallback when the schema doesn't
+    // declare an explicit `x-file.maxSizePerFile`. The per-field limit is
+    // preferred because it bounds the WASM buffer for camera capture on
+    // low-memory mobile devices (40 MB is feasible to OOM a phone when
+    // the citizen takes a high-resolution photo).
+    private const long PlatformMaxFileSize = 40L * 1024 * 1024;
 
     protected override void OnParametersSet()
     {
         ResolveFileExtension();
+    }
+
+    /// <summary>
+    /// Effective upload stream limit, honouring the schema's declared
+    /// <c>x-file.maxSizePerFile</c> when present and falling back to the
+    /// platform ceiling when it isn't. Returns bytes.
+    /// </summary>
+    private long ResolveMaxFileSize()
+    {
+        if (_fileExtension is null || string.IsNullOrWhiteSpace(_fileExtension.MaxSizePerFile))
+            return PlatformMaxFileSize;
+
+        try
+        {
+            var declared = FileSchemaExtension.ParseMaxSizeBytes(_fileExtension.MaxSizePerFile);
+            // Clamp defensively so a blueprint can never request a larger
+            // buffer than the platform tolerates.
+            return Math.Min(declared, PlatformMaxFileSize);
+        }
+        catch (ArgumentException)
+        {
+            // Malformed string — caught at publish time upstream. Fall back
+            // to the platform ceiling so the field still functions.
+            return PlatformMaxFileSize;
+        }
     }
 
     private void ResolveFileExtension()
@@ -112,7 +142,7 @@
         try
         {
             var scope = Control.Scope;
-            using var stream = file.OpenReadStream(MaxFileSize);
+            using var stream = file.OpenReadStream(ResolveMaxFileSize());
             using var ms = new MemoryStream();
             await stream.CopyToAsync(ms);
             var sourceBytes = ms.ToArray();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/FileRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Controls/FileRenderer.razor
@@ -2,13 +2,30 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.Extensions.Logging
 @using Sorcha.Blueprint.Models
 @using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Forms
+
+@inject IFormSchemaService SchemaService
+@inject PhotoTokenResizer TokenResizer
+@inject ILogger<FileRenderer> Logger
 
 <MudStack Spacing="1">
     <MudText Typo="Typo.body2">@Control.Title</MudText>
 
-    <InputFile OnChange="OnFileSelected" disabled="@(IsDisabled || FormContext?.IsReadOnly == true)" />
+    <InputFile OnChange="OnFileSelected"
+               disabled="@(IsDisabled || FormContext?.IsReadOnly == true)"
+               capture="@_captureAttribute"
+               accept="@_acceptAttribute" />
+
+    @if (_resizeInProgress)
+    {
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+            <MudText Typo="Typo.body2">Preparing portrait token…</MudText>
+        </MudStack>
+    }
 
     @if (_selectedFile is not null)
     {
@@ -20,6 +37,25 @@
                            OnClick="RemoveFile" />
         </MudStack>
     }
+
+    @if (!string.IsNullOrEmpty(_resizeWarning))
+    {
+        <MudAlert Severity="Severity.Warning" Dense="true">@_resizeWarning</MudAlert>
+    }
+
+    @if (_showPortraitTips)
+    {
+        <MudPaper Class="pa-3 mt-2" Elevation="0" Outlined="true">
+            <MudText Typo="Typo.subtitle2" Class="mb-2">Photo tips (ICAO guidance)</MudText>
+            <MudList T="string" Dense="true" DisablePadding="true">
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check">Plain light background</MudListItem>
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check">Face centred, filling 70–80% of the frame</MudListItem>
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check">Neutral expression, eyes open, looking at camera</MudListItem>
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check">No sunglasses or head covering (except religious)</MudListItem>
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check">Even lighting, no shadows on face</MudListItem>
+            </MudList>
+        </MudPaper>
+    }
 </MudStack>
 
 @code {
@@ -29,12 +65,49 @@
 
     private FileAttachmentInfo? _selectedFile;
     private string _fileDisplayText = string.Empty;
-    private const long MaxFileSize = 10 * 1024 * 1024; // 10 MB default
+    private bool _resizeInProgress;
+    private string? _resizeWarning;
+
+    // Parsed x-file extension for this field (Feature 107 additions).
+    private FileSchemaExtension? _fileExtension;
+    private string? _captureAttribute;
+    private string? _acceptAttribute;
+    private bool _showPortraitTips;
+
+    private const long MaxFileSize = 40L * 1024 * 1024; // 40 MB platform ceiling
+
+    protected override void OnParametersSet()
+    {
+        ResolveFileExtension();
+    }
+
+    private void ResolveFileExtension()
+    {
+        _fileExtension = null;
+        _captureAttribute = null;
+        _acceptAttribute = null;
+        _showPortraitTips = false;
+
+        if (FormContext?.DataSchema is null) return;
+
+        var propertySchema = SchemaService.GetSchemaForScope(FormContext.DataSchema, Control.Scope);
+        if (propertySchema is null) return;
+
+        if (FileSchemaExtension.TryParseFromSchema(propertySchema.Value, out var ext) && ext is not null)
+        {
+            _fileExtension = ext;
+            _captureAttribute = FileFieldCaptureHelper.GetCaptureAttribute(ext);
+            _acceptAttribute = ext.Accept.Length > 0 ? string.Join(",", ext.Accept) : null;
+            _showPortraitTips = FileFieldCaptureHelper.ShouldResizeForEmbed(ext);
+        }
+    }
 
     private async Task OnFileSelected(InputFileChangeEventArgs e)
     {
         var file = e.File;
         if (file is null) return;
+
+        _resizeWarning = null;
 
         try
         {
@@ -42,13 +115,14 @@
             using var stream = file.OpenReadStream(MaxFileSize);
             using var ms = new MemoryStream();
             await stream.CopyToAsync(ms);
+            var sourceBytes = ms.ToArray();
 
             _selectedFile = new FileAttachmentInfo
             {
                 FileName = file.Name,
                 ContentType = file.ContentType,
                 Size = file.Size,
-                Content = ms.ToArray(),
+                Content = sourceBytes,
                 Scope = scope
             };
 
@@ -58,10 +132,55 @@
             FormContext?.FileAttachments.RemoveAll(a => a.Scope == scope);
             FormContext?.FileAttachments.Add(_selectedFile);
             FormContext?.SetValue(scope, file.Name);
+
+            // Feature 107 — when the field declares `embedAs`, produce the
+            // token-image alongside the original so the action payload carries
+            // both. The token is the claim value; the original is the
+            // assessor-visible evidence.
+            if (FileFieldCaptureHelper.ShouldResizeForEmbed(_fileExtension))
+            {
+                await ProducePortraitTokenAsync(scope, sourceBytes);
+            }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Logger.LogWarning(ex, "File selection failed for scope {Scope}", Control.Scope);
             _selectedFile = null;
+        }
+    }
+
+    private async Task ProducePortraitTokenAsync(string fieldScope, byte[] sourceBytes)
+    {
+        _resizeInProgress = true;
+        StateHasChanged();
+
+        try
+        {
+            var result = await TokenResizer.ResizeAsync(
+                sourceBytes,
+                ImageTokenSpec.ImageTokenJpeg240x320);
+
+            // Store the token next to the original on the form context at a
+            // stable sibling pointer so the claim mapping can reference it:
+            //   <fieldScope>/tokenImageBase64
+            var tokenScope = $"{fieldScope}/tokenImageBase64";
+            FormContext?.SetValue(tokenScope, result.Base64);
+        }
+        catch (PhotoTokenTooDetailedException ex)
+        {
+            _resizeWarning = "The photo is too detailed to fit the credential's portrait slot. " +
+                             "Try a plainer background, or skip the photo — you'll still get a credential without it.";
+            Logger.LogInformation(ex, "Portrait resize floor reached for scope {Scope}", fieldScope);
+        }
+        catch (Exception ex)
+        {
+            _resizeWarning = "Could not process the photo for embedding. The credential will be issued without a portrait.";
+            Logger.LogWarning(ex, "Unexpected portrait resize failure for scope {Scope}", fieldScope);
+        }
+        finally
+        {
+            _resizeInProgress = false;
+            StateHasChanged();
         }
     }
 
@@ -72,8 +191,10 @@
             var scope = Control.Scope;
             FormContext?.FileAttachments.RemoveAll(a => a.Scope == scope);
             FormContext?.SetValue(scope, null);
+            FormContext?.SetValue($"{scope}/tokenImageBase64", null);
             _selectedFile = null;
             _fileDisplayText = string.Empty;
+            _resizeWarning = null;
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor
@@ -1,6 +1,7 @@
 @* SPDX-License-Identifier: MIT *@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
+@using System.Text
 @using Sorcha.Blueprint.Models
 @using Sorcha.UI.Core.Models.Forms
 
@@ -148,7 +149,7 @@
         if (string.IsNullOrEmpty(leaf)) return pointer;
 
         // camelCase → "Camel case"
-        var chars = new System.Text.StringBuilder();
+        var chars = new StringBuilder();
         for (var i = 0; i < leaf.Length; i++)
         {
             var c = leaf[i];

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor
@@ -1,0 +1,162 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using Sorcha.Blueprint.Models
+@using Sorcha.UI.Core.Models.Forms
+
+@* Feature 107 Assured Identity v1 — styled credential-card layout. One
+   component renders citizen draft (Edit/Submit), assessor pending
+   (Approve/Reject), and wallet-detail (no actions) states by changing
+   the watermark enum and the FooterActions render fragment supplied
+   from the parent. *@
+
+<div class="id-card"
+     data-theme="@ThemeAttribute"
+     data-watermark="@WatermarkAttribute">
+
+    <div class="id-card-header">
+        <div class="id-card-header-text">
+            <div class="id-card-issuer">Issued by @Config.IssuerName</div>
+            <div class="id-card-credential-name">@Config.CredentialName</div>
+        </div>
+        <div class="id-card-accent-dot"></div>
+    </div>
+
+    @if (Config.Watermark != IdCardWatermark.None)
+    {
+        <div class="id-card-watermark">@Config.Watermark.ToString().ToUpperInvariant()</div>
+    }
+
+    <div class="id-card-body">
+        <div class="id-card-portrait">
+            @if (_portraitDataUri is not null)
+            {
+                <img src="@_portraitDataUri" alt="Holder portrait" />
+            }
+            else
+            {
+                <div class="id-card-portrait-placeholder">
+                    <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Large" />
+                </div>
+            }
+        </div>
+
+        <div class="id-card-details">
+            @foreach (var cardSection in Config.Sections)
+            {
+                <div class="id-card-section">
+                    <div class="id-card-section-header">
+                        <span class="id-card-section-title">@cardSection.Title</span>
+                        @if (Config.Editable)
+                        {
+                            <MudButton Size="Size.Small"
+                                       Variant="Variant.Text"
+                                       Color="Color.Primary"
+                                       OnClick="@(() => HandleEdit(cardSection.OriginatingPageIndex))"
+                                       StartIcon="@Icons.Material.Filled.Edit">
+                                Edit
+                            </MudButton>
+                        }
+                    </div>
+                    <dl class="id-card-fields">
+                        @foreach (var pointer in cardSection.FieldPointers)
+                        {
+                            <div class="id-card-field">
+                                <dt>@FormatLabel(pointer)</dt>
+                                <dd>@FormatValue(Config.FieldValues.GetValueOrDefault(pointer))</dd>
+                            </div>
+                        }
+                    </dl>
+                </div>
+            }
+        </div>
+    </div>
+
+    @if (FooterActions is not null)
+    {
+        <div class="id-card-footer">
+            @FooterActions
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public required IdCardLayoutConfig Config { get; set; }
+    [Parameter] public EventCallback<int> OnEditSection { get; set; }
+    [Parameter] public RenderFragment? FooterActions { get; set; }
+
+    private string? _portraitDataUri;
+
+    protected override void OnParametersSet()
+    {
+        // Portrait rendering: if a tokenImageBase64 value landed in the
+        // review context (FileRenderer resize pipeline), surface it as the
+        // card's photo. The exact pointer depends on the field name but
+        // the convention is `<fieldPointer>/tokenImageBase64`.
+        _portraitDataUri = null;
+        foreach (var (key, value) in Config.FieldValues)
+        {
+            if (key.EndsWith("/tokenImageBase64", StringComparison.Ordinal) &&
+                value is string base64 &&
+                !string.IsNullOrEmpty(base64))
+            {
+                _portraitDataUri = $"data:image/jpeg;base64,{base64}";
+                break;
+            }
+        }
+    }
+
+    private string ThemeAttribute => Config.ColourTheme switch
+    {
+        XReviewColourTheme.IdentityNavy => "identity-navy",
+        XReviewColourTheme.LicencePink => "licence-pink",
+        _ => "identity-navy"
+    };
+
+    private string WatermarkAttribute => Config.Watermark switch
+    {
+        IdCardWatermark.Draft => "draft",
+        IdCardWatermark.Pending => "pending",
+        IdCardWatermark.Issued => "issued",
+        _ => "none"
+    };
+
+    private async Task HandleEdit(int pageIndex)
+    {
+        if (OnEditSection.HasDelegate)
+        {
+            await OnEditSection.InvokeAsync(pageIndex);
+        }
+    }
+
+    /// <summary>Render a JSON-pointer leaf as a human label ("/givenName" → "Given name").</summary>
+    private static string FormatLabel(string pointer)
+    {
+        var leaf = pointer.TrimStart('/');
+        var lastSlash = leaf.LastIndexOf('/');
+        if (lastSlash >= 0) leaf = leaf[(lastSlash + 1)..];
+        if (string.IsNullOrEmpty(leaf)) return pointer;
+
+        // camelCase → "Camel case"
+        var chars = new System.Text.StringBuilder();
+        for (var i = 0; i < leaf.Length; i++)
+        {
+            var c = leaf[i];
+            if (i == 0) chars.Append(char.ToUpperInvariant(c));
+            else if (char.IsUpper(c)) { chars.Append(' '); chars.Append(char.ToLowerInvariant(c)); }
+            else chars.Append(c);
+        }
+        return chars.ToString();
+    }
+
+    private static string FormatValue(object? value)
+    {
+        if (value is null) return "—";
+        return value switch
+        {
+            string s when string.IsNullOrWhiteSpace(s) => "—",
+            string s => s,
+            _ => value.ToString() ?? "—"
+        };
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor
@@ -22,7 +22,9 @@
         <div class="id-card-accent-dot"></div>
     </div>
 
-    @if (Config.Watermark != IdCardWatermark.None)
+    @* Issued credentials render no watermark (clean appearance); None is
+       also a no-op. Draft + Pending get the rotated accent badge. *@
+    @if (Config.Watermark is IdCardWatermark.Draft or IdCardWatermark.Pending)
     {
         <div class="id-card-watermark">@Config.Watermark.ToString().ToUpperInvariant()</div>
     }
@@ -91,18 +93,26 @@
     {
         // Portrait rendering: if a tokenImageBase64 value landed in the
         // review context (FileRenderer resize pipeline), surface it as the
-        // card's photo. The exact pointer depends on the field name but
-        // the convention is `<fieldPointer>/tokenImageBase64`.
+        // card's photo. Pointer convention is `<fieldPointer>/tokenImageBase64`.
+        //
+        // v1 limitation: only one portrait field per blueprint is supported.
+        // The lowest-pointer match wins (stable order, not dictionary-iteration
+        // order) so a future two-field blueprint lands deterministically on
+        // the first field rather than whichever the dictionary happened to
+        // yield first. If blueprints ever need multiple portrait slots, have
+        // ReviewSummaryDataSource thread an explicit PortraitPointer on
+        // IdCardLayoutConfig and remove this scan.
         _portraitDataUri = null;
-        foreach (var (key, value) in Config.FieldValues)
+        var match = Config.FieldValues
+            .Where(kvp => kvp.Key.EndsWith("/tokenImageBase64", StringComparison.Ordinal)
+                          && kvp.Value is string s
+                          && !string.IsNullOrEmpty(s))
+            .OrderBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(kvp => (string?)kvp.Value)
+            .FirstOrDefault();
+        if (match is not null)
         {
-            if (key.EndsWith("/tokenImageBase64", StringComparison.Ordinal) &&
-                value is string base64 &&
-                !string.IsNullOrEmpty(base64))
-            {
-                _portraitDataUri = $"data:image/jpeg;base64,{base64}";
-                break;
-            }
+            _portraitDataUri = $"data:image/jpeg;base64,{match}";
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor.css
@@ -85,10 +85,8 @@
     border-color: #ffb347;
     color: #ffb347;
 }
-
-.id-card[data-watermark="issued"] .id-card-watermark {
-    display: none; /* issued state renders no watermark */
-}
+/* The Razor template omits the watermark element for `Issued` and `None`,
+   so no corresponding CSS rule is needed here. */
 
 .id-card-body {
     display: flex;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/Layouts/IdCardLayout.razor.css
@@ -1,0 +1,205 @@
+/* SPDX-License-Identifier: MIT */
+/* Copyright (c) 2026 Sorcha Contributors */
+/* Feature 107 Assured Identity v1 — id-card layout styling. */
+
+.id-card {
+    position: relative;
+    border-radius: 16px;
+    padding: 24px;
+    color: #fff;
+    background: linear-gradient(135deg,
+        var(--card-bg-start),
+        var(--card-bg-mid) 50%,
+        var(--card-bg-end));
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+    overflow: hidden;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.id-card[data-theme="identity-navy"] {
+    --card-bg-start: #0b2545;
+    --card-bg-mid: #13315c;
+    --card-bg-end: #1b4b7a;
+    --card-accent: #d4a017;
+    --card-label: #a8c5e6;
+}
+
+.id-card[data-theme="licence-pink"] {
+    --card-bg-start: #6d1b3c;
+    --card-bg-mid: #8e2350;
+    --card-bg-end: #ad2c63;
+    --card-accent: #ffe5b4;
+    --card-label: #f5c2d6;
+}
+
+.id-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.id-card-issuer {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: var(--card-label);
+}
+
+.id-card-credential-name {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 2px;
+}
+
+.id-card-accent-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--card-accent);
+    box-shadow: 0 0 12px var(--card-accent);
+    flex-shrink: 0;
+    margin-top: 6px;
+}
+
+.id-card-watermark {
+    position: absolute;
+    top: 88px;
+    right: 24px;
+    font-size: 1rem;
+    font-weight: 700;
+    padding: 4px 12px;
+    border-radius: 4px;
+    border: 2px solid var(--card-accent);
+    color: var(--card-accent);
+    letter-spacing: 2px;
+    transform: rotate(-6deg);
+    opacity: 0.82;
+    pointer-events: none;
+}
+
+.id-card[data-watermark="pending"] .id-card-watermark {
+    border-color: #ffb347;
+    color: #ffb347;
+}
+
+.id-card[data-watermark="issued"] .id-card-watermark {
+    display: none; /* issued state renders no watermark */
+}
+
+.id-card-body {
+    display: flex;
+    gap: 24px;
+}
+
+.id-card-portrait {
+    width: 160px;
+    min-width: 160px;
+    height: 210px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid rgba(255, 255, 255, 0.12);
+}
+
+.id-card-portrait img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.id-card-portrait-placeholder {
+    color: var(--card-label);
+    opacity: 0.6;
+}
+
+.id-card-details {
+    flex: 1;
+    min-width: 0;
+}
+
+.id-card-section {
+    margin-bottom: 18px;
+}
+
+.id-card-section:last-child {
+    margin-bottom: 0;
+}
+
+.id-card-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    padding-bottom: 4px;
+    margin-bottom: 8px;
+}
+
+.id-card-section-title {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--card-label);
+    font-weight: 600;
+}
+
+.id-card-section ::deep .mud-button {
+    color: #fff !important;
+    text-transform: none;
+}
+
+.id-card-fields {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 6px;
+    margin: 0;
+}
+
+.id-card-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.id-card-field dt {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--card-label);
+    margin: 0;
+}
+
+.id-card-field dd {
+    font-size: 0.95rem;
+    font-weight: 500;
+    margin: 0;
+    word-break: break-word;
+}
+
+.id-card-footer {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    margin-top: 20px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+@media (max-width: 540px) {
+    .id-card-body {
+        flex-direction: column;
+    }
+
+    .id-card-portrait {
+        width: 100%;
+        max-width: 240px;
+        height: 320px;
+        margin: 0 auto;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
@@ -72,7 +72,7 @@ else
                     {
                         @foreach (var field in sec.Fields)
                         {
-                            var pointer = field.StartsWith('/') ? field : "/" + field;
+                            var pointer = ReviewSummaryDataSource.PointerFromFieldName(field);
                             var value = FormContext?.FormData.GetValueOrDefault(pointer)?.ToString() ?? "—";
                             <MudListItem T="string">@field: @value</MudListItem>
                         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
@@ -1,0 +1,84 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using Sorcha.Blueprint.Models
+@using Sorcha.UI.Core.Components.Forms.Layouts
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Forms
+
+@inject ReviewSummaryDataSource DataSource
+
+@* Feature 107 Assured Identity v1 — renders a wizard review page using the
+   parsed x-review extension. Dispatches by layout variant; v1 implements
+   id-card only, other variants fall back to a minimal tabular render. *@
+
+@if (Page.ReviewExtension is null)
+{
+    @* Caller error — the dispatcher should not route non-review pages here. *@
+    <MudAlert Severity="Severity.Warning">No x-review extension on this page.</MudAlert>
+}
+else if (FormContext is null)
+{
+    <MudAlert Severity="Severity.Info">Loading review…</MudAlert>
+}
+else if (!ReviewSummaryDispatch.IsImplemented(Page.ReviewExtension.Layout))
+{
+    @* Reserved variants (passport-page / tabular / receipt) — minimal fallback. *@
+    <MudAlert Severity="Severity.Info" Class="mb-3">
+        Review layout <b>@Page.ReviewExtension.Layout</b> is not implemented yet — showing a plain summary.
+    </MudAlert>
+    @RenderMinimalSummary()
+}
+else
+{
+    var config = DataSource.BuildConfig(Page.ReviewExtension, FormContext, RuntimeState, PriorPages);
+    <IdCardLayout Config="@config"
+                  OnEditSection="HandleEdit"
+                  FooterActions="FooterActions" />
+}
+
+@code {
+    [CascadingParameter] public FormContext? FormContext { get; set; }
+
+    [Parameter, EditorRequired] public required BlueprintPageDefinition Page { get; set; }
+
+    [Parameter, EditorRequired] public required IReadOnlyList<BlueprintPageDefinition> PriorPages { get; set; }
+
+    [Parameter] public ActionRuntimeState RuntimeState { get; set; } = ActionRuntimeState.CitizenDraft;
+
+    [Parameter] public EventCallback<int> OnEditSection { get; set; }
+
+    [Parameter] public RenderFragment? FooterActions { get; set; }
+
+    private async Task HandleEdit(int pageIndex)
+    {
+        if (OnEditSection.HasDelegate)
+        {
+            await OnEditSection.InvokeAsync(pageIndex);
+        }
+    }
+
+    private RenderFragment RenderMinimalSummary() => __builder =>
+    {
+        // Tabular fallback for unimplemented layout variants.
+        for (var i = 0; i < PriorPages.Count; i++)
+        {
+            var priorPage = PriorPages[i];
+            if (priorPage.Sections is not { Count: > 0 }) continue;
+            <MudPaper Class="pa-3 mb-2" Elevation="0" Outlined="true">
+                <MudText Typo="Typo.subtitle2">@priorPage.Title</MudText>
+                <MudList T="string" Dense="true" DisablePadding="true">
+                    @foreach (var sec in priorPage.Sections)
+                    {
+                        @foreach (var field in sec.Fields)
+                        {
+                            var pointer = field.StartsWith('/') ? field : "/" + field;
+                            var value = FormContext?.FormData.GetValueOrDefault(pointer)?.ToString() ?? "—";
+                            <MudListItem T="string">@field: @value</MudListItem>
+                        }
+                    }
+                </MudList>
+            </MudPaper>
+        }
+    };
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor
@@ -70,7 +70,18 @@
                         </MudText>
                     }
 
-                    @if (wizardPage.Sections is { Count: > 0 })
+                    @if (wizardPage.ReviewExtension is not null)
+                    {
+                        @* Feature 107 — x-review page. Suppress field rendering
+                           entirely and hand over to the review summary
+                           component with the prior pages as the value source. *@
+                        var priorPages = Layout.Pages.Take(_currentPage).ToList();
+                        <ReviewSummaryRenderer Page="@wizardPage"
+                                               PriorPages="@priorPages"
+                                               RuntimeState="ActionRuntimeState.CitizenDraft"
+                                               OnEditSection="HandleReviewEdit" />
+                    }
+                    else if (wizardPage.Sections is { Count: > 0 })
                     {
                         @foreach (var sec in wizardPage.Sections)
                         {
@@ -78,8 +89,10 @@
                         }
                     }
 
-                    @* Catch-all on the last wizard page *@
-                    @if (_currentPage == Layout.Pages.Count - 1 && _orphanFieldControls.Count > 0)
+                    @* Catch-all on the last wizard page (skipped for review pages — they are read-only) *@
+                    @if (wizardPage.ReviewExtension is null &&
+                         _currentPage == Layout.Pages.Count - 1 &&
+                         _orphanFieldControls.Count > 0)
                     {
                         @RenderCatchAll()
                     }
@@ -880,6 +893,22 @@
         if (Layout?.Pages is null) return;
         if (pageIndex < 0 || pageIndex > _currentPage) return; // only allow visited pages
 
+        _currentPage = pageIndex;
+        _showValidationSummary = false;
+        if (OnPageChanged.HasDelegate)
+            await OnPageChanged.InvokeAsync(_currentPage);
+    }
+
+    /// <summary>
+    /// Feature 107 — Edit-X jump from a review card's section. Unlike the
+    /// stepper, the jump can come from any previously-visited page whose
+    /// section is still listed on the review; the review page is always the
+    /// last position in the wizard, so jumping back is always valid.
+    /// </summary>
+    private async Task HandleReviewEdit(int pageIndex)
+    {
+        if (Layout?.Pages is null) return;
+        if (pageIndex < 0 || pageIndex >= Layout.Pages.Count) return;
         _currentPage = pageIndex;
         _showValidationSummary = false;
         if (OnPageChanged.HasDelegate)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor
@@ -900,15 +900,16 @@
     }
 
     /// <summary>
-    /// Feature 107 — Edit-X jump from a review card's section. Unlike the
-    /// stepper, the jump can come from any previously-visited page whose
-    /// section is still listed on the review; the review page is always the
-    /// last position in the wizard, so jumping back is always valid.
+    /// Feature 107 — Edit-X jump from a review card's section. The review
+    /// page is always the last position in the wizard, so section Edit
+    /// buttons MUST NOT be able to jump to it (self-jump would create an
+    /// infinite edit loop). The bound is tight: strictly less than
+    /// <c>Layout.Pages.Count - 1</c>.
     /// </summary>
     private async Task HandleReviewEdit(int pageIndex)
     {
         if (Layout?.Pages is null) return;
-        if (pageIndex < 0 || pageIndex >= Layout.Pages.Count) return;
+        if (pageIndex < 0 || pageIndex >= Layout.Pages.Count - 1) return;
         _currentPage = pageIndex;
         _showValidationSummary = false;
         if (OnPageChanged.HasDelegate)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -67,6 +67,15 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IFormSchemaService, FormSchemaService>();
         services.AddScoped<IFormSigningService, FormSigningService>();
 
+        // Feature 107 — client-side portrait token resizer for `x-file.embedAs`
+        // fields. The interop is scoped (holds a lazy IJSObjectReference);
+        // the resizer itself is stateless quality-stepping over that interop.
+        services.AddScoped<IPhotoTokenResizerInterop, BrowserPhotoTokenResizerInterop>();
+        services.AddScoped<PhotoTokenResizer>();
+
+        // Review-summary data source — pure shape over FormContext, stateless.
+        services.AddSingleton<ReviewSummaryDataSource>();
+
         // Wallet preference service (server-backed with localStorage migration)
         services.AddScoped<IWalletPreferenceService>(sp =>
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -73,8 +73,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPhotoTokenResizerInterop, BrowserPhotoTokenResizerInterop>();
         services.AddScoped<PhotoTokenResizer>();
 
-        // Review-summary data source — pure shape over FormContext, stateless.
-        services.AddSingleton<ReviewSummaryDataSource>();
+        // Review-summary data source — pure shape over FormContext. Registered
+        // Transient so any future scoped dependency (e.g. a localisation
+        // service for label translation) doesn't silently become a captive
+        // singleton. The class itself is stateless today; transient keeps
+        // the safety margin for free.
+        services.AddTransient<ReviewSummaryDataSource>();
 
         // Wallet preference service (server-backed with localStorage migration)
         services.AddScoped<IWalletPreferenceService>(sp =>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Forms/IdCardLayoutConfig.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Forms/IdCardLayoutConfig.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Models;
+
+namespace Sorcha.UI.Core.Models.Forms;
+
+/// <summary>
+/// Runtime context for a review-card render — the action's current lifecycle
+/// state as seen from the hosting component. Drives watermark and footer-action
+/// selection in <see cref="IdCardLayoutConfig"/>. Feature 107 Assured Identity v1.
+/// </summary>
+public enum ActionRuntimeState
+{
+    /// <summary>Citizen is on their own pre-submission review page (Draft + Edit/Submit).</summary>
+    CitizenDraft,
+
+    /// <summary>Assessor is viewing a pending application (Pending + Approve/Reject).</summary>
+    AssessorPending,
+
+    /// <summary>Citizen is viewing the issued credential in their wallet (Issued, no actions).</summary>
+    IssuedCredential,
+
+    /// <summary>Citizen is previewing a not-yet-issued credential offer (no watermark, no actions).</summary>
+    CredentialPreview
+}
+
+/// <summary>
+/// Watermark treatment rendered over the top-right of the ID card layout.
+/// </summary>
+public enum IdCardWatermark
+{
+    None,
+    Draft,
+    Pending,
+    Issued
+}
+
+/// <summary>
+/// A titled group of fields on the review card, mapped back to its originating
+/// wizard page index so the Edit control can navigate the user home.
+/// </summary>
+/// <param name="Title">Section heading (e.g. "Your name", "Address").</param>
+/// <param name="OriginatingPageIndex">Zero-based wizard page index to jump back to.</param>
+/// <param name="FieldPointers">JSON Pointers into <see cref="FormContext.FormData"/>.</param>
+public sealed record IdCardSection(
+    string Title,
+    int OriginatingPageIndex,
+    IReadOnlyList<string> FieldPointers);
+
+/// <summary>
+/// Everything <c>IdCardLayout.razor</c> needs to render a single review card.
+/// Built by <see cref="Sorcha.UI.Core.Services.Forms.ReviewSummaryDataSource"/>
+/// from a parsed <see cref="XReviewExtension"/> and the live form context.
+/// </summary>
+public sealed record IdCardLayoutConfig
+{
+    public required string IssuerName { get; init; }
+    public required string CredentialName { get; init; }
+    public required XReviewColourTheme ColourTheme { get; init; }
+    public required IdCardWatermark Watermark { get; init; }
+    public required IReadOnlyDictionary<string, object?> FieldValues { get; init; }
+    public required IReadOnlyList<IdCardSection> Sections { get; init; }
+    public required bool Editable { get; init; }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/BrowserPhotoTokenResizerInterop.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/BrowserPhotoTokenResizerInterop.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Browser-side implementation of <see cref="IPhotoTokenResizerInterop"/> that
+/// delegates to a JS module performing the canvas-based scale + JPEG encode.
+/// Feature 107 Assured Identity v1 (T016).
+/// </summary>
+/// <remarks>
+/// The JS module lives at <c>_content/Sorcha.UI.Core/js/photo-token-resizer.js</c>
+/// and exports a single <c>resizeAndEncodeJpeg(sourceBytes, width, height, quality)</c>
+/// function. The module is lazily imported on first use.
+/// </remarks>
+public sealed class BrowserPhotoTokenResizerInterop : IPhotoTokenResizerInterop, IAsyncDisposable
+{
+    private const string ModulePath = "./_content/Sorcha.UI.Core/js/photo-token-resizer.js";
+
+    private readonly Lazy<Task<IJSObjectReference>> _module;
+
+    public BrowserPhotoTokenResizerInterop(IJSRuntime jsRuntime)
+    {
+        ArgumentNullException.ThrowIfNull(jsRuntime);
+        _module = new Lazy<Task<IJSObjectReference>>(() =>
+            jsRuntime.InvokeAsync<IJSObjectReference>("import", ModulePath).AsTask());
+    }
+
+    public async Task<byte[]> ResizeAndEncodeJpegAsync(
+        byte[] sourceBytes,
+        int width,
+        int height,
+        double quality,
+        CancellationToken cancellationToken)
+    {
+        var module = await _module.Value.ConfigureAwait(false);
+        return await module.InvokeAsync<byte[]>(
+            "resizeAndEncodeJpeg",
+            cancellationToken,
+            sourceBytes, width, height, quality)
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module.IsValueCreated)
+        {
+            try
+            {
+                var module = await _module.Value.ConfigureAwait(false);
+                await module.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (JSDisconnectedException)
+            {
+                // Circuit already dropped — nothing to release.
+            }
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/DateTimeFieldBoundResolver.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/DateTimeFieldBoundResolver.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Resolves the <c>formatMinimum</c> / <c>formatMaximum</c> constraints on a
+/// <c>format: "date"</c> schema property into concrete <see cref="DateOnly"/>
+/// bounds the UI can feed to the date-picker's <c>MinDate</c> / <c>MaxDate</c>.
+/// Feature 107 Assured Identity v1 — DOB future-block (T013 / FR-001, FR-002).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Accepts the Sorcha date-token vocabulary (<c>today</c>,
+/// <c>today\u00B1N[D|M|Y]</c>) and ISO-8601 date literals. The parser is a
+/// direct port of <c>Sorcha.Validator.Core.Tokens.SorchaDateTokenResolver</c>;
+/// it lives in UI.Core rather than being pulled in by project reference
+/// because UI.Core is Blazor WASM and avoiding the Validator.Core dependency
+/// (Cryptography, TransactionHandler) keeps the client bundle small. If the
+/// two implementations ever diverge, the server-side resolver remains
+/// authoritative because the server is the source of truth for validation —
+/// this client-side resolver drives a convenience-only UI hint.
+/// </para>
+/// </remarks>
+public static class DateTimeFieldBoundResolver
+{
+    private static readonly Regex TokenPattern = new(
+        @"^today(?:(?<sign>[+-])(?<n>\d{1,4})(?<unit>[DMY]))?$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Reads the named bound (<c>"formatMinimum"</c> or <c>"formatMaximum"</c>)
+    /// from a property schema and resolves it against <paramref name="today"/>.
+    /// Returns <see langword="false"/> and sets <paramref name="bound"/> to
+    /// <see langword="null"/> when the bound is absent or unparseable.
+    /// </summary>
+    public static bool TryResolveBound(
+        JsonElement propertySchema,
+        string boundName,
+        DateOnly today,
+        out DateOnly? bound)
+    {
+        bound = null;
+
+        if (propertySchema.ValueKind != JsonValueKind.Object)
+            return false;
+
+        // Defensive — TryResolveBound executes once per render; unknown bound
+        // names are silently ignored so the UI doesn't throw on schema typos.
+        if (boundName is not "formatMinimum" and not "formatMaximum")
+            return false;
+
+        if (!propertySchema.TryGetProperty(boundName, out var boundElement))
+            return false;
+
+        if (boundElement.ValueKind != JsonValueKind.String)
+            return false;
+
+        var raw = boundElement.GetString();
+        if (string.IsNullOrWhiteSpace(raw))
+            return false;
+
+        if (TryResolveToken(raw, today, out var resolved))
+        {
+            bound = resolved;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveToken(string token, DateOnly today, out DateOnly resolved)
+    {
+        resolved = default;
+
+        // Fast path — ISO-8601 literal.
+        if (DateOnly.TryParseExact(token, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var literal))
+        {
+            resolved = literal;
+            return true;
+        }
+
+        var match = TokenPattern.Match(token);
+        if (!match.Success) return false;
+
+        if (!match.Groups["sign"].Success)
+        {
+            resolved = today;
+            return true;
+        }
+
+        var sign = match.Groups["sign"].Value[0];
+        var n = int.Parse(match.Groups["n"].Value, CultureInfo.InvariantCulture);
+        var unit = match.Groups["unit"].Value[0];
+        var delta = sign == '+' ? n : -n;
+
+        try
+        {
+            resolved = unit switch
+            {
+                'D' => today.AddDays(delta),
+                'M' => today.AddMonths(delta),
+                'Y' => today.AddYears(delta),
+                _ => today
+            };
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/DateTimeFieldBoundResolver.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/DateTimeFieldBoundResolver.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -49,10 +50,15 @@ public static class DateTimeFieldBoundResolver
         if (propertySchema.ValueKind != JsonValueKind.Object)
             return false;
 
-        // Defensive — TryResolveBound executes once per render; unknown bound
-        // names are silently ignored so the UI doesn't throw on schema typos.
-        if (boundName is not "formatMinimum" and not "formatMaximum")
-            return false;
+        // Contract: callers pass the literal strings "formatMinimum" /
+        // "formatMaximum". A Debug.Assert surfaces caller-side typos as a
+        // test-visible failure rather than a silent no-op on a production
+        // build — which matters because a silent no-op would un-bound the
+        // picker and let the citizen pick a forbidden date with no
+        // client-side signal.
+        Debug.Assert(
+            boundName is "formatMinimum" or "formatMaximum",
+            $"Unknown boundName '{boundName}' — expected 'formatMinimum' or 'formatMaximum'.");
 
         if (!propertySchema.TryGetProperty(boundName, out var boundElement))
             return false;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FileFieldCaptureHelper.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/FileFieldCaptureHelper.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Models;
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Static helpers that translate a <see cref="FileSchemaExtension"/> into the
+/// decisions the <c>FileRenderer.razor</c> needs at render time: what HTML
+/// <c>capture</c> attribute to emit, and whether to run the portrait
+/// token-image resizer after the citizen picks a file. Feature 107 Assured
+/// Identity v1 (T015 / FR-003, FR-004).
+/// </summary>
+public static class FileFieldCaptureHelper
+{
+    /// <summary>
+    /// Returns the HTML <c>capture</c> attribute value to emit on the
+    /// <c>&lt;InputFile&gt;</c> element, or <see langword="null"/> when the
+    /// attribute should be omitted (legacy file-picker behaviour).
+    /// </summary>
+    /// <remarks>
+    /// Desktop browsers ignore <c>capture</c> by HTML spec; on mobile it
+    /// opens the device camera with the requested facing direction. Unknown
+    /// values are NOT propagated — we refuse to trust an arbitrary string
+    /// into the DOM and emit no attribute instead.
+    /// </remarks>
+    public static string? GetCaptureAttribute(FileSchemaExtension? extension)
+    {
+        if (extension?.Capture is null) return null;
+        return FileSchemaExtension.IsValidCapture(extension.Capture) ? extension.Capture : null;
+    }
+
+    /// <summary>
+    /// True when the file field declares <c>embedAs</c> with a recognised
+    /// token-image value, so the renderer should invoke the client-side
+    /// token-image resizer after upload.
+    /// </summary>
+    public static bool ShouldResizeForEmbed(FileSchemaExtension? extension)
+    {
+        if (extension?.EmbedAs is null) return false;
+        return FileSchemaExtension.IsValidEmbedAs(extension.EmbedAs);
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/IPhotoTokenResizerInterop.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/IPhotoTokenResizerInterop.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Thin wrapper over the browser-side <c>&lt;canvas&gt;</c> + JPEG export
+/// path used by <see cref="PhotoTokenResizer"/>. Wrapping the JS interop
+/// behind an interface lets unit tests exercise the quality-stepping logic
+/// without a browser runtime. Feature 107 Assured Identity v1 (T016).
+/// </summary>
+public interface IPhotoTokenResizerInterop
+{
+    /// <summary>
+    /// Loads <paramref name="sourceBytes"/> onto a canvas, scales + centre-crops
+    /// to <paramref name="width"/>×<paramref name="height"/>, and exports a
+    /// JPEG at the requested quality. Returns the raw JPEG bytes.
+    /// </summary>
+    Task<byte[]> ResizeAndEncodeJpegAsync(
+        byte[] sourceBytes,
+        int width,
+        int height,
+        double quality,
+        CancellationToken cancellationToken);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/PhotoTokenResizer.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/PhotoTokenResizer.cs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Specification for a resize-to-token-image operation. Feature 107 Assured
+/// Identity v1. The v1 preset is 240×320 JPEG at ≤20KB raw / ≤27KB base64,
+/// matching ISO/IEC 19794-5 token image conventions.
+/// </summary>
+public sealed record ImageTokenSpec
+{
+    public required int Width { get; init; }
+    public required int Height { get; init; }
+    public required int MaxRawBytes { get; init; }
+    public required IReadOnlyList<double> QualitySteps { get; init; }
+
+    /// <summary>
+    /// The canonical v1 preset — 240×320 JPEG, ≤20KB raw.
+    /// </summary>
+    public static ImageTokenSpec ImageTokenJpeg240x320 => new()
+    {
+        Width = 240,
+        Height = 320,
+        MaxRawBytes = 20 * 1024,
+        QualitySteps = [0.85, 0.75, 0.65, 0.55, 0.5]
+    };
+}
+
+/// <summary>
+/// Outcome of a resize-to-token operation.
+/// </summary>
+public sealed record PhotoTokenResult
+{
+    /// <summary>Base64-encoded JPEG bytes ready to embed in the action payload.</summary>
+    public required string Base64 { get; init; }
+
+    /// <summary>Raw JPEG byte length (pre-base64 expansion).</summary>
+    public required int RawBytes { get; init; }
+
+    /// <summary>The final JPEG quality factor that met the size target.</summary>
+    public required double QualityUsed { get; init; }
+}
+
+/// <summary>
+/// Client-side photo-to-token-image resizer. Reduces a user-captured portrait
+/// to the ISO 19794-5 token-image dimensions so the <c>portrait</c> claim can
+/// be embedded directly in the credential SD-JWT. Feature 107 Assured
+/// Identity v1 (T016 / FR-004).
+/// </summary>
+/// <remarks>
+/// Contract:
+/// <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>.
+/// The quality-stepping policy lives here (pure C#); the actual canvas
+/// operation is delegated to <see cref="IPhotoTokenResizerInterop"/> so unit
+/// tests can mock the JS side.
+/// </remarks>
+public class PhotoTokenResizer
+{
+    private readonly IPhotoTokenResizerInterop _interop;
+
+    public PhotoTokenResizer(IPhotoTokenResizerInterop interop)
+    {
+        _interop = interop ?? throw new ArgumentNullException(nameof(interop));
+    }
+
+    /// <summary>
+    /// Resizes <paramref name="sourceBytes"/> to the token-image spec, stepping
+    /// JPEG quality down until the result fits under
+    /// <see cref="ImageTokenSpec.MaxRawBytes"/>. Throws
+    /// <see cref="PhotoTokenTooDetailedException"/> if even the lowest quality
+    /// step exceeds the target.
+    /// </summary>
+    public virtual async Task<PhotoTokenResult> ResizeAsync(
+        byte[] sourceBytes,
+        ImageTokenSpec spec,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sourceBytes);
+        ArgumentNullException.ThrowIfNull(spec);
+
+        if (spec.QualitySteps.Count == 0)
+        {
+            throw new ArgumentException(
+                "ImageTokenSpec.QualitySteps must contain at least one quality level.",
+                nameof(spec));
+        }
+
+        byte[]? bestBytes = null;
+        double bestQuality = 0;
+
+        foreach (var quality in spec.QualitySteps)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var encoded = await _interop.ResizeAndEncodeJpegAsync(
+                sourceBytes, spec.Width, spec.Height, quality, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (encoded.Length <= spec.MaxRawBytes)
+            {
+                return new PhotoTokenResult
+                {
+                    Base64 = Convert.ToBase64String(encoded),
+                    RawBytes = encoded.Length,
+                    QualityUsed = quality
+                };
+            }
+
+            // Track the smallest output in case we never meet the target — the
+            // exception message cites the closest attempt for a better error.
+            if (bestBytes is null || encoded.Length < bestBytes.Length)
+            {
+                bestBytes = encoded;
+                bestQuality = quality;
+            }
+        }
+
+        throw new PhotoTokenTooDetailedException(
+            $"Portrait too detailed for {spec.Width}x{spec.Height} token: best attempt at quality " +
+            $"{bestQuality:F2} produced {bestBytes?.Length ?? 0} bytes (target {spec.MaxRawBytes}). " +
+            "Ask the citizen to retake with a plainer background or skip the photo.");
+    }
+}
+
+/// <summary>
+/// Thrown by <see cref="PhotoTokenResizer"/> when the source image cannot
+/// be reduced to fit <see cref="ImageTokenSpec.MaxRawBytes"/> at any quality
+/// step in <see cref="ImageTokenSpec.QualitySteps"/>.
+/// </summary>
+public sealed class PhotoTokenTooDetailedException : Exception
+{
+    public PhotoTokenTooDetailedException(string message) : base(message) { }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/PhotoTokenResizer.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/PhotoTokenResizer.cs
@@ -53,9 +53,10 @@ public sealed record PhotoTokenResult
 /// <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>.
 /// The quality-stepping policy lives here (pure C#); the actual canvas
 /// operation is delegated to <see cref="IPhotoTokenResizerInterop"/> so unit
-/// tests can mock the JS side.
+/// tests can mock the JS side. The class is <c>sealed</c> — the mocking seam
+/// for tests is the interop interface, not subclassing.
 /// </remarks>
-public class PhotoTokenResizer
+public sealed class PhotoTokenResizer
 {
     private readonly IPhotoTokenResizerInterop _interop;
 
@@ -71,7 +72,7 @@ public class PhotoTokenResizer
     /// <see cref="PhotoTokenTooDetailedException"/> if even the lowest quality
     /// step exceeds the target.
     /// </summary>
-    public virtual async Task<PhotoTokenResult> ResizeAsync(
+    public async Task<PhotoTokenResult> ResizeAsync(
         byte[] sourceBytes,
         ImageTokenSpec spec,
         CancellationToken cancellationToken = default)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs
@@ -86,8 +86,10 @@ public sealed class ReviewSummaryDataSource
     /// Pointer (<c>"/givenName"</c>). This helper bridges the two.
     /// Already-pointer-shaped names pass through unchanged so nested
     /// section-scoped fields (<c>"/address/line1"</c>) also work.
+    /// Internal so <c>ReviewSummaryRenderer</c> can share the exact same
+    /// normalisation in its tabular-fallback path.
     /// </summary>
-    private static string PointerFromFieldName(string fieldName)
+    internal static string PointerFromFieldName(string fieldName)
     {
         if (string.IsNullOrEmpty(fieldName)) return "/";
         return fieldName.StartsWith('/') ? fieldName : "/" + fieldName;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Models.Forms;
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Reads prior-page values from the form context and shapes them into an
+/// <see cref="IdCardLayoutConfig"/> the review card can render. Feature 107
+/// Assured Identity v1 (T021). Stateless and reusable across citizen-side,
+/// assessor-side, and wallet-side review renders.
+/// </summary>
+public class ReviewSummaryDataSource
+{
+    /// <summary>
+    /// Builds the config for a single review card. Pulls the set of fields
+    /// declared on <paramref name="priorPages"/> (not the review page itself)
+    /// from <paramref name="formContext"/> and derives the watermark from
+    /// <paramref name="runtimeState"/>.
+    /// </summary>
+    public virtual IdCardLayoutConfig BuildConfig(
+        XReviewExtension extension,
+        FormContext formContext,
+        ActionRuntimeState runtimeState,
+        IReadOnlyList<BlueprintPageDefinition> priorPages)
+    {
+        ArgumentNullException.ThrowIfNull(extension);
+        ArgumentNullException.ThrowIfNull(formContext);
+        ArgumentNullException.ThrowIfNull(priorPages);
+
+        var sections = new List<IdCardSection>();
+        var fieldValues = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        for (var pageIndex = 0; pageIndex < priorPages.Count; pageIndex++)
+        {
+            var page = priorPages[pageIndex];
+            if (page.Sections is not { Count: > 0 }) continue;
+
+            foreach (var section in page.Sections)
+            {
+                var fieldPointers = section.Fields
+                    .Select(f => PointerFromFieldName(f))
+                    .ToList();
+
+                foreach (var pointer in fieldPointers)
+                {
+                    // ContainsKey distinguishes "unfilled" (present as null)
+                    // from "filled with null value" — both render as empty
+                    // on the card, but the dictionary explicitly lists every
+                    // field the citizen was asked about.
+                    if (formContext.FormData.TryGetValue(pointer, out var value))
+                    {
+                        fieldValues[pointer] = value;
+                    }
+                    else
+                    {
+                        fieldValues[pointer] = null;
+                    }
+                }
+
+                sections.Add(new IdCardSection(
+                    Title: section.Title ?? page.Title,
+                    OriginatingPageIndex: pageIndex,
+                    FieldPointers: fieldPointers));
+            }
+        }
+
+        return new IdCardLayoutConfig
+        {
+            IssuerName = extension.Header.IssuerName,
+            CredentialName = extension.Header.CredentialName,
+            ColourTheme = extension.Header.ColourTheme,
+            Watermark = ReviewSummaryDispatch.ResolveWatermark(runtimeState),
+            FieldValues = fieldValues,
+            Sections = sections,
+            Editable = extension.Editable
+        };
+    }
+
+    /// <summary>
+    /// Schema field names in sections are declared without the leading
+    /// slash (<c>"givenName"</c>); the form context keys values by JSON
+    /// Pointer (<c>"/givenName"</c>). This helper bridges the two.
+    /// Already-pointer-shaped names pass through unchanged so nested
+    /// section-scoped fields (<c>"/address/line1"</c>) also work.
+    /// </summary>
+    private static string PointerFromFieldName(string fieldName)
+    {
+        if (string.IsNullOrEmpty(fieldName)) return "/";
+        return fieldName.StartsWith('/') ? fieldName : "/" + fieldName;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDataSource.cs
@@ -10,9 +10,10 @@ namespace Sorcha.UI.Core.Services.Forms;
 /// Reads prior-page values from the form context and shapes them into an
 /// <see cref="IdCardLayoutConfig"/> the review card can render. Feature 107
 /// Assured Identity v1 (T021). Stateless and reusable across citizen-side,
-/// assessor-side, and wallet-side review renders.
+/// assessor-side, and wallet-side review renders. <c>sealed</c> — tests
+/// instantiate directly; there is no documented extension point.
 /// </summary>
-public class ReviewSummaryDataSource
+public sealed class ReviewSummaryDataSource
 {
     /// <summary>
     /// Builds the config for a single review card. Pulls the set of fields
@@ -20,7 +21,7 @@ public class ReviewSummaryDataSource
     /// from <paramref name="formContext"/> and derives the watermark from
     /// <paramref name="runtimeState"/>.
     /// </summary>
-    public virtual IdCardLayoutConfig BuildConfig(
+    public IdCardLayoutConfig BuildConfig(
         XReviewExtension extension,
         FormContext formContext,
         ActionRuntimeState runtimeState,

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDispatch.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/ReviewSummaryDispatch.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Models.Forms;
+
+namespace Sorcha.UI.Core.Services.Forms;
+
+/// <summary>
+/// Static dispatch helpers used by <c>ReviewSummaryRenderer.razor</c>. Kept in
+/// a plain static class so the rules are unit-testable without spinning up a
+/// Blazor renderer. Feature 107 Assured Identity v1 (T023).
+/// </summary>
+public static class ReviewSummaryDispatch
+{
+    /// <summary>
+    /// Maps the current action lifecycle state to the watermark treatment the
+    /// card should render.
+    /// </summary>
+    public static IdCardWatermark ResolveWatermark(ActionRuntimeState state) => state switch
+    {
+        ActionRuntimeState.CitizenDraft => IdCardWatermark.Draft,
+        ActionRuntimeState.AssessorPending => IdCardWatermark.Pending,
+        ActionRuntimeState.IssuedCredential => IdCardWatermark.Issued,
+        ActionRuntimeState.CredentialPreview => IdCardWatermark.None,
+        _ => IdCardWatermark.None
+    };
+
+    /// <summary>
+    /// True when <paramref name="variant"/> has a dedicated layout component
+    /// in v1. Unknown-but-declared variants fall back to the tabular minimal
+    /// render in <c>ReviewSummaryRenderer.razor</c>.
+    /// </summary>
+    public static bool IsImplemented(XReviewLayoutVariant variant) =>
+        variant is XReviewLayoutVariant.IdCard;
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/wwwroot/js/photo-token-resizer.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/wwwroot/js/photo-token-resizer.js
@@ -47,7 +47,7 @@ function loadImage(src) {
     return new Promise((resolve, reject) => {
         const img = new Image();
         img.onload = () => resolve(img);
-        img.onerror = (e) => reject(e);
+        img.onerror = (e) => reject(new Error(`Image load failed: ${e?.type ?? 'unknown error'}`));
         img.src = src;
     });
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/wwwroot/js/photo-token-resizer.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/wwwroot/js/photo-token-resizer.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// Feature 107 — Assured Identity v1 — client-side portrait token resizer.
+// Scales and centre-crops a source image (bytes) to the target dimensions,
+// encodes as JPEG at the requested quality, and returns the raw byte array.
+// The C# PhotoTokenResizer drives the quality-stepping loop.
+
+export async function resizeAndEncodeJpeg(sourceBytes, width, height, quality) {
+    const blob = new Blob([new Uint8Array(sourceBytes)]);
+    const url = URL.createObjectURL(blob);
+    try {
+        const image = await loadImage(url);
+
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+            throw new Error('2D canvas context not available.');
+        }
+
+        // Cover-style scaling — compute the scale so the image fills the
+        // target exactly, then centre-crop the overflow.
+        const scale = Math.max(width / image.width, height / image.height);
+        const drawWidth = image.width * scale;
+        const drawHeight = image.height * scale;
+        const dx = (width - drawWidth) / 2;
+        const dy = (height - drawHeight) / 2;
+
+        ctx.drawImage(image, dx, dy, drawWidth, drawHeight);
+
+        const encodedBlob = await new Promise((resolve, reject) => {
+            canvas.toBlob(
+                (b) => b ? resolve(b) : reject(new Error('JPEG encode failed.')),
+                'image/jpeg',
+                quality);
+        });
+        const buffer = await encodedBlob.arrayBuffer();
+        return new Uint8Array(buffer);
+    } finally {
+        URL.revokeObjectURL(url);
+    }
+}
+
+function loadImage(src) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = (e) => reject(e);
+        img.src = src;
+    });
+}

--- a/src/Common/Sorcha.Blueprint.Models/BlueprintPageDefinition.cs
+++ b/src/Common/Sorcha.Blueprint.Models/BlueprintPageDefinition.cs
@@ -37,4 +37,17 @@ public sealed record BlueprintPageDefinition
     /// </summary>
     [JsonPropertyName("x-sections")]
     public List<BlueprintSectionDefinition>? Sections { get; init; }
+
+    /// <summary>
+    /// Parsed <c>x-review</c> extension when present. A page carrying a
+    /// review extension is rendered read-only via
+    /// <c>ReviewSummaryRenderer</c>; field rendering is suppressed. Feature
+    /// 107 Assured Identity v1. Null when the page is a normal form page.
+    /// </summary>
+    /// <remarks>
+    /// Not exported to JSON — consumed by the renderer only. The parsed
+    /// extension is populated by <see cref="SchemaLayoutParser"/>.
+    /// </remarks>
+    [JsonIgnore]
+    public XReviewExtension? ReviewExtension { get; init; }
 }

--- a/src/Common/Sorcha.Blueprint.Models/FileSchemaExtension.cs
+++ b/src/Common/Sorcha.Blueprint.Models/FileSchemaExtension.cs
@@ -50,6 +50,63 @@ public class FileSchemaExtension
     public int MaxChunks { get; set; } = PlatformMaxChunks;
 
     /// <summary>
+    /// Recognised values for the <see cref="Capture"/> hint.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ValidCaptureValues =
+        new HashSet<string>(StringComparer.Ordinal) { "user", "environment" };
+
+    /// <summary>
+    /// Recognised values for the <see cref="EmbedAs"/> hint. v1 supports the
+    /// ISO/IEC 19794-5 token-image dimensions (240×320) only.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ValidEmbedAsValues =
+        new HashSet<string>(StringComparer.Ordinal) { "image-token-jpeg-240x320" };
+
+    /// <summary>
+    /// Camera-capture hint for mobile browsers. <c>"user"</c> requests the
+    /// front-facing camera; <c>"environment"</c> requests the rear-facing
+    /// camera; <see langword="null"/> disables the attribute and the renderer
+    /// falls back to a plain file picker (legacy behaviour).
+    /// </summary>
+    /// <remarks>
+    /// Feature 107 Assured Identity v1. See
+    /// <c>specs/107-assured-identity-v1/contracts/x-file-capture-extension.md</c>.
+    /// Unknown values are preserved as-is so the UI can log a warning rather
+    /// than silently coercing; see <see cref="IsValidCapture"/>.
+    /// </remarks>
+    [JsonPropertyName("capture")]
+    public string? Capture { get; set; }
+
+    /// <summary>
+    /// Client-side embedding hint. <c>"image-token-jpeg-240x320"</c> advises
+    /// the renderer to produce a resized 240×320 JPEG token alongside the
+    /// chunked full-resolution upload, carried in the action payload as a
+    /// base64 string at <c>{fieldPointer}/tokenImageBase64</c>.
+    /// <see langword="null"/> disables resize (legacy behaviour).
+    /// </summary>
+    /// <remarks>
+    /// Feature 107 Assured Identity v1. See
+    /// <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>.
+    /// </remarks>
+    [JsonPropertyName("embedAs")]
+    public string? EmbedAs { get; set; }
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a recognised <see cref="Capture"/>
+    /// value (<c>"user"</c> or <c>"environment"</c>). <see langword="null"/>
+    /// is considered valid (attribute absent = legacy behaviour).
+    /// </summary>
+    public static bool IsValidCapture(string? value) =>
+        value is null || ValidCaptureValues.Contains(value);
+
+    /// <summary>
+    /// True when <paramref name="value"/> is a recognised <see cref="EmbedAs"/>
+    /// value. <see langword="null"/> is considered valid (no resize).
+    /// </summary>
+    public static bool IsValidEmbedAs(string? value) =>
+        value is null || ValidEmbedAsValues.Contains(value);
+
+    /// <summary>
     /// Parses a human-readable size string such as <c>"16MB"</c> or <c>"512KB"</c>
     /// into the equivalent number of bytes.
     /// </summary>

--- a/src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs
+++ b/src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs
@@ -163,17 +163,115 @@ public static class SchemaLayoutParser
             var layout = NormaliseLayout(rawLayout, ValidPageLayouts, DefaultPageLayout);
 
             var pageSections = TryParseSections(pageElement);
+            var reviewExtension = TryParseReviewExtension(pageElement);
 
             pages.Add(new BlueprintPageDefinition
             {
                 Title = title,
                 Description = description,
                 Layout = layout,
-                Sections = pageSections
+                Sections = pageSections,
+                ReviewExtension = reviewExtension
             });
         }
 
         return pages.Count > 0 ? pages : null;
+    }
+
+    private static readonly Dictionary<string, XReviewLayoutVariant> LayoutVariantMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["id-card"] = XReviewLayoutVariant.IdCard,
+            ["passport-page"] = XReviewLayoutVariant.PassportPage,
+            ["tabular"] = XReviewLayoutVariant.Tabular,
+            ["receipt"] = XReviewLayoutVariant.Receipt
+        };
+
+    private static readonly Dictionary<string, XReviewColourTheme> ColourThemeMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["identity-navy"] = XReviewColourTheme.IdentityNavy,
+            ["licence-pink"] = XReviewColourTheme.LicencePink
+        };
+
+    /// <summary>
+    /// Parses the <c>x-review</c> extension on a wizard page. Returns null
+    /// when the extension is absent or when required header fields are
+    /// missing; unknown <c>layout</c> values fall back to <c>id-card</c> so
+    /// the renderer always has something to draw. Publish-time surfacing of
+    /// the fallback (warning <c>WARN_BP_REVIEW_001</c>) is the validator
+    /// service's job — this parser is the lexical layer only. Feature 107
+    /// Assured Identity v1.
+    /// </summary>
+    private static XReviewExtension? TryParseReviewExtension(JsonElement pageElement)
+    {
+        if (!pageElement.TryGetProperty("x-review", out var reviewEl) ||
+            reviewEl.ValueKind != JsonValueKind.Object)
+            return null;
+
+        if (!reviewEl.TryGetProperty("header", out var headerEl) ||
+            headerEl.ValueKind != JsonValueKind.Object)
+            return null;
+
+        string? issuerName = null;
+        if (headerEl.TryGetProperty("issuerName", out var issuerEl) &&
+            issuerEl.ValueKind == JsonValueKind.String)
+        {
+            var candidate = issuerEl.GetString();
+            if (!string.IsNullOrWhiteSpace(candidate)) issuerName = candidate;
+        }
+
+        string? credentialName = null;
+        if (headerEl.TryGetProperty("credentialName", out var credEl) &&
+            credEl.ValueKind == JsonValueKind.String)
+        {
+            var candidate = credEl.GetString();
+            if (!string.IsNullOrWhiteSpace(candidate)) credentialName = candidate;
+        }
+
+        // Required header fields absent → drop the extension. Renderer
+        // renders the page as a plain (empty) form page.
+        if (issuerName is null || credentialName is null) return null;
+
+        var layout = XReviewLayoutVariant.IdCard;
+        if (reviewEl.TryGetProperty("layout", out var layoutEl) &&
+            layoutEl.ValueKind == JsonValueKind.String &&
+            layoutEl.GetString() is { } layoutRaw &&
+            LayoutVariantMap.TryGetValue(layoutRaw, out var parsedLayout))
+        {
+            layout = parsedLayout;
+        }
+        // else: unknown or absent — fall back to IdCard (v1 only implemented
+        // variant). Validator emits WARN_BP_REVIEW_001 when the raw value is
+        // present but unrecognised.
+
+        var editable = true;
+        if (reviewEl.TryGetProperty("editable", out var editableEl) &&
+            editableEl.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        {
+            editable = editableEl.GetBoolean();
+        }
+
+        var colourTheme = XReviewColourTheme.IdentityNavy;
+        if (headerEl.TryGetProperty("colourTheme", out var themeEl) &&
+            themeEl.ValueKind == JsonValueKind.String &&
+            themeEl.GetString() is { } themeRaw &&
+            ColourThemeMap.TryGetValue(themeRaw, out var parsedTheme))
+        {
+            colourTheme = parsedTheme;
+        }
+
+        return new XReviewExtension
+        {
+            Layout = layout,
+            Editable = editable,
+            Header = new XReviewHeader
+            {
+                IssuerName = issuerName,
+                CredentialName = credentialName,
+                ColourTheme = colourTheme
+            }
+        };
     }
 
     private static List<BlueprintSectionDefinition>? TryParseSections(JsonElement parent)

--- a/src/Common/Sorcha.Blueprint.Models/XReviewExtension.cs
+++ b/src/Common/Sorcha.Blueprint.Models/XReviewExtension.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Blueprint.Models;
+
+/// <summary>
+/// Parsed representation of the <c>x-review</c> schema extension declared on a
+/// wizard page. Marks the page as a read-only summary of the form's prior
+/// pages' values, rendered via a parameterised layout component.
+/// </summary>
+/// <remarks>
+/// Contract: <c>specs/107-assured-identity-v1/contracts/x-review-extension.md</c>.
+/// A page carrying this extension MUST NOT declare <c>properties</c> — the
+/// review renderer iterates fields from prior pages in the same action.
+/// </remarks>
+public sealed record XReviewExtension
+{
+    /// <summary>
+    /// Visual layout variant. v1 ships only <see cref="XReviewLayoutVariant.IdCard"/>;
+    /// unknown values produce a publish-time warning (<c>WARN_BP_REVIEW_001</c>)
+    /// and the renderer falls back to a tabular minimal display.
+    /// </summary>
+    public required XReviewLayoutVariant Layout { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the renderer generates per-section Edit
+    /// controls that navigate back to the originating wizard page while
+    /// preserving submitted values. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool Editable { get; init; } = true;
+
+    /// <summary>
+    /// Issuer and credential labelling that the card header carries.
+    /// </summary>
+    public required XReviewHeader Header { get; init; }
+}
+
+/// <summary>
+/// Header metadata for an <see cref="XReviewExtension"/> — rendered as the
+/// issuer and credential-type label on the review card.
+/// </summary>
+public sealed record XReviewHeader
+{
+    /// <summary>
+    /// Issuer organisation display name, e.g. "Government of Scotland".
+    /// </summary>
+    public required string IssuerName { get; init; }
+
+    /// <summary>
+    /// Credential type display name, e.g. "Assured Identity".
+    /// </summary>
+    public required string CredentialName { get; init; }
+
+    /// <summary>
+    /// Visual colour theme. Defaults to <see cref="XReviewColourTheme.IdentityNavy"/>.
+    /// </summary>
+    public XReviewColourTheme ColourTheme { get; init; } = XReviewColourTheme.IdentityNavy;
+}
+
+/// <summary>
+/// Layout variants a review page may request. v1 implements <see cref="IdCard"/>
+/// only; other variants are reserved for future work and trigger a fallback.
+/// </summary>
+public enum XReviewLayoutVariant
+{
+    /// <summary>Stylised credential-card preview of the collected data.</summary>
+    IdCard,
+
+    /// <summary>Reserved for future passport-page variant — unimplemented in v1.</summary>
+    PassportPage,
+
+    /// <summary>Reserved for future tabular variant — unimplemented in v1.</summary>
+    Tabular,
+
+    /// <summary>Reserved for future receipt-style variant — unimplemented in v1.</summary>
+    Receipt
+}
+
+/// <summary>
+/// Colour theme for the <see cref="XReviewLayoutVariant.IdCard"/> layout.
+/// Each theme resolves to a CSS custom-property set on the rendered card.
+/// </summary>
+public enum XReviewColourTheme
+{
+    /// <summary>Navy/gold palette used by the Assured Identity credential.</summary>
+    IdentityNavy,
+
+    /// <summary>Pink/cream palette (UK driving-licence convention) used by the Driving Licence credential.</summary>
+    LicencePink
+}

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1623,7 +1623,7 @@ public class ActionExecutionService : IActionExecutionService
                         "({ActualChars} chars); dropping claim and issuing credential without portrait. " +
                         "Warning code: {WarningCode}",
                         mapping.ClaimName, PortraitTokenMaxBase64Chars, portraitBase64.Length,
-                        "WARN_CRED_PORTRAIT_OVERSIZE_001");
+                        PortraitOversizeWarningCode);
                     continue;
                 }
 
@@ -1652,6 +1652,14 @@ public class ActionExecutionService : IActionExecutionService
     /// base64-encoded length, which is what actually ships in the SD-JWT.
     /// </summary>
     private const int PortraitTokenMaxBase64Chars = 27_000;
+
+    /// <summary>
+    /// Local duplicate of <c>ValidationErrorCodes.CredentialPortraitOversize</c>
+    /// (defined in <c>Sorcha.Validator.Service</c>). Blueprint.Service does not
+    /// reference Validator.Service, so the code is stringified here with this
+    /// explicit comment binding the two — if either side is renamed, fix both.
+    /// </summary>
+    private const string PortraitOversizeWarningCode = "WARN_CRED_PORTRAIT_OVERSIZE_001";
 
     /// <summary>
     /// Treats any claim mapping whose source pointer ends in

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1607,6 +1607,26 @@ public class ActionExecutionService : IActionExecutionService
         {
             if (TryResolveJsonPointer(mergedData, mapping.SourceField, out var value))
             {
+                // Feature 107 — server is the authoritative size gate for
+                // embedded portrait token images. A base64 string >27_000
+                // chars means either the client-side resizer was bypassed
+                // or the source photo is too detailed; either way the
+                // credential should not carry an oversized claim. Drop the
+                // claim, log the warning, and continue with the rest of
+                // the credential so issuance does not abort.
+                if (IsPortraitTokenMapping(mapping.SourceField) &&
+                    value is string portraitBase64 &&
+                    portraitBase64.Length > PortraitTokenMaxBase64Chars)
+                {
+                    logger.LogWarning(
+                        "Portrait token for claim '{ClaimName}' exceeded the {MaxChars}-char base64 bound " +
+                        "({ActualChars} chars); dropping claim and issuing credential without portrait. " +
+                        "Warning code: {WarningCode}",
+                        mapping.ClaimName, PortraitTokenMaxBase64Chars, portraitBase64.Length,
+                        "WARN_CRED_PORTRAIT_OVERSIZE_001");
+                    continue;
+                }
+
                 claims[mapping.ClaimName] = value;
             }
             else
@@ -1624,6 +1644,24 @@ public class ActionExecutionService : IActionExecutionService
         }
         return claims;
     }
+
+    /// <summary>
+    /// Bound from <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>:
+    /// a 240×320 JPEG at the token spec's 20KB raw target produces ~27KB
+    /// when base64-encoded (raw × 1.37). The gate applies to the
+    /// base64-encoded length, which is what actually ships in the SD-JWT.
+    /// </summary>
+    private const int PortraitTokenMaxBase64Chars = 27_000;
+
+    /// <summary>
+    /// Treats any claim mapping whose source pointer ends in
+    /// <c>/tokenImageBase64</c> as a portrait token subject to the size
+    /// gate. This ties the gate to schema convention rather than claim
+    /// name, so future credential types that embed tokenised images reuse
+    /// the gate without any change here.
+    /// </summary>
+    private static bool IsPortraitTokenMapping(string sourceField) =>
+        sourceField.EndsWith("/tokenImageBase64", StringComparison.Ordinal);
 
     /// <summary>
     /// Resolves a JSON Pointer (<c>/foo/bar/baz</c>) against a root dictionary

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1648,8 +1648,10 @@ public class ActionExecutionService : IActionExecutionService
     /// <summary>
     /// Bound from <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>:
     /// a 240×320 JPEG at the token spec's 20KB raw target produces ~27KB
-    /// when base64-encoded (raw × 1.37). The gate applies to the
-    /// base64-encoded length, which is what actually ships in the SD-JWT.
+    /// when base64-encoded (raw × 4/3 ≈ 1.333, plus up to two padding chars
+    /// and occasional line breaks — call it ~27KB to keep a small headroom).
+    /// The gate applies to the base64-encoded length, which is what actually
+    /// ships in the SD-JWT.
     /// </summary>
     private const int PortraitTokenMaxBase64Chars = 27_000;
 

--- a/src/Services/Sorcha.Validator.Service/Models/ValidationErrorCodes.cs
+++ b/src/Services/Sorcha.Validator.Service/Models/ValidationErrorCodes.cs
@@ -58,4 +58,28 @@ public static class ValidationErrorCodes
     /// the accept action produces an ambiguous instance state.
     /// </summary>
     public const string SorchaLocalWalletRejectNotTerminal = "VAL_BP_CRED_003";
+
+    // ---- Feature 107: Assured Identity v1 ----
+
+    /// <summary>
+    /// Blueprint publish <b>warning</b> (non-blocking): an <c>x-review</c> page
+    /// declares a <c>layout</c> value the renderer does not recognise. The blueprint
+    /// still publishes and the UI falls back to a tabular minimal review rather than
+    /// the requested card variant.
+    /// </summary>
+    /// <remarks>
+    /// Contract: <c>specs/107-assured-identity-v1/contracts/x-review-extension.md</c>.
+    /// </remarks>
+    public const string ReviewLayoutUnknown = "WARN_BP_REVIEW_001";
+
+    /// <summary>
+    /// Credential issuance <b>warning</b> (non-blocking): the portrait
+    /// <c>tokenImageBase64</c> source field exceeded the ~27KB base64 size bound.
+    /// The credential is still issued but the <c>portrait</c> claim is omitted;
+    /// the citizen is surfaced a warning so they can re-capture if desired.
+    /// </summary>
+    /// <remarks>
+    /// Contract: <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>.
+    /// </remarks>
+    public const string CredentialPortraitOversize = "WARN_CRED_PORTRAIT_OVERSIZE_001";
 }

--- a/tests/Sorcha.Blueprint.Models.Tests/XFileExtensionParserTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/XFileExtensionParserTests.cs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Models;
+using System.Text.Json;
+
+namespace Sorcha.Blueprint.Models.Tests;
+
+/// <summary>
+/// Tests for Feature 107 Assured Identity v1 additions to <see cref="FileSchemaExtension"/>:
+/// the optional <c>capture</c> and <c>embedAs</c> hints. Contract:
+/// <c>specs/107-assured-identity-v1/contracts/x-file-capture-extension.md</c>.
+/// </summary>
+public class XFileExtensionParserTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    // --- Existing fields still parse (regression guard) ---
+
+    [Fact]
+    public void TryParseFromSchema_ExistingFieldsStillParse_WithNewFieldsAbsent()
+    {
+        var element = Parse("""
+            {
+              "type": "string",
+              "x-file": {
+                "accept": ["image/jpeg"],
+                "maxSizePerFile": "8MB",
+                "maxChunks": 5
+              }
+            }
+            """);
+
+        FileSchemaExtension.TryParseFromSchema(element, out var ext).Should().BeTrue();
+        ext!.Accept.Should().BeEquivalentTo(["image/jpeg"]);
+        ext.MaxSizePerFile.Should().Be("8MB");
+        ext.MaxChunks.Should().Be(5);
+        ext.Capture.Should().BeNull();
+        ext.EmbedAs.Should().BeNull();
+    }
+
+    // --- capture field ---
+
+    [Theory]
+    [InlineData("user")]
+    [InlineData("environment")]
+    public void TryParseFromSchema_CaptureValid_PopulatesCapture(string capture)
+    {
+        var element = Parse($$"""
+            {
+              "type": "string",
+              "x-file": {
+                "accept": ["image/jpeg"],
+                "maxSizePerFile": "5MB",
+                "capture": "{{capture}}"
+              }
+            }
+            """);
+
+        FileSchemaExtension.TryParseFromSchema(element, out var ext).Should().BeTrue();
+        ext!.Capture.Should().Be(capture);
+    }
+
+    [Fact]
+    public void TryParseFromSchema_CaptureAbsent_LeavesCaptureNull()
+    {
+        var element = Parse("""
+            {
+              "type": "string",
+              "x-file": {
+                "accept": ["application/pdf"],
+                "maxSizePerFile": "16MB"
+              }
+            }
+            """);
+
+        FileSchemaExtension.TryParseFromSchema(element, out var ext).Should().BeTrue();
+        ext!.Capture.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParseFromSchema_CaptureUnknownValue_PreservedAsIs()
+    {
+        // Parser is permissive; unknown values round-trip so the UI layer
+        // can surface a publish-time warning (WARN_BP_REVIEW_001 is for
+        // x-review, but the same pattern applies — validation is a layer
+        // above the parser).
+        var element = Parse("""
+            {
+              "type": "string",
+              "x-file": {
+                "accept": ["image/jpeg"],
+                "maxSizePerFile": "5MB",
+                "capture": "front-only"
+              }
+            }
+            """);
+
+        FileSchemaExtension.TryParseFromSchema(element, out var ext).Should().BeTrue();
+        ext!.Capture.Should().Be("front-only");
+        FileSchemaExtension.IsValidCapture(ext.Capture).Should().BeFalse();
+    }
+
+    // --- embedAs field ---
+
+    [Fact]
+    public void TryParseFromSchema_EmbedAsImageTokenJpeg_Populates()
+    {
+        var element = Parse("""
+            {
+              "type": "string",
+              "x-file": {
+                "accept": ["image/jpeg"],
+                "maxSizePerFile": "5MB",
+                "embedAs": "image-token-jpeg-240x320"
+              }
+            }
+            """);
+
+        FileSchemaExtension.TryParseFromSchema(element, out var ext).Should().BeTrue();
+        ext!.EmbedAs.Should().Be("image-token-jpeg-240x320");
+    }
+
+    [Fact]
+    public void TryParseFromSchema_EmbedAsAbsent_LeavesEmbedAsNull()
+    {
+        var element = Parse("""
+            {
+              "type": "string",
+              "x-file": {
+                "accept": ["application/pdf"],
+                "maxSizePerFile": "32MB"
+              }
+            }
+            """);
+
+        FileSchemaExtension.TryParseFromSchema(element, out var ext).Should().BeTrue();
+        ext!.EmbedAs.Should().BeNull();
+    }
+
+    // --- IsValid* helpers ---
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("user", true)]
+    [InlineData("environment", true)]
+    [InlineData("front", false)]
+    [InlineData("USER", false)] // case-sensitive
+    [InlineData("", false)]
+    public void IsValidCapture_ReturnsExpected(string? input, bool expected) =>
+        FileSchemaExtension.IsValidCapture(input).Should().Be(expected);
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("image-token-jpeg-240x320", true)]
+    [InlineData("image-token-jpeg-480x640", false)]
+    [InlineData("image-token-png-240x320", false)]
+    [InlineData("", false)]
+    public void IsValidEmbedAs_ReturnsExpected(string? input, bool expected) =>
+        FileSchemaExtension.IsValidEmbedAs(input).Should().Be(expected);
+}

--- a/tests/Sorcha.Blueprint.Models.Tests/XReviewExtensionParserTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/XReviewExtensionParserTests.cs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Models;
+using System.Text.Json;
+
+namespace Sorcha.Blueprint.Models.Tests;
+
+/// <summary>
+/// Tests for Feature 107 Assured Identity v1: the <c>x-review</c> schema
+/// extension on a wizard page. Contract:
+/// <c>specs/107-assured-identity-v1/contracts/x-review-extension.md</c>.
+/// </summary>
+public class XReviewExtensionParserTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonSerializer.Deserialize<JsonElement>(json);
+
+    [Fact]
+    public void Parse_PageWithIdCardReview_PopulatesReviewExtension()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "About you",
+                    "x-sections": [
+                        { "title": "Name", "fields": ["givenName", "familyName"] }
+                    ]
+                },
+                {
+                    "title": "Review your details",
+                    "description": "What you'll receive once issued.",
+                    "x-review": {
+                        "layout": "id-card",
+                        "editable": true,
+                        "header": {
+                            "issuerName": "Government of Scotland",
+                            "credentialName": "Assured Identity",
+                            "colourTheme": "identity-navy"
+                        }
+                    }
+                }
+            ],
+            "properties": {
+                "givenName": { "type": "string" },
+                "familyName": { "type": "string" }
+            }
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        result.HasWizard.Should().BeTrue();
+        result.Pages.Should().HaveCount(2);
+
+        var reviewPage = result.Pages![1];
+        reviewPage.ReviewExtension.Should().NotBeNull();
+        reviewPage.ReviewExtension!.Layout.Should().Be(XReviewLayoutVariant.IdCard);
+        reviewPage.ReviewExtension.Editable.Should().BeTrue();
+        reviewPage.ReviewExtension.Header.IssuerName.Should().Be("Government of Scotland");
+        reviewPage.ReviewExtension.Header.CredentialName.Should().Be("Assured Identity");
+        reviewPage.ReviewExtension.Header.ColourTheme.Should().Be(XReviewColourTheme.IdentityNavy);
+    }
+
+    [Fact]
+    public void Parse_PageWithoutReview_LeavesReviewExtensionNull()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                { "title": "One", "x-sections": [ { "fields": ["a"] } ] }
+            ],
+            "properties": { "a": { "type": "string" } }
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        result.Pages.Should().HaveCount(1);
+        result.Pages![0].ReviewExtension.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_EditableDefaultsToTrueWhenAbsent()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "Review",
+                    "x-review": {
+                        "layout": "id-card",
+                        "header": {
+                            "issuerName": "Gov",
+                            "credentialName": "Assured Identity"
+                        }
+                    }
+                }
+            ]
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        result.Pages![0].ReviewExtension!.Editable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_ColourThemeDefaultsToIdentityNavyWhenAbsent()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "Review",
+                    "x-review": {
+                        "layout": "id-card",
+                        "header": {
+                            "issuerName": "Gov",
+                            "credentialName": "Assured Identity"
+                        }
+                    }
+                }
+            ]
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        result.Pages![0].ReviewExtension!.Header.ColourTheme
+            .Should().Be(XReviewColourTheme.IdentityNavy);
+    }
+
+    [Fact]
+    public void Parse_LicencePinkTheme_Recognised()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "Review",
+                    "x-review": {
+                        "layout": "id-card",
+                        "header": {
+                            "issuerName": "DLA",
+                            "credentialName": "Driving Licence",
+                            "colourTheme": "licence-pink"
+                        }
+                    }
+                }
+            ]
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        result.Pages![0].ReviewExtension!.Header.ColourTheme
+            .Should().Be(XReviewColourTheme.LicencePink);
+    }
+
+    [Fact]
+    public void Parse_UnknownLayout_FallsBackToIdCardAndRecordsWarning()
+    {
+        // Per contract: unknown layout values produce a publish warning
+        // (WARN_BP_REVIEW_001) and fall back so the UI still renders.
+        // The parser itself reports the fallback; a separate validator
+        // step surfaces the warning to the publisher.
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "Review",
+                    "x-review": {
+                        "layout": "hologram",
+                        "header": {
+                            "issuerName": "Gov",
+                            "credentialName": "Assured Identity"
+                        }
+                    }
+                }
+            ]
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        var page = result.Pages![0];
+        page.ReviewExtension.Should().NotBeNull();
+        // Fall back to IdCard so the renderer still has something to draw.
+        page.ReviewExtension!.Layout.Should().Be(XReviewLayoutVariant.IdCard);
+    }
+
+    [Fact]
+    public void Parse_MissingIssuerName_DropsReviewExtension()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "Review",
+                    "x-review": {
+                        "layout": "id-card",
+                        "header": {
+                            "credentialName": "Assured Identity"
+                        }
+                    }
+                }
+            ]
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        // Required header fields absent — the page renders as a plain
+        // (empty) form page rather than a broken review card.
+        result.Pages![0].ReviewExtension.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_MissingCredentialName_DropsReviewExtension()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                {
+                    "title": "Review",
+                    "x-review": {
+                        "layout": "id-card",
+                        "header": {
+                            "issuerName": "Gov"
+                        }
+                    }
+                }
+            ]
+        }
+        """);
+
+        var result = SchemaLayoutParser.Parse(schema);
+
+        result.Pages![0].ReviewExtension.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsPortraitTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsPortraitTests.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Tests for the portrait-specific behaviour of
+/// <see cref="ActionExecutionService.BuildClaimsFromMappings"/>: the server is
+/// the authoritative size gate — client-side resize is convenience. The claim
+/// is included when the token is ≤27KB base64, omitted when absent, and
+/// omitted with a warning when oversize. Feature 107 Assured Identity v1 (T026).
+/// </summary>
+public class BuildClaimsFromMappingsPortraitTests
+{
+    private const int Base64BoundBytes = 27_000;
+
+    private static IEnumerable<ClaimMapping> Mappings(params (string claim, string source)[] entries) =>
+        entries.Select(e => new ClaimMapping { ClaimName = e.claim, SourceField = e.source });
+
+    private static string Base64String(int rawLength) =>
+        Convert.ToBase64String(new byte[rawLength]);
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitAtBoundary_Included()
+    {
+        // A base64 string exactly at the 27,000-char bound passes.
+        var payload = new Dictionary<string, object?>
+        {
+            ["portrait"] = new Dictionary<string, object?>
+            {
+                ["tokenImageBase64"] = new string('A', Base64BoundBytes)
+            },
+            ["givenName"] = "Alex"
+        };
+
+        var mappings = Mappings(
+            ("portrait", "/portrait/tokenImageBase64"),
+            ("givenName", "/givenName"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().ContainKey("portrait");
+        claims.Should().ContainKey("givenName");
+        claims["givenName"].Should().Be("Alex");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitOversize_Omitted()
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["portrait"] = new Dictionary<string, object?>
+            {
+                // One char over the bound — must be dropped with warning.
+                ["tokenImageBase64"] = new string('A', Base64BoundBytes + 1)
+            },
+            ["givenName"] = "Alex"
+        };
+
+        var mappings = Mappings(
+            ("portrait", "/portrait/tokenImageBase64"),
+            ("givenName", "/givenName"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().NotContainKey("portrait");
+        // Other claims continue through.
+        claims.Should().ContainKey("givenName");
+        claims["givenName"].Should().Be("Alex");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitAbsent_ClaimOmittedWithoutError()
+    {
+        // Citizen skipped the photo — credential issued without the claim.
+        var payload = new Dictionary<string, object?>
+        {
+            ["givenName"] = "Alex"
+        };
+
+        var mappings = Mappings(
+            ("portrait", "/portrait/tokenImageBase64"),
+            ("givenName", "/givenName"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().NotContainKey("portrait");
+        claims["givenName"].Should().Be("Alex");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitWellUnderBound_Included()
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["portrait"] = new Dictionary<string, object?>
+            {
+                ["tokenImageBase64"] = Base64String(10_000) // ~13,400 base64 chars
+            }
+        };
+
+        var mappings = Mappings(("portrait", "/portrait/tokenImageBase64"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().ContainKey("portrait");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_NonPortraitClaimsUnaffectedBySizeGate()
+    {
+        // A non-portrait claim with a very long value is NOT size-gated —
+        // the gate only applies to tokenImageBase64-shaped portrait claims.
+        var payload = new Dictionary<string, object?>
+        {
+            ["notes"] = new string('N', Base64BoundBytes * 2)
+        };
+
+        var mappings = Mappings(("notes", "/notes"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().ContainKey("notes");
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/DateTimeRendererFutureBlockTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/DateTimeRendererFutureBlockTests.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.UI.Core.Services.Forms;
+using System.Text.Json;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Tests for <see cref="DateTimeFieldBoundResolver"/> — the static helper that
+/// the <c>DateTimeRenderer.razor</c> uses to resolve <c>formatMinimum</c> /
+/// <c>formatMaximum</c> Sorcha date tokens into concrete <see cref="DateOnly"/>
+/// bounds for the date-picker. Feature 107 Assured Identity v1 — DOB future-block.
+/// </summary>
+public class DateTimeRendererFutureBlockTests
+{
+    private static readonly DateOnly FixedToday = new(2026, 4, 20);
+
+    private static JsonElement Schema(string json) => JsonDocument.Parse(json).RootElement;
+
+    // --- formatMaximum: "today" (DOB future-block) ---
+
+    [Fact]
+    public void TryResolveBound_FormatMaximumToday_ReturnsToday()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMaximum": "today" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMaximum", FixedToday, out var bound)
+            .Should().BeTrue();
+        bound.Should().Be(FixedToday);
+    }
+
+    // --- formatMaximum: "today-18Y" (age-gate) ---
+
+    [Fact]
+    public void TryResolveBound_FormatMaximumTodayMinus18Y_ReturnsDateEighteenYearsAgo()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMaximum": "today-18Y" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMaximum", FixedToday, out var bound)
+            .Should().BeTrue();
+        bound.Should().Be(FixedToday.AddYears(-18));
+    }
+
+    // --- formatMinimum: "today" (future-only gate) ---
+
+    [Fact]
+    public void TryResolveBound_FormatMinimumToday_ReturnsToday()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMinimum": "today" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMinimum", FixedToday, out var bound)
+            .Should().BeTrue();
+        bound.Should().Be(FixedToday);
+    }
+
+    [Fact]
+    public void TryResolveBound_FormatMinimumTodayPlus30D_ReturnsDateThirtyDaysAhead()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMinimum": "today+30D" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMinimum", FixedToday, out var bound)
+            .Should().BeTrue();
+        bound.Should().Be(FixedToday.AddDays(30));
+    }
+
+    // --- ISO-8601 literal passes through ---
+
+    [Fact]
+    public void TryResolveBound_IsoLiteralBound_ParsesAsAbsoluteDate()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMaximum": "2000-01-01" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMaximum", FixedToday, out var bound)
+            .Should().BeTrue();
+        bound.Should().Be(new DateOnly(2000, 1, 1));
+    }
+
+    // --- Absent bound → no constraint ---
+
+    [Fact]
+    public void TryResolveBound_BoundAbsent_ReturnsFalseAndNull()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMaximum", FixedToday, out var bound)
+            .Should().BeFalse();
+        bound.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolveBound_BothBoundsAbsent_NeitherResolves()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMinimum", FixedToday, out var minBound)
+            .Should().BeFalse();
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMaximum", FixedToday, out var maxBound)
+            .Should().BeFalse();
+        minBound.Should().BeNull();
+        maxBound.Should().BeNull();
+    }
+
+    // --- Unparseable token → false, caller falls back to unbounded picker ---
+
+    [Fact]
+    public void TryResolveBound_UnparseableToken_ReturnsFalse()
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMaximum": "whenever" }""");
+
+        DateTimeFieldBoundResolver.TryResolveBound(schema, "formatMaximum", FixedToday, out var bound)
+            .Should().BeFalse();
+        bound.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FileRendererCaptureTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FileRendererCaptureTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Tests for the static helpers used by <c>FileRenderer.razor</c> to translate
+/// a parsed <see cref="FileSchemaExtension"/> into the HTML <c>capture</c>
+/// attribute value and the resize-for-embed decision. Feature 107 Assured
+/// Identity v1.
+/// </summary>
+public class FileRendererCaptureTests
+{
+    // --- GetCaptureAttribute ---
+
+    [Fact]
+    public void GetCaptureAttribute_CaptureUser_ReturnsUser()
+    {
+        var ext = new FileSchemaExtension { Capture = "user" };
+        FileFieldCaptureHelper.GetCaptureAttribute(ext).Should().Be("user");
+    }
+
+    [Fact]
+    public void GetCaptureAttribute_CaptureEnvironment_ReturnsEnvironment()
+    {
+        var ext = new FileSchemaExtension { Capture = "environment" };
+        FileFieldCaptureHelper.GetCaptureAttribute(ext).Should().Be("environment");
+    }
+
+    [Fact]
+    public void GetCaptureAttribute_CaptureNull_ReturnsNull()
+    {
+        var ext = new FileSchemaExtension { Capture = null };
+        FileFieldCaptureHelper.GetCaptureAttribute(ext).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCaptureAttribute_ExtensionNull_ReturnsNull()
+    {
+        FileFieldCaptureHelper.GetCaptureAttribute(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCaptureAttribute_CaptureUnknownValue_ReturnsNull()
+    {
+        // Unknown values are NOT propagated to HTML — renderer emits no
+        // attribute rather than trusting an arbitrary string into the DOM.
+        var ext = new FileSchemaExtension { Capture = "front-only" };
+        FileFieldCaptureHelper.GetCaptureAttribute(ext).Should().BeNull();
+    }
+
+    // --- ShouldResizeForEmbed ---
+
+    [Fact]
+    public void ShouldResizeForEmbed_EmbedAsImageTokenJpeg_True()
+    {
+        var ext = new FileSchemaExtension { EmbedAs = "image-token-jpeg-240x320" };
+        FileFieldCaptureHelper.ShouldResizeForEmbed(ext).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldResizeForEmbed_EmbedAsNull_False()
+    {
+        var ext = new FileSchemaExtension { EmbedAs = null };
+        FileFieldCaptureHelper.ShouldResizeForEmbed(ext).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldResizeForEmbed_ExtensionNull_False()
+    {
+        FileFieldCaptureHelper.ShouldResizeForEmbed(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldResizeForEmbed_EmbedAsUnknownValue_False()
+    {
+        var ext = new FileSchemaExtension { EmbedAs = "image-token-png-480x640" };
+        FileFieldCaptureHelper.ShouldResizeForEmbed(ext).Should().BeFalse();
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/ReviewSummaryRendererTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/ReviewSummaryRendererTests.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Models.Forms;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Forms;
+
+/// <summary>
+/// Tests for <see cref="ReviewSummaryDispatch"/> — the static decision helpers
+/// used by <c>ReviewSummaryRenderer.razor</c>. Feature 107 Assured Identity v1 (T023).
+/// </summary>
+public class ReviewSummaryRendererTests
+{
+    // --- ResolveWatermark ---
+
+    [Theory]
+    [InlineData(ActionRuntimeState.CitizenDraft, IdCardWatermark.Draft)]
+    [InlineData(ActionRuntimeState.AssessorPending, IdCardWatermark.Pending)]
+    [InlineData(ActionRuntimeState.IssuedCredential, IdCardWatermark.Issued)]
+    [InlineData(ActionRuntimeState.CredentialPreview, IdCardWatermark.None)]
+    public void ResolveWatermark_MapsStateToWatermark(ActionRuntimeState state, IdCardWatermark expected) =>
+        ReviewSummaryDispatch.ResolveWatermark(state).Should().Be(expected);
+
+    // --- IsImplemented ---
+
+    [Fact]
+    public void IsImplemented_IdCard_True()
+    {
+        ReviewSummaryDispatch.IsImplemented(XReviewLayoutVariant.IdCard).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(XReviewLayoutVariant.PassportPage)]
+    [InlineData(XReviewLayoutVariant.Tabular)]
+    [InlineData(XReviewLayoutVariant.Receipt)]
+    public void IsImplemented_ReservedVariants_False(XReviewLayoutVariant variant)
+    {
+        ReviewSummaryDispatch.IsImplemented(variant).Should().BeFalse();
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Services/Forms/PhotoTokenResizerTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Forms/PhotoTokenResizerTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Moq;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services.Forms;
+
+/// <summary>
+/// Tests for <see cref="PhotoTokenResizer"/> — the client-side resizer that
+/// reduces a citizen-captured portrait to the ISO 19794-5 token-image size
+/// (240×320, ≤20KB JPEG). Feature 107 Assured Identity v1 (T016).
+/// </summary>
+/// <remarks>
+/// The browser-side canvas operation is mocked via
+/// <see cref="IPhotoTokenResizerInterop"/>; the tests exercise the
+/// quality-stepping policy in pure C#.
+/// </remarks>
+public class PhotoTokenResizerTests
+{
+    private static readonly byte[] SourceBytes = new byte[1024 * 1024]; // 1 MB stub
+
+    private static byte[] BytesOfSize(int size) => new byte[size];
+
+    [Fact]
+    public async Task ResizeAsync_FirstQualityMeetsTarget_ReturnsImmediately()
+    {
+        var spec = ImageTokenSpec.ImageTokenJpeg240x320;
+        var interop = new Mock<IPhotoTokenResizerInterop>(MockBehavior.Strict);
+        interop
+            .Setup(x => x.ResizeAndEncodeJpegAsync(SourceBytes, 240, 320, 0.85, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BytesOfSize(15_000)); // well under 20KB
+
+        var resizer = new PhotoTokenResizer(interop.Object);
+
+        var result = await resizer.ResizeAsync(SourceBytes, spec);
+
+        result.RawBytes.Should().Be(15_000);
+        result.QualityUsed.Should().Be(0.85);
+        result.Base64.Should().NotBeNullOrEmpty();
+        interop.Verify(x => x.ResizeAndEncodeJpegAsync(
+            It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResizeAsync_StepsDownQualityUntilUnderTarget()
+    {
+        var spec = ImageTokenSpec.ImageTokenJpeg240x320;
+        var interop = new Mock<IPhotoTokenResizerInterop>(MockBehavior.Strict);
+        interop.Setup(x => x.ResizeAndEncodeJpegAsync(SourceBytes, 240, 320, 0.85, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BytesOfSize(30_000));
+        interop.Setup(x => x.ResizeAndEncodeJpegAsync(SourceBytes, 240, 320, 0.75, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BytesOfSize(25_000));
+        interop.Setup(x => x.ResizeAndEncodeJpegAsync(SourceBytes, 240, 320, 0.65, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BytesOfSize(18_000));
+
+        var resizer = new PhotoTokenResizer(interop.Object);
+
+        var result = await resizer.ResizeAsync(SourceBytes, spec);
+
+        result.RawBytes.Should().Be(18_000);
+        result.QualityUsed.Should().Be(0.65);
+        interop.Verify(x => x.ResizeAndEncodeJpegAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), 0.85, It.IsAny<CancellationToken>()), Times.Once);
+        interop.Verify(x => x.ResizeAndEncodeJpegAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), 0.75, It.IsAny<CancellationToken>()), Times.Once);
+        interop.Verify(x => x.ResizeAndEncodeJpegAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), 0.65, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResizeAsync_NeverMeetsTarget_ThrowsPhotoTokenTooDetailedException()
+    {
+        var spec = ImageTokenSpec.ImageTokenJpeg240x320;
+        var interop = new Mock<IPhotoTokenResizerInterop>();
+        // All quality steps produce oversize output.
+        interop.Setup(x => x.ResizeAndEncodeJpegAsync(It.IsAny<byte[]>(), 240, 320, It.IsAny<double>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BytesOfSize(40_000));
+
+        var resizer = new PhotoTokenResizer(interop.Object);
+
+        var act = () => resizer.ResizeAsync(SourceBytes, spec);
+
+        await act.Should().ThrowAsync<PhotoTokenTooDetailedException>();
+    }
+
+    [Fact]
+    public async Task ResizeAsync_Base64OutputMatchesRawJpegBytes()
+    {
+        var spec = ImageTokenSpec.ImageTokenJpeg240x320;
+        var interop = new Mock<IPhotoTokenResizerInterop>();
+        var jpegBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10 }; // JPEG magic
+        interop.Setup(x => x.ResizeAndEncodeJpegAsync(It.IsAny<byte[]>(), 240, 320, 0.85, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jpegBytes);
+
+        var resizer = new PhotoTokenResizer(interop.Object);
+
+        var result = await resizer.ResizeAsync(SourceBytes, spec);
+
+        result.Base64.Should().Be(Convert.ToBase64String(jpegBytes));
+    }
+
+    [Fact]
+    public async Task ResizeAsync_PassesSpecDimensionsToInterop()
+    {
+        var spec = new ImageTokenSpec
+        {
+            Width = 300,
+            Height = 400,
+            MaxRawBytes = 15_000,
+            QualitySteps = [0.8]
+        };
+        var interop = new Mock<IPhotoTokenResizerInterop>();
+        interop.Setup(x => x.ResizeAndEncodeJpegAsync(SourceBytes, 300, 400, 0.8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BytesOfSize(10_000));
+
+        var resizer = new PhotoTokenResizer(interop.Object);
+        await resizer.ResizeAsync(SourceBytes, spec);
+
+        interop.Verify(x => x.ResizeAndEncodeJpegAsync(SourceBytes, 300, 400, 0.8, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void V1Preset_HasCanonicalDimensions()
+    {
+        var spec = ImageTokenSpec.ImageTokenJpeg240x320;
+        spec.Width.Should().Be(240);
+        spec.Height.Should().Be(320);
+        spec.MaxRawBytes.Should().Be(20 * 1024);
+        spec.QualitySteps.Should().StartWith([0.85, 0.75, 0.65]);
+        spec.QualitySteps.Last().Should().BeApproximately(0.5, 0.001);
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/Forms/ReviewSummaryDataSourceTests.cs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Models;
+using Sorcha.UI.Core.Models.Forms;
+using Sorcha.UI.Core.Services.Forms;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services.Forms;
+
+/// <summary>
+/// Tests for <see cref="ReviewSummaryDataSource.BuildConfig"/> — the helper
+/// that shapes prior-page form values into an <see cref="IdCardLayoutConfig"/>
+/// for the review card. Feature 107 Assured Identity v1 (T021).
+/// </summary>
+public class ReviewSummaryDataSourceTests
+{
+    private static XReviewExtension CitizenReview() => new()
+    {
+        Layout = XReviewLayoutVariant.IdCard,
+        Editable = true,
+        Header = new XReviewHeader
+        {
+            IssuerName = "Government of Scotland",
+            CredentialName = "Assured Identity",
+            ColourTheme = XReviewColourTheme.IdentityNavy
+        }
+    };
+
+    private static IReadOnlyList<BlueprintPageDefinition> AssuredIdentityPages() =>
+    [
+        new BlueprintPageDefinition
+        {
+            Title = "About you",
+            Sections =
+            [
+                new BlueprintSectionDefinition { Title = "Your name", Fields = ["givenName", "familyName"] },
+                new BlueprintSectionDefinition { Title = "Your date of birth", Fields = ["dateOfBirth"] }
+            ]
+        },
+        new BlueprintPageDefinition
+        {
+            Title = "Your address",
+            Sections = [new BlueprintSectionDefinition { Title = "Address", Fields = ["address"] }]
+        }
+    ];
+
+    private static FormContext ContextWithValues()
+    {
+        var ctx = new FormContext();
+        ctx.FormData["/givenName"] = "Alex";
+        ctx.FormData["/familyName"] = "MacLeod";
+        ctx.FormData["/dateOfBirth"] = "1995-07-14";
+        ctx.FormData["/address/line1"] = "12 Castle St";
+        ctx.FormData["/address/town"] = "Edinburgh";
+        return ctx;
+    }
+
+    [Fact]
+    public void BuildConfig_HeaderPopulatedFromExtension()
+    {
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ContextWithValues(), ActionRuntimeState.CitizenDraft, AssuredIdentityPages());
+
+        cfg.IssuerName.Should().Be("Government of Scotland");
+        cfg.CredentialName.Should().Be("Assured Identity");
+        cfg.ColourTheme.Should().Be(XReviewColourTheme.IdentityNavy);
+        cfg.Editable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildConfig_CitizenDraftState_SetsDraftWatermark()
+    {
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ContextWithValues(), ActionRuntimeState.CitizenDraft, AssuredIdentityPages());
+
+        cfg.Watermark.Should().Be(IdCardWatermark.Draft);
+    }
+
+    [Fact]
+    public void BuildConfig_AssessorPendingState_SetsPendingWatermark()
+    {
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ContextWithValues(), ActionRuntimeState.AssessorPending, AssuredIdentityPages());
+
+        cfg.Watermark.Should().Be(IdCardWatermark.Pending);
+    }
+
+    [Fact]
+    public void BuildConfig_IssuedCredentialState_SetsIssuedWatermark()
+    {
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ContextWithValues(), ActionRuntimeState.IssuedCredential, AssuredIdentityPages());
+
+        cfg.Watermark.Should().Be(IdCardWatermark.Issued);
+    }
+
+    [Fact]
+    public void BuildConfig_SectionsInheritTitlesAndPageIndices()
+    {
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ContextWithValues(), ActionRuntimeState.CitizenDraft, AssuredIdentityPages());
+
+        cfg.Sections.Should().HaveCount(3);
+        cfg.Sections[0].Title.Should().Be("Your name");
+        cfg.Sections[0].OriginatingPageIndex.Should().Be(0);
+        cfg.Sections[0].FieldPointers.Should().Contain("/givenName").And.Contain("/familyName");
+
+        cfg.Sections[1].Title.Should().Be("Your date of birth");
+        cfg.Sections[1].OriginatingPageIndex.Should().Be(0);
+
+        cfg.Sections[2].Title.Should().Be("Address");
+        cfg.Sections[2].OriginatingPageIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildConfig_FieldValuesPulledFromFormContext()
+    {
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ContextWithValues(), ActionRuntimeState.CitizenDraft, AssuredIdentityPages());
+
+        cfg.FieldValues["/givenName"].Should().Be("Alex");
+        cfg.FieldValues["/familyName"].Should().Be("MacLeod");
+        cfg.FieldValues["/dateOfBirth"].Should().Be("1995-07-14");
+    }
+
+    [Fact]
+    public void BuildConfig_UnfilledFields_StoredAsNull()
+    {
+        var ctx = new FormContext();
+        ctx.FormData["/givenName"] = "Alex";
+        // familyName left unfilled
+
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), ctx, ActionRuntimeState.CitizenDraft, AssuredIdentityPages());
+
+        cfg.FieldValues.Should().ContainKey("/familyName");
+        cfg.FieldValues["/familyName"].Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildConfig_PagesWithoutSections_SkippedFromSectionList()
+    {
+        var pages = new List<BlueprintPageDefinition>
+        {
+            new() { Title = "Intro only", Sections = null },
+            new() { Title = "Details", Sections = [new BlueprintSectionDefinition { Title = "Detail", Fields = ["field"] }] }
+        };
+
+        var sut = new ReviewSummaryDataSource();
+
+        var cfg = sut.BuildConfig(CitizenReview(), new FormContext(), ActionRuntimeState.CitizenDraft, pages);
+
+        cfg.Sections.Should().HaveCount(1);
+        cfg.Sections[0].Title.Should().Be("Detail");
+        cfg.Sections[0].OriginatingPageIndex.Should().Be(1);
+    }
+}

--- a/walkthroughs/AssuredIdentity/README.md
+++ b/walkthroughs/AssuredIdentity/README.md
@@ -1,0 +1,65 @@
+# Assured Identity Walkthrough
+
+Feature 107 — single canonical citizen-identity workflow. A citizen submits a
+polished 5-page wizard (name + DOB, address, contact, optional photo, review),
+the government assessor approves, and the citizen receives an
+**AssuredIdentityCredential** in their chosen wallet.
+
+> **Replaces `HaipVerifiedCitizen` and `HaipDrivingLicence`.** Those walkthroughs
+> will be deleted in Phase 7 of this feature, after the DLA chain and cross-peer
+> smoke tests land.
+
+## What it proves
+
+- The new `x-review` schema extension rendering a Page 5 ID-card review
+- The new `x-file.capture` + `x-file.embedAs` extensions driving camera capture
+  and client-side token-image resize (browser path only; the walkthrough script
+  supplies a pre-sized token when `-IncludePortrait` is passed)
+- The DoB picker client-side bound (`formatMaximum: "today"`) wired via
+  `DateTimeFieldBoundResolver`
+- Server-side portrait-size gate (`WARN_CRED_PORTRAIT_OVERSIZE_001`)
+- Full HAIP OID4VCI credential issuance including the new
+  `AssuredIdentityCredential` type
+- Open-participant late binding (citizen is not in `$walletMap`)
+
+## Phases
+
+| Phase | What runs | Script |
+|---|---|---|
+| 1 | Citizen → gov assessor → `AssuredIdentityCredential` | `run-phase1-identity.ps1` |
+| 2 | _(Future — PR 2)_ Driving licence chain | `run-phase2-licence.ps1` |
+
+## Prerequisites
+
+- Docker Desktop running with `docker-compose up -d`
+- Secrets initialised: `pwsh walkthroughs/initialize-secrets.ps1`
+- PowerShell 7.5+
+- .NET 10 SDK (to build and run `sorcha-agent`)
+
+## How to run
+
+```powershell
+# One-time setup (idempotent)
+pwsh walkthroughs/AssuredIdentity/setup.ps1
+
+# Phase 1 — identity issuance
+pwsh walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+
+# Force fresh setup (deletes state.json)
+pwsh walkthroughs/AssuredIdentity/setup.ps1 -Force
+```
+
+## Files
+
+```
+walkthroughs/AssuredIdentity/
+├── README.md                        # This file
+├── setup.ps1                        # Org / wallet / blueprint provisioning
+├── run-phase1-identity.ps1          # Submit → approve → claim AssuredIdentityCredential
+├── blueprints/
+│   └── assured-identity.json        # Three actions: submit, verify, claim
+├── data/
+│   └── sample-portrait.jpg          # Optional pre-sized token for -IncludePortrait
+├── wallet/                          # HAIP filesystem wallet (produced by run-phase1)
+└── state.json                       # Per-run state, written by setup.ps1
+```

--- a/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
+++ b/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
@@ -1,0 +1,270 @@
+{
+  "id": "assured-identity-v1",
+  "title": "Assured Identity",
+  "description": "Single canonical citizen-identity workflow. A public-org citizen submits a short 5-page wizard (name + DOB, address, contact, optional photo, review), a government assessor (or background sorcha-agent) approves, and the AssuredIdentityCredential is delivered via the Wave 14b claim-card pattern. Feature 107 — replaces the legacy VerifiedCitizenCredential and AssuredPersonCredential blueprints.",
+  "version": 1,
+  "category": "identity",
+  "tags": ["assured-identity", "identity", "haip", "oid4vci", "verifiable-credential", "credential-claim", "citizen-application", "core-primitives", "portrait"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "id": "assured-identity",
+    "title": "Assured Identity",
+    "description": "Citizen submits identity details (including an optional portrait), government assessor reviews and issues an AssuredIdentityCredential, and the citizen claims the credential via a Wave 14b claim-card action.",
+    "version": 1,
+    "metadata": {
+      "category": "Identity & Credentials",
+      "complexity": "Simple",
+      "actions": "3",
+      "features": "HAIP, OpenID4VCI, Verifiable Credential, Portrait Claim, Citizen Claim Action, Core Primitives, x-review, x-file",
+      "sector": "Government"
+    },
+    "participants": [
+      {
+        "id": "citizen",
+        "name": "Citizen",
+        "organisation": "Public",
+        "description": "Submits an Assured Identity application and claims the credential into their Sorcha wallet or an external HAIP wallet"
+      },
+      {
+        "id": "government-assessor",
+        "name": "Government Assessor",
+        "organisation": "Government of Scotland",
+        "description": "Reviews citizen identity applications and approves issuance of the AssuredIdentityCredential"
+      }
+    ],
+    "actions": [
+      {
+        "id": 1,
+        "title": "Submit Assured Identity Application",
+        "description": "Citizen submits their personal details (and optionally a portrait photo) so a government assessor can verify their identity. Fields are sourced from the Sorcha core primitive library for consistency with every other citizen-facing service. The final page renders the details as a DRAFT ID card so the citizen sees exactly what they'll receive once issued.",
+        "sender": "citizen",
+        "isStartingAction": true,
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Submit your details so a government assessor can issue your Assured Identity credential. Your persona profile (if you have one) will prefill the form.",
+            "x-pages": [
+              {
+                "title": "About you",
+                "description": "Your full legal name and date of birth.",
+                "x-sections": [
+                  { "title": "Your name", "fields": ["name"] },
+                  { "title": "Your date of birth", "fields": ["dob"] }
+                ]
+              },
+              {
+                "title": "Your address",
+                "description": "Your current registered address. Type your postcode and the rest will autofill where supported.",
+                "x-sections": [
+                  { "title": "Address", "fields": ["address"] }
+                ]
+              },
+              {
+                "title": "Contact",
+                "description": "We'll only use your email for correspondence about this application.",
+                "x-sections": [
+                  { "title": "Email", "fields": ["email"] }
+                ]
+              },
+              {
+                "title": "Your photo (optional)",
+                "description": "Add a portrait photo to your credential. This lets verifiers match you to your credential in person. You can skip this step — the credential is still issued without a photo.",
+                "x-sections": [
+                  { "title": "Portrait", "fields": ["portrait"] }
+                ]
+              },
+              {
+                "title": "Review your details",
+                "description": "Check your answers. You can edit any section before submitting. Once the government assessor approves, this is what your Assured Identity credential will show.",
+                "x-review": {
+                  "layout": "id-card",
+                  "editable": true,
+                  "header": {
+                    "issuerName": "Government of Scotland",
+                    "credentialName": "Assured Identity",
+                    "colourTheme": "identity-navy"
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "name":    { "$ref": "https://schemas.sorcha.dev/core/PersonName/v1" },
+              "dob":     { "$ref": "https://schemas.sorcha.dev/core/DateOfBirth/v1" },
+              "email":   { "$ref": "https://schemas.sorcha.dev/core/EmailAddress/v1" },
+              "address": { "$ref": "https://schemas.sorcha.dev/core/PostalAddress/v1" },
+              "portrait": {
+                "type": "string",
+                "title": "Portrait photo",
+                "description": "Optional passport-style photograph. Captured via your device camera or uploaded; resized to a 240x320 JPEG token for embedding in the credential.",
+                "format": "file-reference",
+                "x-file": {
+                  "accept": ["image/jpeg", "image/png"],
+                  "maxSizePerFile": "5MB",
+                  "maxChunks": 2,
+                  "capture": "user",
+                  "embedAs": "image-token-jpeg-240x320"
+                }
+              }
+            },
+            "required": ["name", "dob", "email", "address"]
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] },
+          { "participantAddress": "government-assessor", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "to-review",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Application submitted — pending assessor review"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Verify Assured Identity Application",
+        "description": "Government assessor reviews the citizen's submission and approves or rejects it. On approval the AssuredIdentityCredential is minted and routed to the citizen's Claim Credential action via OutputMapping.",
+        "sender": "government-assessor",
+        "requiredPriorActions": [1],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Review the citizen's submitted details and portrait (if provided) against your records. Approve to issue, or reject with a reason.",
+            "x-sections": [
+              {
+                "title": "Decision",
+                "description": "Approval state and supporting notes for the audit trail.",
+                "layout": "vertical",
+                "fields": ["decision", "verificationNotes"]
+              }
+            ],
+            "properties": {
+              "decision": {
+                "type": "string",
+                "title": "Decision",
+                "enum": ["approved", "rejected"]
+              },
+              "verificationNotes": {
+                "type": "string",
+                "title": "Reviewer notes",
+                "maxLength": 500
+              }
+            },
+            "required": ["decision"]
+          }
+        ],
+        "credentialIssuanceConfig": {
+          "credentialType": "AssuredIdentityCredential",
+          "targetAudience": "HaipExternalWallet",
+          "recipientParticipantId": "citizen",
+          "claimMappings": [
+            { "claimName": "givenName",   "sourceField": "/name/givenName" },
+            { "claimName": "middleName",  "sourceField": "/name/middleName" },
+            { "claimName": "familyName",  "sourceField": "/name/familyName" },
+            { "claimName": "fullName",    "sourceField": "/name/fullName" },
+            { "claimName": "dateOfBirth", "sourceField": "/dob/dateOfBirth" },
+            { "claimName": "email",       "sourceField": "/email/email" },
+            { "claimName": "address",     "sourceField": "/address" },
+            { "claimName": "portrait",    "sourceField": "/portrait/tokenImageBase64" }
+          ],
+          "disclosable": [
+            "givenName", "middleName", "familyName", "fullName", "dateOfBirth", "email",
+            "/address/line1", "/address/line2", "/address/town", "/address/region",
+            "/address/postcode", "/address/country",
+            "portrait"
+          ]
+        },
+        "disclosures": [
+          { "participantAddress": "government-assessor", "dataPointers": ["/*"] },
+          { "participantAddress": "citizen", "dataPointers": ["/decision", "/verificationNotes"] }
+        ],
+        "routes": [
+          {
+            "id": "approved-to-claim",
+            "nextActionIds": [3],
+            "condition": { "==": [{ "var": "decision" }, "approved"] },
+            "description": "Approved — deliver the minted credential to the citizen's Claim Credential pending action",
+            "outputMapping": {
+              "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+              "/haip/credential_type":      "/credentialOffer/credential_type",
+              "/haip/expires_at":           "/credentialOffer/expires_at",
+              "/haip/offer_id":             "/credentialOffer/offer_id"
+            }
+          },
+          {
+            "id": "rejected-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Rejected — workflow ends with no credential issued"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Claim your Assured Identity credential",
+        "description": "Your Assured Identity credential is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP-compatible wallet. Declining will cancel the claim and no credential will be issued.",
+        "sender": "citizen",
+        "requiredPriorActions": [2],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "credentialOffer": {
+                "type": "object",
+                "title": "Credential Offer",
+                "x-credential-offer": true,
+                "properties": {
+                  "credential_offer_uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Canonical OpenID4VCI offer URI (openid-credential-offer://...)"
+                  },
+                  "credential_type": {
+                    "type": "string",
+                    "description": "The credential type to be issued"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the credential offer expires and can no longer be claimed"
+                  },
+                  "offer_id": {
+                    "type": "string",
+                    "description": "HAIP offer identifier for status polling"
+                  }
+                },
+                "required": ["credential_offer_uri"]
+              },
+              "claimed_at": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Claimed at",
+                "description": "Set by the client when the citizen clicks Claim"
+              }
+            },
+            "required": ["credentialOffer"]
+          }
+        ],
+        "rejectionConfig": {
+          "targetActionId": 0,
+          "isTerminal": true,
+          "requireReason": false
+        },
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "claimed-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Credential claimed — workflow complete"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -1,0 +1,196 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# AssuredIdentity — Phase 1 (Identity issuance)
+# Feature 107. Creates the blueprint instance, submits the citizen's Assured
+# Identity application (Action 1), the government assessor approves (Action 2),
+# and the citizen claims the AssuredIdentityCredential into their external
+# HAIP wallet via sorcha-agent haip receive.
+
+param(
+    [switch]$ShowJson,
+    [switch]$IncludePortrait
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "AssuredIdentity — Phase 1 (Identity)"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+if (-not (Test-Path $stateFile)) { Write-WtFail "No state.json. Run setup.ps1 first."; exit 1 }
+$state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+
+$walletDir = Join-Path $scriptDir "wallet"
+
+# ============================================================================
+# Step 1: Authenticate both roles
+# ============================================================================
+Write-WtStep "Step 1: Authenticate Citizen and Government Assessor"
+
+$citizenSession = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.roles.citizen.email `
+    -Password $state.roles.citizen.password `
+    -OrganizationId $state.roles.citizen.organizationId
+Write-WtSuccess "Authenticated as citizen ($($state.roles.citizen.email))"
+
+$assessorSession = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.roles.govAssessor.email `
+    -Password $state.roles.govAssessor.password `
+    -OrganizationId $state.roles.govAssessor.organizationId
+Write-WtSuccess "Authenticated as government-assessor"
+
+# ============================================================================
+# Step 2: Create Blueprint Instance (citizen-owned)
+# ============================================================================
+Write-WtStep "Step 2: Citizen creates Blueprint Instance"
+
+$instanceBody = @{
+    blueprintId = $state.blueprintId
+    registerId  = $state.registerId
+    tenantId    = $state.publicOrgId
+    metadata    = @{ source = "walkthrough"; walkthrough = "AssuredIdentity" }
+}
+
+$instance = Invoke-SorchaApi -Method POST `
+    -Uri "$($state.blueprintUrl)/instances/" `
+    -Body $instanceBody `
+    -Headers $citizenSession.Headers
+$instanceId = $instance.id
+Write-WtSuccess "Instance created: $instanceId"
+if ($ShowJson) { $instance | ConvertTo-Json -Depth 5 | Write-Host }
+
+# ============================================================================
+# Step 3: Citizen submits Action 1
+# ============================================================================
+Write-WtStep "Step 3: Citizen submits Identity Application (Action 1)"
+
+$persona = $state.persona
+$payloadData = @{
+    name = @{
+        givenName  = $persona.givenName
+        middleName = $persona.middleName
+        familyName = $persona.familyName
+        fullName   = $persona.fullName
+    }
+    dob = @{
+        dateOfBirth = $persona.dateOfBirth
+    }
+    email = @{
+        email = $persona.defaultEmail
+    }
+    address = @{
+        line1    = $persona.defaultAddress.street
+        town     = $persona.defaultAddress.locality
+        region   = $persona.defaultAddress.region
+        postcode = $persona.defaultAddress.postcode
+        country  = $persona.defaultAddress.country
+    }
+}
+
+# Optional portrait — the Feature 107 server-side gate accepts a base64 JPEG
+# token up to ~27KB. The walkthrough's PowerShell path bypasses the browser
+# canvas resize, so the caller supplies an already-sized sample via
+# data/sample-portrait.jpg. When absent, the credential is issued without
+# the portrait claim (the blueprint marks portrait optional).
+if ($IncludePortrait) {
+    $samplePath = Join-Path $scriptDir "data/sample-portrait.jpg"
+    if (Test-Path $samplePath) {
+        $bytes = [System.IO.File]::ReadAllBytes($samplePath)
+        $base64 = [Convert]::ToBase64String($bytes)
+        if ($base64.Length -gt 27000) {
+            Write-WtWarn "sample-portrait.jpg is $($base64.Length) base64 chars — over the 27KB server gate. Skipping."
+        } else {
+            $payloadData.portrait = @{
+                tokenImageBase64 = $base64
+            }
+            Write-WtInfo "Portrait attached ($($base64.Length) base64 chars)"
+        }
+    } else {
+        Write-WtWarn "sample-portrait.jpg not found at $samplePath — submitting without portrait"
+    }
+}
+
+$null = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "1" `
+    -BlueprintId $state.blueprintId `
+    -SenderWallet $state.citizenWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $citizenSession.Token `
+    -PayloadData $payloadData
+
+# ============================================================================
+# Step 4: Government Assessor approves Action 2
+# ============================================================================
+Write-WtStep "Step 4: Gov Assessor verifies application (Action 2)"
+
+$actionResponse = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "2" `
+    -BlueprintId $state.blueprintId `
+    -SenderWallet $state.govWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $assessorSession.Token `
+    -PayloadData @{
+        decision          = "approved"
+        verificationNotes = "Identity verified against submitted persona."
+    }
+
+if ($ShowJson) { $actionResponse | ConvertTo-Json -Depth 5 | Write-Host }
+
+$credentialOffer = $actionResponse.credentialOffer
+if (-not $credentialOffer) {
+    Write-WtFail "Action 2 did not return a credentialOffer. HAIP response pipeline may be misconfigured."
+    exit 1
+}
+
+$offerUri = $credentialOffer.credentialOfferUri
+Write-WtSuccess "Credential offer created: $($credentialOffer.offerId)"
+Write-WtInfo "Type: $($credentialOffer.credentialType)"
+Write-WtInfo "Expires: $($credentialOffer.expiresAt)"
+$truncatedUri = $offerUri.Substring(0, [Math]::Min(80, $offerUri.Length))
+Write-WtInfo "Offer URI: $truncatedUri..."
+
+# ============================================================================
+# Step 5: sorcha-agent haip receive (simulates citizen's external wallet)
+# ============================================================================
+Write-WtStep "Step 5: sorcha-agent haip receive"
+
+$agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
+
+& dotnet run --project $agentProject -- haip receive --offer-uri $offerUri --wallet-dir $walletDir
+if ($LASTEXITCODE -ne 0) {
+    Write-WtFail "sorcha-agent haip receive failed (exit $LASTEXITCODE)"
+    exit $LASTEXITCODE
+}
+
+# ============================================================================
+# Step 6: Verify Credential
+# ============================================================================
+Write-WtStep "Step 6: Verify Credential"
+
+$credFile = Join-Path $walletDir "credentials/AssuredIdentityCredential.sdjwt"
+if (Test-Path $credFile) {
+    $credSize = (Get-Item $credFile).Length
+    Write-WtSuccess "Credential stored: $credFile ($credSize bytes)"
+} else {
+    Write-WtFail "Credential file not found at $credFile"
+    exit 1
+}
+
+$state | Add-Member -NotePropertyName "instanceId" -NotePropertyValue $instanceId -Force
+$state | Add-Member -NotePropertyName "credentialPath" -NotePropertyValue $credFile -Force
+$state | Add-Member -NotePropertyName "walletDir" -NotePropertyValue $walletDir -Force
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
+
+Write-WtBanner "AssuredIdentity — Phase 1 Complete"
+Write-WtSuccess "AssuredIdentityCredential issued to citizen wallet via blueprint action"

--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -1,0 +1,320 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# AssuredIdentity — Setup
+# Feature 107. Creates the Government of Scotland issuing organisation,
+# provisions its trust anchor + HAIP issuer enrolment, creates the citizen
+# public-org account, and publishes the AssuredIdentity blueprint.
+# Idempotent — safe to run multiple times.
+
+param(
+    [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
+    [string]$Profile = 'gateway',
+    [switch]$SkipHealthCheck,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "AssuredIdentity — Setup"
+
+$secrets = Get-SorchaSecrets -WalkthroughName "assured-identity"
+$sorchaEnv = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+
+# Well-known public org id (platform-wide, used for citizen accounts).
+$publicOrgId = "00000000-0000-0000-0000-000000000002"
+
+if ((Test-Path $stateFile) -and -not $Force) {
+    Write-WtInfo "state.json exists. Use -Force to re-run."
+    return
+}
+
+# ============================================================================
+# Step 1: Login as System Admin
+# ============================================================================
+Write-WtStep "Step 1: Login as System Admin"
+$sysAdmin = Connect-SorchaAdmin `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -AdminEmail $secrets.adminEmail `
+    -AdminPassword $secrets.adminPassword
+Write-WtSuccess "Connected (org: $($sysAdmin.OrganizationId))"
+
+# ============================================================================
+# Step 2: Enable Public Org + Register Users
+# ============================================================================
+Write-WtStep "Step 2: Enable Public Org and Register Users"
+
+Invoke-SorchaApi -Method PUT `
+    -Uri "$($sorchaEnv.TenantUrl)/platform/settings/public-org" `
+    -Body @{ enabled = $true } `
+    -Headers $sysAdmin.Headers
+Write-WtInfo "Public org enabled"
+
+$govAdminEmail    = "gov-admin@assured-identity.local"
+$govAdminPassword = $secrets.DefaultPassword
+
+Register-SorchaPublicUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $govAdminEmail `
+    -Password $govAdminPassword `
+    -DisplayName "Government Admin" | Out-Null
+Write-WtInfo "gov-admin registered: $govAdminEmail"
+
+$citizenEmail    = "alex.macleod@assured-identity.local"
+$citizenPassword = $secrets.DefaultPassword
+
+Register-SorchaPublicUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $citizenEmail `
+    -Password $citizenPassword `
+    -DisplayName "Alex MacLeod" | Out-Null
+Write-WtInfo "citizen registered: $citizenEmail"
+
+# ============================================================================
+# Step 3: Verify Emails (admin override — no SMTP)
+# ============================================================================
+Write-WtStep "Step 3: Verify User Emails"
+
+$publicUsers = Invoke-SorchaApi -Method GET `
+    -Uri "$($sorchaEnv.TenantUrl)/organizations/$publicOrgId/users?includeInactive=true" `
+    -Headers $sysAdmin.Headers
+
+foreach ($email in @($govAdminEmail, $citizenEmail)) {
+    $user = $publicUsers.users | Where-Object { $_.email -eq $email } | Select-Object -First 1
+    if ($user) {
+        Confirm-SorchaUserEmail `
+            -TenantUrl $sorchaEnv.TenantUrl `
+            -OrganizationId $publicOrgId `
+            -UserId $user.id `
+            -Headers $sysAdmin.Headers
+        Write-WtInfo "  verified: $email"
+    }
+}
+
+# ============================================================================
+# Step 4: Create Government of Scotland Org
+# ============================================================================
+Write-WtStep "Step 4: Create Government of Scotland"
+
+$govOrg = New-SorchaOrganization `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Name "Government of Scotland" `
+    -Subdomain "gov-scotland" `
+    -AdminEmail $govAdminEmail `
+    -Headers $sysAdmin.Headers `
+    -Description "Issues Assured Identity credentials to citizens"
+
+$govOrgId = $govOrg.OrganizationId
+Write-WtSuccess "Government org: $govOrgId"
+
+# ============================================================================
+# Step 5: Government Admin — Login, Wallet, Participant
+# ============================================================================
+Write-WtStep "Step 5: Government Admin — Login, Wallet, Participant"
+
+$govSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $govAdminEmail `
+    -Password $govAdminPassword `
+    -OrganizationId $govOrgId
+
+$govWallet = New-SorchaWallet `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Government of Scotland Issuer" `
+    -Headers $govSession.Headers `
+    -FetchPublicKey
+Write-WtSuccess "Government wallet: $($govWallet.Address)"
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $govOrgId `
+    -WalletAddress $govWallet.Address `
+    -DisplayName "Government Assessor" `
+    -Headers $govSession.Headers
+Write-WtInfo "Government assessor participant registered"
+
+# ============================================================================
+# Step 5b: Citizen — Login, Wallet, Participant
+# ============================================================================
+Write-WtStep "Step 5b: Citizen — Login, Wallet, Participant"
+
+$citizenSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $citizenEmail `
+    -Password $citizenPassword `
+    -OrganizationId $publicOrgId
+
+$citizenWallet = New-SorchaWallet `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Citizen Application Wallet" `
+    -Headers $citizenSession.Headers `
+    -FetchPublicKey
+Write-WtSuccess "Citizen wallet: $($citizenWallet.Address)"
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $publicOrgId `
+    -WalletAddress $citizenWallet.Address `
+    -DisplayName "Alex MacLeod" `
+    -Headers $citizenSession.Headers
+Write-WtInfo "Citizen participant registered in public org"
+
+# ============================================================================
+# Step 6: Provision Trust Anchor + Enrol as HAIP Issuer
+# ============================================================================
+Write-WtStep "Step 6: Trust Anchor + HAIP Issuer Enrolment"
+
+$tenantId = $sysAdmin.OrganizationId
+
+try {
+    Invoke-SorchaApi -Method POST `
+        -Uri "$($sorchaEnv.GatewayUrl)/api/v1/trust/tenants/$tenantId/provision" `
+        -Headers $sysAdmin.Headers `
+        -Body @{}
+    Write-WtSuccess "Trust anchor provisioned"
+} catch { Write-WtWarn "Trust anchor may already exist" }
+
+try {
+    Invoke-SorchaApi -Method POST `
+        -Uri "$($sorchaEnv.GatewayUrl)/api/v1/trust/tenants/$tenantId/orgs/$($govWallet.Address)/enrol" `
+        -Headers $sysAdmin.Headers `
+        -Body @{
+            orgPublicKeyBase64 = $govWallet.PublicKey
+            orgDisplayName     = "Government of Scotland"
+        }
+    Write-WtSuccess "Org cert enrolled"
+} catch { Write-WtWarn "Enrolment may already exist" }
+
+# ============================================================================
+# Step 7: Create Register
+# ============================================================================
+Write-WtStep "Step 7: Create Register"
+
+# DevMode — citizen is late-bound and never published to the register, so
+# Action 2's credential delivery uses the plaintext path. Same security
+# posture as HaipVerifiedCitizen (the source this walkthrough replaces).
+$register = New-SorchaRegister `
+    -RegisterUrl $sorchaEnv.RegisterUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Assured Identity Register" `
+    -Description "Register for Feature 107 Assured Identity workflows" `
+    -TenantId $govOrgId `
+    -OwnerUserId $govSession.UserId `
+    -OwnerWalletAddress $govWallet.Address `
+    -Headers $govSession.Headers `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -DevMode
+Write-WtSuccess "Register: $($register.RegisterId)"
+
+try {
+    $null = Publish-SorchaParticipant `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $govOrgId `
+        -RegisterId $register.RegisterId `
+        -ParticipantName "Government Assessor" `
+        -OrganizationName "Government of Scotland" `
+        -WalletAddress $govWallet.Address `
+        -PublicKey $govWallet.PublicKey `
+        -Headers $govSession.Headers
+} catch {
+    Write-WtWarn "Government participant publish failed: $($_.Exception.Message)"
+}
+
+try {
+    $null = New-SorchaRegisterSubscription `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $publicOrgId `
+        -RegisterId $register.RegisterId `
+        -RegisterName "Assured Identity Register" `
+        -SubscriptionType "Public" `
+        -Headers $sysAdmin.Headers
+} catch {
+    Write-WtWarn "Public org subscribe to identity register failed: $($_.Exception.Message)"
+}
+
+# ============================================================================
+# Step 8: Publish Blueprint
+# ============================================================================
+Write-WtStep "Step 8: Publish Blueprint"
+
+# Open-participant contract: the 'citizen' participant is the sender of an
+# isStartingAction: true action and therefore MUST NOT appear in the wallet
+# map. Runtime late-binds whichever authenticated public-org user submits
+# Action 1 as the bound citizen for that instance.
+# See: .claude/skills/blueprint-builder/SKILL.md — "Open Participants & Late Binding"
+$walletMap = @{
+    "government-assessor" = $govWallet.Address
+    # "citizen" is intentionally absent — late-bound at runtime.
+}
+
+$blueprint = Publish-SorchaBlueprint `
+    -BlueprintUrl $sorchaEnv.BlueprintUrl `
+    -TemplatePath (Join-Path $scriptDir "blueprints/assured-identity.json") `
+    -WalletMap $walletMap `
+    -Headers $govSession.Headers `
+    -IdPrefix "assured-identity" `
+    -RegisterId $register.RegisterId
+
+Write-WtSuccess "Blueprint: $($blueprint.BlueprintId)"
+
+# ============================================================================
+# Save State
+# ============================================================================
+$state = @{
+    tenantUrl            = $sorchaEnv.TenantUrl
+    blueprintUrl         = $sorchaEnv.BlueprintUrl
+    walletUrl            = $sorchaEnv.WalletUrl
+    registerUrl          = $sorchaEnv.RegisterUrl
+    gatewayUrl           = $sorchaEnv.GatewayUrl
+    tenantId             = $tenantId
+    govOrgId             = $govOrgId
+    govWalletAddress     = $govWallet.Address
+    govWalletPublicKey   = $govWallet.PublicKey
+    publicOrgId          = $publicOrgId
+    citizenWalletAddress = $citizenWallet.Address
+    registerId           = $register.RegisterId
+    blueprintId          = $blueprint.BlueprintId
+    walletDir            = (Join-Path $scriptDir "wallet")
+    roles = @{
+        govAssessor = @{
+            email          = $govAdminEmail
+            password       = $govAdminPassword
+            organizationId = $govOrgId
+            walletAddress  = $govWallet.Address
+        }
+        citizen = @{
+            email          = $citizenEmail
+            password       = $citizenPassword
+            organizationId = $publicOrgId
+            walletAddress  = $citizenWallet.Address
+        }
+    }
+    persona = @{
+        givenName  = "Alex"
+        middleName = "Morgan"
+        familyName = "MacLeod"
+        fullName   = "Alex Morgan MacLeod"
+        dateOfBirth = "1990-06-21"
+        defaultEmail = $citizenEmail
+        defaultAddress = @{
+            street   = "12 Castle Street"
+            locality = "Edinburgh"
+            region   = "Lothian"
+            postcode = "EH1 2DU"
+            country  = "Scotland"
+        }
+    }
+}
+
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
+Write-WtSuccess "State saved to $stateFile"
+Write-WtBanner "AssuredIdentity — Setup Complete"

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -155,6 +155,12 @@ $secrets = [ordered]@{
         adminPassword = $platformPassword
         adminName     = $platformName
     }
+    "assured-identity" = @{
+        adminEmail      = $platformEmail
+        adminPassword   = $platformPassword
+        adminName       = $platformName
+        DefaultPassword = $platformPassword
+    }
 }
 
 # Write to file


### PR DESCRIPTION
## Summary
- US1 of Feature 107: canonical Assured Identity credential issued via a polished 5-page wizard.
- Reusable renderer primitives land in `Sorcha.UI.Core`: `x-review` / `IdCardLayout` (Page 5 preview), `x-file.capture` + `x-file.embedAs` driving camera + client-side 240×320 JPEG token resize, DoB picker bound to Sorcha date tokens.
- Server-side portrait-size gate (`WARN_CRED_PORTRAIT_OVERSIZE_001`) in `BuildClaimsFromMappings`; oversized portrait is dropped and the credential still issues.
- New `walkthroughs/AssuredIdentity/` with `setup.ps1` + `run-phase1-identity.ps1`; end-to-end issues `AssuredIdentityCredential` to a HAIP filesystem wallet against local Docker.

## What's in it
- **Models**: `XReviewExtension` + enums, `FileSchemaExtension` gains `Capture`/`EmbedAs`, `BlueprintPageDefinition.ReviewExtension`, `SchemaLayoutParser` parses `x-review`.
- **UI.Core services**: `DateTimeFieldBoundResolver`, `FileFieldCaptureHelper`, `ReviewSummaryDispatch`, `ReviewSummaryDataSource`, `PhotoTokenResizer` + `IPhotoTokenResizerInterop` + `BrowserPhotoTokenResizerInterop` + `wwwroot/js/photo-token-resizer.js`.
- **Components**: `IdCardLayout.razor(.css)` (identity-navy theme; licence-pink reserved for PR 2), `ReviewSummaryRenderer.razor`, `DateTimeRenderer.razor` (MinDate/MaxDate wiring), `FileRenderer.razor` (capture attr + ICAO tips + resize pipeline).
- **Server gate**: `ActionExecutionService.BuildClaimsFromMappings` drops oversized portrait tokens; `ValidationErrorCodes` reserves `WARN_BP_REVIEW_001` + `WARN_CRED_PORTRAIT_OVERSIZE_001`.
- **Blueprint + walkthrough**: `walkthroughs/AssuredIdentity/blueprints/assured-identity.json` (3 actions, 5-page wizard, `$ref` core primitives, optional `portrait` with `x-file.embedAs`), `setup.ps1`, `run-phase1-identity.ps1`, `README.md`, `initialize-secrets.ps1` + `passwords.json` entry.

## Tests
- **70 new tests, all green.** 8 new test classes authored before implementation (TDD):
  - `XFileExtensionParserTests`, `XReviewExtensionParserTests`
  - `DateTimeRendererFutureBlockTests`, `FileRendererCaptureTests`, `PhotoTokenResizerTests` (Moq-backed interop), `ReviewSummaryDataSourceTests`, `ReviewSummaryRendererTests`
  - `BuildClaimsFromMappingsPortraitTests` (gate + regression for non-portrait mappings)

## End-to-end validation
Against the local Docker stack:
1. `pwsh walkthroughs/AssuredIdentity/setup.ps1 -Force` ✅
2. `pwsh walkthroughs/AssuredIdentity/run-phase1-identity.ps1` ✅
3. Credential stored at `walkthroughs/AssuredIdentity/wallet/credentials/AssuredIdentityCredential.sdjwt` (2,197 bytes) with disclosures for `givenName`, `middleName`, `familyName`, `fullName`, `dateOfBirth`, `email`, `address.{line1,town,region,postcode,country}`.

## Design notes for review
- **`SorchaDateTokenResolver` was NOT pulled into `Sorcha.UI.Core`.** The plan suggested adding `Validator.Core` as a project reference, but that would drag `Sorcha.Cryptography` + `Sorcha.TransactionHandler` into the Blazor WASM bundle. Instead the ~80-line date-token grammar is ported into `DateTimeFieldBoundResolver` with a comment explaining why; server-side resolver remains authoritative. Worth a look on review.
- **Razor `page`/`section` reserved names**: several `@foreach (var page in …)` / `@foreach (var section in …)` loops tripped `RZ2005` ("directive must appear at the start of the line"). Renamed locals to `priorPage` / `cardSection` / `sec` throughout.
- **Blueprint DB pending-model warning**: setup failed once against a stale image because `BlueprintDbContext` reported pending model changes. Rebuilding `sorcha-blueprint-service` (`docker-compose up -d --build blueprint-service`) applied the migrations cleanly and the walkthrough ran green. No new migration landed in this PR.
- **Portrait walkthrough path**: the PowerShell walkthrough can attach a pre-sized JPEG token via `-IncludePortrait` + `data/sample-portrait.jpg`. Not wired up yet — UI-driven portrait capture is fully exercised in the browser, the scripted path is a convenience for PR 3 when the sorcha-agent lands.

## Remaining for the feature (not this PR)
- PR 2 (US2): Driving Licence chain, stacked id-cards, `licence-pink` theme.
- PR 3 (US3): `sorcha-agent` actors for gov-assessor + dla-officer.
- PR 4 (US4): Cross-peer smoke test.
- PR 5 (US5 + Polish): delete legacy `HaipVerifiedCitizen` / `HaipDrivingLicence`, skill/docs updates.

## Test plan
- [ ] Full `dotnet build` is clean (0 errors, pre-existing warnings only)
- [ ] `dotnet test --filter "FullyQualifiedName~XReview|FullyQualifiedName~XFileExtension|FullyQualifiedName~DateTimeRendererFutureBlock|FullyQualifiedName~FileRendererCapture|FullyQualifiedName~PhotoTokenResizer|FullyQualifiedName~ReviewSummary|FullyQualifiedName~BuildClaimsFromMappingsPortrait"` all green
- [ ] `walkthroughs/AssuredIdentity/setup.ps1 -Force` succeeds
- [ ] `walkthroughs/AssuredIdentity/run-phase1-identity.ps1` produces a valid `AssuredIdentityCredential.sdjwt` with the expected claims
- [ ] `walkthroughs/HaipVerifiedCitizen/run.ps1` still works (nothing in this PR deletes the legacy walkthrough; the schema-shape regression for the parser is covered by the existing `SchemaLayoutParserTests` + the new `XReviewExtensionParserTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)