### PR TITLE
fix(471): use EncryptedMasterKeyBlob for direct-master derivation

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/SystemRegisterCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/SystemRegisterCommands.cs
@@ -115,37 +115,20 @@ public class SystemRegisterCreateCommand : Command
         var mnemonic = new Mnemonic(Wordlist.English, WordCount.TwentyFour);
         var mnemonicWords = mnemonic.ToString();
 
-        // The runtime wallet-service derives purpose keys via this chain (see
-        // Sorcha.Wallet.Core.Services.Implementation.{KeyManagementService,WalletManager}):
-        //   1. Mnemonic → master ExtKey → take its 32-byte private key as "masterKey"
-        //   2. RecoverWalletAsync stores the BIP44 0/0/0/0 *leaf* private key (after
-        //      ExtKey.CreateFromSeed(masterKey) wrapping) as EncryptedPrivateKey
-        //   3. Sign with derivationPath="sorcha:docket-signing" decrypts that leaf
-        //      and runs ExtKey.CreateFromSeed(leaf) → derives m/44'/0'/0'/0/102
-        // The genesis ceremony MUST replicate this exact chain so the roster pubkey
-        // matches what validator-service signs with at runtime. The previous direct
-        // mnemonic→m/44'/0'/0'/0/102 derivation produced a roster the validator
-        // could never match, leaving the system register stuck pre-seal forever
-        // (#461 phase 4 federation deadlock).
-        var masterKey = mnemonic.DeriveExtKey().PrivateKey.ToBytes();
+        // Direct BIP32 derivation off the master ExtKey — this matches the
+        // runtime sign path post-#471 (wallet-service decrypts the master
+        // seed blob and derives purpose keys with a single HMAC). Pre-#471
+        // the runtime walked a double-HMAC chain (wrap leaf as fresh seed,
+        // derive again); the CLI had to replicate that quirk verbatim to
+        // keep the genesis roster matching the runtime. With the runtime
+        // fixed, the CLI uses the standard BIP32 chain too.
+        var masterExtKey = mnemonic.DeriveExtKey();
 
-        // Derive the BIP44 0/0/0/0 primary leaf the same way RecoverWalletAsync does:
-        // wrap masterKey as a fresh seed, derive 0/0/0/0, take its bytes, generate
-        // an ED25519 keypair — that keypair's PRIVATE KEY is what the wallet stores.
-        var fakeMaster1 = ExtKey.CreateFromSeed(masterKey);
-        var primaryLeafBytes = fakeMaster1.Derive(new KeyPath("m/44'/0'/0'/0/0")).PrivateKey.ToBytes();
-        var primaryKeyResult = await crypto.GenerateKeySetAsync(network, seed: primaryLeafBytes, cancellationToken: ct);
-        if (!primaryKeyResult.IsSuccess)
-        {
-            ConsoleHelper.WriteError($"Primary key generation failed: {primaryKeyResult.ErrorMessage}");
-            return ExitCodes.GeneralError;
-        }
-        var storedPrivateKey = primaryKeyResult.Value!.PrivateKey.Key!;
-
-        // Now derive sorcha:docket-signing the way SignTransactionAsync does:
-        // re-wrap the stored leaf private key as a seed, derive m/44'/0'/0'/0/102.
-        var fakeMaster2 = ExtKey.CreateFromSeed(storedPrivateKey);
-        var derivedPrivateKeyBytes = fakeMaster2.Derive(new KeyPath("m/44'/0'/0'/0/102")).PrivateKey.ToBytes();
+        // Derive sorcha:docket-signing (m/44'/0'/0'/0/102) directly off the
+        // master ExtKey. The resulting public key goes into the genesis
+        // validator roster and the validator-service signs dockets with
+        // the same key derived through the same chain at runtime.
+        var derivedPrivateKeyBytes = masterExtKey.Derive(new KeyPath("m/44'/0'/0'/0/102")).PrivateKey.ToBytes();
 
         // Generate ED25519 keypair from derived 32-byte seed
         var keyResult = await crypto.GenerateKeySetAsync(network, seed: derivedPrivateKeyBytes, cancellationToken: ct);
@@ -160,8 +143,8 @@ public class SystemRegisterCreateCommand : Command
         var privateKeyBytes = keySet.PrivateKey.Key!;
 
         // Also derive the register-control key (m/44'/0'/0'/0/101) for signing the genesis transaction.
-        // Same chain as docket-signing — wrap the stored leaf again, derive at /101.
-        var controlPrivateKeyBytes = fakeMaster2.Derive(new KeyPath("m/44'/0'/0'/0/101")).PrivateKey.ToBytes();
+        // Same direct-master chain as docket-signing — derive off the master ExtKey directly.
+        var controlPrivateKeyBytes = masterExtKey.Derive(new KeyPath("m/44'/0'/0'/0/101")).PrivateKey.ToBytes();
         var controlKeyResult = await crypto.GenerateKeySetAsync(network, seed: controlPrivateKeyBytes, cancellationToken: ct);
         if (!controlKeyResult.IsSuccess)
         {

--- a/src/Core/Sorcha.Wallet.Core/Services/Implementation/WalletManager.cs
+++ b/src/Core/Sorcha.Wallet.Core/Services/Implementation/WalletManager.cs
@@ -388,6 +388,18 @@ public class WalletManager : IWalletService
             var (encryptedKey, keyId) = await _keyManagement.EncryptPrivateKeyAsync(
                 primaryPrivateKey, string.Empty);
 
+            // Encrypt the BIP39 PBKDF2 seed so sign-with-derivationPath can
+            // derive purpose keys (e.g. sorcha:docket-signing →
+            // m/44'/0'/0'/0/102) directly off the master ExtKey, without
+            // the double-HMAC chain that wraps the BIP44 0/0/0/0 leaf as a
+            // fresh seed. See issue #471.
+            //
+            // Re-uses the same encryption key as EncryptedPrivateKey above
+            // so a single rotation covers both fields.
+            var bip39Seed = mnemonic.DeriveBip39Seed(passphrase);
+            var (encryptedMasterSeed, _) = await _keyManagement.EncryptPrivateKeyAsync(
+                bip39Seed, keyId);
+
             // Create wallet entity
             var wallet = new WalletEntity
             {
@@ -395,6 +407,10 @@ public class WalletManager : IWalletService
                 PublicKey = Convert.ToBase64String(primaryPublicKey),
                 EncryptedPrivateKey = encryptedKey,
                 EncryptionKeyId = keyId,
+                EncryptedMasterKeyBlob = encryptedMasterSeed,
+                // RecoveryEnabled stays false — this blob is the wallet-service-
+                // managed master seed for direct derivation, NOT the
+                // Feature 060 recovery-key-encrypted blob.
                 Algorithm = algorithm,
                 Owner = owner,
                 Tenant = tenant,
@@ -753,11 +769,6 @@ public class WalletManager : IWalletService
             }
             else
             {
-                // Local: decrypt private key and sign locally
-                var masterKey = await _keyManagement.DecryptPrivateKeyAsync(
-                    wallet.EncryptedPrivateKey,
-                    wallet.EncryptionKeyId);
-
                 byte[] signingKey;
 
                 // If derivation path provided, derive child key
@@ -769,25 +780,74 @@ public class WalletManager : IWalletService
                         : derivationPath;
 
                     var parsedPath = new DerivationPath(resolvedPath);
-                    var (derivedPrivateKey, derivedPublicKey) = await _keyManagement.DeriveKeyAtPathAsync(
-                        masterKey,
-                        parsedPath,
-                        wallet.Algorithm);
+
+                    // Prefer the direct-master derivation path (issue #471) when
+                    // the wallet carries a wallet-service-managed master seed blob.
+                    // RecoveryEnabled=true means the blob is the Feature 060
+                    // recovery-key-encrypted blob (not decryptable by us routinely)
+                    // — fall back to the legacy double-HMAC chain in that case.
+                    var useDirectMaster =
+                        !wallet.RecoveryEnabled
+                        && !string.IsNullOrEmpty(wallet.EncryptedMasterKeyBlob);
+
+                    byte[] derivedPrivateKey;
+                    byte[] derivedPublicKey;
+
+                    if (useDirectMaster)
+                    {
+                        // Direct chain: encrypted blob → BIP39 PBKDF2 seed →
+                        // ExtKey.CreateFromSeed(seed) → Derive(path). One HMAC,
+                        // matches a from-mnemonic BIP32 derivation.
+                        var bip39Seed = await _keyManagement.DecryptPrivateKeyAsync(
+                            wallet.EncryptedMasterKeyBlob!,
+                            wallet.EncryptionKeyId);
+
+                        (derivedPrivateKey, derivedPublicKey) =
+                            await _keyManagement.DeriveKeyAtPathAsync(
+                                bip39Seed,
+                                parsedPath,
+                                wallet.Algorithm);
+
+                        _logger.LogInformation(
+                            "Signing transaction for wallet {Address} with direct-master derivation at path {Path} (resolved: {ResolvedPath})",
+                            walletAddress, derivationPath, resolvedPath);
+                    }
+                    else
+                    {
+                        // Legacy chain: decrypt the BIP44 0/0/0/0 leaf, re-wrap
+                        // it as a fresh seed (extra HMAC), derive from there.
+                        // Preserved for pre-#471 wallets whose blob is null and
+                        // for Feature 060 wallets where the blob is unreadable.
+                        var leafKey = await _keyManagement.DecryptPrivateKeyAsync(
+                            wallet.EncryptedPrivateKey,
+                            wallet.EncryptionKeyId);
+
+                        (derivedPrivateKey, derivedPublicKey) =
+                            await _keyManagement.DeriveKeyAtPathAsync(
+                                leafKey,
+                                parsedPath,
+                                wallet.Algorithm);
+
+                        _logger.LogInformation(
+                            "Signing transaction for wallet {Address} with legacy-leaf derivation at path {Path} (resolved: {ResolvedPath})",
+                            walletAddress, derivationPath, resolvedPath);
+                    }
 
                     signingKey = derivedPrivateKey;
                     publicKey = derivedPublicKey;
-
-                    _logger.LogInformation(
-                        "Signing transaction for wallet {Address} with derived key at path {Path} (resolved: {ResolvedPath})",
-                        walletAddress, derivationPath, resolvedPath);
                 }
                 else
                 {
-                    signingKey = masterKey;
+                    // No derivation path — sign with the primary leaf private key
+                    // (matches wallet.Address). This branch is unaffected by #471
+                    // — wallet addresses must stay stable across the chain change.
+                    signingKey = await _keyManagement.DecryptPrivateKeyAsync(
+                        wallet.EncryptedPrivateKey,
+                        wallet.EncryptionKeyId);
                     publicKey = Convert.FromBase64String(wallet.PublicKey!);
 
                     _logger.LogInformation(
-                        "Signing transaction for wallet {Address} with master key",
+                        "Signing transaction for wallet {Address} with primary key",
                         walletAddress);
                 }
 

--- a/src/Core/Sorcha.Wallet.Portable/Domain/ValueObjects/Mnemonic.cs
+++ b/src/Core/Sorcha.Wallet.Portable/Domain/ValueObjects/Mnemonic.cs
@@ -61,14 +61,37 @@ public record Mnemonic
     public int WordCount => _mnemonic.Words.Length;
 
     /// <summary>
-    /// Derives a seed from the mnemonic with optional passphrase
+    /// Derives a seed from the mnemonic with optional passphrase.
     /// </summary>
+    /// <remarks>
+    /// Despite the name, this returns the 32-byte master ExtKey private key
+    /// (the output of HMAC-SHA512 over the BIP39 PBKDF2 seed), NOT the raw
+    /// BIP39 PBKDF2 seed itself. Wallet creation has always used this value
+    /// and the address-deriving chain depends on it; renaming the method
+    /// would break wallet-address stability. Prefer <see cref="DeriveBip39Seed"/>
+    /// for new code that needs to round-trip an ExtKey via
+    /// <c>ExtKey.CreateFromSeed(...)</c> without an extra HMAC round.
+    /// </remarks>
     /// <param name="passphrase">Optional passphrase for additional security</param>
-    /// <returns>The derived seed bytes</returns>
+    /// <returns>The derived 32-byte master private key</returns>
     public byte[] DeriveSeed(string? passphrase = null)
     {
         var extKey = _mnemonic.DeriveExtKey(passphrase);
         return extKey.PrivateKey.ToBytes();
+    }
+
+    /// <summary>
+    /// Derives the raw BIP39 PBKDF2 seed (64 bytes) from the mnemonic.
+    /// This is the canonical input to <c>NBitcoin.ExtKey.CreateFromSeed</c>
+    /// for BIP32 hierarchical derivation — feed it in once, derive purpose
+    /// keys directly with the path (e.g. <c>m/44'/0'/0'/0/102</c>) and no
+    /// additional HMAC round.
+    /// </summary>
+    /// <param name="passphrase">Optional BIP39 passphrase</param>
+    /// <returns>The 64-byte BIP39 PBKDF2 seed</returns>
+    public byte[] DeriveBip39Seed(string? passphrase = null)
+    {
+        return _mnemonic.DeriveSeed(passphrase ?? string.Empty);
     }
 
     /// <summary>

--- a/tests/Sorcha.Wallet.Core.Tests/GenesisDerivationProofTests.cs
+++ b/tests/Sorcha.Wallet.Core.Tests/GenesisDerivationProofTests.cs
@@ -69,30 +69,22 @@ public class GenesisDerivationProofTests
         var (mnemonicWords, expectedRosterPubKey) = loaded.Value;
         var crypto = new CryptoModule();
 
-        // Replicate the wallet-service runtime chain — the path that
-        // ValidatorKeyProvider walks when asking for the validator's
-        // docket-signing public key:
+        // Post-#471 chain — runtime + CLI both derive purpose keys directly off
+        // the master ExtKey with a single HMAC inside ExtKey.CreateFromSeed.
         //
-        // 1. Mnemonic.DeriveSeed() returns mnemonic.DeriveExtKey().PrivateKey.ToBytes()
-        //    — the master ExtKey's 32-byte private key (NOT the BIP39 PBKDF2 seed).
+        // Runtime path (WalletManager.SignTransactionAsync, post-#471):
+        //   1. Decrypt wallet.EncryptedMasterKeyBlob → 64-byte BIP39 PBKDF2 seed
+        //   2. ExtKey.CreateFromSeed(seed) → master ExtKey
+        //   3. masterExtKey.Derive("m/44'/0'/0'/0/102") → docket-signing key
+        //
+        // CLI ceremony path (SystemRegisterCommands.ExecuteCreateAsync) does
+        // the same derivation off mnemonic.DeriveExtKey() (which is equivalent
+        // to ExtKey.CreateFromSeed(mnemonic.DeriveSeed())). The genesis file
+        // pubkey we load below was minted by the CLI; this test asserts the
+        // runtime would arrive at the same pubkey from the stored mnemonic.
         var mnemonic = new Mnemonic(mnemonicWords);
-        var masterKey = mnemonic.DeriveExtKey().PrivateKey.ToBytes();
-
-        // 2. RecoverWalletAsync derives the BIP44 0/0/0/0 primary leaf via
-        //    ExtKey.CreateFromSeed(masterKey) — this WRAPS the master priv as
-        //    a fresh seed (extra HMAC-SHA512 layer) — and stores the resulting
-        //    ED25519 private key as EncryptedPrivateKey.
-        var fakeMaster1 = ExtKey.CreateFromSeed(masterKey);
-        var primaryLeafBytes = fakeMaster1.Derive(new KeyPath("m/44'/0'/0'/0/0")).PrivateKey.ToBytes();
-        var primaryKey = await crypto.GenerateKeySetAsync(WalletNetworks.ED25519, seed: primaryLeafBytes);
-        primaryKey.IsSuccess.Should().BeTrue();
-        var storedPrivateKey = primaryKey.Value!.PrivateKey.Key!;
-
-        // 3. SignTransactionAsync with derivationPath="sorcha:docket-signing"
-        //    decrypts the leaf and runs ExtKey.CreateFromSeed(leaf) again,
-        //    deriving m/44'/0'/0'/0/102 from this fake-fresh master.
-        var fakeMaster2 = ExtKey.CreateFromSeed(storedPrivateKey);
-        var docketSigningSeed = fakeMaster2.Derive(new KeyPath("m/44'/0'/0'/0/102")).PrivateKey.ToBytes();
+        var masterExtKey = mnemonic.DeriveExtKey();
+        var docketSigningSeed = masterExtKey.Derive(new KeyPath("m/44'/0'/0'/0/102")).PrivateKey.ToBytes();
         var docketKey = await crypto.GenerateKeySetAsync(WalletNetworks.ED25519, seed: docketSigningSeed);
         docketKey.IsSuccess.Should().BeTrue();
 

--- a/tests/Sorcha.Wallet.Service.Tests/Services/WalletManagerTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/WalletManagerTests.cs
@@ -207,6 +207,43 @@ public class WalletManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task RecoverWalletAsync_ShouldPopulateEncryptedMasterKeyBlob_WithBip39Seed()
+    {
+        // Issue #471: RecoverWalletAsync must populate EncryptedMasterKeyBlob
+        // with the BIP39 PBKDF2 seed (64 bytes) so SignTransactionAsync can
+        // derive purpose keys directly via ExtKey.CreateFromSeed(seed) rather
+        // than the legacy double-HMAC chain off the BIP44 0/0/0/0 leaf.
+        var mnemonic = Mnemonic.Generate(12);
+
+        var wallet = await _walletManager.RecoverWalletAsync(
+            mnemonic, "Test", "ED25519", "user1", "tenant1");
+
+        wallet.EncryptedMasterKeyBlob.Should().NotBeNullOrEmpty(
+            "the master seed blob is the entry point for direct-master derivation");
+        wallet.RecoveryEnabled.Should().BeFalse(
+            "the recovered system wallet blob is wallet-service-managed, not a Feature 060 recovery-key blob");
+
+        // The blob round-trips through the wallet's own EncryptionKeyId, so
+        // wallet-service can decrypt it at sign time without needing a
+        // separately-issued recovery key.
+        var keyManagement = new KeyManagementService(
+            (Sorcha.Wallet.Core.Encryption.Interfaces.IKeyProtectionProvider)_encryptionProvider,
+            _mockCryptoModule.Object,
+            _mockWalletUtilities.Object,
+            Mock.Of<ILogger<KeyManagementService>>());
+        var decrypted = await keyManagement.DecryptPrivateKeyAsync(
+            wallet.EncryptedMasterKeyBlob!, wallet.EncryptionKeyId);
+        decrypted.Length.Should().Be(64,
+            "BIP39 PBKDF2 derives a 64-byte seed — this length is what differentiates the new blob from the legacy 32-byte master priv");
+
+        // The decrypted seed must equal the same NBitcoin BIP39 seed the
+        // mnemonic produces — i.e. the canonical input to ExtKey.CreateFromSeed.
+        var expectedSeed = new NBitcoin.Mnemonic(mnemonic.Phrase).DeriveSeed(string.Empty);
+        decrypted.Should().Equal(expectedSeed,
+            "the blob carries the canonical BIP39 PBKDF2 seed, not the post-HMAC 32-byte master priv");
+    }
+
+    [Fact]
     public async Task RecoverWalletAsync_ShouldThrow_WhenWalletAlreadyExists()
     {
         // Arrange


### PR DESCRIPTION
Closes #471. Wave A piece 2/2 — pairs with #687 (Tenant migration squash) so the next n1 reseed validates both at once.

## Summary

Replaces the wallet-service's double-HMAC purpose-key derivation chain with direct BIP32 derivation off the master ExtKey via a stored encrypted master-seed blob. The CLI ceremony reverts in lockstep so genesis rosters continue to match runtime derivation.

## The bug being fixed

Pre-#471, wallet-service did:

1. `RecoverWalletAsync` stored the BIP44 0/0/0/0 leaf as `EncryptedPrivateKey`
2. `SignTransactionAsync` with `derivationPath` decrypted the leaf and ran `ExtKey.CreateFromSeed(leaf)` again — **second HMAC-SHA512** — then derived `m/44'/0'/0'/0/<purpose>` off this fake-fresh master

Result: purpose keys ended up at the wrong BIP path semantically. The CLI ceremony had to replicate the runtime quirk verbatim (#468) or the genesis roster wouldn't match what validator-service signed with at runtime (#461 phase-4 federation deadlock).

## The fix

| Change | What |
|---|---|
| `Mnemonic.DeriveBip39Seed()` | New method returning the canonical 64-byte BIP39 PBKDF2 seed. The existing `DeriveSeed()` is wrongly named (it returns the 32-byte master priv post-HMAC); renaming would break wallet-address stability. |
| `WalletManager.RecoverWalletAsync` | Encrypts the BIP39 seed via the same `IKeyManagement.EncryptPrivateKeyAsync` used for `EncryptedPrivateKey`. Stores in `EncryptedMasterKeyBlob` with `RecoveryEnabled = false`. |
| `WalletManager.SignTransactionAsync` | When `derivationPath` is provided AND `EncryptedMasterKeyBlob` is populated AND `RecoveryEnabled == false`: decrypts the seed and derives directly via `ExtKey.CreateFromSeed(seed).Derive(path)`. One HMAC. Falls back to legacy leaf-rewrap chain otherwise. |
| `SystemRegisterCommands.ExecuteCreateAsync` (CLI) | Reverts the bug replication from #468. `masterExtKey = mnemonic.DeriveExtKey()`; docket-signing (`/102`) and register-control (`/101`) both derive directly off the master. |

## Coexistence with Feature 060

`EncryptedMasterKeyBlob` is also populated on `CreateWalletAsync` for user wallets, but with a **one-time recovery-key encryption** (Feature 060). That blob is not decryptable by wallet-service at runtime. The new code distinguishes via `RecoveryEnabled`:

| Wallet | `RecoveryEnabled` | Blob contents | Sign-with-derivationPath chain |
|---|---|---|---|
| Pre-#471 wallet | `false` | `null` | Legacy leaf-rewrap (unchanged) |
| Recovered system wallet (this PR) | `false` | IKeyManagement-encrypted BIP39 seed | **New direct-master** |
| Feature 060 user wallet | `true` | Recovery-key-encrypted blob (out-of-band) | Legacy leaf-rewrap (unchanged) |

No schema change. No migration. Existing wallet addresses unaffected — the BIP44 0/0/0/0 leaf path that produces `wallet.Address` is untouched.

## Verification

- `dotnet build` — Wallet.Core, Wallet.Service, Sorcha.Cli all 0 errors.
- `dotnet test tests/Sorcha.Wallet.Core.Tests` — 122/122 pass.
- `dotnet test tests/Sorcha.Wallet.Service.Tests` — 745/745 pass, includes new `RecoverWalletAsync_ShouldPopulateEncryptedMasterKeyBlob_WithBip39Seed` test that round-trips the blob and asserts it carries the canonical 64-byte BIP39 PBKDF2 seed (not the 32-byte master priv).
- `GenesisDerivationProofTests` rewritten to assert the new chain. Skipped in CI (genesis-validator-key.json absent); fires after a re-ceremony to prove runtime pubkey matches genesis roster pubkey.

## Operational impact — requires fresh ceremony + reseed

Existing wallets keep working via the legacy fallback (blob null OR `RecoveryEnabled=true`). But the existing n1 system wallet was derived under the old chain; validating the new chain end-to-end means a fresh ceremony.

Recommended acceptance sequence (Wave A — single reseed):
1. Merge #687 (Tenant migration squash, pending CI)
2. Merge this PR
3. `sorcha system-register create` — generates a fresh ceremony with the new direct-master derivation
4. `n1-reset.ps1 -ImportValidatorKeyPath <new genesis-validator-key.json>` — uses the automation from #686 to wipe + reseed + import
5. Run AssuredIdentity walkthrough to confirm end-to-end signing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)