### PR TITLE
fix: rejection-tx recipients + chain-head tracking + idempotent fork check

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs
@@ -89,6 +89,15 @@ public class StateReconstructionService : IStateReconstructionService
 
         foreach (var tx in transactions.OrderBy(t => t.TimeStamp))
         {
+            // Track the chain head on every instance tx — including rejections and
+            // actions whose data isn't required for the current step. The chain head
+            // is a linkage concern, distinct from the "what data do I need" filter
+            // below. If we only advanced prev on required-action txs, a rejection
+            // (whose actionId is the rejected action, often not in requiredActionIds
+            // for the route-back target) would leave prev stale, and the next
+            // submission would trip VAL_CHAIN_FORK on a non-unique previousTxId.
+            previousTransactionId = tx.TxId;
+
             // Extract action ID from transaction metadata
             var txActionId = ExtractActionIdFromTransaction(tx);
             if (txActionId == null)
@@ -96,7 +105,7 @@ public class StateReconstructionService : IStateReconstructionService
                 continue;
             }
 
-            // Only process if this action is required
+            // Only accumulate state from prior actions whose data is required
             if (!requiredActionIds.Contains(txActionId.Value))
             {
                 continue;
@@ -110,9 +119,6 @@ public class StateReconstructionService : IStateReconstructionService
             {
                 actionData[txActionId.Value.ToString()] = decryptedData.Value;
             }
-
-            // Track the latest transaction for chaining
-            previousTransactionId = tx.TxId;
 
             // Track branch states if present
             var branchId = ExtractBranchIdFromTransaction(tx);

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
@@ -339,6 +339,37 @@ public static class TransactionBuilderServiceExtensions
         // PayloadHash = TxId — same canonical bytes, same hash
         var payloadHash = txId;
 
+        // Rejection recipients: the rejector (so the rejection is visible in their
+        // own wallet context) and the route-back target participant (who needs to
+        // re-attempt the target action). Populating RecipientsWallets is load-bearing:
+        // without it, InboundTransactionRouter can't notify the wallets on docket seal
+        // and StateReconstructionService has no WalletAccess entry to attribute the
+        // transaction against — leaving a hole in the chain walk that causes the
+        // next submission to pick a stale PreviousTransactionId and trip VAL_CHAIN_FORK.
+        var recipients = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (instance.ParticipantWallets != null)
+        {
+            if (!string.IsNullOrEmpty(action.Sender)
+                && instance.ParticipantWallets.TryGetValue(action.Sender, out var senderWallet)
+                && !string.IsNullOrEmpty(senderWallet))
+            {
+                recipients.Add(senderWallet);
+            }
+
+            var targetActionId = action.RejectionConfig?.TargetActionId;
+            if (targetActionId.HasValue)
+            {
+                var targetAction = blueprint.Actions?.FirstOrDefault(a => a.Id == targetActionId.Value);
+                var targetParticipantId = action.RejectionConfig?.TargetParticipantId ?? targetAction?.Sender;
+                if (!string.IsNullOrEmpty(targetParticipantId)
+                    && instance.ParticipantWallets.TryGetValue(targetParticipantId, out var targetWallet)
+                    && !string.IsNullOrEmpty(targetWallet))
+                {
+                    recipients.Add(targetWallet);
+                }
+            }
+        }
+
         return Task.FromResult(new BuiltTransaction
         {
             TransactionData = transactionData,
@@ -346,7 +377,8 @@ public static class TransactionBuilderServiceExtensions
             PayloadHash = payloadHash,
             TransactionType = "rejection",
             RegisterId = instance.RegisterId,
-            Metadata = metadata
+            Metadata = metadata,
+            RecipientsWallets = recipients.ToList()
         });
     }
 }

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -833,14 +833,32 @@ public class ValidationEngine : IValidationEngine
                         || previousTx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control;
                     if (!isControlTx)
                     {
+                        // Fetch up to 50 existing successors so we can distinguish an
+                        // idempotent resubmission (same TxId already present) from a
+                        // genuine fork (different TxId with the same parent). Without
+                        // this dedup, a retry after a transient confirmation failure
+                        // gets a spurious VAL_CHAIN_FORK even though the canonical
+                        // transaction bytes are identical.
                         var existingSuccessors = await _registerClient.GetTransactionsByPrevTxIdAsync(
-                            transaction.RegisterId, previousTxId, 1, 1, ct);
+                            transaction.RegisterId, previousTxId, 1, 50, ct);
 
                         if (existingSuccessors.Total > 0)
                         {
-                            errors.Add(CreateError("VAL_CHAIN_FORK",
-                                $"Fork detected: {existingSuccessors.Total} existing transaction(s) already reference previous transaction '{previousTxId}' in register '{transaction.RegisterId}'",
-                                ValidationErrorCategory.Chain, "PreviousTransactionId"));
+                            var isIdempotentResubmission = existingSuccessors.Transactions?.Any(t =>
+                                string.Equals(t.TxId, transaction.TransactionId, StringComparison.OrdinalIgnoreCase)) == true;
+
+                            if (!isIdempotentResubmission)
+                            {
+                                errors.Add(CreateError("VAL_CHAIN_FORK",
+                                    $"Fork detected: {existingSuccessors.Total} existing transaction(s) already reference previous transaction '{previousTxId}' in register '{transaction.RegisterId}'",
+                                    ValidationErrorCategory.Chain, "PreviousTransactionId"));
+                            }
+                            else
+                            {
+                                _logger.LogInformation(
+                                    "Idempotent resubmission of transaction {TxId} against previous {PrevTxId} in register {RegisterId} — already present, skipping fork error",
+                                    transaction.TransactionId, previousTxId, transaction.RegisterId);
+                            }
                         }
                     }
                 }

--- a/walkthroughs/PropertyInspection/setup.ps1
+++ b/walkthroughs/PropertyInspection/setup.ps1
@@ -89,7 +89,7 @@ $register = New-SorchaRegister `
     -RegisterUrl $sorchaEnv.RegisterUrl `
     -WalletUrl $sorchaEnv.WalletUrl `
     -TenantUrl $sorchaEnv.TenantUrl `
-    -Name "Strathcarron Property Services Register" `
+    -Name "Strathcarron Property Register" `
     -Description "Council property inspection and repair workflow register" `
     -TenantId $housingRole.organizationId `
     -OwnerUserId $housingSession.UserId `
@@ -112,13 +112,13 @@ $contractorSession = Connect-SorchaUser -TenantUrl $sorchaEnv.TenantUrl `
 New-SorchaRegisterSubscription -TenantUrl $sorchaEnv.TenantUrl `
     -OrganizationId $contractorRole.organizationId `
     -RegisterId $register.RegisterId `
-    -RegisterName "Strathcarron Property Services Register" `
+    -RegisterName "Strathcarron Property Register" `
     -SubscriptionType "Public" -Headers $contractorSession.Headers | Out-Null
 
 # Public org subscription (for tenant)
 Add-SorchaPublicOrgSubscription -TenantUrl $sorchaEnv.TenantUrl `
     -RegisterId $register.RegisterId `
-    -RegisterName "Strathcarron Property Services Register" `
+    -RegisterName "Strathcarron Property Register" `
     -SysAdminHeaders $sysAdmin.Headers `
     -SysAdminEmail $councilState.sysAdmin.email | Out-Null
 

--- a/walkthroughs/SelfBuildHouse/building-warrant-template.json
+++ b/walkthroughs/SelfBuildHouse/building-warrant-template.json
@@ -987,7 +987,7 @@
         "rejectionConfig": {
           "targetActionId": 5,
           "requireReason": true,
-          "isTerminal": false
+          "isTerminal": true
         },
         "disclosures": [
           {

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -146,14 +146,15 @@ foreach ($def in $orgDefs) {
 $orgs["public"] = $publicOrgId
 
 # ============================================================================
-# Step 6: Add Team Members (non-admin users) to Their Target Orgs
+# Step 6: Reconcile User -> Org Membership (admins + team members)
 # ============================================================================
-Write-WtStep "Step 6: Add Team Members"
+Write-WtStep "Step 6: Reconcile User -> Org Membership"
 
-# Non-admin, non-citizen users need to be added to their target private org by
-# the sysadmin. Today that's just the building-inspector sharing Strathcarron BS.
-$teamMembers = $userDefs | Where-Object { -not $_.isOrgAdmin -and -not $_.isCitizen }
-foreach ($u in $teamMembers) {
+# Idempotency guard: on re-runs, orgs already exist so New-SorchaOrganization
+# returns the existing id without re-binding the admin email. Ensure every
+# non-citizen user is a member of their target org, regardless of admin/team.
+$nonCitizenUsers = $userDefs | Where-Object { -not $_.isCitizen }
+foreach ($u in $nonCitizenUsers) {
     $orgId = $orgs[$u.org]
     Get-OrCreateUser `
         -TenantUrl $env.TenantUrl `
@@ -252,10 +253,10 @@ $bsSession = $sessionCache["$($users['building-standards-officer'].email)|$($use
 $bsOfficerJwt = Decode-SorchaJwt -Token $bsSession.Token
 $bsOwnerUserId = $bsOfficerJwt.sub
 
-Write-WtInfo "  Creating Strathcarron Building Standards Register..."
+Write-WtInfo "  Creating Strathcarron Warrants Register..."
 $buildingRegister = New-SorchaRegister `
     -RegisterUrl $env.RegisterUrl -WalletUrl $env.WalletUrl -TenantUrl $env.TenantUrl `
-    -Name "Strathcarron Building Standards Register" `
+    -Name "Strathcarron Warrants Register" `
     -Description "Building warrants, staged inspections, and completion certificates for the Strathcarron Council area" `
     -TenantId $users["building-standards-officer"].organizationId `
     -OwnerUserId $bsOwnerUserId `
@@ -301,7 +302,7 @@ foreach ($orgKey in $privateOrgKeys) {
                 -TenantUrl $env.TenantUrl `
                 -OrganizationId $orgId `
                 -RegisterId $buildingRegister.RegisterId `
-                -RegisterName "Strathcarron Building Standards Register" `
+                -RegisterName "Strathcarron Warrants Register" `
                 -SubscriptionType "Public" `
                 -Headers $sysAdmin.Headers
         } catch {

--- a/walkthroughs/council/setup-council.ps1
+++ b/walkthroughs/council/setup-council.ps1
@@ -109,15 +109,26 @@ foreach ($def in $orgDefs) {
     Write-WtInfo "  $($def.name) → $($result.OrganizationId)"
 }
 
-# ── Step 4: Add team members to Strathcarron Council ──────────────
-Write-WtStep "Adding team members to Strathcarron Council"
-$strathcarronId = $orgs["strathcarron"]
-foreach ($u in $teamMemberDefs) {
+# ── Step 4: Reconcile user-org membership (admins + team members) ──
+# Idempotency: on re-runs, orgs already exist, so New-SorchaOrganization
+# returns the existing id without re-binding the admin email. Ensure every
+# user is a member of their target org regardless of admin-vs-team role.
+Write-WtStep "Reconciling user-org membership"
+foreach ($u in $orgAdminDefs) {
+    $orgId = $orgs[$u.orgSubdomain]
     Get-OrCreateUser -TenantUrl $sorchaEnv.TenantUrl `
-        -OrganizationId $strathcarronId `
+        -OrganizationId $orgId `
         -Email $u.email -DisplayName $u.name `
         -Headers $sysAdmin.Headers -Roles @("Administrator", "Consumer") | Out-Null
-    Write-WtInfo "  $($u.name) added to Strathcarron Council"
+    Write-WtInfo "  $($u.name) ensured in $($u.orgSubdomain)"
+}
+foreach ($u in $teamMemberDefs) {
+    $orgId = $orgs[$u.orgSubdomain]
+    Get-OrCreateUser -TenantUrl $sorchaEnv.TenantUrl `
+        -OrganizationId $orgId `
+        -Email $u.email -DisplayName $u.name `
+        -Headers $sysAdmin.Headers -Roles @("Administrator", "Consumer") | Out-Null
+    Write-WtInfo "  $($u.name) ensured in $($u.orgSubdomain)"
 }
 
 # ── Step 5: Login as each user, create wallets, register participants ─

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -139,6 +139,28 @@ $secrets = [ordered]@{
         # First-org admin alias (Highland Construction is the bootstrap org, doubles as platform admin)
         highlandAdminEmail     = $platformEmail
         highlandAdminPassword  = $platformPassword
+        # Per-role credentials (self-build-house setup.ps1 expects these keys)
+        selfBuilderEmail           = "self-builder@citizen.local"
+        selfBuilderPassword        = "Dev_Pass_2025!"
+        selfBuilderName            = "Self-Builder"
+        planningEmail              = "planning@highland-planning.local"
+        planningPassword           = "Dev_Pass_2025!"
+        planningName               = "Planning Officer"
+        buildingStandardsEmail     = "standards@highland-bs.local"
+        buildingStandardsPassword  = "Dev_Pass_2025!"
+        buildingStandardsName      = "Building Standards Officer"
+        buildingInspectorEmail     = "inspector@highland-bs.local"
+        buildingInspectorPassword  = "Dev_Pass_2025!"
+        buildingInspectorName      = "Building Inspector"
+        utilitiesEmail             = "consultations@scottish-water.local"
+        utilitiesPassword          = "Dev_Pass_2025!"
+        utilitiesName              = "Scottish Water Consultations Team"
+        structuralEmail            = "engineer@macgregor-structural.local"
+        structuralPassword         = "Dev_Pass_2025!"
+        structuralName             = "MacGregor Structural Engineers"
+        ecologistEmail             = "surveys@glen-ecology.local"
+        ecologistPassword          = "Dev_Pass_2025!"
+        ecologistName              = "Glen Ecology Surveys"
     }
     "trade-finance" = @{
         adminEmail    = $platformEmail
@@ -160,6 +182,48 @@ $secrets = [ordered]@{
         adminPassword   = $platformPassword
         adminName       = $platformName
         DefaultPassword = $platformPassword
+    }
+    "council" = @{
+        sysAdminEmail               = $platformEmail
+        sysAdminPassword            = $platformPassword
+        planningOfficerEmail        = "planning@strathcarron.local"
+        planningOfficerPassword     = "Dev_Pass_2025!"
+        planningOfficerName         = "Planning Officer"
+        contractorEmail             = "contractor@stoniebridge.local"
+        contractorPassword          = "Dev_Pass_2025!"
+        contractorName              = "Contractor"
+        structuralEmail             = "engineer@murchison.local"
+        structuralPassword          = "Dev_Pass_2025!"
+        structuralName              = "Structural Engineer"
+        ecologistEmail              = "surveys@heatherbank.local"
+        ecologistPassword           = "Dev_Pass_2025!"
+        ecologistName               = "Ecologist"
+        utilitiesEmail              = "consultations@caledonian-water.local"
+        utilitiesPassword           = "Dev_Pass_2025!"
+        utilitiesName               = "Utilities Officer"
+        buildingStandardsEmail      = "standards@strathcarron.local"
+        buildingStandardsPassword   = "Dev_Pass_2025!"
+        buildingStandardsName       = "Building Standards Officer"
+        buildingInspectorEmail      = "inspector@strathcarron.local"
+        buildingInspectorPassword   = "Dev_Pass_2025!"
+        buildingInspectorName       = "Building Inspector"
+        buildingControlEmail        = "control@strathcarron.local"
+        buildingControlPassword     = "Dev_Pass_2025!"
+        buildingControlName         = "Building Control"
+        housingOfficerEmail         = "housing@strathcarron.local"
+        housingOfficerPassword      = "Dev_Pass_2025!"
+        housingOfficerName          = "Housing Officer"
+    }
+    "property-inspection" = @{
+        tenantAEmail    = "tenant-a@citizen.local"
+        tenantAPassword = "Dev_Pass_2025!"
+        tenantAName     = "Tenant A"
+        tenantBEmail    = "tenant-b@citizen.local"
+        tenantBPassword = "Dev_Pass_2025!"
+        tenantBName     = "Tenant B"
+        tenantCEmail    = "tenant-c@citizen.local"
+        tenantCPassword = "Dev_Pass_2025!"
+        tenantCName     = "Tenant C"
     }
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `BuildRejectionTransactionAsync` left `RecipientsWallets` empty, and `StateReconstructionService` only advanced its `previousTransactionId` on required-action txs. Together this meant a rejection left a stale chain head, and the route-back retry chained from the same parent as the rejection — tripping `VAL_CHAIN_FORK`.
- **Fixes**: populate rejection recipients (rejector + route-back target), advance chain head on every instance tx (not just required ones), make validator fork-check idempotent by TxId as defense-in-depth.
- **Also bundled**: walkthrough-side idempotency (council setup reconciles user→org membership) and config fixes (register-name length, VAL_BP_CRED_003 isTerminal, missing secret keys) uncovered while running the walkthrough suite to verify.

## Test plan

- [x] ConstructionPermit: A/B/C all PASS (was B fail @ action 5)
- [x] TradeFinance: golden-path / disputed / declined all PASS (was disputed fail @ resubmit after rejection)
- [x] SelfBuildHouse planning phase: A/B/C all PASS (was A/B fail @ action 3 ecologist after routing)
- [x] `dotnet build` clean on Blueprint + Validator services
- [ ] Warrant phase still fails to start on SelfBuildHouse A/B — separate issue (cross-register handoff), not in scope for this PR

## Files

| File | Fix |
|------|-----|
| `src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs` | Populate `RecipientsWallets` on rejection txs (rejector + route-back target) |
| `src/Services/Sorcha.Blueprint.Service/Services/Implementation/StateReconstructionService.cs` | Advance `previousTransactionId` on every instance tx, separated from the requiredActionIds data-filter |
| `src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs` | VAL_CHAIN_FORK dedups by TxId — treat same-TxId resubmission as idempotent |
| `walkthroughs/council/setup-council.ps1` | Reconcile user→org membership for admins + team on re-runs |
| `walkthroughs/SelfBuildHouse/setup.ps1` | Same reconciliation; shorter register name for 38-char cap |
| `walkthroughs/SelfBuildHouse/building-warrant-template.json` | Foundation Inspection rejection `isTerminal: true` |
| `walkthroughs/PropertyInspection/setup.ps1` | Shorter register name |
| `walkthroughs/initialize-secrets.ps1` | Fill in `council`, `property-inspection`, per-role `self-build-house` secrets |

🤖 Generated with [Claude Code](https://claude.com/claude-code)