### PR TITLE
chore(infra): cap Mongo + Redis memory; fix schemaIndex bootstrap bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
     image: redis:8-alpine
     container_name: sorcha-redis
     restart: unless-stopped
+    # maxmemory caps Redis below the container budget so it can't OOM-kill
+    # itself; volatile-lru evicts only TTL-bearing keys when full so the
+    # event streams (sorcha:events:*, no TTL) and the few persistent state
+    # keys (token-revocation, idempotency anchors) never get dropped.
+    command: ["redis-server", "--maxmemory", "384mb", "--maxmemory-policy", "volatile-lru", "--save", "3600", "1", "300", "100", "60", "10000"]
     ports:
       - "${REDIS_PORT:-16379}:6379"
     volumes:
@@ -65,6 +70,11 @@ services:
     image: mongo:8
     container_name: sorcha-mongodb
     restart: unless-stopped
+    # WiredTiger cache defaults to 50% of HOST RAM, which inside a 1 GB
+    # container would be ~30 GB and gets the kernel to OOM-kill mongod
+    # the moment the working set grows. Cap at 0.5 GB and leave the rest
+    # of the container budget for connections + ingest.
+    command: ["mongod", "--auth", "--bind_ip_all", "--wiredTigerCacheSizeGB", "0.5"]
     ports:
       - "${MONGODB_PORT:-27017}:27017"
     environment:

--- a/docs/reference/db-audit-backlog.md
+++ b/docs/reference/db-audit-backlog.md
@@ -149,6 +149,55 @@ empty. Audit them once a real register is exercised end-to-end:
 
 ---
 
+## Redis (added 2026-04-25 from Redis/Mongo audit)
+
+The two outage-shaped items (unbounded `maxmemory` and `noeviction` policy)
+shipped in PR #404 alongside the `MongoSchemaIndexRepository` bootstrap
+fix. Items below are quality-of-life improvements deferred until they
+have a concrete trigger.
+
+- **Db isolation** — every service uses db 0 today. Splitting into
+  db 0 (cache), db 1 (event streams), db 2 (sessions) makes
+  `INFO keyspace` and `MEMORY USAGE` per-namespace useful, and lets you
+  `FLUSHDB 0` without nuking streams. Touches every service connection
+  string.
+- **Cache hit-ratio observation** — measured 27.5% on a fresh stack
+  (heavy cold-start noise). Re-measure after a real walkthrough; if it
+  stays low, suspect TTL-too-short or churning keys.
+- **AOF for the event streams** — current `appendonly: no` means a Redis
+  crash loses any stream events written between RDB snapshots
+  (~10-min intervals). If event-driven sync is load-bearing for register
+  consistency, switch to `appendonly yes` with `appendfsync everysec`,
+  scoped only to the keys that need it (or accept the loss as the price
+  of cache-only Redis and drive durability from the Postgres ledger).
+
+---
+
+## MongoDB (added 2026-04-25)
+
+PR #404 fixed the schemaIndex bootstrap bug (indexes were never being
+created on the write path). Remaining items:
+
+- **`SearchAsync` regex → `$text`** — `MongoSchemaIndexRepository.SearchAsync`
+  filters with `BsonRegularExpression` (regex) rather than the
+  `$text` operator that the now-created `idx_text_search` index serves.
+  At 1,390 docs the difference is sub-millisecond, but as the schema
+  catalogue grows this becomes a collection scan. Behaviour change
+  (text-index uses word stems, not substring match) so it's a product
+  decision, not just a perf one.
+- **Per-register collection audit** — `MongoRegisterRepository` defines
+  comprehensive indexes on `transactions`, `dockets`, `receipts`
+  (`TxId` unique, `SenderWallet`, `TimeStamp DESC`, `DocketNumber`,
+  `MetaData.TransactionType`, revocation index, etc.) but per-register
+  databases are lazy-created. Verify these all materialise on first use
+  once a real register is exercised end-to-end.
+- **`maxIncomingConnections: 500`** — current default is ~420k. A buggy
+  client looping `MongoClient.Create()` could exhaust file descriptors
+  before hitting any visible cap. Tighten to a sane bound for the
+  expected service count.
+
+---
+
 ## Process notes
 
 - All quick-win indexes were squashed into the InitialCreate migration

--- a/src/Common/Sorcha.Blueprint.Schemas/Repositories/MongoSchemaIndexRepository.cs
+++ b/src/Common/Sorcha.Blueprint.Schemas/Repositories/MongoSchemaIndexRepository.cs
@@ -17,10 +17,7 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
 {
     private readonly IMongoCollection<SchemaIndexEntryDocument> _collection;
     private readonly ILogger<MongoSchemaIndexRepository> _logger;
-
-    /// <summary>
-    /// Initializes with an IMongoDatabase instance.
-    /// </summary>
+    private readonly SemaphoreSlim _indexCreationLock = new(1, 1);
     private bool _indexesCreated;
 
     public MongoSchemaIndexRepository(
@@ -32,14 +29,30 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
         _collection = database.GetCollection<SchemaIndexEntryDocument>("schemaIndex");
     }
 
-    /// <summary>
-    /// Ensures indexes are created. Called lazily on first query.
-    /// </summary>
+    // Idempotent + concurrency-safe + non-throwing. Mirrors ValidatorRegistry's
+    // EnsureMongoIndexesAsync pattern. Must be invoked from every public method
+    // — read paths AND write paths — because the per-instance flag means a
+    // process that only ever upserts would otherwise never trigger index
+    // creation, leaving the collection on _id_ only (the bug fixed here).
     public async Task EnsureIndexesAsync(CancellationToken cancellationToken = default)
     {
         if (_indexesCreated) return;
-        await CreateIndexesAsync();
-        _indexesCreated = true;
+
+        await _indexCreationLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_indexesCreated) return;
+            await CreateIndexesAsync();
+            _indexesCreated = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create schemaIndex MongoDB indexes — will retry on next operation");
+        }
+        finally
+        {
+            _indexCreationLock.Release();
+        }
     }
 
     private async Task CreateIndexesAsync()
@@ -154,6 +167,7 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
         string sourceUri,
         CancellationToken cancellationToken = default)
     {
+        await EnsureIndexesAsync(cancellationToken);
         var filter = Builders<SchemaIndexEntryDocument>.Filter.And(
             Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.SourceProvider, sourceProvider),
             Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.SourceUri, sourceUri));
@@ -166,6 +180,7 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
         string shortCode,
         CancellationToken cancellationToken = default)
     {
+        await EnsureIndexesAsync(cancellationToken);
         var filter = Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.ShortCode, shortCode);
         return await _collection.Find(filter).FirstOrDefaultAsync(cancellationToken);
     }
@@ -175,6 +190,7 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
         SchemaIndexEntryDocument entry,
         CancellationToken cancellationToken = default)
     {
+        await EnsureIndexesAsync(cancellationToken);
         var filter = Builders<SchemaIndexEntryDocument>.Filter.And(
             Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.SourceProvider, entry.SourceProvider),
             Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.SourceUri, entry.SourceUri));
@@ -229,6 +245,7 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
         SchemaIndexStatus status,
         CancellationToken cancellationToken = default)
     {
+        await EnsureIndexesAsync(cancellationToken);
         var filter = Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.SourceProvider, sourceProvider);
         var update = Builders<SchemaIndexEntryDocument>.Update
             .Set(d => d.Status, status.ToString())
@@ -242,6 +259,7 @@ public class MongoSchemaIndexRepository : ISchemaIndexRepository
         string sourceProvider,
         CancellationToken cancellationToken = default)
     {
+        await EnsureIndexesAsync(cancellationToken);
         var filter = Builders<SchemaIndexEntryDocument>.Filter.Eq(d => d.SourceProvider, sourceProvider);
         return (int)await _collection.CountDocumentsAsync(filter, cancellationToken: cancellationToken);
     }


### PR DESCRIPTION
## Summary

P0 + P1 fixes from the Redis/MongoDB audit. Two outage-shaped configuration gaps + one real bug, all verified live after a clean redeploy.

### P0 — outage prevention (compose only)

**`mongodb`** — `--wiredTigerCacheSizeGB 0.5`. Default WiredTiger cache is 50% of *host* RAM (~31 GB on the dev machine); inside a 1 GB container that's an OOM-kill waiting for the working set to grow. Cap at 512 MB so the kernel doesn't reap mongod under load.

**`redis`** — `--maxmemory 384mb --maxmemory-policy volatile-lru`. Defaults were unbounded + `noeviction`: Redis would happily fill the container budget and start failing every write. `volatile-lru` evicts only TTL-bearing keys so persistent state (event streams, token-revocation list) is never dropped.

### P1 — bug fix (code)

**`MongoSchemaIndexRepository.EnsureIndexesAsync`** was invoked only from `SearchAsync`, gated by a per-instance `_indexesCreated` flag. The schema-seeder writes 1,390 entries through `UpsertAsync` paths that never hit `Search`, so the live collection was running on `_id_` alone — every `GetByProviderAndUri` / `GetByShortCode` lookup was a collection scan.

Now uses double-checked locking + `try/catch` (mirroring the `ValidatorRegistry.EnsureMongoIndexesAsync` pattern) and is awaited from every public read AND write method.

### Audit correction

The original audit flagged "Redis Streams growing unbounded" as P1 — that was wrong. The publisher (`RedisStreamEventPublisher.PublishAsync`) already passes `maxLength: _config.MaxStreamLength` + `useApproximateMaxLength: true`, and `XLEN` confirms 0 on every `sorcha:events:*` stream. No change needed; deferred items list updated to reflect this.

## Test plan

- [x] `docker compose config --quiet` clean
- [x] Schema project builds (0 errors)
- [x] `docker compose down -v` + `up -d` — all 13 services reach healthy
- [x] Mongo: `db.serverStatus().wiredTiger.cache['maximum bytes configured']` = **536,870,912 (512 MB)** ✓
- [x] Redis: `CONFIG GET maxmemory` = **402,653,184 (384 MB)** ✓; `CONFIG GET maxmemory-policy` = **volatile-lru** ✓
- [x] Blueprint startup populates 1,390 docs into `sorcha-blueprints.schemaIndex` and **all 6 expected indexes** materialise: `idx_provider_uri_unique`, `idx_text_search`, `idx_sector_status`, `idx_provider`, `idx_last_fetched`, `idx_shortcode_unique` ✓

## Reviewer note

Branches off plain master, no overlap with PR #401 (compose hardening). Backlog (`docs/reference/db-audit-backlog.md`) updated with the remaining Redis/Mongo deferred items: db-isolation, AOF policy for streams, regex→`\$text` migration, per-register collection audit, mongo connection cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)