### PR TITLE
feat(122 US4): inverse-migrate PWA consent/picker dialogs to shared library

### DIFF
--- a/.claude/skills/sorcha-ui/SKILL.md
+++ b/.claude/skills/sorcha-ui/SKILL.md
@@ -251,6 +251,17 @@ PageTest (Playwright NUnit)
 
 Full convention + worked examples: `src/Apps/Sorcha.UI/Sorcha.UI.Core/README.md`. Motivating discovery (what bi-modal coupling did to Feature 122 Phase 2): `specs/122-shared-user-components/phase-2-discovery.md`.
 
+## Shared user-facing component library (Feature 122)
+
+User-facing components shared between `Sorcha.UI` (web) and `Sorcha.Citizen.Wallet` (PWA) live in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User`. Admin / designer / explorer components remain in `Sorcha.UI.Core`. The PWA references `Sorcha.UI.Components.User` directly; `Sorcha.UI.Core` ProjectReferences it (transparent re-export to the six web host apps).
+
+**Placement rule when adding a new component:**
+- User-facing, possibly shared with PWA → `Sorcha.UI.Components.User/Components/<Subject>/`
+- Admin / designer / explorer only → `Sorcha.UI.Core/Components/<Subject>/`
+- User-facing models the PWA also needs → `Sorcha.UI.Components.User/Models/User/<Subject>/` (folder is metadata; namespace stays `Sorcha.UI.Core.Models.<Subject>` per the audience-tag convention above)
+
+Full placement matrix + worked examples: `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md`. CI bundle-hygiene gate: `scripts/check-pwa-bundle.ps1` (wired into `nuget-ci.yml`) asserts forbidden assemblies absent + `Sorcha.UI.Components.User` present in the PWA bundle on every push.
+
 ## Related Skills
 
 - See the **blazor** skill for Blazor WASM component architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ dotnet restore && dotnet build && dotnet test
 
 **Sorcha.UI.Core audience convention (Feature 123):** user-facing and admin-facing code in `Sorcha.UI.Core` is partitioned at folder level into `Services/User/`, `Services/Admin/`, `Services/Shared/` (and the same pattern under `Models/`). Folders carry the audience; namespaces stay at the subject level so consumer `using` directives are stable across moves. See `src/Apps/Sorcha.UI/Sorcha.UI.Core/README.md` for the full convention and bi-modal smell detector.
 
+**Shared user-facing component library (Feature 122):** user-facing components shared between `Sorcha.UI` (web) and `Sorcha.Citizen.Wallet` (PWA) live in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User`. Admin / designer / explorer components remain in `Sorcha.UI.Core`. The PWA references `Sorcha.UI.Components.User` directly; `Sorcha.UI.Core` re-exports via ProjectReference so web hosts pick the same components up transparently. See `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md` for placement rules.
+
 Full project tree: `docs/reference/project-structure.md`. Architecture diagrams: `docs/reference/architecture.md`.
 
 ---

--- a/specs/122-shared-user-components/tasks.md
+++ b/specs/122-shared-user-components/tasks.md
@@ -153,18 +153,18 @@ When Feature 123 merges, the steps below execute against a cleaner target. The o
 
 ### Implementation — Inverse migration (PWA-grown components elevated to the library)
 
-- [ ] T041 [US4] Move `src/Apps/Sorcha.Citizen.Wallet/Components/ConsentSheet.razor` → `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor`. Update its namespace to `Sorcha.UI.Components.User.Components.Presentation`. Use `git mv`.
-- [ ] T042 [US4] [P] Move `src/Apps/Sorcha.Citizen.Wallet/Components/CredentialPickerDialog.razor` → `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/CredentialPickerDialog.razor`. Update namespace. Use `git mv`.
-- [ ] T043 [US4] [P] Move `src/Apps/Sorcha.Citizen.Wallet/Components/NoMatchingCredentialDialog.razor` → `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/NoMatchingCredentialDialog.razor`. Update namespace. Use `git mv`.
-- [ ] T044 [US4] Update `src/Apps/Sorcha.Citizen.Wallet/_Imports.razor` and every Citizen.Wallet page that referenced the three moved components to use the new `Sorcha.UI.Components.User.Components.Presentation` namespace. Grep for `Sorcha.Citizen.Wallet.Components.ConsentSheet`, `...CredentialPickerDialog`, `...NoMatchingCredentialDialog` to find all consumers.
-- [ ] T045 [US4] Run `dotnet build src/Apps/Sorcha.Citizen.Wallet/Sorcha.Citizen.Wallet.csproj`. **Required outcome**: zero errors. Run `scripts/check-pwa-bundle.ps1` to confirm bundle hygiene preserved.
+- [x] T041 [US4] Move `src/Apps/Sorcha.Citizen.Wallet/Components/ConsentSheet.razor` → `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor`. **Namespace deviation**: post-F123, `Sorcha.UI.Components.User` carries `RootNamespace=Sorcha.UI.Core`, so the actual landing namespace is `Sorcha.UI.Core.Components.Presentation` (not the spec's `Sorcha.UI.Components.User.Components.Presentation`). Used `git mv`.
+- [x] T042 [US4] [P] Move `CredentialPickerDialog.razor` to `Sorcha.UI.Core.Components.Presentation` (same namespace deviation as T041). Used `git mv`.
+- [x] T043 [US4] [P] Move `NoMatchingCredentialDialog.razor` to `Sorcha.UI.Core.Components.Presentation` (same namespace deviation). Used `git mv`.
+- [x] T044 [US4] Updated `Sorcha.Citizen.Wallet/_Imports.razor` (+ `@using Sorcha.UI.Core.Components.Presentation` and `@using Sorcha.UI.Core.Models.Presentation`). Records `ParsedPresentationRequest`, `CachedCredential`, `CredentialMatch` moved from `Sorcha.Citizen.Wallet/Services/Presentation/Models.cs` → `Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs` (namespace `Sorcha.UI.Core.Models.Presentation`); 4 service files (`ICredentialCache`, `IndexedDbCredentialCache`, `InMemoryCredentialCache`, `ISyncService`) swapped their using; 2 engine files (`IPresentationEngine`, `PresentationEngine`) added an extra using (engines stay PWA-side); 2 test files updated.
+- [x] T045 [US4] `dotnet build Sorcha.Citizen.Wallet.csproj` 0 errors; `scripts/check-pwa-bundle.ps1` PASSED (107 assemblies, forbidden absent, Sorcha.UI.Components.User present).
 
 ### Implementation — Documentation
 
-- [ ] T046 [US4] Create `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md` containing a condensed version of `specs/122-shared-user-components/quickstart.md`: the consume / add-new / decide-where-it-belongs workflows plus the worked-examples table. Keep it under 200 lines.
-- [ ] T047 [US4] Update `CLAUDE.md` — add a one-line pointer under the existing "Sorcha.UI" or Architecture subsection: "User-facing components shared between `Sorcha.UI` and `Sorcha.Citizen.Wallet` live in `Sorcha.UI.Components.User`. Admin / designer / explorer components remain in `Sorcha.UI.Core`." Match the existing style of the surrounding lines.
-- [ ] T048 [US4] Update `.claude/skills/sorcha-ui/SKILL.md` — add a section "Shared user-facing component library" pointing at `Sorcha.UI.Components.User` with a brief description of the boundary rule. This ensures future skill-driven work places new components correctly on the first attempt (SC-005).
-- [ ] T049 [US4] Commit with message `feat(122): inverse-migrate PWA consent/picker dialogs to shared library; document boundary`.
+- [x] T046 [US4] Component-library `README.md` shipped in F122 PR #657 (Phase 5+6 follow-up) — predates this PR. Already covers the consume / add-new / decide-where-it-belongs workflows.
+- [x] T047 [US4] Added two-paragraph pointer in `CLAUDE.md` directly below the F123 audience-convention block.
+- [x] T048 [US4] Added "Shared user-facing component library (Feature 122)" section to `.claude/skills/sorcha-ui/SKILL.md` with placement rule + bundle-hygiene gate reference.
+- [x] T049 [US4] Commit message: `feat(122 US4): inverse-migrate PWA consent/picker dialogs to shared library; document boundary`.
 
 **Checkpoint**: Inverse migration complete, library boundary documented in three places (library README, CLAUDE.md, sorcha-ui skill). User Story 4 satisfied — developer-experience outcome shipped.
 

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/ICredentialCache.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/ICredentialCache.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using Sorcha.Citizen.Wallet.Services.Presentation;
+using Sorcha.UI.Core.Models.Presentation;
 
 namespace Sorcha.Citizen.Wallet.Services;
 

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/ISyncService.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/ISyncService.cs
@@ -4,7 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using Sorcha.CitizenWallet.Abstractions.Models;
-using Sorcha.Citizen.Wallet.Services.Presentation;
+using Sorcha.UI.Core.Models.Presentation;
 using Sorcha.ServiceClients.CitizenWallet;
 
 namespace Sorcha.Citizen.Wallet.Services;

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/InMemoryCredentialCache.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/InMemoryCredentialCache.cs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Collections.Concurrent;
-using Sorcha.Citizen.Wallet.Services.Presentation;
+using Sorcha.UI.Core.Models.Presentation;
 
 namespace Sorcha.Citizen.Wallet.Services;
 

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbCredentialCache.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IndexedDbCredentialCache.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.JSInterop;
-using Sorcha.Citizen.Wallet.Services.Presentation;
+using Sorcha.UI.Core.Models.Presentation;
 
 namespace Sorcha.Citizen.Wallet.Services;
 

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/IPresentationEngine.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/IPresentationEngine.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Sorcha.UI.Core.Models.Presentation;
+
 namespace Sorcha.Citizen.Wallet.Services.Presentation;
 
 /// <summary>

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/Presentation/PresentationEngine.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Web;
 using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Models.Presentation;
 
 namespace Sorcha.Citizen.Wallet.Services.Presentation;
 

--- a/src/Apps/Sorcha.Citizen.Wallet/_Imports.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/_Imports.razor
@@ -8,3 +8,5 @@
 @using MudBlazor
 @using Sorcha.Citizen.Wallet
 @using Sorcha.Citizen.Wallet.Components
+@using Sorcha.UI.Core.Components.Presentation
+@using Sorcha.UI.Core.Models.Presentation

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor
@@ -6,7 +6,7 @@
     per FR-015: required claims locked-on, optional claims toggleable, the
     primary CTA explicitly labelled to convey intent.
 *@
-@using Sorcha.Citizen.Wallet.Services.Presentation
+@using Sorcha.UI.Core.Models.Presentation
 
 <MudPaper Elevation="2" Class="pa-4">
     <MudText Typo="Typo.subtitle1">@Request.Purpose</MudText>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/CredentialPickerDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/CredentialPickerDialog.razor
@@ -6,7 +6,7 @@
     matches more than one credential the citizen holds. Pure presentational —
     raises OnChosen back to Present.razor.
 *@
-@using Sorcha.Citizen.Wallet.Services.Presentation
+@using Sorcha.UI.Core.Models.Presentation
 
 <MudText Typo="Typo.subtitle1" Class="mb-2">Choose a credential</MudText>
 <MudList T="CredentialMatch" SelectedValueChanged="HandleSelected">

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/NoMatchingCredentialDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Presentation/NoMatchingCredentialDialog.razor
@@ -6,7 +6,7 @@
     wallet holds no credential of the type the verifier asked for. Surfaces the
     requested vct so the citizen knows what's missing, plus a Cancel.
 *@
-@using Sorcha.Citizen.Wallet.Services.Presentation
+@using Sorcha.UI.Core.Models.Presentation
 
 <MudAlert Severity="Severity.Warning" Class="mb-3">
     None of your credentials match this verifier's request for <code>@RequiredVct</code>.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-namespace Sorcha.Citizen.Wallet.Services.Presentation;
+namespace Sorcha.UI.Core.Models.Presentation;
 
 /// <summary>Parsed shape of an <c>openid4vp://</c> cross-device deep link.</summary>
 public sealed record ParsedPresentationRequest

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/EnrolmentServiceTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/EnrolmentServiceTests.cs
@@ -11,8 +11,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sorcha.CitizenWallet.Abstractions.Models;
 using Sorcha.Citizen.Wallet.Services;
-using Sorcha.Citizen.Wallet.Services.Presentation;
 using Sorcha.ServiceClients.CitizenWallet;
+using Sorcha.UI.Core.Models.Presentation;
 using Xunit;
 
 namespace Sorcha.Citizen.Wallet.Tests.Services;

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Sorcha.Citizen.Wallet.Services.Presentation;
+using Sorcha.UI.Core.Models.Presentation;
 using Xunit;
 
 namespace Sorcha.Citizen.Wallet.Tests.Services.Presentation;


### PR DESCRIPTION
Completes Feature 122 Phase 6 / User Story 4 — the inverse migration deferred from PR #653.

## Summary

Three small Razor dialogs and three plain-data records move from the Citizen Wallet PWA into the shared `Sorcha.UI.Components.User` library. No functional change. Sets up the F125 unification work to be a one-PR swap on the web side.

## What moved

| From | To |
|---|---|
| `Sorcha.Citizen.Wallet/Components/ConsentSheet.razor` | `Sorcha.UI.Components.User/Components/Presentation/ConsentSheet.razor` |
| `Sorcha.Citizen.Wallet/Components/CredentialPickerDialog.razor` | `Sorcha.UI.Components.User/Components/Presentation/CredentialPickerDialog.razor` |
| `Sorcha.Citizen.Wallet/Components/NoMatchingCredentialDialog.razor` | `Sorcha.UI.Components.User/Components/Presentation/NoMatchingCredentialDialog.razor` |
| `Sorcha.Citizen.Wallet/Services/Presentation/Models.cs` (3 records) | `Sorcha.UI.Components.User/Models/User/Presentation/PresentationModels.cs` |

Git tracked all four as renames (94–98% similarity) so history is preserved.

## Namespace deviation from spec

Spec T041–T043 specified landing namespace `Sorcha.UI.Components.User.Components.Presentation`. Post-F123 reality: `Sorcha.UI.Components.User` carries `RootNamespace=Sorcha.UI.Core`, so the actual landing namespaces are `Sorcha.UI.Core.Components.Presentation` (dialogs) and `Sorcha.UI.Core.Models.Presentation` (records). Matches the audience-tag convention — folder is metadata, namespace stays at subject level. Annotated against each task in `tasks.md`.

## Documentation (T046–T048)

- T046 README — shipped earlier in F122 PR #657.
- T047 — added a pointer in `CLAUDE.md` below the F123 audience-convention block.
- T048 — added "Shared user-facing component library (Feature 122)" section to `.claude/skills/sorcha-ui/SKILL.md`.

## Verification

- `dotnet build Sorcha.UI.sln` — 0 errors, 0 warnings.
- `dotnet build Sorcha.Citizen.Wallet.csproj` — 0 errors, 0 warnings.
- `dotnet test Sorcha.Citizen.Wallet.Tests` — 53/53 pass.
- `scripts/check-pwa-bundle.ps1` — PASSED, 107 assemblies, forbidden absent, `Sorcha.UI.Components.User` present.

## Deferred to backlog

bUnit tests for the three migrated components (spec T055) — requires creating the `tests/Sorcha.UI.Components.User.Tests/` project which doesn't yet exist post-F122. Filed as a follow-up issue alongside the F125 unification work (replacing `PresentationSubmitDialog` in the web shell with the now-shared `ConsentSheet`).

## Honest scope note

The shared library now holds three components with exactly one consumer (the PWA). This is the deliberate "same-shape" situation the user accepted as a stepping stone: F125 (unification) will close it by making the web shell the second consumer, replacing its bespoke `PresentationSubmitDialog`. Until then, the optical claim "shared library has it" outruns the reality "only the PWA uses it". Follow-up issue filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)