### PR TITLE
fix(register): stop XREADGROUP busy-spin in event subscriber

### DIFF
--- a/src/Core/Sorcha.Register.Storage.Redis/RedisEventStreamConfiguration.cs
+++ b/src/Core/Sorcha.Register.Storage.Redis/RedisEventStreamConfiguration.cs
@@ -24,7 +24,10 @@ public class RedisEventStreamConfiguration
     public int MaxStreamLength { get; set; } = 10000;
 
     /// <summary>
-    /// Block timeout in milliseconds for XREADGROUP
+    /// Idle delay in milliseconds between XREADGROUP polls when no messages are returned.
+    /// The typed StackExchange.Redis StreamReadGroupAsync overload does not expose the
+    /// XREADGROUP BLOCK argument, so the consumer loop sleeps for this duration instead
+    /// of busy-spinning when streams are empty. Default: 5000.
     /// </summary>
     public int ReadBlockMilliseconds { get; set; } = 5000;
 

--- a/src/Core/Sorcha.Register.Storage.Redis/RedisStreamEventSubscriber.cs
+++ b/src/Core/Sorcha.Register.Storage.Redis/RedisStreamEventSubscriber.cs
@@ -119,11 +119,13 @@ public class RedisStreamEventSubscriber : IEventSubscriber
                     _consumerName,
                     _config.BatchSize);
 
+                var processedAny = false;
                 if (results is not null)
                 {
                     foreach (var result in results)
                     {
                         if (result.Entries.Length == 0) continue;
+                        processedAny = true;
 
                         if (subscriptionSnapshot.TryGetValue(result.Key.ToString(), out var handlers))
                         {
@@ -143,6 +145,16 @@ public class RedisStreamEventSubscriber : IEventSubscriber
                         await ReclaimPendingMessagesAsync(db, streamKey, subscriptionSnapshot[streamKey]);
                     }
                     lastPendingClaim = DateTime.UtcNow;
+                }
+
+                // The typed StreamReadGroupAsync overload does not accept the XREADGROUP BLOCK
+                // argument, so an empty read returns immediately. Without a delay this loop spun
+                // ~15k iterations/sec and pegged a vCPU on n1 (load avg ~11 on a 2-vCPU box,
+                // wedging SSH). Sleep when idle; events arriving incur no extra latency because
+                // the next iteration polls right away.
+                if (!processedAny)
+                {
+                    await Task.Delay(_config.ReadBlockMilliseconds, cancellationToken);
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- `RedisStreamEventSubscriber.StartProcessingAsync` called the typed `StreamReadGroupAsync` overload in a `while` loop with no `BLOCK` argument and no delay, so empty reads returned immediately and the loop spun at the rate Redis could serve.
- Add `await Task.Delay(_config.ReadBlockMilliseconds, ct)` when no entries are returned. `ReadBlockMilliseconds` was already on the config (default 5000) but had never been plumbed through.
- Update the misleading docstring on `ReadBlockMilliseconds` (it claimed to be the XREADGROUP BLOCK timeout, which it never was).

## Why
Observed on n1.sorcha.dev (`Standard_D2ads_v7`, 2 vCPU) on 2026-04-24:
- `cmdstat_xreadgroup`: **1,268,161,861 calls in 24h** = ~14,700/sec
- `register-service` 97% CPU, `validator-service` 51% CPU sustained
- Load avg **10.8** → `sshd` starved during banner exchange → SSH appeared wedged while the Azure VM agent (higher priority) survived, so the hypervisor reported "VM running"

Disk fill was the prior hypothesis; falsified — disk was 56%, no OOM, no I/O errors. Root cause is this code path.

The regression test `StartProcessingAsync_EmptyStream_DoesNotBusySpin` landed via PR #384 ahead of this source fix and is currently failing on master; this PR makes it pass.

## Test plan
- [x] `dotnet test tests/Sorcha.Register.Storage.Redis.Tests --filter "FullyQualifiedName~RedisStreamEventSubscriberTests"` — 10/10 pass locally
- [ ] CI green
- [ ] After merge: Docker Publish builds `sorchadev/register-service:latest` + `validator-service:latest`, then `docker compose pull register-service validator-service && up -d --force-recreate` on n1
- [ ] On n1 post-redeploy: `redis-cli INFO commandstats | grep xreadgroup` rate should drop from ~14,700/sec to ≤1/sec; `uptime` load should fall below 1.0