### PR TITLE
fix(jwt): warn when user-type token is missing platform_user_id

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/JwtAuthenticationExtensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/JwtAuthenticationExtensions.cs
@@ -252,6 +252,25 @@ public static class JwtAuthenticationExtensions
                         var userId = context.Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
                         var orgId = context.Principal?.FindFirst("org_id")?.Value;
 
+                        // Defensive observability: every user-type token must carry
+                        // platform_user_id — it's the key for PlatformUser-scoped tables
+                        // (inbox, wallet hub groups, persona, etc). A missing claim
+                        // means callers will hit silent 401 storms on endpoints that
+                        // scope by that key. We've seen this happen when stale Docker
+                        // images get promoted to `latest` without rebuilding from the
+                        // current source. Surface it as a single warning at validation
+                        // time rather than a flood of 401s from downstream handlers.
+                        var tokenType = context.Principal?.FindFirst("token_type")?.Value;
+                        if (string.Equals(tokenType, "user", StringComparison.Ordinal)
+                            && string.IsNullOrEmpty(context.Principal?.FindFirst("platform_user_id")?.Value))
+                        {
+                            logger.LogWarning(
+                                "User-type JWT validated WITHOUT platform_user_id claim on {RequestPath} (sub: {Sub}, org: {OrgId}). " +
+                                "PlatformUser-scoped endpoints (inbox, /hubs/wallet, persona) will return 401. " +
+                                "This typically means the tenant-service image was built before the platform_user_id claim was added — rebuild and redeploy from current master.",
+                                context.HttpContext.Request.Path, userId, orgId);
+                        }
+
                         // Check token revocation if a revocation store is registered (FR-006)
                         var revocationStore = context.HttpContext.RequestServices
                             .GetService<ITokenRevocationStore>();


### PR DESCRIPTION
## Summary

- Adds an `OnTokenValidated` diagnostic warning when a `token_type=user` JWT validates without a `platform_user_id` claim.
- Updates the n1-deploy skill credentials to match what's actually bootstrapped on n1.

## Why

While walking n1 during a UI discovery pass today the admin UI was 401-storming on `/api/me/inbox*` and `/hubs/wallet/negotiate`. Decoded the production JWT from gateway logs — it was missing the `platform_user_id` claim, even though source has emitted it since e66578ae (2026-03-16). String-grepped the deployed `sorcha-tenant-service` binary on n1: zero hits for the literal `platform_user_id`. The `latest` image on Dockerhub is genuinely older than master despite a 2026-05-10 created-at timestamp — promoted/tagged rather than rebuilt.

All `PlatformUser`-scoped endpoints (`MeInboxEndpoints`, `WalletHub` group placement, persona) read `platform_user_id` and return 401 when it's missing. The client retry-on-401 hook then hammers `/api/service-auth/token` every few seconds without ever recovering. Server-side there was zero log signal pointing at the actual cause.

The real fix for n1 is a fresh Docker image build from current master (this PR's merge will produce one via Docker Publish). This warning makes the same situation diagnosable next time — and is also useful in any future case where a caller mints a `token_type=user` JWT without the claim.

## Test plan
- [x] `dotnet build src/Common/Sorcha.ServiceDefaults` clean (0 errors).
- [ ] CI green.
- [ ] Post-merge: pull fresh `sorchadev/tenant-service:latest` + `wallet-service:latest` on n1, restart services, verify `/api/me/inbox` and `/hubs/wallet/negotiate` return 200 for `admin@sorcha.local`, "Reconnecting…" indicator goes away.