### PR TITLE
fix(schema-library): surface sorcha-core primitives under 'core' sector

### DIFF
--- a/src/Common/Sorcha.Blueprint.Schemas/Services/LocalSchemaProvider.cs
+++ b/src/Common/Sorcha.Blueprint.Schemas/Services/LocalSchemaProvider.cs
@@ -129,25 +129,31 @@ public class LocalSchemaProvider : IExternalSchemaProvider, IDisposable
                 try
                 {
                     var json = File.ReadAllText(file);
-                    var schemaFile = JsonSerializer.Deserialize<SchemaFileFormat>(json, CaseInsensitiveJson);
 
-                    if (schemaFile is null || string.IsNullOrWhiteSpace(schemaFile.Identifier)
-                                           || string.IsNullOrWhiteSpace(schemaFile.Title))
+                    // Two on-disk shapes share this tree: (1) Sorcha envelope files
+                    // with top-level identifier/title/category/schema, and (2) raw
+                    // JSON Schema documents (sorcha-core/*.json) with $id at the
+                    // top level, also consumed by CoreSchemaSeedService for $ref
+                    // resolution. Sniff which we have before deserialising so the
+                    // raw-schema files surface in the library listing instead of
+                    // being silently dropped as "invalid".
+                    using var probe = JsonDocument.Parse(json);
+                    var root = probe.RootElement;
+
+                    if (root.TryGetProperty("identifier", out _))
                     {
-                        _logger.LogWarning("Skipping invalid schema file {File}", Path.GetFileName(file));
-                        continue;
+                        var result = TryBuildEnvelopeResult(json, file);
+                        if (result is not null) results.Add(result);
                     }
-
-                    var content = BuildContent(schemaFile);
-                    var sectorTags = BuildSectorTags(schemaFile);
-
-                    results.Add(new ExternalSchemaResult(
-                        Name: schemaFile.Title,
-                        Description: schemaFile.Description ?? $"Sorcha standard schema: {schemaFile.Title}",
-                        Url: $"urn:sorcha:schema:{schemaFile.Identifier}",
-                        Provider: ProviderName,
-                        Content: content,
-                        SectorTags: sectorTags));
+                    else if (root.TryGetProperty("$id", out _))
+                    {
+                        var result = TryBuildRawSchemaResult(json, file);
+                        if (result is not null) results.Add(result);
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Skipping invalid schema file {File} (no identifier or $id)", Path.GetFileName(file));
+                    }
                 }
                 catch (JsonException ex)
                 {
@@ -195,6 +201,66 @@ public class LocalSchemaProvider : IExternalSchemaProvider, IDisposable
 
         // Fallback to base directory path
         return baseDirCandidate;
+    }
+
+    private ExternalSchemaResult? TryBuildEnvelopeResult(string json, string filePath)
+    {
+        var schemaFile = JsonSerializer.Deserialize<SchemaFileFormat>(json, CaseInsensitiveJson);
+
+        if (schemaFile is null || string.IsNullOrWhiteSpace(schemaFile.Identifier)
+                               || string.IsNullOrWhiteSpace(schemaFile.Title))
+        {
+            _logger.LogWarning("Skipping invalid envelope schema file {File}", Path.GetFileName(filePath));
+            return null;
+        }
+
+        return new ExternalSchemaResult(
+            Name: schemaFile.Title,
+            Description: schemaFile.Description ?? $"Sorcha standard schema: {schemaFile.Title}",
+            Url: $"urn:sorcha:schema:{schemaFile.Identifier}",
+            Provider: ProviderName,
+            Content: BuildContent(schemaFile),
+            SectorTags: BuildSectorTags(schemaFile));
+    }
+
+    /// <summary>
+    /// Builds a library entry for a raw JSON Schema document (e.g. the
+    /// <c>blueprints/schemas/sorcha-core/*.json</c> identity primitives that
+    /// <see cref="Sorcha.Blueprint.Schemas.Services"/>' sibling
+    /// <c>CoreSchemaSeedService</c> consumes for <c>$ref</c> resolution).
+    /// Derives identity from <c>$id</c>/<c>title</c> and tags the entry with
+    /// the <c>core</c> sector so it surfaces under the "Sorcha Core Primitives"
+    /// chip in the Schema Library.
+    /// </summary>
+    private ExternalSchemaResult? TryBuildRawSchemaResult(string json, string filePath)
+    {
+        // Parse once into a long-lived JsonDocument we can hand to the result.
+        // The outer `probe` in BuildCatalog is a `using` that gets disposed
+        // before we return, so we parse a fresh document here.
+        var content = JsonDocument.Parse(json);
+        var root = content.RootElement;
+
+        var id = root.TryGetProperty("$id", out var idElement) ? idElement.GetString() : null;
+        var title = root.TryGetProperty("title", out var titleElement) ? titleElement.GetString() : null;
+
+        if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(title))
+        {
+            _logger.LogWarning("Skipping raw schema file {File} (missing $id or title)", Path.GetFileName(filePath));
+            content.Dispose();
+            return null;
+        }
+
+        var description = root.TryGetProperty("description", out var descElement)
+            ? descElement.GetString()
+            : null;
+
+        return new ExternalSchemaResult(
+            Name: title,
+            Description: description ?? $"Sorcha core primitive: {title}",
+            Url: id,
+            Provider: ProviderName,
+            Content: content,
+            SectorTags: ["core"]);
     }
 
     private static JsonDocument BuildContent(SchemaFileFormat file)

--- a/tests/Sorcha.Blueprint.Schemas.Tests/Providers/LocalSchemaProviderTests.cs
+++ b/tests/Sorcha.Blueprint.Schemas.Tests/Providers/LocalSchemaProviderTests.cs
@@ -283,11 +283,104 @@ public class LocalSchemaProviderTests : IDisposable
         catalog.Should().Contain(r => r.Name == "UK Address");
         catalog.Should().Contain(r => r.Name == "Personal Identity");
 
+        // Raw-JSON-Schema core primitives must also surface in the library so
+        // the "Sorcha Core Primitives" sector chip is non-empty — see fix for
+        // the two-pipelines-sharing-a-tree regression.
+        catalog.Should().Contain(r => r.Name == "Personal Name");
+        catalog.Should().Contain(r => r.Name == "Postal Address");
+        catalog.Should().Contain(r => r.Name == "Date of Birth");
+
+        catalog.Where(r => r.SectorTags is not null && r.SectorTags.Contains("core"))
+               .Should().HaveCountGreaterThan(0,
+                   "sorcha-core/*.json primitives must be tagged with the 'core' sector");
+
         // All entries should have content
         catalog.Should().OnlyContain(r => r.Content != null);
 
         // All entries should have the provider name
         catalog.Should().OnlyContain(r => r.Provider == "Sorcha Local");
+    }
+
+    [Fact]
+    public async Task GetCatalogAsync_RawJsonSchemaFile_LoadsAsCorePrimitive()
+    {
+        WriteRawJsonSchemaFile(
+            category: "sorcha-core",
+            fileName: "PersonName.v1.json",
+            id: "https://schemas.sorcha.dev/core/PersonName/v1",
+            title: "Personal Name",
+            description: "A person's name decomposed into given, middle, family, and full forms.");
+
+        var provider = new LocalSchemaProvider(_tempDir, _logger.Object);
+        var catalog = (await provider.GetCatalogAsync()).ToList();
+
+        var entry = catalog.Single();
+        entry.Name.Should().Be("Personal Name");
+        entry.Url.Should().Be("https://schemas.sorcha.dev/core/PersonName/v1");
+        entry.Description.Should().Contain("given, middle, family");
+        entry.SectorTags.Should().Contain("core");
+        entry.Provider.Should().Be("Sorcha Local");
+    }
+
+    [Fact]
+    public async Task GetCatalogAsync_RawJsonSchemaMissingTitle_IsSkipped()
+    {
+        var dir = Path.Combine(_tempDir, "sorcha-core");
+        Directory.CreateDirectory(dir);
+
+        // Raw JSON Schema with $id but no title — should be skipped, not crash.
+        File.WriteAllText(Path.Combine(dir, "bad.json"),
+            """{ "$id": "https://example.com/x", "type": "object" }""");
+
+        var provider = new LocalSchemaProvider(_tempDir, _logger.Object);
+        var catalog = (await provider.GetCatalogAsync()).ToList();
+
+        catalog.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCatalogAsync_MixedFormats_BothSurfaceInCatalog()
+    {
+        // Envelope format (existing path)
+        WriteSchemaFile("people-identity", "uk-address", "UK Address",
+            "Standard UK postal address", "people-identity", ["address", "uk"]);
+
+        // Raw JSON Schema format (new path)
+        WriteRawJsonSchemaFile(
+            category: "sorcha-core",
+            fileName: "EmailAddress.v1.json",
+            id: "https://schemas.sorcha.dev/core/EmailAddress/v1",
+            title: "Email Address",
+            description: "A single email address.");
+
+        var provider = new LocalSchemaProvider(_tempDir, _logger.Object);
+        var catalog = (await provider.GetCatalogAsync()).ToList();
+
+        catalog.Should().HaveCount(2);
+        catalog.Should().Contain(r => r.Name == "UK Address" && r.SectorTags!.Contains("people-identity"));
+        catalog.Should().Contain(r => r.Name == "Email Address" && r.SectorTags!.Contains("core"));
+    }
+
+    private void WriteRawJsonSchemaFile(string category, string fileName, string id, string title, string description)
+    {
+        var dir = Path.Combine(_tempDir, category);
+        Directory.CreateDirectory(dir);
+
+        var schema = new Dictionary<string, object>
+        {
+            ["$id"] = id,
+            ["$schema"] = "https://json-schema.org/draft/2020-12/schema",
+            ["type"] = "object",
+            ["title"] = title,
+            ["description"] = description,
+            ["properties"] = new Dictionary<string, object>
+            {
+                ["sample"] = new Dictionary<string, object> { ["type"] = "string" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(schema, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(Path.Combine(dir, fileName), json);
     }
 
     private void WriteSchemaFile(


### PR DESCRIPTION
LocalSchemaProvider walked the whole blueprints/schemas/ tree expecting Sorcha envelope format (identifier/title/category/tags/schema). The 5 files under sorcha-core/ are raw JSON Schema documents with \ at the top level (consumed by CoreSchemaSeedService for \ resolution), so they failed the envelope check and got dropped as invalid. The 'Sorcha Core Primitives' sector chip (SchemaSector.All id='core') had zero rows to list while the provider reported ~25 entries because 5 files were silently filtered out. Fix: sniff format before deserialising — envelope files take the existing path, raw JSON Schema files take a new path that derives the listing entry from \/title/description and tags them 'core'. Both on-disk pipelines keep their natural shape. 3 new unit tests + updated real-blueprints assertion that Personal Name / Postal Address / Date of Birth surface. Full solution builds clean, 187/187 Schemas tests green.