### PR TITLE
feat(118): TenantSecurityInboxWriter — Category=Security entries for 2FA enable/disable

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/ServiceCollectionExtensions.cs
@@ -193,6 +193,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPlatformUserService, PlatformUserService>();
         // Feature 118 / US3 follow-up #3 — Tenant-side inbox writer for org membership events.
         services.AddScoped<ITenantMembershipInboxWriter, TenantMembershipInboxWriter>();
+        // Feature 118 — Tenant-side inbox writer for security events (2FA enable/disable).
+        services.AddScoped<ITenantSecurityInboxWriter, TenantSecurityInboxWriter>();
         services.AddScoped<IPlatformSettingsService, PlatformSettingsService>();
         services.AddScoped<IOrgProvisioningService, OrgProvisioningService>();
         services.AddScoped<IPlatformUserProvisioningService, PlatformUserProvisioningService>();

--- a/src/Services/Sorcha.Tenant.Service/Services/TenantSecurityInboxWriter.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TenantSecurityInboxWriter.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// Feature 118 — Tenant-side inbox writer for security-relevant account
+/// events (2FA enabled / disabled, etc.). Sibling to
+/// <see cref="ITenantMembershipInboxWriter"/>; same fail-safe semantics:
+/// inbox-write failures are logged but never block the originating
+/// security operation.
+/// </summary>
+public interface ITenantSecurityInboxWriter
+{
+    /// <summary>Write a "2FA enabled" Category=Security inbox entry.</summary>
+    Task WriteTwoFactorEnabledAsync(Guid platformUserId, CancellationToken ct = default);
+
+    /// <summary>Write a "2FA disabled" Category=Security inbox entry.</summary>
+    Task WriteTwoFactorDisabledAsync(Guid platformUserId, CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
+{
+    private readonly IInboxService _inbox;
+    private readonly ILogger<TenantSecurityInboxWriter> _logger;
+
+    /// <summary>Initialises a new <see cref="TenantSecurityInboxWriter"/>.</summary>
+    public TenantSecurityInboxWriter(
+        IInboxService inbox,
+        ILogger<TenantSecurityInboxWriter> logger)
+    {
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task WriteTwoFactorEnabledAsync(Guid platformUserId, CancellationToken ct = default) =>
+        WriteAsync(
+            platformUserId,
+            "two-factor-enabled",
+            title: "Two-factor authentication enabled",
+            summary: "Your account now requires a code from your authenticator app at sign-in.",
+            iconKey: "security.2fa-enabled",
+            ct);
+
+    /// <inheritdoc />
+    public Task WriteTwoFactorDisabledAsync(Guid platformUserId, CancellationToken ct = default) =>
+        WriteAsync(
+            platformUserId,
+            "two-factor-disabled",
+            title: "Two-factor authentication disabled",
+            summary: "Your account is now signing in with password only. Re-enable 2FA from Settings → Security.",
+            iconKey: "security.2fa-disabled",
+            ct);
+
+    private async Task WriteAsync(
+        Guid platformUserId,
+        string eventKey,
+        string title,
+        string summary,
+        string iconKey,
+        CancellationToken ct)
+    {
+        try
+        {
+            var occurredAt = DateTimeOffset.UtcNow;
+            var sourceEventId = DeterministicSourceEventId(platformUserId, eventKey, occurredAt);
+
+            var request = new InboxWriteRequest(
+                PlatformUserId: platformUserId,
+                Category: InboxCategory.Security,
+                Severity: InboxSeverity.Info,
+                CorrelationKey: $"security:{eventKey}:{platformUserId:N}",
+                DetailHref: "/settings/security",
+                SourceEventId: sourceEventId,
+                OccurredAt: occurredAt,
+                Title: title,
+                Summary: summary,
+                IconKey: iconKey);
+
+            var result = await _inbox.WriteAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for security event {EventKey} — PlatformUserId={UserId} EntryId={EntryId}",
+                result.IsIdempotent ? "idempotent" : "created",
+                eventKey, platformUserId, result.Entry.Id);
+        }
+        catch (Exception ex)
+        {
+            // Inbox-write failure must not block the security operation.
+            _logger.LogWarning(ex,
+                "Inbox-write failed for security event {EventKey} — PlatformUserId={UserId}",
+                eventKey, platformUserId);
+        }
+    }
+
+    private static Guid DeterministicSourceEventId(Guid platformUserId, string eventKey, DateTimeOffset occurredAt)
+    {
+        // Each enable/disable event is a fresh occurrence — fold the timestamp
+        // (to the second) into the deterministic id so a user can re-enable
+        // after a previous enable+disable without the second entry collapsing
+        // onto the first via the (PlatformUserId, SourceEventId) unique index.
+        var input = $"sorcha.inbox.security.{eventKey}:{platformUserId:N}:{occurredAt.ToUnixTimeSeconds()}";
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Services/TotpService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TotpService.cs
@@ -34,6 +34,7 @@ public class TotpService : ITotpService
 
     private readonly TenantDbContext _db;
     private readonly IIdentityRepository _identityRepository;
+    private readonly ITenantSecurityInboxWriter _securityInbox;
     private readonly ILogger<TotpService> _logger;
 
     /// <summary>
@@ -45,10 +46,12 @@ public class TotpService : ITotpService
     public TotpService(
         TenantDbContext db,
         IIdentityRepository identityRepository,
+        ITenantSecurityInboxWriter securityInbox,
         ILogger<TotpService> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _identityRepository = identityRepository ?? throw new ArgumentNullException(nameof(identityRepository));
+        _securityInbox = securityInbox ?? throw new ArgumentNullException(nameof(securityInbox));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -148,6 +151,10 @@ public class TotpService : ITotpService
         await UpdateUserPreferencesTwoFactor(userId, true, cancellationToken);
 
         _logger.LogInformation("TOTP enabled for user {UserId}", userId);
+
+        // Feature 118 — emit a Category=Security inbox entry. Fail-safe.
+        await _securityInbox.WriteTwoFactorEnabledAsync(userId, cancellationToken);
+
         return true;
     }
 
@@ -224,6 +231,9 @@ public class TotpService : ITotpService
             await UpdateUserPreferencesTwoFactor(userId, false, cancellationToken);
 
             _logger.LogInformation("TOTP disabled for user {UserId}", userId);
+
+            // Feature 118 — emit a Category=Security inbox entry. Fail-safe.
+            await _securityInbox.WriteTwoFactorDisabledAsync(userId, cancellationToken);
         }
     }
 

--- a/tests/Sorcha.Tenant.Service.Tests/Services/TenantSecurityInboxWriterTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/TenantSecurityInboxWriterTests.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>Unit tests for <see cref="TenantSecurityInboxWriter"/>. Feature 118.</summary>
+public sealed class TenantSecurityInboxWriterTests
+{
+    private readonly Mock<IInboxService> _inbox = new();
+    private readonly TenantSecurityInboxWriter _sut;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public TenantSecurityInboxWriterTests()
+    {
+        _sut = new TenantSecurityInboxWriter(_inbox.Object, NullLogger<TenantSecurityInboxWriter>.Instance);
+    }
+
+    [Fact]
+    public async Task WriteTwoFactorEnabledAsync_PostsExpectedSecurityPayload()
+    {
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteTwoFactorEnabledAsync(_userId);
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(_userId);
+        captured.Category.Should().Be(InboxCategory.Security);
+        captured.Severity.Should().Be(InboxSeverity.Info);
+        captured.CorrelationKey.Should().Be($"security:two-factor-enabled:{_userId:N}");
+        captured.DetailHref.Should().Be("/settings/security");
+        captured.Title.Should().Be("Two-factor authentication enabled");
+        captured.IconKey.Should().Be("security.2fa-enabled");
+    }
+
+    [Fact]
+    public async Task WriteTwoFactorDisabledAsync_PostsExpectedSecurityPayload()
+    {
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteTwoFactorDisabledAsync(_userId);
+
+        captured.Should().NotBeNull();
+        captured!.Category.Should().Be(InboxCategory.Security);
+        captured.CorrelationKey.Should().Be($"security:two-factor-disabled:{_userId:N}");
+        captured.Title.Should().Be("Two-factor authentication disabled");
+        captured.IconKey.Should().Be("security.2fa-disabled");
+    }
+
+    [Fact]
+    public async Task WriteTwoFactorEnabledAsync_SourceEventIdFoldsTimestamp_AvoidsCrossEnableCollapse()
+    {
+        // Two enable events ~1s apart should produce different SourceEventIds so the
+        // second entry isn't suppressed by the (PlatformUserId, SourceEventId) unique
+        // index when a user enables, disables, and re-enables 2FA in quick succession.
+        var sourceIds = new List<Guid>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => sourceIds.Add(r.SourceEventId))
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteTwoFactorEnabledAsync(_userId);
+        await Task.Delay(1100);
+        await _sut.WriteTwoFactorEnabledAsync(_userId);
+
+        sourceIds.Should().HaveCount(2);
+        sourceIds[0].Should().NotBe(sourceIds[1]);
+    }
+
+    [Fact]
+    public async Task WriteTwoFactorEnabledAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("inbox down"));
+
+        var act = () => _sut.WriteTwoFactorEnabledAsync(_userId);
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block the security operation");
+    }
+
+    [Fact]
+    public async Task WriteTwoFactorDisabledAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("inbox down"));
+
+        var act = () => _sut.WriteTwoFactorDisabledAsync(_userId);
+
+        await act.Should().NotThrowAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the fourth durable-inbox writer alongside `BlueprintInboxWriter` (Action), `WalletInboxWriter` (Credential), and `TenantMembershipInboxWriter` (Membership). Same fail-safe semantics — exceptions caught, never block the originating security operation.

`TotpService` now emits a Category=Security inbox entry on:
- `VerifyAndEnableAsync` success → *Two-factor authentication enabled*
- `DisableAsync` (when TOTP was provisioned) → *Two-factor authentication disabled* with a re-enable prompt

`DetailHref=/settings/security` so the click flow lands on the page where the user can review or change the setting.

The deterministic `SourceEventId` folds the unix-second timestamp so re-enabling 2FA after a previous disable produces a fresh entry rather than collapsing onto the original via the `(PlatformUserId, SourceEventId)` unique index. Within the same second the entry IS idempotent — that's the desired safety net for retried calls.

## Test plan
- [x] `TenantSecurityInboxWriterTests` 5/5 passing locally
- [ ] Sign in; enable TOTP; verify a Security inbox entry appears with the enable copy
- [ ] Disable TOTP; verify a Security inbox entry appears with the disable copy and a re-enable prompt
- [ ] Verify clicks navigate to `/settings/security`

🤖 Generated with [Claude Code](https://claude.com/claude-code)