### PR TITLE
test(118): RegisterHub authorize-cutover skipped test (T080)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -172,7 +172,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 
 - [X] T078 [P] [US4] Reflection-based contract test `tests/Sorcha.ServiceDefaults.Tests/Hubs/ThinSignalContractTests.cs` enumerating every method on every `I*HubClient` interface and asserting parameter types are in the allow-list (`string`, `Guid`, `Guid?`, `int`, `long`, `DateTimeOffset`). ChatHub interface excluded explicitly.
 - [ ] T079 [P] [US4] Backplane-observation integration test in `tests/Sorcha.Integration.Tests/Hubs/BackplanePayloadShapeTests.cs` — runs the four notification hubs, triggers one of every event type, subscribes to Redis backplane, asserts every JSON message body conforms to `contracts/hub-signal.schema.json`.
-- [ ] T080 [P] [US4] RegisterHub auth cutover test `tests/Sorcha.Register.Service.Tests/RegisterHubAuthorizeTests.cs` asserting unauthenticated connections are rejected with 401 (initially `[Fact(Skip="awaiting cutover")]`, un-skipped in the second-release task).
+- [X] T080 [P] [US4] RegisterHub auth cutover test `tests/Sorcha.Register.Service.Tests/RegisterHubAuthorizeTests.cs` asserting unauthenticated connections are rejected with 401 (initially `[Fact(Skip="awaiting cutover")]`, un-skipped in the second-release task).
 
 ### Implementation for User Story 4
 

--- a/tests/Sorcha.Register.Service.Tests/RegisterHubAuthorizeTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/RegisterHubAuthorizeTests.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests;
+
+/// <summary>
+/// Feature 118 T080 — guards the RegisterHub <c>[Authorize]</c> cutover.
+/// Once T091 lands, unauthenticated SignalR negotiate against
+/// <c>/hubs/register</c> must be rejected with HTTP 401.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Currently <c>[Fact(Skip = "awaiting cutover")]</c> per the spec — the
+/// hub remains permissive while the <c>sorcha_signalr_connections_total{authenticated=...}</c>
+/// counter (T090) tracks rollout. Un-skip in T091 alongside adding
+/// <c>[Authorize]</c> to <c>RegisterHub</c> and removing the permissive
+/// code path.
+/// </para>
+/// <para>
+/// The matching counter, the existing test
+/// <c>RegisterHubAuthCounterTests</c>, and the UI's token-passing change
+/// (T089 / PR #543) are all already in tree — this scaffolding is the
+/// last piece to flip the auth invariant.
+/// </para>
+/// </remarks>
+public class RegisterHubAuthorizeTests
+{
+    [Fact(Skip = "awaiting cutover (T091 / second-release)")]
+    public async Task UnauthenticatedConnection_IsRejectedWith401()
+    {
+        // Arrange — connect without an access token.
+        var connection = new HubConnectionBuilder()
+            .WithUrl("http://localhost/hubs/register")
+            .Build();
+
+        // Act
+        var act = async () => await connection.StartAsync();
+
+        // Assert — SignalR negotiate returns 401 once [Authorize] is in place.
+        var ex = await act.Should().ThrowAsync<Exception>();
+        ex.Which.Message.Should().Contain("401");
+    }
+}


### PR DESCRIPTION
Closes T080. `[Fact(Skip = "awaiting cutover")]` scaffolding asserting unauthenticated /hubs/register negotiate returns 401 — un-skips at T091. Same pattern as T034 (EventsHub retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)