### PR TITLE
chore(120): renumber placeholder + restore F120 production-issuer docs

### DIFF
--- a/docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md
+++ b/docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md
@@ -1,0 +1,432 @@
+# Production Issuer Signature Verification — Design Document
+
+**Date:** 2026-05-09
+**Author:** Stuart Fraser, with Claude Opus 4.7 (1M context)
+**Status:** Design complete — ready for spec
+**Target feature:** 120 (next available after 119-presentation-seal-ordering)
+**Companion docs:**
+- `Validator2/2026-05-09-programmable-validation-thesis.md` (shared memory)
+- `Validator2/2026-05-09-did-resolution-and-issuer-sig-companion.md` (shared memory)
+
+---
+
+## Executive summary
+
+Sorcha currently accepts any credential as authentic at presentation time. The verifier's `IIssuerKeyResolver` is `OptOutIssuerKeyResolver` (returns null) by default; only a demo-only `JwkRegistryIssuerKeyResolver` exists alongside it for the `/verify/demo/mint` flow. There is no production path that resolves an issuer's DID to a public key and verifies the credential's JWS signature against it.
+
+This design closes that gap by:
+
+1. **Standardising on the W3C-shaped DID resolver stack** (`IDidResolver` / `IDidResolverRegistry`), retiring the legacy `IDIDResolver` interface.
+2. **Publishing every Sorcha-hosted org as both `did:sorcha:org:{addr}` (primary) and `did:web:{platform-domain}:orgs:{orgId}` (federation)**, linked via `alsoKnownAs`.
+3. **Cross-resolving `alsoKnownAs`** at the registry layer with key-material verification — preventing impersonation via compromised `did:web` documents.
+4. **Shipping a `DidResolverBackedIssuerKeyResolver`** that the verifier (and any other point-of-use: wallet sync surface, register inbox projector) consumes.
+5. **Reserving forward-compat slots** on the genesis control record (`RegisterPolicy.requireIssuerSignature`, `RegisterPolicy.permittedIssuers`) so Future B (chain-authoritative issuer-sig in `VAL_CRED_*` validator rules) lands without schema migration.
+6. **Defaulting to enforce-on at ship**, leveraging Sorcha's pre-production status — the walkthrough suite passing with enforcement on is the ship gate, in lieu of a multi-week warn-only soak window.
+
+This is **Future A** in the sequencing companion: verifier-side enforcement. Future B (validator authoritative on issuer-sig at seal time) remains explicitly deferred. The work shipped here is forward-compatible: the resolver code lifts into the validator unchanged when Future B is triggered.
+
+---
+
+## Problem statement
+
+### Current state
+
+| Component | Status |
+|---|---|
+| `OptOutIssuerKeyResolver` | Default. Returns null. Verifier accepts on holder→device chain alone with `RequireIssuerSignature: false`. |
+| `JwkRegistryIssuerKeyResolver` | Demo-only. In-memory map populated by `DemoMintEndpoint` per-mint. Used by the `/verify/demo/mint` test flow. |
+| `IDidResolver` (W3C-shaped) | Live. `SorchaDidResolver`, `KeyDidResolver`, `WebDidResolver` registered via `IDidResolverRegistry`. Consumed by HAIP and Wallet for VP verification but **not by the issuer-key resolver**. |
+| `IDIDResolver` (legacy) | Single consumer (`Sorcha.Register.Service/Program.cs:205`). Returns flat `{PublicKey, Algorithm}` shape. Predates W3C work. Migration debt. |
+| Org DID documents | Not published. `did:sorcha:org:*` resolves dynamically via `IWalletServiceClient`; `did:web:*` for orgs does not exist at all. |
+| `alsoKnownAs` | Not emitted by `SorchaDidResolver`. Not cross-resolved anywhere. |
+| `RequireIssuerSignature: true` | Tripwire — every presentation fails because no resolver returns a key. |
+
+### Gap
+
+The verifier is one OptOut flag-flip away from accepting forged credentials. Until a `DidResolverBackedIssuerKeyResolver` exists, that flip is impossible without breaking everything. Until org DID documents are published with surfaced issuance keys, even a working resolver has nothing to resolve to.
+
+### Why now
+
+Sorcha's near-term focus is real-world adoption (per the programmable-validation thesis). Production credential flows — Feature 106 register-native credentials, Feature 097 OID4VCI, Feature 107 Assured Identity — all assume issuer signature is meaningfully verified. They cannot ship to production with the OptOut default.
+
+---
+
+## Goals and non-goals
+
+### Goals
+
+- **Production-shippable issuer signature verification** for all SD-JWT VC presentations, regardless of whether the credential was issued via OID4VCI, register-native, or demo-mint.
+- **Single canonical DID resolver stack** (W3C-shaped). Legacy `IDIDResolver` retired.
+- **Federation interop**: Sorcha-issued credentials verifiable by standards-compliant external wallets and verifiers, via `did:web`.
+- **Forward-compat** for Future B (chain-authoritative `VAL_CRED_*`). Schema slots reserved; resolver code structured for lift-and-shift into the validator.
+- **Pre-production ship posture**: enforce-on at ship. Walkthrough suite green is the gate.
+
+### Non-goals
+
+- **Validator-side issuer-sig at seal time** — Future B. Deferred until adoption pressure justifies the determinism cost.
+- **BYO-domain `did:web`** — orgs publishing their own `did.json` on a domain they control. Deferred phase; Sorcha-hosted form is the v1 default.
+- **Auto-rotation schedules** — manual rotation via governance op only in v1.
+- **Additional DID methods** (`did:ethr`, `did:ion`, etc.) — additive; the registry pattern means they drop in without touching this work.
+- **Signed `alsoKnownAs` equivalence assertions** — cryptographically cleaner than cross-resolution but requires a Sorcha-specific extension. Cross-resolution wins on standards interop.
+- **Per-credential-type `requireIssuerSignature` policy** — per-action allowlist via `acceptedIssuers` already provides finer-grained control.
+- **Validator gaining `IDidResolverRegistry` access** — Future B concern.
+
+---
+
+## Locked product decisions (the brainstorm output)
+
+The six decisions taken in the 2026-05-09 brainstorm session, captured here so the spec can treat them as starting axioms.
+
+### D1 — Org DID hosting
+
+**Sorcha-hosted, path-based.** Default form `did:web:{platform-domain}:orgs:{orgId}` resolves to `https://{platform-domain}/orgs/{orgId}/did.json`. Static JSON behind the gateway, CDN-cacheable. Document regenerated on key events (key derived, rotated, revoked).
+
+BYO-domain (`did:web:acme.com`) deferred. When upgrading, the old A-form DID stays resolvable indefinitely; both documents declare each other via `alsoKnownAs`.
+
+### D2 — Issuance key lifecycle
+
+**Lazy derivation** at first credential-issuance attempt (slot 1, `KeyUsage.VCIssuance`, BIP44 path under Feature 083). Orgs that never issue credentials never carry an issuance key.
+
+**Manual rotation only in v1.** Governance op rotates; old key remains in the DID document as a `VerificationMethod` until all credentials it signed have expired.
+
+**Compromise revocation = governance op with admin quorum.** Same pattern as Feature 086 `RotateValidatorKey`. Proto-rule code `VAL_CRED_GOV_001` reserved.
+
+### D3 — `kid` convention
+
+**Hybrid: dual-publish + tolerant-verify.**
+
+- DID document publishes **two `VerificationMethod` entries per active key** with identical key material — one versioned (`#vc-issuance-{n}`) and one thumbprint-keyed (`#{rfc7638-thumbprint}`).
+- Issuer-side `kid` defaults to **versioned** per platform configuration. Per-org override slot reserved on the `Organization` model (`KidStyle` enum: `Versioned` | `Thumbprint`), not exposed in v1 UI.
+- Verifier matches kid via **exact string match first**, then **thumbprint fallback** — handles credentials from external issuers whose DID docs only carry one form.
+
+Doc cost: ~200 bytes per active VM. Trivial.
+
+### D4 — `alsoKnownAs` trust model
+
+**Cross-resolve and verify key material.** New method on `IDidResolverRegistry`:
+
+```csharp
+Task<DidDocument?> ResolveWithAlsoKnownAsAsync(string did, CancellationToken ct = default);
+```
+
+Resolves the primary DID, walks `alsoKnownAs`, resolves each linked DID independently, compares `VerificationMethod` key material across the two documents, returns the merged document only if the same public key appears in both. Reject (return null) on mismatch.
+
+Cached at the registry layer. TTLs:
+- `did:web` — 1h default, configurable
+- `did:sorcha:*` — on-event-invalidate via `transaction:confirmed` Redis stream subscription
+- `did:key` — infinite (offline, no refresh possible)
+
+This packaging means the verifier asks the registry once and gets a trustworthy result. Future B (validator-side) inherits the cross-resolution behaviour for free.
+
+### D5 — `RequireIssuerSignature` rollout
+
+**Per-register slot reserved + global flag honoured + default-on at ship.**
+
+- Schema addition to genesis control record: `RegisterPolicy.requireIssuerSignature: bool?` (reserved, not read in v1).
+- v1 reads a single platform config: `IssuerSignature:Required`, default `true`.
+- **No warn-only soak window.** Pre-production status means there are no legacy credentials to nurse. Walkthrough suite green with enforce-on is the ship gate.
+- **Three-way failure-mode logging** from day one:
+  1. `iss` DID does not resolve
+  2. DID resolves but no `VerificationMethod` matches the JWS `kid`
+  3. `VerificationMethod` matches but signature does not verify
+
+Spec records that the default-on-no-soak posture is conditional on pre-production status; the warn-only-then-flip pattern remains the right move for any future feature that materially changes verification behaviour after first external participant.
+
+### D6 — `did:web` trust bootstrap
+
+**Open trust + per-action allowlist.** Already implemented:
+
+- `CredentialRequirement.AcceptedIssuers : IEnumerable<string>?` exists at `src/Common/Sorcha.Blueprint.Models/Credentials/CredentialRequirement.cs:28`.
+- Enforced at three points: `CredentialMatcher.cs:51-52`, `PresentationRequestService.cs:364-365`, `PresentationLifecycleService.cs:133`.
+- Publish-time warning `OPEN_CREDENTIAL_ISSUER` flags empty allowlists.
+
+New schema slot reserved for Future B: `RegisterPolicy.permittedIssuers: string[]?` (register-wide allowlist, not read in v1).
+
+**One new bit of matching logic:** when `alsoKnownAs` cross-resolution succeeds, the matcher accepts either of the linked DIDs. If `acceptedIssuers: ["did:sorcha:org:ws1q..."]` and the credential's `iss=did:web:acme.com` resolves to a doc with `alsoKnownAs: ["did:sorcha:org:ws1q..."]`, the match succeeds.
+
+---
+
+## Architecture
+
+### Component diagram
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ Sorcha.Citizen.Verifier  /  Sorcha.Wallet.Service  /  HAIP         │
+│   VerifiablePresentationValidator                                  │
+│   PresentationRequestService                                       │
+│   InboundCredentialDetector                                        │
+│       │                                                             │
+│       ▼                                                             │
+│   IIssuerKeyResolver  ◄── DidResolverBackedIssuerKeyResolver  NEW  │
+│                            │                                        │
+│                            ▼                                        │
+│                       IDidResolverRegistry                          │
+│                          .ResolveAsync                              │
+│                          .ResolveWithAlsoKnownAsAsync       NEW    │
+│                            │                                        │
+│              ┌─────────────┼─────────────┐                          │
+│              ▼             ▼             ▼                          │
+│       SorchaDidResolver  WebDidResolver  KeyDidResolver             │
+│       (enhanced)         (existing)      (existing)                 │
+│              │                                                      │
+│              ▼                                                      │
+│       IWalletServiceClient                                          │
+│              │                                                      │
+│              ▼                                                      │
+│       Wallet Service                                                │
+└────────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────────┐
+│ Sorcha.Tenant.Service                                               │
+│   IOrgDidDocumentService  ◄── NEW                                   │
+│     - Generates and stores did:sorcha:org and did:web docs          │
+│     - Regenerates on key events                                     │
+│     - Serves did.json at /orgs/{orgId}/did.json                     │
+└────────────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────────────┐
+│ Sorcha.Wallet.Service                                               │
+│   IIssuanceKeyService  ◄── NEW                                      │
+│     - Lazy slot-1 derivation on first issuance                      │
+│     - Rotation governance op handler                                │
+│     - Revocation governance op handler                              │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### New components
+
+| Component | Project | Purpose |
+|---|---|---|
+| `DidResolverBackedIssuerKeyResolver` | `Sorcha.Citizen.Verifier` (initial) — likely promoted to a shared abstraction project later for wallet inbox / register projector reuse | Resolves credential `iss` to a public key via `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync`, matches `kid` via exact-then-thumbprint, returns `IssuerPublicKey` |
+| `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` | `Sorcha.ServiceClients.Http.Did` | Cross-resolves `alsoKnownAs`, verifies key-material match, returns merged DID document or null |
+| `IOrgDidDocumentService` / `OrgDidDocumentService` | `Sorcha.Tenant.Service` | Builds and stores DID documents for orgs; regenerates on key events; exposes the public `did.json` endpoint |
+| `IIssuanceKeyService` / `IssuanceKeyService` | `Sorcha.Wallet.Service` | Lazy slot-1 derivation, rotation, revocation; publishes key changes to `IOrgDidDocumentService` |
+| `OrgDidDocumentEndpoints` | `Sorcha.Tenant.Service` | `GET /orgs/{orgId}/did.json` — public, anonymous, CDN-cacheable |
+
+### Enhanced components
+
+| Component | Change |
+|---|---|
+| `SorchaDidResolver` | Surface issuance key as second `VerificationMethod` in `assertionMethod`; emit `alsoKnownAs` linking to the org's `did:web` form; emit dual VMs (versioned + thumbprint) per active key. |
+| `WebDidResolver` | No code changes — already ships with SSRF protection, document-id roundtrip check, HTTPS-only, 5s timeout. Configuration: ensure `DidResolver:AllowPrivateAddresses` is appropriately set in test vs prod. |
+| `DidResolverRegistry` | Add `ResolveWithAlsoKnownAsAsync` method. Add per-issuer cache keyed by canonical DID. Add Redis-stream subscription for `did:sorcha:*` invalidation. |
+| `VerifiablePresentationValidator` (verifier) | Wire `DidResolverBackedIssuerKeyResolver` as the production `IIssuerKeyResolver`. `JwkRegistryIssuerKeyResolver` retained for tests + demo-mint. |
+| `CredentialMatcher` (Wallet) | Add `alsoKnownAs`-equivalent issuer matching: when `acceptedIssuers` contains a DID and the candidate credential's `iss` resolves with `alsoKnownAs` linking to it, treat as match. |
+| `RegisterControlRecord` model | Add `RegisterPolicy.requireIssuerSignature: bool?` and `RegisterPolicy.permittedIssuers: string[]?`. JSON-null-ignored. |
+| `Organization` model | Add `KidStyle: KidStyle` enum (default `Versioned`). Not exposed in v1 admin UI. |
+
+### Retired components
+
+| Component | Action |
+|---|---|
+| `IDIDResolver` (`Sorcha.Register.Core.Services`) | Migrate single consumer in `Sorcha.Register.Service/Program.cs:205` to `IDidResolverRegistry`. Delete `IDIDResolver`, `DIDResolver`, `DIDResolutionResult`. Update specs/031 + specs/039 references. |
+
+---
+
+## Data flow
+
+### Issuance flow (server-mediated, slot 1 lazy)
+
+1. Org admin or user triggers credential issuance for the first time.
+2. `IIssuanceKeyService.GetOrDeriveAsync(orgId)` checks for existing slot-1 key. If absent, derives via `IKeyManagementService.DeriveKeyAtPathAsync` (Feature 083 slot 1, BIP44 path, context `sorcha:vc-issuance`).
+3. Issuance key material persisted (encrypted, custodial mode).
+4. `IOrgDidDocumentService.RegenerateAsync(orgId, KeyEventReason.IssuanceKeyDerived)` rebuilds and stores both DID documents (`did:sorcha:org:*` and `did:web:platform:orgs:{orgId}`).
+5. Credential JWS signed with the issuance key. Header `kid = did:sorcha:org:{addr}#vc-issuance-1` (or thumbprint per org's `KidStyle`).
+6. Credential issued. `iss` claim = `did:sorcha:org:{addr}` (canonical primary form).
+
+### Verification flow (presentation time)
+
+1. Verifier receives SD-JWT VC presentation. Parses JWS header → `iss`, `kid`.
+2. Verifier calls `IIssuerKeyResolver.ResolveAsync(iss)`.
+3. `DidResolverBackedIssuerKeyResolver` calls `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync(iss)`.
+4. Registry resolves `iss`. If `alsoKnownAs` is non-empty, resolves each linked DID. Verifies key-material match across documents. Returns merged document or null.
+5. `DidResolverBackedIssuerKeyResolver` matches `kid` against `verificationMethod[].id` (exact match first, thumbprint fallback). Returns the matching `JsonWebKey`.
+6. Verifier verifies the JWS signature against the returned key.
+7. Verifier matches the credential against per-action `acceptedIssuers`. Match succeeds if `iss` ∈ `acceptedIssuers` OR any DID in the resolved document's `alsoKnownAs` ∈ `acceptedIssuers`.
+
+### Cross-resolution example
+
+Credential header: `iss=did:web:platform:orgs:abc-123`, `kid=did:web:platform:orgs:abc-123#vc-issuance-1`.
+
+```
+1. ResolveWithAlsoKnownAsAsync("did:web:platform:orgs:abc-123")
+2. WebDidResolver fetches https://platform/orgs/abc-123/did.json
+   Returns: {
+     id: "did:web:platform:orgs:abc-123",
+     alsoKnownAs: ["did:sorcha:org:ws1qABC..."],
+     verificationMethod: [{ id: "...#vc-issuance-1", publicKeyMultibase: "z6MkXYZ..." }, ...]
+   }
+3. Registry walks alsoKnownAs. Resolves "did:sorcha:org:ws1qABC..."
+4. SorchaDidResolver returns: {
+     id: "did:sorcha:org:ws1qABC...",
+     alsoKnownAs: ["did:web:platform:orgs:abc-123"],
+     verificationMethod: [{ id: "...#vc-issuance-1", publicKeyMultibase: "z6MkXYZ..." }, ...]
+   }
+5. Registry verifies same key material in both. Match.
+6. Returns merged document.
+```
+
+If step 5 mismatches (e.g. compromised `did:web` document with attacker's key), registry returns null. Verifier rejects.
+
+---
+
+## Genesis schema additions
+
+### `RegisterControlRecord.RegisterPolicy`
+
+```jsonc
+"registerPolicy": {
+  // ... existing fields ...
+  "requireIssuerSignature": true,                  // optional; null => use platform default
+  "permittedIssuers": ["did:sorcha:org:ws1q..."]   // optional; null/empty => any resolvable issuer
+}
+```
+
+Both fields JSON-null-ignored. v1 does not read them. Future B reads both at validator seal time.
+
+### `Organization` model additions
+
+```csharp
+public class Organization
+{
+    // ... existing fields ...
+
+    public KidStyle DefaultKidStyle { get; set; } = KidStyle.Versioned;
+    // Not exposed in v1 admin UI. Slot reserved for standards-purist orgs.
+}
+
+public enum KidStyle { Versioned = 0, Thumbprint = 1 }
+```
+
+Default `Versioned` means platform-wide default applies. Slot reserved per D3.
+
+---
+
+## Phasing
+
+| Phase | Scope | Cost estimate | Independent? |
+|---|---|---|---|
+| **0 — Cleanup** | Retire legacy `IDIDResolver`. Migrate `Sorcha.Register.Service/Program.cs:205` consumer to `IDidResolverRegistry`. Delete `IDIDResolver`, `DIDResolver`, `DIDResolutionResult`. Update spec references. | 1-2h | Yes — small standalone PR, can ship before anything else |
+| **1 — DID document publishing** | `IOrgDidDocumentService` + `OrgDidDocumentEndpoints`. Generate both forms with `alsoKnownAs`. Dual-VM publishing template. Regeneration triggers on key events. Test: regenerated doc resolves cleanly via both `WebDidResolver` and `SorchaDidResolver`. | 2-3 days | Depends on Phase 0 |
+| **2 — Issuance key lifecycle** | `IIssuanceKeyService` with lazy slot-1 derivation, rotation handler, revocation handler (governance op `VAL_CRED_GOV_001`). Wire `IOrgDidDocumentService.RegenerateAsync` calls on key events. | 2-3 days | Depends on Phase 1 |
+| **3 — Resolver enhancements** | `SorchaDidResolver` enhancement: dual-VM publishing, `alsoKnownAs` emission, issuance-key VM surfaced. `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` with cross-resolution + caching + Redis-stream invalidation. Thumbprint-fallback matching helper. | 3-4 days | Depends on Phases 1+2 |
+| **4 — Issuer key resolver + verifier wiring** | `DidResolverBackedIssuerKeyResolver` in `Sorcha.Citizen.Verifier`. Replace `OptOutIssuerKeyResolver` as production default. `JwkRegistryIssuerKeyResolver` retained for tests. Three-way failure-mode logging. Update `RequireIssuerSignature` default to `true`. | 2-3 days | Depends on Phase 3 |
+| **5 — Genesis schema slots + matching logic** | `RegisterControlRecord.RegisterPolicy.requireIssuerSignature` + `.permittedIssuers` slots reserved. `Organization.DefaultKidStyle` slot reserved. `CredentialMatcher` accepts `alsoKnownAs`-equivalent issuer match. | 1-2 days | Depends on Phase 4 |
+| **6 — Walkthroughs + integration** | Update walkthroughs: AssuredIdentity, TradeFinance, ConstructionPermit, SelfBuildHouse — confirm enforce-on green. Demo-mint flow updated to either use real DID resolution or stay as documented test escape via `JwkRegistryIssuerKeyResolver`. Document the AssuredIdentity action's optional `acceptedIssuers` pin as a hardening recommendation. | 1-2 days | Depends on Phase 5; gates ship |
+
+Total: ~2-3 weeks for an engineer with codebase familiarity. Phase 0 can ship anytime independently; the rest is a sequential chain.
+
+---
+
+## Test strategy
+
+### Pre-production ship gate
+
+The walkthrough suite passing end-to-end with `RequireIssuerSignature: true` is the ship gate. Specifically:
+
+- **AssuredIdentity walkthrough** — exercises `did:sorcha:org:*` issuance and `HaipExternalWallet` presentation. Closes the loop on Feature 107.
+- **TradeFinance walkthrough** — confirms register-native credential flow (Feature 106) verifies under enforce-on.
+- **At least one walkthrough exercising `did:web:*` resolution path** — likely a new variant of an existing walkthrough using the BYO-domain test fixture, or a dedicated federation walkthrough. Required to prove the `WebDidResolver` is on a hot path, not a parked code path.
+- **AssuredIdentity 10/10 verification** (per session resume note for Feature 119) re-runs cleanly after this work merges.
+
+### Unit + integration tests
+
+| Surface | Coverage |
+|---|---|
+| `SorchaDidResolver` enhancement | Dual-VM publishing, `alsoKnownAs` emission, issuance-key VM surfacing, kid format validation |
+| `WebDidResolver` (existing) | SSRF protection regression tests, document-id roundtrip, HTTPS-only enforcement |
+| `DidResolverRegistry.ResolveWithAlsoKnownAsAsync` | Happy path (matching keys), mismatch (compromised document), missing alsoKnownAs (passthrough), TTL expiry, Redis-stream invalidation |
+| `DidResolverBackedIssuerKeyResolver` | Exact-match kid, thumbprint-fallback kid, no match (return null), three failure modes correctly distinguished in logs |
+| `CredentialMatcher` | `alsoKnownAs`-equivalent issuer matching, regression test for direct-DID match |
+| `IOrgDidDocumentService` | Document regeneration on key events, JSON canonical form, public key embedding for both kid styles |
+| `IIssuanceKeyService` | Lazy derivation, rotation flow, revocation flow, idempotency on first-issuance retries |
+
+### Failure-mode logging instrumentation
+
+Three counters on `Sorcha.Verifier.IssuerSignature` meter:
+
+- `sorcha_verifier_issuer_did_unresolved_total` — `iss` does not resolve
+- `sorcha_verifier_issuer_kid_unmatched_total` — DID resolves but no VM matches
+- `sorcha_verifier_issuer_signature_failed_total` — VM matches but signature mismatch
+
+Plus span `verifier.issuer-resolve` parented to `verifier.presentation` with tags `outcome ∈ {success, did-unresolved, kid-unmatched, signature-failed}`.
+
+### Cache observability
+
+Counters on `Sorcha.Did.Resolver` meter:
+
+- `sorcha_did_resolver_cache_hit_total{method, kind}` — kind ∈ {primary, alsoKnownAs}
+- `sorcha_did_resolver_cache_miss_total{method, kind}`
+- `sorcha_did_resolver_cross_resolve_mismatch_total` — alsoKnownAs key material mismatch
+
+---
+
+## Forward-compat for Future B
+
+The work shipped here lifts cleanly into validator-side issuer-sig at seal time when Future B is triggered.
+
+| Element | Future B inheritance |
+|---|---|
+| `DidResolverBackedIssuerKeyResolver` | Same class, lifted into validator process. Same input/output contract. |
+| `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` | Same method called from validator's seal path. |
+| `RegisterPolicy.requireIssuerSignature` slot | Validator reads at seal time. Per-register policy lights up. |
+| `RegisterPolicy.permittedIssuers` slot | Validator enforces issuer allowlist at seal time as `VAL_CRED_002`. |
+| `VAL_CRED_GOV_001` (revoke issuance key) | Already a governance op in Phase 2; Future B adds the validator-side enforcement check. |
+| Cross-resolution caching | Validator inherits the same cache semantics. Determinism question (replay) addressed in Future B's spec — likely by caching resolved keys alongside the seal. |
+
+The validator does not gain network access or new external dependencies in v1. Future B's design conversation can start from "the resolver and verifier already work; the question is whether to call them at seal time" — not "we need to build resolution from scratch."
+
+---
+
+## Open questions deferred to coding time
+
+The questions that don't block spec writing but want answers when the work starts:
+
+| # | Question | Default if not addressed |
+|---|---|---|
+| 1 | Resolver cache TTLs (`did:web` 1h vs 6h vs 24h?) | 1h, configurable |
+| 2 | DID document version metadata (`versionId`, `nextUpdate`) | Defer until rotation lands; v1 single-key has no version story |
+| 3 | Status list signing key (slot 109, `sorcha:citizen-status-signing`) as separate `VerificationMethod` | Add as additive verification relationship in DID doc; not a v1 blocker |
+| 4 | HAIP OID4VCI integration: ensure `credential_issuer` metadata declares same DID as `iss` | Verify in Phase 6 walkthrough validation |
+| 5 | Demo-mint flow — keep `JwkRegistryIssuerKeyResolver` or wire `DidResolverBackedIssuerKeyResolver` with localhost test fixture? | Keep registry; document as test-only escape |
+| 6 | Where does the `Organization.DefaultKidStyle` slot live structurally — main entity or settings sub-entity? | Settings sub-entity; cleaner for future per-org-config additions |
+| 7 | `did.json` cache headers — what's the right `Cache-Control: max-age`? | 6 hours, with explicit invalidation on key events via cache-purge |
+| 8 | Sorcha-hosted `did.json` URL stability across BYO-domain upgrade — keep old URL alive forever, or define a sunset? | Keep alive forever for verification of historical credentials |
+
+---
+
+## Pointers to current code
+
+| Concept | Path |
+|---|---|
+| W3C resolver stack | `src/Common/Sorcha.ServiceClients.Http/Did/` |
+| `IDidResolverRegistry` | `src/Common/Sorcha.ServiceClients.Http/Did/IDidResolverRegistry.cs` + `DidResolverRegistry.cs` |
+| `SorchaDidResolver` | `src/Common/Sorcha.ServiceClients.Http/Did/SorchaDidResolver.cs` |
+| `WebDidResolver` | `src/Common/Sorcha.ServiceClients.Http/Did/WebDidResolver.cs` |
+| `KeyDidResolver` | `src/Common/Sorcha.ServiceClients.Http/Did/KeyDidResolver.cs` |
+| Resolver DI registration | `src/Common/Sorcha.ServiceClients.Http/Extensions/HttpServiceCollectionExtensions.cs:101-120` |
+| Legacy `IDIDResolver` to retire | `src/Core/Sorcha.Register.Core/Services/IDIDResolver.cs` + `DIDResolver.cs` |
+| Legacy consumer | `src/Services/Sorcha.Register.Service/Program.cs:205` |
+| `IIssuerKeyResolver` (verifier) | `src/Apps/Sorcha.Citizen.Verifier/Services/IIssuerKeyResolver.cs` |
+| `DemoMintEndpoint` | `src/Apps/Sorcha.Citizen.Verifier/Endpoints/DemoMintEndpoint.cs` |
+| `VerifiablePresentationValidator` | `src/Apps/Sorcha.Citizen.Verifier/Services/VerifiablePresentationValidator.cs` |
+| `CredentialRequirement.AcceptedIssuers` | `src/Common/Sorcha.Blueprint.Models/Credentials/CredentialRequirement.cs:28` |
+| `CredentialMatcher` | `src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs:51-52` |
+| `PresentationRequestService` allowlist | `src/Services/Sorcha.Wallet.Service/Services/PresentationRequestService.cs:364-365` |
+| `RegisterControlRecord` (target for new slots) | `src/Common/Sorcha.Register.Models/RegisterControlRecord.cs` |
+| `Organization` model (target for `DefaultKidStyle`) | `src/Services/Sorcha.Tenant.Service/Models/Organization.cs` |
+| Feature 083 derivation paths | `src/Common/Sorcha.Cryptography/SorchaDerivationPaths.cs` |
+| Feature 086 `RotateValidatorKey` (precedent for `VAL_CRED_GOV_001`) | `src/Services/Sorcha.Validator.Service/Services/RightsEnforcementService.cs` |
+| `transaction:confirmed` Redis stream (cache invalidation) | `src/Common/Sorcha.Events/IEventSubscriber.cs` |
+| AssuredIdentity walkthrough | `walkthroughs/AssuredIdentity/blueprints/driving-licence.json:103-115` |
+
+---
+
+## Provenance
+
+This design is the output of the 2026-05-09 brainstorm session that immediately followed the programmable-validation thesis. The session walked six locked product decisions one at a time (D1-D6 above). The user's framing throughout: "we should be standards based" — meaning W3C-shaped DID resolution, federation-friendly `did:web` interop, and `alsoKnownAs` as the primary DID-equivalence mechanism rather than Sorcha-specific extensions.
+
+The companion documents in shared memory (`Validator2/2026-05-09-programmable-validation-thesis.md`, `Validator2/2026-05-09-did-resolution-and-issuer-sig-companion.md`) capture the broader architectural framing — particularly the Future A vs Future B distinction and the alignment with the eventual `VAL_CRED_*` validator-side family.
+
+Decisions D5 and D6 reserved schema slots on the genesis control record without reading them in v1. This is the deliberate "reserve-now-read-later" pattern: the schema migration cost is paid once, when the slots are added; the read-side cost is deferred to whenever Future B (or per-register-policy demand) lights them up.

--- a/specs/120-production-issuer-signature-verification/checklists/requirements.md
+++ b/specs/120-production-issuer-signature-verification/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Production Issuer Signature Verification
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- The spec deliberately references an authoritative design document (`docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md`) for implementation-level decisions; these are NOT leaked into the spec itself but are accessible to the planning agent.
+- All six product decisions (D1–D6) were locked in a 2026-05-09 brainstorm session. The spec treats them as starting axioms; `/speckit.clarify` is unlikely to surface new questions about them.
+- The pre-production posture (Assumptions section) is load-bearing for FR-019's default-on rollout; if the platform's pre-production status changes before this ships, FR-019's rollout strategy must be re-evaluated.
+- FR-020, FR-021, and FR-025 encode forward-compatibility for "Future B" (validator-side seal-time verification, deliberately out of scope for this feature). SC-007 is the success criterion that validates this forward-compat actually works.

--- a/specs/120-production-issuer-signature-verification/contracts/did-resolver-registry-contract.md
+++ b/specs/120-production-issuer-signature-verification/contracts/did-resolver-registry-contract.md
@@ -1,0 +1,232 @@
+# Contract: `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync`
+
+**Feature**: 120-production-issuer-signature-verification
+**Phase**: 1 (interface contract)
+**Date**: 2026-05-09
+
+## Scope
+
+This document is the contract for the new method added to `IDidResolverRegistry` (`src/Common/Sorcha.ServiceClients.Http/Did/IDidResolverRegistry.cs`). The method packages cross-resolution + key-material verification + caching as a single operation so every credential-consuming surface (verifier, wallet inbox projector, future validator) inherits identical trust semantics.
+
+The contract is consumed by `DidResolverBackedIssuerKeyResolver`, by `CredentialMatcher`'s equivalence-aware matching path, and by any future caller that needs trustworthy DID resolution following `alsoKnownAs` links.
+
+## Interface
+
+```csharp
+namespace Sorcha.ServiceClients.Did;
+
+public interface IDidResolverRegistry
+{
+    // EXISTING — unchanged
+    Task<DidDocument?> ResolveAsync(string did, CancellationToken ct = default);
+    void Register(IDidResolver resolver);
+
+    // NEW for Feature 120
+    /// <summary>
+    /// Resolves the primary DID and any DIDs declared in its alsoKnownAs property,
+    /// verifies the same verification key material appears in every linked document,
+    /// and returns the merged DidDocument. Returns null if any link fails to resolve,
+    /// or if verification keys diverge across the equivalence chain.
+    /// </summary>
+    /// <param name="did">The primary DID to resolve.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// Merged DidDocument containing the union of verification methods that match
+    /// across all resolved equivalent documents, or null on any cross-resolution failure.
+    /// </returns>
+    Task<DidDocument?> ResolveWithAlsoKnownAsAsync(string did, CancellationToken ct = default);
+}
+```
+
+## Behavioural contract
+
+### Inputs
+
+- `did`: a DID string. May be of any method registered with the registry. Empty/null returns null.
+- `ct`: standard cancellation token. Honoured throughout cross-resolution.
+
+### Outputs
+
+- **Success**: a non-null `DidDocument` whose `verificationMethod` array contains every VM that matches by key material across the entire equivalence chain. The returned document's `id` equals the input DID; `alsoKnownAs` lists the verified equivalent DIDs.
+- **Failure**: returns null. Span/log records the specific failure reason via the `did.alsoKnownAs.match` attribute (`unreachable` | `mismatch` | `none`).
+
+### Resolution algorithm (deterministic)
+
+```
+1. Resolve primary DID via underlying ResolveAsync(did).
+   On null: return null. Tag span outcome=did-unresolved.
+
+2. If primary.alsoKnownAs is null or empty:
+   Tag span did.alsoKnownAs.cross_resolved=false.
+   Return primary (passthrough).
+
+3. For each linked DID in primary.alsoKnownAs:
+   a. Avoid cycles: if linked == did or already-visited, skip.
+   b. Resolve linked via ResolveAsync(linked).
+      On null:
+        Log warning "alsoKnownAs link unreachable for {did}: {linked}".
+        Tag span did.alsoKnownAs.match=unreachable.
+        Return null.
+   c. Compute the intersection of verification-method key material between
+      primary and linked:
+        For each VM in primary.verificationMethod:
+          Look up matching VM in linked.verificationMethod by raw public key bytes
+          (decoded from publicKeyMultibase or publicKeyJwk).
+          If no match: this primary VM is NOT cross-verified.
+          If match: this primary VM IS cross-verified (and so is the linked VM).
+      A cross-verified VM is one whose public key bytes appear in every
+      linked document. Other VMs are dropped.
+
+4. If, after step 3, primary.verificationMethod has ZERO cross-verified VMs:
+   Log warning "alsoKnownAs cross-resolution found no shared keys for {did}".
+   Tag span did.alsoKnownAs.match=mismatch.
+   Return null.
+
+5. Construct merged DidDocument:
+   - id: primary.id
+   - alsoKnownAs: subset of primary.alsoKnownAs that resolved successfully
+   - verificationMethod: only the cross-verified VMs from primary
+   - assertionMethod, authentication, etc.: preserved from primary, filtered
+     to reference only cross-verified VMs
+
+6. Tag span did.alsoKnownAs.cross_resolved=true, did.alsoKnownAs.match=match.
+   Return merged document.
+```
+
+### Caching
+
+Cross-resolution results are cached at the registry layer. Cache key: canonical primary DID. Cache value: the merged document (success) or a sentinel "negative" entry (failure, prevents thundering-herd retries against an unreachable link).
+
+Per-method TTLs:
+
+| Method | Positive TTL | Negative TTL |
+|---|---|---|
+| `did:web` | 1h | 60s |
+| `did:sorcha:*` | infinite (within process); invalidated on `transaction:confirmed` Redis-stream events | 60s |
+| `did:key` | infinite | N/A (no resolution can fail for a syntactically valid did:key) |
+
+Negative-TTL entries are explicitly short to avoid masking transient failures (network blip, brief unavailability) for too long.
+
+Configuration override surface: `DidResolver:Cache:WebTtlMinutes` (default 60), `DidResolver:Cache:NegativeTtlSeconds` (default 60). Both honoured by `DidResolverCache`.
+
+### Concurrency
+
+Multiple concurrent calls for the same DID coalesce: only one resolution chain runs; subsequent callers wait on the in-flight task. Implemented via `LazyAsync` pattern over the cache.
+
+### Idempotency
+
+Pure: same input → same output (within cache TTL). No side effects.
+
+### Telemetry
+
+The method participates in the following spans/metrics:
+
+- **Span `did.resolve.cross`** (Internal): parents the underlying primary + per-link `did.resolve` spans. Tagged with `did.input`, `did.method`, `did.alsoKnownAs.cross_resolved`, `did.alsoKnownAs.match`, `did.alsoKnownAs.link_count`.
+- **Counter `sorcha_did_resolver_cache_hit_total{method, kind}`** where kind ∈ {primary, alsoKnownAs}.
+- **Counter `sorcha_did_resolver_cache_miss_total{method, kind}`**.
+- **Counter `sorcha_did_resolver_cross_resolve_mismatch_total`** — incremented on step 4 (no shared keys found).
+- **Counter `sorcha_did_resolver_alsoKnownAs_unreachable_total`** — incremented on step 3b (link fails to resolve).
+
+Meter: `Sorcha.ServiceClients.Did` (existing for primary `ResolveAsync` instrumentation).
+
+### Failure modes (matrix)
+
+| Condition | Return | Log level | Span outcome | Counter incremented |
+|---|---|---|---|---|
+| Primary DID unresolved | `null` | Warning | `did-unresolved` | (existing primary miss counter) |
+| Primary has no `alsoKnownAs` | passthrough document | Debug | `cross_resolved=false` | — |
+| Linked DID unreachable | `null` | Warning | `unreachable` | `alsoKnownAs_unreachable_total` |
+| Cross-resolved keys mismatch | `null` | Warning | `mismatch` | `cross_resolve_mismatch_total` |
+| All links resolved + keys match | merged document | Debug | `match` | (existing hit counter on cache replay) |
+| Resolver throws exception | propagate | (let caller handle) | (existing primary error attribution) | — |
+
+### Cycle protection
+
+If during step 3, a linked DID's own `alsoKnownAs` references the primary or a previously-visited DID, the visit is skipped (no infinite loop). The first-pass intersection is the canonical answer; transitive cross-resolution is not performed in v1 (see "Out of scope" below).
+
+### Out of scope (this method)
+
+- **Transitive equivalence resolution.** v1 only cross-resolves direct links from the primary's `alsoKnownAs`. If A links to B and B links to C, but A does not link to C, the v1 method returns A's view (with B cross-verified). Transitive walk is deferred — too easy to introduce subtle correctness bugs in v1.
+- **Caching of negative cross-resolution outcomes by link identity.** v1 caches by primary DID only; if A's `alsoKnownAs` link to B is unreachable, the cache entry is keyed on A. A different DID D that also links to B incurs a fresh resolution. Optimisation deferred.
+- **Forced refresh API.** v1 does not expose a "bypass cache" parameter. Callers that suspect stale data invalidate via the existing `transaction:confirmed` Redis-stream event mechanism (for `did:sorcha:*`) or wait out the `did:web` TTL.
+
+## Consumer expectations
+
+`DidResolverBackedIssuerKeyResolver` (the verifier-side `IIssuerKeyResolver` impl):
+
+```csharp
+public async Task<IssuerPublicKey?> ResolveAsync(string issuer, string kid, CancellationToken ct)
+{
+    var doc = await _registry.ResolveWithAlsoKnownAsAsync(issuer, ct);
+    if (doc is null)
+    {
+        // Three-way failure-mode classification per FR-003:
+        //   - did-unresolved if primary failed
+        //   - alsoKnownAs-mismatch if primary OK but cross-resolution failed
+        // We don't get the distinction from the return value alone; we read it
+        // from the OTel span/counter attribution.
+        return null;
+    }
+
+    var vm = MatchKid(doc, kid);   // exact match → thumbprint fallback
+    if (vm is null)
+    {
+        // FR-003 failure mode: kid-unmatched
+        return null;
+    }
+
+    return new IssuerPublicKey(vm, /* metadata for sig verification */);
+}
+```
+
+The classifier above shows why the contract returns `null` rather than throwing — distinct failure modes are surfaced via the existing telemetry, and the consumer's responsibility is to translate `null` into its own three-way bucket per FR-003.
+
+`CredentialMatcher` (allowlist equivalence):
+
+```csharp
+async Task<bool> IsIssuerAcceptedAsync(
+    string credentialIssuer,
+    IEnumerable<string> acceptedIssuers,
+    CancellationToken ct)
+{
+    if (acceptedIssuers.Contains(credentialIssuer))
+        return true;
+
+    var doc = await _registry.ResolveWithAlsoKnownAsAsync(credentialIssuer, ct);
+    if (doc?.AlsoKnownAs is { Count: > 0 } aka)
+    {
+        if (acceptedIssuers.Any(aka.Contains))
+            return true;
+    }
+
+    foreach (var allowed in acceptedIssuers)
+    {
+        var allowedDoc = await _registry.ResolveWithAlsoKnownAsAsync(allowed, ct);
+        if (allowedDoc?.AlsoKnownAs?.Contains(credentialIssuer) == true)
+            return true;
+    }
+
+    return false;
+}
+```
+
+(Pseudocode — actual implementation should batch the allowlist resolutions and short-circuit on first match.)
+
+## Testing
+
+Required unit-test coverage (per Constitution IV, ≥85% on new code):
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `ResolveWithAlsoKnownAs_NoLinks_PassesThrough` | Primary doc has no `alsoKnownAs`. | Returns primary unchanged. |
+| `ResolveWithAlsoKnownAs_OneLinkMatching_ReturnsMerged` | Primary + one link, same VM key material. | Returns merged doc with both alsoKnownAs entries. |
+| `ResolveWithAlsoKnownAs_OneLinkUnreachable_ReturnsNull` | Link's `ResolveAsync` returns null. | Returns null. Span tagged `unreachable`. |
+| `ResolveWithAlsoKnownAs_OneLinkMismatch_ReturnsNull` | Link resolves but VM keys differ. | Returns null. Span tagged `mismatch`. |
+| `ResolveWithAlsoKnownAs_TwoLinks_PartialMatch_ReturnsNull` | Two links, one matches, one mismatches. | Returns null (any mismatch fails). |
+| `ResolveWithAlsoKnownAs_Cycle_DoesNotInfiniteLoop` | Primary links to B, B links to primary. | Resolves once, skips revisit. |
+| `ResolveWithAlsoKnownAs_CacheHit_DoesNotResolve` | Cached entry within TTL. | No underlying resolver invocations. |
+| `ResolveWithAlsoKnownAs_CacheInvalidated_ResolvesFresh` | Cache invalidation event fires. | Next call resolves. |
+| `ResolveWithAlsoKnownAs_NegativeCacheRespectedShortTtl` | Failure cached. | Repeat call within 60s returns null without re-resolving; after 60s, retries. |
+| `ResolveWithAlsoKnownAs_CoalesceConcurrentCalls` | Two concurrent identical calls. | Only one underlying resolution; both receive same result. |
+
+Tests live at `tests/Sorcha.ServiceClients.Tests/Did/DidResolverRegistryCrossResolutionTests.cs`.

--- a/specs/120-production-issuer-signature-verification/contracts/org-did-document-endpoint.openapi.yaml
+++ b/specs/120-production-issuer-signature-verification/contracts/org-did-document-endpoint.openapi.yaml
@@ -1,0 +1,160 @@
+openapi: 3.1.0
+info:
+  title: Sorcha Org DID Document Endpoint
+  version: 1.0.0
+  summary: Public endpoint for resolving organisation DID documents (Feature 120).
+  description: |
+    Sorcha publishes a W3C DID document for every organisation that has an active issuance key.
+    The document is reachable at a stable, well-known URL conforming to the `did:web` resolution
+    rules in W3C DID Core 1.0.
+
+    For an organisation hosted under the platform domain `{platform-domain}` with id `{orgId}`,
+    the federated DID identifier is:
+
+        did:web:{platform-domain}:orgs:{orgId}
+
+    Per the `did:web` method specification, this DID resolves to the URL:
+
+        https://{platform-domain}/orgs/{orgId}/did.json
+
+    External standards-compliant DID resolvers can dereference this document with no
+    Sorcha-specific knowledge.
+
+    The endpoint is anonymous, CDN-cacheable, and conforms to the W3C DID Core 1.0 document
+    schema (https://www.w3.org/TR/did-core/).
+
+servers:
+  - url: https://{platformDomain}
+    variables:
+      platformDomain:
+        default: example.sorcha.dev
+        description: Platform domain configured at deploy time.
+
+paths:
+  /orgs/{orgId}/did.json:
+    get:
+      summary: Resolve an organisation's DID document.
+      description: |
+        Returns the published W3C DID document for the organisation `orgId`. The document
+        declares the organisation's signing keys (verification methods) and an `alsoKnownAs`
+        link to the equivalent `did:sorcha:org:{walletAddress}` identifier.
+
+        Cache headers: `Cache-Control: public, max-age=21600` (6 hours). Explicit cache
+        invalidation occurs on key events (rotation, revocation, additional key derivation).
+      operationId: resolveOrgDidDocument
+      tags: [Discovery]
+      parameters:
+        - name: orgId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The organisation's platform identifier.
+      security: []  # Anonymous; CDN-cacheable.
+      responses:
+        '200':
+          description: DID document found and returned.
+          headers:
+            Cache-Control:
+              schema: { type: string }
+              description: Always `public, max-age=21600`.
+          content:
+            application/did+json:
+              schema:
+                $ref: '#/components/schemas/DidDocument'
+              examples:
+                exampleOrg:
+                  summary: An organisation with one active issuance key.
+                  value:
+                    "@context":
+                      - "https://www.w3.org/ns/did/v1"
+                      - "https://w3id.org/security/suites/jws-2020/v1"
+                    id: "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa"
+                    alsoKnownAs:
+                      - "did:sorcha:org:ws1qta0sk6m4yzgf5...example..."
+                    verificationMethod:
+                      - id: "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa#vc-issuance-1"
+                        type: "JsonWebKey2020"
+                        controller: "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa"
+                        publicKeyMultibase: "z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                      - id: "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa#dGhpc0lzVGhlVGh1bWJwcmludE9mVGhlS2V5LjEyMzQ"
+                        type: "JsonWebKey2020"
+                        controller: "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa"
+                        publicKeyMultibase: "z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+                    assertionMethod:
+                      - "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa#vc-issuance-1"
+                      - "did:web:example.sorcha.dev:orgs:abc-123-def-456-789-aaaaaaaaaaaa#dGhpc0lzVGhlVGh1bWJwcmludE9mVGhlS2V5LjEyMzQ"
+        '404':
+          description: |
+            No DID document found for this organisation. Either the organisation does not exist,
+            or it has not yet issued its first credential (no issuance key derived).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
+components:
+  schemas:
+    DidDocument:
+      type: object
+      description: |
+        W3C DID Document per https://www.w3.org/TR/did-core/. Sorcha-issued documents always
+        carry `alsoKnownAs`, dual `verificationMethod` entries per active key (one versioned,
+        one thumbprint-keyed), and `assertionMethod` referencing all active VMs.
+      required: ["@context", "id", "verificationMethod", "assertionMethod"]
+      properties:
+        "@context":
+          type: array
+          items: { type: string }
+          minItems: 1
+        id:
+          type: string
+          description: The primary DID this document describes.
+        alsoKnownAs:
+          type: array
+          items: { type: string }
+          description: Equivalent identifiers for this organisation (e.g., did:sorcha:org form).
+        verificationMethod:
+          type: array
+          items: { $ref: '#/components/schemas/VerificationMethod' }
+          minItems: 1
+        assertionMethod:
+          type: array
+          items: { type: string }
+          description: Verification method ids permitted for credential issuance.
+        authentication:
+          type: array
+          items: { type: string }
+          description: Verification method ids permitted for authentication.
+
+    VerificationMethod:
+      type: object
+      required: [id, type, controller]
+      properties:
+        id:
+          type: string
+          description: |
+            Fragment-suffixed identifier. Sorcha publishes two per active key:
+              - Versioned: `{did}#vc-issuance-{n}` (n is monotonic, starts at 1)
+              - Thumbprint: `{did}#{rfc7638-base64url-thumbprint}` (43 chars, no padding)
+        type:
+          type: string
+          description: W3C verification method type (e.g., Ed25519VerificationKey2020, JsonWebKey2020).
+        controller:
+          type: string
+        publicKeyMultibase:
+          type: string
+          description: Multibase-encoded (base58btc) multicodec public key.
+        publicKeyJwk:
+          type: object
+          description: JWK form (alternative to multibase). Sorcha currently emits multibase.
+
+    ProblemDetails:
+      type: object
+      description: RFC 7807 problem details.
+      properties:
+        type: { type: string }
+        title: { type: string }
+        status: { type: integer }
+        detail: { type: string }

--- a/specs/120-production-issuer-signature-verification/data-model.md
+++ b/specs/120-production-issuer-signature-verification/data-model.md
@@ -1,0 +1,195 @@
+# Data Model: Production Issuer Signature Verification
+
+**Feature**: 120-production-issuer-signature-verification
+**Phase**: 1 (data model)
+**Date**: 2026-05-09
+
+## Scope
+
+This document captures the data shapes — entities, fields, relationships, validation rules — introduced or modified by Feature 120. Implementation-level concerns (DI lifetimes, EF migrations, JSON serialization quirks) live in the design doc and code; this document is the contract between requirements and persistence.
+
+## Entities
+
+### 1. `OrgDidDocument` (NEW — Tenant Service, persistent)
+
+The published DID document for one organisation. One document covers both `did:sorcha:org:{addr}` and `did:web:{platform}:orgs:{orgId}` — the document declares both identifiers and links them via `alsoKnownAs`.
+
+| Field | Type | Constraints | Source |
+|-------|------|-------------|--------|
+| `Id` | `Guid` | Primary key. | Generated. |
+| `OrganizationId` | `Guid` | FK → `Organization.Id`. Unique (one document per org). | FR-004. |
+| `PrimaryDid` | `string` | Canonical primary DID (`did:sorcha:org:{addr}`). Indexed. Max 200 chars. | FR-005. |
+| `FederatedDid` | `string` | Federated DID (`did:web:{platform}:orgs:{orgId}`). Indexed. Max 200 chars. | FR-005. |
+| `DocumentJson` | `string` | The serialized W3C DID document (the same JSON served at the public endpoint). UTF-8, max 16KB. | FR-007. |
+| `KeyVersionFingerprint` | `string` | Hash of `(PrimaryDid, all-active-VMs sorted by id, alsoKnownAs sorted)`. Used to detect when regeneration is a no-op. | FR-006. |
+| `LastRegeneratedAt` | `DateTimeOffset` | When the document was last regenerated. | FR-006. |
+| `LastRegenerationReason` | `KeyEventReason` enum | What triggered the most recent regeneration: `IssuanceKeyDerived`, `IssuanceKeyRotated`, `IssuanceKeyRevoked`, `StatusSigningKeyDerived`, `Bootstrap`. | FR-006. |
+| `Version` | `int` | Monotonic version counter. Incremented on every regeneration. v1 starts at 1. | Forward-compat for FR-022 (cache invalidation; future version metadata per R8). |
+
+**Validation rules**:
+- `PrimaryDid` MUST start with `did:sorcha:org:`.
+- `FederatedDid` MUST start with `did:web:` and MUST contain the platform domain configured at deploy time.
+- `DocumentJson` MUST parse as a valid W3C DID document with a non-empty `verificationMethod` array. JSON Schema validation REQUIRED on save (per Constitution II).
+- `DocumentJson.alsoKnownAs` MUST contain exactly the other identifier (`PrimaryDid` ↔ `FederatedDid`). Other entries permitted in future for BYO-domain.
+
+**State transitions**:
+- `null` (no document) → `Bootstrap` regeneration on first issuance key derivation (Phase 2 trigger).
+- `IssuanceKeyDerived` → `IssuanceKeyRotated` → `IssuanceKeyRevoked` (manual via governance ops).
+- `StatusSigningKeyDerived` is additive; never invalidates existing VMs.
+
+**Indexing**:
+- Unique index on `OrganizationId` (one doc per org).
+- Index on `PrimaryDid` (resolver lookup path).
+- Index on `FederatedDid` (resolver lookup path).
+
+**Storage**: PostgreSQL via Tenant Service's existing EF Core context. Audited storage interface (`Sorcha.ServiceDefaults.Storage` per Feature 113), but **NOT on the fail-fast list** — this is cache-style storage; rebuildable from the wallet's key state if lost. Logs warning if registered as in-memory; does not gate startup.
+
+---
+
+### 2. `Organization` (EXISTING — additive field)
+
+| Field | Type | Constraints | Source |
+|-------|------|-------------|--------|
+| `DefaultKidStyle` | `KidStyle` enum | Default `Versioned`. Not exposed in v1 admin UI. | FR-013. |
+
+**`KidStyle` enum**: `Versioned = 0` (default — emit `#vc-issuance-{n}` style kid in JWS headers), `Thumbprint = 1` (emit `#{rfc7638-thumbprint}` style kid).
+
+**Migration**: additive non-nullable column with default value `0`. EF migration via `dotnet ef migrations add AddOrganizationDefaultKidStyle`. No data backfill needed.
+
+---
+
+### 3. `RegisterControlRecord.RegisterPolicy` (EXISTING — two additive fields, RESERVED)
+
+| Field | Type | Constraints | Source |
+|-------|------|-------------|--------|
+| `RequireIssuerSignature` | `bool?` | Optional. Null/absent = use platform default. **NOT READ AT V1.** | FR-020. |
+| `PermittedIssuers` | `string[]?` | Optional. Null/empty = no register-wide allowlist (any resolvable issuer). **NOT READ AT V1.** | FR-021. |
+
+**Validation rules**:
+- `RequireIssuerSignature`: `bool?`, no further constraint.
+- `PermittedIssuers`: each entry MUST start with `did:` and MUST be ≤200 chars. Validated by `RegisterPolicyValidator`.
+
+**JSON serialization**: both fields use `JsonIgnoreCondition.WhenWritingNull` so existing genesis records produced before this feature do not gain spurious null fields.
+
+**Forward-compat verification (SC-007)**: a v0.119 register policy record (no `RequireIssuerSignature`, no `PermittedIssuers`) MUST deserialise cleanly with both fields null after this feature ships. Test in `Sorcha.Register.Models.Tests/RegisterControlRecordBackwardCompatTests.cs`.
+
+---
+
+### 4. `IssuanceKeyState` (NEW — Wallet Service, persistent)
+
+The lifecycle state of one organisation's issuance key. Persisted alongside the existing wallet/key infrastructure.
+
+| Field | Type | Constraints | Source |
+|-------|------|-------------|--------|
+| `Id` | `Guid` | Primary key. | Generated. |
+| `OrganizationId` | `Guid` | FK → `Organization.Id`. | FR-018. |
+| `Slot` | `int` | Feature 083 derivation slot. v1 = 1 (`KeyUsage.VCIssuance`). | FR-018. |
+| `RotationIndex` | `int` | Monotonic; starts at 1 for the first derived key, increments on each rotation. Forms the kid suffix `#vc-issuance-{n}`. | FR-011, FR-017. |
+| `Status` | `IssuanceKeyStatus` enum | `Active`, `Rotated`, `Revoked`. | FR-016, FR-017. |
+| `PublicKey` | `byte[]` | Raw public key bytes (pre-multibase encoding). | FR-002. |
+| `Algorithm` | `string` | Wallet algorithm string (`ED25519`, `NIST-P256`, etc.). | Driven by Feature 083. |
+| `Thumbprint` | `string` | RFC 7638 base64url SHA-256 thumbprint of the JWK form. Cached for kid-resolution fallback. | FR-011, FR-012. |
+| `DerivedAt` | `DateTimeOffset` | When this key was derived. | FR-018. |
+| `RotatedAt` | `DateTimeOffset?` | When the key was rotated (status moved to `Rotated`). | FR-017. |
+| `RevokedAt` | `DateTimeOffset?` | When the key was revoked. | FR-016. |
+| `RevocationReason` | `string?` | Free text recorded with the revocation governance op. Max 500 chars. | FR-016. |
+| `RevokedByGovernanceOpId` | `Guid?` | FK to the governance op that revoked the key. | FR-016. |
+
+**`IssuanceKeyStatus` enum**: `Active = 0`, `Rotated = 1`, `Revoked = 2`.
+
+**State transitions**:
+- `null` (no key) → `Active` (first derivation).
+- `Active` → `Rotated` (governance op `RotateIssuanceKey`; new row with incremented `RotationIndex` becomes `Active`).
+- `Active` → `Revoked` (governance op `VAL_CRED_GOV_001`).
+- `Rotated` → `Revoked` permitted (revoking a previously-rotated key).
+- `Revoked` → terminal (no further transitions).
+
+**Validation rules**:
+- For each `(OrganizationId, Slot)` at most ONE row in `Active` status (DB unique partial index).
+- `RotationIndex` MUST be unique per `OrganizationId`.
+- `PublicKey` length MUST match the algorithm's expected raw size (validated by `Sorcha.Cryptography`).
+- `Thumbprint` regex `^[A-Za-z0-9_-]{43}$` (base64url SHA-256, no padding).
+
+**Storage**: PostgreSQL via Wallet Service's existing context. Audited storage interface (Feature 113) — cache-style, NOT on fail-fast list (rebuildable from the master key + persisted state).
+
+**Privacy**: this entity contains no private key material. Private keys remain in Wallet Service's existing custodial storage (Feature 083) and are never returned by `IIssuanceKeyService` queries.
+
+---
+
+### 5. `CredentialRequirement.AcceptedIssuers` (EXISTING — semantic change only)
+
+No model change. The `AcceptedIssuers` field already exists at `src/Common/Sorcha.Blueprint.Models/Credentials/CredentialRequirement.cs:28`.
+
+**Semantic change (FR-014)**: when matching a credential's `IssuerDid` against an `AcceptedIssuers` entry, the match succeeds if:
+1. Direct string match (current behaviour), OR
+2. The credential's `IssuerDid` resolves (via `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync`) to a document whose `alsoKnownAs` contains an entry that matches a string in `AcceptedIssuers`, OR
+3. The string in `AcceptedIssuers` resolves to a document whose `alsoKnownAs` contains the credential's `IssuerDid`.
+
+The third case enables blueprint authors to list a `did:web` form and accept credentials issued under the equivalent `did:sorcha:org` form (and vice versa).
+
+Updated in: `Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs:51-52`, `PresentationRequestService.cs:364-365`. Existing tests preserved + new tests for the equivalence cases.
+
+---
+
+## Relationships
+
+```text
+Organization (1) ────┬──── (1) OrgDidDocument
+                     │
+                     └──── (1..*) IssuanceKeyState  [ at most one Active per slot ]
+
+RegisterControlRecord ──── (1) RegisterPolicy
+                                  ├── RequireIssuerSignature (RESERVED, not read v1)
+                                  └── PermittedIssuers      (RESERVED, not read v1)
+
+CredentialRequirement.AcceptedIssuers (existing) → semantic enhancement only
+```
+
+## Resolution flow (data perspective)
+
+```text
+1. JWS header { iss, kid }
+        │
+        ▼
+2. IDidResolverRegistry.ResolveWithAlsoKnownAsAsync(iss)
+        │
+        ├─→ method dispatch (sorcha | web | key)
+        │       │
+        │       ▼
+        │    SorchaDidResolver | WebDidResolver | KeyDidResolver
+        │       returns DidDocument for primary
+        │
+        ├─→ if doc.alsoKnownAs is non-empty:
+        │       for each linked DID:
+        │           recursive (non-cycling) ResolveAsync
+        │           verify VerificationMethod.publicKeyMultibase matches across docs
+        │       merge into result; null if any link fails or mismatches
+        │
+        └─→ DidDocument { verificationMethod: [ ...VMs across all valid links... ] }
+
+3. Match kid → VerificationMethod
+        │
+        ├─→ exact-string match against verificationMethod[].id
+        │
+        └─→ thumbprint fallback (if no exact match):
+                for each VM:
+                    compute RFC 7638 thumbprint of VM.publicKeyJwk
+                    if matches kid fragment → match
+        │
+        ▼
+4. JsonWebKey extracted; signature verification proceeds.
+```
+
+## Telemetry-touching shapes (informational)
+
+OTel attribute keys defined for this feature (no persistent schema; lists kept here so contributors don't drift them):
+
+| Attribute | Values | Surface |
+|---|---|---|
+| `did.method` | `sorcha`, `web`, `key`, ... | All resolver spans |
+| `did.alsoKnownAs.cross_resolved` | `true`, `false` | `did.resolve` span |
+| `did.alsoKnownAs.match` | `match`, `mismatch`, `unreachable`, `none` | `did.resolve` span |
+| `verifier.issuer.outcome` | `success`, `did-unresolved`, `kid-unmatched`, `signature-failed` | `verifier.issuer-resolve` span |
+| `verifier.issuer.kid_match_mode` | `exact`, `thumbprint-fallback` | `verifier.issuer-resolve` span |
+
+Counters listed in plan.md / spec FR-003 / SC-006.

--- a/specs/120-production-issuer-signature-verification/plan.md
+++ b/specs/120-production-issuer-signature-verification/plan.md
@@ -1,0 +1,144 @@
+# Implementation Plan: Production Issuer Signature Verification
+
+**Branch**: `120-production-issuer-signature-verification` | **Date**: 2026-05-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/120-production-issuer-signature-verification/spec.md`
+**Authoritative design**: `docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md` — source of truth for every locked decision (D1–D6), file paths, class names, phase boundaries.
+
+## Summary
+
+Replace the OptOut/JwkRegistry credential-issuer key resolution surface with a production DID-resolver-backed implementation. Publish every Sorcha-hosted org as both `did:sorcha:org:{addr}` (primary) and `did:web:{platform}:orgs:{orgId}` (federation) linked via `alsoKnownAs` with key-material cross-verification. Retire the legacy parallel `IDIDResolver` interface as a precursor PR. Reserve forward-compat slots on the genesis control record for "Future B" (validator-side at seal time, deferred). Default-on at ship leveraging Sorcha's pre-production posture; walkthrough-suite-green-with-enforce-on is the ship gate.
+
+The architectural call is "verifier-side enforcement now, validator-side deferred." Same resolver code lifts into the validator unchanged when Future B is triggered — the spec slots reserved at v1 are exactly the seam.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10
+**Primary Dependencies**: `Sorcha.ServiceClients.Http` (existing W3C DID resolver stack: `SorchaDidResolver`, `WebDidResolver`, `KeyDidResolver`, `DidResolverRegistry`); `Sorcha.Cryptography` (RFC 7638 thumbprint computation, multibase encoding); `Sorcha.Tenant.Service` (Organization model, governance ops); `Sorcha.Wallet.Service` (Feature 083 key derivation, slot 1 `KeyUsage.VCIssuance`); `Sorcha.Citizen.Verifier` (`VerifiablePresentationValidator`, `IIssuerKeyResolver`); `Sorcha.Register.Models` (`RegisterControlRecord`, `RegisterPolicy` for forward-compat slot reservation); `Sorcha.Events` (`IEventSubscriber` for `transaction:confirmed` Redis stream cache invalidation).
+**Storage**: PostgreSQL (Tenant Service — Organization model extension for `KidStyle`, generated DID documents persisted as cached column on Organization or new `OrgDidDocument` row), Redis (resolver cache; `transaction:confirmed` stream subscription for invalidation), no MongoDB changes.
+**Testing**: xUnit + FluentAssertions + Moq for unit/integration; Playwright E2E for walkthrough-level. Walkthrough suite is the production-readiness ship gate per FR-019 / SC-003.
+**Target Platform**: Linux containers (Docker), Windows dev (PowerShell). Aspire orchestration unchanged.
+**Project Type**: web (microservices) — Tenant Service, Wallet Service, Citizen Verifier all touched; ServiceClients.Http carries the new resolver method.
+**Performance Goals**: Verifier latency for repeat-issuer credentials within one cache window ≤ pre-feature baseline + 0 (hot cache); first-resolution per issuer ≤ 500ms p95 (one `did:sorcha:*` lookup + one `did:web` HTTPS GET, both cacheable). DID document JSON ≤ 16KB per org including dual VMs across 1–3 active keys.
+**Constraints**: Pre-production posture (no in-flight credentials to nurse, default-on at ship is safe per Assumptions in spec); walkthrough-suite-green is the gate (FR-019 / SC-003); legacy `IDIDResolver` retirement (FR-024) MUST ship before this feature's main body to avoid two parallel resolvers in production code; no schema migration on existing register policy records (SC-007).
+**Scale/Scope**: ~25 functional requirements across 7 categories; 6 user stories (2 P1, 2 P2, 2 P3); 7 phase milestones (Phase 0 cleanup standalone + Phases 1–6 sequential); estimated 2-3 weeks for a single engineer with codebase familiarity. Touches 5 services, ~12 new files, ~8 modified files, 3 deletions.
+
+## Constitution Check
+
+*GATE: Pre-Phase-0 — must pass before research kicks off.*
+
+| # | Principle | Status | Notes |
+|---|-----------|--------|-------|
+| I | Microservices-First Architecture | ✅ PASS | Independent deployability preserved. New code lands in existing services (Tenant, Wallet, Citizen Verifier) and the shared `Sorcha.ServiceClients.Http` library. No new services. No upward dependencies introduced — `IIssuerKeyResolver` lives in the verifier app and consumes the `Sorcha.ServiceClients.Did` registry; no Core→Application leakage. |
+| II | Security First | ✅ PASS | Whole feature **is** a security upgrade. Issuance keys remain custodial-mode (Feature 083); revocation gated by admin-quorum governance op (FR-016). Cross-resolution (FR-008) closes the impersonation gap that pure federation would otherwise open. SSRF-protected `WebDidResolver` already in place. No secrets committed. Input validation via FluentValidation on the org DID document publishing endpoint and on governance op payloads. |
+| III | API Documentation | ✅ PASS | New `GET /orgs/{orgId}/did.json` endpoint (Tenant Service) gets `.WithName`/`.WithSummary`/`.WithDescription`. New service-internal contracts on `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` documented via XML comments. OpenAPI exposed unchanged. |
+| IV | Testing Requirements | ✅ PASS | Target ≥85% coverage on new code per project default. Unit tests for `DidResolverBackedIssuerKeyResolver`, `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` (cross-resolution happy path + 4 failure modes), `IOrgDidDocumentService` (regeneration on key events), `IIssuanceKeyService` (lazy derivation idempotency, rotation, revocation). Integration tests use the existing reflection-based static-handler invocation pattern (per `PresentationEndpointTests`). Walkthrough suite is the integration-level gate. |
+| V | Code Quality | ✅ PASS | C# 14 / .NET 10 conventions; nullable reference types enabled; async/await throughout; DI for all new services; no compiler warnings. License header on every new file. |
+| VI | Blueprint Creation Standards | ✅ PASS | No blueprint format changes. `CredentialRequirement.AcceptedIssuers` already exists; this feature adds equivalence-aware matching at consumption time, not at authoring time. JSON-e usage unaffected. |
+| VII | Domain-Driven Design | ✅ PASS | Ubiquitous language preserved: "issuer", "credential", "verification method" all map to existing W3C terms used in the codebase. New entity `OrgDidDocument` follows the same naming convention as existing entities. No "user/workflow/step/visibility/deploy" drift. |
+| VIII | Observability by Default | ✅ PASS | Three new OTel meters defined: `Sorcha.Verifier.IssuerSignature` (three failure-mode counters per FR-003 / SC-006), `Sorcha.Did.Resolver` (cache hit/miss + cross-resolve mismatch counters), and a new span `verifier.issuer-resolve` parented to `verifier.presentation`. Structured logging only (no string interpolation). Health checks unchanged — no new external dependency to probe at startup. |
+
+**Result**: All eight principles pass. No `## Complexity Tracking` entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/120-production-issuer-signature-verification/
+├── plan.md              # This file
+├── spec.md              # Feature specification (already written)
+├── research.md          # Phase 0 output — alternatives considered + decisions
+├── data-model.md        # Phase 1 output — entity definitions
+├── quickstart.md        # Phase 1 output — operator runbook
+├── contracts/
+│   ├── org-did-document-endpoint.openapi.yaml   # Public did.json endpoint
+│   └── did-resolver-registry-contract.md        # IDidResolverRegistry interface contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already written)
+└── tasks.md             # Phase 2 output (/speckit.tasks command — not created here)
+```
+
+### Source code (repository root)
+
+```text
+src/
+├── Common/
+│   ├── Sorcha.ServiceClients.Http/Did/
+│   │   ├── IDidResolverRegistry.cs                    # MODIFIED: + ResolveWithAlsoKnownAsAsync
+│   │   ├── DidResolverRegistry.cs                     # MODIFIED: cross-resolution + cache
+│   │   ├── SorchaDidResolver.cs                       # MODIFIED: dual-VM, alsoKnownAs, issuance VM
+│   │   ├── WebDidResolver.cs                          # UNCHANGED
+│   │   ├── KeyDidResolver.cs                          # UNCHANGED
+│   │   ├── KidThumbprintHelper.cs                     # NEW: RFC 7638 thumbprint + JWK→VM matching
+│   │   └── DidResolverCache.cs                        # NEW: per-method TTL + Redis-stream invalidation
+│   └── Sorcha.Register.Models/
+│       └── RegisterControlRecord.cs                   # MODIFIED: + RegisterPolicy slots (FR-020, FR-021)
+│
+├── Services/
+│   ├── Sorcha.Tenant.Service/
+│   │   ├── Models/
+│   │   │   ├── Organization.cs                        # MODIFIED: + DefaultKidStyle slot (FR-013)
+│   │   │   └── OrgDidDocument.cs                      # NEW: persisted DID document cache
+│   │   ├── Services/
+│   │   │   ├── IOrgDidDocumentService.cs              # NEW: Phase 1
+│   │   │   └── OrgDidDocumentService.cs               # NEW: builds, stores, serves DID documents
+│   │   └── Endpoints/
+│   │       └── OrgDidDocumentEndpoints.cs             # NEW: GET /orgs/{orgId}/did.json (anonymous, CDN-cacheable)
+│   │
+│   └── Sorcha.Wallet.Service/
+│       ├── Services/
+│       │   ├── Interfaces/IIssuanceKeyService.cs      # NEW: Phase 2
+│       │   └── Implementation/IssuanceKeyService.cs   # NEW: lazy derive, rotate, revoke
+│       └── Credentials/
+│           └── CredentialMatcher.cs                   # MODIFIED: alsoKnownAs-equivalent issuer match
+│
+├── Apps/
+│   └── Sorcha.Citizen.Verifier/
+│       └── Services/
+│           ├── IIssuerKeyResolver.cs                  # MODIFIED: replace OptOut as default
+│           └── DidResolverBackedIssuerKeyResolver.cs  # NEW: production impl, Phase 4
+│
+└── Core/
+    └── Sorcha.Register.Core/
+        └── Services/
+            ├── IDIDResolver.cs                        # DELETED (Phase 0)
+            └── DIDResolver.cs                         # DELETED (Phase 0)
+
+tests/
+├── Sorcha.ServiceClients.Tests/Did/
+│   ├── DidResolverRegistryCrossResolutionTests.cs    # NEW
+│   ├── KidThumbprintHelperTests.cs                   # NEW
+│   └── DidResolverCacheTests.cs                      # NEW
+├── Sorcha.Tenant.Service.Tests/
+│   ├── OrgDidDocumentServiceTests.cs                 # NEW
+│   └── OrgDidDocumentEndpointsTests.cs               # NEW
+├── Sorcha.Wallet.Service.Tests/
+│   ├── IssuanceKeyServiceTests.cs                    # NEW
+│   └── Credentials/CredentialMatcherAlsoKnownAsTests.cs  # NEW
+├── Sorcha.Citizen.Verifier.Tests/
+│   └── DidResolverBackedIssuerKeyResolverTests.cs    # NEW
+└── (walkthroughs/)
+    └── AssuredIdentity, TradeFinance, ConstructionPermit, SelfBuildHouse — green with enforce-on
+```
+
+**Structure decision**: Standard Sorcha microservices layout. New shared logic lives in `Sorcha.ServiceClients.Http` (where the existing DID resolver stack already lives). Service-specific logic stays inside its owning service. The verifier app adds the production `IIssuerKeyResolver` implementation; the existing `JwkRegistryIssuerKeyResolver` is retained for tests + the `DemoMintEndpoint` test fixture (open question Q5 in design doc — confirmed in research.md as "keep registry as test escape").
+
+## Phasing (per design doc)
+
+Each phase is independently testable and ships its own atomic commit set per Sorcha conventions. Phase 0 ships first as a standalone PR; Phases 1–6 are a sequential chain on this branch.
+
+| Phase | Scope | Cost | Atomic? |
+|-------|-------|------|---------|
+| **Phase 0** | Retire legacy `IDIDResolver` (FR-024). Migrate `Sorcha.Register.Service/Program.cs:205` consumer to `IDidResolverRegistry`. Delete `IDIDResolver`, `DIDResolver`, `DIDResolutionResult`. Update `specs/031-register-governance/` and `specs/039-verifiable-presentations/` references. **Ships as a separate PR before the rest of this feature.** | 1-2h | Yes — independent |
+| **Phase 1** | DID document publishing — `IOrgDidDocumentService` + endpoint + `OrgDidDocument` model. Generate both forms (`did:sorcha:org`, `did:web`) with `alsoKnownAs`. Dual-VM publishing template. Regeneration triggers on key events. (FR-004, FR-005, FR-006, FR-007, FR-011) | 2-3 days | After Phase 0 |
+| **Phase 2** | Issuance key lifecycle — `IIssuanceKeyService` with lazy slot-1 derivation, manual rotation handler, revocation handler (`VAL_CRED_GOV_001` proto-rule). Wire `IOrgDidDocumentService.RegenerateAsync` calls on key events. (FR-016, FR-017, FR-018) | 2-3 days | After Phase 1 |
+| **Phase 3** | Resolver enhancements — `SorchaDidResolver` dual-VM + `alsoKnownAs` emission + issuance-key VM surfacing. `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` with cross-resolution, key-material verification, caching, Redis-stream invalidation. `KidThumbprintHelper` exact-match → thumbprint-fallback. (FR-008, FR-009, FR-010, FR-012, FR-022, FR-023, FR-025) | 3-4 days | After Phases 1+2 |
+| **Phase 4** | `DidResolverBackedIssuerKeyResolver` in `Sorcha.Citizen.Verifier`. Replace `OptOutIssuerKeyResolver` as production default. `JwkRegistryIssuerKeyResolver` retained for tests. Three-way failure-mode logging (`Sorcha.Verifier.IssuerSignature` meter). Update `RequireIssuerSignature` default to `true`. (FR-001, FR-002, FR-003, FR-019) | 2-3 days | After Phase 3 |
+| **Phase 5** | Genesis schema slots (`RegisterPolicy.requireIssuerSignature`, `RegisterPolicy.permittedIssuers`, `Organization.DefaultKidStyle`). `CredentialMatcher` accepts `alsoKnownAs`-equivalent issuer match. (FR-013, FR-014, FR-015, FR-020, FR-021) | 1-2 days | After Phase 4 |
+| **Phase 6** | Walkthroughs + integration. Update walkthroughs (AssuredIdentity, TradeFinance, ConstructionPermit, SelfBuildHouse) — confirm enforce-on green. Demo-mint flow stays via `JwkRegistryIssuerKeyResolver` as documented test escape. Document the AssuredIdentity action's optional `acceptedIssuers` pin as a hardening recommendation. **Ship gate.** | 1-2 days | After Phase 5; gates ship |
+
+**Total estimate**: ~2-3 weeks for an engineer with codebase familiarity.
+
+## Complexity Tracking
+
+No constitution violations. No entries.

--- a/specs/120-production-issuer-signature-verification/quickstart.md
+++ b/specs/120-production-issuer-signature-verification/quickstart.md
@@ -1,0 +1,236 @@
+# Quickstart: Production Issuer Signature Verification
+
+**Feature**: 120-production-issuer-signature-verification
+**Phase**: 1 (operator runbook)
+**Date**: 2026-05-09
+**Audience**: developers verifying the feature works end-to-end on a clean local stack; operators running the post-merge smoke test on n1.
+
+## Prerequisites
+
+- .NET 10 SDK
+- Docker Desktop (or compatible runtime)
+- A working `docker-compose.yml` at repo root (the standard Sorcha dev stack)
+- For walkthrough validation: PowerShell 7.5+ (`pwsh`)
+
+## Goal
+
+Confirm that:
+
+1. An organisation's first credential issuance lazily derives an issuance key and publishes its DID document under both forms.
+2. The published `did:web` document is reachable, resolves cleanly, and declares `alsoKnownAs` linking to the `did:sorcha:org` form.
+3. A credential issued under a fresh issuance key verifies under enforce-on (`RequireIssuerSignature: true`).
+4. A tampered credential (signature modified, key swapped, `iss` changed) is rejected with the correct three-way failure-mode attribution.
+5. An attacker constructed `did:web` document falsely claiming `alsoKnownAs` to another org's `did:sorcha` form is rejected by cross-resolution.
+6. The walkthrough suite (AssuredIdentity, TradeFinance, ConstructionPermit, SelfBuildHouse) passes end-to-end with enforce-on as the default.
+7. Phase 0 cleanup verified: legacy `IDIDResolver` is gone from the codebase.
+
+## Step 1 — Bring the stack up
+
+```powershell
+# From repo root
+docker-compose up -d
+```
+
+Wait for all services healthy:
+
+```powershell
+docker-compose ps
+```
+
+Aspire dashboard at `http://localhost:18888`; gateway at `http://localhost:80`.
+
+## Step 2 — Verify Phase 0 cleanup
+
+```powershell
+# Should return zero matches across src/
+Select-String -Pattern "IDIDResolver" -Path src/**/*.cs -Recurse
+```
+
+Expected: no results. The legacy interface, its implementation, and the `DIDResolutionResult` shape have all been deleted. The single previous consumer in `Sorcha.Register.Service/Program.cs:205` now uses `IDidResolverRegistry`.
+
+## Step 3 — Trigger first credential issuance for a fresh org
+
+Use the existing demo flow that issues an Assured Identity credential. The walkthrough is fastest:
+
+```powershell
+cd walkthroughs/AssuredIdentity
+./run.ps1 -CleanState
+```
+
+Watch the Tenant Service logs:
+
+```powershell
+docker-compose logs -f tenant-service | Select-String -Pattern "OrgDidDocument"
+```
+
+Expected log lines:
+
+```text
+[INFO] OrgDidDocumentService: lazily deriving issuance key for org {orgId} (first issuance trigger)
+[INFO] OrgDidDocumentService: regenerated DID document for org {orgId} (reason=IssuanceKeyDerived, version=1)
+```
+
+## Step 4 — Resolve the published DID documents
+
+The federated `did:web` form should be reachable at the platform domain.
+
+```powershell
+# Replace {orgId} with the org id from step 3 logs
+curl http://localhost/orgs/{orgId}/did.json | ConvertFrom-Json | Format-List
+```
+
+Expected: a JSON document with `id`, `alsoKnownAs` (one entry pointing at the `did:sorcha:org:` form), `verificationMethod` (two entries — versioned + thumbprint kid styles, both with the same `publicKeyMultibase`), and `assertionMethod` (referencing both VMs).
+
+Cross-check the `did:sorcha:org:` form via the resolver registry. From inside any service that registers `IDidResolverRegistry`:
+
+```csharp
+var doc = await _registry.ResolveAsync("did:sorcha:org:" + walletAddress);
+// doc.alsoKnownAs should contain the did:web form
+// doc.verificationMethod should contain the same dual-VM pair as the did:web doc
+```
+
+## Step 5 — Verify a fresh credential under enforce-on
+
+The Assured Identity walkthrough run from step 3 already exercises issuance and presentation under enforce-on. Confirm in the verifier logs:
+
+```powershell
+docker-compose logs citizen-verifier | Select-String -Pattern "verifier.issuer-resolve"
+```
+
+Expected: spans with `verifier.issuer.outcome=success` and `verifier.issuer.kid_match_mode=exact`. No `did-unresolved`, `kid-unmatched`, or `signature-failed` spans for this happy-path run.
+
+## Step 6 — Inject a tampered credential
+
+This step exercises the three-way failure-mode logging.
+
+### 6a — Tampered signature (signature-failed)
+
+Use the verifier's test seam to submit a credential whose JWS signature has been mutated by a single byte:
+
+```powershell
+./tests/scripts/test-tampered-credential.ps1 -Mutation Signature
+```
+
+Expected: HTTP 400/401 from the presentation endpoint. Verifier metric `sorcha_verifier_issuer_signature_failed_total` increments by 1.
+
+### 6b — Unknown kid (kid-unmatched)
+
+```powershell
+./tests/scripts/test-tampered-credential.ps1 -Mutation UnknownKid
+```
+
+Expected: rejection with `sorcha_verifier_issuer_kid_unmatched_total += 1`.
+
+### 6c — Unresolvable iss (did-unresolved)
+
+```powershell
+./tests/scripts/test-tampered-credential.ps1 -Mutation UnresolvedIss
+```
+
+Expected: rejection with `sorcha_verifier_issuer_did_unresolved_total += 1`.
+
+(If the helper scripts above don't yet exist in the codebase, this step is the place to write them in Phase 4. They're test-fixtures, not production code.)
+
+## Step 7 — Cross-resolution attack scenario
+
+This is the security-critical test. It confirms FR-008 / FR-010 / SC-002.
+
+Use the test fixture that constructs a malicious `did:web` document claiming `alsoKnownAs` to a different organisation's `did:sorcha:org` form, while serving an attacker-controlled signing key:
+
+```powershell
+./tests/scripts/test-cross-resolution-attack.ps1
+```
+
+Expected:
+
+- The malicious credential is rejected.
+- Verifier counter `sorcha_did_resolver_cross_resolve_mismatch_total` increments by 1.
+- Span `did.resolve.cross` tagged `did.alsoKnownAs.match=mismatch`.
+- The credential does NOT impersonate the targeted org.
+
+If the credential is accepted, the cross-resolution implementation is broken — block ship until fixed.
+
+## Step 8 — Run the full walkthrough suite
+
+The ship gate. Each walkthrough must pass end-to-end with enforce-on.
+
+```powershell
+# AssuredIdentity (already covered by step 3 if run; re-run to confirm idempotency)
+cd walkthroughs/AssuredIdentity
+./run.ps1
+
+# TradeFinance
+cd ../TradeFinance
+./run.ps1
+
+# ConstructionPermit
+cd ../ConstructionPermit
+./run.ps1
+
+# SelfBuildHouse
+cd ../SelfBuildHouse
+./run.ps1
+```
+
+Each `run.ps1` should report `PASS` end-to-end. A walkthrough failure under enforce-on is a ship blocker.
+
+## Step 9 — Confirm forward-compat slots (SC-007)
+
+Inspect a freshly-created register's genesis control record. The `RegisterPolicy` should NOT include `requireIssuerSignature` or `permittedIssuers` fields by default (because they're nullable + JSON-null-ignored), but the schema MUST accept them when present without error.
+
+```powershell
+# Roundtrip a control record with both fields populated
+$json = @"
+{
+  "version": 1,
+  "registerPolicy": {
+    "requireIssuerSignature": true,
+    "permittedIssuers": ["did:sorcha:org:ws1q..."]
+  },
+  "validators": [...]
+}
+"@
+$json | dotnet run --project tools/RegisterControlRecordValidator
+```
+
+Expected: `valid=true`. The reserved fields parse cleanly; v1 simply does not act on them.
+
+## Step 10 — Compromise + revocation drill
+
+Optional but recommended for Phase 6 sign-off (validates SC-005).
+
+1. Identify an org's active issuance key via the Tenant admin API.
+2. Initiate a `RevokeIssuanceKey` governance op (proto-rule `VAL_CRED_GOV_001`).
+3. Once quorum reached, attempt to present a credential signed by the now-revoked key.
+4. Confirm rejection with revocation-attributed log line.
+5. Confirm the org can derive a fresh issuance key and resume normal operation.
+
+Time from initiating revocation to first rejection: should be bounded by the governance-op duration (typically minutes).
+
+## Failure triage
+
+If any step fails, the three-way failure-mode logging (FR-003) tells you which layer to look at:
+
+| Symptom | Look at |
+|---|---|
+| `did-unresolved` count rising | `IDidResolverRegistry`, `OrgDidDocumentService`, `WebDidResolver` (network), `SorchaDidResolver` |
+| `kid-unmatched` count rising | `KidThumbprintHelper`, `IIssuanceKeyService` rotation logic, `SorchaDidResolver` dual-VM publishing |
+| `signature-failed` count rising | Cryptographic verification path; possible algorithm mismatch or Multicodec encoding bug |
+| `cross_resolve_mismatch` count rising | Either an actual attack or a real `alsoKnownAs` bookkeeping error in `OrgDidDocumentService` |
+| Walkthrough hangs | Cross-resolution latency — check `DidResolverCache` config, especially `DidResolver:Cache:WebTtlMinutes` |
+
+## What's NOT verified by this quickstart (deferred)
+
+- BYO-domain `did:web` end-to-end (out of scope for v1).
+- Validator-side issuer-sig verification at seal time (Future B; out of scope).
+- Auto-rotation schedules (manual rotation only).
+- New DID methods like `did:ethr` (additive; quickstart will need extension when added).
+
+## Cross-references
+
+- Spec: `specs/120-production-issuer-signature-verification/spec.md`
+- Plan: `specs/120-production-issuer-signature-verification/plan.md`
+- Design: `docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md`
+- Data model: `specs/120-production-issuer-signature-verification/data-model.md`
+- Resolver contract: `specs/120-production-issuer-signature-verification/contracts/did-resolver-registry-contract.md`
+- Endpoint contract: `specs/120-production-issuer-signature-verification/contracts/org-did-document-endpoint.openapi.yaml`

--- a/specs/120-production-issuer-signature-verification/research.md
+++ b/specs/120-production-issuer-signature-verification/research.md
@@ -1,0 +1,225 @@
+# Research: Production Issuer Signature Verification
+
+**Feature**: 120-production-issuer-signature-verification
+**Phase**: 0 (research, alternatives, decision rationale)
+**Date**: 2026-05-09
+**Status**: Complete — no NEEDS CLARIFICATION markers remain
+
+## Scope
+
+The product decisions D1–D6 were locked in a 2026-05-09 brainstorm session and captured in the design doc. This research artifact records, for each decision, the alternatives considered and why they were rejected — the audit trail that makes the decisions defensible to future readers (and to the agent that picks up `/speckit.tasks` next).
+
+No open questions remain. Where the design doc deferred a question to "coding time" (e.g., specific cache TTLs, DID document version metadata), the default is documented here so the planner does not need to revisit them.
+
+---
+
+## R1 — Single canonical resolver interface (FR-024)
+
+**Decision**: Standardise on `IDidResolver` (W3C-shaped, `DidDocument` return). Retire legacy `IDIDResolver` (capital DID, custom `{PublicKey, Algorithm}` return).
+
+**Rationale**:
+- W3C DID Core is the standard the rest of the credential ecosystem (issuers, wallets, verifiers, relying parties) speaks.
+- `IDidResolver` already supports three methods (`SorchaDidResolver`, `WebDidResolver`, `KeyDidResolver`) wired through `IDidResolverRegistry`. The infrastructure is built; only the migration of one consumer is missing.
+- `IDIDResolver` is consumed in exactly one place (`Sorcha.Register.Service/Program.cs:205`). The migration is mechanical.
+- Two parallel resolvers in production code is a maintenance smell that grows the longer it persists.
+
+**Alternatives considered**:
+- *Keep both, deprecate legacy gradually*: rejected. A single consumer doesn't justify a deprecation window. The migration is small enough to do in one PR.
+- *Migrate consumer logic into the legacy interface*: rejected. The legacy shape is non-standard; investing in it would deepen the wrong-direction debt.
+
+**Migration shape**: the `Sorcha.Register.Service/Program.cs:205` call site reads `IDIDResolver.ResolveAsync(did)` and uses `DIDResolutionResult.PublicKey` / `.Algorithm`. The W3C path: call `IDidResolverRegistry.ResolveAsync(did)` → for `did:sorcha:r:*:t:*` (the legacy resolver's specialty), the W3C `SorchaDidResolver` emits service endpoints only, **not** key material extracted from the control transaction payload. The legacy resolver did extract attestation public keys; the W3C resolver punts that to `IRegisterServiceClient.GetTransactionAsync`. **Therefore the migration replaces one DID-resolver call with two service calls** at the consumer site. Acceptable; the consumer is not in a hot path.
+
+---
+
+## R2 — Federation via `did:web` (D1)
+
+**Decision**: Sorcha-hosted, path-based `did:web:{platform-domain}:orgs:{orgId}` → `https://{platform-domain}/orgs/{orgId}/did.json`. Static JSON regenerated on key events. BYO-domain deferred.
+
+**Rationale**:
+- Standards-compliant external wallets and verifiers can resolve `did:web` with zero Sorcha-specific code (SC-004).
+- Static JSON behind the gateway is trivially CDN-cacheable; one route, no per-request work.
+- Path-based form is forward-compatible with later subdomain or BYO-domain via `alsoKnownAs` — old URL stays alive forever.
+
+**Alternatives considered**:
+- *Subdomain-based (`did:web:{orgId}.{platform}`)*: rejected for v1. Smoother BYO upgrade ceremony but requires wildcard TLS, per-org subdomain provisioning, CDN config aware of subdomains. Real ops cost without meeting a real day-1 need.
+- *BYO-domain mandatory*: rejected. High onboarding friction; orgs don't want to operate `/.well-known/did.json` on day 1.
+- *Sorcha-hosted only, no `did:web` form at all*: rejected. Loses federation; `did:sorcha:org` requires Sorcha-specific tooling to resolve.
+
+**Migration to BYO-domain (future)**: when an org upgrades, the old A-form DID stays resolvable indefinitely via the original endpoint. New BYO DID document declares the old form via `alsoKnownAs`; cross-resolution (R4) makes the equivalence safe.
+
+---
+
+## R3 — Hybrid kid scheme (D3)
+
+**Decision**: DID document publishes **two `VerificationMethod` entries per active key** with identical key material — versioned (`#vc-issuance-{n}`) and thumbprint (`#{rfc7638-base64url}`). Issuer signs with versioned-format kid by platform default; per-org override slot reserved (not exposed in v1 UI). Verifier matches kid via exact-string-first, thumbprint-fallback.
+
+**Rationale**:
+- Versioned kids are human-readable in logs and forensic traces (`#vc-issuance-2` says "second issuance key" without inspecting the doc).
+- Thumbprint kids are what standards-purist external implementations tend to publish (matches `did:key`-style conventions).
+- Dual-publishing both forms in the DID document costs ~200 bytes per active VM. Trivial.
+- Verifier-side tolerance (exact match → thumbprint fallback) means inbound credentials from external issuers using either form just work.
+- The platform-default + per-org override pattern is the cheap forward-compat trick: standards-purist orgs that demand thumbprint-only signing can be accommodated without changing platform behaviour.
+
+**Alternatives considered**:
+- *Versioned only*: rejected. Forces external standards-purist verifiers to resolve our specific kid format; loses interop.
+- *Thumbprint only*: rejected. Loses readability in logs, makes rotation trace hostile.
+- *Single VM per key with computed thumbprint matching at verify time*: considered. Verifier-side complexity equivalent (still needs thumbprint computation for fallback). Doc shape is one entry instead of two — saves 200 bytes per key. Lost: external verifiers that only do exact-string matching against published VMs would fail on credentials we sign with the absent form. Rejected for interop simplicity.
+- *Per-credential-type kid style*: rejected as overkill (item 3 in design doc's "open questions"). Per-platform default with per-org override is the right granularity.
+
+---
+
+## R4 — Cross-resolved `alsoKnownAs` with key-material verification (D4)
+
+**Decision**: New method `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync(did, ct)`. Resolves primary DID, walks `alsoKnownAs`, resolves each linked DID, compares `VerificationMethod` key material across all linked documents, returns merged document only when same public key appears in every link. Reject on mismatch or unreachable link.
+
+**Rationale**:
+- `alsoKnownAs` blindly trusted is a privilege-escalation primitive: anyone who controls the `did:web` document hosting can claim equivalence to any organisation and forge credentials in their name.
+- Cross-resolution anchors the equivalence to whichever side is harder to compromise. `did:sorcha:org:*` is anchored to wallet-derived keys (custodial under Feature 083); `did:web:*` is anchored to domain control. Cross-resolving from one to the other requires both to be compromised simultaneously to forge a credential.
+- Cost: one extra DID resolution per *issuer* per cache window, not per presentation. Cache absorbs the overhead in steady state.
+- Packaging in the registry (rather than each consumer) means future B (validator-side at seal time) inherits the behaviour without re-implementation.
+
+**Alternatives considered**:
+- *Trust blindly*: rejected. Documented as a known privilege-escalation path; security review would not accept it.
+- *Signed `alsoKnownAs` assertions*: considered. Cryptographically cleaner (each side cryptographically attests to the equivalence); does not require the second resolution at verify time. Rejected because no W3C primitive exists — would require a Sorcha-specific extension that no external verifier would honour. Cross-resolution gives equivalent security with zero standards drift.
+- *DNS-anchored proofs (e.g., DNSSEC TXT records on the `did:web` domain referencing the `did:sorcha` form)*: rejected. Adds DNS infrastructure dependency to a feature that should be HTTP-only.
+
+**Caching default**: cache key = canonical primary DID; TTL 1h for `did:web`, on-event-invalidate for `did:sorcha:*` (subscribed to `transaction:confirmed` Redis stream — the same mechanism used by Feature 119 for seal-aware ordering). `did:key` is cache-forever (key embedded in identifier; offline; no refresh possible). Cache layer lives in `DidResolverCache` (new), called from the new `ResolveWithAlsoKnownAsAsync` method.
+
+---
+
+## R5 — Pre-production posture: default-on at ship, no warn-only soak (D5)
+
+**Decision**: `IssuerSignature:Required = true` by default at ship. Per-register `RegisterPolicy.requireIssuerSignature` slot reserved (not read at v1). No multi-week warn-only soak window. Walkthrough suite green with enforce-on is the ship gate.
+
+**Rationale**:
+- Sorcha is in pre-production. There are no in-flight credentials issued under the prior accept-everything default that need a deprecation window. Default-on at ship is therefore safe (Assumption #1 in spec).
+- The walkthrough suite is a representative test surface (Assumption #4). Walkthroughs green with enforce-on prove all in-tree flows verify cleanly.
+- The default-off-then-flip pattern exists to manage external customer impact during a behaviour change. With no external customers, it adds operational complexity without value.
+- Three-way failure-mode logging (FR-003) gives developer-time triage signal during dev/staging without the warn-only mode.
+
+**Alternatives considered**:
+- *Default-off, multi-week warn-only soak, deliberate flip-to-true*: appropriate post-first-external-participant. Rejected for pre-production v1 — adds a flip-event that has to be remembered. Recorded in spec's Out of Scope as the right pattern for *future* features.
+- *Per-register-only enforcement (no global)*: rejected. v1 simplification — global flag is one config; per-register reads are deferred to Future B alongside the validator-side rules. The slot is reserved (FR-020) so the migration is zero-cost.
+
+**Forward note (per spec)**: the no-soak posture is conditional on pre-production status. When the platform onboards its first external participant who issues credentials, any subsequent feature that materially changes verification behaviour should revert to the warn-only-then-flip pattern.
+
+---
+
+## R6 — Open trust + per-action allowlist, slots reserved (D6)
+
+**Decision**: v1 accepts any resolvable issuer DID. Per-action allowlist via `CredentialRequirement.AcceptedIssuers` (already implemented and enforced in three places). Per-register `RegisterPolicy.permittedIssuers` slot reserved on genesis (not read at v1). New matching logic: `alsoKnownAs`-equivalent issuer match in `CredentialMatcher`.
+
+**Rationale**:
+- Domain control = identity is the trust model the public web's TLS infrastructure uses. Good enough for v1.
+- Per-action allowlist is the *operational* security gate today regardless of platform-level policy — high-stakes actions (Assured Identity verification, regulated finance flows) pin to specific accredited issuer DIDs in the blueprint. This works whether or not Sorcha curates a platform allowlist.
+- The publish-time `OPEN_CREDENTIAL_ISSUER` warning already nudges blueprint authors to pin issuers for high-stakes credentials.
+- Equivalence-aware matching is the one new bit of matching logic: if `acceptedIssuers: ["did:sorcha:org:ws1q..."]` and the credential's `iss=did:web:...` resolves to a doc with that DID in `alsoKnownAs`, the match succeeds.
+
+**Alternatives considered**:
+- *Platform-curated allowlist*: rejected. Sorcha curating "known-good issuers" is operational ownership Sorcha doesn't want, and per-action pinning is a finer-grained control that obviates it.
+- *Per-register-only allowlist (no per-action)*: rejected. Coarser than needed; multiple actions in a register may legitimately accept different issuer sets.
+- *Per-credential-type allowlist*: rejected as overkill. Per-action already covers it.
+
+---
+
+## R7 — Caching strategy details (Q1, Q7 from design doc)
+
+**Decision**: Per-method TTL with on-event invalidation for platform-internal DIDs. Defaults:
+
+| Method | Cache TTL | Invalidation trigger |
+|---|---|---|
+| `did:web` | 1h | TTL only |
+| `did:sorcha:*` | infinite (within process lifetime) | `transaction:confirmed` Redis stream subscription, plus `IOrgDidDocumentService` direct invalidation on local key events |
+| `did:key` | infinite | None (key embedded in identifier) |
+
+`did.json` HTTP `Cache-Control` header: `public, max-age=21600` (6h) — matches the existing pattern from Feature 114's status-list endpoint. Explicit invalidation on key events propagates faster than max-age via gateway cache-purge.
+
+**Rationale**:
+- 1h `did:web` TTL balances freshness against external server load. Production deployments can tighten this; the 1h ceiling matches what the design doc deferred.
+- `did:sorcha:*` events are local; subscribing to `transaction:confirmed` (the same mechanism used by Feature 119's seal coordinator) invalidates within milliseconds of the on-platform event.
+- `did:key` cannot be invalidated — the identifier *is* the key.
+- 6h `Cache-Control` for the public `did.json` is the conservative ceiling for static published documents; explicit purge on key change makes the lower bound near-zero.
+
+**Alternatives considered**:
+- *No caching*: rejected — every verification incurs a network round trip. Fails SC-009 (steady-state latency).
+- *Cache-forever with explicit invalidation only*: rejected for `did:web` — external server's published document may change without any signal Sorcha can subscribe to.
+- *Aggressive prefetch (warm cache for known issuers)*: deferred to a hardening pass. Not required for v1.
+
+---
+
+## R8 — DID document version metadata (Q2)
+
+**Decision**: Defer to a later feature. v1 single-key-per-org has no version story; multi-key rotation lands metadata incrementally.
+
+**Rationale**: W3C DID Core defines `versionId`, `versionTime`, `nextUpdate` in DID document metadata. These matter when verifiers need to resolve historical states ("what was the document at the time this credential was issued?"). v1 always-active-or-revoked semantics don't need it — every resolution returns the current state, and credentials signed by a revoked key are rejected unconditionally.
+
+When manual rotation lands (Phase 2 already handles single-step rotation), the DID document already carries old + new VMs in the same `verificationMethod` array. Version metadata can be added incrementally to a future hardening pass.
+
+---
+
+## R9 — Status list signing key (slot 109) in DID document (Q3)
+
+**Decision**: Add as additive `VerificationMethod` in the published DID document, with verification relationship `assertionMethod` (matches its purpose — signing status list JWTs that assert per-bit revocation state).
+
+**Rationale**:
+- Feature 114 already derives slot 109 (`sorcha:citizen-status-signing`) per-org for status list JWT signing. Surfacing it in the DID document means external verifiers can verify status-list signatures via the same resolver mechanism as credential signatures.
+- Additive: doesn't conflict with the issuance VM (slot 1, `KeyUsage.VCIssuance`) being in the same document under its own `assertionMethod` entry.
+- Cost: one extra dual-VM pair per org that issues citizen-PWA-targeted credentials. ~400 bytes.
+
+**Implementation note**: `IOrgDidDocumentService.RegenerateAsync` reads both slot-1 and slot-109 keys via `IKeyManagementService` when present; emits both. If either is absent (org has issuance but no citizen-PWA credentials, or vice versa), only the present one appears.
+
+---
+
+## R10 — HAIP OID4VCI integration consistency (Q4)
+
+**Decision**: Phase 6 walkthrough validation includes confirming that OID4VCI `credential_issuer` metadata declares the same DID as the issued credential's `iss` claim. No new code in this feature; validation only.
+
+**Rationale**: Feature 097 (OID4VCI issuer) already exists. The OID4VCI metadata endpoint already declares the issuer's DID. The integration is "the issuer is the same entity in both surfaces" — verifiable end-to-end by issuing through OID4VCI and presenting through the verifier with enforce-on.
+
+If the walkthrough surfaces a mismatch, a small alignment patch lands in this feature's Phase 6. If clean, no work needed.
+
+---
+
+## R11 — Demo-mint flow disposition (Q5)
+
+**Decision**: `JwkRegistryIssuerKeyResolver` retained in `Sorcha.Citizen.Verifier` for tests + `DemoMintEndpoint`. Production `IIssuerKeyResolver` is `DidResolverBackedIssuerKeyResolver`. `DemoMintEndpoint` is documented as test-only; not used in production.
+
+**Rationale**:
+- The demo flow generates per-mint issuer keys on-the-fly. Wiring it through real DID resolution would require publishing per-mint DID documents, which is meaningless for a demo.
+- `JwkRegistryIssuerKeyResolver` already exists as the right level of abstraction for an in-memory, test-only key store.
+- Production wiring (`DidResolverBackedIssuerKeyResolver` as the registered `IIssuerKeyResolver`) and test/demo wiring (`JwkRegistryIssuerKeyResolver` registered in test composition or behind a configuration flag) coexist cleanly.
+
+**Alternatives considered**:
+- *Replace registry with a localhost-served `did:web` test fixture*: rejected. Adds test infrastructure (a test HTTP server, a certificate for HTTPS, etc.) without value beyond what the registry already provides.
+- *Delete the registry, force tests to use real DID resolution*: rejected. Tests would need to publish documents before each test setup; large overhead for marginal "more realistic" testing.
+
+---
+
+## R12 — Where does `Organization.DefaultKidStyle` live structurally (Q6)
+
+**Decision**: Add as a top-level property on `Organization`, not a sub-entity. Default value `KidStyle.Versioned`. Type: enum.
+
+**Rationale**:
+- The setting is per-org, single-valued, and rarely changed. A sub-entity for one field is over-design.
+- Other per-org configuration on `Organization` (branding, billing fields) lives at the top level — consistent.
+- If future per-org credential settings accumulate (e.g., default expiry, default disclosure scope), they may move into a settings sub-entity in a later refactor. Not a v1 concern.
+
+---
+
+## R13 — Sorcha-hosted `did.json` URL stability across BYO upgrade (Q8)
+
+**Decision**: Sorcha-hosted DID documents stay reachable indefinitely. No sunset.
+
+**Rationale**:
+- Already-issued credentials whose `iss` points at the Sorcha-hosted form must remain verifiable forever (until they expire by their own `exp` claim).
+- `alsoKnownAs` linkage between old (Sorcha-hosted) and new (BYO) documents lets cross-resolution validate either direction.
+- Storage cost is negligible: one JSON document per org that ever upgraded, served as static content.
+- The discipline is: **DIDs are forever once published**. This is a property of the W3C model, not a Sorcha-specific commitment — and breaking it would silently invalidate historical credentials, which is exactly what `alsoKnownAs` exists to prevent.
+
+---
+
+## Summary
+
+All 13 research items resolved. No NEEDS CLARIFICATION markers remain. The architectural decisions in the design doc are validated against alternatives; no decision was overturned during research.
+
+**Phase 1 prerequisites**: complete. Proceed to data-model and contracts.

--- a/specs/120-production-issuer-signature-verification/spec.md
+++ b/specs/120-production-issuer-signature-verification/spec.md
@@ -1,0 +1,228 @@
+# Feature Specification: Production Issuer Signature Verification
+
+**Feature Branch**: `120-production-issuer-signature-verification`
+**Created**: 2026-05-09
+**Status**: Draft
+**Input**: User description: see `docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md` for the authoritative design — every architectural and product decision in this spec is locked there and must not be relitigated.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Verifier rejects unverifiable credentials by default (Priority: P1)
+
+A consuming application (the citizen verifier, the wallet's inbound credential pipeline, or any other point-of-use) receives a presented credential. Before accepting any claim from that credential, the platform resolves the issuer's published identity, locates the verification method named in the credential's signature header, and verifies the cryptographic signature. A credential whose issuer cannot be resolved, whose signature header points to no published key, or whose signature does not verify against the published key is rejected.
+
+**Why this priority**: Without this story, a consuming application has no cryptographic basis for trusting any claim made by any credential. Every other story in this feature exists to support this one; until it ships, the platform's credential ecosystem is structurally insecure.
+
+**Independent Test**: Submit three credentials to a presentation flow — one with a valid signature from a published issuer, one with a tampered signature, one whose issuer identity does not resolve. The valid one is accepted; the other two are rejected with distinguishable failure reasons surfaced in operational logs.
+
+**Acceptance Scenarios**:
+
+1. **Given** an organisation has published its identity and an issued credential whose signature is intact, **When** that credential is presented, **Then** the credential is accepted and the verifier records a successful verification outcome.
+2. **Given** a credential whose signature has been altered after issuance, **When** that credential is presented, **Then** the credential is rejected and the failure is recorded as a signature mismatch.
+3. **Given** a credential whose stated issuer cannot be resolved (the identity has no published document, or the published document is unreachable), **When** that credential is presented, **Then** the credential is rejected and the failure is recorded as an unresolved issuer.
+4. **Given** a credential whose signature header references a key identifier not present in the issuer's published document, **When** that credential is presented, **Then** the credential is rejected and the failure is recorded as an unmatched key identifier.
+
+---
+
+### User Story 2 — Organisations have a published verifiable identity (Priority: P1)
+
+When an organisation issues its first credential, the platform automatically publishes a public identity document for that organisation. The document declares the keys the organisation uses to sign credentials and is reachable at a stable, well-known location. The document is regenerated whenever the organisation's signing keys change (rotation, revocation, additional keys added). External parties — including standards-compliant wallets, verifiers, and auditors — can fetch and parse the document using ordinary web infrastructure.
+
+**Why this priority**: User Story 1 has nothing to verify against without a published identity for each issuer. This story is the enabling counterpart to US1 — both must ship together for either to deliver value.
+
+**Independent Test**: Trigger a first credential issuance for a freshly-created organisation. Confirm that the organisation's published identity document is now reachable at the documented well-known location, that it declares at least one signing key, and that a third-party tool (such as a generic W3C DID resolver) can fetch and parse it without Sorcha-specific knowledge.
+
+**Acceptance Scenarios**:
+
+1. **Given** an organisation has never issued a credential, **When** the organisation issues its first credential, **Then** a published identity document for the organisation becomes reachable at a stable URL and that document declares the signing key used for the credential.
+2. **Given** an organisation already has a published identity document, **When** a credential is issued under an already-derived signing key, **Then** the document does not need to be regenerated.
+3. **Given** an organisation's signing key has been changed (rotated or revoked) by an authorised governance action, **When** the change is committed, **Then** the published document reflects the new state on the next request.
+
+---
+
+### User Story 3 — Federation interop without Sorcha-specific tooling (Priority: P2)
+
+A standards-compliant external wallet or verifier — one that understands the IETF/W3C credential and identity standards but has no knowledge of Sorcha's internal naming conventions — can verify a Sorcha-issued credential. The credential carries an identity reference that any standards-compliant resolver can dereference. The published document follows the W3C identity-document conventions in widespread use.
+
+**Why this priority**: Federation is a property the platform claims to support but currently cannot demonstrate. Shipping US1 + US2 with only Sorcha-internal naming would lock the credential ecosystem inside the platform. This story ensures that external interop works on day one — even if it is not heavily exercised at v1.
+
+**Independent Test**: Take a credential issued by Sorcha and present it to a standards-compliant external verifier with no special configuration. The external verifier resolves the issuer, fetches the public key, and verifies the credential without needing any Sorcha-specific code or trust anchor.
+
+**Acceptance Scenarios**:
+
+1. **Given** a credential issued by a Sorcha-hosted organisation, **When** that credential is examined by a standards-compliant external verifier, **Then** the verifier can resolve the issuer's identity and successfully verify the credential's signature using only standard tooling.
+2. **Given** a Sorcha-internal verifier and an externally-issued credential whose issuer publishes a standards-compliant identity document, **When** that credential is presented, **Then** the Sorcha verifier can resolve and verify it through the same path used for Sorcha-internal credentials.
+
+---
+
+### User Story 4 — Cross-resolution prevents identity impersonation (Priority: P2)
+
+When an organisation's identity is reachable through more than one identifier — for example, the platform-internal name and the public-web name — the document at each identifier names the others. A verifier that receives a credential under one identifier looks up the others as well, confirms that the same signing key appears in every linked document, and only then accepts the equivalence as established. If the documents diverge in their published key material, the verifier rejects the credential.
+
+**Why this priority**: Without cross-resolution, anyone who could write to the public-web hosting of an identity document could claim equivalence to any other organisation's identity and issue credentials in their name. This story closes the impersonation gap that US3's federation surface would otherwise open.
+
+**Independent Test**: Construct a fixture in which the public-web identity document falsely claims equivalence to a different organisation's platform-internal identity, while serving an attacker-controlled signing key. Present a credential signed by the attacker's key. The verifier rejects the credential because the platform-internal identity's published document does not contain the attacker's key.
+
+**Acceptance Scenarios**:
+
+1. **Given** an organisation has published consistent identity documents under both its identifiers, **When** a credential signed by that organisation is presented, **Then** the cross-resolution succeeds and the credential is verified normally.
+2. **Given** an attacker has obtained write access to one of an organisation's published documents and altered it to claim equivalence to a different organisation, **When** a credential signed by the attacker's key is presented, **Then** the cross-resolution fails and the credential is rejected.
+3. **Given** one of the documents in an equivalence chain is temporarily unreachable, **When** a credential is presented, **Then** the verifier rejects the credential rather than accepting on the resolvable side alone.
+
+---
+
+### User Story 5 — Per-action issuer allowlist honours equivalent identities (Priority: P3)
+
+A blueprint action that requires a credential from a specific list of issuers should treat all equivalent identifiers for the same issuer as acceptable. A blueprint author who lists the platform-internal identifier should not need to also list the federated identifier (and vice versa) — the platform automatically follows the equivalence chain when matching.
+
+**Why this priority**: This story removes a sharp edge in blueprint authoring. Without it, blueprint authors would need to know about both identifier forms for every issuer they accept, doubling the maintenance surface and creating an obvious source of authoring error. It is P3 because the existing per-action allowlist already enforces the strict-string match correctly; this story adds the equivalence-aware variant.
+
+**Independent Test**: Author a blueprint action whose allowlist contains only the platform-internal identifier of an issuer. Present two credentials from that issuer: one whose signature header references the platform-internal identifier, one whose signature header references the federated identifier. Both are accepted as satisfying the allowlist.
+
+**Acceptance Scenarios**:
+
+1. **Given** an action allowlist names only one of an issuer's published identifiers, **When** a credential is presented under any other equivalent identifier of that issuer, **Then** the allowlist match succeeds and the action proceeds.
+2. **Given** an action allowlist names a specific identifier and a credential is presented from a different issuer entirely (not equivalent), **When** the credential is matched against the allowlist, **Then** the allowlist match fails and the action does not proceed on this credential.
+
+---
+
+### User Story 6 — Issuance key compromise can be remediated by governance (Priority: P3)
+
+If an organisation's signing key is compromised — leaked, stolen, or otherwise lost the property of being controlled only by the organisation — an authorised quorum of administrators can revoke it. After revocation, any credential signed by the revoked key is rejected on the next presentation. Credentials signed before the revocation by the same key are also rejected; the platform's audit log records the revocation event with a timestamp.
+
+**Why this priority**: Key-compromise remediation is a security must-have, but its frequency is low; the v1 manual-rotation, manual-revocation pattern is enough. It is P3 because the existing governance-op machinery (Feature 086 validator roster pattern) provides the precedent and most of the infrastructure; this story is primarily about wiring it to the issuance key.
+
+**Independent Test**: Initiate a governance-op revocation against an organisation's currently-active issuance key. Confirm that subsequent presentation attempts of credentials signed by that key are rejected, that the audit log records the revocation event, and that the organisation can continue to operate (issue future credentials) by deriving a new signing key.
+
+**Acceptance Scenarios**:
+
+1. **Given** an organisation has an active signing key and credentials in circulation signed by that key, **When** an authorised quorum revokes the key, **Then** subsequent presentations of credentials signed by that key are rejected and the audit log records the revocation.
+2. **Given** an organisation's signing key has been revoked, **When** the organisation issues a new credential, **Then** the new credential is signed under a fresh key and the published identity document reflects the new key alongside (or in place of) the revoked one.
+3. **Given** a revocation has been initiated but the quorum has not yet been reached, **When** a credential signed by the (still pending) key is presented, **Then** the credential is verified normally — revocation only takes effect after quorum approval.
+
+---
+
+### Edge Cases
+
+- An organisation's published identity document is briefly unreachable due to a transient network failure: the verifier should not silently fall back to acceptance and should not panic-reject every credential.
+- An organisation rotates its signing key while a credential signed under the previous key is mid-flight: previously-issued credentials remain verifiable until they expire, while new credentials are signed under the new key.
+- A credential's signature header references a key identifier whose form does not match the platform's default style but matches an alternate style published in the same identity document: verification still succeeds.
+- A presented credential names an issuer using an identifier method the platform does not yet support (a method registered with W3C but not implemented in the resolver registry): the credential is rejected with a distinct, actionable failure code.
+- An issuer's identity document declares equivalence with a third party who has not reciprocated the declaration: cross-resolution fails the equivalence check and the credential is rejected.
+- A first-credential-issuance attempt happens during a brief window when the issuance key has just been derived but the identity document has not yet been published: the issuance flow blocks until the document is reachable.
+- An attacker constructs a credential with a forged signature whose corresponding key is not in any published document: the credential is rejected at the unmatched-key-identifier stage.
+- A cached identity document expires mid-presentation: the verifier transparently re-resolves; presentation latency varies but the outcome is correct.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Verification (the core flow)
+
+- **FR-001**: System MUST verify the cryptographic signature of every presented credential against the issuer's published key material before accepting any claim from that credential.
+- **FR-002**: System MUST resolve the credential's issuer identifier through the platform's identity-resolver registry and use the verification method named in the credential's signature header to obtain the verification key.
+- **FR-003**: When the issuer identifier cannot be resolved, when no verification method matches the signature header's key identifier, or when the signature does not verify against the matched key, the system MUST reject the credential and MUST surface the three failure reasons as distinguishable outcomes in operational logs and metrics.
+
+#### Issuer identity publication
+
+- **FR-004**: System MUST publish a public identity document for an organisation no later than the moment that organisation's first credential is issued.
+- **FR-005**: System MUST publish each Sorcha-hosted organisation under both its platform-native identifier and a publicly-resolvable federated identifier, with each document declaring the other as an equivalent identity.
+- **FR-006**: System MUST regenerate an organisation's published identity document whenever the organisation's signing-key state changes (a key is added, rotated, or revoked).
+- **FR-007**: System MUST serve published identity documents at stable, well-known URLs that conform to the relevant external standard for the identifier method, so that standards-compliant external resolvers can dereference them without Sorcha-specific knowledge.
+
+#### Cross-identity verification
+
+- **FR-008**: When an issuer's published identity document declares equivalence with one or more other identifiers, the system MUST resolve each declared equivalent identity, compare the verification methods across all linked documents, and accept the equivalence only when the same verification key appears in every linked document.
+- **FR-009**: When a declared equivalent identity is unreachable, the system MUST reject the credential rather than accept on the basis of the resolvable side alone.
+- **FR-010**: When verification keys diverge across documents in an equivalence chain, the system MUST reject the credential and MUST surface the divergence as a distinct failure reason.
+
+#### Key identifier styles
+
+- **FR-011**: System MUST publish each active signing key under at least two equivalent identifier styles in the issuer's identity document — one human-readable and sequential, and one cryptographically derived from the key itself.
+- **FR-012**: System MUST verify credentials whose signature header references either identifier style, without requiring per-credential or per-issuer configuration to switch between them.
+- **FR-013**: System MUST allow the platform-default identifier style to be expressed as a configuration value, and MUST reserve a per-organisation override slot in the organisation record so that this default can be overridden in future without a schema change.
+
+#### Issuer allowlist matching
+
+- **FR-014**: When a blueprint action declares an allowlist of acceptable issuer identifiers, the system MUST treat any identity declared as equivalent (via the cross-identity mechanism in FR-008) to a listed identifier as also satisfying the allowlist.
+- **FR-015**: System MUST preserve the existing publish-time guardrail that flags blueprint actions with empty allowlists as overly permissive.
+
+#### Lifecycle and governance
+
+- **FR-016**: System MUST allow administrators to revoke an organisation's signing key via a quorum-approved governance action; subsequent presentations of credentials signed by the revoked key MUST be rejected.
+- **FR-017**: System MUST allow administrators to rotate an organisation's signing key via a quorum-approved governance action; previously-issued credentials signed under the prior key MUST remain verifiable until those credentials expire.
+- **FR-018**: System MUST defer the derivation of an organisation's signing key until the moment of that organisation's first credential issuance — organisations that never issue credentials MUST never accumulate unused signing keys.
+
+#### Default enforcement and rollout
+
+- **FR-019**: System MUST provide a platform-level configuration switch that gates whether issuer-signature verification is required, and the default state of that switch at ship MUST be that verification is required.
+- **FR-020**: System MUST reserve, in the per-register policy record, a slot for per-register issuer-signature enforcement that overrides the platform-level switch. The slot MUST NOT be read at v1 but MUST be tolerant of future readers (any future addition of read logic MUST NOT require schema migration of existing records).
+- **FR-021**: System MUST reserve, in the per-register policy record, a slot for a register-wide issuer allowlist. The slot MUST NOT be read at v1 but MUST follow the same forward-compatibility rule as FR-020.
+
+#### Resolver hygiene
+
+- **FR-022**: System MUST cache resolved identity documents for a bounded period appropriate to the identifier method (longer for inherently-immutable methods such as offline-derived keys, shorter for documents fetched over the public web).
+- **FR-023**: System MUST invalidate cached entries for platform-internal identities whenever an on-platform key event for that identity is committed.
+- **FR-024**: System MUST consolidate the platform's identity-resolution surface to a single canonical interface; the legacy parallel resolver MUST be retired before this feature ships.
+
+#### Forward-compatibility
+
+- **FR-025**: The component that resolves an issuer's identity to a verification key MUST be deployable in any process that reads credentials — its public contract MUST NOT depend on its hosting context, so that future deployments (for example in a different service that needs the same capability) are a wiring change rather than a redesign.
+
+### Key Entities *(include if feature involves data)*
+
+- **Issuer Identity Document**: A public, machine-readable description of an organisation's cryptographic identity. Lists the verification methods (public keys) the organisation uses to sign credentials, describes their relationships (which key signs assertions, which key authenticates), and may declare equivalence with other identity documents that represent the same underlying organisation.
+- **Verification Method**: An entry within an identity document representing one specific public key, named by an identifier (the *key identifier*) that credential signatures can reference. Each active signing key may appear as multiple verification methods sharing the same key material under different identifier styles.
+- **Equivalence Declaration**: A claim within one identity document that another identifier represents the same organisation. The platform verifies such claims by cross-resolving the named identifier and comparing key material.
+- **Issuance Key**: The cryptographic key an organisation uses to sign credentials, derived from the organisation's master key under the platform's existing key-derivation infrastructure. Has a lifecycle (derived → active → rotated/revoked) controlled exclusively by the platform's custodial key-management facility.
+- **Issuer Allowlist (per-action)**: An optional declaration on a blueprint action that names which issuer identities may satisfy the action's credential requirement.
+- **Issuer Allowlist (per-register, reserved)**: A future-only declaration on a register's policy record that names which issuer identities may issue credentials referenced anywhere in that register. Reserved at v1 (slot exists, not read).
+- **Issuer-Signature Enforcement Switch**: The platform-level configuration that gates whether issuer-signature verification is mandatory. Default at v1: required. May be overridden per-register in future.
+- **Identity Resolver Registry**: The platform component that turns an identifier into an identity document, dispatching to method-specific resolvers (platform-internal, web-hosted, key-derived, others). Caches results, follows equivalence chains, and consolidates the contract used by every credential-consuming surface.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An attacker who tampers with the signature of any presented credential cannot complete a presentation flow — the tampered credential is rejected before any of its claims are read.
+- **SC-002**: An attacker who controls a credential issuer's public-web hosting and rewrites the published identity document to claim equivalence to a different organisation cannot impersonate that organisation to a Sorcha verifier — the impersonation attempt is detected and the credential rejected.
+- **SC-003**: 100% of the existing walkthrough suite (covering verified identity, finance, permitting, and other primary credential flows) passes end-to-end with issuer-signature verification enforced by default.
+- **SC-004**: A standards-compliant external wallet — one that knows only the IETF/W3C credential and identity standards and nothing about Sorcha — successfully verifies a Sorcha-issued credential using only the published federated identity document, with no Sorcha-specific configuration.
+- **SC-005**: When an issuer's signing key is compromised, the time required for an authorised quorum to revoke that key and have subsequent presentations of compromised credentials rejected is bounded by the duration of a single governance operation — typically minutes, not hours.
+- **SC-006**: The platform's operational dashboard distinguishes the three signature-verification failure causes (unresolved issuer, unmatched key identifier, signature mismatch), enabling operators to triage failures by root cause rather than by symptom.
+- **SC-007**: The future addition of validator-side issuer-signature verification at seal time (deferred to a later phase) requires no schema migration on existing register policy records — the slots reserved at v1 are read by the validator without changes to the record structure.
+- **SC-008**: First-credential-issuance flows for new organisations complete in a single end-to-end ceremony: derive signing key, publish identity document, issue credential — with no manual intervention required between steps.
+- **SC-009**: Steady-state verification latency for repeat issuers (after the first cache miss) does not regress relative to the pre-feature baseline by more than a single resolver round-trip's typical wall-clock time.
+
+## Assumptions
+
+- The platform is in a pre-production posture: there are no in-flight credentials issued under the prior accept-everything default that need a deprecation window. Default-on at ship is therefore safe.
+- Domain control of a publicly-hosted identity document is treated as equivalent to identity ownership of the federated identifier, in line with the trust model used by the public web's TLS infrastructure.
+- An organisation's signing keys are generated, stored, rotated, and revoked exclusively through the platform's existing custodial key-management infrastructure (Feature 083). Self-custody and co-signed modes are out of scope.
+- The walkthrough suite is a representative test surface for production credential flows; passing the suite end-to-end with verification enforced is sufficient evidence that no in-tree flow is broken by the change.
+- The W3C `alsoKnownAs` property is the canonical mechanism for declaring identity equivalence; signed equivalence assertions (a non-standard, Sorcha-specific extension) are explicitly out of scope for v1.
+- The legacy parallel identity-resolver interface has exactly one consumer in the codebase and its retirement is a small, mechanical migration that ships as a precursor PR.
+
+## Dependencies
+
+- **Feature 083 (Org Key Derivation)**: Provides the per-organisation signing-key derivation infrastructure. The issuance key in this feature is derived under that feature's `KeyUsage.VCIssuance` slot.
+- **Feature 086 (Validator Roster pattern)**: Provides the precedent for governance-op key rotation and revocation. The proto-rule code `VAL_CRED_GOV_001` (revoke issuance key) follows this pattern.
+- **Feature 093 (multibase verification method emission)**: Provides the W3C-conforming key encoding used in published identity documents.
+- **W3C DID Core 1.0**: External standard for the identity document structure and the `alsoKnownAs` semantics.
+- **IETF SD-JWT VC**: External standard for the credential format whose signatures this feature verifies.
+
+## Out of Scope
+
+The following are deliberately deferred and MUST NOT be addressed by this feature. Each has a documented forward-compat path so that revisiting it later does not require rework of v1.
+
+- **Validator-side issuer-signature verification at seal time** (the chain-authoritative posture, "Future B" in the design doc). The schema slots reserved by FR-020 and FR-021 exist precisely so this can be added later without migration.
+- **Bring-your-own-domain federated identifiers**. Organisations cannot in v1 publish their identity document on a domain they control; the Sorcha-hosted form is the only federated path. The cross-resolution mechanism (FR-008) is the upgrade hinge — when BYO-domain ships, the old Sorcha-hosted identifier remains resolvable, and the two documents declare each other.
+- **Automatic, schedule-driven key rotation**. v1 supports manual rotation only.
+- **Additional identifier methods beyond those already supported by the platform** (`did:ethr`, `did:ion`, etc.). The resolver registry pattern means each new method is a single additive class without changes to the rest of the feature.
+- **Signed equivalence assertions**. Cross-resolution is the mechanism in v1; a signed-assertion variant (in which an equivalence claim itself carries a cryptographic proof of the second party's consent) is not included.
+- **Per-credential-type issuer-signature enforcement**. The per-action allowlist already covers the operational need at this granularity.
+
+## References
+
+- **Authoritative design**: `docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md` (file paths, class names, phase breakdown, locked decisions D1–D6 with rationale).
+- **Companion architectural memos** (shared memory): `Validator2/2026-05-09-programmable-validation-thesis.md`, `Validator2/2026-05-09-did-resolution-and-issuer-sig-companion.md` — captures the Future A vs Future B framing and the alignment with future validator rule families.

--- a/specs/120-production-issuer-signature-verification/tasks.md
+++ b/specs/120-production-issuer-signature-verification/tasks.md
@@ -1,0 +1,373 @@
+---
+
+description: "Task list for Feature 120 — Production Issuer Signature Verification"
+---
+
+# Tasks: Production Issuer Signature Verification
+
+**Input**: Design documents from `specs/120-production-issuer-signature-verification/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+**Authoritative design**: `docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md`
+
+**Tests**: Tests are REQUIRED per Constitution IV (≥85% coverage on new code) and per the Independent-Test descriptions on each user story in spec.md. Test tasks appear inline within each user story phase.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story. Within each story, tests come before implementation (TDD encouraged per Constitution V).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US6, mapping to spec.md)
+- All file paths absolute from repo root
+
+## Path conventions
+
+Sorcha is a microservices/.NET monorepo. Source under `src/{Apps,Common,Core,Services}/`. Tests under `tests/`. See plan.md → "Source code (repository root)" for the per-feature layout.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify branch, prerequisites, and stack readiness. No new project scaffolding required — Feature 120 lands inside existing services.
+
+- [ ] T001 Verify branch `120-production-issuer-signature-verification` is checked out and `master` is up-to-date in `C:/projects/Sorcha`.
+- [ ] T002 [P] Verify Docker dev stack starts cleanly: `docker-compose up -d` then `docker-compose ps` shows all services healthy.
+- [ ] T003 [P] Verify `dotnet test` baseline passes on the branch before any changes: `cd C:/projects/Sorcha && dotnet test --no-restore` (informational baseline; preserves regression detection later).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Land the shared infrastructure that every user story depends on. Phase 0 cleanup (legacy `IDIDResolver` retirement) is the precondition; the new resolver-registry method signature, kid-matching helper, cache scaffold, and DI wiring close the rest of the gap.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete. Phase 0 cleanup ships as a standalone PR before the rest of this branch (per plan.md → Phase 0 row).
+
+### Phase 0 (legacy retirement) — ships as separate PR
+
+- [ ] T004 Migrate the single `IDIDResolver` consumer at `src/Services/Sorcha.Register.Service/Program.cs:205` to call `IDidResolverRegistry.ResolveAsync` and `IRegisterServiceClient.GetTransactionAsync` instead. Update the consuming code path to extract the public key from the W3C `DidDocument.VerificationMethod` (or from the transaction payload directly via the register client).
+- [ ] T005 Delete `src/Core/Sorcha.Register.Core/Services/IDIDResolver.cs`, `src/Core/Sorcha.Register.Core/Services/DIDResolver.cs`, and the `DIDResolutionResult` type they share. Remove the DI registration in `Sorcha.Register.Service/Program.cs`.
+- [ ] T006 [P] Update spec references: search `specs/031-register-governance/` and `specs/039-verifiable-presentations/` for `IDIDResolver` mentions; replace with `IDidResolverRegistry` or annotate as historical.
+- [ ] T007 [P] Update `.specify/tasks/deferred-tasks.md` and `.specify/specs/sorcha-register-service.md` to drop `IDIDResolver` references.
+- [ ] T008 Run full `dotnet test` after T004-T007 land; confirm green. This is the Phase 0 ship gate — open a separate PR for these changes before continuing.
+
+### Shared infrastructure for Phases 1–6
+
+- [ ] T009 Confirm `Sorcha.Cryptography` exposes (or add) an RFC 7638 JWK thumbprint helper returning base64url SHA-256 (43 chars, no padding). Target file: `src/Common/Sorcha.Cryptography/JsonWebKeyThumbprint.cs` (new if absent).
+- [ ] T010 [P] Add `KidThumbprintHelper` at `src/Common/Sorcha.ServiceClients.Http/Did/KidThumbprintHelper.cs`. Two public statics: `bool TryMatchExact(DidDocument doc, string kid, out VerificationMethod vm)` and `bool TryMatchByThumbprint(DidDocument doc, string kid, out VerificationMethod vm)`. Latter computes thumbprint of each VM's `publicKeyMultibase`/`publicKeyJwk` on demand.
+- [ ] T011 [P] Add `DidResolverCache` at `src/Common/Sorcha.ServiceClients.Http/Did/DidResolverCache.cs`. Memory-backed concurrent cache with per-method TTL (default `did:web` 1h, `did:sorcha` infinite, `did:key` infinite). Negative-result entries with 60s TTL. Concurrent-call coalescing via `LazyAsync`. Configuration via `DidResolver:Cache:WebTtlMinutes` and `DidResolver:Cache:NegativeTtlSeconds`.
+- [ ] T012 Add the `ResolveWithAlsoKnownAsAsync(string did, CancellationToken ct = default)` method signature to `src/Common/Sorcha.ServiceClients.Http/Did/IDidResolverRegistry.cs`. Implementation lands in US4; signature lands here so US1 can compile against it.
+- [ ] T013 Add a stub `ResolveWithAlsoKnownAsAsync` body in `src/Common/Sorcha.ServiceClients.Http/Did/DidResolverRegistry.cs` that delegates to `ResolveAsync` (no cross-resolution yet). Marked with `// TODO(Feature 120 US4): cross-resolve alsoKnownAs with key-material verification`. Real implementation lands in US4.
+- [ ] T014 [P] Subscribe `DidResolverRegistry` to `transaction:confirmed` Redis stream events for `did:sorcha:*` cache invalidation. Use `Sorcha.Events.IEventSubscriber`. Handler invalidates cache entries whose canonical primary DID matches the affected wallet/org. Wire DI in `src/Common/Sorcha.ServiceClients.Http/Extensions/HttpServiceCollectionExtensions.cs`.
+- [ ] T015 Add new `Sorcha.Verifier.IssuerSignature` and `Sorcha.Did.Resolver` OpenTelemetry meters. Define counters per data-model.md "Telemetry-touching shapes" and contracts/did-resolver-registry-contract.md. Counter registration lives in DI extension methods alongside resolver and verifier registration.
+- [ ] T016 [P] Unit tests for `KidThumbprintHelper` at `tests/Sorcha.ServiceClients.Tests/Did/KidThumbprintHelperTests.cs`. Cover: exact-match success, exact-match miss, thumbprint-match success, thumbprint-match miss, malformed VM (no key material).
+- [ ] T017 [P] Unit tests for `DidResolverCache` at `tests/Sorcha.ServiceClients.Tests/Did/DidResolverCacheTests.cs`. Cover: positive TTL respected, negative TTL respected (shorter), method-specific TTLs, concurrent-call coalescing, explicit invalidation by DID.
+
+**Checkpoint**: Foundation ready. Phase 0 cleanup is shipped as a separate PR (T004-T008). T009-T017 land on this feature branch as the foundational commits.
+
+---
+
+## Phase 3: User Story 1 — Verifier rejects unverifiable credentials (Priority: P1) 🎯 MVP (with US2)
+
+**Goal**: Production `IIssuerKeyResolver` resolves the credential's `iss` to a key via `IDidResolverRegistry`, the verifier rejects credentials whose signature does not verify, and three distinct failure modes (unresolved DID, unmatched kid, signature mismatch) are visible in operational logs and metrics.
+
+**Independent Test**: Submit three credentials to a presentation flow — valid, tampered-signature, unresolvable-issuer — and confirm distinct failure-mode counter increments and rejection responses.
+
+> **Note**: US1 ships value only when US2 also ships (US1 has nothing to verify against without published org DID documents). Treat US1+US2 together as the MVP.
+
+### Tests for User Story 1
+
+- [ ] T018 [P] [US1] Unit tests for `DidResolverBackedIssuerKeyResolver` at `tests/Sorcha.Citizen.Verifier.Tests/Services/DidResolverBackedIssuerKeyResolverTests.cs`. Cover: happy path (DID resolves, kid exact-matches VM, key returned), kid thumbprint-fallback, DID unresolved (returns null + counter), kid unmatched (returns null + counter), document has no `verificationMethod` (returns null + counter).
+- [ ] T019 [P] [US1] Integration test for the verifier's full presentation flow with enforce-on at `tests/Sorcha.Citizen.Verifier.Tests/Integration/PresentationVerificationIntegrationTests.cs`. Use the existing `JwkRegistryIssuerKeyResolver` for DI override per test scenario.
+
+### Implementation for User Story 1
+
+- [ ] T020 [US1] Create `DidResolverBackedIssuerKeyResolver` at `src/Apps/Sorcha.Citizen.Verifier/Services/DidResolverBackedIssuerKeyResolver.cs`. Constructor takes `IDidResolverRegistry`, `ILogger`, and a meter. Method `ResolveAsync(string issuer, string kid, CancellationToken ct)` calls `_registry.ResolveWithAlsoKnownAsAsync(issuer)` then `KidThumbprintHelper.TryMatchExact` then `KidThumbprintHelper.TryMatchByThumbprint`. Returns `IssuerPublicKey?` (null on any failure mode). Increments three-way failure-mode counters per FR-003.
+- [ ] T021 [US1] Update `src/Apps/Sorcha.Citizen.Verifier/Services/IIssuerKeyResolver.cs` DI registration: `DidResolverBackedIssuerKeyResolver` becomes the production default; `OptOutIssuerKeyResolver` is removed from production wiring. Test composition retains the option to substitute `JwkRegistryIssuerKeyResolver` via a configuration switch.
+- [ ] T022 [US1] Wire `RequireIssuerSignature` configuration switch. Default value at ship: `true` per FR-019 / D5. Read via `IConfiguration` at the verifier's composition root. Source `appsettings.json` key: `IssuerSignature:Required`.
+- [ ] T023 [US1] Update `VerifiablePresentationValidator` (`src/Apps/Sorcha.Citizen.Verifier/Services/VerifiablePresentationValidator.cs`) to consume the new resolver. Step 4b path replaces the OptOut return with the production resolver call. Logging path differentiates the three failure modes by the counter that was incremented.
+- [ ] T024 [US1] Add the OTel span `verifier.issuer-resolve` parented to the existing `verifier.presentation` span. Attributes: `verifier.issuer.outcome ∈ {success, did-unresolved, kid-unmatched, signature-failed}`, `verifier.issuer.kid_match_mode ∈ {exact, thumbprint-fallback}`. Span instrumentation lives inside `DidResolverBackedIssuerKeyResolver`.
+- [ ] T025 [US1] Add structured-logging entries for each failure mode at `Warning` level (per Constitution VIII — no string interpolation). Each entry includes the credential's `iss`, `kid`, and the failure-mode classifier. Tests confirm log entries surface in `ILogger<DidResolverBackedIssuerKeyResolver>` captured via `xunit.MELT` or equivalent.
+- [ ] T026 [US1] Update DI extension `src/Apps/Sorcha.Citizen.Verifier/Extensions/ServiceCollectionExtensions.cs` (or equivalent) to register `DidResolverBackedIssuerKeyResolver` as the singleton implementation of `IIssuerKeyResolver` and remove `OptOutIssuerKeyResolver` from the production composition.
+
+**Checkpoint**: User Story 1's verifier-side path is functional but cannot be end-to-end tested until at least one issuer has a published DID document (US2). Mocks/test fixtures cover the unit-test surface.
+
+---
+
+## Phase 4: User Story 2 — Organisations have a published verifiable identity (Priority: P1) 🎯 MVP (with US1)
+
+**Goal**: An organisation issuing its first credential lazily derives an issuance key (Feature 083 slot 1, `KeyUsage.VCIssuance`), publishes a W3C-conforming DID document at `/orgs/{orgId}/did.json`, and the document declares both `did:sorcha:org:{addr}` and `did:web:{platform}:orgs:{orgId}` linked via `alsoKnownAs`.
+
+**Independent Test**: Trigger first issuance for a freshly-created org. Confirm the published document is reachable, declares the issuance key under both versioned and thumbprint kid styles (dual VM), and that a generic W3C DID resolver can dereference it without Sorcha-specific knowledge.
+
+### Tests for User Story 2
+
+- [ ] T027 [P] [US2] Unit tests for `IssuanceKeyService` at `tests/Sorcha.Wallet.Service.Tests/Services/IssuanceKeyServiceTests.cs`. Cover: lazy derivation on first call, idempotency on retry, key bytes match Feature 083 slot-1 derivation expectations, `IssuanceKeyState` row created with `Status=Active`, thumbprint computed and persisted.
+- [ ] T028 [P] [US2] Unit tests for `OrgDidDocumentService` at `tests/Sorcha.Tenant.Service.Tests/Services/OrgDidDocumentServiceTests.cs`. Cover: regeneration on each `KeyEventReason`, no-op when `KeyVersionFingerprint` matches, dual-VM emission per active key, `alsoKnownAs` correctly populated in both directions, `assertionMethod` references all active VMs, `KeyVersionFingerprint` deterministic.
+- [ ] T029 [P] [US2] Endpoint test for `GET /orgs/{orgId}/did.json` at `tests/Sorcha.Tenant.Service.Tests/Endpoints/OrgDidDocumentEndpointsTests.cs`. Reflection-based static-handler invocation per existing pattern. Cover: 200 with valid document, 404 for org with no issuance key, `Cache-Control: public, max-age=21600` header present, content-type `application/did+json`.
+- [ ] T030 [P] [US2] Integration test for first-issuance ceremony at `tests/Sorcha.Wallet.Service.Tests/Integration/FirstCredentialIssuanceCeremonyTests.cs`. End-to-end: org creation → first issuance trigger → key derived → DID document published → endpoint serves document. Confirms FR-004's "no later than first issuance" guarantee.
+
+### Implementation for User Story 2
+
+- [ ] T031 [US2] Add `IssuanceKeyState` entity at `src/Services/Sorcha.Wallet.Service/Models/IssuanceKeyState.cs` per data-model.md §4. Fields: `Id`, `OrganizationId`, `Slot`, `RotationIndex`, `Status` (enum), `PublicKey`, `Algorithm`, `Thumbprint`, `DerivedAt`, `RotatedAt?`, `RevokedAt?`, `RevocationReason?`, `RevokedByGovernanceOpId?`. Validation rules per data-model.md.
+- [ ] T032 [US2] Add EF configuration for `IssuanceKeyState` at `src/Services/Sorcha.Wallet.Service/Data/Configurations/IssuanceKeyStateConfiguration.cs`. Unique partial index on `(OrganizationId, Slot)` where `Status = Active`. Unique index on `(OrganizationId, RotationIndex)`.
+- [ ] T033 [US2] Generate EF migration: `dotnet ef migrations add AddIssuanceKeyState --project src/Services/Sorcha.Wallet.Service`. Verify `Designer.cs` and `ModelSnapshot.cs` regenerate cleanly. Use the placeholder connection string env var per MEMORY.md.
+- [ ] T034 [P] [US2] Add `OrgDidDocument` entity at `src/Services/Sorcha.Tenant.Service/Models/OrgDidDocument.cs` per data-model.md §1. Fields: `Id`, `OrganizationId` (unique), `PrimaryDid`, `FederatedDid`, `DocumentJson`, `KeyVersionFingerprint`, `LastRegeneratedAt`, `LastRegenerationReason` (enum), `Version`. Validation rules per data-model.md.
+- [ ] T035 [P] [US2] Add EF configuration for `OrgDidDocument` at `src/Services/Sorcha.Tenant.Service/Data/Configurations/OrgDidDocumentConfiguration.cs`. Unique index on `OrganizationId`; non-unique indexes on `PrimaryDid` and `FederatedDid`.
+- [ ] T036 [US2] Generate EF migration: `dotnet ef migrations add AddOrgDidDocument --project src/Services/Sorcha.Tenant.Service`. Verify designer regenerates.
+- [ ] T037 [US2] Add `IIssuanceKeyService` interface at `src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs`. Methods: `Task<IssuanceKeyState> GetOrDeriveAsync(Guid orgId, CancellationToken ct)`, `Task<IssuanceKeyState> GetActiveAsync(Guid orgId, CancellationToken ct)`, `Task<JsonWebKey> GetPublicJwkAsync(Guid orgId, int rotationIndex, CancellationToken ct)`. Rotation/revoke methods land in US6.
+- [ ] T038 [US2] Implement `IssuanceKeyService` at `src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs`. `GetOrDeriveAsync` is the lazy-derivation entry point. Calls `IKeyManagementService.DeriveKeyAtPathAsync` under context `sorcha:vc-issuance` (Feature 083 slot 1, BIP44 path under `KeyUsage.VCIssuance`). Persists `IssuanceKeyState` with `Status=Active, RotationIndex=1` on first derivation. Idempotent on retries (returns existing active row). Computes thumbprint via `JsonWebKeyThumbprint`.
+- [ ] T039 [US2] Wire `IIssuanceKeyService.GetOrDeriveAsync` into the credential-issuance flow. Identify the call sites in `Sorcha.Wallet.Service` that sign credentials (likely `CredentialIssuanceService` or similar — confirm via grep) and inject `IIssuanceKeyService` to retrieve the active key before signing. Sign step uses `kid = did:sorcha:org:{addr}#vc-issuance-{rotationIndex}` per platform default (versioned style).
+- [ ] T040 [P] [US2] Add `IOrgDidDocumentService` interface at `src/Services/Sorcha.Tenant.Service/Services/IOrgDidDocumentService.cs`. Methods: `Task<OrgDidDocument?> GetAsync(Guid orgId, CancellationToken ct)`, `Task RegenerateAsync(Guid orgId, KeyEventReason reason, CancellationToken ct)`, `Task InvalidateCacheAsync(Guid orgId, CancellationToken ct)` (via Redis stream).
+- [ ] T041 [US2] Implement `OrgDidDocumentService` at `src/Services/Sorcha.Tenant.Service/Services/OrgDidDocumentService.cs`. `RegenerateAsync` reads all active `IssuanceKeyState` rows for the org via a service client, builds the W3C document with dual VMs per active key (versioned id + thumbprint id, both with same `publicKeyMultibase`), populates `alsoKnownAs` with both forms, computes `KeyVersionFingerprint`, persists. Returns existing row unchanged if fingerprint unchanged (no-op optimization).
+- [ ] T042 [P] [US2] Add `KeyEventReason` enum at `src/Services/Sorcha.Tenant.Service/Models/KeyEventReason.cs`. Values: `IssuanceKeyDerived`, `IssuanceKeyRotated`, `IssuanceKeyRevoked`, `StatusSigningKeyDerived`, `Bootstrap`.
+- [ ] T043 [US2] Add `OrgDidDocumentEndpoints` at `src/Services/Sorcha.Tenant.Service/Endpoints/OrgDidDocumentEndpoints.cs` exposing `GET /orgs/{orgId}/did.json`. Anonymous, returns `application/did+json` with `Cache-Control: public, max-age=21600`. Implements the contract at `specs/120-production-issuer-signature-verification/contracts/org-did-document-endpoint.openapi.yaml`. `.WithName("ResolveOrgDidDocument").WithSummary(...).WithDescription(...)`.
+- [ ] T044 [US2] Wire `IOrgDidDocumentService.RegenerateAsync` triggers in `IssuanceKeyService`. Whenever a key event occurs (derivation in this story; rotation/revocation in US6), call `RegenerateAsync` with the appropriate `KeyEventReason`. Cross-service call via the service client pattern (Wallet → Tenant). New service client interface if absent: `IOrgDidDocumentClient` in `src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/`.
+- [ ] T045 [US2] Enhance `SorchaDidResolver` at `src/Common/Sorcha.ServiceClients.Http/Did/SorchaDidResolver.cs`: when resolving `did:sorcha:org:*`, surface the issuance key as a second `VerificationMethod` (in addition to the existing wallet key VM). Emit `alsoKnownAs` linking to the federated `did:web` form. Emit dual VMs (versioned + thumbprint) per active issuance key. Reads issuance keys via the new `IOrgDidDocumentClient` (Wallet→Tenant resolution path) or via `IIssuanceKeyService` if Sorcha.ServiceClients can reach it. Confirm DI graph during integration testing.
+- [ ] T046 [US2] Update `Sorcha.Tenant.Service` DI: register `IOrgDidDocumentService` (Scoped). Register storage interface via `IStorageRegistrationLog` per CLAUDE.md pattern #10 — `OrgDidDocument` is cache-style storage (rebuildable from key state), not on the audited fail-fast list.
+- [ ] T047 [P] [US2] OpenAPI documentation updates: regenerate Tenant Service's OpenAPI to include the new endpoint. Confirm `/.well-known/openapi.json` aggregation reflects it (per Feature 117 discoverability).
+
+**Checkpoint**: User Stories 1 and 2 together form the MVP. End-to-end: org issues first credential → DID doc published → verifier resolves and verifies. The first-issuance ceremony test (T030) validates this slice.
+
+---
+
+## Phase 5: User Story 3 — Federation interop without Sorcha-specific tooling (Priority: P2)
+
+**Goal**: A standards-compliant external wallet/verifier that knows only IETF/W3C standards can verify a Sorcha-issued credential using the published `did:web` document and standard tooling.
+
+**Independent Test**: Use a generic W3C DID resolver library (or `curl` + manual JWS verification) to fetch the published `did:web:{platform}:orgs:{orgId}/.well-known/did.json` (path-based form: `https://{platform}/orgs/{orgId}/did.json`), extract the verification method, verify a sample credential's signature. No Sorcha library required.
+
+### Tests for User Story 3
+
+- [ ] T048 [P] [US3] Standards-compliance test for the published document at `tests/Sorcha.Tenant.Service.Tests/Services/OrgDidDocumentSchemaConformanceTests.cs`. Validate against W3C DID Core 1.0 schema (use a reference schema or a published JSON Schema). Confirm: `@context` includes the W3C DID v1 URI, all required fields present, no Sorcha-specific extensions in mandatory positions.
+- [ ] T049 [P] [US3] Cross-tool resolution test at `tests/integration/FederationInteropTest.cs`. Spawns a generic HTTP client (no Sorcha dependencies), fetches `did.json`, parses with `System.Text.Json` only, extracts `verificationMethod[0].publicKeyMultibase`, decodes via standard multibase library, verifies a fixture-signed credential. No `Sorcha.ServiceClients.*` references.
+
+### Implementation for User Story 3
+
+US3 is mostly testing/validation of US2's output. The implementation work is small.
+
+- [ ] T050 [US3] Confirm `Sorcha.Tenant.Service` adds `application/did+json` to its OpenAPI media-type list (already done in T043; this task verifies and adds explicit OpenAPI annotation if missing).
+- [ ] T051 [US3] Confirm gateway routing exposes `/orgs/{orgId}/did.json` anonymously without auth. Path mapping in YARP config at `src/Services/Sorcha.ApiGateway/yarp.json` — add or verify the `/orgs/{*}` route pattern strips no path and forwards to the Tenant Service.
+- [ ] T052 [P] [US3] Document the federation-interop guarantee in `docs/openid4vc-haip-integration.md` — add a section under "Wallet ecosystem boundary" describing how external wallets resolve Sorcha-issued credentials' issuers via `did:web`.
+
+**Checkpoint**: US3 is fully functional as soon as US2's published document conforms. The story exists in v1 primarily to guard against accidental Sorcha-specific drift in the published document.
+
+---
+
+## Phase 6: User Story 4 — Cross-resolution prevents identity impersonation (Priority: P2)
+
+**Goal**: `IDidResolverRegistry.ResolveWithAlsoKnownAsAsync` cross-resolves linked DIDs, verifies the same verification key appears in every linked document, and rejects on key-material mismatch or unreachable link. Caching at the registry layer means steady-state cost is zero per repeat issuer.
+
+**Independent Test**: Construct an attacker fixture — a `did:web` document falsely claiming `alsoKnownAs` to another org's `did:sorcha` form, while serving an attacker-controlled signing key. Present a credential signed by the attacker's key. The verifier rejects on cross-resolution mismatch.
+
+### Tests for User Story 4
+
+- [ ] T053 [P] [US4] Cross-resolution unit tests at `tests/Sorcha.ServiceClients.Tests/Did/DidResolverRegistryCrossResolutionTests.cs`. Implement all 10 test cases listed in `contracts/did-resolver-registry-contract.md` "Testing" section: passthrough (no links), one-link-matching, one-link-unreachable, one-link-mismatch, two-links-partial-match, cycle-protection, cache-hit, cache-invalidated, negative-cache-short-TTL, concurrent-call-coalescing.
+- [ ] T054 [P] [US4] Cross-resolution attack scenario test fixture at `tests/Sorcha.Citizen.Verifier.Tests/Integration/CrossResolutionAttackScenarioTests.cs`. Constructs a malicious `did:web` document, presents a credential, asserts rejection + counter increment + span tagging.
+
+### Implementation for User Story 4
+
+- [ ] T055 [US4] Replace the stub from T013 with the full `DidResolverRegistry.ResolveWithAlsoKnownAsAsync` implementation per the deterministic algorithm in `contracts/did-resolver-registry-contract.md` "Resolution algorithm". Six steps: (1) resolve primary, (2) passthrough if no `alsoKnownAs`, (3) for each linked DID resolve and intersect VM key material, (4) reject on zero shared keys, (5) construct merged document, (6) tag span and return.
+- [ ] T056 [US4] Integrate `DidResolverCache` (T011) into `ResolveWithAlsoKnownAsAsync`. Cache key = canonical primary DID. Positive entry stores merged document; negative entry stores sentinel with 60s TTL. Method dispatch determines which TTL category applies.
+- [ ] T057 [US4] Wire cycle protection in step 3: maintain a `HashSet<string>` of visited DIDs across the resolution chain; skip revisits. Defensive — any DID document mutually-linking with itself is considered semantically equivalent to "no further `alsoKnownAs` to walk."
+- [ ] T058 [US4] Implement key-material comparison helper at `src/Common/Sorcha.ServiceClients.Http/Did/VerificationKeyMaterialComparer.cs`. Decodes `publicKeyMultibase` (existing `Multicodec.DecodePublicKeyBytes` helper) or `publicKeyJwk`. Constant-time bytes comparison. Returns true iff bytes are equal regardless of fragment id.
+- [ ] T059 [US4] Add the OTel span `did.resolve.cross` parented to caller's active span. Attributes: `did.input`, `did.method`, `did.alsoKnownAs.cross_resolved`, `did.alsoKnownAs.match ∈ {match, mismatch, unreachable, none}`, `did.alsoKnownAs.link_count`. Counter `sorcha_did_resolver_cross_resolve_mismatch_total` and `sorcha_did_resolver_alsoKnownAs_unreachable_total` incremented on the relevant outcomes.
+
+**Checkpoint**: US4's cross-resolution is the security-critical addition. The attack-scenario test (T054) is the gate — if it fails to reject, do not proceed to ship.
+
+---
+
+## Phase 7: User Story 5 — Per-action issuer allowlist honours equivalent identities (Priority: P3)
+
+**Goal**: When a blueprint action's `CredentialRequirement.AcceptedIssuers` lists a DID and the credential's `iss` resolves (via cross-resolution) to a document declaring the listed DID via `alsoKnownAs`, the match succeeds.
+
+**Independent Test**: Author a blueprint action whose allowlist names only the `did:sorcha:org` form of an issuer. Present credentials issued under both `did:sorcha:org:*` and the equivalent `did:web:*` forms. Both satisfy the allowlist.
+
+### Tests for User Story 5
+
+- [ ] T060 [P] [US5] Unit tests for `CredentialMatcher` allowlist equivalence at `tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialMatcherAlsoKnownAsTests.cs`. Cover: direct-match (regression — existing behaviour preserved), credential-iss-resolves-to-allowed-DID, allowed-DID-resolves-to-credential-iss, mismatch (no equivalence), unreachable resolution path.
+
+### Implementation for User Story 5
+
+- [ ] T061 [US5] Update `CredentialMatcher.IsIssuerAcceptedAsync` (or extract the new method if not present) at `src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs:51-52`. Algorithm per `contracts/did-resolver-registry-contract.md` "Consumer expectations": (1) direct-string match, (2) credential issuer's `alsoKnownAs` contains an allowed DID, (3) any allowed DID's `alsoKnownAs` contains the credential issuer. Short-circuit on first match.
+- [ ] T062 [US5] Mirror the same equivalence-aware logic in `PresentationRequestService.cs:364-365` and `PresentationLifecycleService.cs:133`. Refactor into a shared static helper `IssuerEquivalenceMatcher` at `src/Services/Sorcha.Wallet.Service/Credentials/IssuerEquivalenceMatcher.cs` consumed by all three call sites. Single source of truth.
+- [ ] T063 [US5] Confirm publish-time validator `OPEN_CREDENTIAL_ISSUER` warning continues to fire for empty `acceptedIssuers`. Regression test in `tests/Sorcha.Blueprint.Models.Tests/Credentials/CredentialModelsTests.cs`.
+
+**Checkpoint**: US5 closes the blueprint-author UX edge that empty-or-strict allowlists would otherwise create.
+
+---
+
+## Phase 8: User Story 6 — Issuance key compromise can be remediated by governance (Priority: P3)
+
+**Goal**: An admin quorum can revoke an organisation's active issuance key via a governance op (`VAL_CRED_GOV_001`). After revocation, presentations of credentials signed by the revoked key are rejected. The org can derive a fresh issuance key and continue operating.
+
+**Independent Test**: Initiate `RevokeIssuanceKey` governance op against an org's active key. After quorum reached, present a credential signed by the now-revoked key — confirm rejection. Issue a new credential — confirm it signs under a fresh key.
+
+### Tests for User Story 6
+
+- [ ] T064 [P] [US6] Rotation/revocation unit tests at `tests/Sorcha.Wallet.Service.Tests/Services/IssuanceKeyServiceLifecycleTests.cs`. Cover: `RotateAsync` creates new active row with `RotationIndex+1`, old row moves to `Status=Rotated`; `RevokeAsync` moves active row to `Status=Revoked` with `RevokedAt`; revoking a rotated key permitted; revoking a revoked key idempotent.
+- [ ] T065 [P] [US6] Integration test for the compromise drill at `tests/integration/IssuanceKeyCompromiseDrillTests.cs`. End-to-end: derive key → sign credential → revoke via governance op → present credential → assert rejection within governance-op duration.
+
+### Implementation for User Story 6
+
+- [ ] T066 [US6] Extend `IIssuanceKeyService` (T037) with `Task<IssuanceKeyState> RotateAsync(Guid orgId, Guid governanceOpId, CancellationToken ct)` and `Task RevokeAsync(Guid orgId, int rotationIndex, string reason, Guid governanceOpId, CancellationToken ct)`.
+- [ ] T067 [US6] Implement `RotateAsync` in `IssuanceKeyService`. Derive a new key via `IKeyManagementService.DeriveKeyAtPathAsync` at the next BIP44 path under slot 1 (rotation increments the path index). Move existing active row to `Status=Rotated`, insert new row with `RotationIndex = old + 1, Status = Active`. Trigger `IOrgDidDocumentService.RegenerateAsync` with reason `IssuanceKeyRotated`.
+- [ ] T068 [US6] Implement `RevokeAsync` in `IssuanceKeyService`. Update target row's `Status = Revoked`, set `RevokedAt`, `RevocationReason`, `RevokedByGovernanceOpId`. Trigger `IOrgDidDocumentService.RegenerateAsync` with reason `IssuanceKeyRevoked`.
+- [ ] T069 [US6] Add governance op `VAL_CRED_GOV_001` (RevokeIssuanceKey) to the existing governance models. File: `src/Common/Sorcha.Register.Models/GovernanceModels.cs` — add the new op type alongside `RotateValidatorKey` (Feature 086 precedent). Op payload includes `OrganizationId`, `RotationIndex`, `Reason`.
+- [ ] T070 [US6] Add governance op handler in `Sorcha.Validator.Service/Services/RightsEnforcementService.cs` (or the consuming service) that processes `RevokeIssuanceKey` ops after quorum approval, calling `IIssuanceKeyService.RevokeAsync` via service client. The validator's role is permission enforcement; the actual key state mutation happens in Wallet Service.
+- [ ] T071 [US6] Update `OrgDidDocumentService.RegenerateAsync` (T041) to handle revoked keys. Revoked keys remain in the published document with `assertionMethod` membership removed; the credential's signature still verifies cryptographically against the published key, but the verifier rejects on `Status=Revoked` lookup. Verifier-side check lands in T072.
+- [ ] T072 [US6] Add revocation enforcement in `DidResolverBackedIssuerKeyResolver` (T020). After a successful kid match against a revoked-status `IssuanceKeyState`, return null and increment a new counter `sorcha_verifier_issuer_revoked_key_total`. This means revocation enforcement is verifier-side via the published document (revoked VMs absent from `assertionMethod`); the additional explicit check is defence-in-depth.
+- [ ] T073 [US6] Audit log integration: governance op execution writes an `AuditLogEntry` with the op type, executing admin quorum, target organisation, and timestamp. Use the existing audit log infrastructure (Tenant Service or Validator Service — confirm).
+
+**Checkpoint**: US6 closes the security loop. SC-005 (revocation completes within a single governance-op duration) is the measurable outcome.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Reserved schema slots, walkthrough validation, documentation propagation, ship-gate validation.
+
+### Reserved schema slots (forward-compat for Future B)
+
+- [ ] T074 [P] Add `RegisterPolicy.RequireIssuerSignature: bool?` to `src/Common/Sorcha.Register.Models/RegisterControlRecord.cs` per data-model.md §3 / FR-020. Field is JSON-null-ignored. NOT read at v1.
+- [ ] T075 [P] Add `RegisterPolicy.PermittedIssuers: string[]?` to the same file per data-model.md §3 / FR-021. JSON-null-ignored. NOT read at v1.
+- [ ] T076 [P] Add `Organization.DefaultKidStyle: KidStyle` enum slot at `src/Services/Sorcha.Tenant.Service/Models/Organization.cs` per data-model.md §2 / FR-013. Default `Versioned`. Not exposed in v1 admin UI. New `KidStyle` enum at the same file or in a dedicated model file.
+- [ ] T077 EF migration for `Organization.DefaultKidStyle`: `dotnet ef migrations add AddOrganizationDefaultKidStyle --project src/Services/Sorcha.Tenant.Service`. Verify designer regenerates.
+- [ ] T078 [P] Backward-compat unit test for `RegisterControlRecord` at `tests/Sorcha.Register.Models.Tests/RegisterControlRecordBackwardCompatTests.cs`. Confirms a v0.119 control record (no `RequireIssuerSignature`, no `PermittedIssuers`) deserialises cleanly with both fields null. This is the test that validates SC-007.
+
+### Walkthrough updates (ship gate)
+
+- [ ] T079 [P] Run AssuredIdentity walkthrough end-to-end with `IssuerSignature:Required=true`. Path: `walkthroughs/AssuredIdentity/run.ps1 -CleanState`. Confirm 10/10 success per the existing 10-run validation pattern.
+- [ ] T080 [P] Run TradeFinance walkthrough end-to-end with enforce-on. Path: `walkthroughs/TradeFinance/soak.ps1 -MaxRuns 5`.
+- [ ] T081 [P] Run ConstructionPermit walkthrough end-to-end with enforce-on. Path: `walkthroughs/ConstructionPermit/run.ps1`.
+- [ ] T082 [P] Run SelfBuildHouse walkthrough end-to-end with enforce-on. Path: `walkthroughs/SelfBuildHouse/run.ps1`.
+- [ ] T083 Identify and pin issuers in the AssuredIdentity action's `acceptedIssuers` field (currently empty per `walkthroughs/AssuredIdentity/blueprints/driving-licence.json:103-115`). Document this as a hardening recommendation in the walkthrough's README.
+
+### Demo-mint flow disposition
+
+- [ ] T084 [P] Document `DemoMintEndpoint` and `JwkRegistryIssuerKeyResolver` as test-only. Add a comment header to both files clarifying that production wires `DidResolverBackedIssuerKeyResolver`. Update `docs/superpowers/specs/2026-04-26-citizen-wallet-pwa-design.md` if needed (note the demo-mint's relationship to the new resolver).
+
+### HAIP OID4VCI consistency check (R10)
+
+- [ ] T085 [P] Confirm OID4VCI `credential_issuer` metadata in `Sorcha.Haip.Service` declares the same DID as the credential's `iss` claim. Verify by issuing a credential through OID4VCI and presenting it through the verifier with enforce-on; confirm `verifier.issuer.outcome=success`. If mismatch surfaces, file a small follow-up patch in this feature's branch.
+
+### Documentation propagation
+
+- [ ] T086 [P] Update the `sorcha-architecture` skill at `.claude/skills/sorcha-architecture/SKILL.md` — add a "Production Issuer Signature Verification (Feature 120)" section covering the resolver registry's new method, the published-document endpoint, the issuance-key lifecycle, and the cross-resolution semantics.
+- [ ] T087 [P] Update `docs/reference/API-DOCUMENTATION.md` — add `GET /orgs/{orgId}/did.json` to the Tenant Service endpoint table.
+- [ ] T088 [P] Update `docs/security-model.md` — document issuer-signature verification as production-enforced; document the cross-resolution security property; document the lifecycle for issuance keys.
+- [ ] T089 [P] Update `STANDARDS.md` — confirm W3C DID Core 1.0 and IETF SD-JWT VC are listed as `full|partial` rows; add `did:web` method specification reference if absent.
+- [ ] T090 [P] Update `CLAUDE.md` if any pattern from this feature requires it. Specifically: if the per-org `DefaultKidStyle` slot pattern (settings reserved on entity, not exposed in v1 UI) becomes a generally reused pattern, capture it. Otherwise no edit.
+- [ ] T091 [P] Update `MASTER-TASKS.md` — mark Feature 120 status; remove any TRUST-related items now resolved by this feature; reference the deferred VAL_CRED_* slots as Future B work.
+
+### Final ship validation
+
+- [ ] T092 Run `quickstart.md` end-to-end on a clean local stack — all 10 steps pass. This is the operator-runbook validation.
+- [ ] T093 Run `dotnet test` across the full solution. All tests green; no regressions; new code coverage ≥85% per Constitution IV.
+- [ ] T094 Run `dotnet format` and confirm no warnings.
+- [ ] T095 Open PR for review. Description references the design doc, this spec, and the locked decisions D1–D6. Test plan summarises walkthrough results.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: T001-T003 ship anytime; non-blocking informational checks.
+- **Foundational (Phase 2)**: T004-T008 ship as a separate PR (Phase 0 cleanup) — must merge before T009-T017 land. T009-T017 land on this branch as foundational commits and BLOCK all user stories.
+- **User Stories (Phases 3-8)**: All depend on Foundational completion. **US1 and US2 must ship together** (US1 has nothing to verify against without US2's published documents) — treat as a single MVP deliverable.
+- **Polish (Phase 9)**: Depends on all user stories complete. Walkthrough tasks (T079-T082) are the ship gate.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational. Co-required with US2 for MVP value.
+- **US2 (P1)**: Depends on Foundational. Co-required with US1 for MVP value.
+- **US3 (P2)**: Depends on US2 (testing US2's published document conformance). Largely passive — passes when US2 is done correctly.
+- **US4 (P2)**: Depends on Foundational + US2 (needs DID documents to cross-resolve). The `ResolveWithAlsoKnownAsAsync` stub from T013 means US1 can compile and test against the new method signature even before US4's full implementation lands.
+- **US5 (P3)**: Depends on US4 (cross-resolution).
+- **US6 (P3)**: Depends on US2 (extends `IIssuanceKeyService` with rotation/revocation). Independent of US4 and US5.
+
+### Within Each User Story
+
+- Tests written and confirmed FAILING before implementation lands (TDD per Constitution V encouragement).
+- Models/entities first (`IssuanceKeyState`, `OrgDidDocument`, etc.).
+- Services before endpoints (`IIssuanceKeyService` before `OrgDidDocumentEndpoints`).
+- Endpoints before integration wiring (`OrgDidDocumentEndpoints` before `OrgDidDocumentService.RegenerateAsync` triggers).
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] (T002, T003) can run in parallel.
+- Within Foundational: T006, T007, T010, T011, T014, T016, T017 marked [P] can parallelise after their non-[P] predecessors land.
+- Within US2: T027-T030 (test tasks) parallel; T034, T035, T040, T042 (independent files) parallel; T031-T033 sequential (entity → config → migration).
+- US3 and US5 can run in parallel with US4 and US6 if team capacity allows.
+- Polish phase: T074-T076, T079-T082, T084-T091 all parallelisable.
+
+---
+
+## Parallel Example: User Story 2 (US2)
+
+```text
+# After Foundational checkpoint, launch US2 test scaffolding in parallel:
+Task: T027 [P] [US2] IssuanceKeyService unit tests
+Task: T028 [P] [US2] OrgDidDocumentService unit tests
+Task: T029 [P] [US2] OrgDidDocumentEndpoints endpoint test
+
+# Once tests scaffolded, launch independent model/config tasks in parallel:
+Task: T031 [US2] IssuanceKeyState entity (Wallet)
+Task: T034 [P] [US2] OrgDidDocument entity (Tenant)
+Task: T042 [P] [US2] KeyEventReason enum (Tenant)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 together)
+
+1. Complete Phase 1 (Setup) and Phase 2 (Foundational), including the standalone Phase 0 PR.
+2. Implement US1 + US2 together — they are interdependent for any visible value.
+3. **STOP and VALIDATE**: AssuredIdentity walkthrough green with enforce-on.
+4. Deploy/demo the MVP slice.
+
+### Incremental Delivery
+
+After MVP is shipped, the remaining stories layer on:
+
+1. **US4 (cross-resolution)** — adds the security property that makes federation safe. Critical for any external `did:web` interop. Ship before any external participant onboards.
+2. **US3 (federation interop testing)** — passive validation of US2's output. Mostly a regression-prevention investment.
+3. **US5 (allowlist equivalence)** — UX polish for blueprint authors.
+4. **US6 (compromise revocation)** — security hardening; need not block initial production but should ship soon after.
+
+### Parallel Team Strategy
+
+If multiple developers are available:
+
+1. Whole team completes Setup + Foundational together.
+2. Once Foundational is in:
+   - Developer A: US1 (verifier-side resolver + wiring)
+   - Developer B: US2 (org DID document publishing + issuance key service)
+   - Developer C: US4 (cross-resolution + cache + Redis stream)
+3. Stories integrate via the foundational interfaces (T012, T013) which are stable from Phase 2.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no incomplete-task dependencies.
+- [Story] label maps task to specific user story for traceability.
+- Each user story should be independently completable and testable (US1+US2 jointly form the MVP).
+- Verify tests fail before implementing (Constitution V — TDD encouraged).
+- Commit after each task or logical group; reference Feature 120 task IDs in commit messages.
+- Stop at any checkpoint to validate the current slice independently.
+- Avoid: vague tasks, same-file conflicts, cross-story dependencies that break independence.
+
+---
+
+## Cross-references
+
+- Spec: `specs/120-production-issuer-signature-verification/spec.md`
+- Plan: `specs/120-production-issuer-signature-verification/plan.md`
+- Research: `specs/120-production-issuer-signature-verification/research.md`
+- Data model: `specs/120-production-issuer-signature-verification/data-model.md`
+- Contracts: `specs/120-production-issuer-signature-verification/contracts/`
+- Quickstart: `specs/120-production-issuer-signature-verification/quickstart.md`
+- Authoritative design: `docs/superpowers/specs/2026-05-09-production-issuer-signature-verification-design.md`
+- Companion memos (shared memory): `Validator2/2026-05-09-programmable-validation-thesis.md`, `Validator2/2026-05-09-did-resolution-and-issuer-sig-companion.md`

--- a/specs/121-programmable-validation-rules/spec.md
+++ b/specs/121-programmable-validation-rules/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: Programmable Validation Rule Set (Genesis-Embedded, Governance-Updateable)
 
-**Feature Branch**: `120-programmable-validation-rules`
+**Feature Branch**: `121-programmable-validation-rules`
 **Created**: 2026-05-09
 **Status**: Exploration / not scheduled
 **Source**: View 2 of the post-Feature 119 validator audit (2026-05-09 conversation, Saturday-afternoon thinking session)


### PR DESCRIPTION
## Summary
Resolves the F120 numbering collision. Slot 120 was occupied on master by an unscheduled exploration thesis (`120-programmable-validation-rules`, added in #590). The active feature \"production-issuer-signature-verification\" already had prior work tagged F120 — Phase 0 retirement merged via #592, plus a full set of design/spec/plan/tasks artefacts that lived on a deleted branch.

- Renames the placeholder thesis to `specs/121-programmable-validation-rules/` and updates its `Feature Branch:` reference.
- Restores the F120 production-issuer-signature-verification artefacts (spec, plan, tasks, research, data-model, contracts, quickstart, checklists, design doc) — cherry-picked from the original authoring commit.

No code touched. Pure docs/numbering hygiene to unblock Phase 1.

## Test plan
- [x] `dotnet build` not affected (docs only)
- [x] No code references to old `specs/120-programmable-validation-rules/` path (confirmed via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)