### PR TITLE
test: override SignalR Redis backplane in Register.Service.Tests factory

### DIFF
--- a/tests/Sorcha.Register.Service.Tests/Helpers/RegisterServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Register.Service.Tests/Helpers/RegisterServiceWebApplicationFactory.cs
@@ -7,6 +7,8 @@ using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -14,6 +16,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Sorcha.Register.Core.Events;
 using Sorcha.Register.Models;
+using Sorcha.Register.Service.Hubs;
 using Sorcha.Register.Service.Services;
 using Sorcha.Register.Storage.InMemory;
 using Sorcha.ServiceClients.Peer;
@@ -113,6 +116,19 @@ public class RegisterServiceWebApplicationFactory : WebApplicationFactory<Progra
             var mockPeerClient = new Mock<IPeerServiceClient>();
             ReplaceService<IPeerServiceClient>(services,
                 _ => mockPeerClient.Object);
+
+            // Replace SignalR's Redis-backed HubLifetimeManager with the in-memory
+            // DefaultHubLifetimeManager so RegisterEventBridgeService.PublishAsync
+            // doesn't try to connect to a real Redis at runtime. The production
+            // pipeline registers RedisHubLifetimeManager<RegisterHub> via
+            // AddStackExchangeRedis — the IConnectionMultiplexer mock above doesn't
+            // help because SignalR keeps its own multiplexer inside RedisOptions.
+            // Tests against the in-memory backplane still receive hub events within
+            // a single host (sufficient for the SignalRHubTests in this project).
+            // Cross-replica fan-out tests live in Sorcha.Integration.Tests/MultiNode
+            // and gate on SORCHA_MULTINODE=1, so they're unaffected by this override.
+            services.RemoveAll(typeof(HubLifetimeManager<RegisterHub>));
+            services.AddSingleton<HubLifetimeManager<RegisterHub>, DefaultHubLifetimeManager<RegisterHub>>();
         });
     }
 


### PR DESCRIPTION
## Summary
Closes the 69-test flaky cluster in \`build-and-test\` — all of these were sharing one root cause.

\`WebApplicationFactory\` boots the production pipeline → \`AddSorchaHub<RegisterHub>\` → \`ConfigureSignalRWithBackplane\` finds \`ConnectionStrings:Redis\` (case-insensitive match on the factory's \`ConnectionStrings__redis\` env var that Aspire's \`AddRedisClient\` needs) → wires \`AddStackExchangeRedis\`. \`RedisHubLifetimeManager\` keeps its **own** \`ConnectionMultiplexer\` (separate from the DI mock at line 82), so when \`RegisterEventBridgeService\` publishes events it tries to connect to \`localhost:6379\` and fails. The failure cascades through every test that creates a register via \`TestRegisterHelper\`.

## Fix
Surgical override at the DI boundary. After the production pipeline runs:

\`\`\`csharp
services.RemoveAll(typeof(HubLifetimeManager<RegisterHub>));
services.AddSingleton<HubLifetimeManager<RegisterHub>, DefaultHubLifetimeManager<RegisterHub>>();
\`\`\`

- Production code untouched.
- \`SignalRHubTests\` (5 tests) still pass because the in-memory backplane delivers within a single host.
- Cross-replica fan-out tests live in \`Sorcha.Integration.Tests/MultiNode/HubBackplaneCrossReplicaTests\` and gate on \`SORCHA_MULTINODE=1\` — those are unaffected by this override.

## Test plan
- [x] Full local run: **304/304 pass** (295 succeeded, 9 pre-existing skips, 0 failed)
- [x] Verified the 5 SignalR tests are among the 295 succeeded
- [ ] CI green

## Net impact on build-and-test
After this PR + #618 lands, \`build-and-test\` should drop from **73 failures → 0**:
- 69 Redis-cluster failures: gone (this PR)
- 1 DID resolver F120 regression: gone (#618)
- 3 broken-skip-helper failures: gone (#618)

The flaky cluster in MEMORY.md should be updated to mark the cluster resolved.