### PR TITLE
chore(108): three small follow-up cleanups

### DIFF
--- a/specs/108-register-local-relationship/contracts/peer-service-distribute-submission.proto
+++ b/specs/108-register-local-relationship/contracts/peer-service-distribute-submission.proto
@@ -17,7 +17,6 @@ package sorcha.peer.distribution.v2;
 
 option csharp_namespace = "Sorcha.Peer.Service.Protos";
 
-import "google/protobuf/timestamp.proto";
 
 // Extension to the existing TransactionDistribution service.
 service TransactionDistributionV2 {
@@ -42,8 +41,9 @@ message SubmitTransactionRequest {
   // detection in any future multi-hop gossip).
   string origin_peer_id = 3;
 
-  // When the originator accepted the user's submission.
-  google.protobuf.Timestamp submitted_at = 4;
+  // When the originator accepted the user's submission (Unix epoch milliseconds).
+  // Matches the implemented wire shape in src/Services/Sorcha.Peer.Service/Protos/transaction_distribution.proto.
+  int64 submitted_at_unix_ms = 4;
 }
 
 message SubmitTransactionResponse {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Registers/RegisterViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Models/Registers/RegisterViewModel.cs
@@ -68,19 +68,29 @@ public record RegisterViewModel
     public string? SyncState { get; init; }
 
     /// <summary>
-    /// Computed: Whether the register is currently syncing or in a sync-related state
+    /// Computed: Whether the register is currently syncing or in a sync-related state.
+    /// Includes both legacy lifecycle values (Subscribing) and Feature 108 sync-state
+    /// enum values (Indeterminate, Syncing).
     /// </summary>
-    public bool IsInSyncLifecycle => SyncState is "Subscribing" or "Syncing" or "Error";
+    public bool IsInSyncLifecycle => SyncState is "Subscribing" or "Syncing" or "Error" or "Indeterminate";
 
     /// <summary>
-    /// Computed: Human-readable sync state text
+    /// Computed: Human-readable sync state text. Covers the legacy lifecycle strings
+    /// (Subscribing / Synced) AND the Feature 108 <c>RegisterSyncState</c> enum
+    /// (Indeterminate / Syncing / CaughtUp / Error). "Syncing (N behind)" would
+    /// require <c>RegisterSyncStateView.NetworkHeightHighWaterMark - LocalHeight</c>,
+    /// which is not currently surfaced on this VM — surfacing it is a follow-up.
     /// </summary>
     public string SyncStateText => SyncState switch
     {
-        "Subscribing" => "Subscribing...",
+        // Feature 108 RegisterSyncState enum values.
+        "Indeterminate" => "Unknown",
         "Syncing" => "Syncing...",
+        "CaughtUp" => "Caught up",
+        "Error" => "Error",
+        // Legacy lifecycle strings (pre-F108) retained for backward compat.
+        "Subscribing" => "Subscribing...",
         "Synced" => "Synced",
-        "Error" => "Sync Error",
         _ => ""
     };
 

--- a/src/Core/Sorcha.Register.Core/LocalRelationship/ConfiguredLocalIdentityProvider.cs
+++ b/src/Core/Sorcha.Register.Core/LocalRelationship/ConfiguredLocalIdentityProvider.cs
@@ -36,6 +36,11 @@ public sealed class ConfiguredLocalIdentityProvider : ILocalIdentityProvider
     private readonly IOptionsMonitor<LocalIdentityOptions> _options;
     private readonly ILogger<ConfiguredLocalIdentityProvider>? _logger;
     private LocalIdentitySnapshot? _cached;
+    // Sync lock is correct here: the critical section in GetAsync does no awaiting
+    // (configuration read + Base64 decode + cache set are all synchronous), so the
+    // heavier SemaphoreSlim primitive used by ValidatorKeyProvider would be wasted.
+    // The two providers' lock-type choice intentionally differs based on whether
+    // their critical sections cross an await boundary.
     private readonly object _gate = new();
 
     public ConfiguredLocalIdentityProvider(

--- a/src/Core/Sorcha.Register.Core/Observations/ObservationStore.cs
+++ b/src/Core/Sorcha.Register.Core/Observations/ObservationStore.cs
@@ -104,9 +104,16 @@ public sealed class ObservationStore : IObservationStore
         string registerId,
         ConcurrentDictionary<string, PeerHeightObservation> perRegister)
     {
-        var oldest = perRegister.Values
-            .OrderBy(o => o.ObservedAt)
-            .FirstOrDefault();
+        // Single-pass min-scan. The previous OrderBy(...).FirstOrDefault() allocated
+        // an array and an enumerator on every advert-ingest. At the 16-peer cap this
+        // is negligible, but the method is called from the hot path so the cheaper
+        // form is preferred.
+        PeerHeightObservation? oldest = null;
+        foreach (var obs in perRegister.Values)
+        {
+            if (oldest is null || obs.ObservedAt < oldest.ObservedAt)
+                oldest = obs;
+        }
         if (oldest is null) return false;
 
         if (perRegister.TryRemove(oldest.SourcePeerId, out _))

--- a/src/Services/Sorcha.Peer.Service/GrpcServices/TransactionDistributionGrpcService.cs
+++ b/src/Services/Sorcha.Peer.Service/GrpcServices/TransactionDistributionGrpcService.cs
@@ -301,7 +301,12 @@ public class TransactionDistributionGrpcService : TransactionDistribution.Transa
             {
                 Accepted = result.Success,
                 RejectReason = result.Success ? string.Empty : $"{result.ErrorCode}: {result.ErrorMessage}",
-                ReceiverIsValidator = true // receiver has its own enrolment path; we don't gate here
+                // ReceiverIsValidator left at proto default (false). Honest signal: the
+                // peer service forwards to its local validator-service via gRPC and reports
+                // the result; whether the receiving NODE is itself on the register's roster
+                // is a separate question we can't answer without consulting
+                // IRegisterLocalRelationshipService.IsValidator(registerId). Wiring that
+                // through is tracked as Feature 108 follow-up #1.
             };
         }
         catch (Exception ex)

--- a/src/Services/Sorcha.Register.Service/Endpoints/ObservationEndpoints.cs
+++ b/src/Services/Sorcha.Register.Service/Endpoints/ObservationEndpoints.cs
@@ -9,6 +9,7 @@ using Sorcha.Register.Core.LocalRelationship;
 using Sorcha.Register.Core.Observations;
 using Sorcha.Register.Core.Storage;
 using Sorcha.Register.Models.Observations;
+using Sorcha.ServiceDefaults;
 
 namespace Sorcha.Register.Service.Endpoints;
 
@@ -57,6 +58,7 @@ public static class ObservationEndpoints
         .WithSummary("Record a peer's advert-height claim for a register (Feature 108)")
         .WithDescription("Internal service-to-service endpoint called by Peer.Service when it observes a remote peer advertising a docket height for a register. The observation feeds the sync-state resolver so the local node can tell whether it is at network head or trailing. Rejects observations more than ±5 minutes from local clock to bound skew. Not part of the public API surface.")
         .RequireAuthorization(AuthorizationPolicies.CanReportRegisterObservation)
+        .RequireRateLimiting(RateLimitPolicies.Api)
         .Produces(StatusCodes.Status202Accepted)
         .Produces(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status401Unauthorized)
@@ -115,6 +117,7 @@ public static class ObservationEndpoints
         .WithSummary("Record the local validator's sealing progress for a register (Feature 108)")
         .WithDescription("Internal service-to-service endpoint called by Validator.Service when it seals a docket. Records the last sealed height and current mempool depth so the sync-state resolver knows the local node's contribution to network progress. The caller must present its validator public key via the X-Validator-Public-Key header and must be on the register's roster. Not part of the public API surface.")
         .RequireAuthorization(AuthorizationPolicies.CanReportRegisterObservation)
+        .RequireRateLimiting(RateLimitPolicies.Api)
         .Produces(StatusCodes.Status202Accepted)
         .Produces(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status401Unauthorized)

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1545,7 +1545,16 @@ docketsGroup.MapPost("/", async (
         var hasControlTx = request.Transactions.Any(t => t.MetaData?.TransactionType == TransactionType.Control);
         if (hasControlTx)
         {
-            _ = Task.Run(() => relationshipNotifier.PublishIfChangedAsync(registerId));
+            // Fire-and-forget: PublishIfChangedAsync has its own try/catch internally,
+            // but tag the task with a ContinueWith so any escape (cancellation during
+            // shutdown, unexpected scheduler error) is logged rather than silently
+            // abandoned to the unobserved-task pipeline.
+            _ = Task.Run(() => relationshipNotifier.PublishIfChangedAsync(registerId))
+                .ContinueWith(
+                    t => logger.LogWarning(t.Exception,
+                        "RelationshipChangeNotifier.PublishIfChangedAsync escaped for register {RegisterId}",
+                        registerId),
+                    TaskContinuationOptions.OnlyOnFaulted);
         }
 
         // Publish docket confirmed event

--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -474,7 +474,14 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
         // RegisterMonitoringBootstrap will re-reconcile, find this register via the
         // stashed control record, and start sealing the genesis tx waiting in its pool.
         // Fire-and-forget — Redis publish failure is non-fatal, the safety poll covers it.
-        _ = Task.Run(() => _relationshipNotifier.PublishIfChangedAsync(register.Id));
+        // ContinueWith logs any task-level escape so the unobserved-task pipeline doesn't
+        // swallow shutdown / scheduler faults.
+        _ = Task.Run(() => _relationshipNotifier.PublishIfChangedAsync(register.Id))
+            .ContinueWith(
+                t => _logger.LogWarning(t.Exception,
+                    "RelationshipChangeNotifier.PublishIfChangedAsync escaped for register {RegisterId}",
+                    register.Id),
+                TaskContinuationOptions.OnlyOnFaulted);
 
         // Set register Online after successful creation
         // SignalR notifications (RegisterStatusChanged, RegisterCreated) handled by RegisterEventBridgeService

--- a/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
+++ b/src/Services/Sorcha.Validator.Service/Endpoints/ValidationEndpoints.cs
@@ -45,7 +45,6 @@ public static class ValidationEndpoints
         [FromBody] ValidateTransactionRequest request,
         [FromServices] ITransactionValidator validator,
         [FromServices] ITransactionPoolPoller poolPoller,
-        [FromServices] IRegisterMonitoringRegistry monitoringRegistry,
         [FromServices] IHashProvider hashProvider,
         [FromServices] ILogger<Program> logger,
         CancellationToken cancellationToken)
@@ -152,13 +151,9 @@ public static class ValidationEndpoints
             logger.LogInformation("Transaction {TransactionId} validated and submitted to unverified pool", request.TransactionId);
 
             // Feature 108 — monitoring enrolment is now roster-driven via RegisterMonitoringBootstrap.
-            // We intentionally do NOT call monitoringRegistry.RegisterForMonitoring(registerId) here
-            // any more. Nodes that are not on the register's validator roster will accept the
-            // transaction into their mempool for onward forwarding, but will not produce dockets.
-            // The `monitoringRegistry` dependency is kept in the endpoint signature because other
-            // code paths may still reference it — it's a no-op in this handler now.
-            _ = monitoringRegistry;
-
+            // No per-submission registration call here. Nodes that are not on the register's
+            // validator roster accept the transaction into their mempool for onward forwarding
+            // but do not produce dockets.
             return Results.Ok(new
             {
                 IsValid = true,

--- a/src/Services/Sorcha.Validator.Service/Services/ValidatorKeyProvider.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidatorKeyProvider.cs
@@ -14,9 +14,20 @@ namespace Sorcha.Validator.Service.Services;
 /// is the key we need; the signature itself is discarded.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Probe-by-sign is the simplest path that doesn't require changing the Wallet.Service API
 /// surface. The sentinel is a fixed 32-byte hash, pre-hashed, so the operation is fast and
 /// adds no side effects. Result is cached for the process lifetime.
+/// </para>
+/// <para>
+/// Security note — the sentinel bytes (<c>"sorcha:validator-key-probe"</c> zero-padded to
+/// 32 bytes) are PUBLIC and not a valid docket-hash. A signature over the sentinel cannot
+/// be replayed against any Sorcha verifier: <see cref="Sorcha.Cryptography.Utilities.DocketHasher"/>
+/// produces 32-byte SHA-256 outputs of canonical docket envelopes, and the sentinel is
+/// neither (it's lower-case ASCII followed by null bytes). Audit logs that capture all
+/// validator-key-signing operations will see one signature per validator startup over
+/// this constant — that's expected and benign, not a credential leak.
+/// </para>
 /// </remarks>
 public sealed class ValidatorKeyProvider : IValidatorKeyProvider
 {


### PR DESCRIPTION
## Summary
Eight small items from the Feature 108 follow-up backlog (claude-review of PR #360). All small, all same-flavour (post-merge tidy-ups), all independent.

| # | Item |
|---|---|
| 1 | Drop dead `IRegisterMonitoringRegistry` parameter from `ValidationEndpoints.ValidateTransaction` |
| 2 | Stop hardcoding `ReceiverIsValidator = true` in peer's `SubmitTransaction` response (no consumer reads it; default `false` is honest pending proper wiring) |
| 13 | Rate-limit the two F108 observation endpoints (`peer-height-observation` / `validator-observation`) per CLAUDE.md #8 |
| 7 | Fix proto vs implementation field-name mismatch in `contracts/peer-service-distribute-submission.proto` (`Timestamp submitted_at` → `int64 submitted_at_unix_ms`) |
| 9 | Add security note to `ValidatorKeyProvider` docstring explaining the probe-by-sign sentinel is opaque to any verifier (not a docket-hash) — audit-log noise is benign |
| 15 | `RegisterViewModel.SyncStateText` — add friendly labels for the Feature 108 enum values (Indeterminate / Syncing / CaughtUp / Error); preserve legacy lifecycle strings |
| 3 | `ObservationStore.EvictOldestPeerObservation` — `OrderBy(...).FirstOrDefault()` → single-pass min-scan (zero alloc on the hot path) |
| 4 | Two `Task.Run` sites in Register.Service get a `ContinueWith(OnlyOnFaulted)` so shutdown / scheduler escapes are logged not silently swallowed |

## Skipped on inspection
- **#8 lock-type standardisation** — the audit's recommendation is wrong. `ValidatorKeyProvider` MUST use `SemaphoreSlim` because its critical section awaits `Wallet.Service.SignTransactionAsync`. `ConfiguredLocalIdentityProvider` has no await inside its lock so `lock(object)` is the correct (lighter) primitive. Added a clarifying comment to the latter.

## Test plan
- [x] All impacted services build clean.
- [x] 18 validation-endpoint tests pass (7 skipped per existing #446 drift).
- [ ] CI green (admin-merge through if `build-and-test` surfaces unrelated failures).