### PR TITLE
chore(landing): add GA + consent banner to www.sorcha.dev

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,7 @@ on:
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css'
       - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.js'
+      - 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/consent-banner.js'
       - 'scripts/copy-landing-to-site.js'
       - '.github/workflows/gh-pages.yml'
   workflow_dispatch:

--- a/scripts/copy-landing-to-site.js
+++ b/scripts/copy-landing-to-site.js
@@ -16,7 +16,7 @@ const srcDir = path.join(root, 'src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot')
 const destDir = path.join(root, 'docs/site')
 
 // Files copied verbatim (no rewrites).
-const verbatim = ['landing.css', 'landing.js']
+const verbatim = ['landing.css', 'landing.js', 'consent-banner.js']
 
 // Link rewrites applied to index.html only. The LHS is what appears in the UI
 // source (served under the API gateway); the RHS is the public URL used on

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/consent-banner.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/consent-banner.js
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// Cookie consent banner for the www.sorcha.dev landing page.
+//
+// Shows on first visit (no `sorcha-consent` localStorage entry). Two outcomes:
+//   - Accept  → gtag('consent','update',{ analytics_storage: 'granted' })
+//   - Decline → keeps the default-denied stance from index.html head
+//
+// window.openConsent() is exposed so a footer link can re-open the banner later.
+
+(function () {
+    const STORAGE_KEY = 'sorcha-consent';
+
+    function applyConsent(state) {
+        if (typeof window.gtag === 'function') {
+            window.gtag('consent', 'update', { analytics_storage: state });
+        }
+    }
+
+    function injectStyles() {
+        if (document.getElementById('sorcha-consent-style')) return;
+        const style = document.createElement('style');
+        style.id = 'sorcha-consent-style';
+        style.textContent = `
+            .sorcha-consent {
+                position: fixed;
+                bottom: 1rem;
+                left: 1rem;
+                right: 1rem;
+                max-width: 720px;
+                margin: 0 auto;
+                padding: 1rem 1.25rem;
+                background: #ffffff;
+                color: #111827;
+                border: 1px solid #e5e7eb;
+                border-radius: 12px;
+                box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+                display: flex;
+                flex-direction: column;
+                gap: 0.875rem;
+                z-index: 9999;
+                font-family: 'Inter', system-ui, -apple-system, sans-serif;
+                font-size: 0.9rem;
+                line-height: 1.5;
+            }
+            @media (min-width: 720px) {
+                .sorcha-consent {
+                    flex-direction: row;
+                    align-items: center;
+                    gap: 1.25rem;
+                }
+            }
+            .sorcha-consent__text { flex: 1; }
+            .sorcha-consent__text strong { color: #111827; }
+            .sorcha-consent__text a {
+                color: #4f46e5;
+                text-decoration: underline;
+                text-underline-offset: 2px;
+            }
+            .sorcha-consent__actions {
+                display: flex;
+                gap: 0.5rem;
+                flex-shrink: 0;
+            }
+            .sorcha-consent__btn {
+                appearance: none;
+                border: 1px solid #d1d5db;
+                background: transparent;
+                color: #111827;
+                font: inherit;
+                font-weight: 500;
+                padding: 0.5rem 1rem;
+                border-radius: 8px;
+                cursor: pointer;
+                transition: background 0.15s, border-color 0.15s;
+            }
+            .sorcha-consent__btn:hover { background: #f3f4f6; }
+            .sorcha-consent__btn--primary {
+                background: #4f46e5;
+                border-color: #4f46e5;
+                color: #ffffff;
+            }
+            .sorcha-consent__btn--primary:hover {
+                background: #4338ca;
+                border-color: #4338ca;
+            }
+            @media (prefers-color-scheme: dark) {
+                .sorcha-consent {
+                    background: #1f2937;
+                    color: #f3f4f6;
+                    border-color: #374151;
+                }
+                .sorcha-consent__text strong { color: #f3f4f6; }
+                .sorcha-consent__btn {
+                    border-color: #4b5563;
+                    color: #f3f4f6;
+                }
+                .sorcha-consent__btn:hover { background: #374151; }
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    function showBanner() {
+        injectStyles();
+        const banner = document.createElement('div');
+        banner.className = 'sorcha-consent';
+        banner.setAttribute('role', 'dialog');
+        banner.setAttribute('aria-live', 'polite');
+        banner.setAttribute('aria-label', 'Cookie consent');
+        banner.innerHTML = `
+            <div class="sorcha-consent__text">
+                <strong>We use cookies for analytics.</strong>
+                We use Google Analytics to understand how this site is used so we can improve it.
+                No advertising or cross-site tracking. See our
+                <a href="https://docs.sorcha.dev/privacy" rel="noopener">privacy policy</a> for details.
+            </div>
+            <div class="sorcha-consent__actions">
+                <button class="sorcha-consent__btn" data-action="decline">Decline</button>
+                <button class="sorcha-consent__btn sorcha-consent__btn--primary" data-action="accept">Accept</button>
+            </div>
+        `;
+        banner.querySelector('[data-action="accept"]').addEventListener('click', function () {
+            localStorage.setItem(STORAGE_KEY, 'granted');
+            applyConsent('granted');
+            banner.remove();
+        });
+        banner.querySelector('[data-action="decline"]').addEventListener('click', function () {
+            localStorage.setItem(STORAGE_KEY, 'denied');
+            applyConsent('denied');
+            banner.remove();
+        });
+        document.body.appendChild(banner);
+    }
+
+    function init() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored === 'granted') {
+            applyConsent('granted');
+        } else if (!stored) {
+            showBanner();
+        }
+        window.openConsent = showBanner;
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -35,6 +35,24 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="landing.css">
+
+    <!-- Google Analytics gtag.js — measurement ID is public.
+         Configured in Consent Mode v2 default-denied; banner.js
+         flips analytics_storage to 'granted' on user opt-in. -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B2MKVEP45T"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', {
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            analytics_storage: 'denied',
+            wait_for_update: 500
+        });
+        gtag('js', new Date());
+        gtag('config', 'G-B2MKVEP45T', { anonymize_ip: true });
+    </script>
 </head>
 <body>
     <!-- Navigation -->
@@ -800,5 +818,6 @@
     </footer>
 
     <script src="landing.js"></script>
+    <script src="consent-banner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to #455 — that PR put GA on docs.sorcha.dev (VitePress docs site). www.sorcha.dev is a separate hand-written landing page deployed via GitHub Pages from \`src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html\`. This adds the same setup there.

- GA 4 (\`G-B2MKVEP45T\`) inline in \`<head>\` with Consent Mode v2 default-denied + \`anonymize_ip: true\`
- \`consent-banner.js\` — vanilla-JS banner (no framework dep), Inter font, light + dark via \`prefers-color-scheme\`
- Privacy link points to \`https://docs.sorcha.dev/privacy\` (the policy from #455)
- \`gh-pages.yml\` paths updated to trigger on the new file
- \`copy-landing-to-site.js\` updated to copy the new file alongside \`landing.css\` and \`landing.js\`

## Test plan

- [ ] After merge, gh-pages workflow deploys
- [ ] First visit to www.sorcha.dev shows banner; choice persists across refresh
- [ ] Network tab on Accept: \`collect?…\` requests with cookies; on Decline: cookieless
- [ ] GA Realtime dashboard shows hits ~30s after accepting

🤖 Generated with [Claude Code](https://claude.com/claude-code)