### PR TITLE
feat(118): RegisterHub authenticated-connection counter (T090)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -185,7 +185,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [ ] T087 [US4] Update `EncryptionProgressIndicator.razor` and any other UI consumer that previously read percentage off the hub event to fetch detail via `GET /api/operations/{operationId}`.
 - [ ] T088 [US4] Update `MainLayout.razor` and credential consumers that previously read issuer/credential metadata off the hub event to fetch detail via `GET /api/wallets/{addr}/credentials/{credentialId}`.
 - [X] T089 [US4] Ship UI's `RegisterHubConnection` token-passing change in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs` — pass the JWT via `?access_token=`. Server-side hub still permissive.
-- [ ] T090 [US4] Add `sorcha_signalr_connections_total{hub="register",authenticated=...}` counter to track rollout. Wire in `RegisterHub.OnConnectedAsync`.
+- [X] T090 [US4] Add `sorcha_signalr_connections_total{hub="register",authenticated=...}` counter to track rollout. Wire in `RegisterHub.OnConnectedAsync`.
 - [ ] T091 [US4] **Second-release task** (do not bundle with above): Add `[Authorize]` to `src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs`. Un-skip T080. Remove permissive code path. Only ship after the authenticated counter shows ≥ 99 % adoption.
 
 **Checkpoint**: US4 complete (after second-release task lands). Backplane carries no domain content. RegisterHub closed.

--- a/src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs
+++ b/src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.SignalR;
 using Sorcha.ServiceClients.Subscription;
+using Sorcha.ServiceDefaults.Hubs;
 
 namespace Sorcha.Register.Service.Hubs;
 
@@ -13,13 +14,15 @@ namespace Sorcha.Register.Service.Hubs;
 public class RegisterHub : Hub<IRegisterHubClient>
 {
     private readonly ISubscriptionServiceClient _subscriptionClient;
+    private readonly SignalRMetrics _metrics;
 
     /// <summary>
     /// Initializes the hub with subscription client for access checks
     /// </summary>
-    public RegisterHub(ISubscriptionServiceClient subscriptionClient)
+    public RegisterHub(ISubscriptionServiceClient subscriptionClient, SignalRMetrics metrics)
     {
         _subscriptionClient = subscriptionClient;
+        _metrics = metrics;
     }
 
     /// <summary>
@@ -49,8 +52,19 @@ public class RegisterHub : Hub<IRegisterHubClient>
         await Groups.RemoveFromGroupAsync(Context.ConnectionId, RegisterHubGroups.Register(registerId));
     }
 
+    /// <summary>
+    /// Records the connection in <see cref="SignalRMetrics.ConnectionsTotal"/>
+    /// tagged by authentication state. Drives the cutover gauge per Feature 118
+    /// task T090 — RegisterHub adds <c>[Authorize]</c> only after the
+    /// authenticated tag reaches ≥ 99 % of total.
+    /// </summary>
     public override async Task OnConnectedAsync()
     {
+        var authenticated = Context.User?.Identity?.IsAuthenticated == true;
+        _metrics.ConnectionsTotal.Add(1,
+            new KeyValuePair<string, object?>("hub", "register"),
+            new KeyValuePair<string, object?>("state", "connected"),
+            new KeyValuePair<string, object?>("authenticated", authenticated));
         await base.OnConnectedAsync();
     }
 

--- a/tests/Sorcha.Register.Service.Tests/Hubs/RegisterHubAuthCounterTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Hubs/RegisterHubAuthCounterTests.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using Sorcha.Register.Service.Hubs;
+using Sorcha.ServiceClients.Subscription;
+using Sorcha.ServiceDefaults.Hubs;
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests.Hubs;
+
+/// <summary>
+/// Verifies T090 — RegisterHub.OnConnectedAsync emits the
+/// <c>sorcha_signalr_connections_total</c> counter with the
+/// <c>authenticated</c> tag so the cutover gauge can drive the FR-011
+/// auth-hardening release.
+/// </summary>
+public class RegisterHubAuthCounterTests
+{
+    [Fact]
+    public async Task OnConnectedAsync_AnonymousConnection_RecordsAuthenticatedFalse()
+    {
+        var captured = await CaptureSingleConnectionMeasurementAsync(authenticated: false);
+
+        captured.Tags.Should().Contain(new KeyValuePair<string, object?>("hub", "register"));
+        captured.Tags.Should().Contain(new KeyValuePair<string, object?>("state", "connected"));
+        captured.Tags.Should().Contain(new KeyValuePair<string, object?>("authenticated", false));
+    }
+
+    [Fact]
+    public async Task OnConnectedAsync_AuthenticatedConnection_RecordsAuthenticatedTrue()
+    {
+        var captured = await CaptureSingleConnectionMeasurementAsync(authenticated: true);
+
+        captured.Tags.Should().Contain(new KeyValuePair<string, object?>("authenticated", true));
+    }
+
+    private static async Task<(long Value, IReadOnlyList<KeyValuePair<string, object?>> Tags)>
+        CaptureSingleConnectionMeasurementAsync(bool authenticated)
+    {
+        using var metrics = new SignalRMetrics();
+        using var listener = new MeterListener();
+        long? capturedValue = null;
+        IReadOnlyList<KeyValuePair<string, object?>>? capturedTags = null;
+
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == SignalRMetrics.MeterName &&
+                instrument.Name == "sorcha_signalr_connections_total")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            capturedValue = value;
+            capturedTags = tags.ToArray();
+        });
+        listener.Start();
+
+        var hub = new RegisterHub(Mock.Of<ISubscriptionServiceClient>(), metrics);
+
+        var hubCallerContext = new Mock<HubCallerContext>();
+        hubCallerContext.Setup(c => c.ConnectionId).Returns("test-conn");
+
+        var identity = authenticated
+            ? new ClaimsIdentity(authenticationType: "Bearer")
+            : new ClaimsIdentity();
+        hubCallerContext.Setup(c => c.User).Returns(new ClaimsPrincipal(identity));
+
+        var groups = new Mock<IGroupManager>();
+        hub.Context = hubCallerContext.Object;
+        hub.Groups = groups.Object;
+
+        await hub.OnConnectedAsync();
+
+        capturedValue.Should().Be(1);
+        capturedTags.Should().NotBeNull();
+        return (capturedValue!.Value, capturedTags!);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the `sorcha_signalr_connections_total{hub="register",state="connected",authenticated=...}` counter in `RegisterHub.OnConnectedAsync`. Drives the FR-011 cutover gauge — RegisterHub adds `[Authorize]` only after the `authenticated` tag reaches ≥ 99 % of total (T091, follow-up release; explicitly out of scope for this PR).

## Changes

- `RegisterHub` injects `SignalRMetrics` and emits the counter on every connect.
- New test `RegisterHubAuthCounterTests` covers both anonymous and authenticated paths via a `MeterListener` capture.

## Test plan

- [x] `dotnet build` clean
- [x] `RegisterHubAuthCounterTests` 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)