### PR TITLE
feat(118): security inbox — backup-code-used Category=Security entry (Warning severity)

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Services/TenantSecurityInboxWriter.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TenantSecurityInboxWriter.cs
@@ -26,6 +26,14 @@ public interface ITenantSecurityInboxWriter
     /// "if this wasn't you" copy is the whole point of the surface.
     /// </summary>
     Task WritePasswordResetAsync(Guid platformUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Write a "backup code used" Category=Security entry. Severity is bumped to
+    /// <see cref="InboxSeverity.Warning"/> because backup-code consumption is an
+    /// account-takeover signal worth flagging. Each consumption produces a fresh
+    /// entry (timestamp folded into the SourceEventId).
+    /// </summary>
+    Task WriteBackupCodeUsedAsync(Guid platformUserId, CancellationToken ct = default);
 }
 
 /// <inheritdoc />
@@ -51,6 +59,7 @@ public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
             title: "Two-factor authentication enabled",
             summary: "Your account now requires a code from your authenticator app at sign-in.",
             iconKey: "security.2fa-enabled",
+            severity: InboxSeverity.Info,
             ct);
 
     /// <inheritdoc />
@@ -61,6 +70,7 @@ public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
             title: "Two-factor authentication disabled",
             summary: "Your account is now signing in with password only. Re-enable 2FA from Settings → Security.",
             iconKey: "security.2fa-disabled",
+            severity: InboxSeverity.Info,
             ct);
 
     /// <inheritdoc />
@@ -71,6 +81,18 @@ public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
             title: "Password reset",
             summary: "Your password was reset using the email link. If this wasn't you, contact support immediately.",
             iconKey: "security.password-reset",
+            severity: InboxSeverity.Info,
+            ct);
+
+    /// <inheritdoc />
+    public Task WriteBackupCodeUsedAsync(Guid platformUserId, CancellationToken ct = default) =>
+        WriteAsync(
+            platformUserId,
+            "backup-code-used",
+            title: "Backup code used to sign in",
+            summary: "A 2FA backup code was just consumed during sign-in. If this wasn't you, change your password and review your backup codes immediately.",
+            iconKey: "security.backup-code-used",
+            severity: InboxSeverity.Warning,
             ct);
 
     private async Task WriteAsync(
@@ -79,6 +101,7 @@ public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
         string title,
         string summary,
         string iconKey,
+        InboxSeverity severity,
         CancellationToken ct)
     {
         try
@@ -89,7 +112,7 @@ public sealed class TenantSecurityInboxWriter : ITenantSecurityInboxWriter
             var request = new InboxWriteRequest(
                 PlatformUserId: platformUserId,
                 Category: InboxCategory.Security,
-                Severity: InboxSeverity.Info,
+                Severity: severity,
                 CorrelationKey: $"security:{eventKey}:{platformUserId:N}",
                 DetailHref: "/settings/security",
                 SourceEventId: sourceEventId,

--- a/src/Services/Sorcha.Tenant.Service/Services/TotpService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TotpService.cs
@@ -213,6 +213,10 @@ public class TotpService : ITotpService
         await _db.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Backup code consumed for user {UserId} (index {Index})", userId, matchIndex);
+
+        // Feature 118 — backup-code consumption is an account-takeover signal worth surfacing. Fail-safe.
+        await _securityInbox.WriteBackupCodeUsedAsync(userId, cancellationToken);
+
         return true;
     }
 

--- a/tests/Sorcha.Tenant.Service.Tests/Services/TenantSecurityInboxWriterTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/TenantSecurityInboxWriterTests.cs
@@ -134,4 +134,36 @@ public sealed class TenantSecurityInboxWriterTests
         await act.Should().NotThrowAsync(
             "inbox-write failures must never block a password reset");
     }
+
+    [Fact]
+    public async Task WriteBackupCodeUsedAsync_PostsWarningSeverityPayload()
+    {
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteBackupCodeUsedAsync(_userId);
+
+        captured.Should().NotBeNull();
+        captured!.Category.Should().Be(InboxCategory.Security);
+        captured.Severity.Should().Be(InboxSeverity.Warning);
+        captured.CorrelationKey.Should().Be($"security:backup-code-used:{_userId:N}");
+        captured.Title.Should().Be("Backup code used to sign in");
+        captured.Summary.Should().Contain("change your password");
+        captured.IconKey.Should().Be("security.backup-code-used");
+    }
+
+    [Fact]
+    public async Task WriteBackupCodeUsedAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("inbox down"));
+
+        var act = () => _sut.WriteBackupCodeUsedAsync(_userId);
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block sign-in");
+    }
 }


### PR DESCRIPTION
## Summary

Adds `WriteBackupCodeUsedAsync` to `TenantSecurityInboxWriter` and wires it into `TotpService.ValidateBackupCodeAsync` after a code is consumed. Backup-code consumption is a real account-takeover signal — if the user didn't sign in with a backup code, somebody else did.

- Severity bumped to **Warning** (yellow) so the entry stands out against routine Info entries; the inbox panel's existing severity-colour mapping picks this up automatically.
- Copy directs the user to change their password and review backup codes if it wasn't them.
- Refactored the writer's private `WriteAsync` helper to take a severity parameter so the prior Info-level callers (2FA enable/disable, password reset) retain their shape.

## Test plan
- [x] `TenantSecurityInboxWriterTests` 9/9 passing
- [ ] Sign in using a 2FA backup code; verify a Warning-severity Security inbox entry appears with the takeover-signal copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)