### PR TITLE
refactor(blueprint-models): [#336] move shared validation warning codes to Blueprint.Models

### DIFF
--- a/src/Common/Sorcha.Blueprint.Models/ValidationWarningCodes.cs
+++ b/src/Common/Sorcha.Blueprint.Models/ValidationWarningCodes.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Blueprint.Models;
+
+/// <summary>
+/// Canonical string constants for validation warning codes shared between
+/// services that publish or consume blueprint extensions. New codes that
+/// cross service boundaries belong here so consumers can reference them by
+/// symbol instead of duplicating string literals.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Service-internal validator codes (e.g. <c>VAL_BP_010</c>,
+/// <c>VAL_BP_CRED_*</c>) live alongside the rules that emit them and are
+/// not in scope here.
+/// </para>
+/// </remarks>
+public static class ValidationWarningCodes
+{
+    /// <summary>
+    /// Blueprint publish <b>warning</b> (non-blocking): an <c>x-review</c> page
+    /// declares a <c>layout</c> value the renderer does not recognise. The blueprint
+    /// still publishes and the UI falls back to a tabular minimal review rather than
+    /// the requested card variant.
+    /// </summary>
+    /// <remarks>
+    /// Contract: <c>specs/107-assured-identity-v1/contracts/x-review-extension.md</c>.
+    /// </remarks>
+    public const string ReviewLayoutUnknown = "WARN_BP_REVIEW_001";
+
+    /// <summary>
+    /// Credential issuance <b>warning</b> (non-blocking): the portrait
+    /// <c>tokenImageBase64</c> source field exceeded the ~27KB base64 size bound.
+    /// The credential is still issued but the <c>portrait</c> claim is omitted;
+    /// the citizen is surfaced a warning so they can re-capture if desired.
+    /// </summary>
+    /// <remarks>
+    /// Contract: <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>.
+    /// </remarks>
+    public const string CredentialPortraitOversize = "WARN_CRED_PORTRAIT_OVERSIZE_001";
+}

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -16,6 +16,7 @@ using Sorcha.ServiceClients.Register.Models;
 using Sorcha.ServiceClients.Validator;
 using Sorcha.ServiceClients.Haip;
 using Sorcha.Blueprint.Engine.Credentials;
+using Sorcha.Blueprint.Models;
 using Sorcha.Blueprint.Engine.Interfaces;
 using Sorcha.Blueprint.Models.Credentials;
 using Sorcha.Blueprint.Service.Models;
@@ -1706,7 +1707,7 @@ public class ActionExecutionService : IActionExecutionService
                         "({ActualChars} chars); dropping claim and issuing credential without portrait. " +
                         "Warning code: {WarningCode}",
                         mapping.ClaimName, PortraitTokenMaxBase64Chars, portraitBase64.Length,
-                        PortraitOversizeWarningCode);
+                        ValidationWarningCodes.CredentialPortraitOversize);
                     continue;
                 }
 
@@ -1737,14 +1738,6 @@ public class ActionExecutionService : IActionExecutionService
     /// ships in the SD-JWT.
     /// </summary>
     private const int PortraitTokenMaxBase64Chars = 27_000;
-
-    /// <summary>
-    /// Local duplicate of <c>ValidationErrorCodes.CredentialPortraitOversize</c>
-    /// (defined in <c>Sorcha.Validator.Service</c>). Blueprint.Service does not
-    /// reference Validator.Service, so the code is stringified here with this
-    /// explicit comment binding the two — if either side is renamed, fix both.
-    /// </summary>
-    private const string PortraitOversizeWarningCode = "WARN_CRED_PORTRAIT_OVERSIZE_001";
 
     /// <summary>
     /// Treats any claim mapping whose source pointer ends in

--- a/src/Services/Sorcha.Validator.Service/Models/ValidationErrorCodes.cs
+++ b/src/Services/Sorcha.Validator.Service/Models/ValidationErrorCodes.cs
@@ -60,26 +60,7 @@ public static class ValidationErrorCodes
     public const string SorchaLocalWalletRejectNotTerminal = "VAL_BP_CRED_003";
 
     // ---- Feature 107: Assured Identity v1 ----
-
-    /// <summary>
-    /// Blueprint publish <b>warning</b> (non-blocking): an <c>x-review</c> page
-    /// declares a <c>layout</c> value the renderer does not recognise. The blueprint
-    /// still publishes and the UI falls back to a tabular minimal review rather than
-    /// the requested card variant.
-    /// </summary>
-    /// <remarks>
-    /// Contract: <c>specs/107-assured-identity-v1/contracts/x-review-extension.md</c>.
-    /// </remarks>
-    public const string ReviewLayoutUnknown = "WARN_BP_REVIEW_001";
-
-    /// <summary>
-    /// Credential issuance <b>warning</b> (non-blocking): the portrait
-    /// <c>tokenImageBase64</c> source field exceeded the ~27KB base64 size bound.
-    /// The credential is still issued but the <c>portrait</c> claim is omitted;
-    /// the citizen is surfaced a warning so they can re-capture if desired.
-    /// </summary>
-    /// <remarks>
-    /// Contract: <c>specs/107-assured-identity-v1/contracts/portrait-claim-format.md</c>.
-    /// </remarks>
-    public const string CredentialPortraitOversize = "WARN_CRED_PORTRAIT_OVERSIZE_001";
+    // Cross-service warning codes (ReviewLayoutUnknown, CredentialPortraitOversize)
+    // live in Sorcha.Blueprint.Models.ValidationWarningCodes so Blueprint.Service
+    // and Validator.Service can both reference them by symbol.
 }


### PR DESCRIPTION
## Summary
`WARN_BP_REVIEW_001` and `WARN_CRED_PORTRAIT_OVERSIZE_001` are referenced by both `Sorcha.Blueprint.Service` (issuance-time portrait gate) and `Sorcha.Validator.Service` (publish-time x-review layout check). Until now they lived in `Validator.Service.ValidationErrorCodes`, with `Blueprint.Service` duplicating the literal as a private const + a comment-based "binding".

Moving them to `Sorcha.Blueprint.Models.ValidationWarningCodes` — already referenced by both services — lets each consumer reference by symbol so the next rename is caught at compile time.

Service-internal codes (`VAL_BP_010`, `VAL_BP_CRED_*`) stay in their respective `ValidationErrorCodes` classes, per the issue scope note ("scope separately").

Closes #336

## Test plan
- [x] Full solution build — 0 errors
- [x] `Sorcha.Blueprint.Models.Tests` — 419/419 pass
- [x] `Sorcha.Validator.Core.Tests` — 300/300 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)