### PR TITLE
fix(115): config-driven OAuth callback base URL — Caddy proxy doesn't propagate X-Forwarded-Proto

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -59,6 +59,13 @@ services:
       # After first seed the value persists in tenant.platform_settings; this
       # env var is only consulted when seeding a fresh database. Feature 115.
       PlatformSettings__SeedPublicOrgEnabled: "true"
+      # OAuth callback base URL — explicit because Caddy terminates TLS on
+      # the host and the proxy chain (Caddy → api-gateway → tenant-service)
+      # does not always propagate X-Forwarded-Proto cleanly, causing
+      # http:// to leak into the redirect_uri sent to providers and yielding
+      # redirect_uri_mismatch errors. Set the public origin explicitly per
+      # feature 115 FR-021.
+      OAuth__CallbackBaseUrl: https://n1.sorcha.dev
       # Social login providers — feature 115. ClientId/ClientSecret are
       # interpolated from the host's /opt/sorcha/.env file (gitignored).
       # Buttons for unconfigured providers are hidden client-side, so leaving

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -34,6 +34,29 @@ public static class SocialLoginEndpoints
     public const string CallbackPath = "/auth/social/callback";
 
     /// <summary>
+    /// Resolves the canonical callback URL for OAuth providers. Production
+    /// environments behind a TLS-terminating reverse proxy (Caddy, ALB,
+    /// ingress) MUST set <c>OAuth:CallbackBaseUrl</c> to the public origin
+    /// (e.g. <c>https://n1.sorcha.dev</c>) — relying on
+    /// <see cref="HttpRequest.Scheme"/> alone has produced
+    /// <c>redirect_uri_mismatch</c> errors at Google when the proxy chain
+    /// did not propagate <c>X-Forwarded-Proto</c> cleanly. When the config
+    /// value is unset, falls back to <c>{Scheme}://{Host}</c> from the
+    /// current request — appropriate only for local development.
+    /// Feature 115 FR-021.
+    /// </summary>
+    private static string ResolveCallbackUrl(HttpContext httpContext, IConfiguration configuration)
+    {
+        var configured = configuration["OAuth:CallbackBaseUrl"];
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return $"{configured.TrimEnd('/')}{CallbackPath}";
+        }
+
+        return $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{CallbackPath}";
+    }
+
+    /// <summary>
     /// Maps social login endpoints to the application.
     /// </summary>
     public static IEndpointRouteBuilder MapSocialLoginEndpoints(this IEndpointRouteBuilder app)
@@ -83,6 +106,7 @@ public static class SocialLoginEndpoints
         SocialLoginInitiateRequest request,
         ISocialLoginService socialLoginService,
         IPlatformSettingsService platformSettingsService,
+        IConfiguration configuration,
         HttpContext httpContext,
         ILogger<Program> logger,
         CancellationToken ct)
@@ -107,11 +131,10 @@ public static class SocialLoginEndpoints
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        // Build redirect URI for the callback. This MUST match the registered
-        // redirect URI at the OAuth provider (see docs/guides/SOCIAL-LOGIN-SETUP.md).
-        // Single canonical path per environment per feature 115 FR-021.
-        var baseUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
-        var redirectUri = $"{baseUrl}{CallbackPath}";
+        // Resolve callback URL (config-first, falls back to Request scheme/host).
+        // See ResolveCallbackUrl for why config-first is required behind a
+        // TLS-terminating reverse proxy.
+        var redirectUri = ResolveCallbackUrl(httpContext, configuration);
 
         try
         {
@@ -274,6 +297,7 @@ public static class SocialLoginEndpoints
     private static async Task<IResult> LinkSocialProvider(
         SocialLoginInitiateRequest request,
         ISocialLoginService socialLoginService,
+        IConfiguration configuration,
         HttpContext httpContext,
         ILogger<Program> logger,
         CancellationToken ct)
@@ -296,9 +320,10 @@ public static class SocialLoginEndpoints
             return TypedResults.Unauthorized();
         }
 
-        // Build redirect URI
-        var baseUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
-        var redirectUri = $"{baseUrl}/api/auth/social/callback-redirect";
+        // Build redirect URI — same canonical path as the new-signup flow.
+        // ResolveCallbackUrl honours OAuth:CallbackBaseUrl when set, falling
+        // back to the request scheme/host for local development.
+        var redirectUri = ResolveCallbackUrl(httpContext, configuration);
 
         try
         {


### PR DESCRIPTION
## Summary

Hot fix on top of feature 115 (PR #423, merged earlier today).

DevTools smoke test on n1 caught Google rejecting the consent flow with `redirect_uri_mismatch`. The Tenant Service was sending `http://n1.sorcha.dev/auth/social/callback` (no `s`), but Google's OAuth app is registered with `https://`.

Caddy on the host terminates TLS and proxies HTTP to api-gateway → tenant-service. `ForwardedHeaders` middleware is wired but the proxy chain doesn't propagate `X-Forwarded-Proto` cleanly to the inner service.

## The fix

Read an explicit `OAuth:CallbackBaseUrl` config value (matches the established `Fido2__Origins__0` pattern that solved the same problem). Falls back to `{Request.Scheme}://{Request.Host}` when unset, which is correct for local dev where there's no proxy.

- `SocialLoginEndpoints.ResolveCallbackUrl(httpContext, configuration)` centralises the logic
- Both `InitiateSocialLogin` and `LinkSocialProvider` now call it
- `LinkSocialProvider` also still had the original defunct `/api/auth/social/callback-redirect` path from before PR #423 (escaped my earlier `replace_all`) — fixed in this same change
- `docker-compose.n1.yml` sets `OAuth__CallbackBaseUrl=https://n1.sorcha.dev`

## Test plan

- [x] `dotnet build` clean
- [ ] Re-run `n1-reset.ps1` after Docker Publish completes
- [ ] Re-test Google consent flow in DevTools → should land on Google sign-in page (existing OAuth app already accepts the correct URI)
- [ ] Verify GitHub flow same pattern

OAuth-app registrations are unchanged — the fix produces the URI those apps already expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)