### PR TITLE
fix(n1): restore HAIP service ServiceAuth + ServiceClients env

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -108,6 +108,17 @@ services:
       # against it, so it must be the public URL, not the internal 127.0.0.1
       # default baked into docker-compose.yml.
       Haip__IssuerUrl: https://n1.sorcha.dev
+      # PR #580 — HAIP needs a ServiceAuth client (IDidResolverRegistry construction
+      # transitively resolves ServiceAuthClient via SorchaDidResolver → IWalletServiceClient).
+      # Compose's environment-block merge replaces rather than additive-merges the base
+      # docker-compose.yml block when an override declares its own environment, so these
+      # have to be repeated here. F120's required-issuer-signature default surfaces the
+      # absence of this config as a 500 on every presentation submission.
+      ServiceClients__BlueprintService__Address: http://blueprint-service:8080
+      ServiceClients__TenantService__Address: http://tenant-service:8080
+      ServiceAuth__ClientId: service-haip
+      ServiceAuth__ClientSecret: haip-service-secret
+      ServiceAuth__Scopes: "blueprints:read"
 
   sorcha-ui-web:
     image: sorchadev/ui-web:latest


### PR DESCRIPTION
## Summary
n1's docker-compose.n1.yml haip-service override silently dropped `ServiceAuth__*` and `ServiceClients__*Address` keys (compose merges environment blocks by replacement when both sides declare one). PR #580 made those required at HAIP startup, but n1 hadn't been redeployed since pre-#580 so the gap stayed dormant.

Surfaced today running the AssuredIdentity walkthrough on n1 against F120 master — Phase 1 issuance succeeded, Phase 2 presentation submission returned 500 with 'ServiceAuth:ClientId not configured'. After this patch both phases complete under budget (Phase 1 < 3 min, Phase 2 < 2 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)