### PR TITLE
feat(118): UI-side IInboxApiService HTTP client (Phase 10 step 3)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -747,6 +747,16 @@ public static class ServiceCollectionExtensions
             return new OperationStatusService(httpClient, logger);
         });
 
+        // Feature 118 / US3 — UI-side wrapper for /api/me/inbox/* endpoints.
+        services.AddScoped<IInboxApiService>(sp =>
+        {
+            var handler = sp.GetRequiredService<AuthenticatedHttpMessageHandler>();
+            handler.InnerHandler = new HttpClientHandler();
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
+            var logger = sp.GetRequiredService<ILogger<InboxApiService>>();
+            return new InboxApiService(httpClient, logger);
+        });
+
         // IDP Configuration Client Service (054 - authenticated)
         services.AddScoped<IIdpConfigurationClientService>(sp =>
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IInboxApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/IInboxApiService.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services;
+
+/// <summary>
+/// UI-side wrapper around the Tenant Service inbox endpoints
+/// (<c>/api/me/inbox/*</c>). Phase 5 of Feature 118.
+/// </summary>
+/// <remarks>
+/// Future UI rewrites — <c>PendingActionInbox.razor</c>,
+/// <c>ActivityLogPanel.razor</c>, <c>PendingActionToast.razor</c> — call
+/// this surface to render the durable inbox. The complement to
+/// <see cref="TenantHubConnection"/> for realtime nudges.
+/// </remarks>
+public interface IInboxApiService
+{
+    /// <summary>List the authenticated user's inbox entries, newest first.</summary>
+    /// <param name="page">1-based page number.</param>
+    /// <param name="pageSize">Page size (1..100, server clamps).</param>
+    /// <param name="category">Optional filter — one of Action, Credential, Membership, Security, System, Workflow, Custom.</param>
+    /// <param name="unreadOnly">When true, returns only entries with no <c>ReadAt</c>.</param>
+    /// <param name="includeDismissed">When true, includes dismissed entries (default excludes).</param>
+    Task<InboxPageDto?> ListAsync(
+        int page = 1,
+        int pageSize = 20,
+        string? category = null,
+        bool unreadOnly = false,
+        bool includeDismissed = false,
+        CancellationToken ct = default);
+
+    /// <summary>Fetch a single entry. Returns <c>null</c> if not found or not owned.</summary>
+    Task<InboxEntryDto?> GetByIdAsync(Guid entryId, CancellationToken ct = default);
+
+    /// <summary>Server-authoritative unread count.</summary>
+    Task<int> GetUnreadCountAsync(CancellationToken ct = default);
+
+    /// <summary>Mark an entry as read. Idempotent.</summary>
+    Task<bool> MarkReadAsync(Guid entryId, CancellationToken ct = default);
+
+    /// <summary>Dismiss an entry. Idempotent.</summary>
+    Task<bool> DismissAsync(Guid entryId, CancellationToken ct = default);
+
+    /// <summary>Mark every unread entry read for the authenticated user. Returns count affected.</summary>
+    Task<int> MarkAllReadAsync(CancellationToken ct = default);
+}
+
+/// <summary>Wire shape for an inbox entry returned by the Tenant Service inbox endpoints.</summary>
+public sealed record InboxEntryDto
+{
+    public required Guid Id { get; init; }
+    public required Guid PlatformUserId { get; init; }
+    public required string Category { get; init; }
+    public required string Severity { get; init; }
+    public required string CorrelationKey { get; init; }
+    public required string DetailHref { get; init; }
+    public required Guid SourceEventId { get; init; }
+    public required DateTimeOffset OccurredAt { get; init; }
+    public DateTimeOffset? ReadAt { get; init; }
+    public DateTimeOffset? DismissedAt { get; init; }
+    public required string Title { get; init; }
+    public string? Summary { get; init; }
+    public string? IconKey { get; init; }
+    public string? ChannelHints { get; init; }
+}
+
+/// <summary>Wire shape for the paginated inbox listing.</summary>
+public sealed record InboxPageDto(IReadOnlyList<InboxEntryDto> Entries, int Page, int PageSize, int TotalCount);

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/InboxApiService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/InboxApiService.cs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Extensions;
+
+namespace Sorcha.UI.Core.Services;
+
+/// <summary>
+/// HttpClient implementation of <see cref="IInboxApiService"/>. Talks to
+/// the API gateway routes <c>/api/me/inbox/*</c>; the gateway proxies to
+/// Tenant Service. Phase 5 of Feature 118.
+/// </summary>
+public sealed class InboxApiService : IInboxApiService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<InboxApiService> _logger;
+
+    /// <summary>Initialises a new <see cref="InboxApiService"/>.</summary>
+    public InboxApiService(HttpClient httpClient, ILogger<InboxApiService> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<InboxPageDto?> ListAsync(
+        int page = 1,
+        int pageSize = 20,
+        string? category = null,
+        bool unreadOnly = false,
+        bool includeDismissed = false,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var query = $"?page={page}&pageSize={pageSize}";
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                query += $"&category={Uri.EscapeDataString(category)}";
+            }
+            if (unreadOnly) query += "&unreadOnly=true";
+            if (includeDismissed) query += "&includeDismissed=true";
+
+            using var resp = await _httpClient.GetAsync($"/api/me/inbox{query}", ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("InboxApiService.ListAsync failed: {StatusCode}", resp.StatusCode);
+                return null;
+            }
+            return await resp.Content.ReadFromJsonAsync<InboxPageDto>(JsonDefaults.Api, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "InboxApiService.ListAsync transport error");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<InboxEntryDto?> GetByIdAsync(Guid entryId, CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await _httpClient.GetAsync($"/api/me/inbox/{entryId:D}", ct).ConfigureAwait(false);
+            if (resp.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("InboxApiService.GetByIdAsync failed: {StatusCode}", resp.StatusCode);
+                return null;
+            }
+            return await resp.Content.ReadFromJsonAsync<InboxEntryDto>(JsonDefaults.Api, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "InboxApiService.GetByIdAsync transport error");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetUnreadCountAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await _httpClient.GetAsync("/api/me/inbox/unread-count", ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("InboxApiService.GetUnreadCountAsync failed: {StatusCode}", resp.StatusCode);
+                return 0;
+            }
+            var body = await resp.Content.ReadFromJsonAsync<UnreadCountShape>(JsonDefaults.Api, ct).ConfigureAwait(false);
+            return body?.Unread ?? 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "InboxApiService.GetUnreadCountAsync transport error");
+            return 0;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> MarkReadAsync(Guid entryId, CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await _httpClient.PostAsync($"/api/me/inbox/{entryId:D}/read", content: null, ct).ConfigureAwait(false);
+            return resp.IsSuccessStatusCode;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "InboxApiService.MarkReadAsync transport error");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DismissAsync(Guid entryId, CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await _httpClient.PostAsync($"/api/me/inbox/{entryId:D}/dismiss", content: null, ct).ConfigureAwait(false);
+            return resp.IsSuccessStatusCode;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "InboxApiService.DismissAsync transport error");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<int> MarkAllReadAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await _httpClient.PostAsync("/api/me/inbox/mark-all-read", content: null, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                return 0;
+            }
+            var body = await resp.Content.ReadFromJsonAsync<MarkAllReadShape>(JsonDefaults.Api, ct).ConfigureAwait(false);
+            return body?.Marked ?? 0;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "InboxApiService.MarkAllReadAsync transport error");
+            return 0;
+        }
+    }
+
+    private sealed record UnreadCountShape(int Unread);
+    private sealed record MarkAllReadShape(int Marked);
+}

--- a/tests/Sorcha.UI.Core.Tests/Services/InboxApiServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/InboxApiServiceTests.cs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.UI.Core.Services;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services;
+
+/// <summary>Unit tests for <see cref="InboxApiService"/>. Phase 5 of Feature 118.</summary>
+public class InboxApiServiceTests
+{
+    private static InboxApiService Build(StubHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("http://localhost") },
+            NullLogger<InboxApiService>.Instance);
+
+    [Fact]
+    public async Task ListAsync_BuildsExpectedQueryString()
+    {
+        var handler = new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent("""{"entries":[],"page":2,"pageSize":10,"totalCount":0}""")
+            });
+
+        var sut = Build(handler);
+        var page = await sut.ListAsync(page: 2, pageSize: 10, category: "Action", unreadOnly: true);
+
+        page.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should().Be(
+            "/api/me/inbox?page=2&pageSize=10&category=Action&unreadOnly=true");
+    }
+
+    [Fact]
+    public async Task ListAsync_OnNon200_ReturnsNull()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var sut = Build(handler);
+
+        var page = await sut.ListAsync();
+
+        page.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_On404_ReturnsNullIndistinguishably()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        var sut = Build(handler);
+
+        var entry = await sut.GetByIdAsync(Guid.NewGuid());
+
+        entry.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_ReturnsServerValue()
+    {
+        var handler = new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent("""{"unread":7}""") });
+        var sut = Build(handler);
+
+        (await sut.GetUnreadCountAsync()).Should().Be(7);
+    }
+
+    [Fact]
+    public async Task GetUnreadCountAsync_OnError_ReturnsZero()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var sut = Build(handler);
+
+        (await sut.GetUnreadCountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_PostsToCorrectPath()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        var sut = Build(handler);
+
+        var id = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var ok = await sut.MarkReadAsync(id);
+
+        ok.Should().BeTrue();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be(
+            "/api/me/inbox/11111111-2222-3333-4444-555555555555/read");
+    }
+
+    [Fact]
+    public async Task DismissAsync_PostsToCorrectPath()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        var sut = Build(handler);
+
+        var id = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var ok = await sut.DismissAsync(id);
+
+        ok.Should().BeTrue();
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should().Be(
+            "/api/me/inbox/11111111-2222-3333-4444-555555555555/dismiss");
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_ReturnsCount()
+    {
+        var handler = new StubHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = JsonContent("""{"marked":3}""") });
+        var sut = Build(handler);
+
+        (await sut.MarkAllReadAsync()).Should().Be(3);
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_OnError_ReturnsZero()
+    {
+        var handler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var sut = Build(handler);
+
+        (await sut.MarkAllReadAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task TransportException_OnList_ReturnsNullDoesNotPropagate()
+    {
+        var handler = new StubHandler(_ => throw new HttpRequestException("network down"));
+        var sut = Build(handler);
+
+        var page = await sut.ListAsync();
+
+        page.Should().BeNull();
+    }
+
+    private static StringContent JsonContent(string json) =>
+        new(json, Encoding.UTF8, "application/json");
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+        {
+            _respond = respond;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(_respond(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 10 polish step 3 of 4 — the UI-side wrapper around \`/api/me/inbox/*\` endpoints. Future \`PendingActionInbox\` / \`ActivityLogPanel\` / \`PendingActionToast\` rewrites will consume this surface alongside \`TenantHubConnection\` for realtime nudges.

## Components

- \`IInboxApiService.cs\` — six methods: \`ListAsync\` (paginated, filterable), \`GetByIdAsync\`, \`GetUnreadCountAsync\`, \`MarkReadAsync\`, \`DismissAsync\`, \`MarkAllReadAsync\`. \`InboxEntryDto\` + \`InboxPageDto\` wire shapes match the Tenant Service response payloads.
- \`InboxApiService.cs\` — HttpClient impl. Returns \`null\`/\`false\`/\`0\` on transport error or non-2xx — never throws to the consumer. 404 on \`GetByIdAsync\` returns null indistinguishably (matches the server-side enumeration-oracle protection).
- \`ServiceCollectionExtensions.cs\` — DI registration via \`AuthenticatedHttpMessageHandler\` pattern.

## Tests

\`InboxApiServiceTests\` — **10/10 passing**: query-string construction, 404 indistinguishable, unread count parse, mark-read / dismiss path correctness, error paths return safe defaults, transport exception swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)