### PR TITLE
fix(n1): BootstrapMode=Auto on n1 register-service so it owns the system register (#461 phase 2)

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -34,7 +34,11 @@ services:
     image: sorchadev/register-service:latest
     environment:
       <<: *jwt-env
-      SystemRegister__BootstrapMode: SyncOnly
+      # n1 is the seed node for this network — bootstrap the system register
+      # from the embedded genesis. Other federated nodes use SyncOnly and
+      # pull from n1 (subscriptions wired up by SystemRegisterBootstrapper
+      # in PR #462).
+      SystemRegister__BootstrapMode: Auto
 
   tenant-service:
     image: sorchadev/tenant-service:latest


### PR DESCRIPTION
## Summary

Five-line config change. Switches n1 from \`SystemRegister__BootstrapMode: SyncOnly\` to \`Auto\` so register-service ingests the embedded genesis on restart and finally has the system register.

## Why

PR #462 wired up the peer-service subscription path. Smoke test against n1 revealed n1 had been running in \`SyncOnly\` with no peers, so it had **never** had the system register — a silent gap. The walkthroughs using SME Trade and Trade Finance registers (created via legacy API) were unaffected, so the gap went unnoticed.

Once n1 has the system register, the federation chain is complete:
- n1 → ingest embedded genesis → system register exists → peer-service subscribes (#462) → advertises for sync
- Local in SyncOnly + bootstrap-nodes=[n1] → peer-service subscribes (#462) → pulls from n1

## Risk

Minimal. Auto mode's existing-register check is idempotent — if the system register already existed it would skip ingest. Existing registers (SME Trade, Trade Finance) are untouched (different IDs). No volume wipe.

## Test plan

- [ ] Merge → Docker Publish (no docker image change required, only config — but we'll restart register-service anyway)
- [ ] Deploy: \`docker compose -f … up -d --force-recreate register-service\` on n1
- [ ] Verify n1 logs show \`Ingesting embedded genesis — creating a new local network\` then \`Subscribed peer-service to system register …\`
- [ ] Verify \`sorcha_register_aebf26362e079087571ac0932d4db973\` exists in n1's MongoDB
- [ ] Phase 3: clean local docker, bring up with \`docker-compose.sync-from-n1.yml\` (the reproducer from \`feat/local-sync-from-n1\`), confirm system register replicates locally