### PR TITLE
refactor(118): rename ActionsHubConnection → BlueprintHubConnection (T109)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -260,7 +260,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 
 ### UI rewires (mechanical)
 
-- [ ] T109 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor` to inject `BlueprintHubConnection` instead of `ActionsHubConnection`. Subscribe to `OnActionAvailable` / `OnActionRejected` / `OnWorkflowCompleted`.
+- [X] T109 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor` to inject `BlueprintHubConnection` instead of `ActionsHubConnection`. Subscribe to `OnActionAvailable` / `OnActionRejected` / `OnWorkflowCompleted`.
 - [ ] T110 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor` to inject `WalletHubConnection`. Subscribe to `OnCredentialReceived` / `OnCredentialStatusChanged`.
 - [ ] T111 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor` from `RegisterHubConnection.OnTransactionReceipted` to `WalletHubConnection.OnTransactionReceipted`.
 - [ ] T112 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs` to inject `WalletHubConnection`.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor
@@ -102,10 +102,10 @@
     public IWorkflowService? WorkflowService { get; set; }
 
     /// <summary>
-    /// Optional ActionsHub for real-time push updates. Falls back to polling when null or disconnected.
+    /// Optional BlueprintHub for real-time push updates. Falls back to polling when null or disconnected.
     /// </summary>
     [Parameter]
-    public ActionsHubConnection? ActionsHub { get; set; }
+    public BlueprintHubConnection? BlueprintHub { get; set; }
 
     private EncryptionOperationViewModel? _operation;
     private System.Timers.Timer? _pollTimer;
@@ -120,7 +120,7 @@
         await PollStatusAsync();
 
         // If SignalR is available and connected, prefer push updates over polling
-        if (ActionsHub != null)
+        if (BlueprintHub != null)
         {
             SubscribeToSignalR();
         }
@@ -212,15 +212,15 @@
 
     private void SubscribeToSignalR()
     {
-        if (ActionsHub == null) return;
+        if (BlueprintHub == null) return;
 
-        ActionsHub.OnEncryptionProgress += HandleSignalRProgress;
-        ActionsHub.OnEncryptionComplete += HandleSignalRComplete;
-        ActionsHub.OnEncryptionFailed += HandleSignalRFailed;
-        ActionsHub.OnConnectionStateChanged += HandleHubConnectionChanged;
+        BlueprintHub.OnEncryptionProgress += HandleSignalRProgress;
+        BlueprintHub.OnEncryptionComplete += HandleSignalRComplete;
+        BlueprintHub.OnEncryptionFailed += HandleSignalRFailed;
+        BlueprintHub.OnConnectionStateChanged += HandleHubConnectionChanged;
 
         // If connected, stop polling (SignalR is preferred)
-        if (ActionsHub.ConnectionState.Status == ConnectionStatus.Connected)
+        if (BlueprintHub.ConnectionState.Status == ConnectionStatus.Connected)
         {
             StopPolling();
         }
@@ -233,12 +233,12 @@
 
     private void UnsubscribeFromSignalR()
     {
-        if (ActionsHub == null) return;
+        if (BlueprintHub == null) return;
 
-        ActionsHub.OnEncryptionProgress -= HandleSignalRProgress;
-        ActionsHub.OnEncryptionComplete -= HandleSignalRComplete;
-        ActionsHub.OnEncryptionFailed -= HandleSignalRFailed;
-        ActionsHub.OnConnectionStateChanged -= HandleHubConnectionChanged;
+        BlueprintHub.OnEncryptionProgress -= HandleSignalRProgress;
+        BlueprintHub.OnEncryptionComplete -= HandleSignalRComplete;
+        BlueprintHub.OnEncryptionFailed -= HandleSignalRFailed;
+        BlueprintHub.OnConnectionStateChanged -= HandleHubConnectionChanged;
     }
 
     // Feature 118 T087 — SignalR signals now carry the operation id only;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -374,7 +374,7 @@ public static class ServiceCollectionExtensions
         });
 
         // Actions Hub Connection (SignalR for real-time action notifications)
-        services.AddActionsHubServices(baseAddress);
+        services.AddBlueprintHubServices(baseAddress);
 
         // Events Hub Connection (SignalR for real-time activity event notifications)
         services.AddEventsHubServices(baseAddress);
@@ -474,9 +474,9 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers the Actions Hub connection for real-time action notifications.
     /// </summary>
-    public static IServiceCollection AddActionsHubServices(this IServiceCollection services, string baseAddress)
+    public static IServiceCollection AddBlueprintHubServices(this IServiceCollection services, string baseAddress)
     {
-        services.AddScoped<ActionsHubConnection>(sp =>
+        services.AddScoped<BlueprintHubConnection>(sp =>
         {
             string hubBaseUrl;
             if (Uri.TryCreate(baseAddress, UriKind.Absolute, out var uri))
@@ -490,8 +490,8 @@ public static class ServiceCollectionExtensions
 
             var authService = sp.GetRequiredService<IAuthenticationService>();
             var configService = sp.GetRequiredService<IConfigurationService>();
-            var logger = sp.GetRequiredService<ILogger<ActionsHubConnection>>();
-            return new ActionsHubConnection(hubBaseUrl, authService, configService, logger);
+            var logger = sp.GetRequiredService<ILogger<BlueprintHubConnection>>();
+            return new BlueprintHubConnection(hubBaseUrl, authService, configService, logger);
         });
 
         // Encryption operation tracker (global state across page navigation)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/BlueprintHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/BlueprintHubConnection.cs
@@ -13,19 +13,24 @@ using Sorcha.UI.Core.Services.Configuration;
 namespace Sorcha.UI.Core.Services;
 
 /// <summary>
-/// Manages SignalR connection to the Actions Hub for real-time action notifications.
+/// Manages SignalR connection to the Blueprint Service hub for real-time
+/// workflow notifications.
 /// </summary>
 /// <remarks>
-/// Connects to the Blueprint Service ActionsHub at /actionshub
+/// Connects to the Blueprint Service at <c>/actionshub</c> (legacy alias for
+/// <c>/hubs/blueprint</c> — both routes resolve to the same hub).
 ///
 /// Events received from server:
 /// - ActionAvailable: New action available for a participant
-/// - ActionConfirmed: Action has been confirmed/completed
 /// - ActionRejected: Action was rejected and routed elsewhere
 /// - WorkflowCompleted: Entire workflow has completed
-/// - EncryptionProgress: Encryption operation progress signal
-/// - EncryptionComplete: Encryption operation completed signal
-/// - EncryptionFailed: Encryption operation failed signal
+/// - EncryptionProgress / EncryptionComplete / EncryptionFailed: legacy hosting —
+///   encryption events still emit on BlueprintHub today; they migrate to
+///   <see cref="WalletHubConnection"/> alongside the server-side IBlueprintHubClient
+///   surface trim in a follow-up phase.
+/// - CredentialReceived / CredentialStatusChanged / PendingCredentialCountUpdated:
+///   currently inert (no server emit path); placeholders preserved for the
+///   forthcoming WalletHubConnection migration.
 ///
 /// All notifications use thin signal types (SignalNotification / EncryptionSignal)
 /// that carry only identifiers — UI pulls details through REST endpoints.
@@ -34,9 +39,9 @@ namespace Sorcha.UI.Core.Services;
 /// - Wallet-based notifications (SubscribeToWallet)
 /// - Instance-based notifications (future)
 /// </remarks>
-public class ActionsHubConnection : IAsyncDisposable
+public class BlueprintHubConnection : IAsyncDisposable
 {
-    private readonly ILogger<ActionsHubConnection> _logger;
+    private readonly ILogger<BlueprintHubConnection> _logger;
     private readonly IAuthenticationService _authService;
     private readonly IConfigurationService _configurationService;
     private readonly string _hubUrl;
@@ -103,17 +108,17 @@ public class ActionsHubConnection : IAsyncDisposable
     public ConnectionState ConnectionState => _connectionState;
 
     /// <summary>
-    /// Creates a new ActionsHubConnection.
+    /// Creates a new BlueprintHubConnection.
     /// </summary>
     /// <param name="baseUrl">Base URL of the Blueprint Service (e.g., https://localhost:7000)</param>
     /// <param name="authService">Authentication service for JWT token retrieval</param>
     /// <param name="configurationService">Configuration service for active profile</param>
     /// <param name="logger">Logger for diagnostics</param>
-    public ActionsHubConnection(
+    public BlueprintHubConnection(
         string baseUrl,
         IAuthenticationService authService,
         IConfigurationService configurationService,
-        ILogger<ActionsHubConnection> logger)
+        ILogger<BlueprintHubConnection> logger)
     {
         _hubUrl = $"{baseUrl.TrimEnd('/')}/actionshub";
         _authService = authService;
@@ -128,7 +133,7 @@ public class ActionsHubConnection : IAsyncDisposable
     {
         if (_hubConnection != null)
         {
-            _logger.LogDebug("ActionsHub connection already exists");
+            _logger.LogDebug("BlueprintHub connection already exists");
             return;
         }
 
@@ -143,7 +148,7 @@ public class ActionsHubConnection : IAsyncDisposable
                     {
                         var profileName = await _configurationService.GetActiveProfileNameAsync();
                         var token = await _authService.GetAccessTokenAsync(profileName);
-                        _logger.LogDebug("ActionsHub token provider: profile={Profile}, hasToken={HasToken}",
+                        _logger.LogDebug("BlueprintHub token provider: profile={Profile}, hasToken={HasToken}",
                             profileName, !string.IsNullOrEmpty(token));
                         return token;
                     };
@@ -164,14 +169,14 @@ public class ActionsHubConnection : IAsyncDisposable
             // Handle connection lifecycle
             _hubConnection.Reconnecting += error =>
             {
-                _logger.LogWarning("ActionsHub reconnecting: {Error}", error?.Message);
+                _logger.LogWarning("BlueprintHub reconnecting: {Error}", error?.Message);
                 UpdateConnectionState(ConnectionStatus.Reconnecting, error?.Message);
                 return Task.CompletedTask;
             };
 
             _hubConnection.Reconnected += async connectionId =>
             {
-                _logger.LogInformation("ActionsHub reconnected: {ConnectionId}", connectionId);
+                _logger.LogInformation("BlueprintHub reconnected: {ConnectionId}", connectionId);
                 UpdateConnectionState(ConnectionStatus.Connected);
 
                 // Re-subscribe to all previously subscribed wallets
@@ -180,7 +185,7 @@ public class ActionsHubConnection : IAsyncDisposable
 
             _hubConnection.Closed += error =>
             {
-                _logger.LogWarning("ActionsHub connection closed: {Error}", error?.Message);
+                _logger.LogWarning("BlueprintHub connection closed: {Error}", error?.Message);
                 UpdateConnectionState(ConnectionStatus.Disconnected, error?.Message);
                 return Task.CompletedTask;
             };
@@ -188,11 +193,11 @@ public class ActionsHubConnection : IAsyncDisposable
             await _hubConnection.StartAsync(cancellationToken);
 
             UpdateConnectionState(ConnectionStatus.Connected);
-            _logger.LogInformation("ActionsHub connected to {HubUrl}", _hubUrl);
+            _logger.LogInformation("BlueprintHub connected to {HubUrl}", _hubUrl);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to connect to ActionsHub at {HubUrl}", _hubUrl);
+            _logger.LogError(ex, "Failed to connect to BlueprintHub at {HubUrl}", _hubUrl);
             UpdateConnectionState(ConnectionStatus.Disconnected, ex.Message);
             throw;
         }
@@ -212,11 +217,11 @@ public class ActionsHubConnection : IAsyncDisposable
         {
             await _hubConnection.StopAsync(cancellationToken);
             UpdateConnectionState(ConnectionStatus.Disconnected);
-            _logger.LogInformation("ActionsHub disconnected");
+            _logger.LogInformation("BlueprintHub disconnected");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error stopping ActionsHub connection");
+            _logger.LogError(ex, "Error stopping BlueprintHub connection");
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs
@@ -10,7 +10,7 @@ namespace Sorcha.UI.Core.Services;
 
 /// <summary>
 /// Tracks active encryption operations across page navigations.
-/// Scoped service that subscribes to ActionsHub events and maintains operation state.
+/// Scoped service that subscribes to BlueprintHub events and maintains operation state.
 /// </summary>
 public interface IEncryptionOperationTracker : IDisposable
 {
@@ -39,7 +39,7 @@ public interface IEncryptionOperationTracker : IDisposable
 public sealed class EncryptionOperationTracker : IEncryptionOperationTracker
 {
     private readonly Dictionary<string, EncryptionOperationState> _operations = new();
-    private readonly ActionsHubConnection _actionsHub;
+    private readonly BlueprintHubConnection _blueprintHub;
     private readonly IOperationStatusService _operationStatus;
     private readonly ILogger<EncryptionOperationTracker> _logger;
     private readonly CancellationTokenSource _cts = new();
@@ -60,17 +60,17 @@ public sealed class EncryptionOperationTracker : IEncryptionOperationTracker
     public event Action? OnStateChanged;
 
     public EncryptionOperationTracker(
-        ActionsHubConnection actionsHub,
+        BlueprintHubConnection blueprintHub,
         IOperationStatusService operationStatus,
         ILogger<EncryptionOperationTracker> logger)
     {
-        _actionsHub = actionsHub;
+        _blueprintHub = blueprintHub;
         _operationStatus = operationStatus;
         _logger = logger;
 
-        _actionsHub.OnEncryptionProgress += HandleProgress;
-        _actionsHub.OnEncryptionComplete += HandleComplete;
-        _actionsHub.OnEncryptionFailed += HandleFailed;
+        _blueprintHub.OnEncryptionProgress += HandleProgress;
+        _blueprintHub.OnEncryptionComplete += HandleComplete;
+        _blueprintHub.OnEncryptionFailed += HandleFailed;
     }
 
     /// <inheritdoc />
@@ -201,8 +201,8 @@ public sealed class EncryptionOperationTracker : IEncryptionOperationTracker
 
         _cts.Cancel();
         _cts.Dispose();
-        _actionsHub.OnEncryptionProgress -= HandleProgress;
-        _actionsHub.OnEncryptionComplete -= HandleComplete;
-        _actionsHub.OnEncryptionFailed -= HandleFailed;
+        _blueprintHub.OnEncryptionProgress -= HandleProgress;
+        _blueprintHub.OnEncryptionComplete -= HandleComplete;
+        _blueprintHub.OnEncryptionFailed -= HandleFailed;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -11,7 +11,7 @@
 @inject ITokenRefreshService TokenRefreshService
 @inject IThemeService ThemeService
 @inject IJSRuntime JSRuntime
-@inject ActionsHubConnection ActionsHub
+@inject BlueprintHubConnection BlueprintHub
 @inject TenantHubConnection TenantHub
 @inject IInboxApiService InboxApi
 @inject ISnackbar Snackbar
@@ -283,8 +283,8 @@
             Loc.OnLanguageChanged += OnLanguageChanged;
             await Loc.InitializeAsync();
 
-            ActionsHub.OnCredentialReceived += OnCredentialReceived;
-            ActionsHub.OnPendingCredentialCountUpdated += OnPendingCredentialCountUpdated;
+            BlueprintHub.OnCredentialReceived += OnCredentialReceived;
+            BlueprintHub.OnPendingCredentialCountUpdated += OnPendingCredentialCountUpdated;
 
             // Feature 118 — TenantHub is the authoritative source of the unread
             // bell badge after retirement of the legacy ActivityLogPanel.
@@ -306,8 +306,8 @@
     {
         ThemeService.OnThemeChanged -= OnThemeChanged;
         Loc.OnLanguageChanged -= OnLanguageChanged;
-        ActionsHub.OnCredentialReceived -= OnCredentialReceived;
-        ActionsHub.OnPendingCredentialCountUpdated -= OnPendingCredentialCountUpdated;
+        BlueprintHub.OnCredentialReceived -= OnCredentialReceived;
+        BlueprintHub.OnPendingCredentialCountUpdated -= OnPendingCredentialCountUpdated;
         TenantHub.OnInboxUnreadCountUpdated -= OnInboxUnreadCountUpdated;
         await TenantHub.DisposeAsync();
         await TokenRefreshService.StopAsync();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -22,7 +22,7 @@
 @inject IBlueprintApiService BlueprintApiService
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferenceService
-@inject ActionsHubConnection ActionsHub
+@inject BlueprintHubConnection BlueprintHub
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject ILogger<MyActions> Logger
@@ -240,7 +240,7 @@
     private List<SignalNotification> _recentNotifications = [];
     private List<KeyValuePair<string, List<PendingActionViewModel>>> _groupedActions = [];
     private ConnectionState _connectionState = new();
-    private ActionsHubConnection? _actionsHub = null;
+    private BlueprintHubConnection? _blueprintHub = null;
     private bool _loading = true;
     private bool _serviceError;
     private string _viewMode = "cards";
@@ -251,7 +251,7 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadActionsAsync();
-        await ConnectToActionsHubAsync();
+        await ConnectToBlueprintHubAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -291,33 +291,33 @@
             .ToList();
     }
 
-    private async Task ConnectToActionsHubAsync()
+    private async Task ConnectToBlueprintHubAsync()
     {
-        _actionsHub = ActionsHub;
+        _blueprintHub = BlueprintHub;
 
         // Subscribe to events
-        _actionsHub.OnConnectionStateChanged += HandleConnectionStateChanged;
-        _actionsHub.OnActionAvailable += HandleActionAvailable;
-        _actionsHub.OnActionRejected += HandleActionRejected;
-        _actionsHub.OnWorkflowCompleted += HandleWorkflowCompleted;
+        _blueprintHub.OnConnectionStateChanged += HandleConnectionStateChanged;
+        _blueprintHub.OnActionAvailable += HandleActionAvailable;
+        _blueprintHub.OnActionRejected += HandleActionRejected;
+        _blueprintHub.OnWorkflowCompleted += HandleWorkflowCompleted;
 
         // Sync current state
-        _connectionState = _actionsHub.ConnectionState;
+        _connectionState = _blueprintHub.ConnectionState;
 
         try
         {
-            await _actionsHub.StartAsync();
+            await _blueprintHub.StartAsync();
 
             // Subscribe to user's wallet addresses for targeted notifications
             var wallets = await WalletService.GetWalletsAsync();
             foreach (var wallet in wallets)
             {
-                await _actionsHub.SubscribeToWalletAsync(wallet.Address);
+                await _blueprintHub.SubscribeToWalletAsync(wallet.Address);
             }
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, "Failed to connect to ActionsHub — page will use polling");
+            Logger.LogWarning(ex, "Failed to connect to BlueprintHub — page will use polling");
         }
     }
 
@@ -629,12 +629,12 @@
 
     public ValueTask DisposeAsync()
     {
-        if (_actionsHub != null)
+        if (_blueprintHub != null)
         {
-            _actionsHub.OnConnectionStateChanged -= HandleConnectionStateChanged;
-            _actionsHub.OnActionAvailable -= HandleActionAvailable;
-            _actionsHub.OnActionRejected -= HandleActionRejected;
-            _actionsHub.OnWorkflowCompleted -= HandleWorkflowCompleted;
+            _blueprintHub.OnConnectionStateChanged -= HandleConnectionStateChanged;
+            _blueprintHub.OnActionAvailable -= HandleActionAvailable;
+            _blueprintHub.OnActionRejected -= HandleActionRejected;
+            _blueprintHub.OnWorkflowCompleted -= HandleWorkflowCompleted;
         }
 
         return ValueTask.CompletedTask;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
@@ -20,7 +20,7 @@
 @inject IWorkflowService WorkflowService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
-@inject ActionsHubConnection ActionsHub
+@inject BlueprintHubConnection BlueprintHub
 @implements IDisposable
 
 <PageTitle>My Credentials - Sorcha Platform</PageTitle>
@@ -201,8 +201,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        ActionsHub.OnCredentialReceived += OnCredentialNotification;
-        ActionsHub.OnCredentialStatusChanged += OnCredentialStatusNotification;
+        BlueprintHub.OnCredentialReceived += OnCredentialNotification;
+        BlueprintHub.OnCredentialStatusChanged += OnCredentialStatusNotification;
         await LoadWalletsAsync();
     }
 
@@ -496,7 +496,7 @@
 
     public void Dispose()
     {
-        ActionsHub.OnCredentialReceived -= OnCredentialNotification;
-        ActionsHub.OnCredentialStatusChanged -= OnCredentialStatusNotification;
+        BlueprintHub.OnCredentialReceived -= OnCredentialNotification;
+        BlueprintHub.OnCredentialStatusChanged -= OnCredentialStatusNotification;
     }
 }

--- a/tests/Sorcha.UI.Core.Tests/Components/EncryptionProgressIndicatorTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/EncryptionProgressIndicatorTests.cs
@@ -406,9 +406,9 @@ public class EncryptionProgressIndicatorTests : BunitContext
     // ---------------------------------------------------------------
 
     [Fact]
-    public void ActionsHub_IsNullByDefault()
+    public void BlueprintHub_IsNullByDefault()
     {
-        // Arrange — render without ActionsHub parameter
+        // Arrange — render without BlueprintHub parameter
         var operation = CreateOperation(
             stage: OperationStage.EncryptingPerRecipient,
             percentComplete: 25,
@@ -425,7 +425,7 @@ public class EncryptionProgressIndicatorTests : BunitContext
 
         // Assert — component renders in polling mode (no SignalR)
         cut.Markup.Should().Contain("1 of 4 recipients processed");
-        cut.Instance.ActionsHub.Should().BeNull();
+        cut.Instance.BlueprintHub.Should().BeNull();
     }
 
     [Fact]
@@ -473,13 +473,13 @@ public class EncryptionProgressIndicatorTests : BunitContext
     }
 
     [Fact]
-    public void Dispose_WithActionsHub_UnsubscribesFromEvents()
+    public void Dispose_WithBlueprintHub_UnsubscribesFromEvents()
     {
-        // Arrange — create a real ActionsHubConnection (unconnected) and pass it
+        // Arrange — create a real BlueprintHubConnection (unconnected) and pass it
         var authService = new Mock<Sorcha.UI.Core.Services.Authentication.IAuthenticationService>();
         var configService = new Mock<Sorcha.UI.Core.Services.Configuration.IConfigurationService>();
-        var logger = new Mock<Microsoft.Extensions.Logging.ILogger<ActionsHubConnection>>();
-        var hub = new ActionsHubConnection("http://localhost", authService.Object, configService.Object, logger.Object);
+        var logger = new Mock<Microsoft.Extensions.Logging.ILogger<BlueprintHubConnection>>();
+        var hub = new BlueprintHubConnection("http://localhost", authService.Object, configService.Object, logger.Object);
 
         var operation = CreateOperation(
             stage: OperationStage.EncryptingPerRecipient,
@@ -494,9 +494,9 @@ public class EncryptionProgressIndicatorTests : BunitContext
         // Act
         var cut = Render<EncryptionProgressIndicator>(parameters => parameters
             .Add(p => p.OperationId, "op-hub-dispose")
-            .Add(p => p.ActionsHub, hub));
+            .Add(p => p.BlueprintHub, hub));
 
-        // Assert — Dispose should not throw even when ActionsHub was subscribed
+        // Assert — Dispose should not throw even when BlueprintHub was subscribed
         var act = () => cut.Instance.Dispose();
         act.Should().NotThrow();
     }

--- a/tests/Sorcha.UI.Core.Tests/Services/BlueprintHubConnectionTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/BlueprintHubConnectionTests.cs
@@ -14,11 +14,11 @@ using Xunit;
 namespace Sorcha.UI.Core.Tests.Services;
 
 /// <summary>
-/// Tests for ActionsHubConnection encryption event handlers (T017).
-/// Since ActionsHubConnection creates its own internal HubConnection via HubConnectionBuilder,
+/// Tests for BlueprintHubConnection encryption event handlers (T017).
+/// Since BlueprintHubConnection creates its own internal HubConnection via HubConnectionBuilder,
 /// these tests verify the public event API, default state, and subscribe/unsubscribe behavior.
 /// </summary>
-public class ActionsHubConnectionTests
+public class BlueprintHubConnectionTests
 {
     // ---------------------------------------------------------------
     // Connection state defaults
@@ -224,13 +224,13 @@ public class ActionsHubConnectionTests
     // Helpers
     // ---------------------------------------------------------------
 
-    private static ActionsHubConnection CreateConnection(string baseUrl = "http://localhost")
+    private static BlueprintHubConnection CreateConnection(string baseUrl = "http://localhost")
     {
         var authService = new Mock<IAuthenticationService>();
         var configService = new Mock<IConfigurationService>();
-        var logger = new Mock<ILogger<ActionsHubConnection>>();
+        var logger = new Mock<ILogger<BlueprintHubConnection>>();
 
-        return new ActionsHubConnection(
+        return new BlueprintHubConnection(
             baseUrl,
             authService.Object,
             configService.Object,


### PR DESCRIPTION
## Summary

Pure rename of the UI-side hub client to match the canonical server hub name (Feature 118 US2 — topology consolidation). Renames the file, class, test class, DI registration method, and every consumer reference (parameter names, local variables, log messages).

Wire route is unchanged — still connects to \`/actionshub\` (the legacy alias that resolves to the same hub as \`/hubs/blueprint\`).

Encryption + credential events stay on this connection for now; they migrate to a forthcoming \`WalletHubConnection\` in a follow-up PR alongside the server-side \`IBlueprintHubClient\` surface trim.

## Test plan

- [x] \`dotnet build\` clean
- [x] \`Sorcha.UI.Core.Tests\` 1188/1188 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)