### PR TITLE
feat(114): IndexedDB-backed wallet stores (Wave-2 Tier-1)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -11,19 +11,19 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Register the PWA's services as singletons (single-user-per-tab).
-    /// IDeviceKeyService is wired to <see cref="WebCryptoDeviceKeyService"/> by
-    /// default — the InMemory variant is reserved for unit tests where IJSRuntime
-    /// isn't available. Cache + delegation + status-list start as in-memory MVP
-    /// impls; IndexedDB-backed replacements land with T060-T062.
+    /// Production wiring uses WebCrypto for device keys and IndexedDB for the
+    /// credential cache, delegation store, and status list cache — all backed
+    /// by <c>indexeddb-bridge.js</c>. The in-memory variants are kept for unit
+    /// tests where IJSRuntime isn't available.
     /// </summary>
     public static IServiceCollection AddCitizenWalletServices(this IServiceCollection services)
     {
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IPresentationEngine, PresentationEngine>();
         services.AddSingleton<IDeviceKeyService, WebCryptoDeviceKeyService>();
-        services.AddSingleton<ICredentialCache, InMemoryCredentialCache>();
-        services.AddSingleton<IDelegationStore, InMemoryDelegationStore>();
-        services.AddSingleton<IStatusListService, NoopStatusListService>();
+        services.AddSingleton<ICredentialCache, IndexedDbCredentialCache>();
+        services.AddSingleton<IDelegationStore, IndexedDbDelegationStore>();
+        services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         return services;
     }
 }

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbCredentialCache.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbCredentialCache.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.JSInterop;
+using Sorcha.Citizen.Wallet.Services.Presentation;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Production <see cref="ICredentialCache"/> backed by IndexedDB store
+/// <c>credentials</c> via <c>indexeddb-bridge.js</c>. Each credential is
+/// serialised to JSON and encrypted under the wallet's content key
+/// (AES-GCM-256 in v1; XChaCha20-Poly1305 once the libsodium bridge lands).
+/// The content key is a non-extractable WebCrypto <c>CryptoKey</c> persisted
+/// in the IndexedDB <c>device</c> store via structured-clone.
+/// </summary>
+public sealed class IndexedDbCredentialCache : ICredentialCache
+{
+    private readonly IJSRuntime _js;
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbCredentialCache(IJSRuntime js)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CachedCredential>> ListAsync(CancellationToken ct = default)
+    {
+        var jsonStrings = await _js.InvokeAsync<string[]>("SorchaIndexedDb.listCredentials", ct);
+        var list = new List<CachedCredential>(jsonStrings.Length);
+        foreach (var json in jsonStrings)
+        {
+            var cred = JsonSerializer.Deserialize<CachedCredential>(json, JsonOpts);
+            if (cred is not null) list.Add(cred);
+        }
+        return list;
+    }
+
+    /// <inheritdoc />
+    public async Task UpsertAsync(CachedCredential credential, CancellationToken ct = default)
+    {
+        var json = JsonSerializer.Serialize(credential, JsonOpts);
+        await _js.InvokeVoidAsync("SorchaIndexedDb.putCredential", ct, credential.Id.ToString(), json);
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbDelegationStore.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbDelegationStore.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Production <see cref="IDelegationStore"/> backed by IndexedDB store
+/// <c>delegation</c> via <c>indexeddb-bridge.js</c>. Singleton row keyed
+/// <c>"self"</c>. The delegation JWT is a public credential (signed by the
+/// holder key, bound to a single device JWK) so it is persisted in plaintext
+/// — confidentiality is not a property of the delegation itself.
+/// </summary>
+public sealed class IndexedDbDelegationStore : IDelegationStore
+{
+    private const string StoreName = "delegation";
+    private const string Key = "self";
+
+    private readonly IJSRuntime _js;
+
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbDelegationStore(IJSRuntime js)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> GetCurrentAsync(CancellationToken ct = default)
+    {
+        var row = await _js.InvokeAsync<DelegationRow?>("SorchaIndexedDb.get", ct, StoreName, Key);
+        return row?.Jwt;
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(string compactJwt, CancellationToken ct = default)
+    {
+        var row = new DelegationRow(compactJwt, DateTimeOffset.UtcNow);
+        await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, row, Key);
+    }
+
+    private sealed record DelegationRow(string Jwt, DateTimeOffset SetAt);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbStatusListService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbStatusListService.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.IO.Compression;
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Production <see cref="IStatusListService"/> backed by IndexedDB store
+/// <c>statusLists</c> via <c>indexeddb-bridge.js</c>. Caches IETF Token Status
+/// List 2024 JWTs by URI; on a cache miss, fetches the signed list over HTTP
+/// and stores it. Bit lookup decodes the zlib-compressed bitstring per
+/// draft-ietf-oauth-status-list.
+///
+/// Issuer-signature verification against the org status-signing key is deferred
+/// to a follow-up wave (full DID resolver wiring); v1 trusts the served list
+/// when fetched over TLS. Verifiers do their own signature check independently
+/// — this service is a wallet-side pre-flight to refuse known-revoked
+/// credentials before generating a presentation, not the authoritative check.
+/// </summary>
+public sealed class IndexedDbStatusListService : IStatusListService
+{
+    private const string StoreName = "statusLists";
+
+    private readonly IJSRuntime _js;
+    private readonly HttpClient _http;
+    private readonly TimeProvider _clock;
+
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbStatusListService(IJSRuntime js, HttpClient http, TimeProvider clock)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsRevokedAsync(string uri, int index, CancellationToken ct = default)
+    {
+        var row = await _js.InvokeAsync<StatusListRow?>("SorchaIndexedDb.get", ct, StoreName, uri);
+        var nowEpoch = _clock.GetUtcNow().ToUnixTimeSeconds();
+
+        if (row is null || row.Exp <= nowEpoch)
+        {
+            row = await FetchAsync(uri, ct);
+            if (row is null) return false; // fail-open at wallet pre-flight; verifier still checks
+            await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, row);
+        }
+
+        return BitstringHasIndexSet(row.Bitstring, index);
+    }
+
+    private async Task<StatusListRow?> FetchAsync(string uri, CancellationToken ct)
+    {
+        try
+        {
+            var jwt = await _http.GetStringAsync(uri, ct);
+            return ParseStatusListJwt(uri, jwt);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static StatusListRow? ParseStatusListJwt(string uri, string compactJwt)
+    {
+        var parts = compactJwt.Split('.');
+        if (parts.Length != 3) return null;
+        var payloadBytes = Base64Url.DecodeFromChars(parts[1]);
+        using var doc = JsonDocument.Parse(payloadBytes);
+        var root = doc.RootElement;
+        var iat = root.TryGetProperty("iat", out var iatEl) ? iatEl.GetInt64() : 0;
+        var exp = root.TryGetProperty("exp", out var expEl) ? expEl.GetInt64() : long.MaxValue;
+        if (!root.TryGetProperty("status_list", out var sl)) return null;
+        var lst = sl.GetProperty("lst").GetString() ?? string.Empty;
+        var compressed = Base64Url.DecodeFromChars(lst);
+        var bits = ZlibInflate(compressed);
+        return new StatusListRow(uri, bits, iat, exp, compactJwt, DateTimeOffset.UtcNow);
+    }
+
+    private static byte[] ZlibInflate(byte[] compressed)
+    {
+        using var input = new MemoryStream(compressed);
+        using var deflate = new ZLibStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        deflate.CopyTo(output);
+        return output.ToArray();
+    }
+
+    internal static bool BitstringHasIndexSet(byte[] bitstring, int index)
+    {
+        if (index < 0) return false;
+        var byteIndex = index >> 3;
+        if (byteIndex >= bitstring.Length) return false;
+        var bitInByte = index & 0b111;
+        return (bitstring[byteIndex] & (1 << bitInByte)) != 0;
+    }
+
+    internal sealed record StatusListRow(
+        string Uri,
+        byte[] Bitstring,
+        long Iat,
+        long Exp,
+        string SignedJwt,
+        DateTimeOffset FetchedAt);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
@@ -21,6 +21,7 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="js/webcrypto-bridge.js"></script>
+    <script src="js/indexeddb-bridge.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/js/indexeddb-bridge.js
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/js/indexeddb-bridge.js
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// IndexedDB bridge for the Sorcha citizen wallet PWA (Feature 114, T054).
+// Database name: 'sorcha-wallet', version 1. Five object stores per data-model §B:
+//   device       — singleton, key='self'  — keys, wrapping artefacts, enrolment metadata
+//   delegation   — singleton, key='self'  — current device delegation JWT
+//   credentials  — keyed by id (UUID)     — encrypted SD-JWT VCs
+//   statusLists  — keyed by uri           — cached signed status list JWTs
+//   syncQueue    — autoincrement key      — pending outbound mutations
+//
+// Content-key strategy (deviation from data-model §B1, documented in the wallet README):
+// v1 uses a non-extractable AES-GCM-256 CryptoKey generated on first run and stored
+// directly in IndexedDB (browsers structured-clone CryptoKey natively). XChaCha20-Poly1305
+// via libsodium-js is the production target and lands when the libsodium bridge is added;
+// the wire-format on disk is incompatible between the two so the schema will rev to v2.
+//
+// All exports attach to globalThis.SorchaIndexedDb.
+
+(function () {
+  if (!globalThis.indexedDB) {
+    console.error("[Sorcha] IndexedDB not available — wallet will not persist data.");
+    return;
+  }
+  if (!globalThis.crypto || !globalThis.crypto.subtle) {
+    console.error("[Sorcha] WebCrypto not available — credential cache cannot be encrypted.");
+    return;
+  }
+
+  const DB_NAME = "sorcha-wallet";
+  const DB_VERSION = 1;
+  const CONTENT_KEY_ID = "content-key/v1";
+
+  let dbPromise = null;
+
+  function openDb() {
+    if (dbPromise) return dbPromise;
+    dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = (ev) => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains("device")) db.createObjectStore("device");
+        if (!db.objectStoreNames.contains("delegation")) db.createObjectStore("delegation");
+        if (!db.objectStoreNames.contains("credentials")) db.createObjectStore("credentials", { keyPath: "id" });
+        if (!db.objectStoreNames.contains("statusLists")) db.createObjectStore("statusLists", { keyPath: "uri" });
+        if (!db.objectStoreNames.contains("syncQueue")) db.createObjectStore("syncQueue", { keyPath: "id", autoIncrement: true });
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    return dbPromise;
+  }
+
+  function asPromise(req) {
+    return new Promise((resolve, reject) => {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function put(storeName, value, key) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(storeName, "readwrite");
+      const store = tx.objectStore(storeName);
+      const req = key === undefined ? store.put(value) : store.put(value, key);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function get(storeName, key) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(storeName, "readonly");
+      const store = tx.objectStore(storeName);
+      const req = store.get(key);
+      req.onsuccess = () => resolve(req.result === undefined ? null : req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function del(storeName, key) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(storeName, "readwrite");
+      const store = tx.objectStore(storeName);
+      const req = store.delete(key);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function getAll(storeName) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(storeName, "readonly");
+      const store = tx.objectStore(storeName);
+      const req = store.getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async function clear(storeName) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(storeName, "readwrite");
+      const store = tx.objectStore(storeName);
+      const req = store.clear();
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  // --- content-key + symmetric encryption -----------------------------------
+
+  let contentKeyPromise = null;
+
+  async function getOrCreateContentKey() {
+    if (contentKeyPromise) return contentKeyPromise;
+    contentKeyPromise = (async () => {
+      const existing = await get("device", CONTENT_KEY_ID);
+      if (existing && existing.key) return existing.key;
+      const key = await crypto.subtle.generateKey(
+        { name: "AES-GCM", length: 256 },
+        false /* non-extractable — CryptoKey persists via structured clone */,
+        ["encrypt", "decrypt"]
+      );
+      await put("device", { key }, CONTENT_KEY_ID);
+      return key;
+    })();
+    return contentKeyPromise;
+  }
+
+  function bytesToB64Url(buf) {
+    const bytes = new Uint8Array(buf);
+    let s = "";
+    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+
+  function b64UrlToBytes(s) {
+    s = s.replace(/-/g, "+").replace(/_/g, "/");
+    while (s.length % 4) s += "=";
+    const bin = atob(s);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  }
+
+  async function encryptString(plaintext) {
+    const key = await getOrCreateContentKey();
+    const nonce = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: nonce },
+      key,
+      new TextEncoder().encode(plaintext)
+    );
+    return { nonce: bytesToB64Url(nonce), ciphertext: bytesToB64Url(ciphertext) };
+  }
+
+  async function decryptString(nonceB64, ciphertextB64) {
+    const key = await getOrCreateContentKey();
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: b64UrlToBytes(nonceB64) },
+      key,
+      b64UrlToBytes(ciphertextB64)
+    );
+    return new TextDecoder().decode(plain);
+  }
+
+  // --- credentials ----------------------------------------------------------
+  // Encrypts an opaque payload (callers serialise their own object to JSON first).
+
+  async function putCredential(id, payloadJson) {
+    const { nonce, ciphertext } = await encryptString(payloadJson);
+    await put("credentials", { id, nonce, ciphertext, cachedAt: new Date().toISOString() });
+  }
+
+  async function getCredential(id) {
+    const row = await get("credentials", id);
+    if (!row) return null;
+    return await decryptString(row.nonce, row.ciphertext);
+  }
+
+  async function listCredentials() {
+    const rows = await getAll("credentials");
+    const out = [];
+    for (const row of rows) {
+      out.push(await decryptString(row.nonce, row.ciphertext));
+    }
+    return out;
+  }
+
+  async function deleteCredential(id) {
+    await del("credentials", id);
+  }
+
+  globalThis.SorchaIndexedDb = {
+    // raw store ops
+    put, get, del, getAll, clear,
+    // credentials (encrypted)
+    putCredential, getCredential, listCredentials, deleteCredential,
+  };
+})();

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/IndexedDbStatusListServiceTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/IndexedDbStatusListServiceTests.cs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Citizen.Wallet.Services;
+using Xunit;
+
+namespace Sorcha.Citizen.Wallet.Tests.Services;
+
+/// <summary>
+/// Unit tests for the bitstring decoding + Token Status List 2024 JWT parsing
+/// in <see cref="IndexedDbStatusListService"/>. The IJSRuntime + HttpClient
+/// surface is exercised in integration; these tests cover the pure functions.
+/// </summary>
+public sealed class IndexedDbStatusListServiceTests
+{
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(7, true)]
+    [InlineData(8, true)]
+    [InlineData(9, false)]
+    [InlineData(15, false)]
+    public void BitstringHasIndexSet_ReadsBitsLittleEndianWithinByte(int index, bool expected)
+    {
+        // Byte 0 = 0b1000_0001 (bit 0 set, bit 7 set)
+        // Byte 1 = 0b0000_0001 (bit 8 set, in global numbering)
+        var bits = new byte[] { 0b1000_0001, 0b0000_0001 };
+        IndexedDbStatusListService.BitstringHasIndexSet(bits, index).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BitstringHasIndexSet_OutOfRangeReturnsFalse()
+    {
+        IndexedDbStatusListService.BitstringHasIndexSet(new byte[] { 0xFF }, 8).Should().BeFalse();
+        IndexedDbStatusListService.BitstringHasIndexSet(new byte[] { 0xFF }, -1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseStatusListJwt_RoundtripsBitstringAndExpiry()
+    {
+        // 16-bit bitstring with bit 5 set: byte 0 = 0b0010_0000 = 0x20.
+        var bits = new byte[] { 0b0010_0000, 0x00 };
+        var compressed = ZlibDeflate(bits);
+        var lst = Base64Url.EncodeToString(compressed);
+
+        var payload = new
+        {
+            iss = "did:sorcha:org:test",
+            iat = 1_700_000_000,
+            exp = 1_700_086_400,
+            sub = "https://verify.test/status/0.statuslist+jwt",
+            status_list = new { bits = 1, lst }
+        };
+
+        var jwt = $"{Base64Url.EncodeToString(Encoding.UTF8.GetBytes("{}"))}." +
+                  $"{Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload))}." +
+                  Base64Url.EncodeToString(new byte[] { 0xDE, 0xAD });
+
+        var row = IndexedDbStatusListService.ParseStatusListJwt("https://x", jwt);
+
+        row.Should().NotBeNull();
+        row!.Iat.Should().Be(1_700_000_000);
+        row.Exp.Should().Be(1_700_086_400);
+        IndexedDbStatusListService.BitstringHasIndexSet(row.Bitstring, 5).Should().BeTrue();
+        IndexedDbStatusListService.BitstringHasIndexSet(row.Bitstring, 4).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseStatusListJwt_InvalidShapeReturnsNull()
+    {
+        IndexedDbStatusListService.ParseStatusListJwt("https://x", "not-a-jwt").Should().BeNull();
+    }
+
+    private static byte[] ZlibDeflate(byte[] data)
+    {
+        using var ms = new MemoryStream();
+        using (var deflate = new ZLibStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            deflate.Write(data, 0, data.Length);
+        }
+        return ms.ToArray();
+    }
+}


### PR DESCRIPTION
## Summary

Wave-2 Tier-1 architectural cleanup for Feature 114 (Citizen Wallet PWA). Replaces the in-memory MVP wallet stores with persistent IndexedDB-backed implementations so wallet state survives page refresh.

## Changes

- **`indexeddb-bridge.js`** (T054): generic IDB wrapper for the five object stores from data-model §B + credential-level encryption helpers. Non-extractable AES-GCM-256 CryptoKey persisted via structured-clone in the device store.
- **`IndexedDbCredentialCache`** (T060): JSON-serialise + encrypt + persist by id.
- **`IndexedDbDelegationStore`** (T061): singleton row keyed `"self"`.
- **`IndexedDbStatusListService`** (T062): cache + zlib bitstring decode for IETF Token Status List 2024 JWTs.
- 8 new unit tests for bitstring indexing + JWT parsing. All 20 wallet tests + 19 verifier tests pass.

## Documented deviations (deferred)

- Spec calls for **XChaCha20-Poly1305** at rest. v1 ships AES-GCM-256 — equivalent AEAD strength, native to the browser, no vendoring needed. Schema rev to v2 when the libsodium-js bridge lands.
- Status-list **issuer-signature verification** deferred — wallet pre-flight is best-effort; the verifier remains the authoritative check.

## Test plan

- [x] Wallet unit tests pass (20/20)
- [x] Verifier unit tests pass (19/19)
- [x] Build clean
- [ ] Manual: load credential, refresh page, confirm credential survives (defer to next docker rebuild cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)