### PR TITLE
fix(peer): [#473] kill 5-min stutter in Subscribing→Syncing transition

### DIFF
--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -356,7 +356,7 @@ public class RegisterSyncBackgroundService : BackgroundService
         return sub;
     }
 
-    private async Task ProcessSubscriptionsAsync(CancellationToken cancellationToken)
+    internal async Task ProcessSubscriptionsAsync(CancellationToken cancellationToken)
     {
         foreach (var (registerId, subscription) in _subscriptions.ToList())
         {
@@ -381,10 +381,18 @@ public class RegisterSyncBackgroundService : BackgroundService
         switch (subscription.SyncState)
         {
             case RegisterSyncState.Subscribing:
-                // Transition based on mode
+                // Transition based on mode (FullReplica → Syncing, ForwardOnly → Active).
                 subscription.TransitionToNextState();
                 await PersistSubscriptionAsync(subscription, cancellationToken);
                 await ReportSyncStatusAsync(subscription.RegisterId, subscription.SyncState, cancellationToken);
+
+                // #473: re-fire the immediate-sync signal so the new state is
+                // processed in the same iteration burst rather than waiting a
+                // full PeriodicSyncIntervalMinutes (default 5 min). Without
+                // this, a fresh subscription stutters: iteration 1 transitions
+                // Subscribing→Syncing and returns; the actual PullFullReplica
+                // doesn't happen until iteration 2, after the periodic delay.
+                _immediateSyncSignal.Set();
                 break;
 
             case RegisterSyncState.Syncing:
@@ -398,6 +406,9 @@ public class RegisterSyncBackgroundService : BackgroundService
                         "Register {RegisterId} fully replicated ({Dockets} dockets, {Txs} transactions)",
                         subscription.RegisterId, result.DocketsSynced, result.TransactionsSynced);
                     await ReportSyncStatusAsync(subscription.RegisterId, subscription.SyncState, cancellationToken);
+                    // Same rationale as Subscribing → kick the loop so EnsureLiveSubscription
+                    // for the FullyReplicated state runs without another 5-min wait.
+                    _immediateSyncSignal.Set();
                 }
                 await PersistSubscriptionAsync(subscription, cancellationToken);
                 break;
@@ -417,9 +428,22 @@ public class RegisterSyncBackgroundService : BackgroundService
                         subscription.RegisterId, subscription.ConsecutiveFailures);
                     subscription.SyncState = RegisterSyncState.Subscribing;
                     await PersistSubscriptionAsync(subscription, cancellationToken);
+                    _immediateSyncSignal.Set();
                 }
                 break;
         }
+    }
+
+    /// <summary>
+    /// Test seam: returns true and resets the immediate-sync signal if it was
+    /// set, otherwise returns false. Used by regression tests for #473 to
+    /// assert the signal is re-fired on state transitions.
+    /// </summary>
+    internal bool ConsumeImmediateSyncSignal()
+    {
+        if (!_immediateSyncSignal.IsSet) return false;
+        _immediateSyncSignal.Reset();
+        return true;
     }
 
     /// <summary>

--- a/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSyncBackgroundServiceTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSyncBackgroundServiceTests.cs
@@ -212,6 +212,43 @@ public class RegisterSyncBackgroundServiceTests : IDisposable
         semaphore.Release();
     }
 
+    // --- #473: Subscribing → Syncing transition must re-fire the immediate-sync
+    // signal so PullFullReplicaAsync runs in the same iteration burst, not after
+    // a full PeriodicSyncIntervalMinutes (default 5 min) wait. ---
+
+    [Fact]
+    public async Task SubscribeToRegisterAsync_SetsImmediateSyncSignal()
+    {
+        // Drain anything left over from the test fixture.
+        _service.ConsumeImmediateSyncSignal();
+
+        await _service.SubscribeToRegisterAsync("reg-1", ReplicationMode.FullReplica);
+
+        _service.ConsumeImmediateSyncSignal()
+            .Should().BeTrue("subscribe must wake the sync loop");
+    }
+
+    [Fact]
+    public async Task ProcessSubscriptionsAsync_SubscribingToSyncing_ResignalsImmediateSync()
+    {
+        await _service.SubscribeToRegisterAsync("reg-1", ReplicationMode.FullReplica);
+
+        // Drain the signal that SubscribeToRegisterAsync sets, so we measure
+        // only what ProcessSubscriptionsAsync re-fires.
+        _service.ConsumeImmediateSyncSignal().Should().BeTrue();
+
+        await _service.ProcessSubscriptionsAsync(CancellationToken.None);
+
+        _service.GetSubscription("reg-1")!.SyncState
+            .Should().Be(RegisterSyncState.Syncing,
+                "FullReplica.Subscribing transitions to Syncing");
+        _service.ConsumeImmediateSyncSignal()
+            .Should().BeTrue(
+                "the Subscribing→Syncing transition must re-fire the signal " +
+                "so the next iteration runs PullFullReplicaAsync immediately " +
+                "rather than waiting for the periodic timer (#473)");
+    }
+
     public void Dispose()
     {
         _service.Dispose();


### PR DESCRIPTION
## Summary
- `ProcessSubscriptionAsync` is a single-state-per-call state machine. After `SubscribeToRegisterAsync` fires the immediate-sync signal: iteration 1 transitions Subscribing→Syncing and returns *without pulling*. Iteration 2 — after a full `PeriodicSyncIntervalMinutes` (default 5 min) — actually calls `PullFullReplicaAsync`.
- Pre-PR #469 the loop's exception handler accidentally compressed the stutter to ~30s. The Task.Delay rewrite in #469 exposed the full 5-min wait the config asks for.
- Fix per the issue's Option B — re-fire `_immediateSyncSignal` on every state transition that produces more work (Subscribing→Syncing, Syncing→FullyReplicated, Error retry). The outer loop's WhenAny/Reset cycle then iterates immediately rather than waiting on the periodic timer.

## Test plan
- [x] `dotnet test tests/Sorcha.Peer.Service.Tests` — 679 passing
- [x] New `SubscribeToRegisterAsync_SetsImmediateSyncSignal` — covers initial signal fire
- [x] New `ProcessSubscriptionsAsync_SubscribingToSyncing_ResignalsImmediateSync` — locks in the regression-guard for #473

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)