### PR TITLE
feat(118): TenantHubConnection adopts HubConnectionWithFallback (T103)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -230,7 +230,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 
 - [ ] T101 [US6] Adopt `HubConnectionWithFallback<IWalletHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WalletHubConnection.cs`. Refresher delegate calls existing `GET /api/wallets/{addr}` endpoint.
 - [ ] T102 [P] [US6] Adopt `HubConnectionWithFallback<IBlueprintHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/BlueprintHubConnection.cs`. Refresher calls `GET /api/instances/{id}` per subscribed instance.
-- [ ] T103 [P] [US6] Adopt `HubConnectionWithFallback<ITenantHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TenantHubConnection.cs`. Refresher calls `GET /api/me/inbox/unread-count`.
+- [X] T103 [P] [US6] Adopt `HubConnectionWithFallback<ITenantHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TenantHubConnection.cs`. Refresher calls `GET /api/me/inbox/unread-count`.
 - [ ] T104 [P] [US6] Adopt `HubConnectionWithFallback<IRegisterHubClient>` in `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/RegisterHubConnection.cs`. Refresher calls `GET /api/registers/{id}` per subscribed register.
 - [X] T105 [US6] Surface a "Reconnecting…" affordance in the existing `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor` driven by the connection-state observable on the inbox connection. Inline indicator only — no blocking toast.
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -580,6 +580,7 @@ public static class ServiceCollectionExtensions
             var authService = sp.GetRequiredService<IAuthenticationService>();
             var configService = sp.GetRequiredService<IConfigurationService>();
             var logger = sp.GetRequiredService<ILogger<TenantHubConnection>>();
+            var inboxApi = sp.GetService<IInboxApiService>();
             return new TenantHubConnection(
                 hubBaseUrl,
                 accessTokenProvider: async () =>
@@ -587,7 +588,8 @@ public static class ServiceCollectionExtensions
                     var profileName = await configService.GetActiveProfileNameAsync();
                     return await authService.GetAccessTokenAsync(profileName);
                 },
-                logger);
+                logger,
+                inboxApi);
         });
 
         return services;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TenantHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/TenantHubConnection.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
+using Sorcha.ServiceClients.Http.Hub;
 using Sorcha.UI.Core.Models.Registers;
 
 namespace Sorcha.UI.Core.Services;
@@ -27,9 +28,11 @@ public sealed class TenantHubConnection : IAsyncDisposable
 {
     private readonly string _hubUrl;
     private readonly Func<Task<string?>> _accessTokenProvider;
+    private readonly IInboxApiService? _inboxApi;
     private readonly ILogger<TenantHubConnection> _logger;
 
     private HubConnection? _hubConnection;
+    private HubConnectionWithFallback? _fallbackWrapper;
     private ConnectionState _connectionState = new();
 
     /// <summary>Fires when the server emits <c>InboxEntryAdded(entryId, occurredAt, traceId)</c>.</summary>
@@ -51,11 +54,13 @@ public sealed class TenantHubConnection : IAsyncDisposable
     public TenantHubConnection(
         string baseUrl,
         Func<Task<string?>> accessTokenProvider,
-        ILogger<TenantHubConnection> logger)
+        ILogger<TenantHubConnection> logger,
+        IInboxApiService? inboxApi = null)
     {
         _hubUrl = $"{baseUrl.TrimEnd('/')}/hubs/tenant";
         _accessTokenProvider = accessTokenProvider ?? throw new ArgumentNullException(nameof(accessTokenProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _inboxApi = inboxApi;
     }
 
     /// <summary>
@@ -128,6 +133,13 @@ public sealed class TenantHubConnection : IAsyncDisposable
                 return Task.CompletedTask;
             };
 
+            // Feature 118 T103 — REST polling fallback engages after 90s of
+            // failed reconnect. Refresher hits /api/me/inbox/unread-count and
+            // raises OnInboxUnreadCountUpdated so consumers see fresh state.
+            _fallbackWrapper = new HubConnectionWithFallback(
+                _hubConnection,
+                pollFallback: _inboxApi is null ? null : PollUnreadCountAsync);
+
             await _hubConnection.StartAsync(cancellationToken);
             UpdateConnectionState(ConnectionStatus.Connected);
             _logger.LogInformation("TenantHub connected to {HubUrl}", _hubUrl);
@@ -165,10 +177,39 @@ public sealed class TenantHubConnection : IAsyncDisposable
 
     private async Task DisposeHubConnectionAsync()
     {
+        if (_fallbackWrapper is not null)
+        {
+            try { await _fallbackWrapper.DisposeAsync(); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Error disposing TenantHub fallback wrapper"); }
+            _fallbackWrapper = null;
+        }
         if (_hubConnection is null) return;
         try { await _hubConnection.DisposeAsync(); }
         catch (Exception ex) { _logger.LogWarning(ex, "Error disposing TenantHub connection"); }
         _hubConnection = null;
+    }
+
+    /// <summary>
+    /// Polling-fallback delegate. Invoked by <see cref="HubConnectionWithFallback"/>
+    /// after the configured engage-after window of failed reconnects, then on
+    /// each poll-interval tick until the websocket recovers.
+    /// </summary>
+    private async Task PollUnreadCountAsync(CancellationToken cancellationToken)
+    {
+        if (_inboxApi is null) return;
+        try
+        {
+            var count = await _inboxApi.GetUnreadCountAsync(cancellationToken).ConfigureAwait(false);
+            if (OnInboxUnreadCountUpdated is not null)
+            {
+                await OnInboxUnreadCountUpdated(count, DateTimeOffset.UtcNow, string.Empty)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "TenantHub polling fallback fetch failed");
+        }
     }
 
     private void UpdateConnectionState(ConnectionStatus status, string? errorMessage = null)

--- a/src/Common/Sorcha.ServiceClients.Http/Hub/HubConnectionWithFallback.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Hub/HubConnectionWithFallback.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AspNetCore.SignalR.Client;
 
-namespace Sorcha.ServiceDefaults.Hubs;
+namespace Sorcha.ServiceClients.Http.Hub;
 
 /// <summary>
 /// Wraps a <see cref="HubConnection" /> and exposes a connection-state

--- a/tests/Sorcha.ServiceDefaults.Tests/Hubs/HubConnectionWithFallbackTests.cs
+++ b/tests/Sorcha.ServiceDefaults.Tests/Hubs/HubConnectionWithFallbackTests.cs
@@ -3,7 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.AspNetCore.SignalR.Client;
-using Sorcha.ServiceDefaults.Hubs;
+using Sorcha.ServiceClients.Http.Hub;
 using Xunit;
 
 namespace Sorcha.ServiceDefaults.Tests.Hubs;

--- a/tests/Sorcha.ServiceDefaults.Tests/Sorcha.ServiceDefaults.Tests.csproj
+++ b/tests/Sorcha.ServiceDefaults.Tests/Sorcha.ServiceDefaults.Tests.csproj
@@ -39,6 +39,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Common\Sorcha.ServiceDefaults\Sorcha.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Closes T103 — REST polling fallback for the inbox connection. Engages after 90s of failed reconnect. Refresher calls \`IInboxApiService.GetUnreadCountAsync\` and raises \`OnInboxUnreadCountUpdated\` so the bell badge stays accurate when the WebSocket can't recover.

## Implementation

- \`TenantHubConnection\` accepts an optional \`IInboxApiService\`; when present it wires a \`HubConnectionWithFallback\` wrapper around the inner \`HubConnection\` with a polling delegate.
- DI registration in \`AddTenantHubServices\` resolves \`IInboxApiService\` and passes it through.

## Refactor

\`HubConnectionWithFallback\` moved from \`Sorcha.ServiceDefaults.Hubs\` to \`Sorcha.ServiceClients.Http.Hub\`. UI client projects (Sorcha.UI.Core, Sorcha.Citizen.Wallet, etc.) need this type but referencing \`Sorcha.ServiceDefaults\` would pull in heavy server-only dependencies (Aspire / OpenTelemetry / Serilog / JwtBearer). The new home sits next to \`SorchaHubConnectionBuilder\`.

\`Sorcha.ServiceDefaults.Tests\` gains a project ref to \`Sorcha.ServiceClients.Http\` so the existing 5 wrapper tests continue to cover the relocated type.

## Follow-up

T101 / T102 / T104 (Wallet / Blueprint / Register polling fallback) follow the same pattern in subsequent PRs.

## Test plan

- [x] \`dotnet build\` clean
- [x] \`Sorcha.ServiceDefaults.Tests\` 143/143 pass (includes 5 \`HubConnectionWithFallback\` tests at the new namespace)
- [x] \`Sorcha.UI.Core.Tests\` 1182/1182 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)