### PR TITLE
test(111): integration tests for callback + status endpoints

### DIFF
--- a/specs/111-presentation-lifecycle/tasks.md
+++ b/specs/111-presentation-lifecycle/tasks.md
@@ -101,8 +101,8 @@ Paths are absolute from repo root `C:\Projects\Sorcha\`. Single-project layout p
 
 - [X] T035 [P] [US2] Unit test `tests/Sorcha.Blueprint.Service.Tests/Services/TransactionBuilderServicePresentationOutcomeTests.cs` — success path populates VerifiedClaims + PresentationSubmissionHash; decline path populates Reason only when Minimal, Reason + VerifierDiagnostics when Verbose
 - [X] T036 [P] [US2] Unit test `tests/Sorcha.Blueprint.Service.Tests/Services/PresentationLifecycleServiceOutcomeTests.cs` — HandleOutcomeAsync writes success tx and advances instance; writes decline tx and reroutes; second call with same requestId is no-op (sentinel guards)
-- [ ] T037 [P] [US2] Integration test `tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationOutcomeIntegrationTests.cs` — POST `/api/presentations/callbacks/haip` with success payload after prior initiate; assert outcome tx, instance advance, sentinel set to "success"
-- [ ] T038 [P] [US2] Integration test same file — decline callback writes decline outcome, action terminates; duplicate callback is no-op (returns 200, no new tx)
+- [X] T037 [P] [US2] Integration test `PresentationCallbackIntegrationTests.Callback_SuccessOutcome_WritesTx_AndMarksSentinelSuccess_T037` — POST callback with success payload, outcome tx written, sentinel=success
+- [X] T038 [P] [US2] Integration tests `PresentationCallbackIntegrationTests.Callback_DeclineOutcome_...T038a` + `..._DuplicateCallback_IsIdempotentReplay_...T038b` — decline writes tx + sentinel=decline; duplicate returns 200 with IdempotentReplay=true, no new tx
 - [X] T039 [P] [US2] Unit test `tests/Sorcha.Haip.Service.Tests/Services/HaipPresentationConsumerTests.cs` — verify HAIP verifier result mapping (landed in PR #382 round 1 fix)
 - [ ] T040 [P] [US2] Integration test `tests/Sorcha.Haip.Service.Tests/Integration/PresentationCallbackRelayIntegrationTests.cs` — HAIP VerifierEndpoints direct-post handler forwards verifier result to Blueprint Service callback endpoint with service JWT
 
@@ -155,7 +155,7 @@ Paths are absolute from repo root `C:\Projects\Sorcha\`. Single-project layout p
 - [~] T056 [P] [US4] Unit test sweeper leader election — deferred (requires Redis test harness; `ConnectionMultiplexer.StringSetAsync` SET NX path is standard StackExchange.Redis behaviour)
 - [ ] T057 [P] [US4] Integration test `tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationAbandonmentIntegrationTests.cs` — abandonment happens within 60s of window expiry on opt-in blueprint
 - [ ] T058 [P] [US4] Integration test same file — opt-out blueprint: no abandonment record even after 3x window
-- [ ] T059 [P] [US4] Integration test `PresentationLateOutcomeAfterAbandonmentTests.cs` — force abandonment, then POST callback; both tx visible, outcome sentinel updates to "abandoned+outcome"
+- [X] T059 [P] [US4] Integration test `PresentationCallbackIntegrationTests.Callback_LateAfterAbandonment_WritesOutcome_MarksAbandonedWithOutcome_T059` — sentinel forced to "abandoned"; callback writes outcome, sentinel advances to "abandoned+outcome"
 
 ### Implementation for User Story 4
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationCallbackIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationCallbackIntegrationTests.cs
@@ -13,11 +13,16 @@ using Xunit;
 namespace Sorcha.Blueprint.Service.Tests.Integration;
 
 /// <summary>
-/// T037-T038, T059 — integration tests for the Feature 111 callback + status
+/// T037 / T038 / T059 — integration tests for the Feature 111 callback + status
 /// endpoints. Exercises the HTTP-boundary wiring (path binding, auth, JSON
 /// shape) plus the consumer dispatch → outcome-tx-write → sentinel-state-machine
 /// through the real ASP.NET Core pipeline.
 /// </summary>
+/// <remarks>
+/// The factory is shared via <c>IClassFixture</c> for startup speed. Every test
+/// MUST call <c>_factory.ResetMocksAndState()</c> at the top to avoid bleed
+/// between Moq setups, accumulating invocation lists, and stale pending state.
+/// </remarks>
 public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLifecycleWebApplicationFactory>
 {
     private readonly PresentationLifecycleWebApplicationFactory _factory;
@@ -34,13 +39,13 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     /// successful InitiateAsync — so callback tests don't have to go through
     /// the full /execute pipeline.
     /// </summary>
-    private Guid SeedPending(
+    private async Task<Guid> SeedPendingAsync(
         string consumerName = "haip",
         string outcomeDetailLevel = "minimal",
         bool recordAbandonment = false)
     {
         var id = Guid.NewGuid();
-        _factory.PendingStore.StoreAsync(new PendingPresentation
+        await _factory.PendingStore.StoreAsync(new PendingPresentation
         {
             PresentationRequestId = id,
             InstanceId = Guid.NewGuid(),
@@ -56,15 +61,16 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
             ValidityWindowSeconds = 600,
             CreatedAt = DateTimeOffset.UtcNow,
             InitiatedTransactionId = "tx-initiated-abc"
-        }).GetAwaiter().GetResult();
+        });
         return id;
     }
 
     [Fact]
-    public async Task Callback_SuccessOutcome_WritesTx_AndMarksSentinelSuccess_T037()
+    public async Task Callback_SuccessOutcome_WritesTx_AndMarksSentinelSuccess()
     {
         // Arrange
-        var requestId = SeedPending();
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync();
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             Kind: PresentationOutcomeKind.Success,
             VerifiedClaims: new Dictionary<string, object> { ["name"] = "Alice" },
@@ -72,7 +78,7 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
             VerifierDiagnostics: null,
             PresentationSubmissionHash: "sha256:abc");
 
-        var capturedSubmission = default(TransactionSubmission);
+        TransactionSubmission? capturedSubmission = null;
         _factory.ValidatorClient
             .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
             .Callback<TransactionSubmission, CancellationToken>((sub, _) => capturedSubmission = sub)
@@ -93,25 +99,22 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
         body.IdempotentReplay.Should().BeFalse();
         body.LateAfterAbandonment.Should().BeFalse();
 
-        // Sentinel advanced to "success"
         var sentinel = await _factory.PendingStore.GetOutcomeSentinelAsync(requestId);
         sentinel.Should().Be("success");
 
-        // Validator saw a PresentationOutcome submission with outcomeKind=success
         capturedSubmission.Should().NotBeNull();
         capturedSubmission!.Metadata.Should().ContainKey("outcomeKind")
             .WhoseValue.Should().Be("success");
 
-        // HAIP consumer was invoked with the right context
         _factory.HaipConsumer.InvokedContexts.Should().Contain(c =>
             c.PresentationRequestId == requestId);
     }
 
     [Fact]
-    public async Task Callback_DeclineOutcome_WritesTx_AndMarksSentinelDecline_T038a()
+    public async Task Callback_DeclineOutcome_WritesTx_AndMarksSentinelDecline()
     {
-        // Arrange
-        var requestId = SeedPending();
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync();
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             Kind: PresentationOutcomeKind.Decline,
             VerifiedClaims: null,
@@ -119,12 +122,10 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
             VerifierDiagnostics: null,
             PresentationSubmissionHash: null);
 
-        // Act
         var response = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{requestId}",
             new { error = "expired_credential" });
 
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
         body!.Kind.Should().Be("Decline");
@@ -135,83 +136,76 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     }
 
     [Fact]
-    public async Task Callback_DuplicateCallback_IsIdempotentReplay_NoNewTx_T038b()
+    public async Task Callback_DuplicateCallback_IsIdempotentReplay_NoNewTx()
     {
-        // Arrange
-        var requestId = SeedPending();
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync();
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             PresentationOutcomeKind.Success, new Dictionary<string, object>(), null, null, "sha");
 
         int validatorSubmitCount = 0;
         _factory.ValidatorClient
             .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
-            .Callback(() => Interlocked.Increment(ref validatorSubmitCount))
-            .ReturnsAsync(new TransactionSubmissionResult { Success = true });
+            .Callback<TransactionSubmission, CancellationToken>((sub, _) => Interlocked.Increment(ref validatorSubmitCount))
+            .ReturnsAsync((TransactionSubmission sub, CancellationToken _) =>
+                new TransactionSubmissionResult { Success = true, TransactionId = sub.TransactionId });
 
-        // Act — first callback
         var first = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{requestId}", new { });
         first.StatusCode.Should().Be(HttpStatusCode.OK);
         var firstBody = await first.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
         firstBody!.IdempotentReplay.Should().BeFalse();
 
-        // Act — duplicate callback (same requestId)
         var second = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{requestId}", new { });
 
-        // Assert
         second.StatusCode.Should().Be(HttpStatusCode.OK);
         var secondBody = await second.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
         secondBody!.IdempotentReplay.Should().BeTrue();
         secondBody.OutcomeTransactionId.Should().BeEmpty();
 
-        // Only one tx hit the validator.
         validatorSubmitCount.Should().Be(1);
     }
 
     [Fact]
     public async Task Callback_UnknownRequestId_Returns400()
     {
-        // Arrange — no pending state seeded
+        _factory.ResetMocksAndState();
+
         var response = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{Guid.NewGuid()}",
             new { });
 
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
     public async Task Callback_ConsumerNameMismatch_Returns400()
     {
-        // Arrange — pending state says "haip" but callback path says "other"
-        var requestId = SeedPending(consumerName: "haip");
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync(consumerName: "haip");
 
-        // Act — swap to the unknown consumer via URL path
         var response = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/other-consumer/{requestId}",
             new { });
 
-        // Assert — no consumer matches "other-consumer" in DI, InvalidOperationException → 400
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Fact]
-    public async Task Callback_LateAfterAbandonment_WritesOutcome_MarksAbandonedWithOutcome_T059()
+    public async Task Callback_LateAfterAbandonment_WritesOutcome_MarksAbandonedWithOutcome()
     {
-        // Arrange — force the sentinel to "abandoned" as if the sweeper ran already.
-        var requestId = SeedPending(recordAbandonment: true);
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync(recordAbandonment: true);
         _factory.PendingStore.ForceSentinel(requestId, "abandoned");
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             PresentationOutcomeKind.Success,
             new Dictionary<string, object> { ["name"] = "Alice" },
             null, null, "sha");
 
-        // Act
         var response = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{requestId}", new { });
 
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
         body!.LateAfterAbandonment.Should().BeTrue();
@@ -225,13 +219,11 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task StatusEndpoint_AwaitingPresentation_ReturnsPendingStateOnly()
     {
-        // Arrange
-        var requestId = SeedPending();
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync();
 
-        // Act
         var response = await _client.GetAsync($"/api/presentations/{requestId}/status");
 
-        // Assert — state + expiresAt only; no registerId / instanceId / consumer
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<PresentationStatusResponse>();
         body.Should().NotBeNull();
@@ -239,7 +231,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
         body.State.Should().Be("awaiting-presentation");
         body.ExpiresAt.Should().NotBeNull();
 
-        // Payload JSON must not leak privileged fields.
         var json = await response.Content.ReadAsStringAsync();
         json.Should().NotContain("registerId");
         json.Should().NotContain("instanceId");
@@ -249,14 +240,18 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task StatusEndpoint_AfterSuccessCallback_ReturnsSuccess()
     {
-        // Arrange — seed + success callback
-        var requestId = SeedPending();
+        _factory.ResetMocksAndState();
+        var requestId = await SeedPendingAsync();
+        // Explicit success outcome — avoids inheriting state from any test that
+        // runs before this one under the class-level IClassFixture.
+        _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
+            PresentationOutcomeKind.Success,
+            new Dictionary<string, object>(),
+            null, null, "sha");
         await _client.PostAsJsonAsync($"/api/presentations/callbacks/haip/{requestId}", new { });
 
-        // Act
         var response = await _client.GetAsync($"/api/presentations/{requestId}/status");
 
-        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var body = await response.Content.ReadFromJsonAsync<PresentationStatusResponse>();
         body!.State.Should().Be("success");
@@ -265,6 +260,8 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task StatusEndpoint_UnknownRequestId_Returns404()
     {
+        _factory.ResetMocksAndState();
+
         var response = await _client.GetAsync($"/api/presentations/{Guid.NewGuid()}/status");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationCallbackIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationCallbackIntegrationTests.cs
@@ -19,11 +19,12 @@ namespace Sorcha.Blueprint.Service.Tests.Integration;
 /// through the real ASP.NET Core pipeline.
 /// </summary>
 /// <remarks>
-/// The factory is shared via <c>IClassFixture</c> for startup speed. Every test
-/// MUST call <c>_factory.ResetMocksAndState()</c> at the top to avoid bleed
-/// between Moq setups, accumulating invocation lists, and stale pending state.
+/// The factory is shared via <c>IClassFixture</c> for startup speed.
+/// <see cref="IAsyncLifetime.InitializeAsync"/> calls
+/// <c>ResetMocksAndState()</c> automatically before every test, so individual
+/// tests never have to remember to do it.
 /// </remarks>
-public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLifecycleWebApplicationFactory>
+public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLifecycleWebApplicationFactory>, IAsyncLifetime
 {
     private readonly PresentationLifecycleWebApplicationFactory _factory;
     private readonly HttpClient _client;
@@ -33,6 +34,14 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
         _factory = factory;
         _client = factory.CreateClient();
     }
+
+    public ValueTask InitializeAsync()
+    {
+        _factory.ResetMocksAndState();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     /// <summary>
     /// Seed a pending presentation in the in-memory store — simulates a prior
@@ -69,7 +78,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     public async Task Callback_SuccessOutcome_WritesTx_AndMarksSentinelSuccess()
     {
         // Arrange
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync();
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             Kind: PresentationOutcomeKind.Success,
@@ -113,7 +121,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task Callback_DeclineOutcome_WritesTx_AndMarksSentinelDecline()
     {
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync();
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             Kind: PresentationOutcomeKind.Decline,
@@ -121,6 +128,13 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
             Reason: PresentationDeclineReason.ExpiredCredential,
             VerifierDiagnostics: null,
             PresentationSubmissionHash: null);
+
+        TransactionSubmission? capturedSubmission = null;
+        _factory.ValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .Callback<TransactionSubmission, CancellationToken>((sub, _) => capturedSubmission = sub)
+            .ReturnsAsync((TransactionSubmission sub, CancellationToken _) =>
+                new TransactionSubmissionResult { Success = true, TransactionId = sub.TransactionId });
 
         var response = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{requestId}",
@@ -133,12 +147,17 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
 
         var sentinel = await _factory.PendingStore.GetOutcomeSentinelAsync(requestId);
         sentinel.Should().Be("decline");
+
+        // Parallel check with the success path — outcomeKind must land on the
+        // tx metadata so the US3 retry gate (and any audit consumer) can see it.
+        capturedSubmission.Should().NotBeNull();
+        capturedSubmission!.Metadata.Should().ContainKey("outcomeKind")
+            .WhoseValue.Should().Be("decline");
     }
 
     [Fact]
     public async Task Callback_DuplicateCallback_IsIdempotentReplay_NoNewTx()
     {
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync();
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
             PresentationOutcomeKind.Success, new Dictionary<string, object>(), null, null, "sha");
@@ -162,7 +181,9 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
         second.StatusCode.Should().Be(HttpStatusCode.OK);
         var secondBody = await second.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
         secondBody!.IdempotentReplay.Should().BeTrue();
-        secondBody.OutcomeTransactionId.Should().BeEmpty();
+        // Null-safe assertion: the service may return either null or string.Empty
+        // for an idempotent replay — both are acceptable.
+        secondBody.OutcomeTransactionId.Should().BeNullOrEmpty();
 
         validatorSubmitCount.Should().Be(1);
     }
@@ -170,7 +191,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task Callback_UnknownRequestId_Returns400()
     {
-        _factory.ResetMocksAndState();
 
         var response = await _client.PostAsJsonAsync(
             $"/api/presentations/callbacks/haip/{Guid.NewGuid()}",
@@ -182,7 +202,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task Callback_ConsumerNameMismatch_Returns400()
     {
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync(consumerName: "haip");
 
         var response = await _client.PostAsJsonAsync(
@@ -195,7 +214,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task Callback_LateAfterAbandonment_WritesOutcome_MarksAbandonedWithOutcome()
     {
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync(recordAbandonment: true);
         _factory.PendingStore.ForceSentinel(requestId, "abandoned");
         _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
@@ -219,7 +237,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task StatusEndpoint_AwaitingPresentation_ReturnsPendingStateOnly()
     {
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync();
 
         var response = await _client.GetAsync($"/api/presentations/{requestId}/status");
@@ -229,7 +246,10 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
         body.Should().NotBeNull();
         body!.PresentationRequestId.Should().Be(requestId);
         body.State.Should().Be("awaiting-presentation");
+        // ValidityWindowSeconds = 600 + CreatedAt ≈ now → ExpiresAt in (now, now+601s].
         body.ExpiresAt.Should().NotBeNull();
+        body.ExpiresAt!.Value.Should().BeAfter(DateTimeOffset.UtcNow);
+        body.ExpiresAt!.Value.Should().BeBefore(DateTimeOffset.UtcNow.AddSeconds(601));
 
         var json = await response.Content.ReadAsStringAsync();
         json.Should().NotContain("registerId");
@@ -240,7 +260,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task StatusEndpoint_AfterSuccessCallback_ReturnsSuccess()
     {
-        _factory.ResetMocksAndState();
         var requestId = await SeedPendingAsync();
         // Explicit success outcome — avoids inheriting state from any test that
         // runs before this one under the class-level IClassFixture.
@@ -260,7 +279,6 @@ public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLi
     [Fact]
     public async Task StatusEndpoint_UnknownRequestId_Returns404()
     {
-        _factory.ResetMocksAndState();
 
         var response = await _client.GetAsync($"/api/presentations/{Guid.NewGuid()}/status");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationCallbackIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationCallbackIntegrationTests.cs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Sorcha.Blueprint.Service.Endpoints;
+using Sorcha.Blueprint.Service.Storage.Presentations;
+using Sorcha.PresentationLifecycle.Abstractions;
+using Sorcha.ServiceClients.Validator;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Integration;
+
+/// <summary>
+/// T037-T038, T059 — integration tests for the Feature 111 callback + status
+/// endpoints. Exercises the HTTP-boundary wiring (path binding, auth, JSON
+/// shape) plus the consumer dispatch → outcome-tx-write → sentinel-state-machine
+/// through the real ASP.NET Core pipeline.
+/// </summary>
+public class PresentationCallbackIntegrationTests : IClassFixture<PresentationLifecycleWebApplicationFactory>
+{
+    private readonly PresentationLifecycleWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public PresentationCallbackIntegrationTests(PresentationLifecycleWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    /// <summary>
+    /// Seed a pending presentation in the in-memory store — simulates a prior
+    /// successful InitiateAsync — so callback tests don't have to go through
+    /// the full /execute pipeline.
+    /// </summary>
+    private Guid SeedPending(
+        string consumerName = "haip",
+        string outcomeDetailLevel = "minimal",
+        bool recordAbandonment = false)
+    {
+        var id = Guid.NewGuid();
+        _factory.PendingStore.StoreAsync(new PendingPresentation
+        {
+            PresentationRequestId = id,
+            InstanceId = Guid.NewGuid(),
+            ActionId = 3,
+            RegisterId = "reg-integration",
+            BlueprintId = "bp-integration",
+            SubmitterWallet = "ws11qtestcitizen",
+            ConsumerName = consumerName,
+            DraftPayloadJson = "{}",
+            CredentialRequirementDigestHex = "deadbeef",
+            RecordAbandonment = recordAbandonment,
+            OutcomeDetailLevel = outcomeDetailLevel,
+            ValidityWindowSeconds = 600,
+            CreatedAt = DateTimeOffset.UtcNow,
+            InitiatedTransactionId = "tx-initiated-abc"
+        }).GetAwaiter().GetResult();
+        return id;
+    }
+
+    [Fact]
+    public async Task Callback_SuccessOutcome_WritesTx_AndMarksSentinelSuccess_T037()
+    {
+        // Arrange
+        var requestId = SeedPending();
+        _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
+            Kind: PresentationOutcomeKind.Success,
+            VerifiedClaims: new Dictionary<string, object> { ["name"] = "Alice" },
+            Reason: null,
+            VerifierDiagnostics: null,
+            PresentationSubmissionHash: "sha256:abc");
+
+        var capturedSubmission = default(TransactionSubmission);
+        _factory.ValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .Callback<TransactionSubmission, CancellationToken>((sub, _) => capturedSubmission = sub)
+            .ReturnsAsync((TransactionSubmission sub, CancellationToken _) =>
+                new TransactionSubmissionResult { Success = true, TransactionId = sub.TransactionId });
+
+        // Act
+        var response = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/haip/{requestId}",
+            new { vp_token = "...", state = requestId.ToString() });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
+        body.Should().NotBeNull();
+        body!.Kind.Should().Be("Success");
+        body.OutcomeTransactionId.Should().NotBeNullOrWhiteSpace();
+        body.IdempotentReplay.Should().BeFalse();
+        body.LateAfterAbandonment.Should().BeFalse();
+
+        // Sentinel advanced to "success"
+        var sentinel = await _factory.PendingStore.GetOutcomeSentinelAsync(requestId);
+        sentinel.Should().Be("success");
+
+        // Validator saw a PresentationOutcome submission with outcomeKind=success
+        capturedSubmission.Should().NotBeNull();
+        capturedSubmission!.Metadata.Should().ContainKey("outcomeKind")
+            .WhoseValue.Should().Be("success");
+
+        // HAIP consumer was invoked with the right context
+        _factory.HaipConsumer.InvokedContexts.Should().Contain(c =>
+            c.PresentationRequestId == requestId);
+    }
+
+    [Fact]
+    public async Task Callback_DeclineOutcome_WritesTx_AndMarksSentinelDecline_T038a()
+    {
+        // Arrange
+        var requestId = SeedPending();
+        _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
+            Kind: PresentationOutcomeKind.Decline,
+            VerifiedClaims: null,
+            Reason: PresentationDeclineReason.ExpiredCredential,
+            VerifierDiagnostics: null,
+            PresentationSubmissionHash: null);
+
+        // Act
+        var response = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/haip/{requestId}",
+            new { error = "expired_credential" });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
+        body!.Kind.Should().Be("Decline");
+        body.IdempotentReplay.Should().BeFalse();
+
+        var sentinel = await _factory.PendingStore.GetOutcomeSentinelAsync(requestId);
+        sentinel.Should().Be("decline");
+    }
+
+    [Fact]
+    public async Task Callback_DuplicateCallback_IsIdempotentReplay_NoNewTx_T038b()
+    {
+        // Arrange
+        var requestId = SeedPending();
+        _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
+            PresentationOutcomeKind.Success, new Dictionary<string, object>(), null, null, "sha");
+
+        int validatorSubmitCount = 0;
+        _factory.ValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .Callback(() => Interlocked.Increment(ref validatorSubmitCount))
+            .ReturnsAsync(new TransactionSubmissionResult { Success = true });
+
+        // Act — first callback
+        var first = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/haip/{requestId}", new { });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstBody = await first.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
+        firstBody!.IdempotentReplay.Should().BeFalse();
+
+        // Act — duplicate callback (same requestId)
+        var second = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/haip/{requestId}", new { });
+
+        // Assert
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondBody = await second.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
+        secondBody!.IdempotentReplay.Should().BeTrue();
+        secondBody.OutcomeTransactionId.Should().BeEmpty();
+
+        // Only one tx hit the validator.
+        validatorSubmitCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Callback_UnknownRequestId_Returns400()
+    {
+        // Arrange — no pending state seeded
+        var response = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/haip/{Guid.NewGuid()}",
+            new { });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_ConsumerNameMismatch_Returns400()
+    {
+        // Arrange — pending state says "haip" but callback path says "other"
+        var requestId = SeedPending(consumerName: "haip");
+
+        // Act — swap to the unknown consumer via URL path
+        var response = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/other-consumer/{requestId}",
+            new { });
+
+        // Assert — no consumer matches "other-consumer" in DI, InvalidOperationException → 400
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Callback_LateAfterAbandonment_WritesOutcome_MarksAbandonedWithOutcome_T059()
+    {
+        // Arrange — force the sentinel to "abandoned" as if the sweeper ran already.
+        var requestId = SeedPending(recordAbandonment: true);
+        _factory.PendingStore.ForceSentinel(requestId, "abandoned");
+        _factory.HaipConsumer.NextOutcome = new PresentationOutcome(
+            PresentationOutcomeKind.Success,
+            new Dictionary<string, object> { ["name"] = "Alice" },
+            null, null, "sha");
+
+        // Act
+        var response = await _client.PostAsJsonAsync(
+            $"/api/presentations/callbacks/haip/{requestId}", new { });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PresentationCallbackResponse>();
+        body!.LateAfterAbandonment.Should().BeTrue();
+        body.IdempotentReplay.Should().BeFalse();
+        body.OutcomeTransactionId.Should().NotBeNullOrWhiteSpace();
+
+        var sentinel = await _factory.PendingStore.GetOutcomeSentinelAsync(requestId);
+        sentinel.Should().Be("abandoned+outcome");
+    }
+
+    [Fact]
+    public async Task StatusEndpoint_AwaitingPresentation_ReturnsPendingStateOnly()
+    {
+        // Arrange
+        var requestId = SeedPending();
+
+        // Act
+        var response = await _client.GetAsync($"/api/presentations/{requestId}/status");
+
+        // Assert — state + expiresAt only; no registerId / instanceId / consumer
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PresentationStatusResponse>();
+        body.Should().NotBeNull();
+        body!.PresentationRequestId.Should().Be(requestId);
+        body.State.Should().Be("awaiting-presentation");
+        body.ExpiresAt.Should().NotBeNull();
+
+        // Payload JSON must not leak privileged fields.
+        var json = await response.Content.ReadAsStringAsync();
+        json.Should().NotContain("registerId");
+        json.Should().NotContain("instanceId");
+        json.Should().NotContain("consumerName");
+    }
+
+    [Fact]
+    public async Task StatusEndpoint_AfterSuccessCallback_ReturnsSuccess()
+    {
+        // Arrange — seed + success callback
+        var requestId = SeedPending();
+        await _client.PostAsJsonAsync($"/api/presentations/callbacks/haip/{requestId}", new { });
+
+        // Act
+        var response = await _client.GetAsync($"/api/presentations/{requestId}/status");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<PresentationStatusResponse>();
+        body!.State.Should().Be("success");
+    }
+
+    [Fact]
+    public async Task StatusEndpoint_UnknownRequestId_Returns404()
+    {
+        var response = await _client.GetAsync($"/api/presentations/{Guid.NewGuid()}/status");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Sorcha.Blueprint.Service.Storage;
+using Sorcha.Blueprint.Service.Storage.Presentations;
+using Sorcha.PresentationLifecycle.Abstractions;
+using Sorcha.ServiceClients.Haip;
+using Sorcha.ServiceClients.Validator;
+
+namespace Sorcha.Blueprint.Service.Tests.Integration;
+
+/// <summary>
+/// WebApplicationFactory for Feature 111 integration tests. Extends the base
+/// factory with mocks for IHaipServiceClient, IValidatorServiceClient, and
+/// in-memory replacements for IPendingPresentationStore + IPresentationRateLimiter
+/// so the Redis layer is bypassed (unit-tested separately) and the HTTP-boundary
+/// wiring can be exercised end-to-end.
+/// </summary>
+public sealed class PresentationLifecycleWebApplicationFactory : BlueprintServiceWebApplicationFactory
+{
+    public Mock<IHaipServiceClient> HaipClient { get; } = new();
+    public Mock<IValidatorServiceClient> ValidatorClient { get; } = new();
+    public InMemoryPendingPresentationStore PendingStore { get; } = new();
+    public CountingPresentationRateLimiter RateLimiter { get; } = new();
+    public List<IPresentationConsumer> Consumers { get; } = new();
+
+    /// <summary>
+    /// A fake HAIP consumer that always succeeds. Individual tests can add or
+    /// override consumers via <see cref="Consumers"/> before the host starts.
+    /// </summary>
+    public TestHaipConsumer HaipConsumer { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IHaipServiceClient>();
+            services.AddSingleton(HaipClient.Object);
+
+            services.RemoveAll<IValidatorServiceClient>();
+            services.AddSingleton(ValidatorClient.Object);
+
+            services.RemoveAll<IPendingPresentationStore>();
+            services.AddSingleton<IPendingPresentationStore>(PendingStore);
+
+            services.RemoveAll<IPresentationRateLimiter>();
+            services.AddSingleton<IPresentationRateLimiter>(RateLimiter);
+
+            services.RemoveAll<IEnumerable<IPresentationConsumer>>();
+            services.RemoveAll<IPresentationConsumer>();
+            services.AddSingleton<IPresentationConsumer>(HaipConsumer);
+            foreach (var extra in Consumers)
+            {
+                services.AddSingleton(extra);
+            }
+
+            // HAIP default: successful presentation-request creation.
+            HaipClient
+                .Setup(h => h.CreatePresentationRequestAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<List<string>?>(),
+                    It.IsAny<List<string>?>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new CreatePresentationRequestResult(
+                    RequestId: Guid.NewGuid(),
+                    AuthorizationRequestUri: "openid4vp://authorize?request_uri=...",
+                    RequestUri: "https://haip.test/request-object",
+                    Nonce: "test-nonce",
+                    ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
+
+            // Validator default: all submissions succeed.
+            ValidatorClient
+                .Setup(v => v.GetNextSequenceNumberAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1L);
+
+            ValidatorClient
+                .Setup(v => v.SubmitTransactionAsync(
+                    It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((TransactionSubmission sub, CancellationToken _) =>
+                    new TransactionSubmissionResult
+                    {
+                        Success = true,
+                        TransactionId = sub.TransactionId,
+                        RegisterId = sub.RegisterId
+                    });
+        });
+    }
+}
+
+/// <summary>
+/// In-memory test double for <see cref="IPendingPresentationStore"/>. No TTL
+/// enforcement — tests that care about expiry manipulate the hash directly.
+/// </summary>
+public sealed class InMemoryPendingPresentationStore : IPendingPresentationStore
+{
+    private readonly ConcurrentDictionary<Guid, PendingPresentation> _pending = new();
+    private readonly ConcurrentDictionary<Guid, string> _sentinel = new();
+
+    public Task StoreAsync(PendingPresentation pending, CancellationToken ct = default)
+    {
+        _pending[pending.PresentationRequestId] = pending;
+        return Task.CompletedTask;
+    }
+
+    public Task<PendingPresentation?> GetAsync(Guid presentationRequestId, CancellationToken ct = default)
+        => Task.FromResult(_pending.GetValueOrDefault(presentationRequestId));
+
+    public Task DeleteAsync(Guid presentationRequestId, CancellationToken ct = default)
+    {
+        _pending.TryRemove(presentationRequestId, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> TryClaimOutcomeSentinelAsync(
+        Guid presentationRequestId, string claimantValue, int validityWindowSeconds, CancellationToken ct = default)
+        => Task.FromResult(_sentinel.TryAdd(presentationRequestId, claimantValue));
+
+    public Task<string?> GetOutcomeSentinelAsync(Guid presentationRequestId, CancellationToken ct = default)
+        => Task.FromResult(_sentinel.GetValueOrDefault(presentationRequestId));
+
+    public Task SetOutcomeSentinelAsync(
+        Guid presentationRequestId, string value, int validityWindowSeconds, CancellationToken ct = default)
+    {
+        _sentinel[presentationRequestId] = value;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteOutcomeSentinelAsync(Guid presentationRequestId, CancellationToken ct = default)
+    {
+        _sentinel.TryRemove(presentationRequestId, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<Guid>> ListPendingNearExpiryAsync(TimeSpan withinDuration, int max, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<Guid>>(_pending.Keys.Take(max).ToList());
+
+    /// <summary>Manually force the sentinel value for late-outcome-after-abandonment tests.</summary>
+    public void ForceSentinel(Guid id, string value) => _sentinel[id] = value;
+}
+
+/// <summary>
+/// In-memory test double for <see cref="IPresentationRateLimiter"/> with
+/// counting semantics matching the Redis implementation. Test code sets
+/// <see cref="Threshold"/> directly to control the response.
+/// </summary>
+public sealed class CountingPresentationRateLimiter : IPresentationRateLimiter
+{
+    private readonly ConcurrentDictionary<string, int> _counts = new();
+
+    public int Threshold { get; set; } = 10;
+    public int WindowSeconds { get; set; } = 600;
+
+    public Task<PresentationRateLimitResult> CheckAsync(
+        string walletAddress, string registerId, CancellationToken ct = default)
+    {
+        var key = $"{walletAddress}:{registerId}";
+        var count = _counts.AddOrUpdate(key, 1, (_, v) => v + 1);
+        var allowed = count <= Threshold;
+        return Task.FromResult(new PresentationRateLimitResult(
+            Allowed: allowed,
+            CurrentCount: count,
+            Threshold: Threshold,
+            RetryAfter: allowed ? null : TimeSpan.FromSeconds(WindowSeconds)));
+    }
+}
+
+/// <summary>
+/// Controllable HAIP consumer for integration tests. Each test sets
+/// <see cref="NextOutcome"/> before POSTing a callback.
+/// </summary>
+public sealed class TestHaipConsumer : IPresentationConsumer
+{
+    public string ConsumerName => "haip";
+
+    public PresentationOutcome NextOutcome { get; set; } = new(
+        Kind: PresentationOutcomeKind.Success,
+        VerifiedClaims: new Dictionary<string, object> { ["name"] = "Test" },
+        Reason: null,
+        VerifierDiagnostics: null,
+        PresentationSubmissionHash: "sha256:test");
+
+    public List<PresentationInitiationContext> InvokedContexts { get; } = new();
+
+    public Task<PresentationOutcome> VerifyAsync(
+        PresentationInitiationContext context, object verifierPayload, CancellationToken ct)
+    {
+        InvokedContexts.Add(context);
+        return Task.FromResult(NextOutcome);
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
@@ -35,6 +35,55 @@ public sealed class PresentationLifecycleWebApplicationFactory : BlueprintServic
     /// </summary>
     public TestHaipConsumer HaipConsumer { get; } = new();
 
+    /// <summary>
+    /// Reset all mock state and in-memory stores between tests. The factory is
+    /// shared via <c>IClassFixture</c> for speed, so tests must call this at the
+    /// start of each method to prevent shared-state bleed (Moq last-setup-wins,
+    /// accumulating <see cref="TestHaipConsumer.InvokedContexts"/>, rate-limit
+    /// counters, pending hashes, sentinel values).
+    /// </summary>
+    public void ResetMocksAndState()
+    {
+        HaipClient.Reset();
+        ValidatorClient.Reset();
+        ApplyDefaultMockSetups();
+        PendingStore.Clear();
+        RateLimiter.Reset();
+        HaipConsumer.Reset();
+    }
+
+    private void ApplyDefaultMockSetups()
+    {
+        HaipClient
+            .Setup(h => h.CreatePresentationRequestAsync(
+                It.IsAny<string>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<List<string>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreatePresentationRequestResult(
+                RequestId: Guid.NewGuid(),
+                AuthorizationRequestUri: "openid4vp://authorize?request_uri=...",
+                RequestUri: "https://haip.test/request-object",
+                Nonce: "test-nonce",
+                ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
+
+        ValidatorClient
+            .Setup(v => v.GetNextSequenceNumberAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1L);
+
+        ValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(
+                It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TransactionSubmission sub, CancellationToken _) =>
+                new TransactionSubmissionResult
+                {
+                    Success = true,
+                    TransactionId = sub.TransactionId,
+                    RegisterId = sub.RegisterId
+                });
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         base.ConfigureWebHost(builder);
@@ -61,36 +110,7 @@ public sealed class PresentationLifecycleWebApplicationFactory : BlueprintServic
                 services.AddSingleton(extra);
             }
 
-            // HAIP default: successful presentation-request creation.
-            HaipClient
-                .Setup(h => h.CreatePresentationRequestAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>?>(),
-                    It.IsAny<List<string>?>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new CreatePresentationRequestResult(
-                    RequestId: Guid.NewGuid(),
-                    AuthorizationRequestUri: "openid4vp://authorize?request_uri=...",
-                    RequestUri: "https://haip.test/request-object",
-                    Nonce: "test-nonce",
-                    ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
-
-            // Validator default: all submissions succeed.
-            ValidatorClient
-                .Setup(v => v.GetNextSequenceNumberAsync(
-                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(1L);
-
-            ValidatorClient
-                .Setup(v => v.SubmitTransactionAsync(
-                    It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((TransactionSubmission sub, CancellationToken _) =>
-                    new TransactionSubmissionResult
-                    {
-                        Success = true,
-                        TransactionId = sub.TransactionId,
-                        RegisterId = sub.RegisterId
-                    });
+            ApplyDefaultMockSetups();
         });
     }
 }
@@ -139,11 +159,24 @@ public sealed class InMemoryPendingPresentationStore : IPendingPresentationStore
         return Task.CompletedTask;
     }
 
+    /// <remarks>
+    /// Test-only stub: ignores <paramref name="withinDuration"/> and returns all
+    /// pending keys up to <paramref name="max"/>. The Redis adapter honours the
+    /// TTL-window filter; integration tests that exercise sweeper timing must
+    /// either extend this or use the real <c>RedisPendingPresentationStore</c>.
+    /// </remarks>
     public Task<IReadOnlyList<Guid>> ListPendingNearExpiryAsync(TimeSpan withinDuration, int max, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<Guid>>(_pending.Keys.Take(max).ToList());
 
     /// <summary>Manually force the sentinel value for late-outcome-after-abandonment tests.</summary>
     public void ForceSentinel(Guid id, string value) => _sentinel[id] = value;
+
+    /// <summary>Clear all pending state + sentinels between tests.</summary>
+    public void Clear()
+    {
+        _pending.Clear();
+        _sentinel.Clear();
+    }
 }
 
 /// <summary>
@@ -170,6 +203,14 @@ public sealed class CountingPresentationRateLimiter : IPresentationRateLimiter
             Threshold: Threshold,
             RetryAfter: allowed ? null : TimeSpan.FromSeconds(WindowSeconds)));
     }
+
+    /// <summary>Reset counters between tests.</summary>
+    public void Reset()
+    {
+        _counts.Clear();
+        Threshold = 10;
+        WindowSeconds = 600;
+    }
 }
 
 /// <summary>
@@ -194,5 +235,17 @@ public sealed class TestHaipConsumer : IPresentationConsumer
     {
         InvokedContexts.Add(context);
         return Task.FromResult(NextOutcome);
+    }
+
+    /// <summary>Reset invocation tracking + outcome between tests.</summary>
+    public void Reset()
+    {
+        InvokedContexts.Clear();
+        NextOutcome = new PresentationOutcome(
+            Kind: PresentationOutcomeKind.Success,
+            VerifiedClaims: new Dictionary<string, object> { ["name"] = "Test" },
+            Reason: null,
+            VerifierDiagnostics: null,
+            PresentationSubmissionHash: "sha256:test");
     }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/PresentationLifecycleWebApplicationFactory.cs
@@ -27,6 +27,11 @@ public sealed class PresentationLifecycleWebApplicationFactory : BlueprintServic
     public Mock<IValidatorServiceClient> ValidatorClient { get; } = new();
     public InMemoryPendingPresentationStore PendingStore { get; } = new();
     public CountingPresentationRateLimiter RateLimiter { get; } = new();
+    /// <remarks>
+    /// Populate before the first call to <see cref="WebApplicationFactory{TEntryPoint}.CreateClient()"/>.
+    /// Additions after host creation have no effect because <c>ConfigureWebHost</c>
+    /// only runs once per factory instance (shared via <c>IClassFixture</c>).
+    /// </remarks>
     public List<IPresentationConsumer> Consumers { get; } = new();
 
     /// <summary>
@@ -221,12 +226,7 @@ public sealed class TestHaipConsumer : IPresentationConsumer
 {
     public string ConsumerName => "haip";
 
-    public PresentationOutcome NextOutcome { get; set; } = new(
-        Kind: PresentationOutcomeKind.Success,
-        VerifiedClaims: new Dictionary<string, object> { ["name"] = "Test" },
-        Reason: null,
-        VerifierDiagnostics: null,
-        PresentationSubmissionHash: "sha256:test");
+    public PresentationOutcome NextOutcome { get; set; } = DefaultOutcome();
 
     public List<PresentationInitiationContext> InvokedContexts { get; } = new();
 
@@ -241,11 +241,13 @@ public sealed class TestHaipConsumer : IPresentationConsumer
     public void Reset()
     {
         InvokedContexts.Clear();
-        NextOutcome = new PresentationOutcome(
-            Kind: PresentationOutcomeKind.Success,
-            VerifiedClaims: new Dictionary<string, object> { ["name"] = "Test" },
-            Reason: null,
-            VerifierDiagnostics: null,
-            PresentationSubmissionHash: "sha256:test");
+        NextOutcome = DefaultOutcome();
     }
+
+    private static PresentationOutcome DefaultOutcome() => new(
+        Kind: PresentationOutcomeKind.Success,
+        VerifiedClaims: new Dictionary<string, object> { ["name"] = "Test" },
+        Reason: null,
+        VerifierDiagnostics: null,
+        PresentationSubmissionHash: "sha256:test");
 }


### PR DESCRIPTION
## Summary

Integration-test harness for Feature 111. Closes the three most-valuable integration gaps (T037, T038, T059) — success/decline/duplicate callbacks + late-outcome-after-abandonment + status endpoint.

## Harness design

`PresentationLifecycleWebApplicationFactory` extends the existing `BlueprintServiceWebApplicationFactory` with:

- **`InMemoryPendingPresentationStore`** — full `IPendingPresentationStore` contract (Store/Get/Delete, outcome-sentinel Try/Get/Set/Delete, and a `ForceSentinel` hook for late-outcome tests).
- **`CountingPresentationRateLimiter`** — tunable `Threshold`, per-(wallet,register) counter.
- **`TestHaipConsumer`** — sets `NextOutcome` per test.
- Mocks on `IHaipServiceClient.CreatePresentationRequestAsync` and `IValidatorServiceClient.SubmitTransactionAsync` for happy-path defaults.

The Redis adapters already have dedicated unit tests (`RedisPendingPresentationStoreTests`, `RedisPresentationRateLimiterTests`), so this harness intentionally bypasses Redis — integration coverage focuses on HTTP-boundary wiring, consumer dispatch, and the sentinel state machine.

## Tests (9 new, all passing)

| Test | Task | Covers |
|---|---|---|
| `Callback_SuccessOutcome_WritesTx_AndMarksSentinelSuccess` | **T037** | 200 OK, Kind=Success, outcomeKind metadata, sentinel→success |
| `Callback_DeclineOutcome_WritesTx_AndMarksSentinelDecline` | **T038a** | decline path + sentinel→decline |
| `Callback_DuplicateCallback_IsIdempotentReplay_NoNewTx` | **T038b** | duplicate returns `IdempotentReplay=true`, validator sees 1 tx |
| `Callback_UnknownRequestId_Returns400` | — | error-path |
| `Callback_ConsumerNameMismatch_Returns400` | — | error-path |
| `Callback_LateAfterAbandonment_WritesOutcome_MarksAbandonedWithOutcome` | **T059** | sentinel→abandoned+outcome, outcome tx still written |
| `StatusEndpoint_AwaitingPresentation_ReturnsPendingStateOnly` | — | raw-JSON assertion: no registerId / instanceId / consumerName leaks |
| `StatusEndpoint_AfterSuccessCallback_ReturnsSuccess` | — | end-to-end POST→GET |
| `StatusEndpoint_UnknownRequestId_Returns404` | — | error-path |

## Deferred (follow-up)

T025 (202 response), T026 (429), T050–T051 (retry flow), T053 (rate-limit across retries), T057-T058 (abandonment sweeper timing) — all need the full `/execute` pipeline plumbed (instance + blueprint + participant + delegation-token setup). Tracked on same spec for a follow-up PR.

## Test plan
- [x] `dotnet build` clean
- [x] 71 total presentation unit + integration tests pass (9 new + 62 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)