### PR TITLE
feat(120 Phase 7 / US5): allowlist alsoKnownAs equivalence (T060-T062)

### DIFF
--- a/specs/120-production-issuer-signature-verification/tasks.md
+++ b/specs/120-production-issuer-signature-verification/tasks.md
@@ -183,13 +183,13 @@ US3 is mostly testing/validation of US2's output. The implementation work is sma
 
 ### Tests for User Story 5
 
-- [ ] T060 [P] [US5] Unit tests for `CredentialMatcher` allowlist equivalence at `tests/Sorcha.Wallet.Service.Tests/Credentials/CredentialMatcherAlsoKnownAsTests.cs`. Cover: direct-match (regression — existing behaviour preserved), credential-iss-resolves-to-allowed-DID, allowed-DID-resolves-to-credential-iss, mismatch (no equivalence), unreachable resolution path.
+- [x] T060 [P] [US5] Unit tests at `tests/Sorcha.Wallet.Service.Tests/Credentials/IssuerEquivalenceMatcherTests.cs`. Covers empty allowlist, direct match (no resolve calls), no-registry direct-only, both alsoKnownAs directions, no equivalence, unreachable-then-step3 fallback.
 
 ### Implementation for User Story 5
 
-- [ ] T061 [US5] Update `CredentialMatcher.IsIssuerAcceptedAsync` (or extract the new method if not present) at `src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs:51-52`. Algorithm per `contracts/did-resolver-registry-contract.md` "Consumer expectations": (1) direct-string match, (2) credential issuer's `alsoKnownAs` contains an allowed DID, (3) any allowed DID's `alsoKnownAs` contains the credential issuer. Short-circuit on first match.
-- [ ] T062 [US5] Mirror the same equivalence-aware logic in `PresentationRequestService.cs:364-365` and `PresentationLifecycleService.cs:133`. Refactor into a shared static helper `IssuerEquivalenceMatcher` at `src/Services/Sorcha.Wallet.Service/Credentials/IssuerEquivalenceMatcher.cs` consumed by all three call sites. Single source of truth.
-- [ ] T063 [US5] Confirm publish-time validator `OPEN_CREDENTIAL_ISSUER` warning continues to fire for empty `acceptedIssuers`. Regression test in `tests/Sorcha.Blueprint.Models.Tests/Credentials/CredentialModelsTests.cs`.
+- [x] T061 [US5] `CredentialMatcher.MatchAsync` now routes the issuer check through `IssuerEquivalenceMatcher.IsAcceptedAsync`. Sync `Match` retained for back-compat (direct-string only).
+- [x] T062 [US5] Shared static helper `IssuerEquivalenceMatcher` consumed by `CredentialMatcher.MatchAsync` and `PresentationRequestService.VerifyPresentationAsync`. *(third call site `PresentationLifecycleService.cs:133` was a passthrough — no allowlist match logic at that line; nothing to update there.)*
+- [ ] T063 [US5] Confirm `OPEN_CREDENTIAL_ISSUER` publish-time warning regression test. *(deferred — pre-existing publish-time warning untouched by this PR; spec callout treated as a paired regression check rather than a new test.)*
 
 **Checkpoint**: US5 closes the blueprint-author UX edge that empty-or-strict allowlists would otherwise create.
 

--- a/src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/CredentialMatcher.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.ServiceClients.Did;
 using Sorcha.Wallet.Core.Domain.Entities;
 
 namespace Sorcha.Wallet.Service.Credentials;
@@ -13,6 +14,21 @@ namespace Sorcha.Wallet.Service.Credentials;
 /// </summary>
 public class CredentialMatcher
 {
+    private readonly IDidResolverRegistry? _registry;
+
+    /// <summary>Default constructor — sync direct-string allowlist matching only.</summary>
+    public CredentialMatcher() { }
+
+    /// <summary>
+    /// DI constructor — when wired with an <see cref="IDidResolverRegistry"/>,
+    /// <see cref="MatchAsync"/> honours the Feature 120 US5 alsoKnownAs
+    /// equivalence rules. The legacy sync <see cref="Match"/> path is unchanged.
+    /// </summary>
+    public CredentialMatcher(IDidResolverRegistry registry)
+    {
+        _registry = registry;
+    }
+
     /// <summary>
     /// For each requirement, finds the best matching credential from the stored credentials.
     /// </summary>
@@ -96,6 +112,69 @@ public class CredentialMatcher
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Async match honouring DID alsoKnownAs equivalence (Feature 120 US5 / FR-014).
+    /// Behaves identically to <see cref="Match"/> when the matcher is constructed
+    /// without a resolver registry.
+    /// </summary>
+    public async Task<Dictionary<string, CredentialEntity?>> MatchAsync(
+        IEnumerable<CredentialRequirement> requirements,
+        IReadOnlyList<CredentialEntity> credentials,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(requirements);
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        var result = new Dictionary<string, CredentialEntity?>();
+        foreach (var requirement in requirements)
+        {
+            CredentialEntity? match = null;
+            foreach (var credential in credentials)
+            {
+                if (!string.Equals(credential.Type, requirement.Type, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Feature 120 US5 — equivalence-aware allowlist match.
+                if (!await IssuerEquivalenceMatcher.IsAcceptedAsync(
+                        credential.IssuerDid,
+                        requirement.AcceptedIssuers?.ToArray(),
+                        _registry, ct).ConfigureAwait(false))
+                    continue;
+
+                if (credential.ExpiresAt.HasValue && credential.ExpiresAt.Value <= DateTimeOffset.UtcNow)
+                    continue;
+                if (credential.Status != CredentialStatus.Active)
+                    continue;
+
+                if (requirement.RequiredClaims?.Any() == true)
+                {
+                    var claims = ParseClaims(credential.ClaimsJson);
+                    if (claims is null) continue;
+
+                    var claimsMatch = true;
+                    foreach (var constraint in requirement.RequiredClaims)
+                    {
+                        if (!claims.TryGetValue(constraint.ClaimName, out var value))
+                        {
+                            claimsMatch = false; break;
+                        }
+                        if (constraint.ExpectedValue != null
+                            && !string.Equals(constraint.ExpectedValue.ToString(), value?.ToString(), StringComparison.Ordinal))
+                        {
+                            claimsMatch = false; break;
+                        }
+                    }
+                    if (!claimsMatch) continue;
+                }
+
+                match = credential;
+                break;
+            }
+            result[requirement.Type] = match;
+        }
+        return result;
     }
 
     private static Dictionary<string, object>? ParseClaims(string claimsJson)

--- a/src/Services/Sorcha.Wallet.Service/Credentials/IssuerEquivalenceMatcher.cs
+++ b/src/Services/Sorcha.Wallet.Service/Credentials/IssuerEquivalenceMatcher.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceClients.Did;
+
+namespace Sorcha.Wallet.Service.Credentials;
+
+/// <summary>
+/// Issuer-allowlist equivalence helper (Feature 120 US5 / FR-014).
+/// </summary>
+/// <remarks>
+/// <para>Three-step match per <c>contracts/did-resolver-registry-contract.md</c>
+/// "Consumer expectations":</para>
+/// <list type="number">
+///   <item>Direct-string match against the allowlist (existing behaviour).</item>
+///   <item>The credential's issuer cross-resolves to a document whose <c>alsoKnownAs</c>
+///   contains an allowlist entry.</item>
+///   <item>An allowlist entry cross-resolves to a document whose <c>alsoKnownAs</c>
+///   contains the credential's issuer.</item>
+/// </list>
+/// <para>Short-circuits on first match. When <paramref name="registry"/> is null, only
+/// step 1 runs (sync direct-string match) — which preserves the pre-Feature-120
+/// behaviour for callers that have not yet been wired to the registry.</para>
+/// </remarks>
+public static class IssuerEquivalenceMatcher
+{
+    /// <summary>
+    /// Returns true iff <paramref name="credentialIssuer"/> is accepted by
+    /// <paramref name="acceptedIssuers"/>, honouring DID equivalence via the
+    /// supplied <paramref name="registry"/>.
+    /// </summary>
+    public static async Task<bool> IsAcceptedAsync(
+        string credentialIssuer,
+        IReadOnlyList<string>? acceptedIssuers,
+        IDidResolverRegistry? registry,
+        CancellationToken ct = default)
+    {
+        // No allowlist → any issuer accepted (caller's policy).
+        if (acceptedIssuers is null || acceptedIssuers.Count == 0) return true;
+
+        // Step 1 — direct-string match.
+        if (acceptedIssuers.Contains(credentialIssuer, StringComparer.Ordinal)) return true;
+
+        // Without a registry, equivalence-aware steps cannot run.
+        if (registry is null) return false;
+
+        // Step 2 — credential issuer's alsoKnownAs contains an allowlist entry.
+        var credentialDoc = await registry.ResolveWithAlsoKnownAsAsync(credentialIssuer, ct).ConfigureAwait(false);
+        if (credentialDoc?.AlsoKnownAs is { Count: > 0 } credentialAka)
+        {
+            foreach (var allowed in acceptedIssuers)
+            {
+                if (credentialAka.Contains(allowed, StringComparer.Ordinal)) return true;
+            }
+        }
+
+        // Step 3 — any allowlist entry's alsoKnownAs contains the credential's issuer.
+        foreach (var allowed in acceptedIssuers)
+        {
+            var allowedDoc = await registry.ResolveWithAlsoKnownAsAsync(allowed, ct).ConfigureAwait(false);
+            if (allowedDoc?.AlsoKnownAs?.Contains(credentialIssuer, StringComparer.Ordinal) == true)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -275,7 +275,8 @@ public static class CredentialEndpoints
         CancellationToken cancellationToken = default)
     {
         var credentials = await store.GetByWalletAsync(walletAddress, cancellationToken);
-        var matches = matcher.Match(requirements, credentials);
+        // Feature 120 US5 — async path honours DID alsoKnownAs equivalence.
+        var matches = await matcher.MatchAsync(requirements, credentials, cancellationToken);
 
         var response = matches.Select(kvp => new
         {

--- a/src/Services/Sorcha.Wallet.Service/Services/PresentationRequestService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/PresentationRequestService.cs
@@ -360,16 +360,22 @@ public class PresentationRequestService : IPresentationRequestService
             });
         }
 
-        // 4. Issuer check
-        if (request.AcceptedIssuers is { Length: > 0 } &&
-            !request.AcceptedIssuers.Contains(credential.IssuerDid))
+        // 4. Issuer check — Feature 120 US5 honours DID alsoKnownAs equivalence
+        // when an IDidResolverRegistry is wired (production path); falls back to
+        // direct-string match when not (legacy / test composition).
+        if (request.AcceptedIssuers is { Length: > 0 })
         {
-            errors.Add(new VerificationError
+            var accepted = await Credentials.IssuerEquivalenceMatcher.IsAcceptedAsync(
+                credential.IssuerDid, request.AcceptedIssuers, _didRegistry);
+            if (!accepted)
             {
-                RequirementType = request.CredentialType,
-                FailureReason = "UntrustedIssuer",
-                Message = $"Issuer '{credential.IssuerDid}' not in accepted issuers list"
-            });
+                errors.Add(new VerificationError
+                {
+                    RequirementType = request.CredentialType,
+                    FailureReason = "UntrustedIssuer",
+                    Message = $"Issuer '{credential.IssuerDid}' not in accepted issuers list"
+                });
+            }
         }
 
         // 5. Status check (active)

--- a/tests/Sorcha.Wallet.Service.Tests/Credentials/IssuerEquivalenceMatcherTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Credentials/IssuerEquivalenceMatcherTests.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Moq;
+using Sorcha.ServiceClients.Did;
+using Sorcha.Wallet.Service.Credentials;
+using Xunit;
+
+namespace Sorcha.Wallet.Service.Tests.Credentials;
+
+/// <summary>
+/// Feature 120 US5 / FR-014 — issuer-allowlist equivalence honours
+/// <c>alsoKnownAs</c> bidirectionally.
+/// </summary>
+public class IssuerEquivalenceMatcherTests
+{
+    private const string CredIss = "did:sorcha:org:abc";
+    private const string AllowedDidWeb = "did:web:example.com:orgs:abc";
+    private const string OtherIss = "did:sorcha:org:somewhere-else";
+
+    private static IDidResolverRegistry Registry(Action<Mock<IDidResolverRegistry>>? setup = null)
+    {
+        var m = new Mock<IDidResolverRegistry>();
+        setup?.Invoke(m);
+        return m.Object;
+    }
+
+    [Fact]
+    public async Task EmptyAllowlist_ReturnsTrue()
+    {
+        var ok = await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, null, Registry());
+        ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DirectMatch_ReturnsTrue_DoesNotResolve()
+    {
+        var calls = 0;
+        var reg = Registry(m => m.Setup(r => r.ResolveWithAlsoKnownAsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls++)
+            .ReturnsAsync((DidDocument?)null));
+
+        var ok = await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [CredIss], reg);
+
+        ok.Should().BeTrue();
+        calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NoRegistry_DirectMatchOnly()
+    {
+        (await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [CredIss], null)).Should().BeTrue();
+        (await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [AllowedDidWeb], null)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CredentialIssuerAlsoKnownAsContainsAllowed_ReturnsTrue()
+    {
+        var reg = Registry(m =>
+        {
+            m.Setup(r => r.ResolveWithAlsoKnownAsAsync(CredIss, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DidDocument { Id = CredIss, AlsoKnownAs = [AllowedDidWeb] });
+        });
+
+        var ok = await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [AllowedDidWeb], reg);
+        ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AllowedDidAlsoKnownAsContainsCredentialIssuer_ReturnsTrue()
+    {
+        var reg = Registry(m =>
+        {
+            m.Setup(r => r.ResolveWithAlsoKnownAsAsync(CredIss, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DidDocument { Id = CredIss });
+            m.Setup(r => r.ResolveWithAlsoKnownAsAsync(AllowedDidWeb, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DidDocument { Id = AllowedDidWeb, AlsoKnownAs = [CredIss] });
+        });
+
+        var ok = await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [AllowedDidWeb], reg);
+        ok.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NoEquivalence_ReturnsFalse()
+    {
+        var reg = Registry(m =>
+        {
+            m.Setup(r => r.ResolveWithAlsoKnownAsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string did, CancellationToken _) => new DidDocument { Id = did });
+        });
+
+        var ok = await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [OtherIss], reg);
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CredentialUnreachable_FallsThroughToStep3()
+    {
+        var reg = Registry(m =>
+        {
+            m.Setup(r => r.ResolveWithAlsoKnownAsAsync(CredIss, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DidDocument?)null);
+            m.Setup(r => r.ResolveWithAlsoKnownAsAsync(AllowedDidWeb, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DidDocument { Id = AllowedDidWeb, AlsoKnownAs = [CredIss] });
+        });
+
+        var ok = await IssuerEquivalenceMatcher.IsAcceptedAsync(CredIss, [AllowedDidWeb], reg);
+        ok.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
Phase 7 / User Story 5 of Feature 120 — closes FR-014. Blueprint authors who list a `did:web` form in `CredentialRequirement.AcceptedIssuers` now accept credentials issued under the equivalent `did:sorcha:org` form (and vice versa).

### Tasks landed
| Task | Detail |
|---|---|
| T062 | `IssuerEquivalenceMatcher` static helper — direct match → credential's alsoKnownAs → allowed DIDs' alsoKnownAs |
| T061 | `CredentialMatcher.MatchAsync` routes through the helper; sync `Match` retained for back-compat |
| T062 | Mirrored in `PresentationRequestService.VerifyPresentationAsync` |
| T060 | 7 unit tests on `IssuerEquivalenceMatcher` |

### Tasks deferred
- **T063** `OPEN_CREDENTIAL_ISSUER` publish-time warning regression — untouched by this PR.

### Compatibility
- Sync `CredentialMatcher.Match` preserved for callers that haven't been wired to the resolver registry.
- New async `CredentialMatcher.MatchAsync` and `IssuerEquivalenceMatcher.IsAcceptedAsync` are the production paths.
- 729/729 `Sorcha.Wallet.Service.Tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)