### PR TITLE
fix(register): pre-create system register row with genesis control record (#461 phase 4)

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -34,14 +34,14 @@ services:
     image: sorchadev/register-service:latest
     environment:
       <<: *jwt-env
-      # SyncOnly until federation onboarding is designed (#461 phase 3+).
-      # Auto attempts genesis ingest, but n1's validator-service uses
-      # wallet 'local-validator' which is not in the embedded genesis's
-      # validator roster (the genesis names ws11qpej4g…). Without a
-      # multi-wallet validator or a re-run of the genesis ceremony per
-      # deployment, the genesis ingest leaves the system register stub-
-      # state with no docket sealed.
-      SystemRegister__BootstrapMode: SyncOnly
+      # n1 is the seed node for the sorcha-dev network. Auto mode runs the
+      # genesis-ingest path on first boot when no peer is available. PR #465
+      # added /api/v1/wallets/system/recover so the genesis-ceremony key can
+      # be imported into the validator's system wallet pre-deploy, and this
+      # PR pre-creates the register row with the genesis control record so
+      # validator-service enrols on its 30s reconcile cycle and seals docket 0.
+      # Replicas joining the network use SyncOnly via per-deployment overrides.
+      SystemRegister__BootstrapMode: Auto
 
   tenant-service:
     image: sorchadev/tenant-service:latest

--- a/src/Services/Sorcha.Register.Service/Services/GenesisIngestionService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/GenesisIngestionService.cs
@@ -5,7 +5,10 @@ using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Sorcha.Cryptography.Enums;
 using Sorcha.Cryptography.Interfaces;
+using Sorcha.Register.Core.Managers;
+using Sorcha.Register.Models;
 using Sorcha.Register.Models.Constants;
+using Sorcha.Register.Models.Enums;
 using Sorcha.Register.Models.Genesis;
 using Sorcha.ServiceClients.Validator;
 using Sorcha.ServiceDefaults;
@@ -163,5 +166,74 @@ public class GenesisIngestionService
     public bool VerifyGenesisFingerprint(byte[] publicKey, string trustedFingerprint)
     {
         return GenesisSignatureVerifier.MatchesFingerprint(publicKey, trustedFingerprint);
+    }
+
+    /// <summary>
+    /// Pre-creates the system register row with the genesis control record stashed in
+    /// <see cref="Register.InitialControlRecord"/> before genesis ingest.
+    /// </summary>
+    /// <remarks>
+    /// Breaks the validator-enrolment deadlock: <c>RegisterLocalRelationshipService</c>
+    /// derives the local roster relationship from <c>InitialControlRecord</c> when no
+    /// genesis docket is yet sealed, which lets <c>RegisterMonitoringBootstrap</c> in
+    /// validator-service enrol for the system register on its 30s reconcile cycle —
+    /// without this, the validator never sees the register and docket 0 is never
+    /// sealed, so the row never appears.
+    ///
+    /// Idempotent: returns silently if the register already exists locally.
+    /// </remarks>
+    public async Task EnsureSystemRegisterRowAsync(
+        SystemRegisterGenesis genesis,
+        RegisterManager registerManager,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(genesis);
+        ArgumentNullException.ThrowIfNull(registerManager);
+
+        var existing = await registerManager.GetRegisterAsync(
+            SystemRegisterConstants.SystemRegisterId, cancellationToken);
+        if (existing is not null)
+        {
+            _logger.LogDebug(
+                "System register row already exists (Height={Height}); skipping pre-create",
+                existing.Height);
+            return;
+        }
+
+        RegisterControlRecord? controlRecord;
+        try
+        {
+            var payloadBytes = Convert.FromBase64String(genesis.GenesisTransaction.Payload);
+            controlRecord = JsonSerializer.Deserialize<RegisterControlRecord>(payloadBytes);
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to decode genesis payload into RegisterControlRecord — " +
+                "skipping pre-create. Validator enrolment will rely on docket-0 seal.");
+            return;
+        }
+
+        if (controlRecord is null)
+        {
+            _logger.LogWarning(
+                "Genesis payload decoded to null RegisterControlRecord — skipping pre-create");
+            return;
+        }
+
+        await registerManager.CreateRegisterAsync(
+            name: SystemRegisterConstants.SystemRegisterName,
+            advertise: true,
+            isFullReplica: true,
+            registerId: SystemRegisterConstants.SystemRegisterId,
+            description: "Sorcha platform system register — root of trust for blueprints and governance.",
+            purpose: RegisterPurpose.System,
+            initialControlRecord: controlRecord,
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation(
+            "Pre-created system register row with stashed control record " +
+            "(roster size={RosterSize}) — validator can now enrol pre-seal",
+            controlRecord.Validators?.Validators.Count ?? 0);
     }
 }

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
@@ -239,6 +239,13 @@ public class SystemRegisterBootstrapper : BackgroundService
                 "Genesis loaded: Network={NetworkId}, Fingerprint={Fingerprint}",
                 genesis.NetworkId, genesis.GenesisPublicKeyFingerprint);
 
+            // Pre-create the register row with the control record stashed so the
+            // validator can derive its roster relationship and enrol BEFORE docket 0
+            // is sealed. Without this the validator never enrols → docket never seals
+            // → register row never appears (chicken-and-egg).
+            await genesisIngestion.EnsureSystemRegisterRowAsync(
+                genesis, registerManager, cancellationToken);
+
             var ingested = await genesisIngestion.IngestGenesisAsync(genesis, cancellationToken);
             if (!ingested)
             {
@@ -297,6 +304,11 @@ public class SystemRegisterBootstrapper : BackgroundService
                         "Set BootstrapMode to SyncOnly to join an existing network instead. " +
                         "(Network={NetworkId}, Fingerprint={Fingerprint})",
                         genesis.NetworkId, genesis.GenesisPublicKeyFingerprint);
+
+                    // Pre-create the register row so the validator can enrol pre-seal
+                    // (see EnsureSystemRegisterRowAsync remarks).
+                    await genesisIngestion.EnsureSystemRegisterRowAsync(
+                        genesis, registerManager, cancellationToken);
 
                     var ingested = await genesisIngestion.IngestGenesisAsync(genesis, cancellationToken);
                     if (!ingested)

--- a/tests/Sorcha.Register.Service.Tests/Services/SystemRegisterBootstrapperTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Services/SystemRegisterBootstrapperTests.cs
@@ -10,7 +10,6 @@ using Sorcha.Cryptography.Enums;
 using Sorcha.Cryptography.Interfaces;
 using Sorcha.Register.Core.Events;
 using Sorcha.Register.Core.Managers;
-using Sorcha.Cryptography.Interfaces;
 using Sorcha.Register.Core.Storage;
 using Sorcha.Register.Models.Constants;
 using Sorcha.Register.Models.Genesis;
@@ -194,6 +193,98 @@ public class SystemRegisterBootstrapperTests
                     s.BlueprintId == GenesisConstants.BlueprintId),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task GenesisIngestionService_EnsureRow_PreCreatesRegisterWithControlRecord()
+    {
+        // Arrange: registry has no system register; genesis payload carries a
+        // valid RegisterControlRecord so the pre-create can stash it.
+        Register.Models.Register? captured = null;
+        _mockRepository
+            .Setup(r => r.GetRegisterAsync(SystemRegisterConstants.SystemRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Register.Models.Register?)null);
+        _mockRepository
+            .Setup(r => r.InsertRegisterAsync(It.IsAny<Register.Models.Register>(), It.IsAny<CancellationToken>()))
+            .Callback<Register.Models.Register, CancellationToken>((reg, _) => captured = reg)
+            .ReturnsAsync((Register.Models.Register reg, CancellationToken _) => reg);
+
+        var registerManager = new RegisterManager(_mockRepository.Object, _mockEventPublisher.Object);
+        var options = Options.Create(new SystemRegisterOptions());
+        var service = new GenesisIngestionService(
+            options, _validatorClient.Object, _cryptoModule.Object, _ingestionLogger.Object);
+
+        var genesis = CreateTestGenesisWithValidControlRecord();
+
+        // Act
+        await service.EnsureSystemRegisterRowAsync(genesis, registerManager, CancellationToken.None);
+
+        // Assert: register row inserted, InitialControlRecord stashed with roster
+        captured.Should().NotBeNull();
+        captured!.Id.Should().Be(SystemRegisterConstants.SystemRegisterId);
+        captured.Purpose.Should().Be(Register.Models.Enums.RegisterPurpose.System);
+        captured.InitialControlRecord.Should().NotBeNull();
+        captured.InitialControlRecord!.Validators.Should().NotBeNull();
+        captured.InitialControlRecord.Validators!.Validators.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GenesisIngestionService_EnsureRow_IsIdempotentWhenRegisterExists()
+    {
+        // Arrange: register already exists locally
+        var existingRegister = new Register.Models.Register
+        {
+            Id = SystemRegisterConstants.SystemRegisterId,
+            Name = SystemRegisterConstants.SystemRegisterName,
+            Height = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _mockRepository
+            .Setup(r => r.GetRegisterAsync(SystemRegisterConstants.SystemRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingRegister);
+
+        var registerManager = new RegisterManager(_mockRepository.Object, _mockEventPublisher.Object);
+        var options = Options.Create(new SystemRegisterOptions());
+        var service = new GenesisIngestionService(
+            options, _validatorClient.Object, _cryptoModule.Object, _ingestionLogger.Object);
+
+        var genesis = CreateTestGenesisWithValidControlRecord();
+
+        // Act
+        await service.EnsureSystemRegisterRowAsync(genesis, registerManager, CancellationToken.None);
+
+        // Assert: no insert attempted
+        _mockRepository.Verify(
+            r => r.InsertRegisterAsync(It.IsAny<Register.Models.Register>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GenesisIngestionService_EnsureRow_SkipsOnUnparseablePayload()
+    {
+        // Arrange: payload isn't valid JSON for RegisterControlRecord
+        _mockRepository
+            .Setup(r => r.GetRegisterAsync(SystemRegisterConstants.SystemRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Register.Models.Register?)null);
+
+        var registerManager = new RegisterManager(_mockRepository.Object, _mockEventPublisher.Object);
+        var options = Options.Create(new SystemRegisterOptions());
+        var service = new GenesisIngestionService(
+            options, _validatorClient.Object, _cryptoModule.Object, _ingestionLogger.Object);
+
+        var genesis = CreateTestGenesis(); // Payload is `{"registerId":"test"}` — not a control record but valid JSON
+        // Force a hard parse failure by putting non-JSON in the payload
+        genesis.GenesisTransaction.Payload = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes("not json at all"));
+
+        // Act — should not throw
+        await service.EnsureSystemRegisterRowAsync(genesis, registerManager, CancellationToken.None);
+
+        // Assert: no insert attempted (decode failed → skip)
+        _mockRepository.Verify(
+            r => r.InsertRegisterAsync(It.IsAny<Register.Models.Register>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -526,6 +617,56 @@ public class SystemRegisterBootstrapperTests
                 RequiredSignatures = 1,
                 Version = 1
             },
+            GenesisPublicKeyFingerprint = GenesisFileLoader.ComputeFingerprint(publicKey)
+        };
+    }
+
+    private static SystemRegisterGenesis CreateTestGenesisWithValidControlRecord()
+    {
+        var publicKey = new byte[32];
+        Array.Fill(publicKey, (byte)0x02);
+
+        var controlRecord = new Register.Models.RegisterControlRecord
+        {
+            Validators = new Register.Models.ValidatorRoster
+            {
+                Validators =
+                [
+                    new Register.Models.ValidatorRosterEntry
+                    {
+                        ValidatorId = "test-validator",
+                        PublicKey = Convert.ToBase64String(publicKey),
+                        Algorithm = Register.Models.SignatureAlgorithm.ED25519,
+                        DerivationContext = "sorcha:docket-signing",
+                        Status = Register.Models.ValidatorKeyStatus.Active,
+                        AuthorizedAt = DateTimeOffset.UtcNow
+                    }
+                ],
+                RequiredSignatures = 1,
+                Version = 1
+            }
+        };
+        var payloadBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(controlRecord);
+
+        return new SystemRegisterGenesis
+        {
+            Version = 1,
+            NetworkId = "test-network",
+            GenesisTransaction = new GenesisTransactionData
+            {
+                TxId = GenesisSignatureVerifier.ComputeGenesisTxId(),
+                Payload = Convert.ToBase64String(payloadBytes),
+                PayloadHash = Convert.ToHexString(
+                    System.Security.Cryptography.SHA256.HashData(payloadBytes)).ToLowerInvariant(),
+                Signature = new GenesisSignature
+                {
+                    PublicKey = Convert.ToBase64String(publicKey),
+                    SignatureValue = Convert.ToBase64String(new byte[64]),
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow
+                }
+            },
+            ValidatorRoster = controlRecord.Validators!,
             GenesisPublicKeyFingerprint = GenesisFileLoader.ComputeFingerprint(publicKey)
         };
     }

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
@@ -134,6 +134,11 @@ public class RegisterCreationOrchestratorTests
             .Setup(b => b.RebuildAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new BloomFilterStats(0, 1024, 3, DateTimeOffset.UtcNow));
 
+        var relationshipNotifier = new RelationshipChangeNotifier(
+            Mock.Of<Sorcha.Register.Core.LocalRelationship.IRegisterLocalRelationshipService>(),
+            Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>(),
+            Mock.Of<ILogger<RelationshipChangeNotifier>>());
+
         _orchestrator = new RegisterCreationOrchestrator(
             _mockLogger.Object,
             _mockRegisterManager.Object,
@@ -146,7 +151,8 @@ public class RegisterCreationOrchestratorTests
             _mockPendingStore.Object,
             _mockPeerClient.Object,
             _mockTenantSubscriptionClient.Object,
-            _mockBloomFilterRebuilder.Object);
+            _mockBloomFilterRebuilder.Object,
+            relationshipNotifier);
     }
 
     #region InitiateAsync Tests
@@ -358,7 +364,8 @@ public class RegisterCreationOrchestratorTests
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<RegisterPurpose>(),
-                It.IsAny<string?>(),
+                It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(createdRegister);
 
@@ -454,7 +461,8 @@ public class RegisterCreationOrchestratorTests
             .Setup(m => m.CreateRegisterAsync(
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
-                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.Register
             {
@@ -523,7 +531,8 @@ public class RegisterCreationOrchestratorTests
             .Setup(m => m.CreateRegisterAsync(
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
-                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.Register
             {
@@ -696,7 +705,8 @@ public class RegisterCreationOrchestratorTests
             .Setup(m => m.CreateRegisterAsync(
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
-                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.Register
             {
@@ -759,7 +769,8 @@ public class RegisterCreationOrchestratorTests
             .Setup(m => m.CreateRegisterAsync(
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
                 It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
-                It.IsAny<RegisterPurpose>(), It.IsAny<string?>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.Register
             {
@@ -844,7 +855,8 @@ public class RegisterCreationOrchestratorTests
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
                 It.IsAny<RegisterPurpose>(),
-                It.IsAny<string?>(),
+                It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Sorcha.Register.Models.Register
             {

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
@@ -74,6 +74,11 @@ public class RegisterCreationPolicyTests
             .Setup(s => s.Add(It.IsAny<string>(), It.IsAny<PendingRegistration>()))
             .Callback<string, PendingRegistration>((_, pending) => _capturedPending = pending);
 
+        var relationshipNotifier = new RelationshipChangeNotifier(
+            Mock.Of<Sorcha.Register.Core.LocalRelationship.IRegisterLocalRelationshipService>(),
+            Mock.Of<Sorcha.Register.Core.Events.IEventPublisher>(),
+            Mock.Of<ILogger<RelationshipChangeNotifier>>());
+
         _orchestrator = new RegisterCreationOrchestrator(
             _mockLogger.Object,
             mockRegisterManager.Object,
@@ -86,7 +91,8 @@ public class RegisterCreationPolicyTests
             _mockPendingStore.Object,
             mockPeerClient.Object,
             Mock.Of<ITenantSubscriptionClient>(),
-            mockBloomRebuilder.Object);
+            mockBloomRebuilder.Object,
+            relationshipNotifier);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fixes the validator-enrolment chicken-and-egg deadlock that left genesis transactions sitting in the mempool with Height stuck at 0
- `GenesisIngestionService.EnsureSystemRegisterRowAsync` now pre-creates the system register row with `InitialControlRecord` stashed from the genesis payload, before submitting to validator-service
- The existing pre-seal fallback in `RegisterLocalRelationshipService.ComputeAsync` then lets validator-service's `RegisterMonitoringBootstrap` enrol for the system register on its 30s reconcile cycle, and docket 0 seals normally
- Flips master's `docker-compose.n1.yml` back to `BootstrapMode=Auto` (PR #464 reverted it to SyncOnly when n1 was wedged; with PR #465 + this PR n1 is the seed node again)
- Drive-by: fixes pre-existing build errors in `RegisterCreationOrchestratorTests` / `RegisterCreationPolicyTests` so the new tests can run

## Why this works
Validator-service's `RegisterMonitoringBootstrap` enrols by querying register-service's `/api/internal/my-validated-registers`, which derives roster relationships from either (a) a sealed genesis docket, or (b) the `InitialControlRecord` stash on the register row. Neither existed for the system register pre-seal — the row itself was only created when `WriteDocket` landed for docket 0, but the docket couldn't seal until the validator enrolled.

By decoding the `RegisterControlRecord` from the genesis payload and inserting the row with that record stashed, the pre-seal branch in `RegisterLocalRelationshipService.ComputeAsync` (lines 132-149) is now reachable for the system register on a fresh node. The validator's reconcile loop then picks it up exactly like every other register.

Hooked into `BootstrapAutoAsync` and `BootstrapGenesisFileAsync`; `SyncOnly` mode is unchanged because the register arrives from peers via P2P sync.

## Safety
Preserves Feature 108's roster-driven enrolment invariant. A node only ever pre-creates the row when ingesting the genesis itself, and `DeriveRoles` only returns `Validator` if the node's wallet pubkey matches a roster entry on the stashed control record. Non-validators with a different wallet still won't enrol or seal.

## Test plan
- [x] New unit tests in `SystemRegisterBootstrapperTests` (3 tests, all green):
  - pre-creates row with control record on fresh node
  - is idempotent when register already exists
  - skips gracefully on unparseable payload
- [ ] **n1 verify** (after merge + Docker Publish + redeploy):
  1. `docker compose down -v` on n1, then bring up wallet-service alone, import genesis key via `/api/v1/wallets/system/recover`, bring up rest
  2. `sorcha_register_registry.registers` contains `aebf26362e079087571ac0932d4db973` at `Height>0`
  3. `RegisterSync.GetRegisterSyncStatus` from outside n1 returns `SYNC_STATE_ACTIVE`
  4. Local clean docker + `docker-compose.sync-from-n1.yml` replicates the system register from n1

## Follow-ups (deferred)
- Update `scripts/n1-setup-remote.sh` to orchestrate the wallet-service-first import flow automatically (today the recipe lives in network-bootstrap SKILL.md Step 5 and is run manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)