### PR TITLE
feat(118): [T089] RegisterHubConnection — pass JWT via ?access_token=

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -184,7 +184,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [ ] T086 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `ITenantHubClient` per `contracts/tenant-hub-client.cs.md`.
 - [ ] T087 [US4] Update `EncryptionProgressIndicator.razor` and any other UI consumer that previously read percentage off the hub event to fetch detail via `GET /api/operations/{operationId}`.
 - [ ] T088 [US4] Update `MainLayout.razor` and credential consumers that previously read issuer/credential metadata off the hub event to fetch detail via `GET /api/wallets/{addr}/credentials/{credentialId}`.
-- [ ] T089 [US4] Ship UI's `RegisterHubConnection` token-passing change in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs` — pass the JWT via `?access_token=`. Server-side hub still permissive.
+- [X] T089 [US4] Ship UI's `RegisterHubConnection` token-passing change in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs` — pass the JWT via `?access_token=`. Server-side hub still permissive.
 - [ ] T090 [US4] Add `sorcha_signalr_connections_total{hub="register",authenticated=...}` counter to track rollout. Wire in `RegisterHub.OnConnectedAsync`.
 - [ ] T091 [US4] **Second-release task** (do not bundle with above): Add `[Authorize]` to `src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs`. Un-skip T080. Remove permissive code path. Only ship after the authenticated counter shows ≥ 99 % adoption.
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -890,8 +890,11 @@ public static class ServiceCollectionExtensions
             return new TransactionService(httpClient, logger);
         });
 
-        // Register Hub Connection (SignalR)
-        // Strip the /app/ path prefix — SignalR hubs are at the API Gateway root
+        // Register Hub Connection (SignalR).
+        // Strip the /app/ path prefix — SignalR hubs are at the API Gateway root.
+        // Feature 118 / T089 — pass the JWT via ?access_token= so the server can
+        // identify the connection. The hub is permissive today; the [Authorize]
+        // cutover (T080) lands in a later release.
         services.AddScoped<RegisterHubConnection>(sp =>
         {
             string hubBaseUrl;
@@ -904,8 +907,17 @@ public static class ServiceCollectionExtensions
                 hubBaseUrl = "";
             }
 
+            var authService = sp.GetRequiredService<IAuthenticationService>();
+            var configService = sp.GetRequiredService<IConfigurationService>();
             var logger = sp.GetRequiredService<ILogger<RegisterHubConnection>>();
-            return new RegisterHubConnection(hubBaseUrl, logger);
+            return new RegisterHubConnection(
+                hubBaseUrl,
+                accessTokenProvider: async () =>
+                {
+                    var profileName = await configService.GetActiveProfileNameAsync();
+                    return await authService.GetAccessTokenAsync(profileName);
+                },
+                logger);
         });
 
         return services;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs
@@ -14,6 +14,7 @@ public class RegisterHubConnection : IAsyncDisposable
 {
     private readonly ILogger<RegisterHubConnection> _logger;
     private readonly string _hubUrl;
+    private readonly Func<Task<string?>>? _accessTokenProvider;
     private HubConnection? _hubConnection;
     private ConnectionState _connectionState = new();
     private readonly HashSet<string> _subscribedRegisters = [];
@@ -71,9 +72,30 @@ public class RegisterHubConnection : IAsyncDisposable
     /// </summary>
     public ConnectionState ConnectionState => _connectionState;
 
+    /// <summary>
+    /// Initialises the connection without an access-token provider. Compatible
+    /// with the pre-Feature-118 wire shape — used by tests and any caller that
+    /// has not yet been migrated to authenticated hubs.
+    /// </summary>
     public RegisterHubConnection(string baseUrl, ILogger<RegisterHubConnection> logger)
+        : this(baseUrl, accessTokenProvider: null, logger)
+    {
+    }
+
+    /// <summary>
+    /// Initialises the connection with an access-token provider. The token
+    /// rides on the SignalR negotiate as <c>?access_token=</c> and on the
+    /// websocket upgrade as a query string. Required for the upcoming
+    /// RegisterHub <c>[Authorize]</c> cutover (T080); permissive on the
+    /// server today so this change is forward-compatible (T089).
+    /// </summary>
+    public RegisterHubConnection(
+        string baseUrl,
+        Func<Task<string?>>? accessTokenProvider,
+        ILogger<RegisterHubConnection> logger)
     {
         _hubUrl = $"{baseUrl.TrimEnd('/')}/hubs/register";
+        _accessTokenProvider = accessTokenProvider;
         _logger = logger;
     }
 
@@ -98,7 +120,13 @@ public class RegisterHubConnection : IAsyncDisposable
         try
         {
             _hubConnection = new HubConnectionBuilder()
-                .WithUrl(_hubUrl)
+                .WithUrl(_hubUrl, options =>
+                {
+                    if (_accessTokenProvider is not null)
+                    {
+                        options.AccessTokenProvider = _accessTokenProvider;
+                    }
+                })
                 .WithAutomaticReconnect(new[]
                 {
                     TimeSpan.FromSeconds(0),


### PR DESCRIPTION
## Summary

Migrates the UI's `RegisterHubConnection` to the same access-token-provider pattern `TenantHubConnection` has used since PR #515. The server-side hub is still permissive (no `[Authorize]` yet); this is the forward-compatible ship that lets the cutover task (T080) land in a later release without a client-side dependency.

- Two ctor overloads: legacy `(baseUrl, logger)` for tests/back-compat, new `(baseUrl, accessTokenProvider, logger)` for production.
- DI registration in `Sorcha.UI.Core.Extensions.ServiceCollectionExtensions` resolves `IAuthenticationService` + `IConfigurationService` and wires the same active-profile token lookup the Tenant hub uses.
- `WithUrl` sets `options.AccessTokenProvider` when a provider is supplied; falls through to the unauthenticated path otherwise.

Closes T089 in `specs/118-notifications-architecture/tasks.md`.

## Test plan
- [x] `RegisterHubConnectionTests` 28/28 passing locally with the legacy ctor (back-compat verified)
- [ ] Sign in to Sorcha.UI; open a register page; verify the SignalR negotiate request carries `access_token` query string

🤖 Generated with [Claude Code](https://claude.com/claude-code)