### PR TITLE
feat(118): [T117] PendingActionToast — inbox-driven toast for Category=Action

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -271,7 +271,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 
 - [ ] T115 Rewrite `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor` so the unread-count badge reads from `TenantHubConnection.OnInboxUnreadCountUpdated` plus a REST seed from `GET /api/me/inbox/unread-count` on mount. Remove `EventsHubConnection` injection.
 - [ ] T116 Rewrite `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/ActivityLogPanel.razor` to render from `GET /api/me/inbox` paginated results, with `TenantHubConnection.OnInboxEntryAdded` triggering page-1 refresh. Implement 30 s correlation grouping in the render path.
-- [ ] T117 Rewrite `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor` to fire on `OnInboxEntryAdded` filtered to `Category=Action`. Toast carries title only; click navigates to `DetailHref`.
+- [X] T117 Rewrite `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor` to fire on `OnInboxEntryAdded` filtered to `Category=Action`. Toast carries title only; click navigates to `DetailHref`.
 - [ ] T118 Rewrite `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionInbox.razor` so it IS the inbox UI: list view, per-entry read/dismiss buttons calling the inbox API, correlation grouping, category filters.
 
 ### Non-UI subscribers

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -261,7 +261,10 @@
     <ActivityLogPanel @bind-IsOpen="_activityLogOpen" OnEventsRead="RefreshUnreadCount" />
     <OperationNotificationListener />
     <CryptoProgressPopover />
-    @* PendingActionToast removed — activity log panel now handles all notifications *@
+    @* Feature 118 / T117 — inbox-driven toast for Category=Action entries.
+       Subscribes to TenantHub.OnInboxEntryAdded, fetches entry detail, and
+       shows a snackbar with click-through to DetailHref. *@
+    <PendingActionToast />
     <PendingActionInbox @bind-IsOpen="_pendingInboxOpen" />
 
     @* Feature 118 — durable inbox UI. *@

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor
@@ -2,57 +2,73 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @implements IDisposable
-@inject EventsHubConnection EventsHub
+@inject TenantHubConnection TenantHub
+@inject IInboxApiService InboxApi
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
-@using Sorcha.UI.Core.Models.Actions
+@inject ILogger<PendingActionToast> Logger
 @using Sorcha.UI.Core.Services
 @using MudBlazor
 
-@code {
-    private readonly Queue<SignalNotification> _queue = new();
-    private bool _processing;
+@*
+    Feature 118 / T117 — toast surface for inbox entries with Category=Action.
 
+    Subscribes to TenantHub.OnInboxEntryAdded (thin signal — entryId only),
+    fetches the entry via the inbox REST endpoint, and shows a snackbar when
+    the category is Action. Click navigates to the entry's DetailHref.
+*@
+
+@code {
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        EventsHub.OnPendingActionReceived += HandlePendingAction;
+        TenantHub.OnInboxEntryAdded += HandleInboxEntryAddedAsync;
     }
 
-    private void HandlePendingAction(SignalNotification signal)
+    private async Task HandleInboxEntryAddedAsync(string entryId, DateTimeOffset occurredAt, string traceId)
     {
-        InvokeAsync(async () =>
+        if (!Guid.TryParse(entryId, out var id))
         {
-            _queue.Enqueue(signal);
-            if (_processing) return;
-            _processing = true;
+            return;
+        }
 
-            while (_queue.Count > 0)
+        try
+        {
+            var entry = await InboxApi.GetByIdAsync(id);
+            if (entry is null || !string.Equals(entry.Category, "Action", StringComparison.Ordinal))
             {
-                var notification = _queue.Dequeue();
-                ShowToast(notification);
-                if (_queue.Count > 0)
-                    await Task.Delay(300); // Brief delay between queued toasts
+                return;
             }
 
-            _processing = false;
-        });
-    }
+            var detailHref = entry.DetailHref;
+            var title = entry.Title;
 
-    private void ShowToast(SignalNotification signal)
-    {
-        var message = "New action available";
-
-        Snackbar.Add(message, Severity.Info, config =>
+            await InvokeAsync(() =>
+            {
+                Snackbar.Add(title, Severity.Info, config =>
+                {
+                    config.VisibleStateDuration = 5000;
+                    config.ShowCloseIcon = true;
+                    config.OnClick = _ =>
+                    {
+                        if (!string.IsNullOrWhiteSpace(detailHref))
+                        {
+                            Navigation.NavigateTo(detailHref);
+                        }
+                        return Task.CompletedTask;
+                    };
+                });
+            });
+        }
+        catch (Exception ex)
         {
-            config.VisibleStateDuration = 5000;
-            config.ShowCloseIcon = true;
-        });
+            Logger.LogWarning(ex, "PendingActionToast — failed to load inbox entry {EntryId}", entryId);
+        }
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
-        EventsHub.OnPendingActionReceived -= HandlePendingAction;
+        TenantHub.OnInboxEntryAdded -= HandleInboxEntryAddedAsync;
     }
 }


### PR DESCRIPTION
## Summary

- Rewrites `PendingActionToast.razor` to subscribe to `TenantHub.OnInboxEntryAdded`, fetch the entry via `IInboxApiService.GetByIdAsync`, and fire a snackbar only when `Category=Action`.
- Click navigates to the entry's `DetailHref`; non-Action categories are skipped silently.
- Re-mounts the component in `MainLayout` (it was stubbed out under the old EventsHub model).

The inbox bell already shows the durable unread count; the toast adds an in-flight nudge so users don't miss action-required items that just landed.

Closes T117 in `specs/118-notifications-architecture/tasks.md`.

## Test plan
- [ ] Sign in to Sorcha.UI; trigger a workflow action that creates a Category=Action inbox entry; toast fires with the entry title.
- [ ] Click the toast snackbar; navigates to the action's DetailHref.
- [ ] Trigger a Credential / Membership entry; no toast fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)