### PR TITLE
fix(wallet): scope credential lookups by (walletAddress, credentialId)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -221,9 +221,12 @@ public static class CredentialEndpoints
         ICredentialStore store,
         CancellationToken cancellationToken = default)
     {
-        var credential = await store.GetByIdAsync(credentialId, cancellationToken);
+        // Wallet-scoped lookup — credential IDs are not globally unique when a
+        // credential exists on both the issuer's wallet (Active) and the
+        // recipient's wallet (PendingAcceptance via InboundCredentialDetector).
+        var credential = await store.GetByIdForWalletAsync(credentialId, walletAddress, cancellationToken);
 
-        if (credential == null || credential.WalletAddress != walletAddress)
+        if (credential == null)
             return Results.NotFound();
 
         return Results.Ok(credential);
@@ -257,9 +260,9 @@ public static class CredentialEndpoints
         ICredentialStore store,
         CancellationToken cancellationToken = default)
     {
-        var credential = await store.GetByIdAsync(credentialId, cancellationToken);
+        var credential = await store.GetByIdForWalletAsync(credentialId, walletAddress, cancellationToken);
 
-        if (credential == null || credential.WalletAddress != walletAddress)
+        if (credential == null)
             return Results.NotFound();
 
         await store.DeleteAsync(credentialId, cancellationToken);
@@ -272,9 +275,9 @@ public static class CredentialEndpoints
         ICredentialStore store,
         CancellationToken cancellationToken = default)
     {
-        var credential = await store.GetByIdAsync(credentialId, cancellationToken);
+        var credential = await store.GetByIdForWalletAsync(credentialId, walletAddress, cancellationToken);
 
-        if (credential == null || credential.WalletAddress != walletAddress)
+        if (credential == null)
             return Results.NotFound();
 
         return Results.Ok(new
@@ -346,9 +349,9 @@ public static class CredentialEndpoints
             return Results.BadRequest(new { error = $"Invalid status value: {request.Status}. Allowed: Active, Suspended, Revoked, Consumed" });
         }
 
-        var credential = await store.GetByIdAsync(credentialId, cancellationToken);
+        var credential = await store.GetByIdForWalletAsync(credentialId, walletAddress, cancellationToken);
 
-        if (credential == null || credential.WalletAddress != walletAddress)
+        if (credential == null)
             return Results.NotFound();
 
         var previousStatus = credential.Status;
@@ -399,9 +402,15 @@ public static class CredentialEndpoints
         }
 
         // Read previous status for the SignalR event (needed BEFORE the patch runs).
-        var existing = await store.GetByIdAsync(credentialId, cancellationToken);
-        if (existing is null
-            || !string.Equals(existing.WalletAddress, walletAddress, StringComparison.OrdinalIgnoreCase))
+        // Use the wallet-scoped lookup — credential IDs are NOT globally unique
+        // when a credential is recorded on both the issuer's wallet (Active at
+        // issuance time) and the recipient's wallet (PendingAcceptance via
+        // InboundCredentialDetector). Looking up by credential-id alone returns
+        // an arbitrary one of the two rows, then the wallet-address mismatch
+        // check 404s the legitimate caller. Bug surfaced by the TradeFinance
+        // walkthrough credential-fetch step.
+        var existing = await store.GetByIdForWalletAsync(credentialId, walletAddress, cancellationToken);
+        if (existing is null)
         {
             return Results.NotFound();
         }


### PR DESCRIPTION
## Summary

TradeFinance walkthrough on n1 fails at the invoice-finance handover: holder PATCH `/credentials/{id}` returns 404 even though the credential exists and the preceding GET listed it.

## Root cause

A credential ID is **not globally unique** in `wallet.Credentials` — a credential lives on both:
- the issuer's wallet (Status=Active, recorded at issuance)
- the recipient's wallet (Status=PendingAcceptance, recorded by `InboundCredentialDetector`)

Five endpoints used `GetByIdAsync(credentialId)` (no wallet filter) → `FirstOrDefault` → arbitrary row → wallet-mismatch check → 404 against the legitimate caller acting on the recipient's row.

Confirmed in the live n1 DB:

```
 urn:uuid:a4b38936-... | Active            | ws11qpp6...  ← issuer
 urn:uuid:a4b38936-... | PendingAcceptance | ws11qq3u...  ← recipient
```

## Fix

Switch all five endpoints to the existing `GetByIdForWalletAsync(credentialId, walletAddress)` which composites both keys in EF. The explicit wallet-mismatch check becomes redundant (now implicit at query time).

Endpoints touched:
- `GetCredential`
- `DeleteCredential`
- `ExportCredential`
- `UpdateCredentialStatus` (legacy `/status`)
- `PatchCredentialStatus` (Feature 106 holder accept/decline)

`PresentationRequestService.GetByIdAsync` (line 250) is **not touched** — different code path with different invariants. Flagged in the commit message for follow-up audit.

## Test plan

- [x] `dotnet build` clean
- [ ] Re-deploy n1, re-run `walkthroughs/TradeFinance/run.ps1 -Scenario all`
- [ ] All 3 scenarios complete (procurement + finance phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)