### PR TITLE
fix(SEC-013): HAIP internal endpoints require service auth

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Haip/HaipServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Haip/HaipServiceClient.cs
@@ -4,6 +4,8 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Helpers;
 
 namespace Sorcha.ServiceClients.Haip;
 
@@ -14,11 +16,16 @@ namespace Sorcha.ServiceClients.Haip;
 public class HaipServiceClient : IHaipServiceClient
 {
     private readonly HttpClient _httpClient;
+    private readonly IServiceAuthClient _serviceAuth;
     private readonly ILogger<HaipServiceClient> _logger;
 
-    public HaipServiceClient(HttpClient httpClient, ILogger<HaipServiceClient> logger)
+    public HaipServiceClient(
+        HttpClient httpClient,
+        IServiceAuthClient serviceAuth,
+        ILogger<HaipServiceClient> logger)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _serviceAuth = serviceAuth ?? throw new ArgumentNullException(nameof(serviceAuth));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -40,6 +47,7 @@ public class HaipServiceClient : IHaipServiceClient
             disclosablePaths
         };
 
+        await SetAuthHeaderAsync(ct);
         var response = await _httpClient.PostAsJsonAsync("/api/v1/offers", request, ct);
         response.EnsureSuccessStatusCode();
 
@@ -66,6 +74,7 @@ public class HaipServiceClient : IHaipServiceClient
             acceptedIssuers
         };
 
+        await SetAuthHeaderAsync(ct);
         var response = await _httpClient.PostAsJsonAsync("/api/v1/verifier/requests", request, ct);
         response.EnsureSuccessStatusCode();
 
@@ -82,6 +91,7 @@ public class HaipServiceClient : IHaipServiceClient
     /// <inheritdoc />
     public async Task<OfferStatusResult?> GetOfferStatusAsync(Guid offerId, CancellationToken ct = default)
     {
+        await SetAuthHeaderAsync(ct);
         var response = await _httpClient.GetAsync($"/api/v1/offers/{offerId}", ct);
         if (!response.IsSuccessStatusCode) return null;
 
@@ -99,6 +109,7 @@ public class HaipServiceClient : IHaipServiceClient
     public async Task<VerificationResultResponse?> GetVerificationResultAsync(
         Guid requestId, CancellationToken ct = default)
     {
+        await SetAuthHeaderAsync(ct);
         var response = await _httpClient.GetAsync($"/api/v1/verifier/requests/{requestId}/result", ct);
         if (!response.IsSuccessStatusCode) return null;
 
@@ -116,4 +127,8 @@ public class HaipServiceClient : IHaipServiceClient
             null, // Verified claims deserialized on demand
             null);
     }
+
+    private Task SetAuthHeaderAsync(CancellationToken cancellationToken) =>
+        ServiceClientAuthHelper.SetAuthHeaderAsync(
+            _httpClient, _serviceAuth, _logger, "HAIP Service", cancellationToken);
 }

--- a/src/Services/Sorcha.Haip.Service/Endpoints/OfferEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/OfferEndpoints.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Sorcha.Haip.Service.Services;
 
 namespace Sorcha.Haip.Service.Endpoints;
@@ -28,14 +29,14 @@ public static class OfferEndpoints
                 "Returns the offer details and a URI for QR code rendering.")
             .Produces<object>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
-            .AllowAnonymous(); // Internal service-to-service: Blueprint Service calls directly
+            .RequireAuthorization(AuthorizationPolicies.RequireService); // SEC-013
 
         group.MapGet("/{offerId:guid}", GetOfferStatus)
             .WithName("GetOfferStatus")
             .WithSummary("Get Credential Offer status (service-to-service)")
             .Produces<object>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
-            .AllowAnonymous(); // Internal service-to-service: UI polls via API Gateway (which adds auth)
+            .RequireAuthorization(AuthorizationPolicies.RequireService); // SEC-013
     }
 
     private static async Task<IResult> CreateOffer(

--- a/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/VerifierEndpoints.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using Sorcha.Haip.Service.Models;
 using Sorcha.Haip.Service.Services;
 
@@ -28,7 +29,7 @@ public static class VerifierEndpoints
                 "Returns the Authorization Request URI for QR code rendering.")
             .Produces<object>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
-            .AllowAnonymous(); // Internal service-to-service: Blueprint Service calls directly
+            .RequireAuthorization(AuthorizationPolicies.RequireService); // SEC-013
 
         // Public — wallet fetches the signed Request Object
         app.MapGet("/api/v1/verifier/requests/{requestId:guid}/request-object", GetRequestObject)
@@ -64,7 +65,7 @@ public static class VerifierEndpoints
             .WithSummary("Get verification result (service-to-service)")
             .Produces<VerificationResult>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound)
-            .AllowAnonymous(); // Internal service-to-service: UI polls via API Gateway
+            .RequireAuthorization(AuthorizationPolicies.RequireService); // SEC-013
     }
 
     private static async Task<IResult> CreatePresentationRequest(


### PR DESCRIPTION
## Summary

- Replaces ``AllowAnonymous`` on 4 HAIP internal endpoints with ``RequireService`` policy (same pattern as SEC-011).
- ``HaipServiceClient`` now attaches service JWT via ``ServiceClientAuthHelper.SetAuthHeaderAsync``.
- Wallet-facing endpoints (Request Object GET, direct_post POST) correctly stay ``AllowAnonymous`` — the citizen's phone is not a service.

Closes SEC-013 from MASTER-TASKS.md.

## Endpoints now requiring service JWT

| Method | Path | Caller |
|---|---|---|
| POST | /api/v1/offers | Blueprint Service |
| GET | /api/v1/offers/{id} | Blueprint Service (poll) |
| POST | /api/v1/verifier/requests | Blueprint Service |
| GET | /api/v1/verifier/requests/{id}/result | Blueprint Service (poll) |

## Test plan

- [x] ``dotnet build`` clean on HAIP service + ServiceClients.Http
- [x] AssuredIdentity walkthrough passes end-to-end (Phase 1 issuance + Phase 2 credential chain with presentation)
- [x] Anonymous ``POST /api/v1/offers`` → 401
- [x] Anonymous ``POST /api/v1/verifier/requests`` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)