### PR TITLE
fix(120): force higher gateway-route priority for wallet did-document

### DIFF
--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -382,8 +382,8 @@
       "blueprint-file-chunks": { "ClusterId": "blueprint-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Match": { "Path": "/api/file-chunks/{**catch-all}" } },
 
       "wallet-file-download":  { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/v1/wallets/{address}/files/download" }, "Transforms": [ { "PathPattern": "/api/v1/wallets/{address}/files/download" } ] },
-      "wallet-did-document":   { "ClusterId": "wallet-cluster", "Order": 1, "Match": { "Path": "/api/v1/wallets/{address}/did-document" } },
-      "wallet-issuance-key":   { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/v1/orgs/{orgId}/issuance-key/{**remainder}" } },
+      "wallet-did-document":   { "ClusterId": "wallet-cluster", "Order": -1, "Match": { "Path": "/api/v1/wallets/{address}/did-document" } },
+      "wallet-issuance-key":   { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": -1, "Match": { "Path": "/api/v1/orgs/{orgId}/issuance-key/{**remainder}" } },
       "wallet-org-keys":       { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Order": 1, "Match": { "Path": "/api/wallets/org/{**remainder}" }, "Transforms": [ { "PathPattern": "/api/wallets/org/{**remainder}" } ] },
       "wallet-wallets":        { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "RateLimiterPolicy": "strict", "Match": { "Path": "/api/v1/wallets/{**catch-all}" } },
       "wallet-presentations":  { "ClusterId": "wallet-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/v1/presentations/{**catch-all}" } },


### PR DESCRIPTION
Order:1 was lower priority than the catch-all wallet-wallets route's default Order:0, so the catch-all (which requires authentication) won the routing decision and returned 401 on anonymous /did-document requests. Order:-1 makes these routes evaluated first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)