### PR TITLE
feat(110): agent persona mode - one-shot kickoff (MVP)

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -112,7 +112,7 @@ This document now tracks **remaining work for the first production release**, or
 | GAP-018 | Auto-register participant and auto-link wallet during wallet creation | P1 | 12h | ✅ | Feature 077 — auto-link with VerificationMethod="self-created", fire-and-forget from Wallet Service |
 | GAP-019 | Tenant org user admin — PlatformUser provisioning with admin overrides | P1 | 16h | ✅ | Feature 077 — POST /api/platform/users + PUT /api/platform/users/{id}/password, SystemAdmin only |
 | GAP-020 | Multi-org ConstructionPermit walkthrough — complete run.ps1 | P2 | 8h | 🚧 | Setup passes (4 orgs, 5 users, register, subscriptions, blueprint). Run blocked on GAP-019 (per-org users can't login without PlatformUser). Branch: `feature/multi-org-construction-permit`. Also needs: rejection scenario fix, New Submission page visibility test. |
-| GAP-021 | Agent starting-action kickoff — persona mode (once trigger) | P2 | 10h | 🚧 | Feature 110 MVP shipped (PR #371) — `once` trigger + TradeFinance persona file unblocks walkthroughs. Remaining: US2 interval trigger for scenario data, US3 coexistence proof, US4 ConstructionPermit persona parity, Phase 7 docs polish. |
+| GAP-021 | Agent starting-action kickoff — persona mode (once trigger) | P2 | 10h | 🚧 | Feature 110 MVP shipped (PR #371) — `once` trigger + TradeFinance persona file unblocks walkthroughs. Remaining: US2 interval trigger for scenario data, US3 coexistence proof, US4 ConstructionPermit persona parity, Phase 7 docs polish, **wire PersonaHost through AuditLogger** (deferred from research.md R-007 so persona fires land in the `*.jsonl` audit stream alongside reactive decisions). |
 
 ### From Feature 085 (Stored Data Transactions)
 

--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -112,6 +112,7 @@ This document now tracks **remaining work for the first production release**, or
 | GAP-018 | Auto-register participant and auto-link wallet during wallet creation | P1 | 12h | ✅ | Feature 077 — auto-link with VerificationMethod="self-created", fire-and-forget from Wallet Service |
 | GAP-019 | Tenant org user admin — PlatformUser provisioning with admin overrides | P1 | 16h | ✅ | Feature 077 — POST /api/platform/users + PUT /api/platform/users/{id}/password, SystemAdmin only |
 | GAP-020 | Multi-org ConstructionPermit walkthrough — complete run.ps1 | P2 | 8h | 🚧 | Setup passes (4 orgs, 5 users, register, subscriptions, blueprint). Run blocked on GAP-019 (per-org users can't login without PlatformUser). Branch: `feature/multi-org-construction-permit`. Also needs: rejection scenario fix, New Submission page visibility test. |
+| GAP-021 | Agent starting-action kickoff — persona mode (once trigger) | P2 | 10h | 🚧 | Feature 110 MVP shipped (PR #371) — `once` trigger + TradeFinance persona file unblocks walkthroughs. Remaining: US2 interval trigger for scenario data, US3 coexistence proof, US4 ConstructionPermit persona parity, Phase 7 docs polish. |
 
 ### From Feature 085 (Stored Data Transactions)
 

--- a/docs/reference/development-status.md
+++ b/docs/reference/development-status.md
@@ -101,6 +101,15 @@ For detailed implementation status, see the individual section files:
 
 ## Recent Completions
 
+### 2026-04-22
+- **110-Agent-Persona-Mode (MVP)** (Feature 110 User Story 1 shipped via PR #371)
+  - Adds an optional "persona" loop to `Sorcha.Agent` that fires workflow-starting actions on agent launch, unblocking the TradeFinance walkthrough (which hung because action 1 had no prior transaction to populate any inbox).
+  - New `Persona/` namespace: `PersonaDefinition`, `OnceTriggerLoop`, `PayloadTokenResolver` (typed-vs-interpolated `${now|uuid|counter|random.*}`), `PersonaSchemaValidator` (embedded JSON Schema, JsonSchema.Net), `PersonaDefinitionLoader`, `PersonaSubmitter` (thin wrapper over the same `/api/instances/{id}/actions/{i}/execute` path `ActionExecutor` uses).
+  - `ActorDefinition` gains an optional `PersonaFile` field; when null, behaviour is byte-identical to pre-feature (regression test enforced).
+  - `RunCommand` launches `PersonaHost` as a peer task alongside the existing inbox loop; shared `CancellationToken` gives clean shutdown with a 5-second grace window.
+  - 28 new xUnit tests; 89/89 passing; zero warnings.
+  - Scope: `once` trigger only. `interval` trigger + recurring scenario data (User Story 2), coexistence proof (US3), and ConstructionPermit parity (US4) are staged for follow-up PRs.
+
 ### 2026-04-04
 - **084-Mobile-Package-Infrastructure** (Feature 084 complete)
   - Extracted `Sorcha.Wallet.Portable` from Wallet.Core: entities, enums, service interfaces, derivation path builder -- zero EF Core/Npgsql dependencies

--- a/specs/110-agent-persona-mode/checklists/requirements.md
+++ b/specs/110-agent-persona-mode/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Agent Persona Mode
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All 4 user stories (P1 one-shot kickoff, P2 recurring scenario, P2 coexistence, P3 tuning) have independent acceptance scenarios.
+- 16 functional requirements (FR-001 to FR-016) are phrased as MUST statements with testable conditions.
+- 6 success criteria (SC-001 to SC-006) include quantitative thresholds (5 runs, 9–12 minutes, 25% latency, 10 minutes) or binary pass/fail outcomes.
+- Assumptions section documents the deliberate v1 trade-offs (in-memory state, wall-clock triggers, single persona per agent, scenario-author-owned de-dup).
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.

--- a/specs/110-agent-persona-mode/contracts/persona-schema.json
+++ b/specs/110-agent-persona-mode/contracts/persona-schema.json
@@ -18,7 +18,7 @@
     },
     "target": {
       "type": "object",
-      "required": ["blueprintId", "instanceId"],
+      "required": ["blueprintId", "instanceId", "actionIndex"],
       "additionalProperties": false,
       "properties": {
         "blueprintId": {
@@ -29,20 +29,12 @@
           "type": "string",
           "description": "Pre-created blueprint instance ID. Supports {{placeholders}} resolved from state.json."
         },
-        "actionName": {
-          "type": "string",
-          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex. NOT YET SUPPORTED in v1 — the loader rejects actionName-only targets; set actionIndex instead. Name→index lookup is planned for a follow-up feature."
-        },
         "actionIndex": {
           "type": "integer",
           "minimum": 0,
-          "description": "Zero-based index of the target action. Mutually exclusive with actionName."
+          "description": "Zero-based index of the target action in the blueprint."
         }
-      },
-      "oneOf": [
-        { "required": ["actionName"] },
-        { "required": ["actionIndex"] }
-      ]
+      }
     },
     "trigger": {
       "oneOf": [

--- a/specs/110-agent-persona-mode/contracts/persona-schema.json
+++ b/specs/110-agent-persona-mode/contracts/persona-schema.json
@@ -7,6 +7,10 @@
   "required": ["name", "target", "trigger", "payloadTemplate"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor IntelliSense. Ignored at runtime."
+    },
     "name": {
       "type": "string",
       "minLength": 1,
@@ -27,7 +31,7 @@
         },
         "actionName": {
           "type": "string",
-          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex."
+          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex. NOT YET SUPPORTED in v1 — the loader rejects actionName-only targets; set actionIndex instead. Name→index lookup is planned for a follow-up feature."
         },
         "actionIndex": {
           "type": "integer",

--- a/specs/110-agent-persona-mode/contracts/persona-schema.json
+++ b/specs/110-agent-persona-mode/contracts/persona-schema.json
@@ -107,7 +107,7 @@
       "target": {
         "blueprintId": "{{blueprints.procurement-to-pay.id}}",
         "instanceId": "{{instances.procurement-to-pay.id}}",
-        "actionName": "Raise Purchase Order"
+        "actionIndex": 0
       },
       "trigger": { "kind": "once", "delaySeconds": 2 },
       "payloadTemplate": {
@@ -121,7 +121,7 @@
       "target": {
         "blueprintId": "{{blueprints.invoice.id}}",
         "instanceId": "{{instances.invoice.id}}",
-        "actionName": "Raise Invoice"
+        "actionIndex": 4
       },
       "trigger": {
         "kind": "interval",

--- a/specs/110-agent-persona-mode/contracts/persona-schema.json
+++ b/specs/110-agent-persona-mode/contracts/persona-schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sorcha.dev/schemas/agent-persona/v1.json",
+  "title": "Sorcha Agent Persona v1",
+  "description": "Declarative non-reactive behaviour for a Sorcha agent. Referenced from an actor config via the 'personaFile' field.",
+  "type": "object",
+  "required": ["name", "target", "trigger", "payloadTemplate"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable persona label; appears in logs and audit entries."
+    },
+    "target": {
+      "type": "object",
+      "required": ["blueprintId", "instanceId"],
+      "additionalProperties": false,
+      "properties": {
+        "blueprintId": {
+          "type": "string",
+          "description": "Blueprint whose starting action will be submitted. Supports {{placeholders}} resolved from state.json."
+        },
+        "instanceId": {
+          "type": "string",
+          "description": "Pre-created blueprint instance ID. Supports {{placeholders}} resolved from state.json."
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex."
+        },
+        "actionIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based index of the target action. Mutually exclusive with actionName."
+        }
+      },
+      "oneOf": [
+        { "required": ["actionName"] },
+        { "required": ["actionIndex"] }
+      ]
+    },
+    "trigger": {
+      "oneOf": [
+        { "$ref": "#/$defs/onceTrigger" },
+        { "$ref": "#/$defs/intervalTrigger" }
+      ]
+    },
+    "payloadTemplate": {
+      "type": "object",
+      "description": "JSON template submitted at each fire. String values may contain ${token} substitutions; a string that is exactly '${token}' is replaced by the token's typed result (integer, decimal, or array element) rather than a stringified form."
+    }
+  },
+  "$defs": {
+    "onceTrigger": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "once" },
+        "delaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Optional delay between agent start and the single fire."
+        }
+      }
+    },
+    "intervalTrigger": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "interval" },
+        "everySeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Interval between fires in seconds. Mutually exclusive with everyMinutes."
+        },
+        "everyMinutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Interval between fires in minutes. Mutually exclusive with everySeconds."
+        },
+        "startDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Optional delay before the first fire."
+        },
+        "maxIterations": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Stop after N successful fires. Optional."
+        },
+        "until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Stop at this wall-clock timestamp (ISO 8601). Optional."
+        }
+      },
+      "oneOf": [
+        { "required": ["everySeconds"] },
+        { "required": ["everyMinutes"] }
+      ]
+    }
+  },
+  "examples": [
+    {
+      "name": "procurement-mgr-kickoff",
+      "target": {
+        "blueprintId": "{{blueprints.procurement-to-pay.id}}",
+        "instanceId": "{{instances.procurement-to-pay.id}}",
+        "actionName": "Raise Purchase Order"
+      },
+      "trigger": { "kind": "once", "delaySeconds": 2 },
+      "payloadTemplate": {
+        "poReference": "PO-CAIRN-2026-00142",
+        "projectName": "Aviemore Heights Phase 2",
+        "siteAddress": "Plot 7-12, Craig na Gower Avenue, Aviemore, PH22 1RW"
+      }
+    },
+    {
+      "name": "invoice-generator",
+      "target": {
+        "blueprintId": "{{blueprints.invoice.id}}",
+        "instanceId": "{{instances.invoice.id}}",
+        "actionName": "Raise Invoice"
+      },
+      "trigger": {
+        "kind": "interval",
+        "everySeconds": 30,
+        "maxIterations": 20
+      },
+      "payloadTemplate": {
+        "invoiceNumber": "INV-${counter}",
+        "invoiceId": "${uuid}",
+        "issuedAt": "${now}",
+        "amount": "${random.decimal(100, 9999, 2)}",
+        "currency": "${random.choice([\"EUR\",\"GBP\",\"USD\"])}"
+      }
+    }
+  ]
+}

--- a/specs/110-agent-persona-mode/data-model.md
+++ b/specs/110-agent-persona-mode/data-model.md
@@ -1,0 +1,160 @@
+# Phase 1 Data Model: Agent Persona Mode
+
+All types live in `Sorcha.Agent.Persona` (new namespace) unless noted. Records use C# 14 `init`-only properties to match the existing `ActorDefinition` style.
+
+## Top-level types
+
+### `PersonaDefinition` (root record, loaded from persona JSON file)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `Name` | `string` | Yes | Human-readable persona label; surfaces in logs. |
+| `Target` | `PersonaTarget` | Yes | Which blueprint + action + instance this persona submits against. |
+| `Trigger` | `PersonaTrigger` | Yes | Discriminated union: `once` or `interval`. |
+| `PayloadTemplate` | `JsonNode` | Yes | Raw JSON template; tokens resolved per fire. |
+
+**Validation rules**:
+- `Name` non-empty.
+- Exactly one `Trigger` kind set.
+- `PayloadTemplate` must parse as a JSON object.
+- All `${...}` tokens in `PayloadTemplate` must be resolvable by `PayloadTokenResolver` at load time (FR-010).
+
+---
+
+### `PersonaTarget`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `BlueprintId` | `string` | Yes | ID of the blueprint whose starting action is being submitted. Supports `{{blueprints.<key>.id}}` placeholder via existing `VariableResolver`. |
+| `InstanceId` | `string` | Yes | ID of the pre-created instance (created by `run-agents.ps1`). Supports `{{instances.<key>.id}}` placeholder. |
+| `ActionName` | `string` | Yes, unless `ActionIndex` | Human name of the action within the blueprint. |
+| `ActionIndex` | `int?` | Yes, unless `ActionName` | Zero-based position of the action in the blueprint. Either name or index; if both, index wins and a load-time warning is logged. |
+
+**Validation rules**: exactly one of `ActionName`/`ActionIndex` required.
+
+---
+
+### `PersonaTrigger` (discriminated union)
+
+Two subtypes identified by the `Kind` discriminator (`"once"` or `"interval"`).
+
+#### `OnceTrigger`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `Kind` | `"once"` | Yes | Discriminator. |
+| `DelaySeconds` | `int` | No (default `0`) | Delay between agent start and the single fire. Useful when the persona wants to wait for dependent agents to connect SignalR. |
+
+#### `IntervalTrigger`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `Kind` | `"interval"` | Yes | Discriminator. |
+| `EverySeconds` | `int` | Yes (or `EveryMinutes`) | Interval between fires in seconds. |
+| `EveryMinutes` | `int?` | (alternative) | Convenience alias; converted to seconds at load time. Exactly one of `EverySeconds`/`EveryMinutes` required. |
+| `StartDelaySeconds` | `int` | No (default `0`) | Delay before the first fire. |
+| `MaxIterations` | `int?` | No | Stop after N successful fires. |
+| `Until` | `DateTimeOffset?` | No | Stop at wall-clock time (ISO 8601, parsed by `DateTimeOffset.Parse`). |
+
+**Validation rules**:
+- `EverySeconds` or `EveryMinutes` > 0.
+- If `Until` is in the past at load time, log `Warning` and persona exits immediately at startup.
+- `MaxIterations`, if present, > 0.
+
+---
+
+## Internal runtime types
+
+### `PersonaFireContext`
+
+State passed to `PayloadTokenResolver` on each fire.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Iteration` | `int` | 1-based counter. |
+| `Now` | `DateTimeOffset` | Wall-clock at fire time (from injected `TimeProvider`). |
+| `RandomSource` | `IRandomSource` | Seam for test-determinism; wraps `System.Random`. |
+
+---
+
+### `PayloadTokenResolver` (service)
+
+**Responsibility**: Given a template `JsonNode` and a `PersonaFireContext`, produce a concrete `JsonObject` for submission.
+
+**Token grammar** (evaluated only inside string values in the template; string values that are exactly `${token(...)}` are replaced by the token's *typed* result — integer, decimal, array — not a stringified form):
+
+| Token | Example | Result type | Notes |
+|-------|---------|-------------|-------|
+| `${now}` | `"${now}"` | string (ISO 8601) | Current wall-clock, UTC, `O` format. |
+| `${uuid}` | `"${uuid}"` | string | Fresh `Guid.NewGuid().ToString()`. |
+| `${counter}` | `"${counter}"` | integer | Current `Iteration` value. |
+| `${random.int(MIN, MAX)}` | `"${random.int(1, 100)}"` | integer | Inclusive range. |
+| `${random.decimal(MIN, MAX, PRECISION)}` | `"${random.decimal(0, 9999, 2)}"` | number (JSON) | Two-decimal-place price. |
+| `${random.choice([…])}` | `"${random.choice([\"EUR\",\"GBP\",\"USD\"])}"` | matches element type | Literal JSON array of strings or numbers. |
+
+Tokens that are **embedded inside a larger string** (e.g. `"PO-${counter}"`) produce string interpolation of the token's `ToString()`. Tokens that are **the entire string value** preserve the native JSON type (so `"${counter}"` becomes a JSON number, not a string).
+
+### `IPersonaLoop`
+
+```csharp
+public interface IPersonaLoop
+{
+    Task RunAsync(CancellationToken cancellationToken);
+}
+```
+
+Implementations: `OnceTriggerLoop`, `IntervalTriggerLoop`.
+
+### `IPersonaSubmitter`
+
+```csharp
+public interface IPersonaSubmitter
+{
+    Task<PersonaSubmissionResult> SubmitAsync(
+        PersonaDefinition persona,
+        JsonObject resolvedPayload,
+        CancellationToken cancellationToken);
+}
+```
+
+`PersonaSubmissionResult` records `Outcome` (`Submitted`/`TransientFailure`/`HardFailure`) + `DurationMs` + optional error message. The submitter wraps a call to the same `POST /api/instances/{instanceId}/actions/{actionIndex}/execute` endpoint the existing `ActionExecutor` uses.
+
+### `PersonaHost`
+
+Constructor-injected with: `PersonaDefinition`, `IPersonaSubmitter`, `IPayloadTokenResolver`, `ILogger<PersonaHost>`, `TimeProvider`, `IRandomSource`, `AuditLogger`. Selects `OnceTriggerLoop` or `IntervalTriggerLoop` based on `Trigger.Kind`. Exposes `Task RunAsync(CancellationToken)` for launch from `RunCommand`.
+
+---
+
+## Relationships
+
+```text
+ActorDefinition
+└── PersonaFile (string, optional) ──► PersonaDefinition
+                                       ├── PersonaTarget ──► (existing Blueprint, Action, Instance entities)
+                                       ├── PersonaTrigger ──► OnceTrigger | IntervalTrigger
+                                       └── PayloadTemplate ──► resolved at fire time via PayloadTokenResolver
+```
+
+No persona type owns any existing entity; persona only *references* blueprints, actions, and instances that are created and lifecycle-managed elsewhere.
+
+## State transitions
+
+`IPersonaLoop` states:
+
+```text
+NotStarted ──RunAsync()──► Starting ──(delay)──► Firing ──► Submitted ──┐
+                                                     │                   │
+                                                     └─ Failed ──────────┤
+                                                                          │
+                              ┌───────────────────────────────────────────┤
+                              │                                           │
+                              ▼                                           ▼
+                           Stopped (trigger complete, maxIterations,
+                                     until reached, or cancelled)
+```
+
+`OnceTriggerLoop` has exactly one `Firing` transition. `IntervalTriggerLoop` loops between `Firing` and `Submitted`/`Failed` until a stop condition fires.
+
+## Schema-to-code mapping
+
+The persona JSON file's shape is defined formally in [contracts/persona-schema.json](./contracts/persona-schema.json) and mirrored by these record types. The schema is the source of truth for load-time validation; records are the runtime representation.

--- a/specs/110-agent-persona-mode/plan.md
+++ b/specs/110-agent-persona-mode/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Agent Persona Mode
+
+**Branch**: `110-agent-persona-mode` | **Date**: 2026-04-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/110-agent-persona-mode/spec.md`
+
+## Summary
+
+Add an additive "persona loop" to `Sorcha.Agent` that runs alongside the existing reactive inbox loop and submits workflow-starting actions on a trigger. A persona is a JSON file referenced by the actor configuration via a new optional `personaFile` field. Triggers in v1 are `once` (one-shot) and `interval` (recurring, bounded by `maxIterations` and/or `until`). Payloads are JSON templates with a small fixed vocabulary of substitution tokens (`${now}`, `${uuid}`, `${counter}`, `${random.int|decimal|choice}`). The persona reuses the agent's existing authentication, `HttpClient`, and `ActionExecutor`; there is no new auth surface and no separate binary.
+
+This unblocks the TradeFinance and ConstructionPermit walkthroughs (which currently hang because starting actions have nothing in any inbox) and enables scenario-register data generation without new runtime infrastructure.
+
+## Technical Context
+
+**Language/Version**: C# 14, .NET 10
+**Primary Dependencies**: `System.CommandLine` (already in Sorcha.Agent), `System.Text.Json` / `JsonNode` (already in Sorcha.Agent), existing `Sorcha.Agent.Auth.AgentAuthService`, existing `Sorcha.Agent.Execution.ActionExecutor`, existing Blueprint Service REST API
+**Storage**: In-memory only for v1 (persona iteration counter resets on process restart — deliberate trade-off documented in spec Assumptions)
+**Testing**: xUnit + FluentAssertions + Moq (matches existing `tests/Sorcha.Agent.Tests` project)
+**Target Platform**: Any OS where `dotnet` runs (agent already runs cross-platform)
+**Project Type**: Single project addition inside the existing `src/Apps/Sorcha.Agent` console app
+**Performance Goals**: Persona tick overhead negligible compared to HTTP submission cost; reactive inbox latency MUST NOT regress by more than 25% when a persona is present (per spec SC-004)
+**Constraints**: Strictly additive — no opt-in, no regression (FR-016); no new service clients, no new auth paths (FR-013)
+**Scale/Scope**: One persona per agent; walkthrough scenarios in the low tens of agents; recurring personas capped at `maxIterations` — no need for back-pressure architecture beyond respecting the target service's existing rate limits
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Compliance | Notes |
+|-----------|------------|-------|
+| I. Microservices-First | ✅ | Additive change inside one existing service app. No new services, no new cross-service dependencies. |
+| II. Security First | ✅ | No new secrets, no new external boundary. Persona submissions reuse the agent's existing JWT-bearing `HttpClient` and `AgentAuthService` (FR-013). Persona files are author-controlled scenario config, not user input. Input validation handled by the payload-token schema parser (FR-010). |
+| III. API Documentation | ✅ (N/A) | No new HTTP endpoints. Persona file schema is JSON + documented in quickstart. No OpenAPI surface changes. |
+| IV. Testing Requirements | ✅ | All new classes covered by xUnit unit tests; integration test for one-shot kickoff against a mocked Blueprint Service; target ≥85% coverage for new code. Tests deterministic (fixed seed for `random.*` tokens in unit tests). |
+| V. Code Quality | ✅ | `async`/`await` throughout; DI via constructor injection matching existing agent patterns; nullable reference types enabled; no warnings. |
+| VI. Blueprint Standards | ✅ (N/A) | No new blueprints. Personas reference existing blueprints by ID. |
+| VII. Domain-Driven Design | ✅ | New terms added: **Persona**, **Trigger**, **PayloadTemplate**. These extend — not replace — the existing Blueprint/Action/Participant vocabulary. |
+| VIII. Observability | ✅ | Persona loop emits structured logs via existing `ILogger<T>` pattern. Each fire logged with iteration number, target blueprint/action, outcome. Audit entries routed through existing `AuditLogger`. |
+
+**Result**: PASS. No violations, no Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/110-agent-persona-mode/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── persona-schema.json   # JSON Schema for persona files
+└── checklists/
+    └── requirements.md  # Spec quality checklist (existing)
+```
+
+### Source Code (repository root)
+
+```text
+src/Apps/Sorcha.Agent/
+├── Configuration/
+│   ├── ActorDefinition.cs            # EXISTING — add optional PersonaFile property
+│   ├── ActorDefinitionLoader.cs      # EXISTING — resolve persona file path alongside actor file
+│   └── VariableResolver.cs           # EXISTING — reused for ${...} state placeholders; persona tokens are separate
+├── Persona/                           # NEW folder
+│   ├── PersonaDefinition.cs          # NEW — root persona record + Trigger / StopConditions / PayloadTemplate sub-records
+│   ├── PersonaDefinitionLoader.cs    # NEW — load + validate persona JSON file
+│   ├── PersonaSchemaValidator.cs     # NEW — fail-fast token validation (FR-010)
+│   ├── IPayloadTokenResolver.cs      # NEW — interface for token evaluation
+│   ├── PayloadTokenResolver.cs       # NEW — evaluates ${now}, ${uuid}, ${counter}, ${random.*}
+│   ├── IPersonaSubmitter.cs          # NEW — submits a starting action for a persona fire
+│   ├── PersonaSubmitter.cs           # NEW — thin wrapper over existing Blueprint Service submission path
+│   ├── IPersonaLoop.cs               # NEW — runs the persona's trigger loop
+│   ├── OnceTriggerLoop.cs            # NEW — fires once then terminates
+│   ├── IntervalTriggerLoop.cs        # NEW — fires on interval subject to stop conditions
+│   └── PersonaHost.cs                # NEW — composes loader + loop + submitter; launched from RunCommand
+├── Commands/
+│   └── RunCommand.cs                 # EXISTING — wire in PersonaHost alongside inbox loop (additive)
+└── Program.cs                        # EXISTING — no change
+
+tests/Sorcha.Agent.Tests/
+└── Persona/                           # NEW test folder
+    ├── PersonaDefinitionLoaderTests.cs
+    ├── PayloadTokenResolverTests.cs
+    ├── OnceTriggerLoopTests.cs
+    ├── IntervalTriggerLoopTests.cs
+    ├── PersonaSchemaValidatorTests.cs
+    └── PersonaHostIntegrationTests.cs  # exercises RunCommand wiring with a mocked Blueprint Service
+
+walkthroughs/TradeFinance/
+├── actors/
+│   └── procurement-mgr.json           # EXISTING — add "personaFile" field pointing to persona file
+├── personas/                          # NEW folder
+│   └── procurement-mgr-kickoff.persona.json  # NEW — one-shot Raise PO persona
+└── run-agents.ps1                     # EXISTING — no change needed (persona loads automatically from actor config)
+
+walkthroughs/ConstructionPermit/
+├── actors/…                            # EXISTING — add personaFile to the first-action agent
+├── personas/                          # NEW folder
+│   └── <first-action-actor>-kickoff.persona.json   # NEW
+└── run-agents.ps1                     # EXISTING — no change
+```
+
+**Structure Decision**: Single-project addition to `src/Apps/Sorcha.Agent`. A new `Persona/` folder isolates all persona logic; actor-config changes are additive (one optional field). Walkthrough changes are data-only: one new persona file per walkthrough plus a one-line reference in the existing actor config. No changes to `run-agents.ps1`, no new Docker images, no new services.
+
+## Complexity Tracking
+
+*None required — Constitution Check passes without justified violations.*

--- a/specs/110-agent-persona-mode/quickstart.md
+++ b/specs/110-agent-persona-mode/quickstart.md
@@ -1,0 +1,118 @@
+# Quickstart: Agent Persona Mode
+
+A practical, copy-pasteable walkthrough for adding a persona to a Sorcha agent. Read the spec for intent; this is the how.
+
+## 1. Add a persona file
+
+Create a JSON file next to the actor config, typically in `walkthroughs/<Name>/personas/`:
+
+```jsonc
+// walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json
+{
+  "name": "procurement-mgr-kickoff",
+  "target": {
+    "blueprintId": "{{blueprints.procurement-to-pay.id}}",
+    "instanceId":  "{{instances.procurement-to-pay.id}}",
+    "actionName":  "Raise Purchase Order"
+  },
+  "trigger": { "kind": "once", "delaySeconds": 2 },
+  "payloadTemplate": {
+    "poReference":          "PO-CAIRN-2026-00142",
+    "projectName":          "Aviemore Heights Phase 2",
+    "siteAddress":          "Plot 7-12, Craig na Gower Avenue, Aviemore, PH22 1RW",
+    "paymentTerms":         "Net 30",
+    "requiredDeliveryDate": "2026-04-15"
+  }
+}
+```
+
+`{{blueprints.*}}` and `{{instances.*}}` placeholders are resolved from `state.json` by the same `VariableResolver` that already handles actor-config placeholders, so the values you declare in `run-agents.ps1` / `setup.ps1` flow through unchanged.
+
+## 2. Point the actor at it
+
+Add one field to the existing actor config:
+
+```jsonc
+// walkthroughs/TradeFinance/actors/procurement-mgr.json
+{
+  "actor": { "name": "procurement-mgr", ... },
+  "connection": { ... },
+  "inbox": { "signalR": { "enabled": true }, "polling": { ... } },
+  "personaFile": "../personas/procurement-mgr-kickoff.persona.json",   // <── new
+  "mode": "rules",
+  "rules": [ ... ]
+}
+```
+
+Path is relative to the actor file. Absolute paths also work.
+
+## 3. Run the walkthrough
+
+No changes to `run-agents.ps1`. Launch as today:
+
+```powershell
+pwsh walkthroughs/TradeFinance/setup.ps1
+pwsh walkthroughs/TradeFinance/run-agents.ps1
+```
+
+Expected log lines from `procurement-mgr`:
+
+```text
+[12:03:11] Actor "procurement-mgr" starting...
+[12:03:12] Authenticated
+[12:03:12] SignalR enabled
+[12:03:12] Polling enabled (20s interval)
+[12:03:12] Actor "procurement-mgr" started
+[12:03:12] Persona "procurement-mgr-kickoff" loaded (trigger: once, delay: 2s)
+[12:03:14] Persona fire #1 → blueprint=<id>, action="Raise Purchase Order"
+[12:03:14] Persona fire #1 → Submitted (412 ms)
+[12:03:14] Persona "procurement-mgr-kickoff" completed
+```
+
+Other agents (site-mgr, sales-mgr, etc.) react to the now-live workflow through their normal inbox flow — no persona needed on them.
+
+## 4. Recurring scenario-data persona
+
+For populating a register with varied data, swap the trigger and templates:
+
+```jsonc
+{
+  "name": "invoice-generator",
+  "target": {
+    "blueprintId": "{{blueprints.invoice.id}}",
+    "instanceId":  "{{instances.invoice.id}}",
+    "actionName":  "Raise Invoice"
+  },
+  "trigger": {
+    "kind": "interval",
+    "everySeconds": 30,
+    "maxIterations": 20
+  },
+  "payloadTemplate": {
+    "invoiceNumber": "INV-${counter}",
+    "invoiceId":     "${uuid}",
+    "issuedAt":      "${now}",
+    "amount":        "${random.decimal(100, 9999, 2)}",
+    "currency":      "${random.choice([\"EUR\",\"GBP\",\"USD\"])}"
+  }
+}
+```
+
+This fires 20 times, 30 s apart (~10 minutes total), producing 20 register instances with varying amounts and currencies. `"${counter}"` and `"${random.decimal(...)}"` resolve to a JSON number in the submitted payload (not a string) because they are the entire string value.
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Agent logs `Persona load failed: unknown token '${randm.int(...)}'` | Typo — correct to `${random.int(...)}`. |
+| Persona fires but the submission logs `validation rejected`. | Payload doesn't match the blueprint's action schema. Fix the template — the persona doesn't inspect blueprint schemas at load time. |
+| Persona never fires. | Check the actor file resolves `personaFile` to an existing path (logged at agent start). |
+| Recurring persona stops after 1 fire. | `maxIterations: 1` or `until` already in the past — check the persona file. |
+| Reactive inbox behaviour regresses when a persona is present. | File a bug against this feature — FR-011 says this must not happen. |
+
+## 6. What this does NOT do (v1)
+
+- No `cron` triggers, no event triggers, no register-state thresholds.
+- No templating loops or conditionals. If you need those, generate the persona file from a script.
+- No persistence across restarts. Killing and relaunching the agent resets `${counter}` to 1 and re-fires a `once` persona.
+- No de-duplication. If two agents in the same manifest both point at one-shot personas targeting the same starting action, both fire and you get two instances. This is intentional — de-duping is the scenario author's responsibility.

--- a/specs/110-agent-persona-mode/research.md
+++ b/specs/110-agent-persona-mode/research.md
@@ -1,0 +1,85 @@
+# Phase 0 Research: Agent Persona Mode
+
+All items in Technical Context are resolved. No `NEEDS CLARIFICATION` markers remained in the spec. This document records the deliberate design decisions discovered while grounding the plan in the existing `Sorcha.Agent` codebase.
+
+## R-001: Persona file location and actor-config linkage
+
+**Decision**: Persona is a separate JSON file (`<name>.persona.json`), referenced from the existing actor-config file via a new optional `personaFile` property (relative path, resolved against the actor file's directory).
+
+**Rationale**: Keeps personas swappable without editing actor config; preserves existing one-actor-one-file convention in walkthroughs; matches the brainstorm outcome that personas are composable artifacts. The actor config remains the per-agent file launched by `run-agents.ps1`, so there is no change to manifest discovery or launch sequencing.
+
+**Alternatives considered**:
+- Persona inline in actor config (`"persona": { ... }`). Rejected: mixes reactive + initiating concerns in one record and prevents sharing a persona across agents or walkthroughs.
+- Persona discovered by filesystem convention (`<actor-name>.persona.json` next to actor file). Rejected: implicit discovery hides intent and breaks when walkthrough authors want to swap personas per run.
+
+## R-002: Instance creation responsibility
+
+**Decision**: Blueprint-instance creation stays in `run-agents.ps1` (or equivalent setup script). The persona submits an action against an already-created instance whose ID is resolved from `state.json` via the existing `VariableResolver`.
+
+**Rationale**: Mirrors the current pattern in `walkthroughs/TradeFinance/run-agents.ps1` (lines 76–107) where the script creates instances before launching agents. Personas become purely about "submit action N on instance X with payload P", which is the same contract the existing `ActionExecutor` already honours for reactive actions. No new blueprint-service code path required.
+
+**Alternatives considered**:
+- Persona creates the instance at fire time. Rejected: introduces a second creation code path, duplicates logic already in walkthrough scripts, and complicates multi-agent scenarios where several agents submit against the same pre-created instance.
+
+## R-003: Reactive + persona coexistence (loop model)
+
+**Decision**: Persona runs as an independent `Task` launched from `RunCommand.ExecuteAsync` after authentication succeeds. The existing `await foreach` over `CompositeInboxListener.ListenAsync` continues on the main flow. A shared `CancellationToken` stops both on process shutdown. Neither loop awaits the other.
+
+**Rationale**: The existing main loop in `RunCommand.cs` is single-threaded per agent but fully async; launching the persona loop as a peer `Task` avoids restructuring the main loop, reuses the same HttpClient (HttpClient is thread-safe for concurrent requests), and lets the reactive loop continue even when the persona loop blocks on its interval timer. Satisfies FR-011 (neither blocks the other) and SC-004 (≤25% reactive latency regression).
+
+**Alternatives considered**:
+- Interleave persona fires with inbox polls on a single loop. Rejected: couples persona cadence to inbox cadence and starves either side when the other is busy.
+- Run persona in a separate hosted service / background worker. Rejected: over-engineers a small feature; the agent has no existing hosted-service container and adding one for this would violate YAGNI.
+
+## R-004: Payload token vocabulary and resolution
+
+**Decision**: Six tokens, resolved fresh on each fire: `${now}`, `${uuid}`, `${counter}`, `${random.int(min, max)}`, `${random.decimal(min, max, precision)}`, `${random.choice([…])}`. Tokens evaluated by a dedicated `PayloadTokenResolver` that walks the template `JsonNode` tree. Unknown functions or malformed arguments fail at persona load time (not at fire time), so bad templates cannot reach the Blueprint Service.
+
+**Rationale**: This exact vocabulary was agreed in the brainstorm and covers every use case named ("invoice value in range", "fresh UUID per fire", "counter for instance references"). Evaluating at load time means scenario authors see errors before the agent starts submitting, which is dramatically easier to debug than silent `${typo}` strings landing in register data (FR-010).
+
+**Alternatives considered**:
+- Full templating engine (Handlebars / Liquid / Scriban). Rejected: full sub-language to learn, debug, and secure; overkill for six operations.
+- Deferred validation (fail at first fire). Rejected: hides template errors until a scheduled moment, often mid-demo.
+- `Random` implementation: use `System.Random.Shared` for non-test code; unit tests inject a seeded `Random` via a narrow `IRandomSource` seam to keep `${random.*}` tests deterministic.
+
+## R-005: Stop-condition semantics
+
+**Decision**: For interval triggers, persona stops when the first of these becomes true: `maxIterations` reached, `until` wall-clock timestamp passed, agent `CancellationToken` signalled. Missing both `maxIterations` and `until` is **not** an error — the persona runs until the agent process stops. Authors who want a bounded run declare at least one.
+
+**Rationale**: Matches the brainstorm outcome (either or both). Allowing neither keeps the "run forever until killed" scenario expressible without adding a third stop mode. Scenario tests always use `maxIterations` for determinism (SC-003).
+
+**Alternatives considered**:
+- Require at least one stop condition. Rejected: adds an arbitrary validation rule for a scenario (open-ended soak runs) that is legitimate for load testing.
+- Introduce a third `maxDuration` stop condition. Rejected: redundant with `until`; authors can compute `until = now + duration` in the file if they want relative semantics.
+
+## R-006: Failure handling and back-pressure
+
+**Decision**: On persona submission failure (HTTP error, validation reject, rate-limit, transient network): log at `Warning` with full context; do **not** increment the iteration counter; sleep the declared interval (not a retry backoff) before the next attempt; never crash the reactive loop. On non-transient errors repeated three times in a row, log at `Error` and exit the persona loop (reactive loop continues).
+
+**Rationale**: Honours FR-015 (don't lose iteration counter on transient error) and FR-011 (don't abort reactive loop on persona failure). Three consecutive hard failures is a reasonable give-up threshold that prevents a misconfigured persona from hammering a broken endpoint forever while still tolerating a short outage.
+
+**Alternatives considered**:
+- Exponential backoff. Rejected: persona already has a declared interval that acts as natural pacing; adding backoff layered on top complicates reasoning about "when did my 20th invoice arrive".
+- Stop persona on first failure. Rejected: too brittle for a scenario tool that has to survive a Blueprint Service restart.
+
+## R-007: Observability
+
+**Decision**: Each persona fire emits a structured log entry (`ILogger<PersonaHost>`) with fields: `PersonaName`, `Trigger`, `Iteration`, `BlueprintId`, `ActionName`, `Outcome` (`Submitted`/`Failed`/`Stopped`), `DurationMs`. Load-time validation failures emit `Error`-level logs with the offending token or path. Uses the agent's existing audit-log file when declared (`definition.Logging.ActionLog`).
+
+**Rationale**: Matches Constitution Principle VIII (observability by default, structured logging, no string interpolation). Reuses the existing `AuditLogger` pattern so persona fires appear in the same `*.jsonl` stream as reactive decisions, enabling a single grep for "what did this agent do".
+
+## R-008: Testing strategy
+
+**Decision**:
+- **Unit tests (xUnit + FluentAssertions + Moq)** for every new class.
+  - `PayloadTokenResolver` tested with seeded `IRandomSource` for determinism.
+  - `OnceTriggerLoop` asserts single fire then completion.
+  - `IntervalTriggerLoop` tested with a fake clock (`TimeProvider`) — fire at `t=0`, `t=interval`, etc. — and asserts that both `maxIterations` and `until` stop the loop at the right moment.
+  - `PersonaSchemaValidator` rejects `${randm.int(...)}`, `${random.int()}`, `${random.choice([])}`, etc.
+- **Integration test** in `PersonaHostIntegrationTests` spins up `RunCommand.ExecuteAsync` against a mocked `HttpMessageHandler` that stands in for Blueprint Service. Asserts one-shot persona produces exactly one POST to `/api/instances/.../execute` with the resolved payload.
+- **Regression test**: an existing actor config with no `personaFile` field loads and runs identically (FR-012 / SC-005) — covered by an existing-config-shape regression unit test.
+
+**Rationale**: Achieves ≥85% coverage without requiring a live Blueprint Service and keeps the test suite deterministic per Constitution Principle IV.
+
+**Alternatives considered**:
+- End-to-end test against docker-compose stack. Rejected for v1: slow, flaky in CI, and the integration test covers the wiring. An e2e check happens organically when the TradeFinance walkthrough runs.

--- a/specs/110-agent-persona-mode/spec.md
+++ b/specs/110-agent-persona-mode/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Agent Persona Mode
+
+**Feature Branch**: `110-agent-persona-mode`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: Brainstormed design agreeing on a unified persona mechanism that covers both one-shot starting-action kickoff and recurring scenario data generation, with personas declared as per-agent JSON files composed by the walkthrough scenario manifest.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Unblock Walkthrough Kickoff (Priority: P1)
+
+A walkthrough author runs the TradeFinance (or ConstructionPermit) scenario with its existing agent runner. Today the runner launches every agent, but all agents idle because the first action has no prior transaction to put anything in anyone's inbox. With persona mode, the author declares a one-shot persona for the agent that owns the starting action; when the runner launches agents, that persona fires once, submits the starting action, and exits. Downstream agents pick the flow up through their normal reactive inbox behaviour.
+
+**Why this priority**: This is the blocking defect for current demo and walkthrough infrastructure. Without it, the flagship multi-agent walkthroughs cannot run end-to-end from a single command. It is also the smallest, lowest-risk use of the mechanism, so it validates the design before the recurring case is exercised.
+
+**Independent Test**: Fully testable by running the TradeFinance agent runner end-to-end. Success is observable in register state: instance for action 1 exists, submitted by the persona-equipped agent, within seconds of the runner starting, with no human intervention and no separate sequential kickoff script invoked.
+
+**Acceptance Scenarios**:
+
+1. **Given** a walkthrough scenario manifest where the procurement-mgr agent has a one-shot persona file declared, **When** the agent runner is launched, **Then** exactly one instance of the starting action is created in the register within the persona's configured startup window and the persona loop exits cleanly.
+2. **Given** a ConstructionPermit manifest that declares an equivalent one-shot persona for its first-action agent, **When** the runner is launched, **Then** the first action is submitted and the remaining reactive agents progress the workflow without any code change to the agent binary.
+3. **Given** a manifest where the agent that owns the starting action has no persona declared, **When** the runner is launched, **Then** behaviour is identical to today: that agent idles waiting on its inbox and the walkthrough does not progress until an external submission occurs.
+
+---
+
+### User Story 2 - Generate Scenario Register Data (Priority: P2)
+
+A scenario author wants a register populated with realistic volume and variation for a demo or load test. They declare a persona with an interval trigger, a maximum iteration count, and payload templating that varies a monetary amount inside a defined range. Launching the agent produces a stream of workflow instances with differing values, spaced by the interval, until the cap is hit or the stop time is reached, at which point the persona loop stops cleanly while the agent continues responding to any reactive work.
+
+**Why this priority**: This is the richer capability the persona mechanism is being built for, but it depends on the P1 machinery being in place. It directly serves demos, screenshots, and any future load or scale testing that wants plausible data rather than hand-seeded fixtures.
+
+**Independent Test**: Testable by running a single agent with a recurring persona against an empty register and asserting the register contains the expected number of instances, each with a payload value inside the declared range, produced across an elapsed time consistent with the configured interval.
+
+**Acceptance Scenarios**:
+
+1. **Given** a persona configured with interval trigger and a maximum iteration count of 20, **When** the agent is launched and left running, **Then** exactly 20 workflow instances are created, each spaced by approximately the configured interval, with payload values drawn from the declared range, and the persona loop reports completion.
+2. **Given** a persona configured with interval trigger and an absolute stop timestamp earlier than the iteration cap would be reached, **When** the agent runs until that timestamp, **Then** the persona stops submitting new instances at (or before) the timestamp regardless of remaining iteration budget.
+3. **Given** a persona configured with both an iteration cap and a stop timestamp, **When** the agent runs, **Then** the persona stops at whichever limit is hit first.
+4. **Given** a running recurring persona, **When** the agent process is terminated, **Then** the persona stops immediately and no further instances are created.
+
+---
+
+### User Story 3 - Coexistence with Reactive Behaviour (Priority: P2)
+
+An agent may have a persona declared and still be expected to respond to inbound actions routed to its wallet (for instance, the agent that initiates a workflow is often also a responder to later actions in that same workflow). The agent must service both responsibilities concurrently without one blocking the other and without duplicate or lost actions.
+
+**Why this priority**: The design commits to personas being additive rather than a separate mode. If the reactive path regresses when a persona is present, the mechanism cannot be adopted by any agent that also participates in downstream actions, which describes the realistic multi-agent walkthroughs.
+
+**Independent Test**: Testable by running an agent with both a persona declared and a reactive action waiting in its inbox. Both the persona-initiated submission and the reactive response must complete within expected time bounds, each exactly once.
+
+**Acceptance Scenarios**:
+
+1. **Given** an agent with a one-shot persona and an unrelated pending action already addressed to its wallet, **When** the agent is launched, **Then** both the persona submission and the reactive response are executed exactly once and the relative timing does not starve either path.
+2. **Given** an agent with a recurring persona, **When** an inbound action arrives mid-run, **Then** the reactive response is processed without waiting for the next persona tick, and the persona interval is not skewed by the reactive work.
+
+---
+
+### User Story 4 - Human-Editable Scenario Tuning (Priority: P3)
+
+A non-developer (walkthrough author, demo operator) wants to adjust scenario parameters — interval length, iteration count, value range, counterparty list — without editing agent source code or rebuilding. They open the persona file, change the relevant field, and re-run the scenario.
+
+**Why this priority**: Supports the broader goal of making walkthroughs and scenario registers a self-service surface for people who do not maintain the agent codebase. It is the softest of the user-facing criteria; the feature can ship without full polish here, but persona files must at least be human-readable.
+
+**Independent Test**: Ask a non-developer reviewer to change the interval and value range in a supplied persona file, re-run the scenario, and inspect register state. Success is them completing the task without needing to consult agent source.
+
+**Acceptance Scenarios**:
+
+1. **Given** a persona file with an interval of 60 seconds and value range £100–£1,000, **When** an author edits only those fields and re-runs, **Then** the next run uses the new interval and range with no other behaviour changes.
+
+---
+
+### Edge Cases
+
+- **Payload template refers to a token that does not exist** (e.g. typo `${randm.int(...)}`). The persona must fail fast at load time with a clear error rather than silently emitting literal `${...}` into register data.
+- **`until` timestamp is already in the past at agent startup.** The persona must not fire at all; it must log and exit cleanly.
+- **`once` trigger with a non-reachable starting action** (blueprint ID unknown, action name mismatches blueprint, agent wallet not authorised to submit). The persona must surface the failure visibly and not retry indefinitely; reactive behaviour must remain unaffected.
+- **Persona fires faster than the target service can accept submissions** (rate limit, transient outage). The persona must respect the service's back-pressure signal and must not erase the iteration counter on transient failures.
+- **Two personas on two different agents declare the same starting action.** Both fire; two instances are created. This is intentional — de-duplication is the scenario author's responsibility, not the runtime's.
+- **Manifest references a persona file that does not exist or cannot be parsed.** The agent must refuse to start (or start in reactive-only mode with a clear warning, per the configured policy) rather than silently ignoring the persona.
+- **Agent clock skew relative to `until` timestamp.** The persona treats `until` as wall-clock on the agent host; skew is the operator's problem to understand. This is acceptable because persona mode is for demo/scenario use, not consensus-critical work.
+- **Recurring persona interrupted mid-fire by process shutdown.** No guarantee of at-least-once or exactly-once across restarts; on restart the iteration counter resets (v1 is stateless across process lifetimes).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: A persona MUST be declared in its own file, separate from blueprint and agent source, in a human-readable JSON format.
+- **FR-002**: A walkthrough scenario manifest MUST be able to associate an agent with at most one persona file; manifests with no persona reference for an agent MUST produce today's reactive-only behaviour.
+- **FR-003**: The persona file MUST declare a trigger of exactly one of two kinds in v1: `once` or `interval`.
+- **FR-004**: A `once` trigger MUST fire exactly one submission after the agent starts and the persona loop MUST then terminate.
+- **FR-005**: An `interval` trigger MUST accept a duration (seconds or minutes granularity) and MUST fire repeated submissions at approximately that cadence subject to declared stop conditions.
+- **FR-006**: An `interval` trigger MUST support an optional `maxIterations` cap and an optional `until` absolute timestamp; when both are declared the persona MUST stop at whichever limit is reached first.
+- **FR-007**: Killing the agent process MUST immediately stop any persona loop; the persona MUST NOT be resumable across process lifetimes in v1 (iteration state is not persisted).
+- **FR-008**: The persona MUST declare the target of its submission: which blueprint and which action within that blueprint serve as the entry point.
+- **FR-009**: The persona MUST declare a JSON payload template that is submitted at each fire; the template MUST support the following substitution tokens, resolved freshly at each fire: current timestamp in ISO 8601 form, fresh UUID, monotonically increasing iteration counter starting at 1, uniformly random integer in inclusive range, uniformly random decimal with declared precision, and uniform random choice from a literal list.
+- **FR-010**: Payload tokens that reference an unknown function or have malformed arguments MUST cause the persona to fail at load time with an error identifying the offending token; the persona MUST NOT emit unresolved `${...}` text into register data.
+- **FR-011**: An agent with a persona declared MUST continue to service its reactive inbox loop concurrently with its persona loop; neither loop may block the other indefinitely.
+- **FR-012**: An agent without a persona declared MUST behave identically to its current (pre-feature) behaviour.
+- **FR-013**: A persona submission MUST use the same wallet identity, authentication, and service clients as the agent's reactive submissions; there MUST NOT be a separate persona-only identity or auth path.
+- **FR-014**: When a persona is configured but cannot be loaded (file missing, malformed, references a missing blueprint or action, references tokens the runtime cannot resolve), the agent MUST surface the failure loudly before the persona's first scheduled fire and MUST NOT silently degrade to reactive-only without an operator-visible signal.
+- **FR-015**: When a persona submission fails at runtime (service error, rate limit, validation rejection), the persona MUST NOT advance its iteration counter for that failure, MUST respect back-pressure rather than tight-looping, and MUST NOT abort the reactive inbox loop.
+- **FR-016**: The feature MUST be strictly additive: no existing agent, blueprint, walkthrough script, or manifest schema that does not opt in MUST change in behaviour or required configuration.
+
+### Key Entities
+
+- **Persona**: A declarative description of autonomous initiating behaviour for a single agent. Carries a trigger (kind + timing), optional stop conditions, a target blueprint and entry action, and a payload template. Lives in its own file, keyed by the manifest.
+- **Scenario Manifest**: The walkthrough-level definition already responsible for saying which agents run against which blueprint with which wallets. Grows an optional per-agent persona reference. Remains the single place where a scenario is composed.
+- **Trigger**: The when-to-fire half of a persona. `once` fires a single submission at agent start. `interval` fires repeatedly at a declared cadence, bounded by optional `maxIterations` and/or `until`.
+- **Payload Template**: A JSON shape with optional substitution tokens that are evaluated fresh at each fire, producing the concrete payload submitted for the entry action.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Running the TradeFinance walkthrough agent runner with a one-shot persona for its starting-action agent produces a submitted starting action within 30 seconds of runner start, with no manual kickoff step, measured over five consecutive clean runs with zero exceptions.
+- **SC-002**: The ConstructionPermit walkthrough can be unblocked end-to-end by adding a single persona file and one manifest reference, with no changes to the agent binary or any blueprint, demonstrating the mechanism generalises.
+- **SC-003**: A recurring persona declared with an iteration cap of 20, an interval of 30 seconds, and a random decimal payload value in a declared range produces exactly 20 register instances whose payload values all fall within the declared range, across an elapsed time between 9 and 12 minutes, measured over three consecutive runs.
+- **SC-004**: An agent with a persona, placed in a scenario that also routes at least one reactive action to that agent, processes both the persona submission and the reactive response exactly once, with the reactive response latency no worse than a no-persona baseline by more than 25%.
+- **SC-005**: Every existing walkthrough and agent that does not opt into persona mode passes its current test and smoke-run suite unchanged after the feature ships, with zero regressions attributable to persona infrastructure.
+- **SC-006**: A reviewer previously unfamiliar with the agent codebase can edit a supplied persona file to change interval, iteration count, and value range, and re-run the scenario to observe the new behaviour, in under 10 minutes without reading agent source code.
+
+## Assumptions
+
+- Walkthrough scenarios are not held to consensus-grade timing guarantees; wall-clock-driven triggers and host-local state are acceptable for v1.
+- Exactly-once or at-least-once semantics across process restarts are out of scope for v1; iteration state is in-memory only.
+- The agent's existing service clients, wallet auth, and submission path are sufficient for persona submissions with no auth or rate-limit redesign required.
+- Humans writing persona files are comfortable with JSON and a very small token vocabulary; no GUI editor is required in v1.
+- A single persona per agent is sufficient to unblock both walkthrough kickoff and scenario data generation as currently envisioned; multi-persona composition can be added later without reshaping the file or manifest.
+- Scenario authors accept responsibility for avoiding duplicate kickoffs across agents targeting the same starting action; the runtime does not de-duplicate.

--- a/specs/110-agent-persona-mode/tasks.md
+++ b/specs/110-agent-persona-mode/tasks.md
@@ -1,0 +1,284 @@
+---
+description: "Executable task list for feature 110-agent-persona-mode"
+---
+
+# Tasks: Agent Persona Mode
+
+**Input**: Design documents in `specs/110-agent-persona-mode/`
+**Prerequisites**: plan.md, spec.md (P1–P3 user stories), research.md, data-model.md, contracts/persona-schema.json, quickstart.md
+
+**Tests**: Included. Constitution Principle IV mandates ≥85% coverage for new code with deterministic xUnit tests, so every functional task has paired unit and/or integration tests.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing. User Story 1 (P1) is the MVP and delivers the value that unblocks the TradeFinance walkthrough.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Paths are absolute-style relative to repo root (`C:\projects\Sorcha`)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create folders and confirm the new feature compiles against the existing agent project.
+
+- [x] T001 Create folder `src/Apps/Sorcha.Agent/Persona/` with a `.gitkeep` placeholder so subsequent [P] tasks can land in parallel
+- [x] T002 Create folder `tests/Sorcha.Agent.Tests/Persona/` with a `.gitkeep` placeholder
+- [x] T003 [P] Copy `specs/110-agent-persona-mode/contracts/persona-schema.json` to `src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json` and set its `.csproj` build action to `EmbeddedResource` so it ships with the binary
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Wiring, core types, and the validation/submission machinery that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### Actor config extension
+
+- [x] T004 Add `public string? PersonaFile { get; init; }` to `ActorDefinition` in `src/Apps/Sorcha.Agent/Configuration/ActorDefinition.cs` (optional, null when absent; JSON property name `personaFile`)
+- [x] T005 Update `src/Apps/Sorcha.Agent/Configuration/ActorDefinitionLoader.cs` to resolve `PersonaFile` as a path relative to the actor-config file's directory, leaving the value null if the field is absent — do NOT load the persona here, just normalise the path
+- [x] T006 [P] Regression test in `tests/Sorcha.Agent.Tests/Configuration/ActorDefinitionLoaderTests.cs` asserting that an existing actor config with no `personaFile` field loads with `PersonaFile == null` and every other property unchanged (FR-012 / SC-005)
+
+### Core persona types (data-model.md)
+
+- [x] T007 [P] Create `src/Apps/Sorcha.Agent/Persona/PersonaDefinition.cs` with records `PersonaDefinition`, `PersonaTarget`, `PersonaTrigger` (abstract/discriminated), `OnceTrigger`, `IntervalTrigger`, and `PersonaFireContext` matching data-model.md §Top-level types
+- [x] T008 [P] Create `src/Apps/Sorcha.Agent/Persona/IRandomSource.cs` and `src/Apps/Sorcha.Agent/Persona/RandomSource.cs` wrapping `System.Random` with methods `int NextInt(int min, int max)`, `decimal NextDecimal(decimal min, decimal max, int precision)`, `T Choose<T>(IReadOnlyList<T> options)`
+
+### Payload token resolver
+
+- [x] T009 [P] Create `src/Apps/Sorcha.Agent/Persona/IPayloadTokenResolver.cs` with `JsonObject Resolve(JsonNode template, PersonaFireContext ctx)` and `IReadOnlyList<string> ValidateTokens(JsonNode template)`
+- [x] T010 Create `src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs` implementing the six tokens (`${now}`, `${uuid}`, `${counter}`, `${random.int}`, `${random.decimal}`, `${random.choice}`) per data-model.md §Token grammar — string-that-is-exactly-token preserves typed JSON result; embedded token performs string interpolation (depends on T007, T008, T009)
+- [x] T011 [P] Unit tests in `tests/Sorcha.Agent.Tests/Persona/PayloadTokenResolverTests.cs` covering: each token type, typed-vs-interpolated resolution, seeded `IRandomSource` determinism, `ValidateTokens` returns errors for `${randm.int(...)}`, malformed `${random.int()}`, empty `${random.choice([])}`
+
+### Schema validator
+
+- [x] T012 [P] Create `src/Apps/Sorcha.Agent/Persona/PersonaSchemaValidator.cs` that validates a parsed JSON file against the embedded `persona-schema.json` using `JsonSchema.Net` (already a Sorcha dependency) and returns a typed result with errors
+- [x] T013 [P] Unit tests in `tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs` covering: valid once/interval examples pass; missing required fields fail; `oneOf actionName/actionIndex` violation fails; `oneOf everySeconds/everyMinutes` violation fails; `until` with malformed date fails
+
+### Persona definition loader
+
+- [x] T014 Create `src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs` with `static PersonaLoadResult Load(string personaFilePath, string? statePath)` that: reads the file, runs `VariableResolver` over `{{...}}` placeholders, runs `PersonaSchemaValidator`, runs `PayloadTokenResolver.ValidateTokens`, deserialises into `PersonaDefinition`, returns `PersonaLoadResult` with success + errors (depends on T007, T010, T012)
+- [x] T015 [P] Unit tests in `tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs` covering: valid one-shot example loads; valid interval example loads; `{{blueprints.X.id}}` placeholder resolved from mock state; token typo surfaces at load time; missing file returns structured error
+
+### Persona submitter
+
+- [x] T016 Create `src/Apps/Sorcha.Agent/Persona/IPersonaSubmitter.cs` with `Task<PersonaSubmissionResult> SubmitAsync(PersonaDefinition persona, JsonObject payload, CancellationToken ct)` and enum `PersonaSubmissionOutcome { Submitted, TransientFailure, HardFailure }`
+- [x] T017 Create `src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs` that wraps the same `POST /api/instances/{instanceId}/actions/{actionIndex}/execute` path used by `ActionExecutor` (see `src/Apps/Sorcha.Agent/Execution/ActionExecutor.cs`) — take `HttpClient`, `AgentAuthService`, wallet address, register ID via constructor; classify HTTP 5xx / timeout as TransientFailure, HTTP 4xx as HardFailure (depends on T016)
+- [x] T018 [P] Unit tests in `tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs` with a mocked `HttpMessageHandler`: 200 → Submitted; 503 → TransientFailure; 400 → HardFailure; request body matches `{ blueprintId, actionId, instanceId, payload }` shape
+
+### Persona loop interface
+
+- [x] T019 [P] Create `src/Apps/Sorcha.Agent/Persona/IPersonaLoop.cs` with `Task RunAsync(CancellationToken ct)` and `Task<int> CompletedIterations { get; }` property for test observability
+
+### Persona host + RunCommand wiring
+
+- [x] T020 Create `src/Apps/Sorcha.Agent/Persona/PersonaHost.cs` that constructs the correct `IPersonaLoop` implementation based on `persona.Trigger.Kind` and exposes `Task RunAsync(CancellationToken)`; constructor injects `PersonaDefinition`, `IPersonaSubmitter`, `IPayloadTokenResolver`, `ILogger<PersonaHost>`, `TimeProvider`, `IRandomSource`, `AuditLogger` (depends on T010, T017, T019 — loop implementations land in story phases)
+- [x] T021 Update `src/Apps/Sorcha.Agent/Commands/RunCommand.cs` to: after authentication, if `definition.PersonaFile != null`, call `PersonaDefinitionLoader.Load(...)`, fail-fast with `ExitCodes.ConfigurationError` on load errors (FR-014), build a `PersonaHost`, launch `_ = personaHost.RunAsync(cts.Token)` as a peer task before entering the existing inbox `await foreach`; on shutdown, await the persona task with a short grace period (depends on T014, T020)
+
+**Checkpoint**: Foundation ready — any `PersonaTrigger` subtype can now be added by implementing `IPersonaLoop` in a user-story phase. Existing actor configs without `personaFile` still work identically (T006 regression passes).
+
+---
+
+## Phase 3: User Story 1 — Unblock Walkthrough Kickoff (Priority: P1) 🎯 MVP
+
+**Goal**: A `once` trigger fires one submission at agent start, submitting the starting action of a walkthrough blueprint, and TradeFinance `run-agents.ps1` progresses end-to-end without manual kickoff.
+
+**Independent Test**: Run `pwsh walkthroughs/TradeFinance/run-agents.ps1` after `setup.ps1`. Within 30 seconds the procurement-to-pay instance has action 1 ("Raise Purchase Order") submitted by `procurement-mgr` and downstream agents progress the workflow. Satisfies SC-001.
+
+### Tests for User Story 1 ⚠️
+
+> Write tests first; confirm they fail before implementing T024.
+
+- [x] T022 [P] [US1] Unit tests in `tests/Sorcha.Agent.Tests/Persona/OnceTriggerLoopTests.cs` covering: fires exactly once; honours `delaySeconds` using a fake `TimeProvider`; stops immediately on cancellation; surfaces submitter HardFailure as loop exit with logged error; TransientFailure does not re-fire (once == once)
+- [x] T023 [P] [US1] Integration test in `tests/Sorcha.Agent.Tests/Persona/PersonaHostOneShotIntegrationTests.cs` that wires `PersonaHost` + `OnceTriggerLoop` + mocked `HttpMessageHandler` and asserts exactly one POST lands on `/api/instances/.../execute` with the resolved payload
+
+### Implementation for User Story 1
+
+- [x] T024 [US1] Create `src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs` implementing `IPersonaLoop` — awaits `Task.Delay(DelaySeconds, TimeProvider)`, resolves payload via `IPayloadTokenResolver`, submits via `IPersonaSubmitter`, logs fire + outcome, exits (depends on T019, T010, T017)
+- [x] T025 [US1] Extend `PersonaHost.Run` dispatcher (from T020) to route `OnceTrigger` to `OnceTriggerLoop`
+- [x] T026 [P] [US1] Create `walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json` per the quickstart.md example — one-shot, targets `procurement-to-pay` blueprint, action "Raise Purchase Order", payload copied from the existing `rules[0].payload` in `walkthroughs/TradeFinance/actors/procurement-mgr.json`
+- [x] T027 [US1] Add `"personaFile": "../personas/procurement-mgr-kickoff.persona.json"` to `walkthroughs/TradeFinance/actors/procurement-mgr.json` (preserve all other fields including the existing `rules` array, which still governs reactive "Approve/Dispute Invoice" responses)
+- [x] T028 [US1] Add a section "Persona-driven kickoff" to `walkthroughs/TradeFinance/README.md` describing what the persona does and how to disable it (remove the `personaFile` line)
+- [ ] T029 [US1] End-to-end validation: run `pwsh walkthroughs/TradeFinance/setup.ps1` then `pwsh walkthroughs/TradeFinance/run-agents.ps1`; observe persona fire log line in `logs/procurement-mgr.log`; confirm procurement-to-pay instance reaches at least action 2 in the register; record result in a PR comment
+
+**Checkpoint**: TradeFinance walkthrough runs end-to-end from a single command. SC-001 demonstrably satisfied. MVP deliverable.
+
+---
+
+## Phase 4: User Story 2 — Generate Scenario Register Data (Priority: P2)
+
+**Goal**: An `interval` trigger with `maxIterations` and/or `until` submits repeated, varied workflow instances until a declared limit, using `${random.*}` tokens for payload variation.
+
+**Independent Test**: Declare a persona on a spare agent config with `trigger: interval, everySeconds: 5, maxIterations: 3` and a `${random.decimal}` amount. Run the agent. The register contains exactly 3 instances within ~20 seconds, each with a distinct amount in the declared range. Satisfies SC-003 (the 20-iteration variant is the scaled-up confidence check).
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T030 [P] [US2] Unit tests in `tests/Sorcha.Agent.Tests/Persona/IntervalTriggerLoopTests.cs` covering: fires `maxIterations` times when only that is set; stops at `until` when only that is set; stops at whichever hits first when both set; `startDelaySeconds` honoured; TransientFailure does NOT increment counter (FR-015); three consecutive HardFailures exit the loop with Error log; cancellation mid-interval exits immediately; uses fake `TimeProvider` for determinism
+- [ ] T031 [P] [US2] Integration test in `tests/Sorcha.Agent.Tests/Persona/PersonaHostIntervalIntegrationTests.cs` asserts exactly `maxIterations` POSTs with distinct `${counter}` / `${random.decimal}` values visible in the mock handler's captured request bodies
+
+### Implementation for User Story 2
+
+- [ ] T032 [US2] Create `src/Apps/Sorcha.Agent/Persona/IntervalTriggerLoop.cs` implementing `IPersonaLoop` — honours `StartDelaySeconds`, `EverySeconds`/`EveryMinutes`, `MaxIterations`, `Until`; tracks iteration counter; increments only on Submitted; three-strike rule on HardFailure per research.md R-006; uses injected `TimeProvider` for all waits (depends on T019, T010, T017)
+- [ ] T033 [US2] Extend `PersonaHost` dispatcher (from T020) to route `IntervalTrigger` to `IntervalTriggerLoop`
+- [ ] T034 [P] [US2] Create a demonstration persona file `walkthroughs/TradeFinance/personas/invoice-generator.persona.json` matching the recurring example in quickstart.md §4 (20 iterations, 30s interval, varying amounts and currencies)
+- [ ] T035 [P] [US2] Add a "Scenario data generation" section to `walkthroughs/README.md` describing how to attach `invoice-generator.persona.json` to an otherwise-unused agent config for demo data seeding
+
+**Checkpoint**: Recurring persona mechanism works end-to-end. SC-003 satisfied. Feature is functionally complete for scenario authoring.
+
+---
+
+## Phase 5: User Story 3 — Coexistence with Reactive Behaviour (Priority: P2)
+
+**Goal**: An agent with a persona and at least one pending reactive action services both without one starving or skewing the other.
+
+**Independent Test**: Run `procurement-mgr` with its one-shot persona AND a pre-queued inbox action (e.g. an "Approve/Dispute Invoice" routed from a prior register state). Both actions complete exactly once within expected time bounds; reactive-path latency is within 25% of a no-persona baseline. Satisfies SC-004.
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T036 [P] [US3] Integration test in `tests/Sorcha.Agent.Tests/Persona/PersonaReactiveCoexistenceTests.cs` wires `RunCommand.ExecuteAsync` with a mocked inbox listener that yields one pending action and a mocked HTTP handler that captures submissions; asserts two distinct POSTs occur (one persona-initiated, one reactive-initiated) with each originating from its own code path; asserts neither blocks the other (use `TaskCompletionSource` to gate the inbox yield until after the persona fires, then reverse the gate, and confirm both orderings complete)
+- [ ] T037 [P] [US3] Benchmark-style test in `tests/Sorcha.Agent.Tests/Persona/PersonaReactiveLatencyTests.cs`: measures reactive-path round-trip with persona absent vs present; asserts ratio ≤ 1.25 (SC-004 threshold); tagged as a perf test so CI can keep it reliable with generous tolerance if flaky
+
+### Implementation for User Story 3
+
+- [ ] T038 [US3] Review `RunCommand.ExecuteAsync` (already modified in T021) and confirm persona task is launched via `_ = personaHost.RunAsync(cts.Token)` BEFORE the inbox `await foreach`, so the persona begins its `delaySeconds` wait while the inbox listener is being constructed; no additional code change anticipated but capture the decision in a short code comment explaining the ordering
+- [ ] T039 [US3] Ensure cancellation propagates correctly on `Ctrl+C` / shutdown signal: the `CancellationTokenSource` created at the top of `ExecuteAsync` is shared between inbox loop and persona task; on cancellation both observe it within ≤ 1 s. Add a regression test in `tests/Sorcha.Agent.Tests/Persona/PersonaShutdownTests.cs`
+
+**Checkpoint**: Coexistence proven. No regression in reactive latency beyond tolerance. FR-011 and SC-004 satisfied.
+
+---
+
+## Phase 6: User Story 4 — Human-Editable Scenario Tuning (Priority: P3)
+
+**Goal**: A non-developer can change persona parameters and re-run without touching code.
+
+**Independent Test**: Hand a reviewer the `invoice-generator.persona.json` file and ask them to change interval to 15 s, iterations to 10, and value range to 500–5000. Re-run. Register shows 10 instances, 15 s apart, values in the new range. Reviewer completes in under 10 minutes without reading agent source. Satisfies SC-006.
+
+- [ ] T040 [P] [US4] Add a top-of-file comment block (JSONC-style, permitted by `JsonDocumentOptions.AllowTrailingCommas = true, CommentHandling = Skip` in the loader) to both shipped persona files (`procurement-mgr-kickoff.persona.json`, `invoice-generator.persona.json`) explaining each field in one line each. Confirm the existing `PersonaDefinitionLoader` tolerates `//` comments; if not, enable that option in T014
+- [ ] T041 [P] [US4] Apply the same mechanism to ConstructionPermit: create `walkthroughs/ConstructionPermit/personas/<first-action-agent>-kickoff.persona.json` and add `personaFile` to the corresponding actor config — no agent-binary changes (this demonstrates SC-002)
+- [ ] T042 [P] [US4] Publish `contracts/persona-schema.json` to `src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json` (already done by T003) and add a `$schema` link in the shipped persona files pointing to a stable URL (`https://sorcha.dev/schemas/agent-persona/v1.json` — documented as a TODO since the site publish step is out of scope for this feature; schema ships as an embedded resource for local validation)
+- [ ] T043 [US4] Smoke-test the tuning flow: a second developer (or the reviewer) changes the `invoice-generator.persona.json` parameters per the Independent Test and re-runs; record timing and any friction in the PR description
+
+**Checkpoint**: Persona mechanism generalises beyond TradeFinance. SC-002 and SC-006 satisfied.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T044 [P] Update `docs/reference/development-status.md` with Feature 110 status (from 📋 Planned to 🚧 In progress at start, ✅ Complete at end of PR)
+- [ ] T045 [P] Update `.specify/MASTER-TASKS.md` to register Feature 110 under the appropriate theme (walkthrough infrastructure)
+- [ ] T046 [P] Update `src/Apps/Sorcha.Agent/README.md` with a "Persona mode" section pointing at `specs/110-agent-persona-mode/quickstart.md`
+- [ ] T047 [P] Update `walkthroughs/README.md` with a reference to persona-driven kickoff and scenario data generation
+- [ ] T048 Run full `dotnet test` and confirm coverage on `src/Apps/Sorcha.Agent/Persona/**` is ≥ 85% (Constitution Principle IV); add tests for any uncovered branches
+- [ ] T049 Run `dotnet format` across changed files and confirm `dotnet build -warnaserror` produces zero warnings (Constitution Principle V)
+- [ ] T050 Execute `quickstart.md` verbatim end-to-end on a clean checkout to confirm the happy path described there still reflects reality; fix any drift
+- [ ] T051 Update memory: replace the "Blocked: sorcha-agent doesn't auto-submit starting actions" bullet in `C:\Users\StuartFraser\.claude\projects\C--projects-Sorcha\memory\MEMORY.md` with the resolution; update `project_tradefinance_agent_gap.md` to note the fix shipped in Feature 110
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Phase 1.
+- **User Story 1 (Phase 3, P1)**: Depends on Phase 2.
+- **User Story 2 (Phase 4, P2)**: Depends on Phase 2. Independent of US1 (both add their own `IPersonaLoop` impl).
+- **User Story 3 (Phase 5, P2)**: Depends on US1 (needs at least one loop implementation live to prove coexistence). Uses OnceTriggerLoop from US1 in its integration tests.
+- **User Story 4 (Phase 6, P3)**: Depends on US1 and US2 (uses both loop types in its generalisation tasks).
+- **Polish (Phase 7)**: Depends on whichever user stories are being shipped.
+
+### Within Each User Story
+
+- Tests authored first; confirm they fail before implementing.
+- For US1: T022, T023 before T024.
+- For US2: T030, T031 before T032.
+- For US3: T036, T037 before T038, T039.
+- Commit after each task or tightly coupled group.
+
+### Parallel Opportunities
+
+- T006, T007, T008, T009 can all start together after T004/T005.
+- T011, T013, T015, T018 (unit test files) can all run in parallel with each other and with their corresponding implementation tasks once interfaces land.
+- T026, T027 (walkthrough data changes) are independent of T024 (agent code) and can land as a separate commit once T024 is merged.
+- T044–T047 (documentation) are all independent of each other.
+
+---
+
+## Parallel Example: Foundational Phase
+
+```text
+# After T004–T005 are merged, launch in parallel:
+T006  Regression test for actor-config-without-persona
+T007  Persona record types
+T008  IRandomSource + RandomSource
+T009  IPayloadTokenResolver interface
+
+# Then after T007, T008, T009 land, launch in parallel:
+T010  PayloadTokenResolver implementation
+T012  PersonaSchemaValidator
+T016  IPersonaSubmitter interface
+
+# Then test tasks in parallel with each other:
+T011, T013, T015, T018
+```
+
+## Parallel Example: User Story 1
+
+```text
+# Tests first, in parallel:
+T022  OnceTriggerLoopTests
+T023  PersonaHostOneShotIntegrationTests
+
+# Implementation:
+T024  OnceTriggerLoop (depends on T019, T010, T017 from foundation)
+T025  PersonaHost dispatcher update
+
+# Walkthrough data, in parallel with T024:
+T026  procurement-mgr-kickoff.persona.json
+T027  actor config personaFile addition  (must follow T026)
+T028  README update                      (independent)
+
+# End-to-end validation (sequential, last):
+T029
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup).
+2. Complete Phase 2 (Foundational) — the largest phase; everything else is cheap afterwards.
+3. Complete Phase 3 (US1). At this point TradeFinance walkthrough runs end-to-end — ship this even if US2–US4 defer.
+4. **STOP and validate**: run `walkthroughs/TradeFinance/run-agents.ps1` on a clean checkout; capture in PR.
+5. Merge, ship, update docs.
+
+### Incremental Delivery
+
+1. Merge Phase 1+2+3 as PR #1 (≈ 80% of effort, unblocks walkthroughs).
+2. Merge Phase 4 (US2) as PR #2 (recurring personas + invoice-generator demo file).
+3. Merge Phase 5 (US3) as PR #3 (coexistence guarantees proven).
+4. Merge Phase 6 (US4) as PR #4 (ConstructionPermit parity + tuning docs).
+5. Phase 7 polish tasks fold into each PR as relevant.
+
+### Parallel Team Strategy
+
+Single-developer feature in practice; if parallelised:
+- Developer A: Foundational + US1 (critical path).
+- Developer B: US2 after Foundational checkpoint.
+- Developer C: US4 walkthrough data + docs (can start after US1 merges).
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks.
+- [Story] label maps task to spec.md user story for traceability.
+- Every user story is independently shippable (US1 alone solves the stated blocker).
+- Tests must fail before implementation lands (verifies they are real).
+- Commit after each task or logical group; push frequently (per user preference in memory).
+- Documentation updates (Phase 7) are non-optional per CLAUDE.md Documentation Sync Policy.
+- Branch protection requires PR — no direct pushes to master.

--- a/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
@@ -8,6 +8,7 @@ using Sorcha.Agent.Configuration;
 using Sorcha.Agent.Decision;
 using Sorcha.Agent.Execution;
 using Sorcha.Agent.Inbox;
+using Sorcha.Agent.Persona;
 
 namespace Sorcha.Agent.Commands;
 
@@ -68,6 +69,7 @@ public class RunCommand : Command
         var sw = Stopwatch.StartNew();
         var actionsProcessed = 0;
         var errors = 0;
+        Task? personaTask = null;
 
         try
         {
@@ -162,6 +164,40 @@ public class RunCommand : Command
                 loggerFactory.CreateLogger<CompositeInboxListener>(),
                 listeners.ToArray());
 
+            // Persona loop — optional; runs alongside reactive inbox loop when a persona file is declared.
+            // Launched BEFORE entering the inbox loop so its delaySeconds countdown starts immediately.
+            if (!string.IsNullOrWhiteSpace(definition.PersonaFile))
+            {
+                var personaPath = Path.IsPathRooted(definition.PersonaFile)
+                    ? definition.PersonaFile
+                    : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(configPath) ?? ".", definition.PersonaFile));
+
+                var personaLoad = PersonaDefinitionLoader.Load(personaPath, statePath);
+                if (!personaLoad.IsSuccess)
+                {
+                    foreach (var error in personaLoad.Errors)
+                        Console.Error.WriteLine($"  Persona error: {error}");
+                    return ExitCodes.ConfigurationError;
+                }
+
+                var personaSubmitter = new PersonaSubmitter(
+                    httpClient, authService,
+                    definition.Connection.WalletAddress,
+                    definition.Connection.RegisterId,
+                    loggerFactory.CreateLogger<PersonaSubmitter>());
+
+                var personaHost = new PersonaHost(
+                    personaLoad.Definition!,
+                    personaSubmitter,
+                    new PayloadTokenResolver(),
+                    new RandomSource(),
+                    TimeProvider.System,
+                    loggerFactory);
+
+                personaTask = Task.Run(() => personaHost.RunAsync(cancellationToken), cancellationToken);
+                if (!quiet) Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Persona \"{personaLoad.Definition!.Name}\" loaded");
+            }
+
             if (!quiet) Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Actor \"{actorName}\" started");
 
             // Main loop
@@ -221,6 +257,14 @@ public class RunCommand : Command
         {
             Console.Error.WriteLine($"Fatal error: {ex.Message}");
             return ExitCodes.GeneralError;
+        }
+        finally
+        {
+            if (personaTask is not null)
+            {
+                try { await personaTask.WaitAsync(TimeSpan.FromSeconds(5), CancellationToken.None); }
+                catch { /* persona shutdown best-effort */ }
+            }
         }
 
         if (!quiet)

--- a/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
@@ -262,8 +262,16 @@ public class RunCommand : Command
         {
             if (personaTask is not null)
             {
-                try { await personaTask.WaitAsync(TimeSpan.FromSeconds(5), CancellationToken.None); }
-                catch { /* persona shutdown best-effort */ }
+                try
+                {
+                    await personaTask.WaitAsync(TimeSpan.FromSeconds(5), CancellationToken.None);
+                }
+                catch (OperationCanceledException) { /* persona cancelled — expected on shutdown */ }
+                catch (TimeoutException) { /* persona didn't finish in grace window — non-fatal */ }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"  Persona task terminated unexpectedly: {ex.Message}");
+                }
             }
         }
 

--- a/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/RunCommand.cs
@@ -194,7 +194,9 @@ public class RunCommand : Command
                     TimeProvider.System,
                     loggerFactory);
 
-                personaTask = Task.Run(() => personaHost.RunAsync(cancellationToken), cancellationToken);
+                // Don't wrap in Task.Run — personaHost.RunAsync is already async and the wrapper
+                // would box OperationCanceledException as AggregateException on the shutdown join.
+                personaTask = personaHost.RunAsync(cancellationToken);
                 if (!quiet) Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Persona \"{personaLoad.Definition!.Name}\" loaded");
             }
 

--- a/src/Apps/Sorcha.Agent/Configuration/ActorDefinition.cs
+++ b/src/Apps/Sorcha.Agent/Configuration/ActorDefinition.cs
@@ -19,6 +19,12 @@ public record ActorDefinition
     public AiConfig? Ai { get; init; }
     public ResilienceConfig? Resilience { get; init; }
     public LoggingConfig? Logging { get; init; }
+
+    /// <summary>
+    /// Optional path (relative to the actor config file) to a persona definition JSON file.
+    /// When set, the agent runs a persona loop alongside its reactive inbox loop.
+    /// </summary>
+    public string? PersonaFile { get; init; }
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.Agent/Persona/IPayloadTokenResolver.cs
+++ b/src/Apps/Sorcha.Agent/Persona/IPayloadTokenResolver.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Resolves <c>${...}</c> substitution tokens in a persona payload template.
+/// </summary>
+public interface IPayloadTokenResolver
+{
+    /// <summary>
+    /// Returns a deep copy of <paramref name="template"/> with all tokens replaced by their
+    /// concrete values for this fire. Tokens that are the entire string value preserve the
+    /// native JSON type (number, string, literal); embedded tokens perform string interpolation.
+    /// </summary>
+    JsonObject Resolve(JsonNode template, PersonaFireContext ctx);
+
+    /// <summary>
+    /// Walks <paramref name="template"/> and returns a list of token errors (unknown names,
+    /// malformed arguments, empty choice lists). Empty result means the template is valid.
+    /// </summary>
+    IReadOnlyList<string> ValidateTokens(JsonNode template);
+}

--- a/src/Apps/Sorcha.Agent/Persona/IPersonaLoop.cs
+++ b/src/Apps/Sorcha.Agent/Persona/IPersonaLoop.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Long-running persona trigger loop. Implementations fire submissions on their
+/// declared trigger schedule and exit cleanly on cancellation or completion.
+/// </summary>
+public interface IPersonaLoop
+{
+    /// <summary>
+    /// Runs the loop until the trigger completes (e.g. once-trigger fires) or cancellation.
+    /// </summary>
+    Task RunAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Number of successful submissions observed so far. Used in tests and telemetry.
+    /// </summary>
+    int CompletedIterations { get; }
+}

--- a/src/Apps/Sorcha.Agent/Persona/IPersonaSubmitter.cs
+++ b/src/Apps/Sorcha.Agent/Persona/IPersonaSubmitter.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Submits a persona-generated starting action to the Blueprint Service.
+/// </summary>
+public interface IPersonaSubmitter
+{
+    Task<PersonaSubmissionResult> SubmitAsync(
+        PersonaDefinition persona,
+        JsonObject resolvedPayload,
+        CancellationToken cancellationToken);
+}

--- a/src/Apps/Sorcha.Agent/Persona/IPersonaSubmitter.cs
+++ b/src/Apps/Sorcha.Agent/Persona/IPersonaSubmitter.cs
@@ -10,6 +10,15 @@ namespace Sorcha.Agent.Persona;
 /// </summary>
 public interface IPersonaSubmitter
 {
+    /// <summary>
+    /// Submits a single persona-generated action to the Blueprint Service and classifies
+    /// the outcome as <see cref="PersonaSubmissionOutcome.Submitted"/>,
+    /// <see cref="PersonaSubmissionOutcome.TransientFailure"/>, or
+    /// <see cref="PersonaSubmissionOutcome.HardFailure"/>.
+    /// </summary>
+    /// <param name="persona">The persona whose target and identity drive the submission.</param>
+    /// <param name="resolvedPayload">The payload with all <c>${…}</c> tokens evaluated.</param>
+    /// <param name="cancellationToken">Cancellation token; agent shutdown aborts the call.</param>
     Task<PersonaSubmissionResult> SubmitAsync(
         PersonaDefinition persona,
         JsonObject resolvedPayload,

--- a/src/Apps/Sorcha.Agent/Persona/IRandomSource.cs
+++ b/src/Apps/Sorcha.Agent/Persona/IRandomSource.cs
@@ -41,6 +41,10 @@ public sealed class RandomSource : IRandomSource
         if (precision < 0)
             throw new ArgumentException("precision must be >= 0");
 
+        // Deliberate double→decimal cast: NextDouble() is the only uniform-random source on
+        // System.Random. The loss of precision is masked by the subsequent Math.Round to the
+        // author-declared scale, and values here feed demo/scenario payloads — not crypto or
+        // accounting. If a future use needs full-decimal entropy, wrap a crypto RNG instead.
         var range = maxInclusive - minInclusive;
         var sample = (decimal)_random.NextDouble();
         var value = minInclusive + (range * sample);

--- a/src/Apps/Sorcha.Agent/Persona/IRandomSource.cs
+++ b/src/Apps/Sorcha.Agent/Persona/IRandomSource.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Seam over <see cref="System.Random"/> so persona tests can be deterministic.
+/// </summary>
+public interface IRandomSource
+{
+    int NextInt(int minInclusive, int maxInclusive);
+    decimal NextDecimal(decimal minInclusive, decimal maxInclusive, int precision);
+    T Choose<T>(IReadOnlyList<T> options);
+}
+
+/// <summary>
+/// Production <see cref="IRandomSource"/> backed by <see cref="Random"/>.
+/// </summary>
+public sealed class RandomSource : IRandomSource
+{
+    private readonly Random _random;
+
+    public RandomSource() : this(Random.Shared) { }
+
+    public RandomSource(Random random)
+    {
+        _random = random;
+    }
+
+    public int NextInt(int minInclusive, int maxInclusive)
+    {
+        if (maxInclusive < minInclusive)
+            throw new ArgumentException("maxInclusive must be >= minInclusive");
+        return _random.Next(minInclusive, maxInclusive + 1);
+    }
+
+    public decimal NextDecimal(decimal minInclusive, decimal maxInclusive, int precision)
+    {
+        if (maxInclusive < minInclusive)
+            throw new ArgumentException("maxInclusive must be >= minInclusive");
+        if (precision < 0)
+            throw new ArgumentException("precision must be >= 0");
+
+        var range = maxInclusive - minInclusive;
+        var sample = (decimal)_random.NextDouble();
+        var value = minInclusive + (range * sample);
+        return Math.Round(value, precision, MidpointRounding.AwayFromZero);
+    }
+
+    public T Choose<T>(IReadOnlyList<T> options)
+    {
+        if (options.Count == 0)
+            throw new ArgumentException("options must be non-empty");
+        return options[_random.Next(options.Count)];
+    }
+}

--- a/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
+++ b/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Fires a persona exactly once (after an optional startup delay) then exits.
+/// Used for walkthrough-starting-action kickoff (Feature 110 User Story 1).
+/// </summary>
+public sealed class OnceTriggerLoop : IPersonaLoop
+{
+    private readonly PersonaDefinition _definition;
+    private readonly OnceTrigger _trigger;
+    private readonly IPersonaSubmitter _submitter;
+    private readonly IPayloadTokenResolver _resolver;
+    private readonly IRandomSource _random;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<OnceTriggerLoop> _logger;
+    private int _completed;
+
+    public OnceTriggerLoop(
+        PersonaDefinition definition,
+        OnceTrigger trigger,
+        IPersonaSubmitter submitter,
+        IPayloadTokenResolver resolver,
+        IRandomSource random,
+        TimeProvider timeProvider,
+        ILogger<OnceTriggerLoop> logger)
+    {
+        _definition = definition;
+        _trigger = trigger;
+        _submitter = submitter;
+        _resolver = resolver;
+        _random = random;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    public int CompletedIterations => _completed;
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        if (_trigger.DelaySeconds > 0)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(_trigger.DelaySeconds), _timeProvider, cancellationToken);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var ctx = new PersonaFireContext
+        {
+            Iteration = 1,
+            Now = _timeProvider.GetUtcNow(),
+            RandomSource = _random
+        };
+
+        var payload = _resolver.Resolve(_definition.PayloadTemplate, ctx);
+
+        _logger.LogInformation(
+            "Persona {PersonaName} fire #1 -> blueprint={BlueprintId} action={ActionName}",
+            _definition.Name, _definition.Target.BlueprintId,
+            _definition.Target.ActionName ?? $"(index {_definition.Target.ActionIndex})");
+
+        var result = await _submitter.SubmitAsync(_definition, payload, cancellationToken);
+
+        switch (result.Outcome)
+        {
+            case PersonaSubmissionOutcome.Submitted:
+                _completed = 1;
+                _logger.LogInformation(
+                    "Persona {PersonaName} fire #1 -> Submitted ({DurationMs} ms)",
+                    _definition.Name, result.DurationMs);
+                break;
+            case PersonaSubmissionOutcome.TransientFailure:
+                _logger.LogWarning(
+                    "Persona {PersonaName} fire #1 -> TransientFailure: {Error} — once-trigger does not retry",
+                    _definition.Name, result.Error);
+                break;
+            case PersonaSubmissionOutcome.HardFailure:
+                _logger.LogError(
+                    "Persona {PersonaName} fire #1 -> HardFailure: {Error}",
+                    _definition.Name, result.Error);
+                break;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
+++ b/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
@@ -66,7 +66,7 @@ public sealed class OnceTriggerLoop : IPersonaLoop
         switch (result.Outcome)
         {
             case PersonaSubmissionOutcome.Submitted:
-                _completed = 1;
+                _completed++;
                 _logger.LogInformation(
                     "Persona {PersonaName} fire #1 -> Submitted ({DurationMs} ms)",
                     _definition.Name, result.DurationMs);

--- a/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
+++ b/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
@@ -47,8 +47,6 @@ public sealed class OnceTriggerLoop : IPersonaLoop
             await Task.Delay(TimeSpan.FromSeconds(_trigger.DelaySeconds), _timeProvider, cancellationToken);
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
-
         var ctx = new PersonaFireContext
         {
             Iteration = 1,
@@ -74,8 +72,11 @@ public sealed class OnceTriggerLoop : IPersonaLoop
                     _definition.Name, result.DurationMs);
                 break;
             case PersonaSubmissionOutcome.TransientFailure:
-                _logger.LogWarning(
-                    "Persona {PersonaName} fire #1 -> TransientFailure: {Error} — once-trigger does not retry",
+                // Once-trigger does not retry. For walkthrough/demo contexts a startup 429 or 503
+                // that silently produces 0 submissions is confusing, so this is logged at Error
+                // level (not Warning) to surface loudly alongside hard failures.
+                _logger.LogError(
+                    "Persona {PersonaName} fire #1 -> TransientFailure: {Error} — once-trigger does not retry; walkthrough will not progress without manual intervention",
                     _definition.Name, result.Error);
                 break;
             case PersonaSubmissionOutcome.HardFailure:

--- a/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
+++ b/src/Apps/Sorcha.Agent/Persona/OnceTriggerLoop.cs
@@ -18,7 +18,8 @@ public sealed class OnceTriggerLoop : IPersonaLoop
     private readonly IRandomSource _random;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<OnceTriggerLoop> _logger;
-    private int _completed;
+    // volatile: CompletedIterations may be polled from a different task than RunAsync.
+    private volatile int _completed;
 
     public OnceTriggerLoop(
         PersonaDefinition definition,

--- a/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
@@ -23,7 +23,8 @@ public sealed partial class PayloadTokenResolver : IPayloadTokenResolver
         // Re-running validation on every fire would make recurring personas O(template)
         // per tick for no benefit. Malformed tokens surfaced here indicate a loader bug
         // and will throw when EvaluateTokenTyped encounters them.
-        var clone = JsonNode.Parse(template.ToJsonString())!;
+        // DeepClone avoids a string round-trip on every fire — important for interval triggers.
+        var clone = template.DeepClone();
         ResolveNode(clone, ctx);
         return clone.AsObject();
     }

--- a/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Resolves persona payload tokens. See <c>specs/110-agent-persona-mode/data-model.md</c>.
+/// </summary>
+public sealed partial class PayloadTokenResolver : IPayloadTokenResolver
+{
+    // Matches ${name} or ${name(args)} — args may include quoted strings, numbers, arrays.
+    [GeneratedRegex(@"\$\{([a-zA-Z_][a-zA-Z0-9_.]*)(?:\(([^}]*)\))?\}")]
+    private static partial Regex TokenRegex();
+
+    public JsonObject Resolve(JsonNode template, PersonaFireContext ctx)
+    {
+        var errors = ValidateTokens(template);
+        if (errors.Count > 0)
+            throw new InvalidOperationException("Invalid persona payload template: " + string.Join("; ", errors));
+
+        var clone = JsonNode.Parse(template.ToJsonString())!;
+        ResolveNode(clone, ctx);
+        return clone.AsObject();
+    }
+
+    public IReadOnlyList<string> ValidateTokens(JsonNode template)
+    {
+        var errors = new List<string>();
+        WalkStrings(template, value =>
+        {
+            foreach (Match match in TokenRegex().Matches(value))
+            {
+                var name = match.Groups[1].Value;
+                var args = match.Groups[2].Success ? match.Groups[2].Value : null;
+                if (!TryValidateToken(name, args, out var error))
+                    errors.Add(error);
+            }
+        });
+        return errors;
+    }
+
+    private static void ResolveNode(JsonNode? node, PersonaFireContext ctx)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                // Iterate keys snapshot so we can replace values during iteration.
+                foreach (var key in obj.Select(p => p.Key).ToList())
+                {
+                    var child = obj[key];
+                    if (child is JsonValue value && value.TryGetValue<string>(out var s))
+                    {
+                        obj[key] = ResolveString(s, ctx);
+                    }
+                    else
+                    {
+                        ResolveNode(child, ctx);
+                    }
+                }
+                break;
+            case JsonArray arr:
+                for (var i = 0; i < arr.Count; i++)
+                {
+                    var child = arr[i];
+                    if (child is JsonValue value && value.TryGetValue<string>(out var s))
+                    {
+                        arr[i] = ResolveString(s, ctx);
+                    }
+                    else
+                    {
+                        ResolveNode(child, ctx);
+                    }
+                }
+                break;
+        }
+    }
+
+    private static JsonNode? ResolveString(string value, PersonaFireContext ctx)
+    {
+        var matches = TokenRegex().Matches(value);
+        if (matches.Count == 0)
+            return JsonValue.Create(value);
+
+        // Single-token-and-nothing-else case: preserve typed JSON result.
+        if (matches.Count == 1 && matches[0].Value == value)
+        {
+            return EvaluateTokenTyped(matches[0].Groups[1].Value,
+                matches[0].Groups[2].Success ? matches[0].Groups[2].Value : null, ctx);
+        }
+
+        // Embedded tokens: stringify each match and interpolate.
+        return JsonValue.Create(TokenRegex().Replace(value, m =>
+        {
+            var typed = EvaluateTokenTyped(m.Groups[1].Value,
+                m.Groups[2].Success ? m.Groups[2].Value : null, ctx);
+            return StringifyToken(typed);
+        }));
+    }
+
+    private static JsonNode? EvaluateTokenTyped(string name, string? argsText, PersonaFireContext ctx) => name switch
+    {
+        "now"      => JsonValue.Create(ctx.Now.ToString("O", CultureInfo.InvariantCulture)),
+        "uuid"     => JsonValue.Create(Guid.NewGuid().ToString()),
+        "counter"  => JsonValue.Create(ctx.Iteration),
+        "random.int"     => JsonValue.Create(EvaluateRandomInt(argsText, ctx)),
+        "random.decimal" => JsonValue.Create(EvaluateRandomDecimal(argsText, ctx)),
+        "random.choice"  => EvaluateRandomChoice(argsText, ctx),
+        _ => throw new InvalidOperationException($"Unknown token '{name}'")
+    };
+
+    private static string StringifyToken(JsonNode? node)
+    {
+        if (node is null) return "";
+        if (node is JsonValue v && v.TryGetValue<string>(out var s)) return s;
+        return node.ToJsonString();
+    }
+
+    private static int EvaluateRandomInt(string? argsText, PersonaFireContext ctx)
+    {
+        var (min, max) = ParseTwoIntArgs(argsText, "random.int");
+        return ctx.RandomSource.NextInt(min, max);
+    }
+
+    private static decimal EvaluateRandomDecimal(string? argsText, PersonaFireContext ctx)
+    {
+        var parts = SplitArgs(argsText, "random.decimal");
+        if (parts.Count != 3)
+            throw new InvalidOperationException($"random.decimal expects 3 args (min, max, precision); got {parts.Count}");
+        var min = decimal.Parse(parts[0], CultureInfo.InvariantCulture);
+        var max = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+        var precision = int.Parse(parts[2], CultureInfo.InvariantCulture);
+        return ctx.RandomSource.NextDecimal(min, max, precision);
+    }
+
+    private static JsonNode? EvaluateRandomChoice(string? argsText, PersonaFireContext ctx)
+    {
+        if (string.IsNullOrWhiteSpace(argsText))
+            throw new InvalidOperationException("random.choice requires a JSON array argument");
+        var trimmed = argsText.Trim();
+        if (!trimmed.StartsWith('[') || !trimmed.EndsWith(']'))
+            throw new InvalidOperationException("random.choice argument must be a JSON array literal");
+
+        var arr = JsonNode.Parse(trimmed)?.AsArray()
+            ?? throw new InvalidOperationException("random.choice argument failed to parse as JSON array");
+        if (arr.Count == 0)
+            throw new InvalidOperationException("random.choice list must be non-empty");
+
+        var items = arr.ToList();
+        var picked = ctx.RandomSource.Choose(items);
+        return picked?.DeepClone();
+    }
+
+    private static (int min, int max) ParseTwoIntArgs(string? argsText, string name)
+    {
+        var parts = SplitArgs(argsText, name);
+        if (parts.Count != 2)
+            throw new InvalidOperationException($"{name} expects 2 args; got {parts.Count}");
+        return (int.Parse(parts[0], CultureInfo.InvariantCulture),
+                int.Parse(parts[1], CultureInfo.InvariantCulture));
+    }
+
+    // Splits "1, 2, 3" or "1, 2, [\"a\", \"b\"]" — recognises [...] as one chunk.
+    private static List<string> SplitArgs(string? argsText, string name)
+    {
+        if (string.IsNullOrWhiteSpace(argsText))
+            throw new InvalidOperationException($"{name} requires arguments");
+
+        var result = new List<string>();
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < argsText.Length; i++)
+        {
+            var c = argsText[i];
+            if (c == '[') depth++;
+            else if (c == ']') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                result.Add(argsText[start..i].Trim());
+                start = i + 1;
+            }
+        }
+        result.Add(argsText[start..].Trim());
+        return result;
+    }
+
+    private static bool TryValidateToken(string name, string? argsText, out string error)
+    {
+        try
+        {
+            switch (name)
+            {
+                case "now":
+                case "uuid":
+                case "counter":
+                    if (!string.IsNullOrEmpty(argsText))
+                    {
+                        error = $"Token '{name}' does not accept arguments";
+                        return false;
+                    }
+                    break;
+                case "random.int":
+                    ParseTwoIntArgs(argsText, "random.int");
+                    break;
+                case "random.decimal":
+                    var parts = SplitArgs(argsText, "random.decimal");
+                    if (parts.Count != 3) throw new InvalidOperationException($"random.decimal expects 3 args; got {parts.Count}");
+                    decimal.Parse(parts[0], CultureInfo.InvariantCulture);
+                    decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                    int.Parse(parts[2], CultureInfo.InvariantCulture);
+                    break;
+                case "random.choice":
+                    if (string.IsNullOrWhiteSpace(argsText))
+                        throw new InvalidOperationException("random.choice requires a JSON array argument");
+                    var t = argsText.Trim();
+                    if (!t.StartsWith('[') || !t.EndsWith(']'))
+                        throw new InvalidOperationException("random.choice argument must be a JSON array literal");
+                    var arr = JsonNode.Parse(t)?.AsArray()
+                        ?? throw new InvalidOperationException("random.choice argument failed to parse as JSON array");
+                    if (arr.Count == 0)
+                        throw new InvalidOperationException("random.choice list must be non-empty");
+                    break;
+                default:
+                    error = $"Unknown token '{name}'";
+                    return false;
+            }
+            error = "";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = $"Invalid token '${{{name}{(argsText is null ? "" : "(" + argsText + ")")}}}': {ex.Message}";
+            return false;
+        }
+    }
+
+    private static void WalkStrings(JsonNode? node, Action<string> visit)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var p in obj)
+                {
+                    if (p.Value is JsonValue v && v.TryGetValue<string>(out var s)) visit(s);
+                    else WalkStrings(p.Value, visit);
+                }
+                break;
+            case JsonArray arr:
+                foreach (var item in arr)
+                {
+                    if (item is JsonValue v && v.TryGetValue<string>(out var s)) visit(s);
+                    else WalkStrings(item, visit);
+                }
+                break;
+            case JsonValue val when val.TryGetValue<string>(out var s):
+                visit(s);
+                break;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
@@ -19,10 +19,10 @@ public sealed partial class PayloadTokenResolver : IPayloadTokenResolver
 
     public JsonObject Resolve(JsonNode template, PersonaFireContext ctx)
     {
-        var errors = ValidateTokens(template);
-        if (errors.Count > 0)
-            throw new InvalidOperationException("Invalid persona payload template: " + string.Join("; ", errors));
-
+        // Invariant: tokens were already validated at load time via ValidateTokens.
+        // Re-running validation on every fire would make recurring personas O(template)
+        // per tick for no benefit. Malformed tokens surfaced here indicate a loader bug
+        // and will throw when EvaluateTokenTyped encounters them.
         var clone = JsonNode.Parse(template.ToJsonString())!;
         ResolveNode(clone, ctx);
         return clone.AsObject();

--- a/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PayloadTokenResolver.cs
@@ -166,6 +166,10 @@ public sealed partial class PayloadTokenResolver : IPayloadTokenResolver
     }
 
     // Splits "1, 2, 3" or "1, 2, [\"a\", \"b\"]" — recognises [...] as one chunk.
+    // Known limitation: does not honour quoted strings containing unescaped commas.
+    // Not hit by the current token vocabulary (int/decimal args are numeric; random.choice
+    // passes its whole [...] as one chunk so inner commas are handled by JSON parsing).
+    // Revisit if/when a token accepts a bare quoted-string list at the top level.
     private static List<string> SplitArgs(string? argsText, string name)
     {
         if (string.IsNullOrWhiteSpace(argsText))

--- a/src/Apps/Sorcha.Agent/Persona/PersonaDefinition.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaDefinition.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Declarative non-reactive behaviour for a Sorcha agent.
+/// Loaded from a JSON file referenced by an actor config's <c>personaFile</c> field.
+/// </summary>
+public record PersonaDefinition
+{
+    public required string Name { get; init; }
+    public required PersonaTarget Target { get; init; }
+    public required PersonaTrigger Trigger { get; init; }
+    public required JsonNode PayloadTemplate { get; init; }
+}
+
+/// <summary>
+/// Target of a persona submission: blueprint, instance, and starting action.
+/// </summary>
+public record PersonaTarget
+{
+    public required string BlueprintId { get; init; }
+    public required string InstanceId { get; init; }
+    public string? ActionName { get; init; }
+    public int? ActionIndex { get; init; }
+}
+
+/// <summary>
+/// Base class for persona triggers. v1 supports <see cref="OnceTrigger"/> and <see cref="IntervalTrigger"/>.
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(OnceTrigger), "once")]
+[JsonDerivedType(typeof(IntervalTrigger), "interval")]
+public abstract record PersonaTrigger;
+
+/// <summary>
+/// Fires exactly one submission after the agent starts, then exits.
+/// </summary>
+public sealed record OnceTrigger : PersonaTrigger
+{
+    public int DelaySeconds { get; init; } = 0;
+}
+
+/// <summary>
+/// Fires repeated submissions at a declared cadence, bounded by optional stop conditions.
+/// </summary>
+public sealed record IntervalTrigger : PersonaTrigger
+{
+    public int? EverySeconds { get; init; }
+    public int? EveryMinutes { get; init; }
+    public int StartDelaySeconds { get; init; } = 0;
+    public int? MaxIterations { get; init; }
+    public DateTimeOffset? Until { get; init; }
+
+    /// <summary>
+    /// Normalised interval in seconds. Exactly one of <see cref="EverySeconds"/> or
+    /// <see cref="EveryMinutes"/> must be set; schema validation enforces this.
+    /// </summary>
+    public int IntervalSeconds => EverySeconds ?? (EveryMinutes!.Value * 60);
+}
+
+/// <summary>
+/// Runtime context passed to the payload token resolver on each persona fire.
+/// </summary>
+public record PersonaFireContext
+{
+    public required int Iteration { get; init; }
+    public required DateTimeOffset Now { get; init; }
+    public required IRandomSource RandomSource { get; init; }
+}
+
+/// <summary>
+/// Outcome of a single persona submission.
+/// </summary>
+public enum PersonaSubmissionOutcome
+{
+    Submitted,
+    TransientFailure,
+    HardFailure
+}
+
+/// <summary>
+/// Result of a single persona submission.
+/// </summary>
+public record PersonaSubmissionResult(
+    PersonaSubmissionOutcome Outcome,
+    long DurationMs,
+    string? Error = null);

--- a/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Sorcha.Agent.Configuration;
 
 namespace Sorcha.Agent.Persona;
@@ -88,11 +89,20 @@ public static class PersonaDefinitionLoader
         return PersonaLoadResult.Ok(definition);
     }
 
+    // Accepts alphanumerics, dashes, underscores, dots, and colons — the character set
+    // the Blueprint Service emits for IDs. Rejects path separators and URL-meaningful
+    // characters to prevent env-var-sourced values from rewriting the request endpoint.
+    private static readonly Regex SafeIdPattern = new(@"^[A-Za-z0-9._:-]{1,128}$", RegexOptions.Compiled);
+
     private static IEnumerable<string> ValidateSemantics(PersonaDefinition def)
     {
         if (string.IsNullOrWhiteSpace(def.Name)) yield return "name is required";
         if (string.IsNullOrWhiteSpace(def.Target.BlueprintId)) yield return "target.blueprintId is required";
+        else if (!SafeIdPattern.IsMatch(def.Target.BlueprintId))
+            yield return $"target.blueprintId=\"{def.Target.BlueprintId}\" contains disallowed characters (must match {SafeIdPattern})";
         if (string.IsNullOrWhiteSpace(def.Target.InstanceId)) yield return "target.instanceId is required";
+        else if (!SafeIdPattern.IsMatch(def.Target.InstanceId))
+            yield return $"target.instanceId=\"{def.Target.InstanceId}\" contains disallowed characters (must match {SafeIdPattern})";
         if (def.Target.ActionName is null && def.Target.ActionIndex is null)
             yield return "target must include actionName or actionIndex";
         if (def.Target.ActionIndex is int idx && idx < 0)
@@ -131,9 +141,9 @@ public static class PersonaDefinitionLoader
 public record PersonaLoadResult
 {
     public PersonaDefinition? Definition { get; init; }
-    public List<string> Errors { get; init; } = [];
+    public IReadOnlyList<string> Errors { get; init; } = Array.Empty<string>();
     public bool IsSuccess => Errors.Count == 0 && Definition is not null;
 
     public static PersonaLoadResult Ok(PersonaDefinition definition) => new() { Definition = definition };
-    public static PersonaLoadResult Failure(List<string> errors) => new() { Errors = errors };
+    public static PersonaLoadResult Failure(IReadOnlyList<string> errors) => new() { Errors = errors };
 }

--- a/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
@@ -12,6 +12,12 @@ namespace Sorcha.Agent.Persona;
 /// Loads and validates a persona definition JSON file.
 /// Surfaces all errors (schema, token, variable) at load time — FR-010 / FR-014.
 /// </summary>
+/// <remarks>
+/// Variable resolution is delegated to <see cref="VariableResolver"/>, which handles both
+/// <c>$env:NAME</c> (environment variables) and <c>{{key}}</c> (state.json flattened keys)
+/// — the same contract that actor configs use. This is the pre-existing type in
+/// <c>Sorcha.Agent.Configuration</c>; no new resolver is introduced by this feature.
+/// </remarks>
 public static class PersonaDefinitionLoader
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -40,15 +46,20 @@ public static class PersonaDefinitionLoader
             foreach (var u in resolution.UnresolvedVariables)
                 errors.Add($"Unresolved variable: {u}");
 
+        JsonDocument? doc;
+        try { doc = JsonDocument.Parse(resolution.ResolvedJson); }
+        catch (JsonException ex) { return PersonaLoadResult.Failure([$"Invalid JSON: {ex.Message}"]); }
+        using (doc)
+        {
+            var schemaErrors = new PersonaSchemaValidator().Validate(doc.RootElement);
+            errors.AddRange(schemaErrors);
+        }
+
         JsonNode? root;
         try { root = JsonNode.Parse(resolution.ResolvedJson); }
         catch (JsonException ex) { return PersonaLoadResult.Failure([$"Invalid JSON: {ex.Message}"]); }
         if (root is null)
             return PersonaLoadResult.Failure(["Persona file is empty"]);
-
-        var schemaErrors = new PersonaSchemaValidator().Validate(
-            JsonDocument.Parse(root.ToJsonString()).RootElement);
-        errors.AddRange(schemaErrors);
 
         if (root["payloadTemplate"] is JsonNode template)
         {
@@ -86,6 +97,12 @@ public static class PersonaDefinitionLoader
             yield return "target must include actionName or actionIndex";
         if (def.Target.ActionIndex is int idx && idx < 0)
             yield return "target.actionIndex must be >= 0";
+        // v1 note: action-name → index resolution (blueprint fetch) is deferred to a
+        // follow-up feature. Until then, a persona declared with only actionName cannot
+        // be submitted, so we reject at load time rather than crash at first fire.
+        if (def.Target.ActionName is not null && def.Target.ActionIndex is null)
+            yield return "target.actionName is not yet supported in v1 — set target.actionIndex instead "
+                       + "(action-name lookup will land in a follow-up feature)";
 
         switch (def.Trigger)
         {

--- a/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Sorcha.Agent.Configuration;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Loads and validates a persona definition JSON file.
+/// Surfaces all errors (schema, token, variable) at load time — FR-010 / FR-014.
+/// </summary>
+public static class PersonaDefinitionLoader
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    public static PersonaLoadResult Load(string personaFilePath, string? statePath = null)
+    {
+        if (!File.Exists(personaFilePath))
+            return PersonaLoadResult.Failure([$"Persona file not found: {personaFilePath}"]);
+
+        string rawJson;
+        try { rawJson = File.ReadAllText(personaFilePath); }
+        catch (Exception ex) { return PersonaLoadResult.Failure([$"Failed to read persona file: {ex.Message}"]); }
+
+        var errors = new List<string>();
+
+        var stateValues = VariableResolver.LoadStateFile(statePath);
+        var resolution = VariableResolver.Resolve(rawJson, stateValues);
+        if (resolution.HasUnresolved)
+            foreach (var u in resolution.UnresolvedVariables)
+                errors.Add($"Unresolved variable: {u}");
+
+        JsonNode? root;
+        try { root = JsonNode.Parse(resolution.ResolvedJson); }
+        catch (JsonException ex) { return PersonaLoadResult.Failure([$"Invalid JSON: {ex.Message}"]); }
+        if (root is null)
+            return PersonaLoadResult.Failure(["Persona file is empty"]);
+
+        var schemaErrors = new PersonaSchemaValidator().Validate(
+            JsonDocument.Parse(root.ToJsonString()).RootElement);
+        errors.AddRange(schemaErrors);
+
+        if (root["payloadTemplate"] is JsonNode template)
+        {
+            var tokenErrors = new PayloadTokenResolver().ValidateTokens(template);
+            errors.AddRange(tokenErrors);
+        }
+
+        if (errors.Count > 0)
+            return PersonaLoadResult.Failure(errors);
+
+        PersonaDefinition definition;
+        try
+        {
+            definition = root.Deserialize<PersonaDefinition>(JsonOptions)
+                ?? throw new JsonException("Deserialization returned null");
+        }
+        catch (JsonException ex)
+        {
+            return PersonaLoadResult.Failure([$"Failed to deserialize persona: {ex.Message}"]);
+        }
+
+        errors.AddRange(ValidateSemantics(definition));
+        if (errors.Count > 0)
+            return PersonaLoadResult.Failure(errors);
+
+        return PersonaLoadResult.Ok(definition);
+    }
+
+    private static IEnumerable<string> ValidateSemantics(PersonaDefinition def)
+    {
+        if (string.IsNullOrWhiteSpace(def.Name)) yield return "name is required";
+        if (string.IsNullOrWhiteSpace(def.Target.BlueprintId)) yield return "target.blueprintId is required";
+        if (string.IsNullOrWhiteSpace(def.Target.InstanceId)) yield return "target.instanceId is required";
+        if (def.Target.ActionName is null && def.Target.ActionIndex is null)
+            yield return "target must include actionName or actionIndex";
+        if (def.Target.ActionIndex is int idx && idx < 0)
+            yield return "target.actionIndex must be >= 0";
+
+        switch (def.Trigger)
+        {
+            case OnceTrigger once:
+                if (once.DelaySeconds < 0) yield return "trigger.delaySeconds must be >= 0";
+                break;
+            case IntervalTrigger interval:
+                if ((interval.EverySeconds is null) == (interval.EveryMinutes is null))
+                    yield return "interval trigger must set exactly one of everySeconds or everyMinutes";
+                if (interval.EverySeconds is int s && s <= 0) yield return "trigger.everySeconds must be > 0";
+                if (interval.EveryMinutes is int m && m <= 0) yield return "trigger.everyMinutes must be > 0";
+                if (interval.MaxIterations is int mi && mi <= 0) yield return "trigger.maxIterations must be > 0";
+                break;
+        }
+    }
+}
+
+/// <summary>
+/// Result of a persona load. Mirrors <see cref="ActorDefinitionLoadResult"/>.
+/// </summary>
+public record PersonaLoadResult
+{
+    public PersonaDefinition? Definition { get; init; }
+    public List<string> Errors { get; init; } = [];
+    public bool IsSuccess => Errors.Count == 0 && Definition is not null;
+
+    public static PersonaLoadResult Ok(PersonaDefinition definition) => new() { Definition = definition };
+    public static PersonaLoadResult Failure(List<string> errors) => new() { Errors = errors };
+}

--- a/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
@@ -129,6 +129,7 @@ public static class PersonaDefinitionLoader
                 // v1 scope: only the 'once' trigger is implemented. Interval triggers are
                 // permitted by the schema (future-proofing) but rejected at load time so
                 // authors hit the error before the agent starts, not mid-run (FR-014).
+                // TODO(US2): drop this yield when IntervalTriggerLoop lands.
                 yield return "interval triggers are not yet supported in v1 (planned for Feature 110 US2 — use 'once' for now)";
                 break;
         }

--- a/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaDefinitionLoader.cs
@@ -101,8 +101,9 @@ public static class PersonaDefinitionLoader
         // follow-up feature. Until then, a persona declared with only actionName cannot
         // be submitted, so we reject at load time rather than crash at first fire.
         if (def.Target.ActionName is not null && def.Target.ActionIndex is null)
-            yield return "target.actionName is not yet supported in v1 — set target.actionIndex instead "
-                       + "(action-name lookup will land in a follow-up feature)";
+            yield return $"target.actionName=\"{def.Target.ActionName}\" is not yet supported in v1 — set "
+                       + "target.actionIndex to the zero-based position of that action in the blueprint "
+                       + "(e.g. actionIndex: 0 for the starting action). Action-name lookup will land in a follow-up feature.";
 
         switch (def.Trigger)
         {
@@ -115,6 +116,10 @@ public static class PersonaDefinitionLoader
                 if (interval.EverySeconds is int s && s <= 0) yield return "trigger.everySeconds must be > 0";
                 if (interval.EveryMinutes is int m && m <= 0) yield return "trigger.everyMinutes must be > 0";
                 if (interval.MaxIterations is int mi && mi <= 0) yield return "trigger.maxIterations must be > 0";
+                // v1 scope: only the 'once' trigger is implemented. Interval triggers are
+                // permitted by the schema (future-proofing) but rejected at load time so
+                // authors hit the error before the agent starts, not mid-run (FR-014).
+                yield return "interval triggers are not yet supported in v1 (planned for Feature 110 US2 — use 'once' for now)";
                 break;
         }
     }

--- a/src/Apps/Sorcha.Agent/Persona/PersonaHost.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaHost.cs
@@ -59,8 +59,17 @@ public sealed class PersonaHost
         try
         {
             await _loop.RunAsync(cancellationToken);
-            _logger.LogInformation("Persona {PersonaName} completed after {Iterations} iteration(s)",
-                _definition.Name, _loop.CompletedIterations);
+            if (_loop.CompletedIterations == 0)
+            {
+                _logger.LogWarning(
+                    "Persona {PersonaName} exited without any successful submissions — check earlier log lines for the failure reason",
+                    _definition.Name);
+            }
+            else
+            {
+                _logger.LogInformation("Persona {PersonaName} completed after {Iterations} iteration(s)",
+                    _definition.Name, _loop.CompletedIterations);
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/Apps/Sorcha.Agent/Persona/PersonaHost.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaHost.cs
@@ -12,6 +12,11 @@ namespace Sorcha.Agent.Persona;
 /// </summary>
 public sealed class PersonaHost
 {
+    // Feature 110 v1 note: the AuditLogger integration described in research.md R-007
+    // is deferred — persona fires are observable via structured ILogger output but do
+    // not currently land in the agent's *.jsonl audit stream alongside reactive
+    // decisions. To be wired in by the follow-up US2 / Phase 7 work (tracked on
+    // GAP-021 in MASTER-TASKS.md).
     private readonly PersonaDefinition _definition;
     private readonly IPersonaSubmitter _submitter;
     private readonly IPayloadTokenResolver _resolver;
@@ -47,6 +52,9 @@ public sealed class PersonaHost
             OnceTrigger once => new OnceTriggerLoop(
                 _definition, once, _submitter, _resolver, _random, _timeProvider,
                 _loggerFactory.CreateLogger<OnceTriggerLoop>()),
+            // Unreachable in v1: PersonaDefinitionLoader.ValidateSemantics rejects interval
+            // triggers at load time. Defence-in-depth guard in case a future change removes
+            // that check without landing the real IntervalTriggerLoop wiring. TODO(US2): replace.
             IntervalTrigger _ =>
                 throw new NotSupportedException(
                     "Interval triggers are planned for Feature 110 User Story 2 — not implemented in this MVP."),

--- a/src/Apps/Sorcha.Agent/Persona/PersonaHost.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaHost.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Composes a <see cref="PersonaDefinition"/> with the correct <see cref="IPersonaLoop"/>
+/// implementation based on trigger kind. Launched as a peer <see cref="Task"/> from
+/// <see cref="Commands.RunCommand"/>, alongside the reactive inbox loop.
+/// </summary>
+public sealed class PersonaHost
+{
+    private readonly PersonaDefinition _definition;
+    private readonly IPersonaSubmitter _submitter;
+    private readonly IPayloadTokenResolver _resolver;
+    private readonly IRandomSource _random;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<PersonaHost> _logger;
+    private IPersonaLoop? _loop;
+
+    public PersonaHost(
+        PersonaDefinition definition,
+        IPersonaSubmitter submitter,
+        IPayloadTokenResolver resolver,
+        IRandomSource random,
+        TimeProvider timeProvider,
+        ILoggerFactory loggerFactory)
+    {
+        _definition = definition;
+        _submitter = submitter;
+        _resolver = resolver;
+        _random = random;
+        _timeProvider = timeProvider;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<PersonaHost>();
+    }
+
+    public int CompletedIterations => _loop?.CompletedIterations ?? 0;
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        _loop = _definition.Trigger switch
+        {
+            OnceTrigger once => new OnceTriggerLoop(
+                _definition, once, _submitter, _resolver, _random, _timeProvider,
+                _loggerFactory.CreateLogger<OnceTriggerLoop>()),
+            IntervalTrigger _ =>
+                throw new NotSupportedException(
+                    "Interval triggers are planned for Feature 110 User Story 2 — not implemented in this MVP."),
+            _ => throw new NotSupportedException($"Trigger kind '{_definition.Trigger.GetType().Name}' not supported")
+        };
+
+        _logger.LogInformation("Persona {PersonaName} starting (trigger={TriggerKind})",
+            _definition.Name, _definition.Trigger.GetType().Name);
+
+        try
+        {
+            await _loop.RunAsync(cancellationToken);
+            _logger.LogInformation("Persona {PersonaName} completed after {Iterations} iteration(s)",
+                _definition.Name, _loop.CompletedIterations);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Persona {PersonaName} cancelled after {Iterations} iteration(s)",
+                _definition.Name, _loop.CompletedIterations);
+        }
+    }
+}

--- a/src/Apps/Sorcha.Agent/Persona/PersonaSchemaValidator.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaSchemaValidator.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Text.Json;
+using Json.Schema;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Validates a parsed persona JSON file against the embedded persona-schema.json.
+/// </summary>
+public sealed class PersonaSchemaValidator
+{
+    private static readonly Lazy<JsonSchema> Schema = new(LoadSchema);
+
+    /// <summary>
+    /// Returns a flat list of schema violations. Empty result means the file is valid.
+    /// </summary>
+    public IReadOnlyList<string> Validate(JsonElement personaJson)
+    {
+        var options = new EvaluationOptions { OutputFormat = OutputFormat.List };
+        var result = Schema.Value.Evaluate(personaJson, options);
+        if (result.IsValid) return Array.Empty<string>();
+
+        var errors = new List<string>();
+        CollectErrors(result, errors);
+        return errors;
+    }
+
+    private static void CollectErrors(EvaluationResults result, List<string> errors)
+    {
+        if (!result.IsValid && result.Errors is { Count: > 0 })
+        {
+            foreach (var kv in result.Errors)
+                errors.Add($"{result.InstanceLocation}: {kv.Value}");
+        }
+        if (result.Details is { Count: > 0 })
+        {
+            foreach (var detail in result.Details)
+                CollectErrors(detail, errors);
+        }
+    }
+
+    private static JsonSchema LoadSchema()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        const string resourceName = "Sorcha.Agent.Persona.Schemas.persona-schema.json";
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded schema '{resourceName}' not found");
+        using var reader = new StreamReader(stream);
+        return JsonSchema.FromText(reader.ReadToEnd());
+    }
+}

--- a/src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs
@@ -78,6 +78,9 @@ public sealed class PersonaSubmitter : IPersonaSubmitter
                 Content = JsonContent.Create(body)
             };
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            // Mirrors ActionExecutor's contract with the Blueprint Service: the service expects
+            // both Authorization and X-Delegation-Token carrying the same JWT so it can attribute
+            // the action to the originating wallet. Don't drop one without updating the other.
             request.Headers.Add("X-Delegation-Token", token);
 
             var response = await _httpClient.SendAsync(request, cancellationToken);
@@ -92,13 +95,14 @@ public sealed class PersonaSubmitter : IPersonaSubmitter
             }
 
             var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            var truncatedBody = Truncate(errorBody, 500);
             var outcome = IsTransient(response.StatusCode)
                 ? PersonaSubmissionOutcome.TransientFailure
                 : PersonaSubmissionOutcome.HardFailure;
             _logger.LogWarning(
                 "Persona {PersonaName} submission failed: {Status} {Body} (classified {Outcome})",
-                persona.Name, (int)response.StatusCode, errorBody, outcome);
-            return new PersonaSubmissionResult(outcome, sw.ElapsedMilliseconds, $"{(int)response.StatusCode}: {errorBody}");
+                persona.Name, (int)response.StatusCode, truncatedBody, outcome);
+            return new PersonaSubmissionResult(outcome, sw.ElapsedMilliseconds, $"{(int)response.StatusCode}: {truncatedBody}");
         }
         catch (HttpRequestException ex)
         {
@@ -117,4 +121,7 @@ public sealed class PersonaSubmitter : IPersonaSubmitter
         code == HttpStatusCode.RequestTimeout
         || code == HttpStatusCode.TooManyRequests
         || (int)code >= 500;
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..max] + "… [truncated]";
 }

--- a/src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Sorcha.Agent.Auth;
+
+namespace Sorcha.Agent.Persona;
+
+/// <summary>
+/// Submits persona-generated actions by posting to
+/// <c>/api/instances/{instanceId}/actions/{actionIndex}/execute</c>, matching
+/// the contract used by <see cref="Execution.ActionExecutor"/>.
+/// </summary>
+public sealed class PersonaSubmitter : IPersonaSubmitter
+{
+    private readonly HttpClient _httpClient;
+    private readonly Func<CancellationToken, Task<string>> _tokenProvider;
+    private readonly string _walletAddress;
+    private readonly string _registerId;
+    private readonly ILogger<PersonaSubmitter> _logger;
+
+    public PersonaSubmitter(
+        HttpClient httpClient,
+        AgentAuthService authService,
+        string walletAddress,
+        string registerId,
+        ILogger<PersonaSubmitter> logger)
+        : this(httpClient, authService.GetTokenAsync, walletAddress, registerId, logger) { }
+
+    internal PersonaSubmitter(
+        HttpClient httpClient,
+        Func<CancellationToken, Task<string>> tokenProvider,
+        string walletAddress,
+        string registerId,
+        ILogger<PersonaSubmitter> logger)
+    {
+        _httpClient = httpClient;
+        _tokenProvider = tokenProvider;
+        _walletAddress = walletAddress;
+        _registerId = registerId;
+        _logger = logger;
+    }
+
+    public async Task<PersonaSubmissionResult> SubmitAsync(
+        PersonaDefinition persona,
+        JsonObject resolvedPayload,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+        var actionIndex = persona.Target.ActionIndex
+            ?? throw new InvalidOperationException(
+                "PersonaTarget.ActionIndex must be resolved before submission (use PersonaTargetResolver).");
+
+        var endpoint = $"/api/instances/{persona.Target.InstanceId}/actions/{actionIndex}/execute";
+        var body = new
+        {
+            blueprintId = persona.Target.BlueprintId,
+            actionId = actionIndex.ToString(),
+            instanceId = persona.Target.InstanceId,
+            senderWallet = _walletAddress,
+            registerAddress = _registerId,
+            payloadData = (JsonNode)resolvedPayload
+        };
+
+        try
+        {
+            var token = await _tokenProvider(cancellationToken);
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+            {
+                Content = JsonContent.Create(body)
+            };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Headers.Add("X-Delegation-Token", token);
+
+            var response = await _httpClient.SendAsync(request, cancellationToken);
+            sw.Stop();
+
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation(
+                    "Persona {PersonaName} submitted action index {ActionIndex} (blueprint={BlueprintId})",
+                    persona.Name, actionIndex, persona.Target.BlueprintId);
+                return new PersonaSubmissionResult(PersonaSubmissionOutcome.Submitted, sw.ElapsedMilliseconds);
+            }
+
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            var outcome = IsTransient(response.StatusCode)
+                ? PersonaSubmissionOutcome.TransientFailure
+                : PersonaSubmissionOutcome.HardFailure;
+            _logger.LogWarning(
+                "Persona {PersonaName} submission failed: {Status} {Body} (classified {Outcome})",
+                persona.Name, (int)response.StatusCode, errorBody, outcome);
+            return new PersonaSubmissionResult(outcome, sw.ElapsedMilliseconds, $"{(int)response.StatusCode}: {errorBody}");
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            _logger.LogWarning(ex, "Persona {PersonaName} submission network error", persona.Name);
+            return new PersonaSubmissionResult(PersonaSubmissionOutcome.TransientFailure, sw.ElapsedMilliseconds, ex.Message);
+        }
+        catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            sw.Stop();
+            return new PersonaSubmissionResult(PersonaSubmissionOutcome.TransientFailure, sw.ElapsedMilliseconds, "Request timed out");
+        }
+    }
+
+    private static bool IsTransient(HttpStatusCode code) =>
+        code == HttpStatusCode.RequestTimeout
+        || code == HttpStatusCode.TooManyRequests
+        || (int)code >= 500;
+}

--- a/src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs
+++ b/src/Apps/Sorcha.Agent/Persona/PersonaSubmitter.cs
@@ -57,6 +57,9 @@ public sealed class PersonaSubmitter : IPersonaSubmitter
                 "PersonaTarget.ActionIndex must be resolved before submission (use PersonaTargetResolver).");
 
         var endpoint = $"/api/instances/{persona.Target.InstanceId}/actions/{actionIndex}/execute";
+        // Body shape matches Sorcha.Agent.Execution.ActionExecutor verbatim, including the
+        // string-typed actionId (Blueprint Service accepts the string form — see
+        // src/Apps/Sorcha.Agent/Execution/ActionExecutor.cs line ~80).
         var body = new
         {
             blueprintId = persona.Target.BlueprintId,

--- a/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
+++ b/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
@@ -18,7 +18,7 @@
     },
     "target": {
       "type": "object",
-      "required": ["blueprintId", "instanceId"],
+      "required": ["blueprintId", "instanceId", "actionIndex"],
       "additionalProperties": false,
       "properties": {
         "blueprintId": {
@@ -29,20 +29,12 @@
           "type": "string",
           "description": "Pre-created blueprint instance ID. Supports {{placeholders}} resolved from state.json."
         },
-        "actionName": {
-          "type": "string",
-          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex. NOT YET SUPPORTED in v1 — the loader rejects actionName-only targets; set actionIndex instead. Name→index lookup is planned for a follow-up feature."
-        },
         "actionIndex": {
           "type": "integer",
           "minimum": 0,
-          "description": "Zero-based index of the target action. Mutually exclusive with actionName."
+          "description": "Zero-based index of the target action in the blueprint."
         }
-      },
-      "oneOf": [
-        { "required": ["actionName"] },
-        { "required": ["actionIndex"] }
-      ]
+      }
     },
     "trigger": {
       "oneOf": [

--- a/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
+++ b/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
@@ -7,6 +7,10 @@
   "required": ["name", "target", "trigger", "payloadTemplate"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor IntelliSense. Ignored at runtime."
+    },
     "name": {
       "type": "string",
       "minLength": 1,
@@ -27,7 +31,7 @@
         },
         "actionName": {
           "type": "string",
-          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex."
+          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex. NOT YET SUPPORTED in v1 — the loader rejects actionName-only targets; set actionIndex instead. Name→index lookup is planned for a follow-up feature."
         },
         "actionIndex": {
           "type": "integer",

--- a/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
+++ b/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
@@ -107,7 +107,7 @@
       "target": {
         "blueprintId": "{{blueprints.procurement-to-pay.id}}",
         "instanceId": "{{instances.procurement-to-pay.id}}",
-        "actionName": "Raise Purchase Order"
+        "actionIndex": 0
       },
       "trigger": { "kind": "once", "delaySeconds": 2 },
       "payloadTemplate": {
@@ -121,7 +121,7 @@
       "target": {
         "blueprintId": "{{blueprints.invoice.id}}",
         "instanceId": "{{instances.invoice.id}}",
-        "actionName": "Raise Invoice"
+        "actionIndex": 4
       },
       "trigger": {
         "kind": "interval",

--- a/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
+++ b/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sorcha.dev/schemas/agent-persona/v1.json",
+  "title": "Sorcha Agent Persona v1",
+  "description": "Declarative non-reactive behaviour for a Sorcha agent. Referenced from an actor config via the 'personaFile' field.",
+  "type": "object",
+  "required": ["name", "target", "trigger", "payloadTemplate"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable persona label; appears in logs and audit entries."
+    },
+    "target": {
+      "type": "object",
+      "required": ["blueprintId", "instanceId"],
+      "additionalProperties": false,
+      "properties": {
+        "blueprintId": {
+          "type": "string",
+          "description": "Blueprint whose starting action will be submitted. Supports {{placeholders}} resolved from state.json."
+        },
+        "instanceId": {
+          "type": "string",
+          "description": "Pre-created blueprint instance ID. Supports {{placeholders}} resolved from state.json."
+        },
+        "actionName": {
+          "type": "string",
+          "description": "Human name of the target action within the blueprint. Mutually exclusive with actionIndex."
+        },
+        "actionIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero-based index of the target action. Mutually exclusive with actionName."
+        }
+      },
+      "oneOf": [
+        { "required": ["actionName"] },
+        { "required": ["actionIndex"] }
+      ]
+    },
+    "trigger": {
+      "oneOf": [
+        { "$ref": "#/$defs/onceTrigger" },
+        { "$ref": "#/$defs/intervalTrigger" }
+      ]
+    },
+    "payloadTemplate": {
+      "type": "object",
+      "description": "JSON template submitted at each fire. String values may contain ${token} substitutions; a string that is exactly '${token}' is replaced by the token's typed result (integer, decimal, or array element) rather than a stringified form."
+    }
+  },
+  "$defs": {
+    "onceTrigger": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "once" },
+        "delaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Optional delay between agent start and the single fire."
+        }
+      }
+    },
+    "intervalTrigger": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "interval" },
+        "everySeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Interval between fires in seconds. Mutually exclusive with everyMinutes."
+        },
+        "everyMinutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Interval between fires in minutes. Mutually exclusive with everySeconds."
+        },
+        "startDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Optional delay before the first fire."
+        },
+        "maxIterations": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Stop after N successful fires. Optional."
+        },
+        "until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Stop at this wall-clock timestamp (ISO 8601). Optional."
+        }
+      },
+      "oneOf": [
+        { "required": ["everySeconds"] },
+        { "required": ["everyMinutes"] }
+      ]
+    }
+  },
+  "examples": [
+    {
+      "name": "procurement-mgr-kickoff",
+      "target": {
+        "blueprintId": "{{blueprints.procurement-to-pay.id}}",
+        "instanceId": "{{instances.procurement-to-pay.id}}",
+        "actionName": "Raise Purchase Order"
+      },
+      "trigger": { "kind": "once", "delaySeconds": 2 },
+      "payloadTemplate": {
+        "poReference": "PO-CAIRN-2026-00142",
+        "projectName": "Aviemore Heights Phase 2",
+        "siteAddress": "Plot 7-12, Craig na Gower Avenue, Aviemore, PH22 1RW"
+      }
+    },
+    {
+      "name": "invoice-generator",
+      "target": {
+        "blueprintId": "{{blueprints.invoice.id}}",
+        "instanceId": "{{instances.invoice.id}}",
+        "actionName": "Raise Invoice"
+      },
+      "trigger": {
+        "kind": "interval",
+        "everySeconds": 30,
+        "maxIterations": 20
+      },
+      "payloadTemplate": {
+        "invoiceNumber": "INV-${counter}",
+        "invoiceId": "${uuid}",
+        "issuedAt": "${now}",
+        "amount": "${random.decimal(100, 9999, 2)}",
+        "currency": "${random.choice([\"EUR\",\"GBP\",\"USD\"])}"
+      }
+    }
+  ]
+}

--- a/src/Apps/Sorcha.Agent/README.md
+++ b/src/Apps/Sorcha.Agent/README.md
@@ -246,7 +246,25 @@ Hooks that execute before payload submission, e.g. file uploads:
 - **File Upload Pre-Actions** — Chunked encrypted file submission (up to 40MB)
 - **Resilient Execution** — Polly retry/circuit-breaker, SignalR auto-reconnect, JWT auto-refresh
 - **Audit Logging** — JSONL append-only trail of all decisions and submissions
+- **Persona Mode** — Optional autonomous initiator loop alongside reactive inbox (Feature 110)
 - **Cross-Platform** — Runs on Windows, macOS, and Linux
+
+## Persona Mode
+
+A **persona** is an optional JSON file that lets an agent initiate a workflow instead of only reacting to its inbox. Enabled by adding a `personaFile` field to the actor definition:
+
+```jsonc
+{
+  "actor": { "name": "procurement-mgr", ... },
+  "personaFile": "../personas/procurement-mgr-kickoff.persona.json",
+  "mode": "rules",
+  "rules": [ ... ]
+}
+```
+
+The persona file declares a trigger (`once` in v1), a target (blueprint + instance + action index), and a payload template with substitution tokens (`${now}`, `${uuid}`, `${counter}`, `${random.int|decimal|choice}`). The persona loop runs alongside the reactive inbox loop using the same wallet, auth, and HTTP client — agents without `personaFile` are unaffected.
+
+Typical use is unblocking multi-agent walkthroughs that would otherwise hang because the first action has no prior transaction to populate any agent's inbox. See [`specs/110-agent-persona-mode/quickstart.md`](../../../specs/110-agent-persona-mode/quickstart.md) for the full guide.
 
 ## Exit Codes
 

--- a/src/Apps/Sorcha.Agent/Sorcha.Agent.csproj
+++ b/src/Apps/Sorcha.Agent/Sorcha.Agent.csproj
@@ -44,6 +44,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+
+    <!-- Persona schema validation -->
+    <PackageReference Include="JsonSchema.Net" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Persona\Schemas\persona-schema.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Sorcha.Agent.Tests/Configuration/ActorDefinitionLoaderTests.cs
+++ b/tests/Sorcha.Agent.Tests/Configuration/ActorDefinitionLoaderTests.cs
@@ -57,6 +57,40 @@ public class ActorDefinitionLoaderTests : IDisposable
     }
 
     [Fact]
+    public void Load_ConfigWithoutPersonaFile_PreservesNullPersonaFile()
+    {
+        // Regression: existing actor configs (pre-Feature 110) must load unchanged.
+        var path = WriteConfig(ValidActorJson);
+        var result = ActorDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeTrue();
+        result.Definition!.PersonaFile.Should().BeNull();
+    }
+
+    [Fact]
+    public void Load_ConfigWithPersonaFile_CapturesRelativePath()
+    {
+        var json = """
+            {
+              "actor": { "name": "test-actor" },
+              "connection": {
+                "gatewayUrl": "http://localhost",
+                "registerId": "reg-1",
+                "credentials": { "email": "test@example.com", "password": "pass", "organizationId": "org-1" },
+                "walletAddress": "wallet-1"
+              },
+              "inbox": { "polling": { "enabled": true, "intervalSeconds": 30 } },
+              "mode": "rules",
+              "rules": [ { "actionName": "Submit", "decision": "approve", "payload": {} } ],
+              "personaFile": "../personas/test.persona.json"
+            }
+            """;
+        var path = WriteConfig(json);
+        var result = ActorDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeTrue();
+        result.Definition!.PersonaFile.Should().Be("../personas/test.persona.json");
+    }
+
+    [Fact]
     public void Load_MissingFile_ReturnsFailure()
     {
         var result = ActorDefinitionLoader.Load("/nonexistent/actor.json");

--- a/tests/Sorcha.Agent.Tests/Persona/OnceTriggerLoopTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/OnceTriggerLoopTests.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Agent.Persona;
+
+namespace Sorcha.Agent.Tests.Persona;
+
+public class OnceTriggerLoopTests
+{
+    private static PersonaDefinition MakeDefinition() => new()
+    {
+        Name = "test",
+        Target = new PersonaTarget { BlueprintId = "bp-1", InstanceId = "inst-1", ActionIndex = 0 },
+        Trigger = new OnceTrigger { DelaySeconds = 0 },
+        PayloadTemplate = JsonNode.Parse("""{ "value": "${counter}" }""")!
+    };
+
+    private static OnceTriggerLoop MakeLoop(PersonaDefinition def, IPersonaSubmitter submitter) =>
+        new(def, (OnceTrigger)def.Trigger, submitter, new PayloadTokenResolver(),
+            new StubRandom(), TimeProvider.System, NullLogger<OnceTriggerLoop>.Instance);
+
+    [Fact]
+    public async Task RunAsync_Submitted_CompletesOneIteration()
+    {
+        var submitter = new CapturingSubmitter(PersonaSubmissionOutcome.Submitted);
+        var loop = MakeLoop(MakeDefinition(), submitter);
+
+        await loop.RunAsync(CancellationToken.None);
+
+        loop.CompletedIterations.Should().Be(1);
+        submitter.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunAsync_HardFailure_DoesNotIncrementCompleted()
+    {
+        var submitter = new CapturingSubmitter(PersonaSubmissionOutcome.HardFailure);
+        var loop = MakeLoop(MakeDefinition(), submitter);
+
+        await loop.RunAsync(CancellationToken.None);
+
+        loop.CompletedIterations.Should().Be(0);
+        submitter.Calls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RunAsync_TransientFailure_DoesNotRetryForOnceTrigger()
+    {
+        var submitter = new CapturingSubmitter(PersonaSubmissionOutcome.TransientFailure);
+        var loop = MakeLoop(MakeDefinition(), submitter);
+
+        await loop.RunAsync(CancellationToken.None);
+
+        submitter.Calls.Should().Be(1);
+        loop.CompletedIterations.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_CancelledBeforeFire_ThrowsOperationCanceled()
+    {
+        var def = MakeDefinition() with { Trigger = new OnceTrigger { DelaySeconds = 60 } };
+        var submitter = new CapturingSubmitter(PersonaSubmissionOutcome.Submitted);
+        var loop = new OnceTriggerLoop(def, (OnceTrigger)def.Trigger, submitter,
+            new PayloadTokenResolver(), new StubRandom(), TimeProvider.System,
+            NullLogger<OnceTriggerLoop>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        var act = async () => await loop.RunAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        submitter.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_ResolvesPayloadWithCounterOne()
+    {
+        var submitter = new CapturingSubmitter(PersonaSubmissionOutcome.Submitted);
+        var loop = MakeLoop(MakeDefinition(), submitter);
+
+        await loop.RunAsync(CancellationToken.None);
+
+        submitter.LastPayload.Should().NotBeNull();
+        submitter.LastPayload!["value"]!.GetValue<int>().Should().Be(1);
+    }
+
+    private sealed class CapturingSubmitter : IPersonaSubmitter
+    {
+        private readonly PersonaSubmissionOutcome _outcome;
+        public int Calls { get; private set; }
+        public JsonObject? LastPayload { get; private set; }
+
+        public CapturingSubmitter(PersonaSubmissionOutcome outcome) { _outcome = outcome; }
+
+        public Task<PersonaSubmissionResult> SubmitAsync(
+            PersonaDefinition persona, JsonObject resolvedPayload, CancellationToken ct)
+        {
+            Calls++;
+            LastPayload = resolvedPayload;
+            return Task.FromResult(new PersonaSubmissionResult(_outcome, 10));
+        }
+    }
+
+    private sealed class StubRandom : IRandomSource
+    {
+        public int NextInt(int min, int max) => min;
+        public decimal NextDecimal(decimal min, decimal max, int p) => min;
+        public T Choose<T>(IReadOnlyList<T> options) => options[0];
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Persona/OnceTriggerLoopTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/OnceTriggerLoopTests.cs
@@ -66,7 +66,8 @@ public class OnceTriggerLoopTests
             new PayloadTokenResolver(), new StubRandom(), TimeProvider.System,
             NullLogger<OnceTriggerLoop>.Instance);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        // 500ms grace so slow CI runners don't flake against a 60-second inner delay.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
         var act = async () => await loop.RunAsync(cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();

--- a/tests/Sorcha.Agent.Tests/Persona/PayloadTokenResolverTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PayloadTokenResolverTests.cs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Nodes;
+using Sorcha.Agent.Persona;
+
+namespace Sorcha.Agent.Tests.Persona;
+
+public class PayloadTokenResolverTests
+{
+    private sealed class StubRandom : IRandomSource
+    {
+        public int IntValue { get; init; } = 42;
+        public decimal DecimalValue { get; init; } = 99.99m;
+        public int ChoiceIndex { get; init; } = 0;
+
+        public int NextInt(int minInclusive, int maxInclusive) => IntValue;
+        public decimal NextDecimal(decimal minInclusive, decimal maxInclusive, int precision) => DecimalValue;
+        public T Choose<T>(IReadOnlyList<T> options) => options[ChoiceIndex];
+    }
+
+    private static PersonaFireContext Ctx(int iteration = 1, IRandomSource? random = null) => new()
+    {
+        Iteration = iteration,
+        Now = new DateTimeOffset(2026, 4, 22, 12, 0, 0, TimeSpan.Zero),
+        RandomSource = random ?? new StubRandom()
+    };
+
+    [Fact]
+    public void Resolve_CounterTokenAlone_PreservesIntegerType()
+    {
+        var template = JsonNode.Parse("""{ "n": "${counter}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx(iteration: 5));
+        result["n"]!.GetValue<int>().Should().Be(5);
+    }
+
+    [Fact]
+    public void Resolve_CounterTokenEmbedded_InterpolatesAsString()
+    {
+        var template = JsonNode.Parse("""{ "ref": "INV-${counter}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx(iteration: 7));
+        result["ref"]!.GetValue<string>().Should().Be("INV-7");
+    }
+
+    [Fact]
+    public void Resolve_RandomDecimalAlone_ProducesJsonNumber()
+    {
+        var template = JsonNode.Parse("""{ "amount": "${random.decimal(0, 100, 2)}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx(random: new StubRandom { DecimalValue = 42.50m }));
+        result["amount"]!.GetValue<decimal>().Should().Be(42.50m);
+    }
+
+    [Fact]
+    public void Resolve_RandomIntAlone_ProducesJsonNumber()
+    {
+        var template = JsonNode.Parse("""{ "q": "${random.int(1, 100)}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx(random: new StubRandom { IntValue = 77 }));
+        result["q"]!.GetValue<int>().Should().Be(77);
+    }
+
+    [Fact]
+    public void Resolve_RandomChoiceString_PicksElement()
+    {
+        var template = JsonNode.Parse("""{ "ccy": "${random.choice([\"EUR\",\"GBP\",\"USD\"])}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx(random: new StubRandom { ChoiceIndex = 2 }));
+        result["ccy"]!.GetValue<string>().Should().Be("USD");
+    }
+
+    [Fact]
+    public void Resolve_NowTokenAlone_ProducesIso8601String()
+    {
+        var template = JsonNode.Parse("""{ "at": "${now}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx());
+        result["at"]!.GetValue<string>().Should().Be("2026-04-22T12:00:00.0000000+00:00");
+    }
+
+    [Fact]
+    public void Resolve_UuidToken_ProducesNewGuid()
+    {
+        var template = JsonNode.Parse("""{ "id": "${uuid}" }""")!;
+        var result = new PayloadTokenResolver().Resolve(template, Ctx());
+        Guid.TryParse(result["id"]!.GetValue<string>(), out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTokens_UnknownToken_ReturnsError()
+    {
+        var template = JsonNode.Parse("""{ "x": "${randm.int(1,2)}" }""")!;
+        var errors = new PayloadTokenResolver().ValidateTokens(template);
+        errors.Should().ContainSingle().Which.Should().Contain("Unknown token 'randm.int'");
+    }
+
+    [Fact]
+    public void ValidateTokens_RandomIntMissingArgs_ReturnsError()
+    {
+        var template = JsonNode.Parse("""{ "x": "${random.int}" }""")!;
+        var errors = new PayloadTokenResolver().ValidateTokens(template);
+        errors.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void ValidateTokens_EmptyChoiceList_ReturnsError()
+    {
+        var template = JsonNode.Parse("""{ "x": "${random.choice([])}" }""")!;
+        var errors = new PayloadTokenResolver().ValidateTokens(template);
+        errors.Should().ContainSingle().Which.Should().Contain("non-empty");
+    }
+
+    [Fact]
+    public void ValidateTokens_ValidTemplate_ReturnsNoErrors()
+    {
+        var template = JsonNode.Parse("""
+            {
+              "id": "${uuid}",
+              "n": "${counter}",
+              "at": "${now}",
+              "price": "${random.decimal(1, 100, 2)}",
+              "qty": "${random.int(1, 10)}",
+              "ccy": "${random.choice([\"EUR\",\"GBP\"])}",
+              "label": "Invoice-${counter}"
+            }
+            """)!;
+        new PayloadTokenResolver().ValidateTokens(template).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_DeterministicGivenSeed_ProducesSameOutput()
+    {
+        var random = new RandomSource(new Random(42));
+        var template = JsonNode.Parse("""{ "n": "${random.int(0, 1000)}" }""")!;
+        var a = new PayloadTokenResolver().Resolve(template, new PersonaFireContext
+        {
+            Iteration = 1, Now = DateTimeOffset.UtcNow, RandomSource = random
+        });
+
+        var random2 = new RandomSource(new Random(42));
+        var b = new PayloadTokenResolver().Resolve(template, new PersonaFireContext
+        {
+            Iteration = 1, Now = DateTimeOffset.UtcNow, RandomSource = random2
+        });
+
+        a["n"]!.GetValue<int>().Should().Be(b["n"]!.GetValue<int>());
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
@@ -95,6 +95,61 @@ public class PersonaDefinitionLoaderTests : IDisposable
     }
 
     [Fact]
+    public void Load_PersonaFileWithDollarSchemaKey_Accepted()
+    {
+        // Regression: $schema is an IDE-IntelliSense hint. The root schema declares
+        // additionalProperties: false, so $schema must be explicitly permitted.
+        var path = WritePersona("""
+            {
+              "$schema": "../../../specs/110-agent-persona-mode/contracts/persona-schema.json",
+              "name": "ok",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": { "x": 1 }
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Load_InstanceIdWithSlash_Rejected()
+    {
+        // Regression: env-var-sourced IDs can contain path separators that would
+        // silently rewrite the submission endpoint. Must be caught at load time.
+        var path = WritePersona("""
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "../other-instance/execute?x=", "actionIndex": 0 },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": {}
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("instanceId") && e.Contains("disallowed characters"));
+    }
+
+    [Fact]
+    public void Load_ActionNameOnly_RejectedWithHelpfulMessage()
+    {
+        var path = WritePersona("""
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionName": "Raise PO" },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": {}
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("actionName") && e.Contains("actionIndex"));
+    }
+
+    [Fact]
     public void Load_SchemaViolation_ReturnsFailure()
     {
         var path = WritePersona("""

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Agent.Persona;
+
+namespace Sorcha.Agent.Tests.Persona;
+
+public class PersonaDefinitionLoaderTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PersonaDefinitionLoaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"sorcha-persona-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private string WritePersona(string json)
+    {
+        var path = Path.Combine(_tempDir, "test.persona.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public void Load_ValidOnceTrigger_ReturnsSuccess()
+    {
+        var path = WritePersona("""
+            {
+              "name": "kickoff",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "once", "delaySeconds": 2 },
+              "payloadTemplate": { "poReference": "PO-001" }
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Definition!.Name.Should().Be("kickoff");
+        result.Definition.Trigger.Should().BeOfType<OnceTrigger>()
+            .Which.DelaySeconds.Should().Be(2);
+        result.Definition.Target.ActionIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void Load_ValidIntervalTrigger_ReturnsSuccess()
+    {
+        var path = WritePersona("""
+            {
+              "name": "gen",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "interval", "everySeconds": 30, "maxIterations": 5 },
+              "payloadTemplate": { "amount": "${random.int(1,100)}" }
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeTrue();
+        var interval = result.Definition!.Trigger.Should().BeOfType<IntervalTrigger>().Subject;
+        interval.EverySeconds.Should().Be(30);
+        interval.MaxIterations.Should().Be(5);
+        interval.IntervalSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public void Load_MissingFile_ReturnsFailure()
+    {
+        var result = PersonaDefinitionLoader.Load(Path.Combine(_tempDir, "does-not-exist.json"));
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle().Which.Should().Contain("not found");
+    }
+
+    [Fact]
+    public void Load_TokenTypo_ReturnsFailureAtLoadTime()
+    {
+        var path = WritePersona("""
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": { "x": "${randm.int(1,2)}" }
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Unknown token"));
+    }
+
+    [Fact]
+    public void Load_SchemaViolation_ReturnsFailure()
+    {
+        var path = WritePersona("""
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1" },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": {}
+            }
+            """);
+
+        var result = PersonaDefinitionLoader.Load(path);
+        result.IsSuccess.Should().BeFalse();
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
@@ -51,8 +51,10 @@ public class PersonaDefinitionLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Load_ValidIntervalTrigger_ReturnsSuccess()
+    public void Load_IntervalTrigger_RejectedInV1()
     {
+        // Interval triggers are permitted by the schema (future-proofing) but rejected
+        // at load time in v1 so authors see the limit before the agent starts (FR-014).
         var path = WritePersona("""
             {
               "name": "gen",
@@ -63,11 +65,8 @@ public class PersonaDefinitionLoaderTests : IDisposable
             """);
 
         var result = PersonaDefinitionLoader.Load(path);
-        result.IsSuccess.Should().BeTrue();
-        var interval = result.Definition!.Trigger.Should().BeOfType<IntervalTrigger>().Subject;
-        interval.EverySeconds.Should().Be(30);
-        interval.MaxIterations.Should().Be(5);
-        interval.IntervalSeconds.Should().Be(30);
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("interval triggers are not yet supported"));
     }
 
     [Fact]

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaDefinitionLoaderTests.cs
@@ -133,8 +133,10 @@ public class PersonaDefinitionLoaderTests : IDisposable
     }
 
     [Fact]
-    public void Load_ActionNameOnly_RejectedWithHelpfulMessage()
+    public void Load_ActionNameOnly_RejectedAtLoadTime()
     {
+        // v1 requires actionIndex. actionName is an additional property the schema
+        // does not allow; the validator surfaces the failure before semantics run.
         var path = WritePersona("""
             {
               "name": "bad",
@@ -146,7 +148,6 @@ public class PersonaDefinitionLoaderTests : IDisposable
 
         var result = PersonaDefinitionLoader.Load(path);
         result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("actionName") && e.Contains("actionIndex"));
     }
 
     [Fact]

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaHostOneShotIntegrationTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaHostOneShotIntegrationTests.cs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Agent.Persona;
+
+namespace Sorcha.Agent.Tests.Persona;
+
+/// <summary>
+/// End-to-end wiring test for Feature 110 User Story 1 (task T023).
+/// Exercises <see cref="PersonaHost"/> + <see cref="OnceTriggerLoop"/> + real
+/// <see cref="PersonaSubmitter"/> + a stub <see cref="HttpMessageHandler"/>.
+/// Asserts exactly one POST lands on the expected endpoint with the resolved payload.
+/// </summary>
+public class PersonaHostOneShotIntegrationTests
+{
+    [Fact]
+    public async Task PersonaHost_OnceTrigger_ProducesExactlyOneSubmissionWithResolvedPayload()
+    {
+        var handler = new CapturingHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+        var submitter = new PersonaSubmitter(
+            http,
+            _ => Task.FromResult("test-token"),
+            walletAddress: "wallet-abc",
+            registerId: "register-xyz",
+            NullLogger<PersonaSubmitter>.Instance);
+
+        var definition = new PersonaDefinition
+        {
+            Name = "procurement-mgr-kickoff",
+            Target = new PersonaTarget
+            {
+                BlueprintId = "bp-procurement-to-pay",
+                InstanceId = "inst-99",
+                ActionIndex = 0
+            },
+            Trigger = new OnceTrigger { DelaySeconds = 0 },
+            PayloadTemplate = JsonNode.Parse("""
+                {
+                  "poReference": "PO-CAIRN-2026-00142",
+                  "lineItem": "Structural Timber",
+                  "iteration": "${counter}"
+                }
+                """)!
+        };
+
+        var host = new PersonaHost(
+            definition,
+            submitter,
+            new PayloadTokenResolver(),
+            new DeterministicRandom(),
+            TimeProvider.System,
+            NullLoggerFactory.Instance);
+
+        await host.RunAsync(CancellationToken.None);
+
+        handler.Requests.Should().HaveCount(1, "once-trigger must fire exactly once");
+        var request = handler.Requests[0];
+        request.Method.Should().Be(HttpMethod.Post);
+        request.Url.Should().Be("http://localhost/api/instances/inst-99/actions/0/execute");
+
+        // Headers propagate the token via both Authorization and X-Delegation-Token.
+        request.AuthHeader.Should().Be("test-token");
+        request.DelegationHeader.Should().Be("test-token");
+
+        // Body carries the resolved payload with counter=1 (integer, not string).
+        var body = JsonNode.Parse(request.Body)!.AsObject();
+        body["senderWallet"]!.GetValue<string>().Should().Be("wallet-abc");
+        body["registerAddress"]!.GetValue<string>().Should().Be("register-xyz");
+        body["instanceId"]!.GetValue<string>().Should().Be("inst-99");
+        body["blueprintId"]!.GetValue<string>().Should().Be("bp-procurement-to-pay");
+        body["actionId"]!.GetValue<string>().Should().Be("0");
+
+        var payload = body["payloadData"]!.AsObject();
+        payload["poReference"]!.GetValue<string>().Should().Be("PO-CAIRN-2026-00142");
+        payload["iteration"]!.GetValue<int>().Should().Be(1);
+
+        host.CompletedIterations.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PersonaHost_OnceTrigger_CancelledBeforeDelayElapses_ProducesNoSubmission()
+    {
+        var handler = new CapturingHandler();
+        using var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+
+        var submitter = new PersonaSubmitter(
+            http, _ => Task.FromResult("test-token"),
+            "w", "r", NullLogger<PersonaSubmitter>.Instance);
+
+        var definition = new PersonaDefinition
+        {
+            Name = "kickoff-slow",
+            Target = new PersonaTarget { BlueprintId = "bp", InstanceId = "i", ActionIndex = 0 },
+            Trigger = new OnceTrigger { DelaySeconds = 30 },
+            PayloadTemplate = JsonNode.Parse("{}")!
+        };
+
+        var host = new PersonaHost(definition, submitter, new PayloadTokenResolver(),
+            new DeterministicRandom(), TimeProvider.System, NullLoggerFactory.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        await host.RunAsync(cts.Token);
+
+        handler.Requests.Should().BeEmpty();
+        host.CompletedIterations.Should().Be(0);
+    }
+
+    private sealed record CapturedRequest(
+        HttpMethod Method, string Url, string Body, string? AuthHeader, string? DelegationHeader);
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<CapturedRequest> Requests { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null ? "" : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new CapturedRequest(
+                request.Method,
+                request.RequestUri!.ToString(),
+                body,
+                request.Headers.Authorization?.Parameter,
+                request.Headers.TryGetValues("X-Delegation-Token", out var v) ? v.FirstOrDefault() : null));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class DeterministicRandom : IRandomSource
+    {
+        public int NextInt(int min, int max) => min;
+        public decimal NextDecimal(decimal min, decimal max, int p) => min;
+        public T Choose<T>(IReadOnlyList<T> options) => options[0];
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Sorcha.Agent.Persona;
+
+namespace Sorcha.Agent.Tests.Persona;
+
+public class PersonaSchemaValidatorTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    private const string ValidOnce = """
+        {
+          "name": "kickoff",
+          "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+          "trigger": { "kind": "once" },
+          "payloadTemplate": { "poReference": "PO-001" }
+        }
+        """;
+
+    private const string ValidInterval = """
+        {
+          "name": "invoice-gen",
+          "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionName": "Raise Invoice" },
+          "trigger": { "kind": "interval", "everySeconds": 30, "maxIterations": 20 },
+          "payloadTemplate": { "amount": "${random.int(1,100)}" }
+        }
+        """;
+
+    [Fact]
+    public void Validate_ValidOnceTrigger_PassesSchema()
+    {
+        var errors = new PersonaSchemaValidator().Validate(Parse(ValidOnce));
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_ValidIntervalTrigger_PassesSchema()
+    {
+        var errors = new PersonaSchemaValidator().Validate(Parse(ValidInterval));
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_MissingName_Fails()
+    {
+        var json = """
+            {
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": {}
+            }
+            """;
+        new PersonaSchemaValidator().Validate(Parse(json)).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_TargetMissingBothActionNameAndIndex_Fails()
+    {
+        var json = """
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1" },
+              "trigger": { "kind": "once" },
+              "payloadTemplate": {}
+            }
+            """;
+        new PersonaSchemaValidator().Validate(Parse(json)).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_IntervalWithBothEverySecondsAndMinutes_Fails()
+    {
+        var json = """
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "interval", "everySeconds": 30, "everyMinutes": 1 },
+              "payloadTemplate": {}
+            }
+            """;
+        new PersonaSchemaValidator().Validate(Parse(json)).Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_IntervalWithNeitherCadence_Fails()
+    {
+        var json = """
+            {
+              "name": "bad",
+              "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 0 },
+              "trigger": { "kind": "interval" },
+              "payloadTemplate": {}
+            }
+            """;
+        new PersonaSchemaValidator().Validate(Parse(json)).Should().NotBeEmpty();
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs
@@ -8,7 +8,11 @@ namespace Sorcha.Agent.Tests.Persona;
 
 public class PersonaSchemaValidatorTests
 {
-    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+    private static JsonElement Parse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
 
     private const string ValidOnce = """
         {

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaSchemaValidatorTests.cs
@@ -26,7 +26,7 @@ public class PersonaSchemaValidatorTests
     private const string ValidInterval = """
         {
           "name": "invoice-gen",
-          "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionName": "Raise Invoice" },
+          "target": { "blueprintId": "bp-1", "instanceId": "inst-1", "actionIndex": 3 },
           "trigger": { "kind": "interval", "everySeconds": 30, "maxIterations": 20 },
           "payloadTemplate": { "amount": "${random.int(1,100)}" }
         }

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Agent.Persona;
+
+namespace Sorcha.Agent.Tests.Persona;
+
+public class PersonaSubmitterTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public HttpStatusCode Status { get; init; } = HttpStatusCode.OK;
+        public string ResponseBody { get; init; } = "{}";
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastRequestBody { get; private set; }
+        public Exception? ThrowThis { get; init; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (request.Content is not null)
+                LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            if (ThrowThis is not null) throw ThrowThis;
+            return new HttpResponseMessage(Status)
+            {
+                Content = new StringContent(ResponseBody)
+            };
+        }
+    }
+
+    private static PersonaDefinition MakeDefinition() => new()
+    {
+        Name = "test",
+        Target = new PersonaTarget { BlueprintId = "bp-1", InstanceId = "inst-1", ActionIndex = 0 },
+        Trigger = new OnceTrigger(),
+        PayloadTemplate = JsonNode.Parse("{}")!
+    };
+
+    private static PersonaSubmitter MakeSubmitter(StubHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") },
+            _ => Task.FromResult("test-token"),
+            walletAddress: "wallet-1",
+            registerId: "register-1",
+            NullLogger<PersonaSubmitter>.Instance);
+
+    [Fact]
+    public async Task SubmitAsync_HttpOk_ReturnsSubmitted()
+    {
+        var handler = new StubHandler { Status = HttpStatusCode.OK };
+        var submitter = MakeSubmitter(handler);
+
+        var result = await submitter.SubmitAsync(MakeDefinition(),
+            JsonNode.Parse("""{ "v": 1 }""")!.AsObject(), CancellationToken.None);
+
+        result.Outcome.Should().Be(PersonaSubmissionOutcome.Submitted);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_Http503_ReturnsTransientFailure()
+    {
+        var handler = new StubHandler { Status = HttpStatusCode.ServiceUnavailable };
+        var submitter = MakeSubmitter(handler);
+
+        var result = await submitter.SubmitAsync(MakeDefinition(),
+            new JsonObject(), CancellationToken.None);
+
+        result.Outcome.Should().Be(PersonaSubmissionOutcome.TransientFailure);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_Http400_ReturnsHardFailure()
+    {
+        var handler = new StubHandler { Status = HttpStatusCode.BadRequest };
+        var submitter = MakeSubmitter(handler);
+
+        var result = await submitter.SubmitAsync(MakeDefinition(),
+            new JsonObject(), CancellationToken.None);
+
+        result.Outcome.Should().Be(PersonaSubmissionOutcome.HardFailure);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_Http429_ReturnsTransientFailure()
+    {
+        var handler = new StubHandler { Status = HttpStatusCode.TooManyRequests };
+        var submitter = MakeSubmitter(handler);
+
+        var result = await submitter.SubmitAsync(MakeDefinition(),
+            new JsonObject(), CancellationToken.None);
+
+        result.Outcome.Should().Be(PersonaSubmissionOutcome.TransientFailure);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_NetworkError_ReturnsTransientFailure()
+    {
+        var handler = new StubHandler { ThrowThis = new HttpRequestException("boom") };
+        var submitter = MakeSubmitter(handler);
+
+        var result = await submitter.SubmitAsync(MakeDefinition(),
+            new JsonObject(), CancellationToken.None);
+
+        result.Outcome.Should().Be(PersonaSubmissionOutcome.TransientFailure);
+        result.Error.Should().Contain("boom");
+    }
+
+    [Fact]
+    public async Task SubmitAsync_TargetsCorrectEndpointAndSendsPayload()
+    {
+        var handler = new StubHandler { Status = HttpStatusCode.OK };
+        var submitter = MakeSubmitter(handler);
+        var payload = JsonNode.Parse("""{ "amount": 42 }""")!.AsObject();
+
+        await submitter.SubmitAsync(MakeDefinition(), payload, CancellationToken.None);
+
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should()
+            .Be("/api/instances/inst-1/actions/0/execute");
+        handler.LastRequest.Headers.Authorization!.Parameter.Should().Be("test-token");
+        handler.LastRequestBody.Should().Contain("\"amount\":42");
+        handler.LastRequestBody.Should().Contain("\"senderWallet\":\"wallet-1\"");
+        handler.LastRequestBody.Should().Contain("\"registerAddress\":\"register-1\"");
+    }
+
+    [Fact]
+    public async Task SubmitAsync_NullActionIndex_ThrowsInvalidOperation()
+    {
+        var submitter = MakeSubmitter(new StubHandler());
+        var def = MakeDefinition() with
+        {
+            Target = new PersonaTarget { BlueprintId = "bp", InstanceId = "i", ActionName = "by-name-only" }
+        };
+
+        var act = () => submitter.SubmitAsync(def, new JsonObject(), CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ActionIndex*");
+    }
+}

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs
@@ -96,6 +96,22 @@ public class PersonaSubmitterTests
     }
 
     [Fact]
+    public async Task SubmitAsync_RequestTimeout_ReturnsTransientFailure()
+    {
+        // Simulates HttpClient.Timeout expiring: TaskCanceledException thrown when the
+        // caller's CancellationToken is NOT cancelled. Matches the classification branch
+        // in PersonaSubmitter.SubmitAsync.
+        var handler = new StubHandler { ThrowThis = new TaskCanceledException("timeout") };
+        var submitter = MakeSubmitter(handler);
+
+        var result = await submitter.SubmitAsync(MakeDefinition(),
+            new JsonObject(), CancellationToken.None);
+
+        result.Outcome.Should().Be(PersonaSubmissionOutcome.TransientFailure);
+        result.Error.Should().Contain("timed out");
+    }
+
+    [Fact]
     public async Task SubmitAsync_NetworkError_ReturnsTransientFailure()
     {
         var handler = new StubHandler { ThrowThis = new HttpRequestException("boom") };

--- a/tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs
+++ b/tests/Sorcha.Agent.Tests/Persona/PersonaSubmitterTests.cs
@@ -120,6 +120,8 @@ public class PersonaSubmitterTests
         handler.LastRequest!.RequestUri!.PathAndQuery.Should()
             .Be("/api/instances/inst-1/actions/0/execute");
         handler.LastRequest.Headers.Authorization!.Parameter.Should().Be("test-token");
+        // Blueprint Service requires both headers carry the same JWT (see PersonaSubmitter).
+        handler.LastRequest.Headers.GetValues("X-Delegation-Token").Should().ContainSingle().Which.Should().Be("test-token");
         handler.LastRequestBody.Should().Contain("\"amount\":42");
         handler.LastRequestBody.Should().Contain("\"senderWallet\":\"wallet-1\"");
         handler.LastRequestBody.Should().Contain("\"registerAddress\":\"register-1\"");

--- a/walkthroughs/TradeFinance/SUMMARY.md
+++ b/walkthroughs/TradeFinance/SUMMARY.md
@@ -120,4 +120,17 @@ pwsh walkthroughs/TradeFinance/run.ps1 -Scenario all -DisableDevMode -VerifyFLE
 
 ---
 
+## Persona-driven kickoff (Feature 110)
+
+`run-agents.ps1` launches six reactive agents. The **procurement-mgr** agent ships with a
+one-shot persona (`personas/procurement-mgr-kickoff.persona.json`) that fires two seconds
+after startup, submits action 1 ("Raise Purchase Order") against the pre-created
+procurement-to-pay instance, and exits. Downstream agents then pick up the workflow through
+their reactive inbox loops as normal.
+
+To disable persona-driven kickoff and submit the first action manually instead, remove the
+`"personaFile"` line from `actors/procurement-mgr.json`.
+
+---
+
 *This walkthrough targets the Digital Trust Centre of Excellence Innovation Challenge 2: Digitising SME Trade Finance.*

--- a/walkthroughs/TradeFinance/actors/procurement-mgr.json
+++ b/walkthroughs/TradeFinance/actors/procurement-mgr.json
@@ -17,6 +17,7 @@
     "signalR": { "enabled": true },
     "polling": { "enabled": true, "intervalSeconds": 20 }
   },
+  "personaFile": "../personas/procurement-mgr-kickoff.persona.json",
   "mode": "rules",
   "rules": [
     {

--- a/walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json
+++ b/walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../../specs/110-agent-persona-mode/contracts/persona-schema.json",
+  "name": "procurement-mgr-kickoff",
+  "target": {
+    "blueprintId": "{{blueprints.procurement-to-pay.id}}",
+    "instanceId":  "$env:TRADE_PROC_INSTANCE_ID",
+    "actionIndex": 0
+  },
+  "trigger": {
+    "kind": "once",
+    "delaySeconds": 2
+  },
+  "payloadTemplate": {
+    "poReference": "PO-CAIRN-2026-00142",
+    "projectName": "Aviemore Heights Phase 2",
+    "siteAddress": "Plot 7-12, Craig na Gower Avenue, Aviemore, PH22 1RW",
+    "lineItems": [
+      { "description": "Structural Timber C24 (47x200mm)", "quantity": 500, "unit": "linear metres", "unitPrice": 8.50 },
+      { "description": "OSB/3 Structural Board (18mm)", "quantity": 120, "unit": "sheets", "unitPrice": 32.00 },
+      { "description": "Joist Hangers & Connectors (mixed)", "quantity": 10, "unit": "boxes", "unitPrice": 45.00 }
+    ],
+    "deliveryAddress": "Aviemore Heights Phase 2, Craig na Gower Avenue, Aviemore PH22 1RW",
+    "paymentTerms": "Net 30",
+    "requiredDeliveryDate": "2026-04-15"
+  }
+}

--- a/walkthroughs/TradeFinance/run-agents.ps1
+++ b/walkthroughs/TradeFinance/run-agents.ps1
@@ -107,6 +107,11 @@ if (-not $financeInstance -or -not $financeInstance.id) {
 }
 Write-Host "  Finance instance: $($financeInstance.id)" -ForegroundColor Cyan
 
+# --- Expose Instance IDs to Personas (Feature 110) ---
+# Personas resolve $env:*_INSTANCE_ID placeholders at agent-load time.
+[Environment]::SetEnvironmentVariable("TRADE_PROC_INSTANCE_ID", $procInstance.id)
+[Environment]::SetEnvironmentVariable("TRADE_FINANCE_INSTANCE_ID", $financeInstance.id)
+
 # --- Set Password Environment Variables ---
 $rolePasswords = @{
     "PROCUREMENT_MGR_PASSWORD"   = "procurement-mgr"
@@ -202,6 +207,8 @@ foreach ($p in $processes) {
 foreach ($entry in $rolePasswords.GetEnumerator()) {
     [Environment]::SetEnvironmentVariable($entry.Key, $null)
 }
+[Environment]::SetEnvironmentVariable("TRADE_PROC_INSTANCE_ID", $null)
+[Environment]::SetEnvironmentVariable("TRADE_FINANCE_INSTANCE_ID", $null)
 
 if ($allExited) {
     Write-Host "`nAll agents completed." -ForegroundColor Green


### PR DESCRIPTION
## Summary

Implements User Story 1 of [Feature 110](./specs/110-agent-persona-mode/spec.md) — a persona mechanism that unblocks the **TradeFinance walkthrough**, which currently hangs because starting actions have no prior transaction to land in any agent's inbox. A persona fires a submission on agent start; downstream agents progress the workflow through their normal reactive loops.

- Persona is additive: agents without a \`personaFile\` are byte-identical in behaviour (FR-012 / SC-005 guaranteed by regression test).
- Uses the existing \`HttpClient\`, \`AgentAuthService\`, and Blueprint Service endpoint — zero new service surface.
- Payload templates support six substitution tokens with typed-vs-interpolated resolution (\`\"\${counter}\"\` → JSON integer, \`\"INV-\${counter}\"\` → string).

## Scope in this PR

Phases 1 + 2 + 3 from [tasks.md](./specs/110-agent-persona-mode/tasks.md) — **28 of 51 tasks**, delivering the MVP. Follow-up PRs will add US2 (interval triggers / scenario data), US3 (coexistence tests), US4 (ConstructionPermit parity), and Phase 7 polish.

**New files**
- \`src/Apps/Sorcha.Agent/Persona/\` — 10 new types (records, resolver, validator, loader, submitter, once-trigger loop, host)
- \`src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json\` — embedded JSON Schema
- \`walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json\`
- 5 test files, 28 new xUnit tests

**Modified**
- \`ActorDefinition.cs\` — optional \`PersonaFile\` property
- \`RunCommand.cs\` — loads persona, launches \`PersonaHost\` as peer task
- \`Sorcha.Agent.csproj\` — \`JsonSchema.Net\` package + embedded schema resource
- \`walkthroughs/TradeFinance/actors/procurement-mgr.json\` — \`personaFile\` reference
- \`walkthroughs/TradeFinance/run-agents.ps1\` — exposes instance IDs as env vars for persona resolution
- \`walkthroughs/TradeFinance/SUMMARY.md\` — persona section

## Testing

- \`dotnet test tests/Sorcha.Agent.Tests\` → **89/89 passing** (61 existing + 28 new)
- \`dotnet build\` clean, zero warnings
- Coverage for new persona code estimated ≥85% per Constitution Principle IV

## Test plan

- [x] Build green across solution
- [x] All agent unit tests pass
- [x] Token resolver: typed-vs-interpolated rule, validation errors at load time
- [x] Schema validator: oneOf constraints, required fields
- [x] Persona loader: valid once, valid interval, missing file, token typo, schema violation
- [x] Persona submitter: 200 / 400 / 429 / 503 / network-exception outcomes; endpoint + auth header + body shape
- [x] Once-trigger loop: submitted / hard failure / transient failure / cancellation / counter==1
- [x] Regression: existing actor configs load with \`PersonaFile == null\`
- [ ] **E2E TradeFinance walkthrough validation (T029)** — requires live Docker stack; will be run manually before merge

## Out of scope (follow-up PRs)

- **US2**: \`IntervalTriggerLoop\` for recurring scenario data generation
- **US3**: Coexistence proof test + latency regression budget
- **US4**: ConstructionPermit persona + JSONC schema \$ref polish
- **Phase 7**: docs sync (MASTER-TASKS, development-status, README updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)