### PR TITLE
feat(walkthroughs): profile-aware secrets — unblock -Profile n1 runs

### DIFF
--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -22,7 +22,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "AssuredIdentity — Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "assured-identity"
+$secrets = Get-SorchaSecrets -WalkthroughName "assured-identity" -Profile $Profile
 $sorchaEnv = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/walkthroughs/ConstructionPermit/setup.ps1
+++ b/walkthroughs/ConstructionPermit/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -35,7 +35,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "ConstructionPermit — Multi-Org Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "construction-permit"
+$secrets = Get-SorchaSecrets -WalkthroughName "construction-permit" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 # ============================================================================

--- a/walkthroughs/DistributedRegister/setup.ps1
+++ b/walkthroughs/DistributedRegister/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -18,7 +18,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "DistributedRegister — Setup (Local)"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "dist-register"
+$secrets = Get-SorchaSecrets -WalkthroughName "dist-register" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $admin = Connect-SorchaAdmin `

--- a/walkthroughs/DistributedRegister/sync-test.ps1
+++ b/walkthroughs/DistributedRegister/sync-test.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -261,7 +261,7 @@ if ($Phase -le 3) {
     # Test 8: Authenticate on remote peer
     $remoteHeaders = $null
     Test-Step "Authenticate on remote peer" -Critical {
-        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register"
+        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register" -Profile $Profile
         $encodedPassword = [Uri]::EscapeDataString($secrets.adminPassword)
         $loginBody = "grant_type=password&username=$($secrets.adminEmail)&password=$encodedPassword&client_id=sorcha-cli"
         $loginResponse = Invoke-RestMethod -Uri "$remoteGateway/api/service-auth/token" `
@@ -318,7 +318,7 @@ if ($Phase -le 4) {
         $registerId = $syncState.registerId
     }
     if (-not $remoteHeaders) {
-        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register"
+        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register" -Profile $Profile
         $encodedPassword = [Uri]::EscapeDataString($secrets.adminPassword)
         $loginBody = "grant_type=password&username=$($secrets.adminEmail)&password=$encodedPassword&client_id=sorcha-cli"
         $loginResponse = Invoke-RestMethod -Uri "$remoteGateway/api/service-auth/token" `
@@ -372,7 +372,7 @@ if ($Phase -le 5) {
         $registerId = $syncState.registerId
     }
     if (-not $remoteHeaders) {
-        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register"
+        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register" -Profile $Profile
         $encodedPassword = [Uri]::EscapeDataString($secrets.adminPassword)
         $loginBody = "grant_type=password&username=$($secrets.adminEmail)&password=$encodedPassword&client_id=sorcha-cli"
         $loginResponse = Invoke-RestMethod -Uri "$remoteGateway/api/service-auth/token" `
@@ -443,7 +443,7 @@ if ($Phase -le 6) {
         $registerId = $syncState.registerId
     }
     if (-not $remoteHeaders) {
-        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register"
+        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register" -Profile $Profile
         $encodedPassword = [Uri]::EscapeDataString($secrets.adminPassword)
         $loginBody = "grant_type=password&username=$($secrets.adminEmail)&password=$encodedPassword&client_id=sorcha-cli"
         $loginResponse = Invoke-RestMethod -Uri "$remoteGateway/api/service-auth/token" `
@@ -485,7 +485,7 @@ if ($Phase -le 6) {
         }
 
         # Re-authenticate (token may have expired)
-        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register"
+        $secrets = Get-SorchaSecrets -WalkthroughName "dist-register" -Profile $Profile
         $encodedPassword = [Uri]::EscapeDataString($secrets.adminPassword)
         $loginBody = "grant_type=password&username=$($secrets.adminEmail)&password=$encodedPassword&client_id=sorcha-cli"
         $loginResponse = Invoke-RestMethod -Uri "$remoteGateway/api/service-auth/token" `

--- a/walkthroughs/FormCoverage/setup.ps1
+++ b/walkthroughs/FormCoverage/setup.ps1
@@ -24,7 +24,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "FormCoverage — Demo Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "form-coverage"
+$secrets = Get-SorchaSecrets -WalkthroughName "form-coverage" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/walkthroughs/HealthDeclaration/setup.ps1
+++ b/walkthroughs/HealthDeclaration/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -23,7 +23,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "HealthDeclaration — Demo Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "health-declaration"
+$secrets = Get-SorchaSecrets -WalkthroughName "health-declaration" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/walkthroughs/PayloadTests/setup.ps1
+++ b/walkthroughs/PayloadTests/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -24,7 +24,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "PayloadTests — Multi-Org Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "payload-test"
+$secrets = Get-SorchaSecrets -WalkthroughName "payload-test" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/walkthroughs/PerformanceBenchmark/setup.ps1
+++ b/walkthroughs/PerformanceBenchmark/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -19,7 +19,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "PerformanceBenchmark — Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "perf"
+$secrets = Get-SorchaSecrets -WalkthroughName "perf" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $admin = Connect-SorchaAdmin `

--- a/walkthroughs/PropertyInspection/setup.ps1
+++ b/walkthroughs/PropertyInspection/setup.ps1
@@ -22,7 +22,7 @@ Import-Module $modulePath -Force
 
 # ── Environment ───────────────────────────────────────────────────
 $sorchaEnv = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
-$piSecrets = Get-SorchaSecrets -WalkthroughName "property-inspection"
+$piSecrets = Get-SorchaSecrets -WalkthroughName "property-inspection" -Profile $Profile
 
 Write-WtBanner "PropertyInspection Walkthrough Setup"
 

--- a/walkthroughs/RegisterCreationFlow/setup.ps1
+++ b/walkthroughs/RegisterCreationFlow/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -18,7 +18,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "RegisterCreationFlow — Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "register-demo"
+$secrets = Get-SorchaSecrets -WalkthroughName "register-demo" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 # Bootstrap org

--- a/walkthroughs/SelfBuildHouse/run-agents.ps1
+++ b/walkthroughs/SelfBuildHouse/run-agents.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Launches autonomous actor agents for the SelfBuildHouse walkthrough.
 .DESCRIPTION
@@ -35,7 +35,7 @@ if (-not (Test-Path $StatePath)) {
 }
 
 $state = Get-Content $StatePath -Raw | ConvertFrom-Json
-$secrets = Get-SorchaSecrets -WalkthroughName "self-build-house"
+$secrets = Get-SorchaSecrets -WalkthroughName "self-build-house" -Profile $Profile
 
 # Resolve URLs
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -36,7 +36,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "SelfBuildHouse — Multi-Org Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "self-build-house"
+$secrets = Get-SorchaSecrets -WalkthroughName "self-build-house" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -34,7 +34,7 @@ if (-not (Test-Path $configPath)) {
 }
 $config = Get-Content -Path $configPath -Raw | ConvertFrom-Json -Depth 20
 
-$secrets = Get-SorchaSecrets -WalkthroughName "trade-finance"
+$secrets = Get-SorchaSecrets -WalkthroughName "trade-finance" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 # ============================================================================

--- a/walkthroughs/WalletVerification/setup.ps1
+++ b/walkthroughs/WalletVerification/setup.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
@@ -17,7 +17,7 @@ Import-Module $modulePath -Force
 
 Write-WtBanner "WalletVerification — Setup"
 
-$secrets = Get-SorchaSecrets -WalkthroughName "wallet-verify"
+$secrets = Get-SorchaSecrets -WalkthroughName "wallet-verify" -Profile $Profile
 $env = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
 
 $admin = Connect-SorchaAdmin `

--- a/walkthroughs/council/setup-council.ps1
+++ b/walkthroughs/council/setup-council.ps1
@@ -21,7 +21,7 @@ Import-Module $modulePath -Force
 
 # ── Environment ───────────────────────────────────────────────────
 $sorchaEnv = Initialize-SorchaEnvironment -Profile $Profile -SkipHealthCheck:$SkipHealthCheck
-$secrets = Get-SorchaSecrets -WalkthroughName "council"
+$secrets = Get-SorchaSecrets -WalkthroughName "council" -Profile $Profile
 
 Write-WtBanner "Strathcarron Council Universe Setup"
 

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -50,7 +50,19 @@ $secrets = [ordered]@{
     "_meta" = @{
         generatedAt = (Get-Date -Format "o")
         description = "Auto-generated walkthrough credentials. Do NOT commit to source control."
-        note        = "All walkthroughs use the platform seed admin (DatabaseInitializer defaults)."
+        note        = "All walkthroughs use the platform seed admin (DatabaseInitializer defaults). Use _profiles to override admin creds per deployment target. Get-SorchaSecrets -Profile <name> applies _profiles.<name> over the walkthrough's base keys."
+    }
+    "_profiles" = [ordered]@{
+        n1 = [ordered]@{
+            adminEmail              = "admin@sorcha.dev"
+            adminPassword           = "Dev_Pass_2026!"
+            sysAdminEmail           = "admin@sorcha.dev"
+            sysAdminPassword        = "Dev_Pass_2026!"
+            meridianAdminEmail      = "admin@sorcha.dev"
+            meridianAdminPassword   = "Dev_Pass_2026!"
+            highlandAdminEmail      = "admin@sorcha.dev"
+            highlandAdminPassword   = "Dev_Pass_2026!"
+        }
     }
     "platform" = @{
         adminEmail    = $platformEmail

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -8,9 +8,17 @@
 # Usage:
 #   pwsh walkthroughs/initialize-secrets.ps1
 #   pwsh walkthroughs/initialize-secrets.ps1 -Force  # Overwrite existing
+#   pwsh walkthroughs/initialize-secrets.ps1 -N1AdminPassword '...' -N1AdminEmail '...'
+#
+# The local-Docker admin credentials are the well-known dev seed from
+# Sorcha.Tenant.Service/Data/DatabaseInitializer.cs. The n1 deployment
+# credentials are environment-specific — pass them via parameter rather than
+# committing to source.
 
 param(
-    [switch]$Force
+    [switch]$Force,
+    [string]$N1AdminEmail = "admin@sorcha.dev",
+    [string]$N1AdminPassword = "Dev_Pass_2026!"
 )
 
 $ErrorActionPreference = "Stop"
@@ -53,15 +61,18 @@ $secrets = [ordered]@{
         note        = "All walkthroughs use the platform seed admin (DatabaseInitializer defaults). Use _profiles to override admin creds per deployment target. Get-SorchaSecrets -Profile <name> applies _profiles.<name> over the walkthrough's base keys."
     }
     "_profiles" = [ordered]@{
+        # Default values are dev seeds the n1 bootstrap CLI uses on a fresh
+        # cluster (see scripts/n1-deploy.ps1). Override via parameter for any
+        # environment whose admin credentials have been rotated.
         n1 = [ordered]@{
-            adminEmail              = "admin@sorcha.dev"
-            adminPassword           = "Dev_Pass_2026!"
-            sysAdminEmail           = "admin@sorcha.dev"
-            sysAdminPassword        = "Dev_Pass_2026!"
-            meridianAdminEmail      = "admin@sorcha.dev"
-            meridianAdminPassword   = "Dev_Pass_2026!"
-            highlandAdminEmail      = "admin@sorcha.dev"
-            highlandAdminPassword   = "Dev_Pass_2026!"
+            adminEmail              = $N1AdminEmail
+            adminPassword           = $N1AdminPassword
+            sysAdminEmail           = $N1AdminEmail
+            sysAdminPassword        = $N1AdminPassword
+            meridianAdminEmail      = $N1AdminEmail
+            meridianAdminPassword   = $N1AdminPassword
+            highlandAdminEmail      = $N1AdminEmail
+            highlandAdminPassword   = $N1AdminPassword
         }
     }
     "platform" = @{
@@ -251,7 +262,7 @@ Write-Host "Walkthrough credential sets:" -ForegroundColor Yellow
 
 $walkthroughCount = 0
 foreach ($key in $secrets.Keys) {
-    if ($key -eq "_meta" -or $key -eq "platform") { continue }
+    if ($key -eq "_meta" -or $key -eq "_profiles" -or $key -eq "platform") { continue }
     $walkthroughCount++
     Write-Host "  $key" -ForegroundColor White
 }

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -401,13 +401,21 @@ function Get-SorchaSecrets {
     # Profile overrides — global `_profiles.<profile>` wins over walkthrough
     # base keys. Example: the n1 deployment has a different system-admin
     # email/password from the local-Docker bootstrap.
-    if ($Profile -and $allSecrets._profiles) {
-        $profileOverrides = $allSecrets._profiles.$Profile
-        if ($profileOverrides) {
-            foreach ($prop in $profileOverrides.PSObject.Properties) {
-                $result[$prop.Name] = $prop.Value
+    if ($Profile) {
+        if (-not $allSecrets._profiles) {
+            Write-Warning "passwords.json has no _profiles block but profile '$Profile' was requested. Falling back to base credentials — re-run initialize-secrets.ps1 to add profile support."
+        }
+        else {
+            $profileOverrides = $allSecrets._profiles.$Profile
+            if ($profileOverrides) {
+                foreach ($prop in $profileOverrides.PSObject.Properties) {
+                    $result[$prop.Name] = $prop.Value
+                }
+                Write-WtInfo "Applied profile overrides from _profiles.$Profile"
             }
-            Write-WtInfo "Applied profile overrides from _profiles.$Profile"
+            else {
+                Write-Warning "Profile '$Profile' not found in _profiles. Falling back to base credentials — the walkthrough may authenticate against the wrong stack."
+            }
         }
     }
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -351,12 +351,19 @@ function Get-SorchaSecrets {
         Name of the walkthrough (key in passwords.json).
     .PARAMETER SecretsDir
         Path to the .secrets directory. Defaults to walkthroughs/.secrets/.
+    .PARAMETER Profile
+        Optional deployment profile (e.g. "n1"). When supplied, overrides from
+        the top-level `_profiles.<profile>` object take precedence over the
+        walkthrough's base credentials. Lets a single passwords.json file
+        serve both local-Docker and remote deployments without edits between
+        runs.
     .RETURNS
         Hashtable with credential key-value pairs.
     #>
     param(
         [Parameter(Mandatory)][string]$WalkthroughName,
-        [string]$SecretsDir = ""
+        [string]$SecretsDir = "",
+        [string]$Profile = ""
     )
 
     # Default secrets dir relative to module location
@@ -389,6 +396,19 @@ function Get-SorchaSecrets {
     $result = @{}
     foreach ($prop in $wtSecrets.PSObject.Properties) {
         $result[$prop.Name] = $prop.Value
+    }
+
+    # Profile overrides — global `_profiles.<profile>` wins over walkthrough
+    # base keys. Example: the n1 deployment has a different system-admin
+    # email/password from the local-Docker bootstrap.
+    if ($Profile -and $allSecrets._profiles) {
+        $profileOverrides = $allSecrets._profiles.$Profile
+        if ($profileOverrides) {
+            foreach ($prop in $profileOverrides.PSObject.Properties) {
+                $result[$prop.Name] = $prop.Value
+            }
+            Write-WtInfo "Applied profile overrides from _profiles.$Profile"
+        }
     }
 
     return $result


### PR DESCRIPTION
## Summary

`Get-SorchaSecrets` gains a `-Profile` parameter and `passwords.json` gains a `_profiles` block that overrides admin credentials per deployment target. Today's AssuredIdentity walkthrough against n1 silently hit the local Docker stack because the secrets file hardcoded `admin@sorcha.local` / `Dev_Pass_2025!` while n1 bootstraps as `admin@sorcha.dev` / `Dev_Pass_2026!`.

## Changes

- **`SorchaWalkthrough.psm1`** — `Get-SorchaSecrets` accepts an optional `-Profile`. When set, `_profiles.<profile>` keys override the walkthrough's base keys.
- **`passwords.json`** — new `_profiles.n1` section with admin/sysAdmin/meridianAdmin/highlandAdmin credentials for n1.
- **`initialize-secrets.ps1`** — emits the `_profiles.n1` block on regeneration so future setups are profile-aware out of the box.
- **14 walkthrough scripts** patched to thread `$Profile` through `Get-SorchaSecrets`. PingPongN1 hardcodes `"n1"` because it's n1-only by design.

Backward-compatible: when `-Profile` isn't specified or the override doesn't exist, the existing behaviour is preserved exactly.

## Verification

```powershell
Get-SorchaSecrets -WalkthroughName "assured-identity" -Profile "n1"
# adminEmail: admin@sorcha.dev
# adminPassword: Dev_Pass_2026!
```

AssuredIdentity setup `-Profile n1` now authenticates against n1's admin (`Logged in as admin@sorcha.dev`) instead of silently using the local Docker stack.

## Follow-up surfaced (separate issue)

The n1-bootstrapped admin then gets **403** on "Enable Public Org" and "Create Organization" — likely the CLI `bootstrap` doesn't grant the SystemAdmin role the way the local-Docker `DatabaseInitializer` does. Feature 111 T079 (walkthrough validation) is re-blocked on this new gap. Out of scope for this PR.

## Test plan
- [x] `Get-SorchaSecrets -Profile n1` returns n1 creds for AssuredIdentity
- [x] `Get-SorchaSecrets` (no profile) preserves existing behaviour
- [x] `initialize-secrets.ps1 -Force` emits `_profiles.n1` block
- [ ] All 14 patched walkthroughs run cleanly against `-Profile gateway` (default) — same as before this change
- [ ] AssuredIdentity walkthrough completes end-to-end against n1 once the SystemAdmin-role-on-n1 gap is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)