### PR TITLE
fix(register): break validator-enrolment bootstrap deadlock for new registers

### DIFF
--- a/src/Common/Sorcha.Register.Models/Register.cs
+++ b/src/Common/Sorcha.Register.Models/Register.cs
@@ -91,4 +91,15 @@ public class Register
     /// document after Feature 108 persists the new enum-name form.
     /// </remarks>
     public RegisterSyncState? SyncState { get; set; }
+
+    /// <summary>
+    /// Control record stashed at register creation time so local-relationship derivation
+    /// can resolve the roster before the genesis docket is sealed. Denormalised from the
+    /// authoritative copy that lives in the genesis transaction payload (docket 0).
+    /// Once docket 0 is sealed the local-relationship service prefers the docket-sourced
+    /// control record; this stash is the pre-seal fallback that breaks the validator-
+    /// enrolment chicken-and-egg for freshly-created local registers.
+    /// Null on legacy records and on registers synced from a peer.
+    /// </summary>
+    public RegisterControlRecord? InitialControlRecord { get; set; }
 }

--- a/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
+++ b/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
@@ -98,42 +98,60 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
         LocalIdentitySnapshot identity,
         CancellationToken cancellationToken)
     {
-        // Read genesis docket and find its Control transaction.
+        // Primary path: read genesis docket and find its Control transaction.
         var genesis = await _repository.GetDocketAsync(registerId, 0, cancellationToken);
-        if (genesis is null)
+        if (genesis is not null)
         {
-            _logger?.LogDebug(
-                "Cannot derive relationship for register {RegisterId}: genesis docket not present locally",
-                registerId);
-            return null;
-        }
+            var genesisTxs = await _repository.GetTransactionsByDocketAsync(registerId, 0, cancellationToken);
+            var docketControlRecord = TryExtractControlRecord(registerId, genesisTxs);
+            if (docketControlRecord is null)
+            {
+                // No control record — legacy register. Fall back to None (subscriber).
+                return new RegisterLocalRelationship(
+                    RegisterId: registerId,
+                    Roles: RegisterRoleSet.None,
+                    ControlRecordVersion: 0,
+                    DerivedAt: DateTimeOffset.UtcNow);
+            }
 
-        var genesisTxs = await _repository.GetTransactionsByDocketAsync(registerId, 0, cancellationToken);
-        var controlRecord = TryExtractControlRecord(registerId, genesisTxs);
-        if (controlRecord is null)
-        {
-            // No control record — legacy register. Fall back to None (subscriber).
+            var docketRoles = DeriveRoles(docketControlRecord, identity);
+            var docketVersion = (int)(genesis.Id);
+
+            _logger?.LogDebug(
+                "Derived relationship for register {RegisterId}: {Roles} (controlRecordVersion={Version}, source=docket)",
+                registerId, docketRoles, docketVersion);
+
             return new RegisterLocalRelationship(
                 RegisterId: registerId,
-                Roles: RegisterRoleSet.None,
+                Roles: docketRoles,
+                ControlRecordVersion: docketVersion,
+                DerivedAt: DateTimeOffset.UtcNow);
+        }
+
+        // Pre-seal fallback: genesis docket not yet written, but the register row may carry
+        // the stashed InitialControlRecord from FinalizeAsync. This lets the validator enrol
+        // for monitoring before docket 0 exists and breaks the bootstrap deadlock where
+        // the validator can't seal the genesis docket without first seeing a control record,
+        // which can't exist without the genesis docket being sealed.
+        var registerRow = await _repository.GetRegisterAsync(registerId, cancellationToken);
+        if (registerRow?.InitialControlRecord is not null)
+        {
+            var stashRoles = DeriveRoles(registerRow.InitialControlRecord, identity);
+            _logger?.LogDebug(
+                "Derived relationship for register {RegisterId}: {Roles} (controlRecordVersion=0, source=stash)",
+                registerId, stashRoles);
+
+            return new RegisterLocalRelationship(
+                RegisterId: registerId,
+                Roles: stashRoles,
                 ControlRecordVersion: 0,
                 DerivedAt: DateTimeOffset.UtcNow);
         }
 
-        var roles = DeriveRoles(controlRecord, identity);
-        var version = (int)(genesis.Id);
-
-        var result = new RegisterLocalRelationship(
-            RegisterId: registerId,
-            Roles: roles,
-            ControlRecordVersion: version,
-            DerivedAt: DateTimeOffset.UtcNow);
-
         _logger?.LogDebug(
-            "Derived relationship for register {RegisterId}: {Roles} (controlRecordVersion={Version})",
-            registerId, roles, version);
-
-        return result;
+            "Cannot derive relationship for register {RegisterId}: genesis docket not present locally and no stash available",
+            registerId);
+        return null;
     }
 
     private RegisterControlRecord? TryExtractControlRecord(

--- a/src/Core/Sorcha.Register.Core/Managers/RegisterManager.cs
+++ b/src/Core/Sorcha.Register.Core/Managers/RegisterManager.cs
@@ -51,6 +51,7 @@ public class RegisterManager
         bool devMode = false,
         RegisterPurpose purpose = RegisterPurpose.General,
         RegisterSyncState? syncState = null,
+        Models.RegisterControlRecord? initialControlRecord = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -72,6 +73,7 @@ public class RegisterManager
             Purpose = purpose,
             DevMode = devMode,
             SyncState = syncState,
+            InitialControlRecord = initialControlRecord,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -35,6 +35,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
     private readonly IPeerServiceClient _peerClient;
     private readonly ITenantSubscriptionClient _tenantSubscriptionClient;
     private readonly IBloomFilterRebuilder _bloomFilterRebuilder;
+    private readonly RelationshipChangeNotifier _relationshipNotifier;
 
     private readonly TimeSpan _pendingExpirationTime = TimeSpan.FromMinutes(5);
 
@@ -55,7 +56,8 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         IPendingRegistrationStore pendingStore,
         IPeerServiceClient peerClient,
         ITenantSubscriptionClient tenantSubscriptionClient,
-        IBloomFilterRebuilder bloomFilterRebuilder)
+        IBloomFilterRebuilder bloomFilterRebuilder,
+        RelationshipChangeNotifier relationshipNotifier)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _registerManager = registerManager ?? throw new ArgumentNullException(nameof(registerManager));
@@ -69,6 +71,7 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         _peerClient = peerClient ?? throw new ArgumentNullException(nameof(peerClient));
         _tenantSubscriptionClient = tenantSubscriptionClient ?? throw new ArgumentNullException(nameof(tenantSubscriptionClient));
         _bloomFilterRebuilder = bloomFilterRebuilder ?? throw new ArgumentNullException(nameof(bloomFilterRebuilder));
+        _relationshipNotifier = relationshipNotifier ?? throw new ArgumentNullException(nameof(relationshipNotifier));
     }
 
     /// <summary>
@@ -442,7 +445,10 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
             genesisTransaction.TxId);
 
         // Only persist register AFTER genesis succeeds (atomic guarantee)
-        // Use the register ID from the pending registration (established during initiation)
+        // Use the register ID from the pending registration (established during initiation).
+        // Stash the control record so local-relationship derivation can resolve the roster
+        // before the genesis docket is sealed — this is what lets the validator enrol for
+        // monitoring and then seal the genesis tx that's waiting in its pool.
         var register = await _registerManager.CreateRegisterAsync(
             controlRecord.Name,
             advertise: pending.Advertise,
@@ -451,9 +457,17 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
             description: controlRecord.Description,
             devMode: pending.DevMode,
             purpose: pending.Purpose,
+            initialControlRecord: controlRecord,
             cancellationToken: cancellationToken);
 
         _logger.LogInformation("Created register {RegisterId} in database after genesis success", register.Id);
+
+        // Fire relationship-changed event so the local validator enrols for monitoring
+        // without waiting for the next 30-second safety poll. The validator's
+        // RegisterMonitoringBootstrap will re-reconcile, find this register via the
+        // stashed control record, and start sealing the genesis tx waiting in its pool.
+        // Fire-and-forget — Redis publish failure is non-fatal, the safety poll covers it.
+        _ = Task.Run(() => _relationshipNotifier.PublishIfChangedAsync(register.Id));
 
         // Set register Online after successful creation
         // SignalR notifications (RegisterStatusChanged, RegisterCreated) handled by RegisterEventBridgeService

--- a/src/Services/Sorcha.Validator.Service/Services/RegisterMonitoringBootstrap.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/RegisterMonitoringBootstrap.cs
@@ -13,7 +13,7 @@ namespace Sorcha.Validator.Service.Services;
 /// Feature 108. Seeds <see cref="IRegisterMonitoringRegistry"/> at startup and on every
 /// <c>register:relationship-changed</c> Redis event by querying Register.Service for the
 /// list of registers whose roster includes this validator's docket-signing public key.
-/// A 5-minute safety poll reconciles against missed events.
+/// A 30-second safety poll reconciles against missed events.
 /// </summary>
 /// <remarks>
 /// Replaces the side-effect enrolment that previously happened inside
@@ -23,7 +23,7 @@ namespace Sorcha.Validator.Service.Services;
 /// </remarks>
 public sealed class RegisterMonitoringBootstrap : BackgroundService
 {
-    private static readonly TimeSpan SafetyPollInterval = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan SafetyPollInterval = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
 
     private readonly IServiceScopeFactory _scopeFactory;

--- a/tests/Sorcha.Register.Core.Tests/LocalRelationship/RegisterLocalRelationshipServiceTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/LocalRelationship/RegisterLocalRelationshipServiceTests.cs
@@ -107,6 +107,39 @@ public class RegisterLocalRelationshipServiceTests
     }
 
     [Fact]
+    public async Task Derive_NoGenesisDocketButRegisterRowStashesControlRecord_DerivesFromStash()
+    {
+        // Bootstrap fix: before the genesis docket seals we can still enrol the validator
+        // by deriving roles from the stashed InitialControlRecord on the Register row.
+        var record = BuildControlRecord(
+            ownerAddress: LocalWalletAddress,
+            validatorKeys: new[] { LocalValidatorKey });
+
+        var repo = new Mock<IReadOnlyRegisterRepository>();
+        repo.Setup(r => r.GetDocketAsync(RegisterId, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Docket?)null);
+        repo.Setup(r => r.GetRegisterAsync(RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = RegisterId,
+                Name = "Test Register",
+                InitialControlRecord = record
+            });
+
+        var svc = new RegisterLocalRelationshipService(
+            repo.Object,
+            new StaticIdentityProvider(new LocalIdentitySnapshot(new[] { LocalWalletAddress }, LocalValidatorKey)),
+            NullLogger<RegisterLocalRelationshipService>.Instance);
+
+        var rel = await svc.DeriveAsync(RegisterId);
+
+        rel.Should().NotBeNull();
+        rel!.IsOwner.Should().BeTrue();
+        rel.IsValidator.Should().BeTrue();
+        rel.ControlRecordVersion.Should().Be(0);
+    }
+
+    [Fact]
     public async Task Derive_CachesPerRegister_SecondCallDoesNotReReadRepository()
     {
         var record = BuildControlRecord(


### PR DESCRIPTION
## Summary
Post-Feature-108, freshly-created registers fall into a bootstrap deadlock:

1. Genesis tx is submitted → lands in validator's unverified pool.
2. Validator's docket-builder gates on \`IRegisterMonitoringRegistry.IsMonitored\`.
3. Registry is populated by \`RegisterMonitoringBootstrap\` → \`GetMyValidatedRegistersAsync\` → \`DeriveAllAsync\`, which needs docket 0 sealed.
4. Docket 0 sealing requires step 2's enrolment.
5. Enrolment event (\`register:relationship-changed\`) only fires when a docket **containing a control tx** is **written back**.

The 5-minute safety poll eventually recovers, but any action submitted in that window hits BlueprintService's 60s timeout with 400. Reproduced end-to-end on n1.

Three-part fix:
1. **\`Register.InitialControlRecord\`** — new nullable MongoDB-stored field. No migration.
2. **\`RegisterCreationOrchestrator.FinalizeAsync\`** — stash the control record at creation time and fire \`RegisterRelationshipChangedEvent\` immediately so the local validator reconciles without waiting.
3. **\`RegisterLocalRelationshipService.ComputeAsync\`** — fall back to \`Register.InitialControlRecord\` when docket 0 is absent. Docket-sourced derivation remains preferred once docket 0 is sealed.
4. Bonus: safety poll 5min → 30s.

## Test plan
- [x] New unit test: \`Derive_NoGenesisDocketButRegisterRowStashesControlRecord_DerivesFromStash\` — owner+validator roles resolve from stash when docket 0 missing.
- [x] Full \`dotnet build\` clean.
- [x] \`Sorcha.Register.Core.Tests\` — 332/332 pass.
- [ ] Deploy to n1 + re-run AssuredIdentity walkthrough — expect Action 1 to complete well under 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)