### PR TITLE
feat(register): subscribe peer-service to system register on bootstrap (#461 phase 1)

### DIFF
--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
@@ -7,6 +7,7 @@ using Sorcha.Register.Core.Managers;
 using Sorcha.Register.Models;
 using Sorcha.Register.Models.Constants;
 using Sorcha.Register.Models.Genesis;
+using Sorcha.ServiceClients.Peer;
 using Sorcha.ServiceClients.SystemWallet;
 using Sorcha.ServiceDefaults;
 
@@ -120,6 +121,12 @@ public class SystemRegisterBootstrapper : BackgroundService
         var backoffInterval = TimeSpan.FromSeconds(_options.BackoffIntervalSeconds);
         var startTime = DateTimeOffset.UtcNow;
         var attempt = 0;
+
+        // Tell peer-service to start pulling the system register from any peer
+        // that advertises it. Without this, peer-service has no subscription and
+        // RegisterSyncBackgroundService loads zero subscriptions, so the register
+        // never arrives locally and the wait loop below polls forever.
+        await EnsureSystemRegisterPeerSubscriptionAsync(cancellationToken);
 
         // Phase 1: Fast retries
         while (DateTimeOffset.UtcNow - startTime < fastRetryDuration)
@@ -342,6 +349,56 @@ public class SystemRegisterBootstrapper : BackgroundService
 
         var systemRegisterService = scope.ServiceProvider.GetRequiredService<SystemRegisterService>();
         await SeedBlueprintsIfMissingAsync(systemRegisterService, cancellationToken);
+
+        // Ensure peer-service knows to advertise the system register for sync.
+        // Idempotent — SubscribeToRegisterAsync logs a warning and returns the
+        // existing subscription if one already exists. Required for federation:
+        // without this call, downstream peers in SyncOnly mode get NotFound when
+        // querying GetRegisterSyncStatus on this node.
+        await EnsureSystemRegisterPeerSubscriptionAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Tells the local peer-service to subscribe to the system register so it
+    /// is replicated from peers (when joining an existing network) and
+    /// advertised to peers (when this node is part of an established network).
+    /// </summary>
+    /// <remarks>
+    /// Failure is logged but not fatal — bootstrap proceeds. If peer-service is
+    /// unavailable at startup, the operation is dropped; a future restart of
+    /// register-service or a manual subscribe call recovers state.
+    /// </remarks>
+    private async Task EnsureSystemRegisterPeerSubscriptionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var peerClient = scope.ServiceProvider.GetService<IPeerServiceClient>();
+            if (peerClient is null)
+            {
+                _logger.LogWarning(
+                    "IPeerServiceClient not registered — skipping system register peer subscription. " +
+                    "Federation (cross-instance sync) will not work for the system register.");
+                return;
+            }
+
+            await peerClient.SubscribeToRegisterAsync(
+                SystemRegisterConstants.SystemRegisterId,
+                "full-replica",
+                cancellationToken);
+
+            _logger.LogInformation(
+                "Subscribed peer-service to system register {RegisterId} for replication",
+                SystemRegisterConstants.SystemRegisterId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to subscribe peer-service to system register. Bootstrap will continue, " +
+                "but cross-instance sync of the system register will not function until the " +
+                "subscription is created (restart this service or call /api/registers/{0}/subscribe).",
+                SystemRegisterConstants.SystemRegisterId);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Phase 1 of the federation work tracked in #461. Closes the cross-instance system register sync gap with two \`IPeerServiceClient.SubscribeToRegisterAsync\` calls in \`SystemRegisterBootstrapper\`.

## Diagnosis recap

n1 had the system register in MongoDB but n1's peer-service held **zero subscriptions** — \`RegisterSyncBackgroundService Loaded 0 register subscriptions from database\`. The flow that subscribes peer-service when a *new* register is created via the public API (\`Register.Service/Program.cs:399\`) was never wired up for the bootstrap path. Each node had its system register but never told its own peer-service to advertise it. Calling \`RegisterSync.GetRegisterSyncStatus\` from any peer therefore returned:

\`\`\`
Code: NotFound
Message: Register 'aebf26362e079087571ac0932d4db973' not found on this peer
\`\`\`

## Fix

Two call sites:

**1. \`BootstrapSyncOnlyAsync\` — subscribe BEFORE the wait loop.** Without this, the wait loop polls forever because peer-service has no subscription and never pulls. Now: subscribe → peer-service starts pulling from any peer that advertises → register appears locally → wait loop exits.

**2. \`PostBootstrapAsync\` — subscribe AFTER the register exists.** Covers Auto and GenesisFile modes (the cases where this node creates the register itself). The local peer-service now advertises the register so other federated peers can sync from it.

A new helper \`EnsureSystemRegisterPeerSubscriptionAsync\` wraps both sites with try/catch + structured warning so a peer-service hiccup doesn't crash bootstrap.

## What's deliberately out of scope

- \`PeerCommunication.Stream\` server impl — for relay routing between non-routable peers, separate concern, kept open in #461.
- Auto-resubscribe on connect to a new peer — not needed; the subscription is per-register, peer-service polls all configured peers.
- Validator roster verification on replicated dockets — verified at runtime by the existing \`ValidatorKeyCache\`. If a roster mismatch breaks Phase 2 smoke test, that's a follow-up.

## Test plan

- [ ] CI green
- [ ] Phase 2 smoke test: with this PR's images deployed to n1 + run locally with \`docker-compose.sync-from-n1.yml\`, verify:
  - Local logs show \`Subscribed peer-service to system register …\`
  - Local \`sorcha_register_aebf26362e079087571ac0932d4db973\` populates with n1's transaction history
  - \`SystemRegisterBootstrapper\` exits SyncOnly wait loop with \`System register found via peer sync\`