### PR TITLE
fix(walkthroughs): TradeFinance soak.ps1 credential accept + MaxRuns cap

### DIFF
--- a/walkthroughs/TradeFinance/soak.ps1
+++ b/walkthroughs/TradeFinance/soak.ps1
@@ -9,6 +9,7 @@
 
 param(
     [int]$DurationHours = 5,
+    [int]$MaxRuns = 0,                # 0 = unlimited (use DurationHours); >0 = cap iterations
     [int]$MinIntervalSeconds = 180,   # 3 minutes
     [int]$MaxIntervalSeconds = 300,   # 5 minutes
     [switch]$ShowJson
@@ -273,12 +274,17 @@ $runNumber = 0
 $passed = 0
 $failed = 0
 
-Write-WtInfo "Duration: $DurationHours hours (until $($soakEnd.ToString('HH:mm')))"
+if ($MaxRuns -gt 0) {
+    Write-WtInfo "Run cap: $MaxRuns iterations (duration cap also active: $DurationHours h)"
+} else {
+    Write-WtInfo "Duration: $DurationHours hours (until $($soakEnd.ToString('HH:mm')))"
+}
 Write-WtInfo "Interval: ${MinIntervalSeconds}s – ${MaxIntervalSeconds}s between runs"
 Write-WtInfo "Blueprints: $procurementBlueprintId / $financeBlueprintId"
 Write-Host ""
 
 while ((Get-Date) -lt $soakEnd) {
+    if ($MaxRuns -gt 0 -and $runNumber -ge $MaxRuns) { break }
     $runNumber++
     $runStart = Get-Date
     $elapsed = $runStart - $soakStart
@@ -360,6 +366,17 @@ while ((Get-Date) -lt $soakEnd) {
     $credPresentations = @()
 
     try {
+        # Accept any PendingAcceptance VerifiedInvoiceCredentials first (Feature 106 Wave C)
+        $pending = Invoke-SorchaApi -Method GET `
+            -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials?status=PendingAcceptance" `
+            -Headers $credHeaders
+        foreach ($p in ($pending | Where-Object { $_.type -eq "VerifiedInvoiceCredential" })) {
+            $null = Invoke-SorchaApi -Method PATCH `
+                -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials/$($p.id)" `
+                -Body @{ status = "Active" } `
+                -Headers $credHeaders
+        }
+
         $creds = Invoke-SorchaApi -Method GET `
             -Uri "$($env.WalletUrl)/v1/wallets/$salesMgrWallet/credentials" `
             -Headers $credHeaders
@@ -469,8 +486,9 @@ while ((Get-Date) -lt $soakEnd) {
         Write-WtFail "  Run #${runNumber}: FAIL ($([Math]::Round($runDuration.TotalSeconds, 1))s) — passed: $passed, failed: $failed"
     }
 
-    # Wait before next run (skip if time is almost up)
-    if ((Get-Date) -lt $soakEnd.AddMinutes(-5)) {
+    # Wait before next run (skip if time/run cap is almost up)
+    $isLastRun = ($MaxRuns -gt 0 -and $runNumber -ge $MaxRuns)
+    if (-not $isLastRun -and (Get-Date) -lt $soakEnd.AddMinutes(-5)) {
         $waitSecs = Get-Random -Minimum $MinIntervalSeconds -Maximum $MaxIntervalSeconds
         Write-WtInfo "  Next run in ${waitSecs}s ($([Math]::Round($waitSecs / 60, 1))m)..."
         Start-Sleep -Seconds $waitSecs


### PR DESCRIPTION
## Summary

Two fixes to `walkthroughs/TradeFinance/soak.ps1`, both discovered running 5 persona iterations against **n1.sorcha.dev**:

1. **Credential accept step** — Feature 106 Wave C made register-native credential delivery default to `Status=PendingAcceptance`. The holder (sales-mgr) must PATCH to `Active` before the credential can be presented in a downstream register. `run.ps1` already does this; `soak.ps1` did not — so finance action 1 failed every run with `400: No credential presented for requirement 'VerifiedInvoiceCredential'`.
2. **`-MaxRuns` cap** — new optional parameter that caps soak iterations (0 = unlimited, preserves existing duration-based behaviour). Useful for ad-hoc validation runs without waiting a full hour.

## Verification

Before fix: procurement 6/6 passes, finance 0/4 fails on action 1 every run (5/5 failures).
After fix: **5/5 runs PASS, 50 actions across 2 registers** in ~7 minutes against n1.

| Run | Project | Invoice | Advance |
|---|---|---|---|
| 1 | Inverness Waterfront | £12,693.72 | £10,789.66 |
| 2 | Aviemore Heights Phase 2 | £14,235.53 | £13,523.75 |
| 3 | Dingwall Primary Extension | £6,225.14 | £5,291.37 |
| 4 | Kingussie Sports Pavilion | £17,388.11 | £15,649.30 |
| 5 | Elgin Cathedral Close Flats | £12,836.47 | £10,911.00 |

## Follow-up (out of scope)

The `PendingAcceptance → Active` pattern is drifting between `run.ps1` and `soak.ps1`. Worth extracting to a shared helper in `modules/SorchaWalkthrough/SorchaWalkthrough.psm1` so other walkthroughs (ConstructionPermit, SelfBuildHouse) inherit it. Not doing it in this PR to keep the fix focused.

## Test plan

- [x] 5 persona runs against n1 all PASS
- [ ] No change to default behaviour (`MaxRuns=0` means duration-based as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)