### PR TITLE
fix(wallet): close remaining credential-store id-only ambiguity (follow-up to #440/#441)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
@@ -48,14 +48,30 @@ public class CredentialStore : ICredentialStore
     /// <inheritdoc />
     public async Task<CredentialEntity?> GetByIdAsync(string credentialId, CancellationToken ct = default)
     {
-        var credential = await _db.Credentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId, ct);
+        var matches = await _db.Credentials
+            .Where(c => c.Id == credentialId)
+            .ToListAsync(ct);
 
-        if (credential != null)
+        if (matches.Count == 0)
+            return null;
+
+        // Feature 106: issuer and recipient can each hold a row with the same credential id
+        // on single-node deployments. When that happens, prefer the Active copy so verification
+        // sees a valid credential rather than the recipient's PendingAcceptance row. Callers
+        // that know the wallet address should use GetByIdForWalletAsync instead.
+        if (matches.Count > 1)
         {
-            await ExpireStaleCredentialsAsync([credential], ct);
+            _logger.LogWarning(
+                "GetByIdAsync: {Count} rows share credential id {CredentialId} across multiple wallets — " +
+                "use GetByIdForWalletAsync when wallet context is available",
+                matches.Count, credentialId);
         }
 
+        var credential = matches.Count == 1
+            ? matches[0]
+            : matches.FirstOrDefault(c => c.Status == CredentialStatus.Active) ?? matches[0];
+
+        await ExpireStaleCredentialsAsync([credential], ct);
         return credential;
     }
 
@@ -111,10 +127,12 @@ public class CredentialStore : ICredentialStore
     }
 
     /// <inheritdoc />
-    public async Task<bool> DeleteAsync(string credentialId, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(string credentialId, string walletAddress, CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
         var credential = await _db.Credentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId, ct);
+            .FirstOrDefaultAsync(c => c.Id == credentialId && c.WalletAddress == walletAddress, ct);
 
         if (credential == null)
             return false;
@@ -125,18 +143,22 @@ public class CredentialStore : ICredentialStore
     }
 
     /// <inheritdoc />
-    public async Task<bool> UpdateStatusAsync(string credentialId, CredentialStatus status, CancellationToken ct = default)
+    public async Task<bool> UpdateStatusAsync(
+        string credentialId, string walletAddress, CredentialStatus status, CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
         var credential = await _db.Credentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId, ct);
+            .FirstOrDefaultAsync(c => c.Id == credentialId && c.WalletAddress == walletAddress, ct);
 
         if (credential == null)
             return false;
 
         if (!IsValidTransition(credential.Status, status))
         {
-            _logger.LogWarning("Invalid status transition for {CredentialId}: {CurrentStatus} -> {TargetStatus}",
-                credentialId, credential.Status, status);
+            _logger.LogWarning(
+                "Invalid status transition for {CredentialId} wallet {WalletAddress}: {CurrentStatus} -> {TargetStatus}",
+                credentialId, walletAddress, credential.Status, status);
             return false;
         }
 
@@ -144,8 +166,9 @@ public class CredentialStore : ICredentialStore
         credential.Status = status;
         await _db.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Credential status changed: {CredentialId} {PreviousStatus} -> {NewStatus}",
-            credentialId, previousStatus, status);
+        _logger.LogInformation(
+            "Credential status changed: {CredentialId} wallet {WalletAddress} {PreviousStatus} -> {NewStatus}",
+            credentialId, walletAddress, previousStatus, status);
         return true;
     }
 
@@ -225,8 +248,23 @@ public class CredentialStore : ICredentialStore
     /// <inheritdoc />
     public async Task<bool> RecordPresentationAsync(string credentialId, CancellationToken ct = default)
     {
-        var credential = await _db.Credentials
-            .FirstOrDefaultAsync(c => c.Id == credentialId, ct);
+        var matches = await _db.Credentials
+            .Where(c => c.Id == credentialId)
+            .ToListAsync(ct);
+
+        // Feature 106: when issuer and recipient hold the same credential id, prefer the
+        // Active copy so usage is recorded against a valid row. Log so operators are aware.
+        if (matches.Count > 1)
+        {
+            _logger.LogWarning(
+                "RecordPresentationAsync: {Count} rows share credential id {CredentialId} — " +
+                "operating on first Active copy; use wallet-scoped access when wallet context is available",
+                matches.Count, credentialId);
+        }
+
+        var credential = matches.Count == 1
+            ? matches[0]
+            : matches.FirstOrDefault(c => c.Status == CredentialStatus.Active);
 
         if (credential == null || credential.Status != CredentialStatus.Active)
             return false;

--- a/src/Services/Sorcha.Wallet.Service/Credentials/ICredentialStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/ICredentialStore.cs
@@ -16,10 +16,10 @@ public interface ICredentialStore
     Task<IReadOnlyList<CredentialEntity>> GetByWalletAsync(string walletAddress, CancellationToken ct = default);
 
     /// <summary>
-    /// Gets a credential by its ID. Returns the first match across wallets — use
-    /// <see cref="GetByIdForWalletAsync"/> when a specific wallet's copy is required
-    /// (e.g. Feature 106 InboundCredentialDetector dedup, where both issuer and
-    /// recipient hold rows with the same credential id on single-node deployments).
+    /// Gets a credential by its ID. When a single row matches, returns it. When multiple rows
+    /// share the same ID (issuer and recipient wallets on the same node — see Feature 106),
+    /// returns the first Active copy and logs a warning; callers that have a wallet address
+    /// MUST prefer <see cref="GetByIdForWalletAsync"/> for deterministic results.
     /// </summary>
     Task<CredentialEntity?> GetByIdAsync(string credentialId, CancellationToken ct = default);
 
@@ -38,15 +38,20 @@ public interface ICredentialStore
     Task StoreAsync(CredentialEntity credential, CancellationToken ct = default);
 
     /// <summary>
-    /// Deletes a credential from the wallet store.
+    /// Deletes a credential from the wallet store. Scoped to the given wallet address so that
+    /// only the matching <c>(credentialId, walletAddress)</c> row is removed — credential IDs
+    /// are not globally unique when the same credential is held by both issuer and recipient.
+    /// Returns <c>false</c> if no matching row exists.
     /// </summary>
-    Task<bool> DeleteAsync(string credentialId, CancellationToken ct = default);
+    Task<bool> DeleteAsync(string credentialId, string walletAddress, CancellationToken ct = default);
 
     /// <summary>
-    /// Updates the status of a credential (e.g., Active → Revoked). Enforces the state machine
-    /// defined on <see cref="CredentialStatus"/>; returns false on disallowed transitions.
+    /// Updates the status of a credential (e.g., Active → Revoked). Scoped to the given wallet
+    /// address so that only the <c>(credentialId, walletAddress)</c> row is modified. Enforces
+    /// the state machine defined on <see cref="CredentialStatus"/>; returns false on disallowed
+    /// transitions or if no matching row exists.
     /// </summary>
-    Task<bool> UpdateStatusAsync(string credentialId, CredentialStatus status, CancellationToken ct = default);
+    Task<bool> UpdateStatusAsync(string credentialId, string walletAddress, CredentialStatus status, CancellationToken ct = default);
 
     /// <summary>
     /// Feature 106 — transitions a credential's status and returns the updated row.
@@ -76,7 +81,10 @@ public interface ICredentialStore
     /// <summary>
     /// Records a credential presentation, incrementing the count and consuming
     /// the credential if its usage policy limit has been reached.
-    /// Returns true if the credential was consumed by this presentation.
+    /// Returns <c>true</c> if the credential was consumed by this presentation.
+    /// When multiple rows share the same ID (issuer and recipient on the same node),
+    /// operates on the first Active copy and logs a warning; callers that have wallet
+    /// context should use <see cref="GetByIdForWalletAsync"/> and update state directly.
     /// </summary>
     Task<bool> RecordPresentationAsync(string credentialId, CancellationToken ct = default);
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -260,13 +260,11 @@ public static class CredentialEndpoints
         ICredentialStore store,
         CancellationToken cancellationToken = default)
     {
-        var credential = await store.GetByIdForWalletAsync(credentialId, walletAddress, cancellationToken);
-
-        if (credential == null)
-            return Results.NotFound();
-
-        await store.DeleteAsync(credentialId, cancellationToken);
-        return Results.NoContent();
+        // Wallet-scoped delete — credential IDs are not globally unique (Feature 106).
+        // DeleteAsync(credentialId, walletAddress) performs the composite-key lookup and
+        // delete atomically, removing the TOCTOU window of the former pre-check + delete pair.
+        var deleted = await store.DeleteAsync(credentialId, walletAddress, cancellationToken);
+        return deleted ? Results.NoContent() : Results.NotFound();
     }
 
     private static async Task<IResult> ExportCredential(
@@ -355,7 +353,7 @@ public static class CredentialEndpoints
             return Results.NotFound();
 
         var previousStatus = credential.Status;
-        var updated = await store.UpdateStatusAsync(credentialId, targetStatus, cancellationToken);
+        var updated = await store.UpdateStatusAsync(credentialId, walletAddress, targetStatus, cancellationToken);
 
         if (!updated)
             return Results.BadRequest(new { error = $"Invalid status transition from {previousStatus} to {targetStatus}" });

--- a/src/Services/Sorcha.Wallet.Service/Services/PresentationRequestService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/PresentationRequestService.cs
@@ -246,8 +246,13 @@ public class PresentationRequestService : IPresentationRequestService
     {
         var errors = new List<VerificationError>();
 
-        // 1. Look up credential
-        var credential = await _credentialStore.GetByIdAsync(credentialId, ct);
+        // 1. Look up credential — prefer wallet-scoped lookup when the presentation request
+        //    carries a TargetWalletAddress so we never accidentally verify the issuer's copy
+        //    instead of the holder's (Feature 106: same credential id can appear in both wallets).
+        var credential = request.TargetWalletAddress is not null
+            ? await _credentialStore.GetByIdForWalletAsync(credentialId, request.TargetWalletAddress, ct)
+            : await _credentialStore.GetByIdAsync(credentialId, ct);
+
         if (credential == null)
         {
             errors.Add(new VerificationError

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialLifecycleTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialLifecycleTests.cs
@@ -64,7 +64,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential();
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Suspended);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Suspended);
 
         result.Should().BeTrue();
         var updated = await _store.GetByIdAsync("cred-1");
@@ -77,7 +77,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential(status: CredentialStatus.Suspended);
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Active);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Active);
 
         result.Should().BeTrue();
         var updated = await _store.GetByIdAsync("cred-1");
@@ -90,7 +90,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential();
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Revoked);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Revoked);
 
         result.Should().BeTrue();
     }
@@ -101,7 +101,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential(status: CredentialStatus.Suspended);
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Revoked);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Revoked);
 
         result.Should().BeTrue();
     }
@@ -112,7 +112,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential(status: CredentialStatus.Revoked);
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Active);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Active);
 
         result.Should().BeFalse();
         var unchanged = await _store.GetByIdAsync("cred-1");
@@ -125,7 +125,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential(status: CredentialStatus.Expired);
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Active);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Active);
 
         result.Should().BeFalse();
     }
@@ -136,7 +136,7 @@ public class CredentialLifecycleTests : IDisposable
         var cred = CreateCredential(status: CredentialStatus.Consumed);
         await _store.StoreAsync(cred);
 
-        var result = await _store.UpdateStatusAsync("cred-1", CredentialStatus.Active);
+        var result = await _store.UpdateStatusAsync("cred-1", "wallet-1", CredentialStatus.Active);
 
         result.Should().BeFalse();
     }

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialStoreTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialStoreTests.cs
@@ -63,7 +63,8 @@ public class CredentialStoreTests : IDisposable
 
         await _store.StoreAsync(credential);
 
-        var stored = await _db.Credentials.FindAsync("cred-1");
+        var stored = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-1" && c.WalletAddress == "wallet-1");
         stored.Should().NotBeNull();
         stored!.Type.Should().Be("LicenseCredential");
         stored.IssuerDid.Should().Be("did:sorcha:issuer:gov");
@@ -79,7 +80,8 @@ public class CredentialStoreTests : IDisposable
         updated.Status = CredentialStatus.Revoked;
         await _store.StoreAsync(updated);
 
-        var stored = await _db.Credentials.FindAsync("cred-1");
+        var stored = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-1" && c.WalletAddress == "wallet-1");
         stored.Should().NotBeNull();
         stored!.Status.Should().Be(CredentialStatus.Revoked);
     }
@@ -136,21 +138,35 @@ public class CredentialStoreTests : IDisposable
     [Fact]
     public async Task DeleteAsync_ExistingCredential_ReturnsTrue()
     {
-        await _store.StoreAsync(CreateCredential("cred-1"));
+        await _store.StoreAsync(CreateCredential("cred-1", walletAddress: "wallet-1"));
 
-        var deleted = await _store.DeleteAsync("cred-1");
+        var deleted = await _store.DeleteAsync("cred-1", "wallet-1");
 
         deleted.Should().BeTrue();
-        var afterDelete = await _db.Credentials.FindAsync("cred-1");
+        var afterDelete = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-1" && c.WalletAddress == "wallet-1");
         afterDelete.Should().BeNull();
     }
 
     [Fact]
     public async Task DeleteAsync_NonExistentCredential_ReturnsFalse()
     {
-        var deleted = await _store.DeleteAsync("does-not-exist");
+        var deleted = await _store.DeleteAsync("does-not-exist", "wallet-1");
 
         deleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WrongWallet_ReturnsFalseAndLeavesOtherRow()
+    {
+        await _store.StoreAsync(CreateCredential("cred-1", walletAddress: "wallet-issuer"));
+
+        var deleted = await _store.DeleteAsync("cred-1", "wallet-other");
+
+        deleted.Should().BeFalse();
+        var issuerRow = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-1" && c.WalletAddress == "wallet-issuer");
+        issuerRow.Should().NotBeNull();
     }
 
     [Fact]
@@ -211,6 +227,80 @@ public class CredentialStoreTests : IDisposable
 
         results.Should().ContainSingle();
     }
+
+    // ===== Feature 106 disambiguation — same credential id held by issuer and recipient =====
+
+    [Fact]
+    public async Task DeleteAsync_DualWallet_OnlyDeletesTargetRow()
+    {
+        // Issuer stores "cred-dup" as Active; recipient receives it as PendingAcceptance.
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-issuer"));
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-recipient",
+            status: CredentialStatus.PendingAcceptance));
+
+        var deleted = await _store.DeleteAsync("cred-dup", "wallet-recipient");
+
+        deleted.Should().BeTrue();
+        var issuerRow = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-dup" && c.WalletAddress == "wallet-issuer");
+        issuerRow.Should().NotBeNull("issuer row must survive the recipient's delete");
+        var recipientRow = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-dup" && c.WalletAddress == "wallet-recipient");
+        recipientRow.Should().BeNull("recipient row should have been removed");
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_DualWallet_OnlyUpdatesTargetRow()
+    {
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-issuer"));
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-recipient"));
+
+        var updated = await _store.UpdateStatusAsync("cred-dup", "wallet-recipient", CredentialStatus.Revoked);
+
+        updated.Should().BeTrue();
+        var issuerRow = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-dup" && c.WalletAddress == "wallet-issuer");
+        issuerRow!.Status.Should().Be(CredentialStatus.Active, "issuer row must be unaffected");
+        var recipientRow = await _db.Credentials
+            .FirstOrDefaultAsync(c => c.Id == "cred-dup" && c.WalletAddress == "wallet-recipient");
+        recipientRow!.Status.Should().Be(CredentialStatus.Revoked, "recipient row should be revoked");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_DualWallet_PrefersActiveRow()
+    {
+        // Issuer's copy is Active; recipient's copy is PendingAcceptance.
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-issuer"));
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-recipient",
+            status: CredentialStatus.PendingAcceptance));
+
+        var result = await _store.GetByIdAsync("cred-dup");
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(CredentialStatus.Active,
+            "GetByIdAsync must prefer the Active row when multiple exist");
+        result.WalletAddress.Should().Be("wallet-issuer");
+    }
+
+    [Fact]
+    public async Task RecordPresentationAsync_DualWallet_OperatesOnActiveRow()
+    {
+        // Both wallets have Active copies of the same credential.
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-issuer",
+            type: "TradeFinanceCertificate"));
+        await _store.StoreAsync(CreateCredential("cred-dup", walletAddress: "wallet-recipient",
+            type: "TradeFinanceCertificate"));
+
+        var consumed = await _store.RecordPresentationAsync("cred-dup");
+
+        // At least one Active row must have its count incremented.
+        var rows = await _db.Credentials
+            .Where(c => c.Id == "cred-dup")
+            .ToListAsync();
+        rows.Sum(r => r.PresentationCount).Should().Be(1,
+            "exactly one row should have been incremented");
+        consumed.Should().BeFalse("Reusable policy never consumes");
+    }
 }
 
 /// <summary>
@@ -234,10 +324,11 @@ internal class TestCredentialDbContext : WalletDbContext
         modelBuilder.Ignore<WalletAccess>();
         modelBuilder.Ignore<WalletTransaction>();
 
-        // Only configure the Credential entity
+        // Only configure the Credential entity. Use the same composite key as the real schema
+        // so that disambiguation tests can store two rows sharing an Id across different wallets.
         modelBuilder.Entity<CredentialEntity>(entity =>
         {
-            entity.HasKey(e => e.Id);
+            entity.HasKey(e => new { e.Id, e.WalletAddress });
             entity.Property(e => e.Type).IsRequired();
             entity.Property(e => e.IssuerDid).IsRequired();
             entity.Property(e => e.SubjectDid).IsRequired();


### PR DESCRIPTION
## Context

PRs #440 and #441 closed the credential id-only ambiguity at the endpoint layer and in `PatchStatusAsync`, respectively. Four methods in `ICredentialStore` / `CredentialStore` were not covered by those PRs and still used id-only EF queries:

| Method | Risk |
|---|---|
| `DeleteAsync` | Would delete an **arbitrary** one of the two rows (issuer vs recipient) — highest risk |
| `UpdateStatusAsync` | Would update status on the wrong wallet's copy |
| `GetByIdAsync` | Could return the issuer's row instead of the holder's during presentation verification |
| `RecordPresentationAsync` | Could increment the presentation count on the wrong copy |

The duplicate-row pattern (issuer Active + recipient PendingAcceptance/Active sharing the same `credentialId`) was confirmed by the TradeFinance walkthrough in late April 2026.

---

## Design chosen

The two candidate approaches were:

1. **Interface change** — add `walletAddress` to each signature, update every call site.
2. **Defence-in-depth** — keep signatures, internally guard against ambiguous matches.

**Verdict: mixed.** The choice depends on whether the call site has wallet context.

### `DeleteAsync` and `UpdateStatusAsync` — full interface change

Both are only called from `CredentialEndpoints`, which always has `walletAddress` from the URL route. Adding the parameter is trivial and eliminates the TOCTOU window that existed when `DeleteCredential` did a `GetByIdForWalletAsync` pre-check followed by an id-only `DeleteAsync`.

```csharp
// Before (TOCTOU window)
var credential = await store.GetByIdForWalletAsync(credentialId, walletAddress, ct);
if (credential == null) return Results.NotFound();
await store.DeleteAsync(credentialId, ct);          // ← could delete the other wallet's row

// After (atomic wallet-scoped delete)
var deleted = await store.DeleteAsync(credentialId, walletAddress, ct);
return deleted ? Results.NoContent() : Results.NotFound();
```

### `GetByIdAsync` and `RecordPresentationAsync` — defence-in-depth

The presentation-submission flow (`PresentationEndpoints → PresentationRequestService.SubmitPresentationAsync → VerifyPresentationAsync`) does not carry `walletAddress` at the service layer. Changing the method signatures would require cascading `walletAddress` through `IPresentationRequestService.SubmitPresentationAsync` and `SubmitPresentationBody`, which is a larger API change outside this PR's scope.

Instead:
- Both methods now load **all** rows matching the credential id via `Where + ToListAsync`.
- When exactly one row exists (normal case) — behaviour unchanged.
- When multiple rows exist — a `LogWarning` fires and the **first Active copy** is preferred over a PendingAcceptance row, making the behaviour deterministic and consistent with the holder having already accepted the credential before presenting it.
- The `ICredentialStore` XML docs are updated to document this contract.

### Bonus: `PresentationRequestService.VerifyPresentationAsync`

When the presentation request carries a `TargetWalletAddress` (set by the verifier), `VerifyPresentationAsync` now calls `GetByIdForWalletAsync` instead of `GetByIdAsync`, so targeted presentations always verify the holder's own copy regardless of what the issuer's row looks like.

---

## Files changed

| File | Change |
|---|---|
| `Credentials/ICredentialStore.cs` | `DeleteAsync` + `UpdateStatusAsync` gain `walletAddress`; XML docs on all four methods updated |
| `Credentials/CredentialStore.cs` | Composite-key EF queries for `Delete`/`UpdateStatus`; `ToListAsync` + Active-preference guard for `GetById`/`RecordPresentation` |
| `Endpoints/CredentialEndpoints.cs` | `DeleteCredential` simplified to single atomic call; `UpdateCredentialStatus` passes `walletAddress` |
| `Services/PresentationRequestService.cs` | `VerifyPresentationAsync` uses `GetByIdForWalletAsync` when `TargetWalletAddress` is set |
| `Tests/CredentialStoreTests.cs` | Updated signatures; `TestCredentialDbContext` switched to composite `(Id, WalletAddress)` key; 4 new dual-wallet disambiguation tests |
| `Tests/CredentialLifecycleTests.cs` | Updated `UpdateStatusAsync` call sites to pass `walletAddress` |

---

## Test plan

- [ ] `dotnet build src/Services/Sorcha.Wallet.Service/Sorcha.Wallet.Service.csproj` — clean (no compiler errors)
- [ ] `dotnet test tests/Sorcha.Wallet.Service.Tests/` — all existing tests pass
- [ ] New tests pass: `DeleteAsync_DualWallet_OnlyDeletesTargetRow`, `UpdateStatusAsync_DualWallet_OnlyUpdatesTargetRow`, `GetByIdAsync_DualWallet_PrefersActiveRow`, `RecordPresentationAsync_DualWallet_OperatesOnActiveRow`
- [ ] TradeFinance walkthrough credential-fetch step succeeds end-to-end (manual smoke test)
- [ ] Confirm no regressions in `PresentationRequestServiceTests` (all mock setups use requests with no `TargetWalletAddress` → code path unchanged)

---

## What this PR does NOT address

- `RecordPresentationAsync` still operates without explicit wallet scoping. A follow-up PR can thread `walletAddress` through `IPresentationRequestService.SubmitPresentationAsync` and `SubmitPresentationBody` when that API change is accepted.
- The `GetByIdAsync` id-only fallback path remains for open presentation requests (no `TargetWalletAddress`). The defence-in-depth guard makes it safe in practice; callers with wallet context should migrate to `GetByIdForWalletAsync`.

https://claude.ai/code/session_016DTDrbBAtTQJKh4trLRKVr

---
_Generated by [Claude Code](https://claude.ai/code/session_016DTDrbBAtTQJKh4trLRKVr)_