### PR TITLE
test(108): two isolated tests from the follow-up audit

### DIFF
--- a/tests/Sorcha.Register.Core.Tests/LocalRelationship/RegisterLocalRelationshipServiceTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/LocalRelationship/RegisterLocalRelationshipServiceTests.cs
@@ -74,6 +74,29 @@ public class RegisterLocalRelationshipServiceTests
     }
 
     [Fact]
+    public async Task Derive_ValidatorKeyNonNullButNotOnRoster_LocalIsOwner_IsValidatorFalse()
+    {
+        // Isolates the "validator key non-null but not on the roster" signal from the
+        // wallet-mismatch case. Local wallet IS the owner so IsOwner is true; the
+        // validator-key check must independently return false when the local key is
+        // absent from the roster, even though the wallet check succeeded. Guards
+        // against accidental coupling of the two membership decisions.
+        var record = BuildControlRecord(
+            ownerAddress: LocalWalletAddress,
+            validatorKeys: new[] { OtherValidatorKey });
+
+        var svc = BuildService(
+            record,
+            walletAddresses: new[] { LocalWalletAddress },
+            validatorKey: LocalValidatorKey);
+        var rel = await svc.DeriveAsync(RegisterId);
+
+        rel.Should().NotBeNull();
+        rel!.IsOwner.Should().BeTrue();
+        rel.IsValidator.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Derive_PlainSubscriber_ReturnsNoneRolesAndIsSubscriberTrue()
     {
         var record = BuildControlRecord(

--- a/tests/Sorcha.Register.Core.Tests/SyncState/RegisterSyncStateResolverTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/SyncState/RegisterSyncStateResolverTests.cs
@@ -88,6 +88,38 @@ public class RegisterSyncStateResolverTests
     }
 
     [Fact]
+    public void PrunedOwner_ReceivesStaleAdvertFromTrailingPeer_ReturnsCaughtUp()
+    {
+        // Scenario from the Feature 108 follow-up audit: a register owner has pruned
+        // dockets locally (LocalHeight advanced past a docket that has since been
+        // archived/replicated) and then receives a peer advert from a node that's
+        // genuinely trailing. The advert is "old" in the sense that its NetworkHeight
+        // is lower than the owner's LocalHeight. The owner must NOT regress to
+        // Syncing/Indeterminate on the strength of a trailing peer's claim — the
+        // resolver should report CaughtUp because local >= hwm.
+        //
+        // Constructed independently of LocalAheadOfHwm_ReturnsCaughtUp so a future
+        // refactor that mistakenly clamps LocalHeight against hwm gets caught here
+        // even if that test changes.
+        var trailingPeerAdvert = new[]
+        {
+            new PeerHeightObservation(RegisterId, "trailing-peer", 100, DateTimeOffset.UtcNow.AddSeconds(-30))
+        };
+        var view = BuildResolver().Resolve(
+            RegisterId,
+            localHeight: 250,  // owner has pruned past height 100, retains tip 250
+            observations: trailingPeerAdvert,
+            validatorSealing: null,
+            persistedState: null,
+            lastErrorMessage: null);
+
+        view.State.Should().Be(RegisterSyncState.CaughtUp);
+        view.LocalHeight.Should().Be(250);
+        view.NetworkHeightHighWaterMark.Should().Be(100);
+        view.DistinctPeerObservers.Should().Be(1);
+    }
+
+    [Fact]
     public void PersistedError_IsSticky_EvenWhenObservationsFresh()
     {
         var obs = new[] { new PeerHeightObservation(RegisterId, "n1", 10, DateTimeOffset.UtcNow) };


### PR DESCRIPTION
## Summary
Two tests from the Feature 108 follow-up audit (#10 and #11). The third audit item (#12 — NAT'd-subscriber \`ActionExecutionService\` scenario) is **deferred**: the existing \`ActionExecutionServiceTests\` class explicitly skips ExecuteAsync full-flow tests (see comment at line 485-487 of that file) because they need \`ICryptoModule\` / \`IHashProvider\` / \`IPayloadManager\` mock infrastructure that isn't built out. #12 belongs with a future targeted-refactor pass, not a small-fix bundle.

## Tests added

**#10 — \`Derive_ValidatorKeyNonNullButNotOnRoster_LocalIsOwner_IsValidatorFalse\`** (Register.Core.Tests)
Isolates the validator-key-vs-roster check from the wallet-mismatch check. Local wallet IS the owner so \`IsOwner\` is true; the validator-key check must independently return false. Guards against accidental coupling of the two membership decisions in \`DeriveAsync\`.

**#11 — \`PrunedOwner_ReceivesStaleAdvertFromTrailingPeer_ReturnsCaughtUp\`** (Register.Core.Tests)
Owner has pruned dockets past a peer's advertised height. Resolver must report \`CaughtUp\` (local >= hwm). Constructed independently of the existing \`LocalAheadOfHwm_ReturnsCaughtUp\` test so a future refactor that mistakenly clamps \`LocalHeight\` against \`hwm\` gets caught here even if that test changes.

## Test plan
- [x] 323/323 \`Sorcha.Register.Core.Tests\` pass.
- [ ] CI green.