### PR TITLE
docs(118): XML docs on Wallet/Register/Tenant hub clients (T084+T085+T086)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -179,9 +179,9 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [X] T081 [US4] Strip descriptive fields from existing `ActionNotification` / `CredentialNotification` / `EncryptionSignal` records. Replace with the IDs they carry; move descriptive fields (blueprint name, action description, percentage) to the corresponding REST detail endpoints if not already there. Files: `src/Services/Sorcha.Blueprint.Service/Models/Notifications/*.cs`, `src/Services/Sorcha.Wallet.Service/Models/Notifications/*.cs`.
 - [X] T082 [US4] Update every emit site to call the new typed methods on `IBlueprintHubClient` / `IWalletHubClient` with thin-signal parameters. Files: `NotificationService.cs`, `TransactionLifecycleEventBridge.cs`, encryption pipeline emit sites.
 - [X] T083 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `IBlueprintHubClient` per `contracts/blueprint-hub-client.cs.md`.
-- [ ] T084 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `IWalletHubClient` per `contracts/wallet-hub-client.cs.md`.
-- [ ] T085 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `IRegisterHubClient` per `contracts/register-hub-client.cs.md`.
-- [ ] T086 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `ITenantHubClient` per `contracts/tenant-hub-client.cs.md`.
+- [X] T084 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `IWalletHubClient` per `contracts/wallet-hub-client.cs.md`.
+- [X] T085 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `IRegisterHubClient` per `contracts/register-hub-client.cs.md`.
+- [X] T086 [P] [US4] Add `<see cref="..." />` XML docs to every event method on `ITenantHubClient` per `contracts/tenant-hub-client.cs.md`.
 - [X] T087 [US4] Update `EncryptionProgressIndicator.razor` and any other UI consumer that previously read percentage off the hub event to fetch detail via `GET /api/operations/{operationId}`.
 - [X] T088 [US4] Update `MainLayout.razor` and credential consumers that previously read issuer/credential metadata off the hub event to fetch detail via `GET /api/wallets/{addr}/credentials/{credentialId}`.
 - [X] T089 [US4] Ship UI's `RegisterHubConnection` token-passing change in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs` — pass the JWT via `?access_token=`. Server-side hub still permissive.

--- a/src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs
+++ b/src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs
@@ -75,16 +75,78 @@ public class RegisterHub : Hub<IRegisterHubClient>
 }
 
 /// <summary>
-/// Client methods that can be invoked by the hub
+/// Typed client interface for <see cref="RegisterHub"/>. Conforms to the
+/// Feature 118 thin-signal contract — clients fetch full detail through
+/// authenticated REST endpoints referenced in each method's <c>&lt;see cref&gt;</c>
+/// doc.
 /// </summary>
 public interface IRegisterHubClient
 {
+    /// <summary>
+    /// A register was created. Clients fetch full detail via
+    /// <c>GET /api/registers/{registerId}</c>.
+    /// </summary>
+    /// <param name="registerId">Identifier of the new register.</param>
+    /// <param name="name">Display name of the register at create-time.</param>
     Task RegisterCreated(string registerId, string name);
+
+    /// <summary>
+    /// A register was deleted. Clients SHOULD remove cached state for the id;
+    /// <c>GET /api/registers/{registerId}</c> will return 404.
+    /// </summary>
+    /// <param name="registerId">Identifier of the deleted register.</param>
     Task RegisterDeleted(string registerId);
+
+    /// <summary>
+    /// A register's status changed. Clients fetch the current status via
+    /// <c>GET /api/registers/{registerId}</c>.
+    /// </summary>
+    /// <param name="registerId">Identifier of the register whose status changed.</param>
+    /// <param name="status">New status string (e.g. "active", "suspended").</param>
     Task RegisterStatusChanged(string registerId, string status);
+
+    /// <summary>
+    /// A transaction was confirmed in a register. Clients fetch full
+    /// transaction detail via
+    /// <c>GET /api/registers/{registerId}/transactions/{transactionId}</c>.
+    /// </summary>
+    /// <param name="registerId">Identifier of the register.</param>
+    /// <param name="transactionId">Identifier of the confirmed transaction.</param>
     Task TransactionConfirmed(string registerId, string transactionId);
+
+    /// <summary>
+    /// A docket was sealed. Clients fetch docket detail via
+    /// <c>GET /api/registers/{registerId}/dockets/{docketId}</c>.
+    /// </summary>
+    /// <param name="registerId">Identifier of the register.</param>
+    /// <param name="docketId">Sealed docket sequence number.</param>
+    /// <param name="hash">Hex-encoded SHA-256 docket hash.</param>
     Task DocketSealed(string registerId, ulong docketId, string hash);
+
+    /// <summary>
+    /// A register's height advanced. Clients fetch authoritative height via
+    /// <c>GET /api/registers/{registerId}</c>.
+    /// </summary>
+    /// <param name="registerId">Identifier of the register.</param>
+    /// <param name="newHeight">New register height.</param>
     Task RegisterHeightUpdated(string registerId, uint newHeight);
+
+    /// <summary>
+    /// A register's local sync state changed. Clients fetch authoritative
+    /// state via <c>GET /api/registers/{registerId}/sync-state</c>.
+    /// </summary>
+    /// <param name="registerId">Identifier of the register.</param>
+    /// <param name="syncState">New sync state (Indeterminate / Syncing / CaughtUp / Error).</param>
     Task RegisterSyncStateChanged(string registerId, string syncState);
+
+    /// <summary>
+    /// A transaction receipt was issued. Clients fetch the receipt via
+    /// <c>GET /api/registers/{registerId}/transactions/{transactionId}/receipt</c>.
+    /// </summary>
+    /// <param name="transactionId">Identifier of the transaction.</param>
+    /// <param name="registerId">Identifier of the register.</param>
+    /// <param name="docketNumber">Sealed docket sequence number.</param>
+    /// <param name="receiptId">Identifier of the issued receipt.</param>
+    /// <param name="sealedAt">Server timestamp at which the docket was sealed.</param>
     Task TransactionReceipt(string transactionId, string registerId, long docketNumber, string receiptId, DateTimeOffset sealedAt);
 }

--- a/src/Services/Sorcha.Tenant.Service/Hubs/ITenantHubClient.cs
+++ b/src/Services/Sorcha.Tenant.Service/Hubs/ITenantHubClient.cs
@@ -25,23 +25,22 @@ namespace Sorcha.Tenant.Service.Hubs;
 public interface ITenantHubClient
 {
     /// <summary>
-    /// A new inbox entry was written for the user. Carries opaque IDs only; clients
-    /// fetch full content via <c>GET /api/me/inbox/{entryId}</c>.
+    /// A new inbox entry was written for the user. Carries opaque IDs only;
+    /// clients fetch full content via <c>GET /api/me/inbox/{entryId}</c>.
     /// </summary>
     /// <param name="entryId">GUID of the entry, formatted with <c>:N</c> (no hyphens).</param>
     /// <param name="occurredAt">Server timestamp at which the underlying event occurred.</param>
     /// <param name="traceId">W3C trace-id for correlating across the bridge.</param>
-    /// <see href="/api/me/inbox/{entryId}"/>
     Task InboxEntryAdded(string entryId, DateTimeOffset occurredAt, string traceId);
 
     /// <summary>
     /// The authenticated user's unread inbox count changed. Authoritative —
-    /// the client should overwrite, not increment.
+    /// the client should overwrite, not increment. Cold-load via
+    /// <c>GET /api/me/inbox/unread-count</c>.
     /// </summary>
-    /// <param name="unreadCount">New unread count. Cold-load via <c>GET /api/me/inbox/unread-count</c>.</param>
+    /// <param name="unreadCount">New unread count.</param>
     /// <param name="occurredAt">Server timestamp.</param>
-    /// <param name="traceId">W3C trace-id.</param>
-    /// <see href="/api/me/inbox/unread-count"/>
+    /// <param name="traceId">W3C trace-id for correlating across the bridge.</param>
     Task InboxUnreadCountUpdated(int unreadCount, DateTimeOffset occurredAt, string traceId);
 
     // Membership / Security / System announcement events follow in a later phase.

--- a/src/Services/Sorcha.Wallet.Service/Hubs/IWalletHubClient.cs
+++ b/src/Services/Sorcha.Wallet.Service/Hubs/IWalletHubClient.cs
@@ -4,24 +4,36 @@
 namespace Sorcha.Wallet.Service.Hubs;
 
 /// <summary>
-/// Typed client interface for <see cref="WalletHub"/>. Bridge interface added
-/// in Feature 118 Phase 3 (US1 — multi-node correctness).
+/// Typed client interface for <see cref="WalletHub"/>. Every method conforms
+/// to the Feature 118 thin-signal contract — opaque IDs and timestamps only.
+/// Clients fetch full detail through authenticated REST endpoints referenced
+/// in each method's <c>&lt;see cref&gt;</c> doc.
 /// </summary>
 /// <remarks>
-/// Phase 4 (US2) absorbs additional events from the retired EventsHub:
-/// <c>EncryptionProgress</c>, <c>EncryptionComplete</c>, <c>EncryptionFailed</c>,
-/// <c>CredentialReceived</c>, <c>CredentialStatusChanged</c>,
-/// <c>PendingCredentialCountUpdated</c>, plus the new
-/// <c>TransactionReceived</c> / <c>TransactionConfirmed</c> /
-/// <c>TransactionReceipted</c> events for wallet-detail tick state. Today's
-/// interface only carries the citizen-wallet (Feature 114) events that are
-/// already emitted; later phases extend it.
+/// Phase 4 (US2) absorbs additional events from the retired EventsHub and
+/// from the BlueprintHub encryption surface — <c>EncryptionProgress</c>,
+/// <c>EncryptionComplete</c>, <c>EncryptionFailed</c>, <c>CredentialReceived</c>,
+/// <c>CredentialStatusChanged</c>, <c>PendingCredentialCountUpdated</c>, and the
+/// transaction-lifecycle events <c>TransactionReceived</c> /
+/// <c>TransactionConfirmed</c> / <c>TransactionReceipted</c>. Today's interface
+/// only carries the citizen-wallet (Feature 114) events that are already
+/// emitted; later phases extend it.
 /// </remarks>
 public interface IWalletHubClient
 {
-    /// <summary>Citizen device was revoked. Sent on the citizen-wallet group.</summary>
+    /// <summary>
+    /// Citizen device was revoked. Sent on the citizen-wallet group.
+    /// Clients fetch full device detail via
+    /// <c>GET /api/me/devices/{deviceId}</c>.
+    /// </summary>
+    /// <param name="deviceId">Identifier of the revoked device.</param>
     Task DeviceRevoked(Guid deviceId);
 
-    /// <summary>A new credential is available for the citizen's wallet to sync.</summary>
+    /// <summary>
+    /// A new credential is available for the citizen's wallet to sync.
+    /// The wallet pulls the delta via
+    /// <c>GET /api/v1/wallet/sync?since={cursor}</c>.
+    /// </summary>
+    /// <param name="credentialId">Identifier of the newly-available credential.</param>
     Task CredentialAvailable(string credentialId);
 }


### PR DESCRIPTION
## Summary

Documents every event method on `IWalletHubClient`, `IRegisterHubClient`, and `ITenantHubClient` with a `<see cref>`-style reference to the authenticated REST detail endpoint each thin signal points at.

## Changes

- **`IWalletHubClient`** — `DeviceRevoked` and `CredentialAvailable` get parameter docs and REST-endpoint pointers (`GET /api/me/devices/{deviceId}` and `GET /api/v1/wallet/sync?since={cursor}`).
- **`IRegisterHubClient`** — eight events documented; existing parameter shapes preserved (all already allow-list compliant).
- **`ITenantHubClient`** — converted from `<see href>` to the contract-prescribed inline `<c>GET /…</c>` form.

No wire-shape changes. Every method already conforms to the thin-signal allow-list (string / Guid / int / long / ulong / uint / DateTimeOffset).

## Test plan

- [x] `dotnet build` clean across the solution
- [x] No method signature changes — no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)