### PR TITLE
fix(ui): [#339] DateTimeFieldBoundResolver throws on unknown boundName

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/DateTimeFieldBoundResolver.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/Forms/DateTimeFieldBoundResolver.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -51,14 +50,16 @@ public static class DateTimeFieldBoundResolver
             return false;
 
         // Contract: callers pass the literal strings "formatMinimum" /
-        // "formatMaximum". A Debug.Assert surfaces caller-side typos as a
-        // test-visible failure rather than a silent no-op on a production
-        // build — which matters because a silent no-op would un-bound the
-        // picker and let the citizen pick a forbidden date with no
-        // client-side signal.
-        Debug.Assert(
-            boundName is "formatMinimum" or "formatMaximum",
-            $"Unknown boundName '{boundName}' — expected 'formatMinimum' or 'formatMaximum'.");
+        // "formatMaximum". Throw on typo so the bug surfaces in Release
+        // builds (Blazor WASM ships Release; Debug.Assert is stripped) —
+        // a silent no-op would un-bound the picker and let the citizen
+        // pick a forbidden date with no client-side signal.
+        if (boundName is not ("formatMinimum" or "formatMaximum"))
+        {
+            throw new ArgumentException(
+                $"Unknown boundName '{boundName}' — expected 'formatMinimum' or 'formatMaximum'.",
+                nameof(boundName));
+        }
 
         if (!propertySchema.TryGetProperty(boundName, out var boundElement))
             return false;

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/DateTimeRendererFutureBlockTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/DateTimeRendererFutureBlockTests.cs
@@ -114,4 +114,21 @@ public class DateTimeRendererFutureBlockTests
             .Should().BeFalse();
         bound.Should().BeNull();
     }
+
+    // --- Caller-side typo → throws (Release WASM strips Debug.Assert; #339) ---
+
+    [Theory]
+    [InlineData("formatMin")]
+    [InlineData("FormatMaximum")]
+    [InlineData("")]
+    public void TryResolveBound_UnknownBoundName_ThrowsArgumentException(string boundName)
+    {
+        var schema = Schema("""{ "type": "string", "format": "date", "formatMaximum": "today" }""");
+
+        var act = () => DateTimeFieldBoundResolver.TryResolveBound(schema, boundName, FixedToday, out _);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage($"Unknown boundName '{boundName}'*")
+            .And.ParamName.Should().Be("boundName");
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces `Debug.Assert` with `ArgumentException` in `DateTimeFieldBoundResolver.TryResolveBound`.
- `Debug.Assert` is stripped in Release builds; Blazor WASM ships Release. A caller-side typo (e.g. `"formatMin"`) would silently un-bound the date picker — no client-side signal, citizen could pick a forbidden date. Server-side validation remains authoritative so no production harm has occurred, but the failure mode was invisible.
- Added regression `Theory` covering typos, casing variants, and empty string.

## Test plan
- [x] `dotnet test tests/Sorcha.UI.Core.Tests` — 1167 passing
- [x] New `TryResolveBound_UnknownBoundName_ThrowsArgumentException` covers `"formatMin"`, `"FormatMaximum"`, `""`

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)