### PR TITLE
docs(db-audit): mark + record remaining storage backlog items

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ x-sorcha-connections: &sorcha-connections
   ConnectionStrings__Sorcha__Postgres: Host=postgres;Username=sorcha;Password=sorcha_dev_password
   ConnectionStrings__Sorcha__Mongo: &sorcha-mongo mongodb://sorcha:sorcha_dev_password@mongodb:27017
   ConnectionStrings__Sorcha__Redis: &sorcha-redis redis:6379
+  # TODO(db-audit): drop these two Aspire-named aliases once every service that
+  # uses builder.AddRedisClient("redis") / GetConnectionString("mongodb") has
+  # been migrated to a cascade-aware registration that reads :Sorcha:Redis /
+  # :Sorcha:Mongo directly. Today they're needed for back-compat with the Aspire
+  # client extensions in Wallet/Blueprint/Peer/Register/Validator/Haip Program.cs.
   ConnectionStrings__mongodb: *sorcha-mongo
   ConnectionStrings__redis: *sorcha-redis
 

--- a/docs/reference/db-audit-backlog.md
+++ b/docs/reference/db-audit-backlog.md
@@ -5,7 +5,12 @@ Companion to the index quick-wins squashed into the InitialCreate migrations
 deferred because they require **code changes** (new background services,
 view definitions, refactors) rather than a migration tweak.
 
-Captured on 2026-04-25 against `master @ 0b00b2f1`.
+Captured on 2026-04-25 against `master @ 0b00b2f1`. Updated 2026-04-25
+after the storage-coherence track (PRs #405–#408) shipped.
+
+Code-locatable items carry a `// TODO(db-audit):` marker at the relevant
+site so a `grep "TODO(db-audit)"` from any storage / DB sweep surfaces
+them in priority order.
 
 ---
 
@@ -195,6 +200,64 @@ created on the write path). Remaining items:
   client looping `MongoClient.Create()` could exhaust file descriptors
   before hitting any visible cap. Tighten to a sane bound for the
   expected service count.
+
+---
+
+## Storage-coherence follow-ups (added 2026-04-25 after PRs #405–#408)
+
+These five items extend the storage-coherence track. The first four are
+code-locatable and carry inline `// TODO(db-audit):` markers. The fifth is
+diffuse and lives only here.
+
+1. **Sweep Register + Validator onto the SorchaConnections cascade** —
+   marker at `src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterStorageServiceExtensions.cs`.
+   Both services bind MongoDB via the typed `MongoRegisterStorageConfiguration`
+   Options class fed from the bespoke `RegisterStorage:MongoDB` config section,
+   not from `ConnectionStrings:Sorcha:Mongo`. Migration needs either a typed-
+   Options-aware extension to the cascade resolver, or refactoring the
+   IMongoClient registration to read directly from the cascade and letting
+   the Options class carry only database/collection names.
+
+2. **Standardise on `AddDbContextFactory<>` for Tenant + Wallet** — markers at
+   `Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs` (around
+   `AddDbContext<TenantDbContext>`) and `Sorcha.Wallet.Service/Extensions/
+   WalletServiceExtensions.cs` (around `AddDbContext<WalletDbContext>`).
+   Today these use scoped lifetime; Blueprint and Peer use the factory
+   pattern. Background services in Tenant + Wallet currently work around
+   the scoped lifetime via `IServiceScopeFactory` ceremony — the factory
+   removes that. Touches every consumer of those DbContexts.
+
+3. **Drop the Aspire-named compose aliases** (`ConnectionStrings__redis`,
+   `ConnectionStrings__mongodb`) — marker at the `x-sorcha-connections`
+   anchor in `docker-compose.yml`. Today they're the back-compat layer for
+   `builder.AddRedisClient("redis")` / `GetConnectionString("mongodb")`
+   call sites that haven't been migrated to cascade-aware registrations
+   yet. Once every Program.cs reads via the cascade resolver, the aliases
+   become dead config and can go.
+
+4. **Adopt `ICacheStore` opportunistically** — no single marker site since
+   the goal is consistent Redis access across services. Today four patterns
+   coexist (raw `IConnectionMultiplexer`, Aspire `AddRedis*`, `IDistributedCache`,
+   bespoke `Redis*Store` classes). Each time a service's Redis usage gets
+   touched for unrelated reasons, replace the bespoke pattern with
+   `ICacheStore` injection. Convergence comes from incremental adoption,
+   not a single sweep.
+
+5. **All Tenant pruning sweepers** (5 unindexed growth-prone tables:
+   `WalletLinkChallenges`, `InvitationNonces`, `OrgInvitations`,
+   `RegisterInvitationRecords`, `ParticipantAuditEntries`). Already
+   captured in detail in the **Tenant Service → Pruning gaps** section
+   above; remains the highest-effort and highest-value remaining item.
+
+### Note on `MongoRegisterRepository.EnsureIndexesCreatedAsync`
+
+The original audit flagged this as needing the bootstrap pattern fix
+that PR #404 applied to `MongoSchemaIndexRepository`. On closer inspection
+it already uses the correct double-checked-locking pattern with
+`SemaphoreSlim`. The only difference from `ValidatorRegistry` is that
+`MongoRegisterRepository` lets exceptions propagate from `CreateIndexesAsync`
+(retries on the next call) while `ValidatorRegistry` swallows + logs.
+That's a design choice, not a bug — no change needed.
 
 ---
 

--- a/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterStorageServiceExtensions.cs
+++ b/src/Core/Sorcha.Register.Storage.MongoDB/MongoRegisterStorageServiceExtensions.cs
@@ -27,6 +27,12 @@ public static class MongoRegisterStorageServiceExtensions
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
+        // TODO(db-audit): Register + Validator still bind MongoDB via this typed Options
+        // section instead of the SorchaConnections cascade adopted by Tenant/Wallet/Blueprint/
+        // Peer (PRs #405-#408). When this is next touched, either teach the cascade resolver
+        // to back typed Options, or have the IMongoClient registration below pull from
+        // configuration["ConnectionStrings:Sorcha:Mongo"] (with Register/Validator overrides)
+        // and let MongoRegisterStorageConfiguration carry only the database/collection names.
         services.Configure<MongoRegisterStorageConfiguration>(
             configuration.GetSection("RegisterStorage:MongoDB"));
 

--- a/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -110,6 +110,11 @@ public static class ServiceCollectionExtensions
             dataSourceBuilder.EnableDynamicJson();
             var dataSource = dataSourceBuilder.Build();
 
+            // TODO(db-audit): convert to AddDbContextFactory<TenantDbContext>. Scoped lifetime
+            // forces background services (AuditCleanupService, OrgWalletReconciliationService,
+            // CustomDomainVerificationService) to wrap each DB call in IServiceScopeFactory
+            // ceremony; the factory pattern (used by Blueprint + Peer) is safer for parallel
+            // and background work. Adopting it touches every consumer of TenantDbContext.
             services.AddDbContext<TenantDbContext>(options =>
             {
                 options.UseNpgsql(dataSource, npgsqlOptions =>

--- a/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
@@ -115,6 +115,11 @@ public static class WalletServiceExtensions
 
             // Configure PostgreSQL with EF Core using the registered data source
             // IMPORTANT: Do NOT pass connection string again - it will use the registered NpgsqlDataSource
+            // TODO(db-audit): convert to AddDbContextFactory<WalletDbContext>. Same rationale
+            // as TenantDbContext (see ServiceCollectionExtensions.cs). Wallet has background
+            // services (NotificationDigestWorker, OrgWalletReconciliationService consumers)
+            // that benefit from per-operation contexts. Adopting the factory touches every
+            // consumer of WalletDbContext.
             services.AddDbContext<WalletDbContext>((serviceProvider, options) =>
             {
                 // Use the registered NpgsqlDataSource with EnableDynamicJson configured


### PR DESCRIPTION
## Summary

Records the deferred items from the storage-coherence track (PRs #405–#408) so they resurface naturally during future sweeps in this area, not just from someone remembering to read the doc.

## What's marked up

Inline \`// TODO(db-audit):\` markers at four code-locatable sites — discoverable via \`grep -rn \"TODO(db-audit)\"\`:

| Site | Marker says |
|---|---|
| \`MongoRegisterStorageServiceExtensions.cs\` | Register/Validator still bind MongoDB via typed Options instead of cascade |
| \`Sorcha.Tenant.Service/.../ServiceCollectionExtensions.cs\` | Convert \`TenantDbContext\` to \`AddDbContextFactory\` |
| \`Sorcha.Wallet.Service/.../WalletServiceExtensions.cs\` | Convert \`WalletDbContext\` to \`AddDbContextFactory\` |
| \`docker-compose.yml\` x-sorcha-connections anchor | Drop Aspire-named aliases once services migrate off \`builder.AddRedisClient(\"redis\")\` |

## What's in the backlog doc

\`docs/reference/db-audit-backlog.md\` now also captures:

- The 5 remaining storage-track items in priority order, each pointing at its marker site (or noting why \`ICacheStore\` adoption is diffuse and lives only in the doc)
- The 5 unindexed Tenant tables that need pruning sweepers (already there, kept as the highest-effort remaining item)
- A correction: \`MongoRegisterRepository.EnsureIndexesCreatedAsync\` — flagged in the original audit — is actually already using the correct DCL+SemaphoreSlim pattern. No action needed there.

## Test plan

- [x] \`docker compose config --quiet\` clean
- [x] All three projects with marker additions build clean
- [x] \`grep -rn \"TODO(db-audit)\" --include=\"*.cs\" --include=\"*.yml\"\` finds all 4 markers

No behaviour change; comments + doc updates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)