### PR TITLE
feat(118): wire InboxPanel to MainLayout app bar

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -46,6 +46,10 @@
                         <MudBadge Content="@_unreadCount" Color="Color.Error" Overlap="true" />
                     }
                 </MudIconButton>
+                @* Feature 118 — durable inbox bell. Coexists with the legacy
+                   activity log + pending-actions buttons during the parallel-fire
+                   window. *@
+                <MudIconButton Icon="@Icons.Material.Filled.MarkEmailUnread" Color="Color.Inherit" OnClick="@ToggleInboxPanel" Title="Inbox" />
                 <UserProfileMenu />
             </Authorized>
             <NotAuthorized>
@@ -252,6 +256,9 @@
     <CryptoProgressPopover />
     @* PendingActionToast removed — activity log panel now handles all notifications *@
     <PendingActionInbox @bind-IsOpen="_pendingInboxOpen" />
+
+    @* Feature 118 — durable inbox UI. *@
+    <InboxPanel @bind-IsOpen="_inboxPanelOpen" />
 </MudLayout>
 
 </CascadingAuthenticationState>
@@ -261,6 +268,7 @@
     private bool _tokenRefreshStarted;
     private bool _activityLogOpen;
     private bool _pendingInboxOpen;
+    private bool _inboxPanelOpen;
     private int _unreadCount;
     private int _pendingActionCount;
     private int _pendingCredentialCount;
@@ -400,6 +408,11 @@
     private void ToggleActivityLog()
     {
         _activityLogOpen = !_activityLogOpen;
+    }
+
+    private void ToggleInboxPanel()
+    {
+        _inboxPanelOpen = !_inboxPanelOpen;
     }
 
     private async Task TogglePendingInbox()


### PR DESCRIPTION
Closes the loop on the inbox UI surface — the `InboxPanel` from PR #532 now has an entry point in the main app bar. Users click the `MarkEmailUnread` icon → inbox drawer slides out → they can read / dismiss / navigate to entry detail.

Coexists with the existing pending-actions + activity-log buttons during the parallel-fire window. Final consolidation lands when EventsHub retires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)