### PR TITLE
fix(#345): ReviewSummaryRenderer stacked-mode polish (items 1, 2, 4)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Forms/ReviewSummaryRenderer.razor
@@ -104,9 +104,7 @@ else
         // config, and only on a review page. Any one of these being absent
         // falls back to single-card review.
         var requirementList = ActionCredentialRequirements?.ToList();
-        var hasRequirements = requirementList is { Count: > 0 };
-        var hasIssuance = ActionCredentialIssuanceConfig is not null;
-        _isStackedMode = hasRequirements && hasIssuance;
+        _isStackedMode = ShouldEnableStackedMode(requirementList, ActionCredentialIssuanceConfig);
 
         if (_isStackedMode && FormContext is not null && Page.ReviewExtension is not null)
         {
@@ -120,6 +118,21 @@ else
         }
     }
 
+    /// <summary>
+    /// Stacked-mode toggle predicate, factored out for direct unit testing (#345 item 4).
+    /// Returns true iff the action declares both a non-empty credential requirement set
+    /// (the credential the citizen presented) AND a credential-issuance config (the
+    /// credential the citizen will receive). Either being absent disables stacked mode.
+    /// </summary>
+    internal static bool ShouldEnableStackedMode(
+        IReadOnlyList<CredentialRequirement>? requirements,
+        Sorcha.Blueprint.Models.Credentials.CredentialIssuanceConfig? issuanceConfig)
+    {
+        var hasRequirements = requirements is { Count: > 0 };
+        var hasIssuance = issuanceConfig is not null;
+        return hasRequirements && hasIssuance;
+    }
+
     private IdCardLayoutConfig BuildPresentedCardConfig(IReadOnlyList<CredentialRequirement> requirementList)
     {
         // Top card shows the claims the DLA requested from the citizen's
@@ -128,6 +141,11 @@ else
         // shows claim NAMES with a "Verified" badge so the DLA officer
         // sees that the presentation happened. Withheld-optional claims
         // render as faded "— — —".
+        //
+        // v1 limitation (#345 item 2): only the first credential requirement
+        // is rendered. If multiple requirements become a real authoring
+        // pattern, support a stack of presented cards or a multi-credential
+        // top section. Tracked alongside #345.
         var requirement = requirementList[0];
         var sections = new List<IdCardSection>();
         var fieldValues = new Dictionary<string, object?>(StringComparer.Ordinal);
@@ -149,8 +167,13 @@ else
 
         return new IdCardLayoutConfig
         {
-            IssuerName = requirement.AcceptedIssuers?.FirstOrDefault() ?? "Acme Verification Co.",
-            CredentialName = requirement.Type ?? "Assured Identity",
+            // #345 item 1: avoid coupling the generic renderer to one walkthrough's
+            // issuer name. When AcceptedIssuers is null, fall back to a neutral label
+            // rather than a hardcoded organisation name. CredentialName falls back to
+            // a generic "Credential" rather than a specific credential type, for the
+            // same reason.
+            IssuerName = requirement.AcceptedIssuers?.FirstOrDefault() ?? "Unknown Issuer",
+            CredentialName = requirement.Type ?? "Credential",
             ColourTheme = XReviewColourTheme.IdentityNavy,
             Watermark = IdCardWatermark.Issued,
             FieldValues = fieldValues,

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/ReviewSummaryRendererTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/ReviewSummaryRendererTests.cs
@@ -3,6 +3,8 @@
 
 using FluentAssertions;
 using Sorcha.Blueprint.Models;
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.UI.Core.Components.Forms;
 using Sorcha.UI.Core.Models.Forms;
 using Sorcha.UI.Core.Services.Forms;
 using Xunit;
@@ -40,5 +42,53 @@ public class ReviewSummaryRendererTests
     public void IsImplemented_ReservedVariants_False(XReviewLayoutVariant variant)
     {
         ReviewSummaryDispatch.IsImplemented(variant).Should().BeFalse();
+    }
+
+    // --- ReviewSummaryRenderer.ShouldEnableStackedMode (#345 item 4) ---
+
+    private static CredentialIssuanceConfig MinimalIssuance() =>
+        new() { CredentialType = "x", RecipientParticipantId = "p" };
+
+    private static CredentialRequirement MinimalRequirement() =>
+        new() { Type = "AssuredIdentity" };
+
+    [Fact]
+    public void ShouldEnableStackedMode_BothPresent_True()
+    {
+        var requirements = new List<CredentialRequirement> { MinimalRequirement() };
+
+        ReviewSummaryRenderer.ShouldEnableStackedMode(requirements, MinimalIssuance())
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldEnableStackedMode_NullRequirements_False()
+    {
+        ReviewSummaryRenderer.ShouldEnableStackedMode(null, MinimalIssuance())
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldEnableStackedMode_EmptyRequirements_False()
+    {
+        ReviewSummaryRenderer.ShouldEnableStackedMode(
+                new List<CredentialRequirement>(), MinimalIssuance())
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldEnableStackedMode_NullIssuance_False()
+    {
+        var requirements = new List<CredentialRequirement> { MinimalRequirement() };
+
+        ReviewSummaryRenderer.ShouldEnableStackedMode(requirements, null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldEnableStackedMode_BothMissing_False()
+    {
+        ReviewSummaryRenderer.ShouldEnableStackedMode(null, null)
+            .Should().BeFalse();
     }
 }


### PR DESCRIPTION
Closes items 1, 2, and 4 of #345. Item 3 is deferred to its overlapping work in #338 per the issue's own note.

### Item 1 — neutral fallback labels

The stacked top-card hardcoded `Acme Verification Co.` and `Assured Identity` as fallback issuer/credential names. That coupled the generic renderer to one walkthrough's brand. Changed to neutral labels:

| Field | Before | After |
|---|---|---|
| IssuerName | `Acme Verification Co.` | `Unknown Issuer` |
| CredentialName | `Assured Identity` | `Credential` |

Issue text mentioned `Government of Scotland` as the hardcoded value — that string doesn't actually exist anywhere in the codebase; the real fallbacks were the two above. Same fix applies.

### Item 2 — v1 single-requirement limitation noted

Added a comment at `requirementList[0]` documenting the v1-only behaviour and naming the follow-up shape if multiple requirements become a real authoring pattern.

### Item 4 — testable stacked-mode toggle

Extracted the toggle predicate from `OnParametersSet` into a directly testable internal static method:

```csharp
internal static bool ShouldEnableStackedMode(
    IReadOnlyList<CredentialRequirement>? requirements,
    CredentialIssuanceConfig? issuanceConfig)
```

5 new unit tests in `ReviewSummaryRendererTests`:
- both present → true
- null / empty requirements → false
- null issuance → false
- both missing → false

Catches the "toggle correctness" invariant the issue asks about without spinning up a full bUnit fixture for the razor component. The seam is preserved — a deeper bUnit assertion that both configs become non-null after the toggle fires can live in the same shape later if needed.

All 1172 `Sorcha.UI.Core.Tests` pass (was 1167 — 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)