### PR TITLE
fix(472): automate wallet-first import in n1-setup-remote.sh / n1-reset.ps1

### DIFF
--- a/.claude/skills/network-bootstrap/SKILL.md
+++ b/.claude/skills/network-bootstrap/SKILL.md
@@ -166,7 +166,22 @@ owner=validator:{validatorId}, name=system-wallet-{validatorId}` so
 validator-service finds it. Currently `AllowAnonymous`, so no auth
 header needed.
 
-**Procedure:**
+**Procedure (automated — preferred):**
+
+```powershell
+# From your dev box, one command does it all:
+.\scripts\n1-reset.ps1 `
+  -ResourceGroup sorcha-n1-uk `
+  -UpdateCompose `
+  -ImportValidatorKeyPath .\genesis-validator-key.json `
+  -Yes
+```
+
+The script handles the full sequence: tear down with `-v`, bring up wallet-service alone, wait for healthy, POST the mnemonic to `/api/v1/wallets/system/recover` over the compose network, bring up the rest of the stack, then shred the uploaded key file. Mnemonic is never echoed to logs and never appears in process args (passed on stdin to a one-shot curl container).
+
+`-ValidatorId` defaults to `local-validator` and must match `Validator__ValidatorId` on the validator-service.
+
+**Procedure (manual fallback — only if the script can't run):**
 
 ```bash
 # Step 5a: tear down with volumes wiped

--- a/scripts/n1-reset.ps1
+++ b/scripts/n1-reset.ps1
@@ -7,10 +7,15 @@
 # This is the equivalent of "Docker Desktop down -v" + fresh start.
 #
 # Usage:
-#   .\n1-reset.ps1                    # Reset and re-bootstrap
-#   .\n1-reset.ps1 -SkipBootstrap     # Reset without bootstrap
-#   .\n1-reset.ps1 -UpdateCompose     # Also upload latest compose files before reset
-#   .\n1-reset.ps1 -StartVm           # Start the VM first (if auto-shutdown stopped it)
+#   .\n1-reset.ps1                                     # Reset and re-bootstrap
+#   .\n1-reset.ps1 -SkipBootstrap                      # Reset without bootstrap
+#   .\n1-reset.ps1 -UpdateCompose                      # Also upload latest compose files before reset
+#   .\n1-reset.ps1 -StartVm                            # Start the VM first (if auto-shutdown stopped it)
+#   .\n1-reset.ps1 -ImportValidatorKeyPath PATH        # Recover the genesis validator system wallet
+#                                                      # BEFORE the rest of the stack comes up. PATH is
+#                                                      # the local genesis-validator-key.json. Implies a
+#                                                      # full reset. The file is shredded on the remote
+#                                                      # VM after the import completes.
 
 [CmdletBinding()]
 param(
@@ -30,11 +35,39 @@ param(
     [switch]$StartVm,
 
     [Parameter(Mandatory = $false)]
-    [switch]$Yes
+    [switch]$Yes,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ImportValidatorKeyPath = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ValidatorId = "local-validator"
 )
 
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent $PSScriptRoot
+
+# Validate the validator key path up-front — we don't want to wipe the VM
+# and then discover the file doesn't exist or is missing the mnemonic.
+if (-not [string]::IsNullOrEmpty($ImportValidatorKeyPath)) {
+    if (-not (Test-Path $ImportValidatorKeyPath)) {
+        Write-Error "ImportValidatorKeyPath not found: $ImportValidatorKeyPath"
+        exit 1
+    }
+    try {
+        $keyJson = Get-Content $ImportValidatorKeyPath -Raw | ConvertFrom-Json
+    } catch {
+        Write-Error "ImportValidatorKeyPath is not valid JSON: $ImportValidatorKeyPath"
+        exit 1
+    }
+    if ([string]::IsNullOrEmpty($keyJson.mnemonic) -or $keyJson.mnemonic.Split(' ').Count -lt 12) {
+        Write-Error "ImportValidatorKeyPath does not contain a valid mnemonic field"
+        exit 1
+    }
+    # Remove the local copy of the JSON object from the parser cache — the
+    # remote-side script consumes the file directly; we never want to echo it.
+    Remove-Variable keyJson -ErrorAction SilentlyContinue
+}
 
 Write-Host ""
 Write-Host "╔════════════════════════════════════════════════╗" -ForegroundColor Cyan
@@ -89,9 +122,18 @@ if (-not $Yes) {
     Write-Host "  1. Stop all Sorcha containers on n1" -ForegroundColor White
     Write-Host "  2. Delete ALL data volumes (PostgreSQL, MongoDB, Redis)" -ForegroundColor White
     Write-Host "  3. Pull latest images from DockerHub" -ForegroundColor White
-    Write-Host "  4. Start fresh containers" -ForegroundColor White
-    if (-not $SkipBootstrap) {
-        Write-Host "  5. Re-bootstrap (create org, admin user)" -ForegroundColor White
+    if (-not [string]::IsNullOrEmpty($ImportValidatorKeyPath)) {
+        Write-Host "  4. Bring up wallet-service alone" -ForegroundColor White
+        Write-Host "  5. Import genesis validator system wallet (mnemonic from local key file)" -ForegroundColor White
+        Write-Host "  6. Bring up the rest of the stack" -ForegroundColor White
+        if (-not $SkipBootstrap) {
+            Write-Host "  7. Re-bootstrap (create org, admin user)" -ForegroundColor White
+        }
+    } else {
+        Write-Host "  4. Start fresh containers" -ForegroundColor White
+        if (-not $SkipBootstrap) {
+            Write-Host "  5. Re-bootstrap (create org, admin user)" -ForegroundColor White
+        }
     }
     Write-Host ""
     Write-Host "  ⚠  ALL DATA ON n1 WILL BE PERMANENTLY DELETED!" -ForegroundColor Red
@@ -133,6 +175,23 @@ if ($UpdateCompose) {
 }
 
 # ============================================================================
+# Upload validator key file (if importing)
+# ============================================================================
+$remoteKeyPath = ""
+if (-not [string]::IsNullOrEmpty($ImportValidatorKeyPath)) {
+    Write-Host "Uploading genesis validator key..." -ForegroundColor Yellow
+    # Land it in /opt/sorcha next to the compose files. The remote script
+    # shreds the file once the import finishes (success or failure path).
+    $remoteKeyPath = "/opt/sorcha/genesis-validator-key.json"
+    scp -o StrictHostKeyChecking=no $ImportValidatorKeyPath "${AdminUsername}@${vmIp}:$remoteKeyPath"
+    # Tighten permissions immediately so a parallel shell on the VM can't
+    # snapshot the mnemonic between scp and script consumption.
+    ssh -o StrictHostKeyChecking=no "${AdminUsername}@${vmIp}" "chmod 600 $remoteKeyPath"
+    Write-Host "  ✓ Key file uploaded (chmod 600)" -ForegroundColor Green
+    Write-Host ""
+}
+
+# ============================================================================
 # Run reset on VM
 # ============================================================================
 Write-Host "Running reset on n1..." -ForegroundColor Yellow
@@ -141,6 +200,9 @@ Write-Host ""
 $resetArgs = "--reset"
 if ($SkipBootstrap) {
     $resetArgs += " --skip-bootstrap"
+}
+if (-not [string]::IsNullOrEmpty($remoteKeyPath)) {
+    $resetArgs += " --import-validator-key-file=$remoteKeyPath --validator-id=$ValidatorId"
 }
 
 ssh -o StrictHostKeyChecking=no -t "${AdminUsername}@${vmIp}" "cd /opt/sorcha && ./n1-setup-remote.sh $resetArgs"

--- a/scripts/n1-setup-remote.sh
+++ b/scripts/n1-setup-remote.sh
@@ -10,12 +10,25 @@
 # 4. Run bootstrap (create org, admin user, service principal)
 #
 # Usage: ./n1-setup-remote.sh [--reset] [--skip-bootstrap]
+#                             [--import-validator-key-file=PATH] [--validator-id=ID]
+#
+# --import-validator-key-file=PATH    Recover the system wallet from a
+#   genesis-validator-key.json BEFORE the rest of the stack comes up. The
+#   wallet-service is the only container brought up first; the mnemonic is
+#   POSTed to /api/v1/wallets/system/recover; then the rest of the stack
+#   starts. Implies --reset. The key file is shredded after import.
+#   This is the safe ordering for federation seed nodes — without it,
+#   validator-service may auto-generate the wrong system wallet (issue #461 trap).
+#
+# --validator-id=ID    Validator ID to bind the recovered system wallet to.
+#   Must match Validator__ValidatorId on validator-service (default: local-validator).
 
 set -euo pipefail
 
 SORCHA_DIR="/opt/sorcha"
 COMPOSE_CMD="docker compose -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml"
 MAX_WAIT=300  # 5 minutes max wait for healthy services
+COMPOSE_NETWORK="sorcha_sorcha-network"  # network for one-shot curl during wallet import
 
 # Colors
 RED='\033[0;31m'
@@ -32,13 +45,42 @@ err()  { echo -e "${RED}✗ ${NC}$1"; }
 # Parse arguments
 RESET=false
 SKIP_BOOTSTRAP=false
+IMPORT_KEY_FILE=""
+VALIDATOR_ID="local-validator"
 for arg in "$@"; do
     case $arg in
         --reset) RESET=true ;;
         --skip-bootstrap) SKIP_BOOTSTRAP=true ;;
+        --import-validator-key-file=*) IMPORT_KEY_FILE="${arg#*=}" ;;
+        --validator-id=*) VALIDATOR_ID="${arg#*=}" ;;
         *) warn "Unknown argument: $arg" ;;
     esac
 done
+
+# --import-validator-key-file implies --reset; a fresh wallet recovery
+# only makes sense against a wiped data dir.
+if [ -n "$IMPORT_KEY_FILE" ]; then
+    if [ "$RESET" != true ]; then
+        log "--import-validator-key-file implies --reset; enabling reset"
+        RESET=true
+    fi
+    if [ ! -f "$IMPORT_KEY_FILE" ]; then
+        err "Key file not found: $IMPORT_KEY_FILE"
+        exit 1
+    fi
+    # Sanity-check the JSON has a mnemonic field before we wipe data.
+    # We don't echo anything from the file — the validator below either
+    # exits 0 (mnemonic present) or non-zero (missing/invalid JSON).
+    if ! python3 -c "import json,sys; d=json.load(open(sys.argv[1])); m=d['mnemonic']; sys.exit(0 if isinstance(m,str) and len(m.split())>=12 else 1)" "$IMPORT_KEY_FILE" 2>/dev/null; then
+        err "Key file does not contain a valid 'mnemonic' field: $IMPORT_KEY_FILE"
+        exit 1
+    fi
+    # Shred the key file on script exit — success or failure. The mnemonic
+    # is sensitive material and there's no reason it should outlive the
+    # import. `shred` is preferred (overwrites before unlink); fall back to
+    # plain rm on filesystems where shred is unavailable.
+    trap '[ -f "$IMPORT_KEY_FILE" ] && (shred -u "$IMPORT_KEY_FILE" 2>/dev/null || rm -f "$IMPORT_KEY_FILE") || true' EXIT
+fi
 
 cd "$SORCHA_DIR"
 
@@ -93,7 +135,74 @@ docker volume create sorcha_wallet-encryption-keys 2>/dev/null || true
 docker run --rm -v sorcha_wallet-encryption-keys:/data alpine chown -R 1654:1654 /data 2>/dev/null || true
 ok "Wallet encryption permissions set"
 
-# Start services
+# Wallet-first import — must run BEFORE the rest of the stack so that
+# validator-service's first CreateOrRetrieveSystemWalletAsync call finds
+# the recovered wallet instead of silently generating a fresh one (which
+# would then have a pubkey absent from the genesis roster).
+if [ -n "$IMPORT_KEY_FILE" ]; then
+    log "Bringing up wallet-service ALONE for genesis-key import..."
+    $COMPOSE_CMD up -d wallet-service
+    ok "wallet-service started"
+
+    log "Waiting for wallet-service to be healthy..."
+    elapsed=0
+    while [ $elapsed -lt $MAX_WAIT ]; do
+        status=$(docker inspect --format='{{.State.Health.Status}}' sorcha-wallet-service 2>/dev/null || echo "not_found")
+        if [ "$status" = "healthy" ]; then
+            ok "wallet-service is healthy"
+            break
+        fi
+        echo "  Status: $status (${elapsed}s elapsed)"
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    if [ "$status" != "healthy" ]; then
+        err "wallet-service did not become healthy within ${MAX_WAIT}s; aborting before mnemonic POST"
+        exit 1
+    fi
+
+    log "Recovering system wallet from $IMPORT_KEY_FILE (validatorId=$VALIDATOR_ID)..."
+    # Read mnemonic into memory only — never to disk, never to logs.
+    # We pipe the JSON body into curl via stdin so the mnemonic isn't
+    # visible in `ps`/`docker inspect` args.
+    MNEMONIC=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['mnemonic'])" "$IMPORT_KEY_FILE")
+    RECOVER_BODY=$(python3 -c "import json,sys; print(json.dumps({'validatorId':sys.argv[1],'mnemonic':sys.argv[2],'algorithm':'ED25519'}))" "$VALIDATOR_ID" "$MNEMONIC")
+    unset MNEMONIC  # zeroize the shell var, the body is what we pass on
+
+    # One-shot curl on the compose network — wallet-service image has no shell.
+    # The body is fed on stdin (-d @-) so it doesn't appear in process args.
+    # Response body lands in a host-side /tmp file (mounted into the container)
+    # so we can extract the address after the curl container exits.
+    RECOVER_RESP_FILE=$(mktemp /tmp/recover-resp.XXXXXX)
+    HTTP_STATUS=$(printf '%s' "$RECOVER_BODY" | docker run --rm -i \
+        --network="$COMPOSE_NETWORK" \
+        -v "$RECOVER_RESP_FILE:/recover-resp" \
+        curlimages/curl:latest \
+        -sk -o /recover-resp -w '%{http_code}' \
+        -X POST http://wallet-service:8080/api/v1/wallets/system/recover \
+        -H 'Content-Type: application/json' \
+        -d @- 2>/dev/null || echo "000")
+    unset RECOVER_BODY  # zeroize once curl has consumed it
+
+    if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "201" ]; then
+        ok "System wallet recovered (HTTP $HTTP_STATUS)"
+        # The response carries the wallet address — safe to surface, not sensitive.
+        python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(f'  -> wallet address: {d.get(\"address\",\"<unknown>\")}')" "$RECOVER_RESP_FILE" 2>/dev/null || true
+        rm -f "$RECOVER_RESP_FILE"
+    elif [ "$HTTP_STATUS" = "409" ]; then
+        rm -f "$RECOVER_RESP_FILE"
+        err "System wallet already exists (HTTP 409). validator-service may have raced ahead and auto-generated the wrong wallet."
+        err "Recovery requires manual SQL surgery — see .claude/skills/network-bootstrap/SKILL.md Step 5 trailer."
+        exit 1
+    else
+        rm -f "$RECOVER_RESP_FILE"
+        err "Wallet recovery failed (HTTP $HTTP_STATUS). Check wallet-service logs:"
+        err "  docker compose logs wallet-service"
+        exit 1
+    fi
+fi
+
+# Start services (or the rest of them, if wallet-service is already up)
 log "Starting all services..."
 $COMPOSE_CMD up -d
 ok "Compose up complete"


### PR DESCRIPTION
Closes #472.

## Summary

Replaces the manual five-step recipe (down → up wallet-service alone → wait healthy → POST mnemonic → up rest) with a single flag on the existing deploy scripts. The recipe currently lives in the `network-bootstrap` skill Step 5 and is run by hand; this PR moves it into the script and surfaces it through `n1-reset.ps1`.

## Usage after this PR

```powershell
.\scripts\n1-reset.ps1 `
  -ResourceGroup sorcha-n1-uk `
  -UpdateCompose `
  -ImportValidatorKeyPath .\genesis-validator-key.json `
  -Yes
```

That's the entire fresh-seed-node deploy. The script handles tear-down, wallet-first sequence, mnemonic POST, and shreds the uploaded key file on the VM when done.

Without the flag, behaviour is unchanged (existing replica-style reset path).

## Mnemonic handling

The new path is constructed so the mnemonic never appears in process args or logs:

| Stage | Mechanism |
|---|---|
| Local → VM | `scp` (not `ssh` arg) |
| Landing on VM | `chmod 600` immediately after scp |
| Bash extract | `python3 -c "...print(d['mnemonic'])"` into shell var |
| Body construction | Immediate transfer into a JSON body string, then `unset` of the shell var |
| HTTP POST | Body fed to `curl` on stdin (`-d @-`) — never an argument |
| Cleanup | `trap` on EXIT shreds the key file (`shred -u`, falls back to `rm -f`) |

Failure modes are handled:
- **File missing / invalid JSON / no mnemonic** — caught locally in `n1-reset.ps1` BEFORE the VM is wiped.
- **wallet-service unhealthy after MAX_WAIT** — abort before mnemonic POST.
- **HTTP 409** — explicit "validator-service raced ahead" diagnostic pointing at the SQL-surgery trailer in the skill.
- **Other HTTP non-2xx** — abort with a pointer to `docker compose logs wallet-service`.

## Documentation

- `.claude/skills/network-bootstrap/SKILL.md` Step 5 — automated procedure listed first, manual fallback retained for emergencies.
- `~/.claude/skills/n1-deploy/SKILL.md` — same restructuring (this file lives in user-global memory, not the repo, so it's not in the diff).

## Verification

- `bash -n scripts/n1-setup-remote.sh` — syntax OK
- `pwsh` PSParser tokenize on `scripts/n1-reset.ps1` — syntax OK
- **End-to-end against a real n1 fresh deploy is the user's acceptance step** (per issue acceptance criteria — needs a live Azure VM). Recommended verification command:
  ```powershell
  .\scripts\n1-reset.ps1 -ResourceGroup sorcha-n1-uk -UpdateCompose `
    -ImportValidatorKeyPath .\genesis-validator-key.json -Yes
  ```
  Acceptance: system register `Height > 0` after the full bootstrap.

## Out of scope

- The full bootstrap flow (`sorcha bootstrap --profile n1`) is still a separate command after the reset — this PR only addresses the wallet-first ordering, which is what gates federation correctness.
- Issue #471 (use `EncryptedMasterKeyBlob` for direct-master derivation) is a related but independent P0 — both are in the wallet area but touch different code (this PR is scripts only; #471 is wallet-service runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)