### PR TITLE
chore(walkthroughs): use seed admin on every stack, drop n1 profile override

### DIFF
--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -8,17 +8,17 @@
 # Usage:
 #   pwsh walkthroughs/initialize-secrets.ps1
 #   pwsh walkthroughs/initialize-secrets.ps1 -Force  # Overwrite existing
-#   pwsh walkthroughs/initialize-secrets.ps1 -N1AdminPassword '...' -N1AdminEmail '...'
 #
-# The local-Docker admin credentials are the well-known dev seed from
-# Sorcha.Tenant.Service/Data/DatabaseInitializer.cs. The n1 deployment
-# credentials are environment-specific — pass them via parameter rather than
-# committing to source.
+# All walkthrough admin credentials are the platform seed admin defined in
+# Sorcha.Tenant.Service/Data/DatabaseInitializer.cs (admin@sorcha.local /
+# Dev_Pass_2025!). DatabaseInitializer runs at Tenant Service startup on
+# every stack — local Docker and remote deployments alike — so the seed
+# admin is always present. No per-deployment credential overrides are
+# needed; if a deployment ever rotates the seed admin's password, add a
+# _profiles.<name> block here and pass -Profile <name> to the walkthrough.
 
 param(
-    [switch]$Force,
-    [string]$N1AdminEmail = "admin@sorcha.dev",
-    [string]$N1AdminPassword = "Dev_Pass_2026!"
+    [switch]$Force
 )
 
 $ErrorActionPreference = "Stop"
@@ -58,22 +58,7 @@ $secrets = [ordered]@{
     "_meta" = @{
         generatedAt = (Get-Date -Format "o")
         description = "Auto-generated walkthrough credentials. Do NOT commit to source control."
-        note        = "All walkthroughs use the platform seed admin (DatabaseInitializer defaults). Use _profiles to override admin creds per deployment target. Get-SorchaSecrets -Profile <name> applies _profiles.<name> over the walkthrough's base keys."
-    }
-    "_profiles" = [ordered]@{
-        # Default values are dev seeds the n1 bootstrap CLI uses on a fresh
-        # cluster (see scripts/n1-deploy.ps1). Override via parameter for any
-        # environment whose admin credentials have been rotated.
-        n1 = [ordered]@{
-            adminEmail              = $N1AdminEmail
-            adminPassword           = $N1AdminPassword
-            sysAdminEmail           = $N1AdminEmail
-            sysAdminPassword        = $N1AdminPassword
-            meridianAdminEmail      = $N1AdminEmail
-            meridianAdminPassword   = $N1AdminPassword
-            highlandAdminEmail      = $N1AdminEmail
-            highlandAdminPassword   = $N1AdminPassword
-        }
+        note        = "All walkthroughs use the platform seed admin (DatabaseInitializer defaults: admin@sorcha.local / Dev_Pass_2025!). The seed admin exists on every Sorcha stack (local Docker and remote deployments alike) because DatabaseInitializer runs at Tenant Service startup. _profiles is reserved for future per-deployment credential overrides; none are needed today."
     }
     "platform" = @{
         adminEmail    = $platformEmail

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -399,23 +399,17 @@ function Get-SorchaSecrets {
     }
 
     # Profile overrides — global `_profiles.<profile>` wins over walkthrough
-    # base keys. Example: the n1 deployment has a different system-admin
-    # email/password from the local-Docker bootstrap.
-    if ($Profile) {
-        if (-not $allSecrets._profiles) {
-            Write-Warning "passwords.json has no _profiles block but profile '$Profile' was requested. Falling back to base credentials — re-run initialize-secrets.ps1 to add profile support."
-        }
-        else {
-            $profileOverrides = $allSecrets._profiles.$Profile
-            if ($profileOverrides) {
-                foreach ($prop in $profileOverrides.PSObject.Properties) {
-                    $result[$prop.Name] = $prop.Value
-                }
-                Write-WtInfo "Applied profile overrides from _profiles.$Profile"
+    # base keys when present. Used only when a deployment has rotated the
+    # seed admin password; the default case (no _profiles block, or no entry
+    # for this profile) is silent because base credentials work on every
+    # stack DatabaseInitializer has seeded.
+    if ($Profile -and $allSecrets._profiles) {
+        $profileOverrides = $allSecrets._profiles.$Profile
+        if ($profileOverrides) {
+            foreach ($prop in $profileOverrides.PSObject.Properties) {
+                $result[$prop.Name] = $prop.Value
             }
-            else {
-                Write-Warning "Profile '$Profile' not found in _profiles. Falling back to base credentials — the walkthrough may authenticate against the wrong stack."
-            }
+            Write-WtInfo "Applied profile overrides from _profiles.$Profile"
         }
     }
 


### PR DESCRIPTION
## Summary
- Drop the `_profiles.n1` credential override that pointed walkthroughs at `admin@sorcha.dev` on n1.
- Walkthroughs now use `admin@sorcha.local` (the DatabaseInitializer-seeded SystemAdmin) on every stack.
- Soften the missing-profile warning in `Get-SorchaSecrets` so the now-expected silent fallback isn't noisy.

## Why
The `_profiles.n1` override was patching a symptom by routing to the wrong user. `admin@sorcha.dev` is provisioned by the CLI bootstrap step in `n1-deploy.ps1` with only `UserRole.Administrator`, so any walkthrough call hitting a SystemAdmin-gated endpoint (e.g. `PUT /platform/settings/public-org`) failed on n1.

`DatabaseInitializer` already seeds `admin@sorcha.local` with the full SystemAdmin role set at Tenant Service startup on every stack — local Docker and n1 alike. That user works correctly for every walkthrough, no per-deployment override needed.

The `_profiles` infrastructure stays in place for genuine future need (e.g. a deployment that rotates the seed admin password).

## Test plan
- [x] `pwsh walkthroughs/initialize-secrets.ps1 -Force` regenerates without `_profiles` and reports 16 walkthroughs (no `_profiles` inflation).
- [x] `Grep` confirms no walkthrough script references `admin@sorcha.dev` or `Dev_Pass_2026`.
- [ ] Run a walkthrough against n1 (e.g. `pwsh walkthroughs/RegisterCreationFlow/setup.ps1 -Profile n1`) once images redeploy.
- [ ] Run a walkthrough against local Docker (sanity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)