### PR TITLE
fix(gateway): support HEAD on the three /.well-known discovery endpoints

### DIFF
--- a/src/Services/Sorcha.ApiGateway/Discoverability/McpManifestEndpoint.cs
+++ b/src/Services/Sorcha.ApiGateway/Discoverability/McpManifestEndpoint.cs
@@ -28,7 +28,7 @@ internal static class McpManifestEndpoint
 
     public static IEndpointRouteBuilder MapMcpManifestEndpoint(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/.well-known/mcp.json", HandleAsync)
+        endpoints.MapMethods("/.well-known/mcp.json", new[] { "GET", "HEAD" }, HandleAsync)
             .ExcludeFromDescription();
         return endpoints;
     }

--- a/src/Services/Sorcha.ApiGateway/Discoverability/WellKnownOpenApiEndpoints.cs
+++ b/src/Services/Sorcha.ApiGateway/Discoverability/WellKnownOpenApiEndpoints.cs
@@ -39,14 +39,16 @@ internal static class WellKnownOpenApiEndpoints
 
     /// <summary>
     /// Wires both well-known routes. Call after the OpenAPI aggregation route has been
-    /// registered so the underlying service is in DI.
+    /// registered so the underlying service is in DI. Both routes accept GET and HEAD —
+    /// HEAD is RFC-required for any GET resource, and discovery clients (curl -I,
+    /// HTTP cache validators, link checkers) probe with HEAD before a full fetch.
     /// </summary>
     public static IEndpointRouteBuilder MapWellKnownOpenApiEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/.well-known/openapi.json", HandleJsonAsync)
+        endpoints.MapMethods("/.well-known/openapi.json", new[] { "GET", "HEAD" }, HandleJsonAsync)
             .ExcludeFromDescription();
 
-        endpoints.MapGet("/.well-known/openapi.yaml", HandleYamlAsync)
+        endpoints.MapMethods("/.well-known/openapi.yaml", new[] { "GET", "HEAD" }, HandleYamlAsync)
             .ExcludeFromDescription();
 
         return endpoints;

--- a/tests/Sorcha.Gateway.Integration.Tests/McpManifestWellKnownTests.cs
+++ b/tests/Sorcha.Gateway.Integration.Tests/McpManifestWellKnownTests.cs
@@ -29,6 +29,20 @@ public class McpManifestWellKnownTests : GatewayIntegrationTestBase
     }
 
     [Fact]
+    public async Task HEAD_WellKnownMcpJson_Returns200_NoBody()
+    {
+        SkipIfInfrastructureUnavailable();
+
+        var response = await GatewayClient!.SendAsync(new HttpRequestMessage(HttpMethod.Head, ManifestPath));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        response.Headers.CacheControl?.ToString().Should().Contain("max-age=300");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().BeEmpty("HEAD must return no body");
+    }
+
+    [Fact]
     public async Task Manifest_ContainsRequiredFields()
     {
         SkipIfInfrastructureUnavailable();

--- a/tests/Sorcha.Gateway.Integration.Tests/OpenApiWellKnownTests.cs
+++ b/tests/Sorcha.Gateway.Integration.Tests/OpenApiWellKnownTests.cs
@@ -30,6 +30,34 @@ public class OpenApiWellKnownTests : GatewayIntegrationTestBase
     }
 
     [Fact]
+    public async Task HEAD_WellKnownOpenapiJson_Returns200_NoBody()
+    {
+        SkipIfInfrastructureUnavailable();
+
+        var response = await GatewayClient!.SendAsync(new HttpRequestMessage(HttpMethod.Head, WellKnownJsonPath));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        response.Headers.CacheControl?.ToString().Should().Contain("max-age=300");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().BeEmpty("HEAD must return no body");
+    }
+
+    [Fact]
+    public async Task HEAD_WellKnownOpenapiYaml_Returns200_NoBody()
+    {
+        SkipIfInfrastructureUnavailable();
+
+        var response = await GatewayClient!.SendAsync(new HttpRequestMessage(HttpMethod.Head, WellKnownYamlPath));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/yaml");
+        response.Headers.CacheControl?.ToString().Should().Contain("max-age=300");
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().BeEmpty("HEAD must return no body");
+    }
+
+    [Fact]
     public async Task GET_WellKnownOpenapiYaml_Returns200_WithApplicationYamlContentType()
     {
         SkipIfInfrastructureUnavailable();


### PR DESCRIPTION
## Summary

`curl -I` and other HEAD probes return 404 against the three discovery URLs. Fix: register HEAD alongside GET via `MapMethods`.

- `/.well-known/openapi.json`
- `/.well-known/openapi.yaml`
- `/.well-known/mcp.json`

HEAD is RFC-required for any GET resource. Cache validators, link checkers (including the `lychee` one in this repo's CI), and discovery clients probe with HEAD before fetching the full body. Returning 404 breaks them.

ASP.NET Core's response pipeline truncates the body for HEAD automatically while preserving headers (Content-Type, Cache-Control).

## Tests

Three new integration tests assert HEAD returns 200 with correct headers and empty body. Pattern is one per existing GET test in the same fixtures.

## How I found it

During the live Feature 117 quickstart verification today: `curl -I /.well-known/openapi.yaml` returned 404 while the corresponding GET worked. Same shape for the other two endpoints.

## Test plan

- [x] `dotnet build src/Services/Sorcha.ApiGateway/` clean
- [ ] CI green
- [ ] After merge, rebuild gateway image, `curl -I http://localhost/.well-known/openapi.{json,yaml}` and `/.well-known/mcp.json` all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)