### PR TITLE
fix(tenant/jwt): preserve platform_user_id across refresh

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Services/TokenService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TokenService.cs
@@ -111,7 +111,7 @@ public class TokenService : ITokenService
         var refreshTokenExpiry = DateTimeOffset.UtcNow.AddHours(_config.RefreshTokenLifetimeHours);
 
         var accessToken = GenerateToken(claims, accessTokenExpiry);
-        var refreshToken = GenerateRefreshToken(refreshTokenJti, user.Id.ToString(), organization.Id.ToString(), refreshTokenExpiry);
+        var refreshToken = GenerateRefreshToken(refreshTokenJti, user.Id.ToString(), organization.Id.ToString(), refreshTokenExpiry, platformUserId.ToString());
 
         // Track tokens for potential bulk revocation
         await _revocationService.TrackTokenAsync(
@@ -272,8 +272,20 @@ public class TokenService : ITokenService
                 claims.Add(new Claim(TokenClaimConstants.OrgId, orgId));
             }
 
-            // Add platform user ID if present in refresh token
+            // Add platform user ID if present in refresh token. For refresh
+            // tokens minted before this claim was persisted, fall back to the
+            // UserIdentity row — UserIdentity.PlatformUserId is the canonical
+            // source — so existing sessions don't lose access to PlatformUser-
+            // scoped endpoints (inbox, /hubs/wallet, persona) after the next
+            // refresh.
             var platformUserId = principal.FindFirst("platform_user_id")?.Value;
+            if (string.IsNullOrEmpty(platformUserId) && user.PlatformUserId != Guid.Empty)
+            {
+                platformUserId = user.PlatformUserId.ToString();
+                _logger.LogDebug(
+                    "Refresh token for user {UserId} lacked platform_user_id claim; recovered from UserIdentity.PlatformUserId",
+                    user.Id);
+            }
             if (!string.IsNullOrEmpty(platformUserId))
             {
                 claims.Add(new Claim("platform_user_id", platformUserId));
@@ -459,7 +471,7 @@ public class TokenService : ITokenService
         return _tokenHandler.WriteToken(token);
     }
 
-    private string GenerateRefreshToken(string jti, string userId, string? orgId, DateTimeOffset expiry)
+    private string GenerateRefreshToken(string jti, string userId, string? orgId, DateTimeOffset expiry, string? platformUserId = null)
     {
         var claims = new List<Claim>
         {
@@ -471,6 +483,16 @@ public class TokenService : ITokenService
         if (!string.IsNullOrEmpty(orgId))
         {
             claims.Add(new Claim(TokenClaimConstants.OrgId, orgId));
+        }
+
+        // Persist platform_user_id on the refresh token so RefreshTokenAsync
+        // can re-emit it on the rebuilt access token. Without this, every
+        // refreshed access token drops the claim and all PlatformUser-scoped
+        // endpoints (inbox, /hubs/wallet, persona) start 401-ing within the
+        // access-token lifetime.
+        if (!string.IsNullOrEmpty(platformUserId))
+        {
+            claims.Add(new Claim("platform_user_id", platformUserId));
         }
 
         return GenerateToken(claims, expiry);


### PR DESCRIPTION
## Summary

- `GenerateRefreshToken` now persists `platform_user_id` on the refresh token.
- `RefreshTokenAsync` falls back to `UserIdentity.PlatformUserId` when refreshing a pre-existing refresh token that lacks the claim.

## Why

After #624 redeployed n1 with the platform_user_id-emitting tenant-service, login still produced 401-storms on `/api/me/inbox` and `/hubs/wallet/negotiate`. Captured all access tokens from the gateway logs and decoded them:

```
16:03:10 login         → access jti 7e6142f8  platform_user_id ✓
16:03:14 refresh (+4s) → access jti d47eb10b  platform_user_id ✗  ← bug
16:04:48 login         → access jti …8        platform_user_id ✓
16:04:52 refresh (+4s) → access jti 43a01808  platform_user_id ✗
```

Login emits the claim correctly; `RefreshTokenAsync` strips it. The bug is in `GenerateRefreshToken` (TokenService.cs:462) — it carried `sub`, `jti`, `token_use`, optionally `org_id`, but **not** `platform_user_id`. So `RefreshTokenAsync`'s `principal.FindFirst("platform_user_id")?.Value` always returned null and the rebuilt access token came out without the claim.

The WASM client refreshes proactively within seconds of login, so this manifested as the 401-storm symptoms observed in the discovery pass.

The fallback in (2) means existing sessions on n1 don't have to log out and back in — the next refresh recovers the claim from `UserIdentity.PlatformUserId`.

## Test plan
- [x] `dotnet build src/Services/Sorcha.Tenant.Service` clean.
- [ ] CI green.
- [ ] Post-merge redeploy on n1: log in fresh, observe `platform_user_id` present on both the immediate token AND the auto-refreshed token 4 s later; `/api/me/inbox` and `/hubs/wallet/negotiate` stay 200; the F624 diagnostic warning stays silent.