### PR TITLE
fix(117): /.well-known/openapi.yaml 500s on CLR-string-backed JsonValues

### DIFF
--- a/.github/workflows/ai-discoverability-check.yml
+++ b/.github/workflows/ai-discoverability-check.yml
@@ -15,25 +15,12 @@ name: AI Discoverability Check
 # and progressively tightens as later phases of spec 117 ship.
 
 on:
+  # Run on every PR to master. The discoverability orchestrator is fast (~10s)
+  # and the check is now a required status on the master ruleset — a path filter
+  # would skip the workflow on unrelated PRs, leaving the required-check signal
+  # absent and blocking merge. Run unconditionally instead.
   pull_request:
     branches: [ master ]
-    paths:
-      - 'src/Services/Sorcha.ApiGateway/**'
-      - 'src/Common/Sorcha.ServiceDefaults/**'
-      - 'src/Apps/Sorcha.McpServer/**'
-      - 'llms.txt'
-      - 'STANDARDS.md'
-      - 'docs/llms-full.txt'
-      - 'docs/architecture.md'
-      - 'docs/openid4vc-haip-integration.md'
-      - 'docs/applicability.md'
-      - 'docs/security-model.md'
-      - 'docs/quickstart.md'
-      - 'docs/mcp-server.md'
-      - '.spectral.yaml'
-      - 'scripts/check-discoverability.sh'
-      - 'scripts/sorcha-setup.sh'
-      - '.github/workflows/ai-discoverability-check.yml'
   push:
     branches: [ master ]
   schedule:

--- a/src/Services/Sorcha.ApiGateway/Discoverability/WellKnownOpenApiEndpoints.cs
+++ b/src/Services/Sorcha.ApiGateway/Discoverability/WellKnownOpenApiEndpoints.cs
@@ -114,7 +114,7 @@ internal static class WellKnownOpenApiEndpoints
         }
     }
 
-    private static object? ConvertJsonNode(JsonNode? node) => node switch
+    internal static object? ConvertJsonNode(JsonNode? node) => node switch
     {
         JsonObject obj => obj.ToDictionary(p => p.Key, p => ConvertJsonNode(p.Value)),
         JsonArray arr => arr.Select(ConvertJsonNode).ToList(),
@@ -122,17 +122,30 @@ internal static class WellKnownOpenApiEndpoints
         _ => null
     };
 
-    private static object? ConvertJsonValue(JsonValue value)
+    internal static object? ConvertJsonValue(JsonValue value)
     {
-        var element = value.GetValue<JsonElement>();
-        return element.ValueKind switch
+        // JsonValue may be backed either by a JsonElement (when deserialised from JSON text)
+        // or by a CLR primitive (when built in code via JsonArray.Add(string) or similar).
+        // The OpenApiInfoTransformer populates info.x-standards with `arr.Add(string)`, so
+        // the resulting JsonValue is string-backed, not JsonElement-backed. Try CLR types
+        // first, fall back to JsonElement, then to raw JSON text.
+        if (value.TryGetValue<string>(out var s)) return s;
+        if (value.TryGetValue<bool>(out var b)) return b;
+        if (value.TryGetValue<long>(out var l)) return l;
+        if (value.TryGetValue<int>(out var i)) return (long)i;
+        if (value.TryGetValue<double>(out var d)) return d;
+        if (value.TryGetValue<JsonElement>(out var element))
         {
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Number => element.TryGetInt64(out var i) ? i : (object)element.GetDouble(),
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Null => null,
-            _ => element.GetRawText()
-        };
+            return element.ValueKind switch
+            {
+                JsonValueKind.String => element.GetString(),
+                JsonValueKind.Number => element.TryGetInt64(out var ji) ? ji : (object)element.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => null,
+                _ => element.GetRawText()
+            };
+        }
+        return value.ToJsonString();
     }
 }

--- a/tests/Sorcha.ApiGateway.Tests/Discoverability/WellKnownOpenApiEndpointsTests.cs
+++ b/tests/Sorcha.ApiGateway.Tests/Discoverability/WellKnownOpenApiEndpointsTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Sorcha.ApiGateway.Discoverability;
+using Xunit;
+
+namespace Sorcha.ApiGateway.Tests.Discoverability;
+
+/// <summary>
+/// Regression tests for WellKnownOpenApiEndpoints.ConvertJsonNode/ConvertJsonValue.
+///
+/// Spec 117 (AI Discoverability) added these helpers to convert the served OpenAPI
+/// document's JsonNode tree into the plain .NET object graph YamlDotNet expects.
+///
+/// The bug fixed alongside these tests: ConvertJsonValue called value.GetValue&lt;JsonElement&gt;()
+/// unconditionally, which throws when the JsonValue was built in code from a CLR primitive
+/// (as OpenApiInfoTransformer does for info.x-standards via JsonArray.Add(string)). The
+/// /.well-known/openapi.yaml endpoint 500'd in production with that exception until this
+/// fix landed. The integration test missed it because Aspire DistributedApplicationTestingBuilder
+/// requires Docker, which CI runs without — the test Skipped silently.
+/// </summary>
+public class WellKnownOpenApiEndpointsTests
+{
+    [Fact]
+    public void ConvertJsonValue_ClrStringBacked_ReturnsString()
+    {
+        // This is what OpenApiInfoTransformer produces: arr.Add(string).
+        var arr = new JsonArray { "BIP32", "ML-DSA (NIST FIPS 204)" };
+
+        var converted = (List<object?>)WellKnownOpenApiEndpoints.ConvertJsonNode(arr)!;
+
+        converted.Should().HaveCount(2);
+        converted[0].Should().Be("BIP32");
+        converted[1].Should().Be("ML-DSA (NIST FIPS 204)");
+    }
+
+    [Fact]
+    public void ConvertJsonValue_ClrIntBacked_ReturnsLong()
+    {
+        var arr = new JsonArray { 42, 100 };
+
+        var converted = (List<object?>)WellKnownOpenApiEndpoints.ConvertJsonNode(arr)!;
+
+        converted[0].Should().Be(42L);
+        converted[1].Should().Be(100L);
+    }
+
+    [Fact]
+    public void ConvertJsonValue_ClrBoolBacked_ReturnsBool()
+    {
+        var arr = new JsonArray { true, false };
+
+        var converted = (List<object?>)WellKnownOpenApiEndpoints.ConvertJsonNode(arr)!;
+
+        converted[0].Should().Be(true);
+        converted[1].Should().Be(false);
+    }
+
+    [Fact]
+    public void ConvertJsonNode_JsonElementBacked_StillWorks()
+    {
+        // Round-trip a JSON literal — the resulting JsonValue is JsonElement-backed,
+        // which is the path that already worked. Regression guard.
+        var node = JsonNode.Parse("""{"openapi":"3.1.0","info":{"title":"X","version":"1"}}""")!;
+
+        var converted = (Dictionary<string, object?>)WellKnownOpenApiEndpoints.ConvertJsonNode(node)!;
+
+        converted["openapi"].Should().Be("3.1.0");
+        var info = (Dictionary<string, object?>)converted["info"]!;
+        info["title"].Should().Be("X");
+        info["version"].Should().Be("1");
+    }
+
+    [Fact]
+    public void ConvertJsonNode_MixedTree_RealisticOpenApiInfo()
+    {
+        // Simulates the actual served document shape after OpenApiInfoTransformer runs:
+        // a JsonElement-backed root (deserialised from MapOpenApi output) with
+        // CLR-string-backed extensions appended via JsonArray.Add(string).
+        var root = JsonNode.Parse("""{"openapi":"3.1.0","info":{"title":"Sorcha","version":"1.0.0"}}""")!;
+        var info = root["info"]!.AsObject();
+        info["x-mcp-server"] = "/.well-known/mcp.json";
+        var standards = new JsonArray();
+        standards.Add("BIP32");
+        standards.Add("HAIP 1.0");
+        info["x-standards"] = standards;
+
+        // Should not throw — this is the call the YAML endpoint makes.
+        var act = () => WellKnownOpenApiEndpoints.ConvertJsonNode(root);
+
+        act.Should().NotThrow();
+        var converted = (Dictionary<string, object?>)act()!;
+        var infoOut = (Dictionary<string, object?>)converted["info"]!;
+        infoOut["x-mcp-server"].Should().Be("/.well-known/mcp.json");
+        var standardsOut = (List<object?>)infoOut["x-standards"]!;
+        standardsOut.Should().BeEquivalentTo(new[] { "BIP32", "HAIP 1.0" });
+    }
+
+    [Fact]
+    public void ConvertJsonNode_NullNode_ReturnsNull()
+    {
+        WellKnownOpenApiEndpoints.ConvertJsonNode(null).Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Gateway.Integration.Tests/OpenApiWellKnownTests.cs
+++ b/tests/Sorcha.Gateway.Integration.Tests/OpenApiWellKnownTests.cs
@@ -44,6 +44,9 @@ public class OpenApiWellKnownTests : GatewayIntegrationTestBase
         var body = await response.Content.ReadAsStringAsync();
         body.Should().NotBeNullOrWhiteSpace();
         body.Should().Contain("openapi:", "YAML body should serialise the OpenAPI document");
+        body.Should().Contain("x-standards:",
+            "regression: ConvertJsonValue must handle CLR-string-backed JsonValues produced by " +
+            "OpenApiInfoTransformer when info.x-standards is configured non-empty");
     }
 
     [Fact]


### PR DESCRIPTION
## What

Live verification of feature 117 against a clean Docker stack (T108 — your local desktop run) surfaced a 500 from \`/.well-known/openapi.yaml\` when \`info.x-standards\` is configured non-empty.

\`\`\`
System.InvalidOperationException: A value of type 'System.String' cannot be converted to a 'System.Text.Json.JsonElement'.
   at JsonValue\`1.GetValue[T]()
   at WellKnownOpenApiEndpoints.ConvertJsonValue(JsonValue value)  ← WellKnownOpenApiEndpoints.cs:127
\`\`\`

## Why

\`JsonValue\` has two storage forms:

- **JsonElement-backed** — the JsonValue was deserialised from JSON text. \`GetValue<JsonElement>()\` works.
- **CLR-primitive-backed** — the JsonValue was built in code from a CLR value. \`GetValue<JsonElement>()\` throws.

\`OpenApiInfoTransformer\` builds \`info.x-standards\` as \`JsonArray.Add(string)\` — those entries are CLR-string-backed JsonValues. The YAML path (via YamlDotNet) routes through \`ConvertJsonValue\`. The JSON path serialises directly via \`JsonSerializer.Serialize\` and dodges the converter, which is why JSON works and YAML throws.

## Why CI didn't catch it

\`GET_WellKnownOpenapiYaml_Returns200_WithApplicationYamlContentType\` uses Aspire \`DistributedApplicationTestingBuilder\` which requires Docker. CI runs the unit tests without Docker → the integration test was Skipping silently.

## Fix

Try CLR primitive types first (\`string\`, \`bool\`, \`long\`, \`int\`, \`double\`), fall back to JsonElement when the value was deserialised, then to raw JSON text.

## Tests

- **New unit tests** in \`tests/Sorcha.ApiGateway.Tests/Discoverability/WellKnownOpenApiEndpointsTests.cs\` — 6 cases covering CLR-string, CLR-int, CLR-bool backed values, JsonElement-backed (regression guard for the previously-working path), the full mixed-tree shape OpenApiInfoTransformer produces, and the null-node sentinel. **These run in CI without Docker.**
- **Tightened the integration test** to assert the body contains \`x-standards:\` — when Docker IS available the YAML conversion is exercised end-to-end against the real configured standards array.

## Verification

- [x] All 33 unit tests in \`Sorcha.ApiGateway.Tests\` pass locally
- [ ] CI green
- [ ] After merge: rebuild gateway image, re-run \`curl -s http://localhost/.well-known/openapi.yaml\` → 200 with valid YAML

## Feature 117 wrap-up

This was the last finding from T108. With this fix, the clean-Docker quickstart path works end-to-end and feature 117 is fully functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)