### PR TITLE
fix(n1): revert BootstrapMode to SyncOnly + document validator-key gap

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -34,11 +34,14 @@ services:
     image: sorchadev/register-service:latest
     environment:
       <<: *jwt-env
-      # n1 is the seed node for this network — bootstrap the system register
-      # from the embedded genesis. Other federated nodes use SyncOnly and
-      # pull from n1 (subscriptions wired up by SystemRegisterBootstrapper
-      # in PR #462).
-      SystemRegister__BootstrapMode: Auto
+      # SyncOnly until federation onboarding is designed (#461 phase 3+).
+      # Auto attempts genesis ingest, but n1's validator-service uses
+      # wallet 'local-validator' which is not in the embedded genesis's
+      # validator roster (the genesis names ws11qpej4g…). Without a
+      # multi-wallet validator or a re-run of the genesis ceremony per
+      # deployment, the genesis ingest leaves the system register stub-
+      # state with no docket sealed.
+      SystemRegister__BootstrapMode: SyncOnly
 
   tenant-service:
     image: sorchadev/tenant-service:latest


### PR DESCRIPTION
## Summary

Reverts #463 (Auto mode on n1) after smoke testing revealed a deeper architectural issue. Adds explanatory comment.

## What we found

n1 ingested the embedded genesis successfully, peer-service subscribed (PR #462's wiring fired correctly), but the system register stayed in stub state with no docket sealed. Root cause:

- **Embedded genesis roster:** \`ws11qpej4gaxgj4jjkscjpme8783knf8t9c2c72kaulsrthsykqzfnayucymst9\` (the genesis ceremony's validator)
- **n1's validator-service:** uses \`local-validator\` as ValidatorId → derives a different pubkey (\`ws11qzh2gv44yjczt5azfrhsjf3uqk7…\`)
- Validator pubkey not in roster → can't seal dockets → register row never reaches Height>0

\`genesis-validator-key.json\` exists with the seed mnemonic for the genesis validator. \`sorcha system-register import-validator-key\` exists. But importing only adds the wallet to wallet-service — validator-service still fetches whichever wallet matches its single \`Validator__ValidatorId\` config string. There's no multi-wallet validator path that would allow n1 to be both the SME-Trade/Trade-Finance validator (using \`local-validator\`) AND the system-register validator (using the imported wallet).

## Status of the federation work

- **PR #462** (peer-service subscribe wiring) ✅ correct, lands and stays
- **PR #463** (n1 BootstrapMode=Auto) ❌ revert — incorrect until the validator-roster question is solved
- **#461 phase 3** ⏳ open — needs design for one of:
  1. Re-run the genesis ceremony per deployment so each instance owns a roster entry
  2. Multi-wallet validator support — validator-service picks the wallet whose pubkey matches the register's roster
  3. Designated-validator-per-register config

Issue #461 will be updated with this finding.

## n1 runtime state

n1's compose was already reverted live (scp + recreate). This PR just brings master in line so a future redeploy doesn't undo the revert.