### PR TITLE
fix(multi-node #2): propagate credential status changes via register tx

### DIFF
--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialStatusChangePayload.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialStatusChangePayload.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Serialization;
+using DataAnnotations = System.ComponentModel.DataAnnotations;
+
+namespace Sorcha.Blueprint.Models.Credentials;
+
+/// <summary>
+/// Payload of a <c>TransactionType.CredentialStatusChange</c> register transaction —
+/// carries an issuer-driven credential lifecycle event (Revoke / Suspend / Reinstate)
+/// that the recipient's wallet node applies to its locally cached credential row.
+/// </summary>
+/// <remarks>
+/// Multi-node audit CRITICAL #2 fix. The W3C BitstringStatusList update remains the
+/// authoritative cross-node mechanism for verifier-side status checks; this payload
+/// keeps the holder's local cached row in sync without relying on direct
+/// wallet-to-wallet HTTP, which silently no-ops on multi-node deployments.
+/// </remarks>
+public class CredentialStatusChangePayload
+{
+    /// <summary>
+    /// DID URI of the credential whose status is changing.
+    /// </summary>
+    [DataAnnotations.Required]
+    [DataAnnotations.MinLength(1)]
+    [DataAnnotations.MaxLength(500)]
+    [JsonPropertyName("credentialId")]
+    public string CredentialId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// New status — one of <c>Revoked</c>, <c>Suspended</c>, <c>Active</c>.
+    /// </summary>
+    [DataAnnotations.Required]
+    [DataAnnotations.MinLength(1)]
+    [DataAnnotations.MaxLength(32)]
+    [JsonPropertyName("newStatus")]
+    public string NewStatus { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Wallet address of the issuing authority requesting the status change.
+    /// Holder-side handler verifies this matches the credential's original issuer
+    /// before applying the change.
+    /// </summary>
+    [DataAnnotations.Required]
+    [DataAnnotations.MinLength(1)]
+    [DataAnnotations.MaxLength(200)]
+    [JsonPropertyName("issuerWallet")]
+    public string IssuerWallet { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Wallet address of the credential holder (subject). Drives recipient routing.
+    /// </summary>
+    [DataAnnotations.Required]
+    [DataAnnotations.MinLength(1)]
+    [DataAnnotations.MaxLength(200)]
+    [JsonPropertyName("subjectDid")]
+    public string SubjectDid { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Issuer-supplied reason — surfaced in holder UI and audit logs.
+    /// </summary>
+    [DataAnnotations.MaxLength(1000)]
+    [JsonPropertyName("reason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Timestamp of the status change.
+    /// </summary>
+    [DataAnnotations.Required]
+    [JsonPropertyName("changedAt")]
+    public DateTimeOffset ChangedAt { get; set; }
+}

--- a/src/Common/Sorcha.Register.Models/Enums/TransactionType.cs
+++ b/src/Common/Sorcha.Register.Models/Enums/TransactionType.cs
@@ -49,5 +49,15 @@ public enum TransactionType
     /// Presentation-abandoned transaction (Feature 111 — validity window expired
     /// with no callback; opt-in per blueprint).
     /// </summary>
-    PresentationAbandoned = 7
+    PresentationAbandoned = 7,
+
+    /// <summary>
+    /// Credential status change (multi-node audit CRITICAL #2 — issuer revokes /
+    /// suspends / reinstates a credential. Recipient is the holder's wallet
+    /// address; the transaction propagates the new status to the holder's node
+    /// via the existing InboundTransactionRouter pipeline. Status list bitstring
+    /// remains the authoritative cross-node check for verifiers — this tx exists
+    /// to keep the holder's locally-cached row in sync.)
+    /// </summary>
+    CredentialStatusChange = 8
 }

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
@@ -447,6 +447,14 @@ public class CredentialIssuanceResult
     /// Index position in the Bitstring Status List.
     /// </summary>
     public int? StatusListIndex { get; init; }
+
+    /// <summary>
+    /// Register the credential was issued against. Needed by Blueprint Service
+    /// credential-lifecycle endpoints (revoke / suspend / reinstate) to submit
+    /// the corresponding <c>CredentialStatusChange</c> register transaction
+    /// (multi-node audit CRITICAL #2).
+    /// </summary>
+    public string? RegisterId { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/CredentialEndpoints.cs
@@ -4,12 +4,16 @@
 #pragma warning disable ASPDEPR002 // WithOpenApi is deprecated; using it for co-located endpoint examples until transformer API stabilizes
 
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;
 
 using Sorcha.Blueprint.Models.Credentials;
 using Sorcha.Blueprint.Service.Services;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Sorcha.ServiceClients.Register;
 using Sorcha.ServiceClients.Wallet;
 
 namespace Sorcha.Blueprint.Service.Endpoints;
@@ -95,6 +99,7 @@ public static class CredentialEndpoints
         string credentialId,
         [FromBody] RevokeCredentialRequest request,
         IWalletServiceClient walletClient,
+        IRegisterServiceClient registerClient,
         IStatusListManager statusListManager,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
@@ -122,6 +127,12 @@ public static class CredentialEndpoints
 
         await TryUpdateRecipientStatus(credential.Value, request.IssuerWallet, credentialId, "Revoked", walletClient, logger, cancellationToken);
 
+        // Multi-node audit CRITICAL #2 — propagate the status change to the holder's node
+        // via a register transaction. Direct UpdateRecipientStatus HTTP only reaches the
+        // holder when issuer + holder share a wallet service; this is the cross-node path.
+        await TrySubmitStatusChangeTransactionAsync(
+            credential.Value, request.IssuerWallet, "Revoked", request.Reason, registerClient, logger, cancellationToken);
+
         // Update bitstring status list (set bit = revoked)
         var statusListUpdated = await TryUpdateStatusListBit(
             credential.Value, true, request.Reason ?? "Revoked", statusListManager, logger, cancellationToken);
@@ -146,6 +157,7 @@ public static class CredentialEndpoints
         string credentialId,
         [FromBody] LifecycleCredentialRequest request,
         IWalletServiceClient walletClient,
+        IRegisterServiceClient registerClient,
         IStatusListManager statusListManager,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
@@ -169,6 +181,10 @@ public static class CredentialEndpoints
 
         await TryUpdateRecipientStatus(credential.Value, request.IssuerWallet, credentialId, "Suspended", walletClient, logger, cancellationToken);
 
+        // Multi-node audit CRITICAL #2 — see RevokeCredential for the same path.
+        await TrySubmitStatusChangeTransactionAsync(
+            credential.Value, request.IssuerWallet, "Suspended", request.Reason, registerClient, logger, cancellationToken);
+
         // Update bitstring status list (set bit = suspended)
         var statusListUpdated = await TryUpdateStatusListBit(
             credential.Value, true, request.Reason ?? "Suspended", statusListManager, logger, cancellationToken);
@@ -191,6 +207,7 @@ public static class CredentialEndpoints
         string credentialId,
         [FromBody] LifecycleCredentialRequest request,
         IWalletServiceClient walletClient,
+        IRegisterServiceClient registerClient,
         IStatusListManager statusListManager,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
@@ -213,6 +230,10 @@ public static class CredentialEndpoints
             return Results.Problem("Failed to reinstate credential");
 
         await TryUpdateRecipientStatus(credential.Value, request.IssuerWallet, credentialId, "Active", walletClient, logger, cancellationToken);
+
+        // Multi-node audit CRITICAL #2 — see RevokeCredential for the same path.
+        await TrySubmitStatusChangeTransactionAsync(
+            credential.Value, request.IssuerWallet, "Active", request.Reason, registerClient, logger, cancellationToken);
 
         // Clear bitstring status list (clear bit = active again)
         var statusListUpdated = await TryUpdateStatusListBit(
@@ -348,6 +369,111 @@ public static class CredentialEndpoints
                 "Failed to update status list bit for credential {CredentialId}",
                 credential.CredentialId);
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Submits a <see cref="TransactionType.CredentialStatusChange"/> register transaction
+    /// so the holder's wallet node — which may be on a different node than the issuer —
+    /// receives the lifecycle event via the existing InboundTransactionRouter pipeline and
+    /// applies the new status to its locally cached credential row. Best-effort: any failure
+    /// here is logged but does not break the lifecycle endpoint (the issuer's local row and
+    /// the BitstringStatusList are already updated and remain the authoritative artefacts).
+    /// </summary>
+    /// <remarks>
+    /// Multi-node audit CRITICAL #2 fix. The direct <c>TryUpdateRecipientStatus</c> HTTP
+    /// call is retained as a same-node fast path — on cross-node deployments it silently
+    /// no-ops (points at the issuer's wallet service), and this register-tx path is what
+    /// actually reaches the holder.
+    /// </remarks>
+    private static async Task TrySubmitStatusChangeTransactionAsync(
+        CredentialIssuanceResult credential,
+        string issuerWallet,
+        string newStatus,
+        string? reason,
+        IRegisterServiceClient registerClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(credential.RegisterId))
+        {
+            // Pre-Feature 106 credentials don't carry the originating RegisterId — there's
+            // nowhere to post the lifecycle tx to. Verifier-side checks still work via the
+            // BitstringStatusList; only the holder-side cached row will be stale.
+            logger.LogDebug(
+                "Skipping CredentialStatusChange register tx for {CredentialId}: no RegisterId on credential record",
+                credential.CredentialId);
+            return;
+        }
+
+        try
+        {
+            var payload = new CredentialStatusChangePayload
+            {
+                CredentialId = credential.CredentialId,
+                NewStatus = newStatus,
+                IssuerWallet = issuerWallet,
+                SubjectDid = credential.SubjectDid,
+                Reason = reason,
+                ChangedAt = DateTimeOffset.UtcNow,
+            };
+
+            var payloadJson = JsonSerializer.Serialize(payload);
+            var payloadBytes = Encoding.UTF8.GetBytes(payloadJson);
+
+            // Tx id = SHA-256(registerId : credentialId : newStatus : unix-ms). Deterministic
+            // enough for log correlation while colliding only on duplicate same-millisecond
+            // submissions (which would themselves be no-ops on the receiver).
+            var txIdSource = $"{credential.RegisterId}:{credential.CredentialId}:{newStatus}:{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+            var txIdHash = SHA256.HashData(Encoding.UTF8.GetBytes(txIdSource));
+            var txId = Convert.ToHexString(txIdHash).ToLowerInvariant();
+
+            var tx = new TransactionModel
+            {
+                TxId = txId,
+                RegisterId = credential.RegisterId,
+                SenderWallet = issuerWallet,
+                RecipientsWallets = new List<string> { credential.SubjectDid },
+                TimeStamp = DateTime.UtcNow,
+                PrevTxId = string.Empty,
+                MetaData = new TransactionMetaData
+                {
+                    RegisterId = credential.RegisterId,
+                    TransactionType = TransactionType.CredentialStatusChange,
+                    TrackingData = new Dictionary<string, string>
+                    {
+                        ["credentialId"] = credential.CredentialId,
+                        ["newStatus"] = newStatus,
+                    },
+                },
+                PayloadCount = 1,
+                Payloads = new[]
+                {
+                    new PayloadModel
+                    {
+                        Data = Convert.ToBase64String(payloadBytes),
+                        ContentType = "application/json",
+                        ContentEncoding = "base64",
+                        WalletAccess = new[] { credential.SubjectDid },
+                    },
+                },
+                Signature = issuerWallet,
+            };
+
+            await registerClient.SubmitTransactionAsync(credential.RegisterId, tx);
+
+            logger.LogInformation(
+                "CredentialStatusChange tx {TxId} submitted: credential {CredentialId} → {NewStatus} (subject {Subject})",
+                txId, credential.CredentialId, newStatus, credential.SubjectDid);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort — log and continue. The BitstringStatusList update is what
+            // gates verifier-side checks; the holder UI will be stale until a future
+            // rebuild or manual refresh.
+            logger.LogWarning(ex,
+                "Failed to submit CredentialStatusChange register tx for {CredentialId} → {NewStatus}",
+                credential.CredentialId, newStatus);
         }
     }
 

--- a/src/Services/Sorcha.Register.Service/Services/Implementation/InboundTransactionRouter.cs
+++ b/src/Services/Sorcha.Register.Service/Services/Implementation/InboundTransactionRouter.cs
@@ -46,11 +46,15 @@ public sealed class InboundTransactionRouter : IInboundTransactionRouter
         bool isRecovery = false,
         CancellationToken cancellationToken = default)
     {
-        // Only route action-type transactions
-        if (transactionType != TransactionType.Action)
+        // Route action-type transactions and credential lifecycle events. Both flow
+        // through the same wallet-notification pipeline; the wallet-side handler
+        // inspects the fetched transaction to decide what to do with it (credential
+        // detector for Action, status-change handler for CredentialStatusChange).
+        if (transactionType != TransactionType.Action
+            && transactionType != TransactionType.CredentialStatusChange)
         {
             _logger.LogDebug(
-                "Skipping non-action transaction {TxId} (type: {Type})",
+                "Skipping non-routed transaction {TxId} (type: {Type})",
                 transactionId, transactionType);
             return 0;
         }

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -101,6 +101,10 @@ builder.Services.AddSingleton<Sorcha.Wallet.Service.Services.Implementation.Inbo
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IInboundCredentialDetector,
     Sorcha.Wallet.Service.Services.Implementation.InboundCredentialDetector>();
 
+// Multi-node audit CRITICAL #2: Inbound credential status change handler
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IInboundCredentialStatusHandler,
+    Sorcha.Wallet.Service.Services.Implementation.InboundCredentialStatusHandler>();
+
 // Feature 047: Digest notification batching (US5)
 builder.Services.AddHostedService<Sorcha.Wallet.Service.Services.Implementation.NotificationDigestWorker>();
 

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialStatusHandler.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/InboundCredentialStatusHandler.cs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.Extensions.Logging;
+
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Register.Models.Enums;
+using Sorcha.ServiceClients.Register;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Multi-node audit CRITICAL #2 — default implementation of
+/// <see cref="IInboundCredentialStatusHandler"/>. Applies issuer-driven credential
+/// lifecycle transitions to the holder's locally cached row when a
+/// <c>TransactionType.CredentialStatusChange</c> tx arrives via the inbound
+/// notification pipeline.
+/// </summary>
+public sealed class InboundCredentialStatusHandler : IInboundCredentialStatusHandler
+{
+    private readonly IRegisterServiceClient _registerClient;
+    private readonly ICredentialStore _credentialStore;
+    private readonly ILogger<InboundCredentialStatusHandler> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
+
+    public InboundCredentialStatusHandler(
+        IRegisterServiceClient registerClient,
+        ICredentialStore credentialStore,
+        ILogger<InboundCredentialStatusHandler> logger)
+    {
+        _registerClient = registerClient ?? throw new ArgumentNullException(nameof(registerClient));
+        _credentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<InboundCredentialStatusResult> TryApplyAsync(
+        string walletAddress,
+        string transactionId,
+        string registerId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var tx = await _registerClient.GetTransactionAsync(registerId, transactionId, cancellationToken);
+            if (tx is null)
+            {
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            // Only inspect credential-status txs — every other type is an Action carrying
+            // a credential issuance, which is the Feature 106 detector's job.
+            if (tx.MetaData?.TransactionType != TransactionType.CredentialStatusChange)
+            {
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            var rawPayload = tx.Payloads?.FirstOrDefault()?.Data;
+            if (string.IsNullOrWhiteSpace(rawPayload))
+            {
+                _logger.LogDebug(
+                    "CredentialStatusChange tx {TxId} has no payload data",
+                    transactionId);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            byte[] payloadBytes;
+            try
+            {
+                payloadBytes = Convert.FromBase64String(rawPayload);
+            }
+            catch (FormatException)
+            {
+                _logger.LogWarning(
+                    "CredentialStatusChange tx {TxId} payload is not base64 — skipping",
+                    transactionId);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            CredentialStatusChangePayload? payload;
+            try
+            {
+                payload = JsonSerializer.Deserialize<CredentialStatusChangePayload>(payloadBytes, JsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex,
+                    "CredentialStatusChange tx {TxId} payload failed to deserialise — skipping",
+                    transactionId);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            if (payload is null
+                || string.IsNullOrWhiteSpace(payload.CredentialId)
+                || string.IsNullOrWhiteSpace(payload.NewStatus)
+                || string.IsNullOrWhiteSpace(payload.IssuerWallet)
+                || string.IsNullOrWhiteSpace(payload.SubjectDid))
+            {
+                _logger.LogWarning(
+                    "CredentialStatusChange tx {TxId} payload missing required fields — skipping",
+                    transactionId);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            // Recipient binding — payload must target this wallet.
+            if (!string.Equals(payload.SubjectDid, walletAddress, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug(
+                    "CredentialStatusChange tx {TxId} not addressed to wallet {Wallet} (subject {Subject})",
+                    transactionId, walletAddress, payload.SubjectDid);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            // Tx-level issuer binding — sender on the register tx must match the payload's
+            // declared issuer. Cheap defence against a hostile sender forging a payload that
+            // claims to be from a different issuer than the one who actually submitted.
+            if (!string.IsNullOrEmpty(tx.SenderWallet)
+                && !string.Equals(tx.SenderWallet, payload.IssuerWallet, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "CredentialStatusChange tx {TxId} sender {Sender} does not match payload issuer {Issuer} — dropping",
+                    transactionId, tx.SenderWallet, payload.IssuerWallet);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            // Credential-level issuer binding — only the credential's original issuer may
+            // change its status. Verifies against the locally stored credential row.
+            var credential = await _credentialStore.GetByIdForWalletAsync(
+                payload.CredentialId, walletAddress, cancellationToken);
+            if (credential is null)
+            {
+                _logger.LogDebug(
+                    "CredentialStatusChange tx {TxId}: no local credential {CredentialId} for wallet {Wallet}",
+                    transactionId, payload.CredentialId, walletAddress);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            if (!string.Equals(credential.IssuerDid, payload.IssuerWallet, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "CredentialStatusChange tx {TxId}: payload issuer {Issuer} does not match credential {CredentialId} original issuer {Original} — dropping",
+                    transactionId, payload.IssuerWallet, payload.CredentialId, credential.IssuerDid);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            if (!TryParseStatus(payload.NewStatus, out var newStatus))
+            {
+                _logger.LogWarning(
+                    "CredentialStatusChange tx {TxId}: unsupported status '{Status}' — only Active / Suspended / Revoked are propagated",
+                    transactionId, payload.NewStatus);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            var updated = await _credentialStore.UpdateStatusAsync(
+                payload.CredentialId, walletAddress, newStatus, cancellationToken);
+            if (!updated)
+            {
+                _logger.LogInformation(
+                    "CredentialStatusChange tx {TxId}: UpdateStatusAsync returned false for credential {CredentialId} (transition may be invalid or already applied)",
+                    transactionId, payload.CredentialId);
+                return InboundCredentialStatusResult.Skipped;
+            }
+
+            _logger.LogInformation(
+                "Applied CredentialStatusChange tx {TxId}: credential {CredentialId} → {NewStatus} for wallet {Wallet}",
+                transactionId, payload.CredentialId, newStatus, walletAddress);
+
+            return new InboundCredentialStatusResult
+            {
+                Applied = true,
+                CredentialId = payload.CredentialId,
+                NewStatus = newStatus.ToString(),
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "InboundCredentialStatusHandler: unexpected error processing tx {TxId} for wallet {Wallet}",
+                transactionId, walletAddress);
+            return InboundCredentialStatusResult.Skipped;
+        }
+    }
+
+    /// <summary>
+    /// Maps the wire-format status string to the wallet's local enum. Only the three
+    /// issuer-driven transitions are propagated; <c>Expired</c> / <c>Consumed</c> /
+    /// <c>PendingAcceptance</c> / <c>Declined</c> are local-lifecycle states owned by
+    /// the holder's node and never carried in a CredentialStatusChange tx.
+    /// </summary>
+    private static bool TryParseStatus(string raw, out CredentialStatus status)
+    {
+        switch (raw.Trim())
+        {
+            case "Active":
+                status = CredentialStatus.Active;
+                return true;
+            case "Suspended":
+                status = CredentialStatus.Suspended;
+                return true;
+            case "Revoked":
+                status = CredentialStatus.Revoked;
+                return true;
+            default:
+                status = CredentialStatus.Active;
+                return false;
+        }
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/NotificationDeliveryService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/NotificationDeliveryService.cs
@@ -51,6 +51,7 @@ public sealed class NotificationDeliveryService : INotificationDeliveryService
     private readonly IParticipantServiceClient _participants;
     private readonly IPlatformInboxClient _inbox;
     private readonly IInboundCredentialDetector? _credentialDetector;
+    private readonly IInboundCredentialStatusHandler? _credentialStatusHandler;
     private readonly ILogger<NotificationDeliveryService> _logger;
 
     /// <summary>Initialises a new <see cref="NotificationDeliveryService"/>.</summary>
@@ -63,7 +64,8 @@ public sealed class NotificationDeliveryService : INotificationDeliveryService
         IParticipantServiceClient participants,
         IPlatformInboxClient inbox,
         ILogger<NotificationDeliveryService> logger,
-        IInboundCredentialDetector? credentialDetector = null)
+        IInboundCredentialDetector? credentialDetector = null,
+        IInboundCredentialStatusHandler? credentialStatusHandler = null)
     {
         _walletRepository = walletRepository;
         _rateLimiter = rateLimiter;
@@ -73,6 +75,7 @@ public sealed class NotificationDeliveryService : INotificationDeliveryService
         _participants = participants;
         _inbox = inbox;
         _credentialDetector = credentialDetector;
+        _credentialStatusHandler = credentialStatusHandler;
         _logger = logger;
     }
 
@@ -130,6 +133,29 @@ public sealed class NotificationDeliveryService : INotificationDeliveryService
                 // implementation drift so a detector bug never breaks notification delivery.
                 _logger.LogError(ex,
                     "InboundCredentialDetector threw for wallet {Wallet} tx {TxId} — delivery will proceed without credential enrichment",
+                    recipientAddress, transactionId);
+            }
+        }
+
+        // Step 2c: Multi-node audit CRITICAL #2 — apply inbound CredentialStatusChange
+        // transactions to the holder's locally cached credential row. Runs alongside the
+        // F106 detector; the handler is contracted to never throw and to no-op on any
+        // non-CredentialStatusChange tx.
+        if (_credentialStatusHandler is not null)
+        {
+            try
+            {
+                await _credentialStatusHandler.TryApplyAsync(
+                    recipientAddress, transactionId, registerId, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "InboundCredentialStatusHandler threw for wallet {Wallet} tx {TxId} — delivery will proceed without status update",
                     recipientAddress, transactionId);
             }
         }

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IInboundCredentialStatusHandler.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IInboundCredentialStatusHandler.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Multi-node audit CRITICAL #2 — applies issuer-driven credential lifecycle
+/// transitions (Revoke / Suspend / Reinstate) to the holder's locally cached
+/// credential row when a <c>TransactionType.CredentialStatusChange</c> register
+/// transaction arrives via the inbound notification pipeline.
+/// </summary>
+/// <remarks>
+/// Called from <c>NotificationDeliveryService.DeliverAsync</c> alongside the
+/// Feature 106 credential detector. The implementation MUST never throw —
+/// failure cases return <see cref="InboundCredentialStatusResult.Skipped"/> so a
+/// malformed status-change tx never breaks notification delivery.
+/// </remarks>
+public interface IInboundCredentialStatusHandler
+{
+    /// <summary>
+    /// Inspect the inbound transaction and apply a credential status change if
+    /// it is a valid <c>CredentialStatusChange</c> tx addressed to the supplied
+    /// wallet. Returns a result indicating whether the row was updated.
+    /// </summary>
+    Task<InboundCredentialStatusResult> TryApplyAsync(
+        string walletAddress,
+        string transactionId,
+        string registerId,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Outcome of <see cref="IInboundCredentialStatusHandler.TryApplyAsync"/>.
+/// </summary>
+public sealed record InboundCredentialStatusResult
+{
+    /// <summary>True when the local credential row was updated.</summary>
+    public required bool Applied { get; init; }
+
+    /// <summary>Credential whose status was updated (when <see cref="Applied"/> is true).</summary>
+    public string? CredentialId { get; init; }
+
+    /// <summary>New status applied to the local row.</summary>
+    public string? NewStatus { get; init; }
+
+    /// <summary>Sentinel result for the not-applicable path.</summary>
+    public static InboundCredentialStatusResult Skipped { get; } = new() { Applied = false };
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Credentials/CredentialRevocationEndpointTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Credentials/CredentialRevocationEndpointTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
 using Sorcha.Blueprint.Service.Endpoints;
 using Sorcha.Blueprint.Service.Services;
+using Sorcha.ServiceClients.Register;
 using Sorcha.ServiceClients.Wallet;
 
 namespace Sorcha.Blueprint.Service.Tests.Credentials;
@@ -13,6 +14,7 @@ namespace Sorcha.Blueprint.Service.Tests.Credentials;
 public class CredentialRevocationEndpointTests
 {
     private readonly Mock<IWalletServiceClient> _walletClientMock = new();
+    private readonly Mock<IRegisterServiceClient> _registerClientMock = new();
     private readonly Mock<IStatusListManager> _statusListManagerMock = new();
     private readonly Mock<ILoggerFactory> _loggerFactoryMock = new();
 
@@ -181,6 +183,7 @@ public class CredentialRevocationEndpointTests
             credentialId,
             request,
             _walletClientMock.Object,
+            _registerClientMock.Object,
             _statusListManagerMock.Object,
             _loggerFactoryMock.Object,
             CancellationToken.None

--- a/tests/Sorcha.Register.Models.Tests/GovernanceModelsTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/GovernanceModelsTests.cs
@@ -256,7 +256,8 @@ public class GovernanceModelsTests
     public void TransactionType_HasExpectedValues()
     {
         // Control, Action, Docket, Participant, Revocation (Feature 079),
-        // PresentationInitiated, PresentationOutcome, PresentationAbandoned (Feature 111)
-        Enum.GetValues<Sorcha.Register.Models.Enums.TransactionType>().Should().HaveCount(8);
+        // PresentationInitiated, PresentationOutcome, PresentationAbandoned (Feature 111),
+        // CredentialStatusChange (multi-node audit CRITICAL #2)
+        Enum.GetValues<Sorcha.Register.Models.Enums.TransactionType>().Should().HaveCount(9);
     }
 }

--- a/tests/Sorcha.Register.Models.Tests/ParticipantRecordTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/ParticipantRecordTests.cs
@@ -271,11 +271,12 @@ public class ParticipantRecordTests
     }
 
     [Fact]
-    public void TransactionType_HasEightValues()
+    public void TransactionType_HasNineValues()
     {
         // Control, Action, Docket, Participant, Revocation (Feature 079),
-        // PresentationInitiated, PresentationOutcome, PresentationAbandoned (Feature 111)
-        Enum.GetValues<TransactionType>().Should().HaveCount(8);
+        // PresentationInitiated, PresentationOutcome, PresentationAbandoned (Feature 111),
+        // CredentialStatusChange (multi-node audit CRITICAL #2)
+        Enum.GetValues<TransactionType>().Should().HaveCount(9);
     }
 
     #endregion

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialStatusListUrlGuardTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/IssueCredentialStatusListUrlGuardTests.cs
@@ -104,6 +104,7 @@ public sealed class IssueCredentialStatusListUrlGuardTests
             null!, // ICredentialStore
             new NullLoggerFactory(),
             null!, // IWalletInboxWriter — not reached by the URL guard
+            null,  // IIssuanceKeyService (optional — F120)
             null,  // IOrgCertChainProvider (optional)
             CancellationToken.None
         ]);

--- a/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialStatusHandlerTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/InboundCredentialStatusHandlerTests.cs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Sorcha.Blueprint.Models.Credentials;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Sorcha.ServiceClients.Register;
+using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Service.Credentials;
+using Sorcha.Wallet.Service.Services.Implementation;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Multi-node audit CRITICAL #2 — coverage for <see cref="InboundCredentialStatusHandler"/>.
+/// </summary>
+public class InboundCredentialStatusHandlerTests
+{
+    private const string HolderWallet = "ws11qholder";
+    private const string IssuerWallet = "ws11qissuer";
+    private const string CredentialId = "urn:uuid:test-credential-1";
+    private const string RegisterId = "abc123";
+    private const string TxId = "deadbeef";
+
+    [Fact]
+    public async Task TryApply_StatusChangeForLocalCredential_AppliesUpdate()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildStatusChangeTx(NewStatus: "Revoked"));
+
+        store.Setup(s => s.GetByIdForWalletAsync(CredentialId, HolderWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CredentialEntity
+            {
+                Id = CredentialId,
+                Type = "TestCredential",
+                IssuerDid = IssuerWallet,
+                SubjectDid = HolderWallet,
+                WalletAddress = HolderWallet,
+                ClaimsJson = "{}",
+                RawToken = "fake-token",
+                IssuedAt = DateTimeOffset.UtcNow,
+                Status = CredentialStatus.Active,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+        store.Setup(s => s.UpdateStatusAsync(CredentialId, HolderWallet, CredentialStatus.Revoked, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeTrue();
+        result.CredentialId.Should().Be(CredentialId);
+        result.NewStatus.Should().Be("Revoked");
+        store.Verify(s => s.UpdateStatusAsync(CredentialId, HolderWallet, CredentialStatus.Revoked, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TryApply_NonStatusChangeTransaction_Skips()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TransactionModel
+            {
+                TxId = TxId,
+                RegisterId = RegisterId,
+                MetaData = new TransactionMetaData { RegisterId = RegisterId, TransactionType = TransactionType.Action },
+            });
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeFalse();
+        store.Verify(s => s.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CredentialStatus>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryApply_PayloadIssuerMismatchesTxSender_Drops()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        var tx = BuildStatusChangeTx(NewStatus: "Revoked");
+        tx.SenderWallet = "ws11qhostile";  // Tx sender doesn't match payload's claimed issuer.
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tx);
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeFalse();
+        store.Verify(s => s.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CredentialStatus>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryApply_PayloadIssuerMismatchesLocalCredentialIssuer_Drops()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildStatusChangeTx(NewStatus: "Revoked"));
+
+        // Local credential was issued by a DIFFERENT issuer than the one in the payload.
+        store.Setup(s => s.GetByIdForWalletAsync(CredentialId, HolderWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CredentialEntity
+            {
+                Id = CredentialId,
+                Type = "TestCredential",
+                IssuerDid = "ws11qsomeoneelse",
+                SubjectDid = HolderWallet,
+                WalletAddress = HolderWallet,
+                ClaimsJson = "{}",
+                RawToken = "fake-token",
+                IssuedAt = DateTimeOffset.UtcNow,
+                Status = CredentialStatus.Active,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeFalse();
+        store.Verify(s => s.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CredentialStatus>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryApply_LocalCredentialMissing_Skips()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildStatusChangeTx(NewStatus: "Revoked"));
+
+        store.Setup(s => s.GetByIdForWalletAsync(CredentialId, HolderWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CredentialEntity?)null);
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryApply_UnsupportedStatus_Skips()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BuildStatusChangeTx(NewStatus: "Expired"));  // Holder-local-only state, not propagated by issuer.
+
+        store.Setup(s => s.GetByIdForWalletAsync(CredentialId, HolderWallet, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CredentialEntity
+            {
+                Id = CredentialId,
+                Type = "TestCredential",
+                IssuerDid = IssuerWallet,
+                SubjectDid = HolderWallet,
+                WalletAddress = HolderWallet,
+                ClaimsJson = "{}",
+                RawToken = "fake-token",
+                IssuedAt = DateTimeOffset.UtcNow,
+                Status = CredentialStatus.Active,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeFalse();
+        store.Verify(s => s.UpdateStatusAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CredentialStatus>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task TryApply_RegisterClientThrows_DoesNotPropagate()
+    {
+        var register = new Mock<IRegisterServiceClient>();
+        var store = new Mock<ICredentialStore>();
+
+        register.Setup(r => r.GetTransactionAsync(RegisterId, TxId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("register down"));
+
+        var handler = new InboundCredentialStatusHandler(
+            register.Object, store.Object, NullLogger<InboundCredentialStatusHandler>.Instance);
+
+        var result = await handler.TryApplyAsync(HolderWallet, TxId, RegisterId, CancellationToken.None);
+
+        result.Applied.Should().BeFalse();
+    }
+
+    private static TransactionModel BuildStatusChangeTx(string NewStatus)
+    {
+        var payload = new CredentialStatusChangePayload
+        {
+            CredentialId = CredentialId,
+            NewStatus = NewStatus,
+            IssuerWallet = IssuerWallet,
+            SubjectDid = HolderWallet,
+            ChangedAt = DateTimeOffset.UtcNow,
+        };
+        var json = JsonSerializer.Serialize(payload);
+        var bytes = Encoding.UTF8.GetBytes(json);
+
+        return new TransactionModel
+        {
+            TxId = TxId,
+            RegisterId = RegisterId,
+            SenderWallet = IssuerWallet,
+            RecipientsWallets = new List<string> { HolderWallet },
+            TimeStamp = DateTime.UtcNow,
+            PrevTxId = string.Empty,
+            MetaData = new TransactionMetaData
+            {
+                RegisterId = RegisterId,
+                TransactionType = TransactionType.CredentialStatusChange,
+            },
+            PayloadCount = 1,
+            Payloads = new[]
+            {
+                new PayloadModel
+                {
+                    Data = Convert.ToBase64String(bytes),
+                    ContentType = "application/json",
+                    ContentEncoding = "base64",
+                },
+            },
+            Signature = IssuerWallet,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Closes multi-node audit **CRITICAL #2** — credential status changes (revoke / suspend / reinstate) now propagate to the holder's wallet node via a register transaction instead of a direct HTTP call that only worked when issuer + holder shared a wallet service. The W3C BitstringStatusList stays as the authoritative verifier-side check; this PR keeps the holder's locally cached row in sync cross-node.

## Architecture (aligns with Sorcha DAD model)

- **New** `TransactionType.CredentialStatusChange = 8` carrying `CredentialStatusChangePayload` (credentialId, newStatus, issuerWallet, subjectDid, reason, changedAt).
- **Issuer side** (Blueprint Service `CredentialEndpoints`): `TrySubmitStatusChangeTransactionAsync` builds + submits the register tx alongside the existing direct HTTP call (kept as a same-node fast path; harmless no-op cross-node).
- **Register Service** (`InboundTransactionRouter`): routes the new type through the same bloom-filter + wallet-notification pipeline used for Action txs.
- **Wallet Service**: new `IInboundCredentialStatusHandler` invoked from `NotificationDeliveryService` alongside the Feature 106 credential detector. Three-way issuer binding check (tx-sender ↔ payload-issuer ↔ credential's original issuer) before applying via `CredentialStore.UpdateStatusAsync`.

Plumbed `CredentialIssuanceResult.RegisterId` so the issuer endpoint can determine which register to write to.

## Why a register tx instead of holder-side status-list polling

Both approaches keep the verifier path correct via BitstringStatusList. The register tx beats holder-side polling on:
- **Privacy**: holder-side polling leaks "I hold a credential from issuer X" to the issuer's status-list endpoint; register tx is authenticated push.
- **DAD alignment**: alteration is recorded on the immutable ledger, exactly the architectural model.
- **Performance**: one register write per status change vs N×M holder polling.
- **Latency**: push-based, seconds.

## Test plan
- [x] 7 new tests in `InboundCredentialStatusHandlerTests` — happy path, three-way issuer binding, missing local credential, unsupported status, register-client exception swallowing.
- [x] Full solution build clean (0 errors).
- [ ] CI green.