### PR TITLE
fix(api-gateway): remove invalid YARP comment route added in PR #420

### DIFF
--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -314,7 +314,6 @@
       "wallet-wallets":        { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Match": { "Path": "/api/v1/wallets/{**catch-all}" } },
       "wallet-presentations":  { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/v1/presentations/{**catch-all}" } },
 
-      "_comment-feature-114": "Citizen wallet PWA + status list + reference verifier (Feature 114)",
       "wallet-citizen-status-public": { "ClusterId": "wallet-cluster", "Order": 1, "Match": { "Path": "/api/v1/wallet/status/{**catch-all}" } },
       "wallet-citizen":               { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Order": 2, "Match": { "Path": "/api/v1/wallet/{**catch-all}" } },
       "citizen-wallet-pwa":           { "ClusterId": "citizen-wallet-cluster", "Match": { "Path": "/wallet/{**catch-all}" }, "Transforms": [ { "X-Forwarded": "Set" } ] },


### PR DESCRIPTION
Drops the '_comment-feature-114' entry that YARP parsed as a real route, crashing api-gateway on startup. Caught when redeploying n1 after #420 merged. See commit message.