### PR TITLE
perf(ui): [#341] reuse canvas in photo-token-resizer + document blob-URL assumption

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/wwwroot/js/photo-token-resizer.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/wwwroot/js/photo-token-resizer.js
@@ -6,19 +6,33 @@
 // encodes as JPEG at the requested quality, and returns the raw byte array.
 // The C# PhotoTokenResizer drives the quality-stepping loop.
 
+// Reused across quality steps (up to 5 per upload) — saves GC churn on
+// low-end mobile during camera capture.
+let sharedCanvas = null;
+
+function getCanvas(width, height) {
+    if (!sharedCanvas) {
+        sharedCanvas = document.createElement('canvas');
+    }
+    sharedCanvas.width = width;
+    sharedCanvas.height = height;
+    return sharedCanvas;
+}
+
 export async function resizeAndEncodeJpeg(sourceBytes, width, height, quality) {
     const blob = new Blob([new Uint8Array(sourceBytes)]);
     const url = URL.createObjectURL(blob);
     try {
         const image = await loadImage(url);
 
-        const canvas = document.createElement('canvas');
-        canvas.width = width;
-        canvas.height = height;
+        const canvas = getCanvas(width, height);
         const ctx = canvas.getContext('2d');
         if (!ctx) {
             throw new Error('2D canvas context not available.');
         }
+        // Setting width/height implicitly clears the canvas, but be explicit
+        // for the case where width and height match the previous step.
+        ctx.clearRect(0, 0, width, height);
 
         // Cover-style scaling — compute the scale so the image fills the
         // target exactly, then centre-crop the overflow.
@@ -46,6 +60,12 @@ export async function resizeAndEncodeJpeg(sourceBytes, width, height, quality) {
 function loadImage(src) {
     return new Promise((resolve, reject) => {
         const img = new Image();
+        // Sources are blob: URLs (same-origin, see resizeAndEncodeJpeg) so the
+        // canvas is not tainted and toBlob() succeeds. If a future change
+        // routes pre-signed cross-origin URLs through here, set
+        // img.crossOrigin = 'anonymous' before assigning src and ensure the
+        // remote responds with Access-Control-Allow-Origin, otherwise
+        // canvas.toBlob will throw a SecurityError.
         img.onload = () => resolve(img);
         img.onerror = (e) => reject(new Error(`Image load failed: ${e?.type ?? 'unknown error'}`));
         img.src = src;


### PR DESCRIPTION
## Summary
- Cache module-level `<canvas>` across quality steps (up to 5 per upload). Saves GC churn on low-end mobile during camera capture.
- Add comment in `loadImage()` documenting the same-origin blob: URL assumption and what to set if the source ever becomes a pre-signed cross-origin URL.

Closes #341

## Test plan
- [x] No tests around this file (client-side JS, exercised live during portrait upload). Manual verification on the AssuredIdentity flow on next n1 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)