### PR TITLE
feat(tenant): demo-environment banner on auth pages

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -50,6 +50,10 @@ services:
       # (TOTP, Strict) keep their production defaults.
       RateLimiting__PlatformAuthPermitLimit: 500
       RateLimiting__PlatformAuthQueueLimit: 100
+      # n1 is a public demo node — render an informational banner on auth pages
+      # so visitors know the environment may be reset without notice. Plain
+      # informational notice; no consent gate, no friction.
+      DemoEnvironment__Enabled: "true"
 
   peer-service:
     image: sorchadev/peer-service:latest

--- a/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Polly;
 using Polly.CircuitBreaker;
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Data.Repositories;
+using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Services;
 using StackExchange.Redis;
 
@@ -68,6 +69,10 @@ public static class ServiceCollectionExtensions
 
         // Add email sender
         services.AddTenantEmail(configuration);
+
+        // Demo-environment banner flag (e.g. n1.sorcha.dev). Default off; flipped
+        // on per deployment via the DemoEnvironment__Enabled env var.
+        services.Configure<DemoEnvironmentSettings>(configuration.GetSection("DemoEnvironment"));
 
         // Add FIDO2/WebAuthn services
         services.AddFido2WebAuthn(configuration);

--- a/src/Services/Sorcha.Tenant.Service/Models/DemoEnvironmentSettings.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/DemoEnvironmentSettings.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Tenant.Service.Models;
+
+/// <summary>
+/// Configuration flag for shared demo deployments (e.g. n1.sorcha.dev).
+/// When enabled, public auth pages render an informational banner warning
+/// new sign-ups that the environment is a technology demonstrator and may
+/// be reset without notice. Default off — production deployments stay clean.
+///
+/// Bound from the "DemoEnvironment" config section. Override per environment
+/// via env vars (DemoEnvironment__Enabled, DemoEnvironment__Message) — the
+/// expected place to flip this on is docker-compose.&lt;target&gt;.yml.
+/// </summary>
+public class DemoEnvironmentSettings
+{
+    /// <summary>Whether the demo banner is displayed on auth pages.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Banner copy shown to visitors. Plain text — rendered HTML-encoded by
+    /// the page so the value cannot inject markup. A sensible default is
+    /// supplied so the banner is informative even if the deployment leaves
+    /// Message unset.
+    /// </summary>
+    public string Message { get; set; } =
+        "This is a public technology demonstrator. Accounts and data may be reset at any time without notice. Please don't sign up with personal data you wouldn't be comfortable losing.";
+}

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
@@ -4,6 +4,14 @@
     ViewData["Title"] = "Sign In";
 }
 
+@if (Model.DemoBannerEnabled)
+{
+    <div class="demo-environment-notice" role="note" aria-label="Demo environment notice">
+        <span class="demo-icon" aria-hidden="true">&#9888;</span>
+        <span><strong>Technology demonstrator.</strong> @Model.DemoBannerMessage</span>
+    </div>
+}
+
 <div class="auth-card">
     <div class="auth-header">
         <h2>Sign In</h2>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
 using Sorcha.Tenant.Service.Data.Repositories;
 using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Models.Dtos;
@@ -23,6 +24,7 @@ public class LoginModel : PageModel
     private readonly IIdentityRepository _identityRepository;
     private readonly IOrganizationRepository _organizationRepository;
     private readonly ILogger<LoginModel> _logger;
+    private readonly DemoEnvironmentSettings _demoSettings;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginModel"/> class.
@@ -33,7 +35,8 @@ public class LoginModel : PageModel
         ITokenService tokenService,
         IIdentityRepository identityRepository,
         IOrganizationRepository organizationRepository,
-        ILogger<LoginModel> logger)
+        ILogger<LoginModel> logger,
+        IOptions<DemoEnvironmentSettings> demoSettings)
     {
         _loginService = loginService;
         _totpService = totpService;
@@ -41,7 +44,14 @@ public class LoginModel : PageModel
         _identityRepository = identityRepository;
         _organizationRepository = organizationRepository;
         _logger = logger;
+        _demoSettings = demoSettings.Value;
     }
+
+    /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
+    public bool DemoBannerEnabled => _demoSettings.Enabled;
+
+    /// <summary>Demo-environment banner copy — rendered HTML-encoded.</summary>
+    public string DemoBannerMessage => _demoSettings.Message;
 
     /// <summary>
     /// User email address.

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml
@@ -4,6 +4,14 @@
     ViewData["Title"] = "Sign Up";
 }
 
+@if (Model.DemoBannerEnabled)
+{
+    <div class="demo-environment-notice" role="note" aria-label="Demo environment notice">
+        <span class="demo-icon" aria-hidden="true">&#9888;</span>
+        <span><strong>Technology demonstrator.</strong> @Model.DemoBannerMessage</span>
+    </div>
+}
+
 <div class="auth-card">
     <div class="auth-header">
         <h2>Create Account</h2>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
@@ -4,6 +4,8 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Services;
 
 namespace Sorcha.Tenant.Service.Pages.Auth;
@@ -16,17 +18,26 @@ public class SignupModel : PageModel
 {
     private readonly IRegistrationService _registrationService;
     private readonly ILogger<SignupModel> _logger;
+    private readonly DemoEnvironmentSettings _demoSettings;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SignupModel"/> class.
     /// </summary>
     public SignupModel(
         IRegistrationService registrationService,
-        ILogger<SignupModel> logger)
+        ILogger<SignupModel> logger,
+        IOptions<DemoEnvironmentSettings> demoSettings)
     {
         _registrationService = registrationService;
         _logger = logger;
+        _demoSettings = demoSettings.Value;
     }
+
+    /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
+    public bool DemoBannerEnabled => _demoSettings.Enabled;
+
+    /// <summary>Demo-environment banner copy — rendered HTML-encoded.</summary>
+    public string DemoBannerMessage => _demoSettings.Message;
 
     /// <summary>
     /// User's display name.

--- a/src/Services/Sorcha.Tenant.Service/appsettings.json
+++ b/src/Services/Sorcha.Tenant.Service/appsettings.json
@@ -77,6 +77,11 @@
     "PlatformAuthPermitLimit": 50
   },
 
+  "DemoEnvironment": {
+    "Enabled": false,
+    "Message": "This is a public technology demonstrator. Accounts and data may be reset at any time without notice. Please don't sign up with personal data you wouldn't be comfortable losing."
+  },
+
   "Trust": {
     "BaseUrl": "https://sorcha.example/api/v1/trust",
     "DefaultCaAlgorithm": "ES256",

--- a/src/Services/Sorcha.Tenant.Service/wwwroot/css/auth.css
+++ b/src/Services/Sorcha.Tenant.Service/wwwroot/css/auth.css
@@ -187,3 +187,30 @@
     color: var(--primary-color);
     border-bottom-color: var(--primary-color);
 }
+
+/* Demo-environment notice — informational banner shown above the auth-card on
+   shared demo deployments (e.g. n1.sorcha.dev). Driven by DemoEnvironment:Enabled. */
+.demo-environment-notice {
+    max-width: 460px;
+    margin: 0 auto 1rem;
+    padding: 0.75rem 1rem;
+    background: #fff8e1;
+    border: 1px solid #f0c674;
+    border-radius: 8px;
+    color: #5a4500;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.demo-environment-notice .demo-icon {
+    flex: 0 0 auto;
+    font-size: 1.1rem;
+    line-height: 1.4;
+}
+
+.demo-environment-notice strong {
+    color: #3a2d00;
+}


### PR DESCRIPTION
## Summary
Adds an informational banner above `/auth/signup` and `/auth/login` warning that the deployment is a public technology demonstrator and may be reset without notice. Driven by `DemoEnvironment:Enabled` config; default off, flipped on for n1.sorcha.dev via `docker-compose.n1.yml`.

Plain informational notice. No consent checkbox, no friction.

## Why
n1.sorcha.dev is world-reachable. A drive-by visitor signing up today has no way to know the environment may be wiped. Cheap to fix now; removes a small reputational and data-hygiene worry. Same pattern scales to any future demo deployment via the env var.

## Shape
- New `DemoEnvironmentSettings` options class (Enabled + Message) bound from the `DemoEnvironment` config section, mirroring the existing `EmailSettings` pattern in `ServiceCollectionExtensions.cs:244`.
- `IOptions<DemoEnvironmentSettings>` injected into the Signup and Login page models, exposed as `DemoBannerEnabled` + `DemoBannerMessage`.
- `auth.css` carries a `.demo-environment-notice` style — soft amber, sits above the auth-card, accessible via `role="note"`.
- Razor renders the message HTML-encoded (`@Model.DemoBannerMessage`), so any future env-var override is XSS-safe.
- Default in `appsettings.json` is `Enabled: false`. `docker-compose.n1.yml` adds `DemoEnvironment__Enabled: "true"` to the tenant-service block.

## Verified
- `dotnet build src/Services/Sorcha.Tenant.Service` clean (0 errors, pre-existing warnings only).
- Local stack with default config — banner absent.
- Local stack with `DemoEnvironment__Enabled=true` overlay — banner present on both Signup and Login. Screenshots in `tmp/demo-banner-screenshots/` (not committed).

## Test plan
- [x] Banner absent by default on local Docker.
- [x] Banner present on Signup with override.
- [x] Banner present on Login with override.
- [ ] Verify on n1 once images redeploy (CI build → SSH pull → recreate tenant-service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)