### PR TITLE
fix(wallet): wallet-scope PatchStatusAsync query (follow-up to #440)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
@@ -156,13 +156,16 @@ public class CredentialStore : ICredentialStore
         CredentialStatus newStatus,
         CancellationToken ct = default)
     {
+        // Wallet-scoped lookup — credential IDs are not globally unique when a
+        // credential exists on both the issuer's wallet (Active at issuance)
+        // and the recipient's wallet (PendingAcceptance via
+        // InboundCredentialDetector). Filtering by both keys at the EF query
+        // is the only safe way to find the row a holder is operating on.
         var credential = await _db.Credentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId, ct);
+            .FirstOrDefaultAsync(
+                c => c.Id == credentialId && c.WalletAddress == walletAddress, ct);
 
         if (credential is null)
-            return null;
-
-        if (!string.Equals(credential.WalletAddress, walletAddress, StringComparison.OrdinalIgnoreCase))
             return null;
 
         // Idempotent no-op (data-model INV-2 discussion): patching to the same status


### PR DESCRIPTION
## Summary

Follow-up to PR #440. The endpoint-level fix worked for the pre-flight read, but `PatchStatusAsync` (called for the actual mutation) had the same id-only ambiguity one layer deeper, so the holder accept still 404'd.

## Live confirmation

After deploying #440 and re-running TradeFinance against n1 — same 404. Wallet logs show:
```
HTTP "PATCH" "/api/v1/wallets/.../credentials/urn:uuid:..." responded 404 in 4.9645 ms
```

DB still showed two rows for the same credential ID (issuer Active + recipient PendingAcceptance), and `PatchStatusAsync.FirstOrDefaultAsync(c => c.Id == credentialId)` returned the issuer's row, then the explicit mismatch check returned null, which the endpoint read as 404.

## Fix

Composite-key query at the EF layer:

```csharp
var credential = await _db.Credentials
    .FirstOrDefaultAsync(
        c => c.Id == credentialId && c.WalletAddress == walletAddress, ct);
```

The redundant `string.Equals(WalletAddress, walletAddress, OrdinalIgnoreCase)` check after the lookup is removed.

## Out of scope (follow-up)

`DeleteAsync`, `UpdateStatusAsync`, `RecordPresentationAsync`, and the legacy `GetByIdAsync` have the same ambiguity but their interface signatures don't accept `walletAddress`. That's a bigger refactor (likely interface changes). Most callers already wallet-scope at the endpoint layer per #440. Captured for follow-up.

## Test plan

- [x] `dotnet build` clean
- [ ] Re-deploy `wallet-service`, re-run `walkthroughs/TradeFinance/run.ps1 -Scenario all`
- [ ] All 3 scenarios complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)