### PR TITLE
feat(124): PR-B — enrol Done copy (US1) + waiting state (US2)

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/Components/WaitingCard.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Components/WaitingCard.razor
@@ -1,0 +1,25 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 124 (US2, FR-002). Pulsing skeleton card rendered on the wallet
+    Home when a pending-application notice is set for the signed-in citizen.
+    Plain HTML + CSS animation (no MudBlazor dialog chrome) — the design
+    intent is "calm placeholder where a credential will land", not a modal.
+*@
+
+<div class="sorcha-waiting-card" role="status" aria-live="polite"
+     aria-label="@($"{Label} application is being reviewed.")">
+    <MudText Typo="Typo.body1" Class="mb-3">
+        Your <strong>@Label</strong> application is being reviewed.
+        You'll see it here when it's ready.
+    </MudText>
+    <div class="sorcha-waiting-card__line sorcha-waiting-card__line--long"></div>
+    <div class="sorcha-waiting-card__line sorcha-waiting-card__line--mid"></div>
+    <div class="sorcha-waiting-card__line sorcha-waiting-card__line--short"></div>
+</div>
+
+@code {
+    /// <summary>Application label rendered inline in the waiting message.</summary>
+    [Parameter, EditorRequired] public string Label { get; set; } = string.Empty;
+}

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Enrol.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Enrol.razor
@@ -109,10 +109,22 @@
         <MudStep Title="Done">
             @if (_result is not null)
             {
-                <MudAlert Severity="Severity.Success" Class="mb-3">
-                    Enrolled. Loaded <strong>@_result.CredentialsLoaded</strong> credential(s).
-                    Delegation valid until <strong>@_result.DelegationExpiresAt.ToLocalTime():f</strong>.
-                </MudAlert>
+                @if (_result.CredentialsLoaded == 0)
+                {
+                    @* Feature 124 (US1, FR-001): forward-looking copy for first-time citizens
+                       so a freshly-enrolled wallet doesn't read as "something is missing". *@
+                    <MudAlert Severity="Severity.Success" Class="mb-3">
+                        Enrolled. Your wallet is ready — submit your council application
+                        to receive your first credential.
+                    </MudAlert>
+                }
+                else
+                {
+                    <MudAlert Severity="Severity.Success" Class="mb-3">
+                        Enrolled. Loaded <strong>@_result.CredentialsLoaded</strong> credential(s).
+                        Delegation valid until <strong>@_result.DelegationExpiresAt.ToLocalTime():f</strong>.
+                    </MudAlert>
+                }
                 <MudButton Variant="Variant.Filled" Color="Color.Primary"
                            OnClick="@(() => Nav.NavigateTo("/"))">
                     Open wallet

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -22,6 +22,7 @@
 @inject IServerClockObserver ServerClock
 @inject CitizenWalletHubConnection Hub
 @inject HttpClient Http
+@inject IPendingApplicationClient PendingApplications
 @inject NavigationManager Nav
 @inject ILogger<Index> Logger
 @implements IAsyncDisposable
@@ -55,15 +56,25 @@
     }
     else if (_credentials.Count == 0)
     {
-        <MudAlert Severity="Severity.Info" Class="mb-3" data-testid="home-empty-state">
-            No credentials yet. Enrol this device to load yours, or try the demo card.
-        </MudAlert>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                   StartIcon="@Icons.Material.Filled.PhoneIphone"
-                   OnClick="@(() => Nav.NavigateTo("/enrol"))" FullWidth="true" Class="mb-2"
-                   data-testid="enrol-device-button">
-            Enrol this device
-        </MudButton>
+        @* Feature 124 (US2, FR-002): when a pending-application notice is set,
+           replace the bare empty state with the waiting-card so the citizen sees
+           a designed in-progress beat rather than "nothing here". *@
+        @if (_pendingNotice is not null)
+        {
+            <WaitingCard Label="@_pendingNotice.Label" data-testid="home-waiting-state" />
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Info" Class="mb-3" data-testid="home-empty-state">
+                No credentials yet. Enrol this device to load yours, or try the demo card.
+            </MudAlert>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.PhoneIphone"
+                       OnClick="@(() => Nav.NavigateTo("/enrol"))" FullWidth="true" Class="mb-2"
+                       data-testid="enrol-device-button">
+                Enrol this device
+            </MudButton>
+        }
     }
     else
     {
@@ -115,6 +126,7 @@
 
 @code {
     private IReadOnlyList<CachedCredential>? _credentials;
+    private PendingApplicationView? _pendingNotice;
     private bool _seeding;
     private bool _syncing;
     private string? _seedError;
@@ -124,6 +136,7 @@
     protected override async Task OnInitializedAsync()
     {
         _credentials = await Credentials.ListAsync();
+        await RefreshPendingNoticeAsync();
         // Fire-and-forget background sync — refreshes the cache from server without
         // blocking first paint. UI updates via StateHasChanged when sync completes.
         _ = SyncNowAsync(silentSuccess: true);
@@ -192,6 +205,25 @@
         }
     }
 
+    /// <summary>
+    /// Feature 124 (US2). Re-reads the citizen's pending-application notice on
+    /// every Home render trigger. Silently swallows transport errors — the
+    /// notice is purely a UX hint, not a correctness primitive.
+    /// </summary>
+    private async Task RefreshPendingNoticeAsync()
+    {
+        try
+        {
+            _pendingNotice = await PendingApplications.GetAsync();
+        }
+        catch (Exception ex)
+        {
+            // Notice fetch is best-effort; never block Home on it.
+            Logger.LogDebug(ex, "Pending-application notice fetch failed");
+            _pendingNotice = null;
+        }
+    }
+
     private async Task SyncNowAsync(bool silentSuccess = false)
     {
         if (_syncing) return;
@@ -201,6 +233,19 @@
         {
             var outcome = await Sync.SyncAsync();
             _credentials = await Credentials.ListAsync();
+
+            // Feature 124 (US2, FR-003): the waiting state drops as soon as a
+            // credential is visible. Server-side clearing is the walkthrough
+            // script's job; the wallet's UX rule is "credentials present →
+            // no waiting card".
+            if (_credentials.Count > 0)
+            {
+                _pendingNotice = null;
+            }
+            else
+            {
+                await RefreshPendingNoticeAsync();
+            }
             _syncSeverity = Severity.Success;
             _syncStatus = outcome.Mode == SyncMode.FullSnapshot
                 ? $"Synced — pulled full snapshot ({outcome.Added} credential(s))."

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/css/welcome-takeover.css
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/css/welcome-takeover.css
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: MIT
+   Copyright (c) 2026 Sorcha Contributors
+
+   Feature 124 animation primitives. Mobile-first, GPU-composited keyframes.
+   Two consumers in v1:
+   - WaitingCard.razor (US2, T021) — pulsing skeleton placeholder while a
+     citizen's application is in review.
+   - WelcomeTakeover.razor (US3, T028) — fade-in + dismiss-out for the
+     first-credential takeover overlay. Added in the PR-C slice. */
+
+@keyframes sorcha-skeleton-pulse {
+    0%   { opacity: 0.4; }
+    50%  { opacity: 0.8; }
+    100% { opacity: 0.4; }
+}
+
+.sorcha-waiting-card {
+    border-radius: 16px;
+    padding: 24px;
+    margin-top: 16px;
+    background: linear-gradient(135deg, #e6e9ef 0%, #f3f5f9 100%);
+    min-height: 180px;
+    animation: sorcha-skeleton-pulse 1.4s ease-in-out infinite;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.sorcha-waiting-card__line {
+    height: 12px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.08);
+    margin-bottom: 12px;
+}
+
+.sorcha-waiting-card__line--short { width: 40%; }
+.sorcha-waiting-card__line--mid   { width: 65%; }
+.sorcha-waiting-card__line--long  { width: 90%; }

--- a/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
+++ b/src/Apps/Sorcha.Citizen.Wallet/wwwroot/index.html
@@ -8,6 +8,7 @@
     <link rel="manifest" href="manifest.webmanifest" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
+    <link href="css/welcome-takeover.css" rel="stylesheet" />
 </head>
 <body>
     <div id="app">

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationEndpointTests.cs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Security.Claims;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Wallet.Service.Endpoints;
+using Sorcha.Wallet.Service.Models;
+using Sorcha.Wallet.Service.Services.Interfaces;
+using Sorcha.Wallet.Service.Validators;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Endpoint handler tests for <see cref="PendingApplicationEndpoints"/>
+/// (Feature 124, T026). Uses the reflection-based static-handler invocation
+/// pattern shared by the other citizen-wallet endpoint tests.
+/// </summary>
+public sealed class PendingApplicationEndpointTests
+{
+    private static readonly Guid PlatformUserId = Guid.NewGuid();
+
+    private sealed class FakeStore : IPendingApplicationStore
+    {
+        private readonly Dictionary<Guid, PendingApplicationNotice> _store = [];
+        public int SetCalls { get; private set; }
+        public int ClearCalls { get; private set; }
+        public int GetCalls { get; private set; }
+
+        public Task<PendingApplicationNotice?> GetAsync(Guid platformUserId, CancellationToken ct = default)
+        {
+            GetCalls++;
+            return Task.FromResult(_store.TryGetValue(platformUserId, out var n) ? n : null);
+        }
+
+        public Task<PendingApplicationNotice> SetAsync(Guid platformUserId, string label, CancellationToken ct = default)
+        {
+            SetCalls++;
+            var notice = new PendingApplicationNotice(label, DateTimeOffset.UtcNow);
+            _store[platformUserId] = notice;
+            return Task.FromResult(notice);
+        }
+
+        public Task ClearAsync(Guid platformUserId, CancellationToken ct = default)
+        {
+            ClearCalls++;
+            _store.Remove(platformUserId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private static HttpContext BuildHttpContext(Guid? platformUserId)
+    {
+        var ctx = new DefaultHttpContext();
+        var claims = new List<Claim>();
+        if (platformUserId is not null)
+            claims.Add(new Claim("platform_user_id", platformUserId.Value.ToString()));
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        return ctx;
+    }
+
+    private static async Task<IResult> InvokeHandlerAsync(string name, object[] args)
+    {
+        var method = typeof(PendingApplicationEndpoints).GetMethod(name,
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        method.Should().NotBeNull($"Handler {name} should exist on PendingApplicationEndpoints");
+        return await (Task<IResult>)method.Invoke(null, args)!;
+    }
+
+    [Fact]
+    public async Task Get_NoPlatformUserClaim_ReturnsUnauthorized()
+    {
+        var store = new FakeStore();
+        var ctx = BuildHttpContext(null);
+        var result = await InvokeHandlerAsync("GetPendingApplication",
+            [ctx, store, CancellationToken.None]);
+
+        result.GetType().Name.Should().Contain("Unauthorized");
+        store.GetCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Get_NoNoticeSet_ReturnsOkWithNullNotice()
+    {
+        var store = new FakeStore();
+        var ctx = BuildHttpContext(PlatformUserId);
+        var result = await InvokeHandlerAsync("GetPendingApplication",
+            [ctx, store, CancellationToken.None]);
+
+        var ok = result.Should().BeOfType<Ok<PendingApplicationEnvelope>>().Subject;
+        ok.Value!.Notice.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Get_NoticeSet_ReturnsOkWithNotice()
+    {
+        var store = new FakeStore();
+        await store.SetAsync(PlatformUserId, "Assured Identity");
+        var ctx = BuildHttpContext(PlatformUserId);
+        var result = await InvokeHandlerAsync("GetPendingApplication",
+            [ctx, store, CancellationToken.None]);
+
+        var ok = result.Should().BeOfType<Ok<PendingApplicationEnvelope>>().Subject;
+        ok.Value!.Notice.Should().NotBeNull();
+        ok.Value.Notice!.Label.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public async Task Set_ValidLabel_PersistsAndReturnsEnvelope()
+    {
+        var store = new FakeStore();
+        var validator = new SetPendingApplicationRequestValidator();
+        var ctx = BuildHttpContext(PlatformUserId);
+        var request = new SetPendingApplicationRequest { Label = "Assured Identity" };
+
+        var result = await InvokeHandlerAsync("SetPendingApplication",
+            [request, ctx, (IValidator<SetPendingApplicationRequest>)validator, store,
+                NullLogger<Program>.Instance, CancellationToken.None]);
+
+        var ok = result.Should().BeOfType<Ok<PendingApplicationEnvelope>>().Subject;
+        ok.Value!.Notice!.Label.Should().Be("Assured Identity");
+        store.SetCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Set_TrimsLabelBeforePersisting()
+    {
+        var store = new FakeStore();
+        var validator = new SetPendingApplicationRequestValidator();
+        var ctx = BuildHttpContext(PlatformUserId);
+        var request = new SetPendingApplicationRequest { Label = "  Assured Identity  " };
+
+        var result = await InvokeHandlerAsync("SetPendingApplication",
+            [request, ctx, (IValidator<SetPendingApplicationRequest>)validator, store,
+                NullLogger<Program>.Instance, CancellationToken.None]);
+
+        result.Should().BeOfType<Ok<PendingApplicationEnvelope>>();
+        (await store.GetAsync(PlatformUserId))!.Label.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public async Task Set_ReplacesPriorNotice()
+    {
+        var store = new FakeStore();
+        await store.SetAsync(PlatformUserId, "Driving Licence");
+        var validator = new SetPendingApplicationRequestValidator();
+        var ctx = BuildHttpContext(PlatformUserId);
+        var request = new SetPendingApplicationRequest { Label = "Assured Identity" };
+
+        await InvokeHandlerAsync("SetPendingApplication",
+            [request, ctx, (IValidator<SetPendingApplicationRequest>)validator, store,
+                NullLogger<Program>.Instance, CancellationToken.None]);
+
+        (await store.GetAsync(PlatformUserId))!.Label.Should().Be("Assured Identity");
+    }
+
+    [Fact]
+    public async Task Set_InvalidLabel_ReturnsValidationProblem()
+    {
+        var store = new FakeStore();
+        var validator = new SetPendingApplicationRequestValidator();
+        var ctx = BuildHttpContext(PlatformUserId);
+        var request = new SetPendingApplicationRequest { Label = "   " };
+
+        var result = await InvokeHandlerAsync("SetPendingApplication",
+            [request, ctx, (IValidator<SetPendingApplicationRequest>)validator, store,
+                NullLogger<Program>.Instance, CancellationToken.None]);
+
+        result.GetType().Name.Should().Contain("ProblemHttpResult", "validation problem flows through Results.ValidationProblem");
+        store.SetCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Set_NoPlatformUserClaim_ReturnsUnauthorized()
+    {
+        var store = new FakeStore();
+        var validator = new SetPendingApplicationRequestValidator();
+        var ctx = BuildHttpContext(null);
+        var request = new SetPendingApplicationRequest { Label = "Assured Identity" };
+
+        var result = await InvokeHandlerAsync("SetPendingApplication",
+            [request, ctx, (IValidator<SetPendingApplicationRequest>)validator, store,
+                NullLogger<Program>.Instance, CancellationToken.None]);
+
+        result.GetType().Name.Should().Contain("Unauthorized");
+        store.SetCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Clear_PresentNotice_RemovesAndReturnsNoContent()
+    {
+        var store = new FakeStore();
+        await store.SetAsync(PlatformUserId, "Assured Identity");
+        var ctx = BuildHttpContext(PlatformUserId);
+
+        var result = await InvokeHandlerAsync("ClearPendingApplication",
+            [ctx, store, NullLogger<Program>.Instance, CancellationToken.None]);
+
+        result.GetType().Name.Should().Contain("NoContent");
+        (await store.GetAsync(PlatformUserId)).Should().BeNull();
+        store.ClearCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Clear_AbsentNotice_IsIdempotent()
+    {
+        var store = new FakeStore();
+        var ctx = BuildHttpContext(PlatformUserId);
+
+        var result = await InvokeHandlerAsync("ClearPendingApplication",
+            [ctx, store, NullLogger<Program>.Instance, CancellationToken.None]);
+
+        result.GetType().Name.Should().Contain("NoContent");
+        store.ClearCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Clear_NoPlatformUserClaim_ReturnsUnauthorized()
+    {
+        var store = new FakeStore();
+        var ctx = BuildHttpContext(null);
+
+        var result = await InvokeHandlerAsync("ClearPendingApplication",
+            [ctx, store, NullLogger<Program>.Instance, CancellationToken.None]);
+
+        result.GetType().Name.Should().Contain("Unauthorized");
+        store.ClearCalls.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

PR-B of Feature 124. First user-visible slice — wires PR-A's foundational store/endpoints into UI behaviour. Tracks T018–T026 from \`specs/124-assured-identity-pwa/tasks.md\`.

## What's in

**PWA — enrol Done copy (US1, FR-001)**
- \`Pages/Enrol.razor\` Done step now branches on \`_result.CredentialsLoaded == 0\` → forward-looking copy ("Enrolled. Your wallet is ready — submit your council application to receive your first credential."). Non-zero path keeps the existing "Loaded N credential(s)" copy.

**PWA — waiting state (US2, FR-002/FR-003)**
- New \`Components/WaitingCard.razor\` — plain HTML + CSS pulsing skeleton with aria-live=polite.
- New \`wwwroot/css/welcome-takeover.css\` — \`sorcha-skeleton-pulse\` keyframe + \`.sorcha-waiting-card\` styling. Linked from \`index.html\`. Also home for the WelcomeTakeover fade keyframes that land in PR-C.
- \`Pages/Index.razor\` — injects \`IPendingApplicationClient\`, fetches notice in \`OnInitializedAsync\` + every \`SyncNowAsync\` completion, swaps the empty-credentials branch for \`<WaitingCard Label="…" />\` when a notice is set. Waiting state drops the instant \`_credentials.Count > 0\` (FR-003).

**Server tests — endpoint handlers (T026)**
- \`PendingApplicationEndpointTests\` (11 facts) — reflection-based static-handler invocation pattern mirroring \`CitizenWalletRevokeEndpointTests\`.
- Covers all three routes × claim presence × outcome branches: GET (no-claim 401, absent null, present notice), PUT (valid, trims whitespace, replaces prior, invalid → ValidationProblem, no-claim 401), DELETE (present, idempotent absent, no-claim 401).

## Deferred

T019 (Enrol Done bUnit), T024 (WaitingCard component test), T025 (Index waiting-state integration test) — bUnit is not currently wired into \`Sorcha.Citizen.Wallet.Tests\`. These rendered-UI assertions are far better exercised end-to-end; PR-E's Playwright suite (T052–T054) carries equivalent coverage at the right layer.

## Verification

- \`dotnet build src/Apps/Sorcha.Citizen.Wallet/\` — clean.
- \`dotnet test tests/Sorcha.Wallet.Service.Tests/\` — **768/768 pass** (was 757; +11 endpoint tests), 0 failures.
- \`dotnet test tests/Sorcha.Citizen.Wallet.Tests/\` — **57/57 pass**, 0 failures.

## Test plan

- [x] Wallet service tests green (+11 endpoint).
- [x] PWA tests green.
- [x] PWA builds clean.
- [ ] Manual PWA inspection in PR-E quickstart pass: set notice via curl, open wallet, confirm WaitingCard renders; clear notice, confirm Home reverts.
- [ ] Enrol-done conditional verified in PR-E quickstart pass on a fresh wallet (0-credential path) and on a returning device (non-zero path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)