### PR TITLE
feat(120 kid-swap): sign credentials with org issuance key + emit kid header

### DIFF
--- a/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
@@ -43,7 +43,8 @@ public interface ISdJwtService
         string algorithm,
         DateTimeOffset? expiresAt = null,
         CancellationToken cancellationToken = default,
-        IReadOnlyList<byte[]>? x5cChain = null);
+        IReadOnlyList<byte[]>? x5cChain = null,
+        string? kid = null);
 
     /// <summary>
     /// Creates a new SD-JWT VC token with selective disclosure and holder key binding (cnf).
@@ -69,7 +70,8 @@ public interface ISdJwtService
         JsonElement holderJwk,
         DateTimeOffset? expiresAt = null,
         CancellationToken cancellationToken = default,
-        IReadOnlyList<byte[]>? x5cChain = null);
+        IReadOnlyList<byte[]>? x5cChain = null,
+        string? kid = null);
 
     /// <summary>
     /// Verifies an SD-JWT token's signature, structure, and extracts all disclosed claims.

--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -48,10 +48,11 @@ public class SdJwtService : ISdJwtService
         string algorithm,
         DateTimeOffset? expiresAt = null,
         CancellationToken cancellationToken = default,
-        IReadOnlyList<byte[]>? x5cChain = null)
+        IReadOnlyList<byte[]>? x5cChain = null,
+        string? kid = null)
     {
         return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject, signingKey,
-            algorithm, holderJwk: null, expiresAt, x5cChain, cancellationToken);
+            algorithm, holderJwk: null, expiresAt, x5cChain, kid, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -65,10 +66,11 @@ public class SdJwtService : ISdJwtService
         JsonElement holderJwk,
         DateTimeOffset? expiresAt = null,
         CancellationToken cancellationToken = default,
-        IReadOnlyList<byte[]>? x5cChain = null)
+        IReadOnlyList<byte[]>? x5cChain = null,
+        string? kid = null)
     {
         return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject, signingKey,
-            algorithm, holderJwk, expiresAt, x5cChain, cancellationToken);
+            algorithm, holderJwk, expiresAt, x5cChain, kid, cancellationToken);
     }
 
     private Task<SdJwtToken> CreateTokenCoreAsync(
@@ -81,6 +83,7 @@ public class SdJwtService : ISdJwtService
         JsonElement? holderJwk,
         DateTimeOffset? expiresAt,
         IReadOnlyList<byte[]>? x5cChain,
+        string? kid,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(claims);
@@ -170,6 +173,14 @@ public class SdJwtService : ISdJwtService
             ["alg"] = MapAlgorithm(algorithm),
             ["typ"] = "vc+sd-jwt"
         };
+
+        // Feature 120 — kid header for issuer-key resolution. Production callers pass
+        // the versioned form (`did:sorcha:org:{addr}#vc-issuance-{n}`) so verifiers can
+        // resolve the matching VerificationMethod via DidResolverBackedIssuerKeyResolver.
+        if (!string.IsNullOrEmpty(kid))
+        {
+            header["kid"] = kid;
+        }
 
         // Feature 096 US3 — x5c chain, if the caller supplied one. RFC 7515 §4.1.6
         // mandates base64 (NOT base64url) encoding for x5c entries.

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -538,27 +538,43 @@ public static class CredentialEndpoints
         var logger = loggerFactory.CreateLogger("Sorcha.Wallet.Service.Endpoints.CredentialEndpoints");
 
         // Feature 120 T039 — ensure the org's VC issuance key + published DID
-        // document exist before signing (FR-004 "no later than first issuance"
-        // guarantee). Idempotent on retries; non-throwing — signing remains
-        // wallet-key-based pending the kid-swap follow-up.
+        // document exist before signing (FR-004 "no later than first issuance").
+        // Then attempt to swap to the issuance key for signing (kid-swap, #604):
+        // when the org has an Active issuance key, the credential is signed with
+        // it and the JWS kid header carries did:sorcha:org:{addr}#vc-issuance-{n}
+        // so verifiers resolve to the published DID document.
+        Sorcha.Wallet.Service.Services.Interfaces.IssuanceSigningMaterial? issuanceMaterial = null;
         if (issuanceKeyService is not null
             && Guid.TryParse(request.TenantId, out var issuanceOrgId))
         {
             try
             {
                 _ = await issuanceKeyService.GetOrDeriveAsync(issuanceOrgId, cancellationToken);
+                issuanceMaterial = await issuanceKeyService
+                    .GetActiveSigningMaterialAsync(issuanceOrgId, cancellationToken);
             }
             catch (Exception ex)
             {
                 logger.LogWarning(ex,
-                    "Issuance key derivation failed for org {OrgId} during credential issuance — falling through to wallet-key signing",
+                    "Issuance key path failed for org {OrgId} — falling through to wallet-key signing",
                     issuanceOrgId);
             }
         }
 
-        // 2. Decrypt the wallet's private key
-        var privateKey = await keyManagement.DecryptPrivateKeyAsync(
-            wallet.EncryptedPrivateKey, wallet.EncryptionKeyId);
+        // 2. Decrypt the wallet's private key (only used when issuance-key swap is unavailable).
+        var privateKey = issuanceMaterial?.PrivateKey
+            ?? await keyManagement.DecryptPrivateKeyAsync(
+                wallet.EncryptedPrivateKey, wallet.EncryptionKeyId);
+        var signingAlgorithm = issuanceMaterial?.Algorithm ?? wallet.Algorithm;
+        var signingIssuer = issuanceMaterial?.IssuerDid ?? walletAddress;
+        var signingKid = issuanceMaterial?.Kid;
+
+        if (issuanceMaterial is not null)
+        {
+            logger.LogInformation(
+                "Feature 120 kid-swap: signing credential with org issuance key kid={Kid} for org {OrgId}",
+                signingKid, issuanceMaterial.OrganizationId);
+        }
 
         // 3. Calculate expiry
         var issuedAt = DateTimeOffset.UtcNow;
@@ -632,13 +648,14 @@ public static class CredentialEndpoints
         var token = await sdJwtService.CreateTokenAsync(
             claims,
             request.DisclosableClaims,
-            walletAddress,
-            request.RecipientWallet,
-            privateKey,
-            wallet.Algorithm,
-            expiresAt,
-            cancellationToken,
-            x5cChain);
+            issuer: signingIssuer,
+            subject: request.RecipientWallet,
+            signingKey: privateKey,
+            algorithm: signingAlgorithm,
+            expiresAt: expiresAt,
+            cancellationToken: cancellationToken,
+            x5cChain: x5cChain,
+            kid: signingKid);
 
         // 5. Generate credential ID
         var credentialId = $"urn:uuid:{Guid.NewGuid()}";

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
@@ -31,6 +31,7 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
     private readonly WalletDbContext _db;
     private readonly IOrgKeyDerivationService _orgKey;
     private readonly IOrgDidDocumentClient _didDocClient;
+    private readonly Sorcha.Wallet.Core.Services.Interfaces.IOrgKeyProtectionProvider _orgKeyProtection;
     private readonly ILogger<IssuanceKeyService> _logger;
 
     /// <summary>DI-friendly constructor.</summary>
@@ -38,11 +39,13 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
         WalletDbContext db,
         IOrgKeyDerivationService orgKey,
         IOrgDidDocumentClient didDocClient,
+        Sorcha.Wallet.Core.Services.Interfaces.IOrgKeyProtectionProvider orgKeyProtection,
         ILogger<IssuanceKeyService> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _orgKey = orgKey ?? throw new ArgumentNullException(nameof(orgKey));
         _didDocClient = didDocClient ?? throw new ArgumentNullException(nameof(didDocClient));
+        _orgKeyProtection = orgKeyProtection ?? throw new ArgumentNullException(nameof(orgKeyProtection));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -161,6 +164,82 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
         var jwkJson = BuildJwk(row.Algorithm, row.PublicKey);
         using var doc = JsonDocument.Parse(jwkJson);
         return doc.RootElement.Clone();
+    }
+
+    /// <inheritdoc />
+    public async Task<Sorcha.Wallet.Service.Services.Interfaces.IssuanceSigningMaterial?> GetActiveSigningMaterialAsync(
+        Guid organizationId, CancellationToken ct = default)
+    {
+        var state = await _db.IssuanceKeyStates
+            .FirstOrDefaultAsync(
+                k => k.OrganizationId == organizationId
+                  && k.Slot == IssuanceSlot
+                  && k.Status == IssuanceKeyStatus.Active,
+                ct)
+            .ConfigureAwait(false);
+        if (state is null) return null;
+
+        // The issuance key's private material lives in the Wallet that
+        // OrgKeyDerivationService created when the key was derived. Look it up via
+        // the DerivedKeyRecord (KeyUsage = VCIssuance) for this org.
+        var derivedRecord = await _db.DerivedKeyRecords
+            .FirstOrDefaultAsync(
+                d => d.OrganizationId == organizationId.ToString()
+                  && d.KeyUsage == KeyUsage.VCIssuance
+                  && d.Status == DerivedKeyStatus.Active,
+                ct)
+            .ConfigureAwait(false);
+        if (derivedRecord is null)
+        {
+            _logger.LogWarning(
+                "IssuanceKeyState row exists for org {OrgId} but no matching DerivedKeyRecord was found — schema drift",
+                organizationId);
+            return null;
+        }
+
+        var wallet = await _db.Wallets
+            .FirstOrDefaultAsync(w => w.Address == derivedRecord.WalletAddress, ct)
+            .ConfigureAwait(false);
+        if (wallet is null || string.IsNullOrEmpty(wallet.EncryptedPrivateKey))
+        {
+            _logger.LogWarning(
+                "DerivedKeyRecord points at wallet {Addr} but the wallet has no encrypted private key — recovery state",
+                derivedRecord.WalletAddress);
+            return null;
+        }
+
+        byte[] privateKey;
+        try
+        {
+            // Org-derived wallets are encrypted via IOrgKeyProtectionProvider (uses
+            // OrgKeyProtection:EncryptionKey) NOT IKeyManagementService (uses the
+            // wallet-master-key from LinuxSecretService). Mismatching providers gives
+            // an AES-GCM AuthenticationTagMismatchException at runtime.
+            privateKey = await _orgKeyProtection
+                .DecryptSeedAsync(
+                    Convert.FromBase64String(wallet.EncryptedPrivateKey),
+                    wallet.EncryptionKeyId,
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to decrypt issuance private key for org {OrgId} wallet {Addr}",
+                organizationId, derivedRecord.WalletAddress);
+            return null;
+        }
+
+        var issuerDid = $"did:sorcha:org:{derivedRecord.WalletAddress}";
+        var kid = $"{issuerDid}#vc-issuance-{state.RotationIndex}";
+
+        return new Sorcha.Wallet.Service.Services.Interfaces.IssuanceSigningMaterial(
+            OrganizationId: organizationId,
+            IssuerDid: issuerDid,
+            Kid: kid,
+            PrivateKey: privateKey,
+            Algorithm: state.Algorithm,
+            RotationIndex: state.RotationIndex);
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs
@@ -38,4 +38,33 @@ public interface IIssuanceKeyService
     /// </summary>
     Task<System.Text.Json.JsonElement?> GetPublicJwkAsync(
         Guid organizationId, int rotationIndex, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the active issuance key's signing material (decrypted private key + kid +
+    /// algorithm + issuer DID), or null when the org has no Active issuance key.
+    /// </summary>
+    /// <remarks>
+    /// Production credential-mint callers use this to swap from wallet-key-signing to
+    /// org-issuance-key-signing (Feature 120 kid-swap). Emits the versioned kid form
+    /// <c>did:sorcha:org:{addr}#vc-issuance-{rotationIndex}</c> per platform default (D3).
+    /// </remarks>
+    Task<IssuanceSigningMaterial?> GetActiveSigningMaterialAsync(
+        Guid organizationId, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Decrypted signing material for an org's active VC issuance key (Feature 120 kid-swap).
+/// </summary>
+/// <param name="OrganizationId">Owning organisation.</param>
+/// <param name="IssuerDid">Canonical issuer DID — <c>did:sorcha:org:{addr}</c>.</param>
+/// <param name="Kid">JWS <c>kid</c> header value — versioned form <c>did:sorcha:org:{addr}#vc-issuance-{rotationIndex}</c>.</param>
+/// <param name="PrivateKey">Decrypted private key bytes — must be wiped by caller after signing.</param>
+/// <param name="Algorithm">Signing algorithm string (e.g., <c>ED25519</c>).</param>
+/// <param name="RotationIndex">Monotonic rotation counter.</param>
+public sealed record IssuanceSigningMaterial(
+    Guid OrganizationId,
+    string IssuerDid,
+    string Kid,
+    byte[] PrivateKey,
+    string Algorithm,
+    int RotationIndex);


### PR DESCRIPTION
## Summary
Completes the F120 production-issuer-signature arc on the wallet path. When the org has an Active issuance key (Feature 083 derived under `KeyUsage.VCIssuance`), `IssueCredential` now signs with that key and emits the JWS `kid` header so verifiers can resolve the matching VM in the published DID document.

### Wire-level evidence (direct API call, local stack)
```json
JWS HEADER: {
  "alg":"EdDSA",
  "typ":"vc+sd-jwt",
  "kid":"did:sorcha:org:ws11qp0tta5233up97l6vhjpr0vuy8uysnq2gen8fwj4s6d9d2zkz52zjrwtmtj#vc-issuance-1"
}
iss: did:sorcha:org:ws11qp0tta5233up97l6vhjpr0vuy8uysnq2gen8fwj4s6d9d2zkz52zjrwtmtj
```
The kid resolves through `DidResolverBackedIssuerKeyResolver` (#595) → published Tenant DID document (#596) → `VerificationMethod` `vc-issuance-1`.

### Changes
- `ISdJwtService` gains optional `kid` parameter on both `CreateTokenAsync` overloads (additive, back-compat).
- `IIssuanceKeyService` gains `GetActiveSigningMaterialAsync` returning decrypted signing material (kid, private key, algorithm, issuer DID). Decryption via `IOrgKeyProtectionProvider` to match `OrgKeyDerivationService`'s encryption side — `IKeyManagementService` would give `AuthenticationTagMismatchException` (different protection scheme).
- `CredentialEndpoints.IssueCredential` swaps `signingKey + algorithm + issuer + kid` when an Active issuance key exists; falls through to wallet-key signing otherwise.

### Coverage
- ✅ Wallet path (action-executor → `IWalletServiceClient.IssueCredentialAsync`): kid-swap fires.
- ⏭ HAIP path (pre-authorized_code flow → `HaipCredentialMinter`): NOT covered yet. HAIP signs with its own configured/ephemeral key. Demo walkthroughs (AssuredIdentity etc.) currently mint via HAIP so the kid-swap evidence requires direct API tests. HAIP-side kid-swap needs a sign-on-behalf bridge to wallet (sending private keys cross-service is unsafe) — separate follow-up.

AssuredIdentity walkthrough still green: 00:49 total, both phases under SC-001/SC-002 budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)