### PR TITLE
feat(118): TenantMembershipInboxWriter — welcome inbox entry on org join (T077)

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -191,6 +191,8 @@ public static class ServiceCollectionExtensions
 
         // Platform services
         services.AddScoped<IPlatformUserService, PlatformUserService>();
+        // Feature 118 / US3 follow-up #3 — Tenant-side inbox writer for org membership events.
+        services.AddScoped<ITenantMembershipInboxWriter, TenantMembershipInboxWriter>();
         services.AddScoped<IPlatformSettingsService, PlatformSettingsService>();
         services.AddScoped<IOrgProvisioningService, OrgProvisioningService>();
         services.AddScoped<IPlatformUserProvisioningService, PlatformUserProvisioningService>();

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
@@ -19,6 +19,8 @@ public class PlatformUserService : IPlatformUserService
     private readonly TenantDbContext _db;
     private readonly ILogger<PlatformUserService> _logger;
     private readonly LockoutConfig _lockoutConfig;
+    /// <summary>Optional inbox writer (Feature 118 / US3 Phase-5 follow-up #3). Null in tests where membership inbox emission is irrelevant.</summary>
+    private readonly ITenantMembershipInboxWriter? _inboxWriter;
 
     /// <summary>
     /// Creates a new instance of <see cref="PlatformUserService"/>.
@@ -26,11 +28,17 @@ public class PlatformUserService : IPlatformUserService
     /// <param name="db">The tenant database context.</param>
     /// <param name="logger">The logger instance.</param>
     /// <param name="configuration">Application configuration for lockout thresholds.</param>
-    public PlatformUserService(TenantDbContext db, ILogger<PlatformUserService> logger, IConfiguration configuration)
+    /// <param name="inboxWriter">Optional inbox writer for Feature 118 — fires when a user joins an org.</param>
+    public PlatformUserService(
+        TenantDbContext db,
+        ILogger<PlatformUserService> logger,
+        IConfiguration configuration,
+        ITenantMembershipInboxWriter? inboxWriter = null)
     {
         _db = db;
         _logger = logger;
         _lockoutConfig = LockoutConfig.FromConfiguration(configuration);
+        _inboxWriter = inboxWriter;
     }
 
     /// <inheritdoc />
@@ -170,6 +178,13 @@ public class PlatformUserService : IPlatformUserService
         _logger.LogInformation(
             "Added organisation membership for platform user {UserId} in org {OrgId} with role {Role}",
             platformUserId, organizationId, role);
+
+        // Feature 118 / US3 follow-up #3 — drop a "welcome to {org}" inbox entry.
+        // Optional + fail-safe: writer null-checks and the writer itself catches.
+        if (_inboxWriter is not null)
+        {
+            await _inboxWriter.WriteOrgMembershipAddedAsync(platformUserId, organizationId, role, ct).ConfigureAwait(false);
+        }
 
         return membership;
     }

--- a/src/Services/Sorcha.Tenant.Service/Services/TenantMembershipInboxWriter.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TenantMembershipInboxWriter.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.EntityFrameworkCore;
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// Phase 5 follow-up #3 of Feature 118 — bridges Tenant-domain membership
+/// events to the durable user inbox. Third writer in the triad alongside
+/// <c>BlueprintInboxWriter</c> (Action) and <c>WalletInboxWriter</c>
+/// (Credential). Tenant calls its own inbox directly via <see cref="IInboxService"/>;
+/// no cross-service HTTP hop.
+/// </summary>
+public interface ITenantMembershipInboxWriter
+{
+    /// <summary>Write a "you joined {org}" inbox entry for the user just added to an organisation.</summary>
+    Task WriteOrgMembershipAddedAsync(
+        Guid platformUserId,
+        Guid organizationId,
+        string role,
+        CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class TenantMembershipInboxWriter : ITenantMembershipInboxWriter
+{
+    private readonly IInboxService _inbox;
+    private readonly TenantDbContext _db;
+    private readonly ILogger<TenantMembershipInboxWriter> _logger;
+
+    /// <summary>Initialises a new <see cref="TenantMembershipInboxWriter"/>.</summary>
+    public TenantMembershipInboxWriter(
+        IInboxService inbox,
+        TenantDbContext db,
+        ILogger<TenantMembershipInboxWriter> logger)
+    {
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteOrgMembershipAddedAsync(
+        Guid platformUserId,
+        Guid organizationId,
+        string role,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var orgName = await _db.Organizations
+                .AsNoTracking()
+                .Where(o => o.Id == organizationId)
+                .Select(o => o.Name)
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false)
+                ?? "your new organisation";
+
+            var sourceEventId = DeterministicSourceEventId(platformUserId, organizationId);
+            var request = new InboxWriteRequest(
+                PlatformUserId: platformUserId,
+                Category: InboxCategory.Membership,
+                Severity: InboxSeverity.Info,
+                CorrelationKey: $"membership:{organizationId:N}",
+                DetailHref: $"/api/me/organizations/{organizationId:D}",
+                SourceEventId: sourceEventId,
+                OccurredAt: DateTimeOffset.UtcNow,
+                Title: $"Welcome to {orgName}",
+                Summary: string.IsNullOrWhiteSpace(role) ? null : $"Role: {role}",
+                IconKey: "membership.added");
+
+            var result = await _inbox.WriteAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for org membership added — PlatformUserId={UserId} OrgId={OrgId} EntryId={EntryId}",
+                result.IsIdempotent ? "idempotent" : "created",
+                platformUserId, organizationId, result.Entry.Id);
+        }
+        catch (Exception ex)
+        {
+            // Inbox-write failure must not block the membership operation.
+            _logger.LogWarning(ex,
+                "Inbox-write failed for org membership added — PlatformUserId={UserId} OrgId={OrgId}",
+                platformUserId, organizationId);
+        }
+    }
+
+    private static Guid DeterministicSourceEventId(Guid platformUserId, Guid organizationId)
+    {
+        var input = $"sorcha.inbox.org-membership-added:{platformUserId:N}:{organizationId:N}";
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/TenantMembershipInboxWriterTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/TenantMembershipInboxWriterTests.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+using Sorcha.Tenant.Service.Tests.Helpers;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>Unit tests for <see cref="TenantMembershipInboxWriter"/>. Phase 5 follow-up #3 of Feature 118.</summary>
+public sealed class TenantMembershipInboxWriterTests : IDisposable
+{
+    private readonly Sorcha.Tenant.Service.Data.TenantDbContext _db;
+    private readonly Mock<IInboxService> _inbox = new();
+    private readonly TenantMembershipInboxWriter _sut;
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _orgId = Guid.NewGuid();
+
+    public TenantMembershipInboxWriterTests()
+    {
+        _db = InMemoryDbContextFactory.Create();
+        _sut = new TenantMembershipInboxWriter(_inbox.Object, _db, NullLogger<TenantMembershipInboxWriter>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task WriteOrgMembershipAddedAsync_LooksUpOrgName_AndPostsExpectedPayload()
+    {
+        _db.Organizations.Add(new Organization
+        {
+            Id = _orgId,
+            Name = "Acme Inc.",
+            Subdomain = "acme",
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteOrgMembershipAddedAsync(_userId, _orgId, "Member");
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(_userId);
+        captured.Category.Should().Be(InboxCategory.Membership);
+        captured.Severity.Should().Be(InboxSeverity.Info);
+        captured.CorrelationKey.Should().Be($"membership:{_orgId:N}");
+        captured.Title.Should().Be("Welcome to Acme Inc.");
+        captured.Summary.Should().Be("Role: Member");
+    }
+
+    [Fact]
+    public async Task WriteOrgMembershipAddedAsync_OrgMissing_FallsBackToGenericTitle()
+    {
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteOrgMembershipAddedAsync(_userId, _orgId, "Admin");
+
+        captured!.Title.Should().Be("Welcome to your new organisation");
+        captured.Summary.Should().Be("Role: Admin");
+    }
+
+    [Fact]
+    public async Task WriteOrgMembershipAddedAsync_DeterministicSourceEventId_CollapsesDuplicates()
+    {
+        var sourceIds = new List<Guid>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => sourceIds.Add(r.SourceEventId))
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: true));
+
+        await _sut.WriteOrgMembershipAddedAsync(_userId, _orgId, "Member");
+        await _sut.WriteOrgMembershipAddedAsync(_userId, _orgId, "Member");
+
+        sourceIds.Should().HaveCount(2);
+        sourceIds[0].Should().Be(sourceIds[1]);
+    }
+
+    [Fact]
+    public async Task WriteOrgMembershipAddedAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("inbox down"));
+
+        var act = () => _sut.WriteOrgMembershipAddedAsync(_userId, _orgId, "Member");
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block the org membership operation");
+    }
+}


### PR DESCRIPTION
Closes the writer triad. Three writer patterns now demonstrated end-to-end:

| Domain | Writer | Path |
|---|---|---|
| Action | `BlueprintInboxWriter` (#521) | Cross-service HTTP |
| Credential | `WalletInboxWriter` (#525) | Cross-service HTTP |
| **Membership** | `TenantMembershipInboxWriter` (this) | In-process `IInboxService` |

When `PlatformUserService.AddOrgMembershipAsync` persists a new membership, the writer drops a `Welcome to {OrgName}` inbox entry with `Category=Membership`. Same deterministic `SourceEventId` pattern (SHA1 RFC 4122 v5) so duplicate writes collapse on Tenant's unique index.

`PlatformUserService` constructor takes the writer optionally (defaults to null) — existing tests and manual injection sites work unchanged.

Tests: 4/4 passing — happy path with org-name lookup, missing-org fallback, deterministic SourceEventId, inbox-throws-doesnt-propagate.

Spec FR-031 — first of three Tenant-domain writers. Security alerts + system announcements follow when those event types materialise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)