### PR TITLE
feat(114): additive MyDevices page + Playwright (US3 PR5, T121/T122)

### DIFF
--- a/specs/114-citizen-wallet-pwa/tasks.md
+++ b/specs/114-citizen-wallet-pwa/tasks.md
@@ -266,8 +266,8 @@ This is a multi-app .NET 10 monorepo. New code lives in `src/Apps/Sorcha.Citizen
 
 ### Sorcha.UI.Web — additive My Devices page
 
-- [ ] T121 [US3] Create `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor` — new additive page in the existing Sorcha.UI.Web (does NOT modify any existing page; FR-035 holds). Calls `GET /api/v1/me/devices`, surfaces the same list + revoke action. Linked from the existing MyProfile menu (one new menu entry).
-- [ ] T122 [P] [US3] Add E2E coverage for the additive MyDevices page in `tests/Sorcha.UI.E2E.Tests/Docker/MyDevicesTests.cs` (extends existing UI test pattern, not the wallet test pattern).
+- [x] T121 [US3] Create `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor` — new additive page in the existing Sorcha.UI.Web (does NOT modify any existing page; FR-035 holds). Calls `GET /api/v1/me/devices`, surfaces the same list + revoke action. Linked from the existing MyProfile menu (one new menu entry).
+- [x] T122 [P] [US3] Add E2E coverage for the additive MyDevices page in `tests/Sorcha.UI.E2E.Tests/Docker/MyDevicesTests.cs` (extends existing UI test pattern, not the wallet test pattern).
 
 **Checkpoint**: Recovery flow works end to end. Citizen can revoke from either wallet or main UI; lost device is rejected by verifier within the documented status-list refresh interval; new device enrols + recovers credentials with no re-issuance.
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/UserProfileMenu.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/UserProfileMenu.razor
@@ -49,6 +49,11 @@
     <MudMenuItem Icon="@Icons.Material.Filled.Person" OnClick="@(() => Navigation.NavigateTo("profile"))">
         My Profile
     </MudMenuItem>
+    <MudMenuItem Icon="@Icons.Material.Filled.Devices"
+                 OnClick="@(() => Navigation.NavigateTo("my-devices"))"
+                 data-testid="user-menu-my-devices">
+        My Devices
+    </MudMenuItem>
     <MudMenuItem Icon="@Icons.Material.Filled.Token" OnClick="OpenJwtViewer">
         View Token
     </MudMenuItem>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
@@ -1,0 +1,202 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@*
+    My Devices (Feature 114, T121 — US3 PR5). Additive page giving the
+    citizen a recovery surface from the main Sorcha web UI: list every
+    enrolled wallet device + revoke any one of them. Backed by the
+    Tenant Service endpoints landed in PR #501:
+
+      GET    /api/v1/me/devices            (list)
+      DELETE /api/v1/me/devices/{deviceId} (revoke — Tenant flips local
+              row + S2S to Wallet to flip status-list bit + broadcast
+              SignalR DeviceRevoked)
+
+    FR-035 (additive only): no existing pages were modified to add this
+    surface; the menu link in UserProfileMenu is a one-line additive
+    MudMenuItem alongside the existing entries.
+*@
+
+@page "/my-devices"
+@rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
+@attribute [Authorize]
+
+@using System.Net
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.Extensions.Logging
+@using MudBlazor
+@using Sorcha.CitizenWallet.Abstractions.Models
+
+@inject HttpClient Http
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+@inject ILogger<MyDevices> Logger
+
+<PageTitle>My Devices - Sorcha Platform</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
+    <MudText Typo="Typo.h4" Class="mb-2">
+        <MudIcon Icon="@Icons.Material.Filled.Devices" Class="mr-2" />
+        My Devices
+    </MudText>
+    <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+        Wallet devices you've enrolled. Lost your phone? Revoke it here so
+        verifiers reject any further presentations from that device.
+    </MudText>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="my-8" />
+    }
+    else if (_loadError is not null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-3" data-testid="my-devices-error">
+            @_loadError
+        </MudAlert>
+        <MudButton Variant="Variant.Outlined" OnClick="LoadAsync">Retry</MudButton>
+    }
+    else if (_devices is null || _devices.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" data-testid="my-devices-empty">
+            No wallet devices enrolled yet. Once you enrol from the citizen
+            wallet PWA, devices will appear here.
+        </MudAlert>
+    }
+    else
+    {
+        <MudPaper Elevation="1">
+            <MudList T="DeviceSummary" Dense="false" data-testid="my-devices-list">
+                @foreach (var device in _devices)
+                {
+                    <MudListItem T="DeviceSummary" data-testid="@($"my-devices-row-{device.DeviceId}")">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Class="w-100">
+                            <MudIcon Icon="@(device.Status == DeviceStatus.Active ? Icons.Material.Filled.PhoneIphone : Icons.Material.Outlined.PhoneIphone)"
+                                     Color="@(device.Status == DeviceStatus.Active ? Color.Primary : Color.Default)" />
+                            <MudStack Row="false" Spacing="0" Class="flex-grow-1">
+                                <MudText Typo="Typo.body1"><strong>@device.Label</strong></MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    @device.Platform · enrolled @device.EnrolledAt.ToLocalTime().ToString("d MMM yyyy")
+                                </MudText>
+                                <MudText Typo="Typo.caption">
+                                    @if (device.Status == DeviceStatus.Active)
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">Active</MudChip>
+                                    }
+                                    else
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Error" Variant="Variant.Outlined">Revoked</MudChip>
+                                        @if (device.RevokedAt is not null)
+                                        {
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ms-1" Inline="true">
+                                                @device.RevokedAt.Value.ToLocalTime().ToString("d MMM yyyy")
+                                            </MudText>
+                                        }
+                                    }
+                                </MudText>
+                            </MudStack>
+                            @if (device.Status == DeviceStatus.Active)
+                            {
+                                <MudButton Variant="Variant.Outlined" Color="Color.Error"
+                                           StartIcon="@Icons.Material.Filled.Delete"
+                                           Disabled="@(_busyDeviceId == device.DeviceId)"
+                                           OnClick="() => RevokeAsync(device)"
+                                           data-testid="@($"my-devices-revoke-{device.DeviceId}")">
+                                    Revoke
+                                </MudButton>
+                            }
+                        </MudStack>
+                    </MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    }
+</MudContainer>
+
+@code {
+    private List<DeviceSummary>? _devices;
+    private bool _loading = true;
+    private string? _loadError;
+    private Guid? _busyDeviceId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _loadError = null;
+        try
+        {
+            var response = await Http.GetFromJsonAsync<DeviceListResponse>("/api/v1/me/devices");
+            _devices = response?.Devices.ToList() ?? new List<DeviceSummary>();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load /api/v1/me/devices");
+            _loadError = "Could not load devices. Check your connection and try again.";
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task RevokeAsync(DeviceSummary device)
+    {
+        var confirm = await DialogService.ShowMessageBoxAsync(
+            "Revoke device?",
+            $"Revoking \"{device.Label}\" is permanent. Verifiers that refresh the citizen-devices status list will reject any further presentations from this device. You cannot un-revoke.",
+            yesText: "Revoke",
+            cancelText: "Cancel",
+            options: new DialogOptions { CloseButton = true });
+        if (confirm != true) return;
+
+        _busyDeviceId = device.DeviceId;
+        try
+        {
+            var response = await Http.DeleteAsync($"/api/v1/me/devices/{device.DeviceId}");
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                var idx = _devices!.FindIndex(d => d.DeviceId == device.DeviceId);
+                if (idx >= 0)
+                {
+                    _devices[idx] = device with
+                    {
+                        Status = DeviceStatus.Revoked,
+                        RevokedAt = DateTimeOffset.UtcNow
+                    };
+                }
+                Snackbar.Add("Device revoked.", Severity.Success);
+            }
+            else if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                Snackbar.Add("Device not found.", Severity.Warning);
+                await LoadAsync();
+            }
+            else if (response.StatusCode == HttpStatusCode.BadGateway)
+            {
+                // Tenant row IS revoked but Wallet S2S failed. Caller should retry.
+                Snackbar.Add(
+                    "Device marked revoked, but the wallet status-list flip failed. Try again to complete revocation.",
+                    Severity.Warning);
+                await LoadAsync();
+            }
+            else
+            {
+                Snackbar.Add($"Revoke failed (HTTP {(int)response.StatusCode}).", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Revoke /api/v1/me/devices/{DeviceId} failed", device.DeviceId);
+            Snackbar.Add($"Revoke failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _busyDeviceId = null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Sorcha.UI.Web.Client.csproj
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Sorcha.UI.Web.Client.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\..\Common\Sorcha.Blueprint.Models\Sorcha.Blueprint.Models.csproj" />
     <ProjectReference Include="..\..\..\Core\Sorcha.Blueprint.Fluent\Sorcha.Blueprint.Fluent.csproj" />
     <ProjectReference Include="..\..\..\Core\Sorcha.Blueprint.Schemas.Client\Sorcha.Blueprint.Schemas.Client.csproj" />
+    <ProjectReference Include="..\..\..\Common\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Sorcha.UI.E2E.Tests/Docker/MyDevicesTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/MyDevicesTests.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+using Sorcha.UI.E2E.Tests.PageObjects.Shared;
+
+namespace Sorcha.UI.E2E.Tests.Docker;
+
+/// <summary>
+/// E2E coverage for the additive <c>/my-devices</c> page (Feature 114, T122 — US3 PR5).
+/// Validates that an authenticated citizen can reach the page from the user-profile menu
+/// and that the empty / list states render with the right test ids. Revoke-flow happy
+/// path is covered by the citizen-wallet E2E suite (T149 — Polish phase) once a real
+/// device has been enrolled; here we only need to prove the additive web surface and
+/// menu link don't regress and call the right Tenant endpoint.
+/// </summary>
+[TestFixture]
+[Category("Docker")]
+[Category("Devices")]
+[Category("Authenticated")]
+[Parallelizable(ParallelScope.Self)]
+public class MyDevicesTests : AuthenticatedDockerTestBase
+{
+    [Test]
+    [Retry(2)]
+    public async Task MyDevices_PageLoads_HeadingVisible()
+    {
+        await NavigateAuthenticatedAsync(TestConstants.AuthenticatedRoutes.MyDevices);
+        await MudBlazorHelpers.WaitForBlazorAsync(Page, TestConstants.PageLoadTimeout);
+
+        var heading = Page.Locator("h4:has-text('My Devices')");
+        await heading.WaitForAsync(new() { Timeout = TestConstants.ElementTimeout });
+        Assert.That(await heading.IsVisibleAsync(), Is.True,
+            "MyDevices page should render with the 'My Devices' h4 heading");
+    }
+
+    [Test]
+    [Retry(2)]
+    public async Task MyDevices_NoEnrolledDevices_ShowsEmptyState()
+    {
+        // The default test user has no wallet devices enrolled (PWA enrolment is a
+        // separate flow). Assert the empty-state alert renders so the page handles
+        // zero rows gracefully — the failure mode we care about is "page crashes
+        // because Devices is null".
+        await NavigateAuthenticatedAsync(TestConstants.AuthenticatedRoutes.MyDevices);
+        await MudBlazorHelpers.WaitForBlazorAsync(Page, TestConstants.PageLoadTimeout);
+
+        // Either the empty state OR an existing list — both are acceptable; what
+        // we don't want is the error alert.
+        var error = Page.Locator("[data-testid='my-devices-error']");
+        await Page.WaitForTimeoutAsync(TestConstants.ShortWait);
+        Assert.That(await error.CountAsync(), Is.EqualTo(0),
+            "MyDevices should not surface an error alert on a clean load");
+
+        var empty = Page.Locator("[data-testid='my-devices-empty']");
+        var list = Page.Locator("[data-testid='my-devices-list']");
+        var hasEmpty = await empty.CountAsync() > 0;
+        var hasList = await list.CountAsync() > 0;
+        Assert.That(hasEmpty || hasList, Is.True,
+            "MyDevices should render either the empty-state alert or the device list");
+    }
+
+    [Test]
+    [Retry(2)]
+    public async Task UserProfileMenu_ContainsMyDevicesLink()
+    {
+        await NavigateAuthenticatedAsync(TestConstants.AuthenticatedRoutes.Dashboard);
+        await MudBlazorHelpers.WaitForBlazorAsync(Page, TestConstants.PageLoadTimeout);
+
+        // Open the user profile menu — pattern follows the existing UserProfileMenu
+        // (avatar button in the top app bar). The menu items render lazily, so we
+        // assert the new MyDevices entry is present after opening.
+        var avatar = Page.Locator(".mud-avatar").First;
+        if (await avatar.CountAsync() > 0)
+        {
+            await avatar.ClickAsync();
+            await Page.WaitForTimeoutAsync(TestConstants.ShortWait);
+        }
+
+        var myDevicesItem = Page.Locator("[data-testid='user-menu-my-devices']");
+        Assert.That(await myDevicesItem.CountAsync(), Is.GreaterThan(0),
+            "UserProfileMenu should expose a 'My Devices' menu item linking to /my-devices");
+    }
+}

--- a/tests/Sorcha.UI.E2E.Tests/Infrastructure/TestConstants.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Infrastructure/TestConstants.cs
@@ -157,5 +157,6 @@ public static class TestConstants
         public const string NotificationSettings = $"{AppBase}/settings/notifications";
         public const string Credentials = $"{AppBase}/credentials";
         public const string Help = $"{AppBase}/help";
+        public const string MyDevices = $"{AppBase}/my-devices";
     }
 }


### PR DESCRIPTION
## Summary

Closes US3 with the **recovery surface** in the main Sorcha web UI: "I lost my phone, log in here, see and revoke devices." Additive — no existing pages modified (FR-035).

This is the final PR for US3. Stack landed: **#501** → **#512** → **#513** → **#514** → **#515** → this.

## What's new

**Web UI (Sorcha.UI.Web.Client)**
- `Pages/MyDevices.razor` — `/my-devices` route, `[Authorize]`. Lists `DeviceSummary` rows from `GET /api/v1/me/devices` (PR1). Active rows show a Revoke button gated by a `MudMessageBox` confirmation. Revoke calls `DELETE /api/v1/me/devices/{id}` which (PR2b) flips the Tenant row **and** dispatches Tenant→Wallet S2S to flip the status-list bit + broadcast SignalR `DeviceRevoked`. Handles 204/404/502 with appropriate Snackbar messaging.
- `Sorcha.UI.Web.Client.csproj` — adds `ProjectReference` to `Sorcha.CitizenWallet.Abstractions` for the shared `DeviceSummary` / `DeviceListResponse` / `DeviceStatus` contract DTOs (matches the pattern set in PR1 for Tenant Service).

**Navigation (Sorcha.UI.Core)**
- `Components/Shared/UserProfileMenu.razor` — one new `MudMenuItem` ("My Devices", `Icons.Material.Filled.Devices`) alongside the existing My Profile / View Token / Settings entries. One-line additive change.

**E2E (Sorcha.UI.E2E.Tests)**
- `Docker/MyDevicesTests.cs` — 3 tests:
  - Page loads with the h4 heading
  - Clean-load shows either empty-state or list (never the error alert)
  - UserProfileMenu surfaces the My Devices link with the right `data-testid`
- `TestConstants.AuthenticatedRoutes.MyDevices = /my-devices`

Revoke happy-path E2E from this surface is deferred to the citizen-wallet E2E suite (Polish T149) since it needs a real PWA enrolment first; the Wallet-side WebApplicationFactory tests in PR2b/PR3 already cover the server-side revoke chain end-to-end.

## Test plan
- [x] `dotnet build C:/Projects/Sorcha/Sorcha.sln` clean
- [x] All affected tests green locally
- [ ] Manual smoke deferred to n1 reset + walkthrough (post-merge of all US3)

## US3 done — what's next?

After this lands, **US3 is fully on master**. Natural follow-ups:
- Manual smoke on n1 (reset + the HaipVerifiedCitizen walkthrough exercises the chain)
- US4 (auto-receive new credentials via SignalR push) — T123-T131
- US5 (presentation history) — T132-T143

🤖 Generated with [Claude Code](https://claude.com/claude-code)