### PR TITLE
feat(118): WalletInboxWriter — credential issuance produces inbox entries (US3 follow-up #2, T074)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -536,6 +536,7 @@ public static class CredentialEndpoints
         ISdJwtService sdJwtService,
         ICredentialStore store,
         ILoggerFactory loggerFactory,
+        Sorcha.Wallet.Service.Services.Implementation.IWalletInboxWriter inboxWriter,
         IOrgCertChainProvider? orgCertChainProvider = null,
         CancellationToken cancellationToken = default)
     {
@@ -742,6 +743,16 @@ public static class CredentialEndpoints
         logger.LogInformation(
             "Issued credential {CredentialId} of type {Type} from {Issuer} to {Recipient}",
             credentialId, request.CredentialType, walletAddress, request.RecipientWallet);
+
+        // Feature 118 / US3 follow-up #2: drop a durable inbox entry on the
+        // recipient's user. Fail-safe: any write error is swallowed by the
+        // writer so credential issuance is unaffected.
+        await inboxWriter.WriteCredentialReceivedAsync(
+            recipientWalletAddress: request.RecipientWallet,
+            credentialId: credentialId,
+            credentialType: request.CredentialType,
+            issuerOrgName: request.IssuerOrgName,
+            ct: cancellationToken).ConfigureAwait(false);
 
         return Results.Ok(new IssuedCredentialResponse
         {

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -60,6 +60,11 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificationDeliveryService,
     Sorcha.Wallet.Service.Services.Implementation.NotificationDeliveryService>();
 
+// Feature 118 / US3 follow-up #2 — wire WalletInboxWriter so credential issuance
+// also produces durable inbox entries via Tenant Service.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Implementation.IWalletInboxWriter,
+    Sorcha.Wallet.Service.Services.Implementation.WalletInboxWriter>();
+
 // Singleton TrustServiceClient — 5-min cert cache must survive across requests,
 // so the HttpClient is captured once. PooledConnectionLifetime caps connection
 // age at 2 min so DNS / mTLS rotation lands via connection recycling.

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/WalletInboxWriter.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/WalletInboxWriter.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceClients.Inbox;
+using Sorcha.ServiceClients.Participant;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Phase 5 follow-up #2 of Feature 118 — bridges Wallet Service credential
+/// issuance events to the durable user inbox owned by Tenant Service.
+/// Symmetric to <c>BlueprintInboxWriter</c> in Blueprint Service.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolves the recipient wallet through the participant service to a
+/// <c>UserIdentity.Id</c>, then through Tenant's
+/// <c>/api/internal/users/by-identity/{id}</c> to the cross-org
+/// <c>PlatformUserId</c> the inbox is keyed on. Posts an inbox entry via
+/// <see cref="IPlatformInboxClient"/>. Fail-safe: every step short-circuits
+/// silently on <c>null</c>, and inbox-write exceptions are caught so
+/// credential issuance is never affected by an inbox-write failure.
+/// </para>
+/// <para>
+/// Idempotency is keyed on <c>(PlatformUserId, SourceEventId)</c> at Tenant.
+/// The <c>SourceEventId</c> is built deterministically from
+/// <c>(recipientWallet, credentialId)</c> so duplicate-issuance retries (or
+/// the rare double-fire path) collapse to the same row.
+/// </para>
+/// </remarks>
+public interface IWalletInboxWriter
+{
+    /// <summary>Write a "you received a new credential" inbox entry for the recipient wallet's owning user.</summary>
+    Task WriteCredentialReceivedAsync(
+        string recipientWalletAddress,
+        string credentialId,
+        string credentialType,
+        string? issuerOrgName = null,
+        CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class WalletInboxWriter : IWalletInboxWriter
+{
+    private readonly IParticipantServiceClient _participants;
+    private readonly IPlatformInboxClient _inbox;
+    private readonly ILogger<WalletInboxWriter> _logger;
+
+    /// <summary>Initialises a new <see cref="WalletInboxWriter"/>.</summary>
+    public WalletInboxWriter(
+        IParticipantServiceClient participants,
+        IPlatformInboxClient inbox,
+        ILogger<WalletInboxWriter> logger)
+    {
+        _participants = participants ?? throw new ArgumentNullException(nameof(participants));
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteCredentialReceivedAsync(
+        string recipientWalletAddress,
+        string credentialId,
+        string credentialType,
+        string? issuerOrgName = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(recipientWalletAddress) ||
+            string.IsNullOrWhiteSpace(credentialId) ||
+            string.IsNullOrWhiteSpace(credentialType))
+        {
+            return;
+        }
+
+        try
+        {
+            var participant = await _participants.GetByWalletAddressAsync(recipientWalletAddress, ct).ConfigureAwait(false);
+            if (participant is null)
+            {
+                _logger.LogDebug(
+                    "Inbox skip — no participant for recipient wallet {Wallet}",
+                    recipientWalletAddress);
+                return;
+            }
+
+            var platformUserId = await _inbox.ResolvePlatformUserIdAsync(participant.UserId, ct).ConfigureAwait(false);
+            if (platformUserId is null)
+            {
+                _logger.LogDebug(
+                    "Inbox skip — could not resolve PlatformUserId for UserIdentity {UserIdentityId}",
+                    participant.UserId);
+                return;
+            }
+
+            var sourceEventId = DeterministicSourceEventId(recipientWalletAddress, credentialId);
+            var displayTitle = string.IsNullOrWhiteSpace(issuerOrgName)
+                ? $"New credential: {credentialType}"
+                : $"{issuerOrgName} issued you a {credentialType}";
+
+            var payload = new InboxWritePayload(
+                PlatformUserId: platformUserId.Value,
+                Category: "Credential",
+                Severity: "Info",
+                CorrelationKey: $"credential:{recipientWalletAddress}:{credentialId}",
+                DetailHref: $"/api/v1/wallets/{recipientWalletAddress}/credentials/{credentialId}",
+                SourceEventId: sourceEventId,
+                OccurredAt: DateTimeOffset.UtcNow,
+                Title: displayTitle,
+                Summary: null,
+                IconKey: "credential.received");
+
+            var outcome = await _inbox.WriteAsync(payload, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for credential received — RecipientWallet={Wallet} CredentialId={CredentialId} Type={Type} EntryId={EntryId}",
+                outcome.Idempotent ? "idempotent" : "created",
+                recipientWalletAddress, credentialId, credentialType, outcome.EntryId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Inbox-write failed for credential received — RecipientWallet={Wallet} CredentialId={CredentialId}",
+                recipientWalletAddress, credentialId);
+        }
+    }
+
+    private static Guid DeterministicSourceEventId(string recipientWalletAddress, string credentialId)
+    {
+        var input = $"sorcha.inbox.credential-received:{recipientWalletAddress}:{credentialId}";
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/WalletInboxWriterTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/WalletInboxWriterTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.ServiceClients.Inbox;
+using Sorcha.ServiceClients.Participant;
+using Sorcha.Wallet.Service.Services.Implementation;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>Unit tests for <see cref="WalletInboxWriter"/>. Phase 5 follow-up #2 of Feature 118.</summary>
+public class WalletInboxWriterTests
+{
+    private readonly Mock<IParticipantServiceClient> _participants = new();
+    private readonly Mock<IPlatformInboxClient> _inbox = new();
+    private readonly WalletInboxWriter _sut;
+
+    public WalletInboxWriterTests()
+    {
+        _sut = new WalletInboxWriter(_participants.Object, _inbox.Object, NullLogger<WalletInboxWriter>.Instance);
+    }
+
+    [Fact]
+    public async Task WriteCredentialReceivedAsync_HappyPath_PostsExpectedPayload()
+    {
+        var participant = BuildParticipant();
+        var platformUserId = Guid.NewGuid();
+        InboxWritePayload? captured = null;
+
+        _participants.Setup(p => p.GetByWalletAddressAsync("recipient-wallet", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(participant.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(platformUserId);
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteCredentialReceivedAsync("recipient-wallet", "cred-abc", "Verified Citizen", "Acme Inc.");
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(platformUserId);
+        captured.Category.Should().Be("Credential");
+        captured.CorrelationKey.Should().Be("credential:recipient-wallet:cred-abc");
+        captured.DetailHref.Should().Be("/api/v1/wallets/recipient-wallet/credentials/cred-abc");
+        captured.Title.Should().Be("Acme Inc. issued you a Verified Citizen");
+    }
+
+    [Fact]
+    public async Task WriteCredentialReceivedAsync_NoIssuerOrgName_FallsBackToTypeOnly()
+    {
+        var participant = BuildParticipant();
+        InboxWritePayload? captured = null;
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteCredentialReceivedAsync("recipient-wallet", "cred-abc", "Driving Licence");
+
+        captured!.Title.Should().Be("New credential: Driving Licence");
+    }
+
+    [Fact]
+    public async Task WriteCredentialReceivedAsync_NoParticipant_SkipsInbox()
+    {
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ParticipantInfo?)null);
+
+        await _sut.WriteCredentialReceivedAsync("recipient-wallet", "cred-abc", "Verified Citizen");
+
+        _inbox.Verify(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WriteCredentialReceivedAsync_DeterministicSourceEventId_CollapsesDuplicates()
+    {
+        var participant = BuildParticipant();
+        var sourceIds = new List<Guid>();
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => sourceIds.Add(p.SourceEventId))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: true));
+
+        await _sut.WriteCredentialReceivedAsync("recipient-wallet", "cred-abc", "Verified Citizen");
+        await _sut.WriteCredentialReceivedAsync("recipient-wallet", "cred-abc", "Verified Citizen");
+
+        sourceIds.Should().HaveCount(2);
+        sourceIds[0].Should().Be(sourceIds[1]);
+    }
+
+    [Fact]
+    public async Task WriteCredentialReceivedAsync_InboxThrows_DoesNotPropagate()
+    {
+        var participant = BuildParticipant();
+        _participants.Setup(p => p.GetByWalletAddressAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(participant);
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Tenant unavailable"));
+
+        var act = () => _sut.WriteCredentialReceivedAsync("recipient-wallet", "cred-abc", "Verified Citizen");
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block credential issuance");
+    }
+
+    private static ParticipantInfo BuildParticipant() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            OrganizationId = Guid.NewGuid(),
+            DisplayName = "Test",
+            Email = "test@example.com",
+            Status = "Active",
+        };
+}


### PR DESCRIPTION
## Summary

Symmetric to PR #521. When \`IssueCredential\` succeeds the recipient now gets a durable inbox entry with \`Category=Credential\` in addition to the existing notification path. Closes spec FR-029 (Wallet writes credential entries).

## Components

- \`Services/Implementation/WalletInboxWriter.cs\` (new) — same shape as \`BlueprintInboxWriter\`: wallet → ParticipantInfo → PlatformUserId → \`POST /api/internal/inbox\`. Title is \`"{Org} issued you a {Type}"\` if \`issuerOrgName\` is supplied, else \`"New credential: {Type}"\`. Deterministic \`SourceEventId\` from \`(recipientWallet, credentialId)\` so duplicate-issuance retries collapse on the Tenant unique index. Fail-safe: every step short-circuits silently; exceptions caught so credential issuance is never blocked.
- \`Endpoints/CredentialEndpoints.cs\` — \`IssueCredential\` gains an \`IWalletInboxWriter\` parameter; calls \`WriteCredentialReceivedAsync\` after the issuance success log.
- \`Program.cs\` — DI registration.

## Tests

\`WalletInboxWriterTests\` — 5/5 passing: happy path, no-issuer-org-name title fallback, no participant skip, deterministic source-event-id reuse, throws-doesn't-propagate.

## Phase 5 inbox writer triad

| Domain | Writer | PR |
|---|---|---|
| Action (Blueprint) | \`BlueprintInboxWriter\` | #521 |
| Credential (Wallet) | \`WalletInboxWriter\` | this |
| Membership / Security / System (Tenant) | \`TenantInboxBridgeService\` | Phase 10 follow-up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)