### PR TITLE
fix(f108): align register/validator ValidatorId — shared-wallet contract

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -207,6 +207,7 @@ Register genesis control records include a `validators` field declaring authoriz
 - **ValidatorKeyCache**: Multi-key roster per register; `IsAuthorizedSigner(registerId, publicKey)` checks Active + Rotated keys
 - **Governance**: `AddValidator`, `RemoveValidator`, `RotateValidatorKey` operation types on the existing governance proposal endpoint
 - **External roster (FR-014)**: Register creation accepts optional external validator list for future System Register (087)
+- **Shared-wallet contract**: Register.Service (`SystemWalletSigning:ValidatorId`) and Validator.Service (`Validator:ValidatorId`) MUST be configured with the same identifier on a given node. Both call `IWalletServiceClient.CreateOrRetrieveSystemWalletAsync` with that string; wallets are keyed by it. Register.Service uses the resulting wallet to populate the `sorcha:docket-signing` pubkey on new registers' rosters; Validator.Service uses it to sign dockets. Divergent IDs → different derived keys → validator never matches its own roster entry → dockets never seal. In docker-compose this is `local-validator`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,8 +257,15 @@ services:
       ServiceClients__PeerService__Address: http://sorcha-peer-service:5000
       ServiceClients__PeerService__HttpAddress: http://sorcha-peer-service:8080
       ServiceClients__PeerService__GrpcAddress: http://sorcha-peer-service:5000
-      # System wallet signing (for blueprint publish, governance Control TXs)
-      SystemWalletSigning__ValidatorId: docker-register-1
+      # System wallet signing (for blueprint publish, governance Control TXs).
+      # MUST match Validator__ValidatorId on validator-service — see note on that
+      # setting below. Both services hit Wallet.Service's CreateOrRetrieveSystemWallet
+      # with this identifier; when Register.Service builds a new register's validator
+      # roster (Feature 108), it derives the docket-signing key under the SAME wallet
+      # that Validator.Service will later sign dockets with. Divergent values leave
+      # every locally-created register with a roster the validator doesn't match,
+      # so docket sealing never starts.
+      SystemWalletSigning__ValidatorId: local-validator
       # Service-to-service auth for Wallet Service calls
       ServiceAuth__ClientId: register-service
       ServiceAuth__ClientSecret: register-service-secret
@@ -425,8 +432,13 @@ services:
       ServiceAuth__ClientId: validator-service
       ServiceAuth__ClientSecret: validator-service-secret
       ServiceAuth__Scopes: "registers:write registers:read blueprints:read"
-      # Validator configuration
-      Validator__ValidatorId: docker-validator-1
+      # Validator configuration.
+      # Shared identifier for this node's local-validator system wallet.
+      # MUST match register-service's SystemWalletSigning__ValidatorId — see note
+      # there. Feature 108: the validator's docket-signing key (derived under this
+      # wallet via "sorcha:docket-signing") is what Register.Service puts on a
+      # new register's roster, so both services must derive under the same wallet.
+      Validator__ValidatorId: local-validator
       # SystemWalletAddress left empty - wallet created automatically on startup
       Validator__SystemWalletAddress: ""
       # Service client configuration for inter-service communication

--- a/src/Common/Sorcha.ServiceClients.Http/SystemWallet/SystemWalletSigningOptions.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/SystemWallet/SystemWalletSigningOptions.cs
@@ -9,8 +9,21 @@ namespace Sorcha.ServiceClients.SystemWallet;
 public class SystemWalletSigningOptions
 {
     /// <summary>
-    /// Unique identifier for the validator/service instance, used for wallet creation and retrieval
+    /// Identifier for this node's local-validator system wallet. Passed verbatim to
+    /// <c>IWalletServiceClient.CreateOrRetrieveSystemWalletAsync</c> — wallets are
+    /// keyed by this string, so every service that signs on this validator's behalf
+    /// MUST use the same value.
     /// </summary>
+    /// <remarks>
+    /// Feature 108 roster-extraction contract: Register.Service populates a newly-created
+    /// register's validator roster with the <c>sorcha:docket-signing</c> pubkey derived
+    /// under this wallet. Validator.Service later signs dockets with the key derived
+    /// under its own <c>Validator:ValidatorId</c> wallet. If the two IDs diverge, the
+    /// roster pubkey won't match the signing key, validator roster matching fails,
+    /// <c>RegisterMonitoringBootstrap</c> never enrols the register, and dockets are
+    /// never sealed. Align <c>SystemWalletSigning:ValidatorId</c> on Register.Service
+    /// with <c>Validator:ValidatorId</c> on Validator.Service (same node → same value).
+    /// </remarks>
     public required string ValidatorId { get; set; }
 
     /// <summary>

--- a/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
+++ b/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
@@ -76,19 +76,12 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
         byte[]? validatorPublicKeyOverride = null,
         CancellationToken cancellationToken = default)
     {
-        var registers = (await _repository.GetRegistersAsync(cancellationToken)).ToList();
+        var registers = await _repository.GetRegistersAsync(cancellationToken);
         var identity = await _identityProvider.GetAsync(cancellationToken);
         if (validatorPublicKeyOverride is { Length: > 0 })
         {
             identity = identity with { ValidatorPublicKey = validatorPublicKeyOverride };
         }
-
-        // DIAG (F108 bootstrap probe — remove once fix confirmed)
-        _logger?.LogInformation(
-            "DIAG DeriveAllAsync: {RegisterCount} register(s) in repository; override={HasOverride}, walletAddresses={WalletCount}",
-            registers.Count,
-            validatorPublicKeyOverride is { Length: > 0 },
-            identity.WalletAddresses.Count);
 
         var results = new List<RegisterLocalRelationship>();
         foreach (var register in registers)
@@ -97,12 +90,6 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
             if (derived is not null)
                 results.Add(derived);
         }
-
-        // DIAG: how many relationships came back with IsValidator=true?
-        var validatorCount = results.Count(r => r.IsValidator);
-        _logger?.LogInformation(
-            "DIAG DeriveAllAsync: {NonNullCount} non-null relationship(s), {ValidatorCount} with IsValidator=true",
-            results.Count, validatorCount);
         return results;
     }
 
@@ -147,18 +134,11 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
         // the validator can't seal the genesis docket without first seeing a control record,
         // which can't exist without the genesis docket being sealed.
         var registerRow = await _repository.GetRegisterAsync(registerId, cancellationToken);
-        // DIAG (F108 bootstrap probe — remove once fix confirmed)
-        _logger?.LogInformation(
-            "DIAG ComputeAsync stash path for {RegisterId}: registerRowFound={RowFound}, InitialControlRecord={HasStash}, rosterEntries={RosterCount}",
-            registerId,
-            registerRow is not null,
-            registerRow?.InitialControlRecord is not null,
-            registerRow?.InitialControlRecord?.Validators?.Validators.Count ?? 0);
         if (registerRow?.InitialControlRecord is not null)
         {
             var stashRoles = DeriveRoles(registerRow.InitialControlRecord, identity);
-            _logger?.LogInformation(
-                "DIAG ComputeAsync stash path for {RegisterId}: derived roles={Roles} (source=stash)",
+            _logger?.LogDebug(
+                "Derived relationship for register {RegisterId}: {Roles} (controlRecordVersion=0, source=stash)",
                 registerId, stashRoles);
 
             return new RegisterLocalRelationship(
@@ -206,7 +186,7 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
         return null;
     }
 
-    private RegisterRoleSet DeriveRoles(RegisterControlRecord controlRecord, LocalIdentitySnapshot identity)
+    private static RegisterRoleSet DeriveRoles(RegisterControlRecord controlRecord, LocalIdentitySnapshot identity)
     {
         var roles = RegisterRoleSet.None;
 
@@ -232,11 +212,6 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
         if (identity.ValidatorPublicKey is { Length: > 0 } validatorKey &&
             controlRecord.Validators is { } roster)
         {
-            // DIAG (F108 bootstrap probe — remove once fix confirmed)
-            var overrideB64 = Convert.ToBase64String(validatorKey);
-            _logger?.LogInformation(
-                "DIAG DeriveRoles roster compare: override={Override} ({Bytes}B) vs {EntryCount} roster entries",
-                overrideB64, validatorKey.Length, roster.Validators.Count);
             foreach (var entry in roster.Validators)
             {
                 if (string.IsNullOrEmpty(entry.PublicKey)) continue;
@@ -248,29 +223,15 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
                 }
                 catch (FormatException)
                 {
-                    _logger?.LogInformation(
-                        "DIAG DeriveRoles: roster entry PublicKey={Key} failed base64 decode",
-                        entry.PublicKey);
                     continue;
                 }
 
-                var match = entryKey.AsSpan().SequenceEqual(validatorKey);
-                _logger?.LogInformation(
-                    "DIAG DeriveRoles: entry PublicKey={Entry} ({EntryBytes}B) match={Match}",
-                    entry.PublicKey, entryKey.Length, match);
-                if (match)
+                if (entryKey.AsSpan().SequenceEqual(validatorKey))
                 {
                     roles |= RegisterRoleSet.Validator;
                     break;
                 }
             }
-        }
-        else
-        {
-            _logger?.LogInformation(
-                "DIAG DeriveRoles: skipping validator match — identityKey={HasKey}, roster={HasRoster}",
-                identity.ValidatorPublicKey is { Length: > 0 },
-                controlRecord.Validators is not null);
         }
 
         return roles;

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -302,6 +302,13 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         // Populate validator roster (FR-001, FR-014)
         // If an external roster is provided (future System Register, FR-014), use it.
         // Otherwise, derive the local validator's docket-signing key from the system wallet.
+        //
+        // Contract (Feature 108): the wallet we sign-under here is the one identified by
+        // SystemWalletSigning:ValidatorId, which MUST match Validator:ValidatorId on the
+        // validator service of this node. Both services then derive the same
+        // sorcha:docket-signing key from the same underlying wallet, and the validator
+        // recognises the roster entry as its own. See SystemWalletSigningOptions.ValidatorId
+        // and ValidatorConfiguration.ValidatorId for the contract.
         if (controlRecord.Validators == null)
         {
             // TODO: Replace with IWalletServiceClient.GetDerivedPublicKeyAsync() when available.

--- a/src/Services/Sorcha.Validator.Service/Configuration/ValidatorConfiguration.cs
+++ b/src/Services/Sorcha.Validator.Service/Configuration/ValidatorConfiguration.cs
@@ -9,8 +9,23 @@ namespace Sorcha.Validator.Service.Configuration;
 public class ValidatorConfiguration
 {
     /// <summary>
-    /// Unique identifier for this validator instance
+    /// Identifier for this node's local-validator system wallet. Passed verbatim to
+    /// <c>IWalletServiceClient.CreateOrRetrieveSystemWalletAsync</c> by both
+    /// <see cref="Services.SystemWalletInitializer"/> (at startup) and
+    /// <see cref="Services.DocketBuilder"/> (on first docket seal).
     /// </summary>
+    /// <remarks>
+    /// Feature 108 roster-extraction contract: Register.Service populates a newly-created
+    /// register's validator roster with the <c>sorcha:docket-signing</c> pubkey derived
+    /// under the wallet identified by <c>SystemWalletSigning:ValidatorId</c> in its own
+    /// config. Validator.Service later signs dockets with the key derived under the
+    /// wallet identified by this property. If the two IDs diverge, the roster entry
+    /// won't match the signing key, validator roster matching fails, and docket sealing
+    /// never starts for any locally-created register.
+    /// MUST match <c>SystemWalletSigning:ValidatorId</c> on Register.Service (same node
+    /// → same value). Defaults to a random GUID for tests; production/docker environments
+    /// should set this explicitly.
+    /// </remarks>
     public string ValidatorId { get; set; } = Guid.NewGuid().ToString();
 
     /// <summary>

--- a/src/Services/Sorcha.Validator.Service/Services/RegisterMonitoringBootstrap.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/RegisterMonitoringBootstrap.cs
@@ -120,25 +120,13 @@ public sealed class RegisterMonitoringBootstrap : BackgroundService
             return false;
         }
 
-        // DIAG (F108 bootstrap probe — remove once fix confirmed): log the validator
-        // pubkey we're sending so it can be compared against the roster entry stored
-        // on the register's InitialControlRecord.
-        _logger.LogInformation(
-            "DIAG reconcile: sending validator pubkey base64={Key} ({Bytes} bytes)",
-            Convert.ToBase64String(key), key.Length);
-
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var registerClient = scope.ServiceProvider.GetRequiredService<IRegisterServiceClient>();
 
             var rosterRegisters = await registerClient.GetMyValidatedRegistersAsync(key, ct);
-            // DIAG: what did the endpoint return?
-            var rosterList = rosterRegisters.ToList();
-            _logger.LogInformation(
-                "DIAG reconcile: my-validated-registers returned {Count} register(s): [{Ids}]",
-                rosterList.Count, string.Join(",", rosterList));
-            var desired = new HashSet<string>(rosterList, StringComparer.Ordinal);
+            var desired = new HashSet<string>(rosterRegisters, StringComparer.Ordinal);
             var current = _registry.GetAll().ToHashSet(StringComparer.Ordinal);
 
             // Add newly-rostered.


### PR DESCRIPTION
## Summary
Close the Feature 108 bootstrap deadlock.

After PR #363 (stash + relationship event + 30s safety poll) the validator still never enrolled on n1. PR #364's three-probe diff isolated the reason: **Register.Service and Validator.Service were deriving from different underlying system wallets**, so the docket-signing pubkey Register.Service wrote onto each new register's roster was never the one Validator.Service actually signed with.

## Root cause
Both services call \`IWalletServiceClient.CreateOrRetrieveSystemWalletAsync\` with a per-service identifier:
- Register.Service: \`SystemWalletSigning__ValidatorId=docker-register-1\`
- Validator.Service: \`Validator__ValidatorId=docker-validator-1\`

Wallet.Service keys wallets by that string → different wallets → different BIP32 roots → different derived \`sorcha:docket-signing\` keys. Roster match in \`DeriveRoles\` always returned false.

## Fix
- \`docker-compose.yml\` → both identifiers converged on \`local-validator\`.
- Doc comments on \`SystemWalletSigningOptions.ValidatorId\` and \`ValidatorConfiguration.ValidatorId\` spell out the contract (mutually MUST-match, failure mode).
- Inline comment on \`RegisterCreationOrchestrator\`'s roster-key derivation block pointing at both options.
- \`sorcha-architecture\` skill (Validator Key Roster section) now documents the shared-wallet contract so future readers see it without source diving.
- Reverts PR #364's temporary \`DIAG\` logs.

## Verification
- [x] Full \`dotnet build\` clean.
- [x] 332/332 \`Register.Core\` tests pass.
- [ ] Deploy to n1 → verify validator enrols, Phase 1 completes well under 60s.

## Migration note
Existing registers sealed against the old \`docker-register-1\` roster key are orphaned — the new \`local-validator\`-derived key won't match. Docker dev and n1 are reset between runs so this is fine there; production rekey is N/A at current maturity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)