### PR TITLE
feat(118): wire TenantHub inbox bell into MainLayout

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -379,6 +379,9 @@ public static class ServiceCollectionExtensions
         // Events Hub Connection (SignalR for real-time activity event notifications)
         services.AddEventsHubServices(baseAddress);
 
+        // Tenant Hub Connection (Phase 5 of Feature 118 — durable inbox events)
+        services.AddTenantHubServices(baseAddress);
+
         // Theme Service (043 - T042)
         services.AddScoped<IThemeService>(sp =>
         {
@@ -518,6 +521,41 @@ public static class ServiceCollectionExtensions
             var configService = sp.GetRequiredService<IConfigurationService>();
             var logger = sp.GetRequiredService<ILogger<EventsHubConnection>>();
             return new EventsHubConnection(hubBaseUrl, authService, configService, logger);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="TenantHubConnection"/> for real-time inbox events
+    /// (Phase 5 of Feature 118). Bell badge + activity panel + pending-action
+    /// inbox subscribe to <c>OnInboxEntryAdded</c> + <c>OnInboxUnreadCountUpdated</c>.
+    /// </summary>
+    public static IServiceCollection AddTenantHubServices(this IServiceCollection services, string baseAddress)
+    {
+        services.AddScoped<TenantHubConnection>(sp =>
+        {
+            string hubBaseUrl;
+            if (Uri.TryCreate(baseAddress, UriKind.Absolute, out var uri))
+            {
+                hubBaseUrl = $"{uri.Scheme}://{uri.Authority}";
+            }
+            else
+            {
+                hubBaseUrl = "";
+            }
+
+            var authService = sp.GetRequiredService<IAuthenticationService>();
+            var configService = sp.GetRequiredService<IConfigurationService>();
+            var logger = sp.GetRequiredService<ILogger<TenantHubConnection>>();
+            return new TenantHubConnection(
+                hubBaseUrl,
+                accessTokenProvider: async () =>
+                {
+                    var profileName = await configService.GetActiveProfileNameAsync();
+                    return await authService.GetAccessTokenAsync(profileName);
+                },
+                logger);
         });
 
         return services;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -14,6 +14,7 @@
 @inject IJSRuntime JSRuntime
 @inject EventsHubConnection EventsHub
 @inject ActionsHubConnection ActionsHub
+@inject TenantHubConnection TenantHub
 @inject ISnackbar Snackbar
 @inject ILocalizationService Loc
 @inject IPendingActionService PendingActionService
@@ -300,6 +301,21 @@
             ActionsHub.OnCredentialReceived += OnCredentialReceived;
             ActionsHub.OnPendingCredentialCountUpdated += OnPendingCredentialCountUpdated;
 
+            // Feature 118 Phase 5 — also subscribe to TenantHub inbox events. The
+            // bell uses whichever number is higher between the legacy EventsHub
+            // unread count and the TenantHub inbox unread count during the
+            // parallel-fire window. When EventsHub retires the bell will read
+            // only TenantHub.
+            TenantHub.OnInboxUnreadCountUpdated += OnInboxUnreadCountUpdated;
+            try
+            {
+                await TenantHub.StartAsync();
+            }
+            catch (Exception)
+            {
+                // Hub may be unavailable — auto-reconnect handles transient outages.
+            }
+
             StateHasChanged();
         }
     }
@@ -312,7 +328,9 @@
         EventsHub.OnPendingActionReceived -= OnPendingActionReceived;
         ActionsHub.OnCredentialReceived -= OnCredentialReceived;
         ActionsHub.OnPendingCredentialCountUpdated -= OnPendingCredentialCountUpdated;
+        TenantHub.OnInboxUnreadCountUpdated -= OnInboxUnreadCountUpdated;
         await EventsHub.DisconnectAsync();
+        await TenantHub.DisposeAsync();
         await TokenRefreshService.StopAsync();
     }
 
@@ -333,6 +351,22 @@
     {
         _unreadCount = count == IncrementByOneSignal ? _unreadCount + 1 : count;
         InvokeAsync(StateHasChanged);
+    }
+
+    /// <summary>
+    /// Feature 118 / US3 — TenantHub inbox unread-count handler. Authoritative
+    /// from the server (no -1 increment-by-one signal); the bell renders the
+    /// max of the legacy EventsHub count and this TenantHub count during the
+    /// parallel-fire window. After EventsHub retires the bell reads only this.
+    /// </summary>
+    private Task OnInboxUnreadCountUpdated(int unreadCount, DateTimeOffset occurredAt, string traceId)
+    {
+        if (unreadCount > _unreadCount)
+        {
+            _unreadCount = unreadCount;
+            InvokeAsync(StateHasChanged);
+        }
+        return Task.CompletedTask;
     }
 
     private readonly MudTheme _theme = new()


### PR DESCRIPTION
## Summary

Phase 10 polish step 2 of 4. The notification bell now also listens for inbox-unread-count updates from TenantHub. The badge takes the max of the legacy EventsHub count and the TenantHub count during the parallel-fire window; once EventsHub retires the bell reads only TenantHub.

## Changes

\`Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs\`
- \`AddTenantHubServices\` — DI registration mirroring \`AddEventsHubServices\`. Resolves the JWT via active profile + \`IAuthenticationService.GetAccessTokenAsync(profileName)\`. Wired into \`AddSorchaUiServices\` alongside \`AddEventsHubServices\`.

\`Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor\`
- \`@inject TenantHubConnection TenantHub\`
- Subscribes to \`OnInboxUnreadCountUpdated\` in \`OnAfterRenderAsync\` (after the auth check)
- \`StartAsync\` wrapped in try/catch — auto-reconnect handles transient outages, hub failures don't break the layout
- \`DisposeAsync\` cleanly unsubscribes + disposes the connection
- Handler takes \`max(_unreadCount, newInboxCount)\` so users see the higher number during parallel-fire

## Out of scope (next Phase-10 PRs)

- \`PendingActionInbox.razor\` → IS the inbox UI (rewrite)
- \`ActivityLogPanel.razor\` → inbox-driven feed (rewrite)
- \`PendingActionToast.razor\` → inbox-driven toast (rewrite)
- \`BlueprintHubConnection\` / \`WalletHubConnection\` split from \`ActionsHubConnection\`
- EventsHub deletion (gauge-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)