### PR TITLE
test(ui): fix stale WorkflowService error-contract assertion

### DIFF
--- a/tests/Sorcha.UI.Core.Tests/Services/WorkflowServiceAsyncTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/WorkflowServiceAsyncTests.cs
@@ -117,6 +117,7 @@ public class WorkflowServiceAsyncTests : IDisposable
 
         result.Should().NotBeNull();
         result!.ErrorStatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        result.InstanceId.Should().Be("inst-001");
         result.TransactionId.Should().BeNullOrEmpty();
     }
 }

--- a/tests/Sorcha.UI.Core.Tests/Services/WorkflowServiceAsyncTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/WorkflowServiceAsyncTests.cs
@@ -115,10 +115,6 @@ public class WorkflowServiceAsyncTests : IDisposable
 
         var result = await _service.SubmitActionExecuteAsync(CreateRequest());
 
-        // Per PR #265: non-success responses surface a populated result with
-        // ErrorMessage/ErrorStatusCode so the UI can show the real reason
-        // (schema, wallet mismatch, credential requirement) instead of a
-        // generic "appears in pending actions" message.
         result.Should().NotBeNull();
         result!.ErrorStatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
         result.TransactionId.Should().BeNullOrEmpty();

--- a/tests/Sorcha.UI.Core.Tests/Services/WorkflowServiceAsyncTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/WorkflowServiceAsyncTests.cs
@@ -109,12 +109,18 @@ public class WorkflowServiceAsyncTests : IDisposable
     }
 
     [Fact]
-    public async Task SubmitActionExecuteAsync_ServerError_ReturnsNull()
+    public async Task SubmitActionExecuteAsync_ServerError_ReturnsErrorResult()
     {
         SetupResponse(HttpStatusCode.InternalServerError);
 
         var result = await _service.SubmitActionExecuteAsync(CreateRequest());
 
-        result.Should().BeNull();
+        // Per PR #265: non-success responses surface a populated result with
+        // ErrorMessage/ErrorStatusCode so the UI can show the real reason
+        // (schema, wallet mismatch, credential requirement) instead of a
+        // generic "appears in pending actions" message.
+        result.Should().NotBeNull();
+        result!.ErrorStatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
+        result.TransactionId.Should().BeNullOrEmpty();
     }
 }


### PR DESCRIPTION
## Summary

Fixes the sole `build-and-test` CI failure that's been going red on every PR for weeks. It's not flaky — it's stale.

- **Test** (`WorkflowServiceAsyncTests.cs:112`) asserted the service returns \`null\` on HTTP 500.
- **Production code** (PR #265) was intentionally changed to return a populated \`ActionSubmissionResultViewModel\` with \`ErrorMessage\` + \`ErrorStatusCode\` so the UI can surface the real reason (schema violation, wallet mismatch, credential requirement) instead of a generic "appears in pending actions" message.
- **The test was never updated** to match the new contract, so it has been deterministically failing ever since.

## Change

- Rename \`…_ReturnsNull\` → \`…_ReturnsErrorResult\` to describe the actual contract
- Assert \`ErrorStatusCode == 500\` and \`TransactionId\` empty, rather than the whole result being null
- Short code comment pointing at PR #265 for the "why"

## Verification

\`\`\`
Passed!  - Failed: 0, Passed: 3, Skipped: 0, Total: 3
\`\`\`

(The three tests are the full \`SubmitActionExecuteAsync\` cluster — sync/async/error.)

## Why this matters

PRs #354, #357, #375, #376, #378, #379 all merged with this test failing. A persistently red CI gate becomes invisible — the next *real* regression in \`build-and-test\` won't trigger anyone to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)