### PR TITLE
feat(114): clock-skew banner (T101)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -34,17 +34,26 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IEnrolmentService, EnrolmentService>();
         services.AddSingleton<IDelegationRenewalClient, DelegationRenewalClient>();
 
+        // Server-clock observer (T101) — populated by the ServerClockHandler on
+        // every outbound HTTP call; read by Pages/Index.razor to surface a
+        // clock-skew banner if the device drifts far from the server.
+        services.AddSingleton<IServerClockObserver, ServerClockObserver>();
+        services.AddTransient<ServerClockHandler>();
+
         // Auth surface: a separate HttpClient that does NOT inject the bearer
-        // token (so sign-in requests don't carry stale tokens).
+        // token (so sign-in requests don't carry stale tokens). Still observes
+        // the server clock — sign-in is a great moment to capture initial drift.
         services.AddTransient<BearerTokenHandler>();
         services.AddHttpClient<IAuthService, AuthService>(c =>
-            c.BaseAddress = new Uri(gatewayBaseAddress));
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<ServerClockHandler>();
 
         // Citizen wallet client: every outbound call automatically carries the
-        // wallet's stored bearer token.
+        // wallet's stored bearer token AND records server clock observations.
         services.AddHttpClient<ICitizenWalletClient, CitizenWalletClient>(c =>
             c.BaseAddress = new Uri(gatewayBaseAddress))
-            .AddHttpMessageHandler<BearerTokenHandler>();
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
 
         return services;
     }

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -19,6 +19,7 @@
 @inject IDeviceKeyService DeviceKey
 @inject ISyncService Sync
 @inject IDelegationRenewalClient Renewal
+@inject IServerClockObserver ServerClock
 @inject HttpClient Http
 @inject NavigationManager Nav
 @inject ILogger<Index> Logger
@@ -27,6 +28,24 @@
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
     <MudText Typo="Typo.h5" Class="mb-3">Your credentials</MudText>
+
+    @{
+        var skewMinutes = (int)Math.Abs(ServerClock.GetSkew().TotalMinutes);
+    }
+    @if (skewMinutes >= 60)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-3">
+            Your device clock is off by ~@skewMinutes minutes. Presentations will be
+            rejected by verifiers. Fix your device clock, then refresh.
+        </MudAlert>
+    }
+    else if (skewMinutes >= 5)
+    {
+        <MudAlert Severity="Severity.Warning" Class="mb-3">
+            Your device clock is ~@skewMinutes minutes off the server. Verifiers may
+            reject offline presentations until you correct it.
+        </MudAlert>
+    }
 
     @if (_credentials is null)
     {

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IServerClockObserver.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IServerClockObserver.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Tracks the most recent server time the wallet has observed (Feature 114, T101).
+/// HTTP responses from the Wallet Service carry a <c>Date</c> header; the
+/// <see cref="ServerClockHandler"/> DelegatingHandler captures it on every
+/// outbound call. Pages read <see cref="GetSkew"/> to surface a banner when
+/// the device clock has drifted more than the documented threshold (per
+/// FR-020: warn at 5 minutes, block presentations at 60 minutes).
+/// </summary>
+public interface IServerClockObserver
+{
+    /// <summary>Record an observation of the server's clock time.</summary>
+    void Record(DateTimeOffset serverTime);
+
+    /// <summary>
+    /// Returns <c>(observed-at, server-time, deviceMinusServer)</c> from the
+    /// most recent observation, or null if the wallet has never made an
+    /// authenticated server call this session.
+    /// </summary>
+    ServerClockObservation? GetLatest();
+
+    /// <summary>
+    /// Convenience: returns the device-minus-server skew, or
+    /// <see cref="TimeSpan.Zero"/> if no observation exists.
+    /// </summary>
+    TimeSpan GetSkew();
+}
+
+/// <summary>One observation of server time relative to device time.</summary>
+/// <param name="ObservedAtDeviceUtc">Device's UTC time when the observation was recorded.</param>
+/// <param name="ServerUtc">Server's UTC time as advertised in the HTTP <c>Date</c> header.</param>
+/// <param name="Skew">Device minus server (positive = device clock ahead).</param>
+public sealed record ServerClockObservation(
+    DateTimeOffset ObservedAtDeviceUtc,
+    DateTimeOffset ServerUtc,
+    TimeSpan Skew);
+
+/// <summary>Default thread-safe in-memory <see cref="IServerClockObserver"/>.</summary>
+public sealed class ServerClockObserver : IServerClockObserver
+{
+    private readonly TimeProvider _clock;
+    private readonly object _gate = new();
+    private ServerClockObservation? _latest;
+
+    /// <summary>Initialises a new instance.</summary>
+    public ServerClockObserver(TimeProvider clock)
+    {
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    /// <inheritdoc />
+    public void Record(DateTimeOffset serverTime)
+    {
+        var deviceNow = _clock.GetUtcNow();
+        var skew = deviceNow - serverTime;
+        lock (_gate)
+        {
+            _latest = new ServerClockObservation(deviceNow, serverTime, skew);
+        }
+    }
+
+    /// <inheritdoc />
+    public ServerClockObservation? GetLatest()
+    {
+        lock (_gate) { return _latest; }
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetSkew()
+        => GetLatest()?.Skew ?? TimeSpan.Zero;
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/ServerClockHandler.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/ServerClockHandler.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// HTTP message handler that snapshots the server's <c>Date</c> response
+/// header into <see cref="IServerClockObserver"/> on every call (Feature 114,
+/// T101). Sits in the same pipeline as <see cref="BearerTokenHandler"/> so
+/// it observes every authenticated outbound request without callers having
+/// to opt in.
+/// </summary>
+public sealed class ServerClockHandler : DelegatingHandler
+{
+    private readonly IServerClockObserver _observer;
+
+    /// <summary>Initialises a new instance.</summary>
+    public ServerClockHandler(IServerClockObserver observer)
+    {
+        _observer = observer ?? throw new ArgumentNullException(nameof(observer));
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken);
+        if (response.Headers.Date is { } serverDate)
+        {
+            _observer.Record(serverDate);
+        }
+        return response;
+    }
+}

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/ServerClockTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/ServerClockTests.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Citizen.Wallet.Services;
+using Xunit;
+
+namespace Sorcha.Citizen.Wallet.Tests.Services;
+
+/// <summary>
+/// Tests for the clock-skew observation pipeline (Feature 114, T101):
+/// <see cref="ServerClockObserver"/> stores the most recent reading,
+/// <see cref="ServerClockHandler"/> snapshots every response's Date header.
+/// </summary>
+public sealed class ServerClockTests
+{
+    [Fact]
+    public void ServerClockObserver_BeforeAnyObservation_ReturnsZeroSkew()
+    {
+        var sut = new ServerClockObserver(TimeProvider.System);
+
+        sut.GetLatest().Should().BeNull();
+        sut.GetSkew().Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void ServerClockObserver_DeviceAheadOfServer_ReportsPositiveSkew()
+    {
+        var device = DateTimeOffset.Parse("2026-04-26T12:10:00Z");
+        var server = DateTimeOffset.Parse("2026-04-26T12:00:00Z");
+        var clock = new FixedClock(device);
+        var sut = new ServerClockObserver(clock);
+
+        sut.Record(server);
+
+        var latest = sut.GetLatest();
+        latest.Should().NotBeNull();
+        latest!.Skew.Should().Be(TimeSpan.FromMinutes(10));
+    }
+
+    [Fact]
+    public void ServerClockObserver_DeviceBehindServer_ReportsNegativeSkew()
+    {
+        var device = DateTimeOffset.Parse("2026-04-26T11:55:00Z");
+        var server = DateTimeOffset.Parse("2026-04-26T12:00:00Z");
+        var sut = new ServerClockObserver(new FixedClock(device));
+
+        sut.Record(server);
+
+        sut.GetSkew().Should().Be(TimeSpan.FromMinutes(-5));
+    }
+
+    [Fact]
+    public async Task ServerClockHandler_RecordsEveryResponseDate()
+    {
+        var clock = new FixedClock(DateTimeOffset.Parse("2026-04-26T12:30:00Z"));
+        var observer = new ServerClockObserver(clock);
+        var inner = new StubHandler(req =>
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.OK);
+            resp.Headers.Date = DateTimeOffset.Parse("2026-04-26T12:25:00Z");
+            return resp;
+        });
+        var handler = new ServerClockHandler(observer) { InnerHandler = inner };
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+
+        await http.GetAsync("api/v1/wallet/sync");
+
+        observer.GetSkew().Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public async Task ServerClockHandler_NoDateHeader_LeavesObserverUntouched()
+    {
+        var observer = new ServerClockObserver(TimeProvider.System);
+        var inner = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)); // no Date
+        inner.SuppressDateAutoSet = true;
+        var handler = new ServerClockHandler(observer) { InnerHandler = inner };
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
+
+        await http.GetAsync("api/v1/wallet/sync");
+
+        observer.GetLatest().Should().BeNull("a missing Date header must not record a bogus observation");
+    }
+
+    private sealed class FixedClock : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FixedClock(DateTimeOffset now) => _now = now;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public bool SuppressDateAutoSet { get; set; }
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var response = _respond(request);
+            if (SuppressDateAutoSet)
+            {
+                // HttpClient may auto-populate Date on responses without one;
+                // explicitly clear so the test sees what the SUT sees.
+                response.Headers.Date = null;
+            }
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PWA surfaces a Warning at ≥5 min device-vs-server drift and an Error at ≥60 min, per FR-020.

## Changes
- **`IServerClockObserver` + `ServerClockObserver`** — thread-safe singleton holding the most recent server-time observation.
- **`ServerClockHandler`** — DelegatingHandler snapshots `Response.Headers.Date` on every outbound call. Wired to both the auth and citizen-wallet typed clients.
- **`Index.razor`** renders the banner above the credential list.
- 5 new unit tests. All 45 wallet tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)