### PR TITLE
fix(gateway): classify Degraded health responses correctly + tighten overall-status logic

### DIFF
--- a/src/Services/Sorcha.ApiGateway/Services/HealthAggregationService.cs
+++ b/src/Services/Sorcha.ApiGateway/Services/HealthAggregationService.cs
@@ -58,13 +58,41 @@ public class HealthAggregationService
             response.Services[serviceName] = health;
         }
 
-        // Determine overall status
-        var allHealthy = response.Services.Values.All(s => s.Status == "healthy");
-        var anyHealthy = response.Services.Values.Any(s => s.Status == "healthy");
-
-        response.Status = allHealthy ? "healthy" : anyHealthy ? "degraded" : "unhealthy";
+        response.Status = DetermineOverallStatus(response.Services.Values.Select(s => s.Status));
 
         return response;
+    }
+
+    /// <summary>
+    /// Maps the plain-text body of an Aspire <c>/health</c> response onto the canonical
+    /// gateway status strings. Aspire emits one of "Healthy", "Degraded", or "Unhealthy"
+    /// (case-insensitive); anything else maps to "unknown".
+    /// </summary>
+    internal static string ClassifyHealthResponseText(string responseBody)
+    {
+        var status = responseBody?.Trim().ToLowerInvariant() ?? string.Empty;
+        return status switch
+        {
+            "healthy" => "healthy",
+            "degraded" => "degraded",
+            "unhealthy" => "unhealthy",
+            _ => "unknown"
+        };
+    }
+
+    /// <summary>
+    /// Aggregates per-service statuses into a single overall status:
+    /// "healthy" iff every service is healthy; "unhealthy" if any service is
+    /// confirmed unhealthy; otherwise "degraded" (at least one service is
+    /// degraded or unknown but none are confirmed unhealthy).
+    /// </summary>
+    internal static string DetermineOverallStatus(IEnumerable<string> serviceStatuses)
+    {
+        var statuses = serviceStatuses.ToList();
+        if (statuses.Count == 0) return "unknown";
+        if (statuses.All(s => s == "healthy")) return "healthy";
+        if (statuses.Any(s => s == "unhealthy")) return "unhealthy";
+        return "degraded";
     }
 
     /// <summary>
@@ -120,13 +148,10 @@ public class HealthAggregationService
             {
                 var content = await response.Content.ReadAsStringAsync(cancellationToken);
 
-                // Aspire health endpoint returns plain text "Healthy" or "Unhealthy"
-                // Not JSON with a status property
-                var status = content.Trim().ToLowerInvariant();
-
+                // Aspire health endpoint returns plain text "Healthy", "Degraded", or "Unhealthy".
                 return new ServiceHealth
                 {
-                    Status = status == "healthy" ? "healthy" : status == "unhealthy" ? "unhealthy" : "unknown",
+                    Status = ClassifyHealthResponseText(content),
                     Endpoint = endpoint
                 };
             }

--- a/tests/Sorcha.ApiGateway.Tests/Services/HealthAggregationServiceTests.cs
+++ b/tests/Sorcha.ApiGateway.Tests/Services/HealthAggregationServiceTests.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.ApiGateway.Services;
+using Xunit;
+
+namespace Sorcha.ApiGateway.Tests.Services;
+
+/// <summary>
+/// Unit tests for HealthAggregationService classification helpers.
+///
+/// Regression context: the gateway aggregator's per-service classifier had no branch
+/// for ASP.NET Core's "Degraded" status. Validator (and any other service) reporting
+/// Degraded — which in production happens whenever an audited storage interface is on
+/// an in-memory backend per the Sorcha.ServiceDefaults storage-providers health check —
+/// was mapped to "unknown" and the overall gateway health flipped to "degraded"
+/// permanently. /api/health smoke tests therefore returned a false-negative signal
+/// every time the stack ran without persistent storage configured.
+/// </summary>
+public class HealthAggregationServiceTests
+{
+    [Theory]
+    [InlineData("Healthy", "healthy")]
+    [InlineData("healthy", "healthy")]
+    [InlineData("HEALTHY", "healthy")]
+    [InlineData("Degraded", "degraded")]
+    [InlineData("degraded", "degraded")]
+    [InlineData("Unhealthy", "unhealthy")]
+    [InlineData("unhealthy", "unhealthy")]
+    [InlineData("  Healthy  ", "healthy")]
+    public void ClassifyHealthResponseText_RecognisesAspireStatuses(string body, string expected)
+    {
+        HealthAggregationService.ClassifyHealthResponseText(body).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("OK")]
+    [InlineData("running")]
+    [InlineData("???")]
+    public void ClassifyHealthResponseText_UnrecognisedBody_ReturnsUnknown(string body)
+    {
+        HealthAggregationService.ClassifyHealthResponseText(body).Should().Be("unknown");
+    }
+
+    [Fact]
+    public void ClassifyHealthResponseText_NullBody_ReturnsUnknown()
+    {
+        HealthAggregationService.ClassifyHealthResponseText(null!).Should().Be("unknown");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_AllHealthy_ReturnsHealthy()
+    {
+        HealthAggregationService.DetermineOverallStatus(new[] { "healthy", "healthy", "healthy" })
+            .Should().Be("healthy");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_AnyUnhealthy_ReturnsUnhealthy()
+    {
+        HealthAggregationService.DetermineOverallStatus(new[] { "healthy", "unhealthy", "healthy" })
+            .Should().Be("unhealthy");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_OneDegradedRestHealthy_ReturnsDegraded()
+    {
+        // Regression: this was previously "degraded" only because anyHealthy was true.
+        // With "Degraded" now correctly classified, the same outcome holds — and we
+        // pin the assertion so future refactors don't slide back to "unhealthy".
+        HealthAggregationService.DetermineOverallStatus(new[] { "healthy", "degraded", "healthy" })
+            .Should().Be("degraded");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_AllDegraded_ReturnsDegraded()
+    {
+        // Regression: previously this case returned "unhealthy" because anyHealthy was false.
+        HealthAggregationService.DetermineOverallStatus(new[] { "degraded", "degraded", "degraded" })
+            .Should().Be("degraded");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_OneUnknownRestHealthy_ReturnsDegraded()
+    {
+        HealthAggregationService.DetermineOverallStatus(new[] { "healthy", "unknown", "healthy" })
+            .Should().Be("degraded");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_UnhealthyWinsOverDegraded()
+    {
+        HealthAggregationService.DetermineOverallStatus(new[] { "degraded", "unhealthy", "degraded" })
+            .Should().Be("unhealthy");
+    }
+
+    [Fact]
+    public void DetermineOverallStatus_EmptyInput_ReturnsUnknown()
+    {
+        HealthAggregationService.DetermineOverallStatus(Array.Empty<string>())
+            .Should().Be("unknown");
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes in HealthAggregationService, surfaced live during Feature 117's T108 quickstart verification.

### Bug 1 — Degraded misclassified as unknown

ASP.NET Core's health-check endpoint returns one of three plain-text strings: `Healthy`, `Degraded`, `Unhealthy`. The classifier had no branch for `Degraded` and fell through to `unknown`. Production trigger: any service whose audited storage interface is on an in-memory backend (per the Sorcha.ServiceDefaults storage-providers health check) reports `Degraded` — and the gateway then permanently marked it as unknown.

### Bug 2 — overall-status aggregation

Previously:
```csharp
allHealthy ? "healthy" : anyHealthy ? "degraded" : "unhealthy"
```
which classified an all-degraded stack as "unhealthy". Now:
- All healthy → `healthy`
- Any unhealthy → `unhealthy`
- Otherwise (any degraded or unknown but no confirmed unhealthy) → `degraded`

## Tests

New unit-test file at `tests/Sorcha.ApiGateway.Tests/Services/HealthAggregationServiceTests.cs`. Covers both classifiers across every status, including the regression cases (Degraded service, all-degraded stack, the unhealthy-wins-over-degraded ordering). 9 tests added; all 53 tests in the project pass.

## How I found it

During the live Feature 117 quickstart verification on a clean Docker stack today: the gateway aggregate showed `validator = unknown` for minutes while `docker logs` showed the validator returning `200` with body `Degraded` (the expected response when running with the in-memory `IVerifiedTransactionQueue`).

## Test plan

- [x] All gateway unit tests pass (`dotnet test tests/Sorcha.ApiGateway.Tests`)
- [ ] CI green
- [ ] After merge, rebuild gateway image, restart stack, confirm `/api/health` reports validator as `degraded` (not `unknown`) and overall as `degraded` (not `unhealthy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)