### PR TITLE
feat(114): PWA Devices page with rename + revoke (US3 PR4, T120)

### DIFF
--- a/specs/114-citizen-wallet-pwa/tasks.md
+++ b/specs/114-citizen-wallet-pwa/tasks.md
@@ -262,7 +262,7 @@ This is a multi-app .NET 10 monorepo. New code lives in `src/Apps/Sorcha.Citizen
 
 ### PWA — device manager page
 
-- [ ] T120 [US3] Create `src/Apps/Sorcha.Citizen.Wallet/Pages/Devices.razor` — `/wallet/devices` route, lists devices with label / platform / enrolledAt / status. Per-row actions: rename (calls `PUT /devices/{id}/label`), revoke (calls `DELETE /devices/{id}`, with confirm dialog).
+- [x] T120 [US3] Create `src/Apps/Sorcha.Citizen.Wallet/Pages/Devices.razor` — `/wallet/devices` route, lists devices with label / platform / enrolledAt / status. Per-row actions: rename (calls `PUT /devices/{id}/label`), revoke (calls `DELETE /devices/{id}`, with confirm dialog). (Replaces the placeholder; uses two new MudDialog modals — `RenameDeviceDialog`, `ConfirmRevokeDialog` — and extends `ICitizenWalletClient` with `ListDevicesAsync` / `RenameDeviceAsync` / `RevokeDeviceAsync`.)
 
 ### Sorcha.UI.Web — additive My Devices page
 

--- a/src/Apps/Sorcha.Citizen.Wallet/Components/ConfirmRevokeDialog.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Components/ConfirmRevokeDialog.razor
@@ -1,0 +1,50 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Confirm-revoke modal (Feature 114, T120 — US3 PR4). Revoke is
+    destructive across the device's whole lifecycle — verifiers will
+    reject any presentation made from it once the status-list bit
+    propagates. Make the user type DEVICE LABEL to confirm.
+*@
+
+<MudDialog>
+    <DialogContent>
+        <MudAlert Severity="Severity.Warning" Class="mb-3">
+            Revoking <strong>@DeviceLabel</strong> is permanent. Any verifier
+            that refreshes the citizen-devices status list will reject
+            presentations signed by this device. You cannot un-revoke.
+        </MudAlert>
+        <MudText Typo="Typo.body2" Class="mb-2">
+            Type <strong>@DeviceLabel</strong> to confirm:
+        </MudText>
+        <MudTextField @bind-Value="_typed"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      Immediate="true"
+                      data-testid="revoke-confirm-input" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" data-testid="revoke-cancel">Cancel</MudButton>
+        <MudButton Color="Color.Error"
+                   Variant="Variant.Filled"
+                   Disabled="@(!IsConfirmed)"
+                   OnClick="Confirm"
+                   data-testid="revoke-confirm">
+            Revoke
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = null!;
+
+    [Parameter, EditorRequired] public string DeviceLabel { get; set; } = string.Empty;
+
+    private string _typed = string.Empty;
+
+    private bool IsConfirmed => string.Equals(_typed, DeviceLabel, StringComparison.Ordinal);
+
+    private void Confirm() => Dialog.Close(DialogResult.Ok(true));
+    private void Cancel() => Dialog.Cancel();
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Components/RenameDeviceDialog.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Components/RenameDeviceDialog.razor
@@ -1,0 +1,54 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Rename-device modal (Feature 114, T120 — US3 PR4). Returns the new
+    label string on Save, Canceled on Cancel.
+*@
+
+<MudDialog>
+    <DialogContent>
+        <MudTextField @bind-Value="_label"
+                      Label="Device label"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      MaxLength="120"
+                      Counter="120"
+                      Immediate="true"
+                      data-testid="rename-input" />
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
+            1–120 characters. The label is shown in your device list and on the main Sorcha web UI.
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" data-testid="rename-cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   Disabled="@(!IsValid)"
+                   OnClick="Save"
+                   data-testid="rename-save">
+            Save
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance Dialog { get; set; } = null!;
+
+    [Parameter, EditorRequired] public string CurrentLabel { get; set; } = string.Empty;
+
+    private string _label = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        _label = CurrentLabel;
+    }
+
+    private bool IsValid =>
+        !string.IsNullOrWhiteSpace(_label) &&
+        _label.Length <= 120 &&
+        !string.Equals(_label, CurrentLabel, StringComparison.Ordinal);
+
+    private void Save() => Dialog.Close(DialogResult.Ok(_label));
+    private void Cancel() => Dialog.Cancel();
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Devices.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Devices.razor
@@ -2,16 +2,200 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Placeholder Devices page (T120 — full implementation lands with US3).
+    Devices (Feature 114, T120 — US3 PR4). Lists the citizen's enrolled
+    wallet devices with per-row rename + revoke. Backed by:
+      GET    /api/v1/wallet/devices  (PR3)
+      PUT    /api/v1/wallet/devices/{id}/label  (PR3)
+      DELETE /api/v1/wallet/devices/{id}  (PR2b — flips status-list bit
+              + broadcasts WalletHub.DeviceRevoked)
+
+    Revocation is destructive across the device's whole lifecycle —
+    confirm gate before calling; status changes show in the list as
+    Revoked once the call returns.
 *@
 @page "/devices"
 @layout MainLayout
+@using Sorcha.CitizenWallet.Abstractions.Models
+@using Sorcha.ServiceClients.CitizenWallet
+@inject ICitizenWalletClient WalletClient
+@inject IDialogService Dialogs
+@inject ISnackbar Snackbar
+@inject ILogger<Devices> Logger
 
 <PageTitle>Devices</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
-    <MudText Typo="Typo.h5">Your devices</MudText>
-    <MudAlert Severity="Severity.Info" Class="mt-3">
-        Device management lands with US3 (recovery flow).
-    </MudAlert>
+    <MudText Typo="Typo.h5" Class="mb-3">Your devices</MudText>
+
+    @if (_loading)
+    {
+        <MudProgressCircular Indeterminate="true" />
+    }
+    else if (_loadError is not null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-3">@_loadError</MudAlert>
+        <MudButton Variant="Variant.Outlined" OnClick="LoadAsync">Retry</MudButton>
+    }
+    else if (_devices is null || _devices.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info">
+            No devices enrolled yet. Once you enrol on this device, it will appear here.
+        </MudAlert>
+    }
+    else
+    {
+        <MudList T="DeviceSummary" Dense="false" data-testid="device-list">
+            @foreach (var device in _devices)
+            {
+                <MudListItem T="DeviceSummary" data-testid="@($"device-row-{device.DeviceId}")">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Class="w-100">
+                        <MudStack Row="false" Spacing="0" Class="flex-grow-1">
+                            <MudText Typo="Typo.body1">
+                                <strong>@device.Label</strong>
+                            </MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                @device.Platform · enrolled @device.EnrolledAt.ToLocalTime().ToString("d MMM yyyy")
+                            </MudText>
+                            <MudText Typo="Typo.caption">
+                                @if (device.Status == DeviceStatus.Active)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">Active</MudChip>
+                                }
+                                else
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Error" Variant="Variant.Outlined">Revoked</MudChip>
+                                    @if (device.RevokedAt is not null)
+                                    {
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ms-1" Inline="true">
+                                            @device.RevokedAt.Value.ToLocalTime().ToString("d MMM yyyy")
+                                        </MudText>
+                                    }
+                                }
+                            </MudText>
+                        </MudStack>
+                        @if (device.Status == DeviceStatus.Active)
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                           data-testid="@($"rename-{device.DeviceId}")"
+                                           Disabled="@(_busyDeviceId == device.DeviceId)"
+                                           OnClick="() => RenameAsync(device)" />
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                           Color="Color.Error"
+                                           data-testid="@($"revoke-{device.DeviceId}")"
+                                           Disabled="@(_busyDeviceId == device.DeviceId)"
+                                           OnClick="() => RevokeAsync(device)" />
+                        }
+                    </MudStack>
+                </MudListItem>
+            }
+        </MudList>
+    }
 </MudContainer>
+
+@code {
+    private List<DeviceSummary>? _devices;
+    private bool _loading = true;
+    private string? _loadError;
+    private Guid? _busyDeviceId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _loadError = null;
+        try
+        {
+            var response = await WalletClient.ListDevicesAsync();
+            _devices = response.Devices.ToList();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load devices");
+            _loadError = "Could not load devices. Check your connection and try again.";
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task RenameAsync(DeviceSummary device)
+    {
+        var parameters = new DialogParameters
+        {
+            ["CurrentLabel"] = device.Label,
+        };
+        var dialog = await Dialogs.ShowAsync<RenameDeviceDialog>("Rename device", parameters);
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not string newLabel) return;
+        if (string.Equals(newLabel, device.Label, StringComparison.Ordinal)) return;
+
+        _busyDeviceId = device.DeviceId;
+        try
+        {
+            var ok = await WalletClient.RenameDeviceAsync(device.DeviceId, newLabel);
+            if (ok)
+            {
+                // Optimistic UI update — server already accepted the change.
+                var idx = _devices!.FindIndex(d => d.DeviceId == device.DeviceId);
+                _devices[idx] = device with { Label = newLabel };
+                Snackbar.Add("Device renamed.", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add("Device not found.", Severity.Warning);
+                await LoadAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Rename device failed");
+            Snackbar.Add($"Rename failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _busyDeviceId = null;
+        }
+    }
+
+    private async Task RevokeAsync(DeviceSummary device)
+    {
+        var parameters = new DialogParameters
+        {
+            ["DeviceLabel"] = device.Label,
+        };
+        var dialog = await Dialogs.ShowAsync<ConfirmRevokeDialog>("Revoke device", parameters);
+        var result = await dialog.Result;
+        if (result is null || result.Canceled) return;
+
+        _busyDeviceId = device.DeviceId;
+        try
+        {
+            var ok = await WalletClient.RevokeDeviceAsync(device.DeviceId);
+            if (ok)
+            {
+                var idx = _devices!.FindIndex(d => d.DeviceId == device.DeviceId);
+                _devices[idx] = device with { Status = DeviceStatus.Revoked, RevokedAt = DateTimeOffset.UtcNow };
+                Snackbar.Add("Device revoked.", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add("Device not found.", Severity.Warning);
+                await LoadAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Revoke device failed");
+            Snackbar.Add($"Revoke failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _busyDeviceId = null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/_Imports.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/_Imports.razor
@@ -7,3 +7,4 @@
 @using Microsoft.JSInterop
 @using MudBlazor
 @using Sorcha.Citizen.Wallet
+@using Sorcha.Citizen.Wallet.Components

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/CitizenWalletClient.cs
@@ -107,4 +107,38 @@ public sealed class CitizenWalletClient : ICitizenWalletClient
         return await response.Content.ReadFromJsonAsync<DelegationRenewalResponse>(JsonOptions, ct)
             ?? throw new InvalidOperationException("Wallet Service returned an empty body for /devices/renew-delegation.");
     }
+
+    /// <inheritdoc />
+    public async Task<DeviceListResponse> ListDevicesAsync(CancellationToken ct = default)
+    {
+        var response = await _httpClient.GetAsync("api/v1/wallet/devices", ct);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<DeviceListResponse>(JsonOptions, ct)
+            ?? throw new InvalidOperationException("Wallet Service returned an empty body for /devices.");
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RenameDeviceAsync(
+        Guid deviceId, string label, CancellationToken ct = default)
+    {
+        var response = await _httpClient.PutAsJsonAsync(
+            $"api/v1/wallet/devices/{deviceId}/label",
+            new DeviceLabelUpdateRequest { Label = label },
+            JsonOptions, ct);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return false;
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RevokeDeviceAsync(
+        Guid deviceId, CancellationToken ct = default)
+    {
+        var response = await _httpClient.DeleteAsync($"api/v1/wallet/devices/{deviceId}", ct);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return false;
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
 }

--- a/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/ICitizenWalletClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/CitizenWallet/ICitizenWalletClient.cs
@@ -50,4 +50,24 @@ public interface ICitizenWalletClient
     /// </summary>
     Task<DelegationRenewalResponse?> RenewDelegationAsync(
         Guid deviceId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists the citizen's enrolled devices (active + revoked, ordered by
+    /// enrolment desc). Calls <c>GET /api/v1/wallet/devices</c>.
+    /// </summary>
+    Task<DeviceListResponse> ListDevicesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Renames a device. Calls <c>PUT /api/v1/wallet/devices/{id}/label</c>.
+    /// Returns <c>false</c> on 404 (unknown / not owned).
+    /// </summary>
+    Task<bool> RenameDeviceAsync(
+        Guid deviceId, string label, CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes a device. Calls <c>DELETE /api/v1/wallet/devices/{id}</c>.
+    /// Returns <c>false</c> on 404 (unknown / not owned).
+    /// </summary>
+    Task<bool> RevokeDeviceAsync(
+        Guid deviceId, CancellationToken ct = default);
 }


### PR DESCRIPTION
## Summary

Replaces the placeholder `Devices.razor` with the real US3 device manager — list, rename, revoke. Closes the PWA-side recovery loop on top of the server-side work landed in PRs #501 (T113-T115), #512 (StatusListId prep), #513 (T116-T117/T119), and #514 (T118 read+rename).

## What's new

**Pages**
- `Devices.razor` (rewrite): MudList of `DeviceSummary` rows. Active devices show rename + revoke icon buttons; revoked devices show as a chip with `RevokedAt` timestamp and no actions. Optimistic UI on success; re-fetches on 404 (covers concurrent-revoke race against web-UI).

**Components**
- `RenameDeviceDialog.razor`: MudDialog with `MudTextField` bound to `_label`, 1..120 validation, immediate, no-op on unchanged input.
- `ConfirmRevokeDialog.razor`: MudDialog with **type-the-label** confirmation gate. Revocation is destructive (verifiers reject every presentation from the device once the status list refreshes), so we treat it like a `DELETE /api/v1/wallet/devices/{id}` of last resort, not a casual click-through.

**ServiceClients.Http (`ICitizenWalletClient`)**
- `ListDevicesAsync()` — GET /api/v1/wallet/devices
- `RenameDeviceAsync(deviceId, label)` — PUT label; returns `false` on 404
- `RevokeDeviceAsync(deviceId)` — DELETE; returns `false` on 404

**Imports**
- Add `Sorcha.Citizen.Wallet.Components` to `_Imports.razor` so the page resolves dialog types without per-file `@using`.

## Tests

- 45/45 existing PWA unit tests still green
- New page coverage lives in the Playwright E2E suite scheduled for T122 (PR5 of US3) — this is the codebase pattern for the PWA per `tasks.md` and the `sorcha-ui` skill

## Test plan
- [x] `dotnet build C:/Projects/Sorcha/Sorcha.sln` clean
- [x] PWA + ServiceClients build clean
- [x] Citizen.Wallet.Tests (45) all green
- [ ] Manual smoke deferred until PR5 lands the additive web `MyDevices` page + Playwright; n1 reset + walkthrough is the natural moment

## Out of scope (PR5)
- T121 — additive `MyDevices.razor` in `Sorcha.UI.Web.Client` (web UI side of recovery)
- T122 — Playwright E2E covering both PWA Devices and web MyDevices

🤖 Generated with [Claude Code](https://claude.com/claude-code)