### PR TITLE
feat(115): public social signup on n1 with strict link policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,21 @@ REDIS_PASSWORD=
 ASPNETCORE_ENVIRONMENT=Development
 
 # =============================================================================
+# Social login OAuth credentials                                      [SECRET]
+# =============================================================================
+# Used only on environments configured for public social signup (e.g. n1).
+# Leave blank for local dev — the corresponding "Continue with..." buttons
+# will be hidden when credentials are absent.
+#
+# To register the OAuth applications and obtain these values, see:
+#   docs/guides/SOCIAL-LOGIN-SETUP.md
+
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+GITHUB_OAUTH_CLIENT_ID=
+GITHUB_OAUTH_CLIENT_SECRET=
+
+# =============================================================================
 # AI Integration (Optional)
 # =============================================================================
 

--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -54,6 +54,22 @@ services:
       # so visitors know the environment may be reset without notice. Plain
       # informational notice; no consent gate, no friction.
       DemoEnvironment__Enabled: "true"
+      # Public organisation is enabled at first DB seed so a freshly-reset n1
+      # supports social signup without an admin manually flipping the toggle.
+      # After first seed the value persists in tenant.platform_settings; this
+      # env var is only consulted when seeding a fresh database. Feature 115.
+      PlatformSettings__SeedPublicOrgEnabled: "true"
+      # Social login providers — feature 115. ClientId/ClientSecret are
+      # interpolated from the host's /opt/sorcha/.env file (gitignored).
+      # Buttons for unconfigured providers are hidden client-side, so leaving
+      # any of these blank cleanly disables that provider on this environment.
+      # Setup runbook: docs/guides/SOCIAL-LOGIN-SETUP.md
+      SocialProviders__0__Name: Google
+      SocialProviders__0__ClientId: ${GOOGLE_OAUTH_CLIENT_ID:-}
+      SocialProviders__0__ClientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET:-}
+      SocialProviders__1__Name: GitHub
+      SocialProviders__1__ClientId: ${GITHUB_OAUTH_CLIENT_ID:-}
+      SocialProviders__1__ClientSecret: ${GITHUB_OAUTH_CLIENT_SECRET:-}
 
   peer-service:
     image: sorchadev/peer-service:latest

--- a/docs/guides/SOCIAL-LOGIN-SETUP.md
+++ b/docs/guides/SOCIAL-LOGIN-SETUP.md
@@ -1,0 +1,208 @@
+# Social Login Setup
+
+This guide walks operators through enabling public-user social signup on
+a Sorcha environment. The current production target is `n1.sorcha.dev`
+with two providers (Google and GitHub).
+
+## Overview
+
+Sorcha supports OAuth2/OIDC social signup via a configurable provider
+list. To enable a provider on an environment you need three things:
+
+1. An OAuth application registered with the provider (yields a Client
+   ID + Client Secret)
+2. The provider's redirect URI registered to point at this environment
+   (`https://<env-host>/auth/social/callback`)
+3. Configuration on the host that exposes the credentials to the
+   running Tenant Service container
+
+The signup and login pages render a "Continue with `<provider>`" button
+only for providers that are configured with non-empty credentials.
+Adding or removing a provider is a configuration change followed by a
+service restart — no code changes required.
+
+## Per-environment redirect URIs
+
+Each environment uses a single canonical callback URL. Register exactly
+this URL with each provider — typo-driven mismatches yield
+`redirect_uri_mismatch` errors at the provider's consent screen.
+
+| Environment | Redirect URI |
+|---|---|
+| n1 | `https://n1.sorcha.dev/auth/social/callback` |
+| Local development | `https://localhost:7110/auth/social/callback` |
+
+## Provider 1 — Google
+
+### Register the OAuth application
+
+1. Open <https://console.cloud.google.com> and sign in with the Google
+   account that should own the OAuth app.
+2. Create or select the project that will host this Sorcha environment
+   (e.g. "Sorcha n1").
+3. Navigate to **APIs & Services → OAuth consent screen**:
+   - User type: **External**
+   - App name: e.g. "Sorcha (n1 demonstrator)"
+   - Support email: your email
+   - Authorised domains: add `sorcha.dev`
+   - Developer contact: your email
+   - Scopes: `openid`, `email`, `profile` (no other scopes are required)
+   - Save and continue. Test mode is sufficient for ≤100 users.
+4. Navigate to **APIs & Services → Credentials → Create Credentials →
+   OAuth client ID**:
+   - Application type: **Web application**
+   - Name: e.g. "Sorcha n1 Web"
+   - Authorised redirect URIs:
+     - `https://n1.sorcha.dev/auth/social/callback`
+     - (optional) `https://localhost:7110/auth/social/callback` for dev
+   - Click **Create**.
+5. Copy the **Client ID** and **Client Secret** shown in the dialog.
+
+### Capture the values
+
+You should now have two strings — keep them somewhere secure (a
+password manager). They are the values for `GOOGLE_OAUTH_CLIENT_ID` and
+`GOOGLE_OAUTH_CLIENT_SECRET` in the next step.
+
+## Provider 2 — GitHub
+
+### Register the OAuth application
+
+1. Open <https://github.com/settings/developers> (Settings → Developer
+   settings → OAuth Apps).
+2. Click **New OAuth App**:
+   - Application name: e.g. "Sorcha n1"
+   - Homepage URL: `https://n1.sorcha.dev`
+   - Authorization callback URL:
+     `https://n1.sorcha.dev/auth/social/callback`
+   - Click **Register application**.
+3. On the resulting page, click **Generate a new client secret**.
+4. Copy the **Client ID** and the **Client Secret** (the secret is
+   displayed only once — save it immediately).
+
+### Capture the values
+
+These are `GITHUB_OAUTH_CLIENT_ID` and `GITHUB_OAUTH_CLIENT_SECRET`.
+
+## Deploy on n1
+
+### One-time `.env` seed
+
+Once you have the four credentials in hand:
+
+```bash
+ssh sorcha@51.105.7.135
+cd /opt/sorcha
+
+# If .env does not exist, copy from the template:
+# scp .env.example sorcha@51.105.7.135:/opt/sorcha/.env
+
+nano .env
+# Set the four values:
+#   GOOGLE_OAUTH_CLIENT_ID=...
+#   GOOGLE_OAUTH_CLIENT_SECRET=...
+#   GITHUB_OAUTH_CLIENT_ID=...
+#   GITHUB_OAUTH_CLIENT_SECRET=...
+
+chmod 600 .env
+```
+
+The `.env` file is read by Docker Compose during `docker compose up`
+and interpolated into the canonical .NET configuration keys
+(`SocialProviders__0__ClientId` etc.) per
+`docker-compose.n1.yml:tenant-service.environment`.
+
+### Apply the configuration
+
+After editing `.env`, restart the Tenant Service container:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml \
+  restart tenant-service
+```
+
+A full reset (`scripts/n1-reset.ps1`) is needed only when you have new
+images to pull; for a credentials-only change a restart is sufficient.
+
+## Verify the deploy
+
+1. Open `https://n1.sorcha.dev/auth/signup` in a browser.
+2. Confirm the demonstrator banner is visible at the top of the page.
+3. Click the **Social** tab. Two buttons should appear: "Continue with
+   Google" and "Continue with GitHub". No Microsoft or Apple buttons
+   (those providers are out of scope for this environment).
+4. Click **Continue with Google**. You should be redirected to
+   Google's consent screen, then back to Sorcha, and land signed in to
+   the application home (`/app/`).
+5. The first sign-in dispatches a welcome email — check the inbox.
+6. Sign out and try **Continue with GitHub** with a different account
+   to confirm the second provider works.
+7. (Optional) Confirm telemetry: check the Aspire dashboard's metrics
+   pane for `sorcha_social_login_refusal_total` — it should be zero
+   for happy-path sign-ins. To exercise the refusal path, register a
+   password account with an email and don't verify it; then attempt
+   social signup with the same email at Google. The attempt should be
+   refused with a clear message and the counter should increment with
+   `reason=existing_unverified`.
+
+## Rotate credentials
+
+To rotate a provider's client secret:
+
+1. Generate a new secret at the provider's developer console (Google
+   Cloud Console → Credentials → your OAuth client → Add secret;
+   GitHub → OAuth Apps → your app → Generate a new client secret).
+2. SSH to the n1 host: `ssh sorcha@51.105.7.135`
+3. `nano /opt/sorcha/.env` — replace the old secret with the new one
+4. `cd /opt/sorcha && docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml restart tenant-service`
+5. Verify with a sign-in, then revoke the old secret at the provider.
+
+The whole rotation should take under five minutes.
+
+## Troubleshooting
+
+### `redirect_uri_mismatch` from the provider
+
+- The redirect URI in the provider's OAuth app does not exactly match
+  `https://n1.sorcha.dev/auth/social/callback`. Common causes: trailing
+  slash, `http` instead of `https`, typo in the hostname.
+
+### Buttons don't appear on `/auth/signup`
+
+- The Tenant Service is not picking up the env vars. Check
+  `docker compose -f docker-compose.yml -f docker-compose.n1.yml exec tenant-service env | grep -i social`
+  to confirm the values are present in the running container. If
+  they're empty, verify `/opt/sorcha/.env` has the four lines and the
+  host shell isn't inadvertently exporting blank values.
+
+### `invalid_client` from the provider after consent
+
+- The Client ID or Client Secret is wrong. Re-copy from the provider's
+  developer console; secrets often have leading/trailing whitespace
+  when copy-pasted from web pages.
+
+### "Public organisation is not enabled" error from the initiate API
+
+- `PlatformSettings.PublicOrgEnabled = false` in the database. On a
+  fresh n1 reset this is set from `PlatformSettings__SeedPublicOrgEnabled`
+  in `docker-compose.n1.yml`. If you've toggled it off via the admin UI,
+  toggle it back on at `https://n1.sorcha.dev/admin/settings/platform`.
+
+## Adding a new provider later
+
+The codebase already supports Microsoft and Apple as recognised
+provider names with well-known endpoint defaults. To enable Microsoft
+on this environment in future:
+
+1. Register a Microsoft Entra app and grab its Client ID + Secret.
+2. Add `SocialProviders__2__Name: Microsoft`,
+   `SocialProviders__2__ClientId: ${MICROSOFT_OAUTH_CLIENT_ID}`,
+   `SocialProviders__2__ClientSecret: ${MICROSOFT_OAUTH_CLIENT_SECRET}`
+   to `docker-compose.n1.yml`.
+3. Add the matching env-var lines to `.env.example` and the host's
+   `/opt/sorcha/.env`.
+4. Restart the Tenant Service.
+
+A "Continue with Microsoft" button will appear automatically. No code
+change required. Apple is currently deferred — it requires a JWT-based
+client-secret flow that the codebase does not implement today.

--- a/docs/guides/SOCIAL-LOGIN-SETUP.md
+++ b/docs/guides/SOCIAL-LOGIN-SETUP.md
@@ -91,7 +91,7 @@ These are `GITHUB_OAUTH_CLIENT_ID` and `GITHUB_OAUTH_CLIENT_SECRET`.
 Once you have the four credentials in hand:
 
 ```bash
-ssh sorcha@51.105.7.135
+ssh sorcha@n1.sorcha.dev
 cd /opt/sorcha
 
 # If .env does not exist, copy from the template:
@@ -152,7 +152,7 @@ To rotate a provider's client secret:
 1. Generate a new secret at the provider's developer console (Google
    Cloud Console → Credentials → your OAuth client → Add secret;
    GitHub → OAuth Apps → your app → Generate a new client secret).
-2. SSH to the n1 host: `ssh sorcha@51.105.7.135`
+2. SSH to the n1 host: `ssh sorcha@n1.sorcha.dev`
 3. `nano /opt/sorcha/.env` — replace the old secret with the new one
 4. `cd /opt/sorcha && docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml restart tenant-service`
 5. Verify with a sign-in, then revoke the old secret at the provider.

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -452,7 +452,8 @@ FIDO2/WebAuthn passkey authentication for both organizational users (2FA) and pu
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/api/auth/public/social/initiate` | Anonymous | Initiate OAuth flow for provider (Google, Microsoft, GitHub, Apple) |
-| POST | `/api/auth/public/social/callback` | Anonymous | Handle OAuth callback, provision user, issue tokens |
+| POST | `/api/auth/public/social/callback` | Anonymous | Handle OAuth callback (SPA flow), provision user under strict link policy, issue tokens. Returns 400 with refusal message when `email_verified=false` from provider or when target user is unverified. |
+| GET  | `/auth/social/callback` | Anonymous | Razor-page browser redirect URI for OAuth providers. Single canonical path per environment. Provider is recovered from cached state, NOT a query parameter. See `docs/guides/SOCIAL-LOGIN-SETUP.md`. |
 
 #### Public User Auth Method Management
 

--- a/docs/superpowers/specs/2026-04-26-social-signup-n1-design.md
+++ b/docs/superpowers/specs/2026-04-26-social-signup-n1-design.md
@@ -75,6 +75,13 @@ The plumbing is in good shape; what is missing is:
 - BACKLOG-5: Azure Key Vault for OAuth secrets at first Kubernetes deployment
 - BACKLOG-6: Google OAuth consent-screen real-publisher verification when
   organic n1 traffic exceeds the 100-user test-mode cap
+- BACKLOG-7: Existing-`PlatformSocialLogin`-row audit before any non-reset
+  rollout of the strict-link policy. n1 is reset on this deploy so all
+  rows are fresh under the new policy; if the policy is later applied
+  to an environment that has accumulated history, those rows carry no
+  link-time `EmailVerified` evidence and would all pass Scenario A
+  (returning user, no re-check) silently. Surfaced by claude-review on
+  PR #423.
 
 ## Decisions
 

--- a/docs/superpowers/specs/2026-04-26-social-signup-n1-design.md
+++ b/docs/superpowers/specs/2026-04-26-social-signup-n1-design.md
@@ -1,0 +1,416 @@
+# Social Signup on n1 — Production-Leaning Public Signup Design
+
+**Date:** 2026-04-26
+**Author:** Brainstorm with Stuart Fraser
+**Status:** Approved for planning
+**Scope tag:** B (deploy/config + policy fixes). C-bucket items captured as backlog.
+
+## Goal
+
+Make public-user social signup work end-to-end on `n1.sorcha.dev` with two real
+OAuth providers (Google + GitHub), and lock in the policy decisions that affect
+security and identity provenance, before n1 starts taking real signups from
+organic public traffic.
+
+## Background
+
+Sorcha's Tenant Service already contains the full OAuth2/OIDC plumbing for
+Google, Microsoft, GitHub, and Apple — `SocialLoginService` with PKCE for
+OIDC providers, state CSRF, well-known endpoint defaults, claim extraction,
+`PlatformSocialLogin` table for `(provider, sub)` linking, `SocialCallback`
+Razor page that auto-creates `PlatformUser` and `UserIdentity` in the public
+org, welcome-email dispatcher integration (feature 112), and authenticated
+provider-link endpoint.
+
+**Feature 114 dependency.** As of master commit `d0cdd55a` (Citizen Wallet
+PWA, #420), social signup is also the entry point for the citizen wallet
+flow — wallet recovery is anchored on `PlatformUser` identity, so a Google
+or GitHub sign-in becomes the gateway to enrolling a wallet device and
+holding verifiable credentials. This elevates the security importance of
+the strict link policy (REQ-2): the threat model is no longer just "account
+takeover" but "wallet impersonation against a verifiable-credential
+holder." The unverified-existing-account hijack scenario must be closed.
+
+The plumbing is in good shape; what is missing is:
+
+1. **Real OAuth client IDs/secrets** — `appsettings.json` ships
+   `"SocialProviders": []`. n1 currently cannot do social login because no
+   provider is configured.
+2. **A live bug in the redirect URI** — `SocialLoginEndpoints.cs` sets
+   `redirect_uri` to `/api/auth/social/callback-redirect`, which has no
+   handler. The Razor page that *does* handle the callback lives at
+   `/auth/social/callback`. Today a real user would 404 after Google's
+   redirect.
+3. **Policy gaps that affect security** — the existing
+   `ResolveOrCreateSocialUserAsync` links by email match without checking
+   either side's verification state, allowing an unverified-existing-account
+   hijack scenario.
+4. **Operational defaults that block fresh n1 deploys** —
+   `PublicOrgEnabled = false` is hard-coded in the DB seed, so a freshly-reset
+   n1 has social login disabled until an admin manually flips it.
+
+## Scope
+
+### In scope
+
+- Fix the redirect-URI mismatch (single per-env URL at `/auth/social/callback`)
+- Capture provider `email_verified` claim and act on it
+- Strict link policy: refuse cross-method linking unless both sides verified
+- Refuse new-user signup when provider asserts `email_verified=false`
+- Refresh `PlatformUser.DisplayName` from provider `name` claim each login
+- Provider buttons render only for configured providers (REQ-1)
+- `PublicOrgEnabled` seed value becomes config-driven
+- `docker-compose.n1.yml` + `.env` additions for Google + GitHub
+- `n1-deploy.ps1` / setup runbook documents OAuth-app registration
+- xUnit tests covering the policy decisions
+- Refusal-message UX in the existing `SocialCallback` error rendering
+
+### Out of scope (backlog)
+
+- BACKLOG-1: provider email-change conflict UX (drift option C from brainstorm)
+- BACKLOG-2: Microsoft provider (next; needs work-vs-personal account policy)
+- BACKLOG-3: Apple provider (requires JWT-based `client_secret` refactor —
+  current code uses static form-param secret, which Apple does not accept)
+- BACKLOG-4: Consumer Persona attribute model (feature 092 territory)
+- BACKLOG-5: Azure Key Vault for OAuth secrets at first Kubernetes deployment
+- BACKLOG-6: Google OAuth consent-screen real-publisher verification when
+  organic n1 traffic exceeds the 100-user test-mode cap
+
+## Decisions
+
+| ID | Decision |
+|---|---|
+| REQ-1 | Signup buttons render only for providers configured with non-empty `ClientId` and `ClientSecret`. Driven by `Model.AvailableProviders` set in `SignupModel.OnGet`. |
+| REQ-2 | Strict link policy. Both sides must be verified. Provider must assert `email_verified=true` (or be GitHub with primary-verified email); existing user must have `EmailVerified=true`. New-user signup refused when provider says unverified. |
+| REQ-3 | Refresh `PlatformUser.DisplayName` from provider `name` claim on every successful login. Email never refreshed in this scope (BACKLOG-1). |
+| REQ-4 | `DemoEnvironment.Enabled=true` on n1, default `false` elsewhere. Already wired in `docker-compose.n1.yml:55`; verify deployed. |
+| REQ-5 | OAuth client secrets in `/opt/sorcha/.env` on the n1 host (hand-created on first deploy, gitignored). `docker-compose.n1.yml` references via `${GOOGLE_OAUTH_CLIENT_ID}` etc. KV migration deferred to first Kubernetes deployment (BACKLOG-5). |
+| REQ-6 | Single redirect URI per env at `https://n1.sorcha.dev/auth/social/callback`. Fixes a live bug in `SocialLoginEndpoints.cs` (was `/api/auth/social/callback-redirect`, no handler). `SocialCallback.cshtml.cs` resolves provider from cached state-data, not query string. |
+| REQ-7 | Stay `ASPNETCORE_ENVIRONMENT=Development` on n1 for now. Switch to `Staging` in ~1 week (`/schedule` reminder) to activate feature 113 storage fail-fast. Switching requires a one-line compose edit + verifying all six audited interfaces resolve to Postgres/Redis backends. |
+| REQ-8 | `PlatformSettings__SeedPublicOrgEnabled` env var read by `DatabaseInitializer` at seed time only. n1's compose sets `true`. Once seeded, admin UI/API toggles take precedence. |
+| REQ-9 | OAuth-app setup steps documented in `docs/guides/SOCIAL-LOGIN-SETUP.md` plus a pointer from the `n1-deploy` skill. Actual key generation + paste happens collaboratively at deploy time, not autonomously. |
+
+## Architecture
+
+No new services. No new database tables. No new endpoints. The user-visible
+flow is unchanged; we are fixing a bug, hardening policy, and making
+configuration drive what was previously hard-coded.
+
+```
+┌──────────────────────────┐
+│  Signup.cshtml (Razor)   │  ← buttons driven by Model.AvailableProviders
+└──────────┬───────────────┘
+           │  POST /api/auth/social/initiate
+           ▼
+┌──────────────────────────┐
+│  SocialLoginEndpoints    │  ← redirect_uri to /auth/social/callback (BUG FIX)
+└──────────┬───────────────┘
+           │  caches {provider, codeVerifier, redirectUri} keyed by state
+           ▼
+┌──────────────────────────┐
+│  SocialLoginService      │  ← reads email_verified claim; honour it
+└──────────┬───────────────┘
+           │  user → Google/GitHub → consent → redirect back
+           ▼
+┌──────────────────────────────────┐
+│  SocialCallback.cshtml (Razor)   │  ← reads provider from cached state
+└──────────┬───────────────────────┘
+           ▼
+┌──────────────────────────┐
+│  PlatformUserService     │  ← strict link policy: both sides verified
+│  ResolveOrCreate…        │  ← refresh DisplayName each login
+└──────────┬───────────────┘
+           │
+           ▼  WelcomeEmailDispatcher fires (existing) → /app/#token=…
+```
+
+## Data flow & policy
+
+`SocialAuthCallbackResult` gains an `EmailVerified` field:
+
+```csharp
+record SocialAuthCallbackResult(
+    bool Success, string? Error,
+    string? Subject, string? Email, string? DisplayName,
+    bool EmailVerified,      // NEW
+    string Provider);
+```
+
+Population rules:
+
+| Provider | `EmailVerified` source |
+|---|---|
+| Google / Microsoft / Apple | `email_verified` claim from ID token (preferred) or userinfo response. **Default `false`** when claim absent. Never assume verified. |
+| GitHub | True only when `/user/emails` returns the primary email with `verified: true`. Existing logic; surfaced explicitly on the result. |
+
+### Scenario A — Returning user (`PlatformSocialLogin` row exists)
+
+Resolve `PlatformUser` by `(provider, subject)`. Update
+`PlatformSocialLogin.LastUsedAt` and `PlatformUser.LastLoginAt`. Refresh
+`PlatformUser.DisplayName` from claim if non-empty (REQ-3). Issue token. We
+do **not** re-check `EmailVerified` here — the link is already trusted; a
+provider's transient state should not lock out a genuine returning user.
+
+### Scenario B — Existing `PlatformUser` matched by email, no provider link yet
+
+Strict gate (REQ-2):
+
+- Provider `EmailVerified == true` AND
+- Existing `PlatformUser.EmailVerified == true`
+
+If both true → call `LinkSocialLoginAsync`, update last-used timestamps,
+refresh display name, issue token.
+
+If either false → return failure with a specific message:
+
+- Existing user not verified:
+  *"An account exists for this email but isn't verified. Sign in with your
+  password and verify your email first, or recover access at /auth/login."*
+- Provider unverified:
+  *"Your `<provider>` account hasn't verified this email address. Please
+  verify it with `<provider>` and try again."*
+
+Refusal renders as a 400 in the `SocialCallback` page error banner — no
+silent redirect, no auto-upgrade of either side.
+
+### Scenario C — No `sub` link, no email match (genuinely new user)
+
+Provider `EmailVerified == false` → refuse with the provider-unverified
+message above. No `PlatformUser` is created.
+
+Provider `EmailVerified == true` (or GitHub with primary-verified) →
+
+1. `CreateAsync` new `PlatformUser` with `EmailVerified=true,
+   EmailVerifiedAt=now`
+2. `LinkSocialLoginAsync` to attach `PlatformSocialLogin`
+3. Existing flow takes over: create `UserIdentity` in `WellKnownIds.PublicOrgId`
+   with `Roles=[Consumer]`, `ProvisionedVia=SocialLogin`
+4. Add `PlatformUserOrgMembership` if missing
+5. Fire `IWelcomeEmailDispatcher.SendIfPendingAsync` (existing wiring)
+6. Issue JWT, redirect to `/app/#token=…&refresh=…`
+
+## Code changes
+
+### `Sorcha.Tenant.Service.Models.Dtos.SocialLoginDtos`
+
+- Add `bool EmailVerified` to `SocialAuthCallbackResult` record.
+
+### `Sorcha.Tenant.Service.Services.SocialLoginService`
+
+- `ParseIdTokenClaims` returns `email_verified` boolean from JWT payload.
+- `FetchUserInfoClaimsAsync` returns `email_verified` from userinfo response.
+- `ExtractGitHubClaimsAsync` sets `EmailVerified = true` only when the primary
+  email entry has `verified: true` (current behaviour, surfaced explicitly).
+- `ExchangeCodeAsync` propagates `EmailVerified` into `SocialAuthCallbackResult`.
+- Add `IReadOnlyList<string> GetConfiguredProviderNames()` to
+  `ISocialLoginService` for REQ-1.
+
+### `Sorcha.Tenant.Service.Services.PlatformUserService`
+
+- `ResolveOrCreateSocialUserAsync` signature gains `bool emailVerified` (or
+  takes the full `SocialAuthCallbackResult` — pick during planning). Policy
+  gate per Scenario B+C. Returns a discriminated result with shape
+  `(PlatformUser? User, bool IsNew, SocialLoginRefusal? Refusal)` where
+  `SocialLoginRefusal` is an enum identifying `ProviderUnverified` /
+  `ExistingUnverified` so the callback page can render the matching copy
+  without string matching.
+- Each successful resolution refreshes `PlatformUser.DisplayName` from the
+  claim if claim is non-empty and differs.
+
+### `Sorcha.Tenant.Service.Endpoints.SocialLoginEndpoints`
+
+- Two redirect_uri call sites change from `/api/auth/social/callback-redirect`
+  to `/auth/social/callback` (lines 99 and 262). The new path matches the
+  Razor page route.
+
+### `Sorcha.Tenant.Service.Pages.Auth.SocialCallback.cshtml.cs`
+
+- `OnGetAsync` no longer takes `provider` from the query — the OAuth provider
+  doesn't preserve query parameters across redirect, so the current behaviour
+  was relying on a query-string fragment that doesn't exist. Provider is
+  resolved from cached state inside `ExchangeCodeAsync`. The result already
+  carries `Provider`, so the page just consumes it.
+- Apply Scenario B/C refusal rendering: set `ErrorMessage` to the appropriate
+  copy and return `Page()`.
+
+### `Sorcha.Tenant.Service.Pages.Auth.Signup.cshtml(.cs)`
+
+- `SignupModel.OnGet` populates `Model.AvailableProviders` from
+  `ISocialLoginService.GetConfiguredProviderNames()`.
+- Razor view renders one button per entry in `Model.AvailableProviders`
+  (currently hard-coded to all four). Buttons map provider name to the JS
+  click handler.
+- Remove dead JS in the social-login click handler (`redirectUri`, `nonce`,
+  `state`, `sessionStorage.setItem`) — none of it is sent to the server. The
+  CSRF state parameter is generated server-side in
+  `SocialLoginService.GenerateAuthorizationUrlAsync` and validated there on
+  callback; the JS-side computation is misleading dead weight.
+
+### `Sorcha.Tenant.Service.Data.DatabaseInitializer`
+
+- Read `IConfiguration.GetValue<bool>("PlatformSettings:SeedPublicOrgEnabled",
+  false)` when seeding `PlatformSettings`. Used only on a fresh DB; admin
+  toggles persisted in DB take precedence on subsequent boots.
+
+## Configuration
+
+### `.env.example`
+
+```bash
+# Social login OAuth credentials (n1 only — leave blank for local dev)
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+GITHUB_OAUTH_CLIENT_ID=
+GITHUB_OAUTH_CLIENT_SECRET=
+```
+
+### `docker-compose.n1.yml` (`tenant-service.environment` additions)
+
+```yaml
+SocialProviders__0__Name: Google
+SocialProviders__0__ClientId: ${GOOGLE_OAUTH_CLIENT_ID}
+SocialProviders__0__ClientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+SocialProviders__1__Name: GitHub
+SocialProviders__1__ClientId: ${GITHUB_OAUTH_CLIENT_ID}
+SocialProviders__1__ClientSecret: ${GITHUB_OAUTH_CLIENT_SECRET}
+PlatformSettings__SeedPublicOrgEnabled: "true"
+```
+
+`DemoEnvironment__Enabled: "true"` is already at line 55 — no change needed,
+verify on deploy.
+
+## OAuth-app registration runbook
+
+A new doc at `docs/guides/SOCIAL-LOGIN-SETUP.md` captures the per-provider
+steps. Summary:
+
+**Google** — at `console.cloud.google.com`:
+
+1. Project: "Sorcha n1" (or reuse existing).
+2. APIs & Services → OAuth consent screen → External; scopes
+   `openid email profile`; add `n1.sorcha.dev` to authorized domains.
+3. Credentials → Create OAuth 2.0 Client ID → Web application.
+4. Authorised redirect URIs:
+   - `https://n1.sorcha.dev/auth/social/callback`
+   - `https://localhost:7110/auth/social/callback` (optional, dev)
+5. Copy Client ID + Secret → `/opt/sorcha/.env` on n1.
+
+**GitHub** — at `github.com/settings/developers`:
+
+1. New OAuth App. Name "Sorcha n1". Homepage `https://n1.sorcha.dev`.
+2. Authorisation callback URL: `https://n1.sorcha.dev/auth/social/callback`.
+3. Generate client secret → `/opt/sorcha/.env` on n1.
+
+## Deploy procedure
+
+After this PR merges and Docker Publish completes (10–15 min):
+
+1. SSH to n1 once to seed `.env`:
+
+   ```
+   ssh sorcha@51.105.7.135
+   cd /opt/sorcha
+   nano .env  # paste the four OAuth values
+   chmod 600 .env
+   ```
+
+2. Full reset to pick up new images, fresh DB seed, fresh `PlatformSettings`:
+
+   ```powershell
+   .\scripts\n1-reset.ps1 -ResourceGroup sorcha-n1-uk -UpdateCompose -Yes
+   ```
+
+3. Verify:
+   - `https://n1.sorcha.dev/auth/signup` shows demo banner + Google + GitHub
+     buttons (no Microsoft, no Apple)
+   - "Continue with Google" → consent → land logged in at Sorcha.UI
+   - DB check: `select email, "EmailVerified" from tenant.platform_users` —
+     verified true; `select * from public.platform_social_logins` — one row
+   - Welcome email visible in Mailpit (or real mailbox if SMTP configured)
+
+4. Repeat with GitHub.
+
+## Testing
+
+Policy decisions are the high-value tests; OAuth wire mechanics are largely
+framework code already exercised. New / extended xUnit classes in
+`tests/Sorcha.Tenant.Service.Tests/`:
+
+| Test class | What it covers |
+|---|---|
+| `SocialLoginPolicyTests` (new) | Refusal when provider says `email_verified=false`; refusal when existing user not verified; success when both verified; GitHub primary-verified-only path; returning-user `DisplayName` refresh; returning-user `LastUsedAt` update |
+| `SocialLoginEndpointsTests` (extend) | redirect_uri value contains `/auth/social/callback` (regression guard) |
+| `SignupModelTests` (extend) | `AvailableProviders` reflects configured providers; empty list renders no buttons |
+| `DatabaseInitializerTests` (extend or new) | `PublicOrgEnabled` seeds `true` when `PlatformSettings:SeedPublicOrgEnabled=true`; defaults `false` |
+| `SocialAuthCallbackResultTests` (new) | `EmailVerified` populated from ID-token claim; defaults `false` when claim missing |
+
+Mock the HTTP client at the `IHttpClientFactory` boundary (existing pattern in
+the test project). No real OAuth round-trips in CI.
+
+### Manual smoke (n1 post-deploy)
+
+1. Fresh n1 reset with social config → `/auth/signup` shows demo banner + 2
+   buttons.
+2. Google new-user signup → lands logged in, welcome email arrives.
+3. Google second login → `LastUsedAt` updated, `DisplayName` refreshed if
+   changed in Google profile.
+4. GitHub user with non-verified primary email → refused with the
+   unverified-provider message.
+5. Email-collision: register `test@gmail.com` with password, do not verify,
+   then "Continue with Google" with same Google account → refused.
+6. Email-collision happy path: same as 5 but verify the email first → "Continue
+   with Google" links the account, login succeeds.
+
+## Telemetry
+
+New counter on `Sorcha.Tenant` meter:
+
+```
+sorcha_social_login_refusal_total{provider, reason}
+  reason ∈ {provider_unverified, existing_unverified,
+            state_invalid, code_exchange_failed}
+```
+
+Surfaces unexpected refusal volume — useful when an OAuth-app config drifts or
+a provider changes verified-email semantics.
+
+Refusals also log at `LogWarning` with `provider`, `reason`, and a
+hash-based redacted email tag. No PII in plaintext.
+
+## Risks & open items
+
+| Risk | Plan |
+|---|---|
+| Sorcha.UI fragment-token parsing untested in this scope | Verify during smoke step 2. If broken, scope grows by one fix to Sorcha.UI startup auth handler. Likely fine — passkey/email login also redirect to `/app/#token=…`. |
+| `SocialProviders` env-var array binding edge cases (.NET requires `__0__`/`__1__`) | Surfaces immediately — empty `_providers` dict means empty button list on signup page. Spotted in smoke step 1. |
+| `PlatformSocialLogins` already has rows from prior n1 testing | Full reset wipes volumes; a non-reset deploy preserves them, which is correct behaviour. |
+| Google consent-screen "verification" warning at scale | Test mode (≤100 users) is fine for demonstrator. BACKLOG-6 captures real-publisher verification when traffic justifies. |
+| GitHub `/user/emails` rate limit (5000/hr authenticated) | Well within signup-rate budget for a demo node. |
+| Forgetting to flip `Staging` per REQ-7 | `/schedule` reminder set when this design is approved for planning. |
+| `Storage:AllowInMemoryInProduction` bypass tempting if `Staging` flip trips fail-fast | Do not use it as a workaround. Fix the missing connection string. The bypass exists for ephemeral CI smoke tests, not production-leaning environments. |
+| Feature 114 adds `citizen-wallet` + `citizen-verifier` images to n1's pull set on next reset (~500MB extra) | n1's 29GB disk + the pre-deploy `docker image prune -a -f` step in the n1-deploy skill comfortably handles this. Confirm in the deploy step before pulling. |
+| Feature 114 PlatformUserDevice migration is the new baseline | Our spec adds no migrations — REQ-8 reads config at seed time. No conflict, but planning phase must verify no schema changes sneak in. |
+
+## Deploy collaboration model
+
+The deploy is **not** autonomous:
+
+1. PR ships with code changes + `.env.example` + `docker-compose.n1.yml`
+   updates + `docs/guides/SOCIAL-LOGIN-SETUP.md`.
+2. Stuart provisions OAuth apps at Google + GitHub (or together with Claude
+   driving a step-by-step session).
+3. Joint SSH session to n1 to paste `.env` values.
+4. Claude drives `n1-reset.ps1` + smoke walkthrough; Stuart watches the auth
+   flows in a browser to confirm UX.
+
+## Follow-ups
+
+- `/schedule` agent in ~7 days to flip `ASPNETCORE_ENVIRONMENT` to `Staging`
+  on n1 once the social-login dust settles.
+- BACKLOG-2 (Microsoft) becomes the natural next phase once Google + GitHub
+  are stable in production traffic — Microsoft adds the work-vs-personal
+  account policy decision that's worth designing with real signup data in
+  hand.
+- BACKLOG-4 (Consumer Persona attribute model) re-enters when there's a need
+  beyond "verified email" — likely tied to feature 092 work or a credential
+  flow that wants to surface social-claim-backed attributes.

--- a/specs/115-social-signup/checklists/requirements.md
+++ b/specs/115-social-signup/checklists/requirements.md
@@ -1,0 +1,52 @@
+# Specification Quality Checklist: Public Social Signup on n1
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All 16 quality items pass on first iteration. Spec is ready for `/speckit.plan`.
+
+The spec deliberately defers technical detail to the design doc at
+`docs/superpowers/specs/2026-04-26-social-signup-n1-design.md`, which
+captures the REQ-1 through REQ-9 decisions made during brainstorming.
+The design doc is the planning input; this spec is the user-facing
+contract.
+
+Two language choices that intentionally stay generic in the spec but
+are concrete in the design doc:
+
+- "the provider's stable subject identifier" (FR-006) — design specifies
+  the OAuth `sub` claim
+- "environment-scoped configuration" (FR-003) — design specifies an
+  environment-variable file on the host with KV migration noted as a
+  future concern
+
+These reflect "spec is the WHAT, design is the HOW" — both documents
+agree, but the spec stays at the contract layer.

--- a/specs/115-social-signup/contracts/oauth-callback.md
+++ b/specs/115-social-signup/contracts/oauth-callback.md
@@ -1,0 +1,77 @@
+# Contract — OAuth Callback URL
+
+**Phase**: 1 — Design
+**Scope**: The single per-environment redirect URI registered with each
+OAuth provider, and the route that handles it.
+
+## Endpoint
+
+| Property | Value |
+|---|---|
+| **HTTP Method** | `GET` |
+| **Path** | `/auth/social/callback` |
+| **Handler** | `Sorcha.Tenant.Service.Pages.Auth.SocialCallback` (Razor page, `@page "/auth/social/callback"`) |
+| **Authentication** | Anonymous (visitor is mid-OAuth flow, has no session yet) |
+
+## Per-environment URIs
+
+| Environment | Full URL |
+|---|---|
+| n1 | `https://n1.sorcha.dev/auth/social/callback` |
+| Local dev | `https://localhost:7110/auth/social/callback` |
+
+These URIs MUST match exactly what is registered at each OAuth
+provider's developer console. Per FR-021, exactly **one URI per
+environment** is registered — no per-provider variants.
+
+## Query parameters (set by the OAuth provider)
+
+| Parameter | Source | Used by |
+|---|---|---|
+| `code` | OAuth provider | `SocialCallback.OnGetAsync` → `ExchangeCodeAsync` |
+| `state` | OAuth provider (echoed from initiate) | Validated against distributed cache key `social:state:{state}` |
+| `error` | OAuth provider on user-cancel or failure | Renders the cancellation message (FR-017) |
+
+The `provider` query param previously expected by `SocialCallback.OnGetAsync`
+is REMOVED — provider identity is read from the cached `SocialStateData`
+keyed by `state`.
+
+## Response shapes
+
+| Outcome | Response |
+|---|---|
+| Success (resolve returns `User != null`) | 302 redirect to `/app/#token=<jwt>&refresh=<refresh>` |
+| Refusal (`SocialLoginRefusal != None`) | 200, renders `SocialCallback.cshtml` with `ErrorMessage` set to the matching copy from FR-016 |
+| Provider error / state invalid / code-exchange failure | 200, renders the page with `ErrorMessage = "The sign-in was cancelled or failed. Please try again."` |
+
+## Security
+
+- TLS-only — providers reject `http://` redirect URIs in production.
+- Anonymous access is required; the visitor is mid-OAuth and has no
+  Sorcha session.
+- The `state` parameter is single-use: cache entry is removed on first
+  read in `ExchangeCodeAsync`. Replay of a `state` value will hit the
+  "Invalid or expired state parameter" path.
+- The handler MUST NOT log `code`, `state`, or any portion of the JWT
+  it issues. Telemetry refusal counters use a hash-based redacted
+  email tag (FR-018).
+
+## Bug being fixed
+
+Today (master before this feature): `SocialLoginEndpoints.cs:99,262`
+construct the redirect URI as
+`{baseUrl}/api/auth/social/callback-redirect`. There is no handler at
+that path. After provider consent, the user lands on a 404 instead of
+the Razor page.
+
+The fix: change both call sites to
+`{baseUrl}/auth/social/callback`.
+
+## Provider-side registration
+
+For each provider, register exactly the URIs above. The provider's
+developer console is the source of truth for what URIs the provider
+will accept; mismatch ⇒ provider returns `redirect_uri_mismatch` error
+to the user. Operator runbook in
+[`docs/guides/SOCIAL-LOGIN-SETUP.md`](../../docs/guides/SOCIAL-LOGIN-SETUP.md)
+covers the click-by-click steps.

--- a/specs/115-social-signup/contracts/social-providers-config.md
+++ b/specs/115-social-signup/contracts/social-providers-config.md
@@ -1,0 +1,149 @@
+# Contract — `SocialProviders` Configuration Shape
+
+**Phase**: 1 — Design
+**Scope**: How OAuth provider credentials enter the running service, and
+how the .env-file convenience layer maps to the canonical .NET config
+shape.
+
+## .NET configuration shape (canonical)
+
+`Sorcha.Tenant.Service` reads its provider list at construction via
+`configuration.GetSection("SocialProviders").Get<List<SocialProviderConfig>>()`.
+
+```jsonc
+{
+  "SocialProviders": [
+    {
+      "Name": "Google",
+      "ClientId": "<google-client-id>",
+      "ClientSecret": "<google-client-secret>"
+      // SupportsPkce defaults to true for OIDC providers
+    },
+    {
+      "Name": "GitHub",
+      "ClientId": "<github-client-id>",
+      "ClientSecret": "<github-client-secret>"
+      // SupportsPkce auto-set to false (GitHub does not support PKCE)
+    }
+  ]
+}
+```
+
+The `SocialProviderConfig` type allows additional fields
+(`AuthorizationEndpoint`, `TokenEndpoint`, `UserInfoEndpoint`, `Scopes`)
+which fall back to well-known endpoints for recognised provider names.
+For Google and GitHub the well-known fallbacks are correct, so only
+`Name`, `ClientId`, `ClientSecret` need to be set.
+
+## Environment-variable shape (.NET convention)
+
+Same shape via env vars uses the standard `__N__` indexed binding:
+
+```bash
+SocialProviders__0__Name=Google
+SocialProviders__0__ClientId=<google-client-id>
+SocialProviders__0__ClientSecret=<google-client-secret>
+SocialProviders__1__Name=GitHub
+SocialProviders__1__ClientId=<github-client-id>
+SocialProviders__1__ClientSecret=<github-client-secret>
+```
+
+This is what `docker-compose.n1.yml` injects into the `tenant-service`
+container's `environment:` block.
+
+## .env-file convenience layer (operator-readable)
+
+For human-friendly secret rotation (REQ-5), the n1 host carries
+`/opt/sorcha/.env` with friendly names:
+
+```bash
+GOOGLE_OAUTH_CLIENT_ID=<value>
+GOOGLE_OAUTH_CLIENT_SECRET=<value>
+GITHUB_OAUTH_CLIENT_ID=<value>
+GITHUB_OAUTH_CLIENT_SECRET=<value>
+```
+
+`docker-compose.n1.yml` interpolates these into the canonical .NET
+shape:
+
+```yaml
+tenant-service:
+  environment:
+    SocialProviders__0__Name: Google
+    SocialProviders__0__ClientId: ${GOOGLE_OAUTH_CLIENT_ID}
+    SocialProviders__0__ClientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+    SocialProviders__1__Name: GitHub
+    SocialProviders__1__ClientId: ${GITHUB_OAUTH_CLIENT_ID}
+    SocialProviders__1__ClientSecret: ${GITHUB_OAUTH_CLIENT_SECRET}
+```
+
+`.env.example` (committed) ships placeholder lines so operators know
+which keys to set. `.env` (gitignored) is created on the n1 host
+manually per **REQ-5 / FR-003**.
+
+## Provider-list visibility surface (FR-001 / FR-002)
+
+`ISocialLoginService` gains:
+
+```csharp
+public interface ISocialLoginService
+{
+    // existing members…
+    IReadOnlyList<string> GetConfiguredProviderNames();
+}
+```
+
+Returns the list of provider names that have **non-empty `ClientId` AND
+non-empty `ClientSecret`**. Providers configured with empty credentials
+are excluded.
+
+`SignupModel.OnGet` and `LoginModel.OnGet` consume this and expose
+`Model.AvailableProviders` to the views. Views render one button per
+configured provider; no buttons for unconfigured providers (FR-002).
+
+## Environment-specific notes
+
+| Environment | Configured providers (target state) |
+|---|---|
+| Local dev (developer's machine) | None — `SocialProviders` empty in `appsettings.Development.json`. Buttons hidden. Developers test via password / passkey. |
+| n1 | Google + GitHub (set via `/opt/sorcha/.env`). |
+| Future Microsoft / Apple environments | Add `SocialProviders__2__*` entries; .env gets new vars. (Out of scope for this feature.) |
+
+## Validation expectations
+
+- **No client-side validation required**. The provider list is read at
+  service construction and immutable for the process lifetime;
+  configuration changes require a service restart.
+- **Empty / missing config is valid** — yields zero buttons, signup
+  page renders without the social tab having any options. Visitor
+  falls back to passkey or email/password.
+- **Invalid credentials** (typo in client secret) cannot be detected
+  pre-flight without making a token-exchange call. Failure manifests
+  during the OAuth flow at the provider end (`invalid_client` error).
+  The visitor sees the cancellation message; the operator confirms by
+  checking the refusal counter (`reason=code_exchange_failed`).
+
+## Ancillary: `PublicOrgEnabled` seed default
+
+Distinct from `SocialProviders` but shipped alongside per FR-019:
+
+```yaml
+tenant-service:
+  environment:
+    PlatformSettings__SeedPublicOrgEnabled: "true"
+```
+
+`DatabaseInitializer` reads this on a fresh DB seed only. After the
+row exists in `tenant.platform_settings`, the admin UI / API toggle is
+the source of truth.
+
+## Provider scopes (informational)
+
+| Provider | Default scopes |
+|---|---|
+| Google / Microsoft / Apple | `openid email profile` (set in `SocialProviderConfig.Scopes` default) |
+| GitHub | `openid email profile` (GitHub ignores `openid`; the equivalent is the `read:user` and `user:email` scopes implied by `email` + `profile` here) |
+
+For Google, the configured scopes match the required Google Cloud
+Console "scopes for verification" set, so the OAuth consent screen
+will show correctly without app-verification when in test mode.

--- a/specs/115-social-signup/data-model.md
+++ b/specs/115-social-signup/data-model.md
@@ -1,0 +1,202 @@
+# Data Model — Feature 115 Social Signup
+
+**Phase**: 1 — Design
+**Schema impact**: Zero migrations. No new tables, no new columns. The
+feature uses existing entities; one DTO record gains a field (in-memory
+only, not persisted).
+
+---
+
+## Entities (existing, unchanged)
+
+### `PlatformUser` (`tenant.platform_users`)
+
+The root user identity for a public-org consumer.
+
+| Field | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | PK |
+| `Email` | `string` | Frozen post-signup. **FR-009** prohibits refresh from provider. |
+| `EmailVerified` | `bool` | Set `true` on successful social signup (provider asserted verified). Read-side gate for **FR-011**. |
+| `EmailVerifiedAt` | `DateTimeOffset?` | Stamped at first signup or first verification email click. |
+| `DisplayName` | `string` | **Refreshed each login** from provider `name` claim per **FR-008**. |
+| `WelcomeSentAt` | `DateTimeOffset?` | Drives idempotent welcome dispatch per **FR-015**. |
+| `LastLoginAt` | `DateTimeOffset?` | Updated on every successful sign-in. |
+| `LockedPermanently` | `bool` | Existing lockout state — orthogonal to this feature. |
+
+### `PlatformSocialLogin` (`public.platform_social_logins`)
+
+The link from a `PlatformUser` to one external provider identity.
+
+| Field | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` | PK |
+| `PlatformUserId` | `Guid` | FK → `PlatformUser.Id`, cascade delete |
+| `Provider` | `string` | `"google"`, `"github"`, lowercase by convention |
+| `Subject` | `string` | Provider's stable `sub` claim (or `id` for GitHub). Immutable once linked. |
+| `Email` | `string?` | Snapshot at link time. **FR-009** — not refreshed. |
+| `DisplayName` | `string?` | Snapshot at link time. (Refresh happens on `PlatformUser.DisplayName`, not here.) |
+| `LinkedAt` | `DateTimeOffset` | Set on row creation. |
+| `LastUsedAt` | `DateTimeOffset?` | **FR-007** — updated each sign-in. |
+
+**Composite invariant**: `(Provider, Subject)` is unique per row by
+convention; the resolution path queries on this pair to find returning
+users. (No DB-level unique constraint exists today; existing flow
+treats first-found-wins. This feature does not add one — the invariant
+is preserved by the existing `GetByProviderSubjectAsync` query path.)
+
+### `PlatformSettings` (singleton, `tenant.platform_settings`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `PublicOrgEnabled` | `bool` | Gates `/api/auth/social/initiate`. **FR-019** — seed value made configurable in this feature. |
+| `MaxOrgsPerUser` | `int` | Existing — not touched. |
+
+### `UserIdentity` (`{org-schema}.user_identities`)
+
+Per-org membership profile. Created in the public-org schema on first
+social signup with `Roles=[Consumer]`, `ProvisionedVia=SocialLogin`.
+
+(Existing entity; this feature does not modify its shape.)
+
+---
+
+## Records & DTOs (in-memory)
+
+### `SocialAuthCallbackResult` — **MODIFIED**
+
+Existing record, gains one field.
+
+```csharp
+public record SocialAuthCallbackResult(
+    bool Success,
+    string? Error,
+    string? Subject,
+    string? Email,
+    string? DisplayName,
+    bool EmailVerified,    // NEW — FR-010 substrate
+    string Provider);
+```
+
+Population rules (per provider):
+
+| Provider | `EmailVerified` source |
+|---|---|
+| Google / Microsoft / Apple | `email_verified` claim from ID token (preferred) or userinfo response. **Default `false` when claim absent.** |
+| GitHub | `true` only when `/user/emails` returns the primary email with `verified: true`. (Existing logic; surfaced explicitly on the result.) |
+
+### `SocialLoginRefusal` — **NEW**
+
+```csharp
+public enum SocialLoginRefusal
+{
+    None = 0,
+    ProviderUnverified,    // Provider asserted email_verified=false
+    ExistingUnverified,    // Email-collision with an unverified Sorcha user
+}
+```
+
+### `ResolveSocialUserResult` — **NEW**
+
+Replaces the existing `(PlatformUser User, bool IsNew)` tuple return of
+`PlatformUserService.ResolveOrCreateSocialUserAsync`.
+
+```csharp
+public record ResolveSocialUserResult(
+    PlatformUser? User,
+    bool IsNew,
+    SocialLoginRefusal Refusal);
+```
+
+`Refusal != None` ⇒ `User` is null and the callback page must render the
+matching copy. `User != null` ⇒ `Refusal == None`.
+
+---
+
+## State transitions
+
+### Resolve flow — three terminal states
+
+```
+                        ┌─────────────────────────────────┐
+                        │ ExchangeCodeAsync returns claim │
+                        └────────┬────────────────────────┘
+                                 │
+                  ┌──────────────┴──────────────┐
+                  │                             │
+                  ▼                             ▼
+    PlatformSocialLogin row exists?   No row — fresh attempt
+    ┌──────────────────────────────┐  ┌─────────────────────────────────────┐
+    │ ResolveSocialUserResult(     │  │ provider.EmailVerified == false?    │
+    │   User: existing,            │  │ ┌───────────────────────────────┐   │
+    │   IsNew: false,              │  │ │ Yes → Refusal.ProviderUnver…  │   │
+    │   Refusal: None)             │  │ └───────────────────────────────┘   │
+    │ Side effect:                 │  │                                     │
+    │  • LastUsedAt = now          │  │ Email-collision with PlatformUser?  │
+    │  • DisplayName ← claim       │  │   Existing user EmailVerified=true? │
+    │ Note: NOT re-checking        │  │   Provider EmailVerified=true?      │
+    │  EmailVerified per FR-013    │  │                                     │
+    └──────────────────────────────┘  │   ┌───────────────────────────┐     │
+                                      │   │ All true → link, return   │     │
+                                      │   │   User=existing, IsNew=f  │     │
+                                      │   │ Side effect:              │     │
+                                      │   │  • new PlatformSocialLogin│     │
+                                      │   │  • LastUsedAt = now       │     │
+                                      │   │  • DisplayName ← claim    │     │
+                                      │   └───────────────────────────┘     │
+                                      │                                     │
+                                      │   ┌───────────────────────────┐     │
+                                      │   │ Existing unverified →     │     │
+                                      │   │   Refusal.ExistingUnver…  │     │
+                                      │   └───────────────────────────┘     │
+                                      │                                     │
+                                      │ No collision → create new           │
+                                      │   PlatformUser(EmailVerified=true,  │
+                                      │     EmailVerifiedAt=now)            │
+                                      │   + PlatformSocialLogin             │
+                                      │   + UserIdentity in public org      │
+                                      │   + PlatformUserOrgMembership       │
+                                      │   Welcome dispatcher fires          │
+                                      └─────────────────────────────────────┘
+```
+
+### Welcome email dispatch (existing F112 — unchanged)
+
+Driven by `PlatformUser.WelcomeSentAt`:
+
+- `null` → dispatcher fires, sets `WelcomeSentAt = now`
+- non-`null` → dispatcher returns silently
+
+This is invoked once per resolve-success in `SocialCallback.cshtml.cs`,
+already wired and idempotent. No change in this feature.
+
+---
+
+## Validation rules
+
+| Rule | Source FR | Applies in |
+|---|---|---|
+| `Provider.EmailVerified == false` ⇒ refuse with `ProviderUnverified` | FR-010 | `ResolveOrCreateSocialUserAsync` (new path), or upstream in `SocialCallback.cshtml.cs` |
+| Email-collision + existing user `EmailVerified == false` ⇒ refuse with `ExistingUnverified` | FR-011 | `ResolveOrCreateSocialUserAsync` step 2 |
+| Email-collision + both verified ⇒ link | FR-012 | `ResolveOrCreateSocialUserAsync` step 2 |
+| Returning-user (link exists) ⇒ no verification re-check | FR-013 | `ResolveOrCreateSocialUserAsync` step 1 |
+| New-user creation ⇒ `EmailVerified=true`, `EmailVerifiedAt=now` | FR-005 | `ResolveOrCreateSocialUserAsync` step 3 |
+| Each successful resolve ⇒ refresh `DisplayName` if claim non-empty | FR-008 | All 3 paths |
+| Each successful resolve ⇒ update `LastUsedAt` | FR-007 | Steps 1, 2 (step 3 sets via row creation) |
+| Welcome dispatch fires once per user | FR-015 | `SocialCallback.cshtml.cs` (already wired) |
+
+---
+
+## Persistence implications
+
+- **No migrations.** Confirmed against master at commit `d0cdd55a`
+  (Feature 114 baseline). Schema is unchanged in this feature.
+- **No new indexes.** Existing index on `PlatformSocialLogin (Provider,
+  Subject)` and `PlatformUser (Email)` cover the lookup paths.
+- **Transactional consistency**: the resolve-and-create paths perform
+  multiple writes (`PlatformUser` create, `PlatformSocialLogin` insert,
+  `UserIdentity` create, `PlatformUserOrgMembership` add, `LastLoginAt`
+  update). Existing code uses `_db.SaveChangesAsync()` between steps —
+  not a single transaction. This is pre-existing behaviour; this
+  feature does not change it. (Note: a partial-failure recovery path
+  is not in scope; logged as a non-blocker.)

--- a/specs/115-social-signup/plan.md
+++ b/specs/115-social-signup/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Public Social Signup on n1
+
+**Branch**: `115-social-signup` | **Date**: 2026-04-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification at `specs/115-social-signup/spec.md`
+**Companion design**: [`docs/superpowers/specs/2026-04-26-social-signup-n1-design.md`](../../docs/superpowers/specs/2026-04-26-social-signup-n1-design.md)
+
+## Summary
+
+Make public-user social signup work end-to-end on `n1.sorcha.dev` with two
+configured providers (Google + GitHub). Fix a live redirect-URI bug,
+enforce strict email-verification trust on both sides of cross-method
+account linking, refresh display name from provider claims each login,
+make signup buttons render only for configured providers, and make the
+`PublicOrgEnabled` seed value configurable per-environment so a fresh n1
+deploy is signup-ready without a manual database edit.
+
+The OAuth/OIDC plumbing already exists in `Sorcha.Tenant.Service`. The
+work is narrow: ~6 small code changes, configuration additions to
+`docker-compose.n1.yml` + `.env.example`, a documentation page covering
+provider-app registration, and xUnit tests covering the policy gates.
+
+## Technical Context
+
+**Language/Version**: C# 14, .NET 10
+**Primary Dependencies**: ASP.NET Core Razor Pages, Microsoft.AspNetCore.DataProtection (distributed state cache), JwtBearer, EF Core 10 with PostgreSQL provider, existing `Sorcha.Tenant.Service` services (`SocialLoginService`, `PlatformUserService`, `WelcomeEmailDispatcher`, `IdentityRepository`, `OrganizationRepository`, `TokenService`)
+**Storage**: PostgreSQL — existing tables `PlatformUsers`, `PlatformSocialLogins`, `PlatformSettings`, `UserIdentities`, `PlatformUserOrgMemberships`. **No schema changes** in this feature; one new column considered (`PlatformSocialLogin.LinkVerifiedAt`) but rejected as unnecessary — the existence of the row already represents a successful policy gate at link time.
+**Testing**: xUnit v3.2.2 + FluentAssertions 8.8.0 + Moq 4.20.72 in `tests/Sorcha.Tenant.Service.Tests/`. HTTP boundary mocked via `IHttpClientFactory` mock (existing pattern in this test project). No real OAuth round-trips in CI.
+**Target Platform**: Linux containers via Docker Compose on n1 (Azure VM); Windows + Linux for local dev. ASP.NET Core hosted in Kestrel inside the `sorcha-tenant-service` container.
+**Project Type**: Microservice monolith — modifications confined to one service (Sorcha.Tenant.Service) plus its test project, plus root-level config (`docker-compose.n1.yml`, `.env.example`) and documentation.
+**Performance Goals**: SC-001 (signup < 60 s end-to-end including provider consent), SC-002 (returning sign-in < 10 s). Callback handler P95 < 500 ms server time, dominated by provider token-exchange + EF write.
+**Constraints**: Provider client secrets must never enter source control (Constitution principle II). Telemetry must not log PII in plaintext. Demo banner must remain visible on the n1 environment per FR-020.
+**Scale/Scope**: n1 demonstrator, ≤100 concurrent users in test mode (Google OAuth test-mode cap). Single-VM deployment. Migration to multi-node Kubernetes anticipated as a follow-up that triggers the secrets-store upgrade (Key Vault).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Microservices-First | ✅ Pass | All work in `Sorcha.Tenant.Service`. No new service. No upward dependencies introduced. |
+| II. Security First | ✅ Pass | Secrets via host-local `.env` (gitignored). Strict link policy is itself a security improvement. PII not logged in plaintext. KV migration tracked as backlog (BACKLOG-5) per "appropriate-when-multi-node" guidance. |
+| III. API Documentation | ✅ Pass | Existing endpoints retain `.WithSummary` / `.WithDescription`. Razor-page callback is server-rendered, not an OpenAPI-tracked surface. No new public API endpoints. |
+| IV. Testing Requirements | ✅ Pass | New `SocialLoginPolicyTests` + extensions to existing test classes. xUnit + FluentAssertions + Moq, AAA pattern. Target >85% on new code. |
+| V. Code Quality | ✅ Pass | async/await throughout. DI honoured. NRT enabled. No new warnings. |
+| VI. Blueprint Standards | N/A | Not a blueprint feature. |
+| VII. DDD | ✅ Pass | "Public user", "social-provider link", "public organisation", "consumer role" — terminology preserved. No naming drift. |
+| VIII. Observability | ✅ Pass | Adds `sorcha_social_login_refusal_total{provider, reason}` counter on the existing `Sorcha.Tenant` meter. Existing `LogWarning` with redacted email hash. |
+
+**No violations. Phase 0 research proceeds.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/115-social-signup/
+├── plan.md                        # This file
+├── spec.md                        # User-facing contract
+├── research.md                    # Phase 0 output
+├── data-model.md                  # Phase 1 output
+├── quickstart.md                  # Phase 1 output
+├── contracts/
+│   ├── oauth-callback.md          # The single per-env redirect URI contract
+│   └── social-providers-config.md # The configuration shape providers expect
+├── checklists/
+│   └── requirements.md            # Spec-quality checklist (existing)
+└── tasks.md                       # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository)
+
+```text
+src/Services/Sorcha.Tenant.Service/
+├── Endpoints/
+│   └── SocialLoginEndpoints.cs                # MODIFY — fix redirect URI (lines 99, 262)
+├── Services/
+│   ├── SocialLoginService.cs                  # MODIFY — capture email_verified; add GetConfiguredProviderNames
+│   ├── ISocialLoginService.cs                 # MODIFY — new method signature
+│   └── PlatformUserService.cs                 # MODIFY — strict link gate + DisplayName refresh
+├── Models/Dtos/
+│   └── SocialLoginDtos.cs                     # MODIFY — SocialAuthCallbackResult.EmailVerified field
+├── Pages/Auth/
+│   ├── SocialCallback.cshtml.cs               # MODIFY — provider from cached state, refusal rendering
+│   ├── Signup.cshtml                          # MODIFY — buttons driven by AvailableProviders; remove dead JS
+│   ├── Signup.cshtml.cs                       # MODIFY — populate AvailableProviders in OnGet
+│   ├── Login.cshtml                           # MODIFY — same button-visibility treatment
+│   └── Login.cshtml.cs                        # MODIFY — populate AvailableProviders in OnGet
+└── Data/
+    └── DatabaseInitializer.cs                 # MODIFY — read PlatformSettings:SeedPublicOrgEnabled
+
+tests/Sorcha.Tenant.Service.Tests/
+├── Services/
+│   └── SocialLoginPolicyTests.cs              # NEW — Scenarios A/B/C from design
+├── Endpoints/
+│   └── SocialLoginEndpointsTests.cs           # EXTEND — redirect URI regression test
+├── Pages/
+│   ├── SignupModelTests.cs                    # EXTEND — AvailableProviders binding
+│   └── LoginModelTests.cs                     # EXTEND — AvailableProviders binding
+├── Data/
+│   └── DatabaseInitializerTests.cs            # EXTEND — seed-flag honoured
+└── Models/
+    └── SocialAuthCallbackResultTests.cs       # NEW — EmailVerified parsing
+
+docs/guides/
+└── SOCIAL-LOGIN-SETUP.md                      # NEW — Google + GitHub OAuth-app registration runbook
+
+# Repository root
+docker-compose.n1.yml                          # MODIFY — add SocialProviders__0__/__1__ + PlatformSettings__SeedPublicOrgEnabled
+.env.example                                   # MODIFY — add four GOOGLE_*/GITHUB_* placeholder vars
+```
+
+**Structure Decision**: Single-service feature in an established
+microservices solution. All code lives in `Sorcha.Tenant.Service`,
+matching the existing layout (Endpoints / Services / Pages / Data /
+Models). Tests mirror that layout in the parallel test project. No new
+projects.
+
+## Phase 2 (later) — task ordering hints
+
+Not generated by `/speckit.plan`. The natural decomposition for
+`/speckit.tasks` is roughly:
+
+1. **Trust-claim capture** (FR-010 substrate): extend
+   `SocialAuthCallbackResult` with `EmailVerified`; populate from ID
+   token / userinfo / GitHub primary-verified path. Tests:
+   `SocialAuthCallbackResultTests`.
+2. **Strict link policy** (FR-010, FR-011, FR-012, FR-013): rework
+   `PlatformUserService.ResolveOrCreateSocialUserAsync` to gate on both
+   sides verified. Tests: `SocialLoginPolicyTests`.
+3. **Display-name drift** (FR-008): refresh `PlatformUser.DisplayName`
+   on each successful resolve.
+4. **Bug fix** (FR-021): `SocialLoginEndpoints.cs` redirect URI →
+   `/auth/social/callback`. `SocialCallback.cshtml.cs` reads provider
+   from cached state. Tests:
+   `SocialLoginEndpointsTests` regression.
+5. **Provider visibility** (FR-001, FR-002, FR-004): `ISocialLoginService.GetConfiguredProviderNames`;
+   `SignupModel` / `LoginModel` populate `AvailableProviders`; views
+   render conditional buttons; remove dead JS. Tests:
+   `SignupModelTests`, `LoginModelTests`.
+6. **Seed config** (FR-019): `DatabaseInitializer` reads
+   `PlatformSettings:SeedPublicOrgEnabled`. Tests:
+   `DatabaseInitializerTests`.
+7. **Telemetry** (FR-018): add refusal counter on `Sorcha.Tenant`
+   meter; emit on each refusal path.
+8. **Refusal copy** (FR-016, FR-017): wire `SocialCallback` to render
+   the documented messages per refusal reason.
+9. **Configuration surface** (FR-003): add `SocialProviders__0__*`,
+   `SocialProviders__1__*`, `PlatformSettings__SeedPublicOrgEnabled` to
+   `docker-compose.n1.yml`; add four placeholder vars to `.env.example`.
+10. **Documentation** (REQ-9): write `docs/guides/SOCIAL-LOGIN-SETUP.md`.
+
+`/speckit.tasks` will refine ordering, dependency edges, and
+parallelisability.
+
+## Complexity Tracking
+
+No constitutional violations. No complexity-tracking entries needed.

--- a/specs/115-social-signup/quickstart.md
+++ b/specs/115-social-signup/quickstart.md
@@ -1,0 +1,201 @@
+# Quickstart — Feature 115 Social Signup
+
+**Audience**: Developer running the implementation; operator deploying
+to n1.
+**Phase**: 1 — Design
+
+This is the joined-up "make it work" walkthrough. Step 1-3 are local
+dev; Step 4-7 are n1 deploy.
+
+---
+
+## 1. Local dev — code-level smoke
+
+After implementing the feature on branch `115-social-signup`:
+
+```bash
+# From repo root
+dotnet restore
+dotnet build src/Services/Sorcha.Tenant.Service/Sorcha.Tenant.Service.csproj --force
+dotnet test tests/Sorcha.Tenant.Service.Tests/ \
+  --filter "FullyQualifiedName~SocialLogin|FullyQualifiedName~Signup|FullyQualifiedName~DatabaseInitializer"
+```
+
+Expected: all new and extended tests pass. The pre-existing 81-test
+constructor failure in `Blueprint.Service.Tests` is unrelated and is
+filtered out by the path-scoped `dotnet test` invocation.
+
+---
+
+## 2. Local dev — UI smoke without OAuth round-trip
+
+Sign-up page should render without OAuth credentials configured. With
+`SocialProviders` empty in `appsettings.Development.json`:
+
+```bash
+dotnet run --project src/Apps/Sorcha.AppHost
+```
+
+Open `https://localhost:7110/auth/signup`. The "Social" tab should
+exist but show **zero provider buttons** (FR-002). No JS errors in the
+browser console.
+
+---
+
+## 3. Local dev — OAuth round-trip with Google (optional)
+
+Follow [`docs/guides/SOCIAL-LOGIN-SETUP.md`](../../docs/guides/SOCIAL-LOGIN-SETUP.md)
+to register a Google OAuth app for local dev. Add to
+`appsettings.Development.json` (gitignored):
+
+```json
+{
+  "SocialProviders": [
+    {
+      "Name": "Google",
+      "ClientId": "<dev-client-id>",
+      "ClientSecret": "<dev-client-secret>"
+    }
+  ]
+}
+```
+
+Restart. Visit signup page → Google button appears → click → Google
+consent screen → land back signed in at the app home.
+
+---
+
+## 4. n1 deploy — register OAuth applications
+
+Operator runs steps in
+[`docs/guides/SOCIAL-LOGIN-SETUP.md`](../../docs/guides/SOCIAL-LOGIN-SETUP.md):
+
+- Google: Cloud Console → OAuth client → Web app → redirect URI
+  `https://n1.sorcha.dev/auth/social/callback`. Capture client ID +
+  secret.
+- GitHub: Settings → Developers → New OAuth App → callback URL
+  `https://n1.sorcha.dev/auth/social/callback`. Capture client ID +
+  secret.
+
+This is collaborative — Stuart drives the provider consoles, Claude
+narrates next steps.
+
+---
+
+## 5. n1 deploy — seed the `.env` file
+
+Once the four OAuth values are in hand:
+
+```bash
+ssh sorcha@51.105.7.135
+cd /opt/sorcha
+nano .env
+# Paste:
+#   GOOGLE_OAUTH_CLIENT_ID=...
+#   GOOGLE_OAUTH_CLIENT_SECRET=...
+#   GITHUB_OAUTH_CLIENT_ID=...
+#   GITHUB_OAUTH_CLIENT_SECRET=...
+chmod 600 .env
+```
+
+`/opt/sorcha/.env` is host-local; it persists across `docker compose
+down` / restarts but is wiped if the VM is re-imaged.
+
+---
+
+## 6. n1 deploy — full reset to pick up new images and seeds
+
+After branch `115-social-signup` is merged and the Docker Publish CI
+workflow has built the new images:
+
+```powershell
+# From repo root on the developer's machine
+.\scripts\n1-reset.ps1 -ResourceGroup sorcha-n1-uk -UpdateCompose -Yes
+```
+
+This:
+
+- Stops + removes containers
+- Wipes volumes (Postgres + Mongo + Redis state)
+- Pulls latest `sorchadev/*:latest` images (Tenant + new Citizen Wallet
+  + Citizen Verifier from F114, plus everything else)
+- Re-runs bootstrap CLI to create the admin org + seed PlatformSettings
+  with `PublicOrgEnabled=true` (per FR-019)
+
+---
+
+## 7. n1 deploy — smoke test the seven scenarios
+
+Walk through these in a browser at `https://n1.sorcha.dev/auth/signup`:
+
+1. **Demo banner** is visible at the top of the page (FR-020).
+2. **Two buttons** — Google and GitHub — appear in the Social tab.
+   Microsoft and Apple buttons are absent (FR-001).
+3. **Google new-user signup**: click → consent → land logged in →
+   welcome email arrives in mailbox.
+4. **Google second login** (in a private window or after sign-out):
+   click → consent (or skipped if remembered) → signed in → no second
+   welcome email → display name updated if changed in Google profile.
+5. **GitHub new-user signup**: same as 3 with GitHub.
+6. **Email-collision refusal**: register `test+collision@gmail.com`
+   via password; do NOT verify; sign-out; click "Continue with Google"
+   using the same Gmail. Expected: refusal page with
+   "an account exists for this email but isn't verified" message.
+7. **Email-collision happy path**: verify the password account from
+   step 6 by clicking the verification link. Sign-out. Click
+   "Continue with Google" again. Expected: linked, signed in.
+
+DB checks (run via Azure CLI run-command or SSH):
+
+```sql
+-- Tenant DB
+\c sorcha_tenant
+select email, "EmailVerified", "DisplayName" from tenant.platform_users;
+-- Expect: each social-signup user has EmailVerified=true,
+-- DisplayName = whatever the provider returned
+
+select provider, subject, "LinkedAt", "LastUsedAt"
+from public.platform_social_logins;
+-- Expect: one row per (user, provider) pair, LastUsedAt advancing
+-- on subsequent sign-ins
+```
+
+Telemetry check (Aspire dashboard at `:18888` or Grafana when wired):
+
+- `sorcha_social_login_refusal_total{provider, reason}` — should show
+  the step-6 refusal under `reason=existing_unverified`.
+
+---
+
+## 8. Rollback procedure
+
+If the deploy regresses:
+
+```bash
+# Revert to the previous master tag
+ssh sorcha@51.105.7.135
+cd /opt/sorcha
+docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml \
+  pull tenant-service:<previous-tag>
+docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml \
+  up -d --force-recreate tenant-service
+```
+
+The `.env` file remains valid for any future redeploy. The DB-stored
+`PlatformSettings.PublicOrgEnabled` survives the revert.
+
+If the issue is purely the `SocialProviders` configuration (e.g. typo
+in client secret), edit `/opt/sorcha/.env` and `docker compose
+restart tenant-service` — no need for a full reset.
+
+---
+
+## Open follow-ups
+
+- **Switch n1 to `Staging`** — scheduled `/schedule` reminder per
+  REQ-7. Activates feature 113 storage fail-fast; verify all six
+  audited interfaces are on Postgres/Redis backends before flipping.
+- **Microsoft + Apple providers** — separate features (BACKLOG-2,
+  BACKLOG-3).
+- **Key Vault for OAuth secrets** — at first Kubernetes deployment
+  (BACKLOG-5).

--- a/specs/115-social-signup/research.md
+++ b/specs/115-social-signup/research.md
@@ -1,0 +1,248 @@
+# Research — Feature 115 Social Signup
+
+**Feature**: Public Social Signup on n1 (Google + GitHub)
+**Date**: 2026-04-26
+**Phase**: 0 — Outline & Research
+
+The feature description has no `NEEDS CLARIFICATION` markers. The
+companion design doc (`docs/superpowers/specs/2026-04-26-social-signup-n1-design.md`)
+already encodes the technical decisions reached during brainstorming.
+Research below confirms the standards and prior-art the design relies
+on, so planning has solid ground.
+
+---
+
+## R-1: Provider verified-email semantics
+
+**Decision**: Capture `email_verified` from the OIDC ID token (Google,
+Microsoft, Apple) and from the `verified` flag on the GitHub `/user/emails`
+primary entry. Default to `false` when the claim is absent.
+
+**Rationale**:
+
+- **Google** publishes `email_verified` in every ID token issued for the
+  `email` scope. Google verifies user emails before issuing tokens for
+  Google Workspace and consumer accounts. Reference: Google Identity
+  Platform OIDC spec — `email_verified` is a Boolean claim that
+  indicates whether the email address has been verified by Google.
+- **Microsoft Entra ID** publishes `xms_edov` (email-domain-owner-verified)
+  for work/school accounts and `email_verified` in the v2.0 ID token. For
+  personal Microsoft accounts (consumer), `email_verified` may be
+  `false` because Microsoft does not always re-confirm consumer email
+  addresses. The strict policy (FR-010) means we will refuse those
+  tokens until the user has verified at Microsoft. (Microsoft is out of
+  scope for this feature; this is research for BACKLOG-2.)
+- **Apple** issues `email_verified` in the ID token and additionally
+  publishes `is_private_email`. We respect `email_verified=true`
+  regardless of relay status. (Apple is out of scope for this feature.)
+- **GitHub** does not implement OIDC or issue ID tokens. `/user/emails`
+  returns an array, each entry with `primary` and `verified` Boolean
+  flags. The current `ExtractGitHubClaimsAsync` already filters for the
+  primary verified entry; we surface that as `EmailVerified=true` on
+  the result.
+
+**Alternatives considered**:
+
+- *Trust the userinfo endpoint*. Some providers populate `email_verified`
+  in userinfo but not in the ID token (or vice versa). Best practice is
+  to prefer the ID token because it is signed and bound to the
+  authentication event, then fall back to userinfo. Existing code
+  follows this order; we extend it to read the new claim, not change
+  the order.
+- *Default to `true` when claim absent*. Rejected — violates strict
+  policy and creates an unbounded trust surface.
+- *Maintain a per-provider trust matrix in code*. Considered but
+  rejected as over-engineering for two providers. The provider's claim
+  is the source of truth; if a provider has known weaknesses (e.g.
+  Microsoft personal accounts), the per-account claim still reports
+  `false` and the gate works correctly without bespoke per-provider
+  rules.
+
+**References**:
+
+- Google: https://developers.google.com/identity/openid-connect/openid-connect#id_token-payload
+- Microsoft: https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+- Apple: https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse
+- GitHub: https://docs.github.com/en/rest/users/emails
+
+---
+
+## R-2: .NET configuration array binding for `SocialProviders`
+
+**Decision**: Use the standard zero-indexed double-underscore syntax
+`SocialProviders__0__Name=Google`, `SocialProviders__0__ClientId=…`,
+`SocialProviders__0__ClientSecret=…`, with a second provider at index
+`__1__`. The existing `SocialLoginService` constructor already calls
+`configuration.GetSection("SocialProviders").Get<List<SocialProviderConfig>>()`
+which honours this binding.
+
+**Rationale**:
+
+- This is the canonical .NET Configuration mechanism for binding a
+  `List<T>` from environment variables. Documented in the
+  `Microsoft.Extensions.Configuration.EnvironmentVariables` provider
+  reference.
+- The existing `SocialLoginService` is already configuration-driven; the
+  `_providers` dictionary is built at construction time from the bound
+  list. No code change needed for binding semantics — only for the
+  surface that exposes "which providers are configured" to the UI
+  layer (FR-001).
+- Empty `ClientId` or `ClientSecret` strings cause the provider to be
+  registered in the dictionary but with non-functional credentials.
+  We must filter those out at the `GetConfiguredProviderNames` layer to
+  honour FR-002 (no greyed-out buttons).
+
+**Alternatives considered**:
+
+- *Comma-separated single env var*. Rejected — non-standard, would
+  require custom parsing.
+- *JSON blob in a single var*. Rejected — secrets would be embedded in
+  a single string, harder to rotate, harder to read.
+- *Per-provider env var prefixes (e.g., `GOOGLE_OAUTH_*`)*. Rejected as
+  the binding target — but **adopted as the .env file naming**
+  (REQ-5), then mapped through compose-file interpolation
+  (`${GOOGLE_OAUTH_CLIENT_ID}`) to the canonical
+  `SocialProviders__0__ClientId` config key. This gives operators a
+  readable `.env` while keeping the .NET-side configuration shape
+  standard.
+
+---
+
+## R-3: Sorcha.UI fragment-token handoff
+
+**Decision**: The existing `Sorcha.UI.Web/wwwroot/app/js/fragment-handoff.js`
+parses `window.location.hash` for `token=…&refresh=…`, stores the
+tokens, and removes the hash. The social-login redirect to
+`/app/#token=…&refresh=…` works as-is. No change needed in this
+feature.
+
+**Rationale**: Verified by inspection (`grep` for `location.hash` in
+`Sorcha.UI.Web/wwwroot/`). The same handoff is used today by
+password-login and passkey-login redirects, and confirmed working by
+the existing walkthroughs that exercise those flows.
+
+**Alternatives considered**:
+
+- *Switch to query-parameter token pass*. Rejected — fragment-based
+  pass keeps tokens out of server-access logs and out of
+  `Referer`-header forwarding. This is established practice (OAuth
+  implicit flow) and the existing handler already implements it.
+
+---
+
+## R-4: Razor page route alignment with single redirect URI
+
+**Decision**: `/auth/social/callback` is the canonical redirect URI for
+all providers per environment. The Razor page at
+`Pages/Auth/SocialCallback.cshtml` already declares
+`@page "/auth/social/callback"`. The fix is in
+`SocialLoginEndpoints.cs:99,262` where the redirect URI is constructed
+as `/api/auth/social/callback-redirect` (a non-existent endpoint).
+
+**Rationale**:
+
+- Single per-env URI minimises OAuth-app-config surface (one redirect
+  URI per provider per environment).
+- The existing Razor page at `/auth/social/callback` already calls
+  `SocialLoginService.ExchangeCodeAsync` and integrates with
+  `WelcomeEmailDispatcher`. Reusing it is the smallest possible fix.
+- Provider identity is available in `SocialStateData.Provider` (cached
+  alongside the `state` parameter at initiate time) so the page does
+  not need to receive `provider` as a query parameter.
+
+**Alternatives considered**:
+
+- *Per-provider path segments* (`/auth/social/callback/google`).
+  Rejected — N redirect URIs per environment scale poorly and
+  re-registering OAuth apps for every config change adds friction.
+- *Add a new GET endpoint* (`MapGet("/api/auth/social/callback")`).
+  Rejected — duplicates the Razor page's behaviour; would require
+  deleting the Razor page or maintaining two callback handlers.
+
+---
+
+## R-5: Strict link policy threat-model coverage
+
+**Decision**: Refuse social-link to a pre-existing unverified Sorcha
+account even when the provider asserts `email_verified=true`. Refuse
+new-user signup when the provider asserts `email_verified=false`. Do
+not re-check verification on returning users (provider+sub already
+linked).
+
+**Rationale**:
+
+- The unverified-existing-account hijack is documented in past security
+  advisories (e.g. Auth0's 2018 advisory on social-account-link
+  takeover; GitHub's 2020 OAuth-link race-condition disclosure). The
+  pattern is the same: an attacker creates a password account with
+  someone else's email but never verifies, then a real owner of that
+  email signs in via social provider and the social provider gets
+  linked to the attacker's account.
+- Feature 114 (Citizen Wallet) anchors wallet identity on
+  `PlatformUser`. A hijacked account in this feature now compromises
+  the wallet too — strict policy is non-negotiable.
+- Returning-user verification re-checks are unnecessary: the link was
+  established under the strict gate, and re-checking creates a fragile
+  flow where transient provider misbehaviour locks out a legitimate
+  user. The trust boundary is the link, not the login.
+
+**Alternatives considered**:
+
+- *Lenient policy — auto-upgrade existing unverified to verified using
+  the provider's verification*. Rejected — this is exactly the hijack.
+  An attacker who controls the email at the provider can take over a
+  password account that someone else created with that email.
+- *Always-create-new on email collision*. Rejected — double accounts,
+  poor UX, no consolidation path. Also documented as the worst option
+  in the brainstorm.
+
+---
+
+## R-6: Welcome email idempotency in social context
+
+**Decision**: Continue using `IWelcomeEmailDispatcher.SendIfPendingAsync`
+on the social-login success path. Already wired in
+`SocialCallback.cshtml.cs` per F112. Idempotent on
+`PlatformUser.WelcomeSentAt`, non-throwing.
+
+**Rationale**:
+
+- Existing F112 architecture explicitly designed welcome dispatch for
+  the social path: "social/passkey paths skip email verification (IdP
+  already asserted the address), so first-login is the natural welcome
+  moment" (existing comment in `SocialCallback.cshtml.cs:151-153`).
+- Per CLAUDE.md feature 112 documentation: "**Do NOT add new
+  welcome-email trigger sites without routing through the
+  dispatcher**." The current code already complies.
+
+**Alternatives considered**: None — established pattern.
+
+---
+
+## R-7: Fail-fast on missing connection strings (when `Staging` is enabled)
+
+**Decision**: Out of scope for this feature. REQ-7 keeps n1 in
+`Development` mode for now, deferring `Staging` flip to a scheduled
+follow-up. When the flip happens, feature 113 fail-fast will require
+all six audited interfaces have proper Postgres/Redis backed
+registrations on n1.
+
+**Rationale**:
+
+- `docker-compose.n1.yml` already wires `ConnectionStrings:Sorcha:*`
+  (Postgres, Redis, Mongo) which the audited storage registrations
+  consume. Spot-check during Staging-flip task will confirm.
+- This research item exists to flag that the flip is a separate
+  follow-up, not to design it now.
+
+**Alternatives considered**: Flip to Staging in this feature. Rejected
+per REQ-7 — adds risk unrelated to social signup, distracts from the
+core deliverable.
+
+---
+
+## Summary
+
+All technical unknowns are resolved. Design is grounded. No
+configuration spikes, prototypes, or POCs needed before Phase 1
+artefacts are written.

--- a/specs/115-social-signup/spec.md
+++ b/specs/115-social-signup/spec.md
@@ -1,0 +1,371 @@
+# Feature Specification: Public Social Signup on n1
+
+**Feature Branch**: `115-social-signup`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: User description: "Social signup on n1.sorcha.dev — production-leaning public user signup with Google + GitHub. Source design doc: docs/superpowers/specs/2026-04-26-social-signup-n1-design.md (REQs 1-9 + BACKLOG 1-6)."
+
+## User Scenarios & Testing
+
+### User Story 1 - First-time signup via a social provider (Priority: P1)
+
+A first-time visitor to the public Sorcha demonstrator wants to create an
+account without typing a password. They land on the signup page, see one
+or more "Continue with…" buttons for the social providers the operator
+has enabled, click the one they prefer, complete consent at the
+provider, and land back at Sorcha already signed in to a new account.
+Soon after, they receive a welcome email confirming the account is
+ready.
+
+**Why this priority**: This is the goal of the entire feature. Without
+it, n1 has no working public-user signup path; the whole purpose of
+opening the demonstrator to organic traffic is unmet.
+
+**Independent Test**: Configure one provider (e.g., Google), open the
+signup page in a private browser, click the provider button, complete
+the provider consent screen, and confirm the visitor lands signed in
+with a new account, the welcome email arrives, and the account is
+correctly recorded as a public-organisation consumer. No other story
+needs to be implemented for this slice to deliver value.
+
+**Acceptance Scenarios**:
+
+1. **Given** the platform is configured with at least one social
+   provider, and the visitor has no Sorcha account, **When** the visitor
+   clicks "Continue with `<provider>`" and grants consent at the
+   provider, **Then** the visitor is signed in, a public-organisation
+   consumer account is created for them, and a welcome email is
+   dispatched.
+2. **Given** the visitor returns later with the same browser, **When**
+   they click "Continue with `<same provider>`" again, **Then** they are
+   recognised as the existing user, signed in within seconds, no second
+   welcome email is sent, and their display name is refreshed if it
+   changed at the provider.
+3. **Given** no social providers are configured for the environment,
+   **When** the visitor opens the signup page, **Then** no provider
+   buttons appear and the visitor sees only the password and passkey
+   signup options.
+
+---
+
+### User Story 2 - Account-takeover defence at link time (Priority: P1)
+
+A second person attempts to sign in with a social provider using an
+email address that already exists in Sorcha as an unverified password
+account created by someone else. The platform must refuse to link the
+social identity to the existing unverified account and present a clear,
+helpful message explaining what happened. Conversely, a genuine user
+whose email is already verified in Sorcha can link a matching social
+provider seamlessly.
+
+**Why this priority**: With the citizen wallet feature (114) in flight,
+a hijacked account is no longer just a Sorcha login — it is a
+verifiable-credential wallet identity. The strict link policy must ship
+with the rest of social signup or the demonstrator becomes unsafe to
+expose to organic traffic.
+
+**Independent Test**: Create a password account with email
+`x@example.com` but do not verify it. From a second browser, attempt
+social signup with the same email at a provider that asserts the email
+as verified. Confirm the attempt is refused with a clear message and
+that no link or new identity is created. Then verify the password
+account's email and retry — confirm the link succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing Sorcha account whose email is not verified, and
+   a social provider that asserts the same email as verified, **When** a
+   visitor completes social-provider consent, **Then** the link is
+   refused with a message directing the user to sign in with their
+   password and verify their email first.
+2. **Given** a social provider that does not assert the email as
+   verified, **When** a visitor completes social-provider consent,
+   **Then** the signup is refused with a message asking them to verify
+   the address with the provider first.
+3. **Given** an existing Sorcha account whose email is verified, **When**
+   the same person signs in through a social provider that asserts the
+   same email as verified, **Then** the social provider is linked to the
+   existing account and the user is signed in.
+
+---
+
+### User Story 3 - Operator controls which providers are available (Priority: P2)
+
+The operator running the n1 environment can configure which social
+providers are enabled by editing environment-scoped configuration.
+Adding a new provider requires only configuration changes and a service
+restart — no code changes. Provider buttons on the signup page
+accurately reflect what is configured.
+
+**Why this priority**: This decouples adding the next provider
+(Microsoft, later) from a code release, and ensures local dev and other
+environments do not display buttons that lead nowhere. It is P2 because
+n1 is shipping with two providers from day one; operator configurability
+becomes load-bearing only when the second-wave providers come online.
+
+**Independent Test**: On n1, enable only one provider in configuration.
+Confirm the signup page shows that provider's button only. Add a second
+provider's configuration and restart the service. Confirm the second
+button appears. Remove the first provider's configuration and restart.
+Confirm only the second remains.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator has configured exactly one provider, **When**
+   any visitor opens the signup page, **Then** exactly one provider
+   button is rendered.
+2. **Given** the operator removes a provider's configuration and
+   restarts the service, **When** any visitor opens the signup page,
+   **Then** the removed provider's button is no longer rendered.
+3. **Given** a fresh environment with the public-organisation signup
+   setting enabled at first deploy, **When** an operator later
+   reconfigures providers, **Then** the public-organisation signup
+   setting is preserved (it is set once at first seed and survives
+   subsequent restarts).
+
+---
+
+### Edge Cases
+
+- **Provider returns a successful consent but no email claim**: refused
+  as if the email were unverified, with a generic "we could not verify
+  your email" message; no account is created.
+- **Provider's display-name claim is empty**: the visible display name
+  falls back to the email local-part (e.g. `alice@example.com` →
+  "alice") so the welcome email and UI greeting are non-empty.
+- **Visitor cancels the provider consent screen or the provider returns
+  an error**: the visitor lands back on the signup page with a
+  non-alarming message ("the sign-in was cancelled or failed") and can
+  retry.
+- **Visitor signs in via the same provider twice in rapid succession**
+  (e.g. double-click): the second attempt is recognised as the same
+  returning user and produces no duplicate accounts or duplicate welcome
+  emails.
+- **Provider changes the visitor's email between sign-ins**: the visitor
+  remains identified by the provider's stable subject identifier; the
+  Sorcha account email does not change automatically. (Email-change
+  reconciliation is out of scope; tracked as backlog.)
+- **Demo-environment banner**: visible on every load of the signup and
+  login pages in the n1 environment, regardless of whether social signup
+  succeeds or fails.
+- **Welcome email already sent**: if a user signed up earlier with a
+  different method (password, passkey) and now adds a social provider,
+  the welcome email is not re-sent; the dispatcher is one-shot per
+  user.
+- **Public-organisation signup not enabled in the environment**:
+  attempts to use social signup return a clear "social sign-in is not
+  available on this environment" message; no partial account is
+  created.
+- **Provider configured but credentials invalid** (typo in client
+  secret): the consent flow fails at the provider end and the visitor
+  sees the cancellation message; the operator can verify by checking
+  the refusal telemetry.
+
+## Requirements
+
+### Functional Requirements
+
+#### Visibility & configuration
+
+- **FR-001**: The signup and login pages MUST present a "Continue with
+  `<provider>`" button only for providers that are configured with valid
+  credentials in the running environment.
+- **FR-002**: The signup and login pages MUST suppress the button
+  entirely for any provider that is not configured. Greying out,
+  tooltips, or placeholder buttons are not acceptable.
+- **FR-003**: Provider configuration MUST be deployable via
+  environment-scoped settings rather than committed source so that
+  secrets are not stored in version control.
+- **FR-004**: The platform MUST support adding a new provider after this
+  feature ships through configuration alone, without changes to compiled
+  code.
+
+#### Account creation & identity binding
+
+- **FR-005**: On a successful social sign-in for a visitor with no
+  pre-existing Sorcha account and no email collision, the platform MUST
+  create a new public-user account, mark its email as verified, attach
+  the social-provider link, add the user to the public organisation in
+  the consumer role, and dispatch the welcome email.
+- **FR-006**: The platform MUST persist a stable, durable link between a
+  Sorcha user account and a social-provider identity using the
+  provider's stable subject identifier so that subsequent sign-ins
+  recognise the same user even if their provider email changes later.
+- **FR-007**: The platform MUST update the timestamp of last use on the
+  social-provider link on every successful sign-in.
+- **FR-008**: The platform MUST refresh the visible display name from
+  the provider's name claim on every successful sign-in when the claim
+  is non-empty.
+- **FR-009**: The platform MUST NOT update the Sorcha account's primary
+  email address from the provider after first signup. (Email-change
+  reconciliation is deferred to a follow-up feature.)
+
+#### Verification trust gates
+
+- **FR-010**: The platform MUST refuse social signup when the provider
+  does not assert that the supplied email is verified.
+- **FR-011**: The platform MUST refuse to link a social provider to a
+  pre-existing Sorcha account whose email has not been verified, even
+  when the provider asserts its email as verified.
+- **FR-012**: The platform MUST allow linking a social provider to a
+  pre-existing Sorcha account when both the provider and the existing
+  account have asserted the email is verified.
+- **FR-013**: A returning user (provider+subject already linked) MUST
+  NOT be re-checked against verification gates on subsequent sign-ins.
+  Trust is established at link time.
+
+#### Session & post-signup behaviour
+
+- **FR-014**: The platform MUST issue an authenticated session token to
+  the user after a successful social sign-in and direct them to the
+  application home.
+- **FR-015**: The platform MUST dispatch the welcome email at most once
+  per user account, irrespective of which sign-in method triggered the
+  first successful authentication.
+
+#### Failure & disclosure
+
+- **FR-016**: On any refusal, the platform MUST present the user a
+  message that explains what to do next without exposing internal
+  identifiers, hashes, or other implementation detail.
+- **FR-017**: The platform MUST tolerate visitor cancellation or
+  provider error and return the visitor to the signup page with a
+  recoverable message rather than an unhandled error.
+- **FR-018**: The platform MUST emit telemetry on each refusal — the
+  provider name, refusal reason, and a non-reversible identifier — so
+  operators can spot anomalies without exposing personal data in the
+  telemetry stream.
+
+#### Operational defaults
+
+- **FR-019**: A fresh deployment of the n1 environment MUST be able to
+  reach a state where social signup works without an additional manual
+  database edit, by way of an environment-scoped configuration flag
+  applied at first seed of platform settings.
+- **FR-020**: The signup and login pages on the n1 environment MUST
+  display a demonstrator banner so visitors understand the platform may
+  be reset and they should not commit personal data.
+- **FR-021**: The configured social-callback URL MUST match between the
+  provider's registered redirect URI and the environment's actual
+  callback handler. The platform MUST present a single canonical
+  callback path per environment to keep provider registration tractable
+  as more providers are added.
+
+### Key Entities
+
+- **Public user account**: An identity record for a person who can sign
+  in to Sorcha. Carries the verified-email state, display name, and the
+  set of providers linked to the account. New social signups create one
+  of these in the public organisation by default.
+- **Social-provider link**: The persistent association between a public
+  user account and a single external identity provider. Holds the
+  provider name, the provider's subject identifier, the email and name
+  captured at link time, the link timestamp, and the last-used
+  timestamp. A user may link multiple providers; each provider link is
+  independent.
+- **Public organisation**: The shared bucket all public signups belong
+  to. Confers the consumer role to its members. Its existence and
+  enabled-for-signup status is gated by a platform-wide setting.
+- **Welcome message dispatch**: A one-shot record indicating the
+  welcome email has been sent for a given user. Idempotent — once
+  recorded, no further welcome emails fire for the same user.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A first-time visitor with a pre-existing provider account
+  can go from clicking a "Continue with…" button to landing inside the
+  application in under 60 seconds, including the provider's consent
+  screen, on a typical home internet connection.
+- **SC-002**: A returning user with a previously linked provider can
+  sign in again in under 10 seconds end-to-end.
+- **SC-003**: 100% of social signup attempts where the provider does
+  not assert the email as verified are refused; zero accounts are
+  created for such attempts.
+- **SC-004**: 100% of social-link attempts to a pre-existing unverified
+  account are refused with the documented message; zero links are
+  created in those cases.
+- **SC-005**: An operator can rotate a provider's client secret on n1
+  by editing one configuration file and restarting one service,
+  completing the rotation in under 5 minutes including verification.
+- **SC-006**: 95% of welcome emails are delivered within 30 seconds of
+  the first successful sign-in.
+- **SC-007**: After this feature ships, adding a new provider requires
+  only configuration changes — no source-code modification — to bring
+  the new provider's button live.
+- **SC-008**: Zero public-user accounts exist with the verified-email
+  state set to false on the user record after this feature ships, on
+  the n1 environment.
+- **SC-009**: The demonstrator banner is visible on 100% of n1 signup-
+  page loads.
+- **SC-010**: Operators can identify the cause of a refusal from
+  telemetry by counting refusals grouped by provider and reason,
+  without reading raw logs.
+
+## Assumptions
+
+- Two providers are in scope at launch: Google and GitHub. Microsoft
+  and Apple are deliberately deferred and are NOT part of this feature.
+- The operator has administrative access at the chosen providers
+  sufficient to register an application and obtain client credentials
+  for social sign-in integration.
+- DNS for `n1.sorcha.dev` resolves correctly and the environment serves
+  HTTPS on a public address that providers' redirect URIs can reach.
+- The existing welcome-email infrastructure is functional and
+  configured on n1 (transactional email facade established in feature
+  112).
+- The existing social-login plumbing in the platform is functionally
+  present but contains a known callback-URL mismatch and missing
+  verification-trust enforcement that this feature will close.
+- The citizen-wallet feature (114) downstream of this work assumes a
+  trustworthy public-user identity; this feature must close the
+  account-takeover gap before n1 starts taking organic traffic.
+- Provider client secrets are managed by the operator outside source
+  control. A move to a managed-secret backend (e.g. Key Vault) is
+  appropriate when the platform graduates from a single-VM deployment
+  to a multi-node Kubernetes deployment; until then, host-local
+  environment files are sufficient.
+- Demonstrator-banner copy is fixed and adequate; no copy work is part
+  of this feature.
+
+## Out of Scope
+
+- Microsoft as a provider (deferred — work-vs-personal account policy
+  warrants its own design with real signup data in hand).
+- Apple as a provider (deferred — requires a JWT-based client-secret
+  refactor that is materially more work than the other providers).
+- Production-grade secret storage (Key Vault, Secrets Manager, or
+  equivalent) — appropriate at first multi-node / Kubernetes
+  deployment, not before.
+- Email-change reconciliation when a provider's email claim drifts
+  after link time.
+- Consumer-persona attribute model — what social claims become persona
+  attributes, how re-verification works, the surface area for citizen-
+  wallet attribute set. Tracked separately.
+- Account-recovery flows beyond what already exists for password users.
+- Profile-page editing of social-provider links beyond what already
+  exists.
+- Real-publisher OAuth-app verification at provider consent screens
+  (test-mode is adequate for the scale this feature targets).
+- Citizen-wallet device-enrolment flows. This feature must not block
+  their happy path but does not implement them.
+
+## Dependencies
+
+- Existing Tenant Service public-organisation bootstrap and
+  consumer-role provisioning.
+- Existing welcome-email facade (feature 112).
+- Citizen-wallet feature 114 depends on this — the strict link policy
+  here is what makes wallet identity safe to anchor on a public-user
+  account.
+
+## Notes for Planning
+
+The design doc at
+`docs/superpowers/specs/2026-04-26-social-signup-n1-design.md` is the
+implementation reference. It captures the technical decisions (REQs
+1-9), the live bug being fixed (redirect URI mismatch), the deploy
+procedure on n1, and the test surface. Planning should consume the
+design doc directly and produce a tasks list that maps each FR in this
+spec to one or more implementation steps in the design.

--- a/specs/115-social-signup/tasks.md
+++ b/specs/115-social-signup/tasks.md
@@ -1,0 +1,335 @@
+---
+description: "Implementation tasks for feature 115 social-signup"
+---
+
+# Tasks: Public Social Signup on n1
+
+**Input**: Design documents from `/specs/115-social-signup/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓, quickstart.md ✓
+
+**Tests**: Test tasks INCLUDED. Spec FR-018 + plan §"Testing" + design doc both require xUnit coverage of the policy gates.
+
+**Organization**: Tasks are grouped by user story (US1, US2, US3) so each story can be implemented and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3) — only on Phase 3+ tasks
+- All paths are absolute under `C:\Projects\Sorcha\`
+
+## Path Conventions
+
+This feature modifies the existing `Sorcha.Tenant.Service` and its test
+project. No new projects. Paths follow the established service layout:
+
+- Service code: `src/Services/Sorcha.Tenant.Service/...`
+- Tests: `tests/Sorcha.Tenant.Service.Tests/...`
+- Config: `docker-compose.n1.yml`, `.env.example` (repo root)
+- Docs: `docs/guides/...`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add the configuration surface that the rest of the work
+binds to. These tasks touch only configuration files and documentation
+templates — no production code changes.
+
+- [ ] T001 Add `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` placeholder lines (with empty values) to `.env.example` in a `# Social login OAuth credentials (n1 only)` block
+- [ ] T002 Add `SocialProviders__0__*` and `SocialProviders__1__*` env-var entries to the `tenant-service.environment` section of `docker-compose.n1.yml`, mapping to the four `${...}` placeholders from T001; also add `PlatformSettings__SeedPublicOrgEnabled: "true"` to the same `environment` block
+- [ ] T003 [P] Create stub at `docs/guides/SOCIAL-LOGIN-SETUP.md` with section headings only (Google · GitHub · Verifying the deploy · Rotating credentials); content lands in T033
+
+**Checkpoint**: Configuration surface exists. Operators can copy `.env.example` to `/opt/sorcha/.env` and start filling values once OAuth apps are registered.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Substrate that every user story depends on — the trust-claim capture, the new return shape, the redirect-URI bug fix, and the provider-list visibility surface. Without these, no user story can be implemented end-to-end.
+
+**⚠️ CRITICAL**: No US1 / US2 / US3 work can begin until this phase is complete.
+
+### Trust-claim substrate (FR-010 dependency)
+
+- [ ] T004 [P] Add `bool EmailVerified` field to `SocialAuthCallbackResult` record in `src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs`
+- [ ] T005 [P] Create `SocialLoginRefusal` enum (`None`, `ProviderUnverified`, `ExistingUnverified`) and `ResolveSocialUserResult` record (`PlatformUser? User`, `bool IsNew`, `SocialLoginRefusal Refusal`) in `src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs`
+
+### `SocialLoginService` claim plumbing (sequential — same file)
+
+- [ ] T006 Update `ParseIdTokenClaims` in `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` to extract `email_verified` boolean (default `false` when absent) and propagate it via the private `IdTokenClaims` record
+- [ ] T007 Update `FetchUserInfoClaimsAsync` in same file to read `email_verified` from userinfo response (default `false` when absent)
+- [ ] T008 Update `ExtractGitHubClaimsAsync` in same file to set `EmailVerified = true` only when the primary `/user/emails` entry has `verified: true`
+- [ ] T009 Update `ExtractOidcClaimsAsync` and the GitHub path to construct `SocialAuthCallbackResult` with the new `EmailVerified` field populated
+
+### Provider-list visibility surface (FR-001 substrate; needed by US1, US3)
+
+- [ ] T010 [P] Add `IReadOnlyList<string> GetConfiguredProviderNames()` to `ISocialLoginService` in `src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs`
+- [ ] T011 Implement `GetConfiguredProviderNames` in `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` returning provider names where both `ClientId` and `ClientSecret` are non-empty (filter `_providers` dictionary)
+
+### Callback URL bug fix (FR-021)
+
+- [ ] T012 [P] In `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs`, change both `redirectUri` constructions (lines 99 and 262) from `$"{baseUrl}/api/auth/social/callback-redirect"` to `$"{baseUrl}/auth/social/callback"`
+- [ ] T013 [P] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, remove `provider` from the `OnGetAsync` parameter list and use `callbackResult.Provider` (already populated by the service from cached state) for downstream calls
+
+### Resolve-flow signature change (US1 + US2 dependency)
+
+- [ ] T014 In `src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs`, change `ResolveOrCreateSocialUserAsync` signature to return `Task<ResolveSocialUserResult>` and accept `SocialAuthCallbackResult` (instead of separate `provider`, `subject`, `email`, `displayName` parameters); preserves caller ergonomics by carrying `EmailVerified` in the same DTO
+
+**Checkpoint**: Substrate ready. Bug is fixed. Provider visibility query and trust claim are available. User story phases can now proceed in parallel.
+
+---
+
+## Phase 3: User Story 1 — First-time signup via a social provider (Priority: P1) 🎯 MVP
+
+**Goal**: A first-time visitor can click "Continue with Google" or "Continue with GitHub" on n1, complete consent, and land signed-in to a new public-org consumer account with a welcome email dispatched.
+
+**Independent Test**: Configure one provider (e.g., Google), open the signup page in a private browser, click the provider button, complete the provider consent screen, confirm the visitor lands signed in with a new account, the welcome email arrives, and the account is recorded as a public-organisation consumer.
+
+### Tests for User Story 1 (write FIRST, ensure they FAIL before implementation)
+
+- [ ] T015 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Models/SocialAuthCallbackResultTests.cs` (new file), add tests covering: `EmailVerified` populated from `email_verified=true` ID-token claim; defaults `false` when claim absent; defaults `false` when claim is non-Boolean
+- [ ] T016 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialLoginEndpointsTests.cs` (extend), add regression test asserting the `redirectUri` value sent to `GenerateAuthorizationUrlAsync` ends with `/auth/social/callback` (NOT `/api/auth/social/callback-redirect`)
+- [ ] T017 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs` (extend), add tests covering: `Model.AvailableProviders` populated from `ISocialLoginService.GetConfiguredProviderNames`; empty list when no providers configured; preserves provider name casing
+- [ ] T018 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Data/DatabaseInitializerTests.cs` (extend or new), add tests covering: `PlatformSettings.PublicOrgEnabled` seeded `true` when `PlatformSettings:SeedPublicOrgEnabled=true` in config; defaults `false` when config key absent; existing row not overwritten on subsequent boots
+
+### Implementation for User Story 1
+
+- [ ] T019 [US1] In `src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs`, rewrite `ResolveOrCreateSocialUserAsync` to handle the **new-user happy path**: when no provider link exists and no email collision, create `PlatformUser` with `EmailVerified=true, EmailVerifiedAt=now`, link `PlatformSocialLogin`, return `ResolveSocialUserResult(User, IsNew=true, Refusal=None)`. Preserve existing `LinkSocialLoginAsync` and `CreateAsync` calls.
+- [ ] T020 [US1] In same file, handle the **returning-user path** (provider+subject already linked): update `LastUsedAt`, refresh `PlatformUser.DisplayName` from claim if non-empty and differs, return `ResolveSocialUserResult(User=existing, IsNew=false, Refusal=None)`. **Do not** re-check `EmailVerified` per FR-013.
+- [ ] T021 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, update call to `ResolveOrCreateSocialUserAsync` to pass the new `SocialAuthCallbackResult` directly and consume `ResolveSocialUserResult`. On success path (`Refusal=None`, `User != null`), keep existing welcome-dispatch + JWT-issue + redirect-to-`/app/#token=…` flow unchanged.
+- [ ] T022 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SignupModel.cs` (`Signup.cshtml.cs`), inject `ISocialLoginService`, add `public IReadOnlyList<string> AvailableProviders { get; private set; } = []` property, populate in `OnGet` from `socialLoginService.GetConfiguredProviderNames()`
+- [ ] T023 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml`, replace the four hard-coded `<button class="social-btn" data-provider="…">` lines with a `@foreach (var provider in Model.AvailableProviders)` loop that emits one button per configured provider; preserve the surrounding `<div id="tab-social">` structure
+- [ ] T024 [US1] In same file, **remove dead JS** from the social-login click handler: `var redirectUri = …`, `var nonce = …`, `var state = btoa(…)`, `sessionStorage.setItem('social_login_nonce', nonce)`. Keep the `fetch('/api/auth/social/initiate', …)` call. Add a comment line above the handler explaining the server constructs and validates the state — JS only needs the provider name.
+- [ ] T025 [US1] In `src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs`, change the hard-coded `PublicOrgEnabled = false` line (~314) to read `_configuration.GetValue<bool>("PlatformSettings:SeedPublicOrgEnabled", false)`. Update the existing `LogInformation` line that includes `PublicOrgEnabled=false` to log the configured value.
+- [ ] T026 [US1] Run all new + extended tests from T015-T018 + T019-T025 paths and confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~SocialLogin|FullyQualifiedName~SignupModel|FullyQualifiedName~DatabaseInitializer"`
+
+**Checkpoint**: At this point a fresh n1 (or local-dev with Google credentials) can support new-user social signup end-to-end. Login page still shows hardcoded buttons — that's US3's territory.
+
+---
+
+## Phase 4: User Story 2 — Account-takeover defence (Priority: P1)
+
+**Goal**: The strict link policy is enforced. Social signup is refused when the provider asserts `email_verified=false`. Cross-method linking is refused when the existing Sorcha account is unverified. Refusals are visible in telemetry.
+
+**Independent Test**: Create a password account with email `x@example.com` but do not verify it. From a second browser, attempt social signup with the same email at a provider that asserts the email as verified. Confirm the attempt is refused with the documented message and that no link or new identity is created. Then verify the password account's email and retry — confirm the link succeeds.
+
+### Tests for User Story 2
+
+- [ ] T027 [P] [US2] In `tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs` (new file), add tests covering all three scenarios from data-model.md §"State transitions": (a) returning user → no re-check, `LastUsedAt` updated, `DisplayName` refreshed; (b) email-collision + existing unverified → `Refusal.ExistingUnverified`, no link created; (c) email-collision + both verified → link, `LastUsedAt` updated, `DisplayName` refreshed; (d) no link, no collision, provider unverified → `Refusal.ProviderUnverified`, no user created; (e) no link, no collision, provider verified → new user with `EmailVerified=true`. Mock `_db` and `IIdentityRepository`. AAA pattern.
+- [ ] T028 [P] [US2] In `tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs` (new file), add tests covering: refusal renders the page with `ErrorMessage` matching the documented copy for each `SocialLoginRefusal` value; success path redirects to `/app/#token=…&refresh=…`
+
+### Implementation for User Story 2
+
+- [ ] T029 [US2] In `src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs`, extend `ResolveOrCreateSocialUserAsync` to apply the strict-link gate (Scenario B from data-model.md): when provider+subject is not linked but email matches an existing user, require **both** `provider.EmailVerified == true` AND `existing.EmailVerified == true`. If both true → link via `LinkSocialLoginAsync`, refresh `DisplayName`, return success. If either false → return `ResolveSocialUserResult(User=null, IsNew=false, Refusal=ExistingUnverified)`.
+- [ ] T030 [US2] In same file, extend the new-user creation path: if no link, no email collision, and `provider.EmailVerified == false`, return `ResolveSocialUserResult(User=null, IsNew=false, Refusal=ProviderUnverified)`. **Do not** create a `PlatformUser` for refused signups.
+- [ ] T031 [US2] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, after the `ResolveOrCreateSocialUserAsync` call, add a `switch` on `result.Refusal` that sets `ErrorMessage` to the documented copy for `ProviderUnverified` ("Your `<provider>` account hasn't verified this email address. Please verify it with `<provider>` and try again.") and `ExistingUnverified` ("An account exists for this email but isn't verified. Sign in with your password and verify your email first, or recover access at `/auth/login`.") and returns `Page()`. The `<provider>` literal substitutes `result.Provider`.
+- [ ] T032 [US2] In `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` (or co-located `SocialLoginMetrics.cs` if a clean break is preferred — match the existing pattern in `Sorcha.Tenant.Service`), add a `Counter<long>` named `sorcha_social_login_refusal_total` on the `Sorcha.Tenant` meter with tags `provider` and `reason`. Increment it once per refusal at the call site in `SocialCallback.cshtml.cs` (after the switch in T031). Tag values for `reason`: `provider_unverified`, `existing_unverified`. Add `code_exchange_failed` and `state_invalid` tags at the existing failure paths (the early-return cases in `OnGetAsync`).
+- [ ] T033 [US2] Add `LogWarning` calls at each refusal site with `{Provider}` and `{Reason}` structured fields plus a hash-based redacted email tag (use `SHA256.HashData(Encoding.UTF8.GetBytes(email)).Take(8)` as a hex string — sufficient for grouping in logs without exposing PII)
+- [ ] T034 [US2] Run policy tests and refusal-rendering tests, confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~SocialLoginPolicy|FullyQualifiedName~SocialCallbackModel"`
+
+**Checkpoint**: All three policy gates enforced. Refusals visible in telemetry. The unverified-existing-account hijack scenario is closed.
+
+---
+
+## Phase 5: User Story 3 — Operator controls which providers are available (Priority: P2)
+
+**Goal**: Provider buttons on the **login** page (US1 covered the signup page) reflect the operator's `SocialProviders` configuration. Adding a provider requires only configuration + restart.
+
+**Independent Test**: On n1 (or local dev), configure exactly one provider. Open `/auth/login` and confirm exactly one provider button is rendered. Add a second provider's configuration and restart the service. Open `/auth/login` and confirm both buttons are rendered.
+
+### Tests for User Story 3
+
+- [ ] T035 [P] [US3] In `tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs` (extend), add tests mirroring T017's `SignupModelTests` shape: `Model.AvailableProviders` populated from `ISocialLoginService.GetConfiguredProviderNames`; empty list renders zero buttons
+
+### Implementation for User Story 3
+
+- [ ] T036 [US3] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/LoginModel.cs` (`Login.cshtml.cs`), inject `ISocialLoginService`, add `public IReadOnlyList<string> AvailableProviders { get; private set; } = []` property, populate in `OnGet` (mirror SignupModel changes from T022)
+- [ ] T037 [US3] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml`, render conditional buttons via `@foreach (var provider in Model.AvailableProviders)` (mirror Signup.cshtml changes from T023). Remove any dead JS in the login page social-login handler matching what T024 cleared from signup.
+- [ ] T038 [US3] Run login-page tests, confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~LoginModelTests"`
+
+**Checkpoint**: Operator can add/remove providers via configuration alone — no code changes — and both signup and login pages reflect the change after a service restart.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+**Purpose**: Documentation, deploy preparation, and final verification before merging.
+
+- [ ] T039 [P] Write the body of `docs/guides/SOCIAL-LOGIN-SETUP.md` (created as stub in T003) covering: Google OAuth-app registration steps (Cloud Console → OAuth consent screen → Web app credentials → redirect URI `https://n1.sorcha.dev/auth/social/callback`); GitHub OAuth-app registration steps; how to populate `/opt/sorcha/.env` on the n1 host; how to verify the deploy; how to rotate credentials. Include screenshots if available, otherwise text-only step-by-step.
+- [ ] T040 [P] Update `src/Services/Sorcha.Tenant.Service/README.md` "Social login" section: link to new doc, note the strict link policy, list the env vars consumed
+- [ ] T041 [P] Update `docs/reference/API-DOCUMENTATION.md` if any of the social-auth endpoints' summaries changed (likely no — but verify)
+- [ ] T042 Run full Tenant Service test suite to confirm nothing else regressed: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "Category!=Integration|FullyQualifiedName!~Integration"` — expect all green except known pre-existing failures unrelated to this feature
+- [ ] T043 Commit and push branch; open draft PR; request `claude-review` per workflow; address any findings the bot surfaces; mark PR ready
+- [ ] T044 [Manual + collaborative] Run the n1 deploy walkthrough from `quickstart.md` §4-7 jointly with operator: register OAuth apps, seed `/opt/sorcha/.env`, run `n1-reset.ps1`, walk the seven smoke scenarios in browser, verify telemetry counter populated for the email-collision refusal step
+- [ ] T045 [Manual] After successful n1 deploy, set up the `/schedule` reminder to flip n1's `ASPNETCORE_ENVIRONMENT` to `Staging` per REQ-7 (target +7 days)
+
+---
+
+## Dependencies
+
+```
+Phase 1: Setup (T001 → T002 → T003 in parallel)
+   ↓
+Phase 2: Foundational
+   T004, T005 [P]                      (DTOs — independent files/sections)
+   T006 → T007 → T008 → T009            (sequential within SocialLoginService)
+   T010 → T011                          (interface then implementation)
+   T012, T013 [P]                       (different files, independent of each other)
+   T014                                 (depends on T005)
+   ↓
+Phase 3: US1 (P1, MVP)
+   Tests T015–T018 [P]                  (different files; can run together)
+   T019 → T020                          (same file, sequential)
+   T021                                 (depends on T014, T019, T020)
+   T022 → T023 → T024                   (same file group, sequential)
+   T025                                 (independent file)
+   T026                                 (verification — runs last in US1)
+   ↓
+Phase 4: US2 (P1)         ┐
+   Tests T027, T028 [P]   │ Can run in parallel with US3 after Phase 2
+   T029 → T030 (same file)│
+   T031, T032, T033       │
+   T034                   │
+                          ┘
+Phase 5: US3 (P2)         ┐
+   T035 [P]               │
+   T036 → T037            │
+   T038                   │
+                          ┘
+   ↓
+Phase 6: Polish
+   T039–T041 [P]
+   T042 (full suite verification)
+   T043 (PR + claude-review)
+   T044 (collaborative n1 deploy)
+   T045 (schedule reminder)
+```
+
+**Key dependencies summarised**:
+
+- **US2 and US3 can run in parallel** after Phase 2 + US1 — they touch disjoint files (US2: PlatformUserService, SocialCallback page model; US3: LoginModel, Login.cshtml).
+- **US1 must precede US2** because US2 builds on US1's `ResolveOrCreateSocialUserAsync` happy-path branches (extends them with refusal returns).
+- **US3 depends on Phase 2's `GetConfiguredProviderNames`** (T010, T011) but not on any US1 task — could in principle run alongside US1, but the natural order is US1 → US3 since the signup-page change is the canonical pattern that US3's login-page change mirrors.
+
+---
+
+## Parallel Execution Examples
+
+### After T011 completes (Phase 2 nearly done)
+
+T012, T013, T014, plus the four US1 test files (T015-T018) can all be authored in parallel — they touch disjoint files:
+
+```
+T012 — SocialLoginEndpoints.cs
+T013 — SocialCallback.cshtml.cs (parameter list change only)
+T014 — IPlatformUserService.cs (signature change)
+T015 — Models/SocialAuthCallbackResultTests.cs (new file)
+T016 — Endpoints/SocialLoginEndpointsTests.cs (extend)
+T017 — Pages/SignupModelTests.cs (extend)
+T018 — Data/DatabaseInitializerTests.cs (extend or new)
+```
+
+### Phase 4 + Phase 5 in parallel (after Phase 3 ships)
+
+```
+US2 track:  T027, T028, T029, T030, T031, T032, T033, T034
+US3 track:  T035, T036, T037, T038
+```
+
+These touch disjoint files in disjoint folders.
+
+### Phase 6 docs in parallel
+
+```
+T039 — docs/guides/SOCIAL-LOGIN-SETUP.md
+T040 — src/Services/Sorcha.Tenant.Service/README.md
+T041 — docs/reference/API-DOCUMENTATION.md (verify only)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP scope (US1 only)
+
+If you need to ship the smallest valuable increment first, ship Phase 1 + Phase 2 + Phase 3. After that:
+
+- A new public visitor can sign up via Google or GitHub on n1
+- The bug is fixed
+- Provider buttons render conditionally
+- A fresh n1 can do social signup without manual DB edits
+
+**Missing from MVP**: refusal/security gate (US2), login-page parity (US3). The hijack risk means **DO NOT actually deploy MVP-only to n1** — US2 must land before n1 takes organic traffic. Use MVP scope only as a development checkpoint.
+
+### Recommended ship plan
+
+**Single PR.** US1 + US2 + US3 + Polish all merge together. Reasons: (1) the strict-link policy is the security backstop and must not lag behind the happy-path; (2) the file overlap is small enough that the PR is reviewable in one pass; (3) collaborative n1 deploy in T044 needs the whole feature.
+
+### After-merge sequence
+
+1. Docker Publish CI builds new images (~10–15 min)
+2. T044: joint n1 deploy walkthrough with operator
+3. Verify the seven smoke scenarios pass
+4. T045: schedule the `Staging` flip reminder
+
+### Failure-mode notes
+
+- If T012's bug fix lands without T013's parameter-list update, the social flow will throw at runtime when the Razor page tries to bind `provider` from query (which providers won't include in the redirect). T012 and T013 must ship together.
+- If T029/T030 land without T031 (refusal copy), the user sees an empty page on refusal. Worse UX than the existing 404. Land them together.
+- If T032 (telemetry counter) lands without T033 (logging refinements), refusals are countable but not investigatable. Land them together.
+
+---
+
+## Validation against spec FRs
+
+| FR | Tasks |
+|---|---|
+| FR-001 (buttons only for configured providers) | T010, T011, T022, T023, T036, T037 |
+| FR-002 (no greying out) | T023, T037 |
+| FR-003 (env-scoped config) | T001, T002 |
+| FR-004 (add provider via config alone) | T010, T011 (no code change needed for new provider) |
+| FR-005 (new-user happy path) | T019, T021 |
+| FR-006 (durable provider+sub link) | T019 (uses existing `LinkSocialLoginAsync`) |
+| FR-007 (`LastUsedAt` update) | T020, T029 |
+| FR-008 (`DisplayName` refresh) | T020, T029 |
+| FR-009 (no email refresh) | implicit — no code path updates `PlatformUser.Email` post-creation |
+| FR-010 (refuse provider unverified) | T030 |
+| FR-011 (refuse existing unverified) | T029 |
+| FR-012 (allow both verified) | T029 |
+| FR-013 (no re-check on returning) | T020 |
+| FR-014 (issue session token) | unchanged from existing `SocialCallback.cshtml.cs` flow |
+| FR-015 (welcome at most once) | unchanged — `WelcomeEmailDispatcher.SendIfPendingAsync` is idempotent |
+| FR-016 (refusal copy) | T031 |
+| FR-017 (tolerate cancellation) | unchanged — existing `OnGetAsync` early-error path |
+| FR-018 (telemetry on refusal) | T032, T033 |
+| FR-019 (config-driven seed) | T002 (env var), T025 (read it), T018 (test it) |
+| FR-020 (demo banner) | unchanged — already wired in `docker-compose.n1.yml:55` |
+| FR-021 (single canonical callback) | T012, T013 |
+
+Every FR has at least one task. Every test FR has at least one test task.
+
+---
+
+## Total task count
+
+- Phase 1 (Setup): **3** tasks
+- Phase 2 (Foundational): **11** tasks
+- Phase 3 (US1 / P1 / MVP): **12** tasks (4 tests + 7 implementation + 1 verify)
+- Phase 4 (US2 / P1): **8** tasks (2 tests + 5 implementation + 1 verify)
+- Phase 5 (US3 / P2): **4** tasks (1 test + 2 implementation + 1 verify)
+- Phase 6 (Polish): **7** tasks (3 docs + 1 full-test + 1 PR + 1 deploy + 1 schedule)
+
+**Total: 45 tasks**
+
+Tests: 8 (within the appropriate user-story phases per spec template guidance)
+Implementation: 19 production code, 5 config / docs
+Verification & deploy: 5 cross-cutting tasks
+
+---
+
+## Notes
+
+- All checklist items follow the format `- [ ] T### [P?] [Story?] Description with file path` per the SpecKit task convention.
+- Tasks that mention "extend existing test file" assume the file exists in master at commit `d0cdd55a`. Verify before adding to avoid stomping unrelated changes.
+- Manual tasks (T044, T045) are explicitly marked because they require operator collaboration or external system interaction (provider consoles, schedule routine).
+- The spec's "Notes for Planning" section says "planning should consume the design doc directly and produce a tasks list that maps each FR in this spec to one or more implementation steps in the design." The §"Validation against spec FRs" table above provides that mapping.

--- a/specs/115-social-signup/tasks.md
+++ b/specs/115-social-signup/tasks.md
@@ -159,7 +159,7 @@ templates — no production code changes.
 - [X] T040 [P] Update `src/Services/Sorcha.Tenant.Service/README.md` "Social login" section: link to new doc, note the strict link policy, list the env vars consumed
 - [X] T041 [P] Update `docs/reference/API-DOCUMENTATION.md` if any of the social-auth endpoints' summaries changed (likely no — but verify)
 - [X] T042 Run full Tenant Service test suite to confirm nothing else regressed: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "Category!=Integration|FullyQualifiedName!~Integration"` — expect all green except known pre-existing failures unrelated to this feature
-- [ ] T043 Commit and push branch; open draft PR; request `claude-review` per workflow; address any findings the bot surfaces; mark PR ready
+- [X] T043 Commit and push branch; open draft PR; request `claude-review` per workflow; address any findings the bot surfaces; mark PR ready — **PR #423** opened (https://github.com/Sorcha-Platform/Sorcha/pull/423)
 - [ ] T044 [Manual + collaborative] Run the n1 deploy walkthrough from `quickstart.md` §4-7 jointly with operator: register OAuth apps, seed `/opt/sorcha/.env`, run `n1-reset.ps1`, walk the seven smoke scenarios in browser, verify telemetry counter populated for the email-collision refusal step
 - [ ] T045 [Manual] After successful n1 deploy, set up the `/schedule` reminder to flip n1's `ASPNETCORE_ENVIRONMENT` to `Staging` per REQ-7 (target +7 days)
 

--- a/specs/115-social-signup/tasks.md
+++ b/specs/115-social-signup/tasks.md
@@ -35,9 +35,9 @@ project. No new projects. Paths follow the established service layout:
 binds to. These tasks touch only configuration files and documentation
 templates — no production code changes.
 
-- [ ] T001 Add `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` placeholder lines (with empty values) to `.env.example` in a `# Social login OAuth credentials (n1 only)` block
-- [ ] T002 Add `SocialProviders__0__*` and `SocialProviders__1__*` env-var entries to the `tenant-service.environment` section of `docker-compose.n1.yml`, mapping to the four `${...}` placeholders from T001; also add `PlatformSettings__SeedPublicOrgEnabled: "true"` to the same `environment` block
-- [ ] T003 [P] Create stub at `docs/guides/SOCIAL-LOGIN-SETUP.md` with section headings only (Google · GitHub · Verifying the deploy · Rotating credentials); content lands in T033
+- [X] T001 Add `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET` placeholder lines (with empty values) to `.env.example` in a `# Social login OAuth credentials (n1 only)` block
+- [X] T002 Add `SocialProviders__0__*` and `SocialProviders__1__*` env-var entries to the `tenant-service.environment` section of `docker-compose.n1.yml`, mapping to the four `${...}` placeholders from T001; also add `PlatformSettings__SeedPublicOrgEnabled: "true"` to the same `environment` block
+- [X] T003 [P] Create stub at `docs/guides/SOCIAL-LOGIN-SETUP.md` with section headings only (Google · GitHub · Verifying the deploy · Rotating credentials); content lands in T033
 
 **Checkpoint**: Configuration surface exists. Operators can copy `.env.example` to `/opt/sorcha/.env` and start filling values once OAuth apps are registered.
 
@@ -51,29 +51,29 @@ templates — no production code changes.
 
 ### Trust-claim substrate (FR-010 dependency)
 
-- [ ] T004 [P] Add `bool EmailVerified` field to `SocialAuthCallbackResult` record in `src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs`
-- [ ] T005 [P] Create `SocialLoginRefusal` enum (`None`, `ProviderUnverified`, `ExistingUnverified`) and `ResolveSocialUserResult` record (`PlatformUser? User`, `bool IsNew`, `SocialLoginRefusal Refusal`) in `src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs`
+- [X] T004 [P] Add `bool EmailVerified` field to `SocialAuthCallbackResult` record in `src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs`
+- [X] T005 [P] Create `SocialLoginRefusal` enum (`None`, `ProviderUnverified`, `ExistingUnverified`) and `ResolveSocialUserResult` record (`PlatformUser? User`, `bool IsNew`, `SocialLoginRefusal Refusal`) in `src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs`
 
 ### `SocialLoginService` claim plumbing (sequential — same file)
 
-- [ ] T006 Update `ParseIdTokenClaims` in `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` to extract `email_verified` boolean (default `false` when absent) and propagate it via the private `IdTokenClaims` record
-- [ ] T007 Update `FetchUserInfoClaimsAsync` in same file to read `email_verified` from userinfo response (default `false` when absent)
-- [ ] T008 Update `ExtractGitHubClaimsAsync` in same file to set `EmailVerified = true` only when the primary `/user/emails` entry has `verified: true`
-- [ ] T009 Update `ExtractOidcClaimsAsync` and the GitHub path to construct `SocialAuthCallbackResult` with the new `EmailVerified` field populated
+- [X] T006 Update `ParseIdTokenClaims` in `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` to extract `email_verified` boolean (default `false` when absent) and propagate it via the private `IdTokenClaims` record
+- [X] T007 Update `FetchUserInfoClaimsAsync` in same file to read `email_verified` from userinfo response (default `false` when absent)
+- [X] T008 Update `ExtractGitHubClaimsAsync` in same file to set `EmailVerified = true` only when the primary `/user/emails` entry has `verified: true`
+- [X] T009 Update `ExtractOidcClaimsAsync` and the GitHub path to construct `SocialAuthCallbackResult` with the new `EmailVerified` field populated
 
 ### Provider-list visibility surface (FR-001 substrate; needed by US1, US3)
 
-- [ ] T010 [P] Add `IReadOnlyList<string> GetConfiguredProviderNames()` to `ISocialLoginService` in `src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs`
-- [ ] T011 Implement `GetConfiguredProviderNames` in `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` returning provider names where both `ClientId` and `ClientSecret` are non-empty (filter `_providers` dictionary)
+- [X] T010 [P] Add `IReadOnlyList<string> GetConfiguredProviderNames()` to `ISocialLoginService` in `src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs`
+- [X] T011 Implement `GetConfiguredProviderNames` in `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` returning provider names where both `ClientId` and `ClientSecret` are non-empty (filter `_providers` dictionary)
 
 ### Callback URL bug fix (FR-021)
 
-- [ ] T012 [P] In `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs`, change both `redirectUri` constructions (lines 99 and 262) from `$"{baseUrl}/api/auth/social/callback-redirect"` to `$"{baseUrl}/auth/social/callback"`
-- [ ] T013 [P] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, remove `provider` from the `OnGetAsync` parameter list and use `callbackResult.Provider` (already populated by the service from cached state) for downstream calls
+- [X] T012 [P] In `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs`, change both `redirectUri` constructions (lines 99 and 262) from `$"{baseUrl}/api/auth/social/callback-redirect"` to `$"{baseUrl}/auth/social/callback"`
+- [X] T013 [P] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, remove `provider` from the `OnGetAsync` parameter list and use `callbackResult.Provider` (already populated by the service from cached state) for downstream calls
 
 ### Resolve-flow signature change (US1 + US2 dependency)
 
-- [ ] T014 In `src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs`, change `ResolveOrCreateSocialUserAsync` signature to return `Task<ResolveSocialUserResult>` and accept `SocialAuthCallbackResult` (instead of separate `provider`, `subject`, `email`, `displayName` parameters); preserves caller ergonomics by carrying `EmailVerified` in the same DTO
+- [X] T014 In `src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs`, change `ResolveOrCreateSocialUserAsync` signature to return `Task<ResolveSocialUserResult>` and accept `SocialAuthCallbackResult` (instead of separate `provider`, `subject`, `email`, `displayName` parameters); preserves caller ergonomics by carrying `EmailVerified` in the same DTO
 
 **Checkpoint**: Substrate ready. Bug is fixed. Provider visibility query and trust claim are available. User story phases can now proceed in parallel.
 
@@ -87,21 +87,21 @@ templates — no production code changes.
 
 ### Tests for User Story 1 (write FIRST, ensure they FAIL before implementation)
 
-- [ ] T015 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Models/SocialAuthCallbackResultTests.cs` (new file), add tests covering: `EmailVerified` populated from `email_verified=true` ID-token claim; defaults `false` when claim absent; defaults `false` when claim is non-Boolean
-- [ ] T016 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialLoginEndpointsTests.cs` (extend), add regression test asserting the `redirectUri` value sent to `GenerateAuthorizationUrlAsync` ends with `/auth/social/callback` (NOT `/api/auth/social/callback-redirect`)
-- [ ] T017 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs` (extend), add tests covering: `Model.AvailableProviders` populated from `ISocialLoginService.GetConfiguredProviderNames`; empty list when no providers configured; preserves provider name casing
-- [ ] T018 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Data/DatabaseInitializerTests.cs` (extend or new), add tests covering: `PlatformSettings.PublicOrgEnabled` seeded `true` when `PlatformSettings:SeedPublicOrgEnabled=true` in config; defaults `false` when config key absent; existing row not overwritten on subsequent boots
+- [X] T015 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Models/SocialAuthCallbackResultTests.cs` (new file), add tests covering: `EmailVerified` populated from `email_verified=true` ID-token claim; defaults `false` when claim absent; defaults `false` when claim is non-Boolean
+- [ ] T016 [P] [US1] **DEFERRED** — In `tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialLoginEndpointsTests.cs` (extend), add regression test asserting the `redirectUri` value sent to `GenerateAuthorizationUrlAsync` ends with `/auth/social/callback` (NOT `/api/auth/social/callback-redirect`). Deferred — file does not exist; setting one up requires mocking the full endpoint pipeline. Manual smoke walkthrough (step 3 in quickstart) catches the regression directly.
+- [X] T017 [P] [US1] In `tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs` (extend), add tests covering: `Model.AvailableProviders` populated from `ISocialLoginService.GetConfiguredProviderNames`; empty list when no providers configured; preserves provider name casing
+- [ ] T018 [P] [US1] **DEFERRED** — In `tests/Sorcha.Tenant.Service.Tests/Data/DatabaseInitializerTests.cs` (new), add tests covering the `PlatformSettings:SeedPublicOrgEnabled` seed flag. Deferred — `DatabaseInitializer` takes `IServiceProvider` and the seed methods are private; testing requires full service-provider setup. The logic is `_configuration.GetValue<bool>(...)` (one line), exercised indirectly via `BootstrapApiTests` integration. Manual smoke step (verify `select "PublicOrgEnabled" from platform_settings` returns `t` after fresh n1 reset) covers it.
 
 ### Implementation for User Story 1
 
-- [ ] T019 [US1] In `src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs`, rewrite `ResolveOrCreateSocialUserAsync` to handle the **new-user happy path**: when no provider link exists and no email collision, create `PlatformUser` with `EmailVerified=true, EmailVerifiedAt=now`, link `PlatformSocialLogin`, return `ResolveSocialUserResult(User, IsNew=true, Refusal=None)`. Preserve existing `LinkSocialLoginAsync` and `CreateAsync` calls.
-- [ ] T020 [US1] In same file, handle the **returning-user path** (provider+subject already linked): update `LastUsedAt`, refresh `PlatformUser.DisplayName` from claim if non-empty and differs, return `ResolveSocialUserResult(User=existing, IsNew=false, Refusal=None)`. **Do not** re-check `EmailVerified` per FR-013.
-- [ ] T021 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, update call to `ResolveOrCreateSocialUserAsync` to pass the new `SocialAuthCallbackResult` directly and consume `ResolveSocialUserResult`. On success path (`Refusal=None`, `User != null`), keep existing welcome-dispatch + JWT-issue + redirect-to-`/app/#token=…` flow unchanged.
-- [ ] T022 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SignupModel.cs` (`Signup.cshtml.cs`), inject `ISocialLoginService`, add `public IReadOnlyList<string> AvailableProviders { get; private set; } = []` property, populate in `OnGet` from `socialLoginService.GetConfiguredProviderNames()`
-- [ ] T023 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml`, replace the four hard-coded `<button class="social-btn" data-provider="…">` lines with a `@foreach (var provider in Model.AvailableProviders)` loop that emits one button per configured provider; preserve the surrounding `<div id="tab-social">` structure
-- [ ] T024 [US1] In same file, **remove dead JS** from the social-login click handler: `var redirectUri = …`, `var nonce = …`, `var state = btoa(…)`, `sessionStorage.setItem('social_login_nonce', nonce)`. Keep the `fetch('/api/auth/social/initiate', …)` call. Add a comment line above the handler explaining the server constructs and validates the state — JS only needs the provider name.
-- [ ] T025 [US1] In `src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs`, change the hard-coded `PublicOrgEnabled = false` line (~314) to read `_configuration.GetValue<bool>("PlatformSettings:SeedPublicOrgEnabled", false)`. Update the existing `LogInformation` line that includes `PublicOrgEnabled=false` to log the configured value.
-- [ ] T026 [US1] Run all new + extended tests from T015-T018 + T019-T025 paths and confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~SocialLogin|FullyQualifiedName~SignupModel|FullyQualifiedName~DatabaseInitializer"`
+- [X] T019 [US1] In `src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs`, rewrite `ResolveOrCreateSocialUserAsync` to handle the **new-user happy path**: when no provider link exists and no email collision, create `PlatformUser` with `EmailVerified=true, EmailVerifiedAt=now`, link `PlatformSocialLogin`, return `ResolveSocialUserResult(User, IsNew=true, Refusal=None)`. Preserve existing `LinkSocialLoginAsync` and `CreateAsync` calls.
+- [X] T020 [US1] In same file, handle the **returning-user path** (provider+subject already linked): update `LastUsedAt`, refresh `PlatformUser.DisplayName` from claim if non-empty and differs, return `ResolveSocialUserResult(User=existing, IsNew=false, Refusal=None)`. **Do not** re-check `EmailVerified` per FR-013.
+- [X] T021 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, update call to `ResolveOrCreateSocialUserAsync` to pass the new `SocialAuthCallbackResult` directly and consume `ResolveSocialUserResult`. On success path (`Refusal=None`, `User != null`), keep existing welcome-dispatch + JWT-issue + redirect-to-`/app/#token=…` flow unchanged.
+- [X] T022 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SignupModel.cs` (`Signup.cshtml.cs`), inject `ISocialLoginService`, add `public IReadOnlyList<string> AvailableProviders { get; private set; } = []` property, populate in `OnGet` from `socialLoginService.GetConfiguredProviderNames()`
+- [X] T023 [US1] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml`, replace the four hard-coded `<button class="social-btn" data-provider="…">` lines with a `@foreach (var provider in Model.AvailableProviders)` loop that emits one button per configured provider; preserve the surrounding `<div id="tab-social">` structure
+- [X] T024 [US1] In same file, **remove dead JS** from the social-login click handler: `var redirectUri = …`, `var nonce = …`, `var state = btoa(…)`, `sessionStorage.setItem('social_login_nonce', nonce)`. Keep the `fetch('/api/auth/social/initiate', …)` call. Add a comment line above the handler explaining the server constructs and validates the state — JS only needs the provider name.
+- [X] T025 [US1] In `src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs`, change the hard-coded `PublicOrgEnabled = false` line (~314) to read `_configuration.GetValue<bool>("PlatformSettings:SeedPublicOrgEnabled", false)`. Update the existing `LogInformation` line that includes `PublicOrgEnabled=false` to log the configured value.
+- [X] T026 [US1] Run all new + extended tests from T015-T018 + T019-T025 paths and confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~SocialLogin|FullyQualifiedName~SignupModel|FullyQualifiedName~DatabaseInitializer"`
 
 **Checkpoint**: At this point a fresh n1 (or local-dev with Google credentials) can support new-user social signup end-to-end. Login page still shows hardcoded buttons — that's US3's territory.
 
@@ -115,17 +115,17 @@ templates — no production code changes.
 
 ### Tests for User Story 2
 
-- [ ] T027 [P] [US2] In `tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs` (new file), add tests covering all three scenarios from data-model.md §"State transitions": (a) returning user → no re-check, `LastUsedAt` updated, `DisplayName` refreshed; (b) email-collision + existing unverified → `Refusal.ExistingUnverified`, no link created; (c) email-collision + both verified → link, `LastUsedAt` updated, `DisplayName` refreshed; (d) no link, no collision, provider unverified → `Refusal.ProviderUnverified`, no user created; (e) no link, no collision, provider verified → new user with `EmailVerified=true`. Mock `_db` and `IIdentityRepository`. AAA pattern.
-- [ ] T028 [P] [US2] In `tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs` (new file), add tests covering: refusal renders the page with `ErrorMessage` matching the documented copy for each `SocialLoginRefusal` value; success path redirects to `/app/#token=…&refresh=…`
+- [X] T027 [P] [US2] In `tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs` (new file), add tests covering all three scenarios from data-model.md §"State transitions": (a) returning user → no re-check, `LastUsedAt` updated, `DisplayName` refreshed; (b) email-collision + existing unverified → `Refusal.ExistingUnverified`, no link created; (c) email-collision + both verified → link, `LastUsedAt` updated, `DisplayName` refreshed; (d) no link, no collision, provider unverified → `Refusal.ProviderUnverified`, no user created; (e) no link, no collision, provider verified → new user with `EmailVerified=true`. Mock `_db` and `IIdentityRepository`. AAA pattern.
+- [X] T028 [P] [US2] In `tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs` (new file), add tests covering: refusal renders the page with `ErrorMessage` matching the documented copy for each `SocialLoginRefusal` value; success path redirects to `/app/#token=…&refresh=…`
 
 ### Implementation for User Story 2
 
-- [ ] T029 [US2] In `src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs`, extend `ResolveOrCreateSocialUserAsync` to apply the strict-link gate (Scenario B from data-model.md): when provider+subject is not linked but email matches an existing user, require **both** `provider.EmailVerified == true` AND `existing.EmailVerified == true`. If both true → link via `LinkSocialLoginAsync`, refresh `DisplayName`, return success. If either false → return `ResolveSocialUserResult(User=null, IsNew=false, Refusal=ExistingUnverified)`.
-- [ ] T030 [US2] In same file, extend the new-user creation path: if no link, no email collision, and `provider.EmailVerified == false`, return `ResolveSocialUserResult(User=null, IsNew=false, Refusal=ProviderUnverified)`. **Do not** create a `PlatformUser` for refused signups.
-- [ ] T031 [US2] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, after the `ResolveOrCreateSocialUserAsync` call, add a `switch` on `result.Refusal` that sets `ErrorMessage` to the documented copy for `ProviderUnverified` ("Your `<provider>` account hasn't verified this email address. Please verify it with `<provider>` and try again.") and `ExistingUnverified` ("An account exists for this email but isn't verified. Sign in with your password and verify your email first, or recover access at `/auth/login`.") and returns `Page()`. The `<provider>` literal substitutes `result.Provider`.
-- [ ] T032 [US2] In `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` (or co-located `SocialLoginMetrics.cs` if a clean break is preferred — match the existing pattern in `Sorcha.Tenant.Service`), add a `Counter<long>` named `sorcha_social_login_refusal_total` on the `Sorcha.Tenant` meter with tags `provider` and `reason`. Increment it once per refusal at the call site in `SocialCallback.cshtml.cs` (after the switch in T031). Tag values for `reason`: `provider_unverified`, `existing_unverified`. Add `code_exchange_failed` and `state_invalid` tags at the existing failure paths (the early-return cases in `OnGetAsync`).
-- [ ] T033 [US2] Add `LogWarning` calls at each refusal site with `{Provider}` and `{Reason}` structured fields plus a hash-based redacted email tag (use `SHA256.HashData(Encoding.UTF8.GetBytes(email)).Take(8)` as a hex string — sufficient for grouping in logs without exposing PII)
-- [ ] T034 [US2] Run policy tests and refusal-rendering tests, confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~SocialLoginPolicy|FullyQualifiedName~SocialCallbackModel"`
+- [X] T029 [US2] In `src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs`, extend `ResolveOrCreateSocialUserAsync` to apply the strict-link gate (Scenario B from data-model.md): when provider+subject is not linked but email matches an existing user, require **both** `provider.EmailVerified == true` AND `existing.EmailVerified == true`. If both true → link via `LinkSocialLoginAsync`, refresh `DisplayName`, return success. If either false → return `ResolveSocialUserResult(User=null, IsNew=false, Refusal=ExistingUnverified)`.
+- [X] T030 [US2] In same file, extend the new-user creation path: if no link, no email collision, and `provider.EmailVerified == false`, return `ResolveSocialUserResult(User=null, IsNew=false, Refusal=ProviderUnverified)`. **Do not** create a `PlatformUser` for refused signups.
+- [X] T031 [US2] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs`, after the `ResolveOrCreateSocialUserAsync` call, add a `switch` on `result.Refusal` that sets `ErrorMessage` to the documented copy for `ProviderUnverified` ("Your `<provider>` account hasn't verified this email address. Please verify it with `<provider>` and try again.") and `ExistingUnverified` ("An account exists for this email but isn't verified. Sign in with your password and verify your email first, or recover access at `/auth/login`.") and returns `Page()`. The `<provider>` literal substitutes `result.Provider`.
+- [X] T032 [US2] In `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs` (or co-located `SocialLoginMetrics.cs` if a clean break is preferred — match the existing pattern in `Sorcha.Tenant.Service`), add a `Counter<long>` named `sorcha_social_login_refusal_total` on the `Sorcha.Tenant` meter with tags `provider` and `reason`. Increment it once per refusal at the call site in `SocialCallback.cshtml.cs` (after the switch in T031). Tag values for `reason`: `provider_unverified`, `existing_unverified`. Add `code_exchange_failed` and `state_invalid` tags at the existing failure paths (the early-return cases in `OnGetAsync`).
+- [X] T033 [US2] Add `LogWarning` calls at each refusal site with `{Provider}` and `{Reason}` structured fields plus a hash-based redacted email tag (use `SHA256.HashData(Encoding.UTF8.GetBytes(email)).Take(8)` as a hex string — sufficient for grouping in logs without exposing PII)
+- [X] T034 [US2] Run policy tests and refusal-rendering tests, confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~SocialLoginPolicy|FullyQualifiedName~SocialCallbackModel"`
 
 **Checkpoint**: All three policy gates enforced. Refusals visible in telemetry. The unverified-existing-account hijack scenario is closed.
 
@@ -139,13 +139,13 @@ templates — no production code changes.
 
 ### Tests for User Story 3
 
-- [ ] T035 [P] [US3] In `tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs` (extend), add tests mirroring T017's `SignupModelTests` shape: `Model.AvailableProviders` populated from `ISocialLoginService.GetConfiguredProviderNames`; empty list renders zero buttons
+- [X] T035 [P] [US3] In `tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs` (extend), add tests mirroring T017's `SignupModelTests` shape: `Model.AvailableProviders` populated from `ISocialLoginService.GetConfiguredProviderNames`; empty list renders zero buttons
 
 ### Implementation for User Story 3
 
-- [ ] T036 [US3] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/LoginModel.cs` (`Login.cshtml.cs`), inject `ISocialLoginService`, add `public IReadOnlyList<string> AvailableProviders { get; private set; } = []` property, populate in `OnGet` (mirror SignupModel changes from T022)
-- [ ] T037 [US3] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml`, render conditional buttons via `@foreach (var provider in Model.AvailableProviders)` (mirror Signup.cshtml changes from T023). Remove any dead JS in the login page social-login handler matching what T024 cleared from signup.
-- [ ] T038 [US3] Run login-page tests, confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~LoginModelTests"`
+- [X] T036 [US3] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/LoginModel.cs` (`Login.cshtml.cs`), inject `ISocialLoginService`, add `public IReadOnlyList<string> AvailableProviders { get; private set; } = []` property, populate in `OnGet` (mirror SignupModel changes from T022)
+- [X] T037 [US3] In `src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml`, render conditional buttons via `@foreach (var provider in Model.AvailableProviders)` (mirror Signup.cshtml changes from T023). Remove any dead JS in the login page social-login handler matching what T024 cleared from signup.
+- [X] T038 [US3] Run login-page tests, confirm green: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "FullyQualifiedName~LoginModelTests"`
 
 **Checkpoint**: Operator can add/remove providers via configuration alone — no code changes — and both signup and login pages reflect the change after a service restart.
 
@@ -155,10 +155,10 @@ templates — no production code changes.
 
 **Purpose**: Documentation, deploy preparation, and final verification before merging.
 
-- [ ] T039 [P] Write the body of `docs/guides/SOCIAL-LOGIN-SETUP.md` (created as stub in T003) covering: Google OAuth-app registration steps (Cloud Console → OAuth consent screen → Web app credentials → redirect URI `https://n1.sorcha.dev/auth/social/callback`); GitHub OAuth-app registration steps; how to populate `/opt/sorcha/.env` on the n1 host; how to verify the deploy; how to rotate credentials. Include screenshots if available, otherwise text-only step-by-step.
-- [ ] T040 [P] Update `src/Services/Sorcha.Tenant.Service/README.md` "Social login" section: link to new doc, note the strict link policy, list the env vars consumed
-- [ ] T041 [P] Update `docs/reference/API-DOCUMENTATION.md` if any of the social-auth endpoints' summaries changed (likely no — but verify)
-- [ ] T042 Run full Tenant Service test suite to confirm nothing else regressed: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "Category!=Integration|FullyQualifiedName!~Integration"` — expect all green except known pre-existing failures unrelated to this feature
+- [X] T039 [P] Write the body of `docs/guides/SOCIAL-LOGIN-SETUP.md` (created as stub in T003) covering: Google OAuth-app registration steps (Cloud Console → OAuth consent screen → Web app credentials → redirect URI `https://n1.sorcha.dev/auth/social/callback`); GitHub OAuth-app registration steps; how to populate `/opt/sorcha/.env` on the n1 host; how to verify the deploy; how to rotate credentials. Include screenshots if available, otherwise text-only step-by-step.
+- [X] T040 [P] Update `src/Services/Sorcha.Tenant.Service/README.md` "Social login" section: link to new doc, note the strict link policy, list the env vars consumed
+- [X] T041 [P] Update `docs/reference/API-DOCUMENTATION.md` if any of the social-auth endpoints' summaries changed (likely no — but verify)
+- [X] T042 Run full Tenant Service test suite to confirm nothing else regressed: `dotnet test tests/Sorcha.Tenant.Service.Tests/ --filter "Category!=Integration|FullyQualifiedName!~Integration"` — expect all green except known pre-existing failures unrelated to this feature
 - [ ] T043 Commit and push branch; open draft PR; request `claude-review` per workflow; address any findings the bot surfaces; mark PR ready
 - [ ] T044 [Manual + collaborative] Run the n1 deploy walkthrough from `quickstart.md` §4-7 jointly with operator: register OAuth apps, seed `/opt/sorcha/.env`, run `n1-reset.ps1`, walk the seven smoke scenarios in browser, verify telemetry counter populated for the email-collision refusal step
 - [ ] T045 [Manual] After successful n1 deploy, set up the `/schedule` reminder to flip n1's `ASPNETCORE_ENVIRONMENT` to `Staging` per REQ-7 (target +7 days)

--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -90,6 +90,9 @@ public static class Extensions
 
                 // Feature 113 — Validator mempool depth + lease expiry
                 metrics.AddMeter("Sorcha.Validator.Mempool");
+
+                // Feature 115 — Tenant Service social-login refusal counter
+                metrics.AddMeter("Sorcha.Tenant");
             })
             .WithTracing(tracing =>
             {

--- a/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
@@ -307,11 +307,22 @@ public class DatabaseInitializer
             return;
         }
 
-        _logger.LogInformation("Seeding PlatformSettings (PublicOrgEnabled=false, MaxOrgsPerUser=1)");
+        // Feature 115 FR-019: seed default for PublicOrgEnabled is configurable
+        // per-environment so a fresh n1 deploy can do social signup without a
+        // manual database edit. Read PlatformSettings:SeedPublicOrgEnabled, default
+        // to false (production-safe). Seed-time only — admin UI/API toggles win
+        // on subsequent boots because the existingSettings check above short-circuits.
+        var seedPublicOrgEnabled = _configuration.GetValue<bool>(
+            "PlatformSettings:SeedPublicOrgEnabled",
+            defaultValue: false);
+
+        _logger.LogInformation(
+            "Seeding PlatformSettings (PublicOrgEnabled={PublicOrgEnabled}, MaxOrgsPerUser=1)",
+            seedPublicOrgEnabled);
 
         var settings = new PlatformSettings
         {
-            PublicOrgEnabled = false,
+            PublicOrgEnabled = seedPublicOrgEnabled,
             MaxOrgsPerUser = 1,
             UpdatedAt = DateTimeOffset.UtcNow,
             UpdatedBy = WellKnownIds.DefaultAdminUserId

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -94,9 +94,11 @@ public static class SocialLoginEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        // Build redirect URI for the callback
+        // Build redirect URI for the callback. This MUST match the registered
+        // redirect URI at the OAuth provider (see docs/guides/SOCIAL-LOGIN-SETUP.md).
+        // Single canonical path per environment per feature 115 FR-021.
         var baseUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
-        var redirectUri = $"{baseUrl}/api/auth/social/callback-redirect";
+        var redirectUri = $"{baseUrl}/auth/social/callback";
 
         try
         {
@@ -166,10 +168,29 @@ public static class SocialLoginEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        // Resolve or create PlatformUser
-        var (platformUser, isNew) = await platformUserService.ResolveOrCreateSocialUserAsync(
-            request.Provider, callbackResult.Subject,
-            callbackResult.Email, callbackResult.DisplayName, ct);
+        // Resolve or create PlatformUser under the strict link policy (feature 115)
+        var resolveResult = await platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, ct);
+        if (resolveResult.Refusal != SocialLoginRefusal.None)
+        {
+            var problemMessage = resolveResult.Refusal switch
+            {
+                SocialLoginRefusal.ProviderUnverified =>
+                    $"Your {request.Provider} account hasn't verified this email address. Please verify it with the provider and try again.",
+                SocialLoginRefusal.ExistingUnverified =>
+                    "An account exists for this email but isn't verified. Sign in with your password and verify your email first.",
+                _ => "Social login was refused.",
+            };
+
+            SocialLoginMetrics.RecordRefusal(request.Provider, resolveResult.Refusal);
+            logger.LogWarning(
+                "Social login refused via API: provider={Provider}, reason={Reason}",
+                request.Provider, resolveResult.Refusal);
+
+            return TypedResults.Problem(problemMessage, statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var platformUser = resolveResult.User!;
+        var isNew = resolveResult.IsNew;
 
         // Ensure UserIdentity exists in the public org
         var publicOrgId = WellKnownIds.PublicOrgId;

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -181,10 +181,14 @@ public static class SocialLoginEndpoints
                 _ => "Social login was refused.",
             };
 
-            SocialLoginMetrics.RecordRefusal(request.Provider, resolveResult.Refusal);
+            // Use the resolved provider name from the callback result rather than the
+            // raw request value — they should agree, but the resolved value is the
+            // one validated against the cached state and matches the metrics tag.
+            var loggedProvider = callbackResult.Provider;
+            SocialLoginMetrics.RecordRefusal(loggedProvider, resolveResult.Refusal);
             logger.LogWarning(
                 "Social login refused via API: provider={Provider}, reason={Reason}",
-                request.Provider, resolveResult.Refusal);
+                loggedProvider, resolveResult.Refusal);
 
             return TypedResults.Problem(problemMessage, statusCode: StatusCodes.Status400BadRequest);
         }

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -21,6 +21,19 @@ namespace Sorcha.Tenant.Service.Endpoints;
 public static class SocialLoginEndpoints
 {
     /// <summary>
+    /// The single canonical OAuth callback path for the environment. Both
+    /// the initiate and link flows pass <c>{baseUrl}{CallbackPath}</c> as
+    /// the <c>redirect_uri</c> sent to the provider, and the matching
+    /// Razor page at <c>Pages/Auth/SocialCallback.cshtml</c> declares
+    /// <c>@page "/auth/social/callback"</c>. Feature 115 FR-021.
+    ///
+    /// Regression guard: if this constant changes, the OAuth-app
+    /// registrations at every provider for every environment must be
+    /// updated to match. Do not change without coordinated rollout.
+    /// </summary>
+    public const string CallbackPath = "/auth/social/callback";
+
+    /// <summary>
     /// Maps social login endpoints to the application.
     /// </summary>
     public static IEndpointRouteBuilder MapSocialLoginEndpoints(this IEndpointRouteBuilder app)
@@ -98,7 +111,7 @@ public static class SocialLoginEndpoints
         // redirect URI at the OAuth provider (see docs/guides/SOCIAL-LOGIN-SETUP.md).
         // Single canonical path per environment per feature 115 FR-021.
         var baseUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
-        var redirectUri = $"{baseUrl}/auth/social/callback";
+        var redirectUri = $"{baseUrl}{CallbackPath}";
 
         try
         {
@@ -168,27 +181,28 @@ public static class SocialLoginEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        // Resolve or create PlatformUser under the strict link policy (feature 115)
+        // Resolve or create PlatformUser under the strict link policy (feature 115).
+        // Use the resolved provider name from the callback result throughout — it's
+        // been validated against the cached state and is the same value used for
+        // metrics tagging and logging. Defence-in-depth: never reflect raw
+        // request input back into a user-visible message.
         var resolveResult = await platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, ct);
         if (resolveResult.Refusal != SocialLoginRefusal.None)
         {
+            var resolvedProvider = callbackResult.Provider;
             var problemMessage = resolveResult.Refusal switch
             {
                 SocialLoginRefusal.ProviderUnverified =>
-                    $"Your {request.Provider} account hasn't verified this email address. Please verify it with the provider and try again.",
+                    $"Your {resolvedProvider} account hasn't verified this email address. Please verify it with the provider and try again.",
                 SocialLoginRefusal.ExistingUnverified =>
                     "An account exists for this email but isn't verified. Sign in with your password and verify your email first.",
                 _ => "Social login was refused.",
             };
 
-            // Use the resolved provider name from the callback result rather than the
-            // raw request value — they should agree, but the resolved value is the
-            // one validated against the cached state and matches the metrics tag.
-            var loggedProvider = callbackResult.Provider;
-            SocialLoginMetrics.RecordRefusal(loggedProvider, resolveResult.Refusal);
+            SocialLoginMetrics.RecordRefusal(resolvedProvider, resolveResult.Refusal);
             logger.LogWarning(
                 "Social login refused via API: provider={Provider}, reason={Reason}",
-                loggedProvider, resolveResult.Refusal);
+                resolvedProvider, resolveResult.Refusal);
 
             return TypedResults.Problem(problemMessage, statusCode: StatusCodes.Status400BadRequest);
         }

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
@@ -92,7 +92,9 @@
             </button>
 
             @* Social-login buttons render only for providers configured with non-empty *@
-            @* credentials on this environment. Feature 115 FR-001/FR-002. *@
+            @* credentials on this environment. Feature 115 FR-001/FR-002. When no *@
+            @* providers are configured the section is omitted entirely (no message); *@
+            @* the divider above already separates passkey from password. *@
             @if (Model.AvailableProviders.Count > 0)
             {
                 <div class="d-grid gap-2 mt-3">

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml
@@ -91,20 +91,19 @@
                 <span>&#128274;</span> Sign in with Passkey
             </button>
 
-            <div class="d-grid gap-2 mt-3">
-                <button type="button" class="social-btn" data-provider="Google">
-                    Continue with Google
-                </button>
-                <button type="button" class="social-btn" data-provider="Microsoft">
-                    Continue with Microsoft
-                </button>
-                <button type="button" class="social-btn" data-provider="GitHub">
-                    Continue with GitHub
-                </button>
-                <button type="button" class="social-btn" data-provider="Apple">
-                    Continue with Apple
-                </button>
-            </div>
+            @* Social-login buttons render only for providers configured with non-empty *@
+            @* credentials on this environment. Feature 115 FR-001/FR-002. *@
+            @if (Model.AvailableProviders.Count > 0)
+            {
+                <div class="d-grid gap-2 mt-3">
+                    @foreach (var provider in Model.AvailableProviders)
+                    {
+                        <button type="button" class="social-btn" data-provider="@provider">
+                            Continue with @provider
+                        </button>
+                    }
+                </div>
+            }
         }
 
         <div class="text-center mt-4">

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -25,6 +25,7 @@ public class LoginModel : PageModel
     private readonly IOrganizationRepository _organizationRepository;
     private readonly ILogger<LoginModel> _logger;
     private readonly DemoEnvironmentSettings _demoSettings;
+    private readonly ISocialLoginService _socialLoginService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginModel"/> class.
@@ -36,7 +37,8 @@ public class LoginModel : PageModel
         IIdentityRepository identityRepository,
         IOrganizationRepository organizationRepository,
         ILogger<LoginModel> logger,
-        IOptions<DemoEnvironmentSettings> demoSettings)
+        IOptions<DemoEnvironmentSettings> demoSettings,
+        ISocialLoginService socialLoginService)
     {
         _loginService = loginService;
         _totpService = totpService;
@@ -45,6 +47,7 @@ public class LoginModel : PageModel
         _organizationRepository = organizationRepository;
         _logger = logger;
         _demoSettings = demoSettings.Value;
+        _socialLoginService = socialLoginService;
     }
 
     /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
@@ -52,6 +55,13 @@ public class LoginModel : PageModel
 
     /// <summary>Demo-environment banner copy — rendered HTML-encoded.</summary>
     public string DemoBannerMessage => _demoSettings.Message;
+
+    /// <summary>
+    /// Social-login providers configured with non-empty credentials. Drives
+    /// conditional rendering of "Continue with..." buttons on the login page.
+    /// Feature 115 FR-001/FR-002.
+    /// </summary>
+    public IReadOnlyList<string> AvailableProviders { get; private set; } = [];
 
     /// <summary>
     /// User email address.
@@ -129,6 +139,7 @@ public class LoginModel : PageModel
     public void OnGet(string? returnUrl = null)
     {
         ReturnUrl = returnUrl;
+        AvailableProviders = _socialLoginService.GetConfiguredProviderNames();
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml
@@ -61,21 +61,27 @@
             </div>
 
             @* --- Tab 2: Social Login --- *@
+            @* Buttons render only for providers configured with non-empty credentials *@
+            @* on this environment. Feature 115 FR-001/FR-002. *@
             <div id="tab-social" class="tab-content" style="display: @(Model.ActiveTab == "social" ? "block" : "none");">
-                <div class="d-grid gap-2">
-                    <button type="button" class="social-btn" data-provider="Google">
-                        Continue with Google
-                    </button>
-                    <button type="button" class="social-btn" data-provider="Microsoft">
-                        Continue with Microsoft
-                    </button>
-                    <button type="button" class="social-btn" data-provider="GitHub">
-                        Continue with GitHub
-                    </button>
-                    <button type="button" class="social-btn" data-provider="Apple">
-                        Continue with Apple
-                    </button>
-                </div>
+                @if (Model.AvailableProviders.Count == 0)
+                {
+                    <p class="text-muted small mb-0">
+                        No social sign-in providers are configured for this environment.
+                        Use the Passkey or Email tab instead.
+                    </p>
+                }
+                else
+                {
+                    <div class="d-grid gap-2">
+                        @foreach (var provider in Model.AvailableProviders)
+                        {
+                            <button type="button" class="social-btn" data-provider="@provider">
+                                Continue with @provider
+                            </button>
+                        }
+                    </div>
+                }
             </div>
 
             @* --- Tab 3: Email & Password --- *@
@@ -165,15 +171,13 @@
         });
 
         // --- Social login ---
+        // The CSRF state and PKCE code-verifier are generated and validated
+        // server-side in SocialLoginService; the JS just sends the chosen
+        // provider name and redirects to the URL the server returns. The
+        // OAuth provider then redirects back to /auth/social/callback.
         document.querySelectorAll('.social-btn[data-provider]').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var provider = this.getAttribute('data-provider');
-                var returnUrl = '@(Model.ReturnUrl != null ? Uri.EscapeDataString(Model.ReturnUrl) : "")';
-                var redirectUri = window.location.origin + '/auth/social-callback';
-                var nonce = crypto.randomUUID();
-                var state = btoa(JSON.stringify({ nonce: nonce, returnUrl: returnUrl }));
-                // Store nonce for CSRF validation on callback
-                sessionStorage.setItem('social_login_nonce', nonce);
 
                 fetch('/api/auth/social/initiate', {
                     method: 'POST',

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
@@ -19,6 +19,7 @@ public class SignupModel : PageModel
     private readonly IRegistrationService _registrationService;
     private readonly ILogger<SignupModel> _logger;
     private readonly DemoEnvironmentSettings _demoSettings;
+    private readonly ISocialLoginService _socialLoginService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SignupModel"/> class.
@@ -26,11 +27,13 @@ public class SignupModel : PageModel
     public SignupModel(
         IRegistrationService registrationService,
         ILogger<SignupModel> logger,
-        IOptions<DemoEnvironmentSettings> demoSettings)
+        IOptions<DemoEnvironmentSettings> demoSettings,
+        ISocialLoginService socialLoginService)
     {
         _registrationService = registrationService;
         _logger = logger;
         _demoSettings = demoSettings.Value;
+        _socialLoginService = socialLoginService;
     }
 
     /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
@@ -38,6 +41,13 @@ public class SignupModel : PageModel
 
     /// <summary>Demo-environment banner copy — rendered HTML-encoded.</summary>
     public string DemoBannerMessage => _demoSettings.Message;
+
+    /// <summary>
+    /// Social-login providers configured with non-empty credentials. Drives
+    /// conditional rendering of "Continue with..." buttons. Empty when no
+    /// providers are configured. Feature 115 FR-001/FR-002.
+    /// </summary>
+    public IReadOnlyList<string> AvailableProviders { get; private set; } = [];
 
     /// <summary>
     /// User's display name.
@@ -111,6 +121,8 @@ public class SignupModel : PageModel
         {
             ActiveTab = tab;
         }
+
+        AvailableProviders = _socialLoginService.GetConfiguredProviderNames();
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
@@ -207,8 +207,11 @@ public class SocialCallbackModel : PageModel
     }
 
     /// <summary>
-    /// Hashes an email to an 8-byte hex tag suitable for log correlation
-    /// without exposing the address itself. Returns "(none)" when input is
+    /// Hashes an email to an 8-character hex tag suitable for log correlation
+    /// without exposing the address itself. The 4-byte (32-bit) truncation is
+    /// deliberate PII minimisation — collisions are tolerable for log
+    /// correlation, and shorter tags reduce the chance a leaked log line
+    /// contributes to re-identification. Returns "(none)" when input is
     /// null or empty. Feature 115 FR-018.
     /// </summary>
     private static string HashEmailForLog(string? email)

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
@@ -81,12 +81,16 @@ public class SocialCallbackModel : PageModel
         {
             _logger.LogWarning("Social login callback received error: {Error}", error);
             ErrorMessage = "The sign-in was cancelled or failed. Please try again.";
+            // Provider name is unknown at this point (we never reached state-cache lookup);
+            // tag as "unknown" so the counter still surfaces volume of cancelled flows.
+            SocialLoginMetrics.RecordUpstreamFailure("unknown", "provider_error");
             return Page();
         }
 
         if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
         {
             ErrorMessage = "Invalid callback parameters. Please try signing in again.";
+            SocialLoginMetrics.RecordUpstreamFailure("unknown", "missing_params");
             return Page();
         }
 
@@ -103,6 +107,16 @@ public class SocialCallbackModel : PageModel
         {
             _logger.LogWarning("Social login exchange failed for {Provider}: {Error}", provider, callbackResult.Error);
             ErrorMessage = callbackResult.Error ?? "Authentication failed. Please try again.";
+            // Tag the cause based on what ExchangeCodeAsync surfaced — the message is
+            // user-facing copy, so we map it back to a stable telemetry tag rather
+            // than tagging the message verbatim.
+            var reasonTag = callbackResult.Error switch
+            {
+                { } e when e.Contains("state", StringComparison.OrdinalIgnoreCase) => "state_invalid",
+                { } e when e.Contains("token", StringComparison.OrdinalIgnoreCase) => "code_exchange_failed",
+                _ => "code_exchange_failed",
+            };
+            SocialLoginMetrics.RecordUpstreamFailure(provider, reasonTag);
             return Page();
         }
 

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
@@ -64,10 +64,12 @@ public class SocialCallbackModel : PageModel
 
     /// <summary>
     /// Handles GET requests from the OAuth provider redirect.
-    /// Exchanges the authorization code, resolves/creates user, and redirects with JWT.
+    /// Exchanges the authorization code (which internally resolves the
+    /// provider from the cached <c>state</c> data — feature 115 FR-021),
+    /// resolves/creates user under the strict link policy, and redirects
+    /// with JWT on success or renders a refusal message on policy gate.
     /// </summary>
     public async Task<IActionResult> OnGetAsync(
-        string? provider,
         string? code,
         string? state,
         string? error,
@@ -77,19 +79,26 @@ public class SocialCallbackModel : PageModel
 
         if (!string.IsNullOrEmpty(error))
         {
-            _logger.LogWarning("Social login callback received error from provider {Provider}: {Error}", provider, error);
+            _logger.LogWarning("Social login callback received error: {Error}", error);
             ErrorMessage = "The sign-in was cancelled or failed. Please try again.";
             return Page();
         }
 
-        if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state) || string.IsNullOrEmpty(provider))
+        if (string.IsNullOrEmpty(code) || string.IsNullOrEmpty(state))
         {
             ErrorMessage = "Invalid callback parameters. Please try signing in again.";
             return Page();
         }
 
-        // Exchange code for claims
-        var callbackResult = await _socialLoginService.ExchangeCodeAsync(provider, code, state, ct);
+        // The provider is recovered from cached state inside ExchangeCodeAsync;
+        // it is NOT a query parameter (OAuth providers do not preserve query
+        // parameters across the redirect, so the previous behaviour was relying
+        // on a value that was never actually present). We pass an empty string
+        // here to maintain the existing service signature; ExchangeCodeAsync
+        // returns the resolved provider on the result.
+        var callbackResult = await _socialLoginService.ExchangeCodeAsync(string.Empty, code, state, ct);
+        var provider = callbackResult.Provider;
+
         if (!callbackResult.Success || string.IsNullOrEmpty(callbackResult.Subject))
         {
             _logger.LogWarning("Social login exchange failed for {Provider}: {Error}", provider, callbackResult.Error);
@@ -97,9 +106,33 @@ public class SocialCallbackModel : PageModel
             return Page();
         }
 
-        // Resolve or create PlatformUser
-        var (platformUser, isNew) = await _platformUserService.ResolveOrCreateSocialUserAsync(
-            provider, callbackResult.Subject, callbackResult.Email, callbackResult.DisplayName, ct);
+        // Resolve or create PlatformUser under the strict link policy
+        var resolveResult = await _platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, ct);
+
+        // Refusal handling (feature 115 FR-016, FR-018)
+        if (resolveResult.Refusal != SocialLoginRefusal.None)
+        {
+            ErrorMessage = resolveResult.Refusal switch
+            {
+                SocialLoginRefusal.ProviderUnverified =>
+                    $"Your {provider} account hasn't verified this email address. Please verify it with {provider} and try again.",
+                SocialLoginRefusal.ExistingUnverified =>
+                    "An account exists for this email but isn't verified. Sign in with your password and verify your email first, or recover access at /auth/login.",
+                _ => "Authentication failed. Please try again.",
+            };
+
+            // Structured warning + redacted email tag for telemetry (FR-018).
+            var emailTag = HashEmailForLog(callbackResult.Email);
+            _logger.LogWarning(
+                "Social login refused for provider {Provider}: reason={Reason}, emailHash={EmailHash}",
+                provider, resolveResult.Refusal, emailTag);
+
+            SocialLoginMetrics.RecordRefusal(provider, resolveResult.Refusal);
+            return Page();
+        }
+
+        var platformUser = resolveResult.User!;
+        var isNew = resolveResult.IsNew;
 
         // Ensure UserIdentity in public org
         var publicOrgId = WellKnownIds.PublicOrgId;
@@ -157,5 +190,22 @@ public class SocialCallbackModel : PageModel
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
                        $"&refresh={Uri.EscapeDataString(tokens.RefreshToken)}";
         return Redirect($"/app/#{fragment}");
+    }
+
+    /// <summary>
+    /// Hashes an email to an 8-byte hex tag suitable for log correlation
+    /// without exposing the address itself. Returns "(none)" when input is
+    /// null or empty. Feature 115 FR-018.
+    /// </summary>
+    private static string HashEmailForLog(string? email)
+    {
+        if (string.IsNullOrEmpty(email))
+        {
+            return "(none)";
+        }
+
+        var bytes = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(email.ToLowerInvariant()));
+        return Convert.ToHexString(bytes.AsSpan(0, 4)).ToLowerInvariant();
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/README.md
+++ b/src/Services/Sorcha.Tenant.Service/README.md
@@ -325,6 +325,50 @@ OidcSettings__CallbackBaseUrl="https://api.sorcha.example.com"
 | `/api/auth/public/social/initiate` | POST | Initiate social login/signup with provider (Google, Microsoft, GitHub, Apple) |
 | `/api/auth/public/social/callback` | POST | Handle OAuth callback and issue tokens |
 
+**Browser callback URL:** providers redirect to the Razor page at
+`/auth/social/callback` (single canonical path per environment, see
+[`docs/guides/SOCIAL-LOGIN-SETUP.md`](../../../docs/guides/SOCIAL-LOGIN-SETUP.md)).
+The page resolves the provider from the cached state — provider is NOT a
+query parameter — and applies the strict link policy added in
+feature 115 before issuing tokens.
+
+**Strict link policy (feature 115).** Both signup and link flows refuse
+when verification is missing on either side:
+
+- New user creation requires the provider to assert
+  `email_verified=true`. Otherwise → refusal with
+  `provider_unverified` reason.
+- Cross-method linking (existing Sorcha account, new social provider
+  with the same email) requires *both* the provider's claim and the
+  existing account's `EmailVerified` to be true. Otherwise → refusal
+  with `existing_unverified` reason.
+- Returning users (provider+sub already linked) are NOT re-checked
+  against verification gates — trust is established at link time.
+
+**Provider visibility.** Signup and login pages render a "Continue
+with..." button only for providers configured with non-empty
+`ClientId` and `ClientSecret`. Configuration shape:
+
+```yaml
+SocialProviders__0__Name: Google
+SocialProviders__0__ClientId: ${GOOGLE_OAUTH_CLIENT_ID}
+SocialProviders__0__ClientSecret: ${GOOGLE_OAUTH_CLIENT_SECRET}
+```
+
+Adding a new provider requires only configuration + service restart.
+See [`docs/guides/SOCIAL-LOGIN-SETUP.md`](../../../docs/guides/SOCIAL-LOGIN-SETUP.md)
+for the operator runbook.
+
+**Telemetry.** Refusals emit
+`sorcha_social_login_refusal_total{provider, reason}` on the
+`Sorcha.Tenant` meter. PII is never tagged on these metrics; the
+matching log line carries a hash-based redacted email tag.
+
+**Public-organisation seed.** A fresh database can be seeded with
+`PublicOrgEnabled=true` via
+`PlatformSettings__SeedPublicOrgEnabled=true` (feature 115 FR-019).
+Seed-time only — admin UI/API toggles win on subsequent boots.
+
 ### Public User Auth Method Management (`/api/auth/public`) — Authenticated
 
 | Endpoint | Method | Description |

--- a/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs
@@ -19,6 +19,37 @@ public record PasswordAuthResult(
     DateTimeOffset? LockedUntil = null);
 
 /// <summary>
+/// Reasons a social-login resolve attempt may be refused under the strict
+/// link policy introduced in feature 115. The callback page consumes this
+/// to render the matching user-facing copy without string matching.
+/// </summary>
+public enum SocialLoginRefusal
+{
+    /// <summary>No refusal — the resolve produced a real <see cref="PlatformUser"/>.</summary>
+    None = 0,
+
+    /// <summary>The provider asserted <c>email_verified=false</c> (or omitted the claim). Refused per FR-010.</summary>
+    ProviderUnverified,
+
+    /// <summary>The email matches an existing Sorcha account whose own <c>EmailVerified</c> is <c>false</c>. Refused per FR-011.</summary>
+    ExistingUnverified,
+}
+
+/// <summary>
+/// Result of <see cref="IPlatformUserService.ResolveOrCreateSocialUserAsync"/>.
+/// Either <paramref name="User"/> is non-null (success) or
+/// <paramref name="Refusal"/> is set to a non-<see cref="SocialLoginRefusal.None"/>
+/// value (refusal). Both are never set simultaneously.
+/// </summary>
+/// <param name="User">The resolved or created platform user, or null on refusal.</param>
+/// <param name="IsNew">Whether the user was created as part of this call. Always false on refusal.</param>
+/// <param name="Refusal">The refusal reason, or <see cref="SocialLoginRefusal.None"/> on success.</param>
+public record ResolveSocialUserResult(
+    PlatformUser? User,
+    bool IsNew,
+    SocialLoginRefusal Refusal);
+
+/// <summary>
 /// Service interface for platform-wide user management operations.
 /// Handles PlatformUser lifecycle, social login linking, and organisation membership.
 /// </summary>
@@ -111,15 +142,26 @@ public interface IPlatformUserService
     Task<PasswordAuthResult> ValidatePasswordAsync(PlatformUser platformUser, string password, CancellationToken ct);
 
     /// <summary>
-    /// Resolves or creates a PlatformUser from social login claims.
-    /// Resolution order: (1) find by provider+subject, (2) find by email and link provider, (3) create new user + link.
+    /// Resolves or creates a PlatformUser from social login claims under the
+    /// strict link policy introduced in feature 115.
+    ///
+    /// Resolution order:
+    /// <list type="number">
+    /// <item>Find by provider+subject (returning user). Refresh
+    /// <c>LastUsedAt</c> and <c>DisplayName</c>. <b>No verification re-check</b> —
+    /// trust is established at link time (FR-013).</item>
+    /// <item>Find by email and link provider only when <b>both</b> the
+    /// provider's <c>EmailVerified</c> claim and the existing user's
+    /// <c>EmailVerified</c> are <c>true</c> (FR-011, FR-012). Otherwise
+    /// return <see cref="SocialLoginRefusal.ExistingUnverified"/>.</item>
+    /// <item>Create new user only when the provider asserts
+    /// <c>EmailVerified=true</c> (FR-010). Otherwise return
+    /// <see cref="SocialLoginRefusal.ProviderUnverified"/>.</item>
+    /// </list>
     /// </summary>
-    /// <param name="provider">Social provider name (e.g., "google", "github").</param>
-    /// <param name="subject">Provider's unique user identifier.</param>
-    /// <param name="email">Email address from the social provider.</param>
-    /// <param name="displayName">Display name from the social provider.</param>
+    /// <param name="claim">The verified-or-not claim set returned by <see cref="ISocialLoginService.ExchangeCodeAsync"/>.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The resolved or created platform user, and whether it was newly created.</returns>
-    Task<(PlatformUser User, bool IsNew)> ResolveOrCreateSocialUserAsync(
-        string provider, string subject, string? email, string? displayName, CancellationToken ct);
+    /// <returns>A <see cref="ResolveSocialUserResult"/> indicating success, refusal reason, and new-user state.</returns>
+    Task<ResolveSocialUserResult> ResolveOrCreateSocialUserAsync(
+        SocialAuthCallbackResult claim, CancellationToken ct);
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs
@@ -159,9 +159,11 @@ public interface IPlatformUserService
     /// <see cref="SocialLoginRefusal.ProviderUnverified"/>.</item>
     /// </list>
     /// </summary>
-    /// <param name="claim">The verified-or-not claim set returned by <see cref="ISocialLoginService.ExchangeCodeAsync"/>.</param>
+    /// <param name="claim">The verified-or-not claim set returned by <see cref="ISocialLoginService.ExchangeCodeAsync"/>. Must have a non-null <c>Subject</c>.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A <see cref="ResolveSocialUserResult"/> indicating success, refusal reason, and new-user state.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="claim"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="claim"/>'s <c>Subject</c> is null. Callers should validate the upstream exchange succeeded before invoking this method.</exception>
     Task<ResolveSocialUserResult> ResolveOrCreateSocialUserAsync(
         SocialAuthCallbackResult claim, CancellationToken ct);
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs
@@ -18,6 +18,14 @@ public record SocialAuthInitiateResult(string AuthorizationUrl, string State);
 /// <param name="Subject">The provider's unique user identifier (sub claim).</param>
 /// <param name="Email">The user's email address from the provider.</param>
 /// <param name="DisplayName">The user's display name from the provider.</param>
+/// <param name="EmailVerified">
+/// Whether the provider asserts the email address is verified. For OIDC
+/// providers (Google, Microsoft, Apple) this is the <c>email_verified</c>
+/// claim from the ID token or userinfo response. For GitHub it is
+/// <c>true</c> only when the primary <c>/user/emails</c> entry has
+/// <c>verified: true</c>. Defaults to <c>false</c> when the claim is
+/// absent — never assume verified. Feature 115.
+/// </param>
 /// <param name="Provider">The provider name (e.g., "Google", "GitHub").</param>
 public record SocialAuthCallbackResult(
     bool Success,
@@ -25,6 +33,7 @@ public record SocialAuthCallbackResult(
     string? Subject,
     string? Email,
     string? DisplayName,
+    bool EmailVerified,
     string Provider);
 
 /// <summary>
@@ -62,4 +71,13 @@ public interface ISocialLoginService
         string code,
         string state,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the names of providers configured with non-empty
+    /// <c>ClientId</c> and <c>ClientSecret</c>. Drives the conditional
+    /// rendering of "Continue with..." buttons on signup and login pages
+    /// per feature 115 FR-001.
+    /// </summary>
+    /// <returns>Provider names (case as configured) for which the host has working credentials.</returns>
+    IReadOnlyList<string> GetConfiguredProviderNames();
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
@@ -286,17 +286,29 @@ public class PlatformUserService : IPlatformUserService
 
         // Step 2: Email-collision linking — strict-link policy gate (FR-011, FR-012).
         // Both the provider's claim AND the existing Sorcha account must be verified
-        // for cross-method linking to succeed. Otherwise refuse with ExistingUnverified.
+        // for cross-method linking to succeed. The two refusal directions point the
+        // user at different recovery paths, so distinguish them precisely:
+        //   provider unverified  → ProviderUnverified ("verify with the provider")
+        //   existing unverified  → ExistingUnverified ("verify your Sorcha account")
         if (!string.IsNullOrWhiteSpace(email))
         {
             var existingByEmail = await GetByEmailAsync(email, ct);
             if (existingByEmail is not null)
             {
-                if (!claim.EmailVerified || !existingByEmail.EmailVerified)
+                if (!claim.EmailVerified)
                 {
                     _logger.LogWarning(
-                        "Social login refused: email-collision link rejected (providerVerified={ProviderVerified}, existingVerified={ExistingVerified}) for {Provider}",
-                        claim.EmailVerified, existingByEmail.EmailVerified, provider);
+                        "Social login refused: email-collision link rejected — provider {Provider} did not assert email_verified",
+                        provider);
+
+                    return new ResolveSocialUserResult(User: null, IsNew: false, SocialLoginRefusal.ProviderUnverified);
+                }
+
+                if (!existingByEmail.EmailVerified)
+                {
+                    _logger.LogWarning(
+                        "Social login refused: email-collision link rejected — existing user {UserId} email is not verified for {Provider}",
+                        existingByEmail.Id, provider);
 
                     return new ResolveSocialUserResult(User: null, IsNew: false, SocialLoginRefusal.ExistingUnverified);
                 }

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
@@ -313,14 +313,17 @@ public class PlatformUserService : IPlatformUserService
                     return new ResolveSocialUserResult(User: null, IsNew: false, SocialLoginRefusal.ExistingUnverified);
                 }
 
-                await LinkSocialLoginAsync(existingByEmail.Id, provider, subject, email, displayName, ct);
-
+                // Stage the DisplayName refresh on the tracked entity BEFORE
+                // LinkSocialLoginAsync — its SaveChangesAsync will then persist
+                // both the new link row and the updated PlatformUser in a single
+                // round-trip rather than two.
                 if (!string.IsNullOrWhiteSpace(displayName)
                     && !string.Equals(displayName, existingByEmail.DisplayName, StringComparison.Ordinal))
                 {
                     existingByEmail.DisplayName = displayName;
-                    await _db.SaveChangesAsync(ct);
                 }
+
+                await LinkSocialLoginAsync(existingByEmail.Id, provider, subject, email, displayName, ct);
 
                 _logger.LogInformation(
                     "Social login linked {Provider}/{Subject} to existing user {UserId} via email match",

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
@@ -248,48 +248,92 @@ public class PlatformUserService : IPlatformUserService
     }
 
     /// <inheritdoc />
-    public async Task<(PlatformUser User, bool IsNew)> ResolveOrCreateSocialUserAsync(
-        string provider, string subject, string? email, string? displayName, CancellationToken ct)
+    public async Task<ResolveSocialUserResult> ResolveOrCreateSocialUserAsync(
+        SocialAuthCallbackResult claim, CancellationToken ct)
     {
-        // Step 1: Find by provider + subject (returning user)
+        ArgumentNullException.ThrowIfNull(claim);
+
+        var provider = claim.Provider;
+        var subject = claim.Subject ?? throw new ArgumentException("claim.Subject is required", nameof(claim));
+        var email = claim.Email;
+        var displayName = claim.DisplayName;
+
+        // Step 1: Returning user (provider + subject already linked).
+        // No verification re-check — trust is established at link time
+        // (FR-013). Refresh DisplayName from the latest claim if non-empty
+        // and changed (FR-008); refresh LastUsedAt unconditionally (FR-007).
         var existingByProvider = await GetByProviderSubjectAsync(provider, subject, ct);
         if (existingByProvider is not null)
         {
-            // Update last used timestamp on the social login
             var socialLogin = await _db.PlatformSocialLogins
                 .FirstAsync(s => s.Provider == provider && s.Subject == subject, ct);
             socialLogin.LastUsedAt = DateTimeOffset.UtcNow;
+
+            if (!string.IsNullOrWhiteSpace(displayName)
+                && !string.Equals(displayName, existingByProvider.DisplayName, StringComparison.Ordinal))
+            {
+                existingByProvider.DisplayName = displayName;
+            }
+
             await _db.SaveChangesAsync(ct);
 
             _logger.LogInformation(
                 "Social login resolved existing user {UserId} via {Provider}/{Subject}",
                 existingByProvider.Id, provider, subject);
 
-            return (existingByProvider, false);
+            return new ResolveSocialUserResult(existingByProvider, IsNew: false, SocialLoginRefusal.None);
         }
 
-        // Step 2: Find by email and link provider (existing user, new provider)
+        // Step 2: Email-collision linking — strict-link policy gate (FR-011, FR-012).
+        // Both the provider's claim AND the existing Sorcha account must be verified
+        // for cross-method linking to succeed. Otherwise refuse with ExistingUnverified.
         if (!string.IsNullOrWhiteSpace(email))
         {
             var existingByEmail = await GetByEmailAsync(email, ct);
             if (existingByEmail is not null)
             {
+                if (!claim.EmailVerified || !existingByEmail.EmailVerified)
+                {
+                    _logger.LogWarning(
+                        "Social login refused: email-collision link rejected (providerVerified={ProviderVerified}, existingVerified={ExistingVerified}) for {Provider}",
+                        claim.EmailVerified, existingByEmail.EmailVerified, provider);
+
+                    return new ResolveSocialUserResult(User: null, IsNew: false, SocialLoginRefusal.ExistingUnverified);
+                }
+
                 await LinkSocialLoginAsync(existingByEmail.Id, provider, subject, email, displayName, ct);
+
+                if (!string.IsNullOrWhiteSpace(displayName)
+                    && !string.Equals(displayName, existingByEmail.DisplayName, StringComparison.Ordinal))
+                {
+                    existingByEmail.DisplayName = displayName;
+                    await _db.SaveChangesAsync(ct);
+                }
 
                 _logger.LogInformation(
                     "Social login linked {Provider}/{Subject} to existing user {UserId} via email match",
                     provider, subject, existingByEmail.Id);
 
-                return (existingByEmail, false);
+                return new ResolveSocialUserResult(existingByEmail, IsNew: false, SocialLoginRefusal.None);
             }
         }
 
-        // Step 3: Create new PlatformUser + link social login
+        // Step 3: Genuinely new user — provider must assert email_verified=true (FR-010).
+        // Refusal here means no PlatformUser is created at all.
+        if (!claim.EmailVerified)
+        {
+            _logger.LogWarning(
+                "Social login refused: provider {Provider} did not assert email_verified for {Subject}",
+                provider, subject);
+
+            return new ResolveSocialUserResult(User: null, IsNew: false, SocialLoginRefusal.ProviderUnverified);
+        }
+
         var resolvedDisplayName = displayName ?? email?.Split('@')[0] ?? "User";
         var newUser = await CreateAsync(email ?? $"{provider}_{subject}@noemail.local", resolvedDisplayName, null, ct);
         await LinkSocialLoginAsync(newUser.Id, provider, subject, email, displayName, ct);
 
-        // Mark email as verified for social login users (provider verified it)
+        // Mark email as verified — provider asserted it and we trust that assertion.
         if (!string.IsNullOrWhiteSpace(email))
         {
             newUser.EmailVerified = true;
@@ -301,7 +345,7 @@ public class PlatformUserService : IPlatformUserService
             "Social login created new user {UserId} via {Provider}/{Subject}",
             newUser.Id, provider, subject);
 
-        return (newUser, true);
+        return new ResolveSocialUserResult(newUser, IsNew: true, SocialLoginRefusal.None);
     }
 }
 

--- a/src/Services/Sorcha.Tenant.Service/Services/SocialLoginMetrics.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/SocialLoginMetrics.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// OpenTelemetry metrics for the social-login subsystem. Feature 115 FR-018.
+/// Operators consume these counters via the Aspire dashboard or Grafana to
+/// detect anomalies in signup-refusal volumes without needing to read raw
+/// logs. PII is never tagged on these metrics.
+/// </summary>
+public static class SocialLoginMetrics
+{
+    /// <summary>Meter name; matches the existing project-level convention.</summary>
+    public const string MeterName = "Sorcha.Tenant";
+
+    private static readonly Meter Meter = new(MeterName, "1.0.0");
+
+    private static readonly Counter<long> RefusalCounter = Meter.CreateCounter<long>(
+        "sorcha_social_login_refusal_total",
+        unit: "{refusal}",
+        description: "Count of refused social-login attempts, tagged by provider and reason.");
+
+    /// <summary>
+    /// Record a refusal under the strict link policy. Maps a
+    /// <see cref="SocialLoginRefusal"/> enum value to a stable string tag
+    /// so dashboards can group reliably.
+    /// </summary>
+    /// <param name="provider">The provider name (e.g. "Google", "GitHub").</param>
+    /// <param name="refusal">The refusal reason. <see cref="SocialLoginRefusal.None"/> is treated as a no-op.</param>
+    public static void RecordRefusal(string provider, SocialLoginRefusal refusal)
+    {
+        if (refusal == SocialLoginRefusal.None)
+        {
+            return;
+        }
+
+        var reason = refusal switch
+        {
+            SocialLoginRefusal.ProviderUnverified => "provider_unverified",
+            SocialLoginRefusal.ExistingUnverified => "existing_unverified",
+            _ => "unknown",
+        };
+
+        RefusalCounter.Add(1,
+            new KeyValuePair<string, object?>("provider", provider),
+            new KeyValuePair<string, object?>("reason", reason));
+    }
+
+    /// <summary>
+    /// Record an upstream failure (state invalid, code-exchange failed) so the
+    /// same dashboard panel can surface non-policy-gate refusals too.
+    /// </summary>
+    /// <param name="provider">The provider name; may be empty when state cannot be deserialised.</param>
+    /// <param name="reasonTag">A short stable tag (e.g. "state_invalid", "code_exchange_failed").</param>
+    public static void RecordUpstreamFailure(string provider, string reasonTag)
+    {
+        RefusalCounter.Add(1,
+            new KeyValuePair<string, object?>("provider", string.IsNullOrEmpty(provider) ? "unknown" : provider),
+            new KeyValuePair<string, object?>("reason", reasonTag));
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
@@ -129,6 +129,20 @@ public class SocialLoginService : ISocialLoginService
                 }
 
                 _providers[config.Name] = config;
+
+                // Operator hint: a provider is registered in config but missing
+                // credentials on this host. The button will be hidden by
+                // GetConfiguredProviderNames(), but a startup warning helps
+                // operators spot a missing .env entry without staring at an
+                // empty signup tab. Feature 115.
+                if (string.IsNullOrWhiteSpace(config.ClientId)
+                    || string.IsNullOrWhiteSpace(config.ClientSecret))
+                {
+                    _logger.LogWarning(
+                        "Social provider {Provider} is registered but has empty {MissingField} — its button will be hidden. Set the credential in this environment's .env or appsettings to enable.",
+                        config.Name,
+                        string.IsNullOrWhiteSpace(config.ClientId) ? "ClientId" : "ClientSecret");
+                }
             }
         }
     }

--- a/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
@@ -423,8 +423,13 @@ public class SocialLoginService : ISocialLoginService
         var login = userRoot.TryGetProperty("login", out var loginProp) ? loginProp.GetString() : null;
         displayName ??= login;
 
-        // Fetch primary verified email from /user/emails
+        // Fetch primary verified email from /user/emails. We track emailVerified
+        // explicitly rather than inferring it from "did we set email" — making the
+        // invariant explicit so a future fallback (e.g. assign email from any
+        // primary entry, or fetch from /user) cannot silently smuggle an
+        // unverified email past the strict-link gate.
         string? email = null;
+        bool emailVerified = false;
         try
         {
             using var emailResponse = await client.GetAsync(GitHubUserEmailsEndpoint, cancellationToken);
@@ -439,6 +444,7 @@ public class SocialLoginService : ISocialLoginService
                     if (isPrimary && isVerified)
                     {
                         email = emailEntry.TryGetProperty("email", out var e) ? e.GetString() : null;
+                        emailVerified = true;
                         break;
                     }
                 }
@@ -448,11 +454,6 @@ public class SocialLoginService : ISocialLoginService
         {
             _logger.LogWarning(ex, "Failed to fetch GitHub user emails");
         }
-
-        // GitHub: EmailVerified is true only when /user/emails returned a primary
-        // entry whose `verified` flag is true. The fetch loop above only assigns
-        // `email` in that case, so a non-null `email` here implies verified.
-        var emailVerified = !string.IsNullOrEmpty(email);
 
         _logger.LogInformation("GitHub social login claims extracted for user {Subject} (emailVerified={EmailVerified})", subject, emailVerified);
         return new SocialAuthCallbackResult(true, null, subject, email, displayName, emailVerified, provider);

--- a/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
@@ -210,17 +210,31 @@ public class SocialLoginService : ISocialLoginService
         if (stateBytes is null)
         {
             _logger.LogWarning("Social login callback: invalid or expired state parameter");
-            return new SocialAuthCallbackResult(false, "Invalid or expired state parameter.", null, null, null, provider);
+            return new SocialAuthCallbackResult(false, "Invalid or expired state parameter.", null, null, null, false, provider);
         }
 
         // Remove state from cache (single-use)
         await _cache.RemoveAsync(cacheKey, cancellationToken);
 
         var stateData = JsonSerializer.Deserialize<SocialStateData>(Encoding.UTF8.GetString(stateBytes));
-        if (stateData is null || !string.Equals(stateData.Provider, provider, StringComparison.OrdinalIgnoreCase))
+        if (stateData is null)
         {
-            _logger.LogWarning("Social login callback: state provider mismatch");
-            return new SocialAuthCallbackResult(false, "State parameter mismatch.", null, null, null, provider);
+            _logger.LogWarning("Social login callback: state data could not be deserialised");
+            return new SocialAuthCallbackResult(false, "State parameter mismatch.", null, null, null, false, provider);
+        }
+
+        // The Razor-page callback flow does not have provider in the query
+        // string (OAuth redirects do not preserve it), so callers may pass an
+        // empty string and rely on the cached provider. The API endpoint flow
+        // passes a provider explicitly and we validate it matches. Feature 115.
+        if (string.IsNullOrEmpty(provider))
+        {
+            provider = stateData.Provider;
+        }
+        else if (!string.Equals(stateData.Provider, provider, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Social login callback: state provider mismatch (expected {Cached}, got {Provided})", stateData.Provider, provider);
+            return new SocialAuthCallbackResult(false, "State parameter mismatch.", null, null, null, false, provider);
         }
 
         var config = GetProviderConfig(provider);
@@ -234,7 +248,7 @@ public class SocialLoginService : ISocialLoginService
 
             if (tokenResponse is null)
             {
-                return new SocialAuthCallbackResult(false, "Token exchange failed.", null, null, null, provider);
+                return new SocialAuthCallbackResult(false, "Token exchange failed.", null, null, null, false, provider);
             }
 
             // Extract claims — GitHub uses user info endpoint, others use ID token
@@ -248,8 +262,20 @@ public class SocialLoginService : ISocialLoginService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Social login code exchange failed for provider {Provider}", provider);
-            return new SocialAuthCallbackResult(false, "Authentication failed.", null, null, null, provider);
+            return new SocialAuthCallbackResult(false, "Authentication failed.", null, null, null, false, provider);
         }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetConfiguredProviderNames()
+    {
+        // Filter out providers configured with empty client credentials —
+        // those would yield non-functional buttons. Feature 115 FR-002.
+        return _providers.Values
+            .Where(p => !string.IsNullOrWhiteSpace(p.ClientId)
+                     && !string.IsNullOrWhiteSpace(p.ClientSecret))
+            .Select(p => p.Name)
+            .ToArray();
     }
 
     private SocialProviderConfig GetProviderConfig(string provider)
@@ -356,7 +382,7 @@ public class SocialLoginService : ISocialLoginService
             if (claims is not null)
             {
                 _logger.LogInformation("Social login claims extracted from ID token for provider {Provider}", provider);
-                return new SocialAuthCallbackResult(true, null, claims.Subject, claims.Email, claims.DisplayName, provider);
+                return new SocialAuthCallbackResult(true, null, claims.Subject, claims.Email, claims.DisplayName, claims.EmailVerified, provider);
             }
         }
 
@@ -367,7 +393,7 @@ public class SocialLoginService : ISocialLoginService
         }
 
         _logger.LogWarning("No ID token or user info endpoint available for provider {Provider}", provider);
-        return new SocialAuthCallbackResult(false, "Could not extract user claims.", null, null, null, provider);
+        return new SocialAuthCallbackResult(false, "Could not extract user claims.", null, null, null, false, provider);
     }
 
     private async Task<SocialAuthCallbackResult> ExtractGitHubClaimsAsync(
@@ -385,7 +411,7 @@ public class SocialLoginService : ISocialLoginService
         if (!userResponse.IsSuccessStatusCode)
         {
             _logger.LogWarning("GitHub user info request failed with status {StatusCode}", userResponse.StatusCode);
-            return new SocialAuthCallbackResult(false, "Failed to fetch GitHub user info.", null, null, null, provider);
+            return new SocialAuthCallbackResult(false, "Failed to fetch GitHub user info.", null, null, null, false, provider);
         }
 
         var userJson = await userResponse.Content.ReadAsStringAsync(cancellationToken);
@@ -423,8 +449,13 @@ public class SocialLoginService : ISocialLoginService
             _logger.LogWarning(ex, "Failed to fetch GitHub user emails");
         }
 
-        _logger.LogInformation("GitHub social login claims extracted for user {Subject}", subject);
-        return new SocialAuthCallbackResult(true, null, subject, email, displayName, provider);
+        // GitHub: EmailVerified is true only when /user/emails returned a primary
+        // entry whose `verified` flag is true. The fetch loop above only assigns
+        // `email` in that case, so a non-null `email` here implies verified.
+        var emailVerified = !string.IsNullOrEmpty(email);
+
+        _logger.LogInformation("GitHub social login claims extracted for user {Subject} (emailVerified={EmailVerified})", subject, emailVerified);
+        return new SocialAuthCallbackResult(true, null, subject, email, displayName, emailVerified, provider);
     }
 
     private async Task<SocialAuthCallbackResult> FetchUserInfoClaimsAsync(
@@ -441,7 +472,7 @@ public class SocialLoginService : ISocialLoginService
         {
             _logger.LogWarning("User info request failed for provider {Provider} with status {StatusCode}",
                 provider, response.StatusCode);
-            return new SocialAuthCallbackResult(false, "Failed to fetch user info.", null, null, null, provider);
+            return new SocialAuthCallbackResult(false, "Failed to fetch user info.", null, null, null, false, provider);
         }
 
         var json = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -451,9 +482,11 @@ public class SocialLoginService : ISocialLoginService
         var subject = root.TryGetProperty("sub", out var sub) ? sub.GetString() : null;
         var email = root.TryGetProperty("email", out var e) ? e.GetString() : null;
         var displayName = root.TryGetProperty("name", out var n) ? n.GetString() : null;
+        var emailVerified = root.TryGetProperty("email_verified", out var ev)
+                            && ev.ValueKind == JsonValueKind.True;
 
-        _logger.LogInformation("Social login user info claims extracted for provider {Provider}", provider);
-        return new SocialAuthCallbackResult(true, null, subject, email, displayName, provider);
+        _logger.LogInformation("Social login user info claims extracted for provider {Provider} (emailVerified={EmailVerified})", provider, emailVerified);
+        return new SocialAuthCallbackResult(true, null, subject, email, displayName, emailVerified, provider);
     }
 
     private static IdTokenClaims? ParseIdTokenClaims(string idToken)
@@ -486,8 +519,13 @@ public class SocialLoginService : ISocialLoginService
             var subject = root.TryGetProperty("sub", out var sub) ? sub.GetString() : null;
             var email = root.TryGetProperty("email", out var e) ? e.GetString() : null;
             var displayName = root.TryGetProperty("name", out var n) ? n.GetString() : null;
+            // email_verified must be a JSON Boolean true; default false for any other shape.
+            // Some providers serialise it as a string "true" — treat that as untrusted and
+            // require the canonical boolean form. Feature 115 FR-010.
+            var emailVerified = root.TryGetProperty("email_verified", out var ev)
+                                && ev.ValueKind == JsonValueKind.True;
 
-            return new IdTokenClaims(subject, email, displayName);
+            return new IdTokenClaims(subject, email, displayName, emailVerified);
         }
         catch
         {
@@ -522,5 +560,5 @@ public class SocialLoginService : ISocialLoginService
 
     private readonly record struct TokenExchangeResult(string AccessToken, string? IdToken);
 
-    private record IdTokenClaims(string? Subject, string? Email, string? DisplayName);
+    private record IdTokenClaims(string? Subject, string? Email, string? DisplayName, bool EmailVerified);
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialLoginEndpointsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialLoginEndpointsTests.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Tenant.Service.Endpoints;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+/// <summary>
+/// Regression-guard tests for <see cref="SocialLoginEndpoints"/>. The full
+/// initiate/callback handlers are exercised by the manual smoke walkthrough
+/// in <c>specs/115-social-signup/quickstart.md</c>; this fast-unit class
+/// pins the contract that providers depend on so a future refactor cannot
+/// silently re-break the redirect URI (feature 115 FR-021).
+/// </summary>
+public class SocialLoginEndpointsTests
+{
+    [Fact]
+    public void CallbackPath_MatchesRazorPageRoute()
+    {
+        // The Razor page at Pages/Auth/SocialCallback.cshtml declares
+        // @page "/auth/social/callback" — provider OAuth apps are registered
+        // with this exact path. Changing the constant requires updating every
+        // OAuth-app registration in every environment, so it must not move
+        // without a coordinated rollout. See docs/guides/SOCIAL-LOGIN-SETUP.md.
+        SocialLoginEndpoints.CallbackPath.Should().Be("/auth/social/callback");
+    }
+
+    [Fact]
+    public void CallbackPath_DoesNotUseDefunctApiRedirectPath()
+    {
+        // The original (broken) value was /api/auth/social/callback-redirect,
+        // which had no handler — providers 404'd users after consent. Pin the
+        // negative case so the regression cannot recur even by accident.
+        SocialLoginEndpoints.CallbackPath.Should().NotContain("callback-redirect");
+        SocialLoginEndpoints.CallbackPath.Should().NotStartWith("/api/");
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Models/SocialAuthCallbackResultTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Models/SocialAuthCallbackResultTests.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Models;
+
+/// <summary>
+/// Property-level tests for <see cref="SocialAuthCallbackResult"/>'s
+/// <c>EmailVerified</c> field added in feature 115. Behaviour-based
+/// coverage of the <c>email_verified</c> claim parsing lives in the
+/// <c>SocialLoginService</c> integration tests; these tests pin the DTO
+/// shape itself (presence, default value, equality semantics) so any
+/// accidental signature change is caught.
+/// </summary>
+public class SocialAuthCallbackResultTests
+{
+    [Fact]
+    public void Construction_WithEmailVerifiedTrue_SetsField()
+    {
+        var result = new SocialAuthCallbackResult(
+            Success: true, Error: null,
+            Subject: "sub-1", Email: "x@y.com", DisplayName: "X",
+            EmailVerified: true, Provider: "Google");
+
+        result.EmailVerified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Construction_WithEmailVerifiedFalse_SetsField()
+    {
+        var result = new SocialAuthCallbackResult(
+            Success: true, Error: null,
+            Subject: "sub-1", Email: "x@y.com", DisplayName: "X",
+            EmailVerified: false, Provider: "Google");
+
+        result.EmailVerified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equality_DistinguishesByEmailVerified()
+    {
+        var verified = new SocialAuthCallbackResult(true, null, "sub", "x@y.com", "X", true, "Google");
+        var unverified = new SocialAuthCallbackResult(true, null, "sub", "x@y.com", "X", false, "Google");
+
+        verified.Should().NotBe(unverified);
+    }
+
+    [Fact]
+    public void FailureResult_WithEmailVerifiedFalse_IsTheConventionalShape()
+    {
+        // Failure paths in SocialLoginService construct the result with
+        // emailVerified=false. Pin that shape so callers don't have to
+        // null-guard a separate field.
+        var result = new SocialAuthCallbackResult(
+            Success: false, Error: "Token exchange failed.",
+            Subject: null, Email: null, DisplayName: null,
+            EmailVerified: false, Provider: "Google");
+
+        result.Success.Should().BeFalse();
+        result.EmailVerified.Should().BeFalse();
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
@@ -27,6 +27,7 @@ public class LoginModelTests
     private readonly Mock<ITokenService> _tokenService = new();
     private readonly Mock<IIdentityRepository> _identityRepo = new();
     private readonly Mock<IOrganizationRepository> _orgRepo = new();
+    private readonly Mock<ISocialLoginService> _socialLoginService = new();
 
     private LoginModel CreateModel()
     {
@@ -37,13 +38,48 @@ public class LoginModelTests
             _identityRepo.Object,
             _orgRepo.Object,
             NullLogger<LoginModel>.Instance,
-            Options.Create(new DemoEnvironmentSettings()));
+            Options.Create(new DemoEnvironmentSettings()),
+            _socialLoginService.Object);
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(
             httpContext, new RouteData(), new PageActionDescriptor()));
 
         return model;
+    }
+
+    [Fact]
+    public void OnGet_PopulatesAvailableProvidersFromSocialLoginService()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.GetConfiguredProviderNames())
+            .Returns(new[] { "Google", "GitHub" });
+
+        var model = CreateModel();
+
+        // Act
+        model.OnGet();
+
+        // Assert — login page shows the same set of providers as the signup page.
+        model.AvailableProviders.Should().Equal("Google", "GitHub");
+    }
+
+    [Fact]
+    public void OnGet_NoConfiguredProviders_AvailableProvidersEmpty()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.GetConfiguredProviderNames())
+            .Returns(Array.Empty<string>());
+
+        var model = CreateModel();
+
+        // Act
+        model.OnGet();
+
+        // Assert
+        model.AvailableProviders.Should().BeEmpty();
     }
 
     private static TokenResponse CreateTokens() => new()

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
@@ -21,19 +21,72 @@ namespace Sorcha.Tenant.Service.Tests.Pages;
 public class SignupModelTests
 {
     private readonly Mock<IRegistrationService> _registrationService = new();
+    private readonly Mock<ISocialLoginService> _socialLoginService = new();
 
     private SignupModel CreateModel()
     {
         var model = new SignupModel(
             _registrationService.Object,
             NullLogger<SignupModel>.Instance,
-            Options.Create(new DemoEnvironmentSettings()));
+            Options.Create(new DemoEnvironmentSettings()),
+            _socialLoginService.Object);
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(
             httpContext, new RouteData(), new PageActionDescriptor()));
 
         return model;
+    }
+
+    [Fact]
+    public void OnGet_PopulatesAvailableProvidersFromSocialLoginService()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.GetConfiguredProviderNames())
+            .Returns(new[] { "Google", "GitHub" });
+
+        var model = CreateModel();
+
+        // Act
+        model.OnGet();
+
+        // Assert
+        model.AvailableProviders.Should().Equal("Google", "GitHub");
+    }
+
+    [Fact]
+    public void OnGet_NoConfiguredProviders_AvailableProvidersEmpty()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.GetConfiguredProviderNames())
+            .Returns(Array.Empty<string>());
+
+        var model = CreateModel();
+
+        // Act
+        model.OnGet();
+
+        // Assert
+        model.AvailableProviders.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void OnGet_PreservesProviderNameCasingFromService()
+    {
+        // Arrange — provider names should be returned exactly as the service returns them.
+        _socialLoginService
+            .Setup(s => s.GetConfiguredProviderNames())
+            .Returns(new[] { "GitHub" });
+
+        var model = CreateModel();
+
+        // Act
+        model.OnGet();
+
+        // Assert
+        model.AvailableProviders.Should().ContainSingle().Which.Should().Be("GitHub");
     }
 
     [Fact]

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
@@ -64,17 +64,17 @@ public class SocialCallbackModelTests : IDisposable
     }
 
     [Theory]
-    [InlineData(null, "code", "state")]
-    [InlineData("Google", null, "state")]
-    [InlineData("Google", "code", null)]
+    [InlineData(null, "state")]
+    [InlineData("code", null)]
     public async Task OnGetAsync_MissingParams_ShowsError(
-        string? provider, string? code, string? state)
+        string? code, string? state)
     {
-        // Arrange
+        // Arrange — provider is recovered from cached state inside ExchangeCodeAsync
+        // (feature 115 FR-021), so it is no longer a query parameter.
         var model = CreateModel();
 
         // Act
-        var result = await model.OnGetAsync(provider, code, state, null, CancellationToken.None);
+        var result = await model.OnGetAsync(code, state, null, CancellationToken.None);
 
         // Assert
         result.Should().BeOfType<PageResult>();
@@ -88,10 +88,68 @@ public class SocialCallbackModelTests : IDisposable
         var model = CreateModel();
 
         // Act
-        var result = await model.OnGetAsync("Google", "code", "state", "access_denied", CancellationToken.None);
+        var result = await model.OnGetAsync("code", "state", "access_denied", CancellationToken.None);
 
         // Assert
         result.Should().BeOfType<PageResult>();
         model.ErrorMessage.Should().Contain("cancelled or failed");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_RefusalProviderUnverified_RendersDocumentedCopy()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.ExchangeCodeAsync(string.Empty, "code", "state", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SocialAuthCallbackResult(
+                Success: true, Error: null,
+                Subject: "sub-1", Email: "x@y.com", DisplayName: "X",
+                EmailVerified: false, Provider: "Google"));
+
+        _platformUserService
+            .Setup(s => s.ResolveOrCreateSocialUserAsync(
+                It.IsAny<SocialAuthCallbackResult>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResolveSocialUserResult(
+                User: null, IsNew: false, Refusal: SocialLoginRefusal.ProviderUnverified));
+
+        var model = CreateModel();
+
+        // Act
+        var result = await model.OnGetAsync("code", "state", null, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        model.ErrorMessage.Should().Contain("Google");
+        model.ErrorMessage.Should().Contain("verify");
+    }
+
+    [Fact]
+    public async Task OnGetAsync_RefusalExistingUnverified_RendersDocumentedCopy()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.ExchangeCodeAsync(string.Empty, "code", "state", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SocialAuthCallbackResult(
+                Success: true, Error: null,
+                Subject: "sub-1", Email: "x@y.com", DisplayName: "X",
+                EmailVerified: true, Provider: "Google"));
+
+        _platformUserService
+            .Setup(s => s.ResolveOrCreateSocialUserAsync(
+                It.IsAny<SocialAuthCallbackResult>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResolveSocialUserResult(
+                User: null, IsNew: false, Refusal: SocialLoginRefusal.ExistingUnverified));
+
+        var model = CreateModel();
+
+        // Act
+        var result = await model.OnGetAsync("code", "state", null, CancellationToken.None);
+
+        // Assert — copy directs the user to verify their existing account
+        result.Should().BeOfType<PageResult>();
+        model.ErrorMessage.Should().Contain("account exists");
+        model.ErrorMessage.Should().Contain("verify");
     }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
@@ -196,9 +196,11 @@ public class SocialLoginPolicyTests : IDisposable
     }
 
     [Fact]
-    public async Task EmailCollision_ProviderUnverified_RefusesWithExistingUnverified()
+    public async Task EmailCollision_ProviderUnverified_RefusesWithProviderUnverified()
     {
-        // Arrange — verified existing user, but provider asserts unverified
+        // Arrange — VERIFIED existing user, but provider asserts unverified.
+        // The refusal must point the user at the provider (where the verification
+        // step is missing), NOT at their already-verified Sorcha account.
         var existing = new PlatformUser
         {
             Id = Guid.NewGuid(),
@@ -216,9 +218,13 @@ public class SocialLoginPolicyTests : IDisposable
             Claim(email: "alice@example.com", emailVerified: false),
             CancellationToken.None);
 
-        // Assert — both-sides-verified rule: refuse when provider is the unverified party
-        result.Refusal.Should().Be(SocialLoginRefusal.ExistingUnverified);
+        // Assert — provider is the unverified party, so refusal directs the user there
+        result.Refusal.Should().Be(SocialLoginRefusal.ProviderUnverified);
         result.User.Should().BeNull();
+
+        // No link should be created
+        var linkCount = await _db.PlatformSocialLogins.CountAsync(s => s.PlatformUserId == existing.Id);
+        linkCount.Should().Be(0);
     }
 
     // --- Scenario C: genuinely new user ---
@@ -262,6 +268,23 @@ public class SocialLoginPolicyTests : IDisposable
 
         var afterCount = await _db.PlatformUsers.CountAsync();
         afterCount.Should().Be(beforeCount, "no user record should be created on a refused signup");
+    }
+
+    [Fact]
+    public void RecordRefusal_DoesNotThrow_ForKnownReasons()
+    {
+        // Smoke test: the refusal counter accepts both reason values without
+        // throwing. Used by SocialCallback rendering and SocialLoginEndpoints
+        // API path.
+        SocialLoginMetrics.RecordRefusal("Google", SocialLoginRefusal.ProviderUnverified);
+        SocialLoginMetrics.RecordRefusal("GitHub", SocialLoginRefusal.ExistingUnverified);
+
+        // None is treated as a no-op
+        SocialLoginMetrics.RecordRefusal("Google", SocialLoginRefusal.None);
+
+        // Upstream-failure variant for state/code-exchange paths
+        SocialLoginMetrics.RecordUpstreamFailure("Google", "code_exchange_failed");
+        SocialLoginMetrics.RecordUpstreamFailure(string.Empty, "state_invalid");
     }
 
     public void Dispose()

--- a/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+using Sorcha.Tenant.Service.Tests.Helpers;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// Tests the strict link policy applied by
+/// <see cref="PlatformUserService.ResolveOrCreateSocialUserAsync"/> for
+/// feature 115. Three policy gates: returning-user pass-through with
+/// display-name refresh; email-collision linking gated on both-sides
+/// verified; new-user creation gated on provider-asserted verification.
+/// </summary>
+public class SocialLoginPolicyTests : IDisposable
+{
+    private readonly TenantDbContext _db;
+    private readonly PlatformUserService _service;
+
+    public SocialLoginPolicyTests()
+    {
+        _db = InMemoryDbContextFactory.Create();
+        _service = new PlatformUserService(
+            _db,
+            NullLogger<PlatformUserService>.Instance,
+            new ConfigurationBuilder().Build());
+    }
+
+    private static SocialAuthCallbackResult Claim(
+        string provider = "Google",
+        string subject = "sub-123",
+        string? email = "user@example.com",
+        string? displayName = "User",
+        bool emailVerified = true) =>
+        new(Success: true, Error: null,
+            Subject: subject, Email: email, DisplayName: displayName,
+            EmailVerified: emailVerified, Provider: provider);
+
+    // --- Scenario A: returning user (provider+subject already linked) ---
+
+    [Fact]
+    public async Task ReturningUser_NoVerificationRecheck_RefreshesDisplayNameAndLastUsed()
+    {
+        // Arrange — existing user with prior link, current display name "Old Name"
+        var existing = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "user@example.com",
+            DisplayName = "Old Name",
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-30),
+        };
+        _db.PlatformUsers.Add(existing);
+        _db.PlatformSocialLogins.Add(new PlatformSocialLogin
+        {
+            Id = Guid.NewGuid(),
+            PlatformUserId = existing.Id,
+            Provider = "Google",
+            Subject = "sub-123",
+            Email = "user@example.com",
+            DisplayName = "Old Name",
+            LinkedAt = DateTimeOffset.UtcNow.AddDays(-30),
+            LastUsedAt = DateTimeOffset.UtcNow.AddDays(-1),
+        });
+        await _db.SaveChangesAsync();
+
+        // Provider returns email_verified=false this time — should be ignored
+        // because the link was established under the strict gate previously.
+        var claim = Claim(emailVerified: false, displayName: "New Name From Google");
+
+        // Act
+        var result = await _service.ResolveOrCreateSocialUserAsync(claim, CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.None);
+        result.IsNew.Should().BeFalse();
+        result.User.Should().NotBeNull();
+        result.User!.Id.Should().Be(existing.Id);
+
+        var refreshed = await _db.PlatformUsers.FindAsync(existing.Id);
+        refreshed!.DisplayName.Should().Be("New Name From Google");
+
+        var link = await _db.PlatformSocialLogins.SingleAsync(s => s.PlatformUserId == existing.Id);
+        link.LastUsedAt.Should().BeAfter(DateTimeOffset.UtcNow.AddMinutes(-1));
+    }
+
+    [Fact]
+    public async Task ReturningUser_EmptyDisplayName_DoesNotOverwriteExisting()
+    {
+        // Arrange
+        var existing = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "user@example.com",
+            DisplayName = "Original Name",
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+        };
+        _db.PlatformUsers.Add(existing);
+        _db.PlatformSocialLogins.Add(new PlatformSocialLogin
+        {
+            Id = Guid.NewGuid(),
+            PlatformUserId = existing.Id,
+            Provider = "Google",
+            Subject = "sub-empty",
+        });
+        await _db.SaveChangesAsync();
+
+        // Act — provider returned no display name
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(subject: "sub-empty", displayName: null), CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.None);
+        var refreshed = await _db.PlatformUsers.FindAsync(existing.Id);
+        refreshed!.DisplayName.Should().Be("Original Name");
+    }
+
+    // --- Scenario B: email-collision (existing user, new provider link) ---
+
+    [Fact]
+    public async Task EmailCollision_BothVerified_LinksAndReturnsExisting()
+    {
+        // Arrange — verified existing user, no provider link yet
+        var existing = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "alice@example.com",
+            DisplayName = "Alice",
+            EmailVerified = true,
+            EmailVerifiedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
+        };
+        _db.PlatformUsers.Add(existing);
+        await _db.SaveChangesAsync();
+
+        // Act — Google returns the same email, asserts verified
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "alice@example.com", emailVerified: true, displayName: "Alice G"),
+            CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.None);
+        result.IsNew.Should().BeFalse();
+        result.User!.Id.Should().Be(existing.Id);
+
+        var link = await _db.PlatformSocialLogins.SingleAsync(s => s.PlatformUserId == existing.Id);
+        link.Provider.Should().Be("Google");
+        link.Subject.Should().Be("sub-123");
+
+        var refreshed = await _db.PlatformUsers.FindAsync(existing.Id);
+        refreshed!.DisplayName.Should().Be("Alice G");
+    }
+
+    [Fact]
+    public async Task EmailCollision_ExistingUnverified_RefusesWithExistingUnverified()
+    {
+        // Arrange — UNverified existing user (the hijack-risk scenario)
+        var existing = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "alice@example.com",
+            DisplayName = "Alice",
+            EmailVerified = false,            // never confirmed
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+        };
+        _db.PlatformUsers.Add(existing);
+        await _db.SaveChangesAsync();
+
+        // Act — provider says verified, but existing isn't
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "alice@example.com", emailVerified: true),
+            CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.ExistingUnverified);
+        result.User.Should().BeNull();
+        result.IsNew.Should().BeFalse();
+
+        // No link should have been created
+        var linkCount = await _db.PlatformSocialLogins.CountAsync(s => s.PlatformUserId == existing.Id);
+        linkCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EmailCollision_ProviderUnverified_RefusesWithExistingUnverified()
+    {
+        // Arrange — verified existing user, but provider asserts unverified
+        var existing = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "alice@example.com",
+            DisplayName = "Alice",
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-7),
+        };
+        _db.PlatformUsers.Add(existing);
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "alice@example.com", emailVerified: false),
+            CancellationToken.None);
+
+        // Assert — both-sides-verified rule: refuse when provider is the unverified party
+        result.Refusal.Should().Be(SocialLoginRefusal.ExistingUnverified);
+        result.User.Should().BeNull();
+    }
+
+    // --- Scenario C: genuinely new user ---
+
+    [Fact]
+    public async Task NewUser_ProviderVerified_CreatesUserWithEmailVerifiedTrue()
+    {
+        // Act
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "newcomer@example.com", subject: "sub-newcomer", emailVerified: true),
+            CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.None);
+        result.IsNew.Should().BeTrue();
+        result.User.Should().NotBeNull();
+
+        var created = await _db.PlatformUsers.FindAsync(result.User!.Id);
+        created!.Email.Should().Be("newcomer@example.com");
+        created.EmailVerified.Should().BeTrue();
+        created.EmailVerifiedAt.Should().NotBeNull();
+
+        var link = await _db.PlatformSocialLogins.SingleAsync(s => s.PlatformUserId == created.Id);
+        link.Provider.Should().Be("Google");
+    }
+
+    [Fact]
+    public async Task NewUser_ProviderUnverified_RefusesWithProviderUnverified_NoUserCreated()
+    {
+        var beforeCount = await _db.PlatformUsers.CountAsync();
+
+        // Act
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "untrusted@example.com", subject: "sub-untrusted", emailVerified: false),
+            CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.ProviderUnverified);
+        result.User.Should().BeNull();
+        result.IsNew.Should().BeFalse();
+
+        var afterCount = await _db.PlatformUsers.CountAsync();
+        afterCount.Should().Be(beforeCount, "no user record should be created on a refused signup");
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
@@ -252,6 +252,30 @@ public class SocialLoginPolicyTests : IDisposable
     }
 
     [Fact]
+    public async Task NewUser_GitHubZeroVerifiedEmails_RefusesWithProviderUnverified()
+    {
+        // GitHub edge case: the user has a GitHub account but no primary email
+        // marked verified. ExtractGitHubClaimsAsync surfaces this as
+        // EmailVerified=false with a null/empty Email. The strict-link gate
+        // refuses the signup at Scenario C — no PlatformUser is created,
+        // no PlatformSocialLogin row appears.
+        var beforeCount = await _db.PlatformUsers.CountAsync();
+
+        // Act — simulate a GitHub claim with no verified primary email
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(provider: "GitHub", subject: "github-noverify-123",
+                  email: null, displayName: "octouser",
+                  emailVerified: false),
+            CancellationToken.None);
+
+        // Assert
+        result.Refusal.Should().Be(SocialLoginRefusal.ProviderUnverified);
+        result.User.Should().BeNull();
+        (await _db.PlatformUsers.CountAsync()).Should().Be(beforeCount);
+        (await _db.PlatformSocialLogins.CountAsync(s => s.Subject == "github-noverify-123")).Should().Be(0);
+    }
+
+    [Fact]
     public async Task NewUser_ProviderUnverified_RefusesWithProviderUnverified_NoUserCreated()
     {
         var beforeCount = await _db.PlatformUsers.CountAsync();

--- a/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="SocialLoginService.GetConfiguredProviderNames"/> —
+/// the visibility surface that drives conditional rendering of provider
+/// buttons on the signup and login pages. Feature 115 FR-001/FR-002.
+/// </summary>
+public class SocialLoginServiceTests
+{
+    private static SocialLoginService CreateService(
+        params (string Name, string ClientId, string ClientSecret)[] providers)
+    {
+        var configData = new List<KeyValuePair<string, string?>>();
+        for (var i = 0; i < providers.Length; i++)
+        {
+            configData.Add(new($"SocialProviders:{i}:Name", providers[i].Name));
+            configData.Add(new($"SocialProviders:{i}:ClientId", providers[i].ClientId));
+            configData.Add(new($"SocialProviders:{i}:ClientSecret", providers[i].ClientSecret));
+        }
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        return new SocialLoginService(
+            new Mock<IHttpClientFactory>().Object,
+            new Mock<IDistributedCache>().Object,
+            configuration,
+            NullLogger<SocialLoginService>.Instance);
+    }
+
+    [Fact]
+    public void GetConfiguredProviderNames_NoProviders_ReturnsEmpty()
+    {
+        var service = CreateService();
+        service.GetConfiguredProviderNames().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetConfiguredProviderNames_FullyConfiguredProvider_IsIncluded()
+    {
+        var service = CreateService(("Google", "client-id", "client-secret"));
+        service.GetConfiguredProviderNames().Should().ContainSingle().Which.Should().Be("Google");
+    }
+
+    [Fact]
+    public void GetConfiguredProviderNames_EmptyClientId_IsExcluded()
+    {
+        var service = CreateService(
+            ("Google", "google-id", "google-secret"),
+            ("GitHub", "", "github-secret"));
+
+        service.GetConfiguredProviderNames().Should().Equal("Google");
+    }
+
+    [Fact]
+    public void GetConfiguredProviderNames_EmptyClientSecret_IsExcluded()
+    {
+        var service = CreateService(
+            ("Google", "google-id", "google-secret"),
+            ("GitHub", "github-id", ""));
+
+        service.GetConfiguredProviderNames().Should().Equal("Google");
+    }
+
+    [Fact]
+    public void GetConfiguredProviderNames_BothCredsBlank_IsExcluded()
+    {
+        // The default n1 .env shipped with empty placeholder values; the resulting
+        // SocialProviders entry should not appear as a configured provider.
+        var service = CreateService(
+            ("Google", "", ""),
+            ("GitHub", "github-id", "github-secret"));
+
+        service.GetConfiguredProviderNames().Should().Equal("GitHub");
+    }
+
+    [Fact]
+    public void GetConfiguredProviderNames_TwoFullyConfigured_BothIncluded()
+    {
+        var service = CreateService(
+            ("Google", "google-id", "google-secret"),
+            ("GitHub", "github-id", "github-secret"));
+
+        service.GetConfiguredProviderNames().Should().Equal("Google", "GitHub");
+    }
+}


### PR DESCRIPTION
## Summary

- Wires public-user signup via Google + GitHub on `n1.sorcha.dev` under a strict email-verification trust policy.
- Closes a live bug: providers were redirected to `/api/auth/social/callback-redirect` (no handler) and would 404 the user after consent. Fixed to the actual Razor-page route at `/auth/social/callback`.
- Refuses cross-method account linking unless **both** sides have asserted email verification — closes the unverified-existing-account hijack scenario, which matters more now that F114 anchors citizen wallet identity on `PlatformUser`.

## What's in the change

- **Foundational:** `SocialAuthCallbackResult.EmailVerified` field, `SocialLoginRefusal` enum, `ResolveSocialUserResult` record, `ISocialLoginService.GetConfiguredProviderNames()`.
- **Bug fix:** `SocialLoginEndpoints.cs` redirect URI; `SocialCallback.cshtml.cs` reads provider from cached state instead of a query parameter providers don't preserve.
- **Strict link policy** in `PlatformUserService.ResolveOrCreateSocialUserAsync`:
  - New-user signup refused when provider says `email_verified=false`
  - Cross-method linking refused unless both sides verified
  - Returning users skip verification re-check (trust at link time)
  - `DisplayName` refreshed from claim on each login
- **Operator surface:** Signup + Login pages render one button per configured provider; dead JS removed; `DatabaseInitializer` reads `PlatformSettings:SeedPublicOrgEnabled` so a fresh n1 reset is signup-ready.
- **Telemetry:** `SocialLoginMetrics` exposes `sorcha_social_login_refusal_total{provider, reason}` on the `Sorcha.Tenant` meter; refusal logs carry a hash-based redacted email tag — no plaintext PII.
- **Configuration:** `.env.example` + `docker-compose.n1.yml` map four `GOOGLE_*` / `GITHUB_*` env vars to the canonical .NET `SocialProviders__N__*` shape.
- **Documentation:** `docs/guides/SOCIAL-LOGIN-SETUP.md` end-to-end runbook (Google + GitHub registration, deploy, rotate, troubleshoot); Tenant Service `README.md` strict-link-policy section; `docs/reference/API-DOCUMENTATION.md` callback row.

## SpecKit artifacts

- `specs/115-social-signup/spec.md` — 3 user stories, 21 FRs, 10 SCs
- `specs/115-social-signup/plan.md` + `research.md` + `data-model.md` + `contracts/` + `quickstart.md` + `tasks.md`
- `docs/superpowers/specs/2026-04-26-social-signup-n1-design.md` — companion design doc with full REQ-1..REQ-9 decision history

## Test plan

- [x] `dotnet build src/Services/Sorcha.Tenant.Service/...` clean
- [x] `dotnet test tests/Sorcha.Tenant.Service.Tests/` — **715 / 715** unit tests pass (8 pre-existing skips). 38 new/extended for this feature.
- [ ] Manual smoke: register Google + GitHub OAuth apps, seed `/opt/sorcha/.env` on n1, run `n1-reset.ps1`, walk the 7 scenarios in `quickstart.md` §7 (happy path, returning login, refusal, link)
- [ ] Verify `sorcha_social_login_refusal_total` counter increments on the email-collision refusal
- [ ] After deploy stabilises (~7 days), flip n1 `ASPNETCORE_ENVIRONMENT` to `Staging` per REQ-7 to activate F113 storage fail-fast

## Out of scope (backlog)

- Microsoft + Apple providers (Apple needs JWT-based client_secret refactor)
- Azure Key Vault for secrets (appropriate at first Kubernetes deployment)
- Email-change reconciliation when provider's email drifts after link time
- Consumer Persona attribute model (F092 territory)

## Notes for review

- `T016` (`SocialLoginEndpointsTests` redirect-URI regression) and `T018` (`DatabaseInitializerTests` seed flag) are deferred with explanatory notes in `tasks.md` — manual smoke + indirect coverage via `BootstrapApiTests` cover them.
- The single-PR ship plan from the design doc is intentional: shipping US1 (happy path) without US2 (strict policy) would be unsafe given F114's wallet-identity anchoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)