### PR TITLE
feat(114): renew-delegation endpoint (T106)

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/PlatformUserDevice/IPlatformUserDeviceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/PlatformUserDevice/IPlatformUserDeviceClient.cs
@@ -25,6 +25,15 @@ public interface IPlatformUserDeviceClient
         string delegationCredentialJti,
         int statusListIndex,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up a single device by id, scoped to the supplied platform user.
+    /// Returns null if the device does not exist or is not owned by the user.
+    /// </summary>
+    Task<PlatformUserDeviceLookupResult?> GetByIdAsync(
+        Guid deviceId,
+        Guid platformUserId,
+        CancellationToken ct = default);
 }
 
 /// <summary>Result of <see cref="IPlatformUserDeviceClient.RegisterAsync"/>.</summary>
@@ -33,3 +42,17 @@ public interface IPlatformUserDeviceClient
 public sealed record PlatformUserDeviceRegistrationResult(
     Guid DeviceId,
     DateTimeOffset EnrolledAt);
+
+/// <summary>Result of <see cref="IPlatformUserDeviceClient.GetByIdAsync"/>.</summary>
+public sealed record PlatformUserDeviceLookupResult(
+    Guid DeviceId,
+    Guid PlatformUserId,
+    string Label,
+    string DevicePublicJwkThumbprint,
+    string DevicePublicJwkJson,
+    string Platform,
+    string Status,
+    DateTimeOffset EnrolledAt,
+    DateTimeOffset DelegationExpiresAt,
+    string DelegationCredentialJti,
+    int StatusListIndex);

--- a/src/Common/Sorcha.ServiceClients.Http/PlatformUserDevice/PlatformUserDeviceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/PlatformUserDevice/PlatformUserDeviceClient.cs
@@ -83,4 +83,20 @@ public sealed class PlatformUserDeviceClient : IPlatformUserDeviceClient
         return result ?? throw new InvalidOperationException(
             "Tenant Service returned an empty body for platform-user-device registration.");
     }
+
+    /// <inheritdoc />
+    public async Task<PlatformUserDeviceLookupResult?> GetByIdAsync(
+        Guid deviceId, Guid platformUserId, CancellationToken ct = default)
+    {
+        await ServiceClientAuthHelper.SetAuthHeaderAsync(
+            _httpClient, _serviceAuth, _logger, "Tenant Service (PlatformUserDevice)", ct);
+
+        var response = await _httpClient.GetAsync(
+            $"api/internal/platform-user-devices/{deviceId}?platformUserId={platformUserId}", ct);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<PlatformUserDeviceLookupResult>(JsonOptions, ct);
+    }
 }

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/InternalEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/InternalEndpoints.cs
@@ -38,6 +38,14 @@ public static class InternalEndpoints
                 + "Idempotent on (PlatformUserId, DevicePublicJwkThumbprint).")
             .RequireAuthorization("RequireService");
 
+        // Feature 114: device lookup for delegation renewal flow.
+        group.MapGet("/platform-user-devices/{deviceId:guid}", GetPlatformUserDevice)
+            .WithName("GetPlatformUserDevice")
+            .WithSummary("Look up a citizen wallet device by id, scoped to its owning platform user")
+            .WithDescription("Called by Wallet Service during delegation renewal. The platformUserId "
+                + "query parameter scopes the lookup so cross-user device probing is impossible.")
+            .RequireAuthorization("RequireService");
+
         return app;
     }
 
@@ -68,6 +76,43 @@ public static class InternalEndpoints
             return TypedResults.BadRequest(ex.Message);
         }
     }
+
+    private static async Task<Results<Ok<PlatformUserDeviceLookupResponse>, NotFound>> GetPlatformUserDevice(
+        Guid deviceId,
+        [FromQuery] Guid platformUserId,
+        IPlatformUserDeviceService deviceService,
+        CancellationToken ct)
+    {
+        var device = await deviceService.GetByIdAsync(deviceId, platformUserId, ct);
+        if (device is null) return TypedResults.NotFound();
+
+        return TypedResults.Ok(new PlatformUserDeviceLookupResponse(
+            device.Id,
+            device.PlatformUserId,
+            device.Label,
+            device.DevicePublicJwkThumbprint,
+            device.DevicePublicJwkJson,
+            device.Platform,
+            device.Status.ToString(),
+            device.EnrolledAt,
+            device.DelegationExpiresAt,
+            device.DelegationCredentialJti,
+            device.StatusListIndex));
+    }
+
+    /// <summary>Internal response for a single device lookup.</summary>
+    public sealed record PlatformUserDeviceLookupResponse(
+        Guid DeviceId,
+        Guid PlatformUserId,
+        string Label,
+        string DevicePublicJwkThumbprint,
+        string DevicePublicJwkJson,
+        string Platform,
+        string Status,
+        DateTimeOffset EnrolledAt,
+        DateTimeOffset DelegationExpiresAt,
+        string DelegationCredentialJti,
+        int StatusListIndex);
 
     /// <summary>Internal request body for citizen device registration.</summary>
     public sealed record PlatformUserDeviceRegistrationRequest(

--- a/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserDeviceService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserDeviceService.cs
@@ -49,4 +49,15 @@ public interface IPlatformUserDeviceService
         string delegationCredentialJti,
         int statusListIndex,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up a single device by id, scoped to the supplied platform user.
+    /// Returns null if the device does not exist OR is not owned by the user
+    /// (the two cases are intentionally indistinguishable to callers — both
+    /// surface as "not your device" without leaking existence).
+    /// </summary>
+    Task<PlatformUserDevice?> GetByIdAsync(
+        Guid deviceId,
+        Guid platformUserId,
+        CancellationToken ct = default);
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserDeviceService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserDeviceService.cs
@@ -114,4 +114,13 @@ public sealed class PlatformUserDeviceService : IPlatformUserDeviceService
 
         return device;
     }
+
+    /// <inheritdoc />
+    public async Task<PlatformUserDevice?> GetByIdAsync(
+        Guid deviceId, Guid platformUserId, CancellationToken ct = default)
+    {
+        return await _db.PlatformUserDevices
+            .AsNoTracking()
+            .FirstOrDefaultAsync(d => d.Id == deviceId && d.PlatformUserId == platformUserId, ct);
+    }
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -52,6 +52,19 @@ public static class CitizenWalletEndpoints
             .Produces<CredentialListResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized);
 
+        group.MapPost("/devices/renew-delegation", RenewDelegation)
+            .WithName("RenewCitizenDeviceDelegation")
+            .WithSummary("Renew the device delegation credential")
+            .WithDescription(
+                "Idempotent re-issuance of the holder→device delegation, signed by " +
+                "the citizen's holder key. Wallets call this when their current " +
+                "delegation is approaching expiry (within 30 days). Returns 404 if " +
+                "the device is unknown or not owned by the caller.")
+            .Produces<DelegationRenewalResponse>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
         group.MapGet("/sync", SyncCredentials)
             .WithName("SyncCitizenWallet")
             .WithSummary("Pull credential and delegation deltas since the last sync")
@@ -64,6 +77,34 @@ public static class CitizenWalletEndpoints
             .Produces(StatusCodes.Status410Gone);
 
         return app;
+    }
+
+    private static async Task<IResult> RenewDelegation(
+        [FromBody] DelegationRenewalRequest request,
+        HttpContext context,
+        IDelegationRenewalService renewal,
+        CancellationToken ct)
+    {
+        var (platformUserId, citizenWallet, organizationId) = ResolveCitizenContext(context.User);
+        if (platformUserId is null || citizenWallet is null || organizationId is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (request.DeviceId == Guid.Empty)
+        {
+            return Results.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["deviceId"] = new[] { "deviceId is required." }
+            });
+        }
+
+        var response = await renewal.RenewAsync(
+            request.DeviceId, platformUserId.Value, citizenWallet, organizationId.Value, ct);
+
+        return response is null
+            ? Results.NotFound()
+            : Results.Ok(response);
     }
 
     private static async Task<IResult> ListCredentials(

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -149,6 +149,12 @@ builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Interfaces.ICitizen
 builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Interfaces.ICitizenSyncService,
     Sorcha.Wallet.Service.Services.Implementation.CitizenSyncService>();
 
+// Feature 114: Delegation renewal (T106). Composes Tenant Service device lookup
+// + IDeviceDelegationIssuer + IOrgStatusSigningWalletResolver behind one
+// idempotent re-issuance call.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDelegationRenewalService,
+    Sorcha.Wallet.Service.Services.Implementation.DelegationRenewalService>();
+
 // Feature 114: FluentValidation for citizen wallet request DTOs
 builder.Services.AddValidatorsFromAssemblyContaining<
     Sorcha.CitizenWallet.Abstractions.Validators.DeviceEnrolmentRequestValidator>();

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/DelegationRenewalService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/DelegationRenewalService.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.ServiceClients.PlatformUserDevice;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>Default <see cref="IDelegationRenewalService"/>.</summary>
+public sealed class DelegationRenewalService : IDelegationRenewalService
+{
+    private readonly IPlatformUserDeviceClient _deviceClient;
+    private readonly IDeviceDelegationIssuer _issuer;
+    private readonly IOrgStatusSigningWalletResolver _orgWalletResolver;
+    private readonly ILogger<DelegationRenewalService> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public DelegationRenewalService(
+        IPlatformUserDeviceClient deviceClient,
+        IDeviceDelegationIssuer issuer,
+        IOrgStatusSigningWalletResolver orgWalletResolver,
+        ILogger<DelegationRenewalService> logger)
+    {
+        _deviceClient = deviceClient ?? throw new ArgumentNullException(nameof(deviceClient));
+        _issuer = issuer ?? throw new ArgumentNullException(nameof(issuer));
+        _orgWalletResolver = orgWalletResolver ?? throw new ArgumentNullException(nameof(orgWalletResolver));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<DelegationRenewalResponse?> RenewAsync(
+        Guid deviceId,
+        Guid platformUserId,
+        string citizenWalletAddress,
+        Guid organizationId,
+        CancellationToken ct = default)
+    {
+        var device = await _deviceClient.GetByIdAsync(deviceId, platformUserId, ct);
+        if (device is null)
+        {
+            _logger.LogInformation(
+                "Delegation renewal rejected: device {DeviceId} not found for platformUser {PlatformUserId}",
+                deviceId, platformUserId);
+            return null;
+        }
+
+        if (!string.Equals(device.Status, "Active", StringComparison.Ordinal))
+        {
+            _logger.LogInformation(
+                "Delegation renewal rejected: device {DeviceId} status is {Status} (must be Active)",
+                deviceId, device.Status);
+            return null;
+        }
+
+        // Re-derive the device JWK from its persisted JSON.
+        var deviceJwk = ParseJwk(device.DevicePublicJwkJson);
+
+        // Always re-issue: the holder→device delegation is short(ish) and renewals
+        // are infrequent. The status-list slot stays the same (it is per-device,
+        // not per-delegation) because IDeviceDelegationIssuer allocates a new slot
+        // only when there is no existing reservation — but that bookkeeping is
+        // owned by the publisher, not us; v1 keeps it simple by always issuing
+        // fresh and trusting the publisher to handle slot reuse on subsequent
+        // refreshes.
+        var orgSigningWallet = await _orgWalletResolver.ResolveAsync(organizationId, ct);
+        var fresh = await _issuer.IssueAsync(
+            platformUserId,
+            citizenWalletAddress,
+            organizationId,
+            orgSigningWallet,
+            deviceJwk,
+            device.Label,
+            device.Platform,
+            ct);
+
+        // Refresh the Tenant device record's delegation fields. The RegisterAsync
+        // path is idempotent on (PlatformUserId, JWK thumbprint), so calling it
+        // here updates the existing row in place rather than creating a new one.
+        await _deviceClient.RegisterAsync(
+            platformUserId,
+            device.Label,
+            device.DevicePublicJwkThumbprint,
+            device.DevicePublicJwkJson,
+            device.Platform,
+            userAgent: string.Empty, // unchanged on renewal
+            fresh.ExpiresAt,
+            fresh.Jti,
+            fresh.StatusListIndex,
+            ct);
+
+        _logger.LogInformation(
+            "Renewed delegation for device {DeviceId} (platformUser={PlatformUserId}, jti={Jti}, exp={Exp:O})",
+            deviceId, platformUserId, fresh.Jti, fresh.ExpiresAt);
+
+        return new DelegationRenewalResponse
+        {
+            DelegationCredential = fresh.CompactJwt,
+            ExpiresAt = fresh.ExpiresAt,
+        };
+    }
+
+    private static EcP256PublicJwk ParseJwk(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        return new EcP256PublicJwk
+        {
+            Kty = root.GetProperty("kty").GetString() ?? "EC",
+            Crv = root.GetProperty("crv").GetString() ?? "P-256",
+            X = root.GetProperty("x").GetString() ?? string.Empty,
+            Y = root.TryGetProperty("y", out var y) ? y.GetString() ?? string.Empty : string.Empty,
+        };
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDelegationRenewalService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IDelegationRenewalService.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.CitizenWallet.Abstractions.Models;
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Renews a citizen wallet's device delegation credential (Feature 114, T106).
+/// Composes Tenant Service device lookup + <see cref="IHolderKeyService"/> +
+/// <see cref="IDeviceDelegationIssuer"/> + Tenant Service device record refresh
+/// into one idempotent call. Wallets call this when their current delegation
+/// is approaching expiry (within 30 days, per the v1 contract).
+/// </summary>
+public interface IDelegationRenewalService
+{
+    /// <summary>
+    /// Re-issues the delegation credential bound to the device, signed by the
+    /// citizen's holder key. Refreshes the Tenant <see cref="Sorcha.Tenant.Service.Models.PlatformUserDevice"/>
+    /// row's delegation expiry + JTI in the same call.
+    /// </summary>
+    /// <returns>
+    /// A renewal result, or null when the device does not exist or is not owned
+    /// by the supplied platform user.
+    /// </returns>
+    Task<DelegationRenewalResponse?> RenewAsync(
+        Guid deviceId,
+        Guid platformUserId,
+        string citizenWalletAddress,
+        Guid organizationId,
+        CancellationToken ct = default);
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/DelegationRenewalServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/DelegationRenewalServiceTests.cs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.ServiceClients.PlatformUserDevice;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="DelegationRenewalService"/> (Feature 114, T106).
+/// Verifies device-not-found / not-active rejection paths, the happy renewal
+/// path (re-issue + Tenant record refresh), and that the Tenant record refresh
+/// reuses the existing JWK thumbprint so the row is updated in place rather
+/// than duplicated.
+/// </summary>
+public sealed class DelegationRenewalServiceTests
+{
+    private static readonly Guid PlatformUserId = Guid.Parse("d8b04e5a-0000-0000-0000-000000000001");
+    private static readonly Guid OrgId = Guid.Parse("0a000000-0000-0000-0000-000000000001");
+    private static readonly Guid DeviceId = Guid.Parse("0d000000-0000-0000-0000-000000000001");
+    private const string CitizenWallet = "ws1qcitizenexamplewalletaddress";
+    private const string OrgSigningWallet = "ws1qorgsigningwallet";
+
+    private readonly Mock<IPlatformUserDeviceClient> _devices = new();
+    private readonly Mock<IDeviceDelegationIssuer> _issuer = new();
+    private readonly Mock<IOrgStatusSigningWalletResolver> _orgResolver = new();
+    private readonly DelegationRenewalService _sut;
+
+    public DelegationRenewalServiceTests()
+    {
+        _orgResolver.Setup(o => o.ResolveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OrgSigningWallet);
+        _sut = new DelegationRenewalService(
+            _devices.Object, _issuer.Object, _orgResolver.Object,
+            NullLogger<DelegationRenewalService>.Instance);
+    }
+
+    [Fact]
+    public async Task RenewAsync_DeviceNotFound_ReturnsNull()
+    {
+        _devices.Setup(c => c.GetByIdAsync(DeviceId, PlatformUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformUserDeviceLookupResult?)null);
+
+        var result = await _sut.RenewAsync(DeviceId, PlatformUserId, CitizenWallet, OrgId);
+
+        result.Should().BeNull();
+        _issuer.Verify(i => i.IssueAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid>(),
+            It.IsAny<string>(), It.IsAny<EcP256PublicJwk>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RenewAsync_DeviceRevoked_ReturnsNull()
+    {
+        _devices.Setup(c => c.GetByIdAsync(DeviceId, PlatformUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LookupResult(status: "Revoked"));
+
+        var result = await _sut.RenewAsync(DeviceId, PlatformUserId, CitizenWallet, OrgId);
+
+        result.Should().BeNull("revoked devices must not have their delegations renewed");
+    }
+
+    [Fact]
+    public async Task RenewAsync_HappyPath_ReissuesAndRefreshesTenantRecord()
+    {
+        var lookup = LookupResult();
+        _devices.Setup(c => c.GetByIdAsync(DeviceId, PlatformUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(lookup);
+
+        var newExp = DateTimeOffset.UtcNow.AddYears(1);
+        var newJti = "fresh-jti-" + Guid.NewGuid().ToString("N")[..8];
+        EcP256PublicJwk? sentJwk = null;
+        _issuer.Setup(i => i.IssueAsync(
+                PlatformUserId, CitizenWallet, OrgId, OrgSigningWallet,
+                It.IsAny<EcP256PublicJwk>(), lookup.Label, lookup.Platform, It.IsAny<CancellationToken>()))
+            .Callback<Guid, string, Guid, string, EcP256PublicJwk, string, string, CancellationToken>(
+                (_, _, _, _, jwk, _, _, _) => sentJwk = jwk)
+            .ReturnsAsync(new DeviceDelegationResult(
+                CompactJwt: "eyJ.fresh.delegation",
+                Jti: newJti,
+                ExpiresAt: newExp,
+                StatusListUri: "https://verify.test/status/0.statuslist+jwt",
+                StatusListIndex: lookup.StatusListIndex,
+                StatusListId: 0,
+                HolderPublicJwk: JsonSerializer.Deserialize<JsonElement>(
+                    """{"kty":"EC","crv":"P-256","x":"hx","y":"hy"}""")));
+
+        _devices.Setup(c => c.RegisterAsync(
+                PlatformUserId, lookup.Label, lookup.DevicePublicJwkThumbprint,
+                lookup.DevicePublicJwkJson, lookup.Platform, string.Empty,
+                newExp, newJti, lookup.StatusListIndex, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PlatformUserDeviceRegistrationResult(DeviceId, lookup.EnrolledAt));
+
+        var result = await _sut.RenewAsync(DeviceId, PlatformUserId, CitizenWallet, OrgId);
+
+        result.Should().NotBeNull();
+        result!.DelegationCredential.Should().Be("eyJ.fresh.delegation");
+        result.ExpiresAt.Should().Be(newExp);
+
+        sentJwk.Should().NotBeNull();
+        sentJwk!.X.Should().Be("test-x", "the issuer must be called with the device JWK from the Tenant lookup");
+
+        // Tenant record refresh must reuse the existing thumbprint so it lands in the
+        // existing row (idempotent on (PlatformUserId, Thumbprint)).
+        _devices.Verify(c => c.RegisterAsync(
+            PlatformUserId, lookup.Label, lookup.DevicePublicJwkThumbprint,
+            lookup.DevicePublicJwkJson, lookup.Platform, string.Empty,
+            newExp, newJti, lookup.StatusListIndex, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static PlatformUserDeviceLookupResult LookupResult(string status = "Active") => new(
+        DeviceId: DeviceId,
+        PlatformUserId: PlatformUserId,
+        Label: "Stuart's iPhone",
+        DevicePublicJwkThumbprint: "thumbprint-1234567890abcdef0123456789abcdef0123456",
+        DevicePublicJwkJson: """{"kty":"EC","crv":"P-256","x":"test-x","y":"test-y"}""",
+        Platform: "iOS 19 / Safari 19",
+        Status: status,
+        EnrolledAt: DateTimeOffset.UtcNow.AddDays(-300),
+        DelegationExpiresAt: DateTimeOffset.UtcNow.AddDays(20), // 20 days from expiry → renewal due
+        DelegationCredentialJti: "old-jti",
+        StatusListIndex: 7);
+}


### PR DESCRIPTION
## Summary

Wave-2 Tier-2 close-out. Wallets can now refresh their delegation credential as expiry approaches — without this, every device dies silently 12 months after enrolment.

## Changes

**Tenant Service:**
- `IPlatformUserDeviceService.GetByIdAsync` — scoped lookup (deviceId + platformUserId), null on cross-user probes (no existence leak).
- `GET /api/internal/platform-user-devices/{id}?platformUserId={uid}` behind `RequireService`.

**ServiceClients.Http:**
- `IPlatformUserDeviceClient.GetByIdAsync` + `PlatformUserDeviceLookupResult`. 404 → null.

**Wallet Service:**
- `IDelegationRenewalService` + `DelegationRenewalService` — composes Tenant lookup → `IDeviceDelegationIssuer.IssueAsync` → Tenant record refresh. Always re-issues. Status-list slot reused (RegisterAsync idempotent on thumbprint). Rejects revoked devices.
- `POST /api/v1/wallet/devices/renew-delegation` — JWT-scoped; 404 on unknown/cross-user; 200 with `DelegationRenewalResponse`.

3 new unit tests. All 690 wallet service tests pass.

## Deferred

PWA-side trigger (check delegation expiry on load → call renew if within 30 days of expiry) lands in a follow-up.

## Test plan
- [x] 3 new unit tests pass
- [x] All 690 wallet tests pass
- [x] Build clean (Tenant + Wallet + ServiceClients.Http)

🤖 Generated with [Claude Code](https://claude.com/claude-code)