### PR TITLE
test(118): EventsHub retirement skipped test (T034)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -94,7 +94,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [X] T031 [P] [US2] Topology-enforcement unit test in `tests/Sorcha.ServiceDefaults.Tests/Hubs/HubTopologyTests.cs` that uses reflection across the loaded service assemblies to assert exactly five `Hub<>` types exist and the four non-Chat hubs use `AddSorchaHub`.
 - [X] T032 [P] [US2] Existing `tests/Sorcha.Blueprint.Service.Tests/Integration/SignalRIntegrationTests.cs` updated for the rename (new hub class `BlueprintHub`, alias path semantics).
 - [X] T033 [P] [US2] New `tests/Sorcha.Tenant.Service.Tests/Hubs/TenantHubTests.cs` covering connect, claim guard, group membership for `user:{platformUserId:N}` on connect.
-- [ ] T034 [P] [US2] EventsHub retirement test in `tests/Sorcha.Blueprint.Service.Tests/Integration/EventsHubRetirementTests.cs` asserting the `410 Gone` response shape after retirement (initially `[Fact(Skip="awaiting decommission step")]`).
+- [X] T034 [P] [US2] EventsHub retirement test in `tests/Sorcha.Blueprint.Service.Tests/Integration/EventsHubRetirementTests.cs` asserting the `410 Gone` response shape after retirement (initially `[Fact(Skip="awaiting decommission step")]`).
 
 ### Implementation for User Story 2
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/EventsHubRetirementTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/EventsHubRetirementTests.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Integration;
+
+/// <summary>
+/// Feature 118 T034 — guards the EventsHub retirement (Phase 10). Once
+/// the hub is decommissioned per spec FR-038, the legacy <c>/eventshub</c>
+/// route must respond with HTTP 410 Gone carrying a deprecation message
+/// pointing clients at TenantHub / WalletHub / BlueprintHub.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Currently <c>[Fact(Skip = "awaiting decommission step")]</c> because
+/// EventsHub still hosts InboundActionReceived / EventReceived /
+/// CredentialStatusChanged / EncryptionOperationCompleted (DeferredExemptions
+/// in <c>ThinSignalContractTests</c> reflect the same).
+/// </para>
+/// <para>
+/// Un-skip in T121 alongside removing the EventsHub class, the four
+/// IEventsHubClient methods, the bridge service, and the
+/// AddSorchaHub&lt;EventsHub,IEventsHubClient&gt; registration. Update
+/// HubTopologyTests.ExpectedHubFqns to drop EventsHub at the same time.
+/// </para>
+/// </remarks>
+public class EventsHubRetirementTests
+{
+    [Fact(Skip = "awaiting decommission step (T121 / Phase 10)")]
+    public async Task LegacyEventsHubRoute_ReturnsGoneWithDeprecationMessage()
+    {
+        // Arrange — caller hits the legacy /eventshub route after retirement.
+        // The expected response shape is HTTP 410 Gone carrying a body that
+        // names the destination hubs (TenantHub for inbox, WalletHub for
+        // credential events, BlueprintHub for action lifecycle).
+        var connection = new HubConnectionBuilder()
+            .WithUrl("http://localhost/eventshub")
+            .Build();
+
+        // Act
+        var act = async () => await connection.StartAsync();
+
+        // Assert — connection refusal carrying 410 status and the deprecation
+        // body. The exact body shape is TBD pending T121; this assertion
+        // tightens at decommission time.
+        var ex = await act.Should().ThrowAsync<Exception>();
+        ex.Which.Message.Should().Contain("410");
+    }
+}


### PR DESCRIPTION
## Summary

Lands the skipped \`EventsHubRetirementTests\` test class now so the un-skip step at decommission (T121 / Phase 10) is a single-line change rather than a fresh file. Asserts the legacy \`/eventshub\` route returns HTTP 410 Gone after retirement.

## Why now

The XML doc on the test class names the moving parts that retirement will touch — the four \`IEventsHubClient\` methods in \`ThinSignalContractTests.DeferredExemptions\`, the \`AddSorchaHub<EventsHub,IEventsHubClient>\` registration, the bridge service, and \`HubTopologyTests.ExpectedHubFqns\`. Future-me lands at this test and finds the checklist already written.

## Test plan

- [x] \`dotnet build\` clean
- [x] Test runs (skipped) — 1/1 skipped, no other suite impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)