### PR TITLE
feat(114): citizen wallet auth foundation (T109 part 1)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Sorcha.Citizen.Wallet.Services;
 using Sorcha.Citizen.Wallet.Services.Presentation;
+using Sorcha.ServiceClients.CitizenWallet;
 
 namespace Sorcha.Citizen.Wallet.Extensions;
 
@@ -16,7 +18,8 @@ public static class ServiceCollectionExtensions
     /// by <c>indexeddb-bridge.js</c>. The in-memory variants are kept for unit
     /// tests where IJSRuntime isn't available.
     /// </summary>
-    public static IServiceCollection AddCitizenWalletServices(this IServiceCollection services)
+    public static IServiceCollection AddCitizenWalletServices(
+        this IServiceCollection services, string gatewayBaseAddress)
     {
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IPresentationEngine, PresentationEngine>();
@@ -25,7 +28,21 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IDelegationStore, IndexedDbDelegationStore>();
         services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();
+        services.AddSingleton<IAccessTokenStore, IndexedDbAccessTokenStore>();
         services.AddSingleton<ISyncService, SyncService>();
+
+        // Auth surface: a separate HttpClient that does NOT inject the bearer
+        // token (so sign-in requests don't carry stale tokens).
+        services.AddTransient<BearerTokenHandler>();
+        services.AddHttpClient<IAuthService, AuthService>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress));
+
+        // Citizen wallet client: every outbound call automatically carries the
+        // wallet's stored bearer token.
+        services.AddHttpClient<ICitizenWalletClient, CitizenWalletClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>();
+
         return services;
     }
 }

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Settings.razor
@@ -10,7 +10,9 @@
 @page "/settings"
 @layout MainLayout
 @using Microsoft.JSInterop
+@using Sorcha.Citizen.Wallet.Services
 @inject IJSRuntime Js
+@inject IAuthService Auth
 @inject ILogger<Settings> Logger
 
 <PageTitle>Settings</PageTitle>
@@ -51,26 +53,113 @@
     <MudCard Class="mb-3">
         <MudCardHeader>
             <CardHeaderContent>
+                <MudText Typo="Typo.subtitle1">Account</MudText>
+            </CardHeaderContent>
+        </MudCardHeader>
+        <MudCardContent>
+            @if (_signedInEmail is not null)
+            {
+                <MudText Typo="Typo.body2" Class="mb-2">
+                    Signed in as <strong>@_signedInEmail</strong>
+                </MudText>
+                <MudButton StartIcon="@Icons.Material.Filled.Logout"
+                           Variant="Variant.Outlined" Color="Color.Error"
+                           OnClick="SignOutAsync">
+                    Sign out
+                </MudButton>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-2">
+                    Sign in to sync your credentials. Full enrolment wizard
+                    (device labelling, key gen, /devices/enrol) lands next.
+                </MudText>
+                <MudTextField @bind-Value="_email" Label="Email"
+                              Variant="Variant.Outlined" Margin="Margin.Dense"
+                              Class="mb-2" InputType="InputType.Email" />
+                <MudTextField @bind-Value="_password" Label="Password"
+                              Variant="Variant.Outlined" Margin="Margin.Dense"
+                              Class="mb-2" InputType="InputType.Password" />
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           OnClick="SignInAsync" Disabled="@_signingIn" FullWidth="true">
+                    @(_signingIn ? "Signing in…" : "Sign in")
+                </MudButton>
+                @if (!string.IsNullOrEmpty(_signInError))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">
+                        @_signInError
+                    </MudAlert>
+                }
+            }
+        </MudCardContent>
+    </MudCard>
+
+    <MudCard Class="mb-3">
+        <MudCardHeader>
+            <CardHeaderContent>
                 <MudText Typo="Typo.subtitle1">Session</MudText>
             </CardHeaderContent>
         </MudCardHeader>
         <MudCardContent>
-            <MudStack Spacing="2">
-                <MudButton StartIcon="@Icons.Material.Filled.Lock"
-                           Variant="Variant.Outlined" Disabled="true">
-                    Lock now (biometric gate — tier 4 polish)
-                </MudButton>
-                <MudButton StartIcon="@Icons.Material.Filled.Logout"
-                           Variant="Variant.Outlined" Color="Color.Error" Disabled="true">
-                    Sign out (enrolment auth — US2)
-                </MudButton>
-            </MudStack>
+            <MudButton StartIcon="@Icons.Material.Filled.Lock"
+                       Variant="Variant.Outlined" Disabled="true">
+                Lock now (biometric gate — tier 4 polish)
+            </MudButton>
         </MudCardContent>
     </MudCard>
 </MudContainer>
 
 @code {
     private StorageInfo? _storage;
+    private string? _signedInEmail;
+    private string _email = string.Empty;
+    private string _password = string.Empty;
+    private string? _signInError;
+    private bool _signingIn;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _signedInEmail = await Auth.GetSignedInEmailAsync();
+    }
+
+    private async Task SignInAsync()
+    {
+        _signInError = null;
+        if (string.IsNullOrWhiteSpace(_email) || string.IsNullOrWhiteSpace(_password))
+        {
+            _signInError = "Email and password are required.";
+            return;
+        }
+        _signingIn = true;
+        try
+        {
+            var result = await Auth.SignInAsync(_email, _password);
+            if (result.IsSuccess)
+            {
+                _signedInEmail = await Auth.GetSignedInEmailAsync();
+                _password = string.Empty;
+            }
+            else
+            {
+                _signInError = result.ErrorMessage ?? "Sign-in failed.";
+            }
+        }
+        catch (Exception ex)
+        {
+            _signInError = ex.Message;
+            Logger.LogError(ex, "Sign-in threw");
+        }
+        finally
+        {
+            _signingIn = false;
+        }
+    }
+
+    private async Task SignOutAsync()
+    {
+        await Auth.SignOutAsync();
+        _signedInEmail = null;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Apps/Sorcha.Citizen.Wallet/Program.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Program.cs
@@ -15,6 +15,11 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddAuthorizationCore();
 builder.Services.AddMudServices();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-builder.Services.AddCitizenWalletServices();
+
+// Gateway base address for typed Sorcha service clients. The wallet PWA is
+// mounted at /wallet/ behind the API Gateway; gateway-relative routes start
+// at the host root so we strip the /wallet/ prefix off the BaseAddress.
+var hostRoot = new Uri(builder.HostEnvironment.BaseAddress).GetLeftPart(UriPartial.Authority) + "/";
+builder.Services.AddCitizenWalletServices(hostRoot);
 
 await builder.Build().RunAsync();

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/BearerTokenHandler.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/BearerTokenHandler.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Headers;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// HTTP message handler that attaches the wallet's stored bearer token to
+/// every outbound request. Sits at the head of the <see cref="HttpClient"/>
+/// pipeline used by <see cref="Sorcha.ServiceClients.CitizenWallet.ICitizenWalletClient"/>
+/// and the demo-mint helper. If the token store is empty, requests go out
+/// unauthenticated and the server returns 401 — that's the trigger for the
+/// UI to surface the sign-in prompt (Feature 114, T109 foundation).
+/// </summary>
+public sealed class BearerTokenHandler : DelegatingHandler
+{
+    private readonly IAccessTokenStore _store;
+
+    /// <summary>Initialises a new instance.</summary>
+    public BearerTokenHandler(IAccessTokenStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var record = await _store.GetAsync(cancellationToken);
+        if (record is not null && !string.IsNullOrEmpty(record.AccessToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", record.AccessToken);
+        }
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IAccessTokenStore.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IAccessTokenStore.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Persists the citizen JWT (and a small amount of identity metadata)
+/// across page reloads so the wallet stays signed in (Feature 114, T109
+/// foundation). Production lives in the IndexedDB <c>device</c> store
+/// keyed <c>access-token</c>; the in-memory variant is used by unit tests
+/// where IJSRuntime isn't available.
+/// </summary>
+public interface IAccessTokenStore
+{
+    /// <summary>Returns the persisted token, or null if signed out.</summary>
+    Task<AccessTokenRecord?> GetAsync(CancellationToken ct = default);
+
+    /// <summary>Persist a freshly-issued token.</summary>
+    Task SetAsync(AccessTokenRecord record, CancellationToken ct = default);
+
+    /// <summary>Remove the stored token (sign out).</summary>
+    Task ClearAsync(CancellationToken ct = default);
+}
+
+/// <summary>The wallet's stored access token plus the identity context it carries.</summary>
+/// <param name="AccessToken">JWT access token.</param>
+/// <param name="ExpiresAt">UTC expiry derived from the OAuth <c>expires_in</c> at issue time.</param>
+/// <param name="Email">Citizen email, captured at sign-in for display only (NOT used for auth).</param>
+public sealed record AccessTokenRecord(string AccessToken, DateTimeOffset ExpiresAt, string? Email);
+
+/// <summary>In-memory <see cref="IAccessTokenStore"/> for unit tests.</summary>
+public sealed class InMemoryAccessTokenStore : IAccessTokenStore
+{
+    private AccessTokenRecord? _record;
+    /// <inheritdoc />
+    public Task<AccessTokenRecord?> GetAsync(CancellationToken ct = default) => Task.FromResult(_record);
+    /// <inheritdoc />
+    public Task SetAsync(AccessTokenRecord record, CancellationToken ct = default) { _record = record; return Task.CompletedTask; }
+    /// <inheritdoc />
+    public Task ClearAsync(CancellationToken ct = default) { _record = null; return Task.CompletedTask; }
+}
+
+/// <summary>IndexedDB-backed <see cref="IAccessTokenStore"/>.</summary>
+public sealed class IndexedDbAccessTokenStore : IAccessTokenStore
+{
+    private const string StoreName = "device";
+    private const string Key = "access-token";
+
+    private readonly IJSRuntime _js;
+
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbAccessTokenStore(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public async Task<AccessTokenRecord?> GetAsync(CancellationToken ct = default)
+    {
+        var row = await _js.InvokeAsync<AccessTokenRecord?>("SorchaIndexedDb.get", ct, StoreName, Key);
+        if (row is null) return null;
+        if (row.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            // Expired — purge so callers see signed-out state.
+            await ClearAsync(ct);
+            return null;
+        }
+        return row;
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(AccessTokenRecord record, CancellationToken ct = default)
+    {
+        await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, record, Key);
+    }
+
+    /// <inheritdoc />
+    public async Task ClearAsync(CancellationToken ct = default)
+    {
+        await _js.InvokeVoidAsync("SorchaIndexedDb.del", ct, StoreName, Key);
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IAuthService.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// PWA-side authentication facade (Feature 114, T109 foundation). Wraps the
+/// existing Tenant Service <c>POST /api/auth/login</c> surface so the wallet
+/// can obtain a citizen JWT, persist it via <see cref="IAccessTokenStore"/>,
+/// and surface a clean signed-in / signed-out signal to the UI.
+/// </summary>
+public interface IAuthService
+{
+    /// <summary>True if the wallet currently holds a non-expired access token.</summary>
+    Task<bool> IsSignedInAsync(CancellationToken ct = default);
+
+    /// <summary>The signed-in citizen's email if known, else null.</summary>
+    Task<string?> GetSignedInEmailAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Sign in with email + password. Persists the access token on success.
+    /// Returns a result describing the outcome (success, invalid credentials,
+    /// 2FA required — 2FA flow lands in a follow-up).
+    /// </summary>
+    Task<SignInResult> SignInAsync(string email, string password, CancellationToken ct = default);
+
+    /// <summary>Clears the persisted token.</summary>
+    Task SignOutAsync(CancellationToken ct = default);
+}
+
+/// <summary>Outcome of <see cref="IAuthService.SignInAsync"/>.</summary>
+public sealed record SignInResult(SignInStatus Status, string? ErrorMessage = null)
+{
+    /// <summary>Convenience for happy-path checks.</summary>
+    public bool IsSuccess => Status == SignInStatus.Success;
+}
+
+/// <summary>Possible sign-in outcomes.</summary>
+public enum SignInStatus
+{
+    /// <summary>Sign-in completed; token persisted.</summary>
+    Success = 0,
+    /// <summary>Server rejected the credentials.</summary>
+    InvalidCredentials = 1,
+    /// <summary>Two-factor required — handled in a follow-up wave.</summary>
+    TwoFactorRequired = 2,
+    /// <summary>Network or server error.</summary>
+    ServerError = 3,
+}
+
+/// <summary>
+/// Default <see cref="IAuthService"/>. Calls <c>POST /api/auth/login</c> via
+/// the Tenant Service through the API Gateway. Uses a dedicated unauthenticated
+/// HttpClient (no <see cref="BearerTokenHandler"/>) to avoid sending stale
+/// tokens with sign-in requests.
+/// </summary>
+public sealed class AuthService : IAuthService
+{
+    private readonly HttpClient _http;
+    private readonly IAccessTokenStore _store;
+
+    /// <summary>Initialises a new instance.</summary>
+    public AuthService(HttpClient http, IAccessTokenStore store)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> IsSignedInAsync(CancellationToken ct = default)
+        => await _store.GetAsync(ct) is not null;
+
+    /// <inheritdoc />
+    public async Task<string?> GetSignedInEmailAsync(CancellationToken ct = default)
+        => (await _store.GetAsync(ct))?.Email;
+
+    /// <inheritdoc />
+    public async Task<SignInResult> SignInAsync(string email, string password, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        try
+        {
+            var response = await _http.PostAsJsonAsync(
+                "api/auth/login",
+                new LoginRequest(email.Trim(), password),
+                ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                return new SignInResult(SignInStatus.InvalidCredentials, "Invalid email or password.");
+            }
+            response.EnsureSuccessStatusCode();
+
+            var body = await response.Content.ReadFromJsonAsync<LoginResponse>(ct);
+            if (body is null) return new SignInResult(SignInStatus.ServerError, "Empty response from auth server.");
+
+            if (body.RequiresTwoFactor)
+            {
+                return new SignInResult(SignInStatus.TwoFactorRequired,
+                    "Two-factor authentication is required — full 2FA flow lands in a follow-up wave.");
+            }
+
+            if (string.IsNullOrEmpty(body.AccessToken))
+            {
+                return new SignInResult(SignInStatus.ServerError, "Auth server did not return an access token.");
+            }
+
+            var record = new AccessTokenRecord(
+                body.AccessToken,
+                DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, body.ExpiresIn)),
+                email.Trim());
+            await _store.SetAsync(record, ct);
+            return new SignInResult(SignInStatus.Success);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SignInResult(SignInStatus.ServerError, ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task SignOutAsync(CancellationToken ct = default) => _store.ClearAsync(ct);
+
+    private sealed record LoginRequest(string Email, string Password);
+
+    private sealed record LoginResponse(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("requires_two_factor")] bool RequiresTwoFactor);
+}

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/AuthAndBearerTests.cs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Citizen.Wallet.Services;
+using Xunit;
+
+namespace Sorcha.Citizen.Wallet.Tests.Services;
+
+/// <summary>
+/// Tests for the auth foundation (Feature 114, T109): <see cref="AuthService"/>
+/// happy / unhappy paths, and <see cref="BearerTokenHandler"/> stamping the
+/// Authorization header from <see cref="IAccessTokenStore"/>.
+/// </summary>
+public sealed class AuthAndBearerTests
+{
+    [Fact]
+    public async Task AuthService_SuccessfulLogin_PersistsTokenAndEmail()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var handler = new StubHttpHandler((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().EndWith("/api/auth/login");
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"access_token":"jwt-here","expires_in":3600,"requires_two_factor":false}""",
+                    Encoding.UTF8, "application/json"),
+            };
+        });
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+        var auth = new AuthService(http, store);
+
+        var result = await auth.SignInAsync("citizen@example.com", "secret-pw");
+
+        result.IsSuccess.Should().BeTrue();
+        var record = await store.GetAsync();
+        record.Should().NotBeNull();
+        record!.AccessToken.Should().Be("jwt-here");
+        record.Email.Should().Be("citizen@example.com");
+        record.ExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow.AddMinutes(50));
+    }
+
+    [Fact]
+    public async Task AuthService_401Response_ReturnsInvalidCredentials()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var handler = new StubHttpHandler((_, _) => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+
+        var result = await auth.SignInAsync("citizen@example.com", "wrong");
+
+        result.Status.Should().Be(SignInStatus.InvalidCredentials);
+        (await store.GetAsync()).Should().BeNull("failed sign-in must not persist a token");
+    }
+
+    [Fact]
+    public async Task AuthService_TwoFactorRequired_ReturnsTwoFactorStatus()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var handler = new StubHttpHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"access_token":null,"expires_in":0,"requires_two_factor":true}""",
+                Encoding.UTF8, "application/json"),
+        });
+        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+
+        var result = await auth.SignInAsync("citizen@example.com", "pw");
+
+        result.Status.Should().Be(SignInStatus.TwoFactorRequired);
+        (await store.GetAsync()).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AuthService_SignOut_ClearsToken()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("jwt", DateTimeOffset.UtcNow.AddHours(1), "x@example.com"));
+        var auth = new AuthService(new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage())),
+            store);
+
+        await auth.SignOutAsync();
+
+        (await auth.IsSignedInAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task BearerTokenHandler_AddsAuthorizationHeader_WhenTokenPresent()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("the-token", DateTimeOffset.UtcNow.AddHours(1), "x@example.com"));
+
+        string? observedAuth = null;
+        var inner = new StubHttpHandler((req, _) =>
+        {
+            observedAuth = req.Headers.Authorization?.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var bearer = new BearerTokenHandler(store) { InnerHandler = inner };
+        var http = new HttpClient(bearer) { BaseAddress = new Uri("https://localhost/") };
+
+        await http.GetAsync("api/v1/wallet/sync");
+
+        observedAuth.Should().Be("Bearer the-token");
+    }
+
+    [Fact]
+    public async Task BearerTokenHandler_OmitsHeader_WhenSignedOut()
+    {
+        var store = new InMemoryAccessTokenStore();
+        string? observedAuth = "sentinel";
+        var inner = new StubHttpHandler((req, _) =>
+        {
+            observedAuth = req.Headers.Authorization?.ToString();
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var bearer = new BearerTokenHandler(store) { InnerHandler = inner };
+        var http = new HttpClient(bearer) { BaseAddress = new Uri("https://localhost/") };
+
+        await http.GetAsync("api/v1/wallet/sync");
+
+        observedAuth.Should().BeNull("requests must go out unauthenticated when no token is stored");
+    }
+
+    private sealed class StubHttpHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _respond;
+        public StubHttpHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond)
+            => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(_respond(request, ct));
+    }
+}


### PR DESCRIPTION
## Summary

Wave-2 Tier-2 close-out, first slice of T109. Adds the auth plumbing the EnrolmentWizard will sit on top of.

After this PR the wallet's HTTP pipeline carries the citizen JWT automatically — Sync, /credentials, /devices/enrol all stop 401-ing once the user signs in.

## Changes

- **Token plumbing**: `IAccessTokenStore` + `InMemoryAccessTokenStore` (tests) + `IndexedDbAccessTokenStore` (auto-purges on expiry).
- **`BearerTokenHandler`**: DelegatingHandler that stamps `Authorization: Bearer` from the store. Omits cleanly when signed out so 401 surfaces naturally.
- **`IAuthService` + `AuthService`**: wraps `POST /api/auth/login`. Handles 401 → invalid creds, 2FA-required → status, server errors, success → token persistence (with email captured for display).
- **Typed HttpClient pipeline**: Auth gets unauthenticated client (so sign-in doesn't carry stale tokens); CitizenWalletClient gets bearer-stamped client. Gateway base address derived from host root.
- **Settings UI**: sign-in form when signed out, \"Signed in as <email>\" + Sign out when signed in.
- 6 new unit tests. All 31 wallet tests pass.

## Deferred to T109 part 2

- EnrolmentWizard.razor multi-step UX (label entry → device key gen ceremony → /devices/enrol → initial /credentials pull → success).
- 2FA flow (currently surfaces a clean error).

## Test plan

- [x] 6 new unit tests (auth + bearer)
- [x] All 31 wallet tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)