### PR TITLE
Feature 114 Phase 3: MVP UI completion (T088-T100, partial T054-T067)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -46,7 +46,8 @@
       "Bash(grep -E --line-buffered \"^#[0-9]+ naming|DONE|ERROR|error:|failed|Successfully|CACHED|sha256.*$|Building [0-9]\")",
       "PowerShell(try { $r = Invoke-WebRequest -Uri \"https://n1.sorcha.dev/\" -TimeoutSec 10 -SkipHttpErrorCheck; \"HTTP $\\($r.StatusCode\\)\" } catch { \"ERROR: $\\($_.Exception.Message\\)\" })",
       "PowerShell(dotnet ef migrations)",
-      "PowerShell(dotnet ef migrations *)"
+      "PowerShell(dotnet ef migrations *)",
+      "Read(//c/Users/STUART~1/AppData/Local/Temp/claude/C--projects-Sorcha/a8c05a83-167a-4776-8fbd-e2d2224d5be7/tasks/**)"
     ],
     "deny": [],
     "ask": []

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/App.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/App.razor
@@ -14,5 +14,6 @@
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 </html>

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/App.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/App.razor
@@ -7,7 +7,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <base href="/" />
+    <base href="/verify/" />
     <link rel="stylesheet" href="@Assets["_content/MudBlazor/MudBlazor.min.css"]" />
     <HeadOutlet />
 </head>

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Index.razor
@@ -6,6 +6,7 @@
     to ask for, hits Start, and is sent to the QR session page.
 *@
 @page "/"
+@page "/verify"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Http
@@ -66,7 +67,7 @@
             var baseUri = ResolveBaseUri();
             var result = await Builder.CreateAsync(
                 verifierOrgId, _purpose, _vct, required, optional, baseUri);
-            Nav.NavigateTo($"/verify/{result.Session.SessionId}");
+            Nav.NavigateTo($"/verify/s/{result.Session.SessionId}");
         }
         catch (Exception ex)
         {

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Index.razor
@@ -2,16 +2,95 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Placeholder home page for the reference verifier. Replaced by
-    VerifierSession.razor + Outcome.razor in Phase 3 / US1 (T092-T093).
+    Reference verifier landing page (Feature 114, T092). The operator chooses what
+    to ask for, hits Start, and is sent to the QR session page.
 *@
 @page "/"
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Http
+@using Sorcha.Citizen.Verifier.Services
+@inject IPresentationRequestBuilder Builder
+@inject NavigationManager Nav
+@inject IHttpContextAccessor? HttpAccessor
 
 <PageTitle>Sorcha Reference Verifier</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
-    <MudText Typo="Typo.h4">Sorcha Reference Verifier</MudText>
-    <MudText Typo="Typo.body1" Class="mt-2">
-        Feature 114 verifier shell. Real verification flow lands in Phase 3 / US1.
+    <MudText Typo="Typo.h4" Class="mb-4">Sorcha Reference Verifier</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-6">
+        Build an OID4VP cross-device presentation request and show its QR. Citizens
+        scan the code with the Sorcha wallet PWA, approve disclosure, and the result
+        appears here in real time.
     </MudText>
+
+    <MudPaper Elevation="1" Class="pa-4">
+        <MudStack Spacing="3">
+            <MudTextField @bind-Value="_purpose" Label="Purpose"
+                          HelperText="Shown to the citizen on the consent sheet."
+                          Required="true" />
+            <MudTextField @bind-Value="_vct" Label="Required credential type (vct)"
+                          Required="true" />
+            <MudTextField @bind-Value="_required" Label="Required claims (comma separated)" />
+            <MudTextField @bind-Value="_optional" Label="Optional claims (comma separated)" />
+            <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                       OnClick="StartAsync" Disabled="@_starting">
+                @(_starting ? "Starting…" : "Start verification")
+            </MudButton>
+            @if (!string.IsNullOrEmpty(_error))
+            {
+                <MudAlert Severity="Severity.Error">@_error</MudAlert>
+            }
+        </MudStack>
+    </MudPaper>
 </MudContainer>
+
+@code {
+    private string _purpose = "Confirm identity";
+    private string _vct = "https://sorcha.dev/vc/test/v1";
+    private string _required = "givenName";
+    private string _optional = "familyName";
+    private bool _starting;
+    private string? _error;
+
+    private async Task StartAsync()
+    {
+        _error = null;
+        _starting = true;
+        try
+        {
+            var required = SplitCsv(_required);
+            var optional = SplitCsv(_optional);
+            // Demo verifier org id is deterministic — trusts that the citizen wallet pins this kid.
+            var verifierOrgId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+            var baseUri = ResolveBaseUri();
+            var result = await Builder.CreateAsync(
+                verifierOrgId, _purpose, _vct, required, optional, baseUri);
+            Nav.NavigateTo($"/verify/{result.Session.SessionId}");
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _starting = false;
+        }
+    }
+
+    private static List<string> SplitCsv(string raw) => raw
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .ToList();
+
+    private string ResolveBaseUri()
+    {
+        // Behind the gateway the verifier sees /verify/* as its mount prefix; build the
+        // response URI relative to whatever host scanned the QR.
+        var ctx = HttpAccessor?.HttpContext;
+        if (ctx is not null)
+        {
+            return $"{ctx.Request.Scheme}://{ctx.Request.Host.Value}";
+        }
+        return Nav.BaseUri.TrimEnd('/');
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Index.razor
@@ -6,7 +6,6 @@
     to ask for, hits Start, and is sent to the QR session page.
 *@
 @page "/"
-@page "/verify"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Http
@@ -67,7 +66,7 @@
             var baseUri = ResolveBaseUri();
             var result = await Builder.CreateAsync(
                 verifierOrgId, _purpose, _vct, required, optional, baseUri);
-            Nav.NavigateTo($"/verify/s/{result.Session.SessionId}");
+            Nav.NavigateTo($"s/{result.Session.SessionId}");
         }
         catch (Exception ex)
         {

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Outcome.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Outcome.razor
@@ -6,7 +6,7 @@
     after the citizen wallet posts an outcome — accepted (with disclosed claims
     table) or rejected (with reasons).
 *@
-@page "/verify/{SessionId}/outcome"
+@page "/verify/s/{SessionId}/outcome"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using Sorcha.Citizen.Verifier.Services
 @inject IVerifierSessionStore Store
@@ -21,7 +21,7 @@
     else if (_session.Outcome is null)
     {
         <MudAlert Severity="Severity.Info">Still pending — return to the QR page.</MudAlert>
-        <MudButton Class="mt-4" Variant="Variant.Outlined" Href="@($"/verify/{SessionId}")">Back to QR</MudButton>
+        <MudButton Class="mt-4" Variant="Variant.Outlined" Href="@($"/verify/s/{SessionId}")">Back to QR</MudButton>
     }
     else if (_session.Outcome.Accepted)
     {

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Outcome.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Outcome.razor
@@ -1,0 +1,72 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Verifier outcome page (Feature 114, T093). Single screen the operator sees
+    after the citizen wallet posts an outcome — accepted (with disclosed claims
+    table) or rejected (with reasons).
+*@
+@page "/verify/{SessionId}/outcome"
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+@using Sorcha.Citizen.Verifier.Services
+@inject IVerifierSessionStore Store
+
+<PageTitle>Verifier outcome</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
+    @if (_session is null)
+    {
+        <MudAlert Severity="Severity.Warning">Session not found or expired.</MudAlert>
+    }
+    else if (_session.Outcome is null)
+    {
+        <MudAlert Severity="Severity.Info">Still pending — return to the QR page.</MudAlert>
+        <MudButton Class="mt-4" Variant="Variant.Outlined" Href="@($"/verify/{SessionId}")">Back to QR</MudButton>
+    }
+    else if (_session.Outcome.Accepted)
+    {
+        <MudAlert Severity="Severity.Success" Icon="@Icons.Material.Filled.VerifiedUser" Class="mb-4">
+            Presentation accepted.
+        </MudAlert>
+        <MudText Typo="Typo.h6" Class="mb-2">@_session.Purpose</MudText>
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+            Disclosed claims from <code>@_session.RequiredVct</code>:
+        </MudText>
+        <MudPaper Elevation="1" Class="pa-4">
+            <MudList T="string" Dense="true">
+                @foreach (var (name, value) in _session.Outcome.DisclosedClaims)
+                {
+                    <MudListItem T="string">
+                        <strong>@name:</strong> @value?.ToString()
+                    </MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    }
+    else
+    {
+        <MudAlert Severity="Severity.Error" Icon="@Icons.Material.Filled.Block" Class="mb-4">
+            Presentation rejected.
+        </MudAlert>
+        <MudPaper Elevation="1" Class="pa-4">
+            <MudList T="string" Dense="true">
+                @foreach (var err in _session.Outcome.Errors)
+                {
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.ErrorOutline">@err</MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    }
+
+    <MudButton Class="mt-6" Variant="Variant.Outlined" Href="/">Start a new verification</MudButton>
+</MudContainer>
+
+@code {
+    [Parameter] public string SessionId { get; set; } = string.Empty;
+    private Models.VerifierSession? _session;
+
+    protected override void OnInitialized()
+    {
+        _session = Store.Get(SessionId);
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Outcome.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/Outcome.razor
@@ -6,7 +6,7 @@
     after the citizen wallet posts an outcome — accepted (with disclosed claims
     table) or rejected (with reasons).
 *@
-@page "/verify/s/{SessionId}/outcome"
+@page "/s/{SessionId}/outcome"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using Sorcha.Citizen.Verifier.Services
 @inject IVerifierSessionStore Store
@@ -21,7 +21,7 @@
     else if (_session.Outcome is null)
     {
         <MudAlert Severity="Severity.Info">Still pending — return to the QR page.</MudAlert>
-        <MudButton Class="mt-4" Variant="Variant.Outlined" Href="@($"/verify/s/{SessionId}")">Back to QR</MudButton>
+        <MudButton Class="mt-4" Variant="Variant.Outlined" Href="@($"s/{SessionId}")">Back to QR</MudButton>
     }
     else if (_session.Outcome.Accepted)
     {
@@ -58,7 +58,7 @@
         </MudPaper>
     }
 
-    <MudButton Class="mt-6" Variant="Variant.Outlined" Href="/">Start a new verification</MudButton>
+    <MudButton Class="mt-6" Variant="Variant.Outlined" Href="">Start a new verification</MudButton>
 </MudContainer>
 
 @code {

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/VerifierSession.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/VerifierSession.razor
@@ -1,0 +1,130 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Verifier session page (Feature 114, T092). Renders the QR for an open session
+    and polls /verify/r/{sessionId}/status until the citizen wallet POSTs an
+    outcome, then routes to /verify/{sessionId}/outcome.
+*@
+@page "/verify/{SessionId}"
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+@implements IDisposable
+@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components
+@using Sorcha.Citizen.Verifier.Endpoints
+@using Sorcha.Citizen.Verifier.Services
+@inject IVerifierSessionStore Store
+@inject IPresentationRequestBuilder Builder
+@inject QrRenderer Qr
+@inject IHttpClientFactory HttpFactory
+@inject NavigationManager Nav
+
+<PageTitle>Verifier session</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
+    @if (_session is null)
+    {
+        <MudAlert Severity="Severity.Warning">
+            Session not found or expired. Start a new verification from the home page.
+        </MudAlert>
+        <MudButton Class="mt-4" Variant="Variant.Outlined" Href="/">Back</MudButton>
+    }
+    else
+    {
+        <MudText Typo="Typo.h5" Class="mb-2">@_session.Purpose</MudText>
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+            Scan with the Sorcha wallet to share <strong>@string.Join(", ", _session.RequiredClaims)</strong>
+            from a <code>@_session.RequiredVct</code> credential.
+        </MudText>
+
+        @if (!string.IsNullOrEmpty(_qrDataUrl))
+        {
+            <MudPaper Elevation="2" Class="pa-4 d-flex flex-column align-center" Style="width: fit-content; margin: 0 auto;">
+                <img src="@_qrDataUrl" alt="OID4VP request QR"
+                     style="image-rendering: pixelated; max-width: 320px; width: 100%;" />
+                <MudText Typo="Typo.caption" Class="mt-2">Session @_session.SessionId</MudText>
+            </MudPaper>
+
+            <MudExpansionPanels Class="mt-4">
+                <MudExpansionPanel Text="Show deep link (debug)">
+                    <MudText Typo="Typo.body2" Style="word-break: break-all; font-family: monospace;">
+                        @_deepLink
+                    </MudText>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        }
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-4 d-block">
+            Waiting for citizen response… (auto-refresh every 2 s)
+        </MudText>
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public string SessionId { get; set; } = string.Empty;
+
+    private Models.VerifierSession? _session;
+    private string? _deepLink;
+    private string? _qrDataUrl;
+    private CancellationTokenSource? _pollCts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _session = Store.Get(SessionId);
+        if (_session is null) return;
+
+        // Re-derive the QR/deep-link payload by asking the builder for the cached link
+        // shape — easier than persisting the link in the session record.
+        var responseBaseUri = $"{Nav.BaseUri.TrimEnd('/')}";
+        // Reconstruct deep-link fragments from the existing session — avoids creating a new one.
+        _deepLink = ReconstructDeepLink(_session, responseBaseUri);
+        _qrDataUrl = Qr.RenderDataUrl(_deepLink);
+
+        _pollCts = new CancellationTokenSource();
+        _ = Task.Run(() => PollAsync(_pollCts.Token));
+        await Task.CompletedTask;
+    }
+
+    private async Task PollAsync(CancellationToken ct)
+    {
+        var http = HttpFactory.CreateClient();
+        http.BaseAddress = new Uri(Nav.BaseUri);
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var status = await http.GetFromJsonAsync<SessionStatusResponse>(
+                    $"verify/r/{SessionId}/status", ct);
+                if (status is not null && status.Status != "pending")
+                {
+                    await InvokeAsync(() => Nav.NavigateTo($"/verify/{SessionId}/outcome"));
+                    return;
+                }
+            }
+            catch
+            {
+                // network blip — keep polling
+            }
+            try { await Task.Delay(TimeSpan.FromSeconds(2), ct); }
+            catch (TaskCanceledException) { return; }
+        }
+    }
+
+    private static string ReconstructDeepLink(Models.VerifierSession s, string responseBaseUri)
+    {
+        var pd = PresentationRequestBuilder.BuildPresentationDefinitionJson(
+            s.SessionId, s.RequiredVct, s.RequiredClaims, s.OptionalClaims, s.Purpose);
+        return "openid4vp://?" +
+            $"client_id={Uri.EscapeDataString(s.ClientId)}" +
+            "&response_mode=direct_post" +
+            $"&response_uri={Uri.EscapeDataString($"{responseBaseUri}/verify/r/{s.SessionId}/response")}" +
+            $"&nonce={Uri.EscapeDataString(s.Nonce)}" +
+            $"&presentation_definition={Uri.EscapeDataString(pd)}";
+    }
+
+    public void Dispose()
+    {
+        _pollCts?.Cancel();
+        _pollCts?.Dispose();
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/VerifierSession.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/VerifierSession.razor
@@ -6,7 +6,7 @@
     and polls /verify/r/{sessionId}/status until the citizen wallet POSTs an
     outcome, then routes to /verify/{sessionId}/outcome.
 *@
-@page "/verify/{SessionId}"
+@page "/verify/s/{SessionId}"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @implements IDisposable
 @using System.Net.Http
@@ -97,7 +97,7 @@
                     $"verify/r/{SessionId}/status", ct);
                 if (status is not null && status.Status != "pending")
                 {
-                    await InvokeAsync(() => Nav.NavigateTo($"/verify/{SessionId}/outcome"));
+                    await InvokeAsync(() => Nav.NavigateTo($"/verify/s/{SessionId}/outcome"));
                     return;
                 }
             }

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/VerifierSession.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/Pages/VerifierSession.razor
@@ -6,7 +6,7 @@
     and polls /verify/r/{sessionId}/status until the citizen wallet POSTs an
     outcome, then routes to /verify/{sessionId}/outcome.
 *@
-@page "/verify/s/{SessionId}"
+@page "/s/{SessionId}"
 @rendermode @(new InteractiveServerRenderMode(prerender: false))
 @implements IDisposable
 @using System.Net.Http
@@ -94,10 +94,10 @@
             try
             {
                 var status = await http.GetFromJsonAsync<SessionStatusResponse>(
-                    $"verify/r/{SessionId}/status", ct);
+                    $"r/{SessionId}/status", ct);
                 if (status is not null && status.Status != "pending")
                 {
-                    await InvokeAsync(() => Nav.NavigateTo($"/verify/s/{SessionId}/outcome"));
+                    await InvokeAsync(() => Nav.NavigateTo($"s/{SessionId}/outcome"));
                     return;
                 }
             }

--- a/src/Apps/Sorcha.Citizen.Verifier/Components/_Imports.razor
+++ b/src/Apps/Sorcha.Citizen.Verifier/Components/_Imports.razor
@@ -7,3 +7,6 @@
 @using MudBlazor
 @using Sorcha.Citizen.Verifier
 @using Sorcha.Citizen.Verifier.Components
+@using Sorcha.Citizen.Verifier.Services
+@using Sorcha.Citizen.Verifier.Services.Models
+@using Models = Sorcha.Citizen.Verifier.Services.Models

--- a/src/Apps/Sorcha.Citizen.Verifier/Endpoints/DemoMintEndpoint.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Endpoints/DemoMintEndpoint.cs
@@ -28,7 +28,7 @@ public static class DemoMintEndpoint
     /// <summary>Maps the demo mint endpoint at <c>POST /verify/demo/mint</c>.</summary>
     public static IEndpointRouteBuilder MapDemoMintEndpoint(this IEndpointRouteBuilder routes)
     {
-        routes.MapPost("/verify/demo/mint", Handle)
+        routes.MapPost("/demo/mint", Handle)
             .WithName("CitizenVerifierDemoMint")
             .WithSummary("Demo-only — mint a credential + delegation bound to a wallet's device key.")
             .WithDescription(

--- a/src/Apps/Sorcha.Citizen.Verifier/Endpoints/DemoMintEndpoint.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Endpoints/DemoMintEndpoint.cs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Sorcha.Citizen.Verifier.Endpoints;
+
+/// <summary>
+/// Demo-only credential minter. The wallet posts its device public JWK; the
+/// endpoint mints a fresh holder key + issuer key, builds an SD-JWT VC bound
+/// to the holder, builds a holder→device delegation credential, and returns
+/// everything for the wallet to seed its cache. Lets the MVP demo run without
+/// the real enrolment + issuance pipelines (US2).
+///
+/// <para><strong>NOT for production.</strong> The minted material is not anchored
+/// to any real Sorcha trust root and is regenerated per call.</para>
+/// </summary>
+public static class DemoMintEndpoint
+{
+    private const string DemoVct = "https://sorcha.dev/vc/demo-id-card/v1";
+
+    /// <summary>Maps the demo mint endpoint at <c>POST /verify/demo/mint</c>.</summary>
+    public static IEndpointRouteBuilder MapDemoMintEndpoint(this IEndpointRouteBuilder routes)
+    {
+        routes.MapPost("/verify/demo/mint", Handle)
+            .WithName("CitizenVerifierDemoMint")
+            .WithSummary("Demo-only — mint a credential + delegation bound to a wallet's device key.")
+            .WithDescription(
+                "Returns a freshly-signed SD-JWT VC + holder→device delegation credential " +
+                "with random demo keys. Used by the wallet PWA to seed its cache for the MVP demo.")
+            .Accepts<DemoMintRequest>("application/json")
+            .Produces<DemoMintResponse>();
+        return routes;
+    }
+
+    private static IResult Handle(DemoMintRequest body)
+    {
+        if (body.DeviceJwk.ValueKind != JsonValueKind.Object)
+        {
+            return Results.BadRequest(new { error = "deviceJwk must be a JWK object." });
+        }
+
+        using var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var holderJwk = JwkOf(holder);
+        var holderJwkEl = JsonSerializer.Deserialize<JsonElement>(holderJwk);
+        var holderThumbprint = Thumbprint(holderJwkEl);
+        var deviceThumbprint = Thumbprint(body.DeviceJwk);
+
+        // Demo claims — selectively-disclosable.
+        var givenName = ("givenName", "Stuart");
+        var familyName = ("familyName", "Fraser");
+        var dateOfBirth = ("dateOfBirth", "1980-01-01");
+
+        var (givenSeg, _) = MintDisclosure(givenName.Item1, givenName.Item2);
+        var (familySeg, _) = MintDisclosure(familyName.Item1, familyName.Item2);
+        var (dobSeg, _) = MintDisclosure(dateOfBirth.Item1, dateOfBirth.Item2);
+
+        var nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        var credentialPayload = new Dictionary<string, object>
+        {
+            ["iss"] = "did:sorcha:org:demo",
+            ["iat"] = nowUnix,
+            ["vct"] = DemoVct,
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = holderJwkEl },
+        };
+        var credentialJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            credentialPayload, issuer);
+
+        var rawSdJwt = $"{credentialJwt}~{givenSeg}~{familySeg}~{dobSeg}";
+
+        var delegationPayload = new Dictionary<string, object>
+        {
+            ["iss"] = $"did:sorcha:holder:{holderThumbprint}",
+            ["sub"] = $"did:sorcha:device:{deviceThumbprint}",
+            ["iat"] = nowUnix,
+            ["exp"] = DateTimeOffset.UtcNow.AddDays(365).ToUnixTimeSeconds(),
+            ["vct"] = "https://sorcha.dev/vc/citizen-device-delegation/v1",
+            ["delegated_capabilities"] = new[] { "presentation.holder-key-binding" },
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = body.DeviceJwk },
+            // Status-list bit deliberately omitted in demo mode — wallet's NoopStatusListService
+            // returns false anyway, and the validator skips status checks when uri/idx absent.
+        };
+        var delegationJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            delegationPayload, holder);
+
+        var response = new DemoMintResponse(
+            CredentialId: Guid.NewGuid(),
+            Vct: DemoVct,
+            DisplayLabel: "Demo identity card",
+            RawSdJwt: rawSdJwt,
+            AvailableClaimNames: ["givenName", "familyName", "dateOfBirth"],
+            DelegationJwt: delegationJwt,
+            HolderPublicJwk: holderJwkEl);
+
+        return Results.Ok(response);
+    }
+
+    private static (string Segment, string Hash) MintDisclosure(string name, string value)
+    {
+        Span<byte> salt = stackalloc byte[16];
+        RandomNumberGenerator.Fill(salt);
+        var array = JsonSerializer.SerializeToUtf8Bytes(new object[]
+        {
+            Base64Url.EncodeToString(salt), name, value,
+        });
+        var segment = Base64Url.EncodeToString(array);
+        var hash = Base64Url.EncodeToString(SHA256.HashData(Encoding.ASCII.GetBytes(segment)));
+        return (segment, hash);
+    }
+
+    private static string SignEs256(Dictionary<string, object> header, Dictionary<string, object> payload, ECDsa signer)
+    {
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.ASCII.GetBytes($"{headerSeg}.{payloadSeg}");
+        var sig = signer.SignData(signingInput, HashAlgorithmName.SHA256);
+        return $"{headerSeg}.{payloadSeg}.{Base64Url.EncodeToString(sig)}";
+    }
+
+    private static string JwkOf(ECDsa ecdsa)
+    {
+        var p = ecdsa.ExportParameters(false);
+        return JsonSerializer.Serialize(new
+        {
+            kty = "EC",
+            crv = "P-256",
+            x = Base64Url.EncodeToString(p.Q.X!),
+            y = Base64Url.EncodeToString(p.Q.Y!),
+        });
+    }
+
+    private static string Thumbprint(JsonElement jwk)
+    {
+        var canonical =
+            $"{{\"crv\":\"{jwk.GetProperty("crv").GetString()}\"," +
+            $"\"kty\":\"{jwk.GetProperty("kty").GetString()}\"," +
+            $"\"x\":\"{jwk.GetProperty("x").GetString()}\"," +
+            $"\"y\":\"{jwk.GetProperty("y").GetString()}\"}}";
+        return Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+}
+
+/// <summary>Body for <c>POST /verify/demo/mint</c>.</summary>
+public sealed record DemoMintRequest(JsonElement DeviceJwk);
+
+/// <summary>Response for <c>POST /verify/demo/mint</c>.</summary>
+public sealed record DemoMintResponse(
+    Guid CredentialId,
+    string Vct,
+    string DisplayLabel,
+    string RawSdJwt,
+    IReadOnlyList<string> AvailableClaimNames,
+    string DelegationJwt,
+    JsonElement HolderPublicJwk);

--- a/src/Apps/Sorcha.Citizen.Verifier/Endpoints/PresentationResponseEndpoints.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Endpoints/PresentationResponseEndpoints.cs
@@ -21,7 +21,7 @@ public static class PresentationResponseEndpoints
     /// <summary>Maps the verifier callback + status endpoints.</summary>
     public static IEndpointRouteBuilder MapPresentationResponseEndpoints(this IEndpointRouteBuilder routes)
     {
-        routes.MapPost("/verify/r/{sessionId}/response", HandleResponseAsync)
+        routes.MapPost("/r/{sessionId}/response", HandleResponseAsync)
             .WithName("CitizenVerifierPresentationResponse")
             .WithSummary("Wallet POSTs an OID4VP vp_token + delegation here.")
             .WithDescription(
@@ -32,7 +32,7 @@ public static class PresentationResponseEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound);
 
-        routes.MapGet("/verify/r/{sessionId}/status", HandleStatus)
+        routes.MapGet("/r/{sessionId}/status", HandleStatus)
             .WithName("CitizenVerifierPresentationStatus")
             .WithSummary("Read the current outcome of a verifier session.")
             .WithDescription("Used by the verifier UI to poll for completion. Returns 404 if the session is unknown or expired.")

--- a/src/Apps/Sorcha.Citizen.Verifier/Endpoints/PresentationResponseEndpoints.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Endpoints/PresentationResponseEndpoints.cs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Sorcha.Citizen.Verifier.Services;
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Endpoints;
+
+/// <summary>
+/// Verifier callback surface — the wallet POSTs its <c>vp_token</c> here after the citizen
+/// approves disclosure (Feature 114, T091). Anonymous; integrity comes from the KB-JWT
+/// + delegation chain inside the body, not bearer auth.
+/// </summary>
+public static class PresentationResponseEndpoints
+{
+    /// <summary>Maps the verifier callback endpoint.</summary>
+    public static IEndpointRouteBuilder MapPresentationResponseEndpoints(this IEndpointRouteBuilder routes)
+    {
+        routes.MapPost("/verify/r/{sessionId}/response", HandleResponseAsync)
+            .WithName("CitizenVerifierPresentationResponse")
+            .WithSummary("Wallet POSTs an OID4VP vp_token + delegation here.")
+            .WithDescription(
+                "Validates the SD-JWT VC + holder→device delegation chain offline, " +
+                "stores the outcome on the verifier session, and returns 204.")
+            .Accepts<VerificationCallbackBody>("application/json")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
+        return routes;
+    }
+
+    private static async Task<IResult> HandleResponseAsync(
+        string sessionId,
+        VerificationCallbackBody body,
+        IVerifierSessionStore store,
+        IVerifiablePresentationValidator validator,
+        ILogger<PresentationRequestBuilder> logger,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(body.VpToken))
+        {
+            return Results.BadRequest(new { error = "vp_token is required" });
+        }
+
+        var session = store.Get(sessionId);
+        if (session is null)
+        {
+            logger.LogWarning(
+                "Presentation response posted for unknown / expired session {SessionId}", sessionId);
+            return Results.NotFound(new { error = "session not found or expired" });
+        }
+        if (session.Outcome is not null)
+        {
+            // Idempotent: a second submission against an already-decided session returns the original outcome.
+            return Results.NoContent();
+        }
+
+        var outcome = await validator.ValidateAsync(session, body.VpToken, body.Delegation, ct);
+        store.Update(session with { Outcome = outcome });
+        return Results.NoContent();
+    }
+}
+
+/// <summary>Body shape for the verifier callback.</summary>
+/// <param name="VpToken">The SD-JWT VC compact form including disclosures and KB-JWT.</param>
+/// <param name="Delegation">The device delegation credential (separate compact JWT).</param>
+public sealed record VerificationCallbackBody(string VpToken, string? Delegation);

--- a/src/Apps/Sorcha.Citizen.Verifier/Endpoints/PresentationResponseEndpoints.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Endpoints/PresentationResponseEndpoints.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -17,7 +18,7 @@ namespace Sorcha.Citizen.Verifier.Endpoints;
 /// </summary>
 public static class PresentationResponseEndpoints
 {
-    /// <summary>Maps the verifier callback endpoint.</summary>
+    /// <summary>Maps the verifier callback + status endpoints.</summary>
     public static IEndpointRouteBuilder MapPresentationResponseEndpoints(this IEndpointRouteBuilder routes)
     {
         routes.MapPost("/verify/r/{sessionId}/response", HandleResponseAsync)
@@ -31,7 +32,35 @@ public static class PresentationResponseEndpoints
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound);
 
+        routes.MapGet("/verify/r/{sessionId}/status", HandleStatus)
+            .WithName("CitizenVerifierPresentationStatus")
+            .WithSummary("Read the current outcome of a verifier session.")
+            .WithDescription("Used by the verifier UI to poll for completion. Returns 404 if the session is unknown or expired.")
+            .Produces<SessionStatusResponse>()
+            .Produces(StatusCodes.Status404NotFound);
+
         return routes;
+    }
+
+    private static IResult HandleStatus(string sessionId, IVerifierSessionStore store)
+    {
+        var session = store.Get(sessionId);
+        if (session is null) return Results.NotFound();
+
+        if (session.Outcome is null)
+        {
+            return Results.Ok(new SessionStatusResponse(
+                Status: "pending", Purpose: session.Purpose,
+                Accepted: null, Errors: null, DisclosedClaims: null));
+        }
+
+        return Results.Ok(new SessionStatusResponse(
+            Status: session.Outcome.Accepted ? "accepted" : "rejected",
+            Purpose: session.Purpose,
+            Accepted: session.Outcome.Accepted,
+            Errors: session.Outcome.Errors,
+            DisclosedClaims: session.Outcome.DisclosedClaims
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString())));
     }
 
     private static async Task<IResult> HandleResponseAsync(
@@ -70,3 +99,16 @@ public static class PresentationResponseEndpoints
 /// <param name="VpToken">The SD-JWT VC compact form including disclosures and KB-JWT.</param>
 /// <param name="Delegation">The device delegation credential (separate compact JWT).</param>
 public sealed record VerificationCallbackBody(string VpToken, string? Delegation);
+
+/// <summary>Status payload returned by <c>GET /verify/r/{sessionId}/status</c>.</summary>
+/// <param name="Status">One of <c>pending</c>, <c>accepted</c>, <c>rejected</c>.</param>
+/// <param name="Purpose">Verifier-supplied human-readable purpose.</param>
+/// <param name="Accepted">Null while pending; true/false once decided.</param>
+/// <param name="Errors">Rejection reasons; null on accept or pending.</param>
+/// <param name="DisclosedClaims">Disclosed claim values, stringified for transport.</param>
+public sealed record SessionStatusResponse(
+    string Status,
+    string Purpose,
+    bool? Accepted,
+    IReadOnlyList<string>? Errors,
+    IReadOnlyDictionary<string, string?>? DisclosedClaims);

--- a/src/Apps/Sorcha.Citizen.Verifier/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Extensions/ServiceCollectionExtensions.cs
@@ -1,23 +1,29 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Sorcha.Citizen.Verifier.Services;
 
 namespace Sorcha.Citizen.Verifier.Extensions;
 
 /// <summary>
-/// DI extensions for the Sorcha citizen reference verifier (Feature 114, T073).
+/// DI extensions for the Sorcha citizen reference verifier (Feature 114).
 /// </summary>
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the verifier's services. Status list cache uses a typed HttpClient
-    /// so production deployments can plug in resilience handlers (Polly, etc.) without
-    /// touching this code.
+    /// Registers verifier services — status list cache (T072), presentation request
+    /// builder (T088), session store, and the VP validator (T089). The status list
+    /// cache uses a typed HttpClient so production deployments can plug in resilience
+    /// handlers (Polly, etc.) without touching this code.
     /// </summary>
     public static IServiceCollection AddCitizenVerifier(this IServiceCollection services)
     {
         services.AddHttpClient<IStatusListCache, StatusListCache>();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddSingleton<IVerifierSessionStore, InMemoryVerifierSessionStore>();
+        services.AddSingleton<IPresentationRequestBuilder, PresentationRequestBuilder>();
+        services.AddSingleton<IVerifiablePresentationValidator, VerifiablePresentationValidator>();
         return services;
     }
 }

--- a/src/Apps/Sorcha.Citizen.Verifier/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IVerifierSessionStore, InMemoryVerifierSessionStore>();
         services.AddSingleton<IPresentationRequestBuilder, PresentationRequestBuilder>();
         services.AddSingleton<IVerifiablePresentationValidator, VerifiablePresentationValidator>();
+        services.AddSingleton<QrRenderer>();
         return services;
     }
 }

--- a/src/Apps/Sorcha.Citizen.Verifier/Program.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Program.cs
@@ -13,6 +13,8 @@ builder.AddServiceDefaults();
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 builder.Services.AddMudServices();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddHttpClient();
 
 // Feature 114: verifier services (status list cache; VP validator + presentation
 // request builder land with T088-T091).

--- a/src/Apps/Sorcha.Citizen.Verifier/Program.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Program.cs
@@ -3,6 +3,7 @@
 
 using MudBlazor.Services;
 using Sorcha.Citizen.Verifier.Components;
+using Sorcha.Citizen.Verifier.Endpoints;
 using Sorcha.Citizen.Verifier.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -29,6 +30,8 @@ if (!app.Environment.IsDevelopment())
 
 app.UseStaticFiles();
 app.UseAntiforgery();
+
+app.MapPresentationResponseEndpoints();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/src/Apps/Sorcha.Citizen.Verifier/Program.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Program.cs
@@ -34,6 +34,7 @@ app.UseStaticFiles();
 app.UseAntiforgery();
 
 app.MapPresentationResponseEndpoints();
+app.MapDemoMintEndpoint();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/IPresentationRequestBuilder.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/IPresentationRequestBuilder.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <summary>
+/// Builds OID4VP cross-device presentation requests for the reference verifier
+/// (Feature 114, T088). Persists the resulting <see cref="VerifierSession"/> in the
+/// session store and returns the deep link the verifier UI renders as a QR.
+/// </summary>
+public interface IPresentationRequestBuilder
+{
+    /// <summary>
+    /// Create a fresh session and return the QR-encodable <c>openid4vp://</c> deep link.
+    /// </summary>
+    /// <param name="verifierOrgId">Verifier org id — used to build the <c>client_id</c> DID.</param>
+    /// <param name="purpose">Human-readable purpose displayed by the wallet.</param>
+    /// <param name="requiredVct">Required credential type URI.</param>
+    /// <param name="requiredClaims">Mandatory claim names.</param>
+    /// <param name="optionalClaims">Optional claim names.</param>
+    /// <param name="responseBaseUri">Base URI of the verifier (e.g. <c>https://verify.sorcha.dev</c>) — used to build the <c>response_uri</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The deep link plus the underlying session.</returns>
+    Task<PresentationRequestResult> CreateAsync(
+        Guid verifierOrgId,
+        string purpose,
+        string requiredVct,
+        IReadOnlyList<string> requiredClaims,
+        IReadOnlyList<string> optionalClaims,
+        string responseBaseUri,
+        CancellationToken ct = default);
+}
+
+/// <summary>Result of <see cref="IPresentationRequestBuilder.CreateAsync"/>.</summary>
+public sealed record PresentationRequestResult(string DeepLink, VerifierSession Session);

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/IVerifiablePresentationValidator.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/IVerifiablePresentationValidator.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <summary>
+/// Validates a wallet-submitted vp_token against an open <see cref="VerifierSession"/>.
+/// Performs offline-friendly chain validation: issuer signature, holder→device delegation,
+/// KB-JWT signature, status-list checks, claim disclosure consistency.
+///
+/// Per design §3 / data-model §C: the citizen presents an SD-JWT VC bound to their
+/// holder key (cnf.jwk == holder JWK). The KB-JWT is signed by the device key, but
+/// the device's authority comes from a separate device delegation credential signed
+/// by the holder key. The validator therefore unwraps:
+///
+/// <list type="number">
+///   <item>vp_token (SD-JWT VC) — issued + signed by an org, cnf.jwk = holder JWK</item>
+///   <item>KB-JWT — signed by device key, audience and nonce match the session</item>
+///   <item>Device delegation credential — separately included; signed by holder key, cnf.jwk = device JWK, status-list bit unset</item>
+/// </list>
+/// </summary>
+public interface IVerifiablePresentationValidator
+{
+    /// <summary>Validate a wallet's <c>vp_token</c> + delegation credential against an open session.</summary>
+    Task<VerificationOutcome> ValidateAsync(
+        VerifierSession session,
+        string vpToken,
+        string? delegationCredential,
+        CancellationToken ct = default);
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/IVerifierSessionStore.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/IVerifierSessionStore.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <summary>
+/// In-memory session store for the reference verifier. Keys are session ids; values are
+/// pending or completed <see cref="VerifierSession"/>s. The reference impl is a singleton —
+/// production verifiers would back this with Redis. v1 scope is a demo-grade verifier.
+/// </summary>
+public interface IVerifierSessionStore
+{
+    /// <summary>Persist a newly-created session.</summary>
+    void Add(VerifierSession session);
+
+    /// <summary>Fetch by id. Returns null if missing or expired.</summary>
+    VerifierSession? Get(string sessionId);
+
+    /// <summary>Replace the session record (typically to attach an outcome).</summary>
+    void Update(VerifierSession session);
+
+    /// <summary>Drop sessions whose <see cref="VerifierSession.ExpiresAt"/> has passed.</summary>
+    void PruneExpired(DateTimeOffset now);
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/InMemoryVerifierSessionStore.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/InMemoryVerifierSessionStore.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <inheritdoc />
+public sealed class InMemoryVerifierSessionStore : IVerifierSessionStore
+{
+    private readonly ConcurrentDictionary<string, VerifierSession> _sessions = new();
+
+    /// <inheritdoc />
+    public void Add(VerifierSession session) => _sessions[session.SessionId] = session;
+
+    /// <inheritdoc />
+    public VerifierSession? Get(string sessionId)
+    {
+        if (!_sessions.TryGetValue(sessionId, out var session)) return null;
+        if (session.ExpiresAt <= DateTimeOffset.UtcNow && session.Outcome is null)
+        {
+            _sessions.TryRemove(sessionId, out _);
+            return null;
+        }
+        return session;
+    }
+
+    /// <inheritdoc />
+    public void Update(VerifierSession session) => _sessions[session.SessionId] = session;
+
+    /// <inheritdoc />
+    public void PruneExpired(DateTimeOffset now)
+    {
+        foreach (var (id, session) in _sessions)
+        {
+            if (session.ExpiresAt <= now && session.Outcome is null)
+            {
+                _sessions.TryRemove(id, out _);
+            }
+        }
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/Models/VerifierSession.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/Models/VerifierSession.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Verifier.Services.Models;
+
+/// <summary>
+/// In-memory verifier session — the link between a generated presentation request
+/// (QR shown to the citizen) and the eventual outcome reported back to the
+/// browser. One per QR scan attempt; pruned on completion or expiry.
+/// </summary>
+public sealed record VerifierSession
+{
+    /// <summary>Opaque session identifier embedded in the request URL.</summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>Verifier organisation DID — the audience the wallet binds the KB-JWT to.</summary>
+    public required string ClientId { get; init; }
+
+    /// <summary>Random nonce — wallet must echo this in the KB-JWT.</summary>
+    public required string Nonce { get; init; }
+
+    /// <summary>The intended credential type URI (vct) the verifier requires.</summary>
+    public required string RequiredVct { get; init; }
+
+    /// <summary>Required claim names the citizen must disclose. Empty = none mandatory.</summary>
+    public required IReadOnlyList<string> RequiredClaims { get; init; }
+
+    /// <summary>Optional claim names the citizen may disclose. Used for consent UI.</summary>
+    public IReadOnlyList<string> OptionalClaims { get; init; } = [];
+
+    /// <summary>Human-readable purpose shown in the wallet's consent sheet.</summary>
+    public required string Purpose { get; init; }
+
+    /// <summary>UTC time the session was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>UTC time the session expires (typically CreatedAt + 5 min).</summary>
+    public required DateTimeOffset ExpiresAt { get; init; }
+
+    /// <summary>Outcome — null while pending.</summary>
+    public VerificationOutcome? Outcome { get; init; }
+}
+
+/// <summary>Result of verifying a wallet's vp_token submission.</summary>
+public sealed record VerificationOutcome
+{
+    /// <summary>True if every check passed.</summary>
+    public required bool Accepted { get; init; }
+
+    /// <summary>Disclosed claim values, keyed by claim name.</summary>
+    public required IReadOnlyDictionary<string, object?> DisclosedClaims { get; init; }
+
+    /// <summary>Human-readable rejection reasons. Empty when Accepted is true.</summary>
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    /// <summary>UTC time the verifier completed validation.</summary>
+    public required DateTimeOffset CompletedAt { get; init; }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/PresentationRequestBuilder.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/PresentationRequestBuilder.cs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Web;
+using Microsoft.Extensions.Logging;
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <summary>
+/// Default <see cref="IPresentationRequestBuilder"/>. Builds an unsigned OID4VP
+/// cross-device request per research §R-008. The request is conveyed inline as
+/// query parameters so the wallet can parse it offline without fetching
+/// <c>request_uri</c>. The wallet's KB-JWT is what carries integrity for v1 —
+/// signed-request mode is a hardening item for a later phase.
+/// </summary>
+public sealed class PresentationRequestBuilder : IPresentationRequestBuilder
+{
+    private readonly IVerifierSessionStore _store;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<PresentationRequestBuilder> _logger;
+
+    /// <summary>Default validity window for a generated request.</summary>
+    public static readonly TimeSpan DefaultValidity = TimeSpan.FromMinutes(5);
+
+    /// <summary>Initialises a new instance.</summary>
+    public PresentationRequestBuilder(
+        IVerifierSessionStore store,
+        TimeProvider clock,
+        ILogger<PresentationRequestBuilder> logger)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task<PresentationRequestResult> CreateAsync(
+        Guid verifierOrgId,
+        string purpose,
+        string requiredVct,
+        IReadOnlyList<string> requiredClaims,
+        IReadOnlyList<string> optionalClaims,
+        string responseBaseUri,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(purpose);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requiredVct);
+        ArgumentException.ThrowIfNullOrWhiteSpace(responseBaseUri);
+        ArgumentNullException.ThrowIfNull(requiredClaims);
+        ArgumentNullException.ThrowIfNull(optionalClaims);
+
+        var sessionId = NewUrlSafeId(16);
+        var nonce = NewUrlSafeId(16);
+        var clientId = $"did:sorcha:verifier:{verifierOrgId:N}";
+        var now = _clock.GetUtcNow();
+
+        var session = new VerifierSession
+        {
+            SessionId = sessionId,
+            ClientId = clientId,
+            Nonce = nonce,
+            RequiredVct = requiredVct,
+            RequiredClaims = requiredClaims,
+            OptionalClaims = optionalClaims,
+            Purpose = purpose,
+            CreatedAt = now,
+            ExpiresAt = now + DefaultValidity,
+        };
+
+        _store.Add(session);
+
+        var presentationDefinition = BuildPresentationDefinitionJson(
+            sessionId, requiredVct, requiredClaims, optionalClaims, purpose);
+
+        var responseUri = $"{responseBaseUri.TrimEnd('/')}/verify/r/{sessionId}/response";
+
+        var deepLink =
+            "openid4vp://?" +
+            $"client_id={Uri.EscapeDataString(clientId)}" +
+            "&response_mode=direct_post" +
+            $"&response_uri={Uri.EscapeDataString(responseUri)}" +
+            $"&nonce={Uri.EscapeDataString(nonce)}" +
+            $"&presentation_definition={Uri.EscapeDataString(presentationDefinition)}";
+
+        _logger.LogInformation(
+            "Verifier session created: id={SessionId}, vct={Vct}, requiredClaims={Required}",
+            sessionId, requiredVct, requiredClaims.Count);
+
+        return Task.FromResult(new PresentationRequestResult(deepLink, session));
+    }
+
+    /// <summary>
+    /// Build a Presentation Exchange (PEX) presentation_definition document. We use the
+    /// standard PEX shape with a single <c>input_descriptor</c> that constrains by
+    /// <c>vct</c> and lists every required + optional claim as a JSON pointer path.
+    /// Required claims have <c>optional=false</c>; optional ones <c>optional=true</c>.
+    /// </summary>
+    internal static string BuildPresentationDefinitionJson(
+        string sessionId,
+        string vct,
+        IReadOnlyList<string> requiredClaims,
+        IReadOnlyList<string> optionalClaims,
+        string purpose)
+    {
+        var fields = new List<object>
+        {
+            // vct constraint — every credential surfacing this descriptor must declare the type
+            new
+            {
+                path = new[] { "$.vct" },
+                filter = new { type = "string", @const = vct }
+            }
+        };
+
+        foreach (var claim in requiredClaims)
+        {
+            fields.Add(new { path = new[] { ToJsonPath(claim) }, optional = false });
+        }
+        foreach (var claim in optionalClaims)
+        {
+            fields.Add(new { path = new[] { ToJsonPath(claim) }, optional = true });
+        }
+
+        var doc = new
+        {
+            id = sessionId,
+            input_descriptors = new[]
+            {
+                new
+                {
+                    id = "primary",
+                    name = vct,
+                    purpose,
+                    constraints = new
+                    {
+                        limit_disclosure = "required",
+                        fields = fields.ToArray()
+                    }
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(doc);
+    }
+
+    private static string ToJsonPath(string claimName)
+    {
+        // Allow callers to pass either a bare claim name ("givenName") or a JSON pointer
+        // ("/credentialSubject/givenName"). Convert pointer form to JSONPath dotted form.
+        if (claimName.StartsWith('/'))
+        {
+            return "$" + claimName.Replace('/', '.');
+        }
+        return $"$.{claimName}";
+    }
+
+    private static string NewUrlSafeId(int byteLen)
+    {
+        Span<byte> buf = stackalloc byte[byteLen];
+        RandomNumberGenerator.Fill(buf);
+        return Base64Url.EncodeToString(buf);
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/QrRenderer.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/QrRenderer.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using QRCoder;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <summary>
+/// Server-side QR rendering — produces a base64 PNG data URL for any payload.
+/// QRCoder is the existing Sorcha-blessed encoder (see <c>Sorcha.UI.Core/Services/QrPresentationService.cs</c>).
+/// </summary>
+public sealed class QrRenderer
+{
+    /// <summary>Render a payload to a data URL suitable for an <c>&lt;img src&gt;</c>.</summary>
+    public string RenderDataUrl(string payload, int pixelsPerModule = 8)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(payload);
+        using var generator = new QRCodeGenerator();
+        using var data = generator.CreateQrCode(payload, QRCodeGenerator.ECCLevel.M);
+        var png = new PngByteQRCode(data).GetGraphic(pixelsPerModule);
+        return $"data:image/png;base64,{Convert.ToBase64String(png)}";
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Services/VerifiablePresentationValidator.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/VerifiablePresentationValidator.cs
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.Citizen.Verifier.Services.Models;
+
+namespace Sorcha.Citizen.Verifier.Services;
+
+/// <summary>
+/// v1 reference verifier validator. Performs the offline chain check the citizen
+/// wallet PWA design requires:
+///
+/// <list type="number">
+///   <item>Parse the SD-JWT VC compact form (<c>credential.disclosure1.disclosureN.kbjwt</c>).</item>
+///   <item>Extract the holder JWK from the credential's <c>cnf.jwk</c> claim.</item>
+///   <item>Verify the device delegation credential's signature with that holder JWK,
+///         extract the device JWK from its <c>cnf.jwk</c>, and check its status-list bit.</item>
+///   <item>Verify the KB-JWT signature with the device JWK.</item>
+///   <item>Verify KB-JWT <c>nonce</c> + <c>aud</c> match the verifier session.</item>
+///   <item>Verify required claim names appear in the disclosed claim set.</item>
+/// </list>
+///
+/// <para>v1 deliberately defers full issuer-signature verification — the issuer key
+/// resolver is optional, and when absent the validator trusts the credential payload
+/// shape but logs a warning. Full DID-backed issuer trust lands with the production
+/// verifier hardening pass; the citizen wallet feature's novel contribution is the
+/// holder→device delegation chain, which IS verified here in full.</para>
+/// </summary>
+public sealed class VerifiablePresentationValidator : IVerifiablePresentationValidator
+{
+    private readonly IStatusListCache _statusListCache;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<VerifiablePresentationValidator> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public VerifiablePresentationValidator(
+        IStatusListCache statusListCache,
+        TimeProvider clock,
+        ILogger<VerifiablePresentationValidator> logger)
+    {
+        _statusListCache = statusListCache ?? throw new ArgumentNullException(nameof(statusListCache));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<VerificationOutcome> ValidateAsync(
+        VerifierSession session,
+        string vpToken,
+        string? delegationCredential,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(vpToken);
+
+        var errors = new List<string>();
+        var disclosed = new Dictionary<string, object?>();
+
+        try
+        {
+            // ── 1. Parse the SD-JWT VC compact form ───────────────────────────────
+            var (credentialJwt, disclosureSegments, kbJwt) = SplitSdJwt(vpToken);
+            if (credentialJwt is null)
+            {
+                errors.Add("vp_token is not a valid SD-JWT compact serialisation.");
+                return Failure(errors);
+            }
+            if (kbJwt is null)
+            {
+                errors.Add("vp_token is missing the trailing key-binding JWT.");
+                return Failure(errors);
+            }
+
+            var credentialPayload = TryParseJwtPayload(credentialJwt);
+            if (credentialPayload is null)
+            {
+                errors.Add("vp_token credential JWT is malformed.");
+                return Failure(errors);
+            }
+
+            // ── 2. Validate vct matches the requested credential type ─────────────
+            var vct = TryGetString(credentialPayload.Value, "vct");
+            if (!string.Equals(vct, session.RequiredVct, StringComparison.Ordinal))
+            {
+                errors.Add($"Credential vct '{vct}' does not match required '{session.RequiredVct}'.");
+            }
+
+            // ── 3. Extract holder JWK from credential cnf.jwk ─────────────────────
+            if (!TryExtractCnfJwk(credentialPayload.Value, out var holderJwk))
+            {
+                errors.Add("Credential is missing cnf.jwk (holder key binding).");
+                return Failure(errors);
+            }
+
+            // ── 4. Validate holder→device delegation credential ───────────────────
+            JsonElement deviceJwk = default;
+            if (!string.IsNullOrWhiteSpace(delegationCredential))
+            {
+                var delegationErrors = await ValidateDelegationAsync(
+                    delegationCredential, holderJwk, ct);
+                if (delegationErrors.Count > 0)
+                {
+                    errors.AddRange(delegationErrors);
+                    return Failure(errors);
+                }
+
+                var delegationPayload = TryParseJwtPayload(delegationCredential);
+                if (delegationPayload is null
+                    || !TryExtractCnfJwk(delegationPayload.Value, out deviceJwk))
+                {
+                    errors.Add("Delegation credential is missing cnf.jwk (device key).");
+                    return Failure(errors);
+                }
+            }
+            else
+            {
+                errors.Add("Delegation credential is required for citizen wallet presentations.");
+                return Failure(errors);
+            }
+
+            // ── 5. Verify KB-JWT signature with the device key ────────────────────
+            if (!VerifyJwsSignature(kbJwt, deviceJwk, out var kbPayload))
+            {
+                errors.Add("KB-JWT signature verification failed against device key.");
+                return Failure(errors);
+            }
+
+            // ── 6. Verify KB-JWT nonce + aud match the session ────────────────────
+            var kbNonce = TryGetString(kbPayload, "nonce");
+            var kbAudience = TryGetString(kbPayload, "aud");
+            if (!string.Equals(kbNonce, session.Nonce, StringComparison.Ordinal))
+            {
+                errors.Add("KB-JWT nonce does not match session.");
+            }
+            if (!string.Equals(kbAudience, session.ClientId, StringComparison.Ordinal))
+            {
+                errors.Add("KB-JWT aud does not match verifier client_id.");
+            }
+
+            // ── 7. Extract disclosed claims and check required set ────────────────
+            disclosed = ParseDisclosures(disclosureSegments);
+            foreach (var required in session.RequiredClaims)
+            {
+                if (!disclosed.ContainsKey(required))
+                {
+                    errors.Add($"Required claim '{required}' was not disclosed.");
+                }
+            }
+
+            if (errors.Count > 0) return Failure(errors);
+
+            _logger.LogInformation(
+                "Verifier session {SessionId} accepted: vct={Vct}, claims={Claims}",
+                session.SessionId, session.RequiredVct, disclosed.Count);
+
+            return new VerificationOutcome
+            {
+                Accepted = true,
+                DisclosedClaims = disclosed,
+                Errors = [],
+                CompletedAt = _clock.GetUtcNow(),
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Verifier session {SessionId} threw during validation", session.SessionId);
+            errors.Add($"Validator exception: {ex.Message}");
+            return Failure(errors);
+        }
+    }
+
+    private VerificationOutcome Failure(IReadOnlyList<string> errors) => new()
+    {
+        Accepted = false,
+        DisclosedClaims = new Dictionary<string, object?>(),
+        Errors = errors,
+        CompletedAt = _clock.GetUtcNow(),
+    };
+
+    // ─────────────────────────── parsing helpers ─────────────────────────────────
+
+    /// <summary>
+    /// Split the SD-JWT compact form. Format: <c>jwt~disclosure~...~kbjwt</c>
+    /// where every disclosure is a single base64url segment and the trailing KB-JWT
+    /// is itself a three-part JWT. The terminating <c>~</c> (no KB-JWT) is supported
+    /// but rejected upstream by this caller.
+    /// </summary>
+    internal static (string? Credential, IReadOnlyList<string> Disclosures, string? KbJwt) SplitSdJwt(string vp)
+    {
+        var segments = vp.Split('~');
+        if (segments.Length < 2) return (null, [], null);
+
+        var credential = segments[0];
+        // Last segment is either empty (no KB-JWT) or the KB-JWT itself (contains two dots).
+        var last = segments[^1];
+        var hasKbJwt = !string.IsNullOrEmpty(last) && last.Count(c => c == '.') == 2;
+
+        var disclosureCount = segments.Length - 1 - (hasKbJwt ? 1 : 0);
+        var disclosures = new List<string>(Math.Max(disclosureCount, 0));
+        for (int i = 1; i <= disclosureCount; i++)
+        {
+            if (!string.IsNullOrEmpty(segments[i])) disclosures.Add(segments[i]);
+        }
+        return (credential, disclosures, hasKbJwt ? last : null);
+    }
+
+    /// <summary>Parse a JWT's payload to a JsonElement; returns null if malformed.</summary>
+    internal static JsonElement? TryParseJwtPayload(string jwt)
+    {
+        try
+        {
+            var parts = jwt.Split('.');
+            if (parts.Length != 3) return null;
+            var bytes = Base64Url.DecodeFromChars(parts[1]);
+            return JsonSerializer.Deserialize<JsonElement>(bytes);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetString(JsonElement obj, string name)
+        => obj.ValueKind == JsonValueKind.Object
+           && obj.TryGetProperty(name, out var v)
+           && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static bool TryExtractCnfJwk(JsonElement payload, out JsonElement jwk)
+    {
+        jwk = default;
+        if (payload.ValueKind != JsonValueKind.Object) return false;
+        if (!payload.TryGetProperty("cnf", out var cnf)) return false;
+        if (cnf.ValueKind != JsonValueKind.Object) return false;
+        if (!cnf.TryGetProperty("jwk", out var inner)) return false;
+        if (inner.ValueKind != JsonValueKind.Object) return false;
+        jwk = inner;
+        return true;
+    }
+
+    /// <summary>
+    /// Parse the SD-JWT disclosure segments into a flat name→value dictionary.
+    /// Each disclosure is base64url(JSON array) of the form <c>[salt, name, value]</c>.
+    /// Mandatory-disclosure (no salt) form <c>[name, value]</c> is also tolerated.
+    /// </summary>
+    internal static Dictionary<string, object?> ParseDisclosures(IReadOnlyList<string> segments)
+    {
+        var disclosed = new Dictionary<string, object?>(segments.Count);
+        foreach (var seg in segments)
+        {
+            try
+            {
+                var bytes = Base64Url.DecodeFromChars(seg);
+                using var doc = JsonDocument.Parse(bytes);
+                if (doc.RootElement.ValueKind != JsonValueKind.Array) continue;
+                var array = doc.RootElement;
+                string? name;
+                JsonElement value;
+                if (array.GetArrayLength() == 3)
+                {
+                    name = array[1].GetString();
+                    value = array[2];
+                }
+                else if (array.GetArrayLength() == 2)
+                {
+                    name = array[0].GetString();
+                    value = array[1];
+                }
+                else continue;
+                if (string.IsNullOrEmpty(name)) continue;
+                disclosed[name] = value.Clone();
+            }
+            catch
+            {
+                // Malformed disclosures are dropped; the required-claim check downstream
+                // will surface the problem to the caller.
+            }
+        }
+        return disclosed;
+    }
+
+    // ─────────────────────────── delegation chain ────────────────────────────────
+
+    private async Task<List<string>> ValidateDelegationAsync(
+        string delegationCredential,
+        JsonElement holderJwk,
+        CancellationToken ct)
+    {
+        var errors = new List<string>();
+
+        var payload = TryParseJwtPayload(delegationCredential);
+        if (payload is null)
+        {
+            errors.Add("Delegation credential is malformed.");
+            return errors;
+        }
+
+        // Verify expiry
+        var now = _clock.GetUtcNow().ToUnixTimeSeconds();
+        var exp = payload.Value.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
+            ? expEl.GetInt64() : (long?)null;
+        if (exp is null || exp <= now)
+        {
+            errors.Add("Delegation credential is expired or missing exp claim.");
+            return errors;
+        }
+
+        // Verify signature with holder key
+        if (!VerifyJwsSignature(delegationCredential, holderJwk, out _))
+        {
+            errors.Add("Delegation credential signature verification failed against holder key.");
+            return errors;
+        }
+
+        // Check status list bit if present
+        if (payload.Value.TryGetProperty("status", out var status)
+            && status.ValueKind == JsonValueKind.Object
+            && status.TryGetProperty("status_list", out var sl)
+            && sl.ValueKind == JsonValueKind.Object
+            && sl.TryGetProperty("uri", out var uriEl) && uriEl.ValueKind == JsonValueKind.String
+            && sl.TryGetProperty("idx", out var idxEl) && idxEl.ValueKind == JsonValueKind.Number)
+        {
+            var revoked = await _statusListCache.IsRevokedAsync(uriEl.GetString()!, idxEl.GetInt32(), ct);
+            if (revoked)
+            {
+                errors.Add("Delegation credential has been revoked via status list.");
+            }
+        }
+
+        return errors;
+    }
+
+    // ─────────────────────────── JWS verification ────────────────────────────────
+
+    /// <summary>
+    /// Verify an ES256 JWS using a JWK. Returns true and the deserialised payload on success;
+    /// false otherwise. Only ES256 is supported in v1 (matches the citizen wallet's WebCrypto
+    /// non-extractable EC P-256 key).
+    /// </summary>
+    internal static bool VerifyJwsSignature(string compactJws, JsonElement publicJwk, out JsonElement payload)
+    {
+        payload = default;
+        try
+        {
+            var parts = compactJws.Split('.');
+            if (parts.Length != 3) return false;
+
+            var headerBytes = Base64Url.DecodeFromChars(parts[0]);
+            var header = JsonSerializer.Deserialize<JsonElement>(headerBytes);
+            var alg = header.TryGetProperty("alg", out var a) && a.ValueKind == JsonValueKind.String
+                ? a.GetString() : null;
+            if (!string.Equals(alg, "ES256", StringComparison.Ordinal)) return false;
+
+            // Reconstruct the EC public key from the JWK
+            var x = publicJwk.GetProperty("x").GetString();
+            var y = publicJwk.GetProperty("y").GetString();
+            if (x is null || y is null) return false;
+
+            using var ecdsa = ECDsa.Create(new ECParameters
+            {
+                Curve = ECCurve.NamedCurves.nistP256,
+                Q = new ECPoint
+                {
+                    X = Base64Url.DecodeFromChars(x),
+                    Y = Base64Url.DecodeFromChars(y),
+                },
+            });
+
+            var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+            var signature = Base64Url.DecodeFromChars(parts[2]);
+
+            if (!ecdsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256))
+            {
+                return false;
+            }
+
+            var payloadBytes = Base64Url.DecodeFromChars(parts[1]);
+            payload = JsonSerializer.Deserialize<JsonElement>(payloadBytes);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Verifier/Sorcha.Citizen.Verifier.csproj
+++ b/src/Apps/Sorcha.Citizen.Verifier/Sorcha.Citizen.Verifier.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="MudBlazor" />
+    <PackageReference Include="QRCoder" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -11,14 +11,16 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Register the PWA's services as singletons (single-user-per-tab).
-    /// v1 MVP wires in-memory implementations; the production WebCrypto +
-    /// IndexedDB-backed bridge implementations land with T054-T067 hardening.
+    /// IDeviceKeyService is wired to <see cref="WebCryptoDeviceKeyService"/> by
+    /// default — the InMemory variant is reserved for unit tests where IJSRuntime
+    /// isn't available. Cache + delegation + status-list start as in-memory MVP
+    /// impls; IndexedDB-backed replacements land with T060-T062.
     /// </summary>
     public static IServiceCollection AddCitizenWalletServices(this IServiceCollection services)
     {
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IPresentationEngine, PresentationEngine>();
-        services.AddSingleton<IDeviceKeyService, InMemoryDeviceKeyService>();
+        services.AddSingleton<IDeviceKeyService, WebCryptoDeviceKeyService>();
         services.AddSingleton<ICredentialCache, InMemoryCredentialCache>();
         services.AddSingleton<IDelegationStore, InMemoryDelegationStore>();
         services.AddSingleton<IStatusListService, NoopStatusListService>();

--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Citizen.Wallet.Services;
+using Sorcha.Citizen.Wallet.Services.Presentation;
+
+namespace Sorcha.Citizen.Wallet.Extensions;
+
+/// <summary>DI extensions for the citizen wallet PWA (Feature 114, T065).</summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the PWA's services as singletons (single-user-per-tab).
+    /// v1 MVP wires in-memory implementations; the production WebCrypto +
+    /// IndexedDB-backed bridge implementations land with T054-T067 hardening.
+    /// </summary>
+    public static IServiceCollection AddCitizenWalletServices(this IServiceCollection services)
+    {
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<IPresentationEngine, PresentationEngine>();
+        services.AddSingleton<IDeviceKeyService, InMemoryDeviceKeyService>();
+        services.AddSingleton<ICredentialCache, InMemoryCredentialCache>();
+        services.AddSingleton<IDelegationStore, InMemoryDelegationStore>();
+        services.AddSingleton<IStatusListService, NoopStatusListService>();
+        return services;
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/MainLayout.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/MainLayout.razor
@@ -1,8 +1,14 @@
 @*
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
+
+    Wallet shell layout (Feature 114, T067). Top app bar plus a bottom nav
+    rail with the four v1 destinations: Home / Devices / Activity / Settings.
+    The Devices/Activity/Settings pages land with US2-US5; the nav entries are
+    placed now so the app shape is final from the MVP demo on.
 *@
 @inherits LayoutComponentBase
+@inject NavigationManager Nav
 
 <MudThemeProvider />
 <MudPopoverProvider />
@@ -12,8 +18,24 @@
 <MudLayout>
     <MudAppBar Elevation="1">
         <MudText Typo="Typo.h6">Sorcha Wallet</MudText>
+        <MudSpacer />
+        <MudIconButton Icon="@Icons.Material.Filled.QrCodeScanner"
+                       Color="Color.Inherit"
+                       OnClick="@(() => Nav.NavigateTo("/present"))"
+                       aria-label="Present a credential" />
     </MudAppBar>
-    <MudMainContent>
+    <MudMainContent Class="pb-16">
         @Body
     </MudMainContent>
+    <MudAppBar Bottom="true" Fixed="true" Elevation="4" Color="Color.Surface" Class="d-flex justify-space-around">
+        <MudIconButton Icon="@Icons.Material.Filled.Home" OnClick="@(() => Nav.NavigateTo("/"))"
+                       aria-label="Home" />
+        <MudIconButton Icon="@Icons.Material.Filled.PhoneIphone" OnClick="@(() => Nav.NavigateTo("/devices"))"
+                       aria-label="Devices" />
+        <MudIconButton Icon="@Icons.Material.Filled.History" OnClick="@(() => Nav.NavigateTo("/activity"))"
+                       aria-label="Activity" />
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="@(() => Nav.NavigateTo("/settings"))"
+                       aria-label="Settings" />
+    </MudAppBar>
 </MudLayout>
+

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Activity.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Activity.razor
@@ -1,0 +1,17 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Placeholder Activity page (T142 — full implementation lands with US5).
+*@
+@page "/activity"
+@layout MainLayout
+
+<PageTitle>Activity</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5">Activity</MudText>
+    <MudAlert Severity="Severity.Info" Class="mt-3">
+        Local presentation log lands with US5.
+    </MudAlert>
+</MudContainer>

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Devices.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Devices.razor
@@ -1,0 +1,17 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Placeholder Devices page (T120 — full implementation lands with US3).
+*@
+@page "/devices"
+@layout MainLayout
+
+<PageTitle>Devices</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5">Your devices</MudText>
+    <MudAlert Severity="Severity.Info" Class="mt-3">
+        Device management lands with US3 (recovery flow).
+    </MudAlert>
+</MudContainer>

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -2,16 +2,56 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Placeholder home page for the citizen wallet PWA. Replaced by Home.razor
-    + EnrolmentWizard.razor in Phase 3 / US2 (T109-T110).
+    Wallet home (Feature 114, T110 placeholder). v1 MVP renders a minimal
+    landing page with a Present button — the credential list view + enrolment
+    wizard land with US2.
 *@
 @page "/"
+@layout MainLayout
+@using Sorcha.Citizen.Wallet.Services
+@using Sorcha.Citizen.Wallet.Services.Presentation
+@inject ICredentialCache Credentials
+@inject NavigationManager Nav
 
 <PageTitle>Sorcha Wallet</PageTitle>
 
-<MudContainer MaxWidth="MaxWidth.Small" Class="mt-8">
-    <MudText Typo="Typo.h4">Sorcha Citizen Wallet</MudText>
-    <MudText Typo="Typo.body1" Class="mt-2">
-        Feature 114 PWA shell. Real UI lands in Phase 3.
-    </MudText>
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5" Class="mb-3">Your credentials</MudText>
+
+    @if (_credentials is null)
+    {
+        <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+    }
+    else if (_credentials.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Class="mb-3">
+            No credentials yet. Enrol via the Sorcha web UI; they'll sync here once
+            US2 lands.
+        </MudAlert>
+    }
+    else
+    {
+        @foreach (var c in _credentials)
+        {
+            <MudCard Class="mb-3">
+                <MudCardContent>
+                    <MudText Typo="Typo.subtitle1">@(c.DisplayLabel ?? c.Vct)</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@c.Vct</MudText>
+                </MudCardContent>
+            </MudCard>
+        }
+    }
+
+    <MudButton Class="mt-4" Color="Color.Primary" Variant="Variant.Filled"
+               StartIcon="@Icons.Material.Filled.QrCodeScanner"
+               OnClick="@(() => Nav.NavigateTo("/present"))">
+        Present a credential
+    </MudButton>
 </MudContainer>
+
+@code {
+    private IReadOnlyList<CachedCredential>? _credentials;
+
+    protected override async Task OnInitializedAsync()
+        => _credentials = await Credentials.ListAsync();
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -2,15 +2,22 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Wallet home (Feature 114, T110 placeholder). v1 MVP renders a minimal
-    landing page with a Present button — the credential list view + enrolment
-    wizard land with US2.
+    Wallet home (Feature 114, T110 placeholder + demo-seed). v1 MVP: lists
+    cached credentials, exposes a Present button, and a "Load demo credential"
+    button that calls the verifier's /verify/demo/mint endpoint to seed the
+    cache without the full enrolment + issuance pipelines (which land with US2).
 *@
 @page "/"
 @layout MainLayout
+@using System.Net.Http
+@using System.Net.Http.Json
+@using System.Text.Json
 @using Sorcha.Citizen.Wallet.Services
 @using Sorcha.Citizen.Wallet.Services.Presentation
 @inject ICredentialCache Credentials
+@inject IDelegationStore Delegation
+@inject IDeviceKeyService DeviceKey
+@inject HttpClient Http
 @inject NavigationManager Nav
 
 <PageTitle>Sorcha Wallet</PageTitle>
@@ -25,8 +32,7 @@
     else if (_credentials.Count == 0)
     {
         <MudAlert Severity="Severity.Info" Class="mb-3">
-            No credentials yet. Enrol via the Sorcha web UI; they'll sync here once
-            US2 lands.
+            No credentials yet. Load a demo credential or wait for US2 enrolment.
         </MudAlert>
     }
     else
@@ -37,21 +43,76 @@
                 <MudCardContent>
                     <MudText Typo="Typo.subtitle1">@(c.DisplayLabel ?? c.Vct)</MudText>
                     <MudText Typo="Typo.caption" Color="Color.Secondary">@c.Vct</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="d-block">
+                        Claims: @string.Join(", ", c.AvailableClaimNames)
+                    </MudText>
                 </MudCardContent>
             </MudCard>
         }
     }
 
-    <MudButton Class="mt-4" Color="Color.Primary" Variant="Variant.Filled"
-               StartIcon="@Icons.Material.Filled.QrCodeScanner"
-               OnClick="@(() => Nav.NavigateTo("/present"))">
-        Present a credential
-    </MudButton>
+    <MudStack Row="true" Spacing="2" Class="mt-4">
+        <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                   StartIcon="@Icons.Material.Filled.QrCodeScanner"
+                   OnClick="@(() => Nav.NavigateTo("/present"))"
+                   Disabled="@(_credentials is null || _credentials.Count == 0)">
+            Present a credential
+        </MudButton>
+        <MudButton Color="Color.Secondary" Variant="Variant.Outlined"
+                   OnClick="LoadDemoAsync" Disabled="@_seeding">
+            @(_seeding ? "Loading…" : "Load demo credential")
+        </MudButton>
+    </MudStack>
+
+    @if (!string.IsNullOrEmpty(_seedError))
+    {
+        <MudAlert Severity="Severity.Error" Class="mt-3">@_seedError</MudAlert>
+    }
 </MudContainer>
 
 @code {
     private IReadOnlyList<CachedCredential>? _credentials;
+    private bool _seeding;
+    private string? _seedError;
 
     protected override async Task OnInitializedAsync()
         => _credentials = await Credentials.ListAsync();
+
+    private async Task LoadDemoAsync()
+    {
+        _seedError = null;
+        _seeding = true;
+        try
+        {
+            var deviceJwk = await DeviceKey.GetPublicJwkAsync();
+            var mintUri = new Uri(new Uri(Nav.BaseUri), "../verify/demo/mint");
+            var resp = await Http.PostAsJsonAsync(mintUri, new { deviceJwk });
+            resp.EnsureSuccessStatusCode();
+            var minted = await resp.Content.ReadFromJsonAsync<DemoMintShape>();
+            if (minted is null) throw new InvalidOperationException("Empty mint response.");
+
+            await Credentials.UpsertAsync(new CachedCredential
+            {
+                Id = minted.CredentialId,
+                Vct = minted.Vct,
+                RawSdJwt = minted.RawSdJwt,
+                AvailableClaimNames = minted.AvailableClaimNames,
+                DisplayLabel = minted.DisplayLabel,
+                IssuerDid = "did:sorcha:org:demo",
+            });
+            await Delegation.SetAsync(minted.DelegationJwt);
+            _credentials = await Credentials.ListAsync();
+        }
+        catch (Exception ex) { _seedError = ex.Message; }
+        finally { _seeding = false; }
+    }
+
+    private sealed record DemoMintShape(
+        Guid CredentialId,
+        string Vct,
+        string DisplayLabel,
+        string RawSdJwt,
+        IReadOnlyList<string> AvailableClaimNames,
+        string DelegationJwt,
+        JsonElement HolderPublicJwk);
 }

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Present.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Present.razor
@@ -1,0 +1,204 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Citizen wallet present page (Feature 114, T096-T100). v1 MVP:
+    paste an openid4vp:// deep link, pick a credential, approve disclosure
+    (required claims locked, optional toggleable), POST the vp_token to the
+    verifier's response_uri. QR scanner integration is queued for hardening.
+*@
+@page "/present"
+@layout MainLayout
+@using System.Net.Http
+@using System.Net.Http.Json
+@using System.Text.Json
+@using Sorcha.Citizen.Wallet.Services
+@using Sorcha.Citizen.Wallet.Services.Presentation
+@inject IPresentationEngine Engine
+@inject ICredentialCache Credentials
+@inject IDeviceKeyService DeviceKey
+@inject IDelegationStore Delegation
+@inject IStatusListService StatusList
+@inject HttpClient Http
+
+<PageTitle>Present a credential</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5" Class="mb-3">Present a credential</MudText>
+
+    @if (_phase == Phase.AwaitingDeepLink)
+    {
+        <MudPaper Elevation="1" Class="pa-4">
+            <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+                Paste the verifier's <code>openid4vp://</code> link. (QR camera scan
+                lands in a follow-up; for the MVP demo we paste.)
+            </MudText>
+            <MudTextField @bind-Value="_deepLink"
+                          Label="Verifier deep link"
+                          Lines="3" Variant="Variant.Outlined" />
+            <MudButton Class="mt-3" Color="Color.Primary" Variant="Variant.Filled"
+                       OnClick="ParseAsync">
+                Continue
+            </MudButton>
+        </MudPaper>
+    }
+    else if (_phase == Phase.NoMatch)
+    {
+        <MudAlert Severity="Severity.Warning" Class="mb-3">
+            None of your credentials match this verifier's request for <code>@_request?.RequiredVct</code>.
+        </MudAlert>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Cancel</MudButton>
+    }
+    else if (_phase == Phase.PickCredential && _matches is not null)
+    {
+        <MudText Typo="Typo.subtitle1" Class="mb-2">Choose a credential</MudText>
+        <MudList T="CredentialMatch" SelectedValueChanged="OnCredentialChosen">
+            @foreach (var m in _matches)
+            {
+                <MudListItem T="CredentialMatch" Value="m">
+                    <strong>@(m.Credential.DisplayLabel ?? m.Credential.Vct)</strong>
+                    <MudText Typo="Typo.caption">id: @m.Credential.Id</MudText>
+                </MudListItem>
+            }
+        </MudList>
+        <MudButton Class="mt-3" Variant="Variant.Outlined" OnClick="Reset">Cancel</MudButton>
+    }
+    else if (_phase == Phase.Consent && _selected is not null && _request is not null)
+    {
+        <MudPaper Elevation="2" Class="pa-4">
+            <MudText Typo="Typo.subtitle1">@_request.Purpose</MudText>
+            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-3 d-block">
+                Audience: <code>@_request.ClientId</code>
+            </MudText>
+
+            <MudText Typo="Typo.body2" Class="mt-3 mb-1"><strong>Required (always shared):</strong></MudText>
+            @foreach (var name in _selected.SatisfiedRequired)
+            {
+                <MudCheckBox T="bool" Value="true" Disabled="true" Label="@name" />
+            }
+
+            @if (_selected.AvailableOptional.Count > 0)
+            {
+                <MudText Typo="Typo.body2" Class="mt-3 mb-1"><strong>Optional:</strong></MudText>
+                @foreach (var name in _selected.AvailableOptional)
+                {
+                    <MudCheckBox T="bool" @bind-Value="_optionalToggles[name]" Label="@name" />
+                }
+            }
+
+            <MudButton Class="mt-4 mr-2" Color="Color.Primary" Variant="Variant.Filled"
+                       OnClick="ConfirmAsync" Disabled="@_busy">
+                @(_busy ? "Sharing…" : "Hold to share")
+            </MudButton>
+            <MudButton Variant="Variant.Outlined" OnClick="Reset" Disabled="@_busy">Cancel</MudButton>
+        </MudPaper>
+    }
+    else if (_phase == Phase.Done)
+    {
+        <MudAlert Severity="@(_responseStatus == "ok" ? Severity.Success : Severity.Error)" Class="mb-3">
+            @_responseMessage
+        </MudAlert>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Done</MudButton>
+    }
+
+    @if (!string.IsNullOrEmpty(_error))
+    {
+        <MudAlert Severity="Severity.Error" Class="mt-3">@_error</MudAlert>
+    }
+</MudContainer>
+
+@code {
+    private enum Phase { AwaitingDeepLink, NoMatch, PickCredential, Consent, Done }
+
+    private Phase _phase = Phase.AwaitingDeepLink;
+    private string _deepLink = string.Empty;
+    private string? _error;
+    private bool _busy;
+    private ParsedPresentationRequest? _request;
+    private IReadOnlyList<CredentialMatch>? _matches;
+    private CredentialMatch? _selected;
+    private Dictionary<string, bool> _optionalToggles = new();
+    private string _responseStatus = string.Empty;
+    private string _responseMessage = string.Empty;
+
+    private async Task ParseAsync()
+    {
+        _error = null;
+        try
+        {
+            _request = Engine.Parse(_deepLink.Trim());
+            var creds = await Credentials.ListAsync();
+            _matches = Engine.Match(_request, creds);
+            if (_matches.Count == 0) { _phase = Phase.NoMatch; return; }
+            if (_matches.Count == 1)
+            {
+                _selected = _matches[0];
+                EnterConsent();
+                return;
+            }
+            _phase = Phase.PickCredential;
+        }
+        catch (Exception ex) { _error = ex.Message; }
+    }
+
+    private void OnCredentialChosen(CredentialMatch? match)
+    {
+        if (match is null) return;
+        _selected = match;
+        EnterConsent();
+    }
+
+    private void EnterConsent()
+    {
+        _optionalToggles = (_selected?.AvailableOptional ?? Array.Empty<string>())
+            .ToDictionary(n => n, _ => false);
+        _phase = Phase.Consent;
+    }
+
+    private async Task ConfirmAsync()
+    {
+        if (_selected is null || _request is null) return;
+        _busy = true;
+        _error = null;
+        try
+        {
+            var approved = _selected.SatisfiedRequired
+                .Concat(_optionalToggles.Where(kv => kv.Value).Select(kv => kv.Key))
+                .ToList();
+
+            var deviceJwk = await DeviceKey.GetPublicJwkAsync();
+            var vp = await Engine.BuildVpTokenAsync(
+                _selected, approved, _request, deviceJwk, DeviceKey.SignAsync);
+
+            var delegationJwt = await Delegation.GetCurrentAsync();
+            var body = new { vpToken = vp, delegation = delegationJwt };
+            var resp = await Http.PostAsJsonAsync(_request.ResponseUri, body);
+            if (resp.IsSuccessStatusCode)
+            {
+                _responseStatus = "ok";
+                _responseMessage = "Verifier accepted the presentation.";
+            }
+            else
+            {
+                _responseStatus = "fail";
+                _responseMessage = $"Verifier returned {(int)resp.StatusCode} {resp.StatusCode}.";
+            }
+            _phase = Phase.Done;
+        }
+        catch (Exception ex) { _error = ex.Message; }
+        finally { _busy = false; }
+    }
+
+    private void Reset()
+    {
+        _phase = Phase.AwaitingDeepLink;
+        _deepLink = string.Empty;
+        _request = null;
+        _matches = null;
+        _selected = null;
+        _optionalToggles = new();
+        _error = null;
+        _responseMessage = string.Empty;
+        _responseStatus = string.Empty;
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Settings.razor
@@ -1,0 +1,17 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Placeholder Settings page (T112 — full implementation lands with US2).
+*@
+@page "/settings"
+@layout MainLayout
+
+<PageTitle>Settings</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5">Settings</MudText>
+    <MudAlert Severity="Severity.Info" Class="mt-3">
+        Lock, sign-out, storage estimate land with US2.
+    </MudAlert>
+</MudContainer>

--- a/src/Apps/Sorcha.Citizen.Wallet/Program.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using Sorcha.Citizen.Wallet;
+using Sorcha.Citizen.Wallet.Extensions;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -14,5 +15,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddAuthorizationCore();
 builder.Services.AddMudServices();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddCitizenWalletServices();
 
 await builder.Build().RunAsync();

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/ICredentialCache.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/ICredentialCache.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Citizen.Wallet.Services.Presentation;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Local credential cache. v1 demo keeps everything in memory; the production impl
+/// (T060) backs a per-credential row in IndexedDB store <c>credentials</c>,
+/// XChaCha20-Poly1305-encrypted under the device-derived content key.
+/// </summary>
+public interface ICredentialCache
+{
+    /// <summary>List all cached credentials available for presentation.</summary>
+    Task<IReadOnlyList<CachedCredential>> ListAsync(CancellationToken ct = default);
+
+    /// <summary>Add (or replace) a credential.</summary>
+    Task UpsertAsync(CachedCredential credential, CancellationToken ct = default);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IDelegationStore.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IDelegationStore.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Holds the wallet's current device delegation credential. Production impl (T061)
+/// is a singleton row in IndexedDB store <c>delegation</c>; v1 demo is in-memory.
+/// </summary>
+public interface IDelegationStore
+{
+    /// <summary>Returns the current compact delegation JWT, or null if not yet enrolled.</summary>
+    Task<string?> GetCurrentAsync(CancellationToken ct = default);
+
+    /// <summary>Replace the current delegation (e.g. after enrolment or renewal).</summary>
+    Task SetAsync(string compactJwt, CancellationToken ct = default);
+}
+
+/// <summary>Demo-grade in-memory <see cref="IDelegationStore"/>.</summary>
+public sealed class InMemoryDelegationStore : IDelegationStore
+{
+    private string? _jwt;
+
+    /// <inheritdoc />
+    public Task<string?> GetCurrentAsync(CancellationToken ct = default) => Task.FromResult(_jwt);
+
+    /// <inheritdoc />
+    public Task SetAsync(string compactJwt, CancellationToken ct = default)
+    {
+        _jwt = compactJwt;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IDeviceKeyService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IDeviceKeyService.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Wraps the device's signing key for the citizen wallet PWA. Production deployments
+/// hold the key as a non-extractable WebCrypto <c>CryptoKey</c> via the
+/// <c>webcrypto-bridge.js</c> JS interop module (T055). v1 ships an in-memory
+/// fallback for the MVP demo so the architecture can be exercised without the JS
+/// bridge — the bridge is queued for the Phase 8 hardening pass.
+/// </summary>
+public interface IDeviceKeyService
+{
+    /// <summary>Get (creating on first call) the device public JWK for the local wallet.</summary>
+    Task<JsonElement> GetPublicJwkAsync(CancellationToken ct = default);
+
+    /// <summary>RFC 7638 thumbprint of the device JWK — stable id used in headers.</summary>
+    Task<string> GetThumbprintAsync(CancellationToken ct = default);
+
+    /// <summary>Sign raw bytes with the device key. Returns the raw signature (ASN.1 fixed format for ES256).</summary>
+    Task<byte[]> SignAsync(byte[] data, CancellationToken ct = default);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IStatusListService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IStatusListService.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// PWA-side mirror of the verifier <c>IStatusListCache</c>. Used by the wallet
+/// during pre-flight to refuse presentations from credentials it knows are
+/// already revoked. Production impl (T062) backs IndexedDB store <c>statusLists</c>.
+/// </summary>
+public interface IStatusListService
+{
+    /// <summary>Returns true if bit <paramref name="index"/> in the list at <paramref name="uri"/> is set.</summary>
+    Task<bool> IsRevokedAsync(string uri, int index, CancellationToken ct = default);
+}
+
+/// <summary>Always-active demo impl — no revocation in v1 MVP.</summary>
+public sealed class NoopStatusListService : IStatusListService
+{
+    /// <inheritdoc />
+    public Task<bool> IsRevokedAsync(string uri, int index, CancellationToken ct = default)
+        => Task.FromResult(false);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/InMemoryCredentialCache.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/InMemoryCredentialCache.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using Sorcha.Citizen.Wallet.Services.Presentation;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Demo-grade in-memory <see cref="ICredentialCache"/>. The production impl
+/// (T060) replaces this with an IndexedDB-backed store wrapped in
+/// XChaCha20-Poly1305 via the libsodium-js bridge.
+/// </summary>
+public sealed class InMemoryCredentialCache : ICredentialCache
+{
+    private readonly ConcurrentDictionary<Guid, CachedCredential> _store = new();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CachedCredential>> ListAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<CachedCredential>>(_store.Values.ToList());
+
+    /// <inheritdoc />
+    public Task UpsertAsync(CachedCredential credential, CancellationToken ct = default)
+    {
+        _store[credential.Id] = credential;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/InMemoryDeviceKeyService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/InMemoryDeviceKeyService.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Demo-grade <see cref="IDeviceKeyService"/>. Generates and caches an ECDSA P-256
+/// keypair in-memory for the lifetime of the WASM runtime. <strong>Not production</strong>:
+/// the production impl wraps a non-extractable WebCrypto <c>CryptoKey</c> (T055).
+/// </summary>
+public sealed class InMemoryDeviceKeyService : IDeviceKeyService, IDisposable
+{
+    private readonly object _lock = new();
+    private ECDsa? _ecdsa;
+    private string? _publicJwkJson;
+    private string? _thumbprint;
+
+    /// <inheritdoc />
+    public Task<JsonElement> GetPublicJwkAsync(CancellationToken ct = default)
+    {
+        EnsureKey();
+        return Task.FromResult(JsonSerializer.Deserialize<JsonElement>(_publicJwkJson!));
+    }
+
+    /// <inheritdoc />
+    public Task<string> GetThumbprintAsync(CancellationToken ct = default)
+    {
+        EnsureKey();
+        return Task.FromResult(_thumbprint!);
+    }
+
+    /// <inheritdoc />
+    public Task<byte[]> SignAsync(byte[] data, CancellationToken ct = default)
+    {
+        EnsureKey();
+        return Task.FromResult(_ecdsa!.SignData(data, HashAlgorithmName.SHA256));
+    }
+
+    private void EnsureKey()
+    {
+        if (_ecdsa is not null) return;
+        lock (_lock)
+        {
+            if (_ecdsa is not null) return;
+            // CA1416: ECDsa.Create(ECCurve) is flagged unsupported on 'browser', but recent
+            // .NET 10 mono-wasm builds DO ship ECDsa via crypto.subtle interop. Either way,
+            // T055 replaces this with the explicit webcrypto-bridge.js path so this call site
+            // disappears in production. Suppressed here because the MVP demo runs against
+            // a runtime where the call works.
+#pragma warning disable CA1416
+            _ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+#pragma warning restore CA1416
+            var p = _ecdsa.ExportParameters(false);
+            var x = Base64Url.EncodeToString(p.Q.X!);
+            var y = Base64Url.EncodeToString(p.Q.Y!);
+            _publicJwkJson = JsonSerializer.Serialize(new { kty = "EC", crv = "P-256", x, y });
+            var canonical = $"{{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{x}\",\"y\":\"{y}\"}}";
+            _thumbprint = Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _ecdsa?.Dispose();
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/IPresentationEngine.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/IPresentationEngine.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Wallet.Services.Presentation;
+
+/// <summary>
+/// Citizen wallet presentation engine (Feature 114, T094). Pure C# — IO-free
+/// except via the <paramref name="deviceSigner"/> delegate, so it runs in the
+/// WASM sandbox without touching JS interop directly.
+///
+/// <para>The signer delegate hides the WebCrypto non-extractable device key:
+/// callers wire it to <c>IDeviceKeyService.SignAsync</c>, which round-trips through
+/// the <c>webcrypto-bridge.js</c> module.</para>
+/// </summary>
+public interface IPresentationEngine
+{
+    /// <summary>Parse an <c>openid4vp://</c> deep link into a structured request.</summary>
+    /// <exception cref="System.FormatException">If the link is not a recognised OID4VP URL.</exception>
+    ParsedPresentationRequest Parse(string openid4vpDeepLink);
+
+    /// <summary>Match a request against the wallet's cached credentials.</summary>
+    /// <returns>Empty if no credential satisfies every required claim.</returns>
+    IReadOnlyList<CredentialMatch> Match(
+        ParsedPresentationRequest request,
+        IReadOnlyList<CachedCredential> credentials);
+
+    /// <summary>
+    /// Build the on-the-wire <c>vp_token</c> for the chosen credential, including
+    /// only the approved disclosure subset and a KB-JWT signed by the device key.
+    /// </summary>
+    /// <param name="match">Selected credential + capability snapshot from <see cref="Match"/>.</param>
+    /// <param name="approvedClaims">Claim names the citizen approved for disclosure (must include all required, may include optional).</param>
+    /// <param name="request">The original request (for nonce + audience binding).</param>
+    /// <param name="deviceJwk">Public JWK of the device key — embedded as <c>kid</c> identifier in the KB-JWT header.</param>
+    /// <param name="deviceSigner">Async delegate that signs raw bytes with the non-extractable WebCrypto device key.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<string> BuildVpTokenAsync(
+        CredentialMatch match,
+        IReadOnlyList<string> approvedClaims,
+        ParsedPresentationRequest request,
+        System.Text.Json.JsonElement deviceJwk,
+        Func<byte[], CancellationToken, Task<byte[]>> deviceSigner,
+        CancellationToken ct = default);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/Models.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/Models.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Wallet.Services.Presentation;
+
+/// <summary>Parsed shape of an <c>openid4vp://</c> cross-device deep link.</summary>
+public sealed record ParsedPresentationRequest
+{
+    /// <summary>The verifier's audience claim — wallet's KB-JWT must echo this in <c>aud</c>.</summary>
+    public required string ClientId { get; init; }
+
+    /// <summary>URL the wallet POSTs the vp_token to (response_uri).</summary>
+    public required string ResponseUri { get; init; }
+
+    /// <summary>Verifier-supplied nonce — wallet's KB-JWT must echo it.</summary>
+    public required string Nonce { get; init; }
+
+    /// <summary>Required credential type URI from the presentation_definition.</summary>
+    public required string RequiredVct { get; init; }
+
+    /// <summary>Mandatory claim names the wallet must disclose.</summary>
+    public required IReadOnlyList<string> RequiredClaims { get; init; }
+
+    /// <summary>Optional claim names the wallet may disclose.</summary>
+    public required IReadOnlyList<string> OptionalClaims { get; init; }
+
+    /// <summary>Display purpose extracted from the presentation_definition.</summary>
+    public string? Purpose { get; init; }
+
+    /// <summary>Response mode; v1 supports <c>direct_post</c>.</summary>
+    public string ResponseMode { get; init; } = "direct_post";
+}
+
+/// <summary>
+/// A credential present in the wallet's cache, in the shape the presentation engine needs.
+/// In production this is materialised by <c>ICredentialCache</c> on demand from IndexedDB.
+/// </summary>
+public sealed record CachedCredential
+{
+    /// <summary>Credential id (UUID assigned by the issuer).</summary>
+    public required Guid Id { get; init; }
+
+    /// <summary>Credential type URI.</summary>
+    public required string Vct { get; init; }
+
+    /// <summary>
+    /// SD-JWT VC compact form: <c>credentialJwt~disclosure1~..~disclosureN</c>.
+    /// Trailing tilde is preserved if present. Does NOT include a KB-JWT — that's
+    /// minted at presentation time.
+    /// </summary>
+    public required string RawSdJwt { get; init; }
+
+    /// <summary>Names of every disclosable claim available in this credential.</summary>
+    public required IReadOnlyList<string> AvailableClaimNames { get; init; }
+
+    /// <summary>Issuer DID — surfaced for the consent sheet.</summary>
+    public string? IssuerDid { get; init; }
+
+    /// <summary>Optional display label (issuer-supplied).</summary>
+    public string? DisplayLabel { get; init; }
+}
+
+/// <summary>
+/// Match result: a cached credential with the disclosure plan for the request.
+/// A match exists only when every required claim is satisfiable.
+/// </summary>
+public sealed record CredentialMatch
+{
+    /// <summary>The matched credential.</summary>
+    public required CachedCredential Credential { get; init; }
+
+    /// <summary>Required claim names this credential can satisfy.</summary>
+    public required IReadOnlyList<string> SatisfiedRequired { get; init; }
+
+    /// <summary>Optional claim names this credential could additionally disclose.</summary>
+    public required IReadOnlyList<string> AvailableOptional { get; init; }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/PresentationEngine.cs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Collections.Specialized;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Web;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.Citizen.Wallet.Services.Presentation;
+
+/// <summary>
+/// Default <see cref="IPresentationEngine"/>. v1 understands the unsigned
+/// query-parameter form of <c>openid4vp://</c> the reference verifier emits
+/// (research §R-008). Signed-request mode is a hardening item for a later phase.
+/// </summary>
+public sealed class PresentationEngine : IPresentationEngine
+{
+    private readonly TimeProvider _clock;
+    private readonly ILogger<PresentationEngine> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public PresentationEngine(TimeProvider clock, ILogger<PresentationEngine> logger)
+    {
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public ParsedPresentationRequest Parse(string openid4vpDeepLink)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(openid4vpDeepLink);
+        if (!openid4vpDeepLink.StartsWith("openid4vp://", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new FormatException("Deep link must start with openid4vp://");
+        }
+
+        var queryStart = openid4vpDeepLink.IndexOf('?');
+        if (queryStart < 0)
+        {
+            throw new FormatException("Deep link is missing the query component.");
+        }
+
+        NameValueCollection parsed = HttpUtility.ParseQueryString(openid4vpDeepLink[(queryStart + 1)..]);
+
+        var clientId = parsed["client_id"]
+            ?? throw new FormatException("Deep link is missing client_id.");
+        var responseUri = parsed["response_uri"]
+            ?? throw new FormatException("Deep link is missing response_uri.");
+        var nonce = parsed["nonce"]
+            ?? throw new FormatException("Deep link is missing nonce.");
+        var responseMode = parsed["response_mode"] ?? "direct_post";
+
+        var pdJson = parsed["presentation_definition"]
+            ?? throw new FormatException("Deep link is missing presentation_definition.");
+
+        var (vct, required, optional, purpose) = ParsePresentationDefinition(pdJson);
+
+        return new ParsedPresentationRequest
+        {
+            ClientId = clientId,
+            ResponseUri = responseUri,
+            Nonce = nonce,
+            RequiredVct = vct,
+            RequiredClaims = required,
+            OptionalClaims = optional,
+            Purpose = purpose,
+            ResponseMode = responseMode,
+        };
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<CredentialMatch> Match(
+        ParsedPresentationRequest request,
+        IReadOnlyList<CachedCredential> credentials)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        var matches = new List<CredentialMatch>();
+        foreach (var credential in credentials)
+        {
+            if (!string.Equals(credential.Vct, request.RequiredVct, StringComparison.Ordinal)) continue;
+
+            var availableNames = new HashSet<string>(credential.AvailableClaimNames, StringComparer.Ordinal);
+            var satisfied = request.RequiredClaims.Where(c => availableNames.Contains(c)).ToList();
+            if (satisfied.Count != request.RequiredClaims.Count)
+            {
+                continue;
+            }
+
+            var optional = request.OptionalClaims.Where(c => availableNames.Contains(c)).ToList();
+            matches.Add(new CredentialMatch
+            {
+                Credential = credential,
+                SatisfiedRequired = satisfied,
+                AvailableOptional = optional,
+            });
+        }
+
+        return matches;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> BuildVpTokenAsync(
+        CredentialMatch match,
+        IReadOnlyList<string> approvedClaims,
+        ParsedPresentationRequest request,
+        JsonElement deviceJwk,
+        Func<byte[], CancellationToken, Task<byte[]>> deviceSigner,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(match);
+        ArgumentNullException.ThrowIfNull(approvedClaims);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(deviceSigner);
+
+        // Sanity check: every required claim must be in the approved set.
+        foreach (var required in request.RequiredClaims)
+        {
+            if (!approvedClaims.Contains(required, StringComparer.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Approved claims do not cover required claim '{required}'.");
+            }
+        }
+
+        var (credentialJwt, allDisclosures, _) = SplitSdJwt(match.Credential.RawSdJwt);
+        if (credentialJwt is null)
+        {
+            throw new InvalidOperationException("Cached credential is not a valid SD-JWT.");
+        }
+
+        // Pick only the disclosures whose claim name was approved.
+        var approvedSet = new HashSet<string>(approvedClaims, StringComparer.Ordinal);
+        var selected = new List<string>(allDisclosures.Count);
+        foreach (var seg in allDisclosures)
+        {
+            var name = ReadDisclosureName(seg);
+            if (name is not null && approvedSet.Contains(name))
+            {
+                selected.Add(seg);
+            }
+        }
+
+        // KB-JWT — header carries the device-key thumbprint as kid; payload binds nonce+aud.
+        var kid = ComputeJwkThumbprint(deviceJwk);
+        var header = new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = "kb+jwt",
+            ["kid"] = kid,
+        };
+        // sd_hash per RFC 9901 §4.3 — SHA-256 of the to-be-presented hashable form.
+        // Compute over the canonical "credentialJwt~disclosure1~..~" prefix.
+        var hashable = credentialJwt + string.Concat(selected.Select(s => "~" + s)) + "~";
+        var sdHash = Base64Url.EncodeToString(SHA256.HashData(Encoding.ASCII.GetBytes(hashable)));
+
+        var payload = new Dictionary<string, object>
+        {
+            ["iat"] = _clock.GetUtcNow().ToUnixTimeSeconds(),
+            ["aud"] = request.ClientId,
+            ["nonce"] = request.Nonce,
+            ["sd_hash"] = sdHash,
+        };
+
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.ASCII.GetBytes($"{headerSeg}.{payloadSeg}");
+        var signature = await deviceSigner(signingInput, ct);
+        var kbJwt = $"{headerSeg}.{payloadSeg}.{Base64Url.EncodeToString(signature)}";
+
+        var vpToken = hashable + kbJwt;
+        _logger.LogInformation(
+            "Built vp_token: credentialId={Id}, disclosures={Count}, audience={Aud}",
+            match.Credential.Id, selected.Count, request.ClientId);
+        return vpToken;
+    }
+
+    // ─────────────────────────── parsing helpers ─────────────────────────────────
+
+    /// <summary>
+    /// Parse the verifier-supplied PEX presentation_definition into the simplified
+    /// shape the engine consumes: required vct, required claim names, optional claim names.
+    /// Mirror image of <c>PresentationRequestBuilder.BuildPresentationDefinitionJson</c>.
+    /// </summary>
+    internal static (string Vct, IReadOnlyList<string> Required, IReadOnlyList<string> Optional, string? Purpose)
+        ParsePresentationDefinition(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var inputDescriptors = root.GetProperty("input_descriptors");
+        if (inputDescriptors.GetArrayLength() == 0)
+        {
+            throw new FormatException("presentation_definition has no input_descriptors.");
+        }
+        var primary = inputDescriptors[0];
+        var purpose = primary.TryGetProperty("purpose", out var p) && p.ValueKind == JsonValueKind.String
+            ? p.GetString() : null;
+
+        var fields = primary.GetProperty("constraints").GetProperty("fields");
+
+        string? vct = null;
+        var required = new List<string>();
+        var optional = new List<string>();
+
+        foreach (var field in fields.EnumerateArray())
+        {
+            var paths = field.GetProperty("path");
+            if (paths.GetArrayLength() == 0) continue;
+            var path = paths[0].GetString();
+            if (path is null) continue;
+
+            // vct constraint
+            if (path == "$.vct" && field.TryGetProperty("filter", out var filter)
+                && filter.TryGetProperty("const", out var constEl)
+                && constEl.ValueKind == JsonValueKind.String)
+            {
+                vct = constEl.GetString();
+                continue;
+            }
+
+            // claim field — convert "$.givenName" → "givenName", or "$.foo.bar" → "/foo/bar"
+            var claimName = FromJsonPath(path);
+            var isOptional = field.TryGetProperty("optional", out var opt)
+                && opt.ValueKind == JsonValueKind.True;
+            if (isOptional) optional.Add(claimName);
+            else required.Add(claimName);
+        }
+
+        if (vct is null)
+        {
+            throw new FormatException("presentation_definition is missing a vct constraint.");
+        }
+        return (vct, required, optional, purpose);
+    }
+
+    private static string FromJsonPath(string path)
+    {
+        if (!path.StartsWith("$.", StringComparison.Ordinal)) return path;
+        var rest = path[2..];
+        return rest.Contains('.') ? "/" + rest.Replace('.', '/') : rest;
+    }
+
+    /// <summary>
+    /// Split the SD-JWT compact form into (credentialJwt, disclosures, kbJwt). Mirror
+    /// of <c>VerifiablePresentationValidator.SplitSdJwt</c> — duplicated here to avoid a
+    /// project reference between wallet and verifier (they ship as separate apps).
+    /// </summary>
+    internal static (string? Credential, IReadOnlyList<string> Disclosures, string? KbJwt) SplitSdJwt(string vp)
+    {
+        var segments = vp.Split('~');
+        if (segments.Length < 1) return (null, [], null);
+
+        var credential = segments[0];
+        var last = segments[^1];
+        var hasKbJwt = !string.IsNullOrEmpty(last) && last.Count(c => c == '.') == 2;
+
+        var disclosureCount = segments.Length - 1 - (hasKbJwt ? 1 : 0);
+        var disclosures = new List<string>(Math.Max(disclosureCount, 0));
+        for (int i = 1; i <= disclosureCount; i++)
+        {
+            if (!string.IsNullOrEmpty(segments[i])) disclosures.Add(segments[i]);
+        }
+        return (credential, disclosures, hasKbJwt ? last : null);
+    }
+
+    /// <summary>Read the claim name out of a single SD-JWT disclosure segment.</summary>
+    internal static string? ReadDisclosureName(string segment)
+    {
+        try
+        {
+            var bytes = Base64Url.DecodeFromChars(segment);
+            using var doc = JsonDocument.Parse(bytes);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array) return null;
+            return doc.RootElement.GetArrayLength() switch
+            {
+                3 => doc.RootElement[1].GetString(),
+                2 => doc.RootElement[0].GetString(),
+                _ => null,
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Compute the RFC 7638 JWK thumbprint for an EC P-256 public JWK.</summary>
+    internal static string ComputeJwkThumbprint(JsonElement jwk)
+    {
+        var crv = jwk.GetProperty("crv").GetString();
+        var kty = jwk.GetProperty("kty").GetString();
+        var x = jwk.GetProperty("x").GetString();
+        var y = jwk.GetProperty("y").GetString();
+        var canonical = $"{{\"crv\":\"{crv}\",\"kty\":\"{kty}\",\"x\":\"{x}\",\"y\":\"{y}\"}}";
+        return Base64Url.EncodeToString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)));
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/WebCryptoDeviceKeyService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/WebCryptoDeviceKeyService.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Production <see cref="IDeviceKeyService"/> backed by the WebCrypto
+/// <c>crypto.subtle</c> API via the <c>webcrypto-bridge.js</c> module. The
+/// underlying private key is non-extractable — it never leaves the browser's
+/// crypto store and never crosses the JS-interop boundary; only the public
+/// JWK and signature bytes do.
+/// </summary>
+public sealed class WebCryptoDeviceKeyService : IDeviceKeyService
+{
+    private const string KeyId = "sorcha-wallet-device";
+    private readonly IJSRuntime _js;
+    private bool _generated;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <summary>Initialises a new instance.</summary>
+    public WebCryptoDeviceKeyService(IJSRuntime js)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+    }
+
+    /// <inheritdoc />
+    public async Task<JsonElement> GetPublicJwkAsync(CancellationToken ct = default)
+    {
+        await EnsureKeyAsync(ct);
+        var json = await _js.InvokeAsync<string>("SorchaWebCrypto.getPublicJwk", ct, KeyId);
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetThumbprintAsync(CancellationToken ct = default)
+    {
+        await EnsureKeyAsync(ct);
+        return await _js.InvokeAsync<string>("SorchaWebCrypto.getThumbprint", ct, KeyId);
+    }
+
+    /// <inheritdoc />
+    public async Task<byte[]> SignAsync(byte[] data, CancellationToken ct = default)
+    {
+        await EnsureKeyAsync(ct);
+        var dataB64 = Base64Url.EncodeToString(data);
+        var sigB64 = await _js.InvokeAsync<string>("SorchaWebCrypto.signEs256", ct, KeyId, dataB64);
+        return Base64Url.DecodeFromChars(sigB64);
+    }
+
+    private async Task EnsureKeyAsync(CancellationToken ct)
+    {
+        if (_generated) return;
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_generated) return;
+            await _js.InvokeAsync<string>("SorchaWebCrypto.generateEcdsaP256", ct, KeyId);
+            _generated = true;
+        }
+        finally { _gate.Release(); }
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Sorcha.Citizen.Wallet.csproj
+++ b/src/Apps/Sorcha.Citizen.Wallet/Sorcha.Citizen.Wallet.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Sorcha.Citizen.Wallet.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" />

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
@@ -20,6 +20,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+    <script src="js/webcrypto-bridge.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script>
         // Service worker registered separately by Blazor in Release builds.

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
@@ -22,6 +22,7 @@
     </div>
     <script src="js/webcrypto-bridge.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>
         // Service worker registered separately by Blazor in Release builds.
     </script>

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/js/webcrypto-bridge.js
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/js/webcrypto-bridge.js
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// WebCrypto bridge for the Sorcha citizen wallet PWA (Feature 114, T055).
+// Holds non-extractable EC P-256 CryptoKey objects in a process-global Map
+// keyed by string id, since CryptoKey instances cannot cross the JS-interop
+// boundary into .NET. The wallet refers to keys by id.
+//
+// All exports are attached to globalThis.SorchaWebCrypto so they are reachable
+// via IJSRuntime.InvokeAsync("SorchaWebCrypto.<fn>", ...).
+
+(function () {
+  const subtle = (globalThis.crypto && globalThis.crypto.subtle) || null;
+  if (!subtle) {
+    console.error("[Sorcha] WebCrypto not available — wallet will not function.");
+    return;
+  }
+
+  const keys = new Map(); // id -> { privateKey, publicKey, publicJwk, thumbprint }
+
+  function bytesToB64Url(buf) {
+    const bytes = new Uint8Array(buf);
+    let s = "";
+    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+
+  function b64UrlToBytes(s) {
+    s = s.replace(/-/g, "+").replace(/_/g, "/");
+    while (s.length % 4) s += "=";
+    const bin = atob(s);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+
+  async function rfc7638Thumbprint(jwk) {
+    // Canonical: {"crv":"...","kty":"...","x":"...","y":"..."}
+    const canonical = `{"crv":"${jwk.crv}","kty":"${jwk.kty}","x":"${jwk.x}","y":"${jwk.y}"}`;
+    const hash = await subtle.digest("SHA-256", new TextEncoder().encode(canonical));
+    return bytesToB64Url(hash);
+  }
+
+  async function generateEcdsaP256(id) {
+    if (keys.has(id)) return id;
+    const pair = await subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false /* non-extractable for the private key */,
+      ["sign", "verify"]
+    );
+    const publicJwk = await subtle.exportKey("jwk", pair.publicKey);
+    // Strip key_ops/ext for clean JWK on the wire.
+    const cleanJwk = { kty: publicJwk.kty, crv: publicJwk.crv, x: publicJwk.x, y: publicJwk.y };
+    const thumbprint = await rfc7638Thumbprint(cleanJwk);
+    keys.set(id, {
+      privateKey: pair.privateKey,
+      publicKey: pair.publicKey,
+      publicJwk: cleanJwk,
+      thumbprint,
+    });
+    return id;
+  }
+
+  function getPublicJwk(id) {
+    const entry = keys.get(id);
+    if (!entry) throw new Error(`No key with id '${id}'`);
+    return JSON.stringify(entry.publicJwk);
+  }
+
+  function getThumbprint(id) {
+    const entry = keys.get(id);
+    if (!entry) throw new Error(`No key with id '${id}'`);
+    return entry.thumbprint;
+  }
+
+  async function signEs256(id, dataB64Url) {
+    const entry = keys.get(id);
+    if (!entry) throw new Error(`No key with id '${id}'`);
+    const data = b64UrlToBytes(dataB64Url);
+    const sig = await subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      entry.privateKey,
+      data
+    );
+    // WebCrypto returns IEEE-P1363 fixed r||s (64 bytes for P-256). .NET ECDsa.VerifyData
+    // defaults to the same format, so no conversion needed.
+    return bytesToB64Url(sig);
+  }
+
+  globalThis.SorchaWebCrypto = {
+    generateEcdsaP256,
+    getPublicJwk,
+    getThumbprint,
+    signEs256,
+  };
+})();

--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -267,6 +267,9 @@ public static class Extensions
                 path.StartsWith("/app", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/explorer", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/not-found", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("/wallet", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("/verify", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith("/hubs/wallet", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/_framework", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/_content", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/_blazor", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -317,7 +317,7 @@
       "wallet-citizen-status-public": { "ClusterId": "wallet-cluster", "Order": 1, "Match": { "Path": "/api/v1/wallet/status/{**catch-all}" } },
       "wallet-citizen":               { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Order": 2, "Match": { "Path": "/api/v1/wallet/{**catch-all}" } },
       "citizen-wallet-pwa":           { "ClusterId": "citizen-wallet-cluster", "Match": { "Path": "/wallet/{**catch-all}" }, "Transforms": [ { "PathRemovePrefix": "/wallet" }, { "X-Forwarded": "Set" } ] },
-      "citizen-verifier":             { "ClusterId": "citizen-verifier-cluster", "Match": { "Path": "/verify/{**catch-all}" }, "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "citizen-verifier":             { "ClusterId": "citizen-verifier-cluster", "Match": { "Path": "/verify/{**catch-all}" }, "Transforms": [ { "PathRemovePrefix": "/verify" }, { "X-Forwarded": "Set" } ] },
 
       "peer-registers-available": {
         "ClusterId": "peer-cluster",

--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -316,7 +316,7 @@
 
       "wallet-citizen-status-public": { "ClusterId": "wallet-cluster", "Order": 1, "Match": { "Path": "/api/v1/wallet/status/{**catch-all}" } },
       "wallet-citizen":               { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Order": 2, "Match": { "Path": "/api/v1/wallet/{**catch-all}" } },
-      "citizen-wallet-pwa":           { "ClusterId": "citizen-wallet-cluster", "Match": { "Path": "/wallet/{**catch-all}" }, "Transforms": [ { "X-Forwarded": "Set" } ] },
+      "citizen-wallet-pwa":           { "ClusterId": "citizen-wallet-cluster", "Match": { "Path": "/wallet/{**catch-all}" }, "Transforms": [ { "PathRemovePrefix": "/wallet" }, { "X-Forwarded": "Set" } ] },
       "citizen-verifier":             { "ClusterId": "citizen-verifier-cluster", "Match": { "Path": "/verify/{**catch-all}" }, "Transforms": [ { "X-Forwarded": "Set" } ] },
 
       "peer-registers-available": {

--- a/tests/Sorcha.Citizen.Verifier.Tests/Services/TestVpFactory.cs
+++ b/tests/Sorcha.Citizen.Verifier.Tests/Services/TestVpFactory.cs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Sorcha.Citizen.Verifier.Tests.Services;
+
+/// <summary>
+/// Test helper that mints golden Citizen Wallet PWA presentation samples.
+/// Mirrors the on-the-wire shape produced by <c>Sorcha.Citizen.Wallet</c>'s
+/// presentation engine (T094): SD-JWT VC (signed by issuer, cnf=holder JWK),
+/// device delegation credential (signed by holder, cnf=device JWK, status_list ref),
+/// KB-JWT (signed by device, audience+nonce binding to the verifier session).
+/// </summary>
+internal static class TestVpFactory
+{
+    public sealed record Bundle(
+        string VpToken,
+        string Delegation,
+        ECDsa IssuerKey,
+        ECDsa HolderKey,
+        ECDsa DeviceKey,
+        string StatusListUri,
+        int StatusListIndex);
+
+    public static Bundle Mint(
+        string vct,
+        Dictionary<string, JsonElement> disclosedClaims,
+        string verifierClientId,
+        string verifierNonce,
+        DateTimeOffset? delegationExpiresAt = null,
+        string statusListUri = "https://verify.test/status/00000000000000000000000000000000/citizen-devices/0.statuslist+jwt",
+        int statusListIndex = 7)
+    {
+        var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var device = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var holderJwk = ToJwk(holder);
+        var deviceJwk = ToJwk(device);
+        var holderThumbprint = Thumbprint(holderJwk);
+        var deviceThumbprint = Thumbprint(deviceJwk);
+
+        // Build SD-JWT VC payload — disclosable claims live in disclosures, not the body.
+        // We embed the SHA-256 hashes in `_sd` per RFC 9901 so a strict consumer would
+        // accept it; the v1 verifier we test only checks disclosure name presence.
+        var disclosures = new List<string>();
+        var sdHashes = new List<string>();
+        foreach (var (name, value) in disclosedClaims)
+        {
+            var (segment, hash) = MintDisclosure(name, value);
+            disclosures.Add(segment);
+            sdHashes.Add(hash);
+        }
+
+        var credentialPayload = new Dictionary<string, object>
+        {
+            ["iss"] = $"did:sorcha:org:test",
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["vct"] = vct,
+            ["_sd"] = sdHashes,
+            ["_sd_alg"] = "sha-256",
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(holderJwk).RootElement },
+        };
+        var credentialJwt = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            credentialPayload, issuer);
+
+        // Delegation credential — signed by holder key, cnf=device JWK
+        var exp = (delegationExpiresAt ?? DateTimeOffset.UtcNow.AddDays(365)).ToUnixTimeSeconds();
+        var delegationPayload = new Dictionary<string, object>
+        {
+            ["iss"] = $"did:sorcha:holder:{holderThumbprint}",
+            ["sub"] = $"did:sorcha:device:{deviceThumbprint}",
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["exp"] = exp,
+            ["vct"] = "https://sorcha.dev/vc/citizen-device-delegation/v1",
+            ["delegated_capabilities"] = new[] { "presentation.holder-key-binding" },
+            ["cnf"] = new Dictionary<string, object> { ["jwk"] = JsonDocument.Parse(deviceJwk).RootElement },
+            ["status"] = new Dictionary<string, object>
+            {
+                ["status_list"] = new Dictionary<string, object>
+                {
+                    ["uri"] = statusListUri,
+                    ["idx"] = statusListIndex,
+                },
+            },
+        };
+        var delegation = SignEs256(
+            new Dictionary<string, object> { ["alg"] = "ES256", ["typ"] = "vc+sd-jwt" },
+            delegationPayload, holder);
+
+        // KB-JWT — signed by device key, audience+nonce binding
+        var kbHeader = new Dictionary<string, object>
+        {
+            ["alg"] = "ES256",
+            ["typ"] = "kb+jwt",
+            ["kid"] = deviceThumbprint,
+        };
+        var kbPayload = new Dictionary<string, object>
+        {
+            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["aud"] = verifierClientId,
+            ["nonce"] = verifierNonce,
+            ["sd_hash"] = "placeholder",
+        };
+        var kbJwt = SignEs256(kbHeader, kbPayload, device);
+
+        var disclosureSegments = string.Concat(disclosures.Select(d => "~" + d));
+        var vpToken = $"{credentialJwt}{disclosureSegments}~{kbJwt}";
+
+        return new Bundle(vpToken, delegation, issuer, holder, device, statusListUri, statusListIndex);
+    }
+
+    /// <summary>Mint a single SD-JWT disclosure segment for a name/value pair, returning (segment, sha256-hash).</summary>
+    public static (string Segment, string Hash) MintDisclosure(string name, JsonElement value)
+    {
+        Span<byte> salt = stackalloc byte[16];
+        RandomNumberGenerator.Fill(salt);
+        var array = JsonSerializer.SerializeToUtf8Bytes(new object[]
+        {
+            Base64Url.EncodeToString(salt), name, value,
+        });
+        var segment = Base64Url.EncodeToString(array);
+        var hashBytes = SHA256.HashData(Encoding.ASCII.GetBytes(segment));
+        return (segment, Base64Url.EncodeToString(hashBytes));
+    }
+
+    public static string SignEs256(Dictionary<string, object> header, Dictionary<string, object> payload, ECDsa signer)
+    {
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.ASCII.GetBytes($"{headerSeg}.{payloadSeg}");
+        var sig = signer.SignData(signingInput, HashAlgorithmName.SHA256);
+        return $"{headerSeg}.{payloadSeg}.{Base64Url.EncodeToString(sig)}";
+    }
+
+    public static string ToJwk(ECDsa ecdsa)
+    {
+        var p = ecdsa.ExportParameters(false);
+        return JsonSerializer.Serialize(new
+        {
+            kty = "EC",
+            crv = "P-256",
+            x = Base64Url.EncodeToString(p.Q.X!),
+            y = Base64Url.EncodeToString(p.Q.Y!),
+        });
+    }
+
+    private static string Thumbprint(string jwkJson)
+    {
+        using var doc = JsonDocument.Parse(jwkJson);
+        var root = doc.RootElement;
+        // RFC 7638 canonical form: members in lexicographic order, no whitespace
+        var canonical =
+            $"{{\"crv\":\"{root.GetProperty("crv").GetString()}\"," +
+            $"\"kty\":\"{root.GetProperty("kty").GetString()}\"," +
+            $"\"x\":\"{root.GetProperty("x").GetString()}\"," +
+            $"\"y\":\"{root.GetProperty("y").GetString()}\"}}";
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+        return Base64Url.EncodeToString(hash);
+    }
+}

--- a/tests/Sorcha.Citizen.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
+++ b/tests/Sorcha.Citizen.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Citizen.Verifier.Services;
+using Sorcha.Citizen.Verifier.Services.Models;
+using Xunit;
+
+namespace Sorcha.Citizen.Verifier.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="VerifiablePresentationValidator"/> (Feature 114, T090).
+/// Exercises the offline holder→device delegation chain end-to-end:
+/// happy path, malformed input, revoked delegation, expired delegation, tampered
+/// KB-JWT, mismatched nonce/aud, missing required claim.
+/// </summary>
+public sealed class VerifiablePresentationValidatorTests
+{
+    private const string Vct = "https://sorcha.dev/vc/test/v1";
+    private const string Nonce = "verifier-nonce-abc";
+    private const string ClientId = "did:sorcha:verifier:00000000000000000000000000000001";
+
+    private readonly Mock<IStatusListCache> _statusList = new();
+    private readonly VerifiablePresentationValidator _validator;
+
+    public VerifiablePresentationValidatorTests()
+    {
+        _statusList
+            .Setup(s => s.IsRevokedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _validator = new VerifiablePresentationValidator(
+            _statusList.Object, TimeProvider.System,
+            NullLogger<VerifiablePresentationValidator>.Instance);
+    }
+
+    private static VerifierSession Session(IReadOnlyList<string>? required = null) => new()
+    {
+        SessionId = "sess-1",
+        ClientId = ClientId,
+        Nonce = Nonce,
+        RequiredVct = Vct,
+        RequiredClaims = required ?? ["givenName"],
+        OptionalClaims = [],
+        Purpose = "test",
+        CreatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+    };
+
+    private static Dictionary<string, System.Text.Json.JsonElement> Claims(params (string Name, string Value)[] pairs)
+    {
+        var d = new Dictionary<string, System.Text.Json.JsonElement>();
+        foreach (var (n, v) in pairs)
+            d[n] = System.Text.Json.JsonSerializer.SerializeToElement(v);
+        return d;
+    }
+
+    [Fact]
+    public async Task ValidateAsync_HappyPath_ReturnsAccepted()
+    {
+        var bundle = TestVpFactory.Mint(Vct,
+            Claims(("givenName", "Stuart"), ("familyName", "Fraser")),
+            ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+        outcome.DisclosedClaims.Should().ContainKey("givenName");
+        outcome.DisclosedClaims.Should().ContainKey("familyName");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingDelegation_Rejected()
+    {
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, null);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("Delegation credential is required", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TamperedKbJwtSignature_Rejected()
+    {
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
+
+        // Flip the last char of the KB-JWT signature
+        var idx = bundle.VpToken.LastIndexOf('~');
+        var tampered = bundle.VpToken[..^1] + (bundle.VpToken[^1] == 'A' ? 'B' : 'A');
+
+        var outcome = await _validator.ValidateAsync(Session(), tampered, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("KB-JWT signature", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_NonceMismatch_Rejected()
+    {
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, "wrong-nonce");
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("nonce", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_AudienceMismatch_Rejected()
+    {
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")),
+            "did:sorcha:verifier:wrong", Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("aud", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ExpiredDelegation_Rejected()
+    {
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce,
+            delegationExpiresAt: DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("expired", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_RevokedDelegation_Rejected()
+    {
+        _statusList
+            .Setup(s => s.IsRevokedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("revoked", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MissingRequiredClaim_Rejected()
+    {
+        var bundle = TestVpFactory.Mint(Vct, Claims(("familyName", "Fraser")), ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(
+            Session(required: ["givenName"]), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("givenName", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_VctMismatch_Rejected()
+    {
+        var bundle = TestVpFactory.Mint("https://sorcha.dev/vc/wrong/v1",
+            Claims(("givenName", "Stuart")), ClientId, Nonce);
+
+        var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("vct", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MalformedVpToken_Rejected()
+    {
+        var outcome = await _validator.ValidateAsync(Session(), "not-a-jwt", "also-not-a-jwt");
+        outcome.Accepted.Should().BeFalse();
+    }
+}
+
+/// <summary>Smoke tests for <see cref="PresentationRequestBuilder"/> (T088).</summary>
+public sealed class PresentationRequestBuilderTests
+{
+    [Fact]
+    public async Task CreateAsync_ProducesDeepLinkAndStoresSession()
+    {
+        var store = new InMemoryVerifierSessionStore();
+        var builder = new PresentationRequestBuilder(
+            store, TimeProvider.System,
+            NullLogger<PresentationRequestBuilder>.Instance);
+
+        var result = await builder.CreateAsync(
+            Guid.NewGuid(), "Confirm identity",
+            "https://sorcha.dev/vc/test/v1",
+            ["givenName"], ["familyName"],
+            "https://verify.local");
+
+        result.DeepLink.Should().StartWith("openid4vp://?");
+        result.DeepLink.Should().Contain("response_mode=direct_post");
+        result.DeepLink.Should().Contain("nonce=");
+        result.DeepLink.Should().Contain("client_id=");
+        result.Session.RequiredClaims.Should().ContainSingle().Which.Should().Be("givenName");
+        store.Get(result.Session.SessionId).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void BuildPresentationDefinitionJson_IncludesRequiredAndOptionalFields()
+    {
+        var json = PresentationRequestBuilder.BuildPresentationDefinitionJson(
+            "sess-1", "https://sorcha.dev/vc/test/v1",
+            ["givenName"], ["familyName"], "purpose");
+
+        json.Should().Contain("\"id\":\"sess-1\"");
+        json.Should().Contain("givenName");
+        json.Should().Contain("familyName");
+        json.Should().Contain("\"limit_disclosure\":\"required\"");
+    }
+}

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Citizen.Wallet.Services.Presentation;
+using Xunit;
+
+namespace Sorcha.Citizen.Wallet.Tests.Services.Presentation;
+
+/// <summary>
+/// Tests for <see cref="PresentationEngine"/> (Feature 114, T095). Covers:
+/// parse happy path + error paths, match (success / wrong vct / missing claim),
+/// build (KB-JWT signature + sd_hash + only-approved-disclosures invariant).
+/// </summary>
+public sealed class PresentationEngineTests
+{
+    private readonly PresentationEngine _engine = new(TimeProvider.System,
+        NullLogger<PresentationEngine>.Instance);
+
+    private const string Vct = "https://sorcha.dev/vc/test/v1";
+    private const string ClientId = "did:sorcha:verifier:00000000000000000000000000000001";
+
+    // ────────────────────────── Parse ──────────────────────────
+
+    [Fact]
+    public void Parse_ValidDeepLink_ReturnsPopulatedRequest()
+    {
+        var pd = MakePresentationDefinition("sess-1", Vct,
+            required: ["givenName"], optional: ["familyName"]);
+        var link = MakeDeepLink(ClientId, "https://verify.test/r/sess-1/response", "n0nce", pd);
+
+        var parsed = _engine.Parse(link);
+
+        parsed.ClientId.Should().Be(ClientId);
+        parsed.Nonce.Should().Be("n0nce");
+        parsed.RequiredVct.Should().Be(Vct);
+        parsed.RequiredClaims.Should().ContainSingle().Which.Should().Be("givenName");
+        parsed.OptionalClaims.Should().ContainSingle().Which.Should().Be("familyName");
+        parsed.ResponseUri.Should().Be("https://verify.test/r/sess-1/response");
+    }
+
+    [Fact]
+    public void Parse_NotOpenid4VpScheme_Throws()
+    {
+        Action act = () => _engine.Parse("https://verify.test/foo");
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Parse_MissingNonce_Throws()
+    {
+        var link = "openid4vp://?client_id=did:test&response_uri=https://x/y" +
+                   "&presentation_definition=" + Uri.EscapeDataString("{}");
+        Action act = () => _engine.Parse(link);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Parse_PresentationDefinitionWithoutVct_Throws()
+    {
+        var pd = JsonSerializer.Serialize(new
+        {
+            id = "x",
+            input_descriptors = new[] { new { id = "p", constraints = new { fields = Array.Empty<object>() } } }
+        });
+        var link = MakeDeepLink(ClientId, "https://verify.test/r/x/response", "n", pd);
+        Action act = () => _engine.Parse(link);
+        act.Should().Throw<FormatException>();
+    }
+
+    // ────────────────────────── Match ──────────────────────────
+
+    [Fact]
+    public void Match_VctAndAllRequired_Satisfied_ReturnsMatch()
+    {
+        var req = MakeRequest(["givenName"], ["familyName"]);
+        var cred = MakeCredential(Vct, ["givenName", "familyName", "dateOfBirth"]);
+
+        var matches = _engine.Match(req, [cred]);
+
+        matches.Should().HaveCount(1);
+        matches[0].SatisfiedRequired.Should().ContainSingle().Which.Should().Be("givenName");
+        matches[0].AvailableOptional.Should().ContainSingle().Which.Should().Be("familyName");
+    }
+
+    [Fact]
+    public void Match_WrongVct_NoMatch()
+    {
+        var req = MakeRequest(["givenName"], []);
+        var cred = MakeCredential("https://wrong/vct", ["givenName"]);
+        _engine.Match(req, [cred]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Match_RequiredClaimMissing_NoMatch()
+    {
+        var req = MakeRequest(["givenName", "ssn"], []);
+        var cred = MakeCredential(Vct, ["givenName"]);
+        _engine.Match(req, [cred]).Should().BeEmpty();
+    }
+
+    // ────────────────────────── BuildVpTokenAsync ──────────────────────────
+
+    [Fact]
+    public async Task BuildVpTokenAsync_HappyPath_KbJwtVerifiesAgainstDeviceKey()
+    {
+        var (cred, allDisclosures) = MakeRealCredential(Vct,
+            ("givenName", "Stuart"), ("familyName", "Fraser"));
+
+        var req = MakeRequest(["givenName"], ["familyName"]);
+        var match = _engine.Match(req, [cred]).Should().ContainSingle().Subject;
+
+        using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JsonSerializer.Deserialize<JsonElement>(JwkOf(deviceEcdsa));
+
+        Func<byte[], CancellationToken, Task<byte[]>> signer =
+            (data, _) => Task.FromResult(deviceEcdsa.SignData(data, HashAlgorithmName.SHA256));
+
+        var vp = await _engine.BuildVpTokenAsync(
+            match,
+            ["givenName", "familyName"],
+            req,
+            deviceJwk,
+            signer);
+
+        // Structural assertions
+        var (credJwt, disclosures, kbJwt) = PresentationEngine.SplitSdJwt(vp);
+        credJwt.Should().NotBeNullOrEmpty();
+        disclosures.Should().HaveCount(2);
+        kbJwt.Should().NotBeNullOrEmpty();
+
+        // KB-JWT signature must verify against the device key
+        var parts = kbJwt!.Split('.');
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64Url.DecodeFromChars(parts[2]);
+        deviceEcdsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256).Should().BeTrue();
+
+        // Payload binds the right nonce + audience
+        var kbPayload = JsonSerializer.Deserialize<JsonElement>(Base64Url.DecodeFromChars(parts[1]));
+        kbPayload.GetProperty("nonce").GetString().Should().Be(req.Nonce);
+        kbPayload.GetProperty("aud").GetString().Should().Be(req.ClientId);
+        kbPayload.GetProperty("sd_hash").GetString().Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task BuildVpTokenAsync_OnlyApprovedDisclosuresAreIncluded()
+    {
+        var (cred, _) = MakeRealCredential(Vct,
+            ("givenName", "Stuart"), ("familyName", "Fraser"), ("dateOfBirth", "1980-01-01"));
+        var req = MakeRequest(["givenName"], ["familyName", "dateOfBirth"]);
+        var match = _engine.Match(req, [cred]).Single();
+
+        using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JsonSerializer.Deserialize<JsonElement>(JwkOf(deviceEcdsa));
+
+        // Only givenName approved — familyName and dateOfBirth withheld
+        var vp = await _engine.BuildVpTokenAsync(
+            match, ["givenName"], req, deviceJwk,
+            (data, _) => Task.FromResult(deviceEcdsa.SignData(data, HashAlgorithmName.SHA256)));
+
+        var (_, disclosures, _) = PresentationEngine.SplitSdJwt(vp);
+        disclosures.Should().HaveCount(1);
+        var name = PresentationEngine.ReadDisclosureName(disclosures[0]);
+        name.Should().Be("givenName");
+    }
+
+    [Fact]
+    public async Task BuildVpTokenAsync_ApprovedClaimsMissingRequired_Throws()
+    {
+        var (cred, _) = MakeRealCredential(Vct, ("givenName", "Stuart"));
+        var req = MakeRequest(["givenName"], []);
+        var match = _engine.Match(req, [cred]).Single();
+
+        using var deviceEcdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var deviceJwk = JsonSerializer.Deserialize<JsonElement>(JwkOf(deviceEcdsa));
+
+        Func<Task> act = async () => await _engine.BuildVpTokenAsync(
+            match, [], req, deviceJwk,
+            (data, _) => Task.FromResult(deviceEcdsa.SignData(data, HashAlgorithmName.SHA256)));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ────────────────────────── helpers ──────────────────────────
+
+    private static ParsedPresentationRequest MakeRequest(IReadOnlyList<string> required, IReadOnlyList<string> optional)
+        => new()
+        {
+            ClientId = ClientId,
+            ResponseUri = "https://verify.test/r/x/response",
+            Nonce = "abc",
+            RequiredVct = Vct,
+            RequiredClaims = required,
+            OptionalClaims = optional,
+        };
+
+    private static CachedCredential MakeCredential(string vct, IReadOnlyList<string> claimNames)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Vct = vct,
+            RawSdJwt = "header.payload.sig",
+            AvailableClaimNames = claimNames,
+        };
+
+    /// <summary>Build a credential whose RawSdJwt is well-formed and includes real disclosures.</summary>
+    private static (CachedCredential Credential, List<string> AllDisclosures) MakeRealCredential(
+        string vct, params (string Name, string Value)[] claims)
+    {
+        // Issuer JWT (signature is irrelevant for engine tests — only structure matters)
+        using var fakeIssuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var headerSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            alg = "ES256",
+            typ = "vc+sd-jwt"
+        }));
+        var payloadSeg = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            iss = "did:sorcha:org:test",
+            vct,
+            iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+        }));
+        var sigInput = Encoding.ASCII.GetBytes($"{headerSeg}.{payloadSeg}");
+        var sig = Base64Url.EncodeToString(fakeIssuer.SignData(sigInput, HashAlgorithmName.SHA256));
+        var credentialJwt = $"{headerSeg}.{payloadSeg}.{sig}";
+
+        var allDisclosures = new List<string>();
+        foreach (var (name, value) in claims)
+        {
+            Span<byte> salt = stackalloc byte[16];
+            RandomNumberGenerator.Fill(salt);
+            var disc = JsonSerializer.SerializeToUtf8Bytes(new object[]
+            {
+                Base64Url.EncodeToString(salt),
+                name,
+                value,
+            });
+            allDisclosures.Add(Base64Url.EncodeToString(disc));
+        }
+
+        var raw = credentialJwt + string.Concat(allDisclosures.Select(d => "~" + d));
+        return (new CachedCredential
+        {
+            Id = Guid.NewGuid(),
+            Vct = vct,
+            RawSdJwt = raw,
+            AvailableClaimNames = claims.Select(c => c.Name).ToList(),
+        }, allDisclosures);
+    }
+
+    private static string MakePresentationDefinition(string id, string vct,
+        IReadOnlyList<string> required, IReadOnlyList<string> optional)
+    {
+        var fields = new List<object>
+        {
+            new { path = new[] { "$.vct" }, filter = new { type = "string", @const = vct } }
+        };
+        foreach (var c in required) fields.Add(new { path = new[] { "$." + c }, optional = false });
+        foreach (var c in optional) fields.Add(new { path = new[] { "$." + c }, optional = true });
+
+        return JsonSerializer.Serialize(new
+        {
+            id,
+            input_descriptors = new[]
+            {
+                new
+                {
+                    id = "primary",
+                    name = vct,
+                    purpose = "test",
+                    constraints = new
+                    {
+                        limit_disclosure = "required",
+                        fields = fields.ToArray()
+                    }
+                }
+            }
+        });
+    }
+
+    private static string MakeDeepLink(string clientId, string responseUri, string nonce, string presentationDefinitionJson)
+        => "openid4vp://?" +
+           $"client_id={Uri.EscapeDataString(clientId)}" +
+           "&response_mode=direct_post" +
+           $"&response_uri={Uri.EscapeDataString(responseUri)}" +
+           $"&nonce={Uri.EscapeDataString(nonce)}" +
+           $"&presentation_definition={Uri.EscapeDataString(presentationDefinitionJson)}";
+
+    private static string JwkOf(ECDsa ecdsa)
+    {
+        var p = ecdsa.ExportParameters(false);
+        return JsonSerializer.Serialize(new
+        {
+            kty = "EC",
+            crv = "P-256",
+            x = Base64Url.EncodeToString(p.Q.X!),
+            y = Base64Url.EncodeToString(p.Q.Y!),
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 / US1 MVP UI for the Citizen Wallet PWA + reference verifier. Live-validated end-to-end in docker.

**Verifier (`Sorcha.Citizen.Verifier`)**
- T088 `IPresentationRequestBuilder` — OID4VP cross-device deep link with inline PEX presentation_definition
- T089 `IVerifiablePresentationValidator` — offline holder→device delegation chain validation (KB-JWT sig, nonce/aud, status-list, required claim disclosure)
- T091 `POST /r/{sessionId}/response` callback + `GET /r/{sessionId}/status` poll
- T092 `VerifierSession.razor` — operator UI, QR via QRCoder, 2s status polling
- T093 `Outcome.razor` — accept/reject + disclosed claims table
- `POST /demo/mint` — one-shot demo credential minter, returns `{rawSdJwt, delegationJwt, holderJwk}` bound to a wallet's device JWK so MVP demo runs without US2 enrolment

**Wallet (`Sorcha.Citizen.Wallet`)**
- T094 `IPresentationEngine` — parse openid4vp deep link, PEX match, build vp_token + KB-JWT via caller-supplied device-signer delegate
- T067 MainLayout — top app bar QR button + bottom nav (Home/Devices/Activity/Settings)
- T096-T100 `Present.razor` — paste deep link → match → consent → POST → result (consent/picker/no-match inlined)
- T055 `webcrypto-bridge.js` + `WebCryptoDeviceKeyService` — non-extractable EC P-256 device key via `crypto.subtle`. Private key never leaves the browser crypto store.
- Service interfaces + in-memory MVP impls for cache/delegation/status-list, DI registration
- Home page `Load demo credential` button calls the verifier mint endpoint and seeds `ICredentialCache` + `IDelegationStore`

**Gateway plumbing**
- YARP `PathRemovePrefix` for `/wallet/*` and `/verify/*`
- CSP allowlist relaxed for `/wallet`, `/verify`, `/hubs/wallet`

**Tests:** 30 new unit tests pass (19 verifier + 11 PWA engine). Solution builds clean.

## Validated live

```bash
docker-compose up -d
```

End-to-end demo confirmed working in the browser:
1. http://localhost/verify → fill form → Start verification → grab deep link
2. http://localhost/wallet/ → Load demo credential → Present → paste → Hold to share
3. Wallet shows "accepted", verifier flips to outcome screen with disclosed claims

## Backlogged for the next wave

- **JS interop bridges** — IndexedDB store, libsodium-js, qr-scanner. Current MVP uses in-memory + paste-link.
- **Real IndexedDB-backed** `ICredentialCache` / `IDelegationStore` / `IStatusListService` (T060-T062)
- **Full DID-backed issuer signature verification** in the validator
- **T101 clock-skew banner**
- **ConsentSheet / Picker / NoMatch as separate components** (currently inlined)
- **US2 enrolment + sync** — replaces the demo-mint shortcut with the real flow
- **US3-US5** — recovery, auto-receive, activity log
- **Polish phase** — Playwright E2E, doc propagation, observability, security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)