### PR TITLE
feat(120): HAIP-side kid-swap via wallet sign-on-behalf

### DIFF
--- a/src/Common/Sorcha.Cryptography/Extensions/CryptographyServiceExtensions.cs
+++ b/src/Common/Sorcha.Cryptography/Extensions/CryptographyServiceExtensions.cs
@@ -19,6 +19,7 @@ public static class CryptographyServiceExtensions
     public static IServiceCollection AddSdJwtServices(this IServiceCollection services)
     {
         services.AddSingleton<ISdJwtService, SdJwtService>();
+        services.AddSingleton<ISdJwtSigner, SdJwtSigner>();
         return services;
     }
 }

--- a/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
@@ -74,6 +74,26 @@ public interface ISdJwtService
         string? kid = null);
 
     /// <summary>
+    /// External-signer overload for sign-on-behalf flows (Feature 120 HAIP kid-swap).
+    /// The caller supplies an <paramref name="externalSigner"/> that produces the
+    /// signature for the unsigned JWS bytes; <paramref name="signingKey"/> may be
+    /// null/empty when the external signer is supplied. Used by HAIP service to
+    /// delegate signing to wallet without holding private key material.
+    /// </summary>
+    Task<SdJwtToken> CreateTokenAsync(
+        Dictionary<string, object> claims,
+        IEnumerable<string>? disclosableClaims,
+        string issuer,
+        string subject,
+        string algorithm,
+        Func<byte[], CancellationToken, Task<byte[]>> externalSigner,
+        JsonElement? holderJwk,
+        string? kid,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<byte[]>? x5cChain = null);
+
+    /// <summary>
     /// Verifies an SD-JWT token's signature, structure, and extracts all disclosed claims.
     /// </summary>
     /// <param name="rawToken">The serialized SD-JWT token.</param>

--- a/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtSigner.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtSigner.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+
+namespace Sorcha.Cryptography.SdJwt;
+
+/// <summary>
+/// Standalone JWS signer extracted so callers that build a JWS in pieces — notably
+/// the Feature 120 sign-on-behalf path on the wallet service — can sign without
+/// going through <see cref="ISdJwtService"/>'s full token-construction pipeline.
+/// </summary>
+public interface ISdJwtSigner
+{
+    /// <summary>
+    /// Signs <paramref name="data"/> with <paramref name="privateKey"/> using
+    /// <paramref name="algorithm"/>. Mirrors the algorithm support in <see cref="SdJwtService"/>.
+    /// </summary>
+    byte[] Sign(byte[] data, byte[] privateKey, string algorithm);
+}
+
+/// <summary>Default <see cref="ISdJwtSigner"/> implementation.</summary>
+public sealed class SdJwtSigner : ISdJwtSigner
+{
+    /// <inheritdoc />
+    public byte[] Sign(byte[] data, byte[] privateKey, string algorithm)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(privateKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(algorithm);
+
+        var alg = algorithm.ToUpperInvariant();
+
+        if (alg is "EDDSA" or "ED25519")
+        {
+            return Sodium.PublicKeyAuth.SignDetached(data, privateKey);
+        }
+
+        if (alg is "ES256" or "P-256" or "P256" or "NIST-P256" or "NISTP256")
+        {
+            using var ecdsa = ECDsa.Create();
+            ecdsa.ImportECPrivateKey(privateKey, out _);
+            return ecdsa.SignData(data, HashAlgorithmName.SHA256);
+        }
+
+        if (alg is "RS256" or "RSA" or "RSA-4096")
+        {
+            using var rsa = RSA.Create();
+            rsa.ImportRSAPrivateKey(privateKey, out _);
+            return rsa.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        }
+
+        throw new NotSupportedException($"Unsupported signing algorithm: {algorithm}");
+    }
+}
+
+/// <summary>Base64url helpers — public surface for components that build JWS pieces externally.</summary>
+public static class Base64UrlHelper
+{
+    /// <summary>Base64url-encode without padding.</summary>
+    public static string Encode(byte[] data)
+        => Convert.ToBase64String(data).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    /// <summary>Base64url-decode (with or without padding).</summary>
+    public static byte[] Decode(string base64Url)
+    {
+        var padded = base64Url.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
+    }
+}

--- a/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/SdJwtService.cs
@@ -52,7 +52,7 @@ public class SdJwtService : ISdJwtService
         string? kid = null)
     {
         return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject, signingKey,
-            algorithm, holderJwk: null, expiresAt, x5cChain, kid, cancellationToken);
+            algorithm, holderJwk: null, expiresAt, x5cChain, kid, externalSigner: null, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -70,10 +70,30 @@ public class SdJwtService : ISdJwtService
         string? kid = null)
     {
         return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject, signingKey,
-            algorithm, holderJwk, expiresAt, x5cChain, kid, cancellationToken);
+            algorithm, holderJwk, expiresAt, x5cChain, kid, externalSigner: null, cancellationToken);
     }
 
-    private Task<SdJwtToken> CreateTokenCoreAsync(
+    /// <inheritdoc />
+    public Task<SdJwtToken> CreateTokenAsync(
+        Dictionary<string, object> claims,
+        IEnumerable<string>? disclosableClaims,
+        string issuer,
+        string subject,
+        string algorithm,
+        Func<byte[], CancellationToken, Task<byte[]>> externalSigner,
+        JsonElement? holderJwk,
+        string? kid,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken cancellationToken = default,
+        IReadOnlyList<byte[]>? x5cChain = null)
+    {
+        ArgumentNullException.ThrowIfNull(externalSigner);
+        return CreateTokenCoreAsync(claims, disclosableClaims, issuer, subject,
+            signingKey: Array.Empty<byte>(), algorithm, holderJwk, expiresAt, x5cChain, kid,
+            externalSigner, cancellationToken);
+    }
+
+    private async Task<SdJwtToken> CreateTokenCoreAsync(
         Dictionary<string, object> claims,
         IEnumerable<string>? disclosableClaims,
         string issuer,
@@ -84,13 +104,19 @@ public class SdJwtService : ISdJwtService
         DateTimeOffset? expiresAt,
         IReadOnlyList<byte[]>? x5cChain,
         string? kid,
+        Func<byte[], CancellationToken, Task<byte[]>>? externalSigner,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(claims);
         ArgumentException.ThrowIfNullOrWhiteSpace(issuer);
         ArgumentException.ThrowIfNullOrWhiteSpace(subject);
-        ArgumentNullException.ThrowIfNull(signingKey);
         ArgumentException.ThrowIfNullOrWhiteSpace(algorithm);
+
+        // signingKey is required when no externalSigner is supplied; ignored otherwise.
+        if (externalSigner is null)
+        {
+            ArgumentNullException.ThrowIfNull(signingKey);
+        }
 
         var disclosableList = disclosableClaims?.ToList() ?? claims.Keys.ToList();
 
@@ -193,7 +219,10 @@ public class SdJwtService : ISdJwtService
         var headerB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(header));
         var payloadB64 = Base64UrlEncode(JsonSerializer.SerializeToUtf8Bytes(payload));
         var signingInput = $"{headerB64}.{payloadB64}";
-        var signature = Sign(Encoding.UTF8.GetBytes(signingInput), signingKey, algorithm);
+        var signingInputBytes = Encoding.UTF8.GetBytes(signingInput);
+        var signature = externalSigner is not null
+            ? await externalSigner(signingInputBytes, cancellationToken).ConfigureAwait(false)
+            : Sign(signingInputBytes, signingKey, algorithm);
         var signatureB64 = Base64UrlEncode(signature);
 
         // Assemble the SD-JWT: header.payload.signature~disclosure1~disclosure2~
@@ -210,7 +239,7 @@ public class SdJwtService : ISdJwtService
             RawToken = rawToken
         };
 
-        return Task.FromResult(token);
+        return token;
     }
 
     /// <inheritdoc />

--- a/src/Common/Sorcha.ServiceClients.Http/Did/SorchaDidResolver.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Did/SorchaDidResolver.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System;
+using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.ServiceClients.Http.Utilities;
 using Sorcha.ServiceClients.Wallet;
@@ -24,9 +25,24 @@ public class SorchaDidResolver : IDidResolver
     private readonly IWalletServiceClient _walletClient;
     private readonly ILogger<SorchaDidResolver> _logger;
 
+    private readonly HttpClient? _publicDidHttp;
+
     public SorchaDidResolver(IWalletServiceClient walletClient, ILogger<SorchaDidResolver> logger)
     {
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Constructor variant with an injected <see cref="HttpClient"/> for anonymous DID
+    /// resolution via wallet's public <c>/api/v1/wallets/{addr}/did-document</c> endpoint
+    /// (Feature 120). Used by services that don't have the service-auth bearer needed
+    /// for the auth-gated wallet GET (notably Sorcha.Haip.Service's verifier path).
+    /// </summary>
+    public SorchaDidResolver(IWalletServiceClient walletClient, HttpClient publicDidHttp, ILogger<SorchaDidResolver> logger)
+    {
+        _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
+        _publicDidHttp = publicDidHttp;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -60,6 +76,31 @@ public class SorchaDidResolver : IDidResolver
         {
             _logger.LogWarning("Organization DID has empty address: {Did}", did);
             return null;
+        }
+
+        // Feature 120 — try the public did-document endpoint first when we have a
+        // pre-configured HttpClient for it. This path doesn't require service-auth and
+        // returns the W3C-shaped doc with publicKeyJwk + the #vc-issuance-{n} alias VM
+        // baked in. Fall back to the auth-gated GetWalletAsync path on failure.
+        if (_publicDidHttp is not null)
+        {
+            try
+            {
+                using var resp = await _publicDidHttp
+                    .GetAsync($"/api/v1/wallets/{address}/did-document", ct)
+                    .ConfigureAwait(false);
+                if (resp.IsSuccessStatusCode)
+                {
+                    var doc = await resp.Content.ReadFromJsonAsync<DidDocument>(ct).ConfigureAwait(false);
+                    if (doc is not null) return doc;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex,
+                    "Public DID resolution path failed for {Did}; falling through to auth-gated wallet client",
+                    did);
+            }
         }
 
         WalletInfo? wallet;
@@ -146,6 +187,16 @@ public class SorchaDidResolver : IDidResolver
             {
                 verificationMethod.PublicKeyMultibase = multibase;
             }
+
+            // Feature 120 — also emit publicKeyJwk so verifiers that only support the
+            // JWK form (notably Sorcha.Haip.Service.HaipPresentationVerifier) can read
+            // the key material. Wallet-derived multibase + JWK reference the same bytes.
+            var jwkJson = TryBuildJwk(wallet.Algorithm, rawKey);
+            if (jwkJson is not null)
+            {
+                using var jwkDoc = System.Text.Json.JsonDocument.Parse(jwkJson);
+                verificationMethod.PublicKeyJwk = jwkDoc.RootElement.Clone();
+            }
             else
             {
                 // Algorithm not in the multicodec table (for example PQC): fail closed.
@@ -167,13 +218,53 @@ public class SorchaDidResolver : IDidResolver
             }
         }
 
+        // Feature 120 — when resolving did:sorcha:org:*, also emit a `#vc-issuance-1`
+        // alias VM pointing at the same key bytes. Credentials minted via the kid-swap
+        // path (#604, #605) carry kid=did:sorcha:org:{addr}#vc-issuance-{n}; verifier
+        // exact-match resolves through this alias. Rotation index >1 lands with US6.
+        var vms = new List<VerificationMethod> { verificationMethod };
+        if (did.StartsWith("did:sorcha:org:", StringComparison.Ordinal))
+        {
+            var issuanceVmId = $"{did}#vc-issuance-1";
+            vms.Add(new VerificationMethod
+            {
+                Id = issuanceVmId,
+                Type = keyType,
+                Controller = did,
+                PublicKeyMultibase = verificationMethod.PublicKeyMultibase,
+                PublicKeyJwk = verificationMethod.PublicKeyJwk
+            });
+        }
+
         return new DidDocument
         {
             Id = did,
-            VerificationMethod = [verificationMethod],
-            Authentication = [keyId],
-            AssertionMethod = [keyId]
+            VerificationMethod = vms,
+            Authentication = vms.Select(v => v.Id).ToList(),
+            AssertionMethod = vms.Select(v => v.Id).ToList()
         };
+    }
+
+    /// <summary>
+    /// Best-effort JWK construction from raw public-key bytes for the algorithms
+    /// Sorcha currently supports. Returns null on unsupported algorithms or when the
+    /// raw byte shape doesn't match the expected encoding.
+    /// </summary>
+    private static string? TryBuildJwk(string algorithm, byte[] rawKey)
+    {
+        var b64u = (byte[] b) =>
+            Convert.ToBase64String(b).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var algo = algorithm?.ToUpperInvariant();
+        if (algo is "ED25519")
+            return $"{{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"{b64u(rawKey)}\"}}";
+        if (algo is "NIST-P256" or "NISTP256" or "P-256" or "P256" or "ECDSA-P256"
+            && rawKey.Length == 65 && rawKey[0] == 0x04)
+        {
+            var x = b64u(rawKey.AsSpan(1, 32).ToArray());
+            var y = b64u(rawKey.AsSpan(33, 32).ToArray());
+            return $"{{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"{x}\",\"y\":\"{y}\"}}";
+        }
+        return null;
     }
 
     private DidDocument? ResolveRegisterDid(string did)

--- a/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IIssuanceKeyClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IIssuanceKeyClient.cs
@@ -18,4 +18,28 @@ public interface IIssuanceKeyClient
     /// Wallet-side derivation failure.
     /// </summary>
     Task EnsureAsync(Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sign-on-behalf — produces a signature using the org's Active issuance private
+    /// key without transmitting key material across services. Returns null when no
+    /// Active issuance key exists (caller should fall back to local signing).
+    /// </summary>
+    /// <param name="organizationId">Owning organisation.</param>
+    /// <param name="dataToSign">The bytes to sign — typically the JWS signing input <c>header.payload</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IssuanceSignResult?> SignAsync(
+        Guid organizationId, byte[] dataToSign, CancellationToken ct = default);
 }
+
+/// <summary>Result of a sign-on-behalf call (Feature 120 HAIP kid-swap).</summary>
+/// <param name="Signature">Raw signature bytes.</param>
+/// <param name="Kid">JWS <c>kid</c> header value to embed.</param>
+/// <param name="IssuerDid">Canonical issuer DID — set as the JWS <c>iss</c> claim.</param>
+/// <param name="Algorithm">Signing algorithm used (e.g., <c>EdDSA</c>).</param>
+/// <param name="RotationIndex">Monotonic rotation counter of the signing key.</param>
+public sealed record IssuanceSignResult(
+    byte[] Signature,
+    string Kid,
+    string IssuerDid,
+    string Algorithm,
+    int RotationIndex);

--- a/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IssuanceKeyClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/IssuanceKey/IssuanceKeyClient.cs
@@ -1,9 +1,25 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net;
+using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Sorcha.ServiceClients.IssuanceKey;
+
+internal sealed class SignOnBehalfRequest
+{
+    public string DataBase64Url { get; set; } = "";
+}
+
+internal sealed class SignOnBehalfResponse
+{
+    public string SignatureBase64Url { get; set; } = "";
+    public string Kid { get; set; } = "";
+    public string IssuerDid { get; set; } = "";
+    public string Algorithm { get; set; } = "";
+    public int RotationIndex { get; set; }
+}
 
 /// <summary>
 /// HTTP-backed <see cref="IIssuanceKeyClient"/> targeting the wallet service's
@@ -43,6 +59,58 @@ public sealed class IssuanceKeyClient : IIssuanceKeyClient
             _logger.LogWarning(ex,
                 "IssuanceKey ensure failed for org {OrgId}; lazy rebuild may recover on next mint",
                 organizationId);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IssuanceSignResult?> SignAsync(
+        Guid organizationId, byte[] dataToSign, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(dataToSign);
+
+        try
+        {
+            var body = new SignOnBehalfRequest
+            {
+                DataBase64Url = Convert.ToBase64String(dataToSign).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+            };
+            var resp = await _http.PostAsJsonAsync(
+                $"/api/v1/orgs/{organizationId}/issuance-key/sign", body, ct).ConfigureAwait(false);
+
+            if (resp.StatusCode == HttpStatusCode.NotFound)
+            {
+                // No Active issuance key — caller falls back to local signing.
+                return null;
+            }
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "IssuanceKey sign returned {Status} for org {OrgId}",
+                    resp.StatusCode, organizationId);
+                return null;
+            }
+
+            var result = await resp.Content.ReadFromJsonAsync<SignOnBehalfResponse>(ct).ConfigureAwait(false);
+            if (result is null) return null;
+
+            var sig = Convert.FromBase64String(result.SignatureBase64Url
+                .Replace('-', '+').Replace('_', '/').PadRight(
+                    result.SignatureBase64Url.Length + (4 - result.SignatureBase64Url.Length % 4) % 4, '='));
+
+            return new IssuanceSignResult(
+                Signature: sig,
+                Kid: result.Kid,
+                IssuerDid: result.IssuerDid,
+                Algorithm: result.Algorithm,
+                RotationIndex: result.RotationIndex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "IssuanceKey sign failed for org {OrgId}; falling back to local signing",
+                organizationId);
+            return null;
         }
     }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -507,6 +507,11 @@ public class ActionExecutionService : IActionExecutionService
         //     carried forward to the claim action via Route.OutputMapping.
         //     Internal Sorcha issuance (issuedCredential) still runs later at
         //     step 9d because it depends on the built transaction context.
+        // Caller's org context — used both for the HAIP offer (so HAIP can swap to the
+        // org's issuance key) and for SorchaLocalWallet credential issuance below.
+        var callerIssuerOrgName = caller?.FindFirst("org_name")?.Value;
+        var callerIssuerTenantId = caller?.FindFirst("org_id")?.Value;
+
         CreateOfferResult? haipOfferResult = null;
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience == TargetAudience.HaipExternalWallet)
@@ -537,9 +542,13 @@ public class ActionExecutionService : IActionExecutionService
                     actionDef.CredentialIssuanceConfig.CredentialType,
                     string.Join(", ", haipClaimsForWire.Keys));
 
+                // Feature 120 — pass the issuer's actual TenantId (org_id from caller
+                // JWT) so HAIP's /credential endpoint can swap to the org's issuance
+                // key. Previously this argument was `instance.RegisterId`, which made
+                // the offer's TenantId a register UUID and bypassed the kid-swap path.
                 haipOfferResult = await _haipClient.CreateCredentialOfferAsync(
                     request.SenderWallet,
-                    instance.RegisterId,
+                    callerIssuerTenantId ?? instance.RegisterId,
                     actionDef.CredentialIssuanceConfig.CredentialType,
                     haipClaimsForWire,
                     actionDef.CredentialIssuanceConfig.Disclosable?.ToList(),
@@ -567,8 +576,10 @@ public class ActionExecutionService : IActionExecutionService
         //     Contract: specs/106-register-native-credentials/contracts/credential-issuance-config.md
         CredentialIssuanceResult? localWalletCredential = null;
         string? localWalletRecipient = null;
-        var issuerOrgName = caller?.FindFirst("org_name")?.Value;
-        var issuerTenantId = caller?.FindFirst("org_id")?.Value;
+        // Reuse the caller's org context computed earlier (used by both the HAIP path
+        // and SorchaLocalWallet path).
+        var issuerOrgName = callerIssuerOrgName;
+        var issuerTenantId = callerIssuerTenantId;
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience is TargetAudience.SorchaLocalWallet
                 or TargetAudience.SorchaInternal)

--- a/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Haip.Service/Endpoints/CredentialEndpoints.cs
@@ -336,21 +336,62 @@ public static class CredentialEndpoints
 
         try
         {
-            var credential = await minter.MintCredentialAsync(
-                issuerDid: issuerUrl,
-                holderJwk: holderJwk ?? default,
-                credentialType: credentialType,
-                claims: claims,
-                disclosablePaths: disclosablePaths,
-                signingKey: signingKey,
-                algorithm: signingAlgorithm,
-                expiresAt: DateTimeOffset.UtcNow.AddYears(1),
-                ct: ct);
+            string credential;
+
+            // Feature 120 kid-swap (#605) — try wallet sign-on-behalf when the offer
+            // carries a TenantId for an org with an Active issuance key. The signed
+            // credential carries kid=did:sorcha:org:{addr}#vc-issuance-{n} so verifiers
+            // resolve to the published DID document rather than HAIP's local key.
+            Sorcha.ServiceClients.IssuanceKey.IssuanceSignResult? signResultProbe = null;
+            if (Guid.TryParse(offer.TenantId, out var orgIdForSign))
+            {
+                signResultProbe = await issuanceKeyClient.SignAsync(orgIdForSign, new byte[] { 0 }, ct);
+            }
+
+            if (signResultProbe is not null)
+            {
+                Func<byte[], CancellationToken, Task<byte[]>> externalSigner = async (data, signCt) =>
+                {
+                    var signed = await issuanceKeyClient.SignAsync(orgIdForSign, data, signCt);
+                    if (signed is null)
+                        throw new InvalidOperationException("Issuance sign-on-behalf returned null mid-mint");
+                    return signed.Signature;
+                };
+
+                credential = await minter.MintCredentialWithExternalSignerAsync(
+                    issuerDid: signResultProbe.IssuerDid,
+                    holderJwk: holderJwk ?? default,
+                    credentialType: credentialType,
+                    claims: claims,
+                    disclosablePaths: disclosablePaths,
+                    externalSigner: externalSigner,
+                    algorithm: signResultProbe.Algorithm,
+                    kid: signResultProbe.Kid,
+                    expiresAt: DateTimeOffset.UtcNow.AddYears(1),
+                    ct: ct);
+            }
+            else
+            {
+                credential = await minter.MintCredentialAsync(
+                    issuerDid: issuerUrl,
+                    holderJwk: holderJwk ?? default,
+                    credentialType: credentialType,
+                    claims: claims,
+                    disclosablePaths: disclosablePaths,
+                    signingKey: signingKey,
+                    algorithm: signingAlgorithm,
+                    expiresAt: DateTimeOffset.UtcNow.AddYears(1),
+                    ct: ct);
+            }
 
             // Inject issuer public key into JWS header for verifier key resolution.
-            // In production this would be an x5c chain; for dev/walkthrough mode we
-            // embed the issuer's public JWK so the verifier can self-resolve.
-            credential = InjectIssuerJwkInHeader(credential, signingKey, signingAlgorithm);
+            // Skipped on the sign-on-behalf path because kid already points to the
+            // published DID document VM — verifier resolves the key via DID resolution
+            // rather than reading it inline from the JWS header.
+            if (signResultProbe is null)
+            {
+                credential = InjectIssuerJwkInHeader(credential, signingKey, signingAlgorithm);
+            }
 
             // Generate a fresh c_nonce for the next request
             var (newNonce, nonceExpiresIn) = await nonceStore.CreateAsync(ct);

--- a/src/Services/Sorcha.Haip.Service/Program.cs
+++ b/src/Services/Sorcha.Haip.Service/Program.cs
@@ -143,6 +143,23 @@ builder.Services.AddHttpClient<
     client.Timeout = TimeSpan.FromSeconds(10);
 });
 
+// Feature 120 — verifier-side anonymous DID resolution. SorchaDidResolver in HAIP
+// hits wallet's /api/v1/wallets/{addr}/did-document (anonymous) so the verifier
+// path doesn't need service-auth bearer just to read the public key.
+builder.Services.AddHttpClient("PublicWalletDid", client =>
+{
+    var walletAddress = builder.Configuration["ServiceClients:WalletService:Address"]
+        ?? "http://wallet-service:8080";
+    client.BaseAddress = new Uri(walletAddress);
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
+// Override SorchaDidResolver registration to use the constructor that takes the public-DID HttpClient.
+builder.Services.AddScoped<Sorcha.ServiceClients.Did.SorchaDidResolver>(sp =>
+    new Sorcha.ServiceClients.Did.SorchaDidResolver(
+        sp.GetRequiredService<Sorcha.ServiceClients.Wallet.IWalletServiceClient>(),
+        sp.GetRequiredService<IHttpClientFactory>().CreateClient("PublicWalletDid"),
+        sp.GetRequiredService<ILogger<Sorcha.ServiceClients.Did.SorchaDidResolver>>()));
+
 var app = builder.Build();
 
 // OpenAPI and Scalar UI

--- a/src/Services/Sorcha.Haip.Service/Services/HaipCredentialMinter.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/HaipCredentialMinter.cs
@@ -52,7 +52,8 @@ public class HaipCredentialMinter
         byte[] signingKey,
         string algorithm,
         DateTimeOffset? expiresAt = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? kid = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(issuerDid);
         ArgumentException.ThrowIfNullOrWhiteSpace(credentialType);
@@ -74,10 +75,61 @@ public class HaipCredentialMinter
             algorithm,
             holderJwk,
             expiresAt,
-            ct);
+            ct,
+            x5cChain: null,
+            kid: kid);
 
         _logger.LogInformation(
             "Minted HAIP credential: {Disclosures} disclosures, token length {Length}",
+            token.Disclosures.Count, token.RawToken.Length);
+
+        return token.RawToken;
+    }
+
+    /// <summary>
+    /// External-signer overload (Feature 120 HAIP kid-swap) — delegates signing to a
+    /// caller-supplied callback that produces the signature without HAIP holding the
+    /// private key. Used to sign credentials with the org's issuance key via the
+    /// wallet service's sign-on-behalf endpoint.
+    /// </summary>
+    public async Task<string> MintCredentialWithExternalSignerAsync(
+        string issuerDid,
+        JsonElement holderJwk,
+        string credentialType,
+        Dictionary<string, object> claims,
+        IEnumerable<string>? disclosablePaths,
+        Func<byte[], CancellationToken, Task<byte[]>> externalSigner,
+        string algorithm,
+        string kid,
+        DateTimeOffset? expiresAt = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(issuerDid);
+        ArgumentException.ThrowIfNullOrWhiteSpace(credentialType);
+        ArgumentNullException.ThrowIfNull(claims);
+        ArgumentNullException.ThrowIfNull(externalSigner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kid);
+
+        var subject = $"urn:credential:{credentialType}:{Guid.NewGuid():N}";
+
+        _logger.LogInformation(
+            "Minting HAIP credential via sign-on-behalf: type={Type}, issuer={Issuer}, kid={Kid}, disclosables={Count}",
+            credentialType, issuerDid, kid, disclosablePaths?.Count() ?? 0);
+
+        var token = await _sdJwtService.CreateTokenAsync(
+            claims,
+            disclosablePaths,
+            issuerDid,
+            subject,
+            algorithm,
+            externalSigner,
+            holderJwk,
+            kid,
+            expiresAt,
+            ct);
+
+        _logger.LogInformation(
+            "Minted HAIP credential (sign-on-behalf): {Disclosures} disclosures, token length {Length}",
             token.Disclosures.Count, token.RawToken.Length);
 
         return token.RawToken;

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/IssuanceKeyEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/IssuanceKeyEndpoints.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -41,6 +42,38 @@ public static class IssuanceKeyEndpoints
             .Produces<EnsureIssuanceKeyResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status500InternalServerError);
 
+        group.MapPost("/sign", SignWithIssuanceKey)
+            .WithName("SignWithOrgIssuanceKey")
+            .WithSummary("Sign-on-behalf — produce a signature using the org's Active issuance key")
+            .WithDescription(
+                "Signs the supplied bytes with the org's Active issuance private key and " +
+                "returns the signature plus the kid / issuer DID / algorithm to embed in " +
+                "the JWS header. Used by Sorcha.Haip.Service to delegate credential signing " +
+                "to wallet without transmitting private key material across services. " +
+                "Returns 404 when no Active issuance key exists.")
+            .Produces<SignWithIssuanceKeyResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status500InternalServerError);
+
+        // Anonymous DID-document resolution endpoint for did:sorcha:org:{addr}.
+        // Verifiers (e.g. Sorcha.Haip.Service.HaipPresentationVerifier via SorchaDidResolver)
+        // need the public key bytes for an org's issuance key, but the wallet GET endpoint
+        // is auth-gated. This endpoint exposes only the public W3C DID document — no
+        // private material — and is keyed on wallet address so resolvers don't need
+        // service-to-service auth.
+        app.MapGet("/api/v1/wallets/{address}/did-document", ResolveWalletDidDocument)
+            .WithName("ResolveWalletDidDocument")
+            .WithSummary("Public DID document resolution by wallet address (Feature 120 verifier path)")
+            .WithDescription(
+                "Returns the W3C DID document for did:sorcha:org:{address} including the " +
+                "wallet's public key under the standard #key-1 verification method id and, " +
+                "if an Active issuance key exists for the controlling org, an alias " +
+                "#vc-issuance-{n} verification method pointing at the same key bytes.")
+            .AllowAnonymous()
+            .Produces(StatusCodes.Status200OK, contentType: "application/did+json")
+            .Produces(StatusCodes.Status404NotFound)
+            .RequireRateLimiting(RateLimitPolicies.Api);
+
         return app;
     }
 
@@ -62,6 +95,143 @@ public static class IssuanceKeyEndpoints
             Thumbprint: state.Thumbprint,
             DerivedAt: state.DerivedAt));
     }
+
+    private static async Task<IResult> ResolveWalletDidDocument(
+        [FromRoute] string address,
+        [FromServices] Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository walletRepository,
+        [FromServices] IIssuanceKeyService issuanceKeyService,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+            return Results.BadRequest(new { error = "address is required" });
+
+        var wallet = await walletRepository.GetByAddressAsync(address, cancellationToken: ct);
+        if (wallet is null) return Results.NotFound();
+
+        var did = $"did:sorcha:org:{address}";
+        var publicKeyB64 = wallet.PublicKey ?? "";
+        var algorithm = wallet.Algorithm;
+
+        // Probe for an Active issuance key for this wallet's controlling org so we can
+        // emit a #vc-issuance-{n} alias VM. Skip silently when the wallet isn't an
+        // issuance-key wallet.
+        int? rotationIndex = null;
+        if (Guid.TryParse(wallet.Tenant, out var orgId))
+        {
+            var material = await issuanceKeyService.GetActiveAsync(orgId, ct);
+            if (material is not null)
+            {
+                rotationIndex = material.RotationIndex;
+                System.Security.Cryptography.CryptographicOperations.ZeroMemory(material.PublicKey);
+            }
+        }
+
+        var vmId = $"{did}#key-1";
+        var vmJwk = TryBuildJwkForResponse(algorithm, publicKeyB64);
+        var vms = new List<object>
+        {
+            new
+            {
+                id = vmId,
+                type = MapAlgorithmToKeyType(algorithm),
+                controller = did,
+                publicKeyJwk = vmJwk
+            }
+        };
+        if (rotationIndex is not null)
+        {
+            vms.Add(new
+            {
+                id = $"{did}#vc-issuance-{rotationIndex}",
+                type = MapAlgorithmToKeyType(algorithm),
+                controller = did,
+                publicKeyJwk = vmJwk
+            });
+        }
+
+        var doc = new Dictionary<string, object>
+        {
+            ["@context"] = new[] { "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" },
+            ["id"] = did,
+            ["verificationMethod"] = vms,
+            ["assertionMethod"] = vms.Select((v, i) => i == 0 ? vmId : $"{did}#vc-issuance-{rotationIndex}").ToArray(),
+            ["authentication"] = vms.Select((v, i) => i == 0 ? vmId : $"{did}#vc-issuance-{rotationIndex}").ToArray()
+        };
+        return Results.Json(doc, contentType: "application/did+json");
+    }
+
+    private static object? TryBuildJwkForResponse(string algorithm, string publicKeyBase64)
+    {
+        if (string.IsNullOrEmpty(publicKeyBase64)) return null;
+        byte[] raw;
+        try { raw = Convert.FromBase64String(publicKeyBase64); }
+        catch (FormatException) { return null; }
+
+        var b64u = (byte[] b) => Convert.ToBase64String(b).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var algo = algorithm?.ToUpperInvariant();
+        if (algo == "ED25519")
+            return new { kty = "OKP", crv = "Ed25519", x = b64u(raw) };
+        if ((algo is "NIST-P256" or "NISTP256" or "P-256" or "P256" or "ECDSA-P256")
+            && raw.Length == 65 && raw[0] == 0x04)
+        {
+            return new
+            {
+                kty = "EC",
+                crv = "P-256",
+                x = b64u(raw.AsSpan(1, 32).ToArray()),
+                y = b64u(raw.AsSpan(33, 32).ToArray())
+            };
+        }
+        return null;
+    }
+
+    private static string MapAlgorithmToKeyType(string algorithm)
+        => algorithm?.ToUpperInvariant() switch
+        {
+            "ED25519" => "Ed25519VerificationKey2020",
+            "NIST-P256" or "NISTP256" or "P-256" or "P256" or "ECDSA-P256" => "JsonWebKey2020",
+            _ => "JsonWebKey2020"
+        };
+
+    private static async Task<IResult> SignWithIssuanceKey(
+        [FromRoute] Guid orgId,
+        [FromBody] SignWithIssuanceKeyRequest request,
+        [FromServices] IIssuanceKeyService service,
+        [FromServices] Sorcha.Cryptography.SdJwt.ISdJwtSigner signer,
+        CancellationToken ct)
+    {
+        if (request is null || string.IsNullOrEmpty(request.DataBase64Url))
+            return Results.BadRequest(new { error = "DataBase64Url is required" });
+
+        var material = await service.GetActiveSigningMaterialAsync(orgId, ct);
+        if (material is null) return Results.NotFound();
+
+        byte[] data;
+        try
+        {
+            data = Sorcha.Cryptography.SdJwt.Base64UrlHelper.Decode(request.DataBase64Url);
+        }
+        catch (FormatException)
+        {
+            return Results.BadRequest(new { error = "DataBase64Url is not valid base64url" });
+        }
+
+        try
+        {
+            var signature = signer.Sign(data, material.PrivateKey, material.Algorithm);
+            return Results.Ok(new SignWithIssuanceKeyResponse(
+                SignatureBase64Url: Sorcha.Cryptography.SdJwt.Base64UrlHelper.Encode(signature),
+                Kid: material.Kid,
+                IssuerDid: material.IssuerDid,
+                Algorithm: material.Algorithm,
+                RotationIndex: material.RotationIndex));
+        }
+        finally
+        {
+            // Wipe the decrypted private key as soon as signing completes.
+            CryptographicOperations.ZeroMemory(material.PrivateKey);
+        }
+    }
 }
 
 /// <summary>Response shape for <c>POST /api/v1/orgs/{orgId}/issuance-key/ensure</c>.</summary>
@@ -71,3 +241,14 @@ public sealed record EnsureIssuanceKeyResponse(
     string Algorithm,
     string Thumbprint,
     DateTimeOffset DerivedAt);
+
+/// <summary>Request body for sign-on-behalf — base64url-encoded bytes to sign.</summary>
+public sealed record SignWithIssuanceKeyRequest(string DataBase64Url);
+
+/// <summary>Response shape for sign-on-behalf — signature + JWS header material.</summary>
+public sealed record SignWithIssuanceKeyResponse(
+    string SignatureBase64Url,
+    string Kid,
+    string IssuerDid,
+    string Algorithm,
+    int RotationIndex);


### PR DESCRIPTION
## Summary
Closes the visible F120 demonstration on walkthroughs. Before this PR, walkthroughs minted credentials via HAIP's `pre-authorized_code` flow which bypassed the wallet kid-swap (#604); credentials carried a self-signed `jwk` header. After this PR, AssuredIdentity full walkthrough (gateway, 00:50) issues credentials with `kid: did:sorcha:org:{addr}#vc-issuance-1` resolving through the published DID document, and Phase 2 verification succeeds via DID resolution (no fallback to header `jwk`).

### What landed
1. **Wallet sign-on-behalf endpoint** `POST /api/v1/orgs/{orgId}/issuance-key/sign` — signs caller-supplied bytes with the org's Active issuance key. Private key stays in wallet-service.
2. **Public DID document endpoint** `GET /api/v1/wallets/{addr}/did-document` (anonymous) — W3C-shaped doc with `#key-1` and `#vc-issuance-{n}` VMs + `publicKeyJwk`.
3. **`ISdJwtSigner` / `Base64UrlHelper`** — public surfaces for piecewise JWS construction.
4. **`ISdJwtService` external-signer overload** — accepts `Func<byte[], CancellationToken, Task<byte[]>>` for sign-on-behalf flows.
5. **`IIssuanceKeyClient.SignAsync`** — cross-service client method. Returns null on 404 so callers can fall back.
6. **`HaipCredentialMinter.MintCredentialWithExternalSignerAsync`** — overload routing through the external-signer path.
7. **HAIP `/credential` orchestration** — probes wallet.SignAsync; routes through external signer when an issuance key exists; skips the inline jwk-in-header on the sign-on-behalf path.
8. **`SorchaDidResolver` public-endpoint path** — new ctor variant uses an anonymous HttpClient for org DIDs. Emits `publicKeyJwk` + `#vc-issuance-1` alias VM.
9. **ActionExecutionService HAIP offer TenantId fix** — was using `instance.RegisterId` as tenantId; now uses the caller's `org_id` JWT claim.

### Coverage
- AssuredIdentity walkthrough (gateway, full): **00:50**
- `IssuanceKeyStates` + `OrgDidDocuments` populated for both walkthrough orgs
- Phase 2 presentation verification succeeds via DID resolution (kid-match against published VM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)