### PR TITLE
feat(tenant): adopt SorchaConnections cascade for Postgres + Redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,18 @@ x-jwt-env: &jwt-env
   JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}
   JwtSettings__SigningKey: ${JWT_SIGNING_KEY:-c29yY2hhLWRvY2tlci1kZXYta2V5LTIwMjUtbWluLTI1Ni1iaXRzLXNlY3VyZQ==}
 
+# Platform-default connection strings, resolved by the SorchaConnections cascade
+# in Sorcha.ServiceDefaults: ConnectionStrings:{Service}:{Kind} falls back to
+# ConnectionStrings:Sorcha:{Kind}. Per-service overrides go in that service's
+# environment block alongside this anchor (e.g. ConnectionStrings__Tenant__Postgres
+# would point Tenant at a different cluster). Postgres carries credentials/host
+# only; the per-service code appends Database={dbName} (e.g. sorcha_tenant) at
+# resolve time. Mongo and Redis don't carry a database/db-index in-band.
+x-sorcha-connections: &sorcha-connections
+  ConnectionStrings__Sorcha__Postgres: Host=postgres;Username=sorcha;Password=sorcha_dev_password
+  ConnectionStrings__Sorcha__Mongo: mongodb://sorcha:sorcha_dev_password@mongodb:27017
+  ConnectionStrings__Sorcha__Redis: redis:6379
+
 # Container hardening profile applied to every Sorcha .NET service.
 # - read_only:true     → root filesystem is immutable; named volumes (DataProtection-Keys,
 #                        wallet-keys) and tmpfs mounts remain writable.
@@ -373,12 +385,15 @@ services:
     ports:
       - "${TENANT_PORT:-5450}:8080"  # Exposed for direct access during development/bootstrap
     environment:
-      <<: [*otel-env, *jwt-env]
+      # Tenant is the SorchaConnections-cascade pilot. Postgres + Redis come from the
+      # *sorcha-connections anchor (default for the platform); the resolver in
+      # Sorcha.ServiceDefaults appends Database=sorcha_tenant. Add a
+      # ConnectionStrings__Tenant__Postgres / __Redis line here if Tenant should ever
+      # diverge from the platform default.
+      <<: [*otel-env, *jwt-env, *sorcha-connections]
       OTEL_SERVICE_NAME: tenant-service
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__TenantDatabase: Host=postgres;Database=sorcha_tenant;Username=sorcha;Password=sorcha_dev_password
-      Redis__ConnectionString: redis:6379
       # Tenant service is the JWT authority - it issues tokens using the installation name
       JwtSettings__SigningKeySource: Configuration
       # Service-to-service auth for Wallet Service calls during wallet link verification

--- a/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Fido2NetLib;
 using Microsoft.EntityFrameworkCore;
 using Polly;
 using Polly.CircuitBreaker;
+using Sorcha.ServiceDefaults;
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Data.Repositories;
 using Sorcha.Tenant.Service.Models;
@@ -88,15 +89,21 @@ public static class ServiceCollectionExtensions
 
     /// <summary>
     /// Adds PostgreSQL database context with multi-tenant support.
+    /// Uses the SorchaConnections cascade: ConnectionStrings:Tenant:Postgres → ConnectionStrings:Sorcha:Postgres.
+    /// Falls back to an in-memory provider when neither key is configured (tests / no-DB scenarios).
     /// </summary>
     public static IServiceCollection AddTenantDatabase(
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var connectionString = configuration.GetConnectionString("TenantDatabase");
+        var hasResolverConfig =
+            !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Tenant:Postgres"])
+            || !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Sorcha:Postgres"]);
 
-        if (!string.IsNullOrEmpty(connectionString))
+        if (hasResolverConfig)
         {
+            var connectionString = configuration.GetSorchaPostgresConnectionString("Tenant", "sorcha_tenant");
+
             // Build a Npgsql data source with dynamic JSON support (required for
             // Dictionary<string, object> → JSONB columns like AuditLogEntry.Details)
             var dataSourceBuilder = new Npgsql.NpgsqlDataSourceBuilder(connectionString);
@@ -191,12 +198,15 @@ public static class ServiceCollectionExtensions
 
     /// <summary>
     /// Adds Redis connection with circuit breaker for token revocation.
+    /// Uses the SorchaConnections cascade: ConnectionStrings:Tenant:Redis → ConnectionStrings:Sorcha:Redis.
     /// </summary>
     public static IServiceCollection AddTenantRedis(
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var redisConnectionString = configuration.GetValue<string>("Redis:ConnectionString");
+        var redisConnectionString =
+            configuration["ConnectionStrings:Tenant:Redis"]
+            ?? configuration["ConnectionStrings:Sorcha:Redis"];
 
         if (!string.IsNullOrEmpty(redisConnectionString))
         {
@@ -225,7 +235,9 @@ public static class ServiceCollectionExtensions
         {
             // Register a null implementation for testing without Redis
             services.AddSingleton<IConnectionMultiplexer>(sp =>
-                throw new InvalidOperationException("Redis is not configured. Set Redis:ConnectionString in configuration."));
+                throw new InvalidOperationException(
+                    "Redis is not configured. Set ConnectionStrings:Sorcha:Redis (platform default) " +
+                    "or ConnectionStrings:Tenant:Redis (override)."));
         }
 
         // Configure token revocation
@@ -320,13 +332,19 @@ public static class ServiceCollectionExtensions
     {
         var healthChecks = services.AddHealthChecks();
 
-        var connectionString = configuration.GetConnectionString("TenantDatabase");
-        if (!string.IsNullOrEmpty(connectionString))
+        var hasResolverConfig =
+            !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Tenant:Postgres"])
+            || !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Sorcha:Postgres"]);
+
+        if (hasResolverConfig)
         {
+            var connectionString = configuration.GetSorchaPostgresConnectionString("Tenant", "sorcha_tenant");
             healthChecks.AddNpgSql(connectionString, name: "postgresql");
         }
 
-        var redisConnectionString = configuration.GetValue<string>("Redis:ConnectionString");
+        var redisConnectionString =
+            configuration["ConnectionStrings:Tenant:Redis"]
+            ?? configuration["ConnectionStrings:Sorcha:Redis"];
         if (!string.IsNullOrEmpty(redisConnectionString))
         {
             healthChecks.AddRedis(redisConnectionString, name: "redis");


### PR DESCRIPTION
## Summary

Tenant is the **pilot adopter** of the cascade resolver shipped in PR #405. It exercises both Postgres (with database-name append) and Redis (no append) and validates the design end-to-end.

## Code changes (\`Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs\`)

\`AddTenantDatabase\`:
- Was: \`configuration.GetConnectionString(\"TenantDatabase\")\` → if empty, InMemory
- Now: cascade lookup → \`configuration.GetSorchaPostgresConnectionString(\"Tenant\", \"sorcha_tenant\")\`. InMemory fallback preserved (checks for cascade keys' existence first; tests still work without any DB config).

\`AddTenantRedis\` + \`AddTenantHealthChecks\`:
- Was: \`configuration.GetValue<string>(\"Redis:ConnectionString\")\` (bespoke key)
- Now: \`configuration[\"ConnectionStrings:Tenant:Redis\"] ?? configuration[\"ConnectionStrings:Sorcha:Redis\"]\` (standard cascade)

Error message updated to point at the new keys when Redis isn't configured.

## Compose changes (\`docker-compose.yml\`)

- Added \`x-sorcha-connections\` YAML anchor at the top with the three platform defaults (\`Postgres\`, \`Mongo\`, \`Redis\`). Sits next to the existing \`x-otel-env\` and \`x-jwt-env\` anchors.
- Tenant's \`environment:\` merges the anchor (\`<<: [*otel-env, *jwt-env, *sorcha-connections]\`).
- Removed Tenant's \`ConnectionStrings__TenantDatabase\` and \`Redis__ConnectionString\` env lines — both are now provided by the anchor.
- Other services unchanged — they keep their bespoke connection-string keys for now and migrate in follow-up PRs.

## What this proves

- The cascade default fills every cascade-aware service from a single source — Tenant now needs zero connection-string env vars of its own.
- Production overrides work without code change: setting \`ConnectionStrings__Tenant__Postgres\` in the env beats the platform default.
- Per-service-credentials future is a config edit (per-service override block) not a code edit.

## Test plan

- [x] \`dotnet build\` Tenant Service — clean
- [x] \`docker compose config --quiet\` — clean
- [x] Tenant resolved env contains only the three \`ConnectionStrings__Sorcha__*\` keys; no legacy \`TenantDatabase\` or \`Redis__ConnectionString\`
- [x] \`docker compose down -v\` + \`up -d\` — Tenant comes up healthy
- [x] EF migration runs against the resolver-supplied connection string and creates all 28 tables in \`sorcha_tenant\`
- [x] \`GET /health\` returns 200

## Follow-ups (not in this PR)

- Sweep remaining services (Wallet, Blueprint, Peer, Register, Validator) onto the cascade — each will look the same as the Tenant changes here.
- Mongo isn't exercised by Tenant; Register/Validator/Peer pilots will be the validation.
- Connection-string key naming cleanup (\`wallet-db\` outlier, \`mongodb\` vs \`MongoDB\` casing) gets fixed during those sweeps for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)