### PR TITLE
feat(114): PWA delegation renewal client + auto-trigger (T106 PWA part)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -30,7 +30,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();
         services.AddSingleton<IAccessTokenStore, IndexedDbAccessTokenStore>();
         services.AddSingleton<ISyncService, SyncService>();
+        services.AddSingleton<IDeviceMetaStore, IndexedDbDeviceMetaStore>();
         services.AddSingleton<IEnrolmentService, EnrolmentService>();
+        services.AddSingleton<IDelegationRenewalClient, DelegationRenewalClient>();
 
         // Auth surface: a separate HttpClient that does NOT inject the bearer
         // token (so sign-in requests don't carry stale tokens).

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -18,6 +18,7 @@
 @inject IDelegationStore Delegation
 @inject IDeviceKeyService DeviceKey
 @inject ISyncService Sync
+@inject IDelegationRenewalClient Renewal
 @inject HttpClient Http
 @inject NavigationManager Nav
 @inject ILogger<Index> Logger
@@ -101,6 +102,32 @@
         // Fire-and-forget background sync — refreshes the cache from server without
         // blocking first paint. UI updates via StateHasChanged when sync completes.
         _ = SyncNowAsync(silentSuccess: true);
+        // Fire-and-forget delegation renewal check — silent unless renewal happens.
+        _ = RenewIfDueAsync();
+    }
+
+    private async Task RenewIfDueAsync()
+    {
+        try
+        {
+            var outcome = await Renewal.RenewIfDueAsync();
+            if (outcome == DelegationRenewalOutcome.Renewed)
+            {
+                _syncSeverity = Severity.Info;
+                _syncStatus = "Device delegation renewed.";
+                StateHasChanged();
+            }
+            else if (outcome == DelegationRenewalOutcome.DeviceNotFound)
+            {
+                _syncSeverity = Severity.Warning;
+                _syncStatus = "This device was revoked on another device. Re-enrol to continue.";
+                StateHasChanged();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Background delegation renewal failed");
+        }
     }
 
     private async Task SyncNowAsync(bool silentSuccess = false)

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IDelegationRenewalClient.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IDelegationRenewalClient.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.CitizenWallet;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// PWA-side renewal trigger (Feature 114, T106 PWA part). Inspects the
+/// persisted delegation expiry; when within the renewal window (default
+/// 30 days), calls the Wallet Service <c>/devices/renew-delegation</c>
+/// endpoint and persists the fresh delegation. No-op otherwise.
+/// </summary>
+public interface IDelegationRenewalClient
+{
+    /// <summary>
+    /// Check expiry and renew if due. Idempotent — safe to call on every
+    /// page load. Returns the outcome describing what happened.
+    /// </summary>
+    Task<DelegationRenewalOutcome> RenewIfDueAsync(CancellationToken ct = default);
+}
+
+/// <summary>What happened on a single <see cref="IDelegationRenewalClient.RenewIfDueAsync"/> call.</summary>
+public enum DelegationRenewalOutcome
+{
+    /// <summary>Wallet not enrolled — nothing to renew.</summary>
+    NotEnrolled = 0,
+    /// <summary>Delegation is still well within its lifetime; no action taken.</summary>
+    NotDue = 1,
+    /// <summary>Renewal succeeded; the new delegation has been persisted.</summary>
+    Renewed = 2,
+    /// <summary>Renewal was attempted but the server responded 404 (device unknown).</summary>
+    DeviceNotFound = 3,
+    /// <summary>Network or server error during renewal — caller may retry.</summary>
+    Failed = 4,
+}
+
+/// <summary>Default <see cref="IDelegationRenewalClient"/>.</summary>
+public sealed class DelegationRenewalClient : IDelegationRenewalClient
+{
+    /// <summary>Renew when within this window of expiry.</summary>
+    public static readonly TimeSpan RenewalWindow = TimeSpan.FromDays(30);
+
+    private readonly IDeviceMetaStore _meta;
+    private readonly IDelegationStore _delegations;
+    private readonly ICitizenWalletClient _client;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<DelegationRenewalClient> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public DelegationRenewalClient(
+        IDeviceMetaStore meta,
+        IDelegationStore delegations,
+        ICitizenWalletClient client,
+        TimeProvider clock,
+        ILogger<DelegationRenewalClient> logger)
+    {
+        _meta = meta ?? throw new ArgumentNullException(nameof(meta));
+        _delegations = delegations ?? throw new ArgumentNullException(nameof(delegations));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<DelegationRenewalOutcome> RenewIfDueAsync(CancellationToken ct = default)
+    {
+        var meta = await _meta.GetAsync(ct);
+        if (meta is null) return DelegationRenewalOutcome.NotEnrolled;
+
+        var now = _clock.GetUtcNow();
+        if (meta.DelegationExpiresAt - now > RenewalWindow)
+        {
+            return DelegationRenewalOutcome.NotDue;
+        }
+
+        try
+        {
+            var renewal = await _client.RenewDelegationAsync(meta.DeviceId, ct);
+            if (renewal is null)
+            {
+                _logger.LogWarning(
+                    "Delegation renewal returned 404 for device {DeviceId}; the device may have been revoked",
+                    meta.DeviceId);
+                return DelegationRenewalOutcome.DeviceNotFound;
+            }
+
+            await _delegations.SetAsync(renewal.DelegationCredential, ct);
+            await _meta.SetAsync(meta with { DelegationExpiresAt = renewal.ExpiresAt }, ct);
+            _logger.LogInformation(
+                "Renewed delegation for device {DeviceId}; new expiry {Exp:O}",
+                meta.DeviceId, renewal.ExpiresAt);
+            return DelegationRenewalOutcome.Renewed;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Delegation renewal HTTP failure for device {DeviceId}", meta.DeviceId);
+            return DelegationRenewalOutcome.Failed;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IDeviceMetaStore.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IDeviceMetaStore.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Persists the wallet's enrolment metadata — server-assigned device id,
+/// citizen-visible label, and current delegation expiry (Feature 114, T106
+/// PWA-side trigger). Lives alongside the device key in the IndexedDB
+/// <c>device</c> store as singleton key <c>enrolment</c>; pulled out of
+/// <see cref="IDelegationStore"/> so the existing string-only delegation
+/// API stays untouched and callers that only need the JWT don't pay for
+/// the metadata.
+/// </summary>
+public interface IDeviceMetaStore
+{
+    /// <summary>Returns the persisted enrolment metadata, or null if not yet enrolled.</summary>
+    Task<DeviceMetaRecord?> GetAsync(CancellationToken ct = default);
+
+    /// <summary>Persist (or replace) the enrolment metadata.</summary>
+    Task SetAsync(DeviceMetaRecord record, CancellationToken ct = default);
+
+    /// <summary>Clear the enrolment metadata (e.g. on sign-out).</summary>
+    Task ClearAsync(CancellationToken ct = default);
+}
+
+/// <summary>The wallet's enrolment metadata, persisted client-side.</summary>
+/// <param name="DeviceId">Server-assigned device id.</param>
+/// <param name="Label">Citizen-editable device label.</param>
+/// <param name="EnrolledAt">UTC time the device was first enrolled.</param>
+/// <param name="DelegationExpiresAt">UTC expiry of the current delegation credential.</param>
+public sealed record DeviceMetaRecord(
+    Guid DeviceId,
+    string Label,
+    DateTimeOffset EnrolledAt,
+    DateTimeOffset DelegationExpiresAt);
+
+/// <summary>In-memory <see cref="IDeviceMetaStore"/> for tests.</summary>
+public sealed class InMemoryDeviceMetaStore : IDeviceMetaStore
+{
+    private DeviceMetaRecord? _record;
+    /// <inheritdoc />
+    public Task<DeviceMetaRecord?> GetAsync(CancellationToken ct = default) => Task.FromResult(_record);
+    /// <inheritdoc />
+    public Task SetAsync(DeviceMetaRecord record, CancellationToken ct = default) { _record = record; return Task.CompletedTask; }
+    /// <inheritdoc />
+    public Task ClearAsync(CancellationToken ct = default) { _record = null; return Task.CompletedTask; }
+}
+
+/// <summary>IndexedDB-backed <see cref="IDeviceMetaStore"/>.</summary>
+public sealed class IndexedDbDeviceMetaStore : IDeviceMetaStore
+{
+    private const string StoreName = "device";
+    private const string Key = "enrolment";
+
+    private readonly IJSRuntime _js;
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbDeviceMetaStore(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public async Task<DeviceMetaRecord?> GetAsync(CancellationToken ct = default)
+        => await _js.InvokeAsync<DeviceMetaRecord?>("SorchaIndexedDb.get", ct, StoreName, Key);
+
+    /// <inheritdoc />
+    public async Task SetAsync(DeviceMetaRecord record, CancellationToken ct = default)
+        => await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, record, Key);
+
+    /// <inheritdoc />
+    public async Task ClearAsync(CancellationToken ct = default)
+        => await _js.InvokeVoidAsync("SorchaIndexedDb.del", ct, StoreName, Key);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IEnrolmentService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IEnrolmentService.cs
@@ -48,8 +48,10 @@ public sealed class EnrolmentService : IEnrolmentService
     private readonly IDeviceKeyService _deviceKeys;
     private readonly ICitizenWalletClient _walletClient;
     private readonly IDelegationStore _delegations;
+    private readonly IDeviceMetaStore _deviceMeta;
     private readonly ISyncService _sync;
     private readonly ICredentialCache _cache;
+    private readonly TimeProvider _clock;
     private readonly ILogger<EnrolmentService> _logger;
 
     /// <summary>Initialises a new instance.</summary>
@@ -57,15 +59,19 @@ public sealed class EnrolmentService : IEnrolmentService
         IDeviceKeyService deviceKeys,
         ICitizenWalletClient walletClient,
         IDelegationStore delegations,
+        IDeviceMetaStore deviceMeta,
         ISyncService sync,
         ICredentialCache cache,
+        TimeProvider clock,
         ILogger<EnrolmentService> logger)
     {
         _deviceKeys = deviceKeys ?? throw new ArgumentNullException(nameof(deviceKeys));
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
         _delegations = delegations ?? throw new ArgumentNullException(nameof(delegations));
+        _deviceMeta = deviceMeta ?? throw new ArgumentNullException(nameof(deviceMeta));
         _sync = sync ?? throw new ArgumentNullException(nameof(sync));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -97,6 +103,14 @@ public sealed class EnrolmentService : IEnrolmentService
 
         // 3. Persist the delegation locally so offline presentations can use it.
         await _delegations.SetAsync(response.DelegationCredential, ct);
+
+        // 3b. Persist enrolment metadata so the renewal trigger can find the
+        //     deviceId + expiry without re-asking the server.
+        await _deviceMeta.SetAsync(new DeviceMetaRecord(
+            response.DeviceId,
+            request.DeviceLabel,
+            EnrolledAt: _clock.GetUtcNow(),
+            response.DelegationExpiresAt), ct);
 
         // 4. Pull the initial credential snapshot via the sync orchestrator —
         //    it handles the cursor bootstrap on top of the snapshot fetch.

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
@@ -91,4 +91,20 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         return await response.Content.ReadFromJsonAsync<CredentialListResponse>(JsonOptions, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /credentials.");
     }
+
+    /// <inheritdoc />
+    public async Task<DelegationRenewalResponse?> RenewDelegationAsync(
+        Guid deviceId, CancellationToken ct = default)
+    {
+        var response = await _httpClient.PostAsJsonAsync(
+            "api/v1/wallet/devices/renew-delegation",
+            new DelegationRenewalRequest { DeviceId = deviceId },
+            JsonOptions, ct);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<DelegationRenewalResponse>(JsonOptions, ct)
+            ?? throw new InvalidOperationException("Wallet Service returned an empty body for /devices/renew-delegation.");
+    }
 }

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/ICitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/ICitizenWalletClient.cs
@@ -42,4 +42,12 @@ public interface ICitizenWalletClient
     /// or to recover after a stale-cursor 410.
     /// </summary>
     Task<CredentialListResponse> ListCredentialsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Renews the device delegation credential for the supplied device id.
+    /// Calls <c>POST /api/v1/wallet/devices/renew-delegation</c>. Returns
+    /// <c>null</c> on 404 (device unknown or not owned by caller).
+    /// </summary>
+    Task<DelegationRenewalResponse?> RenewDelegationAsync(
+        Guid deviceId, CancellationToken ct = default);
 }

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/DelegationRenewalClientTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/DelegationRenewalClientTests.cs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Citizen.Wallet.Services;
+using Sorcha.ServiceClients.CitizenWallet;
+using Xunit;
+
+namespace Sorcha.Citizen.Wallet.Tests.Services;
+
+/// <summary>
+/// Tests for the PWA-side delegation renewal trigger
+/// (<see cref="DelegationRenewalClient"/>, Feature 114, T106 PWA part).
+/// Covers all five outcomes: NotEnrolled, NotDue, Renewed, DeviceNotFound, Failed.
+/// </summary>
+public sealed class DelegationRenewalClientTests
+{
+    private readonly Mock<ICitizenWalletClient> _client = new();
+    private readonly InMemoryDeviceMetaStore _meta = new();
+    private readonly InMemoryDelegationStore _delegations = new();
+    private readonly TestClock _clock = new(DateTimeOffset.Parse("2026-04-26T12:00:00Z"));
+    private readonly DelegationRenewalClient _sut;
+
+    public DelegationRenewalClientTests()
+    {
+        _sut = new DelegationRenewalClient(_meta, _delegations, _client.Object, _clock,
+            NullLogger<DelegationRenewalClient>.Instance);
+    }
+
+    [Fact]
+    public async Task RenewIfDueAsync_NotEnrolled_ReturnsNotEnrolled()
+    {
+        var outcome = await _sut.RenewIfDueAsync();
+
+        outcome.Should().Be(DelegationRenewalOutcome.NotEnrolled);
+        _client.Verify(c => c.RenewDelegationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RenewIfDueAsync_DelegationFarFromExpiry_ReturnsNotDueWithoutCallingServer()
+    {
+        await _meta.SetAsync(NewMeta(DateTimeOffset.Parse("2027-04-26T12:00:00Z"))); // 365 days out
+
+        var outcome = await _sut.RenewIfDueAsync();
+
+        outcome.Should().Be(DelegationRenewalOutcome.NotDue);
+        _client.Verify(c => c.RenewDelegationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RenewIfDueAsync_DelegationWithinRenewalWindow_RenewsAndPersists()
+    {
+        var meta = NewMeta(DateTimeOffset.Parse("2026-05-15T12:00:00Z")); // 19 days out → due
+        await _meta.SetAsync(meta);
+
+        var newExpiry = DateTimeOffset.Parse("2027-04-26T12:00:00Z");
+        _client.Setup(c => c.RenewDelegationAsync(meta.DeviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DelegationRenewalResponse
+            {
+                DelegationCredential = "eyJ.fresh.delegation",
+                ExpiresAt = newExpiry,
+            });
+
+        var outcome = await _sut.RenewIfDueAsync();
+
+        outcome.Should().Be(DelegationRenewalOutcome.Renewed);
+        (await _delegations.GetCurrentAsync()).Should().Be("eyJ.fresh.delegation");
+        var refreshed = await _meta.GetAsync();
+        refreshed!.DelegationExpiresAt.Should().Be(newExpiry);
+        refreshed.DeviceId.Should().Be(meta.DeviceId, "device id must be preserved across the meta refresh");
+    }
+
+    [Fact]
+    public async Task RenewIfDueAsync_Server404_ReturnsDeviceNotFound()
+    {
+        var meta = NewMeta(DateTimeOffset.Parse("2026-05-15T12:00:00Z"));
+        await _meta.SetAsync(meta);
+        _client.Setup(c => c.RenewDelegationAsync(meta.DeviceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DelegationRenewalResponse?)null);
+
+        var outcome = await _sut.RenewIfDueAsync();
+
+        outcome.Should().Be(DelegationRenewalOutcome.DeviceNotFound);
+        // Existing delegation must NOT be cleared — the user might still be able to
+        // present until they re-enrol.
+        (await _meta.GetAsync()).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RenewIfDueAsync_HttpFailure_ReturnsFailed()
+    {
+        var meta = NewMeta(DateTimeOffset.Parse("2026-05-15T12:00:00Z"));
+        await _meta.SetAsync(meta);
+        _client.Setup(c => c.RenewDelegationAsync(meta.DeviceId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("network down"));
+
+        var outcome = await _sut.RenewIfDueAsync();
+
+        outcome.Should().Be(DelegationRenewalOutcome.Failed);
+    }
+
+    private static DeviceMetaRecord NewMeta(DateTimeOffset expiry) => new(
+        DeviceId: Guid.Parse("0d000000-0000-0000-0000-000000000001"),
+        Label: "My iPhone",
+        EnrolledAt: DateTimeOffset.Parse("2025-04-26T12:00:00Z"),
+        DelegationExpiresAt: expiry);
+
+    private sealed class TestClock : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public TestClock(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/EnrolmentServiceTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/EnrolmentServiceTests.cs
@@ -51,9 +51,10 @@ public sealed class EnrolmentServiceTests
                 DelegationExpiresAt = DateTimeOffset.UtcNow.AddYears(1),
             });
 
-        // 3. Delegation store + cache observable.
+        // 3. Delegation store + cache + meta observable.
         var delegations = new InMemoryDelegationStore();
         var cache = new InMemoryCredentialCache();
+        var meta = new InMemoryDeviceMetaStore();
 
         // 4. Sync service runs and reports success.
         var sync = new Mock<ISyncService>();
@@ -61,7 +62,8 @@ public sealed class EnrolmentServiceTests
             .ReturnsAsync(new SyncOutcome(SyncMode.FullSnapshot, 0, 0, 0, []));
 
         var sut = new EnrolmentService(deviceKey.Object, client.Object, delegations,
-            sync.Object, cache, NullLogger<EnrolmentService>.Instance);
+            meta, sync.Object, cache, TimeProvider.System,
+            NullLogger<EnrolmentService>.Instance);
 
         var result = await sut.EnrolAsync("My iPhone", "iOS 19 / Safari 19", "Mozilla/5.0...");
 
@@ -74,6 +76,12 @@ public sealed class EnrolmentServiceTests
         sentRequest.Platform.Should().Be("iOS 19 / Safari 19");
         (await delegations.GetCurrentAsync()).Should().Be("eyJ.delegation.compact");
         sync.Verify(s => s.SyncAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        var persistedMeta = await meta.GetAsync();
+        persistedMeta.Should().NotBeNull();
+        persistedMeta!.DeviceId.Should().Be(deviceId);
+        persistedMeta.Label.Should().Be("My iPhone");
+        persistedMeta.DelegationExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow.AddDays(360));
     }
 
     [Fact]
@@ -103,7 +111,8 @@ public sealed class EnrolmentServiceTests
             .ReturnsAsync(new SyncOutcome(SyncMode.Delta, 0, 0, 0, []));
 
         var sut = new EnrolmentService(deviceKey.Object, client.Object,
-            new InMemoryDelegationStore(), sync.Object, new InMemoryCredentialCache(),
+            new InMemoryDelegationStore(), new InMemoryDeviceMetaStore(),
+            sync.Object, new InMemoryCredentialCache(), TimeProvider.System,
             NullLogger<EnrolmentService>.Instance);
 
         await sut.EnrolAsync("  Padded label  ", "  ", "  ");
@@ -120,8 +129,10 @@ public sealed class EnrolmentServiceTests
             new Mock<IDeviceKeyService>().Object,
             new Mock<ICitizenWalletClient>().Object,
             new InMemoryDelegationStore(),
+            new InMemoryDeviceMetaStore(),
             new Mock<ISyncService>().Object,
             new InMemoryCredentialCache(),
+            TimeProvider.System,
             NullLogger<EnrolmentService>.Instance);
 
         var act = () => sut.EnrolAsync("   ", "iOS", "ua");
@@ -135,8 +146,10 @@ public sealed class EnrolmentServiceTests
             new Mock<IDeviceKeyService>().Object,
             new Mock<ICitizenWalletClient>().Object,
             new InMemoryDelegationStore(),
+            new InMemoryDeviceMetaStore(),
             new Mock<ISyncService>().Object,
             new InMemoryCredentialCache(),
+            TimeProvider.System,
             NullLogger<EnrolmentService>.Instance);
 
         var act = () => sut.EnrolAsync(new string('a', 121), "iOS", "ua");


### PR DESCRIPTION
## Summary

Companion to #435. Wallet now self-renews its delegation as expiry approaches — Home runs the renewal check on every load and silently re-issues if the current delegation is within 30 days of expiry.

## Changes

- **`IDeviceMetaStore`** + InMemory/IndexedDb impls — persists deviceId + label + delegation expiry alongside the device key. Pulled out of `IDelegationStore` so the existing API stays untouched.
- **`EnrolmentService`** writes meta after successful enrol; new `TimeProvider` dep.
- **`IDelegationRenewalClient`** + impl — checks expiry against 30-day window, calls /renew-delegation if due, persists fresh JWT + refreshed expiry. Five outcomes (NotEnrolled, NotDue, Renewed, DeviceNotFound, Failed). 404 → DeviceNotFound rather than throwing.
- **`ICitizenWalletClient.RenewDelegationAsync`** added.
- **`Index.razor`** fires renewal in background on first load. Renewed → info banner; DeviceNotFound → warning banner.
- 5 new `DelegationRenewalClient` tests + EnrolmentService happy-path now asserts meta persistence. All 40 wallet tests pass.

## End-to-end story now closes the renewal loop

1. PR #432: sign in
2. PR #433: enrol device, persist delegation
3. **PR #436 (this)**: every visit to Home, wallet checks expiry; ~30 days from end-of-life, the wallet silently rotates. Citizen never sees a dead wallet.

## Test plan
- [x] 5 new tests pass
- [x] All 40 wallet tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)