### PR TITLE
test(wallet): align IssueCredential test signature with handler

### DIFF
--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialStatusListUrlGuardTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialStatusListUrlGuardTests.cs
@@ -103,6 +103,7 @@ public sealed class IssueCredentialStatusListUrlGuardTests
             null!, // ISdJwtService
             null!, // ICredentialStore
             new NullLoggerFactory(),
+            null!, // IWalletInboxWriter — not reached by the URL guard
             null,  // IOrgCertChainProvider (optional)
             CancellationToken.None
         ]);


### PR DESCRIPTION
## Summary

The `IssueCredential` handler at `src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs:479` takes 10 parameters; the reflection-based invocation in `IssueCredentialStatusListUrlGuardTests.InvokeAsync` was passing 9.

The `IWalletInboxWriter` parameter was added between `loggerFactory` and the optional `IOrgCertChainProvider` at some point, but the test's parameter array was never updated. Result: `TargetParameterCountException` fires inside `MethodInfo.Invoke` before the URL guard ever runs, so all three theory cases fail deterministically every CI run.

This has been on the standing "ignore in CI" list (CLAUDE.md → MEMORY.md → "Pre-existing failure modes to ignore"). Every PR has had to merge with `--admin` because of these three tests. Fixing it now removes one source of `--admin` justification on every future PR.

## Change

One line: add `null!, // IWalletInboxWriter — not reached by the URL guard` to the parameter array, in the slot the handler signature requires it. Same `null!` pattern as the other un-reached collaborators (`IKeyManagementService`, `ISdJwtService`, `ICredentialStore`).

The reflection-based pattern itself is unchanged — it's the canonical pattern from `PresentationEndpointTests` and `CitizenWalletEnrolEndpointTests` and the right shape for this test family.

## Verification

`dotnet test tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj` — **722/722 pass** (was 719/722 before this change). The three previously-failing theory cases now exercise the URL guard and produce the expected BadRequest results.

## Test plan

- [x] `dotnet test tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj` — 722/722 pass
- [ ] CI `build-and-test` — should now go green without the standing `IssueCredentialStatusListUrlGuardTests x3` failures

## Follow-up

Once this lands, MEMORY.md "Pre-existing failure modes to ignore" should drop the `IssueCredentialStatusListUrlGuardTests x3` entry. Will do that as part of the next memory housekeeping pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)