### PR TITLE
feat(114): Home auto-sync + real Settings page (T110, T112)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -17,8 +17,10 @@
 @inject ICredentialCache Credentials
 @inject IDelegationStore Delegation
 @inject IDeviceKeyService DeviceKey
+@inject ISyncService Sync
 @inject HttpClient Http
 @inject NavigationManager Nav
+@inject ILogger<Index> Logger
 
 <PageTitle>Sorcha Wallet</PageTitle>
 
@@ -58,12 +60,21 @@
                    Disabled="@(_credentials is null || _credentials.Count == 0)">
             Present a credential
         </MudButton>
-        <MudButton Color="Color.Secondary" Variant="Variant.Outlined"
+        <MudButton Color="Color.Tertiary" Variant="Variant.Outlined"
+                   StartIcon="@Icons.Material.Filled.Sync"
+                   OnClick="@(() => SyncNowAsync(false))" Disabled="@_syncing">
+            @(_syncing ? "Syncing…" : "Sync now")
+        </MudButton>
+        <MudButton Color="Color.Secondary" Variant="Variant.Text"
                    OnClick="LoadDemoAsync" Disabled="@_seeding">
             @(_seeding ? "Loading…" : "Load demo credential")
         </MudButton>
     </MudStack>
 
+    @if (!string.IsNullOrEmpty(_syncStatus))
+    {
+        <MudAlert Severity="@_syncSeverity" Dense="true" Class="mt-3">@_syncStatus</MudAlert>
+    }
     @if (!string.IsNullOrEmpty(_seedError))
     {
         <MudAlert Severity="Severity.Error" Class="mt-3">@_seedError</MudAlert>
@@ -73,10 +84,57 @@
 @code {
     private IReadOnlyList<CachedCredential>? _credentials;
     private bool _seeding;
+    private bool _syncing;
     private string? _seedError;
+    private string? _syncStatus;
+    private Severity _syncSeverity = Severity.Info;
 
     protected override async Task OnInitializedAsync()
-        => _credentials = await Credentials.ListAsync();
+    {
+        _credentials = await Credentials.ListAsync();
+        // Fire-and-forget background sync — refreshes the cache from server without
+        // blocking first paint. UI updates via StateHasChanged when sync completes.
+        _ = SyncNowAsync(silentSuccess: true);
+    }
+
+    private async Task SyncNowAsync(bool silentSuccess = false)
+    {
+        if (_syncing) return;
+        _syncing = true;
+        _syncStatus = null;
+        try
+        {
+            var outcome = await Sync.SyncAsync();
+            _credentials = await Credentials.ListAsync();
+            _syncSeverity = Severity.Success;
+            _syncStatus = outcome.Mode == SyncMode.FullSnapshot
+                ? $"Synced — pulled full snapshot ({outcome.Added} credential(s))."
+                : $"Synced — {outcome.Added} added, {outcome.Revoked} revoked, {outcome.Replaced} replaced.";
+            if (silentSuccess && outcome.Added == 0 && outcome.Revoked == 0 && outcome.Replaced == 0)
+            {
+                _syncStatus = null; // first-load no-op shouldn't pop a banner
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            _syncSeverity = Severity.Warning;
+            _syncStatus = ex.StatusCode == System.Net.HttpStatusCode.Unauthorized
+                ? "Sync needs sign-in. Enrolment wizard arrives with US2."
+                : $"Sync failed: {ex.Message}";
+            Logger.LogWarning(ex, "Wallet sync failed");
+        }
+        catch (Exception ex)
+        {
+            _syncSeverity = Severity.Error;
+            _syncStatus = $"Sync error: {ex.Message}";
+            Logger.LogError(ex, "Wallet sync threw");
+        }
+        finally
+        {
+            _syncing = false;
+            StateHasChanged();
+        }
+    }
 
     private async Task LoadDemoAsync()
     {

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Settings.razor
@@ -2,16 +2,115 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Placeholder Settings page (T112 — full implementation lands with US2).
+    Settings (Feature 114, T112). Surface the meaningful controls a citizen
+    might reach for: storage usage (navigator.storage.estimate), Sign out
+    (placeholder until US2 enrolment ships), Lock now (placeholder until
+    biometric gate ships in tier 4 polish).
 *@
 @page "/settings"
 @layout MainLayout
+@using Microsoft.JSInterop
+@inject IJSRuntime Js
+@inject ILogger<Settings> Logger
 
 <PageTitle>Settings</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
-    <MudText Typo="Typo.h5">Settings</MudText>
-    <MudAlert Severity="Severity.Info" Class="mt-3">
-        Lock, sign-out, storage estimate land with US2.
-    </MudAlert>
+    <MudText Typo="Typo.h5" Class="mb-3">Settings</MudText>
+
+    <MudCard Class="mb-3">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudText Typo="Typo.subtitle1">Storage</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            @if (_storage is null)
+            {
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+            }
+            else if (_storage.Quota == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    Browser does not expose storage estimates.
+                </MudText>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2">
+                    Using <strong>@FormatBytes(_storage.Usage)</strong>
+                    of <strong>@FormatBytes(_storage.Quota)</strong>
+                    (@(_storage.PercentUsed.ToString("F1"))%).
+                </MudText>
+                <MudProgressLinear Value="_storage.PercentUsed" Color="Color.Primary"
+                                   Class="mt-2" Style="height:8px;" />
+            }
+        </MudCardContent>
+    </MudCard>
+
+    <MudCard Class="mb-3">
+        <MudCardHeader>
+            <CardHeaderContent>
+                <MudText Typo="Typo.subtitle1">Session</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudStack Spacing="2">
+                <MudButton StartIcon="@Icons.Material.Filled.Lock"
+                           Variant="Variant.Outlined" Disabled="true">
+                    Lock now (biometric gate — tier 4 polish)
+                </MudButton>
+                <MudButton StartIcon="@Icons.Material.Filled.Logout"
+                           Variant="Variant.Outlined" Color="Color.Error" Disabled="true">
+                    Sign out (enrolment auth — US2)
+                </MudButton>
+            </MudStack>
+        </MudCardContent>
+    </MudCard>
 </MudContainer>
+
+@code {
+    private StorageInfo? _storage;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        try
+        {
+            // navigator.storage.estimate isn't exposed via a Sorcha bridge; small inline JS.
+            var estimate = await Js.InvokeAsync<StorageEstimate>("eval",
+                "(async () => { if (!navigator.storage?.estimate) return { usage: 0, quota: 0 }; " +
+                "const e = await navigator.storage.estimate(); " +
+                "return { usage: e.usage ?? 0, quota: e.quota ?? 0 }; })()");
+            _storage = new StorageInfo
+            {
+                Usage = estimate.Usage,
+                Quota = estimate.Quota,
+                PercentUsed = estimate.Quota == 0 ? 0 : 100.0 * estimate.Usage / estimate.Quota,
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Could not read storage estimate");
+            _storage = new StorageInfo();
+        }
+        StateHasChanged();
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        if (bytes < 1024L * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+        return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
+    }
+
+    private sealed record StorageEstimate(long Usage, long Quota);
+
+    private sealed class StorageInfo
+    {
+        public long Usage { get; init; }
+        public long Quota { get; init; }
+        public double PercentUsed { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary

Wave-2 Tier-2 third slice. Wires the PWA into the sync surface shipped in #428/#429 and turns the Settings placeholder into something useful.

## Changes

- **`Pages/Index.razor` (T110)** — Auto-runs `ISyncService.SyncAsync` on first load (background, doesn't block first paint). Quiet no-op banner when no deltas. Manual \"Sync now\" button. 401 surfaces as a friendly Warning (\"Sync needs sign-in. Enrolment wizard arrives with US2.\") rather than a crash. Demo-mint button kept as the bridge until US4 issuance flows real credentials through sync.
- **`Pages/Settings.razor` (T112)** — `navigator.storage.estimate` via inline JS interop, live usage/quota progress bar. Lock now + Sign out surfaced as disabled placeholders so the controls exist in the right place without pretending to do work.

## Test plan

- [x] All 25 wallet tests still pass
- [x] Build clean
- [ ] Manual smoke: load wallet, confirm auto-sync attempt + Settings storage display (defer to next docker rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)