### PR TITLE
feat(124): PR-A — pending-application notice + WalletFlags foundational layer

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IEnrolmentService, EnrolmentService>();
         services.AddSingleton<IDelegationRenewalClient, DelegationRenewalClient>();
 
+        // Feature 124 — per-device wallet flags (welcome-takeover dismissal).
+        services.AddSingleton<IWalletFlagsStore, IndexedDbWalletFlagsStore>();
+
         // Server-clock observer (T101) — populated by the ServerClockHandler on
         // every outbound HTTP call; read by Pages/Index.razor to surface a
         // clock-skew banner if the device drifts far from the server.
@@ -51,6 +54,13 @@ public static class ServiceCollectionExtensions
         // Citizen wallet client: every outbound call automatically carries the
         // wallet's stored bearer token AND records server clock observations.
         services.AddHttpClient<ICitizenWalletClient, CitizenWalletClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
+        // Feature 124 — pending-application notice client. Same auth chain as
+        // the citizen wallet client (BearerTokenHandler + ServerClockHandler).
+        services.AddHttpClient<IPendingApplicationClient, HttpPendingApplicationClient>(c =>
             c.BaseAddress = new Uri(gatewayBaseAddress))
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IPendingApplicationClient.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IPendingApplicationClient.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// PWA-side client for the wallet service's pending-application notice surface
+/// (Feature 124). Reads via <c>GET</c>, sets via <c>PUT</c>, clears via
+/// <c>DELETE</c> on <c>/api/v1/wallet/pending-applications</c>. The wallet's
+/// existing <see cref="BearerTokenHandler"/> chain injects the citizen JWT;
+/// callers do not pass a token explicitly.
+/// </summary>
+public interface IPendingApplicationClient
+{
+    /// <summary>Returns the currently set notice, or null when absent.</summary>
+    Task<PendingApplicationView?> GetAsync(CancellationToken ct = default);
+
+    /// <summary>Sets (or replaces) the notice with the supplied label.</summary>
+    Task<PendingApplicationView> SetAsync(string label, CancellationToken ct = default);
+
+    /// <summary>Clears the notice. Idempotent.</summary>
+    Task ClearAsync(CancellationToken ct = default);
+}
+
+/// <summary>Wallet PWA's view of a pending-application notice.</summary>
+/// <param name="Label">Human-readable application label.</param>
+/// <param name="SetAt">UTC time the notice was set.</param>
+public sealed record PendingApplicationView(string Label, DateTimeOffset SetAt);
+
+/// <summary>
+/// Default <see cref="IPendingApplicationClient"/> implementation. Uses the
+/// PWA's shared <see cref="HttpClient"/> (which carries the BearerTokenHandler
+/// + ServerClockHandler chain).
+/// </summary>
+public sealed class HttpPendingApplicationClient : IPendingApplicationClient
+{
+    private const string Path = "/api/v1/wallet/pending-applications";
+
+    private readonly HttpClient _http;
+
+    /// <summary>Initialises a new instance.</summary>
+    public HttpPendingApplicationClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    /// <inheritdoc />
+    public async Task<PendingApplicationView?> GetAsync(CancellationToken ct = default)
+    {
+        using var response = await _http.GetAsync(Path, ct).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
+        response.EnsureSuccessStatusCode();
+        var envelope = await response.Content.ReadFromJsonAsync<PendingApplicationEnvelope>(ct).ConfigureAwait(false);
+        return envelope?.Notice;
+    }
+
+    /// <inheritdoc />
+    public async Task<PendingApplicationView> SetAsync(string label, CancellationToken ct = default)
+    {
+        using var response = await _http.PutAsJsonAsync(
+            Path,
+            new SetPendingApplicationRequest(label),
+            ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        var envelope = await response.Content.ReadFromJsonAsync<PendingApplicationEnvelope>(ct).ConfigureAwait(false);
+        return envelope?.Notice
+            ?? throw new InvalidOperationException("Wallet service returned a SetPendingApplication response with no notice.");
+    }
+
+    /// <inheritdoc />
+    public async Task ClearAsync(CancellationToken ct = default)
+    {
+        using var response = await _http.DeleteAsync(Path, ct).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NoContent) return;
+        response.EnsureSuccessStatusCode();
+    }
+
+    private sealed record PendingApplicationEnvelope(PendingApplicationView? Notice);
+    private sealed record SetPendingApplicationRequest(string Label);
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Services/IWalletFlagsStore.cs
+++ b/src/Apps/Sorcha.Citizen.Wallet/Services/IWalletFlagsStore.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Citizen.Wallet.Services;
+
+/// <summary>
+/// Per-device flags persisted client-side in IndexedDB (Feature 124).
+/// Initially carries only the welcome-takeover dismissal record; designed to
+/// accept further flags as later specs land. Co-tenants the existing
+/// <c>device</c> store alongside <see cref="DeviceMetaRecord"/> at key
+/// <c>flags</c>.
+/// </summary>
+public interface IWalletFlagsStore
+{
+    /// <summary>Returns the persisted flags, or null if never written.</summary>
+    Task<WalletFlagsRecord?> GetAsync(CancellationToken ct = default);
+
+    /// <summary>Persist (or replace) the flags record.</summary>
+    Task SetAsync(WalletFlagsRecord record, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Per-device wallet flags. <see cref="WelcomedAt"/> only ever transitions
+/// from null to a UTC timestamp on first dismissal of the welcome takeover;
+/// there is no "un-welcome" path on this device.
+/// </summary>
+/// <param name="WelcomedAt">UTC time the welcome takeover was dismissed.</param>
+public sealed record WalletFlagsRecord(
+    DateTimeOffset? WelcomedAt);
+
+/// <summary>In-memory <see cref="IWalletFlagsStore"/> for tests.</summary>
+public sealed class InMemoryWalletFlagsStore : IWalletFlagsStore
+{
+    private WalletFlagsRecord? _record;
+    /// <inheritdoc />
+    public Task<WalletFlagsRecord?> GetAsync(CancellationToken ct = default) => Task.FromResult(_record);
+    /// <inheritdoc />
+    public Task SetAsync(WalletFlagsRecord record, CancellationToken ct = default)
+    {
+        _record = record;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>IndexedDB-backed <see cref="IWalletFlagsStore"/>.</summary>
+public sealed class IndexedDbWalletFlagsStore : IWalletFlagsStore
+{
+    private const string StoreName = "device";
+    private const string Key = "flags";
+
+    private readonly IJSRuntime _js;
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbWalletFlagsStore(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public async Task<WalletFlagsRecord?> GetAsync(CancellationToken ct = default)
+        => await _js.InvokeAsync<WalletFlagsRecord?>("SorchaIndexedDb.get", ct, StoreName, Key);
+
+    /// <inheritdoc />
+    public async Task SetAsync(WalletFlagsRecord record, CancellationToken ct = default)
+        => await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, record, Key);
+}

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Sorcha.ServiceDefaults;
+using Sorcha.Wallet.Service.Models;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Endpoints;
+
+/// <summary>
+/// Citizen wallet pending-application notice endpoints (Feature 124). Mounted
+/// under <c>/api/v1/wallet/pending-applications</c> alongside the existing
+/// <see cref="CitizenWalletEndpoints"/>. Carries only a human-readable label;
+/// no credential content.
+/// </summary>
+public static class PendingApplicationEndpoints
+{
+    /// <summary>Maps the pending-application notice endpoints.</summary>
+    public static IEndpointRouteBuilder MapPendingApplicationEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/wallet/pending-applications")
+            .WithTags("Citizen Wallet")
+            .RequireAuthorization()
+            .RequireRateLimiting(RateLimitPolicies.Strict);
+
+        group.MapGet("", GetPendingApplication)
+            .WithName("GetPendingApplication")
+            .WithSummary("Read the citizen's current pending-application notice")
+            .WithDescription(
+                "Returns the active notice or null. The wallet calls this on every Home " +
+                "render to decide whether to show the waiting state. Notice is scoped to " +
+                "the calling PlatformUser via JWT.")
+            .Produces<PendingApplicationEnvelope>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        group.MapPut("", SetPendingApplication)
+            .WithName("SetPendingApplication")
+            .WithSummary("Set or replace the citizen's pending-application notice")
+            .WithDescription(
+                "Idempotent. If a prior notice exists, the new label replaces it and the " +
+                "TTL resets. Notice expires after 24 hours unless explicitly cleared first.")
+            .Produces<PendingApplicationEnvelope>(StatusCodes.Status200OK)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        group.MapDelete("", ClearPendingApplication)
+            .WithName("ClearPendingApplication")
+            .WithSummary("Clear the citizen's pending-application notice")
+            .WithDescription(
+                "Idempotent. Returns 204 whether or not a notice was present. The wallet's " +
+                "waiting state clears within one second on next Home render.")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        return app;
+    }
+
+    private static async Task<IResult> GetPendingApplication(
+        HttpContext context,
+        IPendingApplicationStore store,
+        CancellationToken ct)
+    {
+        var platformUserId = ResolvePlatformUserId(context.User);
+        if (platformUserId is null) return Results.Unauthorized();
+
+        var notice = await store.GetAsync(platformUserId.Value, ct);
+        return Results.Ok(new PendingApplicationEnvelope { Notice = notice });
+    }
+
+    private static async Task<IResult> SetPendingApplication(
+        [FromBody] SetPendingApplicationRequest request,
+        HttpContext context,
+        IValidator<SetPendingApplicationRequest> validator,
+        IPendingApplicationStore store,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var validation = await validator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Results.ValidationProblem(validation.ToDictionary());
+        }
+
+        var platformUserId = ResolvePlatformUserId(context.User);
+        if (platformUserId is null) return Results.Unauthorized();
+
+        var notice = await store.SetAsync(platformUserId.Value, request.Label.Trim(), ct);
+        logger.LogInformation(
+            "Pending-application notice set platformUser={PlatformUserId} label={Label}",
+            platformUserId, notice.Label);
+        return Results.Ok(new PendingApplicationEnvelope { Notice = notice });
+    }
+
+    private static async Task<IResult> ClearPendingApplication(
+        HttpContext context,
+        IPendingApplicationStore store,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var platformUserId = ResolvePlatformUserId(context.User);
+        if (platformUserId is null) return Results.Unauthorized();
+
+        await store.ClearAsync(platformUserId.Value, ct);
+        logger.LogInformation(
+            "Pending-application notice cleared platformUser={PlatformUserId}",
+            platformUserId);
+        return Results.NoContent();
+    }
+
+    private static Guid? ResolvePlatformUserId(ClaimsPrincipal user)
+    {
+        var raw = user.FindFirstValue("platform_user_id") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(raw, out var pid) ? pid : null;
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Models/PendingApplicationContracts.cs
+++ b/src/Services/Sorcha.Wallet.Service/Models/PendingApplicationContracts.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Service.Models;
+
+/// <summary>
+/// Request body for setting (or replacing) the citizen's pending-application
+/// notice — the small piece of metadata that drives the wallet's waiting state
+/// when an application is in flight (Feature 124). Carries only a human-readable
+/// label; no credential content.
+/// </summary>
+public sealed class SetPendingApplicationRequest
+{
+    /// <summary>Human-readable application label, e.g. "Assured Identity".</summary>
+    public string Label { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Envelope wrapping the optional pending-application notice. The wrapping
+/// shape lets the wallet deserialise consistently whether or not a notice is
+/// currently set — the field is always present, the value distinguishes
+/// presence.
+/// </summary>
+public sealed class PendingApplicationEnvelope
+{
+    /// <summary>Active notice, or null when no application is pending.</summary>
+    public PendingApplicationNotice? Notice { get; init; }
+}
+
+/// <summary>
+/// Server-side state representing a citizen's in-flight application whose
+/// credential will eventually land in the wallet. Lives in distributed cache
+/// only — never persisted to the relational store.
+/// </summary>
+/// <param name="Label">Human-readable application label (1..80 chars, plain text).</param>
+/// <param name="SetAt">UTC time the notice was set. Informational only.</param>
+public sealed record PendingApplicationNotice(
+    string Label,
+    DateTimeOffset SetAt);

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -190,6 +190,13 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IDeviceRevo
 builder.Services.AddValidatorsFromAssemblyContaining<
     Sorcha.CitizenWallet.Abstractions.Validators.DeviceEnrolmentRequestValidator>();
 
+// Feature 124: pending-application notice store + validators in the Wallet
+// Service assembly (SetPendingApplicationRequestValidator).
+builder.Services.AddValidatorsFromAssemblyContaining<
+    Sorcha.Wallet.Service.Validators.SetPendingApplicationRequestValidator>();
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IPendingApplicationStore,
+    Sorcha.Wallet.Service.Services.Implementation.RedisPendingApplicationStore>();
+
 // Feature 118 — multi-node hub fan-out via Redis backplane (US1).
 // Wires JWT auth + Redis backplane (ChannelPrefix=sorcha:signalr:wallet) +
 // reconnect-with-jitter + OpenTelemetry instrumentation.
@@ -277,6 +284,9 @@ app.MapCitizenStatusListEndpoints();
 // Feature 114: Citizen wallet PWA endpoints (device enrolment, sync, etc.)
 app.MapCitizenWalletEndpoints();
 app.MapCitizenStatusListInternalEndpoints();
+
+// Feature 124: Pending-application notice endpoints (Set / Get / Clear)
+app.MapPendingApplicationEndpoints();
 
 // Feature 114: Citizen wallet SignalR hub. Routed via API Gateway as `/hubs/wallet`.
 // Mapped via MapSorchaHubs from the AddSorchaHub registry (Feature 118 US1).

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/RedisPendingApplicationStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/RedisPendingApplicationStore.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+using Sorcha.Wallet.Service.Models;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// <see cref="IDistributedCache"/>-backed implementation of
+/// <see cref="IPendingApplicationStore"/>. Production resolves to Redis via the
+/// existing Wallet Service registration; tests resolve to the in-memory default.
+/// 24-hour absolute TTL — the notice is by definition ephemeral, ending in
+/// either an explicit clear or expiry (Feature 124, R-001).
+/// </summary>
+public sealed class RedisPendingApplicationStore : IPendingApplicationStore
+{
+    private const string KeyPrefix = "sorcha:wallet:pending-app:";
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private static readonly Meter Meter = new("Sorcha.Wallet.Service");
+    private static readonly Counter<long> NoticeCounter =
+        Meter.CreateCounter<long>("sorcha_pending_application_notice_total");
+
+    private readonly IDistributedCache _cache;
+
+    /// <summary>Initialises a new instance.</summary>
+    public RedisPendingApplicationStore(IDistributedCache cache)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    /// <inheritdoc />
+    public async Task<PendingApplicationNotice?> GetAsync(Guid platformUserId, CancellationToken ct = default)
+    {
+        var bytes = await _cache.GetAsync(KeyFor(platformUserId), ct).ConfigureAwait(false);
+        NoticeCounter.Add(1, new KeyValuePair<string, object?>("op", "read"));
+        if (bytes is null || bytes.Length == 0) return null;
+        return JsonSerializer.Deserialize<PendingApplicationNotice>(bytes, JsonOptions);
+    }
+
+    /// <inheritdoc />
+    public async Task<PendingApplicationNotice> SetAsync(Guid platformUserId, string label, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+            throw new ArgumentException("Label must be non-empty.", nameof(label));
+
+        var notice = new PendingApplicationNotice(label, DateTimeOffset.UtcNow);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(notice, JsonOptions);
+        await _cache.SetAsync(
+            KeyFor(platformUserId),
+            bytes,
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = Ttl },
+            ct).ConfigureAwait(false);
+        NoticeCounter.Add(1, new KeyValuePair<string, object?>("op", "set"));
+        return notice;
+    }
+
+    /// <inheritdoc />
+    public async Task ClearAsync(Guid platformUserId, CancellationToken ct = default)
+    {
+        await _cache.RemoveAsync(KeyFor(platformUserId), ct).ConfigureAwait(false);
+        NoticeCounter.Add(1, new KeyValuePair<string, object?>("op", "clear"));
+    }
+
+    private static string KeyFor(Guid platformUserId) => $"{KeyPrefix}{platformUserId:N}";
+}

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IPendingApplicationStore.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IPendingApplicationStore.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Service.Models;
+
+namespace Sorcha.Wallet.Service.Services.Interfaces;
+
+/// <summary>
+/// Server-side store for the citizen's pending-application notice (Feature 124).
+/// Set by the walkthrough script (or a future application-submission flow) and
+/// read by the wallet PWA every time its Home renders. TTL-based — eventually
+/// self-clearing if no credential ever arrives.
+/// </summary>
+public interface IPendingApplicationStore
+{
+    /// <summary>Reads the citizen's active notice, or null if absent.</summary>
+    Task<PendingApplicationNotice?> GetAsync(Guid platformUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets or replaces the citizen's notice. Idempotent — calling with a new
+    /// label replaces the prior label and resets the TTL.
+    /// </summary>
+    Task<PendingApplicationNotice> SetAsync(Guid platformUserId, string label, CancellationToken ct = default);
+
+    /// <summary>Clears the citizen's notice. Idempotent — no-op if already absent.</summary>
+    Task ClearAsync(Guid platformUserId, CancellationToken ct = default);
+}

--- a/src/Services/Sorcha.Wallet.Service/Validators/SetPendingApplicationRequestValidator.cs
+++ b/src/Services/Sorcha.Wallet.Service/Validators/SetPendingApplicationRequestValidator.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentValidation;
+using Sorcha.Wallet.Service.Models;
+
+namespace Sorcha.Wallet.Service.Validators;
+
+/// <summary>
+/// Validates a <see cref="SetPendingApplicationRequest"/>. Label must be
+/// non-empty after trim and at most 80 characters — plain text only (no HTML,
+/// no claim content) is the data contract; length and non-emptiness are what
+/// can be enforced here.
+/// </summary>
+public sealed class SetPendingApplicationRequestValidator : AbstractValidator<SetPendingApplicationRequest>
+{
+    /// <summary>Initialise validation rules.</summary>
+    public SetPendingApplicationRequestValidator()
+    {
+        RuleFor(x => x.Label)
+            .NotEmpty()
+            .Must(label => !string.IsNullOrWhiteSpace(label))
+                .WithMessage("'Label' must not be empty or whitespace.")
+            .MaximumLength(80);
+    }
+}

--- a/tests/Sorcha.Citizen.Wallet.Tests/Services/WalletFlagsStoreTests.cs
+++ b/tests/Sorcha.Citizen.Wallet.Tests/Services/WalletFlagsStoreTests.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Citizen.Wallet.Services;
+using Xunit;
+
+namespace Sorcha.Citizen.Wallet.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="InMemoryWalletFlagsStore"/> (Feature 124, T017). The
+/// IndexedDB variant is exercised end-to-end by Playwright in the polish phase;
+/// here we verify the round-trip contract.
+/// </summary>
+public sealed class WalletFlagsStoreTests
+{
+    [Fact]
+    public async Task GetAsync_NeverSet_ReturnsNull()
+    {
+        var store = new InMemoryWalletFlagsStore();
+        var record = await store.GetAsync();
+        record.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_ThenGetAsync_RoundTripsRecord()
+    {
+        var store = new InMemoryWalletFlagsStore();
+        var welcomedAt = DateTimeOffset.UtcNow;
+
+        await store.SetAsync(new WalletFlagsRecord(welcomedAt));
+
+        var read = await store.GetAsync();
+        read.Should().NotBeNull();
+        read!.WelcomedAt.Should().Be(welcomedAt);
+    }
+
+    [Fact]
+    public async Task SetAsync_Replace_OverwritesPriorValue()
+    {
+        var store = new InMemoryWalletFlagsStore();
+        var first = DateTimeOffset.UtcNow.AddDays(-1);
+        var second = DateTimeOffset.UtcNow;
+
+        await store.SetAsync(new WalletFlagsRecord(first));
+        await store.SetAsync(new WalletFlagsRecord(second));
+
+        var read = await store.GetAsync();
+        read!.WelcomedAt.Should().Be(second);
+    }
+
+    [Fact]
+    public async Task SetAsync_NullWelcomedAt_IsPersisted()
+    {
+        // Edge case: the store accepts a record with null WelcomedAt — this
+        // is the value used to materialise the default record on lazy reads.
+        var store = new InMemoryWalletFlagsStore();
+        await store.SetAsync(new WalletFlagsRecord(WelcomedAt: null));
+
+        var read = await store.GetAsync();
+        read.Should().NotBeNull();
+        read!.WelcomedAt.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/PendingApplicationStoreTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/PendingApplicationStoreTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Sorcha.Wallet.Service.Services.Implementation;
+using Sorcha.Wallet.Service.Services.Interfaces;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="RedisPendingApplicationStore"/> (Feature 124, T015).
+/// Backed by <see cref="MemoryDistributedCache"/> so the suite is deterministic
+/// and free of Redis dependencies — the contract is the
+/// <see cref="IDistributedCache"/> interface, not the Redis client.
+/// </summary>
+public sealed class PendingApplicationStoreTests
+{
+    private static IPendingApplicationStore NewStore(out IDistributedCache cache)
+    {
+        cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        return new RedisPendingApplicationStore(cache);
+    }
+
+    [Fact]
+    public async Task GetAsync_NoNoticeSet_ReturnsNull()
+    {
+        var store = NewStore(out _);
+        var notice = await store.GetAsync(Guid.NewGuid());
+        notice.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SetAsync_ThenGetAsync_RoundTripsLabel()
+    {
+        var store = NewStore(out _);
+        var platformUserId = Guid.NewGuid();
+
+        var set = await store.SetAsync(platformUserId, "Assured Identity");
+
+        set.Label.Should().Be("Assured Identity");
+        set.SetAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+
+        var read = await store.GetAsync(platformUserId);
+        read.Should().NotBeNull();
+        read!.Label.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public async Task SetAsync_ReplaceLabel_OverwritesPriorValue()
+    {
+        var store = NewStore(out _);
+        var platformUserId = Guid.NewGuid();
+
+        await store.SetAsync(platformUserId, "Assured Identity");
+        await store.SetAsync(platformUserId, "Driving Licence");
+
+        var read = await store.GetAsync(platformUserId);
+        read!.Label.Should().Be("Driving Licence");
+    }
+
+    [Fact]
+    public async Task ClearAsync_RemovesNotice_AndIsIdempotent()
+    {
+        var store = NewStore(out _);
+        var platformUserId = Guid.NewGuid();
+
+        await store.SetAsync(platformUserId, "Assured Identity");
+        await store.ClearAsync(platformUserId);
+
+        (await store.GetAsync(platformUserId)).Should().BeNull();
+
+        // Idempotent — clearing again does not throw.
+        var act = () => store.ClearAsync(platformUserId);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SetAsync_DistinctPlatformUsers_IsolatedKeys()
+    {
+        var store = NewStore(out _);
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+
+        await store.SetAsync(u1, "Assured Identity");
+        await store.SetAsync(u2, "Driving Licence");
+
+        (await store.GetAsync(u1))!.Label.Should().Be("Assured Identity");
+        (await store.GetAsync(u2))!.Label.Should().Be("Driving Licence");
+    }
+
+    [Fact]
+    public async Task SetAsync_WhitespaceLabel_Throws()
+    {
+        var store = NewStore(out _);
+        var act = () => store.SetAsync(Guid.NewGuid(), "   ");
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Validators/SetPendingApplicationRequestValidatorTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Validators/SetPendingApplicationRequestValidatorTests.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Wallet.Service.Models;
+using Sorcha.Wallet.Service.Validators;
+
+namespace Sorcha.Wallet.Service.Tests.Validators;
+
+/// <summary>
+/// Tests for <see cref="SetPendingApplicationRequestValidator"/> (Feature 124, T016).
+/// </summary>
+public sealed class SetPendingApplicationRequestValidatorTests
+{
+    private static readonly SetPendingApplicationRequestValidator Validator = new();
+
+    [Fact]
+    public void EmptyLabel_Fails()
+    {
+        var result = Validator.Validate(new SetPendingApplicationRequest { Label = string.Empty });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(SetPendingApplicationRequest.Label));
+    }
+
+    [Fact]
+    public void WhitespaceLabel_Fails()
+    {
+        var result = Validator.Validate(new SetPendingApplicationRequest { Label = "   " });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LabelOver80Chars_Fails()
+    {
+        var result = Validator.Validate(new SetPendingApplicationRequest { Label = new string('a', 81) });
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(SetPendingApplicationRequest.Label));
+    }
+
+    [Theory]
+    [InlineData("Assured Identity")]
+    [InlineData("X")]
+    public void ValidLabel_Passes(string label)
+    {
+        var result = Validator.Validate(new SetPendingApplicationRequest { Label = label });
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Label80CharsExactly_Passes()
+    {
+        var result = Validator.Validate(new SetPendingApplicationRequest { Label = new string('a', 80) });
+        result.IsValid.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

PR-A of Feature 124 (Strathcarron citizen arc, Spec 1 — AssuredIdentity on the PWA). Lands the server-side pending-application notice surface plus the PWA-side WalletFlags store and pending-application HTTP client that the user-story PRs will build on. No user-visible UI changes in this PR — the wallet still renders the existing empty Home and the existing enrol Done copy.

Tracks T001–T017 from \`specs/124-assured-identity-pwa/tasks.md\`.

## What's in

**Server (Sorcha.Wallet.Service)**
- \`IPendingApplicationStore\` + \`RedisPendingApplicationStore\` — \`IDistributedCache\`-backed, 24 h TTL, keyed by \`sorcha:wallet:pending-app:{platformUserId:N}\`. No EF migration (keeps it off the audit-gated path per R-001).
- \`PendingApplicationEndpoints\` — \`GET/PUT/DELETE /api/v1/wallet/pending-applications\`, citizen JWT, \`RateLimitPolicies.Strict\`, full OpenAPI metadata.
- \`SetPendingApplicationRequestValidator\` — FluentValidation, label non-empty + non-whitespace + ≤ 80 chars.
- OpenTelemetry counter \`sorcha_pending_application_notice_total{op=set|clear|read}\` on the existing \`Sorcha.Wallet.Service\` meter.

**PWA (Sorcha.Citizen.Wallet)**
- \`IWalletFlagsStore\` + IndexedDB + in-memory impls — mirrors the \`IDeviceMetaStore\` pattern, lives in the \`device\` store under key \`flags\`. Single record \`WalletFlagsRecord(DateTimeOffset? WelcomedAt)\`.
- \`IPendingApplicationClient\` + \`HttpPendingApplicationClient\` — uses the wallet's existing BearerTokenHandler + ServerClockHandler chain.

**Tests**
- \`PendingApplicationStoreTests\` (6) — set/clear/read happy paths, idempotency, label replacement, isolation across platform users, whitespace-rejection.
- \`SetPendingApplicationRequestValidatorTests\` (5) — empty / whitespace / over-limit / valid / boundary.
- \`WalletFlagsStoreTests\` (4) — null-on-fresh, round-trip, replacement, null-WelcomedAt persistence.

## Verification

- \`dotnet build src/Services/Sorcha.Wallet.Service/\` — 0 errors (warnings are pre-existing CS1591).
- \`dotnet build src/Apps/Sorcha.Citizen.Wallet/\` — 0 errors.
- \`dotnet test tests/Sorcha.Wallet.Service.Tests/\` — **757/757 pass**, 0 failures.
- \`dotnet test tests/Sorcha.Citizen.Wallet.Tests/\` — **57/57 pass**, 0 failures.

## Out of scope (lands in later PRs)

- PR-B (US1+US2): enrol Done copy + waiting state UI.
- PR-C (US3-US5): foreground takeover + cold-open + idempotence in \`Index.razor\`.
- PR-D (US6): walkthrough rewrite, blueprint \`targetAudience\` flip, HAIP filesystem cleanup.
- PR-E: doc propagation, Playwright E2E, regression checks.

## Test plan

- [x] Wallet service builds clean.
- [x] PWA builds clean.
- [x] Wallet service test suite: 757/757 pass.
- [x] PWA test suite: 57/57 pass.
- [ ] Endpoint handler tests in PR-B (T026 in the spec's task list — needs the in-memory store wired through the existing reflection-handler pattern; sequenced into PR-B alongside the US2 work that consumes the endpoints).
- [ ] curl smoke against \`PUT/GET/DELETE /api/v1/wallet/pending-applications\` once \`docker-compose up\` is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)