### PR TITLE
feat(service-defaults): SorchaConnections cascade resolver

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/SorchaConnectionsExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/SorchaConnectionsExtensions.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Configuration;
+
+namespace Sorcha.ServiceDefaults;
+
+/// <summary>
+/// Connection-string resolution helpers with a Sorcha-platform default + per-service
+/// override pattern.
+///
+/// Lookup order for any (serviceName, kind) pair:
+///   1. <c>ConnectionStrings:{serviceName}:{kind}</c> — service-specific override
+///   2. <c>ConnectionStrings:Sorcha:{kind}</c> — platform-wide default
+///
+/// Where <c>{kind}</c> is one of <c>Postgres</c>, <c>Mongo</c>, <c>Redis</c>.
+///
+/// In environment-variable form (compose, k8s) these become
+/// <c>ConnectionStrings__Sorcha__Postgres</c> / <c>ConnectionStrings__Tenant__Postgres</c>
+/// respectively.
+///
+/// Postgres connection strings carry the database name in-band
+/// (<c>Database=sorcha_tenant</c>); the resolver appends the per-service database
+/// name when the configured base string omits it. Mongo and Redis don't carry
+/// database/db-index in the connection string, so the resolver returns those
+/// untouched.
+/// </summary>
+public static class SorchaConnectionsExtensions
+{
+    private const string DefaultPrefix = "Sorcha";
+
+    /// <summary>
+    /// Resolves a Postgres connection string for the given service. Falls back to the
+    /// <c>Sorcha</c> platform default if no service-specific override is configured.
+    /// Appends <c>Database={databaseName}</c> when the resolved string doesn't already
+    /// specify a database (the common case for the cascade default).
+    /// </summary>
+    public static string GetSorchaPostgresConnectionString(
+        this IConfiguration configuration,
+        string serviceName,
+        string databaseName)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
+
+        var raw = ResolveOrThrow(configuration, serviceName, "Postgres");
+        return EnsureDatabase(raw, databaseName);
+    }
+
+    /// <summary>
+    /// Resolves a Mongo connection string for the given service. The database is
+    /// selected separately via <c>IMongoClient.GetDatabase(name)</c>, so this returns
+    /// the resolved string as-is.
+    /// </summary>
+    public static string GetSorchaMongoConnectionString(
+        this IConfiguration configuration,
+        string serviceName)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+
+        return ResolveOrThrow(configuration, serviceName, "Mongo");
+    }
+
+    /// <summary>
+    /// Resolves a Redis connection string for the given service. Per-service overrides
+    /// are mostly an operational lever (e.g. point one service at a dedicated Redis
+    /// instance); the platform default is the common case.
+    /// </summary>
+    public static string GetSorchaRedisConnectionString(
+        this IConfiguration configuration,
+        string serviceName)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+
+        return ResolveOrThrow(configuration, serviceName, "Redis");
+    }
+
+    private static string ResolveOrThrow(IConfiguration configuration, string serviceName, string kind)
+    {
+        var serviceKey = $"ConnectionStrings:{serviceName}:{kind}";
+        var defaultKey = $"ConnectionStrings:{DefaultPrefix}:{kind}";
+
+        var resolved = configuration[serviceKey] ?? configuration[defaultKey];
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            throw new InvalidOperationException(
+                $"No {kind} connection string configured. Set {serviceKey} (override) " +
+                $"or {defaultKey} (platform default).");
+        }
+        return resolved;
+    }
+
+    private static string EnsureDatabase(string connectionString, string databaseName)
+    {
+        if (connectionString.Contains("Database=", StringComparison.OrdinalIgnoreCase))
+            return connectionString;
+
+        var trimmed = connectionString.TrimEnd();
+        var separator = trimmed.EndsWith(';') ? "" : ";";
+        return $"{trimmed}{separator}Database={databaseName}";
+    }
+}

--- a/tests/Sorcha.ServiceDefaults.Tests/SorchaConnectionsExtensionsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/SorchaConnectionsExtensionsTests.cs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+
+namespace Sorcha.ServiceDefaults.Tests;
+
+/// <summary>
+/// Tests for <see cref="SorchaConnectionsExtensions"/>: the platform-default + per-service
+/// override cascade that resolves Postgres / Mongo / Redis connection strings.
+/// </summary>
+public class SorchaConnectionsExtensionsTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    // ----- Postgres -----
+
+    [Fact]
+    public void GetSorchaPostgresConnectionString_ServiceOverride_WinsOverDefault()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Postgres"] = "Host=default-pg;Username=sorcha",
+            ["ConnectionStrings:Tenant:Postgres"] = "Host=tenant-pg;Username=tenant_user"
+        });
+
+        var result = config.GetSorchaPostgresConnectionString("Tenant", "sorcha_tenant");
+
+        result.Should().Be("Host=tenant-pg;Username=tenant_user;Database=sorcha_tenant");
+    }
+
+    [Fact]
+    public void GetSorchaPostgresConnectionString_NoOverride_FallsBackToDefault()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Postgres"] = "Host=default-pg;Username=sorcha"
+        });
+
+        var result = config.GetSorchaPostgresConnectionString("Tenant", "sorcha_tenant");
+
+        result.Should().Be("Host=default-pg;Username=sorcha;Database=sorcha_tenant");
+    }
+
+    [Fact]
+    public void GetSorchaPostgresConnectionString_AppendsDatabase_WhenMissing()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Postgres"] = "Host=postgres;Username=sorcha;Password=p"
+        });
+
+        var result = config.GetSorchaPostgresConnectionString("Wallet", "sorcha_wallet");
+
+        result.Should().EndWith(";Database=sorcha_wallet");
+    }
+
+    [Fact]
+    public void GetSorchaPostgresConnectionString_PreservesDatabase_WhenAlreadyPresent()
+    {
+        // The override case: an op explicitly set the full string with their own Database name.
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Tenant:Postgres"] = "Host=tenant-pg;Database=custom_db;Username=u"
+        });
+
+        var result = config.GetSorchaPostgresConnectionString("Tenant", "sorcha_tenant");
+
+        result.Should().Be("Host=tenant-pg;Database=custom_db;Username=u");
+    }
+
+    [Fact]
+    public void GetSorchaPostgresConnectionString_HandlesTrailingSemicolonOnBase()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Postgres"] = "Host=postgres;Username=sorcha;"
+        });
+
+        var result = config.GetSorchaPostgresConnectionString("Peer", "sorcha_peer");
+
+        // No double-semicolon
+        result.Should().Be("Host=postgres;Username=sorcha;Database=sorcha_peer");
+    }
+
+    [Fact]
+    public void GetSorchaPostgresConnectionString_NoConfiguration_Throws()
+    {
+        var config = BuildConfig(new());
+
+        var act = () => config.GetSorchaPostgresConnectionString("Tenant", "sorcha_tenant");
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*ConnectionStrings:Tenant:Postgres*ConnectionStrings:Sorcha:Postgres*");
+    }
+
+    // ----- Mongo -----
+
+    [Fact]
+    public void GetSorchaMongoConnectionString_ServiceOverride_WinsOverDefault()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Mongo"] = "mongodb://default-mongo:27017",
+            ["ConnectionStrings:Register:Mongo"] = "mongodb://register-mongo:27017"
+        });
+
+        var result = config.GetSorchaMongoConnectionString("Register");
+
+        result.Should().Be("mongodb://register-mongo:27017");
+    }
+
+    [Fact]
+    public void GetSorchaMongoConnectionString_NoOverride_FallsBackToDefault()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Mongo"] = "mongodb://default-mongo:27017"
+        });
+
+        var result = config.GetSorchaMongoConnectionString("Register");
+
+        result.Should().Be("mongodb://default-mongo:27017");
+    }
+
+    [Fact]
+    public void GetSorchaMongoConnectionString_DoesNotAppendDatabase()
+    {
+        // Mongo selects the DB via IMongoClient.GetDatabase(name), not in the connection string.
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Mongo"] = "mongodb://user:pw@host:27017"
+        });
+
+        var result = config.GetSorchaMongoConnectionString("Register");
+
+        result.Should().NotContain("Database=");
+    }
+
+    // ----- Redis -----
+
+    [Fact]
+    public void GetSorchaRedisConnectionString_ServiceOverride_WinsOverDefault()
+    {
+        var config = BuildConfig(new()
+        {
+            ["ConnectionStrings:Sorcha:Redis"] = "redis:6379",
+            ["ConnectionStrings:Tenant:Redis"] = "tenant-redis:6379"
+        });
+
+        var result = config.GetSorchaRedisConnectionString("Tenant");
+
+        result.Should().Be("tenant-redis:6379");
+    }
+
+    [Fact]
+    public void GetSorchaRedisConnectionString_NoConfiguration_Throws()
+    {
+        var config = BuildConfig(new());
+
+        var act = () => config.GetSorchaRedisConnectionString("Tenant");
+
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("*Redis*");
+    }
+
+    // ----- Argument validation -----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetSorchaPostgresConnectionString_InvalidServiceName_Throws(string? serviceName)
+    {
+        var config = BuildConfig(new());
+        var act = () => config.GetSorchaPostgresConnectionString(serviceName!, "db");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetSorchaPostgresConnectionString_InvalidDatabaseName_Throws(string? databaseName)
+    {
+        var config = BuildConfig(new());
+        var act = () => config.GetSorchaPostgresConnectionString("Tenant", databaseName!);
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`IConfiguration\` extension methods that resolve Postgres / Mongo / Redis connection strings using a **platform-default + per-service-override cascade**.

\`\`\`
ConnectionStrings:Sorcha:Postgres = \"Host=postgres;Username=...;\"   ← default for everyone
ConnectionStrings:Tenant:Postgres = \"Host=other-host;...\"           ← optional override
\`\`\`

Lookup order for any \`(serviceName, kind)\` pair:
1. \`ConnectionStrings:{ServiceName}:{Kind}\` — service-specific override
2. \`ConnectionStrings:Sorcha:{Kind}\` — platform-wide default

Postgres appends \`Database={dbName}\` when the resolved string omits one (the common case for the default — Mongo and Redis don't carry the DB name in-band, so they're returned untouched).

## Why

- Drops ~30 lines of duplicated \`Host=postgres;Username=sorcha;Password=…\` from \`docker-compose.yml\` once services adopt it (shared default + per-service overrides only when truly different).
- Makes the production move to per-service credentials a config change rather than a per-service code edit.
- Aligns with how Aspire's \`AddNpgsqlDbContext\` / \`AddRedisClient\` / \`AddMongoDBClient\` consume connection strings — the resolver wraps the lookup, Aspire sees a single string.

## Scope

**No service migrated yet** — this is the resolver only, designed as a standalone PR so the API can be reviewed before any service is wired through it. Follow-ups (suggested order):
1. Migrate Tenant as the pilot (most varied connection-string usage today)
2. Sweep the remaining services
3. Delete \`IRepository<>\` / \`EFCoreRepository<>\` (independent cleanup, dead infrastructure)

## Test plan

- [x] \`dotnet test --filter SorchaConnectionsExtensionsTests\` — **17/17 pass**
- [x] Coverage:
  - service-override wins over default
  - falls back to default when no override
  - appends \`Database=\` when missing
  - preserves \`Database=\` when explicitly set in override
  - trailing-semicolon handling (no double-\`;\`)
  - throws clear error pointing at both expected keys when neither set
  - Mongo doesn't append \`Database=\`
  - argument validation (null/empty serviceName + databaseName)

🤖 Generated with [Claude Code](https://claude.com/claude-code)