### PR TITLE
fix(blueprint): RecipientsWallets parity on legacy /api/actions POST

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1199,6 +1199,13 @@ actionsGroup.MapPost("/", async (
             TxId = txHashHex,
             RegisterId = request.RegisterAddress,
             SenderWallet = request.SenderWallet,
+            // RecipientsWallets parity with the action-executor path so the Register
+            // Service's InboundTransactionRouter can notify recipients on seal. The
+            // encryptedPayloads dictionary is keyed by recipient wallet address, so
+            // its keys ARE the recipients list. The action-executor path populates
+            // this via BuiltTransaction.RecipientsWallets; this legacy /api/actions
+            // POST entry point was dropping it.
+            RecipientsWallets = encryptedPayloads.Keys.ToList(),
             TimeStamp = DateTime.UtcNow,
             PrevTxId = previousTxId ?? string.Empty,
             MetaData = transaction.Metadata != null ?


### PR DESCRIPTION
## Summary
- The legacy `/api/actions` POST endpoint (Blueprint Service) built `TransactionModel` inline without `RecipientsWallets`, while the action-executor path (`BuiltTransaction.RecipientsWallets`) populates it correctly.
- Investigation of live MongoDB register data confirmed the action-executor path is the production hot path and works (recipients populated). The legacy `/api/actions` POST is now only hit by tests, the CLI, and perf tests — but still a real correctness gap.
- One-line defensive parity fix: `RecipientsWallets = encryptedPayloads.Keys.ToList()`.

## Context
Tracked under the F106 RecipientsWallets pipeline gap memory. PR #311 fixed the runtime path (`DocketBuildTriggerService.WriteDocketAndTransactionsAsync`); this closes the matching gap on the legacy entry point so tests and CLI submissions don't silently regress F106 delivery.

## Test plan
- [x] `dotnet build src/Services/Sorcha.Blueprint.Service` — 0 errors
- [ ] CI green