### PR TITLE
feat(118): security inbox — password-reset Category=Security entry

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Services/PasswordResetService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PasswordResetService.cs
@@ -27,6 +27,7 @@ public class PasswordResetService : IPasswordResetService
     private readonly TenantDbContext _dbContext;
     private readonly IPasswordPolicyService _passwordPolicyService;
     private readonly ITransactionalEmailService _transactional;
+    private readonly ITenantSecurityInboxWriter _securityInbox;
     private readonly ILogger<PasswordResetService> _logger;
 
     /// <summary>
@@ -36,11 +37,13 @@ public class PasswordResetService : IPasswordResetService
         TenantDbContext dbContext,
         IPasswordPolicyService passwordPolicyService,
         ITransactionalEmailService transactional,
+        ITenantSecurityInboxWriter securityInbox,
         ILogger<PasswordResetService> logger)
     {
         _dbContext = dbContext;
         _passwordPolicyService = passwordPolicyService;
         _transactional = transactional;
+        _securityInbox = securityInbox;
         _logger = logger;
     }
 
@@ -165,6 +168,9 @@ public class PasswordResetService : IPasswordResetService
 
         _logger.LogInformation("Password successfully reset for PlatformUser {Email} (PlatformUserId: {PlatformUserId})",
             platformUser.Email, platformUser.Id);
+
+        // Feature 118 — emit a Category=Security inbox entry. Fail-safe.
+        await _securityInbox.WritePasswordResetAsync(platformUser.Id, ct);
 
         return new PasswordResetResult(true);
     }

--- a/src/Services/Sorcha.Tenant.Service/Services/TenantSecurityInboxWriter.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TenantSecurityInboxWriter.cs
@@ -19,6 +19,13 @@ public interface ITenantSecurityInboxWriter
 
     /// <summary>Write a "2FA disabled" Category=Security inbox entry.</summary>
     Task WriteTwoFactorDisabledAsync(Guid platformUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Write a "password reset" Category=Security inbox entry. The fold-by-second
+    /// SourceEventId means a successful reset always produces a fresh entry — the
+    /// "if this wasn't you" copy is the whole point of the surface.
+    /// </summary>
+    Task WritePasswordResetAsync(Guid platformUserId, CancellationToken ct = default);
 }
 
 /// <inheritdoc />
@@ -54,6 +61,16 @@ public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
             title: "Two-factor authentication disabled",
             summary: "Your account is now signing in with password only. Re-enable 2FA from Settings → Security.",
             iconKey: "security.2fa-disabled",
+            ct);
+
+    /// <inheritdoc />
+    public Task WritePasswordResetAsync(Guid platformUserId, CancellationToken ct = default) =>
+        WriteAsync(
+            platformUserId,
+            "password-reset",
+            title: "Password reset",
+            summary: "Your password was reset using the email link. If this wasn't you, contact support immediately.",
+            iconKey: "security.password-reset",
             ct);
 
     private async Task WriteAsync(

--- a/tests/Sorcha.Tenant.Service.Tests/Services/PasswordResetServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/PasswordResetServiceTests.cs
@@ -25,6 +25,7 @@ public class PasswordResetServiceTests : IDisposable
     private readonly TenantDbContext _dbContext;
     private readonly Mock<IPasswordPolicyService> _passwordPolicyService = new();
     private readonly Mock<ITransactionalEmailService> _transactional = new();
+    private readonly Mock<ITenantSecurityInboxWriter> _securityInbox = new();
     private readonly ILogger<PasswordResetService> _logger = NullLogger<PasswordResetService>.Instance;
 
     public PasswordResetServiceTests()
@@ -40,6 +41,7 @@ public class PasswordResetServiceTests : IDisposable
             _dbContext,
             _passwordPolicyService.Object,
             _transactional.Object,
+            _securityInbox.Object,
             _logger);
 
     private UserIdentity CreateTestUser(

--- a/tests/Sorcha.Tenant.Service.Tests/Services/TenantSecurityInboxWriterTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/TenantSecurityInboxWriterTests.cs
@@ -102,4 +102,36 @@ public sealed class TenantSecurityInboxWriterTests
 
         await act.Should().NotThrowAsync();
     }
+
+    [Fact]
+    public async Task WritePasswordResetAsync_PostsExpectedSecurityPayload()
+    {
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WritePasswordResetAsync(_userId);
+
+        captured.Should().NotBeNull();
+        captured!.Category.Should().Be(InboxCategory.Security);
+        captured.CorrelationKey.Should().Be($"security:password-reset:{_userId:N}");
+        captured.DetailHref.Should().Be("/settings/security");
+        captured.Title.Should().Be("Password reset");
+        captured.Summary.Should().Contain("contact support");
+        captured.IconKey.Should().Be("security.password-reset");
+    }
+
+    [Fact]
+    public async Task WritePasswordResetAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("inbox down"));
+
+        var act = () => _sut.WritePasswordResetAsync(_userId);
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block a password reset");
+    }
 }


### PR DESCRIPTION
## Summary

Extends `TenantSecurityInboxWriter` with `WritePasswordResetAsync` and wires it into `PasswordResetService.ResetPasswordAsync`. Every successful password reset now records a durable Category=Security inbox entry with the *if this wasn't you, contact support* copy — mirroring the pattern other platforms use to surface account-takeover signals.

- Fold-by-second `SourceEventId` means each successful reset produces a fresh entry; idempotent within the same second protects retried calls.
- `PasswordResetService` gains an `ITenantSecurityInboxWriter` dependency; existing tests updated to inject the mock.

## Test plan
- [x] `TenantSecurityInboxWriterTests` 7/7 passing
- [x] `PasswordResetServiceTests` recompiled — pre-existing 7 active + 7 skipped, all green
- [ ] Trigger a password reset; verify a Security inbox entry appears with title "Password reset"

🤖 Generated with [Claude Code](https://claude.com/claude-code)