### PR TITLE
feat(114): [US4 PR2] server-side citizen credential projection

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Services/ISyncService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/ISyncService.cs
@@ -184,7 +184,7 @@ public sealed class SyncService : ISyncService
         {
             await _cache.UpsertAsync(new CachedCredential
             {
-                Id = replaced.NewId,
+                Id = StringToCacheGuid(replaced.NewId),
                 Vct = string.Empty,
                 RawSdJwt = replaced.Jwt,
                 AvailableClaimNames = [],
@@ -197,11 +197,24 @@ public sealed class SyncService : ISyncService
 
     private static CachedCredential ToCachedCredential(CachedCredentialPayload payload) => new()
     {
-        Id = payload.Id,
+        // The cache uses Guid as an opaque local key; the canonical credential id
+        // (urn:credential:...) survives in payload.RawSdJwt + the presentation
+        // engine's verifier round-trip. Boundary mapping is deterministic so the
+        // same urn always lands on the same cache row across syncs.
+        Id = StringToCacheGuid(payload.Id),
         Vct = payload.Vct,
         RawSdJwt = payload.Jwt,
         AvailableClaimNames = [],
         IssuerDid = payload.IssuerDid,
     };
 
+    private static Guid StringToCacheGuid(string credentialId)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(credentialId));
+        // First 16 bytes of SHA-256 form a deterministic, well-distributed Guid.
+        var slice = new byte[16];
+        Array.Copy(bytes, slice, 16);
+        return new Guid(slice);
+    }
 }

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Models/CachedCredentialPayload.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Models/CachedCredentialPayload.cs
@@ -12,8 +12,11 @@ namespace Sorcha.CitizenWallet.Abstractions.Models;
 /// </summary>
 public sealed record CachedCredentialPayload
 {
-    /// <summary>Server-assigned credential identifier.</summary>
-    public Guid Id { get; init; }
+    /// <summary>
+    /// Server-assigned credential identifier. Matches <c>CredentialEntity.Id</c>
+    /// (typically a URN like <c>urn:credential:AssuredIdentityCredential:...</c>).
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
 
     /// <summary>Verifiable Credential Type URI (e.g. Verified Citizen, Assured Identity).</summary>
     public string Vct { get; init; } = string.Empty;

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Models/SyncResponse.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Models/SyncResponse.cs
@@ -23,8 +23,12 @@ public enum CredentialRevocationReason
 /// </summary>
 public sealed record RevokedCredentialEntry
 {
-    /// <summary>Credential identifier the wallet should mark as revoked.</summary>
-    public Guid Id { get; init; }
+    /// <summary>
+    /// Credential identifier the wallet should mark as revoked. Matches
+    /// <c>CredentialEntity.Id</c> (typically a URN like
+    /// <c>urn:credential:AssuredIdentityCredential:...</c>).
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
 
     /// <summary>Revocation reason.</summary>
     public CredentialRevocationReason Reason { get; init; }
@@ -39,11 +43,16 @@ public sealed record RevokedCredentialEntry
 /// </summary>
 public sealed record ReplacedCredentialEntry
 {
-    /// <summary>Identifier of the old (now-superseded) credential.</summary>
-    public Guid OldId { get; init; }
+    /// <summary>
+    /// Identifier of the old (now-superseded) credential. Matches
+    /// <c>CredentialEntity.Id</c>.
+    /// </summary>
+    public string OldId { get; init; } = string.Empty;
 
-    /// <summary>Identifier of the new credential.</summary>
-    public Guid NewId { get; init; }
+    /// <summary>
+    /// Identifier of the new credential. Matches <c>CredentialEntity.Id</c>.
+    /// </summary>
+    public string NewId { get; init; } = string.Empty;
 
     /// <summary>Compact-serialised SD-JWT VC of the new credential.</summary>
     public string Jwt { get; init; } = string.Empty;

--- a/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/CredentialStore.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sorcha.Wallet.Core.Data;
 using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Services.Interfaces;
 
 namespace Sorcha.Wallet.Service.Credentials;
 
@@ -23,11 +24,17 @@ public class CredentialStore : ICredentialStore
     };
 
     private readonly WalletDbContext _db;
+    private readonly ICitizenInboxProjector _citizenProjector;
     private readonly ILogger<CredentialStore> _logger;
 
-    public CredentialStore(WalletDbContext db, ILogger<CredentialStore> logger)
+    /// <summary>Initialises a new instance.</summary>
+    public CredentialStore(
+        WalletDbContext db,
+        ICitizenInboxProjector citizenProjector,
+        ILogger<CredentialStore> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _citizenProjector = citizenProjector ?? throw new ArgumentNullException(nameof(citizenProjector));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -169,6 +176,11 @@ public class CredentialStore : ICredentialStore
         _logger.LogInformation(
             "Credential status changed: {CredentialId} wallet {WalletAddress} {PreviousStatus} -> {NewStatus}",
             credentialId, walletAddress, previousStatus, status);
+
+        // Feature 114 US4 — project status change onto citizen sync surface (no-op
+        // when the recipient is not a citizen-PWA holder).
+        await _citizenProjector.OnCredentialStatusChangedAsync(credential, previousStatus, ct);
+
         return true;
     }
 
@@ -211,6 +223,10 @@ public class CredentialStore : ICredentialStore
         _logger.LogInformation(
             "Credential {CredentialId} status patched: {PreviousStatus} → {NewStatus}",
             credentialId, previousStatus, newStatus);
+
+        // Feature 114 US4 — project status change onto citizen sync surface (no-op
+        // when the recipient is not a citizen-PWA holder).
+        await _citizenProjector.OnCredentialStatusChangedAsync(credential, previousStatus, ct);
 
         return credential;
     }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -276,6 +276,7 @@ public static class CitizenWalletEndpoints
         IDeviceDelegationIssuer issuer,
         IOrgStatusSigningWalletResolver orgWalletResolver,
         IPlatformUserDeviceClient deviceClient,
+        IHolderAddressLookup holderAddressLookup,
         ILogger<Program> logger,
         CancellationToken ct)
     {
@@ -290,6 +291,12 @@ public static class CitizenWalletEndpoints
         {
             return Results.Unauthorized();
         }
+
+        // Feature 114 US4 — pin the citizen holder wallet address ↔ PlatformUserId
+        // mapping the moment both are available together (the citizen's JWT carries
+        // both at enrolment time but neither flows to InboundCredentialDetector).
+        // Idempotent on retry.
+        await holderAddressLookup.RegisterAsync(citizenWallet, platformUserId.Value, ct);
 
         var orgSigningWallet = await orgWalletResolver.ResolveAsync(organizationId.Value, ct);
 

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -153,13 +153,23 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IOrgStatusS
 builder.Services.AddHostedService<
     Sorcha.Wallet.Service.Services.Implementation.CitizenStatusListPublisherService>();
 
-// Feature 114: Citizen wallet sync surface (T103). EmptyCitizenCredentialEventStream is a
-// placeholder until the citizen-credential issuance pipeline lands (US4 / Phase 6); the sync
-// surface, sync-token round-trip, and 410 stale-cursor path are still exercised end-to-end.
-builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Interfaces.ICitizenCredentialEventStream,
-    Sorcha.Wallet.Service.Services.Implementation.EmptyCitizenCredentialEventStream>();
-builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Interfaces.ICitizenSyncService,
+// Feature 114 / US4: Citizen wallet sync surface. Reads the citizen-scoped
+// CitizenCredentialEventLog written by CitizenInboxProjector when an inbound
+// credential lands in CredentialStore against a known citizen holder address.
+// Replaces the v1 EmptyCitizenCredentialEventStream placeholder.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.ICitizenCredentialEventStream,
+    Sorcha.Wallet.Service.Services.Implementation.EfCoreCitizenCredentialEventStream>();
+// Scoped (was Singleton) because it now consumes the Scoped EfCoreCitizenCredentialEventStream.
+// CitizenSyncService is stateless apart from its signing key, so per-request creation is cheap.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.ICitizenSyncService,
     Sorcha.Wallet.Service.Services.Implementation.CitizenSyncService>();
+
+// Feature 114 / US4: Holder-address index + citizen-inbox projector. Both
+// scoped because they consume WalletDbContext.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IHolderAddressLookup,
+    Sorcha.Wallet.Service.Services.Implementation.EfCoreHolderAddressLookup>();
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.ICitizenInboxProjector,
+    Sorcha.Wallet.Service.Services.Implementation.CitizenInboxProjector>();
 
 // Feature 114: Delegation renewal (T106). Composes Tenant Service device lookup
 // + IDeviceDelegationIssuer + IOrgStatusSigningWalletResolver behind one

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenInboxProjector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenInboxProjector.cs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.Wallet.Core.Data;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Hubs;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Default implementation of <see cref="ICitizenInboxProjector"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolves the recipient via <see cref="IHolderAddressLookup"/>; if the wallet
+/// address is not a citizen holder the call returns early without touching the
+/// event log or the hub — the org-credential pipeline is preserved unchanged.
+/// </para>
+/// <para>
+/// <c>Seq</c> is allocated as <c>MAX(Seq) + 1</c> for the citizen and persisted
+/// via the unique <c>(PlatformUserId, Seq)</c> index. Concurrent writes for the
+/// same citizen race on the index — losers retry once. This is cheaper than
+/// holding a SERIALIZABLE transaction and matches the existing pattern in the
+/// rest of the wallet service.
+/// </para>
+/// <para>
+/// Hub emission is best-effort: a SignalR backplane failure is logged but does
+/// not break the upstream credential write. The thin-signal contract means the
+/// wallet always re-syncs via REST on next open, so a missed push is a UX
+/// optimisation regression, not a correctness one.
+/// </para>
+/// </remarks>
+public sealed class CitizenInboxProjector : ICitizenInboxProjector
+{
+    private const int SeqRetryAttempts = 3;
+
+    private readonly WalletDbContext _db;
+    private readonly IHolderAddressLookup _holderLookup;
+    private readonly IHubContext<WalletHub, IWalletHubClient> _hub;
+    private readonly ILogger<CitizenInboxProjector> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public CitizenInboxProjector(
+        WalletDbContext db,
+        IHolderAddressLookup holderLookup,
+        IHubContext<WalletHub, IWalletHubClient> hub,
+        ILogger<CitizenInboxProjector> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _holderLookup = holderLookup ?? throw new ArgumentNullException(nameof(holderLookup));
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task OnCredentialAddedAsync(CredentialEntity credential, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+
+        var platformUserId = await _holderLookup.ResolvePlatformUserIdAsync(credential.WalletAddress, ct);
+        if (platformUserId is null)
+        {
+            // Org wallet, not a citizen holder — pipeline unchanged.
+            return;
+        }
+
+        await AppendEventAsync(platformUserId.Value, CitizenCredentialEventKindValues.Added, credential.Id, ct);
+        await EmitCredentialAvailableAsync(platformUserId.Value, credential.Id, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task OnCredentialStatusChangedAsync(
+        CredentialEntity credential,
+        CredentialStatus previousStatus,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+
+        // Wallet PWA only surfaces "the credential just became unusable" transitions;
+        // intermediate states (Active → Suspended) are not part of the citizen sync
+        // contract today.
+        var newStatus = credential.Status;
+        var isRevoked = newStatus is CredentialStatus.Revoked
+                                  or CredentialStatus.Declined;
+        if (!isRevoked || previousStatus == newStatus)
+        {
+            return;
+        }
+
+        var platformUserId = await _holderLookup.ResolvePlatformUserIdAsync(credential.WalletAddress, ct);
+        if (platformUserId is null)
+        {
+            return;
+        }
+
+        await AppendEventAsync(platformUserId.Value, CitizenCredentialEventKindValues.Revoked, credential.Id, ct);
+        await EmitCredentialAvailableAsync(platformUserId.Value, credential.Id, ct);
+    }
+
+    private async Task AppendEventAsync(Guid platformUserId, int kind, string credentialId, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < SeqRetryAttempts; attempt++)
+        {
+            var nextSeq = await _db.CitizenCredentialEventLog
+                .Where(e => e.PlatformUserId == platformUserId)
+                .Select(e => (long?)e.Seq)
+                .MaxAsync(ct) ?? 0L;
+            nextSeq++;
+
+            _db.CitizenCredentialEventLog.Add(new CitizenCredentialEventLog
+            {
+                PlatformUserId = platformUserId,
+                Seq = nextSeq,
+                Kind = kind,
+                CredentialId = credentialId,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+                _logger.LogInformation(
+                    "CitizenCredentialEventLog appended: platformUserId={PlatformUserId} seq={Seq} kind={Kind} credentialId={CredentialId}",
+                    platformUserId, nextSeq, kind, credentialId);
+                return;
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex) && attempt + 1 < SeqRetryAttempts)
+            {
+                // Lost a Seq race with a concurrent write — recompute MAX(Seq) and retry.
+                _db.ChangeTracker.Clear();
+                _logger.LogDebug(
+                    "CitizenCredentialEventLog seq race for {PlatformUserId} (attempt {Attempt}) — retrying",
+                    platformUserId, attempt + 1);
+            }
+        }
+
+        // All retries exhausted — surface as exception so the upstream caller can decide.
+        // The credential write has already succeeded; the pull-on-open path will still
+        // surface the credential, so this is a degraded-but-recoverable state.
+        throw new InvalidOperationException(
+            $"Failed to append CitizenCredentialEventLog for platformUser {platformUserId} after {SeqRetryAttempts} attempts.");
+    }
+
+    private async Task EmitCredentialAvailableAsync(Guid platformUserId, string credentialId, CancellationToken ct)
+    {
+        try
+        {
+            await _hub.Clients
+                .Group(WalletHub.GroupNameFor(platformUserId))
+                .CredentialAvailable(credentialId);
+
+            _logger.LogDebug(
+                "WalletHub.CredentialAvailable emitted: platformUserId={PlatformUserId} credentialId={CredentialId}",
+                platformUserId, credentialId);
+        }
+        catch (Exception ex)
+        {
+            // Hub emission is an optimisation, not the source of truth. A failed push
+            // becomes a missed badge update; the next /sync call still surfaces the
+            // credential. Log loudly so operators notice but do NOT propagate.
+            _logger.LogError(ex,
+                "WalletHub.CredentialAvailable emit failed for platformUserId={PlatformUserId} credentialId={CredentialId} — wallet will pick up on next sync",
+                platformUserId, credentialId);
+        }
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        var message = ex.InnerException?.Message ?? ex.Message;
+        return message.Contains("23505", StringComparison.Ordinal)
+            || message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("UNIQUE constraint", StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+/// <summary>
+/// Numeric values matching <c>Sorcha.Wallet.Service.Services.Interfaces.CitizenCredentialEventKind</c>.
+/// Persisted as <c>integer</c> in <c>CitizenCredentialEventLog.Kind</c>.
+/// </summary>
+internal static class CitizenCredentialEventKindValues
+{
+    public const int Added = 0;
+    public const int Revoked = 1;
+    public const int Replaced = 2;
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenSyncService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenSyncService.cs
@@ -189,7 +189,7 @@ public sealed class CitizenSyncService : ICitizenSyncService
 
     private static IEnumerable<CachedCredentialPayload> ReplayToSnapshot(IReadOnlyList<CitizenCredentialEvent> events)
     {
-        var byId = new Dictionary<Guid, CachedCredentialPayload>();
+        var byId = new Dictionary<string, CachedCredentialPayload>(StringComparer.Ordinal);
         foreach (var evt in events)
         {
             switch (evt.Kind)

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreCitizenCredentialEventStream.cs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Wallet.Core.Data;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="ICitizenCredentialEventStream"/>
+/// (Feature 114 US4). Reads the citizen-scoped event log written by
+/// <see cref="CitizenInboxProjector"/> joined to <see cref="CredentialEntity"/>
+/// for payload composition.
+/// </summary>
+/// <remarks>
+/// Replaces <c>EmptyCitizenCredentialEventStream</c> as the registered
+/// <see cref="ICitizenCredentialEventStream"/>. The composition point in
+/// <see cref="ICitizenSyncService"/> is unchanged; only the event source
+/// switches from "always empty" to "real events from CredentialStore via the
+/// projector."
+/// </remarks>
+public sealed class EfCoreCitizenCredentialEventStream : ICitizenCredentialEventStream
+{
+    private readonly WalletDbContext _db;
+    private readonly ILogger<EfCoreCitizenCredentialEventStream> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public EfCoreCitizenCredentialEventStream(
+        WalletDbContext db,
+        ILogger<EfCoreCitizenCredentialEventStream> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CitizenCredentialEvent>> ReadAsync(
+        Guid platformUserId,
+        long afterSeq,
+        CancellationToken ct = default)
+    {
+        var rows = await _db.CitizenCredentialEventLog
+            .AsNoTracking()
+            .Where(e => e.PlatformUserId == platformUserId && e.Seq > afterSeq)
+            .OrderBy(e => e.Seq)
+            .ToListAsync(ct);
+
+        if (rows.Count == 0)
+        {
+            return Array.Empty<CitizenCredentialEvent>();
+        }
+
+        // Resolve credential payloads in a single round-trip. The composite PK
+        // on Credentials is (Id, WalletAddress); we don't have the WalletAddress
+        // here but the recipient row is the one with status PendingAcceptance /
+        // Active / Revoked / Declined and a SubjectDid that is the citizen's
+        // holder address. For US4 v1 we match on credential id alone and prefer
+        // the recipient row (i.e. NOT Active by issuer) — the issuer audit row
+        // is harmless to surface but never the canonical citizen view.
+        var credentialIds = rows.Select(r => r.CredentialId).Distinct().ToList();
+        var credentials = await _db.Credentials
+            .AsNoTracking()
+            .Where(c => credentialIds.Contains(c.Id))
+            .ToListAsync(ct);
+
+        var byId = credentials
+            .GroupBy(c => c.Id)
+            .ToDictionary(g => g.Key, ChooseRecipientRow);
+
+        var events = new List<CitizenCredentialEvent>(rows.Count);
+        foreach (var row in rows)
+        {
+            if (!byId.TryGetValue(row.CredentialId, out var entity))
+            {
+                _logger.LogWarning(
+                    "CitizenCredentialEventLog row {Seq} references missing credential {CredentialId} for platformUser {PlatformUserId} — skipping",
+                    row.Seq, row.CredentialId, platformUserId);
+                continue;
+            }
+
+            var kind = (CitizenCredentialEventKind)row.Kind;
+            var payload = BuildPayload(kind, entity);
+            events.Add(new CitizenCredentialEvent(row.Seq, kind, payload));
+        }
+
+        return events;
+    }
+
+    /// <inheritdoc />
+    public async Task<long> GetHighestSeqAsync(Guid platformUserId, CancellationToken ct = default)
+    {
+        var max = await _db.CitizenCredentialEventLog
+            .AsNoTracking()
+            .Where(e => e.PlatformUserId == platformUserId)
+            .Select(e => (long?)e.Seq)
+            .MaxAsync(ct);
+
+        return max ?? 0L;
+    }
+
+    /// <summary>
+    /// Prefer the credential row that represents the recipient's holding —
+    /// <c>PendingAcceptance</c> / <c>Active</c> / <c>Declined</c> / <c>Revoked</c>
+    /// over a co-located issuer audit row that is also <c>Active</c>. Falls
+    /// back to the first match when no clearer signal is available.
+    /// </summary>
+    private static CredentialEntity ChooseRecipientRow(IGrouping<string, CredentialEntity> group)
+    {
+        return group.FirstOrDefault(c => c.Status is CredentialStatus.PendingAcceptance
+                                                  or CredentialStatus.Declined
+                                                  or CredentialStatus.Revoked)
+            ?? group.First();
+    }
+
+    private static object BuildPayload(CitizenCredentialEventKind kind, CredentialEntity entity)
+    {
+        return kind switch
+        {
+            CitizenCredentialEventKind.Added => new CachedCredentialPayload
+            {
+                Id = entity.Id,
+                Vct = entity.Type,
+                Jwt = entity.RawToken,
+                IssuerDid = entity.IssuerDid,
+                IssuedAt = entity.IssuedAt,
+                ExpiresAt = entity.ExpiresAt,
+                StatusListUri = null,
+                StatusListIndex = null,
+            },
+            CitizenCredentialEventKind.Revoked => new RevokedCredentialEntry
+            {
+                Id = entity.Id,
+                Reason = MapRevocationReason(entity.Status),
+                RevokedAt = DateTimeOffset.UtcNow,
+            },
+            CitizenCredentialEventKind.Replaced => new ReplacedCredentialEntry
+            {
+                OldId = entity.Id,
+                NewId = entity.Id,
+                Jwt = entity.RawToken,
+                IssuedAt = entity.IssuedAt,
+            },
+            _ => new RevokedCredentialEntry
+            {
+                Id = entity.Id,
+                Reason = CredentialRevocationReason.Erroneous,
+                RevokedAt = DateTimeOffset.UtcNow,
+            },
+        };
+    }
+
+    private static CredentialRevocationReason MapRevocationReason(CredentialStatus status) =>
+        status switch
+        {
+            CredentialStatus.Revoked => CredentialRevocationReason.Withdrawn,
+            CredentialStatus.Declined => CredentialRevocationReason.Withdrawn,
+            CredentialStatus.Expired => CredentialRevocationReason.Expired,
+            _ => CredentialRevocationReason.Erroneous,
+        };
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreHolderAddressLookup.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/EfCoreHolderAddressLookup.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sorcha.Wallet.Core.Data;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="IHolderAddressLookup"/>.
+/// </summary>
+/// <remarks>
+/// Read path is a primary-key lookup against <c>CitizenHolderIndex</c>; the
+/// expected query pattern is one read per inbound-credential detection event,
+/// so the table stays small and an in-memory cache layer would add complexity
+/// without measurable gain. Add Redis caching in a follow-up only if profiling
+/// shows the read becomes a hot path.
+/// <para>
+/// Write path is idempotent on the <c>WalletAddress</c> primary key — citizens
+/// who re-enrol or rotate devices hit the same row. A unique-violation on
+/// concurrent first-time enrolments is treated as a benign race (the existing
+/// row is correct).
+/// </para>
+/// </remarks>
+public sealed class EfCoreHolderAddressLookup : IHolderAddressLookup
+{
+    private readonly WalletDbContext _db;
+    private readonly ILogger<EfCoreHolderAddressLookup> _logger;
+
+    /// <summary>Initialises a new instance.</summary>
+    public EfCoreHolderAddressLookup(WalletDbContext db, ILogger<EfCoreHolderAddressLookup> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<Guid?> ResolvePlatformUserIdAsync(string walletAddress, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
+        var row = await _db.CitizenHolderIndex
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.WalletAddress == walletAddress, ct);
+
+        return row?.PlatformUserId;
+    }
+
+    /// <inheritdoc />
+    public async Task RegisterAsync(string walletAddress, Guid platformUserId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
+        var existing = await _db.CitizenHolderIndex
+            .FirstOrDefaultAsync(e => e.WalletAddress == walletAddress, ct);
+
+        if (existing is not null)
+        {
+            if (existing.PlatformUserId != platformUserId)
+            {
+                _logger.LogWarning(
+                    "CitizenHolderIndex conflict for wallet {Address}: existing PlatformUserId={Existing} != requested {Requested}. " +
+                    "Existing row left unchanged.",
+                    walletAddress, existing.PlatformUserId, platformUserId);
+            }
+            return;
+        }
+
+        _db.CitizenHolderIndex.Add(new CitizenHolderIndex
+        {
+            WalletAddress = walletAddress,
+            PlatformUserId = platformUserId,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+            _logger.LogInformation(
+                "CitizenHolderIndex registered: wallet={Address} platformUserId={PlatformUserId}",
+                walletAddress, platformUserId);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Concurrent first-time enrolment of the same citizen — the other writer won.
+            // The existing row is correct (same WalletAddress → same PlatformUserId).
+            _logger.LogDebug(
+                "CitizenHolderIndex.RegisterAsync race for {Address} — existing row prevailed",
+                walletAddress);
+        }
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex)
+    {
+        // PostgreSQL: 23505 unique_violation. Match on either the SQLSTATE or the
+        // generic "duplicate key" string — provider-specific exception types are
+        // not always available where this check runs.
+        var message = ex.InnerException?.Message ?? ex.Message;
+        return message.Contains("23505", StringComparison.Ordinal)
+            || message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("UNIQUE constraint", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialDetector.cs
@@ -45,6 +45,7 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
     private readonly WalletManager _walletManager;
     private readonly ISymmetricCrypto _symmetricCrypto;
     private readonly ICredentialStore _credentialStore;
+    private readonly ICitizenInboxProjector _citizenProjector;
     private readonly InboundCredentialDetectorMetrics _metrics;
     private readonly ILogger<InboundCredentialDetector> _logger;
 
@@ -60,6 +61,7 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
         WalletManager walletManager,
         ISymmetricCrypto symmetricCrypto,
         ICredentialStore credentialStore,
+        ICitizenInboxProjector citizenProjector,
         InboundCredentialDetectorMetrics metrics,
         ILogger<InboundCredentialDetector> logger)
     {
@@ -67,6 +69,7 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
         _walletManager = walletManager ?? throw new ArgumentNullException(nameof(walletManager));
         _symmetricCrypto = symmetricCrypto ?? throw new ArgumentNullException(nameof(symmetricCrypto));
         _credentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
+        _citizenProjector = citizenProjector ?? throw new ArgumentNullException(nameof(citizenProjector));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -210,6 +213,11 @@ public sealed class InboundCredentialDetector : IInboundCredentialDetector
             };
 
             await _credentialStore.StoreAsync(entity, cancellationToken);
+
+            // Feature 114 US4 — project onto citizen sync surface if the recipient
+            // is a citizen-PWA holder. No-op for org wallets, so the existing
+            // org-credential pipeline is unaffected.
+            await _citizenProjector.OnCredentialAddedAsync(entity, cancellationToken);
 
             _metrics.RecordExtracted();
             _logger.LogInformation(

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/ICitizenInboxProjector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/ICitizenInboxProjector.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Core.Domain.Entities;
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Projects credential-lifecycle changes onto the citizen sync surface
+/// (Feature 114, US4).
+/// </summary>
+/// <remarks>
+/// Single composition point hooked into the existing Feature 106 credential
+/// pipeline:
+/// <list type="bullet">
+///   <item>
+///     <c>InboundCredentialDetector</c> calls
+///     <see cref="OnCredentialAddedAsync"/> after a successful
+///     <c>CredentialStore.StoreAsync</c> for a <c>PendingAcceptance</c> row.
+///   </item>
+///   <item>
+///     <c>CredentialStore.PatchStatusAsync</c> and <c>UpdateStatusAsync</c>
+///     call <see cref="OnCredentialStatusChangedAsync"/> after a successful
+///     status transition.
+///   </item>
+/// </list>
+/// The projector resolves the recipient via <see cref="IHolderAddressLookup"/>;
+/// if the wallet address is not a citizen holder the call is a no-op (the org
+/// credential pipeline is unaffected). When the recipient is a citizen, the
+/// projector appends a <c>CitizenCredentialEventLog</c> row and emits
+/// <c>WalletHub.CredentialAvailable</c> on the citizen's PlatformUser group.
+/// </remarks>
+public interface ICitizenInboxProjector
+{
+    /// <summary>
+    /// Project a newly-stored credential onto the citizen sync surface.
+    /// No-op for non-citizen recipients.
+    /// </summary>
+    Task OnCredentialAddedAsync(CredentialEntity credential, CancellationToken ct = default);
+
+    /// <summary>
+    /// Project a credential-status transition onto the citizen sync surface.
+    /// Emits a <c>Revoked</c>-kind event when the new status is
+    /// <see cref="CredentialStatus.Revoked"/> or <see cref="CredentialStatus.Declined"/>;
+    /// no-op for transitions the wallet PWA does not surface (e.g.
+    /// <c>Active → Suspended</c>).
+    /// </summary>
+    Task OnCredentialStatusChangedAsync(
+        CredentialEntity credential,
+        CredentialStatus previousStatus,
+        CancellationToken ct = default);
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IHolderAddressLookup.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IHolderAddressLookup.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Resolves a citizen holder wallet address to its owning <c>PlatformUserId</c>
+/// (Feature 114, US4).
+/// </summary>
+/// <remarks>
+/// Backed by <c>CitizenHolderIndex</c>. Populated at device-enrolment time
+/// (the moment <c>walletAddress</c> + <c>platformUserId</c> are first available
+/// together via the citizen JWT) and consumed by
+/// <see cref="ICitizenInboxProjector"/> when an inbound credential is detected
+/// — at that point the projector only knows the recipient address, not the
+/// citizen identity, so the index is the bridge.
+/// </remarks>
+public interface IHolderAddressLookup
+{
+    /// <summary>
+    /// Returns the owning <c>PlatformUserId</c> for the given citizen holder
+    /// wallet address, or <c>null</c> if the address is not a known citizen
+    /// holder (e.g. an org wallet).
+    /// </summary>
+    Task<Guid?> ResolvePlatformUserIdAsync(string walletAddress, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists the <paramref name="walletAddress"/> → <paramref name="platformUserId"/>
+    /// mapping. Idempotent — safe to call on every enrolment retry. Existing
+    /// rows are left untouched.
+    /// </summary>
+    Task RegisterAsync(string walletAddress, Guid platformUserId, CancellationToken ct = default);
+}

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/SyncServiceTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/SyncServiceTests.cs
@@ -49,7 +49,7 @@ public sealed class SyncServiceTests
 
         outcome.Mode.Should().Be(SyncMode.Delta);
         outcome.Added.Should().Be(1);
-        (await _cache.ListAsync()).Should().ContainSingle(c => c.Id == added.Id);
+        (await _cache.ListAsync()).Should().ContainSingle(c => c.RawSdJwt == added.Jwt);
         (await _cursors.GetAsync()).Should().Be("cursor-1");
     }
 
@@ -83,7 +83,7 @@ public sealed class SyncServiceTests
 
         outcome.Mode.Should().Be(SyncMode.FullSnapshot);
         outcome.Added.Should().Be(1);
-        (await _cache.ListAsync()).Should().ContainSingle(c => c.Id == snap.Id);
+        (await _cache.ListAsync()).Should().ContainSingle(c => c.RawSdJwt == snap.Jwt);
         (await _cursors.GetAsync()).Should().Be("fresh-cursor",
             "the recovery path must obtain a fresh cursor so the next /sync uses it");
     }
@@ -125,7 +125,7 @@ public sealed class SyncServiceTests
 
     private static CachedCredentialPayload NewPayload() => new()
     {
-        Id = Guid.NewGuid(),
+        Id = $"urn:credential:test:{Guid.NewGuid():N}",
         Vct = "https://sorcha.dev/vc/test/v1",
         Jwt = "eyJ.demo.sd-jwt~disclosure~",
         IssuerDid = "did:sorcha:org:test",

--- a/tests/Sorcha.CitizenWallet.Abstractions.Tests/SerialisationTests.cs
+++ b/tests/Sorcha.CitizenWallet.Abstractions.Tests/SerialisationTests.cs
@@ -77,7 +77,7 @@ public sealed class SerialisationTests
             SyncToken = "opaque-token",
             Credentials = new SyncCredentialChanges
             {
-                Added = [new CachedCredentialPayload { Id = Guid.NewGuid(), Vct = "test", Jwt = "jwt", IssuerDid = "did:test", IssuedAt = DateTimeOffset.UtcNow }]
+                Added = [new CachedCredentialPayload { Id = $"urn:credential:test:{Guid.NewGuid():N}", Vct = "test", Jwt = "jwt", IssuerDid = "did:test", IssuedAt = DateTimeOffset.UtcNow }]
             },
             Delegation = new SyncDelegationUpdate { Renewed = false },
             StatusListsToRefresh = ["https://sorcha.dev/status/1.statuslist+jwt"]

--- a/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/CitizenInboxProjectorTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/CitizenInboxProjectorTests.cs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Hubs;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Sorcha.Wallet.Service.Tests.Services;
+
+namespace Sorcha.Wallet.Service.Tests.CitizenWallet;
+
+/// <summary>
+/// Feature 114 / US4 — unit coverage for <see cref="CitizenInboxProjector"/>.
+/// Verifies the projection rules, hub-emit shape, and Seq monotonicity. The
+/// org-credential pipeline must be unaffected when the recipient is not a
+/// citizen-PWA holder.
+/// </summary>
+public class CitizenInboxProjectorTests
+{
+    private static (
+        CitizenInboxProjector projector,
+        TestCitizenWalletDbContext db,
+        Mock<IHolderAddressLookup> lookup,
+        Mock<IHubContext<WalletHub, IWalletHubClient>> hub,
+        Mock<IWalletHubClient> hubClient,
+        List<(string group, string credentialId)> emissions
+    ) CreateSut([System.Runtime.CompilerServices.CallerMemberName] string testName = "")
+    {
+        var options = new DbContextOptionsBuilder<TestCitizenWalletDbContext>()
+            .UseInMemoryDatabase($"projector-{testName}-{Guid.NewGuid():N}")
+            .Options;
+        var db = new TestCitizenWalletDbContext(options);
+
+        var lookup = new Mock<IHolderAddressLookup>();
+        var hub = new Mock<IHubContext<WalletHub, IWalletHubClient>>();
+        var hubClients = new Mock<IHubClients<IWalletHubClient>>();
+        var hubClient = new Mock<IWalletHubClient>();
+        var emissions = new List<(string, string)>();
+
+        // Capture the group name + credentialId pair every time CredentialAvailable is invoked.
+        hub.SetupGet(h => h.Clients).Returns(hubClients.Object);
+        hubClients.Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string group) =>
+            {
+                hubClient.Setup(c => c.CredentialAvailable(It.IsAny<string>()))
+                    .Callback<string>(credentialId => emissions.Add((group, credentialId)))
+                    .Returns(Task.CompletedTask);
+                return hubClient.Object;
+            });
+
+        var projector = new CitizenInboxProjector(
+            db, lookup.Object, hub.Object, NullLogger<CitizenInboxProjector>.Instance);
+
+        return (projector, db, lookup, hub, hubClient, emissions);
+    }
+
+    private static CredentialEntity NewCredential(string walletAddress, CredentialStatus status = CredentialStatus.PendingAcceptance) =>
+        new()
+        {
+            Id = $"urn:credential:Test:{Guid.NewGuid():N}",
+            Type = "TestCredential/v1",
+            IssuerDid = "did:sorcha:org:ws1qissuer",
+            SubjectDid = walletAddress,
+            ClaimsJson = "{}",
+            RawToken = "header.payload.sig",
+            Status = status,
+            WalletAddress = walletAddress,
+            IssuedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    [Fact]
+    public async Task OnCredentialAddedAsync_CitizenRecipient_AppendsEventAndEmits()
+    {
+        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("ws1qcitizen");
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pid);
+
+        await projector.OnCredentialAddedAsync(credential);
+
+        var rows = await db.CitizenCredentialEventLog.ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].PlatformUserId.Should().Be(pid);
+        rows[0].Kind.Should().Be(0); // Added
+        rows[0].Seq.Should().Be(1);
+        rows[0].CredentialId.Should().Be(credential.Id);
+
+        emissions.Should().ContainSingle();
+        emissions[0].group.Should().Be(WalletHub.GroupNameFor(pid));
+        emissions[0].credentialId.Should().Be(credential.Id);
+    }
+
+    [Fact]
+    public async Task OnCredentialAddedAsync_OrgRecipient_NoOp()
+    {
+        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var credential = NewCredential("ws1qorg");
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qorg", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        await projector.OnCredentialAddedAsync(credential);
+
+        (await db.CitizenCredentialEventLog.CountAsync()).Should().Be(0);
+        emissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OnCredentialAddedAsync_SecondCredential_AdvancesSeq()
+    {
+        var (projector, db, lookup, _, _, _) = CreateSut();
+        var pid = Guid.NewGuid();
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pid);
+
+        await projector.OnCredentialAddedAsync(NewCredential("ws1qcitizen"));
+        await projector.OnCredentialAddedAsync(NewCredential("ws1qcitizen"));
+
+        var seqs = await db.CitizenCredentialEventLog
+            .Where(e => e.PlatformUserId == pid)
+            .OrderBy(e => e.Seq)
+            .Select(e => e.Seq)
+            .ToListAsync();
+        seqs.Should().Equal(1L, 2L);
+    }
+
+    [Fact]
+    public async Task OnCredentialStatusChangedAsync_RevokedTransition_EmitsRevokedEvent()
+    {
+        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("ws1qcitizen", CredentialStatus.Revoked);
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pid);
+
+        await projector.OnCredentialStatusChangedAsync(credential, CredentialStatus.Active);
+
+        var row = await db.CitizenCredentialEventLog.SingleAsync();
+        row.Kind.Should().Be(1); // Revoked
+        emissions.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task OnCredentialStatusChangedAsync_DeclinedTransition_EmitsRevokedEvent()
+    {
+        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("ws1qcitizen", CredentialStatus.Declined);
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pid);
+
+        await projector.OnCredentialStatusChangedAsync(credential, CredentialStatus.PendingAcceptance);
+
+        var row = await db.CitizenCredentialEventLog.SingleAsync();
+        row.Kind.Should().Be(1); // Revoked maps both Revoked and Declined statuses
+        emissions.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task OnCredentialStatusChangedAsync_ActiveTransition_NoOp()
+    {
+        // PendingAcceptance → Active is a successful holder accept. The wallet
+        // already knows about the credential (we sent it as Added when it landed
+        // in PendingAcceptance), so re-emitting on accept would be noise.
+        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var credential = NewCredential("ws1qcitizen", CredentialStatus.Active);
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+
+        await projector.OnCredentialStatusChangedAsync(credential, CredentialStatus.PendingAcceptance);
+
+        (await db.CitizenCredentialEventLog.CountAsync()).Should().Be(0);
+        emissions.Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/EfCoreCitizenCredentialEventStreamTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/EfCoreCitizenCredentialEventStreamTests.cs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Sorcha.Wallet.Service.Tests.Services;
+
+namespace Sorcha.Wallet.Service.Tests.CitizenWallet;
+
+/// <summary>
+/// Feature 114 / US4 — unit coverage for <see cref="EfCoreCitizenCredentialEventStream"/>.
+/// </summary>
+public class EfCoreCitizenCredentialEventStreamTests
+{
+    private static (EfCoreCitizenCredentialEventStream stream, TestCitizenWalletDbContext db) CreateSut(
+        [System.Runtime.CompilerServices.CallerMemberName] string testName = "")
+    {
+        var options = new DbContextOptionsBuilder<TestCitizenWalletDbContext>()
+            .UseInMemoryDatabase($"event-stream-{testName}-{Guid.NewGuid():N}")
+            .Options;
+        var db = new TestCitizenWalletDbContext(options);
+        var stream = new EfCoreCitizenCredentialEventStream(
+            db, NullLogger<EfCoreCitizenCredentialEventStream>.Instance);
+        return (stream, db);
+    }
+
+    private static async Task SeedAsync(
+        TestCitizenWalletDbContext db,
+        Guid platformUserId,
+        params (long Seq, int Kind, string CredentialId, CredentialEntity? Credential)[] events)
+    {
+        foreach (var e in events)
+        {
+            db.CitizenCredentialEventLog.Add(new CitizenCredentialEventLog
+            {
+                PlatformUserId = platformUserId,
+                Seq = e.Seq,
+                Kind = e.Kind,
+                CredentialId = e.CredentialId,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+            if (e.Credential is not null)
+            {
+                db.Credentials.Add(e.Credential);
+            }
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private static CredentialEntity NewCredential(
+        string credentialId,
+        string walletAddress,
+        CredentialStatus status = CredentialStatus.PendingAcceptance) =>
+        new()
+        {
+            Id = credentialId,
+            Type = "TestCredential/v1",
+            IssuerDid = "did:sorcha:org:ws1qissuer",
+            SubjectDid = walletAddress,
+            ClaimsJson = "{}",
+            RawToken = "header.payload.sig",
+            Status = status,
+            WalletAddress = walletAddress,
+            IssuedAt = DateTimeOffset.UtcNow,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+    [Fact]
+    public async Task ReadAsync_AfterSeq_ReturnsOnlyNewerEventsOrdered()
+    {
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        var c1 = NewCredential("urn:credential:1", "ws1qcitizen");
+        var c2 = NewCredential("urn:credential:2", "ws1qcitizen");
+        var c3 = NewCredential("urn:credential:3", "ws1qcitizen");
+        await SeedAsync(db, pid,
+            (1L, 0, c1.Id, c1),
+            (2L, 0, c2.Id, c2),
+            (3L, 0, c3.Id, c3));
+
+        var events = await stream.ReadAsync(pid, afterSeq: 1L);
+
+        events.Should().HaveCount(2);
+        events.Select(e => e.Seq).Should().Equal(2L, 3L);
+    }
+
+    [Fact]
+    public async Task ReadAsync_DifferentPlatformUser_DoesNotLeakEvents()
+    {
+        var (stream, db) = CreateSut();
+        var alice = Guid.NewGuid();
+        var bob = Guid.NewGuid();
+        var aliceCredential = NewCredential("urn:credential:alice", "ws1qalice");
+        var bobCredential = NewCredential("urn:credential:bob", "ws1qbob");
+        await SeedAsync(db, alice, (1L, 0, aliceCredential.Id, aliceCredential));
+        await SeedAsync(db, bob, (1L, 0, bobCredential.Id, bobCredential));
+
+        var aliceEvents = await stream.ReadAsync(alice, afterSeq: 0L);
+        var bobEvents = await stream.ReadAsync(bob, afterSeq: 0L);
+
+        aliceEvents.Should().ContainSingle().Which.Payload.Should().BeOfType<CachedCredentialPayload>()
+            .Which.Id.Should().Be("urn:credential:alice");
+        bobEvents.Should().ContainSingle().Which.Payload.Should().BeOfType<CachedCredentialPayload>()
+            .Which.Id.Should().Be("urn:credential:bob");
+    }
+
+    [Fact]
+    public async Task ReadAsync_AddedKind_ProducesCachedCredentialPayload()
+    {
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("urn:credential:1", "ws1qcitizen");
+        credential.IssuerDid = "did:sorcha:org:ws1qriverside";
+        credential.IssuerOrgName = "Riverside Council";
+        await SeedAsync(db, pid, (1L, 0, credential.Id, credential));
+
+        var events = await stream.ReadAsync(pid, afterSeq: 0L);
+
+        var evt = events.Should().ContainSingle().Subject;
+        evt.Kind.Should().Be(CitizenCredentialEventKind.Added);
+        var payload = evt.Payload.Should().BeOfType<CachedCredentialPayload>().Subject;
+        payload.Id.Should().Be(credential.Id);
+        payload.Vct.Should().Be(credential.Type);
+        payload.IssuerDid.Should().Be(credential.IssuerDid);
+        payload.Jwt.Should().Be(credential.RawToken);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RevokedKind_ProducesRevokedCredentialEntry()
+    {
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("urn:credential:1", "ws1qcitizen", CredentialStatus.Revoked);
+        await SeedAsync(db, pid, (1L, 1, credential.Id, credential));
+
+        var events = await stream.ReadAsync(pid, afterSeq: 0L);
+
+        var evt = events.Should().ContainSingle().Subject;
+        evt.Kind.Should().Be(CitizenCredentialEventKind.Revoked);
+        var payload = evt.Payload.Should().BeOfType<RevokedCredentialEntry>().Subject;
+        payload.Id.Should().Be(credential.Id);
+        payload.Reason.Should().Be(CredentialRevocationReason.Withdrawn);
+    }
+
+    [Fact]
+    public async Task ReadAsync_MissingCredential_SkipsEventGracefully()
+    {
+        // Defensive: an event log row that references a deleted credential should
+        // not crash the sync surface.
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        await SeedAsync(db, pid, (1L, 0, "urn:credential:vanished", null));
+
+        var events = await stream.ReadAsync(pid, afterSeq: 0L);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetHighestSeqAsync_NoEvents_ReturnsZero()
+    {
+        var (stream, _) = CreateSut();
+
+        var max = await stream.GetHighestSeqAsync(Guid.NewGuid());
+
+        max.Should().Be(0L);
+    }
+
+    [Fact]
+    public async Task GetHighestSeqAsync_SeededEvents_ReturnsMaxSeq()
+    {
+        var (stream, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        var c1 = NewCredential("urn:credential:1", "ws1qcitizen");
+        var c2 = NewCredential("urn:credential:2", "ws1qcitizen");
+        await SeedAsync(db, pid, (3L, 0, c1.Id, c1), (7L, 0, c2.Id, c2));
+
+        var max = await stream.GetHighestSeqAsync(pid);
+
+        max.Should().Be(7L);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/HolderAddressLookupTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/HolderAddressLookupTests.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Tests.Services;
+
+namespace Sorcha.Wallet.Service.Tests.CitizenWallet;
+
+/// <summary>
+/// Feature 114 / US4 — unit coverage for <see cref="EfCoreHolderAddressLookup"/>.
+/// </summary>
+public class HolderAddressLookupTests
+{
+    private static (EfCoreHolderAddressLookup lookup, TestCitizenWalletDbContext db) CreateSut(
+        [System.Runtime.CompilerServices.CallerMemberName] string testName = "")
+    {
+        var options = new DbContextOptionsBuilder<TestCitizenWalletDbContext>()
+            .UseInMemoryDatabase($"holder-lookup-{testName}-{Guid.NewGuid():N}")
+            .Options;
+        var db = new TestCitizenWalletDbContext(options);
+        var lookup = new EfCoreHolderAddressLookup(db, NullLogger<EfCoreHolderAddressLookup>.Instance);
+        return (lookup, db);
+    }
+
+    [Fact]
+    public async Task ResolvePlatformUserIdAsync_KnownCitizenAddress_ReturnsPlatformUserId()
+    {
+        var (lookup, db) = CreateSut();
+        var pid = Guid.NewGuid();
+        db.CitizenHolderIndex.Add(new CitizenHolderIndex
+        {
+            WalletAddress = "ws1qcitizen",
+            PlatformUserId = pid,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await db.SaveChangesAsync();
+
+        var result = await lookup.ResolvePlatformUserIdAsync("ws1qcitizen");
+
+        result.Should().Be(pid);
+    }
+
+    [Fact]
+    public async Task ResolvePlatformUserIdAsync_UnknownAddress_ReturnsNull()
+    {
+        var (lookup, _) = CreateSut();
+
+        var result = await lookup.ResolvePlatformUserIdAsync("ws1qorg-not-citizen");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_NewAddress_PersistsRow()
+    {
+        var (lookup, db) = CreateSut();
+        var pid = Guid.NewGuid();
+
+        await lookup.RegisterAsync("ws1qcitizen", pid);
+
+        var row = await db.CitizenHolderIndex.SingleAsync();
+        row.WalletAddress.Should().Be("ws1qcitizen");
+        row.PlatformUserId.Should().Be(pid);
+        row.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task RegisterAsync_SamePlatformUser_IsIdempotent()
+    {
+        var (lookup, db) = CreateSut();
+        var pid = Guid.NewGuid();
+
+        await lookup.RegisterAsync("ws1qcitizen", pid);
+        await lookup.RegisterAsync("ws1qcitizen", pid);
+
+        var rows = await db.CitizenHolderIndex.ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].PlatformUserId.Should().Be(pid);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_DifferentPlatformUserSameAddress_LeavesExistingRow()
+    {
+        // Defensive: an address can never legitimately remap to a new PlatformUser
+        // (slot-108 derivation is deterministic per citizen). If somehow called,
+        // the existing row wins; the new request is logged but not applied.
+        var (lookup, db) = CreateSut();
+        var firstPid = Guid.NewGuid();
+        var secondPid = Guid.NewGuid();
+
+        await lookup.RegisterAsync("ws1qcitizen", firstPid);
+        await lookup.RegisterAsync("ws1qcitizen", secondPid);
+
+        var row = await db.CitizenHolderIndex.SingleAsync();
+        row.PlatformUserId.Should().Be(firstPid);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialLifecycleTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialLifecycleTests.cs
@@ -21,7 +21,10 @@ public class CredentialLifecycleTests : IDisposable
             .Options;
 
         _db = new TestCredentialDbContext(options);
-        _store = new CredentialStore(_db, NullLogger<CredentialStore>.Instance);
+        _store = new CredentialStore(
+            _db,
+            Moq.Mock.Of<Sorcha.Wallet.Service.Services.Interfaces.ICitizenInboxProjector>(),
+            NullLogger<CredentialStore>.Instance);
     }
 
     public void Dispose()

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialStoreTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialStoreTests.cs
@@ -23,7 +23,10 @@ public class CredentialStoreTests : IDisposable
             .Options;
 
         _db = new TestCredentialDbContext(options);
-        _store = new CredentialStore(_db, NullLogger<CredentialStore>.Instance);
+        _store = new CredentialStore(
+            _db,
+            Moq.Mock.Of<Sorcha.Wallet.Service.Services.Interfaces.ICitizenInboxProjector>(),
+            NullLogger<CredentialStore>.Instance);
     }
 
     public void Dispose()

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletEnrolEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletEnrolEndpointTests.cs
@@ -36,6 +36,7 @@ public sealed class CitizenWalletEnrolEndpointTests
 
     private readonly Mock<IValidator<DeviceEnrolmentRequest>> _validator = new();
     private readonly Mock<IHolderKeyService> _holderKeys = new();
+    private readonly Mock<IHolderAddressLookup> _holderAddressLookup = new();
     private readonly Mock<IDeviceDelegationIssuer> _issuer = new();
     private readonly Mock<IOrgStatusSigningWalletResolver> _resolver = new();
     private readonly Mock<IPlatformUserDeviceClient> _deviceClient = new();
@@ -108,6 +109,7 @@ public sealed class CitizenWalletEnrolEndpointTests
             _issuer.Object,
             _resolver.Object,
             _deviceClient.Object,
+            _holderAddressLookup.Object,
             NullLogger<Program>.Instance,
             CancellationToken.None
         ]);

--- a/tests/Sorcha.Wallet.Service.Tests/Services/CitizenSyncServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/CitizenSyncServiceTests.cs
@@ -46,10 +46,10 @@ public sealed class CitizenSyncServiceTests
     [Fact]
     public async Task ComposeDeltaAsync_IncrementalSync_ProjectsAddedRevokedReplaced()
     {
-        var addedId = Guid.NewGuid();
-        var revokedId = Guid.NewGuid();
-        var replacedOldId = Guid.NewGuid();
-        var replacedNewId = Guid.NewGuid();
+        var addedId = $"urn:credential:test:{Guid.NewGuid():N}";
+        var revokedId = $"urn:credential:test:{Guid.NewGuid():N}";
+        var replacedOldId = $"urn:credential:test:{Guid.NewGuid():N}";
+        var replacedNewId = $"urn:credential:test:{Guid.NewGuid():N}";
 
         _events.Append(1, CitizenCredentialEventKind.Added, new CachedCredentialPayload
         {
@@ -121,8 +121,8 @@ public sealed class CitizenSyncServiceTests
     [Fact]
     public async Task ListAllCredentialsAsync_ReplaysToNetSnapshot()
     {
-        var keepId = Guid.NewGuid();
-        var dropId = Guid.NewGuid();
+        var keepId = $"urn:credential:test:{Guid.NewGuid():N}";
+        var dropId = $"urn:credential:test:{Guid.NewGuid():N}";
         _events.Append(1, CitizenCredentialEventKind.Added, NewPayload(keepId));
         _events.Append(2, CitizenCredentialEventKind.Added, NewPayload(dropId));
         _events.Append(3, CitizenCredentialEventKind.Revoked, new RevokedCredentialEntry
@@ -138,9 +138,9 @@ public sealed class CitizenSyncServiceTests
         snapshot.Credentials.Should().NotContain(p => p.Id == dropId);
     }
 
-    private CachedCredentialPayload NewPayload(Guid? id = null) => new()
+    private CachedCredentialPayload NewPayload(string? id = null) => new()
     {
-        Id = id ?? Guid.NewGuid(),
+        Id = id ?? $"urn:credential:test:{Guid.NewGuid():N}",
         Vct = "https://sorcha.dev/vc/test/v1",
         Jwt = "eyJ...",
         IssuerDid = "did:sorcha:org:test",

--- a/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorDevModeTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialDetectorDevModeTests.cs
@@ -238,6 +238,7 @@ public class InboundCredentialDetectorDevModeTests
                 walletManager,
                 symmetricCryptoMock.Object,
                 CredentialStoreMock.Object,
+                Mock.Of<Sorcha.Wallet.Service.Services.Interfaces.ICitizenInboxProjector>(),
                 metrics,
                 NullLogger<InboundCredentialDetector>.Instance);
         }

--- a/tests/Sorcha.Wallet.Service.Tests/Services/TestCitizenWalletDbContext.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/TestCitizenWalletDbContext.cs
@@ -49,5 +49,27 @@ internal sealed class TestCitizenWalletDbContext : WalletDbContext
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => new { e.PlatformUserId, e.PlatformUserDeviceId }).IsUnique();
         });
+
+        // Feature 114 / US4 — citizen holder-address index + credential event log
+        // + a minimal Credentials mapping so EfCoreCitizenCredentialEventStream's
+        // join to CredentialEntity works under the InMemory provider (jsonb /
+        // soft-delete from the production mapping is incompatible with InMemory).
+        modelBuilder.Entity<CitizenHolderIndex>(entity =>
+        {
+            entity.HasKey(e => e.WalletAddress);
+            entity.HasIndex(e => e.PlatformUserId);
+        });
+
+        modelBuilder.Entity<CitizenCredentialEventLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.PlatformUserId, e.Seq }).IsUnique();
+        });
+
+        modelBuilder.Entity<CredentialEntity>(entity =>
+        {
+            entity.HasKey(e => new { e.Id, e.WalletAddress });
+            entity.Property(e => e.Status).HasConversion<string>();
+        });
     }
 }


### PR DESCRIPTION
## Summary

PR2 of 3 for Feature 114 US4. Wires the citizen-side projection over Feature 106's existing credential pipeline. Builds on PR1's foundational schema (#575).

When a credential lands in `CredentialStore` against a citizen holder wallet, the projector appends to `CitizenCredentialEventLog` and emits `WalletHub.CredentialAvailable` on the citizen's PlatformUser group. **Org-credential deliveries are unaffected** — projector is a no-op when the recipient isn't a known citizen.

Architecture rationale: [`specs/114-citizen-wallet-pwa/us4-plan.md`](../blob/master/specs/114-citizen-wallet-pwa/us4-plan.md).

## What's in this PR

### Server projection
- `IHolderAddressLookup` + `EfCoreHolderAddressLookup` — resolves `walletAddress → PlatformUserId` via `CitizenHolderIndex`, registered at enrolment time.
- `ICitizenInboxProjector` + `CitizenInboxProjector` — single composition point. Allocates `Seq` via `MAX(Seq)+1` with unique-index-violation retry. Hub emit is best-effort (log + swallow); the thin-signal contract means a missed push reconciles via the next `/sync`.
- `EfCoreCitizenCredentialEventStream` — replaces `EmptyCitizenCredentialEventStream`. Joins to `CredentialEntity`, prefers the recipient row over any co-located issuer audit row.

### Hooks
- `InboundCredentialDetector` — calls projector after `CredentialStore.StoreAsync`.
- `CredentialStore.PatchStatusAsync` + `UpdateStatusAsync` — projector handles `Revoked`/`Declined` transitions. Other status changes are no-op for the citizen surface (PendingAcceptance → Active doesn't re-emit; the wallet already knows about it).
- `CitizenWalletEndpoints.EnrolDevice` — calls `IHolderAddressLookup.RegisterAsync` (only spot where the citizen JWT carries both walletAddress AND PlatformUserId).

### DI
- `Program.cs`: drops `EmptyCitizenCredentialEventStream` registration; new scoped registrations for `IHolderAddressLookup`, `ICitizenInboxProjector`, `EfCoreCitizenCredentialEventStream`. `CitizenSyncService` becomes Scoped (was Singleton) to avoid a captive-dependency error against the now-Scoped event stream.

### Pre-release contract correction
- `CachedCredentialPayload.Id`, `RevokedCredentialEntry.Id`, `ReplacedCredentialEntry.OldId/NewId` changed from `Guid` to `string`. The shipping `CredentialEntity.Id` is a string URN (`urn:credential:...`); the previous Guid-typed stub never matched any real credential id. The PWA's local cache `CachedCredential.Id` stays `Guid` (opaque cache key); `ToCachedCredential` maps string→Guid deterministically via SHA-256 first-16-bytes so the same URN always lands on the same cache row across syncs.

## Test plan

- [x] **3 new unit test suites** under `tests/Sorcha.Wallet.Service.Tests/CitizenWallet/`:
  - `HolderAddressLookupTests` — hit, miss, idempotent, defensive conflict.
  - `CitizenInboxProjectorTests` — citizen emits + persists; org no-op; Seq advancement; Revoked + Declined transitions; Active transition no-op.
  - `EfCoreCitizenCredentialEventStreamTests` — afterSeq filtering, ordering, cross-citizen isolation, Added/Revoked payload mapping, missing-credential graceful skip, GetHighestSeqAsync.
- [x] 719/722 `Sorcha.Wallet.Service.Tests` (3 failures are the same pre-existing `IssueCredentialStatusListUrlGuard` reflection issue from PR1 — verified on master, not introduced by this PR).
- [x] 21/21 `Sorcha.CitizenWallet.Abstractions.Tests` (Guid→string migration in fixtures).
- [x] 45/45 `Sorcha.Citizen.Wallet.Tests` (PWA-side fixtures updated; cache-id mapping deterministic).

## What's next

**PR3** (final): PWA `CitizenWalletHubConnection`, `Index.razor` subscription, service-worker sync handler, Playwright E2E fixture (`AuthenticatedCitizenWalletTestBase` + `CitizenWalletPushTests`). Per `us4-tasks.md` § 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)