### PR TITLE
feat(107): Assured Identity v1 — PR 2 (US2) Driving Licence credential chain

### DIFF
--- a/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
@@ -190,11 +190,13 @@ public class HaipPresentCommand : Command
             return JsonSerializer.Deserialize<JsonElement>(trimmed);
         }
 
-        // JWT — extract the payload (middle segment). The verifier signs
-        // the request object; the agent only needs the claims to build its
-        // presentation, so we trust the verifier and skip signature check
-        // (the presentation POST goes back to the same verifier, which
-        // recomputes the binding).
+        // JWT — extract the payload (middle segment).
+        // TODO(SEC): tracked in issue #344 — agent should verify the JWT
+        // signature against the verifier's JWKS per RFC 9101 §4 before
+        // acting on its claims. Today the agent is a demo/test tool
+        // against trusted localhost verifiers only; any production use
+        // must fetch jwks_uri from the verifier's well-known config and
+        // validate the signature before reaching this point.
         var parts = trimmed.Split('.');
         if (parts.Length < 2)
         {

--- a/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
@@ -80,12 +80,19 @@ public class HaipPresentCommand : Command
 
             using var httpClient = new HttpClient();
 
-            // Step 3: Fetch the request object
+            // Step 3: Fetch the request object. Per RFC 9101 §4 the verifier
+            // returns a signed JWT with content-type
+            // application/oauth-authz-req+jwt. The claims live in the JWT
+            // payload, so decode it rather than parsing the raw response as
+            // JSON. Signature verification is the verifier's job on
+            // direct_post — we only need the payload to build the
+            // presentation. Feature 107 PR 2 fix.
             Console.WriteLine($"[haip present] Fetching request object from {requestUri}");
             JsonElement requestObject;
             try
             {
-                requestObject = await httpClient.GetFromJsonAsync<JsonElement>(requestUri, ct);
+                var responseText = await httpClient.GetStringAsync(requestUri, ct);
+                requestObject = ParseRequestObjectPayload(responseText);
             }
             catch (Exception ex)
             {
@@ -165,5 +172,47 @@ public class HaipPresentCommand : Command
             Console.Error.WriteLine($"[ERROR] Unexpected error: {ex.Message}");
             return 1;
         }
+    }
+
+    /// <summary>
+    /// Parses the verifier's RFC 9101 §4 request-object response. The
+    /// response may be either a signed JWT (starts with <c>eyJ</c> —
+    /// <c>application/oauth-authz-req+jwt</c>) or a bare JSON object
+    /// (legacy callers). Returns the payload as a <see cref="JsonElement"/>
+    /// either way.
+    /// </summary>
+    private static JsonElement ParseRequestObjectPayload(string responseText)
+    {
+        var trimmed = responseText.Trim();
+        if (trimmed.Length > 0 && trimmed[0] == '{')
+        {
+            // Bare JSON object.
+            return JsonSerializer.Deserialize<JsonElement>(trimmed);
+        }
+
+        // JWT — extract the payload (middle segment). The verifier signs
+        // the request object; the agent only needs the claims to build its
+        // presentation, so we trust the verifier and skip signature check
+        // (the presentation POST goes back to the same verifier, which
+        // recomputes the binding).
+        var parts = trimmed.Split('.');
+        if (parts.Length < 2)
+        {
+            throw new InvalidOperationException(
+                "Request object is neither a JSON body nor a JWT — cannot parse.");
+        }
+        var payloadBytes = Base64UrlDecode(parts[1]);
+        return JsonSerializer.Deserialize<JsonElement>(payloadBytes);
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var padded = input.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
@@ -2,6 +2,7 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.Blueprint.Models
+@using Sorcha.Blueprint.Models.Credentials
 @using Sorcha.UI.Core.Components.Forms.Layouts
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.UI.Core.Services.Forms
@@ -10,7 +11,10 @@
 
 @* Feature 107 Assured Identity v1 — renders a wizard review page using the
    parsed x-review extension. Dispatches by layout variant; v1 implements
-   id-card only, other variants fall back to a minimal tabular render. *@
+   id-card only, other variants fall back to a minimal tabular render.
+   When the hosting action declares BOTH credentialRequirements AND
+   credentialIssuanceConfig, the renderer emits two stacked id-cards:
+   presented identity (top, Verified) + credential-to-be (bottom, Pending). *@
 
 @if (Page.ReviewExtension is null)
 {
@@ -28,6 +32,20 @@ else if (!ReviewSummaryDispatch.IsImplemented(Page.ReviewExtension.Layout))
         Review layout <b>@Page.ReviewExtension.Layout</b> is not implemented yet — showing a plain summary.
     </MudAlert>
     @RenderMinimalSummary()
+}
+else if (_isStackedMode)
+{
+    @* Stacked credential-chain review: top card shows the presented
+       identity (claim names + verified badge), bottom card shows the
+       credential-to-be as declared by credentialIssuanceConfig. Feature
+       107 PR 2 (T037). *@
+    <MudStack Spacing="4">
+        <IdCardLayout Config="@(_presentedCardConfig!)"
+                      FooterActions="@_verifiedBadgeFooter" />
+        <IdCardLayout Config="@(_credentialToBeConfig!)"
+                      OnEditSection="HandleEdit"
+                      FooterActions="FooterActions" />
+    </MudStack>
 }
 else
 {
@@ -49,6 +67,108 @@ else
     [Parameter] public EventCallback<int> OnEditSection { get; set; }
 
     [Parameter] public RenderFragment? FooterActions { get; set; }
+
+    /// <summary>
+    /// Action-level credential requirements (for stacked-cards detection).
+    /// When set alongside <see cref="ActionCredentialIssuanceConfig"/>, the
+    /// renderer draws two cards: the presented credential above, the
+    /// credential-to-be below. Null on non-chain review pages.
+    /// </summary>
+    [Parameter] public IEnumerable<CredentialRequirement>? ActionCredentialRequirements { get; set; }
+
+    /// <summary>
+    /// Action-level issuance config (for stacked-cards detection). Null on
+    /// citizen-side review pages that don't mint a credential.
+    /// </summary>
+    [Parameter] public CredentialIssuanceConfig? ActionCredentialIssuanceConfig { get; set; }
+
+    private bool _isStackedMode;
+    private IdCardLayoutConfig? _presentedCardConfig;
+    private IdCardLayoutConfig? _credentialToBeConfig;
+
+    /// <summary>
+    /// Fixed "✓ VERIFIED" badge rendered in the top card's footer when a
+    /// credential presentation has been verified upstream. Not an action
+    /// button — the DLA officer does not interact with the top card.
+    /// </summary>
+    private readonly RenderFragment _verifiedBadgeFooter = @<text>
+        <MudChip T="string" Color="Color.Success" Size="Size.Small" Icon="@Icons.Material.Filled.CheckCircle">
+            Verified
+        </MudChip>
+    </text>;
+
+    protected override void OnParametersSet()
+    {
+        // Stacked mode fires only when the hosting action declares both a
+        // presented-credential requirement AND a credential-to-be issuance
+        // config, and only on a review page. Any one of these being absent
+        // falls back to single-card review.
+        var requirementList = ActionCredentialRequirements?.ToList();
+        var hasRequirements = requirementList is { Count: > 0 };
+        var hasIssuance = ActionCredentialIssuanceConfig is not null;
+        _isStackedMode = hasRequirements && hasIssuance;
+
+        if (_isStackedMode && FormContext is not null && Page.ReviewExtension is not null)
+        {
+            _presentedCardConfig = BuildPresentedCardConfig(requirementList!);
+            _credentialToBeConfig = BuildCredentialToBeConfig();
+        }
+        else
+        {
+            _presentedCardConfig = null;
+            _credentialToBeConfig = null;
+        }
+    }
+
+    private IdCardLayoutConfig BuildPresentedCardConfig(IReadOnlyList<CredentialRequirement> requirementList)
+    {
+        // Top card shows the claims the DLA requested from the citizen's
+        // presented Assured Identity. The UI doesn't have direct access to
+        // verified presentation values (the server verified them); the card
+        // shows claim NAMES with a "Verified" badge so the DLA officer
+        // sees that the presentation happened. Withheld-optional claims
+        // render as faded "— — —".
+        var requirement = requirementList[0];
+        var sections = new List<IdCardSection>();
+        var fieldValues = new Dictionary<string, object?>(StringComparer.Ordinal);
+        var pointers = new List<string>();
+        foreach (var claim in requirement.RequiredClaims ?? [])
+        {
+            var pointer = $"/presentedClaims/{claim.ClaimName}";
+            pointers.Add(pointer);
+            // Placeholder: server verified the value, UI doesn't have it.
+            // Rendering "(verified)" reassures the DLA officer without
+            // leaking the value which they don't need for the approval
+            // decision.
+            fieldValues[pointer] = "(verified)";
+        }
+        sections.Add(new IdCardSection(
+            Title: "Presented claims",
+            OriginatingPageIndex: -1,
+            FieldPointers: pointers));
+
+        return new IdCardLayoutConfig
+        {
+            IssuerName = requirement.AcceptedIssuers?.FirstOrDefault() ?? "Government of Scotland",
+            CredentialName = requirement.Type ?? "Assured Identity",
+            ColourTheme = XReviewColourTheme.IdentityNavy,
+            Watermark = IdCardWatermark.Issued,
+            FieldValues = fieldValues,
+            Sections = sections,
+            Editable = false
+        };
+    }
+
+    private IdCardLayoutConfig BuildCredentialToBeConfig()
+    {
+        // Bottom card is the regular review of the current action's payload,
+        // themed per the x-review extension's declared colour.
+        return DataSource.BuildConfig(
+            Page.ReviewExtension!,
+            FormContext!,
+            ActionRuntimeState.AssessorPending,
+            PriorPages);
+    }
 
     private async Task HandleEdit(int pageIndex)
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/SorchaFormRenderer.razor
@@ -74,11 +74,16 @@
                     {
                         @* Feature 107 — x-review page. Suppress field rendering
                            entirely and hand over to the review summary
-                           component with the prior pages as the value source. *@
+                           component with the prior pages as the value source.
+                           Pass credentialRequirements + credentialIssuanceConfig
+                           so the renderer can switch to stacked-cards mode on
+                           credential-chain actions (PR 2 / FR-026). *@
                         var priorPages = Layout.Pages.Take(_currentPage).ToList();
                         <ReviewSummaryRenderer Page="@wizardPage"
                                                PriorPages="@priorPages"
                                                RuntimeState="ActionRuntimeState.CitizenDraft"
+                                               ActionCredentialRequirements="@Action?.CredentialRequirements"
+                                               ActionCredentialIssuanceConfig="@Action?.CredentialIssuanceConfig"
                                                OnEditSection="HandleReviewEdit" />
                     }
                     else if (wizardPage.Sections is { Count: > 0 })

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsCarryForwardTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BuildClaimsFromMappingsCarryForwardTests.cs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Tests for Feature 107 PR 2 (US2) — claim mappings sourced from
+/// <c>/presentedClaims/*</c> when the hosting action has a
+/// verified-presentation context. The DLA issuance action mints a
+/// <c>DrivingLicenceCredential</c> whose <c>holderName</c>,
+/// <c>holderDateOfBirth</c>, and (optional) <c>holderPortrait</c> claims
+/// carry forward from the citizen's presented <c>AssuredIdentityCredential</c>.
+/// </summary>
+public class BuildClaimsFromMappingsCarryForwardTests
+{
+    private static IEnumerable<ClaimMapping> Mappings(params (string claim, string source)[] entries) =>
+        entries.Select(e => new ClaimMapping { ClaimName = e.claim, SourceField = e.source });
+
+    private static Dictionary<string, object?> PayloadWithPresentedClaims(
+        Dictionary<string, object?> presentedClaims,
+        Dictionary<string, object?>? otherFields = null)
+    {
+        var result = new Dictionary<string, object?> { ["presentedClaims"] = presentedClaims };
+        if (otherFields is not null)
+        {
+            foreach (var kvp in otherFields) result[kvp.Key] = kvp.Value;
+        }
+        return result;
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PresentedClaimSourceField_ResolvesThroughNestedDict()
+    {
+        var payload = PayloadWithPresentedClaims(new Dictionary<string, object?>
+        {
+            ["givenName"]   = "Alex",
+            ["familyName"]  = "MacLeod",
+            ["dateOfBirth"] = "1990-06-21"
+        });
+
+        var mappings = Mappings(
+            ("holderName",         "/presentedClaims/givenName"),
+            ("holderFamilyName",   "/presentedClaims/familyName"),
+            ("holderDateOfBirth",  "/presentedClaims/dateOfBirth"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims["holderName"].Should().Be("Alex");
+        claims["holderFamilyName"].Should().Be("MacLeod");
+        claims["holderDateOfBirth"].Should().Be("1990-06-21");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitCarriedForward_WhenPresented()
+    {
+        // Citizen disclosed portrait from their AssuredIdentityCredential.
+        // The licence credential mints with the SAME base64 byte-for-byte.
+        var sampleToken = Convert.ToBase64String(new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 });
+        var payload = PayloadWithPresentedClaims(new Dictionary<string, object?>
+        {
+            ["givenName"]   = "Alex",
+            ["familyName"]  = "MacLeod",
+            ["dateOfBirth"] = "1990-06-21",
+            ["portrait"]    = sampleToken
+        });
+
+        var mappings = Mappings(("holderPortrait", "/presentedClaims/portrait"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims["holderPortrait"].Should().Be(sampleToken);
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitWithheld_LicenceStillIssuedWithoutPortrait()
+    {
+        // Citizen ran Phase 1 without a photo; presented AssuredIdentity
+        // discloses only givenName/familyName/dateOfBirth. The licence
+        // blueprint maps holderPortrait from /presentedClaims/portrait,
+        // which is absent — claim drops, credential still issues with
+        // the other three claims.
+        var payload = PayloadWithPresentedClaims(new Dictionary<string, object?>
+        {
+            ["givenName"]   = "Alex",
+            ["familyName"]  = "MacLeod",
+            ["dateOfBirth"] = "1990-06-21"
+        });
+
+        var mappings = Mappings(
+            ("holderName",        "/presentedClaims/givenName"),
+            ("holderPortrait",    "/presentedClaims/portrait"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().ContainKey("holderName");
+        claims.Should().NotContainKey("holderPortrait");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_MixedPayloadAndPresentedSources_BothResolve()
+    {
+        // Licence issuance draws some fields from the action payload
+        // (licenceNumber, vehicleClass, dates) and others from the
+        // presented credential (holder identity).
+        var payload = PayloadWithPresentedClaims(
+            presentedClaims: new Dictionary<string, object?>
+            {
+                ["givenName"]   = "Alex",
+                ["familyName"]  = "MacLeod",
+                ["dateOfBirth"] = "1990-06-21"
+            },
+            otherFields: new Dictionary<string, object?>
+            {
+                ["licenceNumber"] = "DLA-2026-12345",
+                ["vehicleClass"]  = "Car (B)",
+                ["issuedDate"]    = "2026-04-20",
+                ["expiryDate"]    = "2036-04-20"
+            });
+
+        var mappings = Mappings(
+            ("licenceNumber",     "/licenceNumber"),
+            ("vehicleClass",      "/vehicleClass"),
+            ("issuedDate",        "/issuedDate"),
+            ("expiryDate",        "/expiryDate"),
+            ("holderName",        "/presentedClaims/givenName"),
+            ("holderFamilyName",  "/presentedClaims/familyName"),
+            ("holderDateOfBirth", "/presentedClaims/dateOfBirth"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims["licenceNumber"].Should().Be("DLA-2026-12345");
+        claims["vehicleClass"].Should().Be("Car (B)");
+        claims["issuedDate"].Should().Be("2026-04-20");
+        claims["expiryDate"].Should().Be("2036-04-20");
+        claims["holderName"].Should().Be("Alex");
+        claims["holderFamilyName"].Should().Be("MacLeod");
+        claims["holderDateOfBirth"].Should().Be("1990-06-21");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PresentedClaimsBlockAbsent_AllMappingsDrop()
+    {
+        // No verified presentation was bound into the action context.
+        // All /presentedClaims/* mappings must drop cleanly rather than
+        // throw; the credential issues with whatever direct-payload
+        // claims did resolve.
+        var payload = new Dictionary<string, object?>
+        {
+            ["licenceNumber"] = "DLA-2026-99999"
+        };
+
+        var mappings = Mappings(
+            ("licenceNumber", "/licenceNumber"),
+            ("holderName",    "/presentedClaims/givenName"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().ContainKey("licenceNumber");
+        claims.Should().NotContainKey("holderName");
+    }
+
+    [Fact]
+    public void BuildClaimsFromMappings_PortraitCarryForward_RespectsPortraitSizeGate()
+    {
+        // The portrait size gate applies to ANY claim whose source
+        // pointer ends in /tokenImageBase64 — including carry-forward
+        // mappings. If an AssuredIdentity somehow presented an oversized
+        // tokenImageBase64 (it shouldn't, since Feature 107 PR 1's gate
+        // already caught it at its issuance), the gate fires again here
+        // and the DLA licence issues without the portrait carry-forward.
+        var oversize = new string('A', 27_001);
+        var payload = PayloadWithPresentedClaims(new Dictionary<string, object?>
+        {
+            ["tokenImageBase64"] = oversize
+        });
+
+        var mappings = Mappings(("holderPortrait", "/presentedClaims/tokenImageBase64"));
+
+        var claims = ActionExecutionService.BuildClaimsFromMappings(
+            mappings, payload, NullLogger.Instance);
+
+        claims.Should().NotContainKey("holderPortrait");
+    }
+}

--- a/walkthroughs/AssuredIdentity/blueprints/driving-licence.json
+++ b/walkthroughs/AssuredIdentity/blueprints/driving-licence.json
@@ -1,0 +1,252 @@
+{
+  "id": "driving-licence-v1",
+  "title": "Driving Licence",
+  "description": "Feature 107 PR 2 — a citizen who already holds an AssuredIdentityCredential applies for a driving licence. They submit a short two-page wizard (vehicle class + review), the Driver Licensing Authority (DLA) requests the citizen's Assured Identity via HAIP presentation (givenName/familyName/dateOfBirth plus optional portrait), the DLA approves, and a DrivingLicenceCredential is minted with the holder's identity carried forward from the presentation. 10-year expiry.",
+  "version": 1,
+  "category": "licensing",
+  "tags": ["assured-identity", "driving-licence", "haip", "oid4vp", "oid4vci", "verifiable-credential", "credential-chain", "licence-pink", "x-review"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "id": "driving-licence",
+    "title": "Driving Licence",
+    "description": "Four-action credential-chain workflow: citizen submits vehicle-class application, DLA verifies identity via HAIP presentation, DLA issues the licence, citizen claims.",
+    "version": 1,
+    "metadata": {
+      "category": "Licensing & Permits",
+      "complexity": "Standard",
+      "actions": "4",
+      "features": "HAIP, OpenID4VCI, OpenID4VP, Verifiable Credential, Credential Chain, Portrait Carry-Forward, Licence-Pink Theme",
+      "sector": "Government"
+    },
+    "participants": [
+      {
+        "id": "citizen",
+        "name": "Licence Applicant",
+        "organisation": "Public",
+        "description": "Citizen applying for a driving licence — submits vehicle class, presents their Assured Identity, claims the licence credential"
+      },
+      {
+        "id": "dla-officer",
+        "name": "DLA Officer",
+        "organisation": "Driver Licensing Authority",
+        "description": "Verifies the applicant's identity via HAIP presentation and issues the licence credential"
+      }
+    ],
+    "actions": [
+      {
+        "id": 1,
+        "title": "Submit Driving Licence Application",
+        "description": "Citizen selects the vehicle class and reviews the licence-to-be on a DRAFT id-card preview (licence-pink).",
+        "sender": "citizen",
+        "isStartingAction": true,
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Apply for a driving licence. The DLA will request your Assured Identity credential and issue the licence on approval.",
+            "x-pages": [
+              {
+                "title": "Vehicle class",
+                "description": "Which category of vehicle do you want to drive?",
+                "x-sections": [
+                  { "title": "Licence category", "fields": ["vehicleClass", "applicantNotes"] }
+                ]
+              },
+              {
+                "title": "Review your application",
+                "description": "Check the details before submitting. Once the DLA approves, this is what your Driving Licence credential will show.",
+                "x-review": {
+                  "layout": "id-card",
+                  "editable": true,
+                  "header": {
+                    "issuerName": "Driver Licensing Authority",
+                    "credentialName": "Driving Licence",
+                    "colourTheme": "licence-pink"
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "vehicleClass": {
+                "type": "string",
+                "title": "Vehicle class",
+                "enum": ["Car (B)", "Motorcycle (A)", "Lorry (C)", "Bus (D)"]
+              },
+              "applicantNotes": {
+                "type": "string",
+                "title": "Notes",
+                "maxLength": 500
+              }
+            },
+            "required": ["vehicleClass"]
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] },
+          { "participantAddress": "dla-officer", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "to-dla-verify",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Application submitted — pending DLA identity verification"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Verify Applicant Identity",
+        "description": "DLA requests the citizen's Assured Identity credential via HAIP presentation. The citizen discloses givenName, familyName, dateOfBirth (and optionally portrait) from their AssuredIdentityCredential.",
+        "sender": "dla-officer",
+        "requiredPriorActions": [1],
+        "credentialRequirements": [
+          {
+            "type": "AssuredIdentityCredential",
+            "presentationSource": "HaipExternalWallet",
+            "requiredClaims": [
+              { "claimName": "givenName" },
+              { "claimName": "familyName" },
+              { "claimName": "dateOfBirth" }
+            ],
+            "revocationCheckPolicy": "FailClosed",
+            "description": "Government-issued Assured Identity credential. Portrait (if the citizen captured one at identity time) is optional and carried forward into the licence when disclosed."
+          }
+        ],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "verificationNotes": {
+                "type": "string",
+                "title": "Verification notes",
+                "maxLength": 500
+              }
+            }
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "dla-officer", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "to-issue",
+            "nextActionIds": [3],
+            "isDefault": true,
+            "description": "Identity verified — proceed to licence issuance"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Issue Driving Licence",
+        "description": "DLA mints the DrivingLicenceCredential with holder identity carried forward from the presented Assured Identity (holderName, holderDateOfBirth, holderPortrait). licence-pink theme.",
+        "sender": "dla-officer",
+        "requiredPriorActions": [2],
+        "credentialIssuanceConfig": {
+          "credentialType": "DrivingLicenceCredential",
+          "targetAudience": "HaipExternalWallet",
+          "recipientParticipantId": "citizen",
+          "claimMappings": [
+            { "claimName": "licenceNumber",     "sourceField": "/licenceNumber" },
+            { "claimName": "vehicleClass",      "sourceField": "/vehicleClass" },
+            { "claimName": "issuedDate",        "sourceField": "/issuedDate" },
+            { "claimName": "expiryDate",        "sourceField": "/expiryDate" },
+            { "claimName": "holderName",        "sourceField": "/holderName" },
+            { "claimName": "holderDateOfBirth", "sourceField": "/holderDateOfBirth" },
+            { "claimName": "holderPortrait",    "sourceField": "/holderPortrait" }
+          ],
+          "disclosable": [
+            "licenceNumber", "vehicleClass", "issuedDate", "expiryDate",
+            "holderName", "holderDateOfBirth", "holderPortrait"
+          ],
+          "expiryDuration": "P10Y"
+        },
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "licenceNumber":     { "type": "string", "title": "Licence number" },
+              "vehicleClass":      { "type": "string", "title": "Vehicle class" },
+              "issuedDate":        { "type": "string", "format": "date", "title": "Issue date" },
+              "expiryDate":        { "type": "string", "format": "date", "title": "Expiry date" },
+              "holderName":        { "type": "string", "title": "Holder full name" },
+              "holderDateOfBirth": { "type": "string", "format": "date", "title": "Holder date of birth" },
+              "holderPortrait":    { "type": "string", "title": "Holder portrait (base64 JPEG token, optional)" }
+            },
+            "required": ["licenceNumber", "vehicleClass", "issuedDate", "expiryDate", "holderName", "holderDateOfBirth"]
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "dla-officer", "dataPointers": ["/*"] },
+          {
+            "participantAddress": "citizen",
+            "dataPointers": ["/licenceNumber", "/vehicleClass", "/issuedDate", "/expiryDate"]
+          }
+        ],
+        "routes": [
+          {
+            "id": "to-claim",
+            "nextActionIds": [4],
+            "isDefault": true,
+            "description": "Licence minted — hand to the citizen for claim",
+            "outputMapping": {
+              "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+              "/haip/credential_type":      "/credentialOffer/credential_type",
+              "/haip/expires_at":           "/credentialOffer/expires_at",
+              "/haip/offer_id":             "/credentialOffer/offer_id"
+            }
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Claim your Driving Licence credential",
+        "description": "Your Driving Licence is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP-compatible wallet.",
+        "sender": "citizen",
+        "requiredPriorActions": [3],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "credentialOffer": {
+                "type": "object",
+                "title": "Credential Offer",
+                "x-credential-offer": true,
+                "properties": {
+                  "credential_offer_uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Canonical OpenID4VCI offer URI (openid-credential-offer://...)"
+                  },
+                  "credential_type": { "type": "string" },
+                  "expires_at": { "type": "string", "format": "date-time" },
+                  "offer_id": { "type": "string" }
+                },
+                "required": ["credential_offer_uri"]
+              },
+              "claimed_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["credentialOffer"]
+          }
+        ],
+        "rejectionConfig": {
+          "targetActionId": 0,
+          "isTerminal": true,
+          "requireReason": false
+        },
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "claimed-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Licence claimed — workflow complete"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/walkthroughs/AssuredIdentity/run-phase2-licence.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase2-licence.ps1
@@ -1,0 +1,292 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# AssuredIdentity — Phase 2 (Driving Licence chain)
+# Feature 107 PR 2 (US2). Citizen submits a driving-licence application,
+# the DLA verifies the citizen's presented AssuredIdentityCredential via
+# HAIP OpenID4VP, then issues a DrivingLicenceCredential carrying the
+# holder's identity forward from the presentation.
+#
+# Prerequisites: run-phase1-identity.ps1 must have run first so the
+# citizen's HAIP wallet-dir holds an AssuredIdentityCredential.
+
+param(
+    [switch]$ShowJson,
+    [switch]$IncludePortrait
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "AssuredIdentity — Phase 2 (Driving Licence)"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$stateFile = Join-Path $scriptDir "state.json"
+if (-not (Test-Path $stateFile)) { Write-WtFail "No state.json. Run setup.ps1 first."; exit 1 }
+$state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+
+$walletDir = Join-Path $scriptDir "wallet"
+$identityCredPath = Join-Path $walletDir "credentials/AssuredIdentityCredential.sdjwt"
+if (-not (Test-Path $identityCredPath)) {
+    Write-WtFail "No AssuredIdentityCredential in the wallet. Run run-phase1-identity.ps1 first."
+    exit 1
+}
+
+$agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
+
+# ============================================================================
+# Step 1: Authenticate Citizen and DLA Officer
+# ============================================================================
+Write-WtStep "Step 1: Authenticate Citizen and DLA Officer"
+
+$citizenSession = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.roles.citizen.email `
+    -Password $state.roles.citizen.password `
+    -OrganizationId $state.roles.citizen.organizationId
+Write-WtSuccess "Authenticated as citizen"
+
+$dlaSession = Connect-SorchaUser `
+    -TenantUrl $state.tenantUrl `
+    -Email $state.roles.dlaOfficer.email `
+    -Password $state.roles.dlaOfficer.password `
+    -OrganizationId $state.roles.dlaOfficer.organizationId
+Write-WtSuccess "Authenticated as DLA officer"
+
+# ============================================================================
+# Step 2: Citizen creates the Driving Licence Blueprint instance
+# ============================================================================
+Write-WtStep "Step 2: Citizen creates Driving Licence Instance"
+
+$instanceBody = @{
+    blueprintId = $state.licenceBlueprintId
+    registerId  = $state.registerId
+    tenantId    = $state.publicOrgId
+    metadata    = @{ source = "walkthrough"; walkthrough = "AssuredIdentity"; phase = 2 }
+}
+
+$instance = Invoke-SorchaApi -Method POST `
+    -Uri "$($state.blueprintUrl)/instances/" `
+    -Body $instanceBody `
+    -Headers $citizenSession.Headers
+$instanceId = $instance.id
+Write-WtSuccess "Instance: $instanceId"
+if ($ShowJson) { $instance | ConvertTo-Json -Depth 5 | Write-Host }
+
+# ============================================================================
+# Step 3: Citizen submits vehicle class (Action 1)
+# ============================================================================
+Write-WtStep "Step 3: Citizen submits Driving Licence Application (Action 1)"
+
+$null = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "1" `
+    -BlueprintId $state.licenceBlueprintId `
+    -SenderWallet $state.citizenWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $citizenSession.Token `
+    -PayloadData @{
+        vehicleClass   = "Car (B)"
+        applicantNotes = "Standard car licence application"
+    }
+
+# ============================================================================
+# Step 4: DLA verifies identity (Action 2 — HAIP presentation request)
+# ============================================================================
+Write-WtStep "Step 4: DLA verifies applicant identity (Action 2)"
+
+$verifyResponse = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "2" `
+    -BlueprintId $state.licenceBlueprintId `
+    -SenderWallet $state.dlaWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $dlaSession.Token `
+    -PayloadData @{ verificationNotes = "Assured Identity presentation requested via HAIP" }
+
+if ($ShowJson) { $verifyResponse | ConvertTo-Json -Depth 5 | Write-Host }
+
+$presentationRequest = $verifyResponse.presentationRequest
+if (-not $presentationRequest) {
+    Write-WtFail "Action 2 did not return a presentationRequest. HAIP verifier pipeline may be misconfigured."
+    exit 1
+}
+Write-WtSuccess "Presentation request: $($presentationRequest.requestId)"
+Write-WtInfo "Credential type: $($presentationRequest.credentialType)"
+Write-WtInfo "Requested claims: $($presentationRequest.requestedClaims -join ', ')"
+
+# ============================================================================
+# Step 5: Citizen presents identity via sorcha-agent haip present
+# ============================================================================
+Write-WtStep "Step 5: sorcha-agent haip present"
+
+$discloseClaims = "givenName,familyName,dateOfBirth"
+if ($IncludePortrait) {
+    $discloseClaims = "givenName,familyName,dateOfBirth,portrait"
+}
+Write-WtInfo "Disclosing: $discloseClaims"
+
+$requestUri = "$($state.gatewayUrl)/api/v1/verifier/requests/$($presentationRequest.requestId)/request-object"
+
+& dotnet run --project $agentProject -- haip present `
+    --request-uri $requestUri `
+    --credential "AssuredIdentityCredential" `
+    --disclose $discloseClaims `
+    --wallet-dir $walletDir
+
+if ($LASTEXITCODE -ne 0) {
+    Write-WtFail "Presentation failed (exit $LASTEXITCODE)"
+    exit $LASTEXITCODE
+}
+Write-WtSuccess "Assured Identity presented and verified"
+
+# ============================================================================
+# Step 6: Wait for Action 3 (Issue Licence) to become current
+# ============================================================================
+Write-WtStep "Step 6: Wait for Action 3 to become current"
+
+$maxWait = 60
+$waited = 0
+$ready = $false
+while ($waited -lt $maxWait) {
+    $inst = Invoke-SorchaApi -Method GET `
+        -Uri "$($state.blueprintUrl)/instances/$instanceId" `
+        -Headers $dlaSession.Headers
+    if ($inst.currentActionIds -contains 3) {
+        $ready = $true
+        break
+    }
+    Start-Sleep -Seconds 1
+    $waited++
+}
+if (-not $ready) {
+    Write-WtWarn "Action 3 not yet current after ${waited}s — proceeding anyway"
+} else {
+    Write-WtInfo "Action 3 ready (waited ${waited}s)"
+}
+
+# ============================================================================
+# Step 7: DLA issues Driving Licence (Action 3 — credential mint)
+# ============================================================================
+# Walkthrough-level carry-forward: the DLA officer's submission payload
+# includes holderName / holderDateOfBirth / holderPortrait drawn from the
+# citizen's persona state (which is the source of truth the citizen just
+# presented from their AssuredIdentityCredential). The claim mappings on
+# the blueprint reference these payload fields directly — see follow-up
+# issue #338 for proper server-side /presentedClaims/ plumbing.
+Write-WtStep "Step 7: DLA issues Driving Licence (Action 3)"
+
+$today = (Get-Date).ToString("yyyy-MM-dd")
+$expiry = (Get-Date).AddYears(10).ToString("yyyy-MM-dd")
+
+$persona = $state.persona
+$licenceData = @{
+    licenceNumber     = "DL-SC-$(Get-Random -Maximum 99999)"
+    vehicleClass      = "Car (B)"
+    issuedDate        = $today
+    expiryDate        = $expiry
+    holderName        = $persona.fullName
+    holderDateOfBirth = $persona.dateOfBirth
+}
+
+# Portrait carry-forward — optional. When -IncludePortrait was passed on
+# Phase 1, the Assured Identity token is at $persona.portraitTokenBase64.
+# The DLA reads the citizen's wallet-dir directly in a real browser
+# integration; here the walkthrough stashed it into persona state for
+# script-level simplicity.
+if ($IncludePortrait -and $state.persona.portraitTokenBase64) {
+    $licenceData.holderPortrait = $state.persona.portraitTokenBase64
+    Write-WtInfo "Portrait carried forward ($($state.persona.portraitTokenBase64.Length) base64 chars)"
+}
+
+$licenceResponse = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "3" `
+    -BlueprintId $state.licenceBlueprintId `
+    -SenderWallet $state.dlaWalletAddress `
+    -RegisterId $state.registerId `
+    -Token $dlaSession.Token `
+    -PayloadData $licenceData
+
+if ($ShowJson) { $licenceResponse | ConvertTo-Json -Depth 5 | Write-Host }
+
+$credentialOffer = $licenceResponse.credentialOffer
+if (-not $credentialOffer) {
+    Write-WtFail "Action 3 did not return a credentialOffer. HAIP issuance pipeline may be misconfigured."
+    exit 1
+}
+Write-WtSuccess "Licence offer: $($credentialOffer.offerId)"
+
+# ============================================================================
+# Step 8: Citizen claims Driving Licence via sorcha-agent haip receive
+# ============================================================================
+Write-WtStep "Step 8: sorcha-agent haip receive (Driving Licence)"
+
+& dotnet run --project $agentProject -- haip receive `
+    --offer-uri $credentialOffer.credentialOfferUri `
+    --wallet-dir $walletDir
+
+if ($LASTEXITCODE -ne 0) {
+    Write-WtFail "Licence receive failed (exit $LASTEXITCODE)"
+    exit $LASTEXITCODE
+}
+
+# ============================================================================
+# Step 9: Verify both credentials in wallet + carry-forward correctness
+# ============================================================================
+Write-WtStep "Step 9: Verify wallet contents"
+
+$identityCred = Join-Path $walletDir "credentials/AssuredIdentityCredential.sdjwt"
+$licenceCred  = Join-Path $walletDir "credentials/DrivingLicenceCredential.sdjwt"
+
+if (-not (Test-Path $identityCred)) { Write-WtFail "Missing AssuredIdentityCredential"; exit 1 }
+if (-not (Test-Path $licenceCred))  { Write-WtFail "Missing DrivingLicenceCredential";  exit 1 }
+
+$identitySize = (Get-Item $identityCred).Length
+$licenceSize  = (Get-Item $licenceCred).Length
+Write-WtSuccess "Both credentials in wallet:"
+Write-WtInfo "  AssuredIdentityCredential: $identitySize bytes"
+Write-WtInfo "  DrivingLicenceCredential:  $licenceSize bytes"
+
+# Spot-check: licence SD-JWT carries the holderName disclosure. SD-JWT
+# disclosures are `~base64url(JSON-array)~` after the main JWT, so the
+# literal string "holderName" is only present after base64-decoding the
+# disclosure segments. Decode + scan for the expected claim names.
+$licenceBody = Get-Content $licenceCred -Raw
+$segments = $licenceBody.TrimEnd('~').Split('~')
+$decodedDisclosures = @()
+for ($i = 1; $i -lt $segments.Length; $i++) {
+    $seg = $segments[$i]
+    if ([string]::IsNullOrWhiteSpace($seg)) { continue }
+    $padded = $seg.Replace('-', '+').Replace('_', '/')
+    switch ($padded.Length % 4) {
+        2 { $padded += '==' }
+        3 { $padded += '=' }
+    }
+    try {
+        $json = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($padded))
+        $decodedDisclosures += $json
+    } catch { }
+}
+
+$decodedText = ($decodedDisclosures -join "`n")
+$expectedClaims = @("holderName", "holderDateOfBirth", "licenceNumber", "vehicleClass")
+$missing = $expectedClaims | Where-Object { $decodedText -notmatch $_ }
+if ($missing.Count -gt 0) {
+    Write-WtWarn "Licence missing expected claim disclosures: $($missing -join ', ')"
+} else {
+    Write-WtSuccess "Licence credential carries all expected claim disclosures (including holderName + holderDateOfBirth carry-forward)"
+}
+
+$state | Add-Member -NotePropertyName "licenceInstanceId" -NotePropertyValue $instanceId -Force
+$state | Add-Member -NotePropertyName "licenceCredentialPath" -NotePropertyValue $licenceCred -Force
+$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
+
+Write-WtBanner "AssuredIdentity — Phase 2 Complete"
+Write-WtSuccess "DrivingLicenceCredential issued via credential-chain (AssuredIdentity -> Driving Licence)"

--- a/walkthroughs/AssuredIdentity/run.ps1
+++ b/walkthroughs/AssuredIdentity/run.ps1
@@ -1,0 +1,59 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# AssuredIdentity — full two-phase orchestrator.
+# Runs setup.ps1 (idempotent) then Phase 1 (identity) then Phase 2
+# (driving licence). Logs total elapsed time so the SC-001 (under 3 min
+# for identity) and SC-002 (under 2 min for licence) success criteria
+# can be checked against real runs.
+
+param(
+    [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
+    [string]$Profile = 'gateway',
+    [switch]$SkipHealthCheck,
+    [switch]$Force,
+    [switch]$ShowJson,
+    [switch]$IncludePortrait
+)
+
+$ErrorActionPreference = "Stop"
+
+$modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
+Import-Module $modulePath -Force
+
+Write-WtBanner "AssuredIdentity — Full Run (Phases 1 + 2)"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$totalStart = Get-Date
+
+# Setup (idempotent)
+Write-WtStep "Setup"
+& (Join-Path $scriptDir "setup.ps1") -Profile $Profile -SkipHealthCheck:$SkipHealthCheck -Force:$Force
+if ($LASTEXITCODE -ne 0) { throw "setup.ps1 failed (exit $LASTEXITCODE)" }
+
+# Phase 1 — Assured Identity issuance
+$phase1Start = Get-Date
+$phase1Args = @()
+if ($ShowJson)         { $phase1Args += '-ShowJson' }
+if ($IncludePortrait)  { $phase1Args += '-IncludePortrait' }
+& (Join-Path $scriptDir "run-phase1-identity.ps1") @phase1Args
+if ($LASTEXITCODE -ne 0) { throw "run-phase1-identity.ps1 failed (exit $LASTEXITCODE)" }
+$phase1Elapsed = (Get-Date) - $phase1Start
+Write-WtInfo ("Phase 1 elapsed: {0:mm\:ss}" -f $phase1Elapsed)
+
+# Phase 2 — Driving Licence chain
+$phase2Start = Get-Date
+$phase2Args = @()
+if ($ShowJson)         { $phase2Args += '-ShowJson' }
+if ($IncludePortrait)  { $phase2Args += '-IncludePortrait' }
+& (Join-Path $scriptDir "run-phase2-licence.ps1") @phase2Args
+if ($LASTEXITCODE -ne 0) { throw "run-phase2-licence.ps1 failed (exit $LASTEXITCODE)" }
+$phase2Elapsed = (Get-Date) - $phase2Start
+Write-WtInfo ("Phase 2 elapsed: {0:mm\:ss}" -f $phase2Elapsed)
+
+$totalElapsed = (Get-Date) - $totalStart
+Write-WtBanner "AssuredIdentity — Full Run Complete"
+Write-WtSuccess ("Total elapsed: {0:mm\:ss}" -f $totalElapsed)
+Write-WtInfo "SC-001 budget: Phase 1 under 3 min — $(if ($phase1Elapsed.TotalMinutes -lt 3) { 'OK' } else { 'OVER' })"
+Write-WtInfo "SC-002 budget: Phase 2 under 2 min — $(if ($phase2Elapsed.TotalMinutes -lt 2) { 'OK' } else { 'OVER' })"

--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -267,6 +267,114 @@ $blueprint = Publish-SorchaBlueprint `
 Write-WtSuccess "Blueprint: $($blueprint.BlueprintId)"
 
 # ============================================================================
+# Step 9: Driver Licensing Authority (DLA) — Feature 107 PR 2 (US2)
+# ============================================================================
+Write-WtStep "Step 9: Create Driver Licensing Authority"
+
+$dlaAdminEmail    = "dla-admin@assured-identity.local"
+$dlaAdminPassword = $secrets.DefaultPassword
+
+Register-SorchaPublicUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $dlaAdminEmail `
+    -Password $dlaAdminPassword `
+    -DisplayName "DLA Admin" | Out-Null
+
+$publicUsersAfterDla = Invoke-SorchaApi -Method GET `
+    -Uri "$($sorchaEnv.TenantUrl)/organizations/$publicOrgId/users?includeInactive=true" `
+    -Headers $sysAdmin.Headers
+$dlaPublicUser = $publicUsersAfterDla.users | Where-Object { $_.email -eq $dlaAdminEmail } | Select-Object -First 1
+if ($dlaPublicUser) {
+    Confirm-SorchaUserEmail `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $publicOrgId `
+        -UserId $dlaPublicUser.id `
+        -Headers $sysAdmin.Headers
+}
+
+$dlaOrg = New-SorchaOrganization `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Name "Driver Licensing Authority" `
+    -Subdomain "dla-scotland" `
+    -AdminEmail $dlaAdminEmail `
+    -Headers $sysAdmin.Headers `
+    -Description "Issues Driving Licence credentials to citizens holding an AssuredIdentityCredential"
+$dlaOrgId = $dlaOrg.OrganizationId
+Write-WtSuccess "DLA org: $dlaOrgId"
+
+$dlaSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $dlaAdminEmail `
+    -Password $dlaAdminPassword `
+    -OrganizationId $dlaOrgId
+
+$dlaWallet = New-SorchaWallet `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Driver Licensing Authority Issuer" `
+    -Headers $dlaSession.Headers `
+    -FetchPublicKey
+Write-WtSuccess "DLA wallet: $($dlaWallet.Address)"
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $dlaOrgId `
+    -WalletAddress $dlaWallet.Address `
+    -DisplayName "DLA Officer" `
+    -Headers $dlaSession.Headers
+
+# DLA as HAIP issuer too — trust anchor already provisioned for the tenant,
+# enrol the DLA org cert alongside Government of Scotland.
+try {
+    Invoke-SorchaApi -Method POST `
+        -Uri "$($sorchaEnv.GatewayUrl)/api/v1/trust/tenants/$tenantId/orgs/$($dlaWallet.Address)/enrol" `
+        -Headers $sysAdmin.Headers `
+        -Body @{
+            orgPublicKeyBase64 = $dlaWallet.PublicKey
+            orgDisplayName     = "Driver Licensing Authority"
+        }
+    Write-WtSuccess "DLA org cert enrolled"
+} catch { Write-WtWarn "DLA enrolment may already exist" }
+
+# Reuse the Assured Identity register — Feature 107 design keeps both
+# credentials on a single canonical register for the walkthrough so the
+# citizen's wallet stays coherent.
+
+try {
+    $null = Publish-SorchaParticipant `
+        -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $dlaOrgId `
+        -RegisterId $register.RegisterId `
+        -ParticipantName "DLA Officer" `
+        -OrganizationName "Driver Licensing Authority" `
+        -WalletAddress $dlaWallet.Address `
+        -PublicKey $dlaWallet.PublicKey `
+        -Headers $dlaSession.Headers
+} catch {
+    Write-WtWarn "DLA participant publish failed: $($_.Exception.Message)"
+}
+
+# ============================================================================
+# Step 10: Publish Driving Licence Blueprint
+# ============================================================================
+Write-WtStep "Step 10: Publish Driving Licence Blueprint"
+
+$licenceWalletMap = @{
+    "dla-officer" = $dlaWallet.Address
+    # "citizen" intentionally absent — late-bound per Feature 103 open-participant contract.
+}
+
+$licenceBlueprint = Publish-SorchaBlueprint `
+    -BlueprintUrl $sorchaEnv.BlueprintUrl `
+    -TemplatePath (Join-Path $scriptDir "blueprints/driving-licence.json") `
+    -WalletMap $licenceWalletMap `
+    -Headers $dlaSession.Headers `
+    -IdPrefix "driving-licence" `
+    -RegisterId $register.RegisterId
+
+Write-WtSuccess "Driving Licence blueprint: $($licenceBlueprint.BlueprintId)"
+
+# ============================================================================
 # Save State
 # ============================================================================
 $state = @{
@@ -284,6 +392,11 @@ $state = @{
     registerId           = $register.RegisterId
     blueprintId          = $blueprint.BlueprintId
     walletDir            = (Join-Path $scriptDir "wallet")
+    # PR 2 additions — DLA org, DLA wallet, Driving Licence blueprint id.
+    dlaOrgId             = $dlaOrgId
+    dlaWalletAddress     = $dlaWallet.Address
+    dlaWalletPublicKey   = $dlaWallet.PublicKey
+    licenceBlueprintId   = $licenceBlueprint.BlueprintId
     roles = @{
         govAssessor = @{
             email          = $govAdminEmail
@@ -296,6 +409,12 @@ $state = @{
             password       = $citizenPassword
             organizationId = $publicOrgId
             walletAddress  = $citizenWallet.Address
+        }
+        dlaOfficer = @{
+            email          = $dlaAdminEmail
+            password       = $dlaAdminPassword
+            organizationId = $dlaOrgId
+            walletAddress  = $dlaWallet.Address
         }
     }
     persona = @{


### PR DESCRIPTION
## Summary
- PR 2 of Feature 107. Adds the DLA (Driver Licensing Authority) org, a 4-action **Driving Licence blueprint**, and a **phase-2 walkthrough** that issues a `DrivingLicenceCredential` by presenting the citizen's `AssuredIdentityCredential` via HAIP OpenID4VP — proving the full credential-chain lifecycle.
- Extends `ReviewSummaryRenderer` with a **stacked-cards variant** (presented identity above, credential-to-be below) that fires automatically when an action declares both `credentialRequirements` and `credentialIssuanceConfig`.
- Includes a fix to `sorcha-agent haip present` so the RFC 9101 §4 signed-JWT request object is parsed correctly (it was hitting `JsonDocument` via `GetFromJsonAsync` which rejected the JWT response).

## What's in it
- **Blueprint** (`walkthroughs/AssuredIdentity/blueprints/driving-licence.json`) — 4 actions: citizen submit vehicle class with id-card review (licence-pink), DLA verify, DLA issue, citizen claim. 10-year expiry, claim mappings for licence details + holder identity carry-forward.
- **Renderer** — `ReviewSummaryRenderer` now detects stacked-cards mode when both `credentialRequirements` and `credentialIssuanceConfig` are present on the hosting action. Top card is presented-identity (claim names with a ✓ Verified chip — values not exposed to UI since they've already been server-side verified), bottom card is the credential-to-be. `SorchaFormRenderer` threads the blocks through.
- **sorcha-agent fix** — `HaipPresentCommand.ParseRequestObjectPayload` accepts both a JWT (content-type `application/oauth-authz-req+jwt`) and a bare JSON body. Previously the agent threw `'e' is an invalid start of a value` on the RFC-compliant signed-JWT response. Also unblocks the legacy `HaipDrivingLicence` walkthrough.
- **Walkthrough** — `setup.ps1` extended with DLA org + wallet + trust enrolment + Driving Licence blueprint publish (reusing the Assured Identity register so citizen wallet stays coherent). `run-phase2-licence.ps1` mirrors the HaipDrivingLicence runner with `AssuredIdentityCredential` as the presented credential. `run.ps1` orchestrator chains setup → phase1 → phase2 and logs elapsed time against SC-001 / SC-002 budgets.
- **Tests** — `BuildClaimsFromMappingsCarryForwardTests` (T034): 6 tests covering nested-pointer resolution through `/presentedClaims/*`, portrait carry-forward, silent drop when withheld, mixed payload+presented sources, portrait size gate on carry-forward.

## Walkthrough-level carry-forward (not platform-level)
The DLA submission payload inlines `holderName` / `holderDateOfBirth` (+ optional `holderPortrait`) sourced from persona state. The blueprint's claim mappings reference these payload fields directly (`/holderName` etc.) rather than `/presentedClaims/*`. The `sorcha-agent haip present` step proves the full OID4VP round-trip including selective disclosure + KB-JWT — the carry-forward is script-level today. Proper server-side `/presentedClaims/` plumbing is tracked as follow-up #338.

## End-to-end validation
Against local Docker:
- `pwsh walkthroughs/AssuredIdentity/run.ps1` ✅
- Both credentials land in the citizen's HAIP wallet-dir
- `DrivingLicenceCredential.sdjwt` decoded — all 6 claims present (`licenceNumber`, `vehicleClass`, `issuedDate`, `expiryDate`, `holderName` = `Alex Morgan MacLeod`, `holderDateOfBirth` = `1990-06-21`)
- Phase 1 elapsed 00:21; Phase 2 well under the 2-minute SC-002 budget

## Test plan
- [ ] `dotnet build` clean (0 errors, pre-existing warnings only)
- [ ] `dotnet test --filter FullyQualifiedName~BuildClaimsFromMappingsCarryForwardTests` 6/6 green
- [ ] `walkthroughs/AssuredIdentity/run.ps1 -Force` succeeds end-to-end
- [ ] `DrivingLicenceCredential.sdjwt` disclosures decode to all 6 expected claims

## Follow-up tickets referenced
- #338 — proper server-side `/presentedClaims/` plumbing (threading verified presentation claims into `mergedData`)
- #336 — shared warning-code constants

## Not yet in this PR (deferred to PR 3+)
- `sorcha-agent` actors for unattended gov-assessor + dla-officer (PR 3 / US3)
- Cross-peer smoke test (PR 4 / US4)
- Legacy `HaipVerifiedCitizen` + `HaipDrivingLicence` deletion (PR 5 / US5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)