### PR TITLE
refactor(114): extract Present.razor sub-components (T097-T099)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Components/ConsentSheet.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Components/ConsentSheet.razor
@@ -1,0 +1,60 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Consent sheet (Feature 114, T097). The deliberate confirmation surface
+    per FR-015: required claims locked-on, optional claims toggleable, the
+    primary CTA explicitly labelled to convey intent.
+*@
+@using Sorcha.Citizen.Wallet.Services.Presentation
+
+<MudPaper Elevation="2" Class="pa-4">
+    <MudText Typo="Typo.subtitle1">@Request.Purpose</MudText>
+    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-3 d-block">
+        Audience: <code>@Request.ClientId</code>
+    </MudText>
+
+    <MudText Typo="Typo.body2" Class="mt-3 mb-1"><strong>Required (always shared):</strong></MudText>
+    @foreach (var name in Selected.SatisfiedRequired)
+    {
+        <MudCheckBox T="bool" Value="true" Disabled="true" Label="@name" />
+    }
+
+    @if (Selected.AvailableOptional.Count > 0)
+    {
+        <MudText Typo="Typo.body2" Class="mt-3 mb-1"><strong>Optional:</strong></MudText>
+        @foreach (var name in Selected.AvailableOptional)
+        {
+            <MudCheckBox T="bool" @bind-Value="OptionalToggles[name]" Label="@name" />
+        }
+    }
+
+    <MudButton Class="mt-4 mr-2" Color="Color.Primary" Variant="Variant.Filled"
+               OnClick="OnConfirm" Disabled="@Busy">
+        @(Busy ? "Sharing…" : "Hold to share")
+    </MudButton>
+    <MudButton Variant="Variant.Outlined" OnClick="OnCancel" Disabled="@Busy">Cancel</MudButton>
+</MudPaper>
+
+@code {
+    /// <summary>The credential the citizen chose, with the disclosure plan.</summary>
+    [Parameter, EditorRequired] public CredentialMatch Selected { get; set; } = default!;
+
+    /// <summary>The verifier's parsed request (purpose, audience, etc.).</summary>
+    [Parameter, EditorRequired] public ParsedPresentationRequest Request { get; set; } = default!;
+
+    /// <summary>
+    /// Two-way bound dictionary of optional claim names → opt-in flags.
+    /// Owner constructs the dictionary so Reset can clear it.
+    /// </summary>
+    [Parameter, EditorRequired] public Dictionary<string, bool> OptionalToggles { get; set; } = new();
+
+    /// <summary>True while the parent is in the middle of building / posting the vp_token.</summary>
+    [Parameter] public bool Busy { get; set; }
+
+    /// <summary>Invoked when the citizen confirms.</summary>
+    [Parameter] public EventCallback OnConfirm { get; set; }
+
+    /// <summary>Invoked when the citizen cancels.</summary>
+    [Parameter] public EventCallback OnCancel { get; set; }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Components/CredentialPickerDialog.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Components/CredentialPickerDialog.razor
@@ -1,0 +1,38 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Credential picker (Feature 114, T098). Shown when the verifier's request
+    matches more than one credential the citizen holds. Pure presentational —
+    raises OnChosen back to Present.razor.
+*@
+@using Sorcha.Citizen.Wallet.Services.Presentation
+
+<MudText Typo="Typo.subtitle1" Class="mb-2">Choose a credential</MudText>
+<MudList T="CredentialMatch" SelectedValueChanged="HandleSelected">
+    @foreach (var m in Matches)
+    {
+        <MudListItem T="CredentialMatch" Value="m">
+            <strong>@(m.Credential.DisplayLabel ?? m.Credential.Vct)</strong>
+            <MudText Typo="Typo.caption">id: @m.Credential.Id</MudText>
+        </MudListItem>
+    }
+</MudList>
+<MudButton Class="mt-3" Variant="Variant.Outlined" OnClick="OnCancel">Cancel</MudButton>
+
+@code {
+    /// <summary>Candidate matches from the presentation engine.</summary>
+    [Parameter, EditorRequired] public IReadOnlyList<CredentialMatch> Matches { get; set; } = [];
+
+    /// <summary>Invoked with the citizen's selection.</summary>
+    [Parameter] public EventCallback<CredentialMatch> OnChosen { get; set; }
+
+    /// <summary>Invoked when the citizen backs out.</summary>
+    [Parameter] public EventCallback OnCancel { get; set; }
+
+    private async Task HandleSelected(CredentialMatch? match)
+    {
+        if (match is null) return;
+        await OnChosen.InvokeAsync(match);
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Components/NoMatchingCredentialDialog.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Components/NoMatchingCredentialDialog.razor
@@ -1,0 +1,22 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    No-matching-credential dialog (Feature 114, T099). Shown when the citizen's
+    wallet holds no credential of the type the verifier asked for. Surfaces the
+    requested vct so the citizen knows what's missing, plus a Cancel.
+*@
+@using Sorcha.Citizen.Wallet.Services.Presentation
+
+<MudAlert Severity="Severity.Warning" Class="mb-3">
+    None of your credentials match this verifier's request for <code>@RequiredVct</code>.
+</MudAlert>
+<MudButton Variant="Variant.Outlined" OnClick="OnCancel">Cancel</MudButton>
+
+@code {
+    /// <summary>The vct the verifier asked for.</summary>
+    [Parameter, EditorRequired] public string? RequiredVct { get; set; }
+
+    /// <summary>Invoked when the citizen taps Cancel.</summary>
+    [Parameter] public EventCallback OnCancel { get; set; }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Present.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Present.razor
@@ -12,6 +12,7 @@
 @using System.Net.Http
 @using System.Net.Http.Json
 @using System.Text.Json
+@using Sorcha.Citizen.Wallet.Components
 @using Sorcha.Citizen.Wallet.Services
 @using Sorcha.Citizen.Wallet.Services.Presentation
 @inject IPresentationEngine Engine
@@ -44,54 +45,23 @@
     }
     else if (_phase == Phase.NoMatch)
     {
-        <MudAlert Severity="Severity.Warning" Class="mb-3">
-            None of your credentials match this verifier's request for <code>@_request?.RequiredVct</code>.
-        </MudAlert>
-        <MudButton Variant="Variant.Outlined" OnClick="Reset">Cancel</MudButton>
+        <NoMatchingCredentialDialog RequiredVct="@_request?.RequiredVct"
+                                    OnCancel="Reset" />
     }
     else if (_phase == Phase.PickCredential && _matches is not null)
     {
-        <MudText Typo="Typo.subtitle1" Class="mb-2">Choose a credential</MudText>
-        <MudList T="CredentialMatch" SelectedValueChanged="OnCredentialChosen">
-            @foreach (var m in _matches)
-            {
-                <MudListItem T="CredentialMatch" Value="m">
-                    <strong>@(m.Credential.DisplayLabel ?? m.Credential.Vct)</strong>
-                    <MudText Typo="Typo.caption">id: @m.Credential.Id</MudText>
-                </MudListItem>
-            }
-        </MudList>
-        <MudButton Class="mt-3" Variant="Variant.Outlined" OnClick="Reset">Cancel</MudButton>
+        <CredentialPickerDialog Matches="_matches"
+                                OnChosen="OnCredentialChosen"
+                                OnCancel="Reset" />
     }
     else if (_phase == Phase.Consent && _selected is not null && _request is not null)
     {
-        <MudPaper Elevation="2" Class="pa-4">
-            <MudText Typo="Typo.subtitle1">@_request.Purpose</MudText>
-            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-3 d-block">
-                Audience: <code>@_request.ClientId</code>
-            </MudText>
-
-            <MudText Typo="Typo.body2" Class="mt-3 mb-1"><strong>Required (always shared):</strong></MudText>
-            @foreach (var name in _selected.SatisfiedRequired)
-            {
-                <MudCheckBox T="bool" Value="true" Disabled="true" Label="@name" />
-            }
-
-            @if (_selected.AvailableOptional.Count > 0)
-            {
-                <MudText Typo="Typo.body2" Class="mt-3 mb-1"><strong>Optional:</strong></MudText>
-                @foreach (var name in _selected.AvailableOptional)
-                {
-                    <MudCheckBox T="bool" @bind-Value="_optionalToggles[name]" Label="@name" />
-                }
-            }
-
-            <MudButton Class="mt-4 mr-2" Color="Color.Primary" Variant="Variant.Filled"
-                       OnClick="ConfirmAsync" Disabled="@_busy">
-                @(_busy ? "Sharing…" : "Hold to share")
-            </MudButton>
-            <MudButton Variant="Variant.Outlined" OnClick="Reset" Disabled="@_busy">Cancel</MudButton>
-        </MudPaper>
+        <ConsentSheet Selected="_selected"
+                      Request="_request"
+                      OptionalToggles="_optionalToggles"
+                      Busy="_busy"
+                      OnConfirm="ConfirmAsync"
+                      OnCancel="Reset" />
     }
     else if (_phase == Phase.Done)
     {


### PR DESCRIPTION
## Summary

Pure refactor. Pulls the three inline dialogs out of `Present.razor` into reusable named components.

## Changes
- `Components/ConsentSheet.razor` (T097)
- `Components/CredentialPickerDialog.razor` (T098)
- `Components/NoMatchingCredentialDialog.razor` (T099)

`Present.razor` render block drops ~70 lines of inline markup → 3 component invocations with `EditorRequired` parameters and `EventCallback` hooks. No behavioural change. All 45 wallet tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)