### PR TITLE
fix(120): expose wallet did-document + issuance-key routes through API gateway

### DIFF
--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -382,6 +382,8 @@
       "blueprint-file-chunks": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Match": { "Path": "/api/file-chunks/{**catch-all}" } },
 
       "wallet-file-download":  { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/v1/wallets/{address}/files/download" }, "Transforms": [ { "PathPattern": "/api/v1/wallets/{address}/files/download" } ] },
+      "wallet-did-document":   { "ClusterId": "wallet-cluster", "Order": 1, "Match": { "Path": "/api/v1/wallets/{address}/did-document" } },
+      "wallet-issuance-key":   { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/v1/orgs/{orgId}/issuance-key/{**remainder}" } },
       "wallet-org-keys":       { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/wallets/org/{**remainder}" }, "Transforms": [ { "PathPattern": "/api/wallets/org/{**remainder}" } ] },
       "wallet-wallets":        { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Match": { "Path": "/api/v1/wallets/{**catch-all}" } },
       "wallet-presentations":  { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/v1/presentations/{**catch-all}" } },


### PR DESCRIPTION
## Summary
External traffic to `https://n1.sorcha.dev/api/v1/wallets/{addr}/did-document` returns 401 because the order-2 `wallet-wallets` route requires authentication and matches the path. The endpoint itself is anonymous; the gateway just needs an order-1 override.

Adds:
- `wallet-did-document` — anonymous, exact-path match
- `wallet-issuance-key` — auth-gated, covers `/api/v1/orgs/{orgId}/issuance-key/*` (ensure + sign)

Internal HAIP→wallet calls aren't affected (they bypass the gateway). This fix only matters for third-party verifiers resolving `did:sorcha:org:*` via the public n1 hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)