### PR TITLE
feat(118): Phase 5 v1 durable user inbox (US3, T055/T062-T064/T067-T072)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -131,7 +131,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 ### Tests for User Story 3
 
 - [ ] T054 [P] [US3] EF migration test in `tests/Sorcha.Tenant.Service.Tests/Migrations/InboxEntryMigrationTests.cs` (apply, check schema, check indexes).
-- [ ] T055 [P] [US3] `InboxService` unit tests in `tests/Sorcha.Tenant.Service.Tests/Services/InboxServiceTests.cs` covering write, idempotent write, read transition, dismiss transition, mark-all-read.
+- [X] T055 [P] [US3] `InboxService` unit tests in `tests/Sorcha.Tenant.Service.Tests/Services/InboxServiceTests.cs` covering write, idempotent write, read transition, dismiss transition, mark-all-read.
 - [ ] T056 [P] [US3] Redis index tests in `tests/Sorcha.Tenant.Service.Tests/Services/InboxUnreadIndexTests.cs` covering ZADD, ZREM, ZCARD atomicity and Postgres fallback when Redis is down.
 - [ ] T057 [P] [US3] Endpoint integration tests in `tests/Sorcha.Tenant.Service.Tests/Endpoints/MeInboxEndpointsTests.cs` covering all six public endpoints, authorization scoping, idempotency.
 - [ ] T058 [P] [US3] Internal endpoint test in `tests/Sorcha.Tenant.Service.Tests/Endpoints/InternalInboxEndpointsTests.cs` covering RequireService policy gate, idempotent write on `(PlatformUserId, SourceEventId)`, validation errors.
@@ -141,17 +141,17 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 
 ### Implementation for User Story 3
 
-- [ ] T062 [US3] Create `InboxEntry` EF entity, `InboxCategory` and `InboxSeverity` enums, `ChannelHints` `[Flags]` enum at `src/Services/Sorcha.Tenant.Service/Models/InboxEntry.cs` per `data-model.md`.
-- [ ] T063 [US3] Add `InboxEntries` `DbSet` to `src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs` with the five indexes from `data-model.md` § Indexes.
-- [ ] T064 [US3] Create EF migration `Migrations/AddInboxEntry.cs` for the new table.
+- [X] T062 [US3] Create `InboxEntry` EF entity, `InboxCategory` and `InboxSeverity` enums, `ChannelHints` `[Flags]` enum at `src/Services/Sorcha.Tenant.Service/Models/InboxEntry.cs` per `data-model.md`.
+- [X] T063 [US3] Add `InboxEntries` `DbSet` to `src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs` with the five indexes from `data-model.md` § Indexes.
+- [X] T064 [US3] Create EF migration `Migrations/AddInboxEntry.cs` for the new table.
 - [ ] T065 [US3] Implement `IInboxStore` and `EfCoreInboxStore` (Postgres) in `src/Services/Sorcha.Tenant.Service/Services/InboxStore.cs`. Register through `IStorageRegistrationLog` per Feature 113 pattern; production fail-fast applies.
 - [ ] T066 [US3] Implement `IInboxUnreadIndex` (Redis sorted-set wrapper) in `src/Services/Sorcha.Tenant.Service/Services/InboxUnreadIndex.cs` with `ZADD` / `ZREM` / `ZCARD` operations and Postgres `COUNT(*)` fallback. Register through `IStorageRegistrationLog`.
-- [ ] T067 [US3] Implement `IInboxService` and `InboxService` in `src/Services/Sorcha.Tenant.Service/Services/InboxService.cs` orchestrating Postgres write + Redis ZADD + TenantHub event emit. Idempotency on `(PlatformUserId, SourceEventId)`.
-- [ ] T068 [US3] Implement `MeInboxEndpoints` in `src/Services/Sorcha.Tenant.Service/Endpoints/MeInboxEndpoints.cs`: GET /api/me/inbox, GET /{id}, GET /unread-count, POST /{id}/read, POST /{id}/dismiss, POST /mark-all-read. All scoped to caller's `platform_user_id` claim. Per `contracts/inbox-endpoints.openapi.yaml`.
-- [ ] T069 [US3] Implement `InternalInboxEndpoints` in `src/Services/Sorcha.Tenant.Service/Endpoints/InternalInboxEndpoints.cs`: POST /api/internal/inbox gated by `RequireService` policy. Idempotency on the unique index, `200 idempotent:true` response on duplicate.
-- [ ] T070 [US3] Wire endpoints into `src/Services/Sorcha.Tenant.Service/Program.cs`. Add YARP route in `src/Services/Sorcha.ApiGateway/appsettings.json` for `/api/me/inbox/*` and (locally — not gateway-exposed) `/api/internal/inbox`.
-- [ ] T071 [US3] Implement TenantHub inbox event emission in `InboxService`: `InboxEntryAdded(entryId, occurredAt, traceId)` and `InboxUnreadCountUpdated(unreadCount, occurredAt, traceId)` on `TenantHubGroups.User(platformUserId)`. Per `contracts/tenant-hub-client.cs.md`.
-- [ ] T072 [P] [US3] Create `IPlatformInboxClient` HTTP client in `src/Common/Sorcha.ServiceClients.Http/Inbox/IPlatformInboxClient.cs` with `WriteAsync(InboxEntryWriteRequest)` calling `POST /api/internal/inbox` with the existing `ServiceAuthClient` token flow.
+- [X] T067 [US3] Implement `IInboxService` and `InboxService` in `src/Services/Sorcha.Tenant.Service/Services/InboxService.cs` orchestrating Postgres write + Redis ZADD + TenantHub event emit. Idempotency on `(PlatformUserId, SourceEventId)`.
+- [X] T068 [US3] Implement `MeInboxEndpoints` in `src/Services/Sorcha.Tenant.Service/Endpoints/MeInboxEndpoints.cs`: GET /api/me/inbox, GET /{id}, GET /unread-count, POST /{id}/read, POST /{id}/dismiss, POST /mark-all-read. All scoped to caller's `platform_user_id` claim. Per `contracts/inbox-endpoints.openapi.yaml`.
+- [X] T069 [US3] Implement `InternalInboxEndpoints` in `src/Services/Sorcha.Tenant.Service/Endpoints/InternalInboxEndpoints.cs`: POST /api/internal/inbox gated by `RequireService` policy. Idempotency on the unique index, `200 idempotent:true` response on duplicate.
+- [X] T070 [US3] Wire endpoints into `src/Services/Sorcha.Tenant.Service/Program.cs`. Add YARP route in `src/Services/Sorcha.ApiGateway/appsettings.json` for `/api/me/inbox/*` and (locally — not gateway-exposed) `/api/internal/inbox`.
+- [X] T071 [US3] Implement TenantHub inbox event emission in `InboxService`: `InboxEntryAdded(entryId, occurredAt, traceId)` and `InboxUnreadCountUpdated(unreadCount, occurredAt, traceId)` on `TenantHubGroups.User(platformUserId)`. Per `contracts/tenant-hub-client.cs.md`.
+- [X] T072 [P] [US3] Create `IPlatformInboxClient` HTTP client in `src/Common/Sorcha.ServiceClients.Http/Inbox/IPlatformInboxClient.cs` with `WriteAsync(InboxEntryWriteRequest)` calling `POST /api/internal/inbox` with the existing `ServiceAuthClient` token flow.
 - [ ] T073 [US3] Implement `BlueprintInboxWriter` service in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintInboxWriter.cs` invoked by `NotificationService` when an action becomes available. Writes a `Category=Action` entry with `tx:{walletAddr}:{txId}` correlation key. Registered in DI.
 - [ ] T074 [US3] Implement `WalletInboxWriter` service in `src/Services/Sorcha.Wallet.Service/Services/Implementation/WalletInboxWriter.cs` invoked by the credential issuance pipeline. Writes a `Category=Credential` entry with the same correlation key. Registered in DI.
 - [ ] T075 [P] [US3] Update `NotificationDeliveryService` in `src/Services/Sorcha.Wallet.Service/Services/Implementation/NotificationDeliveryService.cs` to invoke `IPlatformInboxClient.WriteAsync` instead of publishing to `wallet:notifications`. Keep the legacy publish during US2 parallel-fire window.

--- a/src/Common/Sorcha.ServiceClients.Http/Extensions/HttpServiceCollectionExtensions.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Extensions/HttpServiceCollectionExtensions.cs
@@ -77,6 +77,10 @@ public static class HttpServiceCollectionExtensions
         services.AddHttpClient<PlatformUserDeviceClient>();
         services.AddScoped<IPlatformUserDeviceClient, PlatformUserDeviceClient>();
 
+        // Feature 118 / US3: durable user inbox writer — POSTs entries to Tenant Service.
+        services.AddHttpClient<Inbox.PlatformInboxClient>();
+        services.AddScoped<Inbox.IPlatformInboxClient, Inbox.PlatformInboxClient>();
+
         // Feature 114: Citizen wallet client used by the PWA to call Wallet Service.
         // Caller-supplied JWT (no service-principal injection — citizen audience required).
         services.AddHttpClient<CitizenWalletClient>();

--- a/src/Common/Sorcha.ServiceClients.Http/Inbox/IPlatformInboxClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Inbox/IPlatformInboxClient.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.ServiceClients.Inbox;
+
+/// <summary>
+/// Service-to-service HTTP client for the Tenant Service internal inbox-write
+/// endpoint. Phase 5 (US3) of Feature 118.
+/// </summary>
+/// <remarks>
+/// Used by emitter services (Blueprint, Wallet, future inbox writers) to drop
+/// a user-facing notification into the durable inbox owned by Tenant Service.
+/// Idempotent on <c>(PlatformUserId, SourceEventId)</c> — duplicate POSTs
+/// resolve to the original entry.
+/// </remarks>
+public interface IPlatformInboxClient
+{
+    /// <summary>
+    /// POST <c>/api/internal/inbox</c>. Returns the persisted entry id and
+    /// whether the write was idempotent (duplicate of an earlier write).
+    /// </summary>
+    Task<InboxWriteOutcome> WriteAsync(InboxWritePayload payload, CancellationToken ct = default);
+}
+
+/// <summary>Wire shape sent to the internal inbox endpoint.</summary>
+public sealed record InboxWritePayload(
+    Guid PlatformUserId,
+    string Category,
+    string Severity,
+    string CorrelationKey,
+    string DetailHref,
+    Guid SourceEventId,
+    DateTimeOffset OccurredAt,
+    string Title,
+    string? Summary = null,
+    string? IconKey = null);
+
+/// <summary>Outcome returned by the internal inbox endpoint.</summary>
+public sealed record InboxWriteOutcome(Guid EntryId, bool Idempotent);

--- a/src/Common/Sorcha.ServiceClients.Http/Inbox/PlatformInboxClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Inbox/PlatformInboxClient.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceClients.Helpers;
+
+namespace Sorcha.ServiceClients.Inbox;
+
+/// <summary>
+/// Default <see cref="IPlatformInboxClient"/> — POSTs to Tenant Service's
+/// <c>/api/internal/inbox</c> behind a <c>RequireService</c> service principal token.
+/// </summary>
+public sealed class PlatformInboxClient : IPlatformInboxClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IServiceAuthClient _serviceAuth;
+    private readonly ILogger<PlatformInboxClient> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    /// <summary>Initialises a new <see cref="PlatformInboxClient"/>.</summary>
+    public PlatformInboxClient(
+        HttpClient httpClient,
+        IServiceAuthClient serviceAuth,
+        IConfiguration configuration,
+        ILogger<PlatformInboxClient> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _serviceAuth = serviceAuth ?? throw new ArgumentNullException(nameof(serviceAuth));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var serviceAddress = configuration["ServiceClients:TenantService:Address"]
+            ?? "https+http://tenant-service";
+
+        if (_httpClient.BaseAddress is null)
+        {
+            _httpClient.BaseAddress = new Uri(serviceAddress.TrimEnd('/') + "/");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<InboxWriteOutcome> WriteAsync(InboxWritePayload payload, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        await ServiceClientAuthHelper.SetAuthHeaderAsync(
+            _httpClient, _serviceAuth, _logger, "Tenant Service (Inbox)", ct);
+
+        var body = new
+        {
+            platformUserId = payload.PlatformUserId,
+            category = payload.Category,
+            severity = payload.Severity,
+            correlationKey = payload.CorrelationKey,
+            detailHref = payload.DetailHref,
+            sourceEventId = payload.SourceEventId,
+            occurredAt = payload.OccurredAt,
+            title = payload.Title,
+            summary = payload.Summary,
+            iconKey = payload.IconKey,
+        };
+
+        using var resp = await _httpClient.PostAsJsonAsync("api/internal/inbox", body, JsonOptions, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+
+        var json = await resp.Content.ReadFromJsonAsync<InboxResponseEnvelope>(JsonOptions, ct).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Tenant inbox endpoint returned empty body");
+
+        return new InboxWriteOutcome(json.Entry?.Id ?? Guid.Empty, json.Idempotent);
+    }
+
+    private sealed record InboxResponseEnvelope(InboxEntryShape? Entry, bool Idempotent);
+
+    private sealed record InboxEntryShape(Guid Id);
+}

--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -334,6 +334,8 @@
         "Match": { "Path": "/auth/{**catch-all}" }
       },
       "tenant-passkey":         { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/passkey/{**catch-all}" } },
+      "me-inbox":               { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/me/inbox/{**catch-all}" } },
+      "me-inbox-list":          { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/me/inbox", "Methods": [ "GET" ] } },
       "register-subscriptions-list":   { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/organizations/{orgId}/register-subscriptions", "Methods": [ "GET" ] } },
       "register-subscriptions-get":    { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/organizations/{orgId}/register-subscriptions/{registerId}", "Methods": [ "GET" ] } },
       "register-subscriptions-create": { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/organizations/{orgId}/register-subscriptions", "Methods": [ "POST" ] } },

--- a/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/TenantDbContext.cs
@@ -41,6 +41,7 @@ public class TenantDbContext : DbContext
     public DbSet<OrganizationRegisterSubscription> OrganizationRegisterSubscriptions => Set<OrganizationRegisterSubscription>();
     public DbSet<RegisterInvitationRecord> RegisterInvitationRecords => Set<RegisterInvitationRecord>();
     public DbSet<InvitationNonce> InvitationNonces => Set<InvitationNonce>();
+    public DbSet<InboxEntry> InboxEntries => Set<InboxEntry>();
 
     // Public schema entities for custom domain resolution
     public DbSet<CustomDomainMapping> CustomDomainMappings => Set<CustomDomainMapping>();
@@ -164,6 +165,79 @@ public class TenantDbContext : DbContext
 
         // Configure AuthChallengeToken entity (public schema) — Feature 116
         ConfigureAuthChallengeToken(modelBuilder);
+
+        // Configure InboxEntry entity (public schema) — Feature 118 / US3 (durable user inbox)
+        ConfigureInboxEntry(modelBuilder);
+    }
+
+    /// <summary>Feature 118 / US3 — durable per-user notification entries.</summary>
+    private void ConfigureInboxEntry(ModelBuilder modelBuilder)
+    {
+        var isInMemory = Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory"
+                      || Database.ProviderName == "Microsoft.EntityFrameworkCore.Sqlite";
+
+        modelBuilder.Entity<InboxEntry>(entity =>
+        {
+            if (isInMemory)
+                entity.ToTable("InboxEntries");
+            else
+                entity.ToTable("InboxEntries", "public");
+
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Category)
+                .HasConversion<string>()
+                .HasMaxLength(32)
+                .IsRequired();
+
+            entity.Property(e => e.Severity)
+                .HasConversion<string>()
+                .HasMaxLength(32)
+                .IsRequired();
+
+            entity.Property(e => e.CorrelationKey)
+                .IsRequired()
+                .HasMaxLength(256);
+
+            entity.Property(e => e.DetailHref)
+                .IsRequired()
+                .HasMaxLength(1024);
+
+            entity.Property(e => e.Title)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            entity.Property(e => e.Summary)
+                .HasMaxLength(1000);
+
+            entity.Property(e => e.IconKey)
+                .HasMaxLength(64);
+
+            entity.Property(e => e.OccurredAt).IsRequired();
+
+            // Idempotency on duplicate writer retries.
+            entity.HasIndex(e => new { e.PlatformUserId, e.SourceEventId })
+                .IsUnique()
+                .HasDatabaseName("IX_InboxEntries_PlatformUserId_SourceEventId");
+
+            // Primary list query.
+            entity.HasIndex(e => new { e.PlatformUserId, e.OccurredAt })
+                .HasDatabaseName("IX_InboxEntries_PlatformUserId_OccurredAt");
+
+            // Sibling-grouping lookup (30s correlation-key window).
+            entity.HasIndex(e => new { e.PlatformUserId, e.CorrelationKey, e.OccurredAt })
+                .HasDatabaseName("IX_InboxEntries_PlatformUserId_CorrelationKey_OccurredAt");
+
+            // Category filter.
+            entity.HasIndex(e => new { e.PlatformUserId, e.Category, e.OccurredAt })
+                .HasDatabaseName("IX_InboxEntries_PlatformUserId_Category_OccurredAt");
+
+            // Cascade delete with PlatformUser.
+            entity.HasOne<PlatformUser>()
+                .WithMany()
+                .HasForeignKey(e => e.PlatformUserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
     }
 
     private void ConfigureOrganization(ModelBuilder modelBuilder)

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/InternalInboxEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/InternalInboxEndpoints.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Endpoints;
+
+/// <summary>
+/// Internal endpoint for service-principal callers to write inbox entries on
+/// behalf of users. Phase 5 (US3) of Feature 118.
+/// </summary>
+/// <remarks>
+/// Idempotent on <c>(PlatformUserId, SourceEventId)</c>. A duplicate POST
+/// returns the original entry with HTTP 200 + <c>Idempotent:true</c>; the
+/// first call returns HTTP 201 Created.
+/// </remarks>
+public static class InternalInboxEndpoints
+{
+    /// <summary>Maps <c>POST /api/internal/inbox</c> with the RequireService policy.</summary>
+    public static IEndpointRouteBuilder MapInternalInboxEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/internal/inbox", WriteAsync)
+            .RequireAuthorization("RequireService")
+            .WithName("WriteInboxEntry")
+            .WithTags("Internal", "Inbox")
+            .WithSummary("Write an inbox entry on behalf of a user. Idempotent on (PlatformUserId, SourceEventId).");
+
+        return app;
+    }
+
+    private static async Task<IResult> WriteAsync(
+        HttpContext context,
+        IInboxService service,
+        InboxWriteRequestDto request,
+        CancellationToken ct)
+    {
+        if (request is null)
+        {
+            return Results.BadRequest(new { error = "request body required" });
+        }
+        if (request.PlatformUserId == Guid.Empty)
+        {
+            return Results.BadRequest(new { error = "platformUserId required" });
+        }
+        if (string.IsNullOrWhiteSpace(request.CorrelationKey))
+        {
+            return Results.BadRequest(new { error = "correlationKey required" });
+        }
+        if (string.IsNullOrWhiteSpace(request.DetailHref) || !request.DetailHref.StartsWith("/api/", StringComparison.Ordinal))
+        {
+            return Results.BadRequest(new { error = "detailHref must start with /api/" });
+        }
+        if (string.IsNullOrWhiteSpace(request.Title) || request.Title.Length > 200)
+        {
+            return Results.BadRequest(new { error = "title required, ≤ 200 chars" });
+        }
+
+        var write = new InboxWriteRequest(
+            PlatformUserId: request.PlatformUserId,
+            Category: request.Category,
+            Severity: request.Severity,
+            CorrelationKey: request.CorrelationKey,
+            DetailHref: request.DetailHref,
+            SourceEventId: request.SourceEventId == Guid.Empty ? Guid.NewGuid() : request.SourceEventId,
+            OccurredAt: request.OccurredAt == default ? DateTimeOffset.UtcNow : request.OccurredAt,
+            Title: request.Title,
+            Summary: request.Summary,
+            IconKey: request.IconKey,
+            ChannelHints: request.ChannelHints,
+            WriterServiceId: request.WriterServiceId);
+
+        var result = await service.WriteAsync(write, ct);
+        if (result.IsIdempotent)
+        {
+            return Results.Ok(new InboxEntryResponseDto(result.Entry, Idempotent:true));
+        }
+        return Results.Created($"/api/me/inbox/{result.Entry.Id:N}", new InboxEntryResponseDto(result.Entry, Idempotent:false));
+    }
+}
+
+/// <summary>Wire shape for <see cref="InternalInboxEndpoints.MapInternalInboxEndpoints"/>.</summary>
+public sealed record InboxWriteRequestDto(
+    Guid PlatformUserId,
+    InboxCategory Category,
+    InboxSeverity Severity,
+    string CorrelationKey,
+    string DetailHref,
+    Guid SourceEventId,
+    DateTimeOffset OccurredAt,
+    string Title,
+    string? Summary = null,
+    string? IconKey = null,
+    ChannelHints? ChannelHints = null,
+    Guid? WriterServiceId = null);
+
+/// <summary>Wire shape returned by the internal write endpoint.</summary>
+public sealed record InboxEntryResponseDto(InboxEntry Entry, bool Idempotent);

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/MeInboxEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/MeInboxEndpoints.cs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Endpoints;
+
+/// <summary>
+/// Public inbox endpoints for the authenticated platform user. Phase 5 (US3) of Feature 118.
+/// </summary>
+/// <remarks>
+/// All endpoints are scoped to the caller's <c>platform_user_id</c> claim so a
+/// caller cannot read or mutate another user's entries. <c>404 Not Found</c> is
+/// returned indistinguishably for entries that don't exist or aren't owned by
+/// the caller — preventing a cross-user enumeration oracle.
+/// </remarks>
+public static class MeInboxEndpoints
+{
+    /// <summary>Maps the <c>/api/me/inbox/*</c> endpoints.</summary>
+    public static IEndpointRouteBuilder MapMeInboxEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/me/inbox")
+            .RequireAuthorization()
+            .WithTags("Inbox");
+
+        group.MapGet("", ListAsync)
+            .WithName("ListMyInbox")
+            .WithSummary("List the authenticated user's inbox entries.")
+            .WithDescription("Paginated, sorted newest first. Excludes dismissed entries unless includeDismissed=true.");
+
+        group.MapGet("unread-count", GetUnreadCountAsync)
+            .WithName("GetMyInboxUnreadCount")
+            .WithSummary("Return the user's unread inbox count.")
+            .WithDescription("Authoritative server-side count. Realtime updates are pushed via TenantHub InboxUnreadCountUpdated.");
+
+        group.MapGet("{id:guid}", GetByIdAsync)
+            .WithName("GetMyInboxEntry")
+            .WithSummary("Fetch a single inbox entry by id.")
+            .WithDescription("Returns 404 indistinguishably if the entry does not exist or is not owned by the caller.");
+
+        group.MapPost("{id:guid}/read", MarkReadAsync)
+            .WithName("MarkMyInboxEntryRead")
+            .WithSummary("Mark an entry as read. Idempotent.");
+
+        group.MapPost("{id:guid}/dismiss", DismissAsync)
+            .WithName("DismissMyInboxEntry")
+            .WithSummary("Dismiss an entry. Idempotent.");
+
+        group.MapPost("mark-all-read", MarkAllReadAsync)
+            .WithName("MarkAllMyInboxEntriesRead")
+            .WithSummary("Mark every unread entry for the authenticated user read.");
+
+        return app;
+    }
+
+    private static async Task<IResult> ListAsync(
+        HttpContext context,
+        IInboxService service,
+        int page = 1,
+        int pageSize = 20,
+        InboxCategory? category = null,
+        bool unreadOnly = false,
+        bool includeDismissed = false,
+        CancellationToken ct = default)
+    {
+        var userId = GetUserId(context);
+        if (userId == Guid.Empty) return Results.Unauthorized();
+
+        var result = await service.GetPageAsync(
+            userId, page, pageSize, category, unreadOnly, includeDismissed, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetUnreadCountAsync(
+        HttpContext context,
+        IInboxService service,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(context);
+        if (userId == Guid.Empty) return Results.Unauthorized();
+        var count = await service.GetUnreadCountAsync(userId, ct);
+        return Results.Ok(new { unread = count });
+    }
+
+    private static async Task<IResult> GetByIdAsync(
+        HttpContext context,
+        IInboxService service,
+        Guid id,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(context);
+        if (userId == Guid.Empty) return Results.Unauthorized();
+        var entry = await service.GetByIdAsync(userId, id, ct);
+        return entry is null ? Results.NotFound() : Results.Ok(entry);
+    }
+
+    private static async Task<IResult> MarkReadAsync(
+        HttpContext context,
+        IInboxService service,
+        Guid id,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(context);
+        if (userId == Guid.Empty) return Results.Unauthorized();
+        var ok = await service.MarkReadAsync(userId, id, ct);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static async Task<IResult> DismissAsync(
+        HttpContext context,
+        IInboxService service,
+        Guid id,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(context);
+        if (userId == Guid.Empty) return Results.Unauthorized();
+        var ok = await service.DismissAsync(userId, id, ct);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static async Task<IResult> MarkAllReadAsync(
+        HttpContext context,
+        IInboxService service,
+        CancellationToken ct)
+    {
+        var userId = GetUserId(context);
+        if (userId == Guid.Empty) return Results.Unauthorized();
+        var marked = await service.MarkAllReadAsync(userId, ct);
+        return Results.Ok(new { marked });
+    }
+
+    private static Guid GetUserId(HttpContext context)
+    {
+        var raw = context.User.FindFirst("platform_user_id")?.Value;
+        return Guid.TryParse(raw, out var id) ? id : Guid.Empty;
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Hubs/ITenantHubClient.cs
+++ b/src/Services/Sorcha.Tenant.Service/Hubs/ITenantHubClient.cs
@@ -24,8 +24,25 @@ namespace Sorcha.Tenant.Service.Hubs;
 /// </remarks>
 public interface ITenantHubClient
 {
-    // No event methods yet — added in Phase 5 (InboxEntryAdded, InboxUnreadCountUpdated)
-    // and later in Phase 4 follow-up work (MembershipChanged, SecurityAlert, SystemAnnouncement).
-    // Keeping the interface empty rather than carrying placeholders so Phase 5 owners
-    // see immediately that they are defining the first real event method.
+    /// <summary>
+    /// A new inbox entry was written for the user. Carries opaque IDs only; clients
+    /// fetch full content via <c>GET /api/me/inbox/{entryId}</c>.
+    /// </summary>
+    /// <param name="entryId">GUID of the entry, formatted with <c>:N</c> (no hyphens).</param>
+    /// <param name="occurredAt">Server timestamp at which the underlying event occurred.</param>
+    /// <param name="traceId">W3C trace-id for correlating across the bridge.</param>
+    /// <see href="/api/me/inbox/{entryId}"/>
+    Task InboxEntryAdded(string entryId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// The authenticated user's unread inbox count changed. Authoritative —
+    /// the client should overwrite, not increment.
+    /// </summary>
+    /// <param name="unreadCount">New unread count. Cold-load via <c>GET /api/me/inbox/unread-count</c>.</param>
+    /// <param name="occurredAt">Server timestamp.</param>
+    /// <param name="traceId">W3C trace-id.</param>
+    /// <see href="/api/me/inbox/unread-count"/>
+    Task InboxUnreadCountUpdated(int unreadCount, DateTimeOffset occurredAt, string traceId);
+
+    // Membership / Security / System announcement events follow in a later phase.
 }

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260505175116_AddInboxEntry.Designer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260505175116_AddInboxEntry.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Sorcha.Tenant.Service.Data;
@@ -13,9 +14,11 @@ using Sorcha.Tenant.Service.Data;
 namespace Sorcha.Tenant.Service.Migrations
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505175116_AddInboxEntry")]
+    partial class AddInboxEntry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Services/Sorcha.Tenant.Service/Migrations/20260505175116_AddInboxEntry.cs
+++ b/src/Services/Sorcha.Tenant.Service/Migrations/20260505175116_AddInboxEntry.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sorcha.Tenant.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInboxEntry : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxEntries",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlatformUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Category = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Severity = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    CorrelationKey = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    DetailHref = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    SourceEventId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OccurredAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ReadAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DismissedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Summary = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IconKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ChannelHints = table.Column<int>(type: "integer", nullable: false),
+                    WriterServiceId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxEntries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InboxEntries_PlatformUsers_PlatformUserId",
+                        column: x => x.PlatformUserId,
+                        principalSchema: "public",
+                        principalTable: "PlatformUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxEntries_PlatformUserId_Category_OccurredAt",
+                schema: "public",
+                table: "InboxEntries",
+                columns: new[] { "PlatformUserId", "Category", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxEntries_PlatformUserId_CorrelationKey_OccurredAt",
+                schema: "public",
+                table: "InboxEntries",
+                columns: new[] { "PlatformUserId", "CorrelationKey", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxEntries_PlatformUserId_OccurredAt",
+                schema: "public",
+                table: "InboxEntries",
+                columns: new[] { "PlatformUserId", "OccurredAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxEntries_PlatformUserId_SourceEventId",
+                schema: "public",
+                table: "InboxEntries",
+                columns: new[] { "PlatformUserId", "SourceEventId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InboxEntries",
+                schema: "public");
+        }
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Models/InboxEntry.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/InboxEntry.cs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Sorcha.Tenant.Service.Models;
+
+/// <summary>
+/// Durable per-user notification entry. Phase 5 (US3) of Feature 118.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The user-facing canonical notification surface. Other services (Blueprint,
+/// Wallet, Tenant itself) write entries via the internal endpoint
+/// <c>POST /api/internal/inbox</c>; the user reads via <c>GET /api/me/inbox</c>
+/// and acts via the read/dismiss endpoints.
+/// </para>
+/// <para>
+/// Idempotency on writes is enforced by the unique index on
+/// <see cref="PlatformUserId"/> + <see cref="SourceEventId"/>: a duplicate POST
+/// with the same source-event id is a no-op that returns the original entry.
+/// </para>
+/// </remarks>
+public class InboxEntry
+{
+    /// <summary>Server-generated GUID primary key.</summary>
+    [Key]
+    public Guid Id { get; set; }
+
+    /// <summary>Owner — the user who can read and act on this entry.</summary>
+    public Guid PlatformUserId { get; set; }
+
+    /// <summary>Domain category. Drives icon and grouping in the UI.</summary>
+    public InboxCategory Category { get; set; }
+
+    /// <summary>Severity level. Drives visual prominence and toast behaviour.</summary>
+    public InboxSeverity Severity { get; set; }
+
+    /// <summary>
+    /// Hierarchical correlation key, e.g. <c>tx:{walletAddress}:{txId}</c> or
+    /// <c>membership:{orgId}</c>. Entries with the same key arriving within
+    /// 30s are grouped visually in the inbox UI.
+    /// </summary>
+    [Required]
+    [MaxLength(256)]
+    public string CorrelationKey { get; set; } = "";
+
+    /// <summary>
+    /// Authenticated REST endpoint to fetch the full render-ready content of
+    /// this entry. MUST be a relative path starting with <c>/api/</c>.
+    /// </summary>
+    [Required]
+    [MaxLength(1024)]
+    public string DetailHref { get; set; } = "";
+
+    /// <summary>
+    /// Writer-supplied source event id. Forms the <c>(PlatformUserId, SourceEventId)</c>
+    /// unique key used for idempotent writes — a writer that retries with the same
+    /// id collapses to a no-op.
+    /// </summary>
+    public Guid SourceEventId { get; set; }
+
+    /// <summary>UTC timestamp at which the underlying event occurred.</summary>
+    public DateTimeOffset OccurredAt { get; set; }
+
+    /// <summary>UTC timestamp at which the user marked the entry read. <c>null</c> = unread.</summary>
+    public DateTimeOffset? ReadAt { get; set; }
+
+    /// <summary>UTC timestamp at which the user dismissed the entry. <c>null</c> = active.</summary>
+    public DateTimeOffset? DismissedAt { get; set; }
+
+    /// <summary>Card title — short, surfaces in the inbox list.</summary>
+    [Required]
+    [MaxLength(200)]
+    public string Title { get; set; } = "";
+
+    /// <summary>Optional one- or two-sentence body. <c>null</c> = title-only entry.</summary>
+    [MaxLength(1000)]
+    public string? Summary { get; set; }
+
+    /// <summary>Optional icon key (e.g., <c>credential.received</c>) for UI rendering.</summary>
+    [MaxLength(64)]
+    public string? IconKey { get; set; }
+
+    /// <summary>
+    /// Bit-flag set of channels the writer or default policy hints should apply
+    /// to this entry. Phase 5 only delivers <see cref="ChannelHints.Inbox"/>;
+    /// push / email / digest dispatchers ship in a follow-up phase.
+    /// </summary>
+    public ChannelHints ChannelHints { get; set; } = ChannelHints.Inbox;
+
+    /// <summary>Optional audit field — id of the writing service principal, if any.</summary>
+    public Guid? WriterServiceId { get; set; }
+}
+
+/// <summary>Domain category of an inbox entry. Drives the rendered icon + grouping.</summary>
+public enum InboxCategory
+{
+    /// <summary>Workflow action requiring user response.</summary>
+    Action = 0,
+
+    /// <summary>Verifiable credential issued to or about the user.</summary>
+    Credential = 1,
+
+    /// <summary>Org membership change — added, removed, role changed.</summary>
+    Membership = 2,
+
+    /// <summary>Security alert — new device login, password reset, etc.</summary>
+    Security = 3,
+
+    /// <summary>Platform-wide system announcement (admin-only emit).</summary>
+    System = 4,
+
+    /// <summary>Workflow lifecycle event not requiring user response (informational).</summary>
+    Workflow = 5,
+
+    /// <summary>Open-ended bucket for future categories.</summary>
+    Custom = 99
+}
+
+/// <summary>Severity level of an inbox entry. Drives visual prominence.</summary>
+public enum InboxSeverity
+{
+    /// <summary>Informational — low prominence.</summary>
+    Info = 0,
+
+    /// <summary>Warning — yellow accent.</summary>
+    Warning = 1,
+
+    /// <summary>Action required — orange accent, toast on arrival.</summary>
+    ActionRequired = 2,
+
+    /// <summary>Critical — red accent, persistent toast until dismissed.</summary>
+    Critical = 3
+}
+
+/// <summary>
+/// Bit-flag set of delivery channels the writer hints (or default policy) should apply
+/// to this entry. Phase 5 only delivers <see cref="Inbox"/> in process; the other channels
+/// are recorded so the phase-5 follow-up dispatcher work can wire them up without a data-model migration.
+/// </summary>
+[Flags]
+public enum ChannelHints
+{
+    /// <summary>No channels — entry is silent (rare; mainly tests).</summary>
+    None = 0,
+
+    /// <summary>In-app notification bell + activity panel + inbox list.</summary>
+    Inbox = 1,
+
+    /// <summary>Web Push notification via VAPID — wired in a follow-up phase.</summary>
+    Push = 2,
+
+    /// <summary>Transactional email — wired in a follow-up phase.</summary>
+    Email = 4,
+
+    /// <summary>Hourly digest grouping — wired in a follow-up phase.</summary>
+    Digest = 8
+}

--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -92,6 +92,10 @@ builder.Services.AddTenantHealthChecks(builder.Configuration);
 builder.Services.AddSorchaHub<TenantHub, ITenantHubClient>(
     builder.Configuration, "/hubs/tenant", "tenant");
 
+// Feature 118 / US3 — durable user inbox.
+builder.Services.AddScoped<Sorcha.Tenant.Service.Services.IInboxService,
+    Sorcha.Tenant.Service.Services.InboxService>();
+
 // Add database initializer for automatic migration and seeding
 // Creates default organization (sorcha.local) and admin user on startup
 builder.Services.AddDatabaseInitializer();
@@ -218,6 +222,10 @@ app.MapRazorPages();
 
 // Feature 118 — map TenantHub at /hubs/tenant (US2). Routed via API Gateway.
 app.MapSorchaHubs();
+
+// Feature 118 / US3 — durable user inbox endpoints.
+app.MapMeInboxEndpoints();
+app.MapInternalInboxEndpoints();
 
 // Health check is provided by MapDefaultEndpoints() which maps /health and /alive
 // The standard Aspire health endpoint returns plain text "Healthy" or "Unhealthy"

--- a/src/Services/Sorcha.Tenant.Service/Services/IInboxService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IInboxService.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// Durable user-inbox surface. Phase 5 (US3) of Feature 118.
+/// </summary>
+/// <remarks>
+/// Service implementations orchestrate the Postgres write, the unread-count
+/// state, and the SignalR <c>InboxEntryAdded</c> / <c>InboxUnreadCountUpdated</c>
+/// events on TenantHub. Call sites:
+/// <list type="bullet">
+/// <item><see cref="WriteAsync"/>: invoked from the internal endpoint <c>POST /api/internal/inbox</c>.</item>
+/// <item><see cref="GetPageAsync"/> / <see cref="GetByIdAsync"/> / <see cref="GetUnreadCountAsync"/>: invoked from the public <c>GET /api/me/inbox*</c> endpoints.</item>
+/// <item><see cref="MarkReadAsync"/> / <see cref="DismissAsync"/> / <see cref="MarkAllReadAsync"/>: invoked from the public <c>POST /api/me/inbox/{id}/*</c> endpoints.</item>
+/// </list>
+/// </remarks>
+public interface IInboxService
+{
+    /// <summary>Write a new inbox entry. Idempotent on <c>(PlatformUserId, SourceEventId)</c>.</summary>
+    /// <returns>
+    /// The persisted entry. <see cref="InboxWriteResult.IsIdempotent"/> is <c>true</c>
+    /// when this was a duplicate write.
+    /// </returns>
+    Task<InboxWriteResult> WriteAsync(InboxWriteRequest request, CancellationToken ct = default);
+
+    /// <summary>Returns a page of the user's inbox entries, newest first. Excludes dismissed entries unless <paramref name="includeDismissed"/> is true.</summary>
+    Task<InboxPage> GetPageAsync(
+        Guid platformUserId,
+        int page = 1,
+        int pageSize = 20,
+        InboxCategory? category = null,
+        bool unreadOnly = false,
+        bool includeDismissed = false,
+        CancellationToken ct = default);
+
+    /// <summary>Returns a single entry, scoped to the calling user. <c>null</c> if not found or not owned.</summary>
+    Task<InboxEntry?> GetByIdAsync(Guid platformUserId, Guid entryId, CancellationToken ct = default);
+
+    /// <summary>Returns the user's unread count.</summary>
+    Task<int> GetUnreadCountAsync(Guid platformUserId, CancellationToken ct = default);
+
+    /// <summary>Marks an entry read. Idempotent. Fires <c>InboxUnreadCountUpdated</c> if state changed.</summary>
+    Task<bool> MarkReadAsync(Guid platformUserId, Guid entryId, CancellationToken ct = default);
+
+    /// <summary>Marks an entry dismissed. Idempotent. Fires <c>InboxUnreadCountUpdated</c> if the entry was unread before.</summary>
+    Task<bool> DismissAsync(Guid platformUserId, Guid entryId, CancellationToken ct = default);
+
+    /// <summary>Marks every unread entry for the user read. Returns the number of entries affected.</summary>
+    Task<int> MarkAllReadAsync(Guid platformUserId, CancellationToken ct = default);
+}
+
+/// <summary>Write request shape for <see cref="IInboxService.WriteAsync"/>.</summary>
+public sealed record InboxWriteRequest(
+    Guid PlatformUserId,
+    InboxCategory Category,
+    InboxSeverity Severity,
+    string CorrelationKey,
+    string DetailHref,
+    Guid SourceEventId,
+    DateTimeOffset OccurredAt,
+    string Title,
+    string? Summary = null,
+    string? IconKey = null,
+    ChannelHints? ChannelHints = null,
+    Guid? WriterServiceId = null);
+
+/// <summary>Result of <see cref="IInboxService.WriteAsync"/>.</summary>
+public sealed record InboxWriteResult(InboxEntry Entry, bool IsIdempotent);
+
+/// <summary>Paginated inbox listing response.</summary>
+public sealed record InboxPage(IReadOnlyList<InboxEntry> Entries, int Page, int PageSize, int TotalCount);

--- a/src/Services/Sorcha.Tenant.Service/Services/InboxService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/InboxService.cs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Hubs;
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// Default <see cref="IInboxService"/> implementation. Postgres source of truth
+/// (via <see cref="TenantDbContext"/>); SignalR fan-out to TenantHub on every
+/// state transition.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Phase 5 v1: unread-count is computed via <c>COUNT(*)</c>. The Redis sorted-set
+/// index from research R-002 is a phase-5 follow-up — at this user volume the
+/// COUNT query is sub-millisecond, and adding the Redis index without first
+/// observing real load would be premature.
+/// </para>
+/// <para>
+/// SignalR emits use the untyped <c>SendAsync</c> path because
+/// <see cref="ITenantHubClient"/> is empty until Phase 5 also lands the hub
+/// methods themselves. The methods below send under the same names that
+/// the typed-client interface declares, so the contract stays consistent.
+/// </para>
+/// </remarks>
+public sealed class InboxService : IInboxService
+{
+    private readonly TenantDbContext _db;
+    private readonly IHubContext<TenantHub> _hub;
+    private readonly ILogger<InboxService> _logger;
+
+    /// <summary>Initialises a new <see cref="InboxService"/>.</summary>
+    public InboxService(TenantDbContext db, IHubContext<TenantHub> hub, ILogger<InboxService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<InboxWriteResult> WriteAsync(InboxWriteRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Idempotency check on (PlatformUserId, SourceEventId).
+        var existing = await _db.InboxEntries
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                e => e.PlatformUserId == request.PlatformUserId && e.SourceEventId == request.SourceEventId,
+                ct).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            _logger.LogDebug(
+                "Inbox idempotent write — entry already exists. PlatformUserId={PlatformUserId} SourceEventId={SourceEventId} EntryId={EntryId}",
+                request.PlatformUserId, request.SourceEventId, existing.Id);
+            return new InboxWriteResult(existing, IsIdempotent: true);
+        }
+
+        var entry = new InboxEntry
+        {
+            Id = Guid.NewGuid(),
+            PlatformUserId = request.PlatformUserId,
+            Category = request.Category,
+            Severity = request.Severity,
+            CorrelationKey = request.CorrelationKey,
+            DetailHref = request.DetailHref,
+            SourceEventId = request.SourceEventId,
+            OccurredAt = request.OccurredAt,
+            Title = request.Title,
+            Summary = request.Summary,
+            IconKey = request.IconKey,
+            ChannelHints = request.ChannelHints ?? DefaultChannelHintsFor(request.Category),
+            WriterServiceId = request.WriterServiceId,
+        };
+
+        _db.InboxEntries.Add(entry);
+        try
+        {
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateException)
+        {
+            // Another concurrent write may have won the unique-index race. Re-read.
+            var raced = await _db.InboxEntries
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    e => e.PlatformUserId == request.PlatformUserId && e.SourceEventId == request.SourceEventId,
+                    ct).ConfigureAwait(false);
+            if (raced is not null)
+            {
+                return new InboxWriteResult(raced, IsIdempotent: true);
+            }
+            throw;
+        }
+
+        _logger.LogInformation(
+            "Inbox entry written. PlatformUserId={PlatformUserId} EntryId={EntryId} Category={Category} CorrelationKey={CorrelationKey}",
+            entry.PlatformUserId, entry.Id, entry.Category, entry.CorrelationKey);
+
+        await EmitInboxEntryAddedAsync(entry, ct).ConfigureAwait(false);
+        await EmitUnreadCountAsync(entry.PlatformUserId, ct).ConfigureAwait(false);
+
+        return new InboxWriteResult(entry, IsIdempotent: false);
+    }
+
+    /// <inheritdoc />
+    public async Task<InboxPage> GetPageAsync(
+        Guid platformUserId,
+        int page = 1,
+        int pageSize = 20,
+        InboxCategory? category = null,
+        bool unreadOnly = false,
+        bool includeDismissed = false,
+        CancellationToken ct = default)
+    {
+        if (page < 1) page = 1;
+        if (pageSize < 1) pageSize = 20;
+        if (pageSize > 100) pageSize = 100;
+
+        var query = _db.InboxEntries
+            .AsNoTracking()
+            .Where(e => e.PlatformUserId == platformUserId);
+
+        if (!includeDismissed)
+        {
+            query = query.Where(e => e.DismissedAt == null);
+        }
+        if (unreadOnly)
+        {
+            query = query.Where(e => e.ReadAt == null);
+        }
+        if (category.HasValue)
+        {
+            query = query.Where(e => e.Category == category.Value);
+        }
+
+        var total = await query.CountAsync(ct).ConfigureAwait(false);
+        var entries = await query
+            .OrderByDescending(e => e.OccurredAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        return new InboxPage(entries, page, pageSize, total);
+    }
+
+    /// <inheritdoc />
+    public async Task<InboxEntry?> GetByIdAsync(Guid platformUserId, Guid entryId, CancellationToken ct = default)
+    {
+        return await _db.InboxEntries
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == entryId && e.PlatformUserId == platformUserId, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetUnreadCountAsync(Guid platformUserId, CancellationToken ct = default)
+    {
+        return await _db.InboxEntries
+            .AsNoTracking()
+            .Where(e => e.PlatformUserId == platformUserId && e.ReadAt == null && e.DismissedAt == null)
+            .CountAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> MarkReadAsync(Guid platformUserId, Guid entryId, CancellationToken ct = default)
+    {
+        var entry = await _db.InboxEntries
+            .FirstOrDefaultAsync(e => e.Id == entryId && e.PlatformUserId == platformUserId, ct)
+            .ConfigureAwait(false);
+        if (entry is null)
+        {
+            return false;
+        }
+
+        if (entry.ReadAt is null)
+        {
+            entry.ReadAt = DateTimeOffset.UtcNow;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            await EmitUnreadCountAsync(platformUserId, ct).ConfigureAwait(false);
+        }
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DismissAsync(Guid platformUserId, Guid entryId, CancellationToken ct = default)
+    {
+        var entry = await _db.InboxEntries
+            .FirstOrDefaultAsync(e => e.Id == entryId && e.PlatformUserId == platformUserId, ct)
+            .ConfigureAwait(false);
+        if (entry is null)
+        {
+            return false;
+        }
+
+        var wasUnread = entry.ReadAt is null && entry.DismissedAt is null;
+        if (entry.DismissedAt is null)
+        {
+            entry.DismissedAt = DateTimeOffset.UtcNow;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            if (wasUnread)
+            {
+                await EmitUnreadCountAsync(platformUserId, ct).ConfigureAwait(false);
+            }
+        }
+        return true;
+    }
+
+    /// <inheritdoc />
+    public async Task<int> MarkAllReadAsync(Guid platformUserId, CancellationToken ct = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        // Use a tracked-entity update path so InMemory provider tests pass; on Postgres
+        // the same path generates a single UPDATE. ExecuteUpdateAsync would be more efficient
+        // for very large unread inboxes — Phase 5 follow-up swaps it in once we add a bulk
+        // op to the InMemoryDbContextFactory test helper.
+        var unread = await _db.InboxEntries
+            .Where(e => e.PlatformUserId == platformUserId && e.ReadAt == null && e.DismissedAt == null)
+            .ToListAsync(ct).ConfigureAwait(false);
+        foreach (var entry in unread)
+        {
+            entry.ReadAt = now;
+        }
+        if (unread.Count > 0)
+        {
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            await EmitUnreadCountAsync(platformUserId, ct).ConfigureAwait(false);
+        }
+        return unread.Count;
+    }
+
+    private static ChannelHints DefaultChannelHintsFor(InboxCategory category) => category switch
+    {
+        InboxCategory.Action       => ChannelHints.Inbox | ChannelHints.Push | ChannelHints.Email,
+        InboxCategory.Credential   => ChannelHints.Inbox | ChannelHints.Push,
+        InboxCategory.Membership   => ChannelHints.Inbox | ChannelHints.Email,
+        InboxCategory.Security     => ChannelHints.Inbox | ChannelHints.Push | ChannelHints.Email,
+        InboxCategory.System       => ChannelHints.Inbox,
+        InboxCategory.Workflow     => ChannelHints.Inbox,
+        _                          => ChannelHints.Inbox,
+    };
+
+    private async Task EmitInboxEntryAddedAsync(InboxEntry entry, CancellationToken ct)
+    {
+        try
+        {
+            // Thin signal: entry id, occurredAt, traceId. No content on the wire.
+            await _hub.Clients.Group(TenantHubGroups.User(entry.PlatformUserId))
+                .SendAsync(
+                    "InboxEntryAdded",
+                    entry.Id.ToString("N"),
+                    entry.OccurredAt,
+                    System.Diagnostics.Activity.Current?.TraceId.ToString() ?? "",
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to emit InboxEntryAdded for {EntryId} to {PlatformUserId}",
+                entry.Id, entry.PlatformUserId);
+        }
+    }
+
+    private async Task EmitUnreadCountAsync(Guid platformUserId, CancellationToken ct)
+    {
+        try
+        {
+            var count = await GetUnreadCountAsync(platformUserId, ct).ConfigureAwait(false);
+            await _hub.Clients.Group(TenantHubGroups.User(platformUserId))
+                .SendAsync(
+                    "InboxUnreadCountUpdated",
+                    count,
+                    DateTimeOffset.UtcNow,
+                    System.Diagnostics.Activity.Current?.TraceId.ToString() ?? "",
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to emit InboxUnreadCountUpdated for {PlatformUserId}",
+                platformUserId);
+        }
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/InboxServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/InboxServiceTests.cs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Hubs;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+using Sorcha.Tenant.Service.Tests.Helpers;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="InboxService"/> covering Phase 5 (US3) acceptance scenarios:
+/// idempotent writes, read transitions, dismiss transitions, mark-all-read,
+/// per-user scoping, and unread-count accuracy.
+/// </summary>
+public sealed class InboxServiceTests : IDisposable
+{
+    private readonly TenantDbContext _db;
+    private readonly InboxService _sut;
+    private readonly Mock<IHubContext<TenantHub>> _hub = new();
+    private readonly Mock<IHubClients> _hubClients = new();
+    private readonly Mock<IClientProxy> _clientProxy = new();
+    private readonly Guid _userA = Guid.NewGuid();
+    private readonly Guid _userB = Guid.NewGuid();
+
+    public InboxServiceTests()
+    {
+        _db = InMemoryDbContextFactory.Create();
+
+        _hub.SetupGet(h => h.Clients).Returns(_hubClients.Object);
+        _hubClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_clientProxy.Object);
+
+        _sut = new InboxService(_db, _hub.Object, NullLogger<InboxService>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    private InboxWriteRequest BuildRequest(
+        Guid? userId = null,
+        Guid? sourceEventId = null,
+        InboxCategory category = InboxCategory.Action,
+        string correlationKey = "tx:wallet-1:0")
+        => new(
+            PlatformUserId: userId ?? _userA,
+            Category: category,
+            Severity: InboxSeverity.ActionRequired,
+            CorrelationKey: correlationKey,
+            DetailHref: "/api/instances/00000000-0000-0000-0000-000000000001/actions/00000000-0000-0000-0000-000000000002",
+            SourceEventId: sourceEventId ?? Guid.NewGuid(),
+            OccurredAt: DateTimeOffset.UtcNow,
+            Title: "Action required");
+
+    [Fact]
+    public async Task WriteAsync_FirstCall_PersistsAndReturnsNonIdempotent()
+    {
+        var result = await _sut.WriteAsync(BuildRequest());
+
+        result.IsIdempotent.Should().BeFalse();
+        result.Entry.Id.Should().NotBeEmpty();
+        result.Entry.PlatformUserId.Should().Be(_userA);
+        result.Entry.ChannelHints.Should().Be(ChannelHints.Inbox | ChannelHints.Push | ChannelHints.Email);
+
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task WriteAsync_DuplicateSourceEventId_IsIdempotent()
+    {
+        var sourceId = Guid.NewGuid();
+        var first = await _sut.WriteAsync(BuildRequest(sourceEventId: sourceId));
+        var second = await _sut.WriteAsync(BuildRequest(sourceEventId: sourceId));
+
+        second.IsIdempotent.Should().BeTrue();
+        second.Entry.Id.Should().Be(first.Entry.Id);
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task WriteAsync_DefaultChannelHints_VariesByCategory()
+    {
+        var actionResult = await _sut.WriteAsync(BuildRequest(category: InboxCategory.Action));
+        var systemResult = await _sut.WriteAsync(BuildRequest(category: InboxCategory.System, correlationKey: "system:1"));
+        var membershipResult = await _sut.WriteAsync(BuildRequest(category: InboxCategory.Membership, correlationKey: "membership:1"));
+
+        actionResult.Entry.ChannelHints.Should().Be(ChannelHints.Inbox | ChannelHints.Push | ChannelHints.Email);
+        systemResult.Entry.ChannelHints.Should().Be(ChannelHints.Inbox);
+        membershipResult.Entry.ChannelHints.Should().Be(ChannelHints.Inbox | ChannelHints.Email);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_ReturnsNewestFirst_ExcludesDismissed_ByDefault()
+    {
+        var first = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:1"));
+        await Task.Delay(5);
+        var second = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:2"));
+        await Task.Delay(5);
+        var third = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:3"));
+
+        await _sut.DismissAsync(_userA, first.Entry.Id);
+
+        var page = await _sut.GetPageAsync(_userA);
+
+        page.TotalCount.Should().Be(2);
+        page.Entries.Should().HaveCount(2);
+        page.Entries[0].Id.Should().Be(third.Entry.Id);
+        page.Entries[1].Id.Should().Be(second.Entry.Id);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_IncludeDismissed_ReturnsAll()
+    {
+        var first = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:1"));
+        await _sut.WriteAsync(BuildRequest(correlationKey: "tx:2"));
+        await _sut.DismissAsync(_userA, first.Entry.Id);
+
+        var page = await _sut.GetPageAsync(_userA, includeDismissed: true);
+
+        page.TotalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetPageAsync_PerUserScoping_DoesNotLeak()
+    {
+        await _sut.WriteAsync(BuildRequest(userId: _userA, correlationKey: "tx:a"));
+        await _sut.WriteAsync(BuildRequest(userId: _userB, correlationKey: "tx:b"));
+
+        var pageA = await _sut.GetPageAsync(_userA);
+        var pageB = await _sut.GetPageAsync(_userB);
+
+        pageA.TotalCount.Should().Be(1);
+        pageB.TotalCount.Should().Be(1);
+        pageA.Entries[0].PlatformUserId.Should().Be(_userA);
+        pageB.Entries[0].PlatformUserId.Should().Be(_userB);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_CrossUser_ReturnsNullIndistinguishably()
+    {
+        var written = await _sut.WriteAsync(BuildRequest(userId: _userA));
+
+        var bView = await _sut.GetByIdAsync(_userB, written.Entry.Id);
+
+        bView.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_SetsReadAt_AndDecrementsUnread()
+    {
+        var written = await _sut.WriteAsync(BuildRequest());
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(1);
+
+        var ok = await _sut.MarkReadAsync(_userA, written.Entry.Id);
+
+        ok.Should().BeTrue();
+        var refreshed = await _sut.GetByIdAsync(_userA, written.Entry.Id);
+        refreshed!.ReadAt.Should().NotBeNull();
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_AlreadyRead_IsIdempotent()
+    {
+        var written = await _sut.WriteAsync(BuildRequest());
+        await _sut.MarkReadAsync(_userA, written.Entry.Id);
+
+        var second = await _sut.MarkReadAsync(_userA, written.Entry.Id);
+
+        second.Should().BeTrue();
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_UnknownEntry_ReturnsFalse()
+    {
+        var ok = await _sut.MarkReadAsync(_userA, Guid.NewGuid());
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DismissAsync_SetsDismissedAt_AndDecrementsUnreadOnlyIfWasUnread()
+    {
+        var unread = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:1"));
+        var read = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:2"));
+        await _sut.MarkReadAsync(_userA, read.Entry.Id);
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(1);
+
+        await _sut.DismissAsync(_userA, read.Entry.Id);  // already-read entry: count unchanged
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(1);
+
+        await _sut.DismissAsync(_userA, unread.Entry.Id);  // unread entry: count goes to 0
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_OnlyTouchesUnreadEntries()
+    {
+        var a = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:1"));
+        var b = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:2"));
+        var c = await _sut.WriteAsync(BuildRequest(correlationKey: "tx:3"));
+        await _sut.MarkReadAsync(_userA, b.Entry.Id);
+
+        var marked = await _sut.MarkAllReadAsync(_userA);
+
+        marked.Should().Be(2, "two entries were unread before mark-all-read");
+        (await _sut.GetUnreadCountAsync(_userA)).Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 (US3) v1 of Feature 118 — the user-facing inbox that the whole spec exists to ship.

Tenant Service now owns a durable per-user notification inbox. Other services emit user-facing notifications via `POST /api/internal/inbox` (RequireService); users read/dismiss/mark-read via `/api/me/inbox/*`; TenantHub fires `InboxEntryAdded` + `InboxUnreadCountUpdated` on every state transition. End-to-end the inbox round-trip works: write → persist → realtime push → read via REST → mark read → unread count drops.

## Components

**Domain** (Tenant Service)
- `Models/InboxEntry.cs` — Postgres-backed entity with Category, Severity, ChannelHints, CorrelationKey, DetailHref, ReadAt / DismissedAt state
- `Migrations/20260505175116_AddInboxEntry` — generated via `dotnet ef`
- `TenantDbContext` adds `InboxEntries` DbSet + four indexes (idempotency unique key, primary list, sibling-grouping, category filter)

**Service** (Tenant Service)
- `IInboxService` — Write / GetPage / GetById / GetUnreadCount / MarkRead / Dismiss / MarkAllRead
- `InboxService` — orchestrates Postgres write + idempotency check + hub event emission. Default `ChannelHints` per category per research R-006 (Action → Inbox+Push+Email; System → Inbox; etc.). `MarkAllReadAsync` uses tracked-entity loop so InMemory provider tests pass

**Endpoints** (Tenant Service)
- Public: `GET /api/me/inbox`, `GET /{id}`, `GET /unread-count`, `POST /{id}/read`, `POST /{id}/dismiss`, `POST /mark-all-read` — all scoped to `platform_user_id` claim
- Internal: `POST /api/internal/inbox` gated by `RequireService` policy. Idempotent on `(PlatformUserId, SourceEventId)` unique index

**Cross-service writer** (Sorcha.ServiceClients.Http)
- `IPlatformInboxClient` + `PlatformInboxClient` — HTTP client behind `ServiceAuthClient` token. Registered via `AddSorchaHttpServiceClients`. Used by future writers (BlueprintInboxWriter, WalletInboxWriter — wiring is the follow-up)

**Hub** (Tenant Service)
- `ITenantHubClient` gains `InboxEntryAdded(entryId, occurredAt, traceId)` + `InboxUnreadCountUpdated(unreadCount, occurredAt, traceId)` — thin signal per FR-016

**API Gateway**
- `/api/me/inbox*` routes added to tenant-cluster behind `RequireAuthenticated`

## Tests

`InboxServiceTests` — **12/12 passing**:
- Idempotent writes (`(PlatformUserId, SourceEventId)` unique key)
- Default ChannelHints vary by category
- Page sorting (newest first), dismissed exclusion by default
- `includeDismissed` returns all
- Per-user scoping (no cross-user leak in list or by-id)
- Cross-user `GetByIdAsync` returns null indistinguishably (no enumeration oracle)
- `MarkRead` sets ReadAt + decrements unread; idempotent on already-read; returns false on unknown
- `Dismiss` decrements unread only when entry was unread
- `MarkAllRead` only touches unread entries

## Out of scope (Phase 5 follow-up + later)

| Deferred item | Why |
|---|---|
| Redis sorted-set unread-count index (FR-024 / R-002) | v1 uses Postgres `COUNT(*)`. Sub-millisecond at expected load. Add Redis when monitoring shows it's needed |
| `BlueprintInboxWriter` / `WalletInboxWriter` wired into existing `NotificationService` / `TransactionLifecycleEventBridge` emit sites (T073–T077) | Each writer needs to resolve wallet → PlatformUserId via `IParticipantServiceClient`. Not difficult but additive — better as a focused follow-up PR |
| `NotificationDeliveryService` + `NotificationDigestWorker` retarget to inbox endpoint | Same as above — the wiring step is what's left |
| `TenantInboxBridgeService` for native Tenant events (membership, security, system announcements) | Tenant-side events; lands when those event categories ship |
| Endpoint integration tests (T057, T058) | InboxService unit tests cover the logic; endpoint smoke is part of the multi-node fixture (deferred since Phase 3) |
| Cross-replica TenantHub multi-node test (T060) | TenantHub now exists, so the skipped test in `HubBackplaneCrossReplicaTests` could be enabled — still gated on the multinode fixture YARP fix from Phase 3 |

## Spec status

| Requirement | After this PR |
|---|---|
| FR-020 (`InboxEntry` durable, fields specified) | ✓ |
| FR-021 (unique index `(PlatformUserId, SourceEventId)`) | ✓ |
| FR-022 (`POST /api/internal/inbox` RequireService, idempotent) | ✓ |
| FR-023 (six public endpoints) | ✓ |
| FR-024 (Redis unread-count index) | Deferred to Phase 5 follow-up — Postgres COUNT(*) for v1 |
| FR-025 (`InboxEntryAdded` + `InboxUnreadCountUpdated` on TenantHub `user:{pid}` group) | ✓ |
| FR-026 (hub events carry IDs only) | ✓ — thin-signal envelope |
| FR-027 (correlation-key visual grouping in UI) | UI work — Phase 10 polish |
| FR-028 (Production fail-fast if InboxEntry storage in-memory) | TODO — write to `IStorageRegistrationLog` is a small follow-up |

## References

- `specs/118-notifications-architecture/spec.md`
- `specs/118-notifications-architecture/plan.md`
- `specs/118-notifications-architecture/data-model.md`
- `specs/118-notifications-architecture/contracts/inbox-endpoints.openapi.yaml`
- `specs/118-notifications-architecture/MIGRATION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)