### PR TITLE
cleanup(validator): post-Feature 119 rule-base hardening + thesis spec entry

### DIFF
--- a/specs/120-programmable-validation-rules/spec.md
+++ b/specs/120-programmable-validation-rules/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: Programmable Validation Rule Set (Genesis-Embedded, Governance-Updateable)
+
+**Feature Branch**: `120-programmable-validation-rules`
+**Created**: 2026-05-09
+**Status**: Exploration / not scheduled
+**Source**: View 2 of the post-Feature 119 validator audit (2026-05-09 conversation, Saturday-afternoon thinking session)
+**Deep technical research**: `C:\Users\stuart\OneDrive\Documents\Claude\Projects\Project Sorcha\Validator2\2026-05-09-programmable-validation-thesis.md` (Cowork)
+**Depends on**: post-Feature 119 validator cleanup (TransactionTypeClassifier + dead-code removal — see PR landing this spec entry).
+
+---
+
+## What this is (and what it isn't)
+
+This is a **future-direction marker**, not a scheduled feature. Its purpose is to give the project tree a single discoverable pointer at the idea so anyone reading the spec list later can see it exists, see its dependencies, and find the deep doc.
+
+It is NOT a P-prioritised user story, has no plan/tasks/contracts, and is not on the active milestone roadmap. It will be picked up — if at all — after a deliberate decision to invest in it as a defining Sorcha capability rather than as a near-term feature.
+
+## One-paragraph thesis
+
+Sorcha's validator currently runs one fixed rule set, hardcoded into the validator binary, applied uniformly to every register. This works for the platform's current scale but bakes in a tradeoff: every register must accept the same workflow-validation policy, and changes to that policy require coordinated binary upgrades across all federated validators. A more powerful design embeds a **rule set in the genesis control record** of each register, makes it **governance-updateable** by the register's admin quorum (using the existing `VAL_PERM_*` quorum mechanism), and binds the **active rule-set version** into every docket so verifiers can replay the chain deterministically years later. Two-tier architecture: protocol invariants (chain integrity, signatures, replay protection) stay hardcoded; workflow policy (action reachability, file size limits, lifecycle exemptions) becomes register-specific data. Cleanly composable with three existing precedents in the codebase: `CryptoPolicy` from genesis, `ValidatorRoster` from genesis, and the quorum-gated governance ops for adding/removing/rotating validators.
+
+## Why this is interesting
+
+**Strategic positioning.** Programmable on-chain validation policy is rare — Hyperledger Fabric has chaincode endorsement policies, Ethereum has nothing equivalent for protocol rules, traditional ledger products have none of it. If Sorcha adopts this as a defining capability, it becomes the only register platform where workflow policy is on-chain, governance-mutable, and auditable across the chain history. That's a thesis-level differentiator, not a feature.
+
+**Technical anchoring.** The pattern already exists in the codebase three times over. `CryptoPolicy` (which signature algorithms are acceptable) is read from genesis. `ValidatorRoster` (who can seal dockets) is read from genesis and updated via `AddValidator` / `RemoveValidator` / `RotateValidatorKey` governance ops with quorum signatures. `VAL_PERM_005/006` enforces quorum thresholds. Generalising these patterns from "narrow concerns" to "rule set" is incremental, not from-scratch.
+
+## Why this is not scheduled
+
+**Cost is large.** Estimated 3-6 months of focused work. New types, new governance ops, new control-record handlers, new validator cache, new docket schema, multi-version replay test infrastructure, spec writing, walkthrough validation, n1 deployment of two versions side-by-side to test soft-fork resistance.
+
+**Timing is wrong.** Sorcha is at ~30% production readiness. Near-term value lies in UX and real-world adoption — getting people *using* Sorcha Data Rails before generalising the validator. The thesis-level differentiator only matters if there are users to differentiate for. Validator theory as USP only pays off downstream of adoption.
+
+**Cleanup must come first.** Doing the programmable rules work without first cleaning up the existing rule base would be building new mechanism on top of existing structural smells (carve-outs scattered across nine inline call sites, mixed protocol-invariant and workflow-policy rules under the same prefix taxonomy, persistence-projection asymmetry between Blueprint and Validator services). The post-Feature 119 cleanup PR (this spec's dependency) closes ~80% of the F119-class structural risk for ~5% of the cost; the thesis can build on a healthier foundation when its time comes.
+
+## Two-tier architecture summary
+
+**Tier 1 — Protocol invariants. Hardcoded. Non-disableable.**
+`VAL_STRUCT_*`, `VAL_SIG_*`, `VAL_HASH_*`, `VAL_GENESIS_*`, `VAL_CHAIN_001/002/003/004`, `VAL_CHAIN_FORK`, `VAL_REPLAY_*`, `VAL_INTERNAL`. Disabling any of these breaks the chain itself or makes verification non-deterministic for future readers.
+
+**Tier 2 — Workflow policy. Genesis-embedded. Quorum-updateable. Per-register.**
+`VAL_BP_*`, `VAL_FILE_002/003/004/005`, `VAL_TIME_002/003`, `VAL_POLICY_001/002` (already governable in narrow form), `VAL_PARTICIPANT_001` (debatable). Disabling any of these violates *this register's intended workflow* but doesn't break chain integrity.
+
+**The split test:** if disabling this rule lets through a transaction that subsequently corrupts the chain or makes verification non-deterministic for any future reader, it's Tier 1. Otherwise it's Tier 2.
+
+## Sequencing
+
+1. **Now (post-Feature 119 cleanup PR):** classifier centralised, dead `BuiltTransaction.ToTransactionModel()` removed. Foundation laid.
+2. **Later (only on adoption signal):** invest in the thesis. New milestone, dedicated owner, 3-6 month timeline. Until then, this spec stays at "exploration / not scheduled."
+
+## Open questions for the next round of thinking
+
+These are recorded in full in the Cowork doc. Headlines:
+
+- **Granularity of governance ops** — per-rule (`EnableRule(VAL_X)` / `DisableRule(VAL_X)` / `SetRuleParameter(VAL_X, k, v)`) versus coarse (`AdoptRuleSetVersion(7)` from a curated catalogue). The latter is dramatically safer.
+- **Soft-fork mitigation** — `minimumValidatorBinaryVersion` field, `effectiveAtBlockHeight` semantics, every-docket `validationPolicyVersion + hash` binding.
+- **What never goes in the rule set** — Tier 1 is enforced by the binary refusing to honour disable ops against protocol-invariant rule IDs. Quorum-capture cannot disable chain integrity.
+- **DSL or config-as-data** — strong recommendation: stay config-as-data forever; the moment a rule needs DSL expressiveness, it's protocol-level and belongs in the binary.
+
+## Success criteria for "this spec was worth filing"
+
+- A future reader unfamiliar with the 2026-05-09 conversation can locate this spec, read it in under 5 minutes, decide whether to dig into the Cowork doc, and know what's been thought through versus what's open.
+- The Cowork doc is self-contained enough that the next thinking-round doesn't have to start from scratch.
+
+## What this spec does NOT include
+
+- A plan, tasks, contracts, data model, research artefacts, or quickstart. Future scheduling work would add those.
+- Any commitment to deliver. This is a directional marker only.
+
+---
+
+**Maintenance:** if the thesis is ever picked up as scheduled work, this file gets superseded by a real spec.md (with status: Active) and the dependency direction reverses — the Cowork research doc becomes a historical reference cited by the new spec.

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
@@ -695,32 +695,13 @@ public class BuiltTransaction
         _ => "Action"
     };
 
-    /// <summary>
-    /// Converts to a TransactionModel for submission to the Register Service
-    /// </summary>
-    public Sorcha.Register.Models.TransactionModel ToTransactionModel()
-    {
-        var metaData = new Sorcha.Register.Models.TransactionMetaData
-        {
-            BlueprintId = Metadata.GetValueOrDefault("blueprintId")?.ToString(),
-            InstanceId = Metadata.GetValueOrDefault("instanceId")?.ToString()
-        };
-
-        if (Metadata.TryGetValue("actionId", out var actionIdObj) && actionIdObj is int actionId)
-        {
-            metaData.ActionId = (uint)actionId;
-        }
-
-        return new Sorcha.Register.Models.TransactionModel
-        {
-            TxId = TxId,
-            RegisterId = RegisterId,
-            SenderWallet = SenderWallet,
-            Signature = Signature != null ? Base64Url.EncodeToString(Signature) : string.Empty,
-            MetaData = metaData,
-            PayloadCount = 0,
-            Payloads = Array.Empty<Sorcha.Register.Models.PayloadModel>(),
-            TimeStamp = DateTime.UtcNow
-        };
-    }
+    // ToTransactionModel() removed in post-Feature-119 cleanup. The method had no
+    // production callers — write-path persistence is owned by the Validator Service
+    // (see Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs around
+    // line 587 where TransactionMetaData is constructed inline from the submission
+    // DTO). Three Feature 119 implementation attempts modified this dead method
+    // believing it was on the production write path; the walkthrough kept failing
+    // until the asymmetry was traced. The reverse mapping (persisted document ->
+    // API response model) lives at Sorcha.Register.Storage.MongoDB/Mappers/
+    // MongoDocumentMapper.ToTransactionModel(MongoTransactionDocument).
 }

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -584,6 +584,12 @@ public class DocketBuildTriggerService : BackgroundService
                             }
                         },
                         RecipientsWallets = t.RecipientsWallets ?? new List<string>(),
+                        // AUTHORITATIVE WRITE-PATH PROJECTION (post-Feature 119 note):
+                        // This block is the single source of truth for what TransactionMetaData
+                        // gets persisted to MongoDB. Blueprint Service's BuiltTransaction does
+                        // NOT have an equivalent ToTransactionModel() method any more — three
+                        // Feature 119 attempts modified that dead method and confirmed it was
+                        // never on the write path. ALL persisted-metadata changes go here.
                         MetaData = new Sorcha.Register.Models.TransactionMetaData
                         {
                             RegisterId = t.RegisterId,

--- a/src/Services/Sorcha.Validator.Service/Services/TransactionTypeClassifier.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/TransactionTypeClassifier.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Register.Models.Constants;
+using Sorcha.Validator.Service.Models;
+
+namespace Sorcha.Validator.Service.Services;
+
+/// <summary>
+/// Centralised transaction-type predicates used by validator rule logic.
+/// Carved out of <see cref="ValidationEngine"/> as part of the post-Feature-119
+/// rule-base cleanup so that exemptions and carve-outs reference a single
+/// predicate registry rather than reimplementing string comparisons inline.
+/// All predicates are pure and depend only on the transaction's structural
+/// fields (BlueprintId, Metadata, Payload).
+/// </summary>
+internal static class TransactionTypeClassifier
+{
+    public static bool IsGenesisOrControlTransaction(Transaction transaction)
+    {
+        if (string.Equals(transaction.BlueprintId, GenesisConstants.BlueprintId, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
+            (string.Equals(typeStr, "Genesis", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(typeStr, "Control", StringComparison.OrdinalIgnoreCase)))
+            return true;
+
+        return false;
+    }
+
+    public static bool IsParticipantTransaction(Transaction transaction)
+    {
+        return transaction.Metadata.TryGetValue("Type", out var typeStr) &&
+               string.Equals(typeStr, "Participant", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsRejectionTransaction(Transaction transaction)
+    {
+        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
+            string.Equals(typeStr, "Rejection", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (transaction.Payload.ValueKind == System.Text.Json.JsonValueKind.Object &&
+            transaction.Payload.TryGetProperty("type", out var payloadType) &&
+            string.Equals(payloadType.GetString(), "rejection", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
+    public static bool IsRevocationTransaction(Transaction transaction)
+    {
+        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
+            string.Equals(typeStr, "Revocation", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (transaction.Metadata.TryGetValue("transactionType", out var txType) &&
+            string.Equals(txType, "Revocation", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// True if the transaction is a presentation lifecycle event:
+    /// <c>PresentationInitiated</c>, <c>PresentationOutcome</c>, or
+    /// <c>PresentationAbandoned</c>. The general predicate — useful for routing
+    /// lifecycle events to the lifecycle-specific code paths in Blueprint and
+    /// Validator services.
+    /// </summary>
+    public static bool IsLifecycleTransaction(Transaction transaction)
+    {
+        if (!transaction.Metadata.TryGetValue("Type", out var typeStr) || typeStr is null)
+            return false;
+
+        return string.Equals(typeStr, "PresentationInitiated", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(typeStr, "PresentationOutcome", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(typeStr, "PresentationAbandoned", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// True if the transaction is an intra-action lifecycle terminal —
+    /// <c>PresentationOutcome</c> or <c>PresentationAbandoned</c>. These are
+    /// the lifecycle events that chain off the same action's
+    /// <c>PresentationInitiated</c> and therefore carry the same ActionId,
+    /// which would trip VAL_BP_003 reflexively. Excludes
+    /// <c>PresentationInitiated</c> — it really does advance from action N-1
+    /// to action N and gets the full reachability check.
+    /// </summary>
+    public static bool IsIntraActionLifecycleTerminal(Transaction transaction)
+    {
+        if (!transaction.Metadata.TryGetValue("Type", out var typeStr) || typeStr is null)
+            return false;
+
+        return string.Equals(typeStr, "PresentationOutcome", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(typeStr, "PresentationAbandoned", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -159,7 +159,7 @@ public class ValidationEngine : IValidationEngine
             }
 
             // 4e. Validate revocation transaction rules
-            if (IsRevocationTransaction(transaction))
+            if (TransactionTypeClassifier.IsRevocationTransaction(transaction))
             {
                 var revResult = await ValidateRevocationAsync(transaction, ct);
                 if (!revResult.IsValid)
@@ -189,7 +189,7 @@ public class ValidationEngine : IValidationEngine
             }
 
             // 5b. Validate sequence number for replay protection (SEC-AUDIT 4.2)
-            if (_walletSequenceRepository != null && !IsGenesisOrControlTransaction(transaction))
+            if (_walletSequenceRepository != null && !TransactionTypeClassifier.IsGenesisOrControlTransaction(transaction))
             {
                 try
                 {
@@ -333,7 +333,7 @@ public class ValidationEngine : IValidationEngine
 
         // BlueprintId and ActionId are required for blueprint-based transactions
         // but not for Participant transactions (which have no blueprint context)
-        if (!IsParticipantTransaction(transaction))
+        if (!TransactionTypeClassifier.IsParticipantTransaction(transaction))
         {
             if (string.IsNullOrWhiteSpace(transaction.BlueprintId))
             {
@@ -428,7 +428,7 @@ public class ValidationEngine : IValidationEngine
         try
         {
             // Genesis/control transactions skip schema validation but MUST have valid signatures (SEC-AUDIT 4.10)
-            if (IsGenesisOrControlTransaction(transaction))
+            if (TransactionTypeClassifier.IsGenesisOrControlTransaction(transaction))
             {
                 _logger.LogDebug("Validating signatures for genesis/control transaction {TransactionId}",
                     transaction.TransactionId);
@@ -466,14 +466,14 @@ public class ValidationEngine : IValidationEngine
             }
 
             // Participant transactions use a built-in schema instead of blueprint schemas
-            if (IsParticipantTransaction(transaction))
+            if (TransactionTypeClassifier.IsParticipantTransaction(transaction))
             {
                 return ValidateParticipantSchema(transaction, sw);
             }
 
             // Skip schema validation for rejection transactions (payload contains rejection
             // metadata, not the action's data schema)
-            if (IsRejectionTransaction(transaction))
+            if (TransactionTypeClassifier.IsRejectionTransaction(transaction))
             {
                 _logger.LogDebug("Skipping schema validation for rejection transaction {TransactionId}",
                     transaction.TransactionId);
@@ -970,7 +970,7 @@ public class ValidationEngine : IValidationEngine
         var errors = new List<ValidationEngineError>();
 
         // Skip for genesis/control transactions
-        if (IsGenesisOrControlTransaction(transaction))
+        if (TransactionTypeClassifier.IsGenesisOrControlTransaction(transaction))
         {
             return ValidationEngineResult.Success(
                 transaction.TransactionId,
@@ -979,7 +979,7 @@ public class ValidationEngine : IValidationEngine
         }
 
         // Skip for participant transactions (no blueprint context)
-        if (IsParticipantTransaction(transaction))
+        if (TransactionTypeClassifier.IsParticipantTransaction(transaction))
         {
             _logger.LogDebug("Skipping blueprint conformance for participant transaction {TransactionId}",
                 transaction.TransactionId);
@@ -990,7 +990,7 @@ public class ValidationEngine : IValidationEngine
         }
 
         // Skip for rejection transactions (payload contains rejection metadata, not action data)
-        if (IsRejectionTransaction(transaction))
+        if (TransactionTypeClassifier.IsRejectionTransaction(transaction))
         {
             _logger.LogDebug("Skipping blueprint conformance for rejection transaction {TransactionId}",
                 transaction.TransactionId);
@@ -1152,11 +1152,7 @@ public class ValidationEngine : IValidationEngine
             //    VAL_BP_003 reflexively (action N is not reachable from action N). Skip the
             //    route check for these tx types — chain integrity is still enforced by
             //    VAL_CHAIN_001 / VAL_CHAIN_FORK; only the workflow-routing check is bypassed.
-            var isIntraActionLifecycleTx =
-                (transaction.Metadata.TryGetValue("Type", out var lifecycleType) &&
-                 lifecycleType is not null &&
-                 (string.Equals(lifecycleType, "PresentationOutcome", StringComparison.OrdinalIgnoreCase) ||
-                  string.Equals(lifecycleType, "PresentationAbandoned", StringComparison.OrdinalIgnoreCase)));
+            var isIntraActionLifecycleTx = TransactionTypeClassifier.IsIntraActionLifecycleTerminal(transaction);
 
             if (!isIntraActionLifecycleTx && !string.IsNullOrWhiteSpace(transaction.PreviousTransactionId))
             {
@@ -1282,54 +1278,8 @@ public class ValidationEngine : IValidationEngine
     }
 
 
-    private static bool IsGenesisOrControlTransaction(Transaction transaction)
-    {
-        if (string.Equals(transaction.BlueprintId, GenesisConstants.BlueprintId, StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
-            (string.Equals(typeStr, "Genesis", StringComparison.OrdinalIgnoreCase) ||
-             string.Equals(typeStr, "Control", StringComparison.OrdinalIgnoreCase)))
-            return true;
-
-        return false;
-    }
-
-    private static bool IsParticipantTransaction(Transaction transaction)
-    {
-        return transaction.Metadata.TryGetValue("Type", out var typeStr) &&
-               string.Equals(typeStr, "Participant", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool IsRejectionTransaction(Transaction transaction)
-    {
-        // Check metadata "Type" key (primary — set by ToTransactionSubmission)
-        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
-            string.Equals(typeStr, "Rejection", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        // Check payload for "type":"rejection" field (fallback — set by BuildRejectionTransactionAsync)
-        if (transaction.Payload.ValueKind == System.Text.Json.JsonValueKind.Object &&
-            transaction.Payload.TryGetProperty("type", out var payloadType) &&
-            string.Equals(payloadType.GetString(), "rejection", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        return false;
-    }
-
-    private static bool IsRevocationTransaction(Transaction transaction)
-    {
-        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
-            string.Equals(typeStr, "Revocation", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        // Fallback: check alternative metadata key
-        if (transaction.Metadata.TryGetValue("transactionType", out var txType) &&
-            string.Equals(txType, "Revocation", StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        return false;
-    }
+    // Transaction-type predicates moved to TransactionTypeClassifier (post-Feature 119
+    // rule-base cleanup). All call sites in this engine route through the classifier.
 
     /// <summary>
     /// Validates a revocation transaction: checks target exists, not already revoked,

--- a/tests/Sorcha.Validator.Service.Tests/Services/TransactionTypeClassifierTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/TransactionTypeClassifierTests.cs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Register.Models.Constants;
+using Sorcha.Validator.Service.Models;
+using Sorcha.Validator.Service.Services;
+using Xunit;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Unit coverage for the centralised transaction-type predicates carved out of
+/// <c>ValidationEngine</c> as part of the post-Feature-119 rule-base cleanup.
+/// </summary>
+public class TransactionTypeClassifierTests
+{
+    private static Transaction TxWithMetadata(
+        params (string Key, string Value)[] entries)
+        => Build(blueprintId: "bp-1", payloadJson: "{}", entries);
+
+    private static Transaction Build(
+        string? blueprintId,
+        string payloadJson,
+        params (string Key, string Value)[] entries)
+    {
+        var meta = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (k, v) in entries) meta[k] = v;
+        return new Transaction
+        {
+            TransactionId = "tx-1",
+            RegisterId = "reg-1",
+            BlueprintId = blueprintId,
+            ActionId = "1",
+            Payload = JsonDocument.Parse(payloadJson).RootElement,
+            PayloadHash = "hash",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Signatures = new List<Signature>(),
+            Metadata = meta,
+        };
+    }
+
+    [Fact]
+    public void IsGenesisOrControlTransaction_BlueprintIdIsGenesis_ReturnsTrue()
+    {
+        var tx = Build(blueprintId: GenesisConstants.BlueprintId, payloadJson: "{}");
+
+        TransactionTypeClassifier.IsGenesisOrControlTransaction(tx).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Genesis")]
+    [InlineData("genesis")]
+    [InlineData("Control")]
+    [InlineData("CONTROL")]
+    public void IsGenesisOrControlTransaction_TypeMetadataMatches_ReturnsTrue(string type)
+    {
+        var tx = TxWithMetadata(("Type", type));
+
+        TransactionTypeClassifier.IsGenesisOrControlTransaction(tx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsGenesisOrControlTransaction_RegularAction_ReturnsFalse()
+    {
+        var tx = TxWithMetadata(("Type", "Action"));
+
+        TransactionTypeClassifier.IsGenesisOrControlTransaction(tx).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Participant", true)]
+    [InlineData("PARTICIPANT", true)]
+    [InlineData("Action", false)]
+    [InlineData("Control", false)]
+    public void IsParticipantTransaction_RecognisesParticipantTypeOnly(string type, bool expected)
+    {
+        var tx = TxWithMetadata(("Type", type));
+
+        TransactionTypeClassifier.IsParticipantTransaction(tx).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsRejectionTransaction_MetadataTypeRejection_ReturnsTrue()
+    {
+        var tx = TxWithMetadata(("Type", "Rejection"));
+
+        TransactionTypeClassifier.IsRejectionTransaction(tx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRejectionTransaction_PayloadTypeRejection_ReturnsTrue()
+    {
+        var tx = Build(blueprintId: "bp-1", payloadJson: """{"type":"rejection"}""");
+
+        TransactionTypeClassifier.IsRejectionTransaction(tx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRejectionTransaction_NeitherPath_ReturnsFalse()
+    {
+        var tx = TxWithMetadata(("Type", "Action"));
+
+        TransactionTypeClassifier.IsRejectionTransaction(tx).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Type", "Revocation", true)]
+    [InlineData("transactionType", "Revocation", true)]
+    [InlineData("Type", "revocation", true)]
+    [InlineData("Type", "Action", false)]
+    public void IsRevocationTransaction_RecognisesEitherKey(string key, string value, bool expected)
+    {
+        var tx = TxWithMetadata((key, value));
+
+        TransactionTypeClassifier.IsRevocationTransaction(tx).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("PresentationInitiated", true)]
+    [InlineData("PresentationOutcome", true)]
+    [InlineData("PresentationAbandoned", true)]
+    [InlineData("presentationoutcome", true)]
+    [InlineData("Action", false)]
+    [InlineData("Control", false)]
+    public void IsLifecycleTransaction_CoversAllThreeLifecycleTypes(string type, bool expected)
+    {
+        var tx = TxWithMetadata(("Type", type));
+
+        TransactionTypeClassifier.IsLifecycleTransaction(tx).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("PresentationOutcome", true)]
+    [InlineData("PresentationAbandoned", true)]
+    [InlineData("PresentationInitiated", false)] // intentionally excluded — gets full reachability check
+    [InlineData("Action", false)]
+    public void IsIntraActionLifecycleTerminal_ExcludesInitiated(string type, bool expected)
+    {
+        var tx = TxWithMetadata(("Type", type));
+
+        TransactionTypeClassifier.IsIntraActionLifecycleTerminal(tx).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsLifecycleTransaction_NoTypeMetadata_ReturnsFalse()
+    {
+        var tx = TxWithMetadata();
+
+        TransactionTypeClassifier.IsLifecycleTransaction(tx).Should().BeFalse();
+        TransactionTypeClassifier.IsIntraActionLifecycleTerminal(tx).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Three commits closing the structural risks Feature 119 surfaced in the validator rule base. Plus a one-page future-direction spec entry pointing at a deeper thesis (held in Cowork, not scheduled).

The work is the output of a Saturday-afternoon analysis session reviewing the F119 trace, asking what it tells us about validator structural health, and then opening into a separate exploratory discussion of programmable validation as a Sorcha-defining capability. The two halves are split deliberately: the cleanup ships now (small, low-risk, real value); the thesis is filed as exploration-not-scheduled (real value but timing-sensitive — UX and adoption come first).

## What's in this PR

### Commit 1 — `TransactionTypeClassifier` (refactor + new predicates)

The four `IsXTransaction` predicates that lived as private statics in `ValidationEngine.cs:1285-1332` (`IsGenesisOrControlTransaction`, `IsParticipantTransaction`, `IsRejectionTransaction`, `IsRevocationTransaction`) move into a new `internal static class TransactionTypeClassifier` alongside two new predicates surfaced by Feature 119:

- `IsLifecycleTransaction` — true for any of `{PresentationInitiated, PresentationOutcome, PresentationAbandoned}`. The general predicate.
- `IsIntraActionLifecycleTerminal` — true for `{PresentationOutcome, PresentationAbandoned}` only. `PresentationInitiated` is intentionally excluded — it really does advance from action N-1 to action N and gets the full reachability check.

The Feature 119 carve-out at `ValidationEngine.cs:1155` (which inlined a string comparison against `PresentationOutcome` / `PresentationAbandoned`) now reads as `TransactionTypeClassifier.IsIntraActionLifecycleTerminal(tx)`. All nine call sites for the four pre-existing predicates rewired to the classifier.

Twelve unit tests added covering positive, negative, and case-insensitivity behaviour.

### Commit 2 — Remove dead `BuiltTransaction.ToTransactionModel()` + flag authoritative write path

`BuiltTransaction.ToTransactionModel()` in `Sorcha.Blueprint.Service` had **zero callers in production code**. Three Feature 119 implementation attempts modified this method believing it was on the production write path; the walkthrough kept failing because the actual write-path is owned by the Validator Service in `DocketBuildTriggerService.cs` around line 587, which constructs `TransactionMetaData` inline from the submission DTO and bypasses `BuiltTransaction.ToTransactionModel()` entirely.

This commit:
- Removes the dead method (28 lines).
- Adds a comment in its place documenting where the write-path actually lives.
- Adds an `// AUTHORITATIVE WRITE-PATH PROJECTION` comment block at the validator-side construction site, so the next developer who needs to change persisted-metadata sees the single source of truth on first reading.

Closes the F119 trap permanently.

### Commit 3 — File `specs/120-programmable-validation-rules/spec.md`

One-page future-direction marker pointing at the deeper "programmable validation via genesis-embedded rule sets" thesis. The substantive technical research lives in Cowork:

```
C:\Users\stuart\OneDrive\Documents\Claude\Projects\Project Sorcha\Validator2\
2026-05-09-programmable-validation-thesis.md
```

Status: exploration / not scheduled. The thesis becomes scheduled work only on a deliberate decision triggered by adoption signals (more registers asking for materially different policy, competitive pressure, regulatory triggers, or a spike in F119-class hidden-coupling bugs). Until then it sits dormant in the spec tree as a discoverable directional marker.

## What's not in this PR

The original View 1 analysis (in conversation) proposed a third cleanup commit — a `RuleExemption` registry centralising the nine carve-outs in the validator. **Walked back during implementation**: only 2 of the 9 carve-outs are pure rule-skips (the F119 one and the genesis-precedes-policy one); the other 7 are section-exemption early-returns or substitutions that need a strategy-pattern refactor, not a registry. A registry that fits 2 cases isn't worth building.

The strategy-pattern refactor is documented in the Cowork thesis (Part 4) as a natural prerequisite for the programmable-validation milestone. Not in scope for this PR.

## Behavioural changes

**None.** Both code commits are pure refactors. The classifier is a mechanical move + two new predicates with the same semantics as the inlined string comparison they replace. The dead-method removal cannot affect runtime behaviour because the method had no production callers.

## Verification

- `dotnet build src/Services/Sorcha.Validator.Service/...` — clean, 0 errors
- `dotnet build src/Services/Sorcha.Blueprint.Service/...` — clean, 0 errors
- `dotnet test tests/Sorcha.Validator.Service.Tests/...` — 950 / 0 / 17 (passed / failed / skipped). Includes the 12 new classifier tests.

## Test plan

- [x] `dotnet build` for both services — clean
- [x] `dotnet test` for Validator.Service.Tests — 950 / 0 / 17
- [ ] CI `build-and-test` should be green or no-worse-than-master (the SignalRIntegrationTests cluster from Feature 118 was fixed in #589; remaining flakes are unrelated to this work)
- [ ] CI Docker builds remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)