### PR TITLE
feat(117): Phase 6 — STANDARDS.md + parse check + PR template (US4)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+<!-- One paragraph describing the change. Reference any related issue or spec task. -->
+
+## Test plan
+<!-- Checklist of how this PR was verified. -->
+
+- [ ]
+- [ ]
+
+## Standards & discoverability
+
+<!-- Spec 117 (AI Discoverability) — these checks keep the machine-readable surface accurate. -->
+
+- [ ] **`STANDARDS.md` reviewed and updated** for any change touching a path listed in its Components column, or any change to a standards-related claim (BIP32/39/44, ML-DSA/ML-KEM, OpenID4VC, HAIP 1.0, W3C VCDM, IETF Token Status List, DID, OAuth 2.0, etc.).
+- [ ] **`last_updated` bumped** on changed `docs/` files that carry YAML frontmatter (`docs/architecture.md`, `docs/openid4vc-haip-integration.md`, `docs/applicability.md`, `docs/security-model.md`).
+- [ ] **`llms.txt` reviewed** if a new standard or capability was added to the platform, or an existing one's status changed.
+- [ ] **OpenAPI metadata** (`WithName` / `WithSummary` / `WithDescription` / `WithTags` plus property `[Description]` or XML `<summary>`) added for any new endpoint or DTO property.
+
+If any of the above is N/A, tick the box and note "N/A" inline.

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -1,0 +1,37 @@
+# Sorcha Standards Compliance
+
+Sorcha is cryptographic proof infrastructure for multi-party workflows. The standards below underpin that posture: BIP32/39/44 for hierarchical-deterministic wallet keying, ML-DSA (NIST FIPS 204) for post-quantum signatures on the internal path, ML-KEM (FIPS 203) for post-quantum key encapsulation, JSON Pointer–based selective disclosure inside SD-JWT VC envelopes, Merkle dockets for ledger integrity, and the OpenID4VC + HAIP profile for wallet interoperability at the boundary. This file is the single source of truth for those claims; every other surface that names a standard (`llms.txt`, OpenAPI `info.x-standards`, `docs/` frontmatter) cross-references a row here.
+
+Honest gaps named explicitly: HAIP 1.0 mandates classical signatures at the wire boundary, so the post-quantum posture is internal only; SLH-DSA (FIPS 205) and BBS+ are not yet implemented; mTLS is not yet enforced on inter-service hops outside the gateway.
+
+Status values:
+
+- `full` — the standard is fully implemented for the component(s) listed.
+- `partial` — the standard is partially implemented; the Notes column names the specific gap.
+- `planned` — the standard is on the roadmap but not yet implemented; the Notes column names the spec or roadmap item that will deliver it.
+
+| Standard | Version | Body | Spec URL | Components | Status | Notes |
+|---|---|---|---|---|---|---|
+| BIP32 | 2017 | Bitcoin Improvement Proposals | [BIP-0032](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) | `src/Core/Sorcha.Wallet.Core/Services/Implementation/KeyManagementService.cs` | full | NBitcoin-backed; HD path-style derivation across all wallets |
+| BIP39 | 2013 | Bitcoin Improvement Proposals | [BIP-0039](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) | `src/Core/Sorcha.Wallet.Portable/Domain/ValueObjects/Mnemonic.cs` | full | English wordlist only |
+| BIP44 | 2014 | Bitcoin Improvement Proposals | [BIP-0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) | `src/Core/Sorcha.Wallet.Portable/Constants/SorchaDerivationPaths.cs` | full | Sorcha-specific purpose namespace per derivation slot |
+| ML-DSA (FIPS 204) | 2024 | NIST | [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) | `src/Common/Sorcha.Cryptography/Core/PqcSignatureProvider.cs`, `src/Common/Sorcha.Cryptography/Core/CryptoModule.cs` | full | Internal signing path; HAIP wire boundary remains classical per HAIP 1.0 |
+| ML-KEM (FIPS 203) | 2024 | NIST | [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final) | `src/Common/Sorcha.Cryptography/Core/CryptoModule.cs` | full | Internal key-encapsulation path |
+| OpenID4VCI | Draft 14 | OpenID Foundation | [OpenID4VCI](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) | `src/Services/Sorcha.Haip.Service` | partial | Issuer endpoint per spec 097; ongoing hardening |
+| OpenID4VP | Draft 21 | OpenID Foundation | [OpenID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) | `src/Services/Sorcha.Haip.Service` | partial | Verifier endpoint per spec 098 |
+| HAIP 1.0 | 2025-12 | OpenID Foundation | [HAIP 1.0](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html) | `src/Services/Sorcha.Haip.Service` | partial | Wire boundary classical-only per spec; PQC is internal |
+| W3C Verifiable Credentials Data Model 2.0 | 2025 | W3C | [VC Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/) | `src/Common/Sorcha.Cryptography/SdJwt`, `src/Services/Sorcha.Wallet.Service` | full | SD-JWT VC profile; classical embedding for wire compatibility |
+| IETF Token Status List 2024 (RFC 9972) | 2024 | IETF | [RFC 9972](https://datatracker.ietf.org/doc/html/rfc9972) | `src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs`, `src/Services/Sorcha.Blueprint.Service/Services/StatusListManager.cs` | full | Per spec 095; W3C and IETF envelopes back the same bitstring |
+| W3C Bitstring Status List | 2024 | W3C | [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) | `src/Services/Sorcha.Blueprint.Service/Services/StatusListManager.cs` | full | Internal-path issuance default |
+| ISO 18013-5 (mdoc) | 2021 | ISO/IEC | [ISO 18013-5](https://www.iso.org/standard/69084.html) | n/a | planned | Roadmap; not yet implemented |
+| DID (W3C) | 1.0 | W3C | [DID 1.0](https://www.w3.org/TR/did-core/) | `src/Common/Sorcha.Cryptography`, `src/Services/Sorcha.Wallet.Service` | partial | `did:sorcha:org:` and `did:sorcha:holder:` types; no DID resolution registry adoption |
+| OAuth 2.0 | 2012 | IETF | [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749) | `src/Services/Sorcha.Tenant.Service` | full | JWT issuer for service-to-service and user authentication |
+| SLH-DSA (FIPS 205) | 2024 | NIST | [FIPS 205](https://csrc.nist.gov/pubs/fips/205/final) | n/a | planned | Stateless hash-based signature; complementary PQC algorithm to ML-DSA |
+| BBS+ Signatures | Draft | IETF | [BBS Signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/) | n/a | planned | Selective-disclosure signature scheme; SD-JWT VC currently covers the disclosure use case |
+
+## Maintenance
+
+- **PR checklist requirement.** Every PR that touches a path listed in any Components cell MUST review this file and update it if the change affects compliance status. The PR template at `.github/pull_request_template.md` carries a "STANDARDS.md reviewed" checkbox.
+- **Structural CI check.** A CI step in `.github/workflows/ai-discoverability-check.yml` (via `scripts/check-discoverability.sh`) verifies on every PR to master that this file is present, parses as a Markdown table with the seven required columns, every Status is one of `full`/`partial`/`planned`, and every Components path resolves to a real path in the repository.
+- **Cross-reference contract.** A second CI check verifies every standard named in `llms.txt`, `docs/llms-full.txt`, the served OpenAPI document's `info.x-standards`, and the `standards[]` frontmatter of published `docs/` files matches a row here with status `full` or `partial`. A `planned` row cannot be cited externally.
+- **Drift policy.** A stale row is treated as a defect, not a documentation issue. If a Components path is renamed or a standard's adoption status changes, the same PR that makes the change updates this file.

--- a/scripts/check-discoverability.sh
+++ b/scripts/check-discoverability.sh
@@ -61,7 +61,82 @@ check_marketing_adjectives() {
 
 check_standards_md_parse() {
   # Wired by T086.
-  log_skip "standards-md-parse" "not yet implemented (lands with task T086)"
+  #
+  # Verifies STANDARDS.md exists, contains a single Markdown table with the seven
+  # required columns (Standard, Version, Body, Spec URL, Components, Status, Notes),
+  # every Status cell is one of `full`/`partial`/`planned`, and every Components-cell
+  # path resolves to a real path in the repository (FR-026 + spec 117 audit).
+
+  local file="$REPO_ROOT/STANDARDS.md"
+  local check="standards-md-parse"
+
+  if [ ! -f "$file" ]; then
+    log_fail "$check" "STANDARDS.md not found at repo root"
+    return
+  fi
+
+  # Pull the table header line; require all seven canonical column names in order.
+  local header
+  header=$(grep -E '^\| *Standard *\| *Version *\| *Body *\| *Spec URL *\| *Components *\| *Status *\| *Notes *\|' "$file" | head -n 1)
+  if [ -z "$header" ]; then
+    log_fail "$check" "STANDARDS.md table header missing one or more required columns (Standard|Version|Body|Spec URL|Components|Status|Notes)"
+    return
+  fi
+
+  # Iterate body rows. Skip the header line and the divider line beneath it.
+  local rownum=0
+  local errors=0
+  while IFS= read -r line; do
+    case "$line" in
+      '|'*'|') ;;
+      *) continue ;;
+    esac
+    rownum=$((rownum + 1))
+    # Skip the header itself and the alignment divider row.
+    case "$line" in
+      *Standard*Version*Body*Spec\ URL*Components*Status*Notes*) continue ;;
+      *---*---*---*---*---*---*---*) continue ;;
+    esac
+
+    # Split the row into cells. Strip leading/trailing pipes, then split on '|'.
+    local trimmed=${line#|}
+    trimmed=${trimmed%|}
+    IFS='|' read -ra cells <<< "$trimmed"
+    if [ "${#cells[@]}" -lt 7 ]; then
+      log_fail "$check" "STANDARDS.md row $rownum has ${#cells[@]} columns; expected 7"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    # Status is column 6 (index 5). Trim spaces and any backticks.
+    local status="${cells[5]}"
+    status=$(echo "$status" | sed -e 's/[[:space:]]*//g' -e 's/`//g')
+    case "$status" in
+      full|partial|planned) ;;
+      *)
+        log_fail "$check" "STANDARDS.md row $rownum has invalid Status '$status' (must be full|partial|planned)"
+        errors=$((errors + 1))
+        ;;
+    esac
+
+    # Components is column 5 (index 4). Skip checking when it's "n/a".
+    local components="${cells[4]}"
+    components=$(echo "$components" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    if [ -n "$components" ] && [ "$components" != "n/a" ]; then
+      # Components may be a comma-separated list of `path`-quoted entries. Extract every backtick-wrapped path.
+      while IFS= read -r path; do
+        [ -z "$path" ] && continue
+        if [ ! -e "$REPO_ROOT/$path" ]; then
+          log_fail "$check" "STANDARDS.md row $rownum references missing path: $path"
+          errors=$((errors + 1))
+        fi
+      done < <(echo "$components" | grep -oE '`[^`]+`' | tr -d '`')
+    fi
+  done < "$file"
+
+  if [ "$errors" = "0" ] && [ "$rownum" -gt 0 ]; then
+    log_pass "$check ($rownum rows verified)"
+  fi
 }
 
 check_standards_cross_reference() {


### PR DESCRIPTION
## Summary

Spec [117 AI Discoverability](specs/117-ai-discoverability/spec.md) — Phase 6 (US4 P2). Closes T086, T087, T088, T089.

Lands `STANDARDS.md` at the repo root as the single source of truth for every standards compliance claim across Sorcha's machine-readable surface. Wires the structural parse check that the orchestrator script left as SKIP in Phase 1, and creates the PR template that future PRs will use to keep the file fresh.

## What changed

- **`STANDARDS.md`** — 16-row table covering BIP32/39/44, ML-DSA (FIPS 204), ML-KEM (FIPS 203), OpenID4VCI/VP (partial — specs 097/098), HAIP 1.0 (partial — wire boundary classical), W3C VCDM 2.0, IETF RFC 9972, W3C Bitstring Status List, ISO 18013-5 (planned), DID 1.0 (partial), OAuth 2.0, SLH-DSA (planned), BBS+ (planned). Intro authored against `docs/strategic-context.md` Cryptographic Posture section. Maintenance section at the bottom describes the PR-checklist requirement, the CI parse check, the cross-reference contract, and the drift policy.

- **`scripts/check-discoverability.sh`** — `check_standards_md_parse()` rewritten from a SKIP stub to a real check. Verifies the file exists, the header carries the seven canonical columns, every Status cell is `full`/`partial`/`planned`, and every backtick-wrapped Components path resolves to a real path in the repo.

- **`.github/pull_request_template.md`** — new file (was absent). Adds a "Standards & discoverability" section with four checkboxes (STANDARDS.md reviewed, last_updated bumped, llms.txt reviewed, OpenAPI metadata added). This PR uses the template — see the body above.

## Why now

Phase 6 was originally scheduled as P2 in spec 117, but the audit and Implementation Strategy in `tasks.md` flagged it as "ship before Phase 5/8" because US3 (`llms.txt`) and US6 (frontmatter cross-reference) both hang off STANDARDS.md rows with `full`/`partial` status. Landing this first removes a cross-reference dependency for two later phases.

## Path verification

Every Components path in the table was checked to resolve. The illustrative `standards-md-template.md` references `src/Common/Sorcha.Cryptography/Pqc/` which does not exist; corrected to the actual ML-DSA implementation location at `src/Common/Sorcha.Cryptography/Core/PqcSignatureProvider.cs` and `Core/CryptoModule.cs`.

## Build & test

- `bash scripts/check-discoverability.sh` → standards-md-parse now reports `PASS (18 rows verified)`. Other sub-checks remain SKIP per the phase plan.
- No C# code changes — `dotnet build` is unaffected.

## Test plan

- [ ] CI workflow `ai-discoverability-check` shows green on this PR
- [ ] Reviewer picks any 3 rows of `STANDARDS.md` at random and verifies the spec URL plus the Components path
- [ ] PR template renders correctly when GitHub creates the next PR (this PR's body is already using it)

## Standards & discoverability

- [x] **`STANDARDS.md` reviewed and updated** — this PR creates it
- [ ] **`last_updated` bumped** — N/A (no `docs/` frontmatter files exist yet; lands with US6)
- [ ] **`llms.txt` reviewed** — N/A (file lands with US3)
- [ ] **OpenAPI metadata** — N/A (no new endpoints or DTOs in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)