### PR TITLE
refactor(111): remove legacy HAIP single-shot path

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -295,10 +295,9 @@ public class ActionExecutionService : IActionExecutionService
             }
             else if (haipRequirement != null && !hasSubmittedPresentations)
             {
-                // Feature 111 removed the legacy single-shot HAIP path. If we reach
-                // this branch it means the blueprint requires a HAIP presentation but
-                // the lifecycle service is not registered — a deployment configuration
-                // error rather than a runtime scenario the code should silently handle.
+                // Deployment-configuration error: this branch is only reachable when
+                // IPresentationLifecycleService is not registered. Fail fast rather
+                // than silently skipping the HAIP requirement.
                 throw new InvalidOperationException(
                     "HAIP presentation requested but IPresentationLifecycleService is not registered. " +
                     "Ensure PresentationLifecycleOptions and related services are wired in the DI container.");
@@ -1051,10 +1050,9 @@ public class ActionExecutionService : IActionExecutionService
                     ExpiresAt = haipOfferResult.ExpiresAt
                 }
                 : null,
-            // Feature 111 — presentation requests now return via the 202 Accepted
-            // short-circuit earlier in ExecuteAsync. The 200 OK response never
-            // carries a PresentationRequest; this field is preserved for
-            // backwards-compatible schema shape only.
+            // Presentation requests surface via the 202 Accepted short-circuit
+            // earlier in ExecuteAsync, so the 200 OK path never populates this.
+            // Field retained for backwards-compatible schema shape.
             PresentationRequest = null
         };
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -231,8 +231,6 @@ public class ActionExecutionService : IActionExecutionService
         }
 
         // 4c. Verify credential presentations against action requirements
-        CreatePresentationRequestResult? haipPresentationResult = null;
-        // Resolve HAIP requirement early — reused in response builder (avoids duplicate LINQ)
         var haipRequirement = actionDef.CredentialRequirements?
             .FirstOrDefault(r => r.PresentationSource == PresentationSource.HaipExternalWallet);
         if (actionDef.CredentialRequirements?.Any() == true)
@@ -295,23 +293,15 @@ public class ActionExecutionService : IActionExecutionService
                     }
                 };
             }
-            else if (haipRequirement != null && !hasSubmittedPresentations && _haipClient != null)
+            else if (haipRequirement != null && !hasSubmittedPresentations)
             {
-                // Legacy path retained for backwards-compat during rollout — exercised only
-                // when the PresentationLifecycleService is not registered. New deployments
-                // should always have the lifecycle service and take the branch above.
-                _logger.LogWarning(
-                    "HAIP presentation taking legacy single-shot path (PresentationLifecycleService not registered)");
-
-                var requiredClaimNames = haipRequirement.RequiredClaims?
-                    .Select(c => c.ClaimName)
-                    .ToList();
-
-                haipPresentationResult = await _haipClient.CreatePresentationRequestAsync(
-                    haipRequirement.Type,
-                    requiredClaimNames,
-                    haipRequirement.AcceptedIssuers?.ToList(),
-                    cancellationToken);
+                // Feature 111 removed the legacy single-shot HAIP path. If we reach
+                // this branch it means the blueprint requires a HAIP presentation but
+                // the lifecycle service is not registered — a deployment configuration
+                // error rather than a runtime scenario the code should silently handle.
+                throw new InvalidOperationException(
+                    "HAIP presentation requested but IPresentationLifecycleService is not registered. " +
+                    "Ensure PresentationLifecycleOptions and related services are wired in the DI container.");
             }
             else if (_credentialVerifier != null)
             {
@@ -1061,17 +1051,11 @@ public class ActionExecutionService : IActionExecutionService
                     ExpiresAt = haipOfferResult.ExpiresAt
                 }
                 : null,
-            PresentationRequest = haipPresentationResult != null
-                ? new HaipPresentationRequestResponse
-                {
-                    RequestId = haipPresentationResult.RequestId,
-                    PresentationRequestUri = haipPresentationResult.AuthorizationRequestUri,
-                    CredentialType = haipRequirement?.Type ?? string.Empty,
-                    RequestedClaims = haipRequirement?.RequiredClaims?
-                        .Select(c => c.ClaimName).ToList(),
-                    ExpiresAt = haipPresentationResult.ExpiresAt
-                }
-                : null
+            // Feature 111 — presentation requests now return via the 202 Accepted
+            // short-circuit earlier in ExecuteAsync. The 200 OK response never
+            // carries a PresentationRequest; this field is preserved for
+            // backwards-compatible schema shape only.
+            PresentationRequest = null
         };
 
         _logger.LogInformation(

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
@@ -14,6 +14,7 @@ using Sorcha.Blueprint.Service.Models.Requests;
 using Sorcha.Blueprint.Service.Services.Implementation;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
+using Sorcha.Blueprint.Models.Credentials;
 using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
 using ActionModel = Sorcha.Blueprint.Models.Action;
 using ParticipantModel = Sorcha.Blueprint.Models.Participant;
@@ -427,6 +428,48 @@ public class ActionExecutionServiceTests
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             _service.ExecuteAsync(instanceId, actionId, request, delegationToken));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HaipRequirementWithoutLifecycleService_ThrowsDeploymentConfigError()
+    {
+        // Regression guard for the removed legacy single-shot HAIP path. When an
+        // action has a HAIP credential requirement and IPresentationLifecycleService
+        // is not registered, the service must fail loud with a configuration error
+        // rather than silently falling through.
+        var instanceId = "test-instance";
+        var actionId = 1;
+        var request = CreateTestRequest() with { SenderWallet = "wallet-applicant" };
+        var delegationToken = "test-token";
+        var instance = CreateTestInstance(instanceId, "blueprint-1");
+        instance.CurrentActionIds = [1];
+        var blueprint = CreateTestBlueprint();
+        var action = blueprint.Actions!.First(a => a.Id == 1);
+        action.CredentialRequirements = new List<CredentialRequirement>
+        {
+            new()
+            {
+                Type = "VerifiedIdentityCredential",
+                PresentationSource = PresentationSource.HaipExternalWallet
+            }
+        };
+
+        _mockInstanceStore
+            .Setup(x => x.GetAsync(instanceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instance);
+        _mockActionResolver
+            .Setup(x => x.GetBlueprintAsync("blueprint-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+        _mockActionResolver
+            .Setup(x => x.GetActionDefinition(blueprint, "1"))
+            .Returns(action);
+
+        // _service was constructed without presentationLifecycle or haipClient —
+        // the branch after the legacy removal should throw.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.ExecuteAsync(instanceId, actionId, request, delegationToken));
+
+        ex.Message.Should().Contain("IPresentationLifecycleService");
     }
 
     // Note: ExecuteAsync full flow test is skipped because it requires complex


### PR DESCRIPTION
## Summary

Wave 4 Polish follow-up to merged PRs #382, #383, #384.

The legacy `_haipClient.CreatePresentationRequestAsync` branch in
`ActionExecutionService` step 4c was retained behind a null-guard during
Feature 111 rollout as a safety net. It's now unreachable in normal
operation — `PresentationLifecycleService` is always registered.

## Changes

- Deleted the `else if (...haipRequirement != null && _haipClient != null)`
  branch; if reached now (indicating a deployment-configuration error),
  throws `InvalidOperationException` with a clear operator-actionable message.
- Removed the `haipPresentationResult` local variable and its mapping
  into `ActionSubmissionResponse.PresentationRequest`.
- The `PresentationRequest` field on the `200 OK` response is preserved
  for backwards-compatible schema shape but is now always `null`
  (presentation requests surface via the `202 Accepted` short-circuit).

## Impact

- `_haipClient` remains in DI — it's still used for credential issuance.
- New deployments that fail to wire the lifecycle service fail fast with
  a readable error instead of silently regressing to single-shot writes.
- No behaviour change for correctly-wired deployments.

## Tests

- 61 presentation unit tests pass.
- Full solution builds clean.

## Test plan
- [x] `dotnet build` clean
- [x] 61 presentation unit tests pass
- [ ] n1 redeploy confirms the lifecycle flow end-to-end (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)