### PR TITLE
fix(peer): RegisterSyncBackgroundService loop dies on first immediate-sync signal

### DIFF
--- a/docker-compose.sync-from-n1.yml
+++ b/docker-compose.sync-from-n1.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Local-from-n1 sync override.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.sync-from-n1.yml up -d
+#
+# Effect:
+#   - peer-service learns about n1.sorcha.dev:50051 as a bootstrap node
+#   - register-service switches BootstrapMode to SyncOnly so it waits for
+#     peer replication to deliver the system register instead of falling
+#     back to the embedded genesis (which would create a divergent local
+#     network).
+#
+# Caveats:
+#   - n1 must be running and the peer-service must be healthy.
+#   - Cross-instance system-register replication via the Peer.Service
+#     replication path is unverified; if local does not receive the
+#     register within the SyncOnly fast-retry window, check peer-service
+#     logs for connection / discovery / subscription errors.
+#   - Same network ID required on both sides — local's embedded genesis
+#     hash must match n1's. (Currently they do — both bootstrap from
+#     src/Common/Sorcha.Register.Models/Resources/system-register-genesis.json.)
+
+services:
+  peer-service:
+    environment:
+      # Tell peer discovery to try n1 on first connect.
+      PeerService__PeerDiscovery__BootstrapNodes__0__NodeId: "n1.sorcha.dev"
+      PeerService__PeerDiscovery__BootstrapNodes__0__Hostname: "n1.sorcha.dev"
+      PeerService__PeerDiscovery__BootstrapNodes__0__Port: "50051"
+      PeerService__PeerDiscovery__BootstrapNodes__0__Priority: "1"
+      # Plaintext h2c — Caddy on n1 terminates TLS and forwards as h2c
+      PeerService__EnableTls: "false"
+
+  register-service:
+    environment:
+      # Wait for peer sync instead of self-bootstrapping with the embedded
+      # genesis. SyncOnly polls fast for FastRetryDurationSeconds (default
+      # 60s), then backs off to BackoffIntervalSeconds (default 30s)
+      # indefinitely, so the service stays alive while peers come online.
+      SystemRegister__BootstrapMode: "SyncOnly"

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -76,8 +76,7 @@ public class RegisterSyncBackgroundService : BackgroundService
         // Load existing subscriptions from database
         await LoadSubscriptionsAsync(stoppingToken);
 
-        using var timer = new PeriodicTimer(
-            TimeSpan.FromMinutes(_syncConfig.PeriodicSyncIntervalMinutes));
+        var periodicInterval = TimeSpan.FromMinutes(_syncConfig.PeriodicSyncIntervalMinutes);
 
         // Establish reverse stream to seed node before processing subscriptions
         Task? reverseStreamTask = null;
@@ -103,11 +102,31 @@ public class RegisterSyncBackgroundService : BackgroundService
                 {
                     await ProcessSubscriptionsAsync(stoppingToken);
 
-                    // Wait for either the periodic timer or an immediate sync signal
-                    var timerTask = timer.WaitForNextTickAsync(stoppingToken).AsTask();
-                    var signalTask = Task.Run(() => _immediateSyncSignal.Wait(stoppingToken), stoppingToken);
-                    await Task.WhenAny(timerTask, signalTask);
+                    // Wait for either the periodic interval or an immediate sync signal.
+                    //
+                    // The earlier implementation used a single PeriodicTimer shared across
+                    // iterations and Task.WhenAny(timer.WaitForNextTickAsync(), signalTask).
+                    // When the signal won the race, the timer's pending WaitForNextTickAsync
+                    // was orphaned but PeriodicTimer holds internal "wait in progress" state
+                    // — the next iteration's WaitForNextTickAsync threw InvalidOperationException
+                    // and the loop never made another pass. (PeriodicTimer disallows concurrent
+                    // or interleaved waiters by design.)
+                    //
+                    // Fresh linked CTS per iteration ensures whichever side loses the race is
+                    // cancelled cleanly before the next iteration starts; Task.Delay is
+                    // stateless across iterations, so no leaked state survives.
+                    using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                    var delayTask = Task.Delay(periodicInterval, waitCts.Token);
+                    var signalTask = Task.Run(
+                        () => _immediateSyncSignal.Wait(waitCts.Token),
+                        waitCts.Token);
+                    await Task.WhenAny(delayTask, signalTask);
                     _immediateSyncSignal.Reset();
+                    waitCts.Cancel();
+                    // Drain both tasks so cancellation completes before next iteration —
+                    // expected OperationCanceledException is swallowed.
+                    try { await delayTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
+                    try { await signalTask.ConfigureAwait(false); } catch (OperationCanceledException) { }
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {


### PR DESCRIPTION
## Summary
- Pre-existing bug in peer-service: \`PeriodicTimer.WaitForNextTickAsync\` disallows interleaved waiters, but the sync loop's \`Task.WhenAny(timerTask, signalTask)\` orphaned the timer wait whenever the signal won. Next iteration's WaitForNextTickAsync threw \`InvalidOperationException\`, caught by the outer handler, 30s delay, throw, repeat
- Net effect: first \`SubscribeToRegisterAsync\` (which sets the immediate-sync signal) breaks the loop for the lifetime of the process — \`ProcessSubscriptionsAsync\` never runs again, and cross-instance register replication silently fails
- Fix: replace the shared timer with a per-iteration linked CTS + \`Task.Delay\` race. Task.Delay is stateless, no leaked state survives iterations, both losers get drained on each pass

## Why this surfaced now
Discovered while verifying #461 phase 4 (federation deadlock): n1's seed-node bootstrap is fixed (#467 + #468), but a local docker stack pointed at n1 with \`docker-compose.sync-from-n1.yml\` couldn't actually pull dockets despite subscribing correctly. Every iteration logged the InvalidOperationException trace — the loop was alive but doing nothing.

## Drive-by
Includes \`docker-compose.sync-from-n1.yml\` (originally on \`feat/local-sync-from-n1\`) so master has the federation reproducer ready for the next verification round.

## Test plan
- [x] Build clean
- [ ] Redeploy local stack with \`-f docker-compose.yml -f docker-compose.sync-from-n1.yml\` after this lands; expect:
  - Subscribe-to-system-register fires immediate-sync signal
  - First ProcessSubscriptionsAsync runs, pulls genesis docket from n1
  - Mongo \`sorcha_register_registry.registers\` shows \`aebf263…\` at \`Height=2\`
  - Loop continues iterating without throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)