### PR TITLE
fix(n1-setup): capture curl stdout and exit code separately for HTTP status parse

### DIFF
--- a/scripts/n1-setup-remote.sh
+++ b/scripts/n1-setup-remote.sh
@@ -174,6 +174,11 @@ if [ -n "$IMPORT_KEY_FILE" ]; then
     # Response body lands in a host-side /tmp file (mounted into the container)
     # so we can extract the address after the curl container exits.
     RECOVER_RESP_FILE=$(mktemp /tmp/recover-resp.XXXXXX)
+    # Don't use `|| echo "000"` inline — pipefail interactions can let curl's
+    # successful %{http_code} stdout AND the fallback echo both land in the
+    # captured string (e.g. "201000"), which then fails to match any expected
+    # status. Capture stdout and exit code separately instead.
+    set +e
     HTTP_STATUS=$(printf '%s' "$RECOVER_BODY" | docker run --rm -i \
         --network="$COMPOSE_NETWORK" \
         -v "$RECOVER_RESP_FILE:/recover-resp" \
@@ -181,8 +186,13 @@ if [ -n "$IMPORT_KEY_FILE" ]; then
         -sk -o /recover-resp -w '%{http_code}' \
         -X POST http://wallet-service:8080/api/v1/wallets/system/recover \
         -H 'Content-Type: application/json' \
-        -d @- 2>/dev/null || echo "000")
+        -d @- 2>/dev/null)
+    CURL_EXIT=$?
+    set -e
     unset RECOVER_BODY  # zeroize once curl has consumed it
+    if [ "$CURL_EXIT" -ne 0 ]; then
+        HTTP_STATUS="000"
+    fi
 
     if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "201" ]; then
         ok "System wallet recovered (HTTP $HTTP_STATUS)"


### PR DESCRIPTION
## Background

#686 added the wallet-first import flow with a curl invocation that captured the HTTP status via:

\`\`\`bash
HTTP_STATUS=\$(... -w '%{http_code}' ... || echo \"000\")
\`\`\`

Under \`set -euo pipefail\`, certain failure paths let both curl's success stdout AND the \`|| echo \"000\"\` fallback land in the captured string. Observed in production during the 2026-05-13 n1 reset:

\`\`\`
✗ Wallet recovery failed (HTTP 201000). Check wallet-service logs:
\`\`\`

Curl actually succeeded (HTTP 201, wallet recovered correctly per wallet-service logs), but the parse reported failure → script bailed → operator finished the reset manually with \`docker compose up -d\`.

## Fix

Split capture into two steps:

1. Capture curl stdout into HTTP_STATUS with no \`||\` fallback.
2. Capture \`\$?\` into CURL_EXIT separately.
3. Promote \`HTTP_STATUS=\"000\"\` only if CURL_EXIT is non-zero.

\`set +e\` / \`set -e\` around the curl + assignment so a non-zero exit doesn't kill the script before inspection.

## Verification

- \`bash -n\` clean.
- Cannot regression-test without a live n1 wipe; will exercise on the next reset cycle. The 2026-05-13 reset (Wave A — #686/#687/#688/#689) was the operational confirmation the bug exists in master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)