### PR TITLE
ci/setup: fix two red workflows (claude-review label, missing dev cert)

### DIFF
--- a/.github/workflows/claude-review-issues.yml
+++ b/.github/workflows/claude-review-issues.yml
@@ -45,6 +45,18 @@ jobs:
           echo "has_comments=true" >> "$GITHUB_OUTPUT"
           echo "$COMMENTS" > /tmp/claude-comments.json
 
+      - name: Ensure claude-review label exists
+        if: steps.get-comments.outputs.has_comments == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Self-heal: previous runs failed with "label 'claude-review' not found".
+          # Create idempotently — `|| true` swallows the conflict on re-run,
+          # so the workflow tolerates manual deletion of the label.
+          gh label create claude-review \
+            --description "Auto-created from Claude code review workflow" \
+            --color 5319e7 || true
+
       - name: Create issues from actionable comments
         if: steps.get-comments.outputs.has_comments == 'true'
         env:

--- a/scripts/sorcha-setup.sh
+++ b/scripts/sorcha-setup.sh
@@ -408,6 +408,76 @@ ENVFILE
 }
 
 # -----------------------------------------------------------------------------
+# Dev HTTPS certificate generation
+# -----------------------------------------------------------------------------
+
+ensure_dev_cert() {
+    # docker-compose mounts ./docker/certs:/https into api-gateway, which is
+    # configured to bind https://+:8443 with /https/aspnetapp.pfx. The .pfx
+    # files are .gitignored (private keys must never be committed), so a fresh
+    # clone has an empty docker/certs/ directory and the api-gateway crashes
+    # on startup with FileNotFoundException. This step generates a self-signed
+    # dev cert on Linux/macOS using openssl — matches the existing Windows
+    # script scripts/generate-dev-cert.ps1. Idempotent.
+    local cert_dir="$PROJECT_DIR/docker/certs"
+    local pfx="$cert_dir/aspnetapp.pfx"
+    local password="SorchaDev2025"   # matches docker-compose api-gateway env
+
+    if [ -f "$pfx" ]; then
+        success "Dev certificate already present at $pfx"
+        return 0
+    fi
+
+    info "Generating self-signed dev certificate for HTTPS..."
+    mkdir -p "$cert_dir"
+
+    if ! command -v openssl &> /dev/null; then
+        warn "openssl not installed — api-gateway HTTPS endpoint will fail to bind. Install openssl or set ASPNETCORE_URLS=http://+:8080 only."
+        return 0
+    fi
+
+    local tmp_key tmp_crt tmp_cnf
+    tmp_key=$(mktemp)
+    tmp_crt=$(mktemp)
+    tmp_cnf=$(mktemp)
+
+    cat > "$tmp_cnf" <<'EOF'
+[req]
+distinguished_name = req_dn
+x509_extensions    = v3_ca
+prompt             = no
+[req_dn]
+CN = localhost
+[v3_ca]
+keyUsage         = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName   = @alt_names
+[alt_names]
+DNS.1 = localhost
+DNS.2 = api-gateway
+DNS.3 = sorcha-ui-web
+IP.1  = 127.0.0.1
+EOF
+
+    openssl req -x509 -newkey rsa:2048 -days 730 -nodes \
+        -keyout "$tmp_key" -out "$tmp_crt" -config "$tmp_cnf" \
+        -extensions v3_ca > /dev/null 2>&1
+
+    openssl pkcs12 -export -out "$pfx" \
+        -inkey "$tmp_key" -in "$tmp_crt" \
+        -password "pass:$password" > /dev/null 2>&1
+
+    rm -f "$tmp_key" "$tmp_crt" "$tmp_cnf"
+
+    if [ ! -f "$pfx" ]; then
+        warn "openssl did not produce $pfx — api-gateway HTTPS bind will fail"
+        return 0
+    fi
+
+    success "Generated dev certificate at $pfx"
+}
+
+# -----------------------------------------------------------------------------
 # Pull and start services
 # -----------------------------------------------------------------------------
 
@@ -508,6 +578,7 @@ main() {
         ask_yes_no "Overwrite with new configuration?" "n" OVERWRITE
         if [ "$OVERWRITE" != "y" ]; then
             info "Keeping existing .env. Starting services..."
+            ensure_dev_cert
             start_services
             wait_for_health
             print_summary
@@ -517,6 +588,7 @@ main() {
 
     ask_configuration
     write_env_file
+    ensure_dev_cert
     pull_images
     start_services
     if ! wait_for_health; then


### PR DESCRIPTION
## Summary
Two of the persistent red GitHub Actions workflows on master, fixed together because they're both small.

### 1. \`Claude Review — Create Issues\` — \`label 'claude-review' not found\`
The workflow tries to apply a \`claude-review\` label to auto-created issues, but the label was never created in the repo. Every run has been red since the workflow landed.

- Created the label out-of-band (\`gh label create claude-review ...\`).
- Added a **self-heal** step that recreates the label on every run (idempotent via \`|| true\`). Future manual deletions of the label won't break the workflow.

### 2. \`Nightly clean-VM quickstart\` — \`/https/aspnetapp.pfx\` not found
\`sorcha-api-gateway\` crashes at startup with \`FileNotFoundException\` for the HTTPS dev cert. \`*.pfx\` is \`.gitignored\` (private keys must never be committed), so a fresh clone has an empty \`docker/certs/\` directory. The api-gateway is configured to bind \`https://+:8443\` with the pfx, so it can't start.

A Windows PowerShell \`generate-dev-cert.ps1\` exists. \`sorcha-setup.sh\` (Linux/macOS, the script CI invokes) had no equivalent. Added an \`ensure_dev_cert()\` function using openssl (already a prereq) that:

- Generates a self-signed 2-year cert with SANs for \`localhost\`, \`api-gateway\`, \`sorcha-ui-web\`, \`127.0.0.1\`.
- Exports to \`docker/certs/aspnetapp.pfx\` with password \`SorchaDev2025\` (matches the docker-compose env).
- Idempotent — skips if the pfx already exists.
- Falls through with a warning if openssl is somehow missing (don't block the whole setup over the HTTPS endpoint alone).

Wired into \`main()\` in both the \`.env\`-overwrite and \`.env\`-keep paths.

## Test plan
- [x] \`gh label list --search claude\` confirms the label now exists.
- [x] \`bash -n scripts/sorcha-setup.sh\` passes.
- [x] Manual openssl pkcs12 round-trip produces a readable .pfx with the configured password.
- [ ] Next Claude Review workflow trigger after merge produces a green run.
- [ ] Next Nightly clean-VM quickstart trigger produces a green run.

## Risk
The Nightly workflow currently runs on a \`schedule\` (cron). I can't trigger it manually without merging. If the cert generation step has a subtle issue (e.g. .NET 10 PKCS#12 loader complaining about openssl 3.x's default cipher), the workflow will fail on its next nightly run with a similar but new error — and I'd iterate.

The fallback if this doesn't work: drop \`https://+:8443\` from the api-gateway compose entry so HTTPS isn't required. Production (n1) uses Caddy for TLS termination upstream of the api-gateway anyway.