### PR TITLE
feat(118): page injects to WalletHubConnection (T110+T111)

### DIFF
--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -261,8 +261,8 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 ### UI rewires (mechanical)
 
 - [X] T109 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor` to inject `BlueprintHubConnection` instead of `ActionsHubConnection`. Subscribe to `OnActionAvailable` / `OnActionRejected` / `OnWorkflowCompleted`.
-- [ ] T110 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor` to inject `WalletHubConnection`. Subscribe to `OnCredentialReceived` / `OnCredentialStatusChanged`.
-- [ ] T111 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor` from `RegisterHubConnection.OnTransactionReceipted` to `WalletHubConnection.OnTransactionReceipted`.
+- [X] T110 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor` to inject `WalletHubConnection`. Subscribe to `OnCredentialReceived` / `OnCredentialStatusChanged`.
+- [X] T111 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor` from `RegisterHubConnection.OnTransactionReceipted` to `WalletHubConnection.OnTransactionReceipted`.
 - [X] T112 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/EncryptionOperationTracker.cs` to inject `WalletHubConnection`.
 - [X] T113 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/EncryptionProgressIndicator.razor` to wire `WalletHubConnection`.
 - [X] T114 [P] Migrate `src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor` to wire `WalletHubConnection`.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WalletHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Services/WalletHubConnection.cs
@@ -60,6 +60,42 @@ public class WalletHubConnection : IAsyncDisposable
     /// <summary>Encryption operation failed. Detail via <c>GET /api/operations/{operationId}</c>.</summary>
     public event Func<EncryptionSignal, Task>? OnEncryptionFailed;
 
+    /// <summary>
+    /// A new inbound transaction arrived for the wallet (post peer-replication).
+    /// Parameters: walletAddress, transactionId. Detail via
+    /// <c>GET /api/wallets/{walletAddress}/transactions/{transactionId}</c>.
+    /// </summary>
+    public event Action<string, string>? OnTransactionReceived;
+
+    /// <summary>
+    /// A transaction sealed by the validator. Tick state advances to confirmed.
+    /// Parameters: walletAddress, transactionId.
+    /// </summary>
+    public event Action<string, string>? OnTransactionConfirmed;
+
+    /// <summary>
+    /// A transaction receipt was generated. Tick state advances to receipted.
+    /// Parameters: walletAddress, transactionId, receiptId.
+    /// </summary>
+    public event Action<string, string, string>? OnTransactionReceipted;
+
+    /// <summary>
+    /// A new org credential was issued to the wallet. Parameters: walletAddress, credentialId.
+    /// Detail via <c>GET /api/wallets/{walletAddress}/credentials/{credentialId}</c>.
+    /// </summary>
+    public event Action<string, string>? OnCredentialReceived;
+
+    /// <summary>
+    /// An org credential's status changed. Parameters: walletAddress, credentialId.
+    /// </summary>
+    public event Action<string, string>? OnCredentialStatusChanged;
+
+    /// <summary>
+    /// The pending-credential count for the wallet changed. Parameters:
+    /// walletAddress, pendingCount.
+    /// </summary>
+    public event Action<string, int>? OnPendingCredentialCountUpdated;
+
     /// <summary>Connection state changed.</summary>
     public event Action<ConnectionState>? OnConnectionStateChanged;
 
@@ -248,6 +284,53 @@ public class WalletHubConnection : IAsyncDisposable
                         Timestamp = occurredAt,
                     });
                 }
+            });
+
+        // Feature 118 — transaction lifecycle events forward-declared on
+        // IWalletHubClient (T045). No active server emit yet; handlers are
+        // wired so consumer pages don't need a follow-up subscribe.
+        _hubConnection.On<string, string, DateTimeOffset, string>("TransactionReceived",
+            (walletAddress, transactionId, _, _) =>
+            {
+                _logger.LogDebug("WalletHub TransactionReceived: {Wallet}/{Tx}", walletAddress, transactionId);
+                OnTransactionReceived?.Invoke(walletAddress, transactionId);
+            });
+
+        _hubConnection.On<string, string, DateTimeOffset, string>("TransactionConfirmed",
+            (walletAddress, transactionId, _, _) =>
+            {
+                _logger.LogDebug("WalletHub TransactionConfirmed: {Wallet}/{Tx}", walletAddress, transactionId);
+                OnTransactionConfirmed?.Invoke(walletAddress, transactionId);
+            });
+
+        _hubConnection.On<string, string, string, DateTimeOffset, string>("TransactionReceipted",
+            (walletAddress, transactionId, receiptId, _, _) =>
+            {
+                _logger.LogDebug("WalletHub TransactionReceipted: {Wallet}/{Tx}/{Receipt}",
+                    walletAddress, transactionId, receiptId);
+                OnTransactionReceipted?.Invoke(walletAddress, transactionId, receiptId);
+            });
+
+        _hubConnection.On<string, string, DateTimeOffset, string>("CredentialReceived",
+            (walletAddress, credentialId, _, _) =>
+            {
+                _logger.LogDebug("WalletHub CredentialReceived: {Wallet}/{Cred}", walletAddress, credentialId);
+                OnCredentialReceived?.Invoke(walletAddress, credentialId);
+            });
+
+        _hubConnection.On<string, string, DateTimeOffset, string>("CredentialStatusChanged",
+            (walletAddress, credentialId, _, _) =>
+            {
+                _logger.LogDebug("WalletHub CredentialStatusChanged: {Wallet}/{Cred}", walletAddress, credentialId);
+                OnCredentialStatusChanged?.Invoke(walletAddress, credentialId);
+            });
+
+        _hubConnection.On<string, int, DateTimeOffset, string>("PendingCredentialCountUpdated",
+            (walletAddress, pendingCount, _, _) =>
+            {
+                _logger.LogDebug("WalletHub PendingCredentialCountUpdated: {Wallet} count={Count}",
+                    walletAddress, pendingCount);
+                OnPendingCredentialCountUpdated?.Invoke(walletAddress, pendingCount);
             });
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
@@ -20,7 +20,7 @@
 @inject IWorkflowService WorkflowService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
-@inject BlueprintHubConnection BlueprintHub
+@inject WalletHubConnection WalletHub
 @implements IDisposable
 
 <PageTitle>My Credentials - Sorcha Platform</PageTitle>
@@ -201,8 +201,10 @@
 
     protected override async Task OnInitializedAsync()
     {
-        BlueprintHub.OnCredentialReceived += OnCredentialNotification;
-        BlueprintHub.OnCredentialStatusChanged += OnCredentialStatusNotification;
+        // Feature 118 T110 — credential events live on WalletHub.
+        WalletHub.OnCredentialReceived += OnWalletCredentialEvent;
+        WalletHub.OnCredentialStatusChanged += OnWalletCredentialEvent;
+        try { await WalletHub.StartAsync(); } catch { /* hub may be unavailable; auto-reconnect handles it */ }
         await LoadWalletsAsync();
     }
 
@@ -476,16 +478,7 @@
         return "expiring soon";
     }
 
-    private void OnCredentialNotification(CredentialNotification notification)
-    {
-        InvokeAsync(async () =>
-        {
-            await LoadAllAsync();
-            StateHasChanged();
-        });
-    }
-
-    private void OnCredentialStatusNotification(CredentialNotification notification)
+    private void OnWalletCredentialEvent(string walletAddress, string credentialId)
     {
         InvokeAsync(async () =>
         {
@@ -496,7 +489,7 @@
 
     public void Dispose()
     {
-        BlueprintHub.OnCredentialReceived -= OnCredentialNotification;
-        BlueprintHub.OnCredentialStatusChanged -= OnCredentialStatusNotification;
+        WalletHub.OnCredentialReceived -= OnWalletCredentialEvent;
+        WalletHub.OnCredentialStatusChanged -= OnWalletCredentialEvent;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
@@ -6,7 +6,7 @@
 @implements IAsyncDisposable
 @inject IWalletApiService WalletService
 @inject ITransactionService TransactionService
-@inject RegisterHubConnection HubConnection
+@inject WalletHubConnection HubConnection
 @inject NavigationManager Navigation
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
@@ -784,9 +784,14 @@
     }
 
     /// <summary>
-    /// Handles real-time receipt notifications via SignalR and updates the transaction list.
+    /// Handles real-time receipt notifications via SignalR and updates the
+    /// transaction list. Feature 118 T111 — switched from RegisterHub to
+    /// WalletHub; the thin signal carries (walletAddress, transactionId,
+    /// receiptId) only. The receipted-at timestamp is set from local UTC
+    /// since the event fired in real time; consumers needing authoritative
+    /// docket/sealing detail call the receipt endpoint directly.
     /// </summary>
-    private async Task HandleTransactionReceipted(string txId, string registerId, long docketNumber, string receiptId, DateTimeOffset sealedAt)
+    private void HandleTransactionReceipted(string walletAddress, string txId, string receiptId)
     {
         var match = transactions.FirstOrDefault(t => t.Transaction.TxId == txId);
         if (match is not null)
@@ -795,11 +800,11 @@
             var updatedTx = match.Transaction with
             {
                 ReceiptId = receiptId,
-                ReceiptedAt = sealedAt.UtcDateTime,
+                ReceiptedAt = DateTime.UtcNow,
                 State = "Receipted"
             };
             transactions[index] = match with { Transaction = updatedTx };
-            await InvokeAsync(StateHasChanged);
+            InvokeAsync(StateHasChanged);
         }
     }
 


### PR DESCRIPTION
Closes T110 and T111. MyCredentials and WalletDetail now inject WalletHubConnection — the canonical wallet-domain hub. WalletHubConnection extended with the six forward-declared transaction + org-credential events matching IWalletHubClient (T045). Server emit sites land as features need them; UI is forward-compatible. `Sorcha.UI.Core.Tests` 1182/1182 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)