### PR TITLE
fix(blueprint): register IPresentationConsumer for haip in Blueprint DI

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -216,6 +216,14 @@ builder.Services.AddScoped<Sorcha.Blueprint.Service.Services.Interfaces.IPresent
 builder.Services.AddSingleton<Sorcha.Blueprint.Service.Services.Infrastructure.IClock,
     Sorcha.Blueprint.Service.Services.Infrastructure.SystemClock>();
 builder.Services.AddSingleton<Sorcha.Blueprint.Service.Services.Implementation.PresentationLifecycleMetrics>();
+
+// Feature 111 — IPresentationConsumer registrations dispatched by name from
+// PresentationLifecycleService. Consumers run in-process here in Blueprint
+// Service because the lifecycle dispatcher resolves them from the local DI
+// container; they cannot live in their originating service's process.
+builder.Services.AddSingleton<Sorcha.PresentationLifecycle.Abstractions.IPresentationConsumer,
+    Sorcha.Blueprint.Service.Services.Implementation.HaipPresentationConsumer>();
+
 builder.Services.AddHostedService<Sorcha.Blueprint.Service.Services.Implementation.AbandonmentSweeper>();
 
 // Feature 103 US1: Redis read-through cache for per-instance participant bindings.

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/HaipPresentationConsumer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/HaipPresentationConsumer.cs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sorcha.PresentationLifecycle.Abstractions;
+
+namespace Sorcha.Blueprint.Service.Services.Implementation;
+
+/// <summary>
+/// Feature 111 — Blueprint-side <see cref="IPresentationConsumer"/> adapter for
+/// HAIP. Reads the verifier-result JSON forwarded by
+/// <c>Sorcha.Haip.Service.Services.PresentationCallbackRelay</c> and maps it
+/// onto a consumer-agnostic <see cref="PresentationOutcome"/> that the
+/// lifecycle service writes to the register.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The consumer interface is registered in Blueprint Service's DI because
+/// Blueprint owns the lifecycle dispatcher
+/// (<c>PresentationLifecycleService</c>) that resolves
+/// <c>IEnumerable&lt;IPresentationConsumer&gt;</c> by name. HAIP Service's own
+/// <c>HaipPresentationConsumer</c> registration is process-local and
+/// unreachable from here — the previous architecture mistake that made the
+/// callback endpoint return <c>"No IPresentationConsumer registered with
+/// name 'haip'."</c> on every HAIP-driven Phase 2 walkthrough.
+/// </para>
+/// <para>
+/// The wire shape mirrors <c>Sorcha.Haip.Service.Models.VerificationResult</c>
+/// — duplicated here so Blueprint Service does not need to project-reference
+/// HAIP Service. Both ends carry <c>[JsonPropertyName]</c> attributes for the
+/// same camelCase property names so the serialized payload is interchangeable.
+/// </para>
+/// </remarks>
+public sealed class HaipPresentationConsumer : IPresentationConsumer
+{
+    private readonly ILogger<HaipPresentationConsumer> _logger;
+
+    public HaipPresentationConsumer(ILogger<HaipPresentationConsumer> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public string ConsumerName => "haip";
+
+    /// <inheritdoc />
+    public Task<PresentationOutcome> VerifyAsync(
+        PresentationInitiationContext context,
+        object verifierPayload,
+        CancellationToken cancellationToken)
+    {
+        var result = verifierPayload switch
+        {
+            HaipVerificationResult vr => vr,
+            JsonElement je => je.Deserialize<HaipVerificationResult>(
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }),
+            _ => null
+        };
+
+        if (result is null)
+        {
+            _logger.LogWarning(
+                "HAIP consumer received unexpected verifier payload type {Type} for requestId {RequestId}",
+                verifierPayload?.GetType().FullName ?? "null", context.PresentationRequestId);
+            return Task.FromResult(new PresentationOutcome(
+                Kind: PresentationOutcomeKind.Decline,
+                VerifiedClaims: null,
+                Reason: PresentationDeclineReason.VerifierError,
+                VerifierDiagnostics: new Dictionary<string, object>
+                {
+                    ["payloadType"] = verifierPayload?.GetType().FullName ?? "null"
+                },
+                PresentationSubmissionHash: null));
+        }
+
+        if (result.IsValid)
+        {
+            var canonical = string.Concat(
+                result.Issuer ?? "",
+                ":",
+                string.Join(",", result.VerifiedClaims.Keys.OrderBy(k => k, StringComparer.Ordinal)));
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
+
+            return Task.FromResult(new PresentationOutcome(
+                Kind: PresentationOutcomeKind.Success,
+                VerifiedClaims: result.VerifiedClaims,
+                Reason: null,
+                VerifierDiagnostics: null,
+                PresentationSubmissionHash: $"sha256:{hash}"));
+        }
+
+        var reason = MapReason(result);
+        var diagnostics = new Dictionary<string, object>
+        {
+            ["errors"] = result.Errors,
+            ["holderKeyVerified"] = result.HolderKeyVerified,
+            ["x5cChainValid"] = result.X5cChainValid ?? (object)false,
+            ["statusCheckResult"] = result.StatusCheckResult ?? (object)string.Empty
+        };
+
+        return Task.FromResult(new PresentationOutcome(
+            Kind: PresentationOutcomeKind.Decline,
+            VerifiedClaims: null,
+            Reason: reason,
+            VerifierDiagnostics: diagnostics,
+            PresentationSubmissionHash: null));
+    }
+
+    private static PresentationDeclineReason MapReason(HaipVerificationResult result)
+    {
+        var allErrors = string.Join(" | ", result.Errors);
+        if (allErrors.Contains("expired", StringComparison.OrdinalIgnoreCase))
+            return PresentationDeclineReason.ExpiredCredential;
+        if (allErrors.Contains("issuer", StringComparison.OrdinalIgnoreCase))
+            return PresentationDeclineReason.WrongIssuer;
+        if (allErrors.Contains("revoked", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(result.StatusCheckResult, "revoked", StringComparison.OrdinalIgnoreCase))
+            return PresentationDeclineReason.Revoked;
+        if (allErrors.Contains("schema", StringComparison.OrdinalIgnoreCase) ||
+            allErrors.Contains("claim", StringComparison.OrdinalIgnoreCase))
+            return PresentationDeclineReason.SchemaMismatch;
+        if (allErrors.Contains("signature", StringComparison.OrdinalIgnoreCase) ||
+            allErrors.Contains("x5c", StringComparison.OrdinalIgnoreCase) ||
+            allErrors.Contains("holder key", StringComparison.OrdinalIgnoreCase))
+            return PresentationDeclineReason.SignatureInvalid;
+        return PresentationDeclineReason.VerifierError;
+    }
+}
+
+/// <summary>
+/// Wire shape for HAIP-side verification results forwarded by
+/// <c>PresentationCallbackRelay</c>. Mirrors
+/// <c>Sorcha.Haip.Service.Models.VerificationResult</c> — kept duplicated
+/// here so this service does not project-reference HAIP Service.
+/// </summary>
+internal sealed class HaipVerificationResult
+{
+    [JsonPropertyName("isValid")]
+    public bool IsValid { get; set; }
+
+    [JsonPropertyName("verifiedClaims")]
+    public Dictionary<string, object> VerifiedClaims { get; set; } = new();
+
+    [JsonPropertyName("errors")]
+    public List<string> Errors { get; set; } = new();
+
+    [JsonPropertyName("holderKeyVerified")]
+    public bool HolderKeyVerified { get; set; }
+
+    [JsonPropertyName("x5cChainValid")]
+    public bool? X5cChainValid { get; set; }
+
+    [JsonPropertyName("statusCheckResult")]
+    public string? StatusCheckResult { get; set; }
+
+    [JsonPropertyName("issuer")]
+    public string? Issuer { get; set; }
+}


### PR DESCRIPTION
## Summary

Second of (probably) three fixes needed to unblock the AssuredIdentity Phase 2 walkthrough end-to-end. Builds on PR #580 (HAIP \`IServiceAuthClient\` DI). Master-branch Feature 111 callback dispatch was broken — Blueprint Service's lifecycle dispatcher resolves \`IEnumerable<IPresentationConsumer>\` from its own DI container, but \`HaipPresentationConsumer\` was only registered in HAIP Service's process (unreachable from here).

## Reproduction

After PR #580 merges:

\`\`\`bash
docker compose down -v && docker compose up -d
./walkthroughs/AssuredIdentity/run.ps1 -Profile gateway
\`\`\`

Phase 2 step 5 (\`sorcha-agent haip present\`) now reaches Blueprint Service successfully (PR #580's fix). The relayed callback then returns **400** with body:

\`\`\`
{"error":"No IPresentationConsumer registered with name 'haip'."}
\`\`\`

Found via the relay's existing response-body logging in HAIP service logs.

## Fix

- **\`src/Services/Sorcha.Blueprint.Service/Services/Implementation/HaipPresentationConsumer.cs\`** — new Blueprint-local consumer that reads the HAIP wire payload, maps it to a consumer-agnostic \`PresentationOutcome\`. Uses the same decline-reason classification + submission-hash logic as the original HAIP-side consumer. Wire shape (\`HaipVerificationResult\`) is duplicated as an internal POCO to avoid a Blueprint→HAIP project reference; \`[JsonPropertyName]\` attributes match the HAIP relay's serialization byte-for-byte.
- **\`Program.cs\`** — register the consumer as a singleton \`IPresentationConsumer\` alongside the lifecycle service.

## Verified

After clean redeploy + walkthrough on this branch:

- ✅ Callback now returns **200** with \`PresentationOutcomeWritten tx ... kind=Success sentinel=success\`
- ✅ The relay-side log confirms \`Blueprint callback relay succeeded\`

Phase 2 still doesn't complete end-to-end — see follow-up below.

## Architectural note

The HAIP-side \`HaipPresentationConsumer\` registration in \`Sorcha.Haip.Service.Program.cs\` is now unreachable from production code paths (only the unit test project references it). Left in place here to avoid expanding scope; should be re-homed alongside the lifecycle service in a future cleanup.

## Follow-on FR-015 gap (NOT fixed in this PR)

After this fix, the callback succeeds and the \`presentation-outcome\` transaction is written with \`kind=Success\` — but **\`PresentationLifecycleService.HandleOutcomeAsync\` does not mark the originating action complete and does not advance the workflow**. FR-015 requires:

> System MUST treat the action as complete (and route downstream) only when a \`presentation-outcome\` with kind 'success' has been written

Currently Action 2 (verify identity) stays awaiting forever; Action 3 (issue licence) returns 400 \"is not a current action\". The fix needs to invoke the \`ActionExecutionService\` completion + routing path (instance state update, \`NotifyWorkflowCompletedAsync\` where appropriate, \`NextAction\` computation) after the validator confirms the outcome transaction. That crosses concern boundaries between \`PresentationLifecycleService\` and \`ActionExecutionService\` and is not a one-line fix — captured here for a focused follow-up PR.

## Test plan

- [x] \`dotnet build\` clean on Blueprint Service
- [x] \`docker compose build blueprint-service\` clean
- [x] Recreated container, healthy
- [x] AssuredIdentity Phase 2 step 5 callback now returns 200 (verified in Blueprint Service logs: \`PresentationOutcomeWritten\`)
- [ ] CI green (\`Run discoverability checks\` is the required gate; \`build-and-test\` known flake — issue #511)

🤖 Generated with [Claude Code](https://claude.com/claude-code)