### PR TITLE
ci: publish citizen-wallet + citizen-verifier images (Feature 114)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -36,6 +36,10 @@ jobs:
             dockerfile: src/Apps/Sorcha.McpServer/Dockerfile
           - service: ui-web
             dockerfile: src/Apps/Sorcha.UI/Sorcha.UI.Web/Dockerfile
+          - service: citizen-wallet
+            dockerfile: src/Apps/Sorcha.Citizen.Wallet/Dockerfile
+          - service: citizen-verifier
+            dockerfile: src/Apps/Sorcha.Citizen.Verifier/Dockerfile
 
     name: Build ${{ matrix.service }}
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Detect changed services
         id: detect
         run: |
-          ALL_SERVICES='["blueprint-service","wallet-service","register-service","tenant-service","peer-service","validator-service","api-gateway","mcp-server","ui-web","haip-service"]'
+          ALL_SERVICES='["blueprint-service","wallet-service","register-service","tenant-service","peer-service","validator-service","api-gateway","mcp-server","ui-web","haip-service","citizen-wallet","citizen-verifier"]'
 
           if [ "${{ github.event.inputs.force_publish_all }}" == "true" ]; then
             echo "Force publishing all services"
@@ -65,6 +65,8 @@ jobs:
           SERVICE_PATHS["mcp-server"]="src/Apps/Sorcha.McpServer/"
           SERVICE_PATHS["ui-web"]="src/Apps/Sorcha.UI/"
           SERVICE_PATHS["haip-service"]="src/Services/Sorcha.Haip.Service/"
+          SERVICE_PATHS["citizen-wallet"]="src/Apps/Sorcha.Citizen.Wallet/"
+          SERVICE_PATHS["citizen-verifier"]="src/Apps/Sorcha.Citizen.Verifier/"
 
           CHANGED="["
           FIRST=true
@@ -113,6 +115,8 @@ jobs:
           DOCKERFILES["mcp-server"]="src/Apps/Sorcha.McpServer/Dockerfile"
           DOCKERFILES["ui-web"]="src/Apps/Sorcha.UI/Sorcha.UI.Web/Dockerfile"
           DOCKERFILES["haip-service"]="src/Services/Sorcha.Haip.Service/Dockerfile"
+          DOCKERFILES["citizen-wallet"]="src/Apps/Sorcha.Citizen.Wallet/Dockerfile"
+          DOCKERFILES["citizen-verifier"]="src/Apps/Sorcha.Citizen.Verifier/Dockerfile"
           echo "dockerfile=${DOCKERFILES[${{ matrix.service }}]}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Adds the two new app images from PR #420 to both Docker workflows so DockerHub and PR-build coverage match the new docker-compose.yml entries.