### PR TITLE
feat(113/PR7): IVerifiedTransactionQueue lease contract + InMemory rename

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Configuration/DocketBuildConfiguration.cs
+++ b/src/Services/Sorcha.Validator.Service/Configuration/DocketBuildConfiguration.cs
@@ -33,7 +33,9 @@ public class DocketBuildConfiguration
     /// If the build crashes or this process dies before ConfirmAsync, the
     /// lease auto-releases on the next ClaimAsync after this many seconds.
     /// Sized to docket-build worst-case plus margin; tune up if validator
-    /// builds take longer than 60s in your deployment.
+    /// builds take longer than 60s in your deployment. Range 1–3600.
     /// </summary>
+    [System.ComponentModel.DataAnnotations.Range(1, 3600,
+        ErrorMessage = "LeaseDurationSeconds must be between 1 and 3600 seconds.")]
     public int LeaseDurationSeconds { get; set; } = 60;
 }

--- a/src/Services/Sorcha.Validator.Service/Configuration/DocketBuildConfiguration.cs
+++ b/src/Services/Sorcha.Validator.Service/Configuration/DocketBuildConfiguration.cs
@@ -27,4 +27,13 @@ public class DocketBuildConfiguration
     /// Whether to allow dockets with zero transactions
     /// </summary>
     public bool AllowEmptyDockets { get; set; } = false;
+
+    /// <summary>
+    /// Lease duration when claiming transactions from the verified queue.
+    /// If the build crashes or this process dies before ConfirmAsync, the
+    /// lease auto-releases on the next ClaimAsync after this many seconds.
+    /// Sized to docket-build worst-case plus margin; tune up if validator
+    /// builds take longer than 60s in your deployment.
+    /// </summary>
+    public int LeaseDurationSeconds { get; set; } = 60;
 }

--- a/src/Services/Sorcha.Validator.Service/Endpoints/MetricsEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/MetricsEndpoints.cs
@@ -128,7 +128,7 @@ public static class MetricsEndpoints
                 OldestTransaction = queueStats.OldestTransaction,
                 NewestTransaction = queueStats.NewestTransaction,
                 TotalEnqueued = queueStats.TotalEnqueued,
-                TotalDequeued = queueStats.TotalDequeued,
+                TotalDequeued = queueStats.TotalConfirmed,
                 TotalExpired = queueStats.TotalExpired
             },
             Caches = new CacheSummary
@@ -243,7 +243,7 @@ public static class MetricsEndpoints
                 OldestTransaction = stats.OldestTransaction,
                 NewestTransaction = stats.NewestTransaction,
                 TotalEnqueued = stats.TotalEnqueued,
-                TotalDequeued = stats.TotalDequeued,
+                TotalDequeued = stats.TotalConfirmed,
                 TotalExpired = stats.TotalExpired
             }
         };

--- a/src/Services/Sorcha.Validator.Service/Extensions/VerifiedQueueExtensions.cs
+++ b/src/Services/Sorcha.Validator.Service/Extensions/VerifiedQueueExtensions.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Sorcha.ServiceDefaults.Storage;
 using Sorcha.Validator.Service.Configuration;
 using Sorcha.Validator.Service.Services;
 using Sorcha.Validator.Service.Services.Interfaces;
@@ -8,16 +9,18 @@ using Sorcha.Validator.Service.Services.Interfaces;
 namespace Sorcha.Validator.Service.Extensions;
 
 /// <summary>
-/// Extension methods for registering verified transaction queue services
+/// Extension methods for registering verified transaction queue services.
 /// </summary>
 public static class VerifiedQueueExtensions
 {
     /// <summary>
-    /// Adds the verified transaction queue and related services to the service collection
+    /// Adds the verified transaction queue and related services to the service collection.
+    /// PR 7 ships only the in-memory implementation; the Redis-backed implementation
+    /// is the next PR.
     /// </summary>
-    /// <param name="services">Service collection</param>
-    /// <param name="configuration">Application configuration</param>
-    /// <returns>Service collection for chaining</returns>
+    /// <param name="services">Service collection.</param>
+    /// <param name="configuration">Application configuration.</param>
+    /// <returns>Service collection for chaining.</returns>
     public static IServiceCollection AddVerifiedTransactionQueue(
         this IServiceCollection services,
         IConfiguration configuration)
@@ -26,8 +29,15 @@ public static class VerifiedQueueExtensions
         services.Configure<VerifiedQueueConfiguration>(
             configuration.GetSection(VerifiedQueueConfiguration.SectionName));
 
-        // Register the queue as singleton (in-memory state)
-        services.AddSingleton<IVerifiedTransactionQueue, VerifiedTransactionQueue>();
+        // Register the in-memory queue and record the choice with the storage
+        // registration log. IVerifiedTransactionQueue is on the audited list —
+        // Production/Staging fail-fast fires when on this in-memory implementation
+        // (unless Storage:AllowInMemoryInProduction=true).
+        services.AddSingleton<IVerifiedTransactionQueue, InMemoryVerifiedTransactionQueue>();
+        services.GetStorageRegistrationLog().RegisterInMemory(
+            typeof(IVerifiedTransactionQueue).FullName!,
+            typeof(InMemoryVerifiedTransactionQueue).FullName!,
+            "Redis-backed mempool not yet wired (PR 8 of feature 113). Mempool will not survive validator restart.");
 
         // Register cleanup background service
         services.AddHostedService<VerifiedQueueCleanupService>();

--- a/src/Services/Sorcha.Validator.Service/Extensions/VerifiedQueueExtensions.cs
+++ b/src/Services/Sorcha.Validator.Service/Extensions/VerifiedQueueExtensions.cs
@@ -37,7 +37,7 @@ public static class VerifiedQueueExtensions
         services.GetStorageRegistrationLog().RegisterInMemory(
             typeof(IVerifiedTransactionQueue).FullName!,
             typeof(InMemoryVerifiedTransactionQueue).FullName!,
-            "Redis-backed mempool not yet wired (PR 8 of feature 113). Mempool will not survive validator restart.");
+            "Validator mempool is in-process — does not survive restart and cannot share state across replicas. Configure a Redis-backed mempool to enable durability and HA-replica deployment.");
 
         // Register cleanup background service
         services.AddHostedService<VerifiedQueueCleanupService>();

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuilder.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuilder.cs
@@ -59,12 +59,19 @@ public class DocketBuilder : IDocketBuilder
         _logger.LogInformation("Building docket for register {RegisterId} (forced: {ForceBuild})",
             registerId, forceBuild);
 
-        IReadOnlyList<VerifiedTransaction> verifiedEntries = [];
+        IReadOnlyList<VerifiedTransactionLease> leases = [];
 
         try
         {
-            // Dequeue verified transactions
-            verifiedEntries = _verifiedQueue.Dequeue(registerId, _buildConfig.MaxTransactionsPerDocket);
+            // Claim verified transactions under a lease. If the build crashes or this
+            // process dies before ConfirmAsync, the lease auto-releases on the next
+            // ClaimAsync (default 60s — see ValidatorMempool:LeaseDurationSeconds).
+            leases = await _verifiedQueue.ClaimAsync(
+                registerId,
+                _buildConfig.MaxTransactionsPerDocket,
+                TimeSpan.FromSeconds(_buildConfig.LeaseDurationSeconds),
+                cancellationToken);
+            var verifiedEntries = leases.Select(l => l.Transaction).ToList();
 
             // Check if register needs genesis docket
             var needsGenesis = await _genesisManager.NeedsGenesisDocketAsync(registerId, cancellationToken);
@@ -179,18 +186,40 @@ public class DocketBuilder : IDocketBuilder
             _logger.LogInformation("Built docket {DocketNumber} for register {RegisterId} with hash {DocketHash}",
                 docketNumber, registerId, docketHash);
 
+            // Confirm the lease — transactions are now committed to the docket.
+            // Today's behaviour matches the previous Dequeue semantics: confirmation
+            // happens at build success, not at downstream seal success. A future PR
+            // can move ConfirmAsync to the seal-success callback site for stronger
+            // crash safety; for now the build-success path matches the prior contract.
+            await _verifiedQueue.ConfirmAsync(
+                registerId,
+                leases.Select(l => l.TransactionId),
+                cancellationToken);
+
             return docket;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to build docket for register {RegisterId}", registerId);
 
-            // Return dequeued transactions to the verified queue so they aren't lost
-            if (verifiedEntries is { Count: > 0 })
+            // Release the claim so the transactions return to the available pool
+            // and another build cycle can pick them up.
+            if (leases is { Count: > 0 })
             {
-                _verifiedQueue.ReturnToQueue(registerId, verifiedEntries);
-                _logger.LogInformation("Returned {Count} transactions to verified queue after build failure for register {RegisterId}",
-                    verifiedEntries.Count, registerId);
+                try
+                {
+                    await _verifiedQueue.ReleaseAsync(
+                        registerId,
+                        leases.Select(l => l.TransactionId),
+                        cancellationToken);
+                    _logger.LogInformation("Released {Count} transactions back to verified queue after build failure for register {RegisterId}",
+                        leases.Count, registerId);
+                }
+                catch (Exception releaseEx)
+                {
+                    // Lease will auto-release on next ClaimAsync; log and continue.
+                    _logger.LogWarning(releaseEx, "ReleaseAsync failed after build failure — lease will auto-release on next claim");
+                }
             }
 
             return null;

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuilder.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuilder.cs
@@ -79,7 +79,18 @@ public class DocketBuilder : IDocketBuilder
             {
                 _logger.LogInformation("Register {RegisterId} needs genesis docket", registerId);
                 var transactions = verifiedEntries.Select(v => v.Transaction).ToList();
-                return await _genesisManager.CreateGenesisDocketAsync(registerId, transactions, cancellationToken);
+                var genesisDocket = await _genesisManager.CreateGenesisDocketAsync(registerId, transactions, cancellationToken);
+
+                // Confirm the lease — transactions are now committed to the genesis docket.
+                // Without this, leases would auto-release on the next claim and the same
+                // transactions would re-surface in a subsequent normal docket, double-processing
+                // them. (caught by claude-review on PR #416)
+                await _verifiedQueue.ConfirmAsync(
+                    registerId,
+                    leases.Select(l => l.TransactionId),
+                    cancellationToken);
+
+                return genesisDocket;
             }
 
             // Unwrap verified transactions

--- a/src/Services/Sorcha.Validator.Service/Services/InMemoryVerifiedTransactionQueue.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/InMemoryVerifiedTransactionQueue.cs
@@ -159,12 +159,19 @@ public class InMemoryVerifiedTransactionQueue : IVerifiedTransactionQueue
             return Task.CompletedTask;
         }
 
-        var released = queue.Release(transactionIds);
-        if (released > 0)
+        var (released, expired) = queue.Release(transactionIds);
+        if (expired > 0)
+        {
+            // Caller asked to release a claim, but the transaction's TTL had elapsed
+            // while it was held. Count this against TotalExpired so the metric covers
+            // both passive (CleanupExpired) and active (Release-time) expiry paths.
+            Interlocked.Add(ref _totalExpired, expired);
+        }
+        if (released > 0 || expired > 0)
         {
             _logger.LogDebug(
-                "Released {Count} transactions back to the available pool for register {RegisterId}",
-                released, registerId);
+                "Released {Count} transactions back to the available pool for register {RegisterId} ({Expired} TTL-expired and dropped)",
+                released, registerId, expired);
         }
         return Task.CompletedTask;
     }
@@ -441,12 +448,13 @@ public class InMemoryVerifiedTransactionQueue : IVerifiedTransactionQueue
             }
         }
 
-        public int Release(IEnumerable<string> transactionIds)
+        public (int Released, int Expired) Release(IEnumerable<string> transactionIds)
         {
             lock (_lock)
             {
                 var now = DateTimeOffset.UtcNow;
                 var released = 0;
+                var expired = 0;
                 foreach (var txId in transactionIds)
                 {
                     if (_claimed.Remove(txId, out var entry))
@@ -454,13 +462,14 @@ public class InMemoryVerifiedTransactionQueue : IVerifiedTransactionQueue
                         if (entry.Transaction.ExpiresAt <= now)
                         {
                             _byId.Remove(txId);
+                            expired++;
                             continue;
                         }
                         _available.Add(entry.Transaction);
                         released++;
                     }
                 }
-                return released;
+                return (released, expired);
             }
         }
 

--- a/src/Services/Sorcha.Validator.Service/Services/InMemoryVerifiedTransactionQueue.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/InMemoryVerifiedTransactionQueue.cs
@@ -10,26 +10,32 @@ using Sorcha.Validator.Service.Services.Interfaces;
 namespace Sorcha.Validator.Service.Services;
 
 /// <summary>
-/// Thread-safe in-memory queue for validated transactions ready for docket building.
-/// Uses priority ordering and TTL-based expiry.
+/// In-process <see cref="IVerifiedTransactionQueue"/> implementation backed
+/// by per-register priority sets with lease-tracked claims. Used as the
+/// dev/test fallback; PR 8 ships a Redis-backed implementation that
+/// survives validator process restart.
 /// </summary>
-public class VerifiedTransactionQueue : IVerifiedTransactionQueue
+/// <remarks>
+/// On the audited storage list — Production / Staging refuse to start when
+/// this implementation is selected (unless overridden by
+/// <c>Storage:AllowInMemoryInProduction=true</c>).
+/// </remarks>
+public class InMemoryVerifiedTransactionQueue : IVerifiedTransactionQueue
 {
     private readonly VerifiedQueueConfiguration _config;
-    private readonly ILogger<VerifiedTransactionQueue> _logger;
+    private readonly ILogger<InMemoryVerifiedTransactionQueue> _logger;
 
-    // Per-register queues
+    // Per-register state.
     private readonly ConcurrentDictionary<string, RegisterQueue> _queues = new();
 
-    // Global statistics
+    // Global statistics.
     private long _totalEnqueued;
-    private long _totalDequeued;
+    private long _totalConfirmed;
     private long _totalExpired;
-    private readonly object _statsLock = new();
 
-    public VerifiedTransactionQueue(
+    public InMemoryVerifiedTransactionQueue(
         IOptions<VerifiedQueueConfiguration> config,
-        ILogger<VerifiedTransactionQueue> logger)
+        ILogger<InMemoryVerifiedTransactionQueue> logger)
     {
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -42,7 +48,6 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
         ArgumentNullException.ThrowIfNull(transaction);
         ArgumentException.ThrowIfNullOrWhiteSpace(transaction.TransactionId);
 
-        // Check global limits
         if (GetTotalCount() >= _config.MaxTotalTransactions)
         {
             _logger.LogWarning(
@@ -51,7 +56,6 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
             return false;
         }
 
-        // Check register limit
         if (_queues.Count >= _config.MaxRegisters && !_queues.ContainsKey(registerId))
         {
             _logger.LogWarning(
@@ -88,28 +92,81 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<VerifiedTransaction> Dequeue(string registerId, int maxCount)
+    public Task<IReadOnlyList<VerifiedTransactionLease>> ClaimAsync(
+        string registerId,
+        int maxCount,
+        TimeSpan leaseDuration,
+        CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
-        if (maxCount <= 0) return [];
+        if (maxCount <= 0)
+        {
+            return Task.FromResult<IReadOnlyList<VerifiedTransactionLease>>([]);
+        }
+        if (leaseDuration <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(leaseDuration), "Lease duration must be positive.");
+        }
+        ct.ThrowIfCancellationRequested();
 
         if (!_queues.TryGetValue(registerId, out var queue))
         {
-            return [];
+            return Task.FromResult<IReadOnlyList<VerifiedTransactionLease>>([]);
         }
 
-        var transactions = queue.Dequeue(maxCount);
-
-        if (transactions.Count > 0)
+        var leases = queue.Claim(registerId, maxCount, leaseDuration);
+        if (leases.Count > 0)
         {
-            Interlocked.Add(ref _totalDequeued, transactions.Count);
-
             _logger.LogDebug(
-                "Dequeued {Count} transactions for register {RegisterId}",
-                transactions.Count, registerId);
+                "Claimed {Count} transactions for register {RegisterId} (lease {LeaseSeconds}s)",
+                leases.Count, registerId, (int)leaseDuration.TotalSeconds);
+        }
+        return Task.FromResult<IReadOnlyList<VerifiedTransactionLease>>(leases);
+    }
+
+    /// <inheritdoc/>
+    public Task ConfirmAsync(string registerId, IEnumerable<string> transactionIds, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        ArgumentNullException.ThrowIfNull(transactionIds);
+        ct.ThrowIfCancellationRequested();
+
+        if (!_queues.TryGetValue(registerId, out var queue))
+        {
+            return Task.CompletedTask;
         }
 
-        return transactions;
+        var confirmed = queue.Confirm(transactionIds);
+        if (confirmed > 0)
+        {
+            Interlocked.Add(ref _totalConfirmed, confirmed);
+            _logger.LogDebug(
+                "Confirmed {Count} transactions for register {RegisterId}",
+                confirmed, registerId);
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task ReleaseAsync(string registerId, IEnumerable<string> transactionIds, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        ArgumentNullException.ThrowIfNull(transactionIds);
+        ct.ThrowIfCancellationRequested();
+
+        if (!_queues.TryGetValue(registerId, out var queue))
+        {
+            return Task.CompletedTask;
+        }
+
+        var released = queue.Release(transactionIds);
+        if (released > 0)
+        {
+            _logger.LogDebug(
+                "Released {Count} transactions back to the available pool for register {RegisterId}",
+                released, registerId);
+        }
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
@@ -124,42 +181,6 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
         }
 
         return queue.Peek(maxCount);
-    }
-
-    /// <inheritdoc/>
-    public void ReturnToQueue(string registerId, IReadOnlyList<VerifiedTransaction> transactions)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
-        ArgumentNullException.ThrowIfNull(transactions);
-
-        if (transactions.Count == 0) return;
-
-        var queue = _queues.GetOrAdd(registerId, _ => new RegisterQueue(_config.MaxTransactionsPerRegister));
-
-        var now = DateTimeOffset.UtcNow;
-        var returned = 0;
-
-        foreach (var tx in transactions)
-        {
-            // Don't return expired transactions
-            if (tx.ExpiresAt <= now)
-            {
-                Interlocked.Increment(ref _totalExpired);
-                continue;
-            }
-
-            if (queue.TryEnqueue(tx))
-            {
-                returned++;
-            }
-        }
-
-        // Adjust dequeue count since we returned them
-        Interlocked.Add(ref _totalDequeued, -returned);
-
-        _logger.LogDebug(
-            "Returned {Count} transactions to queue for register {RegisterId}",
-            returned, registerId);
     }
 
     /// <inheritdoc/>
@@ -194,20 +215,11 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
     public int GetCount(string registerId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
-
-        if (!_queues.TryGetValue(registerId, out var queue))
-        {
-            return 0;
-        }
-
-        return queue.Count;
+        return _queues.TryGetValue(registerId, out var queue) ? queue.Count : 0;
     }
 
     /// <inheritdoc/>
-    public int GetTotalCount()
-    {
-        return _queues.Values.Sum(q => q.Count);
-    }
+    public int GetTotalCount() => _queues.Values.Sum(q => q.Count);
 
     /// <inheritdoc/>
     public VerifiedQueueStats GetStats()
@@ -243,7 +255,7 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
             OldestTransaction = oldest,
             NewestTransaction = newest,
             TotalEnqueued = Interlocked.Read(ref _totalEnqueued),
-            TotalDequeued = Interlocked.Read(ref _totalDequeued),
+            TotalConfirmed = Interlocked.Read(ref _totalConfirmed),
             TotalExpired = Interlocked.Read(ref _totalExpired)
         };
     }
@@ -263,7 +275,6 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
         }
 
         var stats = queue.GetStats();
-
         return new RegisterQueueStats
         {
             RegisterId = registerId,
@@ -278,18 +289,14 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
     public int Clear(string registerId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
-
         if (!_queues.TryRemove(registerId, out var queue))
         {
             return 0;
         }
-
         var count = queue.Count;
-
         _logger.LogInformation(
             "Cleared {Count} transactions for register {RegisterId}",
             count, registerId);
-
         return count;
     }
 
@@ -298,9 +305,7 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
     {
         var total = GetTotalCount();
         _queues.Clear();
-
         _logger.LogInformation("Cleared all verified transaction queues ({Count} transactions)", total);
-
         return total;
     }
 
@@ -308,7 +313,6 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
     public int CleanupExpired()
     {
         var totalRemoved = 0;
-
         foreach (var kvp in _queues)
         {
             var removed = kvp.Value.RemoveExpired();
@@ -316,14 +320,12 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
             {
                 totalRemoved += removed;
                 Interlocked.Add(ref _totalExpired, removed);
-
                 _logger.LogDebug(
                     "Removed {Count} expired transactions from register {RegisterId}",
                     removed, kvp.Key);
             }
         }
 
-        // Remove empty queues
         var emptyQueues = _queues.Where(kvp => kvp.Value.Count == 0).Select(kvp => kvp.Key).ToList();
         foreach (var registerId in emptyQueues)
         {
@@ -334,112 +336,147 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
         {
             _logger.LogInformation("Cleaned up {Count} expired transactions across all registers", totalRemoved);
         }
-
         return totalRemoved;
     }
 
-
     /// <summary>
-    /// Thread-safe priority queue for a single register
+    /// Per-register thread-safe priority queue with lease tracking.
     /// </summary>
     private class RegisterQueue
     {
         private readonly int _maxCapacity;
         private readonly object _lock = new();
-        private readonly SortedSet<VerifiedTransaction> _queue;
+        // Available pool — sorted by priority (desc) then enqueue time (asc).
+        private readonly SortedSet<VerifiedTransaction> _available;
+        // Claimed transactions, keyed by tx id, with their lease expiry.
+        private readonly Dictionary<string, ClaimedEntry> _claimed = new();
+        // Index over both sets so Contains / Remove work uniformly.
         private readonly Dictionary<string, VerifiedTransaction> _byId = new();
 
         public RegisterQueue(int maxCapacity)
         {
             _maxCapacity = maxCapacity;
-            _queue = new SortedSet<VerifiedTransaction>(new PriorityComparer());
+            _available = new SortedSet<VerifiedTransaction>(new PriorityComparer());
         }
 
         public int Count
         {
-            get
-            {
-                lock (_lock)
-                {
-                    return _queue.Count;
-                }
-            }
+            get { lock (_lock) { return _available.Count + _claimed.Count; } }
         }
 
         public bool TryEnqueue(VerifiedTransaction tx)
         {
             lock (_lock)
             {
-                // Check capacity
-                if (_queue.Count >= _maxCapacity)
+                if (_available.Count + _claimed.Count >= _maxCapacity)
                     return false;
-
-                // Check for duplicate
                 if (_byId.ContainsKey(tx.TransactionId))
                     return false;
-
-                _queue.Add(tx);
+                _available.Add(tx);
                 _byId[tx.TransactionId] = tx;
                 return true;
             }
         }
 
-        public IReadOnlyList<VerifiedTransaction> Dequeue(int maxCount)
+        public IReadOnlyList<VerifiedTransactionLease> Claim(string registerId, int maxCount, TimeSpan leaseDuration)
         {
-            var result = new List<VerifiedTransaction>();
-
             lock (_lock)
             {
                 var now = DateTimeOffset.UtcNow;
-                var toRemove = new List<VerifiedTransaction>();
 
-                foreach (var tx in _queue)
+                // First, auto-release any leases that have expired since the last claim.
+                var expiredClaims = _claimed
+                    .Where(kvp => kvp.Value.LeaseExpiresAt <= now)
+                    .ToList();
+                foreach (var (txId, claimed) in expiredClaims)
                 {
-                    if (result.Count >= maxCount)
-                        break;
-
-                    // Skip expired
-                    if (tx.ExpiresAt <= now)
+                    _claimed.Remove(txId);
+                    if (_byId.TryGetValue(txId, out var tx))
                     {
-                        toRemove.Add(tx);
-                        continue;
+                        _available.Add(tx);
                     }
-
-                    result.Add(tx);
-                    toRemove.Add(tx);
                 }
 
-                foreach (var tx in toRemove)
+                // Skip TTL-expired transactions silently — they'll be removed by CleanupExpired.
+                var leaseExpiresAt = now.Add(leaseDuration);
+                var leases = new List<VerifiedTransactionLease>(maxCount);
+                var taken = new List<VerifiedTransaction>();
+                foreach (var tx in _available)
                 {
-                    _queue.Remove(tx);
-                    _byId.Remove(tx.TransactionId);
+                    if (leases.Count >= maxCount) break;
+                    if (tx.ExpiresAt <= now) continue;
+                    leases.Add(new VerifiedTransactionLease
+                    {
+                        RegisterId = registerId,
+                        Transaction = tx,
+                        LeaseExpiresAt = leaseExpiresAt
+                    });
+                    taken.Add(tx);
                 }
-            }
 
-            return result;
+                foreach (var tx in taken)
+                {
+                    _available.Remove(tx);
+                    _claimed[tx.TransactionId] = new ClaimedEntry(tx, leaseExpiresAt);
+                }
+
+                return leases;
+            }
+        }
+
+        public int Confirm(IEnumerable<string> transactionIds)
+        {
+            lock (_lock)
+            {
+                var confirmed = 0;
+                foreach (var txId in transactionIds)
+                {
+                    if (_claimed.Remove(txId))
+                    {
+                        _byId.Remove(txId);
+                        confirmed++;
+                    }
+                }
+                return confirmed;
+            }
+        }
+
+        public int Release(IEnumerable<string> transactionIds)
+        {
+            lock (_lock)
+            {
+                var now = DateTimeOffset.UtcNow;
+                var released = 0;
+                foreach (var txId in transactionIds)
+                {
+                    if (_claimed.Remove(txId, out var entry))
+                    {
+                        if (entry.Transaction.ExpiresAt <= now)
+                        {
+                            _byId.Remove(txId);
+                            continue;
+                        }
+                        _available.Add(entry.Transaction);
+                        released++;
+                    }
+                }
+                return released;
+            }
         }
 
         public IReadOnlyList<VerifiedTransaction> Peek(int maxCount)
         {
-            var result = new List<VerifiedTransaction>();
-
+            var result = new List<VerifiedTransaction>(maxCount);
             lock (_lock)
             {
                 var now = DateTimeOffset.UtcNow;
-
-                foreach (var tx in _queue)
+                foreach (var tx in _available)
                 {
-                    if (result.Count >= maxCount)
-                        break;
-
-                    // Skip expired
-                    if (tx.ExpiresAt <= now)
-                        continue;
-
+                    if (result.Count >= maxCount) break;
+                    if (tx.ExpiresAt <= now) continue;
                     result.Add(tx);
                 }
             }
-
             return result;
         }
 
@@ -449,8 +486,8 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
             {
                 if (!_byId.TryGetValue(transactionId, out var tx))
                     return false;
-
-                _queue.Remove(tx);
+                _available.Remove(tx);
+                _claimed.Remove(transactionId);
                 _byId.Remove(transactionId);
                 return true;
             }
@@ -458,10 +495,7 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
 
         public bool Contains(string transactionId)
         {
-            lock (_lock)
-            {
-                return _byId.ContainsKey(transactionId);
-            }
+            lock (_lock) { return _byId.ContainsKey(transactionId); }
         }
 
         public int RemoveExpired()
@@ -469,15 +503,22 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
             lock (_lock)
             {
                 var now = DateTimeOffset.UtcNow;
-                var expired = _queue.Where(tx => tx.ExpiresAt <= now).ToList();
-
-                foreach (var tx in expired)
+                var expiredAvailable = _available.Where(tx => tx.ExpiresAt <= now).ToList();
+                foreach (var tx in expiredAvailable)
                 {
-                    _queue.Remove(tx);
+                    _available.Remove(tx);
                     _byId.Remove(tx.TransactionId);
                 }
-
-                return expired.Count;
+                var expiredClaimed = _claimed
+                    .Where(kvp => kvp.Value.Transaction.ExpiresAt <= now)
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+                foreach (var txId in expiredClaimed)
+                {
+                    _claimed.Remove(txId);
+                    _byId.Remove(txId);
+                }
+                return expiredAvailable.Count + expiredClaimed.Count;
             }
         }
 
@@ -485,26 +526,25 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
         {
             lock (_lock)
             {
-                if (_queue.Count == 0)
-                    return (0, null, null, 0);
+                var entries = _available.Concat(_claimed.Values.Select(c => c.Transaction)).ToList();
+                if (entries.Count == 0) return (0, null, null, 0);
 
                 var now = DateTimeOffset.UtcNow;
-                var valid = _queue.Where(tx => tx.ExpiresAt > now).ToList();
-
-                if (valid.Count == 0)
-                    return (0, null, null, 0);
+                var valid = entries.Where(tx => tx.ExpiresAt > now).ToList();
+                if (valid.Count == 0) return (0, null, null, 0);
 
                 return (
                     valid.Count,
                     valid.Min(tx => tx.EnqueuedAt),
                     valid.Max(tx => tx.EnqueuedAt),
-                    valid.Average(tx => tx.Priority)
-                );
+                    valid.Average(tx => tx.Priority));
             }
         }
 
+        private sealed record ClaimedEntry(VerifiedTransaction Transaction, DateTimeOffset LeaseExpiresAt);
+
         /// <summary>
-        /// Comparer for priority ordering (higher priority first, then by enqueue time)
+        /// Comparer for priority ordering (higher priority first, then by enqueue time).
         /// </summary>
         private class PriorityComparer : IComparer<VerifiedTransaction>
         {
@@ -514,18 +554,14 @@ public class VerifiedTransactionQueue : IVerifiedTransactionQueue
                 if (x == null) return 1;
                 if (y == null) return -1;
 
-                // Higher priority first (descending)
                 var priorityCompare = y.Priority.CompareTo(x.Priority);
                 if (priorityCompare != 0) return priorityCompare;
 
-                // Earlier enqueue time first (ascending - FIFO within same priority)
                 var timeCompare = x.EnqueuedAt.CompareTo(y.EnqueuedAt);
                 if (timeCompare != 0) return timeCompare;
 
-                // Fallback to transaction ID for uniqueness
                 return string.Compare(x.TransactionId, y.TransactionId, StringComparison.Ordinal);
             }
         }
     }
-
 }

--- a/src/Services/Sorcha.Validator.Service/Services/Interfaces/IVerifiedTransactionQueue.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/Interfaces/IVerifiedTransactionQueue.cs
@@ -6,173 +6,189 @@ using Sorcha.Validator.Service.Models;
 namespace Sorcha.Validator.Service.Services.Interfaces;
 
 /// <summary>
-/// In-memory queue for validated transactions ready for docket building.
-/// Transactions are dequeued by the leader during docket construction.
+/// Mempool of verified-but-not-yet-sealed transactions, partitioned by
+/// register. Backed by an in-process structure today
+/// (<see cref="Sorcha.Validator.Service.Services.InMemoryVerifiedTransactionQueue"/>);
+/// a Redis-backed implementation will land in PR 8 to give the mempool
+/// restart durability and unlock the HA-replica deployment shape.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Contract change vs prior Sorcha versions: the atomic
+/// <c>Dequeue</c>/<c>ReturnToQueue</c> pair is replaced by
+/// <see cref="ClaimAsync"/>/<see cref="ConfirmAsync"/>/<see cref="ReleaseAsync"/>.
+/// </para>
+/// <para>
+/// The lease pattern lets HA-replica deployments share one mempool: the
+/// active validator claims; if it crashes mid-seal, the lease auto-releases
+/// on the next claim by any replica. A single-validator deployment uses the
+/// same API; the lease just expires unobserved.
+/// </para>
+/// </remarks>
 public interface IVerifiedTransactionQueue
 {
     /// <summary>
-    /// Enqueue a validated transaction for docket building
+    /// Adds a verified transaction to the available pool for the given register.
     /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <param name="transaction">Validated transaction</param>
-    /// <param name="priority">Transaction priority (higher = processed first)</param>
-    /// <returns>True if enqueued successfully</returns>
+    /// <returns>True if enqueued; false if rejected (queue full, duplicate, etc.).</returns>
     bool Enqueue(string registerId, Transaction transaction, int priority = 0);
 
     /// <summary>
-    /// Dequeue transactions for docket building (leader only)
+    /// Atomically claims up to <paramref name="maxCount"/> highest-priority
+    /// transactions from the available pool, holding them under a lease
+    /// that expires after <paramref name="leaseDuration"/>. Before claiming,
+    /// any expired leases for this register are released back to the pool.
     /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <param name="maxCount">Maximum transactions to dequeue</param>
-    /// <returns>Transactions ready for docket building</returns>
-    IReadOnlyList<VerifiedTransaction> Dequeue(string registerId, int maxCount);
+    Task<IReadOnlyList<VerifiedTransactionLease>> ClaimAsync(
+        string registerId,
+        int maxCount,
+        TimeSpan leaseDuration,
+        CancellationToken ct);
 
     /// <summary>
-    /// Peek at transactions without removing them
+    /// Confirms the seal of the given transactions. Removes them from the
+    /// claimed set and the underlying payload store. Idempotent — confirming
+    /// an already-confirmed (or never-claimed) transaction is a no-op.
     /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <param name="maxCount">Maximum transactions to peek</param>
-    /// <returns>Preview of queued transactions</returns>
+    Task ConfirmAsync(
+        string registerId,
+        IEnumerable<string> transactionIds,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Releases the claim, returning the transactions to the available pool
+    /// at their original priority. Idempotent.
+    /// </summary>
+    Task ReleaseAsync(
+        string registerId,
+        IEnumerable<string> transactionIds,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Returns up to <paramref name="maxCount"/> available transactions
+    /// without consuming or claiming them. Used by HA standby replicas
+    /// for cache-warming and by introspection tooling. Read-only.
+    /// </summary>
     IReadOnlyList<VerifiedTransaction> Peek(string registerId, int maxCount);
 
-    /// <summary>
-    /// Return transactions to the queue (docket build failed)
-    /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <param name="transactions">Transactions to return</param>
-    void ReturnToQueue(string registerId, IReadOnlyList<VerifiedTransaction> transactions);
-
-    /// <summary>
-    /// Remove a specific transaction from the queue
-    /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <param name="transactionId">Transaction ID to remove</param>
-    /// <returns>True if removed</returns>
+    /// <summary>Remove a specific transaction from the queue (any state).</summary>
     bool Remove(string registerId, string transactionId);
 
-    /// <summary>
-    /// Check if a transaction is in the queue
-    /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <param name="transactionId">Transaction ID</param>
-    /// <returns>True if transaction is queued</returns>
+    /// <summary>Check if a transaction is in the queue (available or claimed).</summary>
     bool Contains(string registerId, string transactionId);
 
-    /// <summary>
-    /// Get the count of queued transactions for a register
-    /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <returns>Transaction count</returns>
+    /// <summary>Get the count of queued transactions for a register (available + claimed).</summary>
     int GetCount(string registerId);
 
-    /// <summary>
-    /// Get total count of queued transactions across all registers
-    /// </summary>
-    /// <returns>Total transaction count</returns>
+    /// <summary>Get total count of queued transactions across all registers.</summary>
     int GetTotalCount();
 
-    /// <summary>
-    /// Get queue statistics
-    /// </summary>
-    /// <returns>Queue statistics</returns>
-    VerifiedQueueStats GetStats();
-
-    /// <summary>
-    /// Get queue statistics for a specific register
-    /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <returns>Register-specific queue statistics</returns>
-    RegisterQueueStats GetRegisterStats(string registerId);
-
-    /// <summary>
-    /// Clear all transactions for a register
-    /// </summary>
-    /// <param name="registerId">Register ID</param>
-    /// <returns>Number of transactions cleared</returns>
+    /// <summary>Clear all transactions for a register.</summary>
     int Clear(string registerId);
 
-    /// <summary>
-    /// Clear all transactions across all registers
-    /// </summary>
-    /// <returns>Number of transactions cleared</returns>
+    /// <summary>Clear all transactions across all registers.</summary>
     int ClearAll();
 
     /// <summary>
-    /// Remove expired transactions from all queues
+    /// Sweeps every register, removing TTL-expired transactions and releasing
+    /// expired leases. Run on a 30s timer by a background hosted service.
     /// </summary>
-    /// <returns>Number of expired transactions removed</returns>
     int CleanupExpired();
+
+    /// <summary>Get queue statistics across all registers.</summary>
+    VerifiedQueueStats GetStats();
+
+    /// <summary>Get queue statistics for a specific register.</summary>
+    RegisterQueueStats GetRegisterStats(string registerId);
 }
 
 /// <summary>
-/// A verified transaction with metadata
+/// Time-bounded hold on a verified transaction returned by
+/// <see cref="IVerifiedTransactionQueue.ClaimAsync"/>.
+/// </summary>
+public sealed record VerifiedTransactionLease
+{
+    /// <summary>Transaction id (convenience accessor).</summary>
+    public string TransactionId => Transaction.TransactionId;
+
+    /// <summary>Owning register.</summary>
+    public required string RegisterId { get; init; }
+
+    /// <summary>The verified transaction payload.</summary>
+    public required VerifiedTransaction Transaction { get; init; }
+
+    /// <summary>UTC time after which the lease auto-releases on next ClaimAsync.</summary>
+    public required DateTimeOffset LeaseExpiresAt { get; init; }
+}
+
+/// <summary>
+/// A verified transaction with metadata.
 /// </summary>
 public record VerifiedTransaction
 {
-    /// <summary>The validated transaction</summary>
+    /// <summary>The validated transaction.</summary>
     public required Transaction Transaction { get; init; }
 
-    /// <summary>When the transaction was validated and enqueued</summary>
+    /// <summary>When the transaction was validated and enqueued.</summary>
     public required DateTimeOffset EnqueuedAt { get; init; }
 
-    /// <summary>Priority for docket ordering (higher = processed first)</summary>
+    /// <summary>Priority for docket ordering (higher = processed first).</summary>
     public required int Priority { get; init; }
 
-    /// <summary>When this entry expires and should be removed</summary>
+    /// <summary>When this entry expires and should be removed.</summary>
     public required DateTimeOffset ExpiresAt { get; init; }
 
-    /// <summary>Transaction ID (convenience accessor)</summary>
+    /// <summary>Transaction ID (convenience accessor).</summary>
     public string TransactionId => Transaction.TransactionId;
 }
 
 /// <summary>
-/// Queue statistics across all registers
+/// Queue statistics across all registers.
 /// </summary>
 public record VerifiedQueueStats
 {
-    /// <summary>Total transactions in queue</summary>
+    /// <summary>Total transactions in queue (available + claimed).</summary>
     public int TotalTransactions { get; init; }
 
-    /// <summary>Number of active registers with queued transactions</summary>
+    /// <summary>Number of active registers with queued transactions.</summary>
     public int ActiveRegisters { get; init; }
 
-    /// <summary>Average transactions per register</summary>
+    /// <summary>Average transactions per register.</summary>
     public double AverageTransactionsPerRegister { get; init; }
 
-    /// <summary>Oldest transaction in queue (null if empty)</summary>
+    /// <summary>Oldest transaction in queue (null if empty).</summary>
     public DateTimeOffset? OldestTransaction { get; init; }
 
-    /// <summary>Newest transaction in queue (null if empty)</summary>
+    /// <summary>Newest transaction in queue (null if empty).</summary>
     public DateTimeOffset? NewestTransaction { get; init; }
 
-    /// <summary>Total transactions enqueued since service start</summary>
+    /// <summary>Total transactions enqueued since service start.</summary>
     public long TotalEnqueued { get; init; }
 
-    /// <summary>Total transactions dequeued since service start</summary>
-    public long TotalDequeued { get; init; }
+    /// <summary>Total transactions confirmed (sealed) since service start.</summary>
+    public long TotalConfirmed { get; init; }
 
-    /// <summary>Total transactions expired since service start</summary>
+    /// <summary>Total transactions expired since service start.</summary>
     public long TotalExpired { get; init; }
 }
 
 /// <summary>
-/// Queue statistics for a specific register
+/// Queue statistics for a specific register.
 /// </summary>
 public record RegisterQueueStats
 {
-    /// <summary>Register ID</summary>
+    /// <summary>Register ID.</summary>
     public required string RegisterId { get; init; }
 
-    /// <summary>Current transaction count</summary>
+    /// <summary>Current transaction count (available + claimed).</summary>
     public int TransactionCount { get; init; }
 
-    /// <summary>Oldest transaction in queue (null if empty)</summary>
+    /// <summary>Oldest transaction in queue (null if empty).</summary>
     public DateTimeOffset? OldestTransaction { get; init; }
 
-    /// <summary>Newest transaction in queue (null if empty)</summary>
+    /// <summary>Newest transaction in queue (null if empty).</summary>
     public DateTimeOffset? NewestTransaction { get; init; }
 
-    /// <summary>Average priority of queued transactions</summary>
+    /// <summary>Average priority of queued transactions.</summary>
     public double AveragePriority { get; init; }
 }

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketBuilderTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketBuilderTests.cs
@@ -38,6 +38,17 @@ public class DocketBuilderTests
     public DocketBuilderTests()
     {
         _mockVerifiedQueue = new Mock<IVerifiedTransactionQueue>();
+        // Default no-op setups for the lease lifecycle methods. Tests that need
+        // to assert on Confirm/Release call these via Verify on top of the defaults.
+        _mockVerifiedQueue
+            .Setup(q => q.ConfirmAsync(
+                It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockVerifiedQueue
+            .Setup(q => q.ReleaseAsync(
+                It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         _mockRegisterClient = new Mock<IRegisterServiceClient>();
         _mockWalletClient = new Mock<IWalletServiceClient>();
         _mockGenesisManager = new Mock<IGenesisManager>();
@@ -156,8 +167,8 @@ public class DocketBuilderTests
             .ReturnsAsync(true);
 
         _mockVerifiedQueue
-            .Setup(q => q.Dequeue(registerId, _buildConfig.MaxTransactionsPerDocket))
-            .Returns(WrapAsVerified(transactions));
+            .Setup(q => q.ClaimAsync(registerId, _buildConfig.MaxTransactionsPerDocket, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WrapAsLeases(registerId, transactions));
 
         _mockGenesisManager
             .Setup(g => g.CreateGenesisDocketAsync(registerId, transactions, It.IsAny<CancellationToken>()))
@@ -188,8 +199,8 @@ public class DocketBuilderTests
             .ReturnsAsync(true);
 
         _mockVerifiedQueue
-            .Setup(q => q.Dequeue(registerId, _buildConfig.MaxTransactionsPerDocket))
-            .Returns(WrapAsVerified(new List<Transaction>()));
+            .Setup(q => q.ClaimAsync(registerId, _buildConfig.MaxTransactionsPerDocket, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WrapAsLeases(registerId, new List<Transaction>()));
 
         _mockGenesisManager
             .Setup(g => g.CreateGenesisDocketAsync(registerId, It.IsAny<List<Transaction>>(), It.IsAny<CancellationToken>()))
@@ -253,8 +264,8 @@ public class DocketBuilderTests
             .ReturnsAsync(false);
 
         _mockVerifiedQueue
-            .Setup(q => q.Dequeue(registerId, _buildConfig.MaxTransactionsPerDocket))
-            .Returns(WrapAsVerified(new List<Transaction>()));
+            .Setup(q => q.ClaimAsync(registerId, _buildConfig.MaxTransactionsPerDocket, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WrapAsLeases(registerId, new List<Transaction>()));
 
         // Act
         var result = await _builder.BuildDocketAsync(registerId);
@@ -399,8 +410,8 @@ public class DocketBuilderTests
             .ReturnsAsync(false);
 
         _mockVerifiedQueue
-            .Setup(q => q.Dequeue(registerId, _buildConfig.MaxTransactionsPerDocket))
-            .Returns(WrapAsVerified(transactions));
+            .Setup(q => q.ClaimAsync(registerId, _buildConfig.MaxTransactionsPerDocket, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WrapAsLeases(registerId, transactions));
 
         _mockRegisterClient
             .Setup(r => r.ReadLatestDocketAsync(registerId, It.IsAny<CancellationToken>()))
@@ -646,8 +657,8 @@ public class DocketBuilderTests
             .ReturnsAsync(false);
 
         _mockVerifiedQueue
-            .Setup(q => q.Dequeue(registerId, _buildConfig.MaxTransactionsPerDocket))
-            .Returns(WrapAsVerified(transactions));
+            .Setup(q => q.ClaimAsync(registerId, _buildConfig.MaxTransactionsPerDocket, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WrapAsLeases(registerId, transactions));
 
         // Convert internal Docket to DocketModel for RegisterServiceClient mock
         DocketModel? docketModel = previousDocket == null ? null : CreateTestDocketModel(previousDocket.DocketNumber, previousDocket.PreviousHash);
@@ -680,6 +691,22 @@ public class DocketBuilderTests
     /// <summary>
     /// Wraps transactions into VerifiedTransaction records for mock setups
     /// </summary>
+    private static IReadOnlyList<VerifiedTransactionLease> WrapAsLeases(string registerId, List<Transaction> transactions)
+    {
+        return transactions.Select(t => new VerifiedTransactionLease
+        {
+            RegisterId = registerId,
+            Transaction = new VerifiedTransaction
+            {
+                Transaction = t,
+                EnqueuedAt = DateTimeOffset.UtcNow,
+                Priority = 0,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+            },
+            LeaseExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1)
+        }).ToList();
+    }
+
     private static IReadOnlyList<VerifiedTransaction> WrapAsVerified(List<Transaction> transactions)
     {
         return transactions.Select(t => new VerifiedTransaction

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketBuilderTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketBuilderTests.cs
@@ -185,6 +185,13 @@ public class DocketBuilderTests
         _mockGenesisManager.Verify(
             g => g.CreateGenesisDocketAsync(registerId, transactions, It.IsAny<CancellationToken>()),
             Times.Once);
+
+        // Genesis path must confirm the lease so the transactions don't re-surface
+        // in a subsequent normal docket once the lease auto-releases. Bug found by
+        // claude-review on PR #416.
+        _mockVerifiedQueue.Verify(
+            q => q.ConfirmAsync(registerId, It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/tests/Sorcha.Validator.Service.Tests/Services/VerifiedTransactionQueueTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/VerifiedTransactionQueueTests.cs
@@ -9,18 +9,26 @@ using Moq;
 using Sorcha.Validator.Service.Configuration;
 using Sorcha.Validator.Service.Models;
 using Sorcha.Validator.Service.Services;
+using Sorcha.Validator.Service.Services.Interfaces;
 
 namespace Sorcha.Validator.Service.Tests.Services;
 
+/// <summary>
+/// Tests for <see cref="InMemoryVerifiedTransactionQueue"/> — the in-process
+/// fallback implementation of <see cref="IVerifiedTransactionQueue"/> with
+/// lease-tracked claims.
+/// </summary>
 public class VerifiedTransactionQueueTests
 {
-    private readonly Mock<ILogger<VerifiedTransactionQueue>> _loggerMock;
+    private static readonly TimeSpan DefaultLease = TimeSpan.FromMinutes(1);
+
+    private readonly Mock<ILogger<InMemoryVerifiedTransactionQueue>> _loggerMock;
     private readonly VerifiedQueueConfiguration _config;
-    private readonly VerifiedTransactionQueue _queue;
+    private readonly InMemoryVerifiedTransactionQueue _queue;
 
     public VerifiedTransactionQueueTests()
     {
-        _loggerMock = new Mock<ILogger<VerifiedTransactionQueue>>();
+        _loggerMock = new Mock<ILogger<InMemoryVerifiedTransactionQueue>>();
 
         _config = new VerifiedQueueConfiguration
         {
@@ -30,289 +38,264 @@ public class VerifiedTransactionQueueTests
             MaxRegisters = 10
         };
 
-        _queue = new VerifiedTransactionQueue(
+        _queue = new InMemoryVerifiedTransactionQueue(
             Options.Create(_config),
             _loggerMock.Object);
+    }
+
+    private async Task<IReadOnlyList<VerifiedTransaction>> ClaimAndReturnAsync(string registerId, int maxCount)
+    {
+        var leases = await _queue.ClaimAsync(registerId, maxCount, DefaultLease, CancellationToken.None);
+        return leases.Select(l => l.Transaction).ToList();
     }
 
     [Fact]
     public void Constructor_WithNullConfig_ThrowsArgumentNullException()
     {
-        // Act
-        var act = () => new VerifiedTransactionQueue(
-            null!,
-            _loggerMock.Object);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("config");
+        var act = () => new InMemoryVerifiedTransactionQueue(null!, _loggerMock.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("config");
     }
 
     [Fact]
     public void Constructor_WithNullLogger_ThrowsArgumentNullException()
     {
-        // Act
-        var act = () => new VerifiedTransactionQueue(
-            Options.Create(_config),
-            null!);
-
-        // Assert
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("logger");
+        var act = () => new InMemoryVerifiedTransactionQueue(Options.Create(_config), null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
     }
 
     [Fact]
     public void Enqueue_WithValidTransaction_ReturnsTrue()
     {
-        // Arrange
-        var registerId = "test-register";
-        var transaction = CreateTestTransaction("tx-1");
+        var result = _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
 
-        // Act
-        var result = _queue.Enqueue(registerId, transaction);
-
-        // Assert
         result.Should().BeTrue();
-        _queue.GetCount(registerId).Should().Be(1);
+        _queue.GetCount("test-register").Should().Be(1);
     }
 
     [Fact]
     public void Enqueue_WithEmptyRegisterId_ThrowsArgumentException()
     {
-        // Arrange
-        var transaction = CreateTestTransaction("tx-1");
-
-        // Act
-        var act = () => _queue.Enqueue("", transaction);
-
-        // Assert
+        var act = () => _queue.Enqueue("", CreateTestTransaction("tx-1"));
         act.Should().Throw<ArgumentException>();
     }
 
     [Fact]
     public void Enqueue_WithNullTransaction_ThrowsArgumentNullException()
     {
-        // Act
         var act = () => _queue.Enqueue("test-register", null!);
-
-        // Assert
         act.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void Enqueue_WhenAtRegisterLimit_ReturnsFalse()
     {
-        // Arrange
-        var registerId = "test-register";
         for (var i = 0; i < _config.MaxTransactionsPerRegister; i++)
         {
-            _queue.Enqueue(registerId, CreateTestTransaction($"tx-{i}"));
+            _queue.Enqueue("test-register", CreateTestTransaction($"tx-{i}"));
         }
 
-        // Act
-        var result = _queue.Enqueue(registerId, CreateTestTransaction("tx-overflow"));
+        var result = _queue.Enqueue("test-register", CreateTestTransaction("tx-overflow"));
 
-        // Assert
         result.Should().BeFalse();
-        _queue.GetCount(registerId).Should().Be(_config.MaxTransactionsPerRegister);
+        _queue.GetCount("test-register").Should().Be(_config.MaxTransactionsPerRegister);
     }
 
     [Fact]
     public void Enqueue_DuplicateTransactionId_ReturnsFalse()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
 
-        // Act
-        var result = _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
+        var result = _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
 
-        // Assert
         result.Should().BeFalse();
-        _queue.GetCount(registerId).Should().Be(1);
+        _queue.GetCount("test-register").Should().Be(1);
     }
 
     [Fact]
-    public void Dequeue_ReturnsTransactionsInPriorityOrder()
+    public async Task ClaimAsync_ReturnsTransactionsInPriorityOrder()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-low"), priority: 1);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-high"), priority: 10);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-medium"), priority: 5);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-low"), priority: 1);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-high"), priority: 10);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-medium"), priority: 5);
 
-        // Act
-        var result = _queue.Dequeue(registerId, 3);
+        var leases = await _queue.ClaimAsync("test-register", 3, DefaultLease, CancellationToken.None);
 
-        // Assert
-        result.Should().HaveCount(3);
-        result[0].TransactionId.Should().Be("tx-high");
-        result[1].TransactionId.Should().Be("tx-medium");
-        result[2].TransactionId.Should().Be("tx-low");
+        leases.Should().HaveCount(3);
+        leases[0].TransactionId.Should().Be("tx-high");
+        leases[1].TransactionId.Should().Be("tx-medium");
+        leases[2].TransactionId.Should().Be("tx-low");
     }
 
     [Fact]
-    public void Dequeue_RemovesTransactionsFromQueue()
+    public async Task ClaimAsync_HoldsTransactionsUnderLease()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-2"));
+        // Claimed transactions should not be visible to subsequent claims until the lease
+        // expires or is released. They remain in GetCount (claimed counts as in-queue).
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-2"));
 
-        // Act
-        var result = _queue.Dequeue(registerId, 1);
+        var first = await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        var second = await _queue.ClaimAsync("test-register", 5, DefaultLease, CancellationToken.None);
 
-        // Assert
-        result.Should().HaveCount(1);
-        _queue.GetCount(registerId).Should().Be(1);
+        first.Should().HaveCount(1);
+        second.Should().HaveCount(1, "the other transaction is still under lease");
+        first[0].TransactionId.Should().NotBe(second[0].TransactionId);
+        _queue.GetCount("test-register").Should().Be(2, "both are still in the queue (one available released by claim, one claimed)");
     }
 
     [Fact]
-    public void Dequeue_FromEmptyQueue_ReturnsEmptyList()
+    public async Task ClaimAsync_FromEmptyQueue_ReturnsEmptyList()
     {
-        // Act
-        var result = _queue.Dequeue("test-register", 10);
-
-        // Assert
-        result.Should().BeEmpty();
+        var leases = await _queue.ClaimAsync("test-register", 10, DefaultLease, CancellationToken.None);
+        leases.Should().BeEmpty();
     }
 
     [Fact]
-    public void Dequeue_WithNonExistentRegister_ReturnsEmptyList()
+    public async Task ClaimAsync_WithNonExistentRegister_ReturnsEmptyList()
     {
-        // Act
-        var result = _queue.Dequeue("nonexistent", 10);
-
-        // Assert
-        result.Should().BeEmpty();
+        var leases = await _queue.ClaimAsync("nonexistent", 10, DefaultLease, CancellationToken.None);
+        leases.Should().BeEmpty();
     }
 
     [Fact]
-    public void Peek_ReturnsTransactionsWithoutRemoving()
+    public async Task ConfirmAsync_RemovesTransactionsPermanently()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-2"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
 
-        // Act
-        var peeked = _queue.Peek(registerId, 2);
+        var leases = await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        await _queue.ConfirmAsync("test-register", leases.Select(l => l.TransactionId), CancellationToken.None);
 
-        // Assert
+        _queue.GetCount("test-register").Should().Be(0);
+        _queue.Contains("test-register", "tx-1").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ConfirmAsync_OnNeverClaimedTransaction_IsNoOp()
+    {
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+
+        await _queue.ConfirmAsync("test-register", new[] { "tx-1" }, CancellationToken.None);
+
+        // tx-1 was never claimed; confirm is a no-op.
+        _queue.GetCount("test-register").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ReleaseAsync_ReturnsTransactionsToAvailablePool()
+    {
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+
+        var leases = await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        await _queue.ReleaseAsync("test-register", leases.Select(l => l.TransactionId), CancellationToken.None);
+
+        // Transaction should be claimable again immediately.
+        var reclaimed = await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        reclaimed.Should().HaveCount(1);
+        reclaimed[0].TransactionId.Should().Be("tx-1");
+    }
+
+    [Fact]
+    public async Task ExpiredLease_AutoReleasesOnNextClaim()
+    {
+        // Use a lease shorter than the test sleep so we can observe auto-release.
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+
+        var firstClaim = await _queue.ClaimAsync("test-register", 1, TimeSpan.FromMilliseconds(50), CancellationToken.None);
+        firstClaim.Should().HaveCount(1);
+
+        // A subsequent claim before lease expiry sees nothing.
+        var midClaim = await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        midClaim.Should().BeEmpty();
+
+        await Task.Delay(80);
+
+        // After expiry, the next claim auto-releases and re-claims the transaction.
+        var afterClaim = await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        afterClaim.Should().HaveCount(1);
+        afterClaim[0].TransactionId.Should().Be("tx-1");
+    }
+
+    [Fact]
+    public void Peek_ReturnsTransactionsWithoutClaiming()
+    {
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-2"));
+
+        var peeked = _queue.Peek("test-register", 2);
+
         peeked.Should().HaveCount(2);
-        _queue.GetCount(registerId).Should().Be(2);
+        _queue.GetCount("test-register").Should().Be(2);
     }
 
     [Fact]
-    public void ReturnToQueue_ReturnsTransactionsToQueue()
+    public async Task Peek_AfterClaim_DoesNotShowClaimedTransactions()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
-        var dequeued = _queue.Dequeue(registerId, 1);
-        _queue.GetCount(registerId).Should().Be(0);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-2"));
 
-        // Act
-        _queue.ReturnToQueue(registerId, dequeued);
+        await _queue.ClaimAsync("test-register", 1, DefaultLease, CancellationToken.None);
+        var peeked = _queue.Peek("test-register", 5);
 
-        // Assert
-        _queue.GetCount(registerId).Should().Be(1);
+        peeked.Should().HaveCount(1, "one transaction is held under lease");
     }
 
     [Fact]
     public void Remove_ExistingTransaction_ReturnsTrue()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
 
-        // Act
-        var result = _queue.Remove(registerId, "tx-1");
+        var result = _queue.Remove("test-register", "tx-1");
 
-        // Assert
         result.Should().BeTrue();
-        _queue.Contains(registerId, "tx-1").Should().BeFalse();
+        _queue.Contains("test-register", "tx-1").Should().BeFalse();
     }
 
     [Fact]
     public void Remove_NonExistingTransaction_ReturnsFalse()
     {
-        // Act
         var result = _queue.Remove("test-register", "nonexistent");
-
-        // Assert
         result.Should().BeFalse();
     }
 
     [Fact]
     public void Contains_ExistingTransaction_ReturnsTrue()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
-
-        // Act
-        var result = _queue.Contains(registerId, "tx-1");
-
-        // Assert
-        result.Should().BeTrue();
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+        _queue.Contains("test-register", "tx-1").Should().BeTrue();
     }
 
     [Fact]
-    public void Contains_NonExistingTransaction_ReturnsFalse()
+    public void GetCount_ReturnsCountForRegister()
     {
-        // Act
-        var result = _queue.Contains("test-register", "nonexistent");
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-2"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-3"));
 
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Fact]
-    public void GetCount_ReturnsCorrectCount()
-    {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-2"));
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-3"));
-
-        // Act
-        var count = _queue.GetCount(registerId);
-
-        // Assert
-        count.Should().Be(3);
+        _queue.GetCount("test-register").Should().Be(3);
     }
 
     [Fact]
     public void GetTotalCount_ReturnsCountAcrossAllRegisters()
     {
-        // Arrange
         _queue.Enqueue("register-1", CreateTestTransaction("tx-1"));
         _queue.Enqueue("register-1", CreateTestTransaction("tx-2"));
         _queue.Enqueue("register-2", CreateTestTransaction("tx-3"));
 
-        // Act
-        var total = _queue.GetTotalCount();
-
-        // Assert
-        total.Should().Be(3);
+        _queue.GetTotalCount().Should().Be(3);
     }
 
     [Fact]
-    public void GetStats_ReturnsCorrectStatistics()
+    public async Task GetStats_ReturnsCorrectStatistics()
     {
-        // Arrange
         _queue.Enqueue("register-1", CreateTestTransaction("tx-1"));
         _queue.Enqueue("register-2", CreateTestTransaction("tx-2"));
-        _queue.Dequeue("register-1", 1);
+        var leases = await _queue.ClaimAsync("register-1", 1, DefaultLease, CancellationToken.None);
+        await _queue.ConfirmAsync("register-1", leases.Select(l => l.TransactionId), CancellationToken.None);
 
-        // Act
         var stats = _queue.GetStats();
 
-        // Assert
         stats.TotalEnqueued.Should().Be(2);
-        stats.TotalDequeued.Should().Be(1);
+        stats.TotalConfirmed.Should().Be(1);
         stats.TotalTransactions.Should().Be(1);
         stats.ActiveRegisters.Should().Be(1);
     }
@@ -320,16 +303,12 @@ public class VerifiedTransactionQueueTests
     [Fact]
     public void GetRegisterStats_ReturnsCorrectStatistics()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"), priority: 5);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-2"), priority: 10);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"), priority: 5);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-2"), priority: 10);
 
-        // Act
-        var stats = _queue.GetRegisterStats(registerId);
+        var stats = _queue.GetRegisterStats("test-register");
 
-        // Assert
-        stats.RegisterId.Should().Be(registerId);
+        stats.RegisterId.Should().Be("test-register");
         stats.TransactionCount.Should().Be(2);
         stats.AveragePriority.Should().Be(7.5);
     }
@@ -337,32 +316,25 @@ public class VerifiedTransactionQueueTests
     [Fact]
     public void Clear_RemovesAllTransactionsForRegister()
     {
-        // Arrange
-        var registerId = "test-register";
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-1"));
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-2"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-1"));
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-2"));
         _queue.Enqueue("other-register", CreateTestTransaction("tx-3"));
 
-        // Act
-        var cleared = _queue.Clear(registerId);
+        var cleared = _queue.Clear("test-register");
 
-        // Assert
         cleared.Should().Be(2);
-        _queue.GetCount(registerId).Should().Be(0);
+        _queue.GetCount("test-register").Should().Be(0);
         _queue.GetCount("other-register").Should().Be(1);
     }
 
     [Fact]
     public void ClearAll_RemovesAllTransactions()
     {
-        // Arrange
         _queue.Enqueue("register-1", CreateTestTransaction("tx-1"));
         _queue.Enqueue("register-2", CreateTestTransaction("tx-2"));
 
-        // Act
         var cleared = _queue.ClearAll();
 
-        // Assert
         cleared.Should().Be(2);
         _queue.GetTotalCount().Should().Be(0);
     }
@@ -370,93 +342,70 @@ public class VerifiedTransactionQueueTests
     [Fact]
     public void Enqueue_WhenMaxRegistersReached_ReturnsFalse()
     {
-        // Arrange - Fill up to max registers
         for (var i = 0; i < _config.MaxRegisters; i++)
         {
             _queue.Enqueue($"register-{i}", CreateTestTransaction($"tx-{i}"));
         }
 
-        // Act - Try to add to a new register
         var result = _queue.Enqueue("new-register", CreateTestTransaction("tx-new"));
 
-        // Assert
         result.Should().BeFalse();
     }
 
     [Fact]
     public void Enqueue_ToExistingRegisterWhenMaxRegistersReached_ReturnsTrue()
     {
-        // Arrange - Fill up to max registers
         for (var i = 0; i < _config.MaxRegisters; i++)
         {
             _queue.Enqueue($"register-{i}", CreateTestTransaction($"tx-{i}"));
         }
 
-        // Act - Add to an existing register
         var result = _queue.Enqueue("register-0", CreateTestTransaction("tx-new"));
 
-        // Assert
         result.Should().BeTrue();
     }
 
     [Fact]
-    public void Enqueue_WithPriority_OrdersCorrectly()
+    public async Task ClaimAsync_WithPriority_OrdersCorrectly()
     {
-        // Arrange
-        var registerId = "test-register";
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-normal"), priority: 0);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-urgent"), priority: 100);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-high"), priority: 50);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-low"), priority: -10);
 
-        // Act - Enqueue in random order with different priorities
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-normal"), priority: 0);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-urgent"), priority: 100);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-high"), priority: 50);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-low"), priority: -10);
+        var leases = await _queue.ClaimAsync("test-register", 4, DefaultLease, CancellationToken.None);
 
-        // Assert - Dequeue should return in priority order
-        var dequeued = _queue.Dequeue(registerId, 4);
-        dequeued[0].TransactionId.Should().Be("tx-urgent");
-        dequeued[1].TransactionId.Should().Be("tx-high");
-        dequeued[2].TransactionId.Should().Be("tx-normal");
-        dequeued[3].TransactionId.Should().Be("tx-low");
+        leases[0].TransactionId.Should().Be("tx-urgent");
+        leases[1].TransactionId.Should().Be("tx-high");
+        leases[2].TransactionId.Should().Be("tx-normal");
+        leases[3].TransactionId.Should().Be("tx-low");
     }
 
     [Fact]
-    public void Dequeue_SamePriority_ReturnsFifoOrder()
+    public async Task ClaimAsync_SamePriority_ReturnsFifoOrder()
     {
-        // Arrange
-        var registerId = "test-register";
-
-        // Enqueue with same priority - should maintain FIFO
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-first"), priority: 5);
-        Thread.Sleep(10); // Small delay to ensure different timestamps
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-second"), priority: 5);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-first"), priority: 5);
         Thread.Sleep(10);
-        _queue.Enqueue(registerId, CreateTestTransaction("tx-third"), priority: 5);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-second"), priority: 5);
+        Thread.Sleep(10);
+        _queue.Enqueue("test-register", CreateTestTransaction("tx-third"), priority: 5);
 
-        // Act
-        var dequeued = _queue.Dequeue(registerId, 3);
+        var leases = await _queue.ClaimAsync("test-register", 3, DefaultLease, CancellationToken.None);
 
-        // Assert - Should be in FIFO order within same priority
-        dequeued[0].TransactionId.Should().Be("tx-first");
-        dequeued[1].TransactionId.Should().Be("tx-second");
-        dequeued[2].TransactionId.Should().Be("tx-third");
+        leases[0].TransactionId.Should().Be("tx-first");
+        leases[1].TransactionId.Should().Be("tx-second");
+        leases[2].TransactionId.Should().Be("tx-third");
     }
 
-    #region Helper Methods
-
-    private static Transaction CreateTestTransaction(string id)
+    private static Transaction CreateTestTransaction(string id) => new()
     {
-        return new Transaction
-        {
-            TransactionId = id,
-            RegisterId = "test-register",
-            BlueprintId = "bp-1",
-            ActionId = "action-1",
-            Payload = JsonSerializer.Deserialize<JsonElement>("{}"),
-            CreatedAt = DateTimeOffset.UtcNow,
-            Signatures = [],
-            PayloadHash = "hash-" + id
-        };
-    }
-
-    #endregion
+        TransactionId = id,
+        RegisterId = "test-register",
+        BlueprintId = "bp-1",
+        ActionId = "action-1",
+        Payload = JsonSerializer.Deserialize<JsonElement>("{}"),
+        CreatedAt = DateTimeOffset.UtcNow,
+        Signatures = [],
+        PayloadHash = "hash-" + id
+    };
 }


### PR DESCRIPTION
## Summary

PR 7 of feature 113. Reshapes the validator mempool contract from atomic `Dequeue`/`ReturnToQueue` to the `Claim`/`Confirm`/`Release` lease pattern that PR 8's Redis-backed implementation needs to coordinate HA validator replicas without double-sealing.

**Behaviour-neutral on the build path** — today's "drop transactions on build success" semantic is preserved (Confirm at end of success path; Release on failure). Mempool is still in-process (renamed `InMemoryVerifiedTransactionQueue`); restart durability comes in PR 8.

## What's in scope

- `IVerifiedTransactionQueue`: `Dequeue`/`ReturnToQueue` removed; `ClaimAsync`/`ConfirmAsync`/`ReleaseAsync` added. New `VerifiedTransactionLease` record. `VerifiedQueueStats.TotalDequeued` → `TotalConfirmed`.
- `VerifiedTransactionQueue.cs` → `InMemoryVerifiedTransactionQueue.cs` (git mv). Per-register state now tracks `_available` + `_claimed` separately with auto-release on lease expiry.
- `VerifiedQueueExtensions.AddVerifiedTransactionQueue` records the choice via `IStorageRegistrationLog`. `IVerifiedTransactionQueue` is on the audited list — Production/Staging fail-fast fires on this in-memory implementation (unless `Storage:AllowInMemoryInProduction=true`).
- `DocketBuildConfiguration.LeaseDurationSeconds` (default 60).
- `DocketBuilder.BuildDocketAsync` migrated to claim/confirm/release. `MetricsEndpoints` continues exposing `TotalDequeued` at the API boundary (mapped from `TotalConfirmed`).
- Tests rewritten: 29 `VerifiedTransactionQueueTests` cover the new contract incl. lease-expiry auto-release; `DocketBuilderTests` mocks migrated from `Dequeue` to `ClaimAsync` with a default no-op `ConfirmAsync`/`ReleaseAsync` setup.

## Test plan

- [x] `dotnet build` clean (0 errors)
- [x] 906 `Sorcha.Validator.Service.Tests` pass on this branch (was 903 on master)
- [x] 30 pre-existing test failures unchanged from master (DocketBuilderTests, ValidationEngine*, TransactionPoolPollerTests — not introduced by this PR; verified by checking out master and running the same suite)
- [ ] CI: pre-existing failures expected; merge with `--admin`

## Why no Redis backing yet

Spec scopes US2 across PR 7 (contract reshape) and PR 8 (Redis backing) so the contract change can be reviewed in isolation. PR 8 lands `RedisVerifiedTransactionQueue`, the OTel metrics, and the deployment manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)