### PR TITLE
fix(083): DerivedKeyRecord FK ordering + OrgDidDocumentClient port

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs
@@ -85,8 +85,13 @@ public static class WalletServiceExtensions
         services.AddHttpClient<Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient,
             Sorcha.ServiceClients.OrgDidDocument.OrgDidDocumentClient>(client =>
             {
+                // Default port 8080 — every Sorcha service listens internally on 8080
+                // (see ASPNETCORE_URLS in docker-compose.yml). The :80 default earlier
+                // resulted in 'Connection refused (tenant-service:80)' on real wires.
                 client.BaseAddress = new Uri(
-                    configuration["ServiceClients:Tenant:BaseAddress"] ?? "http://tenant-service");
+                    configuration["ServiceClients:TenantService:Address"]
+                    ?? configuration["ServiceClients:Tenant:BaseAddress"]
+                    ?? "http://tenant-service:8080");
             });
 
         return services;

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/OrgKeyDerivationService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/OrgKeyDerivationService.cs
@@ -200,9 +200,16 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
                 CustodyMode = CustodyMode.Custodial
             };
 
-            // Create derived key record
+            // Create derived key record. Assign Id explicitly — the Postgres column has
+            // `defaultValueSql: gen_random_uuid()` which only fires at INSERT time, so the
+            // in-memory `Id` would otherwise be Guid.Empty when we wire the FK below.
+            // Without an explicit Id, EF inserts the Wallet first with DerivedKeyRecordId =
+            // '00000000-...' and Postgres rejects it as FK_Wallets_DerivedKeyRecords_DerivedKeyRecordId.
+            // Dormant pre-Feature 120 (no production flow exercised this path); surfaced
+            // when Feature 120's IIssuanceKeyService.GetOrDeriveAsync started invoking it.
             var derivedKeyRecord = new DerivedKeyRecord
             {
+                Id = Guid.NewGuid(),
                 OrgMasterKeyId = masterKey.Id,
                 OrganizationId = organizationId,
                 UserId = userId,
@@ -215,11 +222,13 @@ public class OrgKeyDerivationService : IOrgKeyDerivationService
                 CustodyMode = CustodyMode.Custodial
             };
 
-            _db.Wallets.Add(wallet);
-            _db.DerivedKeyRecords.Add(derivedKeyRecord);
-
-            // Link wallet to derived key record via FK
+            // Link wallet to derived key record via FK BEFORE adding to context — required
+            // so EF's insert-order resolver sees the dependency and inserts DerivedKeyRecord
+            // before Wallet.
             wallet.DerivedKeyRecordId = derivedKeyRecord.Id;
+
+            _db.DerivedKeyRecords.Add(derivedKeyRecord);
+            _db.Wallets.Add(wallet);
 
             await _db.SaveChangesAsync(ct);
 


### PR DESCRIPTION
## Summary
Two related bugs preventing F120's lazy-derivation chain from populating real rows.

**F083 FK ordering**: `OrgKeyDerivationService.DeriveUserKeyAsync` read `derivedKeyRecord.Id` before save (still `Guid.Empty` until Postgres `gen_random_uuid()` fires at INSERT time), wiring `Wallet.DerivedKeyRecordId = '00000000-...'` and tripping `FK_Wallets_DerivedKeyRecords_DerivedKeyRecordId`. Fix: assign `Guid.NewGuid()` explicitly + reorder `Add()` calls. Dormant pre-F120 (no flow exercised this path); F120 T039.2 surfaced it.

**OrgDidDocumentClient port**: Default `http://tenant-service` (port 80) caused `Connection refused` on every snapshot push. Sorcha services listen internally on 8080. Fix: default to `:8080` + accept conventional `ServiceClients:TenantService:Address` key.

## Verification (local)
After fix, `POST /api/v1/orgs/{orgId}/issuance-key/ensure` on a freshly-bootstrapped org with a provisioned master key produces:
- `IssuanceKeyStates`: 1 row (ED25519, RotationIndex=1, real thumbprint)
- `OrgDidDocuments`: 1 row (Version=1, LastRegenerationReason=IssuanceKeyDerived)
- `GET /orgs/{orgId}/did.json`: 200 `application/did+json` with dual VMs (versioned + thumbprint), `alsoKnownAs` link to `did:web:sorcha.dev:orgs:{orgId}`, W3C `@context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)