### PR TITLE
fix(#337): emit WARN_BP_REVIEW_001 when x-review.layout is unknown

### DIFF
--- a/src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs
+++ b/src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs
@@ -187,6 +187,49 @@ public static class SchemaLayoutParser
             ["receipt"] = XReviewLayoutVariant.Receipt
         };
 
+    /// <summary>
+    /// Recognised <c>x-review.layout</c> values, case-insensitive. Exposed so the
+    /// blueprint validator can detect and warn on typos (<c>WARN_BP_REVIEW_001</c>)
+    /// without duplicating the canonical map.
+    /// </summary>
+    public static IReadOnlyCollection<string> KnownReviewLayoutVariants => LayoutVariantMap.Keys;
+
+    /// <summary>
+    /// Walks every <c>x-pages[].x-review.layout</c> on an action schema and yields
+    /// each <em>present-but-unrecognised</em> layout value. Used by the blueprint
+    /// validator to emit <c>WARN_BP_REVIEW_001</c> at publish time for any typo'd
+    /// layout — without this signal, an author who writes <c>"hologram"</c> gets a
+    /// silent fall-back to <c>id-card</c> and never learns their declaration was ignored.
+    /// </summary>
+    /// <remarks>
+    /// Yields the offending raw string per occurrence (so two pages each declaring
+    /// <c>"hologram"</c> yield two values). Absent <c>layout</c> properties are not
+    /// reported — only present values that fail the membership check on
+    /// <see cref="KnownReviewLayoutVariants"/>.
+    /// </remarks>
+    public static IEnumerable<string> EnumerateUnknownReviewLayouts(JsonElement actionSchema)
+    {
+        if (actionSchema.ValueKind != JsonValueKind.Object) yield break;
+        if (!actionSchema.TryGetProperty("x-pages", out var pagesEl) ||
+            pagesEl.ValueKind != JsonValueKind.Array) yield break;
+
+        foreach (var pageEl in pagesEl.EnumerateArray())
+        {
+            if (pageEl.ValueKind != JsonValueKind.Object) continue;
+            if (!pageEl.TryGetProperty("x-review", out var reviewEl) ||
+                reviewEl.ValueKind != JsonValueKind.Object) continue;
+            if (!reviewEl.TryGetProperty("layout", out var layoutEl) ||
+                layoutEl.ValueKind != JsonValueKind.String) continue;
+
+            var raw = layoutEl.GetString();
+            if (string.IsNullOrWhiteSpace(raw)) continue;
+            if (!LayoutVariantMap.ContainsKey(raw))
+            {
+                yield return raw;
+            }
+        }
+    }
+
     private static readonly Dictionary<string, XReviewColourTheme> ColourThemeMap =
         new(StringComparer.OrdinalIgnoreCase)
         {

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -2978,6 +2978,40 @@ public class PublishService(
             }
         }
 
+        // Rule 7d (Feature 107, Issue #337): x-review.layout typo detection.
+        //
+        //   WARN_BP_REVIEW_001 — non-blocking warning. SchemaLayoutParser silently falls
+        //                        back to id-card when an x-review.layout value isn't in
+        //                        the known set. Without this rule a blueprint author who
+        //                        types "hologram" instead of "id-card" gets no signal
+        //                        that their declaration was ignored.
+        //
+        // Implementation calls SchemaLayoutParser.EnumerateUnknownReviewLayouts so the
+        // canonical layout-name set lives in exactly one place.
+        foreach (var action in blueprint.Actions)
+        {
+            if (action.DataSchemas is null) continue;
+            foreach (var schemaDoc in action.DataSchemas)
+            {
+                try
+                {
+                    foreach (var unknownLayout in
+                        Sorcha.Blueprint.Models.SchemaLayoutParser.EnumerateUnknownReviewLayouts(schemaDoc.RootElement))
+                    {
+                        warnings.Add(
+                            $"[{Sorcha.Blueprint.Models.ValidationWarningCodes.ReviewLayoutUnknown}] " +
+                            $"Action {action.Id} ('{action.Title}'): x-review.layout value '{unknownLayout}' " +
+                            $"is not a recognised variant. Renderer falls back to 'id-card'. " +
+                            $"Known variants: {string.Join(", ", Sorcha.Blueprint.Models.SchemaLayoutParser.KnownReviewLayoutVariants)}.");
+                    }
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    // Malformed schema — other rules will surface this
+                }
+            }
+        }
+
         // Rule 7c (Feature 106): credentialIssuanceConfig.targetAudience == SorchaLocalWallet
         // guardrails for register-native credential delivery.
         //

--- a/tests/Sorcha.Blueprint.Models.Tests/XReviewExtensionParserTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/XReviewExtensionParserTests.cs
@@ -249,4 +249,103 @@ public class XReviewExtensionParserTests
 
         result.Pages![0].ReviewExtension.Should().BeNull();
     }
+
+    // -- EnumerateUnknownReviewLayouts (Issue #337, WARN_BP_REVIEW_001 source) --
+
+    [Fact]
+    public void EnumerateUnknownReviewLayouts_AllValid_YieldsNothing()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                { "x-review": { "layout": "id-card",       "header": { "issuerName": "X", "credentialName": "Y" } } },
+                { "x-review": { "layout": "passport-page", "header": { "issuerName": "X", "credentialName": "Y" } } },
+                { "x-review": { "layout": "tabular",       "header": { "issuerName": "X", "credentialName": "Y" } } },
+                { "x-review": { "layout": "receipt",       "header": { "issuerName": "X", "credentialName": "Y" } } }
+            ]
+        }
+        """);
+
+        SchemaLayoutParser.EnumerateUnknownReviewLayouts(schema).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateUnknownReviewLayouts_TypoLayout_YieldsTheTypo()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                { "x-review": { "layout": "hologram", "header": { "issuerName": "X", "credentialName": "Y" } } }
+            ]
+        }
+        """);
+
+        SchemaLayoutParser.EnumerateUnknownReviewLayouts(schema).Should().Equal("hologram");
+    }
+
+    [Fact]
+    public void EnumerateUnknownReviewLayouts_MultipleTypos_YieldsEachOccurrence()
+    {
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                { "x-review": { "layout": "hologram",   "header": { "issuerName": "X", "credentialName": "Y" } } },
+                { "x-review": { "layout": "id-card",    "header": { "issuerName": "X", "credentialName": "Y" } } },
+                { "x-review": { "layout": "id_card",    "header": { "issuerName": "X", "credentialName": "Y" } } }
+            ]
+        }
+        """);
+
+        SchemaLayoutParser.EnumerateUnknownReviewLayouts(schema).Should().Equal("hologram", "id_card");
+    }
+
+    [Fact]
+    public void EnumerateUnknownReviewLayouts_LayoutAbsent_YieldsNothing()
+    {
+        // Absent layout property is not an error — SchemaLayoutParser falls back to id-card.
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                { "x-review": { "header": { "issuerName": "X", "credentialName": "Y" } } }
+            ]
+        }
+        """);
+
+        SchemaLayoutParser.EnumerateUnknownReviewLayouts(schema).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateUnknownReviewLayouts_NoXPages_YieldsNothing()
+    {
+        var schema = Parse("""{ "type": "object", "properties": { "givenName": { "type": "string" } } }""");
+
+        SchemaLayoutParser.EnumerateUnknownReviewLayouts(schema).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateUnknownReviewLayouts_LayoutCaseInsensitive_TreatsKnownVariantsAsValid()
+    {
+        // LayoutVariantMap is OrdinalIgnoreCase, so "ID-CARD" should pass.
+        var schema = Parse("""
+        {
+            "type": "object",
+            "x-pages": [
+                { "x-review": { "layout": "ID-CARD", "header": { "issuerName": "X", "credentialName": "Y" } } }
+            ]
+        }
+        """);
+
+        SchemaLayoutParser.EnumerateUnknownReviewLayouts(schema).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void KnownReviewLayoutVariants_IncludesEveryShippedVariant()
+    {
+        SchemaLayoutParser.KnownReviewLayoutVariants
+            .Should().BeEquivalentTo(new[] { "id-card", "passport-page", "tabular", "receipt" });
+    }
 }


### PR DESCRIPTION
Closes #337.

## Summary

`SchemaLayoutParser` silently fell back to `id-card` when an `x-review.layout` value was unrecognised. An author who mistyped `id-card` as `id_card` or `hologram` got no signal that their declaration had been ignored. The warning code `WARN_BP_REVIEW_001` was reserved in `ValidationWarningCodes` but never emitted.

## Changes

**`src/Common/Sorcha.Blueprint.Models/SchemaLayoutParser.cs`** — two new public surfaces, so the canonical layout-name set lives in exactly one place:

- `KnownReviewLayoutVariants` — the recognised layout strings: `id-card`, `passport-page`, `tabular`, `receipt`
- `EnumerateUnknownReviewLayouts(JsonElement actionSchema)` — walks every `x-pages[].x-review.layout` and yields each *present-but-unrecognised* value. Absent layouts are not reported, only typos.

**`src/Services/Sorcha.Blueprint.Service/Program.cs`** — `BlueprintService.ValidateBlueprint` Rule 7d: walks every action's `DataSchemas`, calls the helper, emits `WARN_BP_REVIEW_001` per offender naming the offending value and the full set of recognised variants.

## Tests

7 new cases on `EnumerateUnknownReviewLayouts` in `XReviewExtensionParserTests` covering:

- All valid: yields nothing
- Single typo: yields the typo
- Multiple typos: yields each occurrence (preserves order, no dedupe — a per-page typo is a per-page warning)
- Absent layout: yields nothing (not a typo, just unset)
- No `x-pages`: yields nothing
- Case insensitivity (`ID-CARD` is fine)
- Canonical-set assertion on `KnownReviewLayoutVariants`

All 426 `Sorcha.Blueprint.Models.Tests` pass.

## Behaviour

Warning is **non-blocking** as the issue requested. Blueprint still publishes; renderer still shows the `id-card` fallback; author now sees a publish-time warning naming the offending value.

## Test plan

- [x] All 426 Blueprint.Models unit tests pass
- [x] `Sorcha.Blueprint.Service` builds clean
- [ ] CI green
- [ ] Optional manual: validate a blueprint with `"layout": "hologram"` and confirm a single `WARN_BP_REVIEW_001` lands in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)