### PR TITLE
test(118): cross-replica TenantHub fan-out test (T060)

### DIFF
--- a/docker-compose.multinode.yml
+++ b/docker-compose.multinode.yml
@@ -11,10 +11,10 @@
 # triggered on replica A reaches the client connected to replica B within 200ms p95
 # (Feature 118 spec NFR-001).
 #
-# Tenant Service multi-replica fixture lands in Phase 4 (US2) when TenantHub is
-# created. Wallet/Register multi-replica fixtures lined up but not exercised in
-# this overlay — they share the same backplane keyspace and are covered by the
-# parameterised cross-replica test once they have their own multinode definitions.
+# Tenant Service multi-replica fixture added in T060 — TenantHub cross-replica
+# delivery uses the same backplane keyspace as Blueprint and is exercised by the
+# same parameterised test class. Wallet/Register multi-replica fixtures lined up
+# but not yet defined here.
 #
 # Referenced by:
 #   - tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
@@ -57,14 +57,60 @@ services:
     networks:
       - sorcha-network
 
-  # ---- API Gateway with sticky-session affinity for Blueprint cluster ----
-  # YARP routes /actionshub /hubs/events /hubs/chat to blueprint-cluster which
-  # now has two destinations. The session-affinity cookie pins each connection
-  # to one replica for the duration of the SignalR session — required because
-  # SignalR negotiate/connect spans multiple HTTP requests.
+  # ---- Replica 1 of Tenant Service ----
+  tenant-service:
+    container_name: sorcha-tenant-service-1
+    environment:
+      OTEL_SERVICE_NAME: tenant-service-1
+      Hub__ReplicaId: tenant-1
+
+  # ---- Replica 2 of Tenant Service ----
+  tenant-service-2:
+    build:
+      context: .
+      dockerfile: src/Services/Sorcha.Tenant.Service/Dockerfile
+    image: sorchadev/tenant-service:latest
+    container_name: sorcha-tenant-service-2
+    restart: unless-stopped
+    mem_limit: 1g
+    environment:
+      ConnectionStrings__Sorcha__Postgres: Host=postgres;Username=sorcha;Password=sorcha_dev_password
+      ConnectionStrings__Sorcha__Mongo: mongodb://sorcha:sorcha_dev_password@mongodb:27017
+      ConnectionStrings__Sorcha__Redis: redis:6379
+      ConnectionStrings__redis: redis:6379
+      ConnectionStrings__mongodb: mongodb://sorcha:sorcha_dev_password@mongodb:27017
+      OTEL_SERVICE_NAME: tenant-service-2
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      Hub__ReplicaId: tenant-2
+      # JWT signing key + installation name MUST match tenant-service-1 so
+      # tokens issued by either replica validate on both.
+      JwtSettings__SigningKeySource: Configuration
+      JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}
+      JwtSettings__SigningKey: ${JWT_SIGNING_KEY:-c29yY2hhLWRvY2tlci1kZXYta2V5LTIwMjUtbWluLTI1Ni1iaXRzLXNlY3VyZQ==}
+      ServiceAuth__ClientId: tenant-service
+      ServiceAuth__ClientSecret: tenant-service-secret
+      ServiceAuth__Scopes: "wallets:sign wallets:verify persona:crypto"
+      ServiceClients__WalletService__Address: http://wallet-service:8080
+    depends_on:
+      - postgres
+      - mongodb
+      - redis
+    networks:
+      - sorcha-network
+
+  # ---- API Gateway with sticky-session affinity for Blueprint + Tenant clusters ----
+  # YARP routes /actionshub /hubs/events /hubs/chat to blueprint-cluster and
+  # /hubs/tenant to tenant-cluster, each with two destinations and a sticky
+  # affinity cookie pinning each SignalR connection to one replica for the
+  # duration of the session.
   api-gateway:
     environment:
       ReverseProxy__Clusters__blueprint-cluster__SessionAffinity__Enabled: "true"
       ReverseProxy__Clusters__blueprint-cluster__SessionAffinity__Policy: Cookie
       ReverseProxy__Clusters__blueprint-cluster__SessionAffinity__AffinityKeyName: ".Sorcha.Affinity.Blueprint"
       ReverseProxy__Clusters__blueprint-cluster__Destinations__blueprint-2__Address: http://blueprint-service-2:8080
+      ReverseProxy__Clusters__tenant-cluster__SessionAffinity__Enabled: "true"
+      ReverseProxy__Clusters__tenant-cluster__SessionAffinity__Policy: Cookie
+      ReverseProxy__Clusters__tenant-cluster__SessionAffinity__AffinityKeyName: ".Sorcha.Affinity.Tenant"
+      ReverseProxy__Clusters__tenant-cluster__Destinations__tenant-2__Address: http://tenant-service-2:8080

--- a/specs/118-notifications-architecture/tasks.md
+++ b/specs/118-notifications-architecture/tasks.md
@@ -136,7 +136,7 @@ Existing multi-service Sorcha monorepo. Source under `src/`, tests under `tests/
 - [X] T057 [P] [US3] Endpoint integration tests in `tests/Sorcha.Tenant.Service.Tests/Endpoints/MeInboxEndpointsTests.cs` covering all six public endpoints, authorization scoping, idempotency.
 - [X] T058 [P] [US3] Internal endpoint test in `tests/Sorcha.Tenant.Service.Tests/Endpoints/InternalInboxEndpointsTests.cs` covering RequireService policy gate, idempotent write on `(PlatformUserId, SourceEventId)`, validation errors.
 - [X] T059 [P] [US3] TenantHub event-emission tests in `tests/Sorcha.Tenant.Service.Tests/Hubs/TenantHubInboxEventsTests.cs` asserting `InboxEntryAdded` and `InboxUnreadCountUpdated` fire on the user group with correct thin-signal shape.
-- [ ] T060 [P] [US3] Cross-replica multi-node test for TenantHub in `tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs` (un-skip the TenantHub case from T017).
+- [X] T060 [P] [US3] Cross-replica multi-node test for TenantHub in `tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs` (un-skip the TenantHub case from T017).
 - [X] T061 [P] [US3] Quickstart end-to-end script `tests/Sorcha.Integration.Tests/Quickstart/InboxRoundTripTests.cs` matching steps 4 and 6 in `quickstart.md` (post entry → realtime fire → REST read → mark read → idempotent re-post).
 
 ### Implementation for User Story 3

--- a/tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
+++ b/tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.SignalR.Client;
 using Xunit;
@@ -80,10 +81,110 @@ public class HubBackplaneCrossReplicaTests
         }
     }
 
-    [Fact(Skip = "TenantHub does not yet exist — created in Phase 4 (US2). This case is parameterised here so the test fixture is ready when TenantHub lands.")]
+    [SkippableFact]
     [Trait("Hub", "Tenant")]
-    public Task TenantHub_EventOnReplicaA_ReachesClientOnReplicaB_WithinBudget() =>
-        Task.CompletedTask;
+    public async Task TenantHub_EventOnReplicaA_ReachesClientOnReplicaB_WithinBudget()
+    {
+        Skip.IfNot(MultinodeEnabled, "Multi-node fixture not running. Set SORCHA_MULTINODE=1 and start docker-compose.multinode.yml.");
+
+        // 1. Acquire admin user token. TenantHub auto-joins user:{platform_user_id}
+        //    on connect; same JWT on both replicas → both pinned to the same
+        //    backplane group, so a write on either replica should fan out to both.
+        using var http = new HttpClient { BaseAddress = new Uri(GatewayUrl) };
+        var userToken = await GetAdminUserTokenAsync(http);
+        var serviceToken = await GetServiceTokenAsync(http);
+
+        var clientOnReplica1 = await ConnectTenantAsync(userToken, affinityCookie: "tenant-1");
+        var clientOnReplica2 = await ConnectTenantAsync(userToken, affinityCookie: "tenant-2");
+
+        try
+        {
+            var receivedOn1 = new TaskCompletionSource<DateTimeOffset>();
+            var receivedOn2 = new TaskCompletionSource<DateTimeOffset>();
+
+            clientOnReplica1.On<string, DateTimeOffset, string>("InboxEntryAdded",
+                (_, _, _) => receivedOn1.TrySetResult(DateTimeOffset.UtcNow));
+            clientOnReplica2.On<string, DateTimeOffset, string>("InboxEntryAdded",
+                (_, _, _) => receivedOn2.TrySetResult(DateTimeOffset.UtcNow));
+
+            // Trigger via the internal write endpoint. The host port mapping varies
+            // between the base compose and the multinode overlay; the write reaches
+            // whichever replica YARP routes the POST to. Backplane fan-out should
+            // reach both subscribers.
+            var sentAt = DateTimeOffset.UtcNow;
+            await TriggerInboxWriteAsync(serviceToken);
+
+            await Task.WhenAll(
+                receivedOn1.Task.WaitAsync(TimeSpan.FromSeconds(5)),
+                receivedOn2.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            (receivedOn1.Task.Result - sentAt).Should().BeLessThan(FanOutBudget);
+            (receivedOn2.Task.Result - sentAt).Should().BeLessThan(FanOutBudget);
+        }
+        finally
+        {
+            await clientOnReplica1.DisposeAsync();
+            await clientOnReplica2.DisposeAsync();
+        }
+    }
+
+    private static async Task<HubConnection> ConnectTenantAsync(string accessToken, string affinityCookie)
+    {
+        var connection = new HubConnectionBuilder()
+            .WithUrl(GatewayUrl + $"/hubs/tenant?access_token={accessToken}", options =>
+            {
+                options.Cookies.Add(new System.Net.Cookie(".Sorcha.Affinity.Tenant", affinityCookie, "/", "localhost"));
+            })
+            .Build();
+        await connection.StartAsync();
+        return connection;
+    }
+
+    private static async Task<string> GetAdminUserTokenAsync(HttpClient http)
+    {
+        var resp = await http.PostAsJsonAsync("/api/auth/login",
+            new { email = "admin@sorcha.local", password = "Dev_Pass_2025!" });
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        return body.GetProperty("access_token").GetString()!;
+    }
+
+    private static async Task<string> GetServiceTokenAsync(HttpClient http)
+    {
+        var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "client_credentials"),
+            new KeyValuePair<string, string>("client_id", "service-blueprint"),
+            new KeyValuePair<string, string>("client_secret", "blueprint-service-secret"),
+        });
+        var resp = await http.PostAsync("/api/service-auth/token", form);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<System.Text.Json.JsonElement>();
+        return body.GetProperty("access_token").GetString()!;
+    }
+
+    private static async Task TriggerInboxWriteAsync(string serviceToken)
+    {
+        // Internal endpoint is service-to-service only — the multinode overlay
+        // exposes both replicas via the host-mapped tenant ports (5450 → tenant-1,
+        // dynamic for tenant-2). Reach replica-1 directly; the backplane handles
+        // fan-out across replicas.
+        using var http = new HttpClient { BaseAddress = new Uri("http://localhost:5450") };
+        http.DefaultRequestHeaders.Add("Authorization", $"Bearer {serviceToken}");
+        var sourceEventId = Guid.NewGuid();
+        var resp = await http.PostAsJsonAsync("/api/internal/inbox", new
+        {
+            platformUserId = Guid.Parse("00000000-0000-0001-0000-000000000001"),
+            category = "Action",
+            severity = "Info",
+            correlationKey = $"multinode:tenant:{sourceEventId:N}",
+            detailHref = "/api/me/inbox",
+            sourceEventId,
+            occurredAt = DateTimeOffset.UtcNow,
+            title = "Multinode TenantHub fan-out test",
+        });
+        resp.EnsureSuccessStatusCode();
+    }
 
     [Fact(Skip = "WalletHub multinode overlay not populated yet — Phase 3 follow-up.")]
     [Trait("Hub", "Wallet")]


### PR DESCRIPTION
Closes T060. Un-skips the parameterised TenantHub case from T017 plus the docker-compose overlay additions needed to host two TenantHub replicas.

## Overlay additions (\`docker-compose.multinode.yml\`)

- \`tenant-service\` renamed to \`sorcha-tenant-service-1\` (\`Hub__ReplicaId=tenant-1\`)
- New \`tenant-service-2\` replica (same image, different env + container name)
- API Gateway gains \`tenant-cluster\` sticky-session affinity (\`.Sorcha.Affinity.Tenant\` cookie + \`tenant-2\` destination)

## Test body

- Acquires admin user JWT + \`service-blueprint\` service-principal JWT
- Connects two SignalR clients to \`/hubs/tenant\` pinned to \`tenant-1\` and \`tenant-2\` via the affinity cookie
- Both auto-join \`user:{platform_user_id}\` on connect (TenantHub group)
- POSTs an inbox entry via \`/api/internal/inbox\` (host port 5450 → tenant-1)
- Asserts both clients receive \`InboxEntryAdded\` within \`FanOutBudget\` (200ms p95 per NFR-001)

## Gating

\`SORCHA_MULTINODE=1\` — same pattern as the existing Blueprint case. The \`multinode-correctness\` CI workflow remains manual-trigger pending the pre-existing YARP destinations-override fix documented in \`MIGRATION.md\`.

## Test plan

- [x] \`dotnet build\` clean
- [ ] Local multinode run deferred — would tear down the user's working single-node stack mid-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)