### PR TITLE
feat(118): BlueprintInboxWriter wires action notifications to durable inbox (US3 follow-up, T073)

### DIFF
--- a/src/Common/Sorcha.ServiceClients.Http/Inbox/IPlatformInboxClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Inbox/IPlatformInboxClient.cs
@@ -20,6 +20,15 @@ public interface IPlatformInboxClient
     /// whether the write was idempotent (duplicate of an earlier write).
     /// </summary>
     Task<InboxWriteOutcome> WriteAsync(InboxWritePayload payload, CancellationToken ct = default);
+
+    /// <summary>
+    /// GET <c>/api/internal/users/by-identity/{userIdentityId}</c>. Resolves the
+    /// org-scoped <c>UserIdentity.Id</c> (which the Participant Service surface
+    /// hands back via <c>ParticipantInfo.UserId</c>) to the cross-org
+    /// <c>PlatformUser.Id</c> the inbox is addressed by.
+    /// </summary>
+    /// <returns>The platform user id, or <c>null</c> if no UserIdentity matches.</returns>
+    Task<Guid?> ResolvePlatformUserIdAsync(Guid userIdentityId, CancellationToken ct = default);
 }
 
 /// <summary>Wire shape sent to the internal inbox endpoint.</summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Inbox/PlatformInboxClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Inbox/PlatformInboxClient.cs
@@ -78,7 +78,26 @@ public sealed class PlatformInboxClient : IPlatformInboxClient
         return new InboxWriteOutcome(json.Entry?.Id ?? Guid.Empty, json.Idempotent);
     }
 
+    /// <inheritdoc />
+    public async Task<Guid?> ResolvePlatformUserIdAsync(Guid userIdentityId, CancellationToken ct = default)
+    {
+        await ServiceClientAuthHelper.SetAuthHeaderAsync(
+            _httpClient, _serviceAuth, _logger, "Tenant Service (Inbox identity resolution)", ct);
+
+        using var resp = await _httpClient.GetAsync($"api/internal/users/by-identity/{userIdentityId:D}", ct).ConfigureAwait(false);
+        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+        resp.EnsureSuccessStatusCode();
+
+        var body = await resp.Content.ReadFromJsonAsync<PlatformUserResolutionShape>(JsonOptions, ct).ConfigureAwait(false);
+        return body?.PlatformUserId;
+    }
+
     private sealed record InboxResponseEnvelope(InboxEntryShape? Entry, bool Idempotent);
 
     private sealed record InboxEntryShape(Guid Id);
+
+    private sealed record PlatformUserResolutionShape(Guid UserIdentityId, Guid PlatformUserId);
 }

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -277,6 +277,11 @@ builder.Services.Configure<HubOptions>(options =>
 builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.INotificationService,
     Sorcha.Blueprint.Service.Services.Implementation.NotificationService>();
 
+// Feature 118 / US3 follow-up — wire BlueprintInboxWriter so action-available
+// notifications also produce durable inbox entries via Tenant Service.
+builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Implementation.IBlueprintInboxWriter,
+    Sorcha.Blueprint.Service.Services.Implementation.BlueprintInboxWriter>();
+
 // Add AI-assisted Blueprint Chat services (Sprint 8)
 builder.Services.AddChatServices(builder.Configuration);
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintInboxWriter.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintInboxWriter.cs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceClients.Inbox;
+using Sorcha.ServiceClients.Participant;
+
+namespace Sorcha.Blueprint.Service.Services.Implementation;
+
+/// <summary>
+/// Phase 5 follow-up of Feature 118 — bridges Blueprint Service workflow events
+/// to the durable user inbox owned by Tenant Service.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolves a wallet address through the participant service to a
+/// <c>UserIdentity.Id</c>, then through Tenant's
+/// <c>/api/internal/users/by-identity/{id}</c> to the cross-org
+/// <c>PlatformUserId</c> the inbox is keyed on. Posts an inbox entry via
+/// <see cref="IPlatformInboxClient"/>. Fail-safe: every step short-circuits
+/// silently on <c>null</c> so an inbox-write failure cannot break the
+/// originating notification path.
+/// </para>
+/// <para>
+/// Idempotency on the inbox side is keyed on
+/// <c>(PlatformUserId, SourceEventId)</c>. The <see cref="ActionAvailableInboxEntry"/>
+/// helper builds a deterministic <c>SourceEventId</c> from
+/// <c>(walletAddress, instanceId, actionId)</c> so retries within a workflow
+/// collapse to the same inbox row.
+/// </para>
+/// </remarks>
+public interface IBlueprintInboxWriter
+{
+    /// <summary>Write a "you have an action available" inbox entry for the wallet's owning user.</summary>
+    Task WriteActionAvailableAsync(
+        string walletAddress,
+        string instanceId,
+        string actionId,
+        string? actionTitle = null,
+        CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class BlueprintInboxWriter : IBlueprintInboxWriter
+{
+    private readonly IParticipantServiceClient _participants;
+    private readonly IPlatformInboxClient _inbox;
+    private readonly ILogger<BlueprintInboxWriter> _logger;
+
+    /// <summary>Initialises a new <see cref="BlueprintInboxWriter"/>.</summary>
+    public BlueprintInboxWriter(
+        IParticipantServiceClient participants,
+        IPlatformInboxClient inbox,
+        ILogger<BlueprintInboxWriter> logger)
+    {
+        _participants = participants ?? throw new ArgumentNullException(nameof(participants));
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteActionAvailableAsync(
+        string walletAddress,
+        string instanceId,
+        string actionId,
+        string? actionTitle = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(walletAddress) ||
+            string.IsNullOrWhiteSpace(instanceId) ||
+            string.IsNullOrWhiteSpace(actionId))
+        {
+            return;
+        }
+
+        try
+        {
+            var participant = await _participants.GetByWalletAddressAsync(walletAddress, ct).ConfigureAwait(false);
+            if (participant is null)
+            {
+                _logger.LogDebug(
+                    "Inbox skip — no participant for wallet {Wallet}",
+                    walletAddress);
+                return;
+            }
+
+            var platformUserId = await _inbox.ResolvePlatformUserIdAsync(participant.UserId, ct).ConfigureAwait(false);
+            if (platformUserId is null)
+            {
+                _logger.LogDebug(
+                    "Inbox skip — could not resolve PlatformUserId for UserIdentity {UserIdentityId}",
+                    participant.UserId);
+                return;
+            }
+
+            var sourceEventId = DeterministicSourceEventId(walletAddress, instanceId, actionId);
+            var payload = new InboxWritePayload(
+                PlatformUserId: platformUserId.Value,
+                Category: "Action",
+                Severity: "ActionRequired",
+                CorrelationKey: $"action:{instanceId}:{actionId}",
+                DetailHref: $"/api/instances/{instanceId}/actions/{actionId}",
+                SourceEventId: sourceEventId,
+                OccurredAt: DateTimeOffset.UtcNow,
+                Title: string.IsNullOrWhiteSpace(actionTitle) ? "Action required" : actionTitle!,
+                Summary: null,
+                IconKey: "action.available");
+
+            var outcome = await _inbox.WriteAsync(payload, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for action available — Wallet={Wallet} Instance={InstanceId} Action={ActionId} EntryId={EntryId}",
+                outcome.Idempotent ? "idempotent" : "created",
+                walletAddress, instanceId, actionId, outcome.EntryId);
+        }
+        catch (Exception ex)
+        {
+            // Inbox-write failures must not break the SignalR notification path.
+            _logger.LogWarning(ex,
+                "Inbox-write failed for action available — Wallet={Wallet} Instance={InstanceId} Action={ActionId}",
+                walletAddress, instanceId, actionId);
+        }
+    }
+
+    /// <summary>
+    /// Builds a deterministic GUID from <c>(walletAddress, instanceId, actionId)</c> so
+    /// duplicate writes for the same workflow event collapse on Tenant's idempotency
+    /// unique index. Uses GUID v5-style namespacing — stable across restarts.
+    /// </summary>
+    private static Guid DeterministicSourceEventId(string walletAddress, string instanceId, string actionId)
+    {
+        // Namespace GUID is the SHA1 of the seed bytes truncated to 16 bytes — the
+        // standard RFC 4122 v5 derivation. We reuse the .NET HashData helper for
+        // brevity; the exact byte order need not match RFC 4122 because we never
+        // claim cryptographic security from the GUID, only stability.
+        var input = $"sorcha.inbox.action-available:{walletAddress}:{instanceId}:{actionId}";
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        // Set version (5) and variant bits per RFC 4122 to keep the value a valid GUID.
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/NotificationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/NotificationService.cs
@@ -17,16 +17,19 @@ public class NotificationService : INotificationService
 {
     private readonly IHubContext<BlueprintHub> _hubContext;
     private readonly IHubContext<EventsHub> _eventsHubContext;
+    private readonly IBlueprintInboxWriter _inboxWriter;
     private readonly ILogger<NotificationService> _logger;
 
     /// <summary>Initialises a new instance of the <see cref="NotificationService"/> class.</summary>
     public NotificationService(
         IHubContext<BlueprintHub> hubContext,
         IHubContext<EventsHub> eventsHubContext,
+        IBlueprintInboxWriter inboxWriter,
         ILogger<NotificationService> logger)
     {
         _hubContext = hubContext;
         _eventsHubContext = eventsHubContext;
+        _inboxWriter = inboxWriter;
         _logger = logger;
     }
 
@@ -49,6 +52,16 @@ public class NotificationService : INotificationService
         };
 
         await SendToWalletAsync(walletAddress, "ActionAvailable", signal, ct);
+
+        // Phase 5 follow-up of Feature 118: also drop a durable inbox entry. The writer
+        // resolves wallet -> participant -> platform user and POSTs to Tenant. Failures
+        // are swallowed so an inbox-write outage cannot break SignalR delivery.
+        await _inboxWriter.WriteActionAvailableAsync(
+            walletAddress: walletAddress,
+            instanceId: instanceId,
+            actionId: signal.CorrelationId?.ToString("N") ?? instanceId,
+            actionTitle: null,
+            ct: ct).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Sent signal {SignalType} to wallet {Wallet} for instance {InstanceId}",

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/InternalEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/InternalEndpoints.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 using Sorcha.Tenant.Service.Data.Repositories;
 using Sorcha.Tenant.Service.Services;
@@ -77,6 +78,18 @@ public static class InternalEndpoints
             .WithDescription("Called by Wallet Service when the citizen renames a device "
                 + "from the PWA. Validates label length 1..120. 404 indistinguishable from "
                 + "non-existence on cross-user mismatch.")
+            .RequireAuthorization("RequireService");
+
+        // Feature 118 (US3 follow-up): resolve UserIdentity.Id → PlatformUser.Id.
+        // Used by inbox writers in other services (Blueprint, Wallet) that have a
+        // ParticipantInfo (which carries the org-scoped UserIdentity id) and need
+        // the cross-org PlatformUserId to address the inbox row.
+        group.MapGet("/users/by-identity/{userIdentityId:guid}", ResolvePlatformUserByIdentity)
+            .WithName("ResolvePlatformUserByIdentity")
+            .WithSummary("Resolve UserIdentity.Id to its owning PlatformUser.Id")
+            .WithDescription("Returns the cross-org PlatformUserId that owns the supplied UserIdentity. "
+                + "Used by inbox writers in other services that resolve participant by wallet but only "
+                + "see the org-scoped identity id in ParticipantInfo. 404 if the UserIdentity does not exist.")
             .RequireAuthorization("RequireService");
 
         return app;
@@ -247,4 +260,28 @@ public static class InternalEndpoints
     }
 
     internal record DomainResolutionResponse(string Subdomain);
+
+    /// <summary>Wire shape for <see cref="ResolvePlatformUserByIdentity"/>.</summary>
+    public sealed record PlatformUserResolution(Guid UserIdentityId, Guid PlatformUserId);
+
+    private static async Task<Results<Ok<PlatformUserResolution>, NotFound>> ResolvePlatformUserByIdentity(
+        Guid userIdentityId,
+        Sorcha.Tenant.Service.Data.TenantDbContext db,
+        CancellationToken ct)
+    {
+        // Single Postgres lookup against the public schema. UserIdentity.PlatformUserId
+        // is the foreign key to the cross-org PlatformUser table — exactly what the
+        // inbox addressing surface needs.
+        var platformUserId = await db.UserIdentities
+            .Where(u => u.Id == userIdentityId)
+            .Select(u => u.PlatformUserId)
+            .FirstOrDefaultAsync(ct);
+
+        if (platformUserId == Guid.Empty)
+        {
+            return TypedResults.NotFound();
+        }
+
+        return TypedResults.Ok(new PlatformUserResolution(userIdentityId, platformUserId));
+    }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintInboxWriterTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintInboxWriterTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.ServiceClients.Inbox;
+using Sorcha.ServiceClients.Participant;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="BlueprintInboxWriter"/>. Phase 5 follow-up of Feature 118.
+/// </summary>
+public class BlueprintInboxWriterTests
+{
+    private readonly Mock<IParticipantServiceClient> _participants = new();
+    private readonly Mock<IPlatformInboxClient> _inbox = new();
+    private readonly BlueprintInboxWriter _sut;
+
+    public BlueprintInboxWriterTests()
+    {
+        _sut = new BlueprintInboxWriter(_participants.Object, _inbox.Object, NullLogger<BlueprintInboxWriter>.Instance);
+    }
+
+    [Fact]
+    public async Task WriteActionAvailableAsync_HappyPath_PostsExpectedPayload()
+    {
+        var participant = BuildParticipant(Guid.NewGuid());
+        var platformUserId = Guid.NewGuid();
+        InboxWritePayload? captured = null;
+
+        _participants.Setup(p => p.GetByWalletAddressAsync("wallet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(participant.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platformUserId);
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteActionAvailableAsync("wallet-1", "instance-A", "action-X", "Sign the form");
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(platformUserId);
+        captured.Category.Should().Be("Action");
+        captured.Severity.Should().Be("ActionRequired");
+        captured.CorrelationKey.Should().Be("action:instance-A:action-X");
+        captured.DetailHref.Should().Be("/api/instances/instance-A/actions/action-X");
+        captured.Title.Should().Be("Sign the form");
+    }
+
+    [Fact]
+    public async Task WriteActionAvailableAsync_NoParticipant_SkipsInbox()
+    {
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ParticipantInfo?)null);
+
+        await _sut.WriteActionAvailableAsync("wallet-1", "instance-A", "action-X");
+
+        _inbox.Verify(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WriteActionAvailableAsync_NoPlatformUserResolution_SkipsInbox()
+    {
+        var participant = BuildParticipant(Guid.NewGuid());
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        await _sut.WriteActionAvailableAsync("wallet-1", "instance-A", "action-X");
+
+        _inbox.Verify(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WriteActionAvailableAsync_DeterministicSourceEventId_ReusesAcrossCalls()
+    {
+        var participant = BuildParticipant(Guid.NewGuid());
+        var platformUserId = Guid.NewGuid();
+        var sourceIds = new List<Guid>();
+
+        _participants.Setup(p => p.GetByWalletAddressAsync("wallet-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platformUserId);
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => sourceIds.Add(p.SourceEventId))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteActionAvailableAsync("wallet-1", "instance-A", "action-X");
+        await _sut.WriteActionAvailableAsync("wallet-1", "instance-A", "action-X");
+
+        sourceIds.Should().HaveCount(2);
+        sourceIds[0].Should().Be(sourceIds[1], "duplicate notifications must collapse to the same idempotency key");
+    }
+
+    [Fact]
+    public async Task WriteActionAvailableAsync_InboxThrows_DoesNotPropagate()
+    {
+        var participant = BuildParticipant(Guid.NewGuid());
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Tenant unavailable"));
+
+        var act = () => _sut.WriteActionAvailableAsync("wallet-1", "instance-A", "action-X");
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never surface to the caller — SignalR delivery must be unaffected");
+    }
+
+    private static ParticipantInfo BuildParticipant(Guid userId) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            OrganizationId = Guid.NewGuid(),
+            DisplayName = "Test",
+            Email = "test@example.com",
+            Status = "Active",
+        };
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/EncryptionNotificationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/EncryptionNotificationTests.cs
@@ -42,6 +42,7 @@ public class EncryptionNotificationTests
         _service = new NotificationService(
             _hubContext.Object,
             _eventsHubContext.Object,
+            new Mock<IBlueprintInboxWriter>().Object,
             NullLogger<NotificationService>.Instance);
     }
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/NotificationServiceEventsHubTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/NotificationServiceEventsHubTests.cs
@@ -46,6 +46,7 @@ public class NotificationServiceEventsHubTests
         _service = new NotificationService(
             _actionsHubContext.Object,
             _eventsHubContext.Object,
+            new Mock<IBlueprintInboxWriter>().Object,
             NullLogger<NotificationService>.Instance);
     }
 


### PR DESCRIPTION
## Summary

Phase 5 follow-up of Feature 118 — closes the end-to-end gap from PR #519. Action-available notifications now produce **durable inbox entries** on Tenant Service in addition to the SignalR push, so a user who is offline at the moment an action is dispatched still sees it on the next page load.

This is the highest user-visible payoff of the whole feature so far: the inbox is no longer just an empty-but-functional surface, it actually fills with entries from real workflow events.

## Components

**Tenant Service** — new internal resolver
- `GET /api/internal/users/by-identity/{userIdentityId}` resolves the org-scoped `UserIdentity.Id` (which the Participant Service surface returns via `ParticipantInfo.UserId`) to the cross-org `PlatformUser.Id` the inbox is keyed on. Single Postgres lookup, 404 indistinguishable on miss.

**Sorcha.ServiceClients.Http/Inbox**
- `IPlatformInboxClient.ResolvePlatformUserIdAsync(userIdentityId, ct)` — GET against the new internal endpoint behind `ServiceAuthClient` bearer token.

**Sorcha.Blueprint.Service**
- `Services/Implementation/BlueprintInboxWriter.cs` (new) — resolves `wallet → ParticipantInfo → PlatformUserId`, builds an inbox payload with `Category=Action`, deterministic `SourceEventId` from `(walletAddress, instanceId, actionId)` so retries collapse on Tenant's `(PlatformUserId, SourceEventId)` unique index. Posts via `IPlatformInboxClient`. **Fail-safe:** every step short-circuits silently on `null`; inbox-write exceptions are caught so SignalR delivery is unaffected.
- `NotificationService.NotifyActionAvailableAsync` now also calls `_inboxWriter.WriteActionAvailableAsync` after the SignalR send.

## Tests

`BlueprintInboxWriterTests` — **5/5 passing**:
- Happy path: posts expected payload (Category=Action, ActionRequired severity, correct CorrelationKey + DetailHref + Title)
- No participant for wallet → inbox skipped
- No PlatformUserId resolution → inbox skipped
- Deterministic SourceEventId: duplicate calls produce the same idempotency key
- Inbox throws → caller does not see exception (SignalR delivery uncoupled from inbox availability)

Existing `EncryptionNotificationTests` and `NotificationServiceEventsHubTests` updated for the new constructor parameter — both still passing (4/4 + 8/8).

## Spec status

| Requirement | After this PR |
|---|---|
| FR-029 (Wallet writes credential entries) | scaffolded — IPlatformInboxClient available, Wallet writer is T074 |
| **FR-030 (Blueprint writes action entries)** | ✓ — wired end-to-end, default ChannelHints (Inbox+Push+Email per category), idempotent |
| FR-031 (Tenant writes membership/security/system entries) | scaffolded |
| FR-032 (no service writes outside its domain) | enforced at the writer interface boundary |

## Out of scope (next follow-ups)

- **T074** WalletInboxWriter — same shape, writes Category=Credential entries from credential-issuance pipeline
- **T075-T076** NotificationDeliveryService + NotificationDigestWorker retarget at the inbox endpoint
- **T077** TenantInboxBridgeService for native Tenant events (membership, security, system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)