### PR TITLE
chore(ci): tighten triggers — concurrency + CodeQL schedule-only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,19 +1,12 @@
 name: CodeQL Security Analysis
 
 on:
-  push:
-    branches: [ master ]
-    # No paths filter: we want a security baseline on every master commit.
-  pull_request:
-    branches: [ master ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - '*.sln'
-      - 'Directory.Packages.props'
-      - '.github/workflows/codeql.yml'
+  # Schedule-only — every Monday at midnight catches newly-disclosed CVEs.
+  # PR and master push triggers were dropped: the weekly run is sufficient
+  # for this codebase and keeps CI minutes down. Re-add a push trigger if
+  # branch protection ever requires CodeQL as a status check.
   schedule:
-    - cron: '0 0 * * 1'  # Run every Monday at midnight — catches newly-disclosed CVEs
+    - cron: '0 0 * * 1'
 
 jobs:
   analyze:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -11,6 +11,10 @@ on:
       - 'docker-compose.yml'
       - 'Directory.Packages.props'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,12 @@ on:
         type: boolean
         default: false
 
+# Serialize master pushes — never overlap a publish run with itself.
+# Don't cancel-in-progress on master: a tag push mid-build should still finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/nuget-ci.yml
+++ b/.github/workflows/nuget-ci.yml
@@ -10,6 +10,10 @@ on:
       - 'Directory.Packages.props'
       - '.github/workflows/nuget-ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,14 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ master ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'playwright.config.*'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/playwright.yml'
   pull_request:
     branches: [ master ]
     paths:
@@ -18,6 +9,11 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/playwright.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

Trims CI waste on PR pushes:

- **Concurrency** on NuGet CI, Docker CI, Playwright: a force-push or fast follow-up push now cancels the previous run instead of stacking.
- **CodeQL** → schedule-only (Mondays). PR + push-to-master triggers dropped per ops decision — the weekly cron is sufficient for this codebase. Re-add a push trigger if branch protection ever requires CodeQL as a status check.
- **Playwright** → drop the master push trigger; PR-only. Squash-merge already ran the PR's CI against the merge tree, so the post-merge run was duplicative.
- **Docker Publish** (master-only): add concurrency *without* `cancel-in-progress` — never overlap two publishes, but never cancel one mid-flight either.

No functional changes to test execution. Wave 1 (#451) is unaffected.

## Estimated saving

~30-40% of PR CI minutes on pushes that get superseded. Plus ~17min/PR saved by skipping CodeQL.

## Test plan

- [ ] CI green on this PR (concurrency stops the first run when the second is pushed — expect to see a cancelled job if I push a fixup)
- [ ] CodeQL no longer appears in this PR's status checks
- [ ] After merge, master push triggers Docker Publish but **not** Playwright or CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)