### PR TITLE
feat(113/PR2): Wallet Service adopts storage registration log

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/Storage/AuditedStorageInterfaces.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/AuditedStorageInterfaces.cs
@@ -31,19 +31,24 @@ internal static class AuditedStorageInterfaces
     public static readonly IReadOnlySet<string> Names = new HashSet<string>(StringComparer.Ordinal)
     {
         // Wallet Service — user wallets, HD-derived keys, signing material.
-        "Sorcha.Wallet.Core.Repositories.IWalletRepository",
+        // FQN matches typeof(Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository).FullName.
+        "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository",
 
         // Register Service — register documents and transaction stream.
+        // Will be verified at adoption time (PR 3) — placeholder, refine if FQN differs.
         "Sorcha.Register.Storage.IRegisterRepository",
 
         // Blueprint Service — workflow instances and per-action state.
+        // Will be verified at adoption time (PR 4) — placeholder, refine if FQN differs.
         "Sorcha.Blueprint.Service.Storage.IInstanceStore",
         "Sorcha.Blueprint.Service.Storage.IActionStore",
 
         // Validator Service — verified-but-not-yet-sealed mempool.
+        // Will be verified at adoption time (PR 7/8) — placeholder, refine if FQN differs.
         "Sorcha.Validator.Service.Storage.IVerifiedTransactionQueue",
 
         // HAIP and other consumers — atomic distributed cache for replay-protection state.
+        // Will be verified at adoption time (PR 5/6) — placeholder, refine if FQN differs.
         "Sorcha.AtomicCache.IAtomicDistributedCache",
     };
 

--- a/src/Common/Sorcha.ServiceDefaults/Storage/AuditedStorageInterfaces.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/AuditedStorageInterfaces.cs
@@ -31,24 +31,23 @@ internal static class AuditedStorageInterfaces
     public static readonly IReadOnlySet<string> Names = new HashSet<string>(StringComparer.Ordinal)
     {
         // Wallet Service — user wallets, HD-derived keys, signing material.
-        // FQN matches typeof(Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository).FullName.
+        // Verified: matches typeof(Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository).FullName.
         "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository",
 
-        // Register Service — register documents and transaction stream.
-        // Will be verified at adoption time (PR 3) — placeholder, refine if FQN differs.
+        // TODO(audit-fqn): Verify against typeof(IRegisterRepository).FullName at adoption time.
+        // Wrong FQN here = silent fail-fast bypass for this interface.
         "Sorcha.Register.Storage.IRegisterRepository",
 
-        // Blueprint Service — workflow instances and per-action state.
-        // Will be verified at adoption time (PR 4) — placeholder, refine if FQN differs.
+        // TODO(audit-fqn): Verify against typeof(IInstanceStore).FullName at adoption time.
         "Sorcha.Blueprint.Service.Storage.IInstanceStore",
+
+        // TODO(audit-fqn): Verify against typeof(IActionStore).FullName at adoption time.
         "Sorcha.Blueprint.Service.Storage.IActionStore",
 
-        // Validator Service — verified-but-not-yet-sealed mempool.
-        // Will be verified at adoption time (PR 7/8) — placeholder, refine if FQN differs.
+        // TODO(audit-fqn): Verify against typeof(IVerifiedTransactionQueue).FullName at adoption time.
         "Sorcha.Validator.Service.Storage.IVerifiedTransactionQueue",
 
-        // HAIP and other consumers — atomic distributed cache for replay-protection state.
-        // Will be verified at adoption time (PR 5/6) — placeholder, refine if FQN differs.
+        // TODO(audit-fqn): Verify against typeof(IAtomicDistributedCache).FullName at adoption time.
         "Sorcha.AtomicCache.IAtomicDistributedCache",
     };
 

--- a/src/Common/Sorcha.ServiceDefaults/Storage/StorageRegistrationEnforcement.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/StorageRegistrationEnforcement.cs
@@ -91,6 +91,27 @@ public static class StorageRegistrationEnforcement
         IHostEnvironment environment,
         ILogger logger)
     {
+        // Emit one log line per registration first so operators see exactly which
+        // interface landed on which implementation, then a summary banner.
+        // Persistent registrations log at Information; in-memory registrations log at
+        // Warning with the greppable [STORAGE-FALLBACK] banner that tooling / log
+        // searches key off.
+        foreach (var record in snapshot)
+        {
+            if (record.IsInMemory)
+            {
+                logger.LogWarning(
+                    "[STORAGE-FALLBACK] {Interface} → {Implementation} — DATA WILL NOT SURVIVE RESTART. Reason: {Reason}",
+                    record.InterfaceName, record.ImplementationName, record.Reason);
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Storage registration: {Interface} → {Implementation} ({Backend})",
+                    record.InterfaceName, record.ImplementationName, record.Backend);
+            }
+        }
+
         var persistent = snapshot.Count(r => !r.IsInMemory);
         var inMemory = snapshot.Count(r => r.IsInMemory);
         var auditedInMemory = snapshot.Count(r => r.IsAudited && r.IsInMemory);

--- a/src/Common/Sorcha.ServiceDefaults/Storage/StorageRegistrationLog.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/StorageRegistrationLog.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using Microsoft.Extensions.Logging;
-
 namespace Sorcha.ServiceDefaults.Storage;
 
 /// <summary>
@@ -10,22 +8,22 @@ namespace Sorcha.ServiceDefaults.Storage;
 /// Thread-safe singleton — accumulates registration records over the lifetime
 /// of the service and exposes an immutable snapshot to callers.
 /// </summary>
+/// <remarks>
+/// Registration calls are pure data capture — they do not log directly.
+/// Logging is deferred to <see cref="StorageEnforcementHostedService"/>
+/// which iterates the snapshot at host startup using the proper DI logger
+/// and emits one Information line per persistent registration plus one
+/// Warning line (with the <c>[STORAGE-FALLBACK]</c> banner) per in-memory
+/// registration. This decoupling lets services materialise the log at
+/// <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/>-extension
+/// time (before the DI container is built and before any logger is
+/// available) without sacrificing log fidelity.
+/// </remarks>
 public sealed class StorageRegistrationLog : IStorageRegistrationLog
 {
-    private readonly ILogger<StorageRegistrationLog> _logger;
     private readonly object _lock = new();
     private readonly List<StorageRegistrationRecord> _records = new();
     private readonly HashSet<string> _seenInterfaces = new(StringComparer.Ordinal);
-
-    /// <summary>
-    /// Creates a new registration log. Typically resolved from DI; only
-    /// constructed manually in tests.
-    /// </summary>
-    public StorageRegistrationLog(ILogger<StorageRegistrationLog> logger)
-    {
-        ArgumentNullException.ThrowIfNull(logger);
-        _logger = logger;
-    }
 
     /// <inheritdoc />
     public void RegisterPersistent(string interfaceName, string implementationName, string backend)
@@ -34,7 +32,7 @@ public sealed class StorageRegistrationLog : IStorageRegistrationLog
         ArgumentException.ThrowIfNullOrWhiteSpace(implementationName);
         ArgumentException.ThrowIfNullOrWhiteSpace(backend);
 
-        var record = Add(new StorageRegistrationRecord(
+        Add(new StorageRegistrationRecord(
             InterfaceName: interfaceName,
             ImplementationName: implementationName,
             Backend: backend,
@@ -42,10 +40,6 @@ public sealed class StorageRegistrationLog : IStorageRegistrationLog
             RegisteredAt: DateTimeOffset.UtcNow,
             IsAudited: AuditedStorageInterfaces.Names.Contains(interfaceName),
             IsInMemory: false));
-
-        _logger.LogInformation(
-            "Storage registration: {Interface} → {Implementation} ({Backend})",
-            record.InterfaceName, record.ImplementationName, record.Backend);
     }
 
     /// <inheritdoc />
@@ -55,7 +49,7 @@ public sealed class StorageRegistrationLog : IStorageRegistrationLog
         ArgumentException.ThrowIfNullOrWhiteSpace(implementationName);
         ArgumentException.ThrowIfNullOrWhiteSpace(reason);
 
-        var record = Add(new StorageRegistrationRecord(
+        Add(new StorageRegistrationRecord(
             InterfaceName: interfaceName,
             ImplementationName: implementationName,
             Backend: AuditedStorageInterfaces.InMemoryBackend,
@@ -63,11 +57,6 @@ public sealed class StorageRegistrationLog : IStorageRegistrationLog
             RegisteredAt: DateTimeOffset.UtcNow,
             IsAudited: AuditedStorageInterfaces.Names.Contains(interfaceName),
             IsInMemory: true));
-
-        // Greppable banner — tooling and operators search for [STORAGE-FALLBACK] in logs.
-        _logger.LogWarning(
-            "[STORAGE-FALLBACK] {Interface} → {Implementation} — DATA WILL NOT SURVIVE RESTART. Reason: {Reason}",
-            record.InterfaceName, record.ImplementationName, record.Reason);
     }
 
     /// <inheritdoc />
@@ -79,7 +68,7 @@ public sealed class StorageRegistrationLog : IStorageRegistrationLog
         }
     }
 
-    private StorageRegistrationRecord Add(StorageRegistrationRecord record)
+    private void Add(StorageRegistrationRecord record)
     {
         lock (_lock)
         {
@@ -93,7 +82,5 @@ public sealed class StorageRegistrationLog : IStorageRegistrationLog
 
             _records.Add(record);
         }
-
-        return record;
     }
 }

--- a/src/Common/Sorcha.ServiceDefaults/Storage/StorageServiceCollectionExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/StorageServiceCollectionExtensions.cs
@@ -20,12 +20,21 @@ public static class StorageServiceCollectionExtensions
     /// <see cref="StorageEnforcementHostedService"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Idempotent — safe to call multiple times. The first call wires the
     /// log, metrics, health check, and enforcement hosted service; subsequent
-    /// calls are no-ops. Services should resolve
-    /// <see cref="IStorageRegistrationLog"/> via DI in their storage-wiring
-    /// helpers and call <c>RegisterPersistent</c> / <c>RegisterInMemory</c>
-    /// at the matching <c>AddScoped</c> / <c>AddSingleton</c> sites.
+    /// calls are no-ops.
+    /// </para>
+    /// <para>
+    /// Services call <see cref="GetStorageRegistrationLog"/> from inside
+    /// their storage-wiring extension methods (e.g.,
+    /// <c>AddWalletDatabase</c>) to obtain the log instance and call
+    /// <c>RegisterPersistent</c> / <c>RegisterInMemory</c> at the matching
+    /// <c>AddScoped</c> / <c>AddSingleton</c> site. The log is registered as
+    /// an instance (eagerly constructed) so it is resolvable before the DI
+    /// container is built — necessary because storage wiring runs at
+    /// <see cref="IServiceCollection"/>-extension time.
+    /// </para>
     /// </remarks>
     public static IServiceCollection AddStorageRegistration(this IServiceCollection services)
     {
@@ -39,7 +48,9 @@ public static class StorageServiceCollectionExtensions
             return services;
         }
 
-        services.AddSingleton<IStorageRegistrationLog, StorageRegistrationLog>();
+        // Eager-construct so service-side AddXxxDatabase extensions can call
+        // GetStorageRegistrationLog at IServiceCollection-extension time.
+        services.AddSingleton<IStorageRegistrationLog>(new StorageRegistrationLog());
         services.AddSingleton<StorageRegistrationMetrics>();
 
         // Force eager construction of the metrics class so its observable instruments are registered
@@ -59,6 +70,40 @@ public static class StorageServiceCollectionExtensions
         services.AddHostedService<StorageEnforcementHostedService>();
 
         return services;
+    }
+
+    /// <summary>
+    /// Returns the <see cref="IStorageRegistrationLog"/> instance registered
+    /// by <see cref="AddStorageRegistration"/>. Service-side storage wiring
+    /// (e.g., <c>AddWalletDatabase</c>) calls this from inside an
+    /// <see cref="IServiceCollection"/> extension method to register
+    /// persistent or in-memory entries before the DI container is built.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <see cref="AddStorageRegistration"/> has not been called
+    /// (typically via <c>builder.AddServiceDefaults()</c>) before this
+    /// method is invoked. Order: <c>AddServiceDefaults</c> first, then any
+    /// <c>AddXxxDatabase</c> extensions that consume the log.
+    /// </exception>
+    public static IStorageRegistrationLog GetStorageRegistrationLog(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IStorageRegistrationLog))
+            ?? throw new InvalidOperationException(
+                $"{nameof(IStorageRegistrationLog)} is not registered. " +
+                $"Call {nameof(AddStorageRegistration)} (typically via builder.AddServiceDefaults()) " +
+                $"before {nameof(GetStorageRegistrationLog)}.");
+
+        if (descriptor.ImplementationInstance is IStorageRegistrationLog instance)
+        {
+            return instance;
+        }
+
+        throw new InvalidOperationException(
+            $"{nameof(IStorageRegistrationLog)} is registered without an instance. " +
+            $"This indicates {nameof(AddStorageRegistration)} was bypassed by a custom " +
+            "registration that does not match the eager-construction pattern.");
     }
 
     /// <summary>

--- a/src/Common/Sorcha.ServiceDefaults/Storage/StorageServiceCollectionExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/StorageServiceCollectionExtensions.cs
@@ -79,22 +79,21 @@ public static class StorageServiceCollectionExtensions
     /// <see cref="IServiceCollection"/> extension method to register
     /// persistent or in-memory entries before the DI container is built.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <see cref="AddStorageRegistration"/> has not been called
-    /// (typically via <c>builder.AddServiceDefaults()</c>) before this
-    /// method is invoked. Order: <c>AddServiceDefaults</c> first, then any
-    /// <c>AddXxxDatabase</c> extensions that consume the log.
-    /// </exception>
+    /// <remarks>
+    /// Defensive: if <see cref="AddStorageRegistration"/> has not yet been
+    /// called on the service collection, this method calls it first. That
+    /// keeps service-extension methods independently unit-testable —
+    /// callers do not have to remember the prerequisite. In production,
+    /// <c>builder.AddServiceDefaults()</c> always wires the log first, so
+    /// the defensive call is a no-op via the idempotency sentinel.
+    /// </remarks>
     public static IStorageRegistrationLog GetStorageRegistrationLog(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IStorageRegistrationLog))
-            ?? throw new InvalidOperationException(
-                $"{nameof(IStorageRegistrationLog)} is not registered. " +
-                $"Call {nameof(AddStorageRegistration)} (typically via builder.AddServiceDefaults()) " +
-                $"before {nameof(GetStorageRegistrationLog)}.");
+        services.AddStorageRegistration();
 
+        var descriptor = services.First(d => d.ServiceType == typeof(IStorageRegistrationLog));
         if (descriptor.ImplementationInstance is IStorageRegistrationLog instance)
         {
             return instance;

--- a/src/Common/Sorcha.ServiceDefaults/Storage/StorageServiceCollectionExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/StorageServiceCollectionExtensions.cs
@@ -93,7 +93,11 @@ public static class StorageServiceCollectionExtensions
 
         services.AddStorageRegistration();
 
-        var descriptor = services.First(d => d.ServiceType == typeof(IStorageRegistrationLog));
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IStorageRegistrationLog))
+            ?? throw new InvalidOperationException(
+                $"{nameof(AddStorageRegistration)} was called but no {nameof(IStorageRegistrationLog)} " +
+                $"descriptor was found in the service collection. This is a bug — please report.");
+
         if (descriptor.ImplementationInstance is IStorageRegistrationLog instance)
         {
             return instance;
@@ -102,7 +106,7 @@ public static class StorageServiceCollectionExtensions
         throw new InvalidOperationException(
             $"{nameof(IStorageRegistrationLog)} is registered without an instance. " +
             $"This indicates {nameof(AddStorageRegistration)} was bypassed by a custom " +
-            "registration that does not match the eager-construction pattern.");
+            "factory or type-based registration that does not match the eager-construction pattern.");
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
@@ -104,9 +104,9 @@ public static class WalletServiceExtensions
             ? configuration.GetSorchaPostgresConnectionString("Wallet", "sorcha_wallet") + ";Timeout=30;Command Timeout=30"
             : null;
 
-        // Feature 113 — record the storage choice in the registration log so operators see what
-        // backend is active (boot log + health check + OTel metrics) and Production/Staging
-        // fail-fast when this audited interface falls through to in-memory.
+        // Record the storage choice so operators see the active backend in boot logs, the
+        // storage-providers health check, and OTel metrics, and so Production/Staging fail-fast
+        // when this audited interface falls through to in-memory.
         var storageLog = services.GetStorageRegistrationLog();
         var interfaceName = typeof(IWalletRepository).FullName!;
 

--- a/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
@@ -108,7 +108,7 @@ public static class WalletServiceExtensions
         // backend is active (boot log + health check + OTel metrics) and Production/Staging
         // fail-fast when this audited interface falls through to in-memory.
         var storageLog = services.GetStorageRegistrationLog();
-        const string interfaceName = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+        var interfaceName = typeof(IWalletRepository).FullName!;
 
         if (!string.IsNullOrEmpty(connectionString))
         {

--- a/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
@@ -11,6 +11,7 @@ using Sorcha.Cryptography.Core;
 using Sorcha.Cryptography.Extensions;
 using Sorcha.Cryptography.Interfaces;
 using Sorcha.ServiceDefaults;
+using Sorcha.ServiceDefaults.Storage;
 using Sorcha.Wallet.Core.Data;
 using Sorcha.Wallet.Core.Encryption.Configuration;
 using Sorcha.Wallet.Core.Encryption.Interfaces;
@@ -103,6 +104,12 @@ public static class WalletServiceExtensions
             ? configuration.GetSorchaPostgresConnectionString("Wallet", "sorcha_wallet") + ";Timeout=30;Command Timeout=30"
             : null;
 
+        // Feature 113 — record the storage choice in the registration log so operators see what
+        // backend is active (boot log + health check + OTel metrics) and Production/Staging
+        // fail-fast when this audited interface falls through to in-memory.
+        var storageLog = services.GetStorageRegistrationLog();
+        const string interfaceName = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+
         if (!string.IsNullOrEmpty(connectionString))
         {
             // Configure NpgsqlDataSource with dynamic JSON support (required for Dictionary<string, string> serialization)
@@ -141,11 +148,19 @@ public static class WalletServiceExtensions
 
             // Use EF Core repository for persistent storage
             services.AddScoped<IWalletRepository, EfCoreWalletRepository>();
+            storageLog.RegisterPersistent(
+                interfaceName,
+                typeof(EfCoreWalletRepository).FullName!,
+                "postgres");
         }
         else
         {
             // Use in-memory repository for development/testing
             services.AddSingleton<IWalletRepository, InMemoryWalletRepository>();
+            storageLog.RegisterInMemory(
+                interfaceName,
+                typeof(InMemoryWalletRepository).FullName!,
+                "no Postgres connection string in ConnectionStrings:Wallet:Postgres or ConnectionStrings:Sorcha:Postgres");
         }
 
         return services;

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageEnforcementHostedServiceTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageEnforcementHostedServiceTests.cs
@@ -18,7 +18,7 @@ public class StorageEnforcementHostedServiceTests
     private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
 
     private static StorageRegistrationLog NewLog() =>
-        new(NullLogger<StorageRegistrationLog>.Instance);
+        new();
 
     private static IHostEnvironment Env(string envName, string app = "Sorcha.Test.Service") =>
         new FakeHostEnvironment { EnvironmentName = envName, ApplicationName = app };

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageEnforcementHostedServiceTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageEnforcementHostedServiceTests.cs
@@ -15,7 +15,7 @@ namespace Sorcha.ServiceDefaults.Tests.Storage;
 /// </summary>
 public class StorageEnforcementHostedServiceTests
 {
-    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository";
 
     private static StorageRegistrationLog NewLog() =>
         new();

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageProvidersHealthCheckTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageProvidersHealthCheckTests.cs
@@ -16,7 +16,7 @@ public class StorageProvidersHealthCheckTests
     private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
 
     private static StorageRegistrationLog NewLog() =>
-        new(NullLogger<StorageRegistrationLog>.Instance);
+        new();
 
     [Fact]
     public async Task Healthy_WhenAllAuditedPersistent()

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageProvidersHealthCheckTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageProvidersHealthCheckTests.cs
@@ -13,7 +13,7 @@ namespace Sorcha.ServiceDefaults.Tests.Storage;
 /// </summary>
 public class StorageProvidersHealthCheckTests
 {
-    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository";
 
     private static StorageRegistrationLog NewLog() =>
         new();
@@ -82,7 +82,7 @@ public class StorageProvidersHealthCheckTests
     public async Task Degraded_DescriptionEnumeratesAllOffenders()
     {
         var log = NewLog();
-        log.RegisterInMemory("Sorcha.Wallet.Core.Repositories.IWalletRepository", "InMemoryWalletRepository", "no postgres");
+        log.RegisterInMemory("Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository", "InMemoryWalletRepository", "no postgres");
         log.RegisterInMemory("Sorcha.Blueprint.Service.Storage.IInstanceStore", "InMemoryInstanceStore", "no postgres");
 
         var check = new StorageProvidersHealthCheck(log);

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationEnforcementTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationEnforcementTests.cs
@@ -18,7 +18,7 @@ public class StorageRegistrationEnforcementTests
     private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
 
     private static StorageRegistrationLog NewLog() =>
-        new(NullLogger<StorageRegistrationLog>.Instance);
+        new();
 
     private static IHostEnvironment Env(string envName, string app = "Sorcha.Test.Service") =>
         new FakeHostEnvironment { EnvironmentName = envName, ApplicationName = app };

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationEnforcementTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationEnforcementTests.cs
@@ -15,7 +15,7 @@ namespace Sorcha.ServiceDefaults.Tests.Storage;
 /// </summary>
 public class StorageRegistrationEnforcementTests
 {
-    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository";
 
     private static StorageRegistrationLog NewLog() =>
         new();
@@ -117,14 +117,14 @@ public class StorageRegistrationEnforcementTests
     public void ThrownMessage_ListsAllOffendingInterfaces()
     {
         var log = NewLog();
-        log.RegisterInMemory("Sorcha.Wallet.Core.Repositories.IWalletRepository", "InMemoryWalletRepository", "no postgres");
+        log.RegisterInMemory("Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository", "InMemoryWalletRepository", "no postgres");
         log.RegisterInMemory("Sorcha.Blueprint.Service.Storage.IInstanceStore", "InMemoryInstanceStore", "no postgres");
 
         var act = () => StorageRegistrationEnforcement.EnforcePersistentStorageInProduction(
             log, Env(Environments.Production), allowInMemoryOverride: false, NullLogger.Instance);
 
         var ex = act.Should().Throw<InvalidOperationException>().Which;
-        ex.Message.Should().Contain("Sorcha.Wallet.Core.Repositories.IWalletRepository");
+        ex.Message.Should().Contain("Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository");
         ex.Message.Should().Contain("Sorcha.Blueprint.Service.Storage.IInstanceStore");
         ex.Message.Should().Contain("InMemoryWalletRepository");
         ex.Message.Should().Contain("InMemoryInstanceStore");

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationLogTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationLogTests.cs
@@ -21,13 +21,13 @@ public class StorageRegistrationLogTests
         var log = NewLog();
 
         log.RegisterPersistent(
-            "Sorcha.Wallet.Core.Repositories.IWalletRepository",
+            "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository",
             "Sorcha.Wallet.Core.Repositories.EfCoreWalletRepository",
             "postgres");
 
         var snapshot = log.Snapshot();
         snapshot.Should().HaveCount(1);
-        snapshot[0].InterfaceName.Should().Be("Sorcha.Wallet.Core.Repositories.IWalletRepository");
+        snapshot[0].InterfaceName.Should().Be("Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository");
         snapshot[0].ImplementationName.Should().Be("Sorcha.Wallet.Core.Repositories.EfCoreWalletRepository");
         snapshot[0].Backend.Should().Be("postgres");
         snapshot[0].IsInMemory.Should().BeFalse();
@@ -40,7 +40,7 @@ public class StorageRegistrationLogTests
         var log = NewLog();
 
         log.RegisterInMemory(
-            "Sorcha.Wallet.Core.Repositories.IWalletRepository",
+            "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository",
             "Sorcha.Wallet.Core.Repositories.InMemoryWalletRepository",
             "no Postgres connection string configured");
 

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationLogTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationLogTests.cs
@@ -13,7 +13,7 @@ namespace Sorcha.ServiceDefaults.Tests.Storage;
 public class StorageRegistrationLogTests
 {
     private static StorageRegistrationLog NewLog() =>
-        new(NullLogger<StorageRegistrationLog>.Instance);
+        new();
 
     [Fact]
     public void RegisterPersistent_WithAuditedInterface_RecordsAuditedNotInMemory()

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationMetricsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationMetricsTests.cs
@@ -41,7 +41,7 @@ public sealed class StorageRegistrationMetricsTests : IDisposable
             .BuildServiceProvider();
 
         _meterFactory = _sp.GetRequiredService<IMeterFactory>();
-        _log = new StorageRegistrationLog(NullLogger<StorageRegistrationLog>.Instance);
+        _log = new StorageRegistrationLog();
         _metrics = new StorageRegistrationMetrics(
             _meterFactory,
             _log,

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationMetricsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageRegistrationMetricsTests.cs
@@ -17,7 +17,7 @@ namespace Sorcha.ServiceDefaults.Tests.Storage;
 /// </summary>
 public sealed class StorageRegistrationMetricsTests : IDisposable
 {
-    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository";
     private const string CacheInterface = "Sorcha.Blueprint.Service.Storage.IBlueprintStore";
 
     /// <summary>
@@ -154,7 +154,7 @@ public sealed class StorageRegistrationMetricsTests : IDisposable
     public void Observations_ReflectFullRegistrationLog()
     {
         _log.RegisterPersistent(
-            "Sorcha.Wallet.Core.Repositories.IWalletRepository",
+            "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository",
             "EfCoreWalletRepository",
             "postgres");
         _log.RegisterInMemory(

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageServiceCollectionExtensionsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageServiceCollectionExtensionsTests.cs
@@ -172,14 +172,17 @@ public class StorageServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void GetStorageRegistrationLog_BeforeAddStorageRegistration_Throws()
+    public void GetStorageRegistrationLog_BeforeAddStorageRegistration_AutoRegistersAndReturns()
     {
+        // Defensive: GetStorageRegistrationLog calls AddStorageRegistration if it hasn't run yet.
+        // This keeps service-extension methods unit-testable in isolation. AddStorageRegistration
+        // is itself idempotent so subsequent AddServiceDefaults() in the same test doesn't double-wire.
         var services = new ServiceCollection();
 
-        var act = () => services.GetStorageRegistrationLog();
+        var log = services.GetStorageRegistrationLog();
 
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*not registered*");
+        log.Should().NotBeNull();
+        services.Where(d => d.ServiceType == typeof(IStorageRegistrationLog)).Should().HaveCount(1);
     }
 
     [Fact]

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageServiceCollectionExtensionsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageServiceCollectionExtensionsTests.cs
@@ -162,13 +162,13 @@ public class StorageServiceCollectionExtensionsTests
         services.AddStorageRegistration();
 
         var log = services.GetStorageRegistrationLog();
-        log.RegisterPersistent("Sorcha.Wallet.Core.Repositories.IWalletRepository", "EfCoreWalletRepository", "postgres");
+        log.RegisterPersistent("Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository", "EfCoreWalletRepository", "postgres");
 
         using var sp = services.BuildServiceProvider();
         var resolved = sp.GetRequiredService<IStorageRegistrationLog>();
 
         resolved.Snapshot().Should().HaveCount(1);
-        resolved.Snapshot()[0].InterfaceName.Should().Be("Sorcha.Wallet.Core.Repositories.IWalletRepository");
+        resolved.Snapshot()[0].InterfaceName.Should().Be("Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository");
     }
 
     [Fact]

--- a/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageServiceCollectionExtensionsTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Storage/StorageServiceCollectionExtensionsTests.cs
@@ -122,4 +122,71 @@ public class StorageServiceCollectionExtensionsTests
         var act = () => services!.AddStorageRegistration();
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void GetStorageRegistrationLog_AfterAddStorageRegistration_ReturnsInstance()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStorageRegistration();
+
+        var log = services.GetStorageRegistrationLog();
+
+        log.Should().NotBeNull();
+        log.Should().BeOfType<StorageRegistrationLog>();
+    }
+
+    [Fact]
+    public void GetStorageRegistrationLog_ReturnsSameInstanceFromDIContainer()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStorageRegistration();
+
+        var fromExtension = services.GetStorageRegistrationLog();
+
+        using var sp = services.BuildServiceProvider();
+        var fromContainer = sp.GetRequiredService<IStorageRegistrationLog>();
+
+        fromContainer.Should().BeSameAs(fromExtension);
+    }
+
+    [Fact]
+    public void GetStorageRegistrationLog_RegistrationsArePreservedThroughBuild()
+    {
+        // Service-side AddXxxDatabase calls register entries on the log instance
+        // BEFORE the container is built. Those entries must survive into the resolved
+        // singleton so EnforcementHostedService and the metrics callbacks see them.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStorageRegistration();
+
+        var log = services.GetStorageRegistrationLog();
+        log.RegisterPersistent("Sorcha.Wallet.Core.Repositories.IWalletRepository", "EfCoreWalletRepository", "postgres");
+
+        using var sp = services.BuildServiceProvider();
+        var resolved = sp.GetRequiredService<IStorageRegistrationLog>();
+
+        resolved.Snapshot().Should().HaveCount(1);
+        resolved.Snapshot()[0].InterfaceName.Should().Be("Sorcha.Wallet.Core.Repositories.IWalletRepository");
+    }
+
+    [Fact]
+    public void GetStorageRegistrationLog_BeforeAddStorageRegistration_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.GetStorageRegistrationLog();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*not registered*");
+    }
+
+    [Fact]
+    public void GetStorageRegistrationLog_NullServices_Throws()
+    {
+        IServiceCollection? services = null;
+        var act = () => services!.GetStorageRegistrationLog();
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/tests/Sorcha.Wallet.Service.Tests/Extensions/AddWalletDatabaseStorageRegistrationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Extensions/AddWalletDatabaseStorageRegistrationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sorcha.ServiceDefaults.Storage;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Service.Extensions;
 
 namespace Sorcha.Wallet.Service.Tests.Extensions;
@@ -21,7 +22,7 @@ namespace Sorcha.Wallet.Service.Tests.Extensions;
 /// </summary>
 public class AddWalletDatabaseStorageRegistrationTests
 {
-    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+    private static readonly string AuditedInterface = typeof(IWalletRepository).FullName!;
 
     private static IConfiguration Config(Dictionary<string, string?>? values = null) =>
         new ConfigurationBuilder()

--- a/tests/Sorcha.Wallet.Service.Tests/Extensions/AddWalletDatabaseStorageRegistrationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Extensions/AddWalletDatabaseStorageRegistrationTests.cs
@@ -111,6 +111,25 @@ public class AddWalletDatabaseStorageRegistrationTests
     }
 
     [Fact]
+    public async Task Staging_NoConnectionString_StorageEnforcementThrows()
+    {
+        // Staging is treated identically to Production for the audited-interface
+        // fail-fast. Mirrors the Production test to pin that contract.
+        var services = NewServicesWithStorageRegistration();
+        services.AddWalletDatabase(Config());
+
+        var hostedService = new StorageEnforcementHostedService(
+            services.GetStorageRegistrationLog(),
+            FakeEnv(Environments.Staging),
+            Config(),
+            NullLogger<StorageEnforcementHostedService>.Instance);
+
+        var assertion = await hostedService.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Message.Should().Contain(AuditedInterface);
+    }
+
+    [Fact]
     public async Task Production_WithBypassFlag_DoesNotThrow()
     {
         var services = NewServicesWithStorageRegistration();

--- a/tests/Sorcha.Wallet.Service.Tests/Extensions/AddWalletDatabaseStorageRegistrationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Extensions/AddWalletDatabaseStorageRegistrationTests.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.ServiceDefaults.Storage;
+using Sorcha.Wallet.Service.Extensions;
+
+namespace Sorcha.Wallet.Service.Tests.Extensions;
+
+/// <summary>
+/// Tests that <see cref="WalletServiceExtensions.AddWalletDatabase"/> registers
+/// itself with the Sorcha.ServiceDefaults storage registration log so that:
+/// (a) operators see <c>IWalletRepository → ...</c> in startup logs, the
+///     <c>storage-providers</c> health check, and the OTel metrics; and
+/// (b) Production / Staging deployments fail-fast when no Postgres
+///     connection string resolves.
+/// </summary>
+public class AddWalletDatabaseStorageRegistrationTests
+{
+    private const string AuditedInterface = "Sorcha.Wallet.Core.Repositories.IWalletRepository";
+
+    private static IConfiguration Config(Dictionary<string, string?>? values = null) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values ?? new Dictionary<string, string?>())
+            .Build();
+
+    private static IServiceCollection NewServicesWithStorageRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStorageRegistration();
+        return services;
+    }
+
+    [Fact]
+    public void NoConnectionString_RegistersInMemory()
+    {
+        var services = NewServicesWithStorageRegistration();
+
+        services.AddWalletDatabase(Config());
+
+        var snapshot = services.GetStorageRegistrationLog().Snapshot();
+        snapshot.Should().HaveCount(1);
+        snapshot[0].InterfaceName.Should().Be(AuditedInterface);
+        snapshot[0].IsInMemory.Should().BeTrue();
+        snapshot[0].IsAudited.Should().BeTrue();
+        snapshot[0].ImplementationName.Should().EndWith("InMemoryWalletRepository");
+        snapshot[0].Reason.Should().Contain("ConnectionStrings:Wallet:Postgres");
+        snapshot[0].Reason.Should().Contain("ConnectionStrings:Sorcha:Postgres");
+    }
+
+    [Fact]
+    public void WalletConnectionString_RegistersPersistent()
+    {
+        var services = NewServicesWithStorageRegistration();
+        var config = Config(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:Wallet:Postgres"] = "Host=wallet-pg;Username=wallet"
+        });
+
+        services.AddWalletDatabase(config);
+
+        var snapshot = services.GetStorageRegistrationLog().Snapshot();
+        snapshot.Should().HaveCount(1);
+        snapshot[0].IsInMemory.Should().BeFalse();
+        snapshot[0].IsAudited.Should().BeTrue();
+        snapshot[0].Backend.Should().Be("postgres");
+        snapshot[0].ImplementationName.Should().EndWith("EfCoreWalletRepository");
+    }
+
+    [Fact]
+    public void SorchaConnectionString_RegistersPersistent()
+    {
+        var services = NewServicesWithStorageRegistration();
+        var config = Config(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:Sorcha:Postgres"] = "Host=default-pg;Username=sorcha"
+        });
+
+        services.AddWalletDatabase(config);
+
+        var snapshot = services.GetStorageRegistrationLog().Snapshot();
+        snapshot.Should().HaveCount(1);
+        snapshot[0].IsInMemory.Should().BeFalse();
+        snapshot[0].Backend.Should().Be("postgres");
+    }
+
+    [Fact]
+    public async Task Production_NoConnectionString_StorageEnforcementThrows()
+    {
+        // The full Wallet startup is too expensive to spin up here; this verifies the
+        // contract: AddWalletDatabase records IWalletRepository as in-memory, and the
+        // standard StorageEnforcementHostedService refuses to start in Production.
+        var services = NewServicesWithStorageRegistration();
+        services.AddWalletDatabase(Config());
+
+        var hostedService = new StorageEnforcementHostedService(
+            services.GetStorageRegistrationLog(),
+            FakeEnv(Environments.Production),
+            Config(),
+            NullLogger<StorageEnforcementHostedService>.Instance);
+
+        var assertion = await hostedService.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Message.Should().Contain(AuditedInterface);
+    }
+
+    [Fact]
+    public async Task Production_WithBypassFlag_DoesNotThrow()
+    {
+        var services = NewServicesWithStorageRegistration();
+        services.AddWalletDatabase(Config());
+
+        var hostedService = new StorageEnforcementHostedService(
+            services.GetStorageRegistrationLog(),
+            FakeEnv(Environments.Production),
+            Config(new Dictionary<string, string?>
+            {
+                [StorageRegistrationEnforcement.AllowInMemoryConfigKey] = "true"
+            }),
+            NullLogger<StorageEnforcementHostedService>.Instance);
+
+        await hostedService.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Development_NoConnectionString_DoesNotThrow()
+    {
+        var services = NewServicesWithStorageRegistration();
+        services.AddWalletDatabase(Config());
+
+        var hostedService = new StorageEnforcementHostedService(
+            services.GetStorageRegistrationLog(),
+            FakeEnv(Environments.Development),
+            Config(),
+            NullLogger<StorageEnforcementHostedService>.Instance);
+
+        await hostedService.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Production_WithConnectionString_DoesNotThrow()
+    {
+        var services = NewServicesWithStorageRegistration();
+        var config = Config(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:Wallet:Postgres"] = "Host=wallet-pg;Username=wallet"
+        });
+        services.AddWalletDatabase(config);
+
+        var hostedService = new StorageEnforcementHostedService(
+            services.GetStorageRegistrationLog(),
+            FakeEnv(Environments.Production),
+            Config(),
+            NullLogger<StorageEnforcementHostedService>.Instance);
+
+        await hostedService.Invoking(s => s.StartAsync(CancellationToken.None))
+            .Should().NotThrowAsync();
+    }
+
+    private static IHostEnvironment FakeEnv(string environment) => new TestHostEnvironment
+    {
+        EnvironmentName = environment,
+        ApplicationName = "Sorcha.Wallet.Service",
+    };
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Sorcha.Wallet.Service";
+        public string ContentRootPath { get; set; } = ".";
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of feature 113. Wallet Service is the first service to adopt the storage registration log infrastructure shipped in PR #410. After this lands, Wallet:

- Logs `Storage registration: IWalletRepository → ...` (or `[STORAGE-FALLBACK] ...`) at host startup
- Reports `Degraded` on `/health/storage-providers` when running in-memory
- Emits `sorcha_storage_provider_info` and `sorcha_storage_fallback_active` on the `Sorcha.Storage` OpenTelemetry meter
- **Refuses to start in Production/Staging** with no Postgres connection string (bypass: `Storage:AllowInMemoryInProduction=true`)

## What's in scope

**Commit 1 — refactor:** Defer storage-log emission from registration time to `StorageEnforcementHostedService.StartAsync`. Adds `services.GetStorageRegistrationLog()` extension that returns the eagerly-constructed singleton instance. Necessary because service extensions (e.g. `AddWalletDatabase`) run at `IServiceCollection`-extension time, before the DI container is built.

**Commit 2 — Wallet adoption:** `WalletServiceExtensions.AddWalletDatabase` calls `RegisterPersistent` / `RegisterInMemory` at the existing fallback decision points. Plus the defensive `GetStorageRegistrationLog` change that lets service extensions be unit-tested in isolation.

## Test plan

- [x] 55 `Sorcha.ServiceDefaults.Tests` Storage tests pass (50 → 55 after adding `GetStorageRegistrationLog` coverage)
- [x] 7 new `AddWalletDatabaseStorageRegistrationTests` covering: no-config registers in-memory, Wallet override registers persistent, Sorcha default registers persistent, Production+InMemory enforcement throws, Production+Bypass passes, Development+InMemory passes, Production+Persistent passes
- [x] Full `Sorcha.Wallet.Service.Tests` suite passes — 644 tests (the defensive `GetStorageRegistrationLog` change unblocked 8 `EncryptionProviderConfigurationTests` that exercise `AddWalletService` directly)
- [ ] Pre-existing CI failures expected: `Tenant.Service.Tests` SignupModel/LoginModel from PR #397; merge with `--admin`

## Pre-existing breakage flagged (unchanged)

Same items as PR #410's commit message — `Sorcha.Tenant.Service.Tests` SignupModel/LoginModel constructor errors from PR #397's demo-environment-banner work. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)