### PR TITLE
test: fix two small flaky-test causes (DID resolver, broken skip helper)

### DIFF
--- a/tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
+++ b/tests/Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests.cs
@@ -224,7 +224,12 @@ public class HubBackplaneCrossReplicaTests
 }
 
 /// <summary>
-/// xUnit Skip-based gating helper for SkippableFact behaviour.
+/// xUnit v3 skip-gating helper. Calls <see cref="Assert.Skip(string)"/> which the
+/// runner records as a Skipped outcome (not a failure). The previous implementation
+/// threw a custom <c>SkipException</c> in the hope that xUnit would treat it as a
+/// skip — it didn't, and every CI run without the required env var counted these
+/// as 3 hard failures in <c>build-and-test</c>. <c>Assert.Skip</c> is the native
+/// xUnit v3 API and behaves correctly.
 /// </summary>
 internal static class Skip
 {
@@ -232,17 +237,15 @@ internal static class Skip
     {
         if (!condition)
         {
-            throw new SkipException(reason);
+            Assert.Skip(reason);
         }
     }
 }
 
-internal sealed class SkipException(string reason) : Exception(reason);
-
 /// <summary>
-/// Marker attribute used in lieu of the Xunit.SkippableFact NuGet package — keeps
-/// the dependency surface minimal. The xUnit runner treats the SkipException above
-/// as a skip when raised from a Fact body.
+/// Marker attribute paired with <see cref="Skip.IfNot"/>. The skip itself is performed
+/// inside the Fact body via <c>Assert.Skip</c> — the attribute is retained as
+/// documentation that the test is conditionally gated.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 internal sealed class SkippableFactAttribute : FactAttribute { }

--- a/tests/Sorcha.ServiceClients.Tests/Did/SorchaDidResolverTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Did/SorchaDidResolverTests.cs
@@ -171,10 +171,20 @@ public class SorchaDidResolverTests
 
         doc.Should().NotBeNull();
         doc!.Id.Should().Be("did:sorcha:org:org-addr-456");
-        doc.VerificationMethod.Should().HaveCount(1);
-        doc.VerificationMethod[0].Type.Should().Be("Ed25519VerificationKey2020");
+
+        // Feature 120 kid-swap (#604/#605): org DIDs emit two VMs — the canonical
+        // `#key-1` and a `#vc-issuance-1` alias pointing at the same key bytes so
+        // credentials carrying kid=did:sorcha:org:{addr}#vc-issuance-{n} resolve
+        // via exact-match. Both must be Ed25519VerificationKey2020.
+        doc.VerificationMethod.Should().HaveCount(2);
+        doc.VerificationMethod[0].Id.Should().Be("did:sorcha:org:org-addr-456#key-1");
+        doc.VerificationMethod[1].Id.Should().Be("did:sorcha:org:org-addr-456#vc-issuance-1");
+        doc.VerificationMethod.Should().AllSatisfy(vm =>
+            vm.Type.Should().Be("Ed25519VerificationKey2020"));
 
         // Feature 093 US3 FR-015: org DIDs produce the same valid multibase as wallet DIDs.
+        // Both VMs point at the same key bytes, so verify the multibase on the canonical
+        // #key-1 entry.
         var multibase = doc.VerificationMethod[0].PublicKeyMultibase;
         multibase.Should().NotBeNull();
         multibase!.Should().StartWith("z");
@@ -184,8 +194,12 @@ public class SorchaDidResolverTests
         decoded[1].Should().Be(0x01);
         decoded.Skip(2).Should().Equal(Ed25519KeyBytes);
 
+        // The issuance alias shares the same key material as the canonical VM.
+        doc.VerificationMethod[1].PublicKeyMultibase.Should().Be(multibase);
+
         doc.Authentication.Should().Contain("did:sorcha:org:org-addr-456#key-1");
         doc.AssertionMethod.Should().Contain("did:sorcha:org:org-addr-456#key-1");
+        doc.AssertionMethod.Should().Contain("did:sorcha:org:org-addr-456#vc-issuance-1");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Two of the three root causes of \`build-and-test\` failures. Quick fixes; the 69-test Redis-backplane cluster remains for a separate (bigger) PR.

### 1. DID resolver test asserted 1 VerificationMethod, F120 emits 2
\`SorchaDidResolverTests.ResolveAsync_OrgDid_ReturnsDidDocumentWithValidMultibase\` expected exactly 1 VM. F120 kid-swap (#604/#605) made org DIDs emit two — the canonical \`#key-1\` and a \`#vc-issuance-1\` alias pointing at the same key bytes so credentials carrying \`kid=did:sorcha:org:{addr}#vc-issuance-{n}\` resolve via exact-match. Test updated to assert both VMs and confirm the alias shares the canonical key material.

### 2. Broken \`Skip.IfNot\` helper turning skips into failures
A custom helper in \`HubBackplaneCrossReplicaTests.cs:229\` threw a bespoke \`SkipException\` with a marker-attribute comment claiming xUnit treats the exception as a skip. xUnit v3 doesn't — it treats it as a fault. The 3 tests gated on \`SORCHA_DOCKER=1\` / \`SORCHA_MULTINODE=1\` therefore counted as hard failures on every CI run without those env vars set.

Replaced with \`Assert.Skip(reason)\` (xUnit v3 native API) which the runner records as Skipped. Verified locally: all 4 \`HubBackplaneCrossReplicaTests\` skip cleanly when \`SORCHA_MULTINODE\` is unset; \`InboxRoundTripTests\` skips cleanly when \`SORCHA_DOCKER\` is unset.

### Net
4 hard failures gone from \`build-and-test\` (1 ServiceClients + 3 Integration). The remaining 69 in \`Sorcha.Register.Service.Tests\` are the Redis-backplane cluster tracked under backlog #585 — separate PR coming.

## Test plan
- [x] \`Sorcha.ServiceClients.Tests --filter ResolveAsync_OrgDid*\` → 4 pass
- [x] \`Sorcha.Integration.Tests --filter *HubBackplane*\` → 4 skip
- [x] \`Sorcha.Integration.Tests --filter *InboxRoundTrip*\` → 1 skip
- [ ] CI green