### PR TITLE
fix(tenant-tests): pass IOptions<DemoEnvironmentSettings> to LoginModel + SignupModel ctors

### DIFF
--- a/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Sorcha.Tenant.Service.Data.Repositories;
 using Sorcha.Tenant.Service.Models;
@@ -35,7 +36,8 @@ public class LoginModelTests
             _tokenService.Object,
             _identityRepo.Object,
             _orgRepo.Object,
-            NullLogger<LoginModel>.Instance);
+            NullLogger<LoginModel>.Instance,
+            Options.Create(new DemoEnvironmentSettings()));
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
@@ -7,7 +7,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
+using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Pages.Auth;
 using Sorcha.Tenant.Service.Services;
 
@@ -24,7 +26,8 @@ public class SignupModelTests
     {
         var model = new SignupModel(
             _registrationService.Object,
-            NullLogger<SignupModel>.Instance);
+            NullLogger<SignupModel>.Instance,
+            Options.Create(new DemoEnvironmentSettings()));
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(


### PR DESCRIPTION
## Summary

Two test files have been blocking `build-and-test` and `Analyze (csharp)` CI on every PR since #397 (demo-environment-banner). The production constructors gained a required `IOptions<DemoEnvironmentSettings>` parameter but the tests weren't updated.

## Fix

Pass `Options.Create(new DemoEnvironmentSettings())` as the new argument in both test factories. Defaults to `Enabled=false` so existing test scenarios are unchanged.

| File | Line |
|------|------|
| `tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs` | 32 |
| `tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs` | 25 |

## Test plan

- [x] `dotnet build tests/Sorcha.Tenant.Service.Tests/` clean
- [x] 17/17 `LoginModelTests` + `SignupModelTests` pass
- [ ] CI: `build-and-test` + `Analyze (csharp)` should now pass on this PR (the fix unblocks itself)

## Impact

After this lands, future PRs no longer need `--admin` merge for these specific CI failures. (Other `link-check` / `nuget-ci` flakiness remains per `MEMORY.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)