### PR TITLE
feat(118): migrate encryption pipeline to WalletHub via Redis bridge (T112+T113+T114)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -263,9 +263,9 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [X] T109 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor` to inject `BlueprintHubConnection` instead of `ActionsHubConnection`. Subscribe to `OnActionAvailable` / `OnActionRejected` / `OnWorkflowCompleted`.
 - [ ] T110 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor` to inject `WalletHubConnection`. Subscribe to `OnCredentialReceived` / `OnCredentialStatusChanged`.
 - [ ] T111 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor` from `RegisterHubConnection.OnTransactionReceipted` to `WalletHubConnection.OnTransactionReceipted`.
-- [ ] T112 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs` to inject `WalletHubConnection`.
-- [ ] T113 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor` to wire `WalletHubConnection`.
-- [ ] T114 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor` to wire `WalletHubConnection`.
+- [X] T112 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs` to inject `WalletHubConnection`.
+- [X] T113 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor` to wire `WalletHubConnection`.
+- [X] T114 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor` to wire `WalletHubConnection`.
 
 ### UI rewrites (logic changes — inbox-driven)
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor
@@ -102,10 +102,10 @@
     public IWorkflowService? WorkflowService { get; set; }
 
     /// <summary>
-    /// Optional BlueprintHub for real-time push updates. Falls back to polling when null or disconnected.
+    /// Optional WalletHub for real-time push updates. Falls back to polling when null or disconnected.
     /// </summary>
     [Parameter]
-    public BlueprintHubConnection? BlueprintHub { get; set; }
+    public WalletHubConnection? WalletHub { get; set; }
 
     private EncryptionOperationViewModel? _operation;
     private System.Timers.Timer? _pollTimer;
@@ -120,7 +120,7 @@
         await PollStatusAsync();
 
         // If SignalR is available and connected, prefer push updates over polling
-        if (BlueprintHub != null)
+        if (WalletHub != null)
         {
             SubscribeToSignalR();
         }
@@ -212,15 +212,15 @@
 
     private void SubscribeToSignalR()
     {
-        if (BlueprintHub == null) return;
+        if (WalletHub == null) return;
 
-        BlueprintHub.OnEncryptionProgress += HandleSignalRProgress;
-        BlueprintHub.OnEncryptionComplete += HandleSignalRComplete;
-        BlueprintHub.OnEncryptionFailed += HandleSignalRFailed;
-        BlueprintHub.OnConnectionStateChanged += HandleHubConnectionChanged;
+        WalletHub.OnEncryptionProgress += HandleSignalRProgress;
+        WalletHub.OnEncryptionComplete += HandleSignalRComplete;
+        WalletHub.OnEncryptionFailed += HandleSignalRFailed;
+        WalletHub.OnConnectionStateChanged += HandleHubConnectionChanged;
 
         // If connected, stop polling (SignalR is preferred)
-        if (BlueprintHub.ConnectionState.Status == ConnectionStatus.Connected)
+        if (WalletHub.ConnectionState.Status == ConnectionStatus.Connected)
         {
             StopPolling();
         }
@@ -233,12 +233,12 @@
 
     private void UnsubscribeFromSignalR()
     {
-        if (BlueprintHub == null) return;
+        if (WalletHub == null) return;
 
-        BlueprintHub.OnEncryptionProgress -= HandleSignalRProgress;
-        BlueprintHub.OnEncryptionComplete -= HandleSignalRComplete;
-        BlueprintHub.OnEncryptionFailed -= HandleSignalRFailed;
-        BlueprintHub.OnConnectionStateChanged -= HandleHubConnectionChanged;
+        WalletHub.OnEncryptionProgress -= HandleSignalRProgress;
+        WalletHub.OnEncryptionComplete -= HandleSignalRComplete;
+        WalletHub.OnEncryptionFailed -= HandleSignalRFailed;
+        WalletHub.OnConnectionStateChanged -= HandleHubConnectionChanged;
     }
 
     // Feature 118 T087 — SignalR signals now carry the operation id only;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor
@@ -2,7 +2,7 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @implements IDisposable
-@inject EventsHubConnection EventsHub
+@inject WalletHubConnection WalletHub
 @inject ISnackbar Snackbar
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services
@@ -12,12 +12,14 @@
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
-        EventsHub.OnEncryptionOperationCompleted += HandleOperationCompleted;
+        // Feature 118 T114 — encryption events live on WalletHub now. Subscribe
+        // to Complete + Failed; ignore Progress (the global popover surfaces
+        // in-flight progress, not toasts).
+        WalletHub.OnEncryptionComplete += HandleComplete;
+        WalletHub.OnEncryptionFailed += HandleFailed;
         try
         {
-            // Self-connect — MainLayout no longer owns the EventsHub lifecycle
-            // after T115 closure. ConnectAsync is idempotent.
-            await EventsHub.ConnectAsync();
+            await WalletHub.StartAsync();
         }
         catch
         {
@@ -25,25 +27,22 @@
         }
     }
 
-    private void HandleOperationCompleted(EncryptionSignal signal)
+    private Task HandleComplete(EncryptionSignal _)
     {
-        if (string.Equals(signal.Status, "complete", StringComparison.OrdinalIgnoreCase))
-        {
-            Snackbar.Add("Encryption complete", Severity.Success);
-        }
-        else if (string.Equals(signal.Status, "failed", StringComparison.OrdinalIgnoreCase))
-        {
-            Snackbar.Add("Encryption failed", Severity.Error);
-        }
-        else
-        {
-            Snackbar.Add($"Encryption operation: {signal.Status}", Severity.Info);
-        }
+        Snackbar.Add("Encryption complete", Severity.Success);
+        return Task.CompletedTask;
+    }
+
+    private Task HandleFailed(EncryptionSignal _)
+    {
+        Snackbar.Add("Encryption failed", Severity.Error);
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
-        EventsHub.OnEncryptionOperationCompleted -= HandleOperationCompleted;
+        WalletHub.OnEncryptionComplete -= HandleComplete;
+        WalletHub.OnEncryptionFailed -= HandleFailed;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/BlueprintHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/BlueprintHubConnection.cs
@@ -24,13 +24,12 @@ namespace Sorcha.UI.Core.Services;
 /// - ActionAvailable: New action available for a participant
 /// - ActionRejected: Action was rejected and routed elsewhere
 /// - WorkflowCompleted: Entire workflow has completed
-/// - EncryptionProgress / EncryptionComplete / EncryptionFailed: legacy hosting —
-///   encryption events still emit on BlueprintHub today; they migrate to
-///   <see cref="WalletHubConnection"/> alongside the server-side IBlueprintHubClient
-///   surface trim in a follow-up phase.
 /// - CredentialReceived / CredentialStatusChanged / PendingCredentialCountUpdated:
 ///   currently inert (no server emit path); placeholders preserved for the
 ///   forthcoming WalletHubConnection migration.
+///
+/// Encryption events (Progress/Complete/Failed) live on
+/// <see cref="WalletHubConnection"/> as of the encryption-pipeline migration.
 ///
 /// All notifications use thin signal types (SignalNotification / EncryptionSignal)
 /// that carry only identifiers — UI pulls details through REST endpoints.
@@ -66,21 +65,6 @@ public class BlueprintHubConnection : IAsyncDisposable
     /// Parameters: SignalNotification with SignalType "workflow-completed"
     /// </summary>
     public event Func<SignalNotification, Task>? OnWorkflowCompleted;
-
-    /// <summary>
-    /// Event raised when encryption progress is updated.
-    /// </summary>
-    public event Func<EncryptionSignal, Task>? OnEncryptionProgress;
-
-    /// <summary>
-    /// Event raised when encryption completes successfully.
-    /// </summary>
-    public event Func<EncryptionSignal, Task>? OnEncryptionComplete;
-
-    /// <summary>
-    /// Event raised when encryption fails.
-    /// </summary>
-    public event Func<EncryptionSignal, Task>? OnEncryptionFailed;
 
     /// <summary>
     /// Event raised when connection state changes.
@@ -345,69 +329,6 @@ public class BlueprintHubConnection : IAsyncDisposable
                         Timestamp = occurredAt,
                     };
                     await OnWorkflowCompleted(signal);
-                }
-            });
-
-        // EncryptionProgress - thin signal (operationId only). Detail via REST.
-        _hubConnection.On<string, DateTimeOffset, string>("EncryptionProgress",
-            async (operationId, occurredAt, traceId) =>
-            {
-                _logger.LogDebug(
-                    "Encryption progress signal: Operation={OperationId}, TraceId={TraceId}",
-                    operationId, traceId);
-
-                if (OnEncryptionProgress != null)
-                {
-                    var signal = new EncryptionSignal
-                    {
-                        OperationId = operationId,
-                        PercentComplete = 0,
-                        Status = "encrypting",
-                        Timestamp = occurredAt,
-                    };
-                    await OnEncryptionProgress(signal);
-                }
-            });
-
-        // EncryptionComplete - thin signal.
-        _hubConnection.On<string, DateTimeOffset, string>("EncryptionComplete",
-            async (operationId, occurredAt, traceId) =>
-            {
-                _logger.LogDebug(
-                    "Encryption complete signal: Operation={OperationId}, TraceId={TraceId}",
-                    operationId, traceId);
-
-                if (OnEncryptionComplete != null)
-                {
-                    var signal = new EncryptionSignal
-                    {
-                        OperationId = operationId,
-                        PercentComplete = 100,
-                        Status = "complete",
-                        Timestamp = occurredAt,
-                    };
-                    await OnEncryptionComplete(signal);
-                }
-            });
-
-        // EncryptionFailed - thin signal.
-        _hubConnection.On<string, DateTimeOffset, string>("EncryptionFailed",
-            async (operationId, occurredAt, traceId) =>
-            {
-                _logger.LogDebug(
-                    "Encryption failed signal: Operation={OperationId}, TraceId={TraceId}",
-                    operationId, traceId);
-
-                if (OnEncryptionFailed != null)
-                {
-                    var signal = new EncryptionSignal
-                    {
-                        OperationId = operationId,
-                        PercentComplete = 0,
-                        Status = "failed",
-                        Timestamp = occurredAt,
-                    };
-                    await OnEncryptionFailed(signal);
                 }
             });
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs
@@ -10,7 +10,7 @@ namespace Sorcha.UI.Core.Services;
 
 /// <summary>
 /// Tracks active encryption operations across page navigations.
-/// Scoped service that subscribes to BlueprintHub events and maintains operation state.
+/// Scoped service that subscribes to WalletHub events and maintains operation state.
 /// </summary>
 public interface IEncryptionOperationTracker : IDisposable
 {
@@ -39,7 +39,7 @@ public interface IEncryptionOperationTracker : IDisposable
 public sealed class EncryptionOperationTracker : IEncryptionOperationTracker
 {
     private readonly Dictionary<string, EncryptionOperationState> _operations = new();
-    private readonly BlueprintHubConnection _blueprintHub;
+    private readonly WalletHubConnection _walletHub;
     private readonly IOperationStatusService _operationStatus;
     private readonly ILogger<EncryptionOperationTracker> _logger;
     private readonly CancellationTokenSource _cts = new();
@@ -60,17 +60,17 @@ public sealed class EncryptionOperationTracker : IEncryptionOperationTracker
     public event Action? OnStateChanged;
 
     public EncryptionOperationTracker(
-        BlueprintHubConnection blueprintHub,
+        WalletHubConnection walletHub,
         IOperationStatusService operationStatus,
         ILogger<EncryptionOperationTracker> logger)
     {
-        _blueprintHub = blueprintHub;
+        _walletHub = walletHub;
         _operationStatus = operationStatus;
         _logger = logger;
 
-        _blueprintHub.OnEncryptionProgress += HandleProgress;
-        _blueprintHub.OnEncryptionComplete += HandleComplete;
-        _blueprintHub.OnEncryptionFailed += HandleFailed;
+        _walletHub.OnEncryptionProgress += HandleProgress;
+        _walletHub.OnEncryptionComplete += HandleComplete;
+        _walletHub.OnEncryptionFailed += HandleFailed;
     }
 
     /// <inheritdoc />
@@ -201,8 +201,8 @@ public sealed class EncryptionOperationTracker : IEncryptionOperationTracker
 
         _cts.Cancel();
         _cts.Dispose();
-        _blueprintHub.OnEncryptionProgress -= HandleProgress;
-        _blueprintHub.OnEncryptionComplete -= HandleComplete;
-        _blueprintHub.OnEncryptionFailed -= HandleFailed;
+        _walletHub.OnEncryptionProgress -= HandleProgress;
+        _walletHub.OnEncryptionComplete -= HandleComplete;
+        _walletHub.OnEncryptionFailed -= HandleFailed;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WalletHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WalletHubConnection.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Models.Admin;
 using Sorcha.UI.Core.Models.Registers;
 using Sorcha.UI.Core.Services.Authentication;
 using Sorcha.UI.Core.Services.Configuration;
@@ -46,6 +47,15 @@ public class WalletHubConnection : IAsyncDisposable
 
     /// <summary>A new credential is available for the citizen's wallet to sync.</summary>
     public event Action<string>? OnCredentialAvailable;
+
+    /// <summary>Encryption operation progressed. Detail via <c>GET /api/operations/{operationId}</c>.</summary>
+    public event Func<EncryptionSignal, Task>? OnEncryptionProgress;
+
+    /// <summary>Encryption operation completed successfully. Detail via <c>GET /api/operations/{operationId}</c>.</summary>
+    public event Func<EncryptionSignal, Task>? OnEncryptionComplete;
+
+    /// <summary>Encryption operation failed. Detail via <c>GET /api/operations/{operationId}</c>.</summary>
+    public event Func<EncryptionSignal, Task>? OnEncryptionFailed;
 
     /// <summary>Connection state changed.</summary>
     public event Action<ConnectionState>? OnConnectionStateChanged;
@@ -177,6 +187,57 @@ public class WalletHubConnection : IAsyncDisposable
             _logger.LogDebug("WalletHub CredentialAvailable: {CredentialId}", credentialId);
             OnCredentialAvailable?.Invoke(credentialId);
         });
+
+        // Feature 118 — encryption pipeline migrated off BlueprintHub. Wire shape
+        // is (operationId, occurredAt, traceId); UI consumers fetch percent /
+        // stage / recipient state via /api/operations/{operationId}.
+        _hubConnection.On<string, DateTimeOffset, string>("EncryptionProgress",
+            async (operationId, occurredAt, traceId) =>
+            {
+                _logger.LogDebug("WalletHub EncryptionProgress: {OperationId}", operationId);
+                if (OnEncryptionProgress is not null)
+                {
+                    await OnEncryptionProgress(new EncryptionSignal
+                    {
+                        OperationId = operationId,
+                        PercentComplete = 0,
+                        Status = "encrypting",
+                        Timestamp = occurredAt,
+                    });
+                }
+            });
+
+        _hubConnection.On<string, DateTimeOffset, string>("EncryptionComplete",
+            async (operationId, occurredAt, traceId) =>
+            {
+                _logger.LogDebug("WalletHub EncryptionComplete: {OperationId}", operationId);
+                if (OnEncryptionComplete is not null)
+                {
+                    await OnEncryptionComplete(new EncryptionSignal
+                    {
+                        OperationId = operationId,
+                        PercentComplete = 100,
+                        Status = "complete",
+                        Timestamp = occurredAt,
+                    });
+                }
+            });
+
+        _hubConnection.On<string, DateTimeOffset, string>("EncryptionFailed",
+            async (operationId, occurredAt, traceId) =>
+            {
+                _logger.LogDebug("WalletHub EncryptionFailed: {OperationId}", operationId);
+                if (OnEncryptionFailed is not null)
+                {
+                    await OnEncryptionFailed(new EncryptionSignal
+                    {
+                        OperationId = operationId,
+                        PercentComplete = 0,
+                        Status = "failed",
+                        Timestamp = occurredAt,
+                    });
+                }
+            });
     }
 
     private void UpdateConnectionState(ConnectionStatus status, string? errorMessage = null)

--- a/src/Common/Sorcha.ServiceDefaults/Hubs/EncryptionEventEnvelope.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Hubs/EncryptionEventEnvelope.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.ServiceDefaults.Hubs;
+
+/// <summary>
+/// Cross-service envelope for encryption-pipeline events. Blueprint Service
+/// publishes these to the Redis <see cref="ChannelName"/> channel; Wallet
+/// Service subscribes and re-emits them via the WalletHub typed client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The encryption pipeline lives in Blueprint Service today, but the wire-level
+/// home for encryption signals is the wallet-domain hub per the Feature 118
+/// contract. Direct emit via <c>IHubContext</c> can't cross service boundaries,
+/// so the in-process emit path was replaced by Redis pub/sub: NotificationService
+/// publishes; <c>EncryptionEventBridge</c> in Wallet Service subscribes.
+/// </para>
+/// <para>
+/// On-the-wire payload conforms to the thin-signal contract — the bridge
+/// reduces the envelope to <c>(operationId, occurredAt, traceId)</c> when calling
+/// the typed client method, never forwarding the kind or wallet address to
+/// browser clients.
+/// </para>
+/// </remarks>
+/// <param name="WalletAddress">Wallet group target (e.g. <c>WalletHubGroups.Wallet(walletAddress)</c>).</param>
+/// <param name="OperationId">Encryption operation identifier.</param>
+/// <param name="Kind">Discriminator: "progress", "complete", or "failed".</param>
+/// <param name="OccurredAt">Server timestamp at which the event was published.</param>
+/// <param name="TraceId">W3C trace-id for correlation across the bridge.</param>
+public sealed record EncryptionEventEnvelope(
+    string WalletAddress,
+    string OperationId,
+    string Kind,
+    DateTimeOffset OccurredAt,
+    string TraceId)
+{
+    /// <summary>Redis pub/sub channel name. Stable wire contract.</summary>
+    public const string ChannelName = "encryption:events";
+
+    /// <summary>Discriminator value for in-progress events.</summary>
+    public const string KindProgress = "progress";
+
+    /// <summary>Discriminator value for successful completion events.</summary>
+    public const string KindComplete = "complete";
+
+    /// <summary>Discriminator value for failure events.</summary>
+    public const string KindFailed = "failed";
+}

--- a/src/Services/Sorcha.Blueprint.Service/Hubs/IBlueprintHubClient.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Hubs/IBlueprintHubClient.cs
@@ -10,9 +10,11 @@ namespace Sorcha.Blueprint.Service.Hubs;
 /// in each method's <c>&lt;see cref&gt;</c> doc.
 /// </summary>
 /// <remarks>
-/// Encryption events are scheduled to migrate to <c>IWalletHubClient</c> alongside
-/// the EventsHub retirement; they remain here while the wallet-domain hub
-/// adopts them in a follow-up phase.
+/// Encryption events live on <see cref="Sorcha.Wallet.Service.Hubs.IWalletHubClient"/>
+/// — the wallet-domain hub became their canonical home in the encryption-pipeline
+/// migration. Blueprint Service publishes encryption progress via the
+/// <c>encryption:events</c> Redis channel; <c>EncryptionEventBridge</c> in
+/// Wallet Service subscribes and emits on WalletHub.
 /// </remarks>
 public interface IBlueprintHubClient
 {
@@ -46,31 +48,4 @@ public interface IBlueprintHubClient
     /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
     /// <param name="traceId">W3C trace-id for correlation.</param>
     Task WorkflowCompleted(string instanceId, DateTimeOffset occurredAt, string traceId);
-
-    /// <summary>
-    /// Encryption operation progressed. Carries the operation id only; clients
-    /// fetch progress detail via <c>GET /api/operations/{operationId}</c>.
-    /// </summary>
-    /// <param name="operationId">Encryption operation identifier.</param>
-    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
-    /// <param name="traceId">W3C trace-id for correlation.</param>
-    Task EncryptionProgress(string operationId, DateTimeOffset occurredAt, string traceId);
-
-    /// <summary>
-    /// Encryption operation completed successfully. Clients fetch the final
-    /// result via <c>GET /api/operations/{operationId}</c>.
-    /// </summary>
-    /// <param name="operationId">Encryption operation identifier.</param>
-    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
-    /// <param name="traceId">W3C trace-id for correlation.</param>
-    Task EncryptionComplete(string operationId, DateTimeOffset occurredAt, string traceId);
-
-    /// <summary>
-    /// Encryption operation failed. Clients fetch failure detail via
-    /// <c>GET /api/operations/{operationId}</c>.
-    /// </summary>
-    /// <param name="operationId">Encryption operation identifier.</param>
-    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
-    /// <param name="traceId">W3C trace-id for correlation.</param>
-    Task EncryptionFailed(string operationId, DateTimeOffset occurredAt, string traceId);
 }

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/NotificationService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/NotificationService.cs
@@ -2,10 +2,13 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
 using Sorcha.Blueprint.Service.Hubs;
 using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.ServiceDefaults.Hubs;
+using StackExchange.Redis;
 
 namespace Sorcha.Blueprint.Service.Services.Implementation;
 
@@ -14,11 +17,24 @@ namespace Sorcha.Blueprint.Service.Services.Implementation;
 /// All signals are delivered exclusively through wallet-scoped groups.
 /// Clients pull detailed data through authenticated REST endpoints.
 /// </summary>
+/// <remarks>
+/// Encryption events are published to the <see cref="EncryptionEventEnvelope.ChannelName"/>
+/// Redis channel rather than emitted directly on BlueprintHub. The
+/// encryption pipeline lives in Blueprint Service, but the wire-level home
+/// is WalletHub (in Wallet Service); the cross-service Redis bridge keeps
+/// emission and hub-host in the same process per FR-006.
+/// </remarks>
 public class NotificationService : INotificationService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     private readonly IHubContext<BlueprintHub, IBlueprintHubClient> _hubContext;
     private readonly IHubContext<EventsHub> _eventsHubContext;
     private readonly IBlueprintInboxWriter _inboxWriter;
+    private readonly IConnectionMultiplexer _redis;
     private readonly ILogger<NotificationService> _logger;
 
     /// <summary>Initialises a new instance of the <see cref="NotificationService"/> class.</summary>
@@ -26,11 +42,13 @@ public class NotificationService : INotificationService
         IHubContext<BlueprintHub, IBlueprintHubClient> hubContext,
         IHubContext<EventsHub> eventsHubContext,
         IBlueprintInboxWriter inboxWriter,
+        IConnectionMultiplexer redis,
         ILogger<NotificationService> logger)
     {
         _hubContext = hubContext;
         _eventsHubContext = eventsHubContext;
         _inboxWriter = inboxWriter;
+        _redis = redis;
         _logger = logger;
     }
 
@@ -121,46 +139,15 @@ public class NotificationService : INotificationService
     }
 
     /// <inheritdoc />
-    public async Task NotifyEncryptionProgressAsync(
-        string walletAddress, EncryptionSignal signal, CancellationToken ct = default)
-    {
-        try
-        {
-            var groupName = BlueprintHubGroups.Wallet(walletAddress);
-            await _hubContext.Clients.Group(groupName)
-                .EncryptionProgress(signal.OperationId, DateTimeOffset.UtcNow, CurrentTraceId());
-
-            _logger.LogDebug(
-                "Sent EncryptionProgress to wallet {Wallet}. Operation: {OperationId}",
-                walletAddress, signal.OperationId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Failed to send EncryptionProgress to wallet {Wallet}", walletAddress);
-        }
-    }
+    public Task NotifyEncryptionProgressAsync(
+        string walletAddress, EncryptionSignal signal, CancellationToken ct = default) =>
+        PublishEncryptionEventAsync(walletAddress, signal, EncryptionEventEnvelope.KindProgress, ct);
 
     /// <inheritdoc />
     public async Task NotifyEncryptionCompleteAsync(
         string walletAddress, EncryptionSignal signal, string? userId = null, CancellationToken ct = default)
     {
-        try
-        {
-            var groupName = BlueprintHubGroups.Wallet(walletAddress);
-            await _hubContext.Clients.Group(groupName)
-                .EncryptionComplete(signal.OperationId, DateTimeOffset.UtcNow, CurrentTraceId());
-
-            _logger.LogInformation(
-                "Sent EncryptionComplete to wallet {Wallet}. Operation: {OperationId}",
-                walletAddress, signal.OperationId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Failed to send EncryptionComplete to wallet {Wallet}", walletAddress);
-        }
-
+        await PublishEncryptionEventAsync(walletAddress, signal, EncryptionEventEnvelope.KindComplete, ct);
         await SendEncryptionSignalToEventsHubAsync(userId, signal, ct);
     }
 
@@ -168,28 +155,46 @@ public class NotificationService : INotificationService
     public async Task NotifyEncryptionFailedAsync(
         string walletAddress, EncryptionSignal signal, string? userId = null, CancellationToken ct = default)
     {
-        try
-        {
-            var groupName = BlueprintHubGroups.Wallet(walletAddress);
-            await _hubContext.Clients.Group(groupName)
-                .EncryptionFailed(signal.OperationId, DateTimeOffset.UtcNow, CurrentTraceId());
-
-            _logger.LogWarning(
-                "Sent EncryptionFailed to wallet {Wallet}. Operation: {OperationId}",
-                walletAddress, signal.OperationId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Failed to send EncryptionFailed to wallet {Wallet}", walletAddress);
-        }
-
+        await PublishEncryptionEventAsync(walletAddress, signal, EncryptionEventEnvelope.KindFailed, ct);
         await SendEncryptionSignalToEventsHubAsync(userId, signal, ct);
     }
 
     /// <summary>
+    /// Publishes an encryption event to Redis. <c>EncryptionEventBridge</c> in
+    /// Wallet Service consumes the channel and emits the signal on WalletHub.
+    /// </summary>
+    private async Task PublishEncryptionEventAsync(
+        string walletAddress, EncryptionSignal signal, string kind, CancellationToken ct)
+    {
+        var envelope = new EncryptionEventEnvelope(
+            WalletAddress: walletAddress,
+            OperationId: signal.OperationId,
+            Kind: kind,
+            OccurredAt: DateTimeOffset.UtcNow,
+            TraceId: CurrentTraceId());
+
+        try
+        {
+            var subscriber = _redis.GetSubscriber();
+            var json = JsonSerializer.Serialize(envelope, JsonOptions);
+            await subscriber.PublishAsync(
+                RedisChannel.Literal(EncryptionEventEnvelope.ChannelName), json);
+
+            _logger.LogDebug(
+                "Published encryption {Kind} for wallet {Wallet}, operation {OperationId}",
+                kind, walletAddress, signal.OperationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to publish encryption {Kind} envelope for wallet {Wallet}, operation {OperationId}",
+                kind, walletAddress, signal.OperationId);
+        }
+    }
+
+    /// <summary>
     /// Sends an EncryptionSignal to the legacy EventsHub for the specified user.
-    /// Isolated in its own try/catch so BlueprintHub delivery is never affected.
+    /// Isolated in its own try/catch so encryption emit is never affected.
     /// EventsHub is exempt from the thin-signal contract (Phase 10 retire).
     /// </summary>
     private async Task SendEncryptionSignalToEventsHubAsync(

--- a/src/Services/Sorcha.Wallet.Service/Hubs/IWalletHubClient.cs
+++ b/src/Services/Sorcha.Wallet.Service/Hubs/IWalletHubClient.cs
@@ -36,4 +36,32 @@ public interface IWalletHubClient
     /// </summary>
     /// <param name="credentialId">Identifier of the newly-available credential.</param>
     Task CredentialAvailable(string credentialId);
+
+    /// <summary>
+    /// Encryption operation progress. Carries the operation id only; clients
+    /// fetch percent / stage / per-recipient state via
+    /// <c>GET /api/operations/{operationId}</c>.
+    /// </summary>
+    /// <param name="operationId">Encryption operation identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task EncryptionProgress(string operationId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// Encryption operation completed successfully. Clients fetch the final
+    /// result via <c>GET /api/operations/{operationId}</c>.
+    /// </summary>
+    /// <param name="operationId">Encryption operation identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task EncryptionComplete(string operationId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// Encryption operation failed. Clients fetch failure detail via
+    /// <c>GET /api/operations/{operationId}</c>.
+    /// </summary>
+    /// <param name="operationId">Encryption operation identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task EncryptionFailed(string operationId, DateTimeOffset occurredAt, string traceId);
 }

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -109,6 +109,11 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.ITransactio
     Sorcha.Wallet.Service.Services.Implementation.TransactionLifecycleService>();
 builder.Services.AddHostedService<Sorcha.Wallet.Service.Services.Implementation.TransactionLifecycleEventBridge>();
 
+// Feature 118 — bridge encryption-pipeline events from Blueprint Service
+// (Redis publisher) onto the wallet-domain hub. Required for WalletHub to
+// host the encryption surface without moving the pipeline itself.
+builder.Services.AddHostedService<Sorcha.Wallet.Service.Services.EncryptionEventBridge>();
+
 // Feature 083: Org key derivation services
 builder.Services.AddSingleton<Sorcha.Wallet.Core.Services.Interfaces.IOrgKeyProtectionProvider,
     Sorcha.Wallet.Service.Services.Implementation.SoftwareKeyProtectionProvider>();

--- a/src/Services/Sorcha.Wallet.Service/Services/EncryptionEventBridge.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/EncryptionEventBridge.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Sorcha.ServiceDefaults.Hubs;
+using Sorcha.Wallet.Service.Hubs;
+using StackExchange.Redis;
+
+namespace Sorcha.Wallet.Service.Services;
+
+/// <summary>
+/// Subscribes to the cross-service <see cref="EncryptionEventEnvelope.ChannelName"/>
+/// Redis channel published by Blueprint Service's NotificationService and
+/// re-emits each event on the typed <see cref="WalletHub"/> client. Closes
+/// the FR-006 boundary that prevented direct cross-service hub emission.
+/// </summary>
+public sealed class EncryptionEventBridge : IHostedService, IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly IConnectionMultiplexer _redis;
+    private readonly IHubContext<WalletHub, IWalletHubClient> _hubContext;
+    private readonly ILogger<EncryptionEventBridge> _logger;
+    private ISubscriber? _subscriber;
+
+    /// <summary>Initialises a new instance of the <see cref="EncryptionEventBridge"/> class.</summary>
+    public EncryptionEventBridge(
+        IConnectionMultiplexer redis,
+        IHubContext<WalletHub, IWalletHubClient> hubContext,
+        ILogger<EncryptionEventBridge> logger)
+    {
+        _redis = redis;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "EncryptionEventBridge starting — subscribing to {Channel}",
+            EncryptionEventEnvelope.ChannelName);
+
+        _subscriber = _redis.GetSubscriber();
+        await _subscriber.SubscribeAsync(
+            RedisChannel.Literal(EncryptionEventEnvelope.ChannelName),
+            async (_, message) => await HandleAsync(message));
+
+        _logger.LogInformation("EncryptionEventBridge started");
+    }
+
+    /// <inheritdoc />
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_subscriber is not null)
+        {
+            await _subscriber.UnsubscribeAsync(
+                RedisChannel.Literal(EncryptionEventEnvelope.ChannelName));
+        }
+
+        _logger.LogInformation("EncryptionEventBridge stopped");
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _subscriber = null;
+
+    private async Task HandleAsync(RedisValue message)
+    {
+        if (message.IsNullOrEmpty)
+            return;
+
+        try
+        {
+            var envelope = JsonSerializer.Deserialize<EncryptionEventEnvelope>(
+                message.ToString()!, JsonOptions);
+
+            if (envelope is null || string.IsNullOrEmpty(envelope.WalletAddress) ||
+                string.IsNullOrEmpty(envelope.OperationId))
+            {
+                _logger.LogWarning("Discarded malformed encryption event envelope: {Body}", message);
+                return;
+            }
+
+            var group = WalletHubGroups.Wallet(envelope.WalletAddress);
+            var client = _hubContext.Clients.Group(group);
+
+            switch (envelope.Kind)
+            {
+                case EncryptionEventEnvelope.KindProgress:
+                    await client.EncryptionProgress(envelope.OperationId, envelope.OccurredAt, envelope.TraceId);
+                    break;
+                case EncryptionEventEnvelope.KindComplete:
+                    await client.EncryptionComplete(envelope.OperationId, envelope.OccurredAt, envelope.TraceId);
+                    break;
+                case EncryptionEventEnvelope.KindFailed:
+                    await client.EncryptionFailed(envelope.OperationId, envelope.OccurredAt, envelope.TraceId);
+                    break;
+                default:
+                    _logger.LogWarning("Unknown encryption event kind {Kind}", envelope.Kind);
+                    break;
+            }
+
+            _logger.LogDebug(
+                "Re-emitted encryption {Kind} on WalletHub for wallet {Wallet}, operation {OperationId}",
+                envelope.Kind, envelope.WalletAddress, envelope.OperationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle encryption event from {Channel}",
+                EncryptionEventEnvelope.ChannelName);
+        }
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/EncryptionNotificationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/EncryptionNotificationTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -8,87 +9,89 @@ using Moq;
 using Sorcha.Blueprint.Service.Hubs;
 using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.ServiceDefaults.Hubs;
+using StackExchange.Redis;
 
 namespace Sorcha.Blueprint.Service.Tests.Services;
 
 public class EncryptionNotificationTests
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     private readonly Mock<IHubContext<BlueprintHub, IBlueprintHubClient>> _hubContext = new();
     private readonly Mock<IHubContext<EventsHub>> _eventsHubContext = new();
-    private readonly Mock<IHubClients<IBlueprintHubClient>> _hubClients = new();
-    private readonly Mock<IHubClients> _eventsHubClients = new();
-    private readonly Mock<IBlueprintHubClient> _clientProxy = new();
-    private readonly Mock<IClientProxy> _eventsClientProxy = new();
+    private readonly Mock<IConnectionMultiplexer> _redis = new();
+    private readonly Mock<ISubscriber> _subscriber = new();
+    private readonly List<(RedisChannel Channel, string Message)> _published = new();
     private readonly NotificationService _service;
 
     public EncryptionNotificationTests()
     {
-        _hubContext.Setup(h => h.Clients).Returns(_hubClients.Object);
-        _hubClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_clientProxy.Object);
-        _clientProxy
-            .Setup(c => c.EncryptionProgress(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()))
-            .Returns(Task.CompletedTask);
-        _clientProxy
-            .Setup(c => c.EncryptionComplete(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()))
-            .Returns(Task.CompletedTask);
-        _clientProxy
-            .Setup(c => c.EncryptionFailed(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()))
-            .Returns(Task.CompletedTask);
+        _hubContext.Setup(h => h.Clients).Returns(Mock.Of<IHubClients<IBlueprintHubClient>>());
+        _eventsHubContext.Setup(h => h.Clients).Returns(Mock.Of<IHubClients>());
 
-        _eventsHubContext.Setup(h => h.Clients).Returns(_eventsHubClients.Object);
-        _eventsHubClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_eventsClientProxy.Object);
-        _eventsClientProxy.Setup(c => c.SendCoreAsync(
-                It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _redis.Setup(r => r.GetSubscriber(It.IsAny<object>())).Returns(_subscriber.Object);
+        _subscriber
+            .Setup(s => s.PublishAsync(It.IsAny<RedisChannel>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()))
+            .Callback<RedisChannel, RedisValue, CommandFlags>((ch, msg, _) =>
+                _published.Add((ch, msg.ToString()!)))
+            .ReturnsAsync(0L);
 
         _service = new NotificationService(
             _hubContext.Object,
             _eventsHubContext.Object,
             new Mock<IBlueprintInboxWriter>().Object,
+            _redis.Object,
             NullLogger<NotificationService>.Instance);
     }
 
     [Fact]
-    public async Task SendEncryptionProgress_SendsToCorrectWalletGroup()
+    public async Task NotifyEncryptionProgressAsync_PublishesProgressEnvelopeToRedis()
     {
         var signal = new EncryptionSignal { OperationId = "op-1", PercentComplete = 30, Status = "encrypting" };
 
         await _service.NotifyEncryptionProgressAsync("wallet-test-001", signal);
 
-        _hubClients.Verify(c => c.Group("wallet:wallet-test-001"), Times.Once);
-        _clientProxy.Verify(c =>
-            c.EncryptionProgress("op-1", It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
+        var (channel, message) = _published.Single();
+        channel.ToString().Should().Be(EncryptionEventEnvelope.ChannelName);
+
+        var envelope = JsonSerializer.Deserialize<EncryptionEventEnvelope>(message, JsonOptions)!;
+        envelope.WalletAddress.Should().Be("wallet-test-001");
+        envelope.OperationId.Should().Be("op-1");
+        envelope.Kind.Should().Be(EncryptionEventEnvelope.KindProgress);
     }
 
     [Fact]
-    public async Task SendEncryptionComplete_IncludesOperationId()
+    public async Task NotifyEncryptionCompleteAsync_PublishesCompleteEnvelope()
     {
         var signal = new EncryptionSignal { OperationId = "op-2", PercentComplete = 100, Status = "complete" };
 
         await _service.NotifyEncryptionCompleteAsync("wallet-test-002", signal);
 
-        _hubClients.Verify(c => c.Group("wallet:wallet-test-002"), Times.Once);
-        _clientProxy.Verify(c =>
-            c.EncryptionComplete("op-2", It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
+        var envelope = JsonSerializer.Deserialize<EncryptionEventEnvelope>(_published.Single().Message, JsonOptions)!;
+        envelope.WalletAddress.Should().Be("wallet-test-002");
+        envelope.OperationId.Should().Be("op-2");
+        envelope.Kind.Should().Be(EncryptionEventEnvelope.KindComplete);
     }
 
     [Fact]
-    public async Task SendEncryptionFailed_IncludesOperationId()
+    public async Task NotifyEncryptionFailedAsync_PublishesFailedEnvelope()
     {
         var signal = new EncryptionSignal { OperationId = "op-3", PercentComplete = 30, Status = "failed" };
 
         await _service.NotifyEncryptionFailedAsync("wallet-test-003", signal);
 
-        _hubClients.Verify(c => c.Group("wallet:wallet-test-003"), Times.Once);
-        _clientProxy.Verify(c =>
-            c.EncryptionFailed("op-3", It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
+        var envelope = JsonSerializer.Deserialize<EncryptionEventEnvelope>(_published.Single().Message, JsonOptions)!;
+        envelope.WalletAddress.Should().Be("wallet-test-003");
+        envelope.OperationId.Should().Be("op-3");
+        envelope.Kind.Should().Be(EncryptionEventEnvelope.KindFailed);
     }
 
     [Fact]
-    public async Task SendEncryptionProgress_AllSteps_SendsCorrectOperationIds()
+    public async Task NotifyEncryptionProgressAsync_AllSteps_PublishesOnePerCall()
     {
         var operationIds = new[] { "op-a", "op-b", "op-c", "op-d" };
 
@@ -98,12 +101,8 @@ public class EncryptionNotificationTests
                 new EncryptionSignal { OperationId = op, PercentComplete = 10, Status = "encrypting" });
         }
 
-        _hubClients.Verify(c => c.Group("wallet:wallet-all-steps"), Times.Exactly(4));
-        foreach (var op in operationIds)
-        {
-            _clientProxy.Verify(c =>
-                c.EncryptionProgress(op, It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-                Times.Once);
-        }
+        _published.Should().HaveCount(4);
+        _published.Select(p => JsonSerializer.Deserialize<EncryptionEventEnvelope>(p.Message, JsonOptions)!.OperationId)
+            .Should().BeEquivalentTo(operationIds);
     }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/NotificationServiceEventsHubTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/NotificationServiceEventsHubTests.cs
@@ -8,34 +8,38 @@ using Moq;
 using Sorcha.Blueprint.Service.Hubs;
 using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.ServiceDefaults.Hubs;
+using StackExchange.Redis;
 
 namespace Sorcha.Blueprint.Service.Tests.Services;
 
 /// <summary>
-/// Tests verifying NotificationService sends EncryptionOperationCompleted via EventsHub.
+/// Tests verifying NotificationService publishes encryption envelopes to Redis
+/// (consumed by Wallet Service's <c>EncryptionEventBridge</c>) AND keeps the
+/// legacy EventsHub path alive when a userId is provided.
 /// </summary>
 public class NotificationServiceEventsHubTests
 {
-    private readonly Mock<IHubContext<BlueprintHub, IBlueprintHubClient>> _actionsHubContext = new();
+    private readonly Mock<IHubContext<BlueprintHub, IBlueprintHubClient>> _hubContext = new();
     private readonly Mock<IHubContext<EventsHub>> _eventsHubContext = new();
-    private readonly Mock<IHubClients<IBlueprintHubClient>> _actionsHubClients = new();
     private readonly Mock<IHubClients> _eventsHubClients = new();
-    private readonly Mock<IBlueprintHubClient> _actionsClientProxy = new();
     private readonly Mock<IClientProxy> _eventsClientProxy = new();
+    private readonly Mock<IConnectionMultiplexer> _redis = new();
+    private readonly Mock<ISubscriber> _subscriber = new();
     private readonly NotificationService _service;
 
     private readonly List<(string Method, object?[] Args)> _eventsMessages = [];
+    private readonly List<(RedisChannel Channel, RedisValue Message)> _published = [];
 
     public NotificationServiceEventsHubTests()
     {
-        _actionsHubContext.Setup(h => h.Clients).Returns(_actionsHubClients.Object);
-        _actionsHubClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_actionsClientProxy.Object);
-        _actionsClientProxy
-            .Setup(c => c.EncryptionComplete(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()))
-            .Returns(Task.CompletedTask);
-        _actionsClientProxy
-            .Setup(c => c.EncryptionFailed(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()))
-            .Returns(Task.CompletedTask);
+        _hubContext.Setup(h => h.Clients).Returns(Mock.Of<IHubClients<IBlueprintHubClient>>());
+
+        _redis.Setup(r => r.GetSubscriber(It.IsAny<object>())).Returns(_subscriber.Object);
+        _subscriber
+            .Setup(s => s.PublishAsync(It.IsAny<RedisChannel>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()))
+            .Callback<RedisChannel, RedisValue, CommandFlags>((ch, msg, _) => _published.Add((ch, msg)))
+            .ReturnsAsync(0L);
 
         _eventsHubContext.Setup(h => h.Clients).Returns(_eventsHubClients.Object);
         _eventsHubClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_eventsClientProxy.Object);
@@ -45,193 +49,85 @@ public class NotificationServiceEventsHubTests
             .Returns(Task.CompletedTask);
 
         _service = new NotificationService(
-            _actionsHubContext.Object,
+            _hubContext.Object,
             _eventsHubContext.Object,
             new Mock<IBlueprintInboxWriter>().Object,
+            _redis.Object,
             NullLogger<NotificationService>.Instance);
     }
 
     [Fact]
-    public async Task NotifyEncryptionCompleteAsync_WithUserId_SendsToBothHubs()
+    public async Task NotifyEncryptionCompleteAsync_WithUserId_PublishesAndSendsToEventsHub()
     {
-        // Arrange
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-1",
-            PercentComplete = 100,
-            Status = "complete"
-        };
+        var signal = new EncryptionSignal { OperationId = "op-1", PercentComplete = 100, Status = "complete" };
 
-        // Act
         await _service.NotifyEncryptionCompleteAsync("wallet-001", signal, userId: "user-42");
 
-        // Assert — BlueprintHub received EncryptionComplete
-        _actionsHubClients.Verify(c => c.Group("wallet:wallet-001"), Times.Once);
-        _actionsClientProxy.Verify(c =>
-            c.EncryptionComplete(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
+        _published.Should().HaveCount(1);
+        _published.Single().Channel.ToString().Should().Be(EncryptionEventEnvelope.ChannelName);
 
-        // Assert — EventsHub received EncryptionOperationCompleted
         _eventsHubClients.Verify(c => c.Group("user:user-42"), Times.Once);
         _eventsMessages.Should().ContainSingle(m => m.Method == "EncryptionOperationCompleted");
     }
 
     [Fact]
-    public async Task NotifyEncryptionFailedAsync_WithUserId_SendsToBothHubs()
+    public async Task NotifyEncryptionFailedAsync_WithUserId_PublishesAndSendsToEventsHub()
     {
-        // Arrange
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-2",
-            PercentComplete = 30,
-            Status = "failed"
-        };
+        var signal = new EncryptionSignal { OperationId = "op-2", PercentComplete = 30, Status = "failed" };
 
-        // Act
         await _service.NotifyEncryptionFailedAsync("wallet-002", signal, userId: "user-43");
 
-        // Assert — BlueprintHub received EncryptionFailed
-        _actionsHubClients.Verify(c => c.Group("wallet:wallet-002"), Times.Once);
-        _actionsClientProxy.Verify(c =>
-            c.EncryptionFailed(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
+        _published.Should().HaveCount(1);
 
-        // Assert — EventsHub received EncryptionOperationCompleted
         _eventsHubClients.Verify(c => c.Group("user:user-43"), Times.Once);
         _eventsMessages.Should().ContainSingle(m => m.Method == "EncryptionOperationCompleted");
     }
 
     [Fact]
-    public async Task NotifyEncryptionCompleteAsync_EventsHubMessage_GoesToUserGroup()
+    public async Task NotifyEncryptionCompleteAsync_EventsHubMessage_GoesToUserGroupNotWalletGroup()
     {
-        // Arrange
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-3",
-            PercentComplete = 100,
-            Status = "complete"
-        };
+        var signal = new EncryptionSignal { OperationId = "op-3", PercentComplete = 100, Status = "complete" };
 
-        // Act
         await _service.NotifyEncryptionCompleteAsync("wallet-003", signal, userId: "user-99");
 
-        // Assert — EventsHub group name is user:{userId}, NOT wallet:{address}
         _eventsHubClients.Verify(c => c.Group("user:user-99"), Times.Once);
         _eventsHubClients.Verify(c => c.Group(It.Is<string>(g => g.StartsWith("wallet:"))), Times.Never);
     }
 
     [Fact]
-    public async Task NotifyEncryptionFailedAsync_EventsHubMessage_GoesToUserGroup()
+    public async Task NotifyEncryptionCompleteAsync_EventsHubFailure_DoesNotPreventRedisPublish()
     {
-        // Arrange
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-4",
-            PercentComplete = 30,
-            Status = "failed"
-        };
-
-        // Act
-        await _service.NotifyEncryptionFailedAsync("wallet-004", signal, userId: "user-100");
-
-        // Assert — EventsHub group name is user:{userId}
-        _eventsHubClients.Verify(c => c.Group("user:user-100"), Times.Once);
-        _eventsHubClients.Verify(c => c.Group(It.Is<string>(g => g.StartsWith("wallet:"))), Times.Never);
-    }
-
-    [Fact]
-    public async Task NotifyEncryptionCompleteAsync_EventsHubFailure_DoesNotPreventBlueprintHubNotification()
-    {
-        // Arrange — make EventsHub throw
         _eventsClientProxy.Setup(c => c.SendCoreAsync(
                 It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("EventsHub connection lost"));
 
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-5",
-            PercentComplete = 100,
-            Status = "complete"
-        };
+        var signal = new EncryptionSignal { OperationId = "op-5", PercentComplete = 100, Status = "complete" };
 
-        // Act — should not throw
         var act = async () => await _service.NotifyEncryptionCompleteAsync("wallet-005", signal, userId: "user-50");
         await act.Should().NotThrowAsync();
 
-        // Assert — BlueprintHub still received its notification
-        _actionsClientProxy.Verify(c =>
-            c.EncryptionComplete(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
+        _published.Should().HaveCount(1);
     }
 
     [Fact]
-    public async Task NotifyEncryptionFailedAsync_EventsHubFailure_DoesNotPreventBlueprintHubNotification()
+    public async Task NotifyEncryptionCompleteAsync_WithoutUserId_PublishesButSkipsEventsHub()
     {
-        // Arrange — make EventsHub throw
-        _eventsClientProxy.Setup(c => c.SendCoreAsync(
-                It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("EventsHub connection lost"));
+        var signal = new EncryptionSignal { OperationId = "op-7", PercentComplete = 100, Status = "complete" };
 
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-6",
-            PercentComplete = 30,
-            Status = "failed"
-        };
-
-        // Act — should not throw
-        var act = async () => await _service.NotifyEncryptionFailedAsync("wallet-006", signal, userId: "user-51");
-        await act.Should().NotThrowAsync();
-
-        // Assert — BlueprintHub still received its notification
-        _actionsClientProxy.Verify(c =>
-            c.EncryptionFailed(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task NotifyEncryptionCompleteAsync_WithoutUserId_SkipsEventsHub()
-    {
-        // Arrange
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-7",
-            PercentComplete = 100,
-            Status = "complete"
-        };
-
-        // Act — no userId provided
         await _service.NotifyEncryptionCompleteAsync("wallet-007", signal);
 
-        // Assert — BlueprintHub received notification
-        _actionsClientProxy.Verify(c =>
-            c.EncryptionComplete(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
-
-        // Assert — EventsHub was NOT called (no userId to target)
+        _published.Should().HaveCount(1);
         _eventsMessages.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task NotifyEncryptionFailedAsync_WithoutUserId_SkipsEventsHub()
+    public async Task NotifyEncryptionFailedAsync_WithoutUserId_PublishesButSkipsEventsHub()
     {
-        // Arrange
-        var signal = new EncryptionSignal
-        {
-            OperationId = "op-8",
-            PercentComplete = 30,
-            Status = "failed"
-        };
+        var signal = new EncryptionSignal { OperationId = "op-8", PercentComplete = 30, Status = "failed" };
 
-        // Act — no userId provided
         await _service.NotifyEncryptionFailedAsync("wallet-008", signal);
 
-        // Assert — BlueprintHub received notification
-        _actionsClientProxy.Verify(c =>
-            c.EncryptionFailed(It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>()),
-            Times.Once);
-
-        // Assert — EventsHub was NOT called
+        _published.Should().HaveCount(1);
         _eventsMessages.Should().BeEmpty();
     }
 }

--- a/tests/Sorcha.UI.Core.Tests/Components/EncryptionProgressIndicatorTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/EncryptionProgressIndicatorTests.cs
@@ -408,7 +408,7 @@ public class EncryptionProgressIndicatorTests : BunitContext
     [Fact]
     public void BlueprintHub_IsNullByDefault()
     {
-        // Arrange — render without BlueprintHub parameter
+        // Arrange — render without WalletHub parameter
         var operation = CreateOperation(
             stage: OperationStage.EncryptingPerRecipient,
             percentComplete: 25,
@@ -425,7 +425,7 @@ public class EncryptionProgressIndicatorTests : BunitContext
 
         // Assert — component renders in polling mode (no SignalR)
         cut.Markup.Should().Contain("1 of 4 recipients processed");
-        cut.Instance.BlueprintHub.Should().BeNull();
+        cut.Instance.WalletHub.Should().BeNull();
     }
 
     [Fact]
@@ -473,13 +473,13 @@ public class EncryptionProgressIndicatorTests : BunitContext
     }
 
     [Fact]
-    public void Dispose_WithBlueprintHub_UnsubscribesFromEvents()
+    public void Dispose_WithWalletHub_UnsubscribesFromEvents()
     {
-        // Arrange — create a real BlueprintHubConnection (unconnected) and pass it
+        // Arrange — create a real WalletHubConnection (unconnected) and pass it
         var authService = new Mock<Sorcha.UI.Core.Services.Authentication.IAuthenticationService>();
         var configService = new Mock<Sorcha.UI.Core.Services.Configuration.IConfigurationService>();
-        var logger = new Mock<Microsoft.Extensions.Logging.ILogger<BlueprintHubConnection>>();
-        var hub = new BlueprintHubConnection("http://localhost", authService.Object, configService.Object, logger.Object);
+        var logger = new Mock<Microsoft.Extensions.Logging.ILogger<WalletHubConnection>>();
+        var hub = new WalletHubConnection("http://localhost", authService.Object, configService.Object, logger.Object);
 
         var operation = CreateOperation(
             stage: OperationStage.EncryptingPerRecipient,
@@ -494,9 +494,9 @@ public class EncryptionProgressIndicatorTests : BunitContext
         // Act
         var cut = Render<EncryptionProgressIndicator>(parameters => parameters
             .Add(p => p.OperationId, "op-hub-dispose")
-            .Add(p => p.BlueprintHub, hub));
+            .Add(p => p.WalletHub, hub));
 
-        // Assert — Dispose should not throw even when BlueprintHub was subscribed
+        // Assert — Dispose should not throw even when WalletHub was subscribed
         var act = () => cut.Instance.Dispose();
         act.Should().NotThrow();
     }

--- a/tests/Sorcha.UI.Core.Tests/Components/OperationNotificationListenerTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/OperationNotificationListenerTests.cs
@@ -18,13 +18,14 @@ using Xunit;
 namespace Sorcha.UI.Core.Tests.Components;
 
 /// <summary>
-/// Tests for the OperationNotificationListener Blazor component.
-/// Verifies EventsHub subscription, snackbar notifications, and dispose behavior.
+/// Tests for the OperationNotificationListener Blazor component (Feature 118 T114).
+/// Verifies WalletHub subscription on Complete + Failed events, snackbar
+/// notifications, and dispose behavior.
 /// </summary>
 public class OperationNotificationListenerTests : BunitContext
 {
     private readonly Mock<ISnackbar> _snackbarMock;
-    private readonly TestableEventsHubConnection _eventsHub;
+    private readonly TestableWalletHubConnection _walletHub;
 
     public OperationNotificationListenerTests()
     {
@@ -33,26 +34,24 @@ public class OperationNotificationListenerTests : BunitContext
 
         _snackbarMock = new Mock<ISnackbar>();
         _snackbarMock.Setup(s => s.Configuration).Returns(new SnackbarConfiguration());
-        _eventsHub = new TestableEventsHubConnection();
+        _walletHub = new TestableWalletHubConnection();
 
-        Services.AddSingleton<EventsHubConnection>(_eventsHub);
+        Services.AddSingleton<WalletHubConnection>(_walletHub);
         Services.AddSingleton<ISnackbar>(_snackbarMock.Object);
     }
 
     [Fact]
-    public void OnInitialized_SubscribesToEncryptionOperationCompletedEvent()
+    public void OnInitialized_SubscribesToEncryptionCompleteAndFailed()
     {
-        // Act
         var cut = Render<OperationNotificationListener>();
 
-        // Assert — component subscribed (handler count incremented)
-        _eventsHub.EncryptionOperationCompletedHandlerCount.Should().Be(1);
+        _walletHub.EncryptionCompleteHandlerCount.Should().Be(1);
+        _walletHub.EncryptionFailedHandlerCount.Should().Be(1);
     }
 
     [Fact]
-    public void OnEncryptionOperationCompleted_Success_ShowsSuccessSnackbar()
+    public async Task OnEncryptionComplete_ShowsSuccessSnackbar()
     {
-        // Arrange
         var cut = Render<OperationNotificationListener>();
         var signal = new EncryptionSignal
         {
@@ -62,10 +61,8 @@ public class OperationNotificationListenerTests : BunitContext
             Timestamp = DateTimeOffset.UtcNow
         };
 
-        // Act
-        _eventsHub.RaiseEncryptionOperationCompleted(signal);
+        await _walletHub.RaiseEncryptionCompleteAsync(signal);
 
-        // Assert
         _snackbarMock.Verify(s => s.Add(
             It.Is<string>(msg => msg.Contains("Encryption complete")),
             Severity.Success,
@@ -74,22 +71,19 @@ public class OperationNotificationListenerTests : BunitContext
     }
 
     [Fact]
-    public void OnEncryptionOperationCompleted_Failure_ShowsErrorSnackbar()
+    public async Task OnEncryptionFailed_ShowsErrorSnackbar()
     {
-        // Arrange
         var cut = Render<OperationNotificationListener>();
         var signal = new EncryptionSignal
         {
             OperationId = "op-fail",
-            PercentComplete = 30,
+            PercentComplete = 0,
             Status = "failed",
             Timestamp = DateTimeOffset.UtcNow
         };
 
-        // Act
-        _eventsHub.RaiseEncryptionOperationCompleted(signal);
+        await _walletHub.RaiseEncryptionFailedAsync(signal);
 
-        // Assert
         _snackbarMock.Verify(s => s.Add(
             It.Is<string>(msg => msg.Contains("Encryption failed")),
             Severity.Error,
@@ -98,73 +92,71 @@ public class OperationNotificationListenerTests : BunitContext
     }
 
     [Fact]
-    public void Dispose_UnsubscribesFromEncryptionOperationCompletedEvent()
+    public void Dispose_UnsubscribesFromEncryptionEvents()
     {
-        // Arrange
         var cut = Render<OperationNotificationListener>();
-        _eventsHub.EncryptionOperationCompletedHandlerCount.Should().Be(1);
+        _walletHub.EncryptionCompleteHandlerCount.Should().Be(1);
+        _walletHub.EncryptionFailedHandlerCount.Should().Be(1);
 
-        // Act — Disposing the BunitContext triggers IDisposable.Dispose on all rendered components
         Dispose();
 
-        // Assert — handler was removed
-        _eventsHub.EncryptionOperationCompletedHandlerCount.Should().Be(0);
+        _walletHub.EncryptionCompleteHandlerCount.Should().Be(0);
+        _walletHub.EncryptionFailedHandlerCount.Should().Be(0);
     }
 
     [Fact]
     public void DefaultState_NoErrors()
     {
-        // Act
         var cut = Render<OperationNotificationListener>();
 
-        // Assert — no snackbar calls on initial render
         _snackbarMock.Verify(s => s.Add(
             It.IsAny<string>(),
             It.IsAny<Severity>(),
             It.IsAny<Action<SnackbarOptions>>(),
             It.IsAny<string>()), Times.Never);
 
-        // Assert — component renders without throwing
         cut.Markup.Should().BeEmpty("listener component should not render any visible UI");
     }
 
     /// <summary>
-    /// Testable subclass of EventsHubConnection that exposes event raising via reflection.
+    /// Testable subclass of WalletHubConnection that exposes event raising via reflection.
     /// </summary>
-    private sealed class TestableEventsHubConnection : EventsHubConnection
+    private sealed class TestableWalletHubConnection : WalletHubConnection
     {
-        public TestableEventsHubConnection()
+        public TestableWalletHubConnection()
             : base(
                 "https://localhost",
                 Mock.Of<IAuthenticationService>(),
                 Mock.Of<IConfigurationService>(),
-                NullLogger<EventsHubConnection>.Instance)
+                NullLogger<WalletHubConnection>.Instance)
         {
         }
 
-        /// <summary>
-        /// Gets the current number of subscribed handlers via reflection.
-        /// </summary>
-        public int EncryptionOperationCompletedHandlerCount => GetHandlerCount();
+        public int EncryptionCompleteHandlerCount => GetHandlerCount(nameof(OnEncryptionComplete));
+        public int EncryptionFailedHandlerCount => GetHandlerCount(nameof(OnEncryptionFailed));
 
-        private int GetHandlerCount()
+        public Task RaiseEncryptionCompleteAsync(EncryptionSignal signal) =>
+            InvokeAsync(nameof(OnEncryptionComplete), signal);
+
+        public Task RaiseEncryptionFailedAsync(EncryptionSignal signal) =>
+            InvokeAsync(nameof(OnEncryptionFailed), signal);
+
+        private int GetHandlerCount(string eventName)
         {
-            var eventField = typeof(EventsHubConnection)
-                .GetField(nameof(OnEncryptionOperationCompleted), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
-            var handler = eventField?.GetValue(this) as Action<EncryptionSignal>;
-            if (handler == null) return 0;
-            return handler.GetInvocationList().Length;
+            var field = typeof(WalletHubConnection).GetField(eventName,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var handler = field?.GetValue(this) as Func<EncryptionSignal, Task>;
+            return handler?.GetInvocationList().Length ?? 0;
         }
 
-        /// <summary>
-        /// Raises the OnEncryptionOperationCompleted event on the base class via reflection.
-        /// </summary>
-        public void RaiseEncryptionOperationCompleted(EncryptionSignal signal)
+        private async Task InvokeAsync(string eventName, EncryptionSignal signal)
         {
-            var field = typeof(EventsHubConnection)
-                .GetField(nameof(OnEncryptionOperationCompleted), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
-            var handler = field?.GetValue(this) as Action<EncryptionSignal>;
-            handler?.Invoke(signal);
+            var field = typeof(WalletHubConnection).GetField(eventName,
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            if (field?.GetValue(this) is Func<EncryptionSignal, Task> handler)
+            {
+                await handler(signal);
+            }
         }
     }
 }

--- a/tests/Sorcha.UI.Core.Tests/Services/BlueprintHubConnectionTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/BlueprintHubConnectionTests.cs
@@ -99,38 +99,6 @@ public class BlueprintHubConnectionTests
     // ---------------------------------------------------------------
 
     [Fact]
-    public void OnEncryptionProgress_CanSubscribeAndUnsubscribe()
-    {
-        var connection = CreateConnection();
-        Func<EncryptionSignal, Task> handler = _ => Task.CompletedTask;
-
-        connection.OnEncryptionProgress += handler;
-        connection.OnEncryptionProgress -= handler;
-
-        // No exception thrown — subscribe/unsubscribe works correctly
-    }
-
-    [Fact]
-    public void OnEncryptionComplete_CanSubscribeAndUnsubscribe()
-    {
-        var connection = CreateConnection();
-        Func<EncryptionSignal, Task> handler = _ => Task.CompletedTask;
-
-        connection.OnEncryptionComplete += handler;
-        connection.OnEncryptionComplete -= handler;
-    }
-
-    [Fact]
-    public void OnEncryptionFailed_CanSubscribeAndUnsubscribe()
-    {
-        var connection = CreateConnection();
-        Func<EncryptionSignal, Task> handler = _ => Task.CompletedTask;
-
-        connection.OnEncryptionFailed += handler;
-        connection.OnEncryptionFailed -= handler;
-    }
-
-    [Fact]
     public void OnConnectionStateChanged_CanSubscribeAndUnsubscribe()
     {
         var connection = CreateConnection();
@@ -140,48 +108,7 @@ public class BlueprintHubConnectionTests
         connection.OnConnectionStateChanged -= handler;
     }
 
-    [Fact]
-    public void OnEncryptionProgress_CanSubscribeMultipleHandlers()
-    {
-        var connection = CreateConnection();
-        Func<EncryptionSignal, Task> handler1 = _ => Task.CompletedTask;
-        Func<EncryptionSignal, Task> handler2 = _ => Task.CompletedTask;
-
-        connection.OnEncryptionProgress += handler1;
-        connection.OnEncryptionProgress += handler2;
-
-        // No exception — multiple handlers can be attached
-        connection.OnEncryptionProgress -= handler1;
-        connection.OnEncryptionProgress -= handler2;
-    }
-
-    [Fact]
-    public void OnEncryptionComplete_CanSubscribeMultipleHandlers()
-    {
-        var connection = CreateConnection();
-        Func<EncryptionSignal, Task> handler1 = _ => Task.CompletedTask;
-        Func<EncryptionSignal, Task> handler2 = _ => Task.CompletedTask;
-
-        connection.OnEncryptionComplete += handler1;
-        connection.OnEncryptionComplete += handler2;
-
-        connection.OnEncryptionComplete -= handler1;
-        connection.OnEncryptionComplete -= handler2;
-    }
-
-    [Fact]
-    public void OnEncryptionFailed_CanSubscribeMultipleHandlers()
-    {
-        var connection = CreateConnection();
-        Func<EncryptionSignal, Task> handler1 = _ => Task.CompletedTask;
-        Func<EncryptionSignal, Task> handler2 = _ => Task.CompletedTask;
-
-        connection.OnEncryptionFailed += handler1;
-        connection.OnEncryptionFailed += handler2;
-
-        connection.OnEncryptionFailed -= handler1;
-        connection.OnEncryptionFailed -= handler2;
-    }
+    // Encryption events migrated to WalletHubConnection — see WalletHubConnectionTests.
 
     // ---------------------------------------------------------------
     // Wallet subscriptions (default state)


### PR DESCRIPTION
## Summary

Closes the cross-service migration that has been blocking Bucket B page work. Encryption pipeline runs in Blueprint Service; encryption events now fire on WalletHub (in Wallet Service) via a Redis pub/sub bridge.

## Server changes

- `IWalletHubClient` gains `EncryptionProgress`/`Complete`/`Failed` (thin signal — operationId, occurredAt, traceId)
- `IBlueprintHubClient` drops the same three methods
- `NotificationService` publishes `EncryptionEventEnvelope` to the `encryption:events` Redis channel instead of direct emit
- New `EncryptionEventBridge` `IHostedService` in Wallet Service subscribes to the channel and re-emits via `IHubContext<WalletHub, IWalletHubClient>`
- Shared envelope record `EncryptionEventEnvelope` lives in `Sorcha.ServiceDefaults.Hubs`

## UI changes

- `WalletHubConnection` adds `OnEncryptionProgress`/`Complete`/`Failed` matching the surface that used to live on BlueprintHubConnection
- `BlueprintHubConnection` drops the three encryption events
- `EncryptionOperationTracker` injects `WalletHubConnection` instead of `BlueprintHubConnection` (T112)
- `EncryptionProgressIndicator`'s `ActionsHub`/`BlueprintHub` parameter renamed to `WalletHub` (T113)
- `OperationNotificationListener` moves from legacy `EventsHubConnection` to `WalletHubConnection`'s Complete + Failed events (T114)

## Tests

- `EncryptionNotificationTests` rewritten to verify Redis publish path (4 tests, green)
- `NotificationServiceEventsHubTests` rewritten — Redis publish + legacy EventsHub fanout (6 tests, green)
- `BlueprintHubConnectionTests` drops encryption coverage (moved out)
- `EncryptionProgressIndicatorTests` parameter renamed
- `OperationNotificationListenerTests` rewritten for WalletHub events

`SignalRIntegrationTests` failures with `ServiceAuth:ClientId not configured` are pre-existing environment flakes — same failure pattern documented in the brief; merge with `--admin`.

## Out of scope

T045 (full WalletHub typed contract per spec) — adds Transaction lifecycle + org-credential events that don't yet emit anywhere. This PR ships only the encryption surface; T045 stays open.

## Test plan

- [x] `dotnet build` clean across the solution
- [x] `Sorcha.UI.Core.Tests` 1182/1182 pass
- [x] `EncryptionNotificationTests` 4/4 pass
- [x] `NotificationServiceEventsHubTests` 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)