### PR TITLE
fix(110): clarify persona actionIndex semantics + correct shipped values

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -42,7 +42,8 @@
       "PowerShell(tail *)",
       "PowerShell(.specify/scripts/powershell/update-agent-context.ps1 -AgentType claude)",
       "PowerShell(.specify/scripts/powershell/check-prerequisites.ps1 -Json)",
-      "PowerShell(.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks)"
+      "PowerShell(.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks)",
+      "Bash(grep -E --line-buffered \"^#[0-9]+ naming|DONE|ERROR|error:|failed|Successfully|CACHED|sha256.*$|Building [0-9]\")"
     ],
     "deny": [],
     "ask": []

--- a/specs/110-agent-persona-mode/contracts/persona-schema.json
+++ b/specs/110-agent-persona-mode/contracts/persona-schema.json
@@ -32,7 +32,7 @@
         "actionIndex": {
           "type": "integer",
           "minimum": 0,
-          "description": "Zero-based index of the target action in the blueprint."
+          "description": "Blueprint action id (the 'id' field on an action, 1-based in published blueprints — so the starting action is usually 1, not 0). The value is sent verbatim as the Blueprint Service's action id; the name 'actionIndex' is historical. Values that don't exist in the blueprint produce a clean 400 at submit time."
         }
       }
     },
@@ -107,7 +107,7 @@
       "target": {
         "blueprintId": "{{blueprints.procurement-to-pay.id}}",
         "instanceId": "{{instances.procurement-to-pay.id}}",
-        "actionIndex": 0
+        "actionIndex": 1
       },
       "trigger": { "kind": "once", "delaySeconds": 2 },
       "payloadTemplate": {
@@ -121,7 +121,7 @@
       "target": {
         "blueprintId": "{{blueprints.invoice.id}}",
         "instanceId": "{{instances.invoice.id}}",
-        "actionIndex": 4
+        "actionIndex": 5
       },
       "trigger": {
         "kind": "interval",

--- a/specs/110-agent-persona-mode/data-model.md
+++ b/specs/110-agent-persona-mode/data-model.md
@@ -28,7 +28,7 @@ All types live in `Sorcha.Agent.Persona` (new namespace) unless noted. Records u
 | `BlueprintId` | `string` | Yes | ID of the blueprint whose starting action is being submitted. Supports `{{blueprints.<key>.id}}` placeholder via existing `VariableResolver`. |
 | `InstanceId` | `string` | Yes | ID of the pre-created instance (created by `run-agents.ps1`). Supports `{{instances.<key>.id}}` placeholder. |
 | `ActionName` | `string` | Yes, unless `ActionIndex` | Human name of the action within the blueprint. |
-| `ActionIndex` | `int?` | Yes, unless `ActionName` | Zero-based position of the action in the blueprint. Either name or index; if both, index wins and a load-time warning is logged. |
+| `ActionIndex` | `int?` | Yes, unless `ActionName` | Blueprint action id (1-based in published blueprints — matches the action's `id` field). The value is sent verbatim as the Blueprint Service's action id; the name `ActionIndex` is historical. Either name or index; if both, index wins and a load-time warning is logged. |
 
 **Validation rules**: exactly one of `ActionName`/`ActionIndex` required.
 

--- a/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
+++ b/src/Apps/Sorcha.Agent/Persona/Schemas/persona-schema.json
@@ -32,7 +32,7 @@
         "actionIndex": {
           "type": "integer",
           "minimum": 0,
-          "description": "Zero-based index of the target action in the blueprint."
+          "description": "Blueprint action id (the 'id' field on an action, 1-based in published blueprints — so the starting action is usually 1, not 0). The value is sent verbatim as the Blueprint Service's action id; the name 'actionIndex' is historical. Values that don't exist in the blueprint produce a clean 400 at submit time."
         }
       }
     },
@@ -107,7 +107,7 @@
       "target": {
         "blueprintId": "{{blueprints.procurement-to-pay.id}}",
         "instanceId": "{{instances.procurement-to-pay.id}}",
-        "actionIndex": 0
+        "actionIndex": 1
       },
       "trigger": { "kind": "once", "delaySeconds": 2 },
       "payloadTemplate": {
@@ -121,7 +121,7 @@
       "target": {
         "blueprintId": "{{blueprints.invoice.id}}",
         "instanceId": "{{instances.invoice.id}}",
-        "actionIndex": 4
+        "actionIndex": 5
       },
       "trigger": {
         "kind": "interval",

--- a/walkthroughs/ConstructionPermit/personas/contractor-kickoff.persona.json
+++ b/walkthroughs/ConstructionPermit/personas/contractor-kickoff.persona.json
@@ -9,11 +9,13 @@
   "name": "contractor-kickoff",
 
   // blueprintId is resolved from state.json (top-level key);
-  // instanceId is exposed by run-agents.ps1 before launch.
+  // instanceId is exposed by run-agents.ps1 before launch;
+  // actionIndex is the Blueprint Service's action.id (1-based).
+  // Action 1 = "Submit Application".
   "target": {
     "blueprintId": "{{blueprintId}}",
     "instanceId":  "$env:CP_PERMIT_INSTANCE_ID",
-    "actionIndex": 0
+    "actionIndex": 1
   },
 
   // 'once' fires a single submission after delaySeconds.

--- a/walkthroughs/TradeFinance/personas/invoice-generator.persona.json
+++ b/walkthroughs/TradeFinance/personas/invoice-generator.persona.json
@@ -8,12 +8,13 @@
   "name": "invoice-generator",
 
   // What to submit. blueprintId is auto-filled from state.json; instanceId
-  // comes from the setup script's env var; actionIndex selects the action
-  // position in the blueprint (0 = first).
+  // comes from the setup script's env var; actionIndex is the Blueprint
+  // Service's action.id (1-based in published blueprints). Action 5 =
+  // "Raise Invoice".
   "target": {
     "blueprintId": "{{blueprints.procurement-to-pay.id}}",
     "instanceId":  "$env:TRADE_PROC_INSTANCE_ID",
-    "actionIndex": 4
+    "actionIndex": 5
   },
 
   // When to fire. 'interval' fires every everySeconds up to maxIterations,

--- a/walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json
+++ b/walkthroughs/TradeFinance/personas/procurement-mgr-kickoff.persona.json
@@ -8,11 +8,13 @@
   "name": "procurement-mgr-kickoff",
 
   // What to submit. blueprintId is resolved from state.json; instanceId
-  // comes from the setup script's env var; actionIndex 0 = first action.
+  // comes from the setup script's env var; actionIndex is the Blueprint
+  // Service's action.id (1-based in published blueprints, NOT a 0-based
+  // array position). Action 1 = "Raise Purchase Order".
   "target": {
     "blueprintId": "{{blueprints.procurement-to-pay.id}}",
     "instanceId":  "$env:TRADE_PROC_INSTANCE_ID",
-    "actionIndex": 0
+    "actionIndex": 1
   },
 
   // 'once' fires a single submission after delaySeconds (default 0). Use


### PR DESCRIPTION
## Summary

Live TradeFinance walkthrough surfaced that \`PersonaTarget.ActionIndex\` is *named* \"Index\" but is sent verbatim as the Blueprint Service's **action id** (1-based in published blueprints, matching each action's \`id\` field). Three shipped persona files had off-by-one values, producing a clean \`400 \"Action 0 not found in blueprint ...\"\` at submit time — which proves Feature 110's failure-classification path works perfectly, but blocks the walkthrough from progressing.

## Data fixes

| Persona file | Was | Now | Target action |
|---|---|---|---|
| \`TradeFinance/personas/procurement-mgr-kickoff.persona.json\` | 0 | **1** | \"Raise Purchase Order\" |
| \`TradeFinance/personas/invoice-generator.persona.json\` | 4 | **5** | \"Raise Invoice\" |
| \`ConstructionPermit/personas/contractor-kickoff.persona.json\` | 0 | **1** | \"Submit Application\" |

## Documentation fixes

- **\`persona-schema.json\`** \`actionIndex\` description rewritten: *\"Blueprint action id (the 'id' field on an action, 1-based in published blueprints — so the starting action is usually 1, not 0). The value is sent verbatim as the Blueprint Service's action id; the name 'actionIndex' is historical.\"* Kept \`minimum: 0\` rather than tightening to 1 — that would break 10+ existing tests that use 0, and a bad value already produces a clean 400 at submit time, so the constraint is semantic rather than numeric.
- **\`persona-schema.json\`** examples now show actionIndex 1 and 5 matching real published blueprints.
- **\`data-model.md\`** \`ActionIndex\` row now describes it as \"Blueprint action id (1-based in published blueprints — matches the action's \`id\` field)\" rather than \"zero-based position\".
- **Embedded schema resource** (\`src/Apps/Sorcha.Agent/Persona/Schemas/\`) synced with the spec source.

## Live-validation evidence (before the fix)

Feature 110's code paths all exercised correctly end-to-end in the live TradeFinance walkthrough:

| Step | Outcome |
|---|---|
| Load \`.persona.json\` with JSONC comments & trailing commas | ✅ |
| Resolve \`{{blueprints.procurement-to-pay.id}}\` from state.json | ✅ |
| Resolve \`\$env:TRADE_PROC_INSTANCE_ID\` from process env | ✅ |
| Start \`PersonaHost\` as peer to inbox listener | ✅ |
| Fire \`OnceTriggerLoop\` after \`DelaySeconds=2\` with resolved target | ✅ |
| POST to \`/api/instances/.../actions/1/execute\` on Blueprint Service | ✅ (server received & processed) |
| Classify client-side timeout as \`TransientFailure\` (not HardFailure) | ✅ |
| Structured \`ILogger\` output in \`procurement-mgr.log\` | ✅ |
| \`AuditLogger\` integration (research R-007) exercised | ✅ |

The walkthrough did not complete end-to-end because Blueprint Service's action submission returned 400 after 60s with \`System.TimeoutException: Transaction X was not confirmed within 60s for register Y\` — a downstream validator-confirmation issue **unrelated to Feature 110**. A \`--no-cache\` image rebuild was attempted to rule out image staleness but did not finish cleanly (Docker Desktop flaked mid-build). T029/T043/T050 live-run verification remains operator-pending as already tracked on GAP-021.

## Test plan

- [x] \`dotnet test tests/Sorcha.Agent.Tests\` → 110/110 still green (schema \`minimum: 0\` preserved so all existing \`actionIndex: 0\` test fixtures still validate)
- [x] \`dotnet build -warnaserror src/Apps/Sorcha.Agent/Sorcha.Agent.csproj\` → 0 warnings, 0 errors
- [ ] Live walkthrough re-run — deferred to operator alongside validator-confirmation fix

## Follow-ups (not this PR)

- **Validator-confirmation timeout** for freshly-created registers — possibly related to the recent f108 fixes (#363, #365) not fully closing the bootstrap path. Needs a separate diagnosis session with the validator service logs.
- **Consider renaming \`ActionIndex\` → \`ActionId\`** in a future breaking-change window. Semantic clarity would be worth it but touches the schema, C# record, tests, docs, and shipped persona files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)