### PR TITLE
fix(tests): wave 1 — clear 16 of 75 known failures

### DIFF
--- a/src/Common/Sorcha.Validator.Core/Validators/ConsensusValidator.cs
+++ b/src/Common/Sorcha.Validator.Core/Validators/ConsensusValidator.cs
@@ -158,7 +158,8 @@ public class ConsensusValidator : IConsensusValidator
         {
             return ValidationResult.Failure(
                 "CV_012",
-                $"Quorum not met. Approval: {approvalPercentage:P2} ({approvalCount}/{totalValidators}), Required: >{requiredThreshold:P2}",
+                FormattableString.Invariant(
+                    $"Quorum not met. Approval: {approvalPercentage * 100:F2}% ({approvalCount}/{totalValidators}), Required: >{requiredThreshold * 100:F2}%"),
                 "Quorum");
         }
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Sorcha.Blueprint.Service.Models;
+using Sorcha.ServiceClients.Register;
 
 namespace Sorcha.Blueprint.Service.Services.Implementation;
 
@@ -65,11 +65,11 @@ public class BlueprintRecoveryService : BackgroundService
     internal async Task RunRecoveryAsync(CancellationToken cancellationToken)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
-        var httpClientFactory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+        var registerClient = scope.ServiceProvider.GetRequiredService<IRegisterServiceClient>();
         var publishedStore = scope.ServiceProvider.GetRequiredService<IPublishedBlueprintStore>();
 
         // Step 1: Discover all registers
-        var registers = await DiscoverRegistersAsync(httpClientFactory, cancellationToken);
+        var registers = await DiscoverRegistersAsync(registerClient, cancellationToken);
         if (registers.Count == 0)
         {
             _logger.LogWarning("No registers discovered during recovery");
@@ -87,15 +87,27 @@ public class BlueprintRecoveryService : BackgroundService
                 RegisterName = registerName
             });
 
+            // After initial recovery, skip registers that have exceeded the retry cap.
+            // The cap does not apply during initial recovery — keep trying so a slow
+            // register still seeds blueprints once it comes online.
+            if (_recoveryState.IsComplete
+                && state.ConsecutiveFailures >= _options.MaxRetryAttempts)
+            {
+                _logger.LogDebug(
+                    "Skipping {RegisterId} ({RegisterName}): exceeded {MaxRetryAttempts} retries",
+                    registerId, registerName, _options.MaxRetryAttempts);
+                continue;
+            }
+
             state.LastCheckedAt = DateTimeOffset.UtcNow;
 
             try
             {
                 var result = await RecoverFromRegisterAsync(
-                    httpClientFactory, publishedStore, registerId, cancellationToken);
+                    registerClient, publishedStore, registerId, cancellationToken);
 
                 state.Status = RegisterHealthStatus.Online;
-                state.Height = result.Height;
+                state.Height = (int)result.Height;
                 state.RecoveredBlueprintCount = result.BlueprintCount;
                 state.LastSuccessAt = DateTimeOffset.UtcNow;
                 state.ConsecutiveFailures = 0;
@@ -122,22 +134,13 @@ public class BlueprintRecoveryService : BackgroundService
     }
 
     private async Task<List<(string Id, string Name)>> DiscoverRegistersAsync(
-        IHttpClientFactory httpClientFactory,
+        IRegisterServiceClient registerClient,
         CancellationToken cancellationToken)
     {
         try
         {
-            var client = httpClientFactory.CreateClient("RegisterService");
-            var response = await client.GetAsync("/api/internal/registers", cancellationToken);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning("Register discovery failed with status {StatusCode}", response.StatusCode);
-                return [];
-            }
-
-            var registers = await response.Content.ReadFromJsonAsync<List<RegisterInfo>>(cancellationToken: cancellationToken);
-            return registers?.Select(r => (r.Id, r.Name)).ToList() ?? [];
+            var registers = await registerClient.GetInternalRegistersAsync(cancellationToken);
+            return registers.Select(r => (r.Id, r.Name)).ToList();
         }
         catch (Exception ex)
         {
@@ -146,29 +149,35 @@ public class BlueprintRecoveryService : BackgroundService
         }
     }
 
-    private async Task<(int Height, int BlueprintCount)> RecoverFromRegisterAsync(
-        IHttpClientFactory httpClientFactory,
+    private async Task<(long Height, int BlueprintCount)> RecoverFromRegisterAsync(
+        IRegisterServiceClient registerClient,
         IPublishedBlueprintStore publishedStore,
         string registerId,
         CancellationToken cancellationToken)
     {
-        var client = httpClientFactory.CreateClient("RegisterService");
-        var response = await client.GetAsync(
-            $"/api/registers/{registerId}/blueprints/published",
-            cancellationToken);
+        var result = await registerClient.GetPublishedBlueprintsAsync(registerId, cancellationToken);
 
-        response.EnsureSuccessStatusCode();
-
-        var result = await response.Content.ReadFromJsonAsync<PublishedBlueprintsResponse>(
-            cancellationToken: cancellationToken);
-
-        if (result?.Blueprints is null || result.Blueprints.Count == 0)
+        // Typed client returns null on failure (network error, non-success status).
+        // Treat as failure so the caller marks the register Offline.
+        if (result is null)
         {
-            return (result?.RegisterHeight ?? 0, 0);
+            throw new InvalidOperationException(
+                $"Failed to fetch published blueprints for register {registerId}");
         }
 
+        if (result.Blueprints.Count == 0)
+        {
+            return (result.RegisterHeight, 0);
+        }
+
+        // Dedup by BlueprintId within the response — take the latest by PublishedAt.
+        // The register may carry multiple publish events for the same blueprint id.
+        var latestPerBlueprint = result.Blueprints
+            .GroupBy(b => b.BlueprintId)
+            .Select(g => g.OrderByDescending(b => b.PublishedAt).First());
+
         var count = 0;
-        foreach (var bp in result.Blueprints)
+        foreach (var bp in latestPerBlueprint)
         {
             try
             {
@@ -201,28 +210,5 @@ public class BlueprintRecoveryService : BackgroundService
         }
 
         return (result.RegisterHeight, count);
-    }
-
-    // DTOs for deserialization
-    private record RegisterInfo
-    {
-        public string Id { get; init; } = string.Empty;
-        public string Name { get; init; } = string.Empty;
-    }
-
-    private record PublishedBlueprintsResponse
-    {
-        public string RegisterId { get; init; } = string.Empty;
-        public List<PublishedBlueprintEntry> Blueprints { get; init; } = [];
-        public int RegisterHeight { get; init; }
-    }
-
-    private record PublishedBlueprintEntry
-    {
-        public string BlueprintId { get; init; } = string.Empty;
-        public string TransactionId { get; init; } = string.Empty;
-        public string PublishedBy { get; init; } = string.Empty;
-        public DateTimeOffset PublishedAt { get; init; }
-        public string BlueprintJson { get; init; } = "{}";
     }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionDevModeTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionDevModeTests.cs
@@ -340,7 +340,7 @@ public class ActionExecutionDevModeTests
             {
                 Signature = new byte[64],
                 PublicKey = new byte[32],
-                SignedBy = "wallet-sender",
+                SignedBy = "wallet-applicant",
                 Algorithm = "ED25519"
             });
 
@@ -378,7 +378,7 @@ public class ActionExecutionDevModeTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>
             {
@@ -387,7 +387,7 @@ public class ActionExecutionDevModeTests
             },
             ExternalRecipientKeys = new Dictionary<string, ExternalKeyInfo>
             {
-                ["wallet-sender"] = new ExternalKeyInfo
+                ["wallet-applicant"] = new ExternalKeyInfo
                 {
                     PublicKey = publicKeyBase64,
                     Algorithm = "ED25519"
@@ -465,7 +465,7 @@ public class ActionExecutionDevModeTests
                 [
                     new WrappedKey
                     {
-                        WalletAddress = "wallet-sender",
+                        WalletAddress = "wallet-applicant",
                         EncryptedKey = new byte[48],
                         Algorithm = WalletNetworks.ED25519
                     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionEncryptionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionEncryptionTests.cs
@@ -519,7 +519,7 @@ public class ActionExecutionEncryptionTests
             {
                 Signature = new byte[64],
                 PublicKey = new byte[32],
-                SignedBy = "wallet-sender",
+                SignedBy = "wallet-applicant",
                 Algorithm = "ED25519"
             });
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceEncryptionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceEncryptionTests.cs
@@ -274,14 +274,14 @@ public class ActionExecutionServiceEncryptionTests
             .Setup(x => x.EncryptDisclosedPayloadsAsync(
                 It.IsAny<DisclosureGroup[]>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(EncryptionResult.Failed("AES key wrap failed", "wallet-sender"));
+            .ReturnsAsync(EncryptionResult.Failed("AES key wrap failed", "wallet-applicant"));
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.ExecuteAsync(instanceId, actionId, request, delegationToken));
 
         ex.Message.Should().Contain("Encryption failed");
-        ex.Message.Should().Contain("wallet-sender");
+        ex.Message.Should().Contain("wallet-applicant");
         ex.Message.Should().Contain("AES key wrap failed");
     }
 
@@ -340,7 +340,7 @@ public class ActionExecutionServiceEncryptionTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>
             {
@@ -349,7 +349,7 @@ public class ActionExecutionServiceEncryptionTests
             },
             ExternalRecipientKeys = new Dictionary<string, ExternalKeyInfo>
             {
-                ["wallet-sender"] = new ExternalKeyInfo
+                ["wallet-applicant"] = new ExternalKeyInfo
                 {
                     PublicKey = Convert.ToBase64String(new byte[32]),
                     Algorithm = "INVALID_ALGO" // Unrecognized algorithm
@@ -469,7 +469,7 @@ public class ActionExecutionServiceEncryptionTests
             {
                 Signature = new byte[64],
                 PublicKey = new byte[32],
-                SignedBy = "wallet-sender",
+                SignedBy = "wallet-applicant",
                 Algorithm = "ED25519"
             });
 
@@ -510,7 +510,7 @@ public class ActionExecutionServiceEncryptionTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>
             {
@@ -526,7 +526,7 @@ public class ActionExecutionServiceEncryptionTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>
             {
@@ -535,7 +535,7 @@ public class ActionExecutionServiceEncryptionTests
             },
             ExternalRecipientKeys = new Dictionary<string, ExternalKeyInfo>
             {
-                ["wallet-sender"] = new ExternalKeyInfo
+                ["wallet-applicant"] = new ExternalKeyInfo
                 {
                     PublicKey = publicKeyBase64,
                     Algorithm = "ED25519"
@@ -613,7 +613,7 @@ public class ActionExecutionServiceEncryptionTests
                 [
                     new WrappedKey
                     {
-                        WalletAddress = "wallet-sender",
+                        WalletAddress = "wallet-applicant",
                         EncryptedKey = new byte[48],
                         Algorithm = WalletNetworks.ED25519
                     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
@@ -333,7 +333,7 @@ public class ActionExecutionServiceTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>()
         };
@@ -594,7 +594,7 @@ public class ActionExecutionServiceTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>() // Missing required fields
         };
@@ -1332,7 +1332,7 @@ public class ActionExecutionServiceTests
         {
             BlueprintId = "blueprint-1",
             ActionId = "1",
-            SenderWallet = "wallet-sender",
+            SenderWallet = "wallet-applicant",
             RegisterAddress = "register-1",
             PayloadData = new Dictionary<string, object>
             {

--- a/tests/Sorcha.Validator.Core.Tests/Validators/ConsensusValidatorTests.cs
+++ b/tests/Sorcha.Validator.Core.Tests/Validators/ConsensusValidatorTests.cs
@@ -647,7 +647,7 @@ public class ConsensusValidatorTests
 
         // Assert - Must be GREATER than threshold, not equal
         result.IsValid.Should().BeFalse();
-        result.Errors[0].Message.Should().Contain(">50.00%"); // Showing "greater than" symbol with percentage
+        result.Errors[0].Message.Should().Contain(">50.00%"); // Showing "greater than" symbol with percentage (deterministic, culture-invariant)
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Wave 1 of the test cleanup plan from #442. Targets the lowest-hanging fixes across three clusters and lands 16 of the 75 known-broken tests as passing.

**Branch base:** depends on #442 (which adds the missing test projects to \`Sorcha.sln\`). Once #442 merges, rebase onto master.

## Results

| Project | Before | After | Cleared |
|---|---|---|---|
| \`Sorcha.Validator.Core.Tests\` | 1 fail | **0 fail** ✅ | 1 (entire project; can be removed from \`KNOWN_BROKEN\`) |
| \`Sorcha.Blueprint.Service.Tests\` | 44 fail | 29 fail | 15 |

## Cluster 1 — \`ConsensusValidator\` percentage formatting (#445)

\`:P2\` emits \`>50.00 %\` with a space on Linux en-US.UTF-8 but \`>50.00%\` on Windows. Replaced with manual \`F2\`-format under \`InvariantCulture\`. Test updated to match the deterministic output.

## Cluster 2 — \`BlueprintRecoveryService\` refactor (#444)

The SUT bypassed \`IRegisterServiceClient\` (which already exposes \`GetInternalRegistersAsync\` + \`GetPublishedBlueprintsAsync\`, doc-commented \"used by Blueprint Service during startup recovery\") and used \`IHttpClientFactory\` directly. The 12 tests that mocked \`IRegisterServiceClient\` never exercised the real code path.

Adopting the typed client also surfaced three real SUT bugs:
1. \`null\` result was silently marked \`Online\` with empty data — now treated as failure → \`Offline\`
2. Duplicate \`BlueprintId\` in a single response added both copies — now deduped to latest by \`PublishedAt\`
3. Retry cap was never applied during periodic refresh — now skips registers exceeding \`MaxRetryAttempts\` once \`IsComplete=true\`

Removed the dead duplicate DTOs (\`RegisterInfo\`, \`PublishedBlueprintsResponse\`, \`PublishedBlueprintEntry\`) from the SUT.

## Cluster 3 — Action-execution wallet auth (#444)

Four test files used \`\"wallet-sender\"\` as \`SenderWallet\` but the test blueprint wired participant \`applicant\` to \`\"wallet-applicant\"\`. Strict authorization rejected. Renamed across the four files. Three tests still fail post-rename (NRE in \`EvaluateRoutingAsync\`) — these need per-test mock setup repair, deferred to Wave 2.

## What's not in this PR

The remaining 29 failures in \`Sorcha.Blueprint.Service.Tests\`:
- 17 × \`NullReferenceException\` cascades from \`EvaluateRoutingAsync\` (Wave 2)
- 6 × \`Moq.MockException\` verify-call drifts (Wave 2)
- 3 × \`Assert.Throws()\` exact-type mismatches (Wave 2)
- 3 × misc one-offs

Plus all 30 in \`Sorcha.Validator.Service.Tests\` (Wave 3, see #446).

## Test plan

- [x] \`dotnet test\` locally — \`Validator.Core.Tests\` 300/300 ✓
- [x] \`dotnet test\` locally — \`Blueprint.Service.Tests\` 631/660 (29 still failing as expected)
- [ ] Once #442 lands, verify CI is green with these tolerated projects' failure counts dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)