### PR TITLE
feat(wallet/blueprint/peer): adopt SorchaConnections cascade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,18 @@ x-jwt-env: &jwt-env
 # would point Tenant at a different cluster). Postgres carries credentials/host
 # only; the per-service code appends Database={dbName} (e.g. sorcha_tenant) at
 # resolve time. Mongo and Redis don't carry a database/db-index in-band.
+#
+# The Aspire-named aliases (ConnectionStrings__redis, ConnectionStrings__mongodb)
+# are deduped via YAML scalar anchors. They exist so services that still use
+# Aspire's builder.AddRedisClient("redis") or GetConnectionString("mongodb")
+# continue to work without code change. Future PR can replace those Aspire-style
+# lookups with cascade-aware registrations and drop the aliases.
 x-sorcha-connections: &sorcha-connections
   ConnectionStrings__Sorcha__Postgres: Host=postgres;Username=sorcha;Password=sorcha_dev_password
-  ConnectionStrings__Sorcha__Mongo: mongodb://sorcha:sorcha_dev_password@mongodb:27017
-  ConnectionStrings__Sorcha__Redis: redis:6379
+  ConnectionStrings__Sorcha__Mongo: &sorcha-mongo mongodb://sorcha:sorcha_dev_password@mongodb:27017
+  ConnectionStrings__Sorcha__Redis: &sorcha-redis redis:6379
+  ConnectionStrings__mongodb: *sorcha-mongo
+  ConnectionStrings__redis: *sorcha-redis
 
 # Container hardening profile applied to every Sorcha .NET service.
 # - read_only:true     → root filesystem is immutable; named volumes (DataProtection-Keys,
@@ -182,13 +190,13 @@ services:
     ports:
       - "${BLUEPRINT_PORT:-5000}:8080"
     environment:
-      <<: [*otel-env, *jwt-env]
+      # Postgres + Mongo + Redis come from the *sorcha-connections anchor.
+      # Blueprint Postgres resolves to sorcha_blueprint via the cascade
+      # (resolver appends Database=sorcha_blueprint).
+      <<: [*otel-env, *jwt-env, *sorcha-connections]
       OTEL_SERVICE_NAME: blueprint-service
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__Redis: redis:6379
-      ConnectionStrings__BlueprintDb: Host=postgres;Database=sorcha_blueprint;Username=sorcha;Password=sorcha_dev_password
-      ConnectionStrings__mongodb: mongodb://sorcha:sorcha_dev_password@mongodb:27017
       # AI Provider configuration (Anthropic Claude API)
       AIProvider__ApiKey: ${ANTHROPIC_API_KEY:-}
       AIProvider__Model: claude-sonnet-4-5-20250929
@@ -250,12 +258,13 @@ services:
     mem_limit: 1g
     # No ports published - internal service only, accessed via API Gateway
     environment:
-      <<: [*otel-env, *jwt-env]
+      # Postgres + Redis come from the *sorcha-connections anchor.
+      # Wallet's Timeout / Command Timeout (30s each) are appended in
+      # WalletServiceExtensions.cs after the resolver returns the base string.
+      <<: [*otel-env, *jwt-env, *sorcha-connections]
       OTEL_SERVICE_NAME: wallet-service
       ASPNETCORE_ENVIRONMENT: Docker
       ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__Redis: redis:6379
-      ConnectionStrings__wallet-db: Host=postgres;Database=sorcha_wallet;Username=sorcha;Password=sorcha_dev_password;Timeout=30;Command Timeout=30
       ServiceAuth__ClientId: service-wallet
       ServiceAuth__ClientSecret: wallet-service-secret
       ServiceAuth__Scopes: "registers:write registers:read"
@@ -451,14 +460,16 @@ services:
     ports:
       - "${PEER_GRPC_PORT:-50051}:5000"  # gRPC for external P2P connections
     environment:
-      <<: [*otel-env, *jwt-env]
+      # Postgres + Mongo + Redis come from the *sorcha-connections anchor.
+      # Peer Postgres resolves to sorcha_peer via the cascade. Mongo lookup
+      # in PeerService Program.cs reads via the cascade resolver too; the
+      # MongoDB__DatabaseName below is the per-service database NAME (not a
+      # connection string) selected via IMongoClient.GetDatabase(name).
+      <<: [*otel-env, *jwt-env, *sorcha-connections]
       OTEL_SERVICE_NAME: peer-service
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
       ASPNETCORE_HTTP_PORTS: "8080"
-      ConnectionStrings__Redis: redis:6379
-      ConnectionStrings__PeerDb: Host=postgres;Database=sorcha_peer;Username=sorcha;Password=sorcha_dev_password
-      MongoDB__ConnectionString: mongodb://sorcha:sorcha_dev_password@mongodb:27017
       MongoDB__DatabaseName: sorcha_system_register
       ServiceAuth__ClientId: service-peer
       ServiceAuth__ClientSecret: peer-service-secret

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -13,6 +13,7 @@ using Sorcha.Blueprint.Service.Extensions;
 using Sorcha.Blueprint.Service.Hubs;
 using Sorcha.Blueprint.Service.Services.Implementation;
 using Sorcha.Blueprint.Service.JsonLd;
+using Sorcha.ServiceDefaults;
 using Sorcha.Blueprint.Service.Services;
 using Sorcha.Blueprint.Schemas.Services;
 using Sorcha.Cryptography.Core;
@@ -46,8 +47,14 @@ builder.AddRedisDistributedCache("redis");
 builder.AddSorchaOpenApi("Sorcha Blueprint Service API",
     "Blueprint workflow management, action execution, credential lifecycle, schema library, and SignalR real-time notifications.");
 
-// Add storage — EF Core + PostgreSQL when configured, InMemory fallback otherwise
-var blueprintDbConn = builder.Configuration.GetConnectionString("BlueprintDb");
+// Add storage — EF Core + PostgreSQL when configured, InMemory fallback otherwise.
+// SorchaConnections cascade: ConnectionStrings:Blueprint:Postgres → ConnectionStrings:Sorcha:Postgres.
+var hasBlueprintPgConfig =
+    !string.IsNullOrWhiteSpace(builder.Configuration["ConnectionStrings:Blueprint:Postgres"])
+    || !string.IsNullOrWhiteSpace(builder.Configuration["ConnectionStrings:Sorcha:Postgres"]);
+var blueprintDbConn = hasBlueprintPgConfig
+    ? builder.Configuration.GetSorchaPostgresConnectionString("Blueprint", "sorcha_blueprint")
+    : null;
 if (!string.IsNullOrEmpty(blueprintDbConn))
 {
     builder.Services.AddDbContextFactory<Sorcha.Blueprint.Service.Data.BlueprintDbContext>(options =>
@@ -277,8 +284,12 @@ builder.Services.AddSingleton<IExternalSchemaProvider>(sp =>
 // Add Schema Library services (034-schema-library)
 builder.Services.AddSingleton<Sorcha.Blueprint.Schemas.Repositories.ISchemaIndexRepository>(sp =>
 {
-    var mongoClient = new MongoDB.Driver.MongoClient(
-        builder.Configuration.GetConnectionString("mongodb") ?? "mongodb://localhost:27017");
+    // SorchaConnections cascade: ConnectionStrings:Blueprint:Mongo → ConnectionStrings:Sorcha:Mongo.
+    // Mongo connection strings carry credentials/host only; database is selected via GetDatabase.
+    var mongoConnStr = builder.Configuration["ConnectionStrings:Blueprint:Mongo"]
+                    ?? builder.Configuration["ConnectionStrings:Sorcha:Mongo"]
+                    ?? "mongodb://localhost:27017";
+    var mongoClient = new MongoDB.Driver.MongoClient(mongoConnStr);
     var database = mongoClient.GetDatabase("sorcha-blueprints");
     var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Sorcha.Blueprint.Schemas.Repositories.MongoSchemaIndexRepository>>();
     return new Sorcha.Blueprint.Schemas.Repositories.MongoSchemaIndexRepository(database, logger);
@@ -293,7 +304,9 @@ builder.Services.AddSingleton<Sorcha.Blueprint.Service.Services.Interfaces.ISect
 // Register MongoDB schema repository for persistent schema storage (063 AI Builder)
 builder.Services.Configure<Sorcha.Blueprint.Schemas.Repositories.MongoSchemaStorageConfiguration>(options =>
 {
-    options.ConnectionString = builder.Configuration.GetConnectionString("mongodb") ?? "mongodb://localhost:27017";
+    options.ConnectionString = builder.Configuration["ConnectionStrings:Blueprint:Mongo"]
+                            ?? builder.Configuration["ConnectionStrings:Sorcha:Mongo"]
+                            ?? "mongodb://localhost:27017";
     options.DatabaseName = "sorcha-blueprints";
     options.CollectionName = "schemas";
 });

--- a/src/Services/Sorcha.Peer.Service/Program.cs
+++ b/src/Services/Sorcha.Peer.Service/Program.cs
@@ -13,6 +13,7 @@ using Sorcha.Peer.Service.Discovery;
 using Sorcha.Peer.Service.Distribution;
 using Sorcha.Peer.Service.Endpoints;
 using Sorcha.Peer.Service.Extensions;
+using Sorcha.ServiceDefaults;
 using Sorcha.Peer.Service.Monitoring;
 using Sorcha.Peer.Service.Network;
 using Sorcha.Peer.Service.Observability;
@@ -79,8 +80,14 @@ builder.WebHost.ConfigureKestrel(options =>
 // Add Redis for advertisement persistence
 builder.AddRedisClient("redis");
 
-// Add PeerDbContext with PostgreSQL (falls back to InMemory if no connection string)
-var peerDbConnectionString = builder.Configuration.GetConnectionString("PeerDb");
+// Add PeerDbContext with PostgreSQL (falls back to InMemory if no connection string).
+// SorchaConnections cascade: ConnectionStrings:Peer:Postgres → ConnectionStrings:Sorcha:Postgres.
+var hasPeerPgConfig =
+    !string.IsNullOrWhiteSpace(builder.Configuration["ConnectionStrings:Peer:Postgres"])
+    || !string.IsNullOrWhiteSpace(builder.Configuration["ConnectionStrings:Sorcha:Postgres"]);
+var peerDbConnectionString = hasPeerPgConfig
+    ? builder.Configuration.GetSorchaPostgresConnectionString("Peer", "sorcha_peer")
+    : null;
 if (!string.IsNullOrEmpty(peerDbConnectionString))
 {
     builder.Services.AddDbContextFactory<Sorcha.Peer.Service.Data.PeerDbContext>(options =>

--- a/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
@@ -10,6 +10,7 @@ using Sorcha.Cryptography;
 using Sorcha.Cryptography.Core;
 using Sorcha.Cryptography.Extensions;
 using Sorcha.Cryptography.Interfaces;
+using Sorcha.ServiceDefaults;
 using Sorcha.Wallet.Core.Data;
 using Sorcha.Wallet.Core.Encryption.Configuration;
 using Sorcha.Wallet.Core.Encryption.Interfaces;
@@ -91,9 +92,16 @@ public static class WalletServiceExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        // Try Aspire connection string name first, then fallback to standard name
-        var connectionString = configuration.GetConnectionString("wallet-db")
-                            ?? configuration.GetConnectionString("WalletDatabase");
+        // SorchaConnections cascade: ConnectionStrings:Wallet:Postgres → ConnectionStrings:Sorcha:Postgres.
+        // Wallet appends Timeout / Command Timeout (30s each) — operational tuning that lives in code
+        // alongside the EnableRetryOnFailure config below, not in the platform-default connection string.
+        var hasResolverConfig =
+            !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Wallet:Postgres"])
+            || !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Sorcha:Postgres"]);
+
+        var connectionString = hasResolverConfig
+            ? configuration.GetSorchaPostgresConnectionString("Wallet", "sorcha_wallet") + ";Timeout=30;Command Timeout=30"
+            : null;
 
         if (!string.IsNullOrEmpty(connectionString))
         {
@@ -148,12 +156,14 @@ public static class WalletServiceExtensions
         this IHealthChecksBuilder builder,
         IConfiguration configuration)
     {
-        // Add PostgreSQL health check if connection string is configured
-        var connectionString = configuration.GetConnectionString("wallet-db")
-                            ?? configuration.GetConnectionString("WalletDatabase");
+        // SorchaConnections cascade — same lookup as AddWalletDatabase above.
+        var hasResolverConfig =
+            !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Wallet:Postgres"])
+            || !string.IsNullOrWhiteSpace(configuration["ConnectionStrings:Sorcha:Postgres"]);
 
-        if (!string.IsNullOrEmpty(connectionString))
+        if (hasResolverConfig)
         {
+            var connectionString = configuration.GetSorchaPostgresConnectionString("Wallet", "sorcha_wallet");
             builder.AddNpgSql(connectionString, name: "wallet-postgresql");
         }
 


### PR DESCRIPTION
## Summary

Sweeps the remaining three services that still used per-service legacy connection-string keys onto the cascade started in PR #405 (resolver) + PR #407 (Tenant pilot).

## Code changes

| Service | Sites migrated |
|---|---|
| **Wallet** | \`AddWalletDatabase\` + \`AddWalletServiceHealthChecks\` — cascade to \`Sorcha:Postgres\`. Wallet-specific \`Timeout=30 / Command Timeout=30\` now appended in code (operational tuning belongs alongside \`EnableRetryOnFailure\`, not in the platform default). |
| **Blueprint** | Three sites — \`AddDbContextFactory<BlueprintDbContext>\` for Postgres, plus two Mongo lookups (\`MongoSchemaIndexRepository\` registration + \`MongoSchemaStorageConfiguration\` options) — all cascade to \`Sorcha:Postgres\` / \`Sorcha:Mongo\`. |
| **Peer** | \`AddDbContextFactory<PeerDbContext>\` cascade to \`Sorcha:Postgres\`. Peer's vestigial \`MongoDB__ConnectionString\` config was unused in code and is removed; \`MongoDB__DatabaseName\` stays (it's a DB NAME used at \`GetDatabase\`-time, not a connection string). |

## Compose changes

- \`x-sorcha-connections\` anchor extended with **Aspire-named aliases** (\`ConnectionStrings__redis\`, \`ConnectionStrings__mongodb\`), deduped from the \`Sorcha:*\` values via YAML scalar anchors — so the actual values appear once. This lets services that still use \`builder.AddRedisClient(\"redis\")\` continue working without code change.
- Wallet, Blueprint, Peer environment blocks merge \`*sorcha-connections\`.
- **Removes 8 legacy env lines**: \`ConnectionStrings__{wallet-db, BlueprintDb, PeerDb, mongodb}\`, three per-service \`ConnectionStrings__Redis\`, plus Peer's unused \`MongoDB__ConnectionString\`.

## Test plan

- [x] All three changed projects build clean (0 errors)
- [x] \`docker compose config\` clean; resolved env shows only \`Sorcha:*\` cascade keys (no \`wallet-db\`/\`BlueprintDb\`/\`PeerDb\` legacy)
- [x] \`docker compose down -v\` + \`up -d\` — all 13 services healthy
- [x] All 4 cascade-aware Postgres DBs created their tables via EF migrations:
  - \`sorcha_tenant\` (28 tables)
  - \`sorcha_wallet\` (13 tables)
  - \`sorcha_blueprint\` (7 tables)
  - \`sorcha_peer\` (5 tables)
- [x] Blueprint's Mongo cascade verified: \`sorcha-blueprints.schemaIndex\` has 1,390 docs + all 6 expected indexes (\`idx_provider_uri_unique\`, \`idx_text_search\`, \`idx_sector_status\`, \`idx_provider\`, \`idx_last_fetched\`, \`idx_shortcode_unique\`)
- [x] \`/health\` returns 200 on gateway, tenant, register, validator

## Out of scope (follow-up)

**Register and Validator** read MongoDB via \`RegisterStorage__MongoDB__ConnectionString\` (a custom Options-bound schema, not \`ConnectionStrings\`). Migrating them needs a different shape — either changing the Options binding to read from the cascade, or extending the resolver to support typed Options. Deferred to a separate PR so this one stays focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)