### PR TITLE
fix(#346): tighten HaipPresentCommand request-object format detection

### DIFF
--- a/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
+++ b/src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Buffers.Text;
 using System.CommandLine;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -181,40 +182,44 @@ public class HaipPresentCommand : Command
     /// (legacy callers). Returns the payload as a <see cref="JsonElement"/>
     /// either way.
     /// </summary>
-    private static JsonElement ParseRequestObjectPayload(string responseText)
+    internal static JsonElement ParseRequestObjectPayload(string responseText)
     {
         var trimmed = responseText.Trim();
-        if (trimmed.Length > 0 && trimmed[0] == '{')
+
+        // Bare JSON object.
+        if (trimmed.StartsWith('{'))
         {
-            // Bare JSON object.
             return JsonSerializer.Deserialize<JsonElement>(trimmed);
         }
 
-        // JWT — extract the payload (middle segment).
-        // TODO(SEC): tracked in issue #344 — agent should verify the JWT
-        // signature against the verifier's JWKS per RFC 9101 §4 before
-        // acting on its claims. Today the agent is a demo/test tool
-        // against trusted localhost verifiers only; any production use
-        // must fetch jwks_uri from the verifier's well-known config and
-        // validate the signature before reaching this point.
-        var parts = trimmed.Split('.');
-        if (parts.Length < 2)
+        // JWT/JWS-compact: every base64url-encoded JOSE header that begins with
+        // '{"alg"' or '{"typ"' (i.e. any compliant JWS or JWE) base64url-encodes
+        // to a string starting with "eyJ". Anything else here is a server error
+        // page, redirect body, plain text, or other non-JOSE response.
+        if (trimmed.StartsWith("eyJ", StringComparison.Ordinal))
         {
-            throw new InvalidOperationException(
-                "Request object is neither a JSON body nor a JWT — cannot parse.");
+            // TODO(SEC): tracked in issue #344 — agent should verify the JWT
+            // signature against the verifier's JWKS per RFC 9101 §4 before
+            // acting on its claims. Today the agent is a demo/test tool
+            // against trusted localhost verifiers only; any production use
+            // must fetch jwks_uri from the verifier's well-known config and
+            // validate the signature before reaching this point.
+            var parts = trimmed.Split('.');
+            if (parts.Length < 2)
+            {
+                throw new InvalidOperationException(
+                    "Request object looks like a JWT (begins with 'eyJ') but does not have at least " +
+                    "two dot-separated segments — cannot extract payload.");
+            }
+            var payloadBytes = Base64Url.DecodeFromChars(parts[1].AsSpan());
+            return JsonSerializer.Deserialize<JsonElement>(payloadBytes);
         }
-        var payloadBytes = Base64UrlDecode(parts[1]);
-        return JsonSerializer.Deserialize<JsonElement>(payloadBytes);
-    }
 
-    private static byte[] Base64UrlDecode(string input)
-    {
-        var padded = input.Replace('-', '+').Replace('_', '/');
-        switch (padded.Length % 4)
-        {
-            case 2: padded += "=="; break;
-            case 3: padded += "="; break;
-        }
-        return Convert.FromBase64String(padded);
+        // Anything else — give the caller a quoted preview so they can see what
+        // came back (HTML error page, plaintext error, redirect body, etc.).
+        var preview = trimmed.Length <= 20 ? trimmed : trimmed[..20];
+        throw new InvalidOperationException(
+            $"Request object is neither a JSON body (starting '{{') nor a compact JWT (starting 'eyJ'). " +
+            $"First {preview.Length} chars of response: \"{preview}\"");
     }
 }

--- a/tests/Sorcha.Agent.Tests/Commands/HaipPresentCommandTests.cs
+++ b/tests/Sorcha.Agent.Tests/Commands/HaipPresentCommandTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Agent.Commands;
+using Xunit;
+
+namespace Sorcha.Agent.Tests.Commands;
+
+/// <summary>
+/// Tests for HaipPresentCommand.ParseRequestObjectPayload, the response-format
+/// detector for OpenID4VP request objects fetched from a verifier. Issue #346
+/// tightened the detection so non-JSON, non-JWT bodies (HTML error pages,
+/// redirect bodies, plain text) produce a clear error with a quoted preview
+/// rather than falling into the JWT-decode branch and surfacing a cryptic
+/// base64 error.
+/// </summary>
+public class HaipPresentCommandTests
+{
+    private static string Base64UrlEncode(string s) =>
+        Base64Url.EncodeToString(Encoding.UTF8.GetBytes(s));
+
+    [Fact]
+    public void ParseRequestObjectPayload_BareJsonObject_DeserialisesPayload()
+    {
+        var json = """{ "client_id": "demo-verifier", "nonce": "abc" }""";
+
+        var payload = HaipPresentCommand.ParseRequestObjectPayload(json);
+
+        payload.GetProperty("client_id").GetString().Should().Be("demo-verifier");
+        payload.GetProperty("nonce").GetString().Should().Be("abc");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_BareJsonObject_TolerantOfLeadingWhitespace()
+    {
+        var json = "  \r\n  { \"client_id\": \"demo\" }";
+
+        var payload = HaipPresentCommand.ParseRequestObjectPayload(json);
+
+        payload.GetProperty("client_id").GetString().Should().Be("demo");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_CompactJwt_ReturnsPayloadSegment()
+    {
+        // A real JWS-compact: header.payload.signature, all base64url. We don't
+        // verify the signature here (issue #344 tracks that); we just need the
+        // payload segment to decode to JSON.
+        var header = Base64UrlEncode("""{"alg":"none","typ":"oauth-authz-req+jwt"}""");
+        var body = Base64UrlEncode("""{"client_id":"demo","nonce":"xyz"}""");
+        var jwt = $"{header}.{body}.";
+
+        var payload = HaipPresentCommand.ParseRequestObjectPayload(jwt);
+
+        payload.GetProperty("client_id").GetString().Should().Be("demo");
+        payload.GetProperty("nonce").GetString().Should().Be("xyz");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_HtmlErrorPage_ThrowsWithPreview()
+    {
+        var html = "<!DOCTYPE html><html><body>Internal Server Error</body></html>";
+        var firstTwenty = html[..20]; // "<!DOCTYPE html><html"
+
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload(html);
+
+        var ex = act.Should().Throw<InvalidOperationException>().Which;
+        ex.Message.Should().Contain("neither a JSON body");
+        ex.Message.Should().Contain("nor a compact JWT");
+        ex.Message.Should().Contain($"\"{firstTwenty}\"",
+            "the first 20 chars must be quoted in the message so the operator " +
+            "can see what the verifier returned");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_PlainTextError_ThrowsWithPreview()
+    {
+        var text = "not authorised";
+
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload(text);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*\"not authorised\"*");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_EmptyResponse_Throws()
+    {
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload("");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*neither a JSON body*nor a compact JWT*");
+    }
+
+    [Fact]
+    public void ParseRequestObjectPayload_LeadingEyJButOnlyOneSegment_Throws()
+    {
+        // Defensive: something starts with "eyJ" but isn't a real JWT. The detector
+        // routes it down the JWT branch but the missing-segments check catches it.
+        var act = () => HaipPresentCommand.ParseRequestObjectPayload("eyJalgIsNoneAndNoDot");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*JWT*at least two dot-separated segments*");
+    }
+}


### PR DESCRIPTION
Closes #346.

## Summary

`ParseRequestObjectPayload` branched on `trimmed[0] == '{'` for JSON vs JWT — anything else (HTML error page, plain-text error, redirect body, reverse-proxy auth challenge) fell through the JWT branch and surfaced a cryptic base64-decode error rather than naming the actual problem.

## Changes

- **Tightened detection** in `src/Apps/Sorcha.Agent/Commands/HaipPresentCommand.cs`:
  - `StartsWith('{')` → bare JSON
  - `StartsWith("eyJ", Ordinal)` → compact JWS/JWE (every base64url-encoded JOSE header begins with this)
  - Anything else → `InvalidOperationException` with the **first 20 characters** of the response quoted in the message. An operator hitting a 502 HTML page or a reverse-proxy auth redirect now sees what they actually got back.

- **Replaced the hand-rolled `Base64UrlDecode`** with `System.Buffers.Text.Base64Url.DecodeFromChars` from the .NET 10 BCL. The issue suggested `Microsoft.AspNetCore.WebUtilities.WebEncoders` but Sorcha.Agent isn't an ASP.NET Core project — that would have added a package reference. `Base64Url` ships in the BCL with the same semantics, zero new deps.

- Promoted `ParseRequestObjectPayload` from private to internal (`Sorcha.Agent.Tests` already has `InternalsVisibleTo`).

## Tests

7 new cases in `tests/Sorcha.Agent.Tests/Commands/HaipPresentCommandTests.cs`:

- Bare JSON object → deserialises payload
- JSON with leading whitespace → tolerated
- Valid compact JWT → returns payload segment
- HTML error page → throws with the 20-char preview quoted
- Plain-text error → same
- Empty response → throws
- `eyJ`-prefix-but-only-one-segment → defensive throw with clear message

All 117 Sorcha.Agent.Tests pass.

## Out of scope

The existing `TODO(SEC)` comment is preserved. Issue #344 still tracks RFC 9101 §4 JWS-signature verification — required before this code is used against an untrusted verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)