### PR TITLE
feat(120 US6): issuance key rotation + revocation lifecycle (T066-T072)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Verifier/Services/DidResolverBackedIssuerKeyResolver.cs
+++ b/src/Apps/Sorcha.Citizen.Verifier/Services/DidResolverBackedIssuerKeyResolver.cs
@@ -116,6 +116,22 @@ public sealed class DidResolverBackedIssuerKeyResolver : IIssuerKeyResolver, IDi
             return null;
         }
 
+        // Feature 120 US6 — reject if the matched VM is not in assertionMethod.
+        // The published DID doc drops revoked-status keys from assertionMethod while
+        // keeping their entry in verificationMethod for verifiable history. A credential
+        // whose kid resolves to a present-but-not-asserting VM was signed by a key
+        // that's been revoked or is otherwise not authorised for assertion.
+        if (doc.AssertionMethod is { Count: > 0 } assertion
+            && !assertion.Any(id => string.Equals(id, matched.Id, StringComparison.Ordinal)))
+        {
+            RecordOutcome(activity, "key-revoked", matchMode);
+            _logger.LogWarning(
+                "Issuer key matched but is not in assertionMethod (revoked or otherwise unauthorised): " +
+                "iss={Issuer} kid={Kid} matched_vm={VmId}",
+                issuer, kid, matched.Id);
+            return null;
+        }
+
         RecordOutcome(activity, "success", matchMode);
         return matched.PublicKeyJwk;
     }

--- a/src/Common/Sorcha.Register.Models/GovernanceModels.cs
+++ b/src/Common/Sorcha.Register.Models/GovernanceModels.cs
@@ -39,7 +39,22 @@ public enum GovernanceOperationType
     /// <summary>
     /// Rotate a validator's signing key (mark old as Rotated, add new Active key)
     /// </summary>
-    RotateValidatorKey = 5
+    RotateValidatorKey = 5,
+
+    /// <summary>
+    /// Feature 120 US6 (VAL_CRED_GOV_001) — revoke an organisation's issuance key.
+    /// After quorum approval, the wallet service marks the named rotation as
+    /// <c>Revoked</c>, the published DID document drops it from
+    /// <c>assertionMethod</c>, and verifiers reject credentials signed by it.
+    /// </summary>
+    RevokeIssuanceKey = 6,
+
+    /// <summary>
+    /// Feature 120 US6 — rotate an organisation's issuance key. Marks the
+    /// existing Active key as <c>Rotated</c> and derives a new key at the next
+    /// rotation index.
+    /// </summary>
+    RotateIssuanceKey = 7
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/IssuanceKeyEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/IssuanceKeyEndpoints.cs
@@ -55,6 +55,27 @@ public static class IssuanceKeyEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status500InternalServerError);
 
+        group.MapPost("/rotate", RotateIssuanceKey)
+            .WithName("RotateOrgIssuanceKey")
+            .WithSummary("Rotate the org's Active issuance key (Feature 120 US6)")
+            .WithDescription(
+                "Marks the existing Active key as Rotated and derives a new key at the next " +
+                "rotation index. Triggers DID document regeneration. Body carries the " +
+                "governance-op id that authorised the rotation (auditing).")
+            .Produces<EnsureIssuanceKeyResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost("/revoke", RevokeIssuanceKey)
+            .WithName("RevokeOrgIssuanceKey")
+            .WithSummary("Revoke a specific issuance key by rotation index (Feature 120 US6)")
+            .WithDescription(
+                "Marks the named rotation as Revoked, records the reason and authorising " +
+                "governance op, and triggers DID document regeneration. The published " +
+                "DID document drops the revoked key from assertionMethod so verifiers " +
+                "reject credentials signed by it. Idempotent on already-revoked keys.")
+            .Produces<RevokeIssuanceKeyResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
+
         // Anonymous DID-document resolution endpoint for did:sorcha:org:{addr}.
         // Verifiers (e.g. Sorcha.Haip.Service.HaipPresentationVerifier via SorchaDidResolver)
         // need the public key bytes for an org's issuance key, but the wallet GET endpoint
@@ -96,6 +117,45 @@ public static class IssuanceKeyEndpoints
             DerivedAt: state.DerivedAt));
     }
 
+    private static async Task<IResult> RotateIssuanceKey(
+        [FromRoute] Guid orgId,
+        [FromBody] RotateIssuanceKeyRequest request,
+        [FromServices] IIssuanceKeyService service,
+        CancellationToken ct)
+    {
+        var newRow = await service.RotateAsync(orgId, request.GovernanceOpId, ct);
+        if (newRow is null)
+            return Results.NotFound(new { error = "No Active issuance key to rotate" });
+
+        return Results.Ok(new EnsureIssuanceKeyResponse(
+            OrganizationId: newRow.OrganizationId,
+            RotationIndex: newRow.RotationIndex,
+            Algorithm: newRow.Algorithm,
+            Thumbprint: newRow.Thumbprint,
+            DerivedAt: newRow.DerivedAt));
+    }
+
+    private static async Task<IResult> RevokeIssuanceKey(
+        [FromRoute] Guid orgId,
+        [FromBody] RevokeIssuanceKeyRequest request,
+        [FromServices] IIssuanceKeyService service,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.Reason))
+            return Results.BadRequest(new { error = "Reason is required" });
+
+        var row = await service.RevokeAsync(
+            orgId, request.RotationIndex, request.Reason, request.GovernanceOpId, ct);
+        if (row is null)
+            return Results.NotFound(new { error = "No issuance key found for the supplied rotation index" });
+
+        return Results.Ok(new RevokeIssuanceKeyResponse(
+            OrganizationId: row.OrganizationId,
+            RotationIndex: row.RotationIndex,
+            Status: row.Status.ToString(),
+            RevokedAt: row.RevokedAt));
+    }
+
     private static async Task<IResult> ResolveWalletDidDocument(
         [FromRoute] string address,
         [FromServices] Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository walletRepository,
@@ -112,18 +172,16 @@ public static class IssuanceKeyEndpoints
         var publicKeyB64 = wallet.PublicKey ?? "";
         var algorithm = wallet.Algorithm;
 
-        // Probe for an Active issuance key for this wallet's controlling org so we can
-        // emit a #vc-issuance-{n} alias VM. Skip silently when the wallet isn't an
-        // issuance-key wallet.
-        int? rotationIndex = null;
+        // Feature 120 US6 — emit one VM per issuance-key row, marking revoked rows by
+        // EXCLUDING them from assertionMethod / authentication. Revoked VMs remain in the
+        // document for verifiable history (a verifier inspecting an old credential's
+        // signature can still read the public key) but cannot be used to assert new
+        // credentials. Result: revocation enforcement is a property of the published
+        // document shape, not a separate verifier-side lookup.
+        IReadOnlyList<Sorcha.Wallet.Core.Domain.Entities.IssuanceKeyState>? allKeys = null;
         if (Guid.TryParse(wallet.Tenant, out var orgId))
         {
-            var material = await issuanceKeyService.GetActiveAsync(orgId, ct);
-            if (material is not null)
-            {
-                rotationIndex = material.RotationIndex;
-                System.Security.Cryptography.CryptographicOperations.ZeroMemory(material.PublicKey);
-            }
+            allKeys = await issuanceKeyService.ListAllAsync(orgId, ct);
         }
 
         var vmId = $"{did}#key-1";
@@ -138,15 +196,25 @@ public static class IssuanceKeyEndpoints
                 publicKeyJwk = vmJwk
             }
         };
-        if (rotationIndex is not null)
+        var assertionIds = new List<string> { vmId };
+
+        if (allKeys is not null)
         {
-            vms.Add(new
+            foreach (var k in allKeys)
             {
-                id = $"{did}#vc-issuance-{rotationIndex}",
-                type = MapAlgorithmToKeyType(algorithm),
-                controller = did,
-                publicKeyJwk = vmJwk
-            });
+                var kid = $"{did}#vc-issuance-{k.RotationIndex}";
+                vms.Add(new
+                {
+                    id = kid,
+                    type = MapAlgorithmToKeyType(k.Algorithm),
+                    controller = did,
+                    publicKeyJwk = vmJwk
+                });
+                if (k.Status == Sorcha.Wallet.Core.Domain.Enums.IssuanceKeyStatus.Active)
+                {
+                    assertionIds.Add(kid);
+                }
+            }
         }
 
         var doc = new Dictionary<string, object>
@@ -154,8 +222,8 @@ public static class IssuanceKeyEndpoints
             ["@context"] = new[] { "https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1" },
             ["id"] = did,
             ["verificationMethod"] = vms,
-            ["assertionMethod"] = vms.Select((v, i) => i == 0 ? vmId : $"{did}#vc-issuance-{rotationIndex}").ToArray(),
-            ["authentication"] = vms.Select((v, i) => i == 0 ? vmId : $"{did}#vc-issuance-{rotationIndex}").ToArray()
+            ["assertionMethod"] = assertionIds.ToArray(),
+            ["authentication"] = assertionIds.ToArray()
         };
         return Results.Json(doc, contentType: "application/did+json");
     }
@@ -241,6 +309,19 @@ public sealed record EnsureIssuanceKeyResponse(
     string Algorithm,
     string Thumbprint,
     DateTimeOffset DerivedAt);
+
+/// <summary>Request body for rotation — carries the authorising governance-op id.</summary>
+public sealed record RotateIssuanceKeyRequest(Guid GovernanceOpId);
+
+/// <summary>Request body for revocation.</summary>
+public sealed record RevokeIssuanceKeyRequest(int RotationIndex, string Reason, Guid GovernanceOpId);
+
+/// <summary>Response for revocation.</summary>
+public sealed record RevokeIssuanceKeyResponse(
+    Guid OrganizationId,
+    int RotationIndex,
+    string Status,
+    DateTimeOffset? RevokedAt);
 
 /// <summary>Request body for sign-on-behalf — base64url-encoded bytes to sign.</summary>
 public sealed record SignWithIssuanceKeyRequest(string DataBase64Url);

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/IssuanceKeyService.cs
@@ -242,6 +242,174 @@ public sealed class IssuanceKeyService : IIssuanceKeyService
             RotationIndex: state.RotationIndex);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<IssuanceKeyState>> ListAllAsync(
+        Guid organizationId, CancellationToken ct = default)
+    {
+        return await _db.IssuanceKeyStates
+            .Where(k => k.OrganizationId == organizationId && k.Slot == IssuanceSlot)
+            .OrderBy(k => k.RotationIndex)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IssuanceKeyState?> RotateAsync(
+        Guid organizationId, Guid governanceOpId, CancellationToken ct = default)
+    {
+        var existing = await _db.IssuanceKeyStates
+            .FirstOrDefaultAsync(
+                k => k.OrganizationId == organizationId
+                  && k.Slot == IssuanceSlot
+                  && k.Status == IssuanceKeyStatus.Active,
+                ct)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+        {
+            _logger.LogWarning(
+                "Cannot rotate issuance key for org {OrgId}: no Active row exists. Did you mean to call GetOrDeriveAsync first?",
+                organizationId);
+            return null;
+        }
+
+        // Move existing Active → Rotated.
+        existing.Status = IssuanceKeyStatus.Rotated;
+        existing.RotatedAt = DateTimeOffset.UtcNow;
+
+        // V1 rotation is a kid-bump only — Feature 083's OrgKeyDerivationService
+        // hardcodes KeyIndex=0 and re-derives the same key on every call, so the
+        // public key bytes don't change between rotation indices. The new IssuanceKeyState
+        // row inherits PublicKey + Thumbprint from the previous Active row; what changes is
+        // the kid suffix (#vc-issuance-{newIndex}). Real cryptographic rotation
+        // (different key bytes per index) lands when OrgKeyDerivationService gains an
+        // explicit rotation-index parameter — separate F083 follow-up.
+        var newRow = new IssuanceKeyState
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            Slot = IssuanceSlot,
+            RotationIndex = existing.RotationIndex + 1,
+            Status = IssuanceKeyStatus.Active,
+            PublicKey = existing.PublicKey,
+            Algorithm = existing.Algorithm,
+            Thumbprint = existing.Thumbprint,
+            DerivedAt = DateTimeOffset.UtcNow
+        };
+        _db.IssuanceKeyStates.Add(newRow);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Issuance key rotated for org {OrgId}: {OldIdx} → {NewIdx} (governance op {GovOp})",
+            organizationId, existing.RotationIndex, newRow.RotationIndex, governanceOpId);
+
+        // DID document regeneration triggered with the new active-keys snapshot.
+        // Look up the wallet address from any DerivedKeyRecord — the address doesn't
+        // change between rotations under the v1 same-key model.
+        var derivedRecord = await _db.DerivedKeyRecords
+            .FirstOrDefaultAsync(
+                d => d.OrganizationId == organizationId.ToString()
+                  && d.KeyUsage == KeyUsage.VCIssuance,
+                ct)
+            .ConfigureAwait(false);
+        if (derivedRecord is not null)
+        {
+            await PushDidDocumentSnapshotAsync(
+                organizationId, derivedRecord.WalletAddress, "IssuanceKeyRotated", ct)
+                .ConfigureAwait(false);
+        }
+
+        return newRow;
+    }
+
+    /// <inheritdoc />
+    public async Task<IssuanceKeyState?> RevokeAsync(
+        Guid organizationId,
+        int rotationIndex,
+        string reason,
+        Guid governanceOpId,
+        CancellationToken ct = default)
+    {
+        var row = await _db.IssuanceKeyStates
+            .FirstOrDefaultAsync(
+                k => k.OrganizationId == organizationId
+                  && k.Slot == IssuanceSlot
+                  && k.RotationIndex == rotationIndex,
+                ct)
+            .ConfigureAwait(false);
+
+        if (row is null) return null;
+
+        if (row.Status == IssuanceKeyStatus.Revoked)
+        {
+            _logger.LogDebug(
+                "Issuance key already revoked for org {OrgId} rotation {Idx} — idempotent no-op",
+                organizationId, rotationIndex);
+            return row;
+        }
+
+        row.Status = IssuanceKeyStatus.Revoked;
+        row.RevokedAt = DateTimeOffset.UtcNow;
+        row.RevocationReason = reason;
+        row.RevokedByGovernanceOpId = governanceOpId;
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogWarning(
+            "Issuance key revoked for org {OrgId} rotation {Idx} reason='{Reason}' (governance op {GovOp})",
+            organizationId, rotationIndex, reason, governanceOpId);
+
+        // Trigger DID document regeneration so the published doc drops the revoked VM
+        // from assertionMethod (verifier-side rejection follows from the W3C doc shape,
+        // no additional check needed in DidResolverBackedIssuerKeyResolver).
+        var derivedRecord = await _db.DerivedKeyRecords
+            .FirstOrDefaultAsync(
+                d => d.OrganizationId == organizationId.ToString()
+                  && d.KeyUsage == KeyUsage.VCIssuance
+                  && d.Status == DerivedKeyStatus.Active,
+                ct)
+            .ConfigureAwait(false);
+        if (derivedRecord is not null)
+        {
+            await PushDidDocumentSnapshotAsync(
+                organizationId, derivedRecord.WalletAddress, "IssuanceKeyRevoked", ct)
+                .ConfigureAwait(false);
+        }
+
+        return row;
+    }
+
+    /// <summary>
+    /// Builds an active-keys snapshot from the current persisted state and pushes it
+    /// to the Tenant Service via <see cref="IOrgDidDocumentClient"/>. Used after
+    /// rotation/revocation to regenerate the published DID document.
+    /// </summary>
+    private async Task PushDidDocumentSnapshotAsync(
+        Guid organizationId, string walletAddress, string keyEventReason, CancellationToken ct)
+    {
+        var activeKeys = await _db.IssuanceKeyStates
+            .Where(k => k.OrganizationId == organizationId
+                     && k.Slot == IssuanceSlot
+                     && k.Status == IssuanceKeyStatus.Active)
+            .OrderBy(k => k.RotationIndex)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var snapshotKeys = activeKeys
+            .Select(k => new OrgDidActiveKey(
+                RotationIndex: k.RotationIndex,
+                Algorithm: k.Algorithm,
+                PublicKeyJwk: BuildJwk(k.Algorithm, k.PublicKey),
+                Thumbprint: k.Thumbprint))
+            .ToList();
+
+        var snapshot = new OrgDidRegenerateRequest(
+            OrganizationId: organizationId,
+            KeyEventReason: keyEventReason,
+            WalletAddress: walletAddress,
+            ActiveKeys: snapshotKeys);
+        await _didDocClient.RegenerateAsync(snapshot, ct).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Builds the JWK JSON for an issuance public key. Currently supports the wallet
     /// algorithms exposed by <see cref="IOrgKeyDerivationService"/> — ED25519 (OKP),

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IIssuanceKeyService.cs
@@ -50,6 +50,36 @@ public interface IIssuanceKeyService
     /// </remarks>
     Task<IssuanceSigningMaterial?> GetActiveSigningMaterialAsync(
         Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every <see cref="IssuanceKeyState"/> row for an org regardless of status.
+    /// Used by the published-DID-document path so callers can decide whether to emit a
+    /// revoked key's VM (default: drop from <c>assertionMethod</c> + omit from VM list).
+    /// </summary>
+    Task<IReadOnlyList<IssuanceKeyState>> ListAllAsync(
+        Guid organizationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Rotates the org's Active issuance key (Feature 120 US6 / T067). Marks the
+    /// existing Active row as <c>Rotated</c> and derives a fresh key at the next
+    /// rotation index. Triggers DID document regeneration with reason
+    /// <c>IssuanceKeyRotated</c>.
+    /// </summary>
+    Task<IssuanceKeyState?> RotateAsync(
+        Guid organizationId, Guid governanceOpId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Revokes a specific issuance key by rotation index (Feature 120 US6 / T068).
+    /// Marks <c>Status=Revoked</c> with <c>RevokedAt</c>, <c>RevocationReason</c>,
+    /// <c>RevokedByGovernanceOpId</c>. Idempotent on already-revoked keys.
+    /// Triggers DID document regeneration with reason <c>IssuanceKeyRevoked</c>.
+    /// </summary>
+    Task<IssuanceKeyState?> RevokeAsync(
+        Guid organizationId,
+        int rotationIndex,
+        string reason,
+        Guid governanceOpId,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/tests/Sorcha.Wallet.Service.Tests/Services/IssuanceKeyServiceLifecycleTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/IssuanceKeyServiceLifecycleTests.cs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.ServiceClients.OrgDidDocument;
+using Sorcha.Wallet.Core.Data;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Domain.Enums;
+using Sorcha.Wallet.Core.Services.Interfaces;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Xunit;
+using WalletEntity = Sorcha.Wallet.Core.Domain.Entities.Wallet;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Feature 120 US6 — covers <see cref="IssuanceKeyService"/>'s rotate/revoke lifecycle
+/// without exercising the full Feature 083 derivation chain (mocked).
+/// </summary>
+public sealed class IssuanceKeyServiceLifecycleTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly WalletDbContext _db;
+    private readonly Mock<IOrgKeyDerivationService> _orgKey = new();
+    private readonly Mock<IOrgDidDocumentClient> _didClient = new();
+    private readonly Mock<IOrgKeyProtectionProvider> _protection = new();
+    private readonly IssuanceKeyService _sut;
+    private readonly Guid _orgId = Guid.NewGuid();
+    private readonly string _walletAddress = "ws11qpdemoissuancewallet";
+
+    public IssuanceKeyServiceLifecycleTests()
+    {
+        // Sqlite in-memory under a test-only DbContext that ignores Postgres-specific
+        // jsonb mappings. The real WalletDbContext maps Wallet.Metadata as
+        // Dictionary<string, string> → jsonb which neither InMemory nor Sqlite accepts.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<WalletDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _db = new TestWalletDbContext(options);
+        _db.Database.EnsureCreated();
+
+        // Idempotent re-derivation (returns the same wallet address each call).
+        _orgKey.Setup(x => x.DeriveUserKeyAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<uint>(), KeyUsage.VCIssuance, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DerivedKeyResult(
+                Guid.NewGuid(), _walletAddress, "m/test", KeyUsage.VCIssuance, 0,
+                "Active", "Custodial", DateTime.UtcNow));
+
+        _didClient.Setup(x => x.RegenerateAsync(It.IsAny<OrgDidRegenerateRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new IssuanceKeyService(
+            _db, _orgKey.Object, _didClient.Object, _protection.Object,
+            NullLogger<IssuanceKeyService>.Instance);
+    }
+
+    private void SeedActiveKey(int rotationIndex = 1)
+    {
+        var publicKey = new byte[32];
+        new Random(42).NextBytes(publicKey);
+
+        _db.IssuanceKeyStates.Add(new IssuanceKeyState
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _orgId,
+            Slot = 1,
+            RotationIndex = rotationIndex,
+            Status = IssuanceKeyStatus.Active,
+            PublicKey = publicKey,
+            Algorithm = "ED25519",
+            Thumbprint = "PLACEHOLDER0000000000000000000000000000Aaa",
+            DerivedAt = DateTimeOffset.UtcNow
+        });
+        _db.DerivedKeyRecords.Add(new DerivedKeyRecord
+        {
+            Id = Guid.NewGuid(),
+            OrgMasterKeyId = Guid.NewGuid(),
+            OrganizationId = _orgId.ToString(),
+            UserId = _orgId.ToString(),
+            DepartmentId = 0,
+            KeyUsage = KeyUsage.VCIssuance,
+            KeyIndex = 0,
+            DerivationPath = "m/test",
+            WalletAddress = _walletAddress,
+            Status = DerivedKeyStatus.Active,
+            CustodyMode = CustodyMode.Custodial
+        });
+        _db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task RotateAsync_NoActiveKey_ReturnsNull()
+    {
+        var result = await _sut.RotateAsync(_orgId, Guid.NewGuid());
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RotateAsync_MovesActiveToRotated_AndCreatesNewActive()
+    {
+        SeedActiveKey(rotationIndex: 1);
+
+        var newRow = await _sut.RotateAsync(_orgId, Guid.NewGuid());
+
+        newRow.Should().NotBeNull();
+        newRow!.RotationIndex.Should().Be(2);
+        newRow.Status.Should().Be(IssuanceKeyStatus.Active);
+
+        var rows = await _db.IssuanceKeyStates
+            .Where(k => k.OrganizationId == _orgId).OrderBy(k => k.RotationIndex).ToListAsync();
+        rows.Should().HaveCount(2);
+        rows[0].RotationIndex.Should().Be(1);
+        rows[0].Status.Should().Be(IssuanceKeyStatus.Rotated);
+        rows[0].RotatedAt.Should().NotBeNull();
+        rows[1].RotationIndex.Should().Be(2);
+        rows[1].Status.Should().Be(IssuanceKeyStatus.Active);
+    }
+
+    [Fact]
+    public async Task RotateAsync_TriggersDidDocumentRegeneration()
+    {
+        SeedActiveKey();
+        await _sut.RotateAsync(_orgId, Guid.NewGuid());
+        _didClient.Verify(x => x.RegenerateAsync(
+            It.Is<OrgDidRegenerateRequest>(r => r.KeyEventReason == "IssuanceKeyRotated"
+                                             && r.OrganizationId == _orgId),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_UnknownRotation_ReturnsNull()
+    {
+        SeedActiveKey();
+        var result = await _sut.RevokeAsync(_orgId, rotationIndex: 99, "test", Guid.NewGuid());
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RevokeAsync_MarksRevokedWithReasonAndOpId()
+    {
+        SeedActiveKey();
+        var govOp = Guid.NewGuid();
+
+        var revoked = await _sut.RevokeAsync(_orgId, 1, "key compromise", govOp);
+
+        revoked.Should().NotBeNull();
+        revoked!.Status.Should().Be(IssuanceKeyStatus.Revoked);
+        revoked.RevokedAt.Should().NotBeNull();
+        revoked.RevocationReason.Should().Be("key compromise");
+        revoked.RevokedByGovernanceOpId.Should().Be(govOp);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_AlreadyRevoked_IsIdempotent()
+    {
+        SeedActiveKey();
+        await _sut.RevokeAsync(_orgId, 1, "first revoke", Guid.NewGuid());
+        var second = await _sut.RevokeAsync(_orgId, 1, "second revoke", Guid.NewGuid());
+
+        // Idempotent — second call returns the existing Revoked row unchanged.
+        second.Should().NotBeNull();
+        second!.Status.Should().Be(IssuanceKeyStatus.Revoked);
+        second.RevocationReason.Should().Be("first revoke");
+    }
+
+    [Fact]
+    public async Task RevokeAsync_RevokedRotatedKey_Permitted()
+    {
+        SeedActiveKey(rotationIndex: 1);
+        // Rotate first so rotation 1 becomes Rotated.
+        await _sut.RotateAsync(_orgId, Guid.NewGuid());
+        // Now revoke the rotated rotation 1 — permitted per data-model state machine.
+        var revoked = await _sut.RevokeAsync(_orgId, 1, "rotated then compromised", Guid.NewGuid());
+        revoked.Should().NotBeNull();
+        revoked!.Status.Should().Be(IssuanceKeyStatus.Revoked);
+    }
+
+    [Fact]
+    public async Task ListAllAsync_ReturnsRowsOrderedByRotationIndex()
+    {
+        SeedActiveKey(rotationIndex: 1);
+        await _sut.RotateAsync(_orgId, Guid.NewGuid()); // creates rotation 2
+        await _sut.RevokeAsync(_orgId, 2, "test", Guid.NewGuid());
+
+        var all = await _sut.ListAllAsync(_orgId);
+
+        all.Should().HaveCount(2);
+        all[0].RotationIndex.Should().Be(1);
+        all[0].Status.Should().Be(IssuanceKeyStatus.Rotated);
+        all[1].RotationIndex.Should().Be(2);
+        all[1].Status.Should().Be(IssuanceKeyStatus.Revoked);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Test DbContext that ignores Postgres-specific jsonb columns + columns with
+    /// Postgres-only defaults (e.g., gen_random_uuid()) so EF model validation passes
+    /// under Sqlite. Retains the IssuanceKeyStates / DerivedKeyRecords mappings the
+    /// service-under-test exercises.
+    /// </summary>
+    /// <summary>
+    /// Minimal Sqlite-friendly DbContext exposing only the entities IssuanceKeyService
+    /// touches. The real WalletDbContext maps several Dictionary&lt;string,string&gt; →
+    /// jsonb columns that neither InMemory nor Sqlite providers accept.
+    /// </summary>
+    private sealed class TestWalletDbContext : WalletDbContext
+    {
+        public TestWalletDbContext(DbContextOptions<WalletDbContext> options) : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasDefaultSchema("wallet");
+
+            // Ignore every other entity type — they bring jsonb / Postgres-specific
+            // mappings the relational test provider can't satisfy. We only need
+            // IssuanceKeyState + DerivedKeyRecord for IssuanceKeyService coverage.
+            modelBuilder.Ignore<WalletEntity>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.WalletAddress>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.WalletAccess>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.WalletTransaction>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.CredentialEntity>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.RecoveryKeyWrap>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.RecoveryAuditLog>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.OrgMasterKey>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.ThresholdKeyGroup>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.SigningKeyShare>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.SigningSession>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.CitizenDeviceStatusList>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.CitizenWalletSyncCursor>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.CitizenHolderIndex>();
+            modelBuilder.Ignore<Sorcha.Wallet.Core.Domain.Entities.CitizenCredentialEventLog>();
+
+            modelBuilder.Entity<IssuanceKeyState>(e =>
+            {
+                e.ToTable("IssuanceKeyStates");
+                e.HasKey(x => x.Id);
+                e.Property(x => x.Status).HasConversion<int>().IsRequired();
+            });
+
+            modelBuilder.Entity<DerivedKeyRecord>(e =>
+            {
+                e.ToTable("DerivedKeyRecords");
+                e.HasKey(x => x.Id);
+                e.Property(x => x.KeyUsage).HasConversion<string>().IsRequired();
+                e.Property(x => x.Status).HasConversion<string>().IsRequired();
+                e.Property(x => x.CustodyMode).HasConversion<string>().IsRequired();
+                e.Ignore(x => x.OrgMasterKey);
+                e.Ignore(x => x.Wallet);
+            });
+        }
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj
+++ b/tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
## Summary
Final F120 user story — admin-driven rotation and revocation for org issuance keys, with verifier-side enforcement via the published DID document shape (revoked VMs absent from `assertionMethod`).

### What landed
- **T066** `IIssuanceKeyService.ListAllAsync` / `RotateAsync` / `RevokeAsync`
- **T067** `RotateAsync` v1 — kid-bump only; same key bytes, new rotation index. Real cryptographic rotation needs OrgKeyDerivationService to gain a rotation-index parameter (F083 follow-up).
- **T068** `RevokeAsync` — `Status=Revoked` + `RevokedAt` + `RevocationReason` + `RevokedByGovernanceOpId`. Idempotent.
- **T069** `GovernanceOperationType.RevokeIssuanceKey = 6` + `RotateIssuanceKey = 7`. Covers VAL_CRED_GOV_001.
- **T071** Public `/api/v1/wallets/{addr}/did-document` endpoint emits one VM per rotation index; only Active rows in `assertionMethod` / `authentication`. Revoked rows stay in `verificationMethod` for verifiable history.
- **T072** `DidResolverBackedIssuerKeyResolver` rejects credentials whose matched VM is not in `assertionMethod` (`verifier.issuer.outcome=key-revoked`).

### Admin endpoints
- `POST /api/v1/orgs/{orgId}/issuance-key/rotate`
- `POST /api/v1/orgs/{orgId}/issuance-key/revoke`

### Deferred
- **T070** governance quorum op handler — needs validator-rule wiring
- **T073** audit log integration

### Tests
8 new `IssuanceKeyServiceLifecycleTests` (rotate flows, revoke flows, idempotency, ListAll ordering). Uses a Sqlite-friendly `TestWalletDbContext` that ignores the real DbContext's jsonb-mapped entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)