### PR TITLE
feat(114): citizen wallet sync surface (Wave-2 Tier-2 part 1)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -42,7 +42,65 @@ public static class CitizenWalletEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status409Conflict);
 
+        group.MapGet("/credentials", ListCredentials)
+            .WithName("ListCitizenCredentials")
+            .WithSummary("Full credential snapshot for the authenticated citizen")
+            .WithDescription(
+                "Returns every credential currently issued to the citizen. Used by a " +
+                "freshly-enrolled wallet to seed its cache; subsequent updates flow " +
+                "through GET /api/v1/wallet/sync.")
+            .Produces<CredentialListResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        group.MapGet("/sync", SyncCredentials)
+            .WithName("SyncCitizenWallet")
+            .WithSummary("Pull credential and delegation deltas since the last sync")
+            .WithDescription(
+                "Returns adds/revokes/replacements since the supplied opaque cursor. " +
+                "Omit the cursor on first sync. Cursors older than 30 days return 410 — " +
+                "the wallet should fall back to GET /credentials.")
+            .Produces<SyncResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status410Gone);
+
         return app;
+    }
+
+    private static async Task<IResult> ListCredentials(
+        HttpContext context,
+        ICitizenSyncService sync,
+        IHolderKeyService holderKeys,
+        CancellationToken ct)
+    {
+        var (platformUserId, citizenWallet, _) = ResolveCitizenContext(context.User);
+        if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
+
+        var holderKeyId = await holderKeys.GetHolderJwkThumbprintAsync(citizenWallet, ct);
+        var snapshot = await sync.ListAllCredentialsAsync(platformUserId.Value, holderKeyId, ct);
+        return Results.Ok(snapshot);
+    }
+
+    private static async Task<IResult> SyncCredentials(
+        HttpContext context,
+        [FromQuery] string? since,
+        ICitizenSyncService sync,
+        IHolderKeyService holderKeys,
+        CancellationToken ct)
+    {
+        var (platformUserId, citizenWallet, _) = ResolveCitizenContext(context.User);
+        if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
+
+        var holderKeyId = await holderKeys.GetHolderJwkThumbprintAsync(citizenWallet, ct);
+        var delta = await sync.ComposeDeltaAsync(platformUserId.Value, holderKeyId, since, ct);
+        if (delta is null)
+        {
+            return Results.Problem(
+                title: "Sync cursor expired",
+                detail: "The supplied sync cursor is older than the maximum cursor age. " +
+                        "Re-seed the cache via GET /api/v1/wallet/credentials.",
+                statusCode: StatusCodes.Status410Gone);
+        }
+        return Results.Ok(delta);
     }
 
     private static async Task<IResult> EnrolDevice(

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -141,6 +141,14 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IOrgStatusS
 builder.Services.AddHostedService<
     Sorcha.Wallet.Service.Services.Implementation.CitizenStatusListPublisherService>();
 
+// Feature 114: Citizen wallet sync surface (T103). EmptyCitizenCredentialEventStream is a
+// placeholder until the citizen-credential issuance pipeline lands (US4 / Phase 6); the sync
+// surface, sync-token round-trip, and 410 stale-cursor path are still exercised end-to-end.
+builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Interfaces.ICitizenCredentialEventStream,
+    Sorcha.Wallet.Service.Services.Implementation.EmptyCitizenCredentialEventStream>();
+builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Interfaces.ICitizenSyncService,
+    Sorcha.Wallet.Service.Services.Implementation.CitizenSyncService>();
+
 // Feature 114: FluentValidation for citizen wallet request DTOs
 builder.Services.AddValidatorsFromAssemblyContaining<
     Sorcha.CitizenWallet.Abstractions.Validators.DeviceEnrolmentRequestValidator>();

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenSyncService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenSyncService.cs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.ObjectModel;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Microsoft.Extensions.Hosting;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Default <see cref="ICitizenSyncService"/>. Sync cursors are HMAC-SHA256 signed
+/// JWTs (research §R-006) carrying <c>{ sub, lastEventSeq, iat }</c>; tokens
+/// older than <see cref="MaxCursorAge"/> are rejected (caller returns 410).
+/// </summary>
+public sealed class CitizenSyncService : ICitizenSyncService
+{
+    /// <summary>Cursor JWTs older than this are stale and force a full re-sync.</summary>
+    public static readonly TimeSpan MaxCursorAge = TimeSpan.FromDays(30);
+
+    /// <summary>Threshold below which a sync response will piggy-back a delegation renewal hint.</summary>
+    public static readonly TimeSpan DelegationRenewalWindow = TimeSpan.FromDays(30);
+
+    private const string CursorIssuer = "sorcha:wallet:citizen-sync";
+    private const string CursorAudience = "sorcha:wallet:citizen-sync";
+    private const string CursorClaimSeq = "seq";
+
+    private readonly ICitizenCredentialEventStream _events;
+    private readonly TimeProvider _clock;
+    private readonly SigningCredentials _signing;
+    private readonly TokenValidationParameters _validation;
+    private readonly JwtSecurityTokenHandler _handler;
+
+    /// <summary>Initialises a new instance.</summary>
+    public CitizenSyncService(
+        ICitizenCredentialEventStream events,
+        JwtSettings jwtSettings,
+        TimeProvider clock)
+    {
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        ArgumentNullException.ThrowIfNull(jwtSettings);
+
+        var keyBytes = Encoding.UTF8.GetBytes(jwtSettings.SigningKey ?? string.Empty);
+        if (keyBytes.Length < 32) Array.Resize(ref keyBytes, 32);
+        var key = new SymmetricSecurityKey(keyBytes);
+        _signing = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        _validation = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = CursorIssuer,
+            ValidateAudience = true,
+            ValidAudience = CursorAudience,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = key,
+            ValidateLifetime = false, // we apply MaxCursorAge ourselves
+            ClockSkew = TimeSpan.Zero,
+        };
+        _handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+    }
+
+    /// <inheritdoc />
+    public async Task<SyncResponse?> ComposeDeltaAsync(
+        Guid platformUserId,
+        string holderKeyId,
+        string? sinceToken,
+        CancellationToken ct = default)
+    {
+        long sinceSeq = 0;
+        if (!string.IsNullOrEmpty(sinceToken))
+        {
+            var parsed = TryParseCursor(sinceToken, holderKeyId);
+            if (parsed is null) return null; // 410
+            sinceSeq = parsed.Value;
+        }
+
+        var newEvents = await _events.ReadAsync(platformUserId, sinceSeq, ct);
+        var newest = newEvents.Count > 0
+            ? newEvents[^1].Seq
+            : await _events.GetHighestSeqAsync(platformUserId, ct);
+
+        var changes = ProjectChanges(newEvents);
+        var statusListsToRefresh = CollectStatusListUris(changes);
+        var nextCursor = MintCursor(holderKeyId, newest);
+
+        return new SyncResponse
+        {
+            SyncToken = nextCursor,
+            Credentials = changes,
+            Delegation = new SyncDelegationUpdate(),
+            StatusListsToRefresh = new ReadOnlyCollection<string>(statusListsToRefresh.ToList()),
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<CredentialListResponse> ListAllCredentialsAsync(
+        Guid platformUserId,
+        string holderKeyId,
+        CancellationToken ct = default)
+    {
+        var allEvents = await _events.ReadAsync(platformUserId, 0, ct);
+        var snapshot = ReplayToSnapshot(allEvents);
+        return new CredentialListResponse
+        {
+            Credentials = new ReadOnlyCollection<CachedCredentialPayload>(snapshot.ToList()),
+        };
+    }
+
+    internal string MintCursor(string holderKeyId, long lastEventSeq)
+    {
+        var now = _clock.GetUtcNow();
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = CursorIssuer,
+            Audience = CursorAudience,
+            IssuedAt = now.UtcDateTime,
+            NotBefore = now.UtcDateTime,
+            Expires = now.Add(MaxCursorAge).UtcDateTime,
+            SigningCredentials = _signing,
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, holderKeyId),
+                new Claim(CursorClaimSeq, lastEventSeq.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            }),
+        };
+        return _handler.CreateEncodedJwt(descriptor);
+    }
+
+    internal long? TryParseCursor(string token, string expectedHolderKeyId)
+    {
+        try
+        {
+            var principal = _handler.ValidateToken(token, _validation, out var jwt);
+            var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+            if (sub is null || !string.Equals(sub, expectedHolderKeyId, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var iat = jwt.ValidFrom;
+            if (_clock.GetUtcNow().UtcDateTime - iat > MaxCursorAge) return null;
+
+            var seqStr = principal.FindFirst(CursorClaimSeq)?.Value;
+            return long.TryParse(seqStr, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var seq) ? seq : null;
+        }
+        catch (SecurityTokenException) { return null; }
+        catch (ArgumentException) { return null; }
+    }
+
+    private static SyncCredentialChanges ProjectChanges(IReadOnlyList<CitizenCredentialEvent> events)
+    {
+        var added = new List<CachedCredentialPayload>();
+        var revoked = new List<RevokedCredentialEntry>();
+        var replaced = new List<ReplacedCredentialEntry>();
+        foreach (var evt in events)
+        {
+            switch (evt.Kind)
+            {
+                case CitizenCredentialEventKind.Added when evt.Payload is CachedCredentialPayload a:
+                    added.Add(a); break;
+                case CitizenCredentialEventKind.Revoked when evt.Payload is RevokedCredentialEntry r:
+                    revoked.Add(r); break;
+                case CitizenCredentialEventKind.Replaced when evt.Payload is ReplacedCredentialEntry rp:
+                    replaced.Add(rp); break;
+            }
+        }
+        return new SyncCredentialChanges
+        {
+            Added = new ReadOnlyCollection<CachedCredentialPayload>(added),
+            Revoked = new ReadOnlyCollection<RevokedCredentialEntry>(revoked),
+            Replaced = new ReadOnlyCollection<ReplacedCredentialEntry>(replaced),
+        };
+    }
+
+    private static IReadOnlyCollection<string> CollectStatusListUris(SyncCredentialChanges changes)
+    {
+        var uris = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var added in changes.Added)
+        {
+            if (!string.IsNullOrEmpty(added.StatusListUri)) uris.Add(added.StatusListUri);
+        }
+        return uris;
+    }
+
+    private static IEnumerable<CachedCredentialPayload> ReplayToSnapshot(IReadOnlyList<CitizenCredentialEvent> events)
+    {
+        var byId = new Dictionary<Guid, CachedCredentialPayload>();
+        foreach (var evt in events)
+        {
+            switch (evt.Kind)
+            {
+                case CitizenCredentialEventKind.Added when evt.Payload is CachedCredentialPayload a:
+                    byId[a.Id] = a; break;
+                case CitizenCredentialEventKind.Revoked when evt.Payload is RevokedCredentialEntry r:
+                    byId.Remove(r.Id); break;
+                case CitizenCredentialEventKind.Replaced when evt.Payload is ReplacedCredentialEntry rp:
+                    byId.Remove(rp.OldId);
+                    // Replacement payload only carries the JWT; full payload arrives via subsequent Added events.
+                    break;
+            }
+        }
+        return byId.Values;
+    }
+}
+
+/// <summary>
+/// Empty credential event source used until the citizen-credential issuance pipeline
+/// lands (US4 / Feature 114 Phase 6). Returns no events so a freshly enrolled wallet
+/// gets an empty snapshot and the sync surface is still exercisable end-to-end.
+/// </summary>
+public sealed class EmptyCitizenCredentialEventStream : ICitizenCredentialEventStream
+{
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CitizenCredentialEvent>> ReadAsync(Guid platformUserId, long afterSeq, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<CitizenCredentialEvent>>(Array.Empty<CitizenCredentialEvent>());
+
+    /// <inheritdoc />
+    public Task<long> GetHighestSeqAsync(Guid platformUserId, CancellationToken ct = default)
+        => Task.FromResult(0L);
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/ICitizenSyncService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/ICitizenSyncService.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.CitizenWallet.Abstractions.Models;
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Composes citizen wallet sync responses (Feature 114, T103). Reads the
+/// citizen's credential events stream, the current device delegation status,
+/// and the set of status lists referenced by their credentials. Mints and
+/// validates the opaque sync cursor (research §R-006: signed compact JWT
+/// with claims <c>{ sub, lastEventSeq, iat }</c>).
+/// </summary>
+public interface ICitizenSyncService
+{
+    /// <summary>
+    /// Compose the delta sync response since the supplied cursor.
+    /// Pass <paramref name="sinceToken"/> = null on first sync.
+    /// </summary>
+    /// <returns>The sync response, or null if the token is too old to service (caller returns 410).</returns>
+    Task<SyncResponse?> ComposeDeltaAsync(
+        Guid platformUserId,
+        string holderKeyId,
+        string? sinceToken,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Compose a full credential snapshot (used by <c>GET /wallet/credentials</c>
+    /// — fresh wallets seed their cache via this path).
+    /// </summary>
+    Task<CredentialListResponse> ListAllCredentialsAsync(
+        Guid platformUserId,
+        string holderKeyId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Source of credential events for a citizen. v1 returns an empty enumeration
+/// because the citizen-credential issuance pipeline lands with US4 / Feature
+/// 114 Phase 6. The interface exists now so the sync surface, sync tokens,
+/// and tests are stable when real events flow in.
+/// </summary>
+public interface ICitizenCredentialEventStream
+{
+    /// <summary>Events strictly newer than <paramref name="afterSeq"/>, ordered ascending.</summary>
+    Task<IReadOnlyList<CitizenCredentialEvent>> ReadAsync(
+        Guid platformUserId,
+        long afterSeq,
+        CancellationToken ct = default);
+
+    /// <summary>Returns the highest event sequence currently observable for this citizen.</summary>
+    Task<long> GetHighestSeqAsync(Guid platformUserId, CancellationToken ct = default);
+}
+
+/// <summary>One change observed in a citizen's credential set.</summary>
+/// <param name="Seq">Monotonic event sequence within this citizen.</param>
+/// <param name="Kind">Event kind: <c>Added</c>, <c>Revoked</c>, or <c>Replaced</c>.</param>
+/// <param name="Payload">
+/// Kind-specific payload — typed under <see cref="Sorcha.CitizenWallet.Abstractions.Models"/>:
+/// <see cref="CachedCredentialPayload"/>, <see cref="RevokedCredentialEntry"/>,
+/// or <see cref="ReplacedCredentialEntry"/>.
+/// </param>
+public sealed record CitizenCredentialEvent(long Seq, CitizenCredentialEventKind Kind, object Payload);
+
+/// <summary>Kinds of credential events the wallet observes through sync.</summary>
+public enum CitizenCredentialEventKind
+{
+    /// <summary>A new credential was issued to this citizen.</summary>
+    Added = 0,
+    /// <summary>An existing credential was revoked.</summary>
+    Revoked = 1,
+    /// <summary>An existing credential was replaced by a newer-version credential.</summary>
+    Replaced = 2
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/CitizenSyncServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/CitizenSyncServiceTests.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.ObjectModel;
+using FluentAssertions;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Microsoft.Extensions.Hosting;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="CitizenSyncService"/> (Feature 114, T103/T104). Covers
+/// sync-token round-trip, first-sync, incremental sync delta projection, replay
+/// to snapshot, and the 410-stale-cursor recovery path.
+/// </summary>
+public sealed class CitizenSyncServiceTests
+{
+    private const string HolderKeyId = "abcdef0123456789abcdef0123456789abcdef0123";
+    private static readonly Guid PlatformUserId = Guid.Parse("d8b04e5a-0000-0000-0000-000000000001");
+
+    private readonly TestClock _clock = new(DateTimeOffset.Parse("2026-01-15T12:00:00Z"));
+    private readonly StubEventStream _events = new();
+    private readonly CitizenSyncService _sut;
+
+    public CitizenSyncServiceTests()
+    {
+        var jwt = new JwtSettings { SigningKey = "unit-test-signing-key-not-for-production-use" };
+        _sut = new CitizenSyncService(_events, jwt, _clock);
+    }
+
+    [Fact]
+    public async Task ComposeDeltaAsync_FirstSync_ReturnsEmptyDeltaAndCursor()
+    {
+        var response = await _sut.ComposeDeltaAsync(PlatformUserId, HolderKeyId, sinceToken: null);
+
+        response.Should().NotBeNull();
+        response!.SyncToken.Should().NotBeNullOrEmpty();
+        response.Credentials.Added.Should().BeEmpty();
+        response.Credentials.Revoked.Should().BeEmpty();
+        response.Credentials.Replaced.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ComposeDeltaAsync_IncrementalSync_ProjectsAddedRevokedReplaced()
+    {
+        var addedId = Guid.NewGuid();
+        var revokedId = Guid.NewGuid();
+        var replacedOldId = Guid.NewGuid();
+        var replacedNewId = Guid.NewGuid();
+
+        _events.Append(1, CitizenCredentialEventKind.Added, new CachedCredentialPayload
+        {
+            Id = addedId,
+            Vct = "https://sorcha.dev/vc/test/v1",
+            Jwt = "eyJ...",
+            IssuerDid = "did:sorcha:org:test",
+            IssuedAt = _clock.GetUtcNow(),
+            StatusListUri = "https://verify.test/status/A.statuslist+jwt",
+        });
+        _events.Append(2, CitizenCredentialEventKind.Revoked, new RevokedCredentialEntry
+        {
+            Id = revokedId,
+            Reason = CredentialRevocationReason.Compromised,
+            RevokedAt = _clock.GetUtcNow(),
+        });
+        _events.Append(3, CitizenCredentialEventKind.Replaced, new ReplacedCredentialEntry
+        {
+            OldId = replacedOldId,
+            NewId = replacedNewId,
+            Jwt = "eyJ...new",
+            IssuedAt = _clock.GetUtcNow(),
+        });
+
+        var response = await _sut.ComposeDeltaAsync(PlatformUserId, HolderKeyId, sinceToken: null);
+
+        response!.Credentials.Added.Should().ContainSingle(p => p.Id == addedId);
+        response.Credentials.Revoked.Should().ContainSingle(p => p.Id == revokedId);
+        response.Credentials.Replaced.Should().ContainSingle(p => p.OldId == replacedOldId && p.NewId == replacedNewId);
+        response.StatusListsToRefresh.Should().ContainSingle(u => u.Contains("A.statuslist"));
+    }
+
+    [Fact]
+    public async Task ComposeDeltaAsync_RoundTripCursor_AdvancesPastConsumedEvents()
+    {
+        _events.Append(1, CitizenCredentialEventKind.Added, NewPayload());
+        var first = await _sut.ComposeDeltaAsync(PlatformUserId, HolderKeyId, null);
+        first!.Credentials.Added.Should().HaveCount(1);
+
+        // Second sync with the returned cursor should yield no new events.
+        _events.Append(2, CitizenCredentialEventKind.Added, NewPayload());
+
+        var second = await _sut.ComposeDeltaAsync(PlatformUserId, HolderKeyId, first.SyncToken);
+        second!.Credentials.Added.Should().HaveCount(1, "only events with seq > 1 should appear");
+    }
+
+    [Fact]
+    public async Task ComposeDeltaAsync_StaleCursor_Returns410Sentinel()
+    {
+        var freshCursor = _sut.MintCursor(HolderKeyId, lastEventSeq: 0);
+        _clock.Advance(CitizenSyncService.MaxCursorAge.Add(TimeSpan.FromMinutes(1)));
+
+        var response = await _sut.ComposeDeltaAsync(PlatformUserId, HolderKeyId, freshCursor);
+
+        response.Should().BeNull("stale cursor must surface as null so the endpoint can return 410");
+    }
+
+    [Fact]
+    public async Task ComposeDeltaAsync_CursorBoundToDifferentHolder_Rejected()
+    {
+        var other = "deadbeef0123456789abcdef0123456789abcdef012";
+        var foreignCursor = _sut.MintCursor(other, lastEventSeq: 0);
+
+        var response = await _sut.ComposeDeltaAsync(PlatformUserId, HolderKeyId, foreignCursor);
+
+        response.Should().BeNull("cursor sub claim must match the calling holder");
+    }
+
+    [Fact]
+    public async Task ListAllCredentialsAsync_ReplaysToNetSnapshot()
+    {
+        var keepId = Guid.NewGuid();
+        var dropId = Guid.NewGuid();
+        _events.Append(1, CitizenCredentialEventKind.Added, NewPayload(keepId));
+        _events.Append(2, CitizenCredentialEventKind.Added, NewPayload(dropId));
+        _events.Append(3, CitizenCredentialEventKind.Revoked, new RevokedCredentialEntry
+        {
+            Id = dropId,
+            Reason = CredentialRevocationReason.Withdrawn,
+            RevokedAt = _clock.GetUtcNow(),
+        });
+
+        var snapshot = await _sut.ListAllCredentialsAsync(PlatformUserId, HolderKeyId);
+
+        snapshot.Credentials.Should().ContainSingle(p => p.Id == keepId);
+        snapshot.Credentials.Should().NotContain(p => p.Id == dropId);
+    }
+
+    private CachedCredentialPayload NewPayload(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        Vct = "https://sorcha.dev/vc/test/v1",
+        Jwt = "eyJ...",
+        IssuerDid = "did:sorcha:org:test",
+        IssuedAt = _clock.GetUtcNow(),
+    };
+
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset _now;
+        public TestClock(DateTimeOffset start) => _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+    }
+
+    private sealed class StubEventStream : ICitizenCredentialEventStream
+    {
+        private readonly List<CitizenCredentialEvent> _events = [];
+
+        public void Append(long seq, CitizenCredentialEventKind kind, object payload)
+            => _events.Add(new CitizenCredentialEvent(seq, kind, payload));
+
+        public Task<IReadOnlyList<CitizenCredentialEvent>> ReadAsync(Guid platformUserId, long afterSeq, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<CitizenCredentialEvent>>(
+                new ReadOnlyCollection<CitizenCredentialEvent>(_events.Where(e => e.Seq > afterSeq).ToList()));
+
+        public Task<long> GetHighestSeqAsync(Guid platformUserId, CancellationToken ct = default)
+            => Task.FromResult(_events.Count == 0 ? 0L : _events[^1].Seq);
+    }
+}


### PR DESCRIPTION
## Summary

Wave-2 Tier-2 first slice for Feature 114 (Citizen Wallet PWA). Adds the server endpoints the PWA needs to seed and incrementally sync its credential cache, replacing the demo-mint shortcut path.

## Changes

- **`ICitizenSyncService` + `CitizenSyncService`** (T103) — composes credential deltas + full snapshots; mints/validates the opaque sync cursor as an HMAC-SHA256 JWT with `{ sub: holderKeyId, seq, iat }` per research §R-006. 30-day cursor lifetime → 410 → wallet falls back to /credentials.
- **`ICitizenCredentialEventStream` + `EmptyCitizenCredentialEventStream`** — abstraction over the not-yet-implemented citizen credential issuance pipeline. Empty stub keeps the sync surface exercisable end-to-end now and stable when real events flow in (US4 / Phase 6).
- **`GET /api/v1/wallet/credentials`** (T102) — full snapshot for fresh-wallet seeding.
- **`GET /api/v1/wallet/sync?since=`** (T102) — incremental delta with cursor advancement.
- 6 new unit tests (T104). All 687 wallet tests pass.

## Deferred

- **T106 renew-delegation endpoint** — needs a Tenant Service `GetByIdAsync` extension to fetch the device JWK by id; cleaner as its own commit.
- **T105 WebApplicationFactory integration tests** — the unit tests cover the meaningful logic; integration tests are scoped for the same follow-up that ships the renewal endpoint.

## Test plan

- [x] 6 new unit tests pass (CitizenSyncService)
- [x] All 687 wallet service tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)