### PR TITLE
fix(compose): [#498] add :Sorcha:Redis cascade key to validator + haip services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -543,7 +543,13 @@ services:
       - "${VALIDATOR_HTTP_PORT:-5800}:8080"   # HTTP REST API and health checks
       - "${VALIDATOR_GRPC_PORT:-5801}:8081"   # gRPC endpoint
     environment:
-      <<: [*otel-env, *jwt-env]
+      # *sorcha-connections supplies ConnectionStrings__Sorcha__{Postgres,Mongo,Redis}
+      # for the cascade-aware resolver in VerifiedQueueExtensions / IRegisterRepository
+      # extensions. ConnectionStrings__Redis below stays for the Aspire-named
+      # AddRedisClient("redis") path until that's migrated. Required for
+      # IVerifiedTransactionQueue → RedisVerifiedTransactionQueue under Staging
+      # (Feature 113 storage audit / issue #498).
+      <<: [*otel-env, *jwt-env, *sorcha-connections]
       OTEL_SERVICE_NAME: validator-service
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
@@ -689,7 +695,10 @@ services:
     mem_limit: 512m
     # No ports published - accessed via API Gateway
     environment:
-      <<: [*otel-env, *jwt-env]
+      # *sorcha-connections supplies ConnectionStrings__Sorcha__Redis for the
+      # IAtomicDistributedCache cascade — required if/when haip-service's
+      # ASPNETCORE_ENVIRONMENT is flipped to Staging (Feature 113 audit / issue #498).
+      <<: [*otel-env, *jwt-env, *sorcha-connections]
       OTEL_SERVICE_NAME: haip-service
       ASPNETCORE_ENVIRONMENT: Docker
       ASPNETCORE_URLS: http://+:8080


### PR DESCRIPTION
## Summary
Closes #498. Adds the `*sorcha-connections` anchor to `validator-service` and `haip-service` environment blocks in `docker-compose.yml` so the cascade keys (`ConnectionStrings__Sorcha__{Postgres,Mongo,Redis}`) are present alongside the Aspire-named `ConnectionStrings__Redis`.

### Why
REQ-7 (Feature 115) needs n1 flipped to `ASPNETCORE_ENVIRONMENT=Staging`. `StorageEnforcementHostedService` (auto-wired by `AddServiceDefaults`) refuses to start any service where a Feature-113-audited interface resolves to an in-memory backend.

- **validator-service** (definitive blocker): `VerifiedQueueExtensions.AddVerifiedTransactionQueue` reads `ConnectionStrings:Validator:Redis` or `ConnectionStrings:Sorcha:Redis`. Neither was set, so `IVerifiedTransactionQueue` was registering as `InMemoryVerifiedTransactionQueue`. Under Staging the service would refuse to start.
- **haip-service** (proactive — currently runs `ASPNETCORE_ENVIRONMENT=Docker` so enforcement isn't tripping yet): `IAtomicDistributedCache` resolution reads the same cascade. Fixing it now means a comprehensive n1 Staging flip won't reopen this.

### Verification
```
$ docker compose -f docker-compose.yml config | grep -E "container_name|ConnectionStrings__Sorcha__Redis"
…
container_name: sorcha-haip-service
  ConnectionStrings__Sorcha__Redis: redis:6379
container_name: sorcha-validator-service
  ConnectionStrings__Sorcha__Redis: redis:6379
```

Both services now expose `ConnectionStrings__Sorcha__Redis=redis:6379` (added) **and** the existing `ConnectionStrings__Redis=redis:6379` (kept for `AddRedisClient("redis")`). No key conflicts.

### Test plan
- [x] `docker compose config` validates with no errors
- [x] Cascade key present on both services post-merge
- [ ] (Operator) Once merged, n1 redeploy: confirm startup log shows  
  `Storage registration: …IVerifiedTransactionQueue → RedisVerifiedTransactionQueue (redis)`
- [ ] (Follow-up PR) `chore(115): flip n1 to Staging environment (REQ-7)` becomes raisable

🤖 Generated with [Claude Code](https://claude.com/claude-code)