### PR TITLE
feat(113/PR3): Register Service adopts storage registration log

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/Storage/AuditedStorageInterfaces.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Storage/AuditedStorageInterfaces.cs
@@ -34,9 +34,9 @@ internal static class AuditedStorageInterfaces
         // Verified: matches typeof(Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository).FullName.
         "Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository",
 
-        // TODO(audit-fqn): Verify against typeof(IRegisterRepository).FullName at adoption time.
-        // Wrong FQN here = silent fail-fast bypass for this interface.
-        "Sorcha.Register.Storage.IRegisterRepository",
+        // Register Service — register documents and transaction stream.
+        // Verified: matches typeof(Sorcha.Register.Core.Storage.IRegisterRepository).FullName.
+        "Sorcha.Register.Core.Storage.IRegisterRepository",
 
         // TODO(audit-fqn): Verify against typeof(IInstanceStore).FullName at adoption time.
         "Sorcha.Blueprint.Service.Storage.IInstanceStore",

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Options;
 using Sorcha.Register.Storage.InMemory;
 using Sorcha.Register.Storage.MongoDB;
 using Sorcha.Register.Storage.Redis;
+using Sorcha.ServiceDefaults.Storage;
 using Sorcha.Register.Service.Endpoints;
 using Sorcha.ServiceClients.Extensions;
 using Sorcha.ServiceClients.Peer;
@@ -94,6 +95,8 @@ builder.Services.AddSingleton<IMongoClient>(sp =>
 
 // Smart configuration: Use MongoDB if configured, otherwise InMemory
 var storageType = builder.Configuration["RegisterStorage:Type"] ?? "InMemory";
+var storageLog = builder.Services.GetStorageRegistrationLog();
+var registerInterfaceName = typeof(IRegisterRepository).FullName!;
 if (storageType.Equals("MongoDB", StringComparison.OrdinalIgnoreCase))
 {
     builder.Services.AddSingleton<IRegisterRepository>(sp =>
@@ -108,6 +111,10 @@ if (storageType.Equals("MongoDB", StringComparison.OrdinalIgnoreCase))
     builder.Services.AddSingleton<IReadOnlyRegisterRepository>(sp =>
         sp.GetRequiredService<IRegisterRepository>());
 
+    storageLog.RegisterPersistent(
+        registerInterfaceName,
+        typeof(MongoRegisterRepository).FullName!,
+        "mongo");
 }
 else
 {
@@ -117,6 +124,11 @@ else
     // Register the same instance as IReadOnlyRegisterRepository
     builder.Services.AddSingleton<IReadOnlyRegisterRepository>(sp =>
         sp.GetRequiredService<IRegisterRepository>());
+
+    storageLog.RegisterInMemory(
+        registerInterfaceName,
+        typeof(InMemoryRegisterRepository).FullName!,
+        "RegisterStorage:Type is not 'MongoDB' (default 'InMemory'). Set RegisterStorage:Type=MongoDB to enable persistent storage.");
 }
 
 // Event infrastructure: Redis Streams for durable event publishing/subscribing

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -106,29 +106,27 @@ if (storageType.Equals("MongoDB", StringComparison.OrdinalIgnoreCase))
         var logger = sp.GetRequiredService<ILogger<MongoRegisterRepository>>();
         return new MongoRegisterRepository(client, options, logger);
     });
-
-    // Register the same instance as IReadOnlyRegisterRepository
-    builder.Services.AddSingleton<IReadOnlyRegisterRepository>(sp =>
-        sp.GetRequiredService<IRegisterRepository>());
-
     storageLog.RegisterPersistent(
         registerInterfaceName,
         typeof(MongoRegisterRepository).FullName!,
         "mongo");
+
+    // Register the same instance as IReadOnlyRegisterRepository
+    builder.Services.AddSingleton<IReadOnlyRegisterRepository>(sp =>
+        sp.GetRequiredService<IRegisterRepository>());
 }
 else
 {
     // Use in-memory storage (default)
     builder.Services.AddSingleton<IRegisterRepository, InMemoryRegisterRepository>();
-
-    // Register the same instance as IReadOnlyRegisterRepository
-    builder.Services.AddSingleton<IReadOnlyRegisterRepository>(sp =>
-        sp.GetRequiredService<IRegisterRepository>());
-
     storageLog.RegisterInMemory(
         registerInterfaceName,
         typeof(InMemoryRegisterRepository).FullName!,
         "RegisterStorage:Type is not 'MongoDB' (default 'InMemory'). Set RegisterStorage:Type=MongoDB to enable persistent storage.");
+
+    // Register the same instance as IReadOnlyRegisterRepository
+    builder.Services.AddSingleton<IReadOnlyRegisterRepository>(sp =>
+        sp.GetRequiredService<IRegisterRepository>());
 }
 
 // Event infrastructure: Redis Streams for durable event publishing/subscribing


### PR DESCRIPTION
## Summary

PR 3 of feature 113. Register Service joins Wallet (PR #411) in adopting the IStorageRegistrationLog infrastructure from PR #410. Two changes:

1. **Register Service Program.cs**: Calls `RegisterPersistent` (MongoDB branch) / `RegisterInMemory` (default branch) at the existing `RegisterStorage:Type` decision point, using `typeof().FullName!` for compile-time FQN safety.
2. **AuditedStorageInterfaces FQN correction**: The previous entry `"Sorcha.Register.Storage.IRegisterRepository"` was wrong — actual namespace is `Sorcha.Register.Core.Storage`. Same silent-fail-fast-bypass bug as IWalletRepository in PR 2; caught at adoption time per the `TODO(audit-fqn)` markers.

## Test plan

- [x] `dotnet build` clean for `Sorcha.Register.Service`
- [ ] Boot the service in Production with `RegisterStorage:Type=InMemory` → service refuses to start (verified at deploy time)
- [ ] Boot in Development → service starts with `[STORAGE-FALLBACK]` warning (verified at deploy time)
- [x] CI: pre-existing failures expected (Tenant SignupModel/LoginModel from PR #397); merge with `--admin`

## Why no new unit tests

Register.Service does its storage wiring inline in Program.cs (not in an extension method like Wallet's `AddWalletDatabase`), so there's no clean unit-testable surface. The registration-log mechanism itself is heavily covered by the 55 ServiceDefaults Storage tests from PR #410. The Register Program.cs change is mechanical — 4-line addition at each branch — and will be verified at deployment time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)