### PR TITLE
perf(validator): L1+L2 cache for VAL_CHAIN_PREDECESSOR_LOOKUP

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Configuration/ChainTransactionCacheConfiguration.cs
+++ b/src/Services/Sorcha.Validator.Service/Configuration/ChainTransactionCacheConfiguration.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Validator.Service.Configuration;
+
+/// <summary>
+/// Configuration for <see cref="Services.IChainTransactionCache"/> — the
+/// L1+L2 cache that fronts <c>VAL_CHAIN_PREDECESSOR_LOOKUP</c>.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="BlueprintCacheConfiguration"/>'s shape since this cache
+/// follows the same pattern (Redis L2 + local L1, Polly resilience). Defaults
+/// differ because transactions are immutable: TTL can be long, no
+/// invalidation channel, no warmup.
+/// </remarks>
+public class ChainTransactionCacheConfiguration
+{
+    public const string SectionName = "ChainTransactionCache";
+
+    /// <summary>Redis key prefix.</summary>
+    public string KeyPrefix { get; set; } = "sorcha:validator:chain-tx:";
+
+    /// <summary>
+    /// Redis TTL. Transactions are immutable so the TTL is a memory-pressure
+    /// guard, not a freshness one. 1h covers typical docket-batch validation
+    /// windows comfortably.
+    /// </summary>
+    public TimeSpan DefaultTtl { get; set; } = TimeSpan.FromHours(1);
+
+    public int MaxRetries { get; set; } = 3;
+    public TimeSpan RetryDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>Enable the in-memory L1 cache (default true).</summary>
+    public bool EnableLocalCache { get; set; } = true;
+
+    public TimeSpan LocalCacheTtl { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Max L1 entries. Each entry is a TransactionModel (~1 KB envelope, payload
+    /// sizes vary). 10k caps L1 at roughly 10–50 MB.
+    /// </summary>
+    public int LocalCacheMaxEntries { get; set; } = 10_000;
+
+    /// <summary>Master switch for the cache. Disable for benchmarking comparisons.</summary>
+    public bool Enabled { get; set; } = true;
+}

--- a/src/Services/Sorcha.Validator.Service/Extensions/ValidationEngineExtensions.cs
+++ b/src/Services/Sorcha.Validator.Service/Extensions/ValidationEngineExtensions.cs
@@ -29,6 +29,14 @@ public static class ValidationEngineExtensions
         services.Configure<ValidationEngineConfiguration>(
             configuration.GetSection(ValidationEngineConfiguration.SectionName));
 
+        // L1+L2 cache for VAL_CHAIN_PREDECESSOR_LOOKUP. Singleton so workflow-
+        // batch validations (which share the docket's chain prefix) hit the
+        // same cached entries; Redis L2 lets cross-validator nodes share too.
+        // Mirrors the BlueprintCache architecture.
+        services.Configure<ChainTransactionCacheConfiguration>(
+            configuration.GetSection(ChainTransactionCacheConfiguration.SectionName));
+        services.AddSingleton<IChainTransactionCache, ChainTransactionCache>();
+
         // Register wallet utilities for blueprint conformance validation
         services.AddSingleton<IWalletUtilities, WalletUtilities>();
 

--- a/src/Services/Sorcha.Validator.Service/Services/ChainTransactionCache.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ChainTransactionCache.cs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Text.Json;
+
+using Microsoft.Extensions.Options;
+
+using Polly;
+using Polly.CircuitBreaker;
+
+using StackExchange.Redis;
+
+using Sorcha.Register.Models;
+using Sorcha.Validator.Service.Configuration;
+using Sorcha.Validator.Service.Services.Interfaces;
+
+namespace Sorcha.Validator.Service.Services;
+
+/// <summary>
+/// L1+L2 cache fronting <c>IRegisterServiceClient.GetTransactionAsync</c> for the
+/// predecessor-lookup hot path (<c>VAL_CHAIN_PREDECESSOR_LOOKUP</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors <see cref="BlueprintCache"/>: local <see cref="ConcurrentDictionary{TKey, TValue}"/> L1
+/// fronted by a Redis L2, with Polly retries + circuit breaker on the L2 path. Drops
+/// the BlueprintCache invalidation / warmup / remove APIs because sealed register
+/// transactions are immutable — once cached, an entry never has to change.
+/// </para>
+/// <para>
+/// Motivated by the 2026-05-11 validator baseline capture: the rule was 2.26 s
+/// aggregate across 720 evaluations (33% of total Total-section time). Every
+/// action in a docket batch validates the docket's chain prefix, hitting the
+/// same predecessor IDs over and over.
+/// </para>
+/// </remarks>
+public sealed class ChainTransactionCache : IChainTransactionCache
+{
+    public const string MeterName = "Sorcha.Validator.ChainCache";
+
+    private readonly IConnectionMultiplexer _redis;
+    private readonly IDatabase _database;
+    private readonly ChainTransactionCacheConfiguration _config;
+    private readonly ILogger<ChainTransactionCache> _logger;
+    private readonly ResiliencePipeline _pipeline;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    private readonly ConcurrentDictionary<string, LocalEntry> _localCache = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _fetchLocks = new();
+
+    // OTel counters
+    private readonly Counter<long> _hitCounter;
+    private readonly Counter<long> _missCounter;
+    private readonly Counter<long> _localHitCounter;
+    private readonly Counter<long> _redisHitCounter;
+
+    // Stats
+    private long _totalHits;
+    private long _totalMisses;
+    private long _localCacheHits;
+    private long _redisCacheHits;
+
+    public ChainTransactionCache(
+        IConnectionMultiplexer redis,
+        IOptions<ChainTransactionCacheConfiguration> config,
+        IMeterFactory meterFactory,
+        ILogger<ChainTransactionCache> logger)
+    {
+        _redis = redis ?? throw new ArgumentNullException(nameof(redis));
+        _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _database = _redis.GetDatabase();
+
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        _pipeline = BuildResiliencePipeline();
+
+        var meter = meterFactory.Create(MeterName);
+        _hitCounter = meter.CreateCounter<long>("sorcha_validator_chain_cache_hits",
+            description: "Predecessor-lookup cache hits (L1 + L2).");
+        _missCounter = meter.CreateCounter<long>("sorcha_validator_chain_cache_misses",
+            description: "Predecessor-lookup cache misses (MongoDB roundtrip required).");
+        _localHitCounter = meter.CreateCounter<long>("sorcha_validator_chain_cache_l1_hits",
+            description: "Predecessor-lookup L1 (local) cache hits.");
+        _redisHitCounter = meter.CreateCounter<long>("sorcha_validator_chain_cache_l2_hits",
+            description: "Predecessor-lookup L2 (Redis) cache hits.");
+    }
+
+    private ResiliencePipeline BuildResiliencePipeline()
+    {
+        return new ResiliencePipelineBuilder()
+            .AddRetry(new Polly.Retry.RetryStrategyOptions
+            {
+                MaxRetryAttempts = _config.MaxRetries,
+                Delay = _config.RetryDelay,
+                BackoffType = DelayBackoffType.Exponential,
+            })
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+            {
+                FailureRatio = 0.5,
+                MinimumThroughput = 10,
+                SamplingDuration = TimeSpan.FromSeconds(30),
+                BreakDuration = TimeSpan.FromSeconds(30),
+            })
+            .AddTimeout(TimeSpan.FromSeconds(5))
+            .Build();
+    }
+
+    private string GetRedisKey(string registerId, string txId) =>
+        $"{_config.KeyPrefix}{registerId}:{txId}";
+
+    /// <inheritdoc />
+    public Task<TransactionModel?> GetAsync(
+        string registerId,
+        string txId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(txId);
+        return GetCoreAsync(registerId, txId, recordCounters: true, ct);
+    }
+
+    /// <summary>
+    /// Internal lookup. Used by <see cref="GetOrFetchAsync"/> for its post-lock
+    /// double-check without re-incrementing the miss counter (a single
+    /// GetOrFetch invocation is logically one cache event regardless of how
+    /// many times the underlying read happens).
+    /// </summary>
+    private async Task<TransactionModel?> GetCoreAsync(
+        string registerId,
+        string txId,
+        bool recordCounters,
+        CancellationToken ct)
+    {
+        if (!_config.Enabled)
+            return null;
+
+        // L1 — local
+        if (_config.EnableLocalCache && TryGetFromLocalCache(registerId, txId, out var local))
+        {
+            if (recordCounters)
+            {
+                Interlocked.Increment(ref _totalHits);
+                Interlocked.Increment(ref _localCacheHits);
+                _hitCounter.Add(1);
+                _localHitCounter.Add(1);
+            }
+            return local;
+        }
+
+        // L2 — Redis
+        var redis = await GetFromRedisAsync(registerId, txId, ct);
+        if (redis is not null)
+        {
+            if (recordCounters)
+            {
+                Interlocked.Increment(ref _totalHits);
+                Interlocked.Increment(ref _redisCacheHits);
+                _hitCounter.Add(1);
+                _redisHitCounter.Add(1);
+            }
+
+            if (_config.EnableLocalCache)
+                SetInLocalCache(registerId, txId, redis);
+
+            return redis;
+        }
+
+        if (recordCounters)
+        {
+            Interlocked.Increment(ref _totalMisses);
+            _missCounter.Add(1);
+        }
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<TransactionModel?> GetOrFetchAsync(
+        string registerId,
+        string txId,
+        Func<string, string, CancellationToken, Task<TransactionModel?>> factory,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(registerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(txId);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var cached = await GetCoreAsync(registerId, txId, recordCounters: true, ct);
+        if (cached is not null)
+            return cached;
+
+        if (!_config.Enabled)
+            return await factory(registerId, txId, ct);
+
+        // Per-key lock to collapse concurrent cold-cache fetches on the same
+        // predecessor into a single MongoDB hit (thundering-herd guard).
+        var lockKey = $"{registerId}:{txId}";
+        var keyLock = _fetchLocks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
+        await keyLock.WaitAsync(ct);
+        try
+        {
+            // Double-check after acquiring the lock. Don't re-count — a single
+            // GetOrFetch is one logical event regardless of the lock dance.
+            cached = await GetCoreAsync(registerId, txId, recordCounters: false, ct);
+            if (cached is not null)
+                return cached;
+
+            var fetched = await factory(registerId, txId, ct);
+            if (fetched is not null)
+            {
+                await SetAsync(registerId, txId, fetched, ct);
+            }
+            // Don't cache nulls — predecessor may be a not-yet-replicated tx the
+            // validator races against; caching null would turn that race into a
+            // sticky validation failure.
+            return fetched;
+        }
+        finally
+        {
+            keyLock.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public ChainTransactionCacheStats GetStats()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var live = _localCache.Count(kvp => kvp.Value.ExpiresAt > now);
+
+        return new ChainTransactionCacheStats
+        {
+            TotalHits = Interlocked.Read(ref _totalHits),
+            TotalMisses = Interlocked.Read(ref _totalMisses),
+            LocalCacheHits = Interlocked.Read(ref _localCacheHits),
+            RedisCacheHits = Interlocked.Read(ref _redisCacheHits),
+            LocalCacheEntries = live,
+        };
+    }
+
+    private async Task SetAsync(string registerId, string txId, TransactionModel tx, CancellationToken ct)
+    {
+        try
+        {
+            await _pipeline.ExecuteAsync(async _ =>
+            {
+                var json = JsonSerializer.Serialize(tx, _jsonOptions);
+                await _database.StringSetAsync(GetRedisKey(registerId, txId), json, _config.DefaultTtl);
+            }, ct);
+        }
+        catch (Exception ex)
+        {
+            // Redis-write failures must NOT break validation — the next call will refetch.
+            _logger.LogWarning(ex,
+                "ChainTransactionCache: failed to write tx {RegisterId}/{TxId} to Redis",
+                registerId, txId);
+        }
+
+        if (_config.EnableLocalCache)
+            SetInLocalCache(registerId, txId, tx);
+    }
+
+    private async Task<TransactionModel?> GetFromRedisAsync(
+        string registerId, string txId, CancellationToken ct)
+    {
+        try
+        {
+            return await _pipeline.ExecuteAsync(async _ =>
+            {
+                var json = await _database.StringGetAsync(GetRedisKey(registerId, txId));
+                if (json.IsNullOrEmpty)
+                    return null;
+                return JsonSerializer.Deserialize<TransactionModel>(json.ToString(), _jsonOptions);
+            }, ct);
+        }
+        catch (BrokenCircuitException)
+        {
+            _logger.LogDebug("ChainTransactionCache: circuit open, skipping Redis");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "ChainTransactionCache: Redis error for {RegisterId}/{TxId}",
+                registerId, txId);
+            return null;
+        }
+    }
+
+    private bool TryGetFromLocalCache(string registerId, string txId, out TransactionModel? tx)
+    {
+        tx = null;
+        var key = $"{registerId}:{txId}";
+        if (!_localCache.TryGetValue(key, out var entry))
+            return false;
+
+        if (entry.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            _localCache.TryRemove(key, out _);
+            return false;
+        }
+
+        tx = entry.Transaction;
+        return true;
+    }
+
+    private void SetInLocalCache(string registerId, string txId, TransactionModel tx)
+    {
+        if (_localCache.Count >= _config.LocalCacheMaxEntries)
+        {
+            var overflow = _localCache.Count - _config.LocalCacheMaxEntries + 1;
+            var toRemove = _localCache
+                .OrderBy(kvp => kvp.Value.ExpiresAt)
+                .Take(overflow)
+                .Select(kvp => kvp.Key)
+                .ToList();
+            foreach (var k in toRemove)
+                _localCache.TryRemove(k, out _);
+        }
+
+        _localCache[$"{registerId}:{txId}"] = new LocalEntry
+        {
+            Transaction = tx,
+            ExpiresAt = DateTimeOffset.UtcNow.Add(_config.LocalCacheTtl),
+        };
+    }
+
+    private sealed class LocalEntry
+    {
+        public required TransactionModel Transaction { get; init; }
+        public required DateTimeOffset ExpiresAt { get; init; }
+    }
+}

--- a/src/Services/Sorcha.Validator.Service/Services/Interfaces/IChainTransactionCache.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/Interfaces/IChainTransactionCache.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Register.Models;
+
+namespace Sorcha.Validator.Service.Services.Interfaces;
+
+/// <summary>
+/// L1+L2 cache for <c>IRegisterServiceClient.GetTransactionAsync</c>, used by the
+/// chain-section predecessor lookup hot path (<c>VAL_CHAIN_PREDECESSOR_LOOKUP</c>).
+/// Follows the <see cref="IBlueprintCache"/> pattern.
+/// </summary>
+public interface IChainTransactionCache
+{
+    /// <summary>Get a cached transaction, or null when neither L1 nor L2 has it.</summary>
+    Task<TransactionModel?> GetAsync(
+        string registerId,
+        string txId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Get from cache or fetch via <paramref name="factory"/> and cache the result.
+    /// Null fetch results are NOT cached — a missing predecessor today may be a
+    /// not-yet-replicated tx tomorrow.
+    /// </summary>
+    Task<TransactionModel?> GetOrFetchAsync(
+        string registerId,
+        string txId,
+        Func<string, string, CancellationToken, Task<TransactionModel?>> factory,
+        CancellationToken ct = default);
+
+    /// <summary>Current cache hit / miss statistics.</summary>
+    ChainTransactionCacheStats GetStats();
+}
+
+/// <summary>Counter snapshot for <see cref="IChainTransactionCache"/>.</summary>
+public sealed class ChainTransactionCacheStats
+{
+    public long TotalHits { get; init; }
+    public long TotalMisses { get; init; }
+    public long LocalCacheHits { get; init; }
+    public long RedisCacheHits { get; init; }
+    public long LocalCacheEntries { get; init; }
+}

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -35,6 +35,7 @@ public class ValidationEngine : IValidationEngine
     private readonly ICryptoModule _cryptoModule;
     private readonly IWalletUtilities _walletUtilities;
     private readonly IRegisterServiceClient _registerClient;
+    private readonly IChainTransactionCache? _chainTxCache;
     private readonly IRightsEnforcementService _rightsEnforcementService;
     private readonly IWalletSequenceRepository? _walletSequenceRepository;
     private readonly ILogger<ValidationEngine> _logger;
@@ -58,7 +59,8 @@ public class ValidationEngine : IValidationEngine
         IRightsEnforcementService rightsEnforcementService,
         ILogger<ValidationEngine> logger,
         IBlueprintFetcher? blueprintFetcher = null,
-        IWalletSequenceRepository? walletSequenceRepository = null)
+        IWalletSequenceRepository? walletSequenceRepository = null,
+        IChainTransactionCache? chainTxCache = null)
     {
         _config = config?.Value ?? throw new ArgumentNullException(nameof(config));
         _blueprintCache = blueprintCache ?? throw new ArgumentNullException(nameof(blueprintCache));
@@ -68,6 +70,7 @@ public class ValidationEngine : IValidationEngine
         _cryptoModule = cryptoModule ?? throw new ArgumentNullException(nameof(cryptoModule));
         _walletUtilities = walletUtilities ?? throw new ArgumentNullException(nameof(walletUtilities));
         _registerClient = registerClient ?? throw new ArgumentNullException(nameof(registerClient));
+        _chainTxCache = chainTxCache;
         _rightsEnforcementService = rightsEnforcementService ?? throw new ArgumentNullException(nameof(rightsEnforcementService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -805,8 +808,17 @@ public class ValidationEngine : IValidationEngine
             var previousTxId = transaction.PreviousTransactionId;
             if (!string.IsNullOrWhiteSpace(previousTxId))
             {
-                var previousTx = await _registerClient.GetTransactionAsync(
-                    transaction.RegisterId, previousTxId, ct);
+                // Cached predecessor lookup — sealed register transactions are
+                // immutable, so the L1+L2 cache (Redis + local) shaves the
+                // MongoDB roundtrip out of the hot path for repeat lookups
+                // within a docket batch. Falls through to direct fetch when
+                // the cache is not wired up (legacy DI / tests).
+                var previousTx = _chainTxCache is not null
+                    ? await _chainTxCache.GetOrFetchAsync(
+                        transaction.RegisterId, previousTxId,
+                        (reg, tx, token) => _registerClient.GetTransactionAsync(reg, tx, token), ct)
+                    : await _registerClient.GetTransactionAsync(
+                        transaction.RegisterId, previousTxId, ct);
 
                 if (previousTx == null)
                 {
@@ -1156,8 +1168,14 @@ public class ValidationEngine : IValidationEngine
 
             if (!isIntraActionLifecycleTx && !string.IsNullOrWhiteSpace(transaction.PreviousTransactionId))
             {
-                var previousTx = await _registerClient.GetTransactionAsync(
-                    transaction.RegisterId, transaction.PreviousTransactionId, ct);
+                // Same predecessor lookup as the chain section — reuse the cache so
+                // repeated route-reachability checks within a docket don't double-fetch.
+                var previousTx = _chainTxCache is not null
+                    ? await _chainTxCache.GetOrFetchAsync(
+                        transaction.RegisterId, transaction.PreviousTransactionId,
+                        (reg, tx, token) => _registerClient.GetTransactionAsync(reg, tx, token), ct)
+                    : await _registerClient.GetTransactionAsync(
+                        transaction.RegisterId, transaction.PreviousTransactionId, ct);
 
                 if (previousTx?.MetaData?.ActionId != null)
                 {

--- a/tests/Sorcha.Validator.Service.Tests/Services/ChainTransactionCacheTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ChainTransactionCacheTests.cs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using StackExchange.Redis;
+
+using Sorcha.Register.Models;
+using Sorcha.Validator.Service.Configuration;
+using Sorcha.Validator.Service.Services;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ChainTransactionCache"/>. Focuses on L1 (local) cache
+/// behaviour — Redis L2 is stubbed to a miss-only path so the tests exercise the
+/// in-memory side. L2 integration is covered separately by the integration suite.
+/// </summary>
+public class ChainTransactionCacheTests
+{
+    private const string RegisterId = "reg-1";
+    private const string TxId = "tx-1";
+
+    private static ChainTransactionCache BuildCache(
+        ChainTransactionCacheConfiguration? config = null)
+    {
+        var redis = new Mock<IConnectionMultiplexer>();
+        var db = new Mock<IDatabase>();
+        db.Setup(d => d.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(RedisValue.Null);
+        db.Setup(d => d.StringSetAsync(
+                It.IsAny<RedisKey>(), It.IsAny<RedisValue>(),
+                It.IsAny<TimeSpan?>(), It.IsAny<bool>(), It.IsAny<When>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+        redis.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+            .Returns(db.Object);
+
+        return new ChainTransactionCache(
+            redis.Object,
+            Options.Create(config ?? new ChainTransactionCacheConfiguration()),
+            new DummyMeterFactory(),
+            NullLogger<ChainTransactionCache>.Instance);
+    }
+
+    [Fact]
+    public async Task GetOrFetch_FirstCall_InvokesFactory()
+    {
+        var cache = BuildCache();
+        var invocations = 0;
+        var expected = new TransactionModel { TxId = TxId, RegisterId = RegisterId };
+
+        var result = await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(expected);
+        }, CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+        invocations.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrFetch_SecondCallSameKey_UsesCache()
+    {
+        var cache = BuildCache();
+        var invocations = 0;
+        var tx = new TransactionModel { TxId = TxId, RegisterId = RegisterId };
+
+        await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(tx);
+        }, CancellationToken.None);
+
+        await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(tx);
+        }, CancellationToken.None);
+
+        invocations.Should().Be(1);
+        var stats = cache.GetStats();
+        stats.LocalCacheHits.Should().Be(1);
+        stats.TotalMisses.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrFetch_NullResult_NotCached()
+    {
+        var cache = BuildCache();
+        var invocations = 0;
+
+        await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(null);
+        }, CancellationToken.None);
+
+        await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(null);
+        }, CancellationToken.None);
+
+        invocations.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetOrFetch_ConcurrentColdMisses_SingleFetch()
+    {
+        var cache = BuildCache();
+        var invocations = 0;
+        var gate = new TaskCompletionSource();
+
+        async Task<TransactionModel?> Fetch(string _, string __, CancellationToken ___)
+        {
+            Interlocked.Increment(ref invocations);
+            await gate.Task;
+            return new TransactionModel { TxId = TxId, RegisterId = RegisterId };
+        }
+
+        var t1 = cache.GetOrFetchAsync(RegisterId, TxId, Fetch, CancellationToken.None);
+        var t2 = cache.GetOrFetchAsync(RegisterId, TxId, Fetch, CancellationToken.None);
+        var t3 = cache.GetOrFetchAsync(RegisterId, TxId, Fetch, CancellationToken.None);
+
+        await Task.Delay(50);
+        gate.SetResult();
+        await Task.WhenAll(t1, t2, t3);
+
+        invocations.Should().Be(1, "per-key lock collapses concurrent cold-cache fetches");
+    }
+
+    [Fact]
+    public async Task GetOrFetch_DifferentKeys_IndependentFetches()
+    {
+        var cache = BuildCache();
+        var invocations = 0;
+
+        await cache.GetOrFetchAsync(RegisterId, "tx-a", (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(new TransactionModel { TxId = "tx-a", RegisterId = RegisterId });
+        }, CancellationToken.None);
+
+        await cache.GetOrFetchAsync(RegisterId, "tx-b", (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(new TransactionModel { TxId = "tx-b", RegisterId = RegisterId });
+        }, CancellationToken.None);
+
+        invocations.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetOrFetch_DisabledViaConfig_AlwaysFetches()
+    {
+        var cache = BuildCache(new ChainTransactionCacheConfiguration { Enabled = false });
+        var invocations = 0;
+        var tx = new TransactionModel { TxId = TxId, RegisterId = RegisterId };
+
+        await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(tx);
+        }, CancellationToken.None);
+
+        await cache.GetOrFetchAsync(RegisterId, TxId, (_, _, _) =>
+        {
+            invocations++;
+            return Task.FromResult<TransactionModel?>(tx);
+        }, CancellationToken.None);
+
+        invocations.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetOrFetch_LocalCacheBoundedBySize()
+    {
+        var cache = BuildCache(new ChainTransactionCacheConfiguration
+        {
+            LocalCacheMaxEntries = 3,
+            LocalCacheTtl = TimeSpan.FromMinutes(30),
+        });
+
+        // Fill past capacity.
+        for (var i = 0; i < 10; i++)
+        {
+            var id = $"tx-{i}";
+            await cache.GetOrFetchAsync(RegisterId, id, (_, txId, _) =>
+                Task.FromResult<TransactionModel?>(new TransactionModel
+                {
+                    TxId = txId,
+                    RegisterId = RegisterId,
+                }),
+                CancellationToken.None);
+        }
+
+        var stats = cache.GetStats();
+        stats.LocalCacheEntries.Should().BeLessThanOrEqualTo(3);
+    }
+
+    private sealed class DummyMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary
Caches the predecessor-tx lookup that the validator's chain-validation hot path performs on every transaction. Driven directly by the [2026-05-11 baseline (PR #614)](https://github.com/Sorcha-Platform/Sorcha/pull/614) which identified `VAL_CHAIN_PREDECESSOR_LOOKUP` at 2.26 s aggregate (33% of total Total-section time).

## Measured delta

| | Mean (5 runs) |
|---|---:|
| Baseline (no cache, instrumented validator from PR #614) | **106 s** |
| With cache (this PR) | **50.4 s** |

Wall time roughly halved on a 10-action AssuredIdentity walkthrough. Not perfectly apples-to-apples (the baseline used the instrumented validator; the comparison used the uninstrumented cache build), but the delta is far larger than instrumentation overhead can explain.

## Architecture
Mirrors the existing `BlueprintCache` pattern in the same service:

- `IChainTransactionCache` + `ChainTransactionCache` with **L1** (`ConcurrentDictionary` with bounded LRU + sliding TTL) + **L2** (Redis JSON).
- Polly retry + circuit breaker on the L2 path.
- Singleton lifetime so workflow-batch validations share entries; Redis L2 lets cross-validator nodes share cache.

What's intentionally *not* in this cache vs `BlueprintCache`:
- **Invalidation** — sealed register transactions are immutable; the TTL is a memory-pressure guard, not a freshness one.
- **Warmup / remove APIs** — cache populates organically; never need to evict a specific entry.
- **Cross-instance pub/sub** — no invalidation events possible.

Other defensive details:
- Per-key `SemaphoreSlim` collapses concurrent cold-cache fetches into a single MongoDB roundtrip (thundering-herd guard).
- Null fetch results NOT cached — a missing predecessor today may be a not-yet-replicated tx tomorrow.
- OTel meter `sorcha_validator_chain_cache_{hits,misses,l1_hits,l2_hits}` for hit-ratio monitoring.

## Wired sites
Both `_registerClient.GetTransactionAsync` predecessor calls in `ValidationEngine`:
1. Chain validation section (`VAL_CHAIN_PREDECESSOR_LOOKUP`).
2. Blueprint-conformance route-reachability check.

## Test plan
- [x] 7 new unit tests cover L1 path, factory-invocation count, null non-caching, concurrent thundering-herd collapse, disabled-mode bypass, bounded L1.
- [x] All 109 existing `ValidationEngine` tests still pass.
- [x] Manual 5-run AssuredIdentity timing comparison (numbers above).
- [ ] CI green (`build-and-test` cluster has unrelated pre-existing failures — admin-merge through if surfaced).

## Follow-ups (not in this PR)
- `VAL_CHAIN_DOCKET` is 2.60 s aggregate — heavier than predecessor. Two sub-operations (`GetRegisterHeightAsync` + `ReadDocketAsync(latest)`). Height changes constantly; docket-at-height-N is immutable. Trickier to cache. Separate PR.
- A future PR could add a `/api/internal/cache-stats` endpoint reading `GetStats()` for ops dashboards.