### PR TITLE
feat(122): Phase 5+6 — PWA bundle-hygiene CI gate + Components.User README

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -62,7 +62,8 @@
       "PowerShell(.\\\\.specify\\\\scripts\\\\powershell\\\\setup-plan.ps1 -Json)",
       "PowerShell(.\\\\.specify\\\\scripts\\\\powershell\\\\update-agent-context.ps1 -AgentType claude)",
       "PowerShell(.\\\\.specify\\\\scripts\\\\powershell\\\\check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks)",
-      "PowerShell(.\\\\.specify\\\\scripts\\\\powershell\\\\check-prerequisites.ps1 -Json)"
+      "PowerShell(.\\\\.specify\\\\scripts\\\\powershell\\\\check-prerequisites.ps1 -Json)",
+      "PowerShell(./scripts/check-pwa-bundle.ps1 2>&1 | Select-Object -Last 30)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/nuget-ci.yml
+++ b/.github/workflows/nuget-ci.yml
@@ -119,6 +119,10 @@ jobs:
           done
           exit $EXIT_CODE
 
+      - name: PWA bundle hygiene check (Feature 122)
+        shell: pwsh
+        run: pwsh scripts/check-pwa-bundle.ps1
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/scripts/check-pwa-bundle.ps1
+++ b/scripts/check-pwa-bundle.ps1
@@ -1,0 +1,103 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Feature 122 bundle-hygiene check.
+#
+# The Sorcha.Citizen.Wallet PWA must not bundle admin / designer
+# assemblies. This script publishes the PWA, inspects the produced
+# wwwroot/_framework/ assembly set, and fails CI when forbidden
+# assemblies are present.
+#
+# Usage:
+#   pwsh scripts/check-pwa-bundle.ps1
+#   pwsh scripts/check-pwa-bundle.ps1 -PublishDir custom/path  # skip publish
+#
+# Exit codes:
+#   0 — bundle is clean
+#   1 — forbidden assembly present, OR required assembly missing
+
+param(
+    [string]$PublishDir = '',
+    [switch]$SkipPublish
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$pwaCsproj = Join-Path $repoRoot 'src/Apps/Sorcha.Citizen.Wallet/Sorcha.Citizen.Wallet.csproj'
+
+if (-not $PublishDir) {
+    $PublishDir = Join-Path $repoRoot 'src/Apps/Sorcha.Citizen.Wallet/bin/Release/net10.0/publish'
+}
+
+if (-not $SkipPublish) {
+    Write-Host "[i] Publishing Sorcha.Citizen.Wallet (Release)..."
+    & dotnet publish $pwaCsproj -c Release -o $PublishDir --nologo /p:CompressionEnabled=false | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "dotnet publish failed (exit $LASTEXITCODE)"
+        exit 1
+    }
+}
+
+$frameworkDir = Join-Path $PublishDir 'wwwroot/_framework'
+if (-not (Test-Path $frameworkDir)) {
+    Write-Error "Framework dir not found: $frameworkDir"
+    exit 1
+}
+
+# Patterns we forbid in the PWA bundle.
+$forbidden = @(
+    'Z.Blazor.Diagrams',
+    'Blazor.Diagrams.Core',
+    'YamlDotNet',
+    'Sorcha.UI.Core'
+)
+
+# Patterns we require to be present (sanity check that the new
+# shared library actually lands in the bundle).
+$required = @(
+    'Sorcha.UI.Components.User'
+)
+
+$assemblies = Get-ChildItem -Path $frameworkDir -Filter '*.wasm' -ErrorAction SilentlyContinue
+if (-not $assemblies) {
+    # Newer SDKs sometimes still emit .dll under _framework; tolerate both.
+    $assemblies = Get-ChildItem -Path $frameworkDir -Filter '*.dll' -ErrorAction SilentlyContinue
+}
+if (-not $assemblies) {
+    Write-Error "No assemblies found under $frameworkDir"
+    exit 1
+}
+
+$names = $assemblies | ForEach-Object { $_.BaseName }
+$failures = @()
+
+foreach ($pattern in $forbidden) {
+    $hits = $names | Where-Object { $_ -like "*$pattern*" }
+    if ($hits) {
+        $failures += "FORBIDDEN: $pattern present as: $($hits -join ', ')"
+    }
+}
+
+foreach ($pattern in $required) {
+    $hits = $names | Where-Object { $_ -like "*$pattern*" }
+    if (-not $hits) {
+        $failures += "MISSING: required $pattern not present"
+    }
+}
+
+if ($failures) {
+    Write-Host ""
+    Write-Host "[X] PWA bundle hygiene check FAILED:" -ForegroundColor Red
+    foreach ($f in $failures) { Write-Host "  - $f" -ForegroundColor Red }
+    Write-Host ""
+    Write-Host "Inspected $($assemblies.Count) assemblies under $frameworkDir"
+    exit 1
+}
+
+Write-Host "[OK] PWA bundle hygiene check PASSED" -ForegroundColor Green
+Write-Host "  Inspected $($assemblies.Count) assemblies under $frameworkDir"
+Write-Host "  Forbidden patterns absent: $($forbidden -join ', ')"
+Write-Host "  Required patterns present: $($required -join ', ')"
+exit 0

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md
@@ -1,0 +1,69 @@
+# Sorcha.UI.Components.User
+
+Shared user-facing Razor component library consumed by both the Sorcha.UI web app family and the `Sorcha.Citizen.Wallet` PWA.
+
+## Why this library exists
+
+The PWA cannot afford to ship admin / designer / explorer code. Before Feature 122, `Sorcha.UI.Core` was the only Razor library and bundled `Z.Blazor.Diagrams`, `YamlDotNet`, and ~3.26 MB of designer-flavoured assembly into anything that referenced it. This library carries only what user-facing components need so the PWA's bundle stays clean.
+
+The web app family transitively picks up this library via `Sorcha.UI.Core`'s ProjectReference — no host-app csproj changes were needed when the extraction landed.
+
+## What lives here
+
+| Surface | Examples |
+|---|---|
+| Components | `Forms/` (full schema-driven form renderer), `Credentials/` (13 cards / dialogs), `Wallet/` (transaction detail, receipt proof, lifecycle ticks), `Participants/` (6 components), `Shared/` (`ConfirmDialog`, `EmptyState`, `JsonTreeView`, etc.) |
+| Services | `Services/User/*` (AddressLookup, Credentials, Forms, Participants, Persona, Wallet), `Services/Shared/*` (Authentication, Blueprints, Configuration, Encryption, Http, Identity, Navigation, Organization) |
+| Models | `Models/User/*` and `Models/Shared/*` |
+| Helpers | `Extensions/Shared/JsonDefaults`, `Utilities/Shared/{MimeTypeIconHelper, UrlValidator}` |
+
+## What deliberately does NOT live here
+
+- Admin / Designer / Explorer / Configuration / Encryption admin pages and their services — these stay in `Sorcha.UI.Core` because they justify UI.Core's continued existence.
+- `Z.Blazor.Diagrams` and `YamlDotNet` — designer-only transitive deps. The csproj **must not** add these even if a moved file happens to compile-time reference them; that signals a misclassification.
+- `BreadcrumbNav`, `UserProfileMenu`, `LogoutConfirmDialog` — web-chrome with auth assumptions the PWA does not share.
+
+## Namespace policy (load-bearing)
+
+The csproj sets `<RootNamespace>Sorcha.UI.Core</RootNamespace>` so every file moved from `Sorcha.UI.Core.*` namespaces keeps its declarations verbatim. The audience signal lives in the **folder**, not in the namespace. Consumer `using` directives across the six web host apps stay valid.
+
+When you add a new file here, declare the same `Sorcha.UI.Core.{Components,Services,Models}.{Foo}` namespace you would have declared in UI.Core; place the file under the audience subfolder it belongs to (`User/`, `Shared/`).
+
+## Audience-tag convention (Feature 123)
+
+Inherited from `Sorcha.UI.Core/README.md`. Recap:
+
+- `Services/User/` — services consumed only by user-facing components/pages.
+- `Services/Shared/` — services consumed by both audiences (both web admin code and PWA user code).
+- `Services/Admin/` — admin-only services. Stays in `Sorcha.UI.Core`.
+
+Same partition for `Models/`, `Extensions/`, `Utilities/`.
+
+### Bi-modal smell detector
+
+If you find yourself writing a service interface that mixes a user-read operation with an admin governance operation, **split it**. The 2026-05-11 attempt at Feature 122 Phase 2 collapsed under exactly this pattern with `IRegisterService`; the recovery (Feature 123) split it into `IRegisterReadService` + `IRegisterGovernanceService`. The same smell test applies to new interfaces.
+
+## Bundle hygiene
+
+The PWA bundle must not contain `Blazor.Diagrams*`, `YamlDotNet*`, or `Sorcha.UI.Core*` assemblies. CI asserts this — see `scripts/check-pwa-bundle.ps1`. When you add a new PackageReference here, ask: does the PWA need this? If no, the dependency belongs in `Sorcha.UI.Core` not here.
+
+## InternalsVisibleTo
+
+This library grants `InternalsVisibleTo` to:
+
+- `Sorcha.UI.Components.User.Tests` — for component-test access
+- `Sorcha.UI.Core` — for cross-library internal helpers like `ReviewSummaryDataSource.PointerFromFieldName` that UI.Core still calls
+- `Sorcha.UI.Core.Tests` — for legacy test access during the migration
+
+The UI.Core grant is intentional: UI.Core is privileged here because it shipped as Components.User's sibling and its consumers transitively expect the same access surface they had pre-extraction.
+
+## Where to add new code
+
+| You're adding... | Put it here |
+|---|---|
+| A user-facing Razor component | `Components/{Forms,Credentials,Wallet,Participants,Shared}/` |
+| A service consumed only by user-facing code | `Services/User/{subject}/` |
+| A service consumed by both audiences | `Services/Shared/{subject}/` |
+| A service used only by admin/designer/explorer | `Sorcha.UI.Core/Services/Admin/{subject}/` |
+| A view-model record used by user-facing components | `Models/User/{subject}/` |
+| A protocol or domain model shared by both audiences | `Models/Shared/{subject}/` |


### PR DESCRIPTION
## Summary

Two post-MVP follow-ups for Feature 122:

- **Phase 5** — Bundle-hygiene CI gate. `scripts/check-pwa-bundle.ps1` publishes the Citizen Wallet PWA in Release, walks `wwwroot/_framework/`, and fails CI when forbidden assemblies (`Z.Blazor.Diagrams`, `Blazor.Diagrams.Core`, `YamlDotNet`, `Sorcha.UI.Core`) are present or the required `Sorcha.UI.Components.User` is missing. Wired into `.github/workflows/nuget-ci.yml` after the test step.

- **Phase 6** — `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md`. Documents why the library exists, what lives there vs `Sorcha.UI.Core`, the load-bearing namespace policy, the F123 audience-tag convention + bi-modal smell detector, the bundle-hygiene contract, and a placement matrix for new code.

## Phase 4 is deliberately not in this PR

The plan's Phase 4 (inverse migration of `ConsentSheet` / `CredentialPickerDialog` / `NoMatchingCredentialDialog` from the PWA into Components.User) turned out to be a redesign rather than a file move. The three components are coupled to PWA-internal protocol types (`ParsedPresentationRequest`, `CachedCredential`) used across `ICredentialCache`, `ISyncService`, `IPresentationEngine`, and several PWA pages. Promoting them properly means redesigning the presentation flow's domain boundaries — work that needs its own spec when there's a web-app presentation flow to share with. Deferred.

## Phase 7

Live-stack PWA proof page + AssuredIdentity walkthrough re-run against the rebuilt stack. Follows in a separate commit/PR after this lands; needs a fresh Docker image build of `ui-web` + `citizen-wallet`.

## Verification

- `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.sln` — 0 errors.
- `pwsh scripts/check-pwa-bundle.ps1` locally on this branch:

  ```
  [OK] PWA bundle hygiene check PASSED
    Inspected 99 assemblies under .../wwwroot/_framework
    Forbidden patterns absent: Z.Blazor.Diagrams, Blazor.Diagrams.Core, YamlDotNet, Sorcha.UI.Core
    Required patterns present: Sorcha.UI.Components.User
  ```

  The extraction genuinely achieved bundle hygiene — no admin/designer assemblies are present in the PWA bundle.

## Test plan

- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.sln` — 0/0
- [x] `pwsh scripts/check-pwa-bundle.ps1` — PASS on this branch
- [x] CI runs the bundle check on every PR going forward (assertion in `nuget-ci.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)