### PR TITLE
feat(120 T039.2): wire IIssuanceKeyService into HaipCredentialMinter path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,7 +298,12 @@ services:
       # requires ALPN which requires TLS.
       ServiceClients__RegisterService__GrpcAddress: http://register-service:5001
       ServiceClients__BlueprintService__Address: http://blueprint-service:8080
-      OrgKeyProtection__EncryptionKey: "dGhpcy1pcy1hLTMyLWJ5dGUtdGVzdC1rZXkh"
+      # Dev-mode AES-256 key (32 bytes base64). The previous placeholder decoded to
+      # 27 bytes, which OrgKeyProtectionProvider's strict validator rejects. The key
+      # only matters when OrgKeyDerivationService actually fires (Feature 083 derived
+      # keys + Feature 120 issuance-key lazy derivation). Production deployments
+      # override this via secret.
+      OrgKeyProtection__EncryptionKey: "OVL5NaJzR/Hpy2H5YgjYBX51Sws+q8oQXDG234SYnQw="
       # Encryption Provider Configuration
       # LinuxSecretService with fallback to file-based key storage (Docker doesn't have D-Bus)
       EncryptionProvider__Type: LinuxSecretService

--- a/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IIssuanceKeyClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IIssuanceKeyClient.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.ServiceClients.IssuanceKey;
+
+/// <summary>
+/// Cross-service trigger for the wallet's lazy VC-issuance-key derivation
+/// (Feature 120 T039). Used by services that mint credentials outside the
+/// direct <c>/credentials/issue</c> path (notably <c>Sorcha.Haip.Service</c>'s
+/// pre-authorized_code flow) to honor FR-004 'no later than first issuance'.
+/// </summary>
+public interface IIssuanceKeyClient
+{
+    /// <summary>
+    /// Idempotently derives (or returns the existing) Active issuance key for the org
+    /// and triggers DID document publish on the Tenant side. Logs and swallows on
+    /// failure — minting a credential should not be blocked by a transient
+    /// Wallet-side derivation failure.
+    /// </summary>
+    Task EnsureAsync(Guid organizationId, CancellationToken ct = default);
+}

--- a/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IssuanceKeyClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IssuanceKeyClient.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.ServiceClients.IssuanceKey;
+
+/// <summary>
+/// HTTP-backed <see cref="IIssuanceKeyClient"/> targeting the wallet service's
+/// <c>POST /api/v1/orgs/{orgId}/issuance-key/ensure</c> endpoint.
+/// </summary>
+public sealed class IssuanceKeyClient : IIssuanceKeyClient
+{
+    private readonly HttpClient _http;
+    private readonly ILogger<IssuanceKeyClient> _logger;
+
+    /// <summary>DI-friendly constructor.</summary>
+    public IssuanceKeyClient(HttpClient http, ILogger<IssuanceKeyClient> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task EnsureAsync(Guid organizationId, CancellationToken ct = default)
+    {
+        try
+        {
+            var resp = await _http.PostAsync(
+                $"/api/v1/orgs/{organizationId}/issuance-key/ensure",
+                content: null,
+                ct).ConfigureAwait(false);
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "IssuanceKey ensure returned {Status} for org {OrgId}",
+                    resp.StatusCode, organizationId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "IssuanceKey ensure failed for org {OrgId}; lazy rebuild may recover on next mint",
+                organizationId);
+        }
+    }
+}

--- a/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
@@ -46,6 +46,7 @@ public static class CredentialEndpoints
         CredentialOfferService offerService,
         IConfiguration configuration,
         ILoggerFactory loggerFactory,
+        Sorcha.ServiceClients.IssuanceKey.IIssuanceKeyClient issuanceKeyClient,
         CancellationToken ct)
     {
         var logger = loggerFactory.CreateLogger("Sorcha.Haip.Service.Endpoints.CredentialEndpoints");
@@ -305,6 +306,24 @@ public static class CredentialEndpoints
 
         var issuerUrl = configuration.GetValue<string>("Haip:IssuerUrl")
             ?? "https://sorcha.example/haip";
+
+        // Feature 120 T039 — ensure the org's VC issuance key + published DID
+        // document exist before signing. Lazy-derives on first issuance for
+        // the org (FR-004), idempotent on retries, non-throwing — falls back
+        // to ephemeral / config signing-key on any wallet failure.
+        if (Guid.TryParse(offer.TenantId, out var issuanceOrgId))
+        {
+            try
+            {
+                await issuanceKeyClient.EnsureAsync(issuanceOrgId, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Issuance key ensure failed for org {OrgId} during HAIP credential mint — DID document publish skipped",
+                    issuanceOrgId);
+            }
+        }
 
         // Use the offer resolved above — every branch below is guaranteed to have
         // a valid offer because the Bearer / lookup gates already rejected the

--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -130,6 +130,19 @@ builder.Services.AddHttpClient<Sorcha.Haip.Service.Services.PresentationCallback
     client.Timeout = TimeSpan.FromSeconds(15);
 });
 
+// Feature 120 T039 — cross-service trigger for the wallet's lazy issuance-key
+// derivation. HAIP's /credential endpoint calls this before minting so the
+// org's published DID document is in place by the time a verifier resolves it.
+builder.Services.AddHttpClient<
+    Sorcha.ServiceClients.IssuanceKey.IIssuanceKeyClient,
+    Sorcha.ServiceClients.IssuanceKey.IssuanceKeyClient>(client =>
+{
+    var walletAddress = builder.Configuration["ServiceClients:WalletService:Address"]
+        ?? "http://wallet-service:8080";
+    client.BaseAddress = new Uri(walletAddress);
+    client.Timeout = TimeSpan.FromSeconds(10);
+});
+
 var app = builder.Build();
 
 // OpenAPI and Scalar UI

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/IssuanceKeyEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/IssuanceKeyEndpoints.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Sorcha.ServiceDefaults;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Endpoints;
+
+/// <summary>
+/// Per-org VC issuance key lifecycle endpoints (Feature 120 US2 / T039).
+/// </summary>
+/// <remarks>
+/// Exposes the lazy-derivation entry point so any service that mints credentials
+/// can trigger the key + DID document publish without owning the wallet
+/// infrastructure directly. Used by Sorcha.Haip.Service's /credential endpoint
+/// to honor FR-004 'no later than first issuance' even when minting via the
+/// pre-authorized_code flow.
+/// </remarks>
+public static class IssuanceKeyEndpoints
+{
+    /// <summary>Maps the issuance key endpoints into the application.</summary>
+    public static IEndpointRouteBuilder MapIssuanceKeyEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/orgs/{orgId:guid}/issuance-key")
+            .WithTags("IssuanceKey")
+            .RequireRateLimiting(RateLimitPolicies.Api);
+
+        group.MapPost("/ensure", EnsureIssuanceKey)
+            .WithName("EnsureOrgIssuanceKey")
+            .WithSummary("Lazily derive (idempotent) the org's VC issuance key")
+            .WithDescription(
+                "Returns 200 with the active key's metadata after deriving it on first call " +
+                "or returning the existing Active row on retry. Triggers DID document " +
+                "regeneration on the Tenant side as a side effect. Designed for callers " +
+                "that mint credentials outside the direct /credentials/issue path " +
+                "(notably Sorcha.Haip.Service's pre-authorized_code flow).")
+            .Produces<EnsureIssuanceKeyResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        return app;
+    }
+
+    private static async Task<IResult> EnsureIssuanceKey(
+        [FromRoute] Guid orgId,
+        [FromServices] IIssuanceKeyService service,
+        CancellationToken ct)
+    {
+        var state = await service.GetOrDeriveAsync(orgId, ct);
+        if (state is null)
+        {
+            // F120 lazy derivation not applicable for this org (no provisioned master key).
+            return Results.Ok(new { provisioned = false, organizationId = orgId });
+        }
+        return Results.Ok(new EnsureIssuanceKeyResponse(
+            OrganizationId: state.OrganizationId,
+            RotationIndex: state.RotationIndex,
+            Algorithm: state.Algorithm,
+            Thumbprint: state.Thumbprint,
+            DerivedAt: state.DerivedAt));
+    }
+}
+
+/// <summary>Response shape for <c>POST /api/v1/orgs/{orgId}/issuance-key/ensure</c>.</summary>
+public sealed record EnsureIssuanceKeyResponse(
+    Guid OrganizationId,
+    int RotationIndex,
+    string Algorithm,
+    string Thumbprint,
+    DateTimeOffset DerivedAt);

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -263,6 +263,7 @@ app.MapDelegationEndpoints();
 app.MapCredentialEndpoints();
 app.MapPresentationEndpoints();
 app.MapOrgKeyEndpoints();
+app.MapIssuanceKeyEndpoints();
 app.MapFileDownloadEndpoints();
 app.MapPersonaCryptoEndpoints();
 

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
@@ -47,7 +47,7 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
     }
 
     /// <inheritdoc />
-    public async Task<IssuanceKeyState> GetOrDeriveAsync(Guid organizationId, CancellationToken ct = default)
+    public async Task<IssuanceKeyState?> GetOrDeriveAsync(Guid organizationId, CancellationToken ct = default)
     {
         // Idempotency — return any existing Active row first.
         var existing = await _db.IssuanceKeyStates
@@ -60,12 +60,28 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
         if (existing is not null) return existing;
 
         // Derive via Feature 083 — uses orgId as both controller and subject for the org's own key.
-        var derived = await _orgKey.DeriveUserKeyAsync(
-            organizationId.ToString(),
-            organizationId.ToString(),
-            departmentId: 0,
-            usage: KeyUsage.VCIssuance,
-            ct: ct).ConfigureAwait(false);
+        // OrgKeyDerivationService throws InvalidOperationException when the org has no
+        // provisioned master key. Treat that as 'F120 lazy derivation not yet applicable'
+        // and return null rather than blowing up the credential-mint call site — master keys
+        // are an explicit org-setup step, not something we want to silently provision here
+        // (provisioning generates a recovery mnemonic that must be backed up).
+        DerivedKeyResult derived;
+        try
+        {
+            derived = await _orgKey.DeriveUserKeyAsync(
+                organizationId.ToString(),
+                organizationId.ToString(),
+                departmentId: 0,
+                usage: KeyUsage.VCIssuance,
+                ct: ct).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("No active master key", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogInformation(
+                "Issuance key derivation skipped for org {OrgId}: no provisioned master key — Feature 083 setup not yet run for this org.",
+                organizationId);
+            return null;
+        }
 
         // Look up the persisted wallet to read the public key bytes.
         var wallet = await _db.Wallets

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs
@@ -19,7 +19,13 @@ public interface IIssuanceKeyService
     /// <summary>
     /// Returns the active issuance key for the org, deriving it on first call. Idempotent.
     /// </summary>
-    Task<IssuanceKeyState> GetOrDeriveAsync(Guid organizationId, CancellationToken ct = default);
+    /// <remarks>
+    /// Returns null when the org has no provisioned <c>OrgMasterKey</c> — issuance keys
+    /// are derived from the master, so the master must exist before lazy derivation can
+    /// run. Callers that hit a null return should treat F120 lazy derivation as
+    /// not-yet-applicable for this org and continue without it.
+    /// </remarks>
+    Task<IssuanceKeyState?> GetOrDeriveAsync(Guid organizationId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the currently-active issuance key for the org, or null if none has been derived.


### PR DESCRIPTION
## Summary
Closes a gap discovered during the post-F120 walkthrough verification: the original T039 wiring (#600) hooked `IIssuanceKeyService.GetOrDeriveAsync` into the wallet's `/credentials/issue` endpoint, but live walkthroughs mint credentials via `Sorcha.Haip.Service`'s pre-authorized_code flow which bypasses that endpoint. Result: zero rows in `IssuanceKeyStates` / `OrgDidDocuments` after a successful AssuredIdentity walkthrough.

This PR adds the cross-service trigger so the HAIP mint path also kicks lazy derivation:

- New `POST /api/v1/orgs/{orgId}/issuance-key/ensure` endpoint on Wallet Service
- New `IIssuanceKeyClient` + HTTP-backed `IssuanceKeyClient` in ServiceClients.Http (mirrors the `OrgDidDocumentClient` pattern from #596)
- HAIP `/credential` endpoint calls `EnsureAsync(orgId)` before mint, fire-and-forget non-throwing

### Service hardening surfaced under T039's invocation
- `IIssuanceKeyService.GetOrDeriveAsync` now returns `IssuanceKeyState?` and gracefully no-ops when the org has no provisioned `OrgMasterKey`. Master-key provisioning is an explicit org-setup step (generates a recovery mnemonic) — silently provisioning inside a credential-mint path would destroy that secret.
- `docker-compose.yml` `OrgKeyProtection__EncryptionKey` placeholder replaced — the previous value decoded to 27 bytes; the validator requires exactly 32. Dormant pre-F120; surfaced now that T039 invokes derivation.

### Pre-existing Feature 083 bug discovered (not fixed here)
`OrgKeyDerivationService.DeriveUserKeyAsync` hits a Postgres FK violation (`FK_Wallets_DerivedKeyRecords_DerivedKeyRecordId`) inside `SaveChangesAsync`. EF entity-tracking ordering — Wallet inserted with a DerivedKeyRecordId not yet present in DerivedKeyRecords. No production flow currently exercises this path, so the bug stayed dormant. The graceful-null behaviour above means walkthroughs proceed unaffected: wallet returns 500, HAIP-side `EnsureAsync` swallows the exception, credential mints normally. Filed as a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)