### PR TITLE
feat(118): inline reconnect indicator in MainLayout (T105)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -232,7 +232,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [ ] T102 [P] [US6] Adopt `HubConnectionWithFallback<IBlueprintHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/BlueprintHubConnection.cs`. Refresher calls `GET /api/instances/{id}` per subscribed instance.
 - [ ] T103 [P] [US6] Adopt `HubConnectionWithFallback<ITenantHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TenantHubConnection.cs`. Refresher calls `GET /api/me/inbox/unread-count`.
 - [ ] T104 [P] [US6] Adopt `HubConnectionWithFallback<IRegisterHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs`. Refresher calls `GET /api/registers/{id}` per subscribed register.
-- [ ] T105 [US6] Surface a "Reconnecting…" affordance in the existing `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor` driven by the connection-state observable on the inbox connection. Inline indicator only — no blocking toast.
+- [X] T105 [US6] Surface a "Reconnecting…" affordance in the existing `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor` driven by the connection-state observable on the inbox connection. Inline indicator only — no blocking toast.
 
 **Checkpoint**: US6 complete. Every hub-backed UI surface degrades gracefully on disconnect.
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -6,6 +6,7 @@
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Models.Credentials
+@using Sorcha.UI.Core.Models.Registers
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
 @inject ITokenRefreshService TokenRefreshService
@@ -40,6 +41,21 @@
                         <MudBadge Content="@_inboxUnreadCount" Color="Color.Primary" Overlap="true" />
                     }
                 </MudIconButton>
+                @* Feature 118 T105 — inline reconnect affordance driven by the
+                   inbox connection state. No blocking toast. *@
+                @if (_inboxConnectionStatus is ConnectionStatus.Reconnecting or ConnectionStatus.Disconnected)
+                {
+                    <MudTooltip Text="@_reconnectTooltip" Placement="Placement.Bottom">
+                        <MudChip T="string"
+                                 Icon="@Icons.Material.Filled.SyncProblem"
+                                 Color="Color.Warning"
+                                 Size="Size.Small"
+                                 Variant="Variant.Text"
+                                 Class="ml-2">
+                            Reconnecting…
+                        </MudChip>
+                    </MudTooltip>
+                }
                 <UserProfileMenu />
             </Authorized>
             <NotAuthorized>
@@ -259,6 +275,23 @@
     private bool _tokenRefreshStarted;
     private bool _inboxPanelOpen;
     private int _inboxUnreadCount;
+    private ConnectionStatus _inboxConnectionStatus = ConnectionStatus.Connecting;
+    private string _reconnectTooltip = "Reconnecting to the notification service…";
+
+    private void OnTenantHubConnectionChanged(ConnectionState state)
+    {
+        InvokeAsync(() =>
+        {
+            _inboxConnectionStatus = state.Status;
+            _reconnectTooltip = state.Status switch
+            {
+                ConnectionStatus.Reconnecting => $"Reconnecting to the notification service (attempt {state.ReconnectAttempts})…",
+                ConnectionStatus.Disconnected => "Notification service disconnected — retrying…",
+                _ => "Connected"
+            };
+            StateHasChanged();
+        });
+    }
     private int _pendingCredentialCount;
     private bool _isDarkMode;
 
@@ -289,6 +322,9 @@
             // Feature 118 — TenantHub is the authoritative source of the unread
             // bell badge after retirement of the legacy ActivityLogPanel.
             TenantHub.OnInboxUnreadCountUpdated += OnInboxUnreadCountUpdated;
+            // T105 — drive the inline "Reconnecting…" affordance off the inbox
+            // connection state.
+            TenantHub.OnConnectionStateChanged += OnTenantHubConnectionChanged;
             try
             {
                 await TenantHub.StartAsync();
@@ -309,6 +345,7 @@
         BlueprintHub.OnCredentialReceived -= OnCredentialReceived;
         BlueprintHub.OnPendingCredentialCountUpdated -= OnPendingCredentialCountUpdated;
         TenantHub.OnInboxUnreadCountUpdated -= OnInboxUnreadCountUpdated;
+        TenantHub.OnConnectionStateChanged -= OnTenantHubConnectionChanged;
         await TenantHub.DisposeAsync();
         await TokenRefreshService.StopAsync();
     }


### PR DESCRIPTION
## Summary

Closes T105 — adds a small \"Reconnecting…\" MudChip in the app bar driven by \`TenantHubConnection.OnConnectionStateChanged\`. Inline only, no blocking toast. Sits next to the inbox bell so the affordance lives on the same surface whose unread count would be stale.

Tooltip text differentiates \`Reconnecting\` (with attempt count) from \`Disconnected\`. Indicator hides on \`Connected\` and on the initial \`Connecting\` state.

T101-T104 (full \`HubConnectionWithFallback\` adoption across all four UI hub clients) remain follow-up — this PR uses the existing connection-state observable that every hub wrapper already exposes.

## Test plan

- [x] \`dotnet build\` clean
- [x] \`Sorcha.UI.Core.Tests\` 1188/1188 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)