### PR TITLE
chore(db): squash 4 quick-win indexes into InitialCreate migrations + audit backlog

### DIFF
--- a/docs/reference/db-audit-backlog.md
+++ b/docs/reference/db-audit-backlog.md
@@ -1,0 +1,161 @@
+# Database Audit — Deferred Backlog
+
+Companion to the index quick-wins squashed into the InitialCreate migrations
+(PR #402). Items here were identified during the per-service DB audit but
+deferred because they require **code changes** (new background services,
+view definitions, refactors) rather than a migration tweak.
+
+Captured on 2026-04-25 against `master @ 0b00b2f1`.
+
+---
+
+## Tenant Service — `sorcha_tenant`
+
+### Pruning gaps — no cleanup background service
+
+These tables grow unbounded under normal use. Today only `ActivityEvents`
+(`EventCleanupService`) and `AuditLogEntries` (`AuditCleanupService`) are
+swept. A unified `DatabaseHousekeepingService` modeled on the existing
+`EventCleanupService` could handle all of them in one hourly tick.
+
+| Table | Trigger field | Suggested rule |
+|---|---|---|
+| `WalletLinkChallenges` | `ExpiresAt` | Delete `WHERE ExpiresAt < now() - 1 day` |
+| `InvitationNonces` | `ConsumedAt` | Delete `WHERE ConsumedAt IS NOT NULL AND ConsumedAt < now() - 30 days` |
+| `OrgInvitations` | `Status`, `ExpiresAt` | Delete `WHERE Status IN ('Expired','Revoked') AND ExpiresAt < now() - 90 days`; keep `Accepted` for audit |
+| `RegisterInvitationRecords` | `Status`, `ExpiresAt` | Same shape as `OrgInvitations` |
+| `ParticipantAuditEntries` | `Timestamp` | Either reuse `Organizations.AuditRetentionMonths` (join via `ParticipantId → Organization`) or add its own retention setting |
+| `PlatformUsers.VerificationToken` / `PasswordResetTokenHash` | `*ExpiresAt` | Daily job nulls fields where `*ExpiresAt < now()` |
+
+Supporting indexes for these sweepers (add when the service is added,
+not before — unused indexes cost write throughput):
+- `WalletLinkChallenges (ExpiresAt) WHERE Status='Pending'`
+- `RegisterInvitationRecords (ExpiresAt) WHERE Status='Pending'`
+- `OrgInvitations (ExpiresAt) WHERE Status='Pending'`
+- `InvitationNonces (ConsumedAt)`
+
+### View candidates
+
+Hold off until indexes (in PR #402) are proven insufficient under real load.
+Views add a maintenance surface without changing fundamental cost.
+
+- **`v_my_organizations`** — `PlatformUserOrgMemberships ⋈ Organizations ⋈
+  ParticipantIdentities` filtered to active rows. Used by the org switcher
+  and "my profile" page.
+- **`v_active_register_subscriptions`** — `OrganizationRegisterSubscriptions
+  ⋈ Organizations` filtered `Status='Active'`. Three call sites today.
+- **Materialised** `mv_org_activity_summary` — counts of users / pending
+  invitations / subscriptions per org for the dashboard. Refresh nightly.
+  Only worth it if dashboard load times become noticeable.
+
+### Choke-point candidates
+
+EXPLAIN-ANALYZE these once production has representative data:
+
+1. **Login → org switcher** (`AuthEndpoints.cs:922`) — joins `UserIdentities
+   ⋈ Organizations` filtered `Status=Active`. A covering index
+   `(PlatformUserId) INCLUDE (OrganizationId, Role)` on
+   `PlatformUserOrgMemberships` could make it index-only.
+2. **`DashboardService.cs:34,39,61`** — count-active-users + count-pending-
+   invitations on every dashboard load. Materialised view candidate above.
+3. **`OrgWalletReconciliationService.cs:93`** — periodic sweep
+   `Status=Active AND WalletAddress IS NULL`. A partial unique index
+   `(Id) WHERE Status='Active' AND WalletAddress IS NULL` makes this
+   O(matches) instead of O(orgs). Likely fine until ~10k orgs.
+
+### Security inconsistency (cross-cutting)
+
+`PlatformUsers.PasswordResetTokenHash` is hashed at rest;
+`PlatformUsers.VerificationToken` is plaintext. Same threat model
+(URL-bearer one-time token), different treatment. Migrate `VerificationToken`
+to a `VerificationTokenHash` column and re-issue all in-flight tokens.
+
+---
+
+## Wallet Service — `sorcha_wallet`
+
+The wallet schema is the best-indexed in the platform (36 non-PK indexes,
+including several smart partials). Items below are speculative until query
+patterns confirm them.
+
+- **`SigningSessions (State, ExpiresAt)`** — for finding expired in-flight
+  sessions. Add when a sweeper is added.
+- **`Credentials (ExpiresAt) WHERE Status='Active'`** — for credential
+  validity / cleanup. Add when revocation/expiry pruning is implemented.
+- **`WalletAccess (ExpiresAt) WHERE RevokedAt IS NULL`** — for delegation
+  expiry checks. Add when delegation auto-expiry is wired up.
+
+Each of these is a quick win if/when the corresponding cleanup or expiry
+behaviour is implemented; adding them now would just be unused write tax.
+
+---
+
+## Blueprint Service — `sorcha_blueprint`
+
+- **Idempotency-key cleanup** — `Actions.IdempotencyExpiry` lets the row's
+  idempotency key expire (`EfCoreActionStore.cs:260`), but expired rows
+  aren't pruned and the field isn't indexed. Two-step: add a background
+  sweeper that nulls `IdempotencyKey` where `IdempotencyExpiry < now()`,
+  then add `(IdempotencyExpiry) WHERE IdempotencyKey IS NOT NULL` to
+  support it.
+- **Migration location is non-canonical** — Blueprint migrations live in
+  `src/Services/Sorcha.Blueprint.Service/Data/Migrations/` rather than the
+  EF default `Migrations/`. Future regens via `dotnet ef migrations add`
+  will drop new files in the canonical location and you'll have to move
+  them. Either standardise on `Migrations/` (move existing files + update
+  namespace) or set `MigrationsAssembly` / output dir explicitly.
+
+---
+
+## Peer Service — `sorcha_peer`
+
+- **`PurgeQueuedTransactionsAsync` loads the entire table to filter TTL
+  in C#** (`PeerDataCleanupService.cs:139`). Push the TTL predicate into
+  SQL: `WHERE EnqueuedAt + (TTL || ' seconds')::interval < now()`. The
+  composite `(Status, EnqueuedAt)` added in PR #402 covers the
+  Completed/Failed branch but the TTL branch still scans the whole table.
+- **`SyncCheckpoints (NextSyncDue)`** — the sync scheduler probably
+  queries "what's due now"; needs confirmation against actual scheduler
+  code, then add the index.
+- **`Peers.LastSeen DESC` for "recent peers" listing** — current index
+  is ASC. If the listing is "most recent first" this becomes a backward
+  scan, fine for small N but worth a DESC index at scale.
+
+---
+
+## MongoDB — Register Service
+
+`sorcha_register_registry.registers` has indexes on `_id`, `Status`,
+`Name`, `Purpose`. No audit done on per-register databases
+(`sorcha_register_<id>`) yet — they're created lazily and currently
+empty. Audit them once a real register is exercised end-to-end:
+
+- Confirm `transactions` collection has `(RegisterId, BlockHeight)` or
+  similar for chronological scans.
+- Confirm `dockets` collection has `(RegisterId, SealedAt DESC)` for
+  the docket viewer.
+- TTL indexes for any ephemeral/replication-state collections.
+
+---
+
+## Tenant — known DB-init oddity (out of scope, but worth flagging)
+
+- `Sorcha.Wallet.Service` logs `Error: libgssapi_krb5.so.2: cannot open
+  shared object file` on startup. The wallet Dockerfile copies kerberos
+  libs into the chiseled image; blueprint and peer do not, and they
+  log the same error. The error is swallowed (Npgsql falls back to
+  password auth) but it's noise, and any future change to PG auth could
+  turn it into a hard failure for blueprint/peer.
+
+---
+
+## Process notes
+
+- All quick-win indexes were squashed into the InitialCreate migration
+  for each affected DbContext rather than added as a follow-up migration.
+  This means a fresh deployment gets the indexes from the first run, no
+  step-up migration needed. Existing dev volumes need to be dropped
+  (`docker compose down -v`) for the squashed migration to apply.
+- Items in this backlog should each become a focused ticket / PR rather
+  than a single "do all the deferred DB work" effort, so they can be
+  prioritised independently against real production signal.

--- a/src/Services/Sorcha.Peer.Service/Data/PeerDbContext.cs
+++ b/src/Services/Sorcha.Peer.Service/Data/PeerDbContext.cs
@@ -108,6 +108,13 @@ public class PeerDbContext : DbContext
             entity.HasIndex(e => e.RegisterId).HasDatabaseName("IX_QueuedTransactions_RegisterId");
             entity.HasIndex(e => e.Status).HasDatabaseName("IX_QueuedTransactions_Status");
             entity.HasIndex(e => e.EnqueuedAt).HasDatabaseName("IX_QueuedTransactions_EnqueuedAt");
+
+            // PeerDataCleanupService.PurgeQueuedTransactionsAsync filters
+            // (Status IN ('Completed','Failed') AND EnqueuedAt < cutoff); the
+            // composite turns it into an index-range scan instead of two
+            // single-column filters AND'd in memory.
+            entity.HasIndex(e => new { e.Status, e.EnqueuedAt })
+                .HasDatabaseName("IX_QueuedTransactions_Status_EnqueuedAt");
         });
     }
 }

--- a/src/Services/Sorcha.Peer.Service/Migrations/20260425152329_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Peer.Service/Migrations/20260425152329_InitialCreate.Designer.cs
@@ -9,10 +9,10 @@ using Sorcha.Peer.Service.Data;
 
 #nullable disable
 
-namespace Sorcha.Peer.Service.Data.Migrations
+namespace Sorcha.Peer.Service.Migrations
 {
     [DbContext(typeof(PeerDbContext))]
-    [Migration("20260331083113_InitialCreate")]
+    [Migration("20260425152329_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -172,6 +172,9 @@ namespace Sorcha.Peer.Service.Data.Migrations
 
                     b.HasIndex("Status")
                         .HasDatabaseName("IX_QueuedTransactions_Status");
+
+                    b.HasIndex("Status", "EnqueuedAt")
+                        .HasDatabaseName("IX_QueuedTransactions_Status_EnqueuedAt");
 
                     b.ToTable("queued_transactions", "peer");
                 });

--- a/src/Services/Sorcha.Peer.Service/Migrations/20260425152329_InitialCreate.cs
+++ b/src/Services/Sorcha.Peer.Service/Migrations/20260425152329_InitialCreate.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Sorcha.Peer.Service.Data.Migrations
+namespace Sorcha.Peer.Service.Migrations
 {
     /// <inheritdoc />
     public partial class InitialCreate : Migration
@@ -141,6 +141,12 @@ namespace Sorcha.Peer.Service.Data.Migrations
                 schema: "peer",
                 table: "queued_transactions",
                 column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QueuedTransactions_Status_EnqueuedAt",
+                schema: "peer",
+                table: "queued_transactions",
+                columns: new[] { "Status", "EnqueuedAt" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_RegisterSubscriptions_RegisterId",

--- a/src/Services/Sorcha.Peer.Service/Migrations/PeerDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Peer.Service/Migrations/PeerDbContextModelSnapshot.cs
@@ -8,7 +8,7 @@ using Sorcha.Peer.Service.Data;
 
 #nullable disable
 
-namespace Sorcha.Peer.Service.Data.Migrations
+namespace Sorcha.Peer.Service.Migrations
 {
     [DbContext(typeof(PeerDbContext))]
     partial class PeerDbContextModelSnapshot : ModelSnapshot
@@ -169,6 +169,9 @@ namespace Sorcha.Peer.Service.Data.Migrations
 
                     b.HasIndex("Status")
                         .HasDatabaseName("IX_QueuedTransactions_Status");
+
+                    b.HasIndex("Status", "EnqueuedAt")
+                        .HasDatabaseName("IX_QueuedTransactions_Status_EnqueuedAt");
 
                     b.ToTable("queued_transactions", "peer");
                 });

--- a/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
@@ -455,6 +455,13 @@ public class TenantDbContext : DbContext
             entity.HasIndex(e => e.EventType);
             entity.HasIndex(e => e.IdentityId);
             entity.HasIndex(e => e.OrganizationId);
+
+            // Composite covering the AuditCleanupService per-org retention sweep
+            // (WHERE OrganizationId = X AND Timestamp < cutoff) and the audit-log
+            // viewer's "this org, newest first" listing.
+            entity.HasIndex(e => new { e.OrganizationId, e.Timestamp })
+                .IsDescending(false, true)
+                .HasDatabaseName("IX_AuditLog_Org_Time");
         });
     }
 
@@ -920,6 +927,14 @@ public class TenantDbContext : DbContext
             entity.HasIndex(e => e.PasswordResetTokenHash)
                 .HasDatabaseName("IX_PlatformUser_PasswordResetTokenHash");
 
+            // EmailVerificationService.VerifyTokenAsync looks up users by raw token;
+            // partial-unique on the populated rows keeps the index small and avoids
+            // a sequential scan on every verify-email click.
+            entity.HasIndex(e => e.VerificationToken)
+                .IsUnique()
+                .HasFilter("\"VerificationToken\" IS NOT NULL")
+                .HasDatabaseName("UQ_PlatformUser_VerificationToken");
+
             entity.HasMany(e => e.SocialLogins)
                 .WithOne(s => s.PlatformUser)
                 .HasForeignKey(s => s.PlatformUserId)
@@ -1132,6 +1147,13 @@ public class TenantDbContext : DbContext
 
             entity.HasIndex(e => e.RegisterId)
                 .HasDatabaseName("IX_OrgRegSub_RegisterId");
+
+            // Hot path: RegisterSubscriptionService and RegisterInvitationService
+            // both filter by (OrganizationId, Status='Active'). Partial keeps the
+            // index narrow even as historical/cancelled subscriptions accumulate.
+            entity.HasIndex(e => e.OrganizationId)
+                .HasFilter("\"Status\" = 'Active'")
+                .HasDatabaseName("IX_OrgRegSub_Org_Active");
 
             entity.HasOne(e => e.Organization)
                 .WithMany()

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260425152258_InitialCreate.Designer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260425152258_InitialCreate.Designer.cs
@@ -14,7 +14,7 @@ using Sorcha.Tenant.Service.Data;
 namespace Sorcha.Tenant.Service.Migrations
 {
     [DbContext(typeof(TenantDbContext))]
-    [Migration("20260408160910_InitialCreate")]
+    [Migration("20260425152258_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -146,6 +146,10 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.HasIndex("OrganizationId");
 
                     b.HasIndex("Timestamp");
+
+                    b.HasIndex("OrganizationId", "Timestamp")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_AuditLog_Org_Time");
 
                     b.ToTable("AuditLogEntries", "public");
                 });
@@ -614,7 +618,8 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("OrganizationId")
-                        .HasDatabaseName("IX_OrgRegSub_OrganizationId");
+                        .HasDatabaseName("IX_OrgRegSub_Org_Active")
+                        .HasFilter("\"Status\" = 'Active'");
 
                     b.HasIndex("RegisterId")
                         .HasDatabaseName("IX_OrgRegSub_RegisterId");
@@ -940,6 +945,11 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasIndex("Status")
                         .HasDatabaseName("IX_PlatformUser_Status");
+
+                    b.HasIndex("VerificationToken")
+                        .IsUnique()
+                        .HasDatabaseName("UQ_PlatformUser_VerificationToken")
+                        .HasFilter("\"VerificationToken\" IS NOT NULL");
 
                     b.ToTable("PlatformUsers", "public");
                 });

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260425152258_InitialCreate.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260425152258_InitialCreate.cs
@@ -683,6 +683,13 @@ namespace Sorcha.Tenant.Service.Migrations
                 filter: "\"IsRead\" = false");
 
             migrationBuilder.CreateIndex(
+                name: "IX_AuditLog_Org_Time",
+                schema: "public",
+                table: "AuditLogEntries",
+                columns: new[] { "OrganizationId", "Timestamp" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
                 name: "IX_AuditLogEntries_EventType",
                 schema: "public",
                 table: "AuditLogEntries",
@@ -762,10 +769,11 @@ namespace Sorcha.Tenant.Service.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
-                name: "IX_OrgRegSub_OrganizationId",
+                name: "IX_OrgRegSub_Org_Active",
                 schema: "public",
                 table: "OrganizationRegisterSubscriptions",
-                column: "OrganizationId");
+                column: "OrganizationId",
+                filter: "\"Status\" = 'Active'");
 
             migrationBuilder.CreateIndex(
                 name: "IX_OrgRegSub_OrgId_RegisterId",
@@ -909,6 +917,14 @@ namespace Sorcha.Tenant.Service.Migrations
                 table: "PlatformUsers",
                 column: "Email",
                 unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UQ_PlatformUser_VerificationToken",
+                schema: "public",
+                table: "PlatformUsers",
+                column: "VerificationToken",
+                unique: true,
+                filter: "\"VerificationToken\" IS NOT NULL");
 
             migrationBuilder.CreateIndex(
                 name: "IX_PushSubscription_UserId",

--- a/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/TenantDbContextModelSnapshot.cs
@@ -144,6 +144,10 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasIndex("Timestamp");
 
+                    b.HasIndex("OrganizationId", "Timestamp")
+                        .IsDescending(false, true)
+                        .HasDatabaseName("IX_AuditLog_Org_Time");
+
                     b.ToTable("AuditLogEntries", "public");
                 });
 
@@ -611,7 +615,8 @@ namespace Sorcha.Tenant.Service.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("OrganizationId")
-                        .HasDatabaseName("IX_OrgRegSub_OrganizationId");
+                        .HasDatabaseName("IX_OrgRegSub_Org_Active")
+                        .HasFilter("\"Status\" = 'Active'");
 
                     b.HasIndex("RegisterId")
                         .HasDatabaseName("IX_OrgRegSub_RegisterId");
@@ -937,6 +942,11 @@ namespace Sorcha.Tenant.Service.Migrations
 
                     b.HasIndex("Status")
                         .HasDatabaseName("IX_PlatformUser_Status");
+
+                    b.HasIndex("VerificationToken")
+                        .IsUnique()
+                        .HasDatabaseName("UQ_PlatformUser_VerificationToken")
+                        .HasFilter("\"VerificationToken\" IS NOT NULL");
 
                     b.ToTable("PlatformUsers", "public");
                 });


### PR DESCRIPTION
## Summary

Per-service DB audit (full report in chat). Adds **4 confirmed-against-code quick-win indexes** baked into the squashed `InitialCreate` migration for each affected DbContext, so a fresh deployment gets them from the first run. All other findings (cleanup services, views, choke-point refactors, security inconsistencies) are captured in a deferred backlog doc.

### Indexes added

| DB | Table | Index | Backs query at |
|---|---|---|---|
| `sorcha_tenant` | `PlatformUsers` | `UQ_PlatformUser_VerificationToken` — partial unique `(VerificationToken) WHERE NOT NULL` | `EmailVerificationService.cs:82` |
| `sorcha_tenant` | `AuditLogEntries` | `IX_AuditLog_Org_Time` — composite `(OrganizationId, Timestamp DESC)` | `AuditCleanupService.cs:99` |
| `sorcha_tenant` | `OrganizationRegisterSubscriptions` | `IX_OrgRegSub_Org_Active` — partial `(OrganizationId) WHERE Status='Active'` | `RegisterSubscriptionService.cs:171` + 2 more |
| `sorcha_peer` | `queued_transactions` | `IX_QueuedTransactions_Status_EnqueuedAt` — composite | `PeerDataCleanupService.cs:135` |

### Approach

- Added `HasIndex` calls in each DbContext (Fluent API).
- Regenerated `InitialCreate` via `dotnet ef migrations remove` + `add InitialCreate` for both Tenant and Peer projects — squashed in, no follow-up migration.
- Wallet and Blueprint had no confirmed quick wins (well-indexed already, or no concrete query patterns to back additions).

**Side-effect:** the regen moved the Peer migration from `src/Services/Sorcha.Peer.Service/Data/Migrations/` to the EF default `src/Services/Sorcha.Peer.Service/Migrations/`. Runtime resolves migrations by type (via the `[DbContext]` attribute on the snapshot), not by path, so this is purely a tidy-up. Future Peer regens won't need to be manually relocated.

### Deferred to backlog

`docs/reference/db-audit-backlog.md` captures everything that needs code (not just migration tweaks):

- **Tenant:** 5 cleanup services for unindexed growth-prone tables (`WalletLinkChallenges`, `InvitationNonces`, `OrgInvitations`, `RegisterInvitationRecords`, `ParticipantAuditEntries`); 3 view candidates; 3 choke-point candidates; security inconsistency between `VerificationToken` (plaintext) and `PasswordResetTokenHash` (hashed).
- **Wallet:** speculative indexes on `SigningSessions`, `Credentials`, `WalletAccess` — add when matching cleanup behaviour is implemented.
- **Blueprint:** idempotency-key cleanup + supporting index; migration-location standardisation.
- **Peer:** push TTL filter into SQL in `PurgeQueuedTransactionsAsync`; investigate `SyncCheckpoints (NextSyncDue)` and `Peers (LastSeen DESC)`.
- **Mongo:** per-register collection audit deferred until a real register is exercised end-to-end.

## Test plan

- [x] Both DbContext projects build clean (0 errors).
- [x] `docker compose down -v` + `up -d` — full clean redeploy from new migrations.
- [x] All 13 services reach healthy.
- [x] All 4 indexes verified live with correct shape via `pg_indexes`:
  - `UQ_PlatformUser_VerificationToken` — partial unique with `(VerificationToken) WHERE NOT NULL` ✓
  - `IX_AuditLog_Org_Time` — composite with `Timestamp DESC` ✓
  - `IX_OrgRegSub_Org_Active` — partial with `WHERE Status='Active'` ✓
  - `IX_QueuedTransactions_Status_EnqueuedAt` — composite ✓
- [x] `/health` returns 200 on gateway, tenant, register.

## Reviewer note

Because this **squashes** into the existing InitialCreate (rather than adding a step-up migration), any environment with an existing `__EFMigrationsHistory` row for the old migration ID (`20260408160910` for tenant, `20260331083113` for peer) will need a `down -v` before redeploying. This is fine for n0/dev — call out before applying to any environment with data worth keeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)