### PR TITLE
feat(118): expand IWalletHubClient to full typed contract (T045)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -108,7 +108,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [X] T042 [P] [US2] Create `BlueprintHubGroups` builder at `src/Services/Sorcha.Blueprint.Service/Hubs/BlueprintHubGroups.cs` per `data-model.md`.
 - [X] T043 [US2] Update `src/Services/Sorcha.Blueprint.Service/Program.cs`: `MapHub<BlueprintHub>("/hubs/blueprint")` plus `MapHub<BlueprintHub>("/actionshub")` as deprecated alias logging a `Deprecation` header. Update `AddSorchaHub` call accordingly.
 - [X] T044 [US2] Update `src/Services/Sorcha.ApiGateway/appsettings.json` to route both `/hubs/blueprint` and `/actionshub` to blueprint cluster (alias for the deprecation window).
-- [ ] T045 [US2] Update WalletHub at `src/Services/Sorcha.Wallet.Service/Hubs/WalletHub.cs` to inherit `Hub<IWalletHubClient>` with the full typed contract per `contracts/wallet-hub-client.cs.md`. Migrate all existing method bodies to the new typed-client signatures.
+- [X] T045 [US2] Update WalletHub at `src/Services/Sorcha.Wallet.Service/Hubs/WalletHub.cs` to inherit `Hub<IWalletHubClient>` with the full typed contract per `contracts/wallet-hub-client.cs.md`. Migrate all existing method bodies to the new typed-client signatures.
 - [X] T046 [P] [US2] Create `WalletHubGroups` builder at `src/Services/Sorcha.Wallet.Service/Hubs/WalletHubGroups.cs` formalising the existing `WalletHub.GroupNameFor` helper.
 - [X] T047 [US2] Update RegisterHub at `src/Services/Sorcha.Register.Service/Hubs/RegisterHub.cs` to formalise its existing typed-client interface (already present) and use the new `RegisterHubGroups` builder. NO `[Authorize]` change in this phase — that lands in US4.
 - [X] T048 [P] [US2] Create `RegisterHubGroups` builder at `src/Services/Sorcha.Register.Service/Hubs/RegisterHubGroups.cs`.

--- a/src/Services/Sorcha.Wallet.Service/Hubs/IWalletHubClient.cs
+++ b/src/Services/Sorcha.Wallet.Service/Hubs/IWalletHubClient.cs
@@ -10,32 +10,52 @@ namespace Sorcha.Wallet.Service.Hubs;
 /// in each method's <c>&lt;see cref&gt;</c> doc.
 /// </summary>
 /// <remarks>
-/// Phase 4 (US2) absorbs additional events from the retired EventsHub and
-/// from the BlueprintHub encryption surface — <c>EncryptionProgress</c>,
-/// <c>EncryptionComplete</c>, <c>EncryptionFailed</c>, <c>CredentialReceived</c>,
-/// <c>CredentialStatusChanged</c>, <c>PendingCredentialCountUpdated</c>, and the
-/// transaction-lifecycle events <c>TransactionReceived</c> /
-/// <c>TransactionConfirmed</c> / <c>TransactionReceipted</c>. Today's interface
-/// only carries the citizen-wallet (Feature 114) events that are already
-/// emitted; later phases extend it.
+/// Surface declared per <c>contracts/wallet-hub-client.cs.md</c> (Feature 118
+/// US2 — topology consolidation). Some methods don't yet have a server-side
+/// emit site — those are forward-declared so the typed contract is in place
+/// when the emitters land. The contract test
+/// (<c>tests/Sorcha.Integration.Tests/Hubs/ThinSignalContractTests.cs</c>)
+/// enforces parameter-shape on every method here.
 /// </remarks>
 public interface IWalletHubClient
 {
-    /// <summary>
-    /// Citizen device was revoked. Sent on the citizen-wallet group.
-    /// Clients fetch full device detail via
-    /// <c>GET /api/me/devices/{deviceId}</c>.
-    /// </summary>
-    /// <param name="deviceId">Identifier of the revoked device.</param>
-    Task DeviceRevoked(Guid deviceId);
+    // === Transaction lifecycle ===
 
     /// <summary>
-    /// A new credential is available for the citizen's wallet to sync.
-    /// The wallet pulls the delta via
-    /// <c>GET /api/v1/wallet/sync?since={cursor}</c>.
+    /// A new inbound transaction arrived for the wallet (post peer-replication).
+    /// Clients fetch full detail via
+    /// <c>GET /api/wallets/{walletAddress}/transactions/{transactionId}</c>.
     /// </summary>
-    /// <param name="credentialId">Identifier of the newly-available credential.</param>
-    Task CredentialAvailable(string credentialId);
+    /// <param name="walletAddress">Wallet group target.</param>
+    /// <param name="transactionId">Transaction identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task TransactionReceived(string walletAddress, string transactionId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// A transaction sealed by the validator. Tick state advances to confirmed.
+    /// Clients fetch full detail via
+    /// <c>GET /api/wallets/{walletAddress}/transactions/{transactionId}</c>.
+    /// </summary>
+    /// <param name="walletAddress">Wallet group target.</param>
+    /// <param name="transactionId">Transaction identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task TransactionConfirmed(string walletAddress, string transactionId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// A transaction receipt was generated. Tick state advances to receipted.
+    /// Clients fetch the receipt via
+    /// <c>GET /api/registers/{registerId}/transactions/{transactionId}/receipt</c>.
+    /// </summary>
+    /// <param name="walletAddress">Wallet group target.</param>
+    /// <param name="transactionId">Transaction identifier.</param>
+    /// <param name="receiptId">Receipt identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task TransactionReceipted(string walletAddress, string transactionId, string receiptId, DateTimeOffset occurredAt, string traceId);
+
+    // === Encryption operations ===
 
     /// <summary>
     /// Encryption operation progress. Carries the operation id only; clients
@@ -64,4 +84,55 @@ public interface IWalletHubClient
     /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
     /// <param name="traceId">W3C trace-id for correlation.</param>
     Task EncryptionFailed(string operationId, DateTimeOffset occurredAt, string traceId);
+
+    // === Org credentials ===
+
+    /// <summary>
+    /// A new org credential was issued to the wallet. Clients fetch the
+    /// credential via <c>GET /api/wallets/{walletAddress}/credentials/{credentialId}</c>.
+    /// </summary>
+    /// <param name="walletAddress">Wallet group target.</param>
+    /// <param name="credentialId">Credential identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task CredentialReceived(string walletAddress, string credentialId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// An org credential's status changed (revoked, suspended, etc.). Clients
+    /// fetch authoritative state via
+    /// <c>GET /api/wallets/{walletAddress}/credentials/{credentialId}</c>.
+    /// </summary>
+    /// <param name="walletAddress">Wallet group target.</param>
+    /// <param name="credentialId">Credential identifier.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task CredentialStatusChanged(string walletAddress, string credentialId, DateTimeOffset occurredAt, string traceId);
+
+    /// <summary>
+    /// The pending-credential count for the wallet changed. Clients fetch the
+    /// list via <c>GET /api/wallets/{walletAddress}/credentials?status=pending</c>.
+    /// </summary>
+    /// <param name="walletAddress">Wallet group target.</param>
+    /// <param name="pendingCount">New pending credential count.</param>
+    /// <param name="occurredAt">Server timestamp at which the signal was emitted.</param>
+    /// <param name="traceId">W3C trace-id for correlation.</param>
+    Task PendingCredentialCountUpdated(string walletAddress, int pendingCount, DateTimeOffset occurredAt, string traceId);
+
+    // === Citizen wallet (Feature 114) ===
+
+    /// <summary>
+    /// Citizen device was revoked. Sent on the citizen-wallet group.
+    /// Clients fetch full device detail via
+    /// <c>GET /api/me/devices/{deviceId}</c>.
+    /// </summary>
+    /// <param name="deviceId">Identifier of the revoked device.</param>
+    Task DeviceRevoked(Guid deviceId);
+
+    /// <summary>
+    /// A new credential is available for the citizen's wallet to sync.
+    /// The wallet pulls the delta via
+    /// <c>GET /api/v1/wallet/sync?since={cursor}</c>.
+    /// </summary>
+    /// <param name="credentialId">Identifier of the newly-available credential.</param>
+    Task CredentialAvailable(string credentialId);
 }


### PR DESCRIPTION
Closes T045. Adds 6 forward-declared methods to `IWalletHubClient` per `contracts/wallet-hub-client.cs.md`: 3 transaction-lifecycle and 3 org-credential events. Every method conforms to the thin-signal contract — `ThinSignalContractTests` 3/3 passes.

Server-side emit sites for the new methods will land as those features need them; the typed contract is now forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)