### PR TITLE
docs(118): document Notifications & Inbox (T123+T124+T126)

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -29,6 +29,14 @@ Status values:
 | SLH-DSA (FIPS 205) | 2024 | NIST | [FIPS 205](https://csrc.nist.gov/pubs/fips/205/final) | n/a | planned | Stateless hash-based signature; complementary PQC algorithm to ML-DSA |
 | BBS+ Signatures | Draft | IETF | [BBS Signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bbs-signatures/) | n/a | planned | Selective-disclosure signature scheme; SD-JWT VC currently covers the disclosure use case |
 
+## Sorcha-implemented capabilities
+
+Internal cross-service capabilities that aren't external standards but are referenced from agent-facing surfaces (`llms.txt`, `docs/`, OpenAPI). Each links to the spec that defines the contract.
+
+| Capability | Status | Spec | Notes |
+|---|---|---|---|
+| Notifications & Inbox | full | [specs/118-notifications-architecture/spec.md](specs/118-notifications-architecture/spec.md) | Five-hub topology (Blueprint, Wallet, Register, Tenant, Chat) with Redis backplane, thin-signal contract (opaque IDs only), and durable per-user inbox with category filtering. ChatHub is the documented streaming exception (FR-019). |
+
 ## Maintenance
 
 - **PR checklist requirement.** Every PR that touches a path listed in any Components cell MUST review this file and update it if the change affects compliance status. The PR template at `.github/pull_request_template.md` carries a "STANDARDS.md reviewed" checkbox.

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -2061,40 +2061,60 @@ Content-Type: application/json
 
 ## Real-time Notifications (SignalR)
 
-### Hub Endpoint: `/actionshub`
+### Hub topology (Feature 118)
 
-### Events
+Five canonical hubs — every notification hub other than ChatHub conforms to the thin-signal contract: events carry opaque IDs, timestamps, and a W3C trace token only. Clients pull full detail via the authenticated REST endpoint linked from the typed-client interface.
 
-#### 1. Subscribe to Actions
+| Hub | Route | Service | Purpose |
+|---|---|---|---|
+| BlueprintHub | `/hubs/blueprint` (alias `/actionshub`) | Blueprint | Action lifecycle, workflow completion, encryption progress |
+| WalletHub | `/hubs/wallet` | Wallet | Citizen-wallet device + credential events; future home for transaction-tick + org-credential events |
+| RegisterHub | `/hubs/register` | Register | Register lifecycle, docket sealing, sync-state changes |
+| TenantHub | `/hubs/tenant` | Tenant | User inbox events (entry added, unread count) |
+| ChatHub | `/hubs/chat` | Blueprint | AI Designer streaming RPC — exempt from thin-signal contract per FR-019 |
+
+Authentication: JWT Bearer via `?access_token=` query parameter (browsers can't set Authorization headers on WebSocket upgrades). The `platform_user_id` claim is required on every notification hub.
+
+### Subscribe to BlueprintHub
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-  .withUrl("http://localhost:5000/actionshub")
+  .withUrl(`/hubs/blueprint?access_token=${jwt}`)
   .build();
 
-// Subscribe to actions for specific wallet/register
-await connection.invoke("SubscribeToActions", "wallet-789", "register-101");
+await connection.invoke("SubscribeToWallet", "wallet-789");
 
-// Listen for action confirmed events
-connection.on("ActionConfirmed", (notification) => {
-  console.log("Action confirmed:", notification);
+connection.on("ActionAvailable", (instanceId, actionId, occurredAt, traceId) => {
+  // Fetch detail via GET /api/instances/{instanceId}/actions/{actionId}
 });
 ```
 
-#### 2. Notification Format
+See each `I*HubClient` interface in tree (`Sorcha.Blueprint.Service.Hubs.IBlueprintHubClient`, etc.) for the authoritative method list and REST detail-endpoint references.
 
-```javascript
-{
-  "transactionHash": "0xabc123def456",
-  "walletAddress": "wallet-789",
-  "registerAddress": "register-101",
-  "blueprintId": "bp-123",
-  "actionId": "0",
-  "instanceId": "instance-abc",
-  "timestamp": "2025-11-17T16:00:00Z",
-  "message": "Transaction confirmed"
-}
-```
+---
+
+## Inbox API
+
+The durable per-user inbox lives in the Tenant Service and is fed by every other service via the internal write endpoint. Real-time updates are delivered through TenantHub's `InboxEntryAdded` and `InboxUnreadCountUpdated` events.
+
+### Public surface (citizen JWT, base path `/api/me/inbox`)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/me/inbox` | List the authenticated user's inbox entries (paginated, optional `category` filter) |
+| GET | `/api/me/inbox/unread-count` | Authoritative unread count for the inbox bell |
+| GET | `/api/me/inbox/{id}` | Fetch a single entry's full content |
+| POST | `/api/me/inbox/{id}/read` | Mark an entry as read |
+| POST | `/api/me/inbox/{id}/dismiss` | Dismiss an entry |
+| POST | `/api/me/inbox/mark-all-read` | Bulk mark every unread entry as read |
+
+### Internal surface (service principal, `RequireService` policy)
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/internal/inbox` | Bridge endpoint called by Blueprint / Wallet writers via `IPlatformInboxClient` to create entries on behalf of a target user. Idempotent on `(PlatformUserId, SourceEventId)`. |
+
+Categories today: `Action`, `Credential`, `Membership`, `Security`. Each writer constructs a deterministic `SourceEventId` (SHA-1 over the natural keys of the event) so retries fold into a single entry.
 
 ---
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -465,8 +465,34 @@ YARP-based API Gateway for routing and aggregation.
 *File Operations:*
 - `GET /api/files/{wallet}/{register}/{tx}/{fileId}` - Download file
 
-*SignalR Hub:*
-- `/actionshub` - Real-time notifications (ActionAvailable, ActionConfirmed, ActionRejected)
+*SignalR Hubs (Feature 118 — five-hub topology):*
+- `/hubs/blueprint` (alias `/actionshub`) — BlueprintHub (Blueprint Service): action lifecycle + encryption progress
+- `/hubs/wallet` — WalletHub (Wallet Service): citizen-wallet device + credential events
+- `/hubs/register` — RegisterHub (Register Service): register lifecycle + docket sealing + sync state
+- `/hubs/tenant` — TenantHub (Tenant Service): durable inbox events
+- `/hubs/chat` — ChatHub (Blueprint Service): AI Designer streaming RPC (FR-019 exception)
+
+Every notification hub uses `services.AddSorchaHub<THub, TClient>(...)` from `Sorcha.ServiceDefaults.Hubs`, which wires JWT Bearer auth, the Redis backplane (per-service `ChannelPrefix=sorcha:signalr:{service}`), reconnect-with-jitter, and the storage-providers fail-fast audit. Multi-replica deployments require Redis or fail-fast at boot.
+
+Every event method on the typed-client interfaces conforms to the **thin-signal contract** — opaque IDs, timestamps, and a W3C trace token only. Clients pull full detail through the authenticated REST endpoint named in the method's `<see cref>` doc. The `ThinSignalContractTests` reflection test guards the surface; `HubTopologyTests` guards the hub set.
+
+*Inbox flow:*
+
+```
+Action emitted on a domain hub (e.g. BlueprintHub.ActionAvailable)
+    ↓
+Domain inbox writer (BlueprintInboxWriter / WalletInboxWriter / TenantSecurityInboxWriter)
+    ↓
+IPlatformInboxClient.WriteAsync (cross-service) or IInboxService.WriteAsync (Tenant local)
+    ↓
+POST /api/internal/inbox  (Tenant Service) — idempotent on (PlatformUserId, SourceEventId)
+    ↓
+EfCoreInboxStore writes the InboxEntry; Redis ZADD to InboxUnreadIndex
+    ↓
+TenantHub broadcasts InboxEntryAdded(entryId, occurredAt, traceId)
+    ↓
+Sorcha.UI MainLayout bell + InboxPanel pull /api/me/inbox to fetch detail
+```
 
 **Features:**
 - RESTful API with Minimal APIs pattern

--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -286,10 +286,10 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 
 ### Docs and observability
 
-- [ ] T123 [P] Update `docs/reference/API-DOCUMENTATION.md` with the new `/api/me/inbox/*`, `/api/internal/inbox`, and the consolidated hub routes.
-- [ ] T124 [P] Update `docs/reference/architecture.md` with the five-hub topology diagram and the inbox flow walkthrough.
+- [X] T123 [P] Update `docs/reference/API-DOCUMENTATION.md` with the new `/api/me/inbox/*`, `/api/internal/inbox`, and the consolidated hub routes.
+- [X] T124 [P] Update `docs/reference/architecture.md` with the five-hub topology diagram and the inbox flow walkthrough.
 - [X] T125 [P] Update `.claude/skills/signalr/SKILL.md` to reflect the five-hub topology, `AddSorchaHub` extension, group builders, and ChatHub exception.
-- [ ] T126 [P] Add a section to `STANDARDS.md` (Feature 117) noting "Notifications & Inbox" as an implemented capability with a link to `specs/118-notifications-architecture/spec.md`.
+- [X] T126 [P] Add a section to `STANDARDS.md` (Feature 117) noting "Notifications & Inbox" as an implemented capability with a link to `specs/118-notifications-architecture/spec.md`.
 - [X] T127 [P] Add Grafana dashboard JSON at `ops/grafana/dashboards/sorcha-signalr.json` consuming the `Sorcha.SignalR` meter (connections, messages-sent, backplane-state, reconnects). Include alert rules for backplane-state ≠ up.
 - [ ] T128 Run quickstart verification end-to-end against a fresh Docker host per `quickstart.md`. Capture pass/fail per step in `specs/118-notifications-architecture/quickstart-verification.md`.
 


### PR DESCRIPTION
## Summary

Documentation pass closing T123, T124, T126 from Feature 118.

## Changes

- **\`docs/reference/API-DOCUMENTATION.md\`** — replaces the legacy single-hub \`/actionshub\` section with the five-hub topology table and adds a new **Inbox API** section covering the public \`/api/me/inbox/*\` surface and the internal \`/api/internal/inbox\` bridge.
- **\`docs/reference/architecture.md\`** — five-hub topology summary, \`AddSorchaHub\` wiring contract, thin-signal contract reference, and inbox flow walkthrough (domain emit → writer → /api/internal/inbox → store → TenantHub broadcast → UI bell).
- **\`STANDARDS.md\`** — new **Sorcha-implemented capabilities** section after the external-standards table; adds Notifications & Inbox with a link to \`specs/118-notifications-architecture/spec.md\`.

## Test plan

- [x] No code changes
- [ ] Discoverability CI check (Feature 117) may flag the new STANDARDS.md row — additive only, won't impact rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)