### PR TITLE
fix(peer): genesis verifier + roster extractor look up Control tx via cache

### DIFF
--- a/src/Services/Sorcha.Peer.Service/Replication/DocketFinalizationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/DocketFinalizationService.cs
@@ -415,77 +415,53 @@ public class DocketFinalizationService
     /// </summary>
     private bool TryExtractValidatorRosterFromDocket(string registerId, CachedDocket genesisDocket)
     {
-        try
+        // CachedDocket.Data is JSON-serialised Sorcha.Register.Models.Docket which carries
+        // only TransactionIds (no inline transactions). Look up the Control transaction
+        // via the register cache instead — that's where full TransactionModel JSON lands
+        // after RegisterReplicationService pulls transactions in parallel with the docket.
+        var controlTx = GenesisControlTransactionLookup.TryFindControl(
+            registerId, genesisDocket, _registerCache, _logger);
+        if (controlTx is null)
         {
-            // The genesis docket data is serialized DocketModel JSON containing transactions.
-            // Each transaction may have Base64Url-encoded payloads with RegisterControlRecord.
-            using var doc = JsonDocument.Parse(genesisDocket.Data);
-            var root = doc.RootElement;
-
-            // Look for transactions array in the docket data
-            JsonElement txArray;
-            if (!root.TryGetProperty("Transactions", out txArray) &&
-                !root.TryGetProperty("transactions", out txArray))
-            {
-                return false;
-            }
-
-            foreach (var tx in txArray.EnumerateArray())
-            {
-                // Only process Control transactions (TransactionType == 0)
-                if ((tx.TryGetProperty("MetaData", out var meta) || tx.TryGetProperty("metaData", out meta))
-                    && meta.ValueKind == JsonValueKind.Object)
-                {
-                    if (meta.TryGetProperty("TransactionType", out var txType) ||
-                        meta.TryGetProperty("transactionType", out txType))
-                    {
-                        if (txType.ValueKind == JsonValueKind.Number && txType.GetInt32() != 0)
-                            continue;
-                    }
-                }
-
-                // Look for payloads
-                JsonElement payloads;
-                if (!tx.TryGetProperty("Payloads", out payloads) &&
-                    !tx.TryGetProperty("payloads", out payloads))
-                    continue;
-
-                foreach (var payload in payloads.EnumerateArray())
-                {
-                    JsonElement dataElement;
-                    if (!payload.TryGetProperty("Data", out dataElement) &&
-                        !payload.TryGetProperty("data", out dataElement))
-                        continue;
-
-                    var payloadData = dataElement.GetString();
-                    if (string.IsNullOrEmpty(payloadData)) continue;
-
-                    try
-                    {
-                        var controlRecordBytes = DecodeBase64Url(payloadData);
-                        if (_validatorKeyCache.ExtractFromControlRecord(registerId, controlRecordBytes))
-                        {
-                            _logger.LogInformation(
-                                "Extracted validator roster from cached genesis docket for register {RegisterId}",
-                                registerId);
-                            return true;
-                        }
-                    }
-                    catch (FormatException)
-                    {
-                        // Not valid Base64Url — try next payload
-                    }
-                }
-            }
-
+            _logger.LogDebug(
+                "No cached Control transaction yet for register {RegisterId} genesis docket — " +
+                "Strategy 1 cannot extract roster, falling through",
+                registerId);
             return false;
         }
-        catch (JsonException ex)
+
+        if (controlTx.Payloads is null || controlTx.Payloads.Length == 0)
         {
-            _logger.LogDebug(ex,
-                "Failed to parse genesis docket transactions for register {RegisterId}", registerId);
+            _logger.LogDebug(
+                "Cached Control transaction {TxId} for register {RegisterId} has no payloads — falling through",
+                controlTx.TxId, registerId);
             return false;
         }
+
+        foreach (var payload in controlTx.Payloads)
+        {
+            if (string.IsNullOrEmpty(payload.Data)) continue;
+
+            byte[] controlRecordBytes;
+            try
+            {
+                controlRecordBytes = DecodeBase64Url(payload.Data);
+            }
+            catch (FormatException)
+            {
+                continue; // Try next payload
+            }
+
+            if (_validatorKeyCache.ExtractFromControlRecord(registerId, controlRecordBytes))
+            {
+                _logger.LogInformation(
+                    "Extracted validator roster from cached genesis Control transaction for register {RegisterId}",
+                    registerId);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool VerifyChainIntegrity(string registerId, CachedDocket docket)

--- a/src/Services/Sorcha.Peer.Service/Replication/GenesisControlTransactionLookup.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/GenesisControlTransactionLookup.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+
+namespace Sorcha.Peer.Service.Replication;
+
+/// <summary>
+/// Resolves the Control transaction inside a cached genesis docket.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The wire format separates dockets and transactions: <c>CachedDocket.Data</c>
+/// is a JSON-serialised <c>Sorcha.Register.Models.Docket</c> which carries only
+/// <c>TransactionIds</c>, while <c>CachedTransaction.Data</c> holds the full
+/// canonical <c>TransactionModel</c> JSON for each transaction.
+/// </para>
+/// <para>
+/// Earlier verifier and roster-extractor code parsed <c>CachedDocket.Data</c>
+/// expecting an inline <c>transactions[]</c> array — that array does not exist
+/// in the wire shape, so every replicated genesis docket got rejected
+/// pre-finalisation. The fix is to iterate <c>docket.TransactionIds</c> and
+/// look each transaction up in the cache, returning the first Control-typed
+/// hit.
+/// </para>
+/// </remarks>
+internal static class GenesisControlTransactionLookup
+{
+    /// <summary>
+    /// Iterates the docket's transaction IDs, looks each up in the register
+    /// cache, deserialises the canonical TransactionModel JSON, and returns
+    /// the first one whose <c>MetaData.TransactionType</c> is
+    /// <see cref="TransactionType.Control"/>.
+    /// </summary>
+    /// <returns>Null if no transactions are cached yet, no Control transaction is
+    /// found, or the cached payload fails to deserialise.</returns>
+    public static TransactionModel? TryFindControl(
+        string registerId,
+        CachedDocket docket,
+        RegisterCache cache,
+        ILogger? logger = null)
+    {
+        var entry = cache.Get(registerId);
+        if (entry is null)
+        {
+            logger?.LogDebug(
+                "GenesisControlTransactionLookup: no cache entry for register {RegisterId}",
+                registerId);
+            return null;
+        }
+
+        if (docket.TransactionIds is null || docket.TransactionIds.Count == 0)
+        {
+            logger?.LogDebug(
+                "GenesisControlTransactionLookup: docket {DocketNumber} for register {RegisterId} has no transaction IDs",
+                docket.Version, registerId);
+            return null;
+        }
+
+        foreach (var txId in docket.TransactionIds)
+        {
+            var cached = entry.GetTransaction(txId);
+            if (cached is null || cached.Data is null || cached.Data.Length == 0)
+                continue;
+
+            TransactionModel? tx;
+            try
+            {
+                // Wire shape is canonical (camelCase) — case-sensitive deserialisation
+                // is required so SenderWallet, MetaData, etc. populate correctly.
+                tx = JsonSerializer.Deserialize<TransactionModel>(
+                    cached.Data, RegisterSerializationOptions.Canonical);
+            }
+            catch (JsonException ex)
+            {
+                logger?.LogDebug(ex,
+                    "GenesisControlTransactionLookup: failed to deserialise tx {TxId} for register {RegisterId}",
+                    txId, registerId);
+                continue;
+            }
+
+            if (tx is null) continue;
+            if (tx.MetaData?.TransactionType != TransactionType.Control) continue;
+
+            // Backfill identity fields the canonical wire shape doesn't always carry —
+            // matches DocketFinalizationService.BuildDocketModel for consistency.
+            tx.RegisterId = registerId;
+            tx.TxId = txId;
+            return tx;
+        }
+
+        return null;
+    }
+}

--- a/src/Services/Sorcha.Peer.Service/Replication/SystemRegisterSyncVerifier.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/SystemRegisterSyncVerifier.cs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sorcha.Cryptography.Enums;
 using Sorcha.Cryptography.Interfaces;
-using Sorcha.Peer.Service.Models;
 using Sorcha.Register.Models.Constants;
 using Sorcha.Register.Models.Genesis;
 using Sorcha.ServiceDefaults;
@@ -40,20 +38,20 @@ public interface ISystemRegisterSyncVerifier
 /// <inheritdoc />
 public class SystemRegisterSyncVerifier : ISystemRegisterSyncVerifier
 {
-    /// <summary>TransactionType.Control = 0 — register governance transactions.</summary>
-    private const int ControlTransactionType = 0;
-
     private readonly ICryptoModule _cryptoModule;
+    private readonly RegisterCache _registerCache;
     private readonly ILogger<SystemRegisterSyncVerifier> _logger;
     private readonly Lazy<SystemRegisterGenesis?> _trustedGenesis;
 
     public SystemRegisterSyncVerifier(
         IOptions<SystemRegisterOptions> options,
         ICryptoModule cryptoModule,
+        RegisterCache registerCache,
         ILogger<SystemRegisterSyncVerifier> logger)
     {
-        _cryptoModule = cryptoModule;
-        _logger = logger;
+        _cryptoModule = cryptoModule ?? throw new ArgumentNullException(nameof(cryptoModule));
+        _registerCache = registerCache ?? throw new ArgumentNullException(nameof(registerCache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _trustedGenesis = new Lazy<SystemRegisterGenesis?>(() =>
         {
             try
@@ -91,41 +89,58 @@ public class SystemRegisterSyncVerifier : ISystemRegisterSyncVerifier
             return false;
         }
 
-        // Extract both payload and signature from the control transaction in a single parse
-        var extracted = TryExtractControlTransaction(genesisDocket);
-        if (extracted is null)
+        // Locate the control transaction via the register cache. The docket itself
+        // only carries TransactionIds — full transactions are pulled separately and
+        // stored in the cache by RegisterReplicationService.
+        var controlTx = GenesisControlTransactionLookup.TryFindControl(
+            registerId, genesisDocket, _registerCache, _logger);
+
+        if (controlTx is null)
         {
-            _logger.LogWarning("System register genesis docket has no valid control transaction — rejecting");
+            _logger.LogWarning(
+                "System register genesis docket has no resolvable control transaction in cache " +
+                "(register {RegisterId}, docket {Docket}, transactionIds={Count}) — rejecting",
+                registerId, genesisDocket.Version, genesisDocket.TransactionIds?.Count ?? 0);
             return false;
         }
 
-        var (controlPayload, peerPublicKey, peerSignatureValue, peerAlgorithm) = extracted.Value;
+        var encodedPayload = controlTx.Payloads is { Length: > 0 } ? controlTx.Payloads[0].Data : null;
+        var encodedSignature = controlTx.Signature;
+        if (string.IsNullOrEmpty(encodedPayload) || string.IsNullOrEmpty(encodedSignature))
+        {
+            _logger.LogWarning(
+                "System register genesis control tx {TxId} for register {RegisterId} " +
+                "is missing payload or signature — rejecting",
+                controlTx.TxId, registerId);
+            return false;
+        }
 
         try
         {
-            // Step 1: Verify the peer's genesis public key matches our trusted fingerprint.
-            // Fingerprint is SHA-256 truncated to 128 bits (32 hex chars). This is sufficient
-            // for collision resistance as a pre-filter; the full cryptographic signature
-            // verification in Step 2 provides the actual security guarantee.
-            var peerPublicKeyBytes = Convert.FromBase64String(peerPublicKey);
-            var trusted = GenesisSignatureVerifier.MatchesFingerprint(
-                peerPublicKeyBytes,
-                trustedGenesis.GenesisPublicKeyFingerprint);
+            // Persisted TransactionModel doesn't carry the signing pubkey or algorithm
+            // (the validator strips them down to a Base64Url signature string + sender
+            // wallet at seal time). Verification therefore uses the trusted genesis
+            // pubkey/algorithm directly — a forged transaction would fail this check
+            // because no peer can produce a valid signature without the genesis private
+            // key, which is destroyed after ceremony.
+            var trustedPubKey = Convert.FromBase64String(
+                trustedGenesis.GenesisTransaction.Signature.PublicKey);
+            var trustedAlgorithm = trustedGenesis.GenesisTransaction.Signature.Algorithm;
 
-            if (!trusted)
+            if (!Enum.TryParse<WalletNetworks>(trustedAlgorithm, ignoreCase: true, out var network))
             {
-                var peerFingerprint = GenesisFileLoader.ComputeFingerprint(peerPublicKeyBytes);
                 _logger.LogError(
-                    "Peer system register rejected: genesis signed by unknown key. " +
-                    "Expected fingerprint: {Expected}, got: {Actual}",
-                    trustedGenesis.GenesisPublicKeyFingerprint, peerFingerprint);
+                    "Trusted genesis algorithm {Algorithm} is not a recognised WalletNetworks value",
+                    trustedAlgorithm);
                 return false;
             }
 
-            // Step 2: Verify the cryptographic signature over the payload.
-            // Fingerprint alone is insufficient — a compromised peer could present
-            // the real public key with a tampered control record.
-            var peerPayloadBytes = Convert.FromBase64String(controlPayload);
+            // Recompute the signed-data hash the same way the CLI ceremony did:
+            //   payloadHash    = SHA256(decoded_control_record_bytes)
+            //   dataToSign     = SHA256(UTF8("{txId}:{payloadHash}"))
+            // The ContentEncoding on docket payloads is "base64url" (see
+            // DocketBuildTriggerService:583), so decode accordingly.
+            var peerPayloadBytes = DecodeBase64Auto(encodedPayload);
             var peerPayloadHash = Convert.ToHexString(
                 System.Security.Cryptography.SHA256.HashData(peerPayloadBytes)).ToLowerInvariant();
             var peerTxId = GenesisSignatureVerifier.ComputeGenesisTxId();
@@ -133,88 +148,59 @@ public class SystemRegisterSyncVerifier : ISystemRegisterSyncVerifier
             var signedDataHash = System.Security.Cryptography.SHA256.HashData(
                 System.Text.Encoding.UTF8.GetBytes(dataToSign));
 
-            var peerSignatureBytes = Convert.FromBase64String(peerSignatureValue);
-
-            if (!Enum.TryParse<WalletNetworks>(peerAlgorithm, ignoreCase: true, out var network))
-            {
-                _logger.LogError("Unsupported algorithm in peer genesis: {Algorithm}", peerAlgorithm);
-                return false;
-            }
+            // Validator persists the signature as Base64Url; ceremony emits Base64.
+            // Try both — same DecodeBase64Auto helper accepts either form.
+            var peerSignatureBytes = DecodeBase64Auto(encodedSignature);
 
             var verifyResult = await _cryptoModule.VerifyAsync(
-                peerSignatureBytes, signedDataHash, (byte)network, peerPublicKeyBytes, cancellationToken);
+                peerSignatureBytes, signedDataHash, (byte)network, trustedPubKey, cancellationToken);
 
             if (verifyResult != CryptoStatus.Success)
             {
                 _logger.LogError(
-                    "Peer system register rejected: genesis signature verification failed ({Status}). " +
-                    "The control record may have been tampered with.",
-                    verifyResult);
+                    "Peer system register rejected: genesis signature verification failed " +
+                    "({Status}) — register {RegisterId}. The control record may have been " +
+                    "tampered with, or the peer's genesis key does not match this network's " +
+                    "trust anchor (fingerprint={Fingerprint}).",
+                    verifyResult, registerId, trustedGenesis.GenesisPublicKeyFingerprint);
                 return false;
             }
 
             _logger.LogInformation(
-                "Peer system register genesis verified: fingerprint={Fingerprint}, signature=VALID",
-                trustedGenesis.GenesisPublicKeyFingerprint);
+                "Peer system register genesis verified for register {RegisterId} " +
+                "(trustedFingerprint={Fingerprint}, signature=VALID)",
+                registerId, trustedGenesis.GenesisPublicKeyFingerprint);
             return true;
         }
         catch (FormatException ex)
         {
-            _logger.LogError(ex, "Failed to decode peer system register genesis data");
+            _logger.LogError(ex,
+                "Failed to decode peer system register genesis data for register {RegisterId}",
+                registerId);
             return false;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to verify peer system register genesis signature");
+            _logger.LogError(ex,
+                "Failed to verify peer system register genesis signature for register {RegisterId}",
+                registerId);
             return false;
         }
     }
 
     /// <summary>
-    /// Extracts payload and signature from the control transaction in a single JSON parse.
-    /// Returns null if the docket has no valid control transaction.
+    /// Tries Base64Url decoding first then standard Base64.
+    /// CLI ceremony writes Base64; validator persists Base64Url. Either may reach us.
     /// </summary>
-    private static (string payload, string publicKey, string signatureValue, string algorithm)?
-        TryExtractControlTransaction(CachedDocket docket)
+    private static byte[] DecodeBase64Auto(string encoded)
     {
-        if (docket.Data is null || docket.Data.Length == 0)
-            return null;
-
-        try
+        var s = encoded.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
         {
-            using var doc = JsonDocument.Parse(docket.Data);
-            var root = doc.RootElement;
-
-            if (!root.TryGetProperty("transactions", out var transactions))
-                return null;
-
-            foreach (var tx in transactions.EnumerateArray())
-            {
-                if (!tx.TryGetProperty("transactionType", out var txType) ||
-                    txType.GetInt32() != ControlTransactionType)
-                    continue;
-
-                var payload = tx.TryGetProperty("payload", out var p) ? p.GetString() : null;
-                if (payload is null)
-                    continue;
-
-                if (!tx.TryGetProperty("signature", out var sig))
-                    continue;
-
-                var pk = sig.TryGetProperty("publicKey", out var pkEl) ? pkEl.GetString() : null;
-                var sv = sig.TryGetProperty("signatureValue", out var svEl) ? svEl.GetString() : null;
-                var algo = sig.TryGetProperty("algorithm", out var algoEl) ? algoEl.GetString() : null;
-
-                if (pk is not null && sv is not null && algo is not null)
-                    return (payload, pk, sv, algo);
-            }
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
         }
-        catch (JsonException ex)
-        {
-            // Docket JSON is malformed — caller will log and reject
-            _ = ex;
-        }
-
-        return null;
+        return Convert.FromBase64String(s);
     }
+
 }

--- a/tests/Sorcha.Peer.Service.Tests/Replication/SystemRegisterSyncVerifierTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Replication/SystemRegisterSyncVerifierTests.cs
@@ -79,10 +79,101 @@ public class SystemRegisterSyncVerifierTests : IDisposable
         result.Should().BeFalse(); // Can't extract control transaction from empty docket
     }
 
+    [Fact]
+    public async Task VerifyGenesis_DocketWithCachedControlTx_ReturnsTrue()
+    {
+        // Replicates the production wire shape: docket carries TransactionIds only,
+        // full TransactionModel JSON lives in the per-transaction cache. Verifier
+        // must look up the Control transaction by ID, decode the payload, and verify
+        // the signature against the trusted genesis pubkey.
+        var registerId = SystemRegisterConstants.SystemRegisterId;
+        var (verifier, cache) = CreateVerifierWithGenesisAndCache();
+
+        // Stage a Control transaction in the cache that references the same payload
+        // and signature the trusted genesis was built from.
+        var txId = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        var controlTx = new Sorcha.Register.Models.TransactionModel
+        {
+            RegisterId = registerId,
+            TxId = txId,
+            SenderWallet = "system",
+            Signature = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            MetaData = new Sorcha.Register.Models.TransactionMetaData
+            {
+                RegisterId = registerId,
+                TransactionType = Sorcha.Register.Models.Enums.TransactionType.Control
+            },
+            Payloads = new[]
+            {
+                new Sorcha.Register.Models.PayloadModel
+                {
+                    Data = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("{\"registerId\":\"test\"}")),
+                    Hash = "deadbeef",
+                    ContentEncoding = "base64url"
+                }
+            }
+        };
+        var txJson = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(
+            controlTx, Sorcha.Register.Models.RegisterSerializationOptions.Canonical);
+
+        cache.GetOrCreate(registerId).AddOrUpdateTransaction(new CachedTransaction
+        {
+            RegisterId = registerId,
+            TransactionId = txId,
+            Data = txJson
+        });
+
+        var docket = new CachedDocket
+        {
+            RegisterId = registerId,
+            Version = 0,
+            Data = Array.Empty<byte>(),
+            DocketHash = "h",
+            TransactionIds = new List<string> { txId }
+        };
+
+        // Crypto module just rubber-stamps — we're testing the lookup + plumbing,
+        // not the signature math (covered by GenesisSignatureVerifierTests).
+        _cryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Sorcha.Cryptography.Enums.CryptoStatus.Success);
+
+        var result = await verifier.VerifySystemRegisterGenesisAsync(
+            registerId, docket, CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifyGenesis_DocketReferencesUncachedTx_ReturnsFalse()
+    {
+        // Sync race: docket arrived before transactions did. Don't crash, don't
+        // accept — log and reject so the next iteration can try again.
+        var registerId = SystemRegisterConstants.SystemRegisterId;
+        var (verifier, _) = CreateVerifierWithGenesisAndCache();
+
+        var docket = new CachedDocket
+        {
+            RegisterId = registerId,
+            Version = 0,
+            Data = Array.Empty<byte>(),
+            DocketHash = "h",
+            TransactionIds = new List<string> { "deadbeef" }
+        };
+
+        var result = await verifier.VerifySystemRegisterGenesisAsync(
+            registerId, docket, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
     private SystemRegisterSyncVerifier CreateVerifier(string? genesisFile = null)
     {
         var options = Options.Create(new SystemRegisterOptions { GenesisFile = genesisFile });
-        return new SystemRegisterSyncVerifier(options, _cryptoModule.Object, _logger.Object);
+        var cache = new RegisterCache(new Mock<ILogger<RegisterCache>>().Object);
+        return new SystemRegisterSyncVerifier(options, _cryptoModule.Object, cache, _logger.Object);
     }
 
     private SystemRegisterSyncVerifier CreateVerifierWithGenesis()
@@ -146,7 +237,72 @@ public class SystemRegisterSyncVerifierTests : IDisposable
         File.WriteAllText(genesisPath, json);
 
         var options = Options.Create(new SystemRegisterOptions { GenesisFile = genesisPath });
-        return new SystemRegisterSyncVerifier(options, _cryptoModule.Object, _logger.Object);
+        var cache = new RegisterCache(new Mock<ILogger<RegisterCache>>().Object);
+        return new SystemRegisterSyncVerifier(options, _cryptoModule.Object, cache, _logger.Object);
+    }
+
+    private (SystemRegisterSyncVerifier Verifier, RegisterCache Cache) CreateVerifierWithGenesisAndCache()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sync-verifier-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        _tempDirs.Add(tempDir);
+        var genesisPath = Path.Combine(tempDir, "genesis.json");
+
+        var publicKey = new byte[32];
+        Array.Fill(publicKey, (byte)0x01);
+        var fingerprint = Register.Models.Genesis.GenesisFileLoader.ComputeFingerprint(publicKey);
+
+        var payload = System.Text.Encoding.UTF8.GetBytes("{\"registerId\":\"test\"}");
+        var payloadHash = Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(payload)).ToLowerInvariant();
+
+        var genesis = new Register.Models.Genesis.SystemRegisterGenesis
+        {
+            Version = 1,
+            NetworkId = "test",
+            GenesisTransaction = new Register.Models.Genesis.GenesisTransactionData
+            {
+                TxId = Register.Models.Genesis.GenesisSignatureVerifier.ComputeGenesisTxId(),
+                Payload = Convert.ToBase64String(payload),
+                PayloadHash = payloadHash,
+                Signature = new Register.Models.Genesis.GenesisSignature
+                {
+                    PublicKey = Convert.ToBase64String(publicKey),
+                    SignatureValue = Convert.ToBase64String(new byte[64]),
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow
+                }
+            },
+            ValidatorRoster = new Register.Models.ValidatorRoster
+            {
+                Validators =
+                [
+                    new Register.Models.ValidatorRosterEntry
+                    {
+                        ValidatorId = "test",
+                        PublicKey = Convert.ToBase64String(publicKey),
+                        Algorithm = Register.Models.SignatureAlgorithm.ED25519,
+                        DerivationContext = "sorcha:docket-signing",
+                        Status = Register.Models.ValidatorKeyStatus.Active,
+                        AuthorizedAt = DateTimeOffset.UtcNow
+                    }
+                ],
+                RequiredSignatures = 1,
+                Version = 1
+            },
+            GenesisPublicKeyFingerprint = fingerprint
+        };
+        File.WriteAllText(genesisPath, System.Text.Json.JsonSerializer.Serialize(genesis,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+                WriteIndented = true
+            }));
+
+        var options = Options.Create(new SystemRegisterOptions { GenesisFile = genesisPath });
+        var cache = new RegisterCache(new Mock<ILogger<RegisterCache>>().Object);
+        var verifier = new SystemRegisterSyncVerifier(options, _cryptoModule.Object, cache, _logger.Object);
+        return (verifier, cache);
     }
 
     private static CachedDocket CreateEmptyDocket(string registerId)


### PR DESCRIPTION
## Summary
Two consumers of \`CachedDocket.Data\` were parsing it expecting an inline \`transactions[]\` array — but the wire shape (JSON-serialised \`Sorcha.Register.Models.Docket\`) only carries \`TransactionIds\`. Full transactions live in the per-transaction cache, populated alongside the docket by \`RegisterReplicationService\`.

Result: every replicated genesis docket got rejected at \`SystemRegisterSyncVerifier\` Step 0 → docket 1 rejected for "validator key not available" → \`WriteDocketAsync\` never fires → local node never sees the system register. The transport works, the gate is closed.

## What changed
- New \`GenesisControlTransactionLookup\` helper: iterates \`docket.TransactionIds\`, looks each up in \`RegisterCache\`, deserialises the canonical \`TransactionModel\` JSON, returns the first Control-typed one
- \`SystemRegisterSyncVerifier\`: takes \`RegisterCache\` in ctor, uses the lookup; verifies signature against the trusted genesis pubkey/algorithm directly (the persisted \`TransactionModel\` doesn't carry pubkey/algorithm — validator strips them at seal time, so the previous "extract from peer tx" path was always going to be empty post-seal)
- \`DocketFinalizationService.TryExtractValidatorRosterFromDocket\`: same lookup pattern; falls through cleanly when transactions haven't arrived yet (sync race)
- Two new tests cover the gaps the existing fixture missed:
  - \`DocketWithCachedControlTx_ReturnsTrue\` — positive path with realistic canonical TransactionModel JSON in cache
  - \`DocketReferencesUncachedTx_ReturnsFalse\` — sync race, reject cleanly

## Why "use trusted pubkey directly" is safe
The validator persists transactions with \`Signature\` as a Base64Url string + \`SenderWallet\` only — pubkey/algorithm are not preserved. So extracting them from the peer's tx was always going to fail post-seal. Using the local trusted pubkey to verify the peer's signature is strictly more secure: a forged peer can't present a different key, and a tampered payload still fails the cryptographic verify.

## Verification
- [x] Verifier tests 7/7 pass (including the 2 new ones)
- [ ] After Docker Publish: local-from-n1 sync should see Height>0 in MongoDB
- [ ] Validator key extraction (Strategy 1) should succeed → docket 1 finalises → register row appears

## Federation work tally for the day
| PR | Layer | Status |
|----|-------|--------|
| #467 | Pre-create register row pre-seal | shipped |
| #468 | CLI ceremony matches wallet runtime | shipped |
| #469 | Peer sync loop survives signal | shipped |
| this | Verifier reads transactions from right place | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)