### PR TITLE
chore: bump LangVersion to C# 14 across solution

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -15,7 +15,7 @@ Use .NET 10 built-in OpenAPI (NOT Swagger/Swashbuckle). Use Scalar.AspNetCore fo
 Minimum 80% unit test coverage for core libraries. Target >85% for new code. Use xUnit as primary testing framework. All tests MUST be deterministic and isolated. Integration tests for all service APIs. Follow Arrange-Act-Assert pattern.
 
 ### V. Code Quality
-Follow C# coding conventions. Use async/await for I/O operations. Leverage dependency injection. Target .NET 10 framework with C# 13. Nullable reference types MUST be enabled. No compiler warnings in Release builds.
+Follow C# coding conventions. Use async/await for I/O operations. Leverage dependency injection. Target .NET 10 framework with C# 14. Nullable reference types MUST be enabled. No compiler warnings in Release builds.
 
 ### VI. Blueprint Creation Standards
 Always create blueprints as JSON or YAML documents (primary format). Use JSON-e (JsonE.NET) for runtime variable replacement. Fluent API is ONLY for rare developer scenarios requiring runtime generation. Store blueprint templates as JSON/YAML files, not C# code.

--- a/.specify/standards/coding-standards.md
+++ b/.specify/standards/coding-standards.md
@@ -16,7 +16,7 @@ This document defines the coding standards and conventions for the Sorcha projec
 
 ### Target Framework & Language Version
 - **Framework**: .NET 10 (net10.0)
-- **Language**: C# 13
+- **Language**: C# 14
 - **Nullable Reference Types**: ENABLED (mandatory)
 - **Implicit Usings**: ENABLED
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ dotnet restore && dotnet build && dotnet test
 
 | Layer | Technology | Purpose |
 |-------|------------|---------|
-| Runtime | .NET 10 / C# 13 | LTS runtime with latest features |
+| Runtime | .NET 10 / C# 14 | LTS runtime with latest features |
 | Orchestration | .NET Aspire 13+ | Service discovery, health checks, telemetry |
 | API | Minimal APIs + Scalar | REST endpoints with OpenAPI docs |
 | Real-time | SignalR + Redis | WebSocket notifications |
@@ -877,7 +877,7 @@ When working on tasks involving these technologies, invoke the corresponding ski
 | yarp | Configures YARP reverse proxy for API gateway routing |
 | mongodb | Configures MongoDB document storage and query operations |
 | aspire | Configures .NET Aspire orchestration, service discovery, and telemetry |
-| dotnet | Manages .NET 10 runtime, C# 13 syntax, and project configuration |
+| dotnet | Manages .NET 10 runtime, C# 14 syntax, and project configuration |
 | blazor | Builds Blazor WASM components for admin and main UI applications |
 | fluent-assertions | Creates readable test assertions with FluentAssertions library |
 | grpc | Defines gRPC services for peer-to-peer network communication |

--- a/src/Apps/Directory.Build.props
+++ b/src/Apps/Directory.Build.props
@@ -11,7 +11,7 @@
 
     <!-- Build Settings -->
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Deterministic>true</Deterministic>

--- a/src/Common/Directory.Build.props
+++ b/src/Common/Directory.Build.props
@@ -11,7 +11,7 @@
 
     <!-- Build Settings -->
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Common/Sorcha.Storage.Redis/RedisCacheStore.cs
+++ b/src/Common/Sorcha.Storage.Redis/RedisCacheStore.cs
@@ -141,7 +141,7 @@ public class RedisCacheStore : ICacheStore, IAsyncDisposable
             }
 
             Interlocked.Increment(ref _hits);
-            return JsonSerializer.Deserialize<T>(result!, _jsonOptions);
+            return JsonSerializer.Deserialize<T>((string)result!, _jsonOptions);
         }
         catch (BrokenCircuitException)
         {

--- a/src/Core/Directory.Build.props
+++ b/src/Core/Directory.Build.props
@@ -11,7 +11,7 @@
 
     <!-- Build Settings -->
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Services/Directory.Build.props
+++ b/src/Services/Directory.Build.props
@@ -11,7 +11,7 @@
 
     <!-- Build Settings -->
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Deterministic>true</Deterministic>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <LangVersion>14</LangVersion>
     <NoWarn>$(NoWarn);xUnit1051;CS1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/tests/Sorcha.Auth.IntegrationTests/Sorcha.Auth.IntegrationTests.csproj
+++ b/tests/Sorcha.Auth.IntegrationTests/Sorcha.Auth.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.Blueprint.Schemas.Core.Tests/Sorcha.Blueprint.Schemas.Core.Tests.csproj
+++ b/tests/Sorcha.Blueprint.Schemas.Core.Tests/Sorcha.Blueprint.Schemas.Core.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/Sorcha.Blueprint.Service.IntegrationTests/Sorcha.Blueprint.Service.IntegrationTests.csproj
+++ b/tests/Sorcha.Blueprint.Service.IntegrationTests/Sorcha.Blueprint.Service.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.Register.Service.IntegrationTests/Sorcha.Register.Service.IntegrationTests.csproj
+++ b/tests/Sorcha.Register.Service.IntegrationTests/Sorcha.Register.Service.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.Register.Storage.MongoDB.Tests/Sorcha.Register.Storage.MongoDB.Tests.csproj
+++ b/tests/Sorcha.Register.Storage.MongoDB.Tests/Sorcha.Register.Storage.MongoDB.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <!-- CS0618: Suppress obsolete Testcontainers constructor warning -->
     <NoWarn>$(NoWarn);CS0618</NoWarn>

--- a/tests/Sorcha.Register.Storage.Tests/Sorcha.Register.Storage.Tests.csproj
+++ b/tests/Sorcha.Register.Storage.Tests/Sorcha.Register.Storage.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Sorcha.Storage.Abstractions.Tests/Sorcha.Storage.Abstractions.Tests.csproj
+++ b/tests/Sorcha.Storage.Abstractions.Tests/Sorcha.Storage.Abstractions.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Sorcha.Storage.EFCore.Tests/Sorcha.Storage.EFCore.Tests.csproj
+++ b/tests/Sorcha.Storage.EFCore.Tests/Sorcha.Storage.EFCore.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/Sorcha.Storage.InMemory.Tests/Sorcha.Storage.InMemory.Tests.csproj
+++ b/tests/Sorcha.Storage.InMemory.Tests/Sorcha.Storage.InMemory.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Sorcha.Storage.MongoDB.Tests/Sorcha.Storage.MongoDB.Tests.csproj
+++ b/tests/Sorcha.Storage.MongoDB.Tests/Sorcha.Storage.MongoDB.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/Sorcha.Storage.Redis.Tests/Sorcha.Storage.Redis.Tests.csproj
+++ b/tests/Sorcha.Storage.Redis.Tests/Sorcha.Storage.Redis.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/Sorcha.Tenant.Models.Tests/Sorcha.Tenant.Models.Tests.csproj
+++ b/tests/Sorcha.Tenant.Models.Tests/Sorcha.Tenant.Models.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/Sorcha.Tenant.Service.IntegrationTests/Sorcha.Tenant.Service.IntegrationTests.csproj
+++ b/tests/Sorcha.Tenant.Service.IntegrationTests/Sorcha.Tenant.Service.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.Testing/Sorcha.Testing.csproj
+++ b/tests/Sorcha.Testing/Sorcha.Testing.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.UI.E2E.Tests/Sorcha.UI.E2E.Tests.csproj
+++ b/tests/Sorcha.UI.E2E.Tests/Sorcha.UI.E2E.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.Validator.Service.IntegrationTests/Sorcha.Validator.Service.IntegrationTests.csproj
+++ b/tests/Sorcha.Validator.Service.IntegrationTests/Sorcha.Validator.Service.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Sorcha.Wallet.Core.Tests/Sorcha.Wallet.Core.Tests.csproj
+++ b/tests/Sorcha.Wallet.Core.Tests/Sorcha.Wallet.Core.Tests.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <!-- xUnit1012: Null used for non-nullable InlineData - intentional for null testing -->

--- a/tests/Sorcha.Wallet.Service.IntegrationTests/Sorcha.Wallet.Service.IntegrationTests.csproj
+++ b/tests/Sorcha.Wallet.Service.IntegrationTests/Sorcha.Wallet.Service.IntegrationTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj
+++ b/tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
Centralises test-project LangVersion into tests/Directory.Build.props (was a mix of 13/14/latest across 19 csprojs), bumps src/* Directory.Build.props from 13 to 14, casts RedisValue to string at RedisCacheStore.cs:144 to disambiguate C# 14 overload resolution (preserves runtime behaviour), and updates CLAUDE.md and .specify docs. Build green; unit tests green except 3 failures that reproduce on master unrelated to this change.