### PR TITLE
fix(haip): register IServiceAuthClient + seed haip service principal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -708,6 +708,14 @@ services:
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__Redis: redis:6379
       Haip__IssuerUrl: http://127.0.0.1
+      # Service-to-service auth — used by PresentationCallbackRelay (Feature 111)
+      # to authenticate the callback into Blueprint Service. Seeded by
+      # Tenant Service DatabaseInitializer as HaipServicePrincipalId.
+      ServiceClients__BlueprintService__Address: http://blueprint-service:8080
+      ServiceClients__TenantService__Address: http://tenant-service:8080
+      ServiceAuth__ClientId: service-haip
+      ServiceAuth__ClientSecret: haip-service-secret
+      ServiceAuth__Scopes: "blueprints:read"
     depends_on:
       redis:
         condition: service_healthy

--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -4,6 +4,7 @@
 using Sorcha.AtomicCache.Extensions;
 using Sorcha.Haip.Service.Endpoints;
 using Sorcha.Haip.Service.Services;
+using Sorcha.ServiceClients.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -114,6 +115,13 @@ builder.Services.AddHttpClient<IetfTokenStatusListChecker>(client =>
 // Feature 111 — HAIP as a consumer of the Timebound Presentation Lifecycle.
 builder.Services.AddSingleton<Sorcha.PresentationLifecycle.Abstractions.IPresentationConsumer,
     Sorcha.Haip.Service.Services.HaipPresentationConsumer>();
+
+// PresentationCallbackRelay needs IServiceAuthClient to authenticate the s2s
+// callback into Blueprint Service. Register the standard service-client stack
+// (matches every other Sorcha service — Blueprint, Register, Tenant, Validator,
+// Wallet, Peer all call AddServiceClients in their Program.cs).
+builder.Services.AddServiceClients(builder.Configuration);
+
 builder.Services.AddHttpClient<Sorcha.Haip.Service.Services.PresentationCallbackRelay>(client =>
 {
     var blueprintAddress = builder.Configuration["ServiceClients:BlueprintService:Address"]

--- a/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs
@@ -30,6 +30,7 @@ public class DatabaseInitializer
     public static readonly Guid PeerServicePrincipalId = new("00000000-0000-0000-0002-000000000004");
     public static readonly Guid ValidatorServicePrincipalId = new("00000000-0000-0000-0002-000000000005");
     public static readonly Guid TenantServicePrincipalId = new("00000000-0000-0000-0002-000000000006");
+    public static readonly Guid HaipServicePrincipalId = new("00000000-0000-0000-0002-000000000007");
 
     // Default credentials (can be overridden via configuration)
     public const string DefaultAdminEmail = "admin@sorcha.local";
@@ -437,6 +438,17 @@ public class DatabaseInitializer
                 // persona feature (092). Only the Tenant Service is issued
                 // this scope.
                 new[] { "wallets:read", "wallets:sign", "wallets:verify", "persona:crypto" }
+            ),
+            (
+                HaipServicePrincipalId,
+                "HAIP Service",
+                "service-haip",
+                "haip-service-secret",
+                // HAIP Service uses its service token to call Blueprint Service's
+                // presentation-callback endpoint (Feature 111). RequireService
+                // policy only checks the token_type=service claim, so the scope
+                // list is informational here. blueprints:read kept narrow.
+                new[] { "blueprints:read" }
             )
         };
 


### PR DESCRIPTION
## Summary

Fixes a master-branch DI regression that broke the AssuredIdentity Phase 2 walkthrough at the HAIP-present step. Discovered via a clean \`docker compose down -v\` + walkthrough.

\`PresentationCallbackRelay\` (Feature 111) requires \`IServiceAuthClient\` to authenticate the s2s callback into Blueprint Service. Every other Sorcha service (Blueprint, Register, Tenant, Validator, Wallet, Peer) calls \`AddServiceClients\` in its \`Program.cs\` to register the standard service-client stack — HAIP didn't.

## Reproduction

\`\`\`bash
docker compose down -v && docker compose up -d
# wait healthy, run AssuredIdentity walkthrough
./walkthroughs/AssuredIdentity/run.ps1 -Profile gateway
\`\`\`

Phase 2 step 5 (\`sorcha-agent haip present\`) returns HTTP 500 from \`/direct-post\`:

\`\`\`
System.InvalidOperationException: Unable to resolve service for type
'Sorcha.ServiceClients.Auth.IServiceAuthClient' while attempting to
activate 'Sorcha.Haip.Service.Services.PresentationCallbackRelay'.
\`\`\`

## Fix

- **\`src/Services/Sorcha.Haip.Service/Program.cs\`** — add \`AddServiceClients(builder.Configuration)\` above the \`PresentationCallbackRelay\` \`HttpClient\` registration. Adds the matching \`using Sorcha.ServiceClients.Extensions\`.
- **\`docker-compose.yml\`** — wire \`ServiceAuth__ClientId\` / \`ClientSecret\` / \`Scopes\` and \`ServiceClients__BlueprintService\` / \`TenantService\` addresses on the \`haip-service\` env block. Mirrors the env block on every other service.
- **\`src/Services/Sorcha.Tenant.Service/Data/DatabaseInitializer.cs\`** — seed a \"HAIP Service\" principal at \`HaipServicePrincipalId\` (\`00000000-0000-0000-0002-000000000007\`) with \`clientId: service-haip\`, dev secret \`haip-service-secret\`, scope \`blueprints:read\`. \`RequireService\` policy only checks the \`token_type=service\` claim, so the scope is informational here.

## Verified

Clean redeploy + AssuredIdentity walkthrough on this branch:

- ✅ Phase 1 (issuance) completes in ~24s (under SC-001 3-min budget)
- ✅ Phase 2 step 5 (\`sorcha-agent haip present\`) now passes — verifier accepts the presentation, the callback relay reaches Blueprint Service successfully

## Follow-on finding (out of scope here)

After this fix, Phase 2 still fails further down the chain:

- \`POST /api/presentations/callbacks/haip/{requestId}\` to Blueprint Service responds **400** on the relayed presentation outcome
- Action 3 (issue driving licence) then 400s because the presentation never reached \`success\` state on the Blueprint side
- That's a Feature 111 callback shape / payload investigation — captured as a follow-up

This PR is the necessary first step. The DI fix unblocks the relay path; the callback-handling bug is a separate fix.

## Test plan

- [x] \`dotnet build\` clean on tenant-service + haip-service
- [x] \`docker compose build tenant-service haip-service\` clean
- [x] \`docker compose down -v && docker compose up -d\` — all services healthy, no DI errors at boot
- [x] \`/api/presentations/callbacks/haip/...\` no longer returns 500 — relay path resolves \`IServiceAuthClient\`
- [x] AssuredIdentity Phase 1 + Phase 2 step 5 pass end-to-end on local Docker
- [ ] CI green (\`Run discoverability checks\` is the required gate; \`build-and-test\` known flake — issue #511)

🤖 Generated with [Claude Code](https://claude.com/claude-code)