### PR TITLE
AI Designer overhaul: composer fix, escape-hatch tools, prompt guardrails, drag-drop uploads

### DIFF
--- a/.claude/skills/blueprint-builder/SKILL.md
+++ b/.claude/skills/blueprint-builder/SKILL.md
@@ -267,14 +267,25 @@ A single helper substitutes tokens at evaluation time. The same component shape 
 
 If your blueprint asks the user for a name, date of birth, email, or postal address, **`$ref` the core component** instead of inlining the JSON Schema. You get validation, layout, persona autofill, and (for postcode) address lookup for free, and your blueprint stays short and focused on the *novel* fields it actually owns.
 
-## Blueprint Validation Rules
+## Blueprint Validation Codes
 
-1. **Participant references**: Every `action.sender` must reference a valid `participant.id`
-2. **Action count**: At least 1 action required
-3. **Participant count**: At least 2 participants required (enforced by `BlueprintBuilder.Build()`)
-4. **Description length**: Min 5 characters
-5. **Title length**: Min 3 characters
-6. **Cycles**: Detected but allowed — produce warnings, not errors
+Publish-time validation runs in `Sorcha.Validator.Service`. Errors block publication; warnings publish but surface in the response.
+
+| Code | Severity | Trigger |
+|------|----------|---------|
+| `MIN_PARTICIPANTS` | error | Fewer than 2 participants |
+| `MIN_ACTIONS` | error | Zero actions |
+| `INVALID_TITLE` | error | Title missing or `<3` chars |
+| `INVALID_DESCRIPTION` | error | Description missing or `<5` chars |
+| `INVALID_PARTICIPANT_REF` | error | An action's sender (or routing target) does not match any `participant.id` |
+| `VAL_BP_010` | error | Starting action's `sender` participant has a non-null `walletAddress` — defeats open submission |
+| `VAL_BP_011` | error | An `outputMapping` target pointer's top-level field is not declared on any next action's schema |
+| `VAL_BP_012` | error | `x-credential-offer: true` on a non-object field |
+| `INVALID_CREDENTIAL_RECIPIENT` | warning | `credentialIssuanceConfig.recipientParticipantId` references an unknown participant |
+| `OPEN_CREDENTIAL_ISSUER` | warning | `credentialRequirements[].acceptedIssuers` empty (any issuer accepted) — usually too permissive |
+| `WARN_BP_006` | warning | An `x-credential-offer` object should declare `credential_offer_uri` in its `required` list |
+| `NO_STARTING_ACTION` | warning | No action marked `isStartingAction: true` |
+| Cycle warning | warning | Cyclic route detected — publish proceeds; set `metadata.hasCycles = "true"` for clarity |
 
 ## Route Types
 
@@ -342,6 +353,40 @@ A route MAY carry data from the current action's execution result into the next 
 
 Route-based routing (via `Action.Routes`) takes precedence over legacy condition-based routing (via `Action.Participants`). Always use `routes` for new blueprints.
 
+## Calculations (JSON Logic)
+
+Per-action computed values evaluated by the engine after schema validation, before routing. Calculations are referenced from routing conditions and `outputMapping` source paths under `/calculations/*`.
+
+```jsonc
+{
+  "id": 0,
+  "title": "Submit",
+  "calculations": {
+    "requiresApproval": { ">": [{ "var": "amount" }, 10000] },
+    "isOverseas":       { "!=": [{ "var": "country" }, "GB"] }
+  },
+  "routes": [
+    { "id": "exec",    "condition": { "var": "requiresApproval" }, "nextActionIds": [2] },
+    { "id": "manager", "isDefault": true, "nextActionIds": [1] }
+  ]
+}
+```
+
+Key names are unrestricted; values are JSON Logic expressions referencing payload fields via `{ "var": "fieldName" }`. Calculations from prior actions listed in `requiredPriorActions` are merged into scope at routing time.
+
+## Required Prior Actions
+
+By default, the engine reconstructs accumulated state from only the immediately preceding action. To make data from earlier actions available for routing or `outputMapping`, list them in `requiredPriorActions`:
+
+```jsonc
+{
+  "id": 5,
+  "requiredPriorActions": [1, 3]
+}
+```
+
+The engine fetches and decrypts those transactions at execution time and merges their disclosed fields into the routing scope.
+
 ## DataSchema Patterns
 
 ### String Field with Validation
@@ -363,6 +408,187 @@ Route-based routing (via `Action.Routes`) takes precedence over legacy condition
 ```json
 { "type": "number", "minimum": 0, "title": "Amount" }
 ```
+
+## Form UX Layout
+
+Beyond JSON Schema's basic shape, Sorcha extends action data schemas with `x-` keywords that drive form rendering. Use these inline on dataSchemas, or rely on transclusion when `$ref`-ing a core component (see Reusable Schema Components).
+
+### Wizard pages (`x-pages`)
+
+Split a single Sorcha action's form into multiple wizard pages. Each page is one screen with Next/Back navigation, but **all pages submit together as one signed transaction**. A new Action is required only when the **sender** changes.
+
+```jsonc
+{
+  "type": "object",
+  "x-pages": [
+    {
+      "title": "Eligibility",
+      "x-sections": [{ "title": "Check eligibility", "fields": ["propertyOwner", "workType"] }]
+    },
+    {
+      "title": "About You",
+      "x-sections": [{ "title": "Your details", "fields": ["givenName", "familyName", "dateOfBirth"] }]
+    },
+    {
+      "title": "Check Your Answers",
+      "description": "Review before submitting."
+    }
+  ],
+  "properties": { /* ... */ }
+}
+```
+
+The final page conventionally titled "Check Your Answers" cues the renderer to show a summary view rather than collecting new fields.
+
+### Sections (`x-sections`)
+
+Group fields under a heading on a single page. `layout: "horizontal"` arranges fields side-by-side; default is vertical.
+
+```jsonc
+"x-sections": [
+  { "title": "Address", "layout": "horizontal", "fields": ["line1", "town", "postcode"] }
+]
+```
+
+### Introduction (`x-introduction`) and width (`x-width`)
+
+`x-introduction` renders Markdown copy at the top of the form (or page). `x-width` controls form max-width: `"narrow"` (480px), `"normal"` (720px, default), `"wide"` (960px), `"full"` (no max).
+
+```jsonc
+{
+  "type": "object",
+  "x-introduction": "Tell us about the work you plan to do. **Most applications take 5 minutes.**",
+  "x-width": "narrow",
+  "properties": { /* ... */ }
+}
+```
+
+### Persona autofill (`x-persona`)
+
+Bind a property to a Sorcha persona attribute (Feature 092). When the citizen has filled their profile, recognised fields auto-populate with a cream tint and a `self` provenance tick. Edit releases the autofill claim.
+
+```jsonc
+"properties": {
+  "applicantEmail": { "type": "string", "format": "email", "x-persona": "defaultEmail" },
+  "dateOfBirth":    { "type": "string", "format": "date", "x-persona": "dateOfBirth" }
+}
+```
+
+Use `"x-persona": false` on a property whose name *would* match a heuristic but should never autofill (e.g. `nextOfKinEmail`). Without an explicit `x-persona`, the inference allowlist applies (`format: email` → defaultEmail, `format: tel` → defaultPhone, `dateOfBirth`/`dob`/`birthDate` → dateOfBirth, postal-address shape → defaultAddress).
+
+### Postcode address lookup (`x-address-lookup`)
+
+Set `"x-address-lookup": true` on a `postcode`-typed string field to enable the lookup control. Most blueprints get this for free by `$ref`-ing `https://schemas.sorcha.dev/core/PostalAddress/v1`.
+
+### File uploads (`x-file`)
+
+Mark a property as a file reference with `format: "file-reference"` and an `x-file` extension. The runtime handles transparent chunking (≤4MB chunks), per-chunk HKDF key derivation, and recipient key wrapping.
+
+```jsonc
+"sitePhoto": {
+  "type": "string",
+  "format": "file-reference",
+  "x-file": {
+    "accept": ["image/jpeg", "image/png"],
+    "maxSizePerFile": "16MB",
+    "maxChunks": 10,
+    "capture": "user",
+    "embedAs": "image-token-jpeg-240x320"
+  }
+}
+```
+
+`capture: "user"` requests the front-facing camera on mobile; `embedAs` triggers the client-side resizer to produce a base64 token at `{fieldPointer}/tokenImageBase64` alongside the chunked original. Full chunking/encryption pipeline lives in the **sorcha-architecture** skill — *Stored Data Transactions API*.
+
+### Review summary (`x-review`)
+
+Mark a wizard page as a read-only summary that renders as a credential id-card preview.
+
+```jsonc
+{
+  "title": "Review your details",
+  "x-review": {
+    "layout": "id-card",
+    "editable": true,
+    "header": {
+      "issuerName": "Acme Verification Co.",
+      "credentialName": "Assured Identity",
+      "colourTheme": "identity-navy"
+    }
+  }
+}
+```
+
+Watermark states (Draft/Pending/Issued/None), stacked-cards behaviour for `credentialRequirements + credentialIssuanceConfig` actions, and portrait capture details live in the **sorcha-architecture** skill — *Cross-Cutting Pattern: Review Summary*.
+
+## Credential Requirements & Issuance
+
+### Requiring a credential to perform an action
+
+```jsonc
+"credentialRequirements": [
+  {
+    "type": "AssuredIdentityCredential",
+    "presentationSource": "HaipExternalWallet",
+    "acceptedIssuers": ["did:sorcha:org:ws1abc..."],
+    "requiredClaims": [
+      { "claimName": "givenName" },
+      { "claimName": "dateOfBirth" }
+    ],
+    "revocationCheckPolicy": "FailClosed",
+    "description": "You must be a verified citizen to start a driving licence application."
+  }
+]
+```
+
+- `presentationSource: "SorchaInternal"` (default) matches against the holder's on-platform Sorcha credentials.
+- `presentationSource: "HaipExternalWallet"` runs the OpenID4VP `direct_post` flow (Feature 098) — required for citizen-facing services that accept external wallets and for credential-bootstrapped open submissions.
+- Empty `acceptedIssuers` accepts any issuer (`OPEN_CREDENTIAL_ISSUER` warning at publish time).
+- Multiple requirements are AND-combined.
+
+### Issuing a credential on action completion
+
+```jsonc
+"credentialIssuanceConfig": {
+  "credentialType": "PlanningPermit",
+  "claimMappings": [
+    { "claimName": "applicantName", "sourceField": "/applicantName" },
+    { "claimName": "siteAddress",   "sourceField": "/siteAddress"   }
+  ],
+  "recipientParticipantId": "applicant",
+  "expiryDuration": "P5Y",
+  "registerId": "planning-decisions",
+  "disclosable": ["applicantName", "siteAddress"],
+  "usagePolicy": "Reusable",
+  "targetAudience": "SorchaLocalWallet"
+}
+```
+
+- `targetAudience: "SorchaLocalWallet"` (Feature 106): the engine seals an X25519-wrapped, AEAD-encrypted SD-JWT VC into the action transaction; the credential peer-replicates and is detected by the holder's Wallet Service regardless of node. Default for on-platform issuance.
+- `targetAudience: "HaipExternalWallet"` (Feature 104): mints an OpenID4VCI offer instead of writing to a wallet. **MUST be paired with a separate Claim action** carrying `x-credential-offer` and `outputMapping` from the issuing route — see Credential Claim Actions below.
+- `targetAudience: "SorchaInternal"` is **deprecated** — bypasses the register and breaks on multi-node deployments. Always prefer `SorchaLocalWallet`.
+- `usagePolicy: "LimitedUse"` requires `maxPresentations: <int>`.
+- `expiryDuration` is ISO 8601 (`P5Y`, `P365D`, `PT24H`); omit for non-expiring credentials.
+
+## Rejection Configuration
+
+Defines what happens when a participant rejects the inbound data on an action.
+
+```jsonc
+"rejectionConfig": {
+  "targetActionId": 1,
+  "targetParticipantId": "applicant",
+  "requireReason": true,
+  "isTerminal": false
+}
+```
+
+- `targetActionId` — action to route to on rejection.
+- `targetParticipantId` (optional) — overrides the target action's default sender; useful when bouncing back to a different participant than the one who originally submitted.
+- `requireReason` (default `true`) — rejections must include a reason string.
+- `isTerminal` — when `true`, rejection ends the workflow in a `Rejected` state instead of routing. Used by the credential claim card's Decline button.
+
+If `rejectionConfig` is omitted, rejection is not allowed for the action.
 
 ## Credential Claim Actions (Feature 104 — wave 14b)
 
@@ -550,6 +776,27 @@ Body: {
 
 Engine pipeline: **validate** (schema check) → **calculate** (JSON Logic) → **route** (determine next) → **disclose** (visibility rules)
 
+## Disclosure Rules
+
+Every action MUST declare at least one `disclosure`. Each disclosure binds a participant to a list of JSON Pointer paths that participant can read on the action's payload.
+
+```jsonc
+"disclosures": [
+  { "participantAddress": "applicant", "dataPointers": ["/*"] },
+  { "participantAddress": "case-officer", "dataPointers": ["/applicantName", "/dateOfBirth", "/siteAddress"] },
+  { "participantAddress": "public-registry", "dataPointers": ["/decision", "/issuedAt"] }
+]
+```
+
+**Rules:**
+- The sender of an action always needs `/*` on their own submitted data — they're the author.
+- Default to **minimal disclosure**. Share only what each participant needs to act.
+- Sensitive fields (NI numbers, bank details, medical data, contact info) should be restricted by default. Approvers may need a summary, not the full document.
+- Use `/*` only when a participant genuinely needs to see everything.
+- Field-level encryption to participant wallets (X25519 wrap + XChaCha20-Poly1305) is automatic — do not add explicit encryption config to the blueprint.
+
+`participantAddress` accepts a participant `id` from the blueprint's `participants` list. The runtime resolves it to the participant's wallet at execution time (or to the late-bound wallet for open participants).
+
 ## Common Patterns
 
 ### Approval Chain (Linear)
@@ -588,7 +835,8 @@ Both → Complete
 
 ## Related Skills
 
-- **dotnet** - .NET 10 / C# 13 patterns
-- **minimal-apis** - Blueprint Service endpoint definitions
-- **xunit** - Testing blueprint validation
-- **blazor** - Template library UI pages
+- **sorcha-architecture** — Cross-cutting feature patterns: Stored Data file uploads (chunking + encryption pipeline), Review Summary id-card watermark states + portrait capture, Timebound Presentation Lifecycle (Feature 111 — Initiated/Outcome/Abandoned events), HAIP credential issuance/presentation internals, Open Participants late-binding runtime details.
+- **dotnet** — .NET 10 / C# 14 patterns
+- **minimal-apis** — Blueprint Service endpoint definitions
+- **xunit** — Testing blueprint validation
+- **blazor** — Template library UI pages

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Chat/ChatAttachment.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Chat/ChatAttachment.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Models.Chat;
+
+/// <summary>
+/// Client-side mirror of the server <c>ChatAttachment</c> shape. SignalR serialises this
+/// type as the wire payload; field names must stay in lock-step with the server record.
+/// </summary>
+public record ChatAttachment
+{
+    /// <summary>The kind of attachment.</summary>
+    public required ChatAttachmentKind Kind { get; init; }
+
+    /// <summary>IANA media type (e.g. <c>image/jpeg</c>, <c>application/pdf</c>).</summary>
+    public required string MediaType { get; init; }
+
+    /// <summary>Raw base64-encoded payload (no <c>data:</c> URI prefix).</summary>
+    public required string Base64Data { get; init; }
+
+    /// <summary>Optional original file name.</summary>
+    public string? FileName { get; init; }
+}
+
+/// <summary>Discriminator for <see cref="ChatAttachment"/>.</summary>
+public enum ChatAttachmentKind
+{
+    /// <summary>Image content (jpeg / png / webp / gif).</summary>
+    Image,
+
+    /// <summary>PDF document.</summary>
+    Pdf
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Chat/ChatMessage.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Chat/ChatMessage.cs
@@ -29,6 +29,11 @@ public record ChatMessage
     public List<ToolExecutionResult> ToolResults { get; init; } = [];
 
     /// <summary>
+    /// Binary attachments displayed alongside the text. Set on user messages with file drops.
+    /// </summary>
+    public List<ChatAttachment> Attachments { get; init; } = [];
+
+    /// <summary>
     /// When the message was created.
     /// </summary>
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/ChatHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/ChatHubConnection.cs
@@ -215,10 +215,12 @@ public class ChatHubConnection : IChatHubConnection
     }
 
     /// <inheritdoc />
-    public async Task SendMessageAsync(string sessionId, string message)
+    public async Task SendMessageAsync(string sessionId, string message, IReadOnlyList<ChatAttachment>? attachments = null)
     {
         EnsureConnected();
-        await _connection.InvokeAsync("SendMessage", sessionId, message);
+        // Pass attachments as a non-null payload so SignalR's parameter binding sees three args.
+        // An empty list is fine — the server treats null and empty equivalently.
+        await _connection.InvokeAsync("SendMessage", sessionId, message, attachments ?? Array.Empty<ChatAttachment>());
     }
 
     /// <inheritdoc />

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IChatHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IChatHubConnection.cs
@@ -75,11 +75,12 @@ public interface IChatHubConnection : IAsyncDisposable
     Task<string> StartSessionAsync(string? existingBlueprintId = null);
 
     /// <summary>
-    /// Sends a user message to the AI.
+    /// Sends a user message to the AI, optionally with image / PDF attachments.
     /// </summary>
     /// <param name="sessionId">Active session ID.</param>
-    /// <param name="message">User's message.</param>
-    Task SendMessageAsync(string sessionId, string message);
+    /// <param name="message">User's message (may be empty when <paramref name="attachments"/> is non-empty).</param>
+    /// <param name="attachments">Optional binary attachments — base64-encoded, mirrors the server record shape.</param>
+    Task SendMessageAsync(string sessionId, string message, IReadOnlyList<ChatAttachment>? attachments = null);
 
     /// <summary>
     /// Cancels the current AI generation.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceDisplay.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Forms/FileReferenceDisplay.razor
@@ -27,15 +27,15 @@
 
 @code {
     /// <summary>List of file references to display. Populated from the action payload — no API calls made on render.</summary>
-    [Parameter] public List<FileReferenceInfo> Files { get; set; } = [];
+    [Parameter] public List<FileReferenceInfo> Files { get; set; } = new();
 
     /// <summary>Raised with the zero-based file index when the user clicks the download button for that file.</summary>
     [Parameter] public EventCallback<int> OnDownload { get; set; }
 
-    private static string FormatSize(long bytes) => bytes switch
+    private static string FormatSize(long bytes)
     {
-        < 1024 => $"{bytes} B",
-        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
-        _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
-    };
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
+    }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerBlueprint.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerBlueprint.razor.css
@@ -1,5 +1,31 @@
 .designer-shell {
+    /* Top MudAppBar (64) + bottom StatusFooter MudAppBar (32) + MudContainer
+       my-4 vertical margins (32) + MainLayout padding-bottom (40). Tune via
+       this variable if layout chrome changes. */
+    --designer-chrome-height: 168px;
     display: grid;
-    grid-template-rows: auto auto 1fr;
+    grid-template-rows: auto 1fr;
+    height: calc(100dvh - var(--designer-chrome-height));
+    min-height: 0;
+}
+
+/* Pass real height through MudTabs so the active panel fills the 1fr row.
+   Without this the panel collapses to content height, breaking the
+   pinned-composer layout in AiDesignerPane. */
+.designer-shell ::deep .mud-tabs {
+    display: flex;
+    flex-direction: column;
     height: 100%;
+    min-height: 0;
+}
+
+.designer-shell ::deep .mud-tabs-panels {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.designer-shell ::deep .mud-tab-panel {
+    height: 100%;
+    min-height: 0;
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
@@ -2,6 +2,7 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @namespace Sorcha.UI.Web.Client.Pages.DesignerShell.Panes
+@using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
 @using MudBlazor
 @using Sorcha.UI.Core.Models.Chat
@@ -15,7 +16,16 @@
 @inject ISnackbar Snackbar
 @implements IAsyncDisposable
 
-<div class="ai-pane" data-testid="ai-tab-panel">
+<div class="ai-pane" id="ai-pane-root" data-testid="ai-tab-panel">
+    @if (_isDragging)
+    {
+        <div class="ai-pane-drop-overlay" data-testid="chat-drop-overlay">
+            <MudIcon Icon="@Icons.Material.Filled.CloudUpload" Size="Size.Large" />
+            <MudText Typo="Typo.h6">Drop files to attach</MudText>
+            <MudText Typo="Typo.caption">Images (JPG / PNG / WebP / GIF up to 5 MB) or PDFs (up to 32 MB) — max @MaxAttachmentsPerMessage per message</MudText>
+        </div>
+    }
+
     <div class="ai-pane-messages" data-testid="chat-message-list" id="ai-pane-messages">
         <div class="ai-pane-messages-inner">
             @foreach (var message in _messages)
@@ -34,8 +44,38 @@
     </div>
 
     <div class="ai-pane-input" data-testid="chat-input-area">
+        @if (_pendingAttachments.Count > 0)
+        {
+            <div class="ai-pane-attachment-chips" data-testid="chat-attachment-chips">
+                @foreach (var att in _pendingAttachments)
+                {
+                    <MudChip T="string"
+                             Color="Color.Primary"
+                             Variant="Variant.Outlined"
+                             Icon="@(att.Kind == ChatAttachmentKind.Image ? Icons.Material.Filled.Image : Icons.Material.Filled.PictureAsPdf)"
+                             OnClose="@(() => RemoveAttachment(att))"
+                             CloseIcon="@Icons.Material.Filled.Close">
+                        @(att.FileName ?? att.MediaType)
+                    </MudChip>
+                }
+            </div>
+        }
+
         <MudPaper Elevation="2" Class="pa-2">
             <div class="d-flex align-center gap-2">
+                <InputFile id="@FileInputElementId"
+                           OnChange="OnInputFilesChanged"
+                           multiple
+                           accept="image/jpeg,image/png,image/webp,image/gif,application/pdf"
+                           class="ai-pane-file-input-hidden" />
+
+                <MudIconButton Icon="@Icons.Material.Filled.AttachFile"
+                               Color="Color.Default"
+                               Disabled="@(!IsConnected || _isProcessing)"
+                               OnClick="OpenFilePicker"
+                               Title="Attach files"
+                               data-testid="chat-attach-button" />
+
                 <MudTextField @bind-Value="_messageInput"
                               Placeholder="@(IsConnected ? "Describe your workflow..." : "Connecting...")"
                               Variant="Variant.Outlined"
@@ -60,7 +100,7 @@
                     <MudButton Color="Color.Primary"
                                Variant="Variant.Filled"
                                OnClick="SendMessageAsync"
-                               Disabled="@(string.IsNullOrWhiteSpace(_messageInput) || !IsConnected)"
+                               Disabled="@((string.IsNullOrWhiteSpace(_messageInput) && _pendingAttachments.Count == 0) || !IsConnected)"
                                StartIcon="@Icons.Material.Filled.Send"
                                data-testid="chat-send-button">
                         Send

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using MudBlazor;
@@ -22,16 +24,22 @@ namespace Sorcha.UI.Web.Client.Pages.DesignerShell.Panes;
 public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
 {
     private readonly List<ChatMessageModel> _messages = [];
+    private readonly List<ChatAttachment> _pendingAttachments = [];
     private AutoScrollController? _autoScroll;
     private string _messageInput = string.Empty;
     private string _currentAssistantMessage = string.Empty;
     private bool _isProcessing;
     private bool _connected;
+    private bool _isDragging;
     private string? _sessionId;
     private bool _initialised;
     private DotNetObjectReference<AiDesignerPane>? _testHookRef;
+    private DotNetObjectReference<AiDesignerPane>? _dropZoneRef;
 
     private const string MessagesElementId = "ai-pane-messages";
+    private const string PaneRootElementId = "ai-pane-root";
+    private const string FileInputElementId = "ai-pane-file-input";
+    private const int MaxAttachmentsPerMessage = 5;
 
     private bool IsConnected => _connected && ChatHub.State == ChatConnectionState.Connected;
 
@@ -68,7 +76,7 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
     {
         if (firstRender)
         {
-            // Register auto-scroll helper expected by AutoScrollController.
+            // Register auto-scroll + drop-zone helpers expected by the JS layer.
             // Data is always passed as arguments — never interpolated into JS.
             try
             {
@@ -76,7 +84,49 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
                     "window.sorcha = window.sorcha || {};" +
                     "window.sorcha.designer = window.sorcha.designer || {};" +
                     "window.sorcha.designer.scrollToBottom = window.sorcha.designer.scrollToBottom || function(id) {" +
-                    "var el = document.getElementById(id); if (el) { el.scrollTop = el.scrollHeight; } };");
+                    "var el = document.getElementById(id); if (el) { el.scrollTop = el.scrollHeight; } };" +
+
+                    // Programmatic file picker open (paperclip button).
+                    "window.sorcha.designer.openFilePicker = window.sorcha.designer.openFilePicker || function(id) {" +
+                    "var el = document.getElementById(id); if (el) { el.value = ''; el.click(); } };" +
+
+                    // Chunked ArrayBuffer → base64 (avoids call-stack overflow on large files).
+                    "window.sorcha.designer._toBase64 = window.sorcha.designer._toBase64 || function(buf) {" +
+                    "var bytes = new Uint8Array(buf), binary = '', chunk = 0x8000;" +
+                    "for (var i = 0; i < bytes.length; i += chunk) {" +
+                    "binary += String.fromCharCode.apply(null, bytes.subarray(i, Math.min(i + chunk, bytes.length))); }" +
+                    "return btoa(binary); };" +
+
+                    // Whole-pane drop zone with depth-counted enter/leave (children fire spurious leaves).
+                    "window.sorcha.designer.attachDropZone = window.sorcha.designer.attachDropZone || function(id, dotNetRef) {" +
+                    "var el = document.getElementById(id); if (!el) return;" +
+                    "if (el.__sorchaDrop) return; el.__sorchaDrop = true;" +
+                    "var depth = 0;" +
+                    "el.addEventListener('dragenter', function(e) {" +
+                    "if (!e.dataTransfer || !Array.from(e.dataTransfer.types || []).includes('Files')) return;" +
+                    "e.preventDefault(); depth++;" +
+                    "if (depth === 1) dotNetRef.invokeMethodAsync('OnDragStart'); });" +
+                    "el.addEventListener('dragover', function(e) {" +
+                    "if (!e.dataTransfer || !Array.from(e.dataTransfer.types || []).includes('Files')) return;" +
+                    "e.preventDefault(); e.dataTransfer.dropEffect = 'copy'; });" +
+                    "el.addEventListener('dragleave', function(e) {" +
+                    "if (!e.dataTransfer || !Array.from(e.dataTransfer.types || []).includes('Files')) return;" +
+                    "depth = Math.max(0, depth - 1);" +
+                    "if (depth === 0) dotNetRef.invokeMethodAsync('OnDragEnd'); });" +
+                    "el.addEventListener('drop', async function(e) {" +
+                    "e.preventDefault(); depth = 0;" +
+                    "dotNetRef.invokeMethodAsync('OnDragEnd');" +
+                    "if (!e.dataTransfer || !e.dataTransfer.files) return;" +
+                    "var out = [];" +
+                    "for (var i = 0; i < e.dataTransfer.files.length; i++) {" +
+                    "var f = e.dataTransfer.files[i];" +
+                    "var buf = await f.arrayBuffer();" +
+                    "out.push({ fileName: f.name, mediaType: f.type || 'application/octet-stream'," +
+                    "base64Data: window.sorcha.designer._toBase64(buf) }); }" +
+                    "await dotNetRef.invokeMethodAsync('OnFilesDropped', JSON.stringify(out)); }); };");
+
+                _dropZoneRef = DotNetObjectReference.Create(this);
+                await JS.InvokeVoidAsync("window.sorcha.designer.attachDropZone", PaneRootElementId, _dropZoneRef);
             }
             catch
             {
@@ -284,7 +334,8 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
                 {
                     Role = MessageRole.Assistant,
                     Content = "Hello! I'm your AI blueprint designer. Describe the workflow you want to create " +
-                              "and I'll help you build it step by step.",
+                              "and I'll help you build it step by step. Drop images or PDFs onto this pane to share " +
+                              "reference material with me.",
                     Timestamp = DateTime.UtcNow
                 });
             }
@@ -295,7 +346,8 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Enter" && !e.ShiftKey && !string.IsNullOrWhiteSpace(_messageInput))
+        if (e.Key == "Enter" && !e.ShiftKey
+            && (!string.IsNullOrWhiteSpace(_messageInput) || _pendingAttachments.Count > 0))
         {
             await SendMessageAsync();
         }
@@ -303,18 +355,23 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
 
     private async Task SendMessageAsync()
     {
-        if (string.IsNullOrWhiteSpace(_messageInput) || string.IsNullOrEmpty(_sessionId))
+        var hasText = !string.IsNullOrWhiteSpace(_messageInput);
+        var hasFiles = _pendingAttachments.Count > 0;
+        if ((!hasText && !hasFiles) || string.IsNullOrEmpty(_sessionId))
         {
             return;
         }
 
         var message = _messageInput;
+        var attachmentsToSend = _pendingAttachments.ToList();
         _messageInput = string.Empty;
+        _pendingAttachments.Clear();
 
         _messages.Add(new ChatMessageModel
         {
             Role = MessageRole.User,
             Content = message,
+            Attachments = attachmentsToSend.ToList(),
             Timestamp = DateTime.UtcNow
         });
         _isProcessing = true;
@@ -322,7 +379,7 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
 
         try
         {
-            await ChatHub.SendMessageAsync(_sessionId, message);
+            await ChatHub.SendMessageAsync(_sessionId, message, attachmentsToSend);
         }
         catch (Exception ex)
         {
@@ -346,6 +403,178 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
         {
             Snackbar.Add($"Failed to cancel: {ex.Message}", Severity.Error);
         }
+    }
+
+    private async Task OpenFilePicker()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("window.sorcha.designer.openFilePicker", FileInputElementId);
+        }
+        catch
+        {
+            // Ignore — JS layer will reattach on next render.
+        }
+    }
+
+    private async Task OnInputFilesChanged(InputFileChangeEventArgs e)
+    {
+        // Click-to-pick path mirrors the drag-drop path: read each file, validate,
+        // base64-encode, and feed the same _pendingAttachments list.
+        foreach (var file in e.GetMultipleFiles(MaxAttachmentsPerMessage))
+        {
+            if (_pendingAttachments.Count >= MaxAttachmentsPerMessage)
+            {
+                Snackbar.Add($"Maximum {MaxAttachmentsPerMessage} attachments per message.", Severity.Warning);
+                break;
+            }
+
+            try
+            {
+                var attachment = await ReadBrowserFileAsync(file);
+                if (attachment != null)
+                {
+                    _pendingAttachments.Add(attachment);
+                }
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Could not attach {file.Name}: {ex.Message}", Severity.Error);
+            }
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task<ChatAttachment?> ReadBrowserFileAsync(IBrowserFile file)
+    {
+        var (kind, ok) = ClassifyMediaType(file.ContentType);
+        if (!ok)
+        {
+            Snackbar.Add($"Unsupported file type: {file.ContentType}", Severity.Warning);
+            return null;
+        }
+
+        var maxSize = kind == ChatAttachmentKind.Image ? 5 * 1024 * 1024L : 32 * 1024 * 1024L;
+        if (file.Size > maxSize)
+        {
+            var limit = kind == ChatAttachmentKind.Image ? "5 MB" : "32 MB";
+            Snackbar.Add($"{file.Name} is too large (max {limit}).", Severity.Warning);
+            return null;
+        }
+
+        await using var stream = file.OpenReadStream(maxAllowedSize: maxSize);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        var base64 = Convert.ToBase64String(ms.ToArray());
+
+        return new ChatAttachment
+        {
+            Kind = kind,
+            MediaType = file.ContentType,
+            Base64Data = base64,
+            FileName = file.Name
+        };
+    }
+
+    private static (ChatAttachmentKind kind, bool ok) ClassifyMediaType(string? mediaType)
+    {
+        return (mediaType ?? string.Empty).ToLowerInvariant() switch
+        {
+            "image/jpeg" or "image/png" or "image/webp" or "image/gif" => (ChatAttachmentKind.Image, true),
+            "application/pdf" => (ChatAttachmentKind.Pdf, true),
+            _ => (ChatAttachmentKind.Image, false)
+        };
+    }
+
+    private void RemoveAttachment(ChatAttachment att)
+    {
+        _pendingAttachments.Remove(att);
+        StateHasChanged();
+    }
+
+    /// <summary>JS callback: drag entered the pane (file payload).</summary>
+    [JSInvokable]
+    public void OnDragStart()
+    {
+        InvokeAsync(() =>
+        {
+            _isDragging = true;
+            StateHasChanged();
+        });
+    }
+
+    /// <summary>JS callback: drag left the pane or drop fired.</summary>
+    [JSInvokable]
+    public void OnDragEnd()
+    {
+        InvokeAsync(() =>
+        {
+            _isDragging = false;
+            StateHasChanged();
+        });
+    }
+
+    /// <summary>
+    /// JS callback: files dropped on the pane. JSON payload is an array of
+    /// <c>{ fileName, mediaType, base64Data }</c>. We classify, validate size,
+    /// and append to <see cref="_pendingAttachments"/>.
+    /// </summary>
+    [JSInvokable]
+    public void OnFilesDropped(string filesJson)
+    {
+        InvokeAsync(() =>
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(filesJson);
+                foreach (var item in doc.RootElement.EnumerateArray())
+                {
+                    if (_pendingAttachments.Count >= MaxAttachmentsPerMessage)
+                    {
+                        Snackbar.Add($"Maximum {MaxAttachmentsPerMessage} attachments per message.", Severity.Warning);
+                        break;
+                    }
+
+                    var fileName = item.TryGetProperty("fileName", out var n) ? n.GetString() : null;
+                    var mediaType = item.TryGetProperty("mediaType", out var mt) ? mt.GetString() : null;
+                    var data = item.TryGetProperty("base64Data", out var d) ? d.GetString() : null;
+
+                    if (string.IsNullOrEmpty(data) || string.IsNullOrEmpty(mediaType))
+                    {
+                        continue;
+                    }
+
+                    var (kind, ok) = ClassifyMediaType(mediaType);
+                    if (!ok)
+                    {
+                        Snackbar.Add($"Unsupported file type: {mediaType}", Severity.Warning);
+                        continue;
+                    }
+
+                    // Server enforces hard limits; reject obvious fails client-side too.
+                    var maxBase64 = kind == ChatAttachmentKind.Image ? 7_000_000 : 45_000_000;
+                    if (data.Length > maxBase64)
+                    {
+                        Snackbar.Add($"{fileName ?? "Attachment"} exceeds the size limit.", Severity.Warning);
+                        continue;
+                    }
+
+                    _pendingAttachments.Add(new ChatAttachment
+                    {
+                        Kind = kind,
+                        MediaType = mediaType,
+                        Base64Data = data,
+                        FileName = fileName
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Failed to read dropped files: {ex.Message}", Severity.Error);
+            }
+            StateHasChanged();
+        });
     }
 
 #if DEBUG || E2E_TEST_HOOKS
@@ -432,5 +661,6 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
         }
 
         _testHookRef?.Dispose();
+        _dropZoneRef?.Dispose();
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.css
@@ -5,6 +5,34 @@
     width: 100%;
     min-height: 0;
     overflow: hidden;
+    /* Establish positioning context for the drop overlay. */
+    position: relative;
+}
+
+.ai-pane-drop-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    background: var(--mud-palette-primary-hover);
+    border: 2px dashed var(--mud-palette-primary);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    pointer-events: none;
+    backdrop-filter: blur(2px);
+}
+
+.ai-pane-attachment-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 4px 8px 8px 8px;
+}
+
+.ai-pane-file-input-hidden {
+    display: none;
 }
 
 .ai-pane-messages {

--- a/src/Services/Sorcha.Blueprint.Service/Hubs/ChatHub.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Hubs/ChatHub.cs
@@ -136,18 +136,20 @@ public class ChatHub : Hub
     }
 
     /// <summary>
-    /// Sends a user message to the AI assistant.
+    /// Sends a user message to the AI assistant. May include image / PDF attachments.
     /// </summary>
     /// <param name="sessionId">Active session ID.</param>
-    /// <param name="message">User's natural language input (max 10000 chars).</param>
-    public async Task SendMessage(string sessionId, string message)
+    /// <param name="message">User's natural language input (max 10000 chars; may be empty when <paramref name="attachments"/> is non-empty).</param>
+    /// <param name="attachments">Optional binary attachments (images, PDFs) — base64-encoded.</param>
+    public async Task SendMessage(string sessionId, string message, IReadOnlyList<ChatAttachment>? attachments = null)
     {
         if (string.IsNullOrWhiteSpace(sessionId))
         {
             throw new HubException("Session ID is required");
         }
 
-        if (string.IsNullOrWhiteSpace(message))
+        var hasAttachments = attachments is { Count: > 0 };
+        if (string.IsNullOrWhiteSpace(message) && !hasAttachments)
         {
             throw new HubException("Message cannot be empty");
         }
@@ -184,6 +186,7 @@ public class ChatHub : Hub
                 {
                     await Clients.Caller.SendAsync("BlueprintUpdated", blueprint, validation);
                 },
+                attachments: attachments,
                 cancellationToken: cts.Token);
 
             // Message complete

--- a/src/Services/Sorcha.Blueprint.Service/Models/Chat/ChatAttachment.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/Chat/ChatAttachment.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Blueprint.Service.Models.Chat;
+
+/// <summary>
+/// A binary attachment (image or PDF) sent alongside a user chat message.
+/// The data is base64-encoded; the orchestrator forwards it to the AI provider as a
+/// content block (Anthropic ImageContent or DocumentContent).
+/// </summary>
+public record ChatAttachment
+{
+    /// <summary>The kind of attachment — drives which Anthropic content block is emitted.</summary>
+    public required ChatAttachmentKind Kind { get; init; }
+
+    /// <summary>IANA media type (e.g. <c>image/jpeg</c>, <c>application/pdf</c>).</summary>
+    public required string MediaType { get; init; }
+
+    /// <summary>Raw base64-encoded payload (no <c>data:</c> URI prefix).</summary>
+    public required string Base64Data { get; init; }
+
+    /// <summary>Optional original file name, retained for display in chat history.</summary>
+    public string? FileName { get; init; }
+}
+
+/// <summary>Discriminator for <see cref="ChatAttachment"/>.</summary>
+public enum ChatAttachmentKind
+{
+    /// <summary>Renders as an Anthropic image content block.</summary>
+    Image,
+
+    /// <summary>Renders as an Anthropic document (PDF) content block.</summary>
+    Pdf
+}

--- a/src/Services/Sorcha.Blueprint.Service/Models/Chat/ChatMessage.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/Chat/ChatMessage.cs
@@ -39,6 +39,13 @@ public record ChatMessage
     public List<ToolResult>? ToolResults { get; init; }
 
     /// <summary>
+    /// Binary attachments (images, PDFs) the user dropped onto the chat. Forwarded to the AI
+    /// provider as content blocks alongside <see cref="Content"/>. Null on assistant messages
+    /// and on user messages with no attachments.
+    /// </summary>
+    public List<ChatAttachment>? Attachments { get; init; }
+
+    /// <summary>
     /// When the message was created.
     /// </summary>
     public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;

--- a/src/Services/Sorcha.Blueprint.Service/Services/AnthropicProviderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/AnthropicProviderService.cs
@@ -179,11 +179,52 @@ public class AnthropicProviderService : IAIProviderService
             }
             else
             {
-                // Regular text message
+                // Regular text message — possibly with image / PDF attachments.
+                var contents = new List<ContentBase>();
+
+                if (msg.Attachments is { Count: > 0 })
+                {
+                    foreach (var att in msg.Attachments)
+                    {
+                        switch (att.Kind)
+                        {
+                            case ChatAttachmentKind.Image:
+                                contents.Add(new ImageContent
+                                {
+                                    Source = new ImageSource
+                                    {
+                                        Type = SourceType.base64,
+                                        MediaType = att.MediaType,
+                                        Data = att.Base64Data
+                                    }
+                                });
+                                break;
+                            case ChatAttachmentKind.Pdf:
+                                contents.Add(new DocumentContent
+                                {
+                                    Source = new DocumentSource
+                                    {
+                                        Type = SourceType.base64,
+                                        MediaType = att.MediaType,
+                                        Data = att.Base64Data
+                                    }
+                                });
+                                break;
+                        }
+                    }
+                }
+
+                // Anthropic requires at least one content block; pad empty messages with
+                // a single space so an attachment-only user message still validates.
+                contents.Add(new TextContent
+                {
+                    Text = string.IsNullOrEmpty(msg.Content) && contents.Count > 0 ? " " : msg.Content
+                });
+
                 result.Add(new Message
                 {
                     Role = role,
-                    Content = [new TextContent { Text = msg.Content }]
+                    Content = contents
                 });
             }
         }

--- a/src/Services/Sorcha.Blueprint.Service/Services/BlueprintToolExecutor.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/BlueprintToolExecutor.cs
@@ -64,6 +64,9 @@ public class BlueprintToolExecutor : IBlueprintToolExecutor
                 "search_templates" => ExecuteSearchTemplatesAsync(arguments, builder, cancellationToken),
                 "require_credential" => Task.FromResult(ExecuteRequireCredential(arguments, builder)),
                 "issue_credential" => Task.FromResult(ExecuteIssueCredential(arguments, builder)),
+                "set_action_schema" => Task.FromResult(ExecuteSetActionSchema(arguments, builder)),
+                "set_action_routes" => Task.FromResult(ExecuteSetActionRoutes(arguments, builder)),
+                "set_action_metadata" => Task.FromResult(ExecuteSetActionMetadata(arguments, builder)),
                 _ => Task.FromResult(ToolResult.Failed(Guid.NewGuid().ToString(), $"Unknown tool: {toolName}"))
             });
         }
@@ -855,6 +858,269 @@ public class BlueprintToolExecutor : IBlueprintToolExecutor
             blueprintChanged: true);
     }
 
+    /// <summary>
+    /// Escape-hatch: replaces or appends a full raw JSON Schema document on the action's
+    /// <c>dataSchemas</c>. Lets the AI emit shapes the typed tools cannot — nested objects,
+    /// arrays, <c>$ref</c>, <c>x-pages</c>/<c>x-sections</c>/<c>x-introduction</c>/<c>x-width</c>,
+    /// <c>x-persona</c>, <c>x-credential-offer</c>, <c>x-review</c>, <c>x-file</c>,
+    /// <c>formatMinimum</c>/<c>formatMaximum</c>, etc.
+    /// </summary>
+    private ToolResult ExecuteSetActionSchema(JsonDocument arguments, BlueprintBuilder builder)
+    {
+        var root = arguments.RootElement;
+        var actionId = root.GetProperty("actionId").GetInt32();
+        var schemaElem = root.GetProperty("schema");
+        var mode = root.TryGetProperty("mode", out var modeProp)
+            ? (modeProp.GetString() ?? "replace").ToLowerInvariant()
+            : "replace";
+
+        if (schemaElem.ValueKind != JsonValueKind.Object)
+        {
+            return ToolResult.Failed(
+                Guid.NewGuid().ToString(),
+                "schema must be a JSON Schema object (with at minimum a 'type' property).");
+        }
+
+        var draft = builder.BuildDraft();
+        var action = draft.Actions.FirstOrDefault(a => a.Id == actionId);
+        if (action == null)
+        {
+            return ToolResult.Failed(
+                Guid.NewGuid().ToString(),
+                $"Action with ID {actionId} not found");
+        }
+
+        var doc = JsonDocument.Parse(schemaElem.GetRawText());
+        var schemas = mode == "append"
+            ? (action.DataSchemas?.ToList() ?? [])
+            : new List<JsonDocument>();
+        schemas.Add(doc);
+        action.DataSchemas = schemas;
+
+        return ToolResult.Succeeded(
+            Guid.NewGuid().ToString(),
+            new
+            {
+                message = $"{(mode == "append" ? "Appended" : "Replaced")} schema on action '{action.Title}'",
+                actionId,
+                mode,
+                schemaCount = schemas.Count
+            },
+            blueprintChanged: true);
+    }
+
+    /// <summary>
+    /// Escape-hatch: replaces the action's full <c>routes</c> array. Supports terminal routes
+    /// (empty <c>nextActionIds</c>), parallel branches (multiple ids), raw JSON Logic conditions,
+    /// <c>branchDeadline</c>, and <c>outputMapping</c> for payload carry-forward (Feature 104).
+    /// </summary>
+    private ToolResult ExecuteSetActionRoutes(JsonDocument arguments, BlueprintBuilder builder)
+    {
+        var root = arguments.RootElement;
+        var actionId = root.GetProperty("actionId").GetInt32();
+        var routesElem = root.GetProperty("routes");
+
+        if (routesElem.ValueKind != JsonValueKind.Array)
+        {
+            return ToolResult.Failed(
+                Guid.NewGuid().ToString(),
+                "routes must be an array (use [] to clear all routes).");
+        }
+
+        var draft = builder.BuildDraft();
+        var action = draft.Actions.FirstOrDefault(a => a.Id == actionId);
+        if (action == null)
+        {
+            return ToolResult.Failed(
+                Guid.NewGuid().ToString(),
+                $"Action with ID {actionId} not found");
+        }
+
+        var routes = new List<Sorcha.Blueprint.Models.Route>();
+        var index = 0;
+        foreach (var routeElem in routesElem.EnumerateArray())
+        {
+            var id = routeElem.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String
+                ? idProp.GetString()!
+                : $"route_{index}";
+
+            var nextActionIds = routeElem.TryGetProperty("nextActionIds", out var nextProp)
+                && nextProp.ValueKind == JsonValueKind.Array
+                ? nextProp.EnumerateArray().Select(n => n.GetInt32()).ToList()
+                : new List<int>();
+
+            var route = new Sorcha.Blueprint.Models.Route
+            {
+                Id = id,
+                NextActionIds = nextActionIds,
+                IsDefault = routeElem.TryGetProperty("isDefault", out var defProp) && defProp.GetBoolean()
+            };
+
+            if (routeElem.TryGetProperty("description", out var descProp)
+                && descProp.ValueKind == JsonValueKind.String)
+            {
+                route.Description = descProp.GetString();
+            }
+
+            if (routeElem.TryGetProperty("branchDeadline", out var deadlineProp)
+                && deadlineProp.ValueKind == JsonValueKind.String)
+            {
+                route.BranchDeadline = deadlineProp.GetString();
+            }
+
+            if (routeElem.TryGetProperty("condition", out var condProp)
+                && condProp.ValueKind != JsonValueKind.Null
+                && condProp.ValueKind != JsonValueKind.Undefined)
+            {
+                route.Condition = System.Text.Json.Nodes.JsonNode.Parse(condProp.GetRawText());
+            }
+
+            if (routeElem.TryGetProperty("outputMapping", out var omProp)
+                && omProp.ValueKind == JsonValueKind.Object)
+            {
+                var map = new Dictionary<string, string>();
+                foreach (var prop in omProp.EnumerateObject())
+                {
+                    if (prop.Value.ValueKind == JsonValueKind.String)
+                    {
+                        map[prop.Name] = prop.Value.GetString()!;
+                    }
+                }
+                if (map.Count > 0)
+                {
+                    route.OutputMapping = map;
+                }
+            }
+
+            routes.Add(route);
+            index++;
+        }
+
+        action.Routes = routes;
+
+        return ToolResult.Succeeded(
+            Guid.NewGuid().ToString(),
+            new
+            {
+                message = $"Set {routes.Count} route(s) on action '{action.Title}'",
+                actionId,
+                routeCount = routes.Count,
+                hasTerminal = routes.Any(r => !r.NextActionIds.Any()),
+                hasOutputMapping = routes.Any(r => r.OutputMapping != null && r.OutputMapping.Count > 0)
+            },
+            blueprintChanged: true);
+    }
+
+    /// <summary>
+    /// Escape-hatch: sparse update of action metadata that the typed tools cannot fully express —
+    /// <c>isStartingAction</c>, <c>instructions</c>, <c>requiredPriorActions</c>, <c>rejectionConfig</c>,
+    /// and the full <c>credentialRequirements</c> / <c>credentialIssuanceConfig</c> shapes including
+    /// <c>presentationSource</c> and <c>targetAudience</c>. Only provided fields are updated.
+    /// </summary>
+    private ToolResult ExecuteSetActionMetadata(JsonDocument arguments, BlueprintBuilder builder)
+    {
+        var root = arguments.RootElement;
+        var actionId = root.GetProperty("actionId").GetInt32();
+
+        var draft = builder.BuildDraft();
+        var action = draft.Actions.FirstOrDefault(a => a.Id == actionId);
+        if (action == null)
+        {
+            return ToolResult.Failed(
+                Guid.NewGuid().ToString(),
+                $"Action with ID {actionId} not found");
+        }
+
+        var updated = new List<string>();
+
+        if (root.TryGetProperty("isStartingAction", out var startProp)
+            && (startProp.ValueKind == JsonValueKind.True || startProp.ValueKind == JsonValueKind.False))
+        {
+            action.IsStartingAction = startProp.GetBoolean();
+            updated.Add("isStartingAction");
+        }
+
+        if (root.TryGetProperty("instructions", out var instrProp)
+            && instrProp.ValueKind == JsonValueKind.String)
+        {
+            action.Instructions = instrProp.GetString();
+            updated.Add("instructions");
+        }
+
+        if (root.TryGetProperty("requiredPriorActions", out var rpaProp)
+            && rpaProp.ValueKind == JsonValueKind.Array)
+        {
+            action.RequiredPriorActions = rpaProp.EnumerateArray().Select(n => n.GetInt32()).ToList();
+            updated.Add("requiredPriorActions");
+        }
+
+        if (root.TryGetProperty("rejectionConfig", out var rejProp))
+        {
+            if (rejProp.ValueKind == JsonValueKind.Null)
+            {
+                action.RejectionConfig = null;
+                updated.Add("rejectionConfig (cleared)");
+            }
+            else if (rejProp.ValueKind == JsonValueKind.Object)
+            {
+                var rc = JsonSerializer.Deserialize<Sorcha.Blueprint.Models.RejectionConfig>(rejProp.GetRawText())
+                    ?? throw new InvalidOperationException("Failed to deserialize rejectionConfig");
+                action.RejectionConfig = rc;
+                updated.Add("rejectionConfig");
+            }
+        }
+
+        if (root.TryGetProperty("credentialRequirements", out var crProp))
+        {
+            if (crProp.ValueKind == JsonValueKind.Null)
+            {
+                action.CredentialRequirements = null;
+                updated.Add("credentialRequirements (cleared)");
+            }
+            else if (crProp.ValueKind == JsonValueKind.Array)
+            {
+                var reqs = JsonSerializer.Deserialize<List<CredentialRequirement>>(crProp.GetRawText())
+                    ?? new List<CredentialRequirement>();
+                action.CredentialRequirements = reqs;
+                updated.Add($"credentialRequirements ({reqs.Count})");
+            }
+        }
+
+        if (root.TryGetProperty("credentialIssuanceConfig", out var ciProp))
+        {
+            if (ciProp.ValueKind == JsonValueKind.Null)
+            {
+                action.CredentialIssuanceConfig = null;
+                updated.Add("credentialIssuanceConfig (cleared)");
+            }
+            else if (ciProp.ValueKind == JsonValueKind.Object)
+            {
+                var cfg = JsonSerializer.Deserialize<CredentialIssuanceConfig>(ciProp.GetRawText())
+                    ?? throw new InvalidOperationException("Failed to deserialize credentialIssuanceConfig");
+                action.CredentialIssuanceConfig = cfg;
+                updated.Add("credentialIssuanceConfig");
+            }
+        }
+
+        if (updated.Count == 0)
+        {
+            return ToolResult.Failed(
+                Guid.NewGuid().ToString(),
+                "No metadata fields provided. Pass at least one of: isStartingAction, instructions, " +
+                "requiredPriorActions, rejectionConfig, credentialRequirements, credentialIssuanceConfig.");
+        }
+
+        return ToolResult.Succeeded(
+            Guid.NewGuid().ToString(),
+            new
+            {
+                message = $"Updated action '{action.Title}' metadata: {string.Join(", ", updated)}",
+                actionId,
+                updated
+            },
+            blueprintChanged: true);
+    }
+
     private ToolResult ExecuteValidateBlueprint(JsonDocument arguments, BlueprintBuilder builder)
     {
         var errors = new List<object>();
@@ -1293,6 +1559,206 @@ public class BlueprintToolExecutor : IBlueprintToolExecutor
                         }
                     },
                     required = new[] { "actionId", "credentialType", "claimMappings", "recipientParticipantId" }
+                }),
+
+            ToolDefinition.Create(
+                "set_action_schema",
+                "Advanced. Replaces (or appends to) an action's data schema with a full raw JSON Schema document. " +
+                "Use this when add_action's flat fields cannot express the shape you need: nested objects, arrays, " +
+                "$ref to core components (PersonName/DateOfBirth/EmailAddress/PostalAddress), x-pages (wizard), " +
+                "x-sections / x-introduction / x-width (form layout), x-persona (autofill bindings), " +
+                "x-credential-offer (claim card — Feature 104), x-review (id-card summary), x-file " +
+                "(file uploads with chunking), or formatMinimum / formatMaximum date constraints with today / " +
+                "today+18Y tokens. Prefer add_action / use_standard_schema for simple flat shapes.",
+                new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        actionId = new { type = "integer", description = "Action ID to attach the schema to" },
+                        schema = new
+                        {
+                            type = "object",
+                            description = "A full JSON Schema 2020-12 object. Pass through unchanged — the renderer and " +
+                                "validator will resolve $ref, x-pages, x-sections, x-persona, x-credential-offer, etc."
+                        },
+                        mode = new
+                        {
+                            type = "string",
+                            @enum = new[] { "replace", "append" },
+                            description = "replace (default) clears the action's existing dataSchemas; append adds this schema to the existing list."
+                        }
+                    },
+                    required = new[] { "actionId", "schema" }
+                }),
+
+            ToolDefinition.Create(
+                "set_action_routes",
+                "Advanced. Replaces an action's routes with the full Route[] shape. Use this when add_routing cannot " +
+                "express what you need: terminal routes (empty nextActionIds means workflow complete), parallel " +
+                "branches (multiple nextActionIds with branchDeadline), raw JSON Logic conditions (any operator, not " +
+                "just the five add_routing exposes), or outputMapping (Feature 104 payload carry-forward — required " +
+                "for credential claim flows). Prefer add_routing for simple linear conditional shapes.",
+                new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        actionId = new { type = "integer", description = "Action ID whose routes will be replaced" },
+                        routes = new
+                        {
+                            type = "array",
+                            description = "Routes evaluated in order. First matching condition wins; the default route fires last.",
+                            items = new
+                            {
+                                type = "object",
+                                properties = new
+                                {
+                                    id = new { type = "string", description = "Unique id within the action (e.g., 'approved-to-claim'). Auto-generated if omitted." },
+                                    nextActionIds = new
+                                    {
+                                        type = "array",
+                                        items = new { type = "integer" },
+                                        description = "Action IDs to route to. Empty array [] terminates the workflow. Multiple IDs create parallel branches."
+                                    },
+                                    condition = new
+                                    {
+                                        type = "object",
+                                        description = "JSON Logic condition (e.g., { \"==\": [{ \"var\": \"decision\" }, \"approved\"] }). Omit for unconditional routes."
+                                    },
+                                    isDefault = new { type = "boolean", description = "Marks this as the fall-through route when no other condition matches." },
+                                    description = new { type = "string", description = "Human-readable note shown in tooling." },
+                                    branchDeadline = new { type = "string", description = "ISO 8601 duration (e.g., 'P7D'). Only meaningful when nextActionIds has multiple entries." },
+                                    outputMapping = new
+                                    {
+                                        type = "object",
+                                        description = "Map source JSON Pointer → target JSON Pointer. Source roots: /payload, /calculations, /haip. Target = next action's prepopulated payload. Required for the credential claim card hand-off in Feature 104.",
+                                        additionalProperties = new { type = "string" }
+                                    }
+                                },
+                                required = new[] { "nextActionIds" }
+                            }
+                        }
+                    },
+                    required = new[] { "actionId", "routes" }
+                }),
+
+            ToolDefinition.Create(
+                "set_action_metadata",
+                "Advanced. Sparse update of action metadata that the typed tools cannot fully express. Pass any " +
+                "subset of: isStartingAction (the open-participant flag), instructions (markdown guidance), " +
+                "requiredPriorActions, rejectionConfig (full shape with isTerminal / requireReason / " +
+                "targetParticipantId / rejectionSchema), credentialRequirements (full shape including " +
+                "presentationSource: HaipExternalWallet | SorchaInternal — typed require_credential cannot set this), " +
+                "credentialIssuanceConfig (full shape including targetAudience: HaipExternalWallet | SorchaLocalWallet — " +
+                "typed issue_credential cannot set this; required for HAIP credential issuance flows). Pass null on a " +
+                "field to clear it. Prefer require_credential / issue_credential for simple SorchaInternal cases.",
+                new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        actionId = new { type = "integer", description = "Action ID to update" },
+                        isStartingAction = new
+                        {
+                            type = "boolean",
+                            description = "When true, the action is open: any wallet may submit, the first sender is " +
+                                "late-bound to the participant role for the instance. Participant referenced by sender " +
+                                "MUST have walletAddress null (publish-time guardrail VAL_BP_010)."
+                        },
+                        instructions = new { type = "string", description = "Markdown guidance shown to the participant (max 5000 chars)." },
+                        requiredPriorActions = new
+                        {
+                            type = "array",
+                            items = new { type = "integer" },
+                            description = "Action IDs whose data must be fetched and decrypted to build the accumulated state for routing evaluation. Defaults to immediately preceding action."
+                        },
+                        rejectionConfig = new
+                        {
+                            type = "object",
+                            description = "Where the workflow goes when this action is rejected. null clears it.",
+                            properties = new
+                            {
+                                targetActionId = new { type = "integer", description = "Action to route to on rejection" },
+                                targetParticipantId = new { type = "string", description = "Override sender for the rejection-target action. Optional." },
+                                requireReason = new { type = "boolean", description = "Whether a rejection reason is mandatory. Default true." },
+                                isTerminal = new { type = "boolean", description = "If true, rejection ends the workflow (Rejected state) instead of routing. Used by the credential claim card decline action." }
+                            }
+                        },
+                        credentialRequirements = new
+                        {
+                            type = "array",
+                            description = "Credentials the participant must present before executing this action. AND-combined. null clears.",
+                            items = new
+                            {
+                                type = "object",
+                                properties = new
+                                {
+                                    type = new { type = "string", description = "Credential type (e.g., 'AssuredIdentityCredential')" },
+                                    acceptedIssuers = new { type = "array", items = new { type = "string" }, description = "Trusted issuer DIDs/addresses. Empty = any issuer." },
+                                    requiredClaims = new
+                                    {
+                                        type = "array",
+                                        items = new
+                                        {
+                                            type = "object",
+                                            properties = new
+                                            {
+                                                claimName = new { type = "string" },
+                                                expectedValue = new { description = "Optional exact-match value." }
+                                            }
+                                        }
+                                    },
+                                    revocationCheckPolicy = new { type = "string", @enum = new[] { "FailClosed", "FailOpen" } },
+                                    presentationSource = new
+                                    {
+                                        type = "string",
+                                        @enum = new[] { "SorchaInternal", "HaipExternalWallet" },
+                                        description = "Where the presentation comes from. SorchaInternal (default) matches against on-platform credentials; HaipExternalWallet requires presentation via the HAIP OpenID4VP verifier — used for credential-bootstrapped open submissions and external wallet flows."
+                                    },
+                                    description = new { type = "string" }
+                                },
+                                required = new[] { "type" }
+                            }
+                        },
+                        credentialIssuanceConfig = new
+                        {
+                            type = "object",
+                            description = "Mints a verifiable credential when this action executes. null clears.",
+                            properties = new
+                            {
+                                credentialType = new { type = "string" },
+                                claimMappings = new
+                                {
+                                    type = "array",
+                                    items = new
+                                    {
+                                        type = "object",
+                                        properties = new
+                                        {
+                                            claimName = new { type = "string" },
+                                            sourceField = new { type = "string", description = "JSON Pointer to action data field" }
+                                        },
+                                        required = new[] { "claimName", "sourceField" }
+                                    }
+                                },
+                                recipientParticipantId = new { type = "string", description = "Participant ID who receives the credential" },
+                                expiryDuration = new { type = "string", description = "ISO 8601 (e.g., 'P365D')" },
+                                registerId = new { type = "string", description = "Optional public register to record on" },
+                                disclosable = new { type = "array", items = new { type = "string" }, description = "Selectively disclosable claim names. Omit = all disclosable." },
+                                usagePolicy = new { type = "string", @enum = new[] { "Reusable", "SingleUse", "LimitedUse" } },
+                                maxPresentations = new { type = "integer", description = "Required when usagePolicy is LimitedUse." },
+                                targetAudience = new
+                                {
+                                    type = "string",
+                                    @enum = new[] { "HaipExternalWallet", "SorchaLocalWallet" },
+                                    description = "Delivery channel. HaipExternalWallet emits an OpenID4VCI offer (Feature 104 — pair with a separate Claim action carrying x-credential-offer + outputMapping). SorchaLocalWallet (Feature 106) seals the encrypted credential into the action transaction for register-native delivery to an on-platform wallet. Avoid the deprecated SorchaInternal value."
+                                }
+                            },
+                            required = new[] { "credentialType", "claimMappings", "recipientParticipantId" }
+                        }
+                    },
+                    required = new[] { "actionId" }
                 })
         };
     }

--- a/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/ChatOrchestrationService.cs
@@ -31,6 +31,50 @@ public class ChatOrchestrationService : IChatOrchestrationService
     private const string BaseSystemPrompt = """
         You are a professional blueprint design assistant for the Sorcha decentralised register platform. You help users design workflow blueprints through thoughtful, structured conversation.
 
+        ## Scope
+
+        You ONLY edit Sorcha blueprint JSON. The tools listed below are exhaustive — every change you make to a blueprint must go through them.
+
+        - If a request cannot be expressed as a change to the current blueprint, decline and translate it into blueprint terms. Example: a user asks to "send a Slack message when approved" — you cannot do that, but you can add a notification participant or an `instructions` block on the approving action. Offer the closest in-blueprint equivalent.
+        - Do not write essays, tutorials, or general workflow advice. If asked off-topic ("explain microservices", "what's a DID?"), give a one-sentence answer and redirect to the blueprint at hand.
+        - Do not invent features that aren't in the tool set. If you find yourself wanting a tool that doesn't exist, surface that to the user — don't fabricate JSON shapes the engine doesn't accept.
+
+        ## Output discipline
+
+        - Default mode each turn: ask ONE focused clarifying question OR call tools. Not both.
+        - Prose is reserved for clarifying tradeoffs, summarising what you just built, or explaining a guardrail you can't satisfy. Keep it short — the user can read the blueprint preview alongside the chat.
+        - If you have enough information to act, act. Call tools rather than narrating what you would do.
+
+        ## Editing existing blueprints
+
+        - When a "Current Blueprint Being Edited" block is appended below, READ IT before suggesting any change. Refer to participants and actions by their existing IDs and titles.
+        - Prefer `update_action` over remove + re-add when changing an action's title/description/sender — it preserves IDs and references downstream.
+        - Make minimal, targeted changes. "Add a date field to the application form" means add ONE field; do not rewrite the whole schema.
+
+        ## Stop conditions
+
+        Stop building when:
+        - `validate_blueprint` returns no errors AND the user's most recent request is satisfied.
+        - The user signals completion ("looks good", "save it", "that's everything").
+        - You hit the same validation error twice — surface it to the user and ask for direction rather than thrashing.
+
+        ## Tool selection — typed first, escape hatches when needed
+
+        Always prefer typed tools when they can express the shape you need. Escape hatches (`set_action_schema`, `set_action_routes`, `set_action_metadata`) accept full raw JSON for shapes the typed tools cannot produce.
+
+        | Goal | Use |
+        |---|---|
+        | Scalar fields with simple constraints | `add_action` (`dataFields`) |
+        | Apply a standardised schema (PersonName, PostalAddress, etc.) | `use_standard_schema` |
+        | Linear conditional routing on one field, five operators | `add_routing` |
+        | Require a Sorcha-internal credential | `require_credential` |
+        | Issue an on-platform credential without HAIP | `issue_credential` |
+        | **Wizard pages, sections, x-persona, x-credential-offer, x-review, x-file, $ref, formatMinimum/formatMaximum, nested objects, arrays** | `set_action_schema` |
+        | **Terminal routes (`nextActionIds: []`), parallel branches, raw JSON Logic, `outputMapping` (Feature 104), `branchDeadline`** | `set_action_routes` |
+        | **HAIP credential flows (`presentationSource: HaipExternalWallet`, `targetAudience: HaipExternalWallet`), `rejectionConfig`, `requiredPriorActions`, `isStartingAction`, action `instructions`** | `set_action_metadata` |
+
+        The typed `require_credential` and `issue_credential` cannot set `presentationSource` or `targetAudience`. Any HAIP flow (Feature 104 credential claim, credential-bootstrapped open submission) MUST use `set_action_metadata` for those properties. Same for `rejectionConfig` (used by the Decline button on credential claim cards) and `requiredPriorActions`.
+
         ## Your Approach
 
         You are professional yet approachable, and genuinely curious about what the user is trying to achieve. You follow this consultative process:
@@ -108,8 +152,13 @@ public class ChatOrchestrationService : IChatOrchestrationService
         - `add_routing` — Add conditional routing logic (supports `outputMapping` for carrying data from one action's execution result into the next action's prepopulated payload — required for the credential claim pattern in Feature 104)
 
         **Credentials:**
-        - `require_credential` — Require a Verified Credential to perform an action
-        - `issue_credential` — Issue a Verified Credential on action completion. When `targetAudience` is `HaipExternalWallet`, ALWAYS add a dedicated Claim action after the issuing action using `x-credential-offer` — see the "Credential Claim Actions" section below. Never rely on the issuing action's sender to display the offer.
+        - `require_credential` — Require a Sorcha-internal Verified Credential to perform an action. Cannot set `presentationSource: HaipExternalWallet` — for HAIP flows, use `set_action_metadata.credentialRequirements`.
+        - `issue_credential` — Issue an on-platform Verified Credential on action completion. Cannot set `targetAudience: HaipExternalWallet` — for HAIP issuance (Feature 104), use `set_action_metadata.credentialIssuanceConfig` AND add a dedicated Claim action after the issuing action using `set_action_schema` with `x-credential-offer`. Never rely on the issuing action's sender to display the offer.
+
+        **Advanced (escape hatches — full raw JSON):**
+        - `set_action_schema` — Replace or append a full JSON Schema document on an action. Required for: `x-pages` wizard layouts, `x-sections`, `x-introduction`, `x-width`, `x-persona` autofill bindings, `x-credential-offer` claim cards, `x-review` id-card summaries, `x-file` chunked uploads, `formatMinimum`/`formatMaximum` date constraints, nested objects, arrays, and `$ref` to core components.
+        - `set_action_routes` — Replace an action's routes with the full Route[] shape. Required for: terminal routes (`nextActionIds: []`), parallel branches with `branchDeadline`, raw JSON Logic conditions beyond the five `add_routing` operators, and `outputMapping` (Feature 104 payload carry-forward).
+        - `set_action_metadata` — Sparse update of action metadata. Required for: `presentationSource: HaipExternalWallet`, `targetAudience: HaipExternalWallet`/`SorchaLocalWallet`, `rejectionConfig` (incl. `isTerminal`), `requiredPriorActions`, `isStartingAction`, action `instructions`. Pass null on a field to clear it.
 
         **Validation:**
         - `validate_blueprint` — Check blueprint validity (always call this at the end)
@@ -159,6 +208,44 @@ public class ChatOrchestrationService : IChatOrchestrationService
         - **file**: File uploads (documents, attachments)
 
         Common patterns: enum for dropdowns, pattern for regex validation, minLength/maxLength for text limits.
+
+        ## Date Constraints
+
+        Use JSON Schema 2020-12 `formatMinimum` / `formatMaximum` with this token vocabulary (set via `set_action_schema`):
+
+        | Token | Meaning |
+        |---|---|
+        | `today` | Current date in the user's timezone |
+        | `today+{N}{D|M|Y}` | N days/months/years from today |
+        | `today-{N}{D|M|Y}` | N days/months/years before today |
+
+        Examples: DateOfBirth → `formatMaximum: "today"` (must be in the past); AppointmentDate → `formatMinimum: "today"` (must be in the future); AgeGate18 → `formatMaximum: "today-18Y"` (at least 18). The same token vocabulary applies to any date or date-time field.
+
+        ## Persona Autofill (Feature 092)
+
+        Citizens have a profile (Settings → My Profile) holding their name, date of birth, default email, default phone, default postal address, and nationality. When a form field is recognised, it auto-populates with a cream tint and a `self` provenance tick — the citizen can edit to release the autofill claim. **This is the user-visible payoff for using core schema components and `x-persona` bindings.**
+
+        Bindings come from two places:
+        1. **Implicit (free)** — `$ref`-ing a core schema component (`PersonName/v1`, `EmailAddress/v1`, `PostalAddress/v1`, etc.) carries persona bindings already, no extra config.
+        2. **Explicit (`x-persona`)** — pin a property to a specific persona attribute via `set_action_schema`:
+           ```jsonc
+           "applicantEmail": { "type": "string", "format": "email", "x-persona": "defaultEmail" }
+           ```
+           Recognised persona keys: `givenName`, `familyName`, `fullName`, `dateOfBirth`, `defaultEmail`, `defaultPhone`, `defaultAddress`, `nationality`. Use `"x-persona": false` to suppress autofill on a field whose name *would* match the heuristic but should never be auto-filled (e.g. `nextOfKinEmail`).
+
+        When pitching a citizen-facing blueprint, mention persona autofill as a UX benefit: "the applicant's name, date of birth, email, and address will pre-populate from their Sorcha profile."
+
+        ## Calculations (JSON Logic)
+
+        Per-action computed values evaluated by the engine after schema validation, before routing. Available to routing conditions and `outputMapping` source paths under `/calculations/*`. Set via raw JSON inside the action object (use `set_action_schema` if exposing them as field defaults; for routing-only computations, they live as a top-level `calculations` object on the action — there is no typed tool for this yet).
+
+        ```jsonc
+        "calculations": {
+          "requiresApproval": { ">": [{ "var": "amount" }, 10000] }
+        }
+        ```
+
+        Common uses: thresholds, eligibility flags, derived values used by conditional routes. Suggest calculations when the user describes a "send to manager only if over £X" pattern.
 
         ## Disclosure Best Practices
 
@@ -274,6 +361,16 @@ public class ChatOrchestrationService : IChatOrchestrationService
         ## Credential Claim Actions (Feature 104 — recommended pattern for HAIP issuance)
 
         When a blueprint **issues a HAIP credential** to an applicant (via `targetAudience: HaipExternalWallet`), the credential offer must reach the **recipient** — not the issuing action sender. Do NOT rely on the assessor's browser to display a QR for the citizen to scan; this is both a UX and cryptographic mistake (the `pre_authorized_code` is a bearer token and whoever redeems it binds the credential to *their* wallet key).
+
+        **Tool path for this pattern (the typed `issue_credential` cannot set `targetAudience: HaipExternalWallet`):**
+        1. `add_action` for action 1 (applicant submission, `isStartingAction: true`).
+        2. `add_action` for action 2 (issuer review).
+        3. `set_action_metadata` on action 2 with `credentialIssuanceConfig: { …, targetAudience: "HaipExternalWallet" }`.
+        4. `add_action` for action 3 (the claim card; same sender as action 1).
+        5. `set_action_schema` on action 3 with the `x-credential-offer` object shape (see below).
+        6. `set_action_metadata` on action 3 with `rejectionConfig: { isTerminal: true }`.
+        7. `set_action_routes` on action 2 with the conditional approval route (containing `outputMapping`) and the terminal rejection route.
+        8. `set_action_routes` on action 3 with the single terminal route `nextActionIds: []`.
 
         **Correct pattern — three actions:**
 
@@ -458,6 +555,7 @@ public class ChatOrchestrationService : IChatOrchestrationService
         Func<string, Task> onChunk,
         Func<string, ToolResult, Task> onToolResult,
         Func<BlueprintModel, ValidationResultDto, Task> onBlueprintUpdate,
+        IReadOnlyList<ChatAttachment>? attachments = null,
         CancellationToken cancellationToken = default)
     {
         var session = await _sessionStore.GetSessionAsync(sessionId)
@@ -473,8 +571,9 @@ public class ChatOrchestrationService : IChatOrchestrationService
             throw new InvalidOperationException("Message limit reached (100 messages per session)");
         }
 
-        // Validate message
-        if (string.IsNullOrWhiteSpace(message))
+        // Allow empty message text when attachments are present (drag-drop with no caption).
+        var hasAttachments = attachments is { Count: > 0 };
+        if (string.IsNullOrWhiteSpace(message) && !hasAttachments)
         {
             throw new ArgumentException("Message cannot be empty");
         }
@@ -484,12 +583,15 @@ public class ChatOrchestrationService : IChatOrchestrationService
             throw new ArgumentException("Message too long (max 10000 characters)");
         }
 
+        ValidateAttachments(attachments);
+
         // Add user message
         var userMessage = new ChatMessage
         {
             SessionId = sessionId,
             Role = MessageRole.User,
-            Content = message
+            Content = message,
+            Attachments = hasAttachments ? attachments!.ToList() : null
         };
         await _sessionStore.AddMessageAsync(sessionId, userMessage);
 
@@ -831,6 +933,75 @@ public class ChatOrchestrationService : IChatOrchestrationService
 
             You can refer to existing elements by their ID or name.
             """);
+    }
+
+    // Anthropic limits: image base64 ≈ 5 MB raw → ~6.7 MB encoded. PDF: 32 MB raw → ~42.7 MB encoded.
+    // We enforce the post-encoding budget directly since that's what we hold.
+    private const long MaxImageBase64Bytes = 7_000_000;
+    private const long MaxPdfBase64Bytes = 45_000_000;
+    private const int MaxAttachmentsPerMessage = 5;
+
+    private static readonly HashSet<string> AllowedImageMediaTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg", "image/png", "image/webp", "image/gif"
+    };
+
+    private static readonly HashSet<string> AllowedPdfMediaTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf"
+    };
+
+    private static void ValidateAttachments(IReadOnlyList<ChatAttachment>? attachments)
+    {
+        if (attachments is not { Count: > 0 })
+        {
+            return;
+        }
+
+        if (attachments.Count > MaxAttachmentsPerMessage)
+        {
+            throw new ArgumentException(
+                $"Too many attachments: {attachments.Count} (max {MaxAttachmentsPerMessage} per message).");
+        }
+
+        foreach (var att in attachments)
+        {
+            if (string.IsNullOrWhiteSpace(att.Base64Data))
+            {
+                throw new ArgumentException($"Attachment {att.FileName ?? "(no name)"} has empty data.");
+            }
+
+            switch (att.Kind)
+            {
+                case ChatAttachmentKind.Image:
+                    if (!AllowedImageMediaTypes.Contains(att.MediaType))
+                    {
+                        throw new ArgumentException(
+                            $"Unsupported image media type: {att.MediaType}. " +
+                            $"Allowed: {string.Join(", ", AllowedImageMediaTypes)}.");
+                    }
+                    if (att.Base64Data.Length > MaxImageBase64Bytes)
+                    {
+                        throw new ArgumentException(
+                            $"Image attachment too large: {att.Base64Data.Length} bytes encoded (max ~{MaxImageBase64Bytes / 1_000_000} MB).");
+                    }
+                    break;
+                case ChatAttachmentKind.Pdf:
+                    if (!AllowedPdfMediaTypes.Contains(att.MediaType))
+                    {
+                        throw new ArgumentException(
+                            $"Unsupported PDF media type: {att.MediaType}. Allowed: application/pdf.");
+                    }
+                    if (att.Base64Data.Length > MaxPdfBase64Bytes)
+                    {
+                        throw new ArgumentException(
+                            $"PDF attachment too large: {att.Base64Data.Length} bytes encoded (max ~{MaxPdfBase64Bytes / 1_000_000} MB).");
+                    }
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown attachment kind: {att.Kind}");
+            }
+        }
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IChatOrchestrationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/IChatOrchestrationService.cs
@@ -33,6 +33,7 @@ public interface IChatOrchestrationService
     /// <param name="onChunk">Callback for each text chunk.</param>
     /// <param name="onToolResult">Callback when a tool is executed.</param>
     /// <param name="onBlueprintUpdate">Callback when the blueprint changes.</param>
+    /// <param name="attachments">Optional binary attachments (images, PDFs) the user dropped onto the chat.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task ProcessMessageAsync(
         string sessionId,
@@ -40,6 +41,7 @@ public interface IChatOrchestrationService
         Func<string, Task> onChunk,
         Func<string, ToolResult, Task> onToolResult,
         Func<BlueprintModel, ValidationResultDto, Task> onBlueprintUpdate,
+        IReadOnlyList<ChatAttachment>? attachments = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintToolExecutorTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintToolExecutorTests.cs
@@ -42,7 +42,7 @@ public class BlueprintToolExecutorTests
         var tools = _executor.GetToolDefinitions();
 
         // Assert
-        tools.Should().HaveCount(13);
+        tools.Should().HaveCount(16);
         tools.Select(t => t.Name).Should().BeEquivalentTo(new[]
         {
             "create_blueprint",
@@ -57,7 +57,10 @@ public class BlueprintToolExecutorTests
             "use_standard_schema",
             "search_templates",
             "require_credential",
-            "issue_credential"
+            "issue_credential",
+            "set_action_schema",
+            "set_action_routes",
+            "set_action_metadata"
         });
     }
 
@@ -683,16 +686,19 @@ public class BlueprintToolExecutorTests
     [Fact]
     public async Task ExecuteSearchSchemas_FiltersByCategory()
     {
-        // Arrange
-        var schemas = new List<SchemaIndexEntryDto>
+        // Arrange — the executor delegates filtering to ISchemaIndexService.SearchAsync.
+        // We assert the executor passes the category through as the `sectors` argument and
+        // returns whatever the service returns (one filtered entry).
+        var filtered = new List<SchemaIndexEntryDto>
         {
-            CreateSchemaIndexEntry("invoice-schema", "Invoice Schema", "finance"),
             CreateSchemaIndexEntry("health-record", "Health Record", "healthcare")
         };
 
         _schemaIndexServiceMock.Setup(s => s.SearchAsync(
-                "record", It.IsAny<string[]?>(), null, null, 50, null, null, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SchemaIndexSearchResponse(schemas.AsReadOnly(), schemas.Count, null, null));
+                "record",
+                It.Is<string[]?>(sectors => sectors != null && sectors.Contains("healthcare")),
+                null, null, 50, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SchemaIndexSearchResponse(filtered.AsReadOnly(), filtered.Count, null, null));
 
         var builder = BlueprintBuilder.Create();
         var args = CreateArgs(new { query = "record", category = "healthcare" });
@@ -1306,6 +1312,282 @@ public class BlueprintToolExecutorTests
             draft.Actions.First(a => a.Id == actionId).CredentialRequirements!.First().Type
                 .Should().Be("ProductPassport");
         }
+    }
+
+    #endregion
+
+    #region Escape-hatch tools
+
+    private async Task<BlueprintBuilder> SeedTwoParticipantOneAction()
+    {
+        var builder = BlueprintBuilder.Create();
+        await _executor.ExecuteAsync("create_blueprint",
+            CreateArgs(new { title = "Esc Hatch Test", description = "Coverage for escape hatch tools" }), builder);
+        await _executor.ExecuteAsync("add_participant",
+            CreateArgs(new { id = "applicant", name = "Applicant" }), builder);
+        await _executor.ExecuteAsync("add_participant",
+            CreateArgs(new { id = "reviewer", name = "Reviewer" }), builder);
+        await _executor.ExecuteAsync("add_action",
+            CreateArgs(new { id = 0, title = "Submit", sender = "applicant", isStartingAction = true }), builder);
+        return builder;
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionSchema_ReplacesWithRawJsonSchemaIncludingExtensions()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        // Schema with x-pages and x-credential-offer — neither expressible via add_action.
+        var rawSchema = new
+        {
+            type = "object",
+            properties = new Dictionary<string, object>
+            {
+                ["credentialOffer"] = new Dictionary<string, object>
+                {
+                    ["type"] = "object",
+                    ["x-credential-offer"] = true,
+                    ["properties"] = new
+                    {
+                        credential_offer_uri = new { type = "string", format = "uri" }
+                    },
+                    ["required"] = new[] { "credential_offer_uri" }
+                }
+            },
+            required = new[] { "credentialOffer" }
+        };
+
+        var result = await _executor.ExecuteAsync("set_action_schema",
+            CreateArgs(new { actionId = 0, schema = rawSchema }), builder);
+
+        result.Success.Should().BeTrue();
+        result.BlueprintChanged.Should().BeTrue();
+        var draft = builder.BuildDraft();
+        var action = draft.Actions.First(a => a.Id == 0);
+        action.DataSchemas.Should().HaveCount(1);
+        var doc = action.DataSchemas!.First();
+        doc.RootElement.GetProperty("properties").GetProperty("credentialOffer")
+            .GetProperty("x-credential-offer").GetBoolean().Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionSchema_AppendModePreservesExisting()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        await _executor.ExecuteAsync("set_action_schema",
+            CreateArgs(new { actionId = 0, schema = new { type = "object", properties = new { a = new { type = "string" } } } }),
+            builder);
+        var result = await _executor.ExecuteAsync("set_action_schema",
+            CreateArgs(new
+            {
+                actionId = 0,
+                mode = "append",
+                schema = new { type = "object", properties = new { b = new { type = "integer" } } }
+            }),
+            builder);
+
+        result.Success.Should().BeTrue();
+        var draft = builder.BuildDraft();
+        draft.Actions.First(a => a.Id == 0).DataSchemas.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionSchema_RejectsNonObjectSchema()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        var result = await _executor.ExecuteAsync("set_action_schema",
+            CreateArgs(new { actionId = 0, schema = "not-an-object" }), builder);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("JSON Schema object");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionRoutes_SetsTerminalAndOutputMappingRoutes()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+        // Add an action 1 so routes can target it
+        await _executor.ExecuteAsync("add_action",
+            CreateArgs(new { id = 1, title = "Claim", sender = "applicant" }), builder);
+
+        var routes = new object[]
+        {
+            new
+            {
+                id = "approved-to-claim",
+                nextActionIds = new[] { 1 },
+                condition = new Dictionary<string, object>
+                {
+                    ["=="] = new object[]
+                    {
+                        new Dictionary<string, object> { ["var"] = "decision" },
+                        "approved"
+                    }
+                },
+                description = "Approved",
+                outputMapping = new Dictionary<string, string>
+                {
+                    ["/haip/credential_offer_uri"] = "/credentialOffer/credential_offer_uri"
+                }
+            },
+            new
+            {
+                id = "rejected-terminal",
+                nextActionIds = Array.Empty<int>(),
+                isDefault = true,
+                description = "Rejected — terminal"
+            }
+        };
+
+        var result = await _executor.ExecuteAsync("set_action_routes",
+            CreateArgs(new { actionId = 0, routes }), builder);
+
+        result.Success.Should().BeTrue();
+        var draft = builder.BuildDraft();
+        var action = draft.Actions.First(a => a.Id == 0);
+        action.Routes.Should().HaveCount(2);
+        var approval = action.Routes!.First(r => r.Id == "approved-to-claim");
+        approval.NextActionIds.Should().BeEquivalentTo(new[] { 1 });
+        approval.Condition.Should().NotBeNull();
+        approval.OutputMapping.Should().ContainKey("/haip/credential_offer_uri");
+        var terminal = action.Routes!.First(r => r.Id == "rejected-terminal");
+        terminal.NextActionIds.Should().BeEmpty();
+        terminal.IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionRoutes_RejectsNonArrayInput()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        var result = await _executor.ExecuteAsync("set_action_routes",
+            CreateArgs(new { actionId = 0, routes = "nope" }), builder);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("array");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionMetadata_SetsRejectionConfigAndCredentialIssuanceWithHaip()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        var result = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new
+            {
+                actionId = 0,
+                isStartingAction = true,
+                requiredPriorActions = new[] { 0 },
+                rejectionConfig = new
+                {
+                    targetActionId = 0,
+                    isTerminal = true,
+                    requireReason = false
+                },
+                credentialIssuanceConfig = new
+                {
+                    credentialType = "AssuredIdentityCredential",
+                    claimMappings = new[]
+                    {
+                        new { claimName = "givenName", sourceField = "/givenName" }
+                    },
+                    recipientParticipantId = "applicant",
+                    targetAudience = "HaipExternalWallet"
+                }
+            }), builder);
+
+        result.Success.Should().BeTrue();
+        var action = builder.BuildDraft().Actions.First(a => a.Id == 0);
+        action.IsStartingAction.Should().BeTrue();
+        action.RequiredPriorActions.Should().BeEquivalentTo(new[] { 0 });
+        action.RejectionConfig.Should().NotBeNull();
+        action.RejectionConfig!.IsTerminal.Should().BeTrue();
+        action.RejectionConfig.RequireReason.Should().BeFalse();
+        action.CredentialIssuanceConfig.Should().NotBeNull();
+        action.CredentialIssuanceConfig!.TargetAudience.Should().Be(TargetAudience.HaipExternalWallet);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionMetadata_SetsCredentialRequirementWithHaipPresentationSource()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        var result = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new
+            {
+                actionId = 0,
+                credentialRequirements = new[]
+                {
+                    new
+                    {
+                        type = "AssuredIdentityCredential",
+                        presentationSource = "HaipExternalWallet",
+                        requiredClaims = new[]
+                        {
+                            new { claimName = "dateOfBirth" }
+                        }
+                    }
+                }
+            }), builder);
+
+        result.Success.Should().BeTrue();
+        var action = builder.BuildDraft().Actions.First(a => a.Id == 0);
+        action.CredentialRequirements.Should().HaveCount(1);
+        action.CredentialRequirements!.First().PresentationSource
+            .Should().Be(PresentationSource.HaipExternalWallet);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionMetadata_NullClearsExistingConfig()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+        await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new
+            {
+                actionId = 0,
+                rejectionConfig = new { targetActionId = 0, isTerminal = true }
+            }), builder);
+        builder.BuildDraft().Actions.First(a => a.Id == 0).RejectionConfig.Should().NotBeNull();
+
+        var clear = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new { actionId = 0, rejectionConfig = (object?)null }), builder);
+
+        clear.Success.Should().BeTrue();
+        builder.BuildDraft().Actions.First(a => a.Id == 0).RejectionConfig.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetActionMetadata_RejectsEmptyUpdate()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        var result = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new { actionId = 0 }), builder);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("at least one");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EscapeHatchTools_FailGracefullyOnUnknownAction()
+    {
+        var builder = await SeedTwoParticipantOneAction();
+
+        var schemaResult = await _executor.ExecuteAsync("set_action_schema",
+            CreateArgs(new { actionId = 999, schema = new { type = "object" } }), builder);
+        var routesResult = await _executor.ExecuteAsync("set_action_routes",
+            CreateArgs(new { actionId = 999, routes = Array.Empty<object>() }), builder);
+        var metaResult = await _executor.ExecuteAsync("set_action_metadata",
+            CreateArgs(new { actionId = 999, isStartingAction = true }), builder);
+
+        schemaResult.Success.Should().BeFalse();
+        routesResult.Success.Should().BeFalse();
+        metaResult.Success.Should().BeFalse();
+        schemaResult.Error.Should().Contain("999");
+        routesResult.Error.Should().Contain("999");
+        metaResult.Error.Should().Contain("999");
     }
 
     #endregion

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ChatOrchestrationServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ChatOrchestrationServiceTests.cs
@@ -540,21 +540,22 @@ public class ChatOrchestrationServiceTests
     [Fact]
     public async Task BuildSystemPrompt_IncludesSchemaTable()
     {
-        // Arrange — set up schema store to return schemas
-        var schemas = new List<Sorcha.Blueprint.Schemas.Models.SchemaEntry>
+        // Arrange — return one schema from the index so the prompt builder writes a row for it.
+        var entries = new List<Sorcha.Blueprint.Service.Models.SchemaIndexEntryDto>
         {
-            new()
-            {
-                Identifier = "invoice-schema",
-                Title = "Invoice Schema",
-                Description = "Standard invoice fields",
-                Version = "1.0.0",
-                Category = Sorcha.Blueprint.Schemas.Models.SchemaCategory.Custom,
-                Source = Sorcha.Blueprint.Schemas.Models.SchemaSource.Internal(),
-                Content = System.Text.Json.JsonDocument.Parse("{}"),
-                SectorTags = new[] { "finance" },
-                FieldCount = 5
-            }
+            new(
+                ShortCode: "invoice-schema",
+                SourceProvider: "internal",
+                SourceUri: "urn:sorcha:schema:invoice-schema",
+                Title: "Invoice Schema",
+                Description: "Standard invoice fields",
+                SectorTags: new[] { "finance" },
+                FieldCount: 5,
+                RequiredFieldCount: 0,
+                SchemaVersion: "1.0.0",
+                Status: "Active",
+                LastFetchedAt: DateTimeOffset.UtcNow,
+                FieldNames: null)
         };
 
         _schemaIndexServiceMock
@@ -568,8 +569,8 @@ public class ChatOrchestrationServiceTests
                 It.IsAny<string?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Blueprint.Service.Models.SchemaIndexSearchResponse(
-                Results: Array.Empty<Sorcha.Blueprint.Service.Models.SchemaIndexEntryDto>(),
-                TotalCount: 0,
+                Results: entries,
+                TotalCount: entries.Count,
                 NextCursor: null,
                 LoadingProviders: null));
 


### PR DESCRIPTION
## Summary

End-to-end overhaul of the `/designer/blueprint` AI assistant and its surrounding skill documentation, plus three pre-existing build/test failures that were blocking the WebClient build.

- **Composer pinning fix.** The AI pane composer drifted with the message list because `DesignerBlueprint.razor.css` declared 3 grid rows for 2 children and depended on a `100%` height that `MudContainer` doesn't pass through. Now anchored via `calc(100dvh - 168px)` with `::deep` rules that propagate height through MudTabs.
- **Escape-hatch designer tools.** The 13 typed tools couldn't produce most of what the prompt teaches (Feature 104 claim shapes, `x-pages`, `x-credential-offer`, `x-review`, `x-file`, terminal routes, parallel branches, `outputMapping`, HAIP `presentationSource` / `targetAudience`, `rejectionConfig`, `requiredPriorActions`). Added `set_action_schema`, `set_action_routes`, `set_action_metadata` that accept full raw JSON. Existing typed tools remain as ergonomic shortcuts.
- **System prompt guardrails.** Added top-level Scope / Output discipline / Editing existing blueprints / Stop conditions / Tool selection sections. The Tool selection table directs the model to typed tools first, escape hatches when needed. Feature 104 section now carries an explicit 8-step tool-call recipe.
- **Skill coverage pass.** `.claude/skills/blueprint-builder/SKILL.md` gained a Validation Codes reference, Calculations, Required Prior Actions, Form UX Layout (x-pages/sections/introduction/width/persona/address-lookup/file/review), full Credential Requirements & Issuance shapes including HAIP audiences, Rejection Configuration, Disclosure Rules, and cross-references to `sorcha-architecture` for runtime internals. Designer prompt picked up date-token table, persona autofill UX, and a calculations introduction.
- **Drag-drop image + PDF uploads.** New `ChatAttachment` record on both server and client, threaded through the SignalR hub, orchestration service (with type/size validation), and `AnthropicProviderService.ConvertMessages` (emits `ImageContent` / `DocumentContent` blocks). UI gains a drop overlay on the AI pane with depth-counted JS handlers, chunked base64 conversion, attachment chips above the composer, and a paperclip click-to-pick fallback. Limits: image ≤5MB, PDF ≤32MB, max 5 per message.
- **Pre-existing fixes.** `FileReferenceDisplay.razor` Razor parser breakage on a `bytes switch { ... }` expression with interpolated arms (replaced with an if-chain). `ExecuteSearchSchemas_FiltersByCategory` and `BuildSystemPrompt_IncludesSchemaTable` mocks repaired — the executor delegates filtering and the prompt builder needs populated schema results.

## Test plan

- [x] `dotnet build src/Services/Sorcha.Blueprint.Service` — clean
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` — clean (was broken on master)
- [x] `dotnet test --filter "FullyQualifiedName~ChatOrchestrationService|FullyQualifiedName~BlueprintToolExecutor"` — 78/78 passing (was 76/78)
- [x] Nine new tests cover escape-hatch tools (raw schema with `x-credential-offer`, append mode, terminal + outputMapping routes, HAIP audience/source enums round-trip, sparse update + null-clear semantics, unknown actionId failure path)
- [ ] Manual: rebuild ui-web and blueprint-service containers; open `/designer/blueprint`; verify composer pins to bottom regardless of message count; drop a JPEG and a PDF onto the pane and confirm chips appear, paperclip button picks files, and the AI receives the attachments
- [ ] Manual: ask the AI to issue a HAIP credential — confirm it produces the three-action shape using the new escape-hatch tools (action 2 with `set_action_metadata.credentialIssuanceConfig.targetAudience: HaipExternalWallet`, action 3 with `set_action_schema` carrying `x-credential-offer`, route via `set_action_routes` with `outputMapping`)

## Notes

- The `Sorcha.UI.Web.Client` build was broken on master before this PR — `FileReferenceDisplay.razor` would not compile. It does now.
- No changes to the existing 13 typed designer tools; they remain backward-compatible. The prompt's Tool selection guidance frames them as "use first when applicable" with escape hatches reserved for advanced shapes the typed surface cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)