### PR TITLE
feat(124): PR-D — walkthrough switched to PWA delivery (US6)

### DIFF
--- a/walkthroughs/AssuredIdentity/README.md
+++ b/walkthroughs/AssuredIdentity/README.md
@@ -1,12 +1,20 @@
 # Assured Identity Walkthrough
 
-Feature 107 — single canonical citizen-identity workflow. A citizen submits a
-polished 5-page wizard (name + DOB, address, contact, optional photo, review),
-the Acme Verification Co. verification analyst approves, and the citizen
-receives an **AssuredIdentityCredential** in their chosen wallet.
+Feature 107 + Feature 124 — single canonical citizen-identity workflow. A
+citizen submits a polished 5-page wizard (name + DOB, address, contact,
+optional photo, review), the Acme Verification Co. verification analyst
+approves, and the citizen receives an **AssuredIdentityCredential** in the
+Citizen Wallet PWA. The first-credential **welcome takeover** (Feature 124)
+fires when the credential lands.
+
+> **Feature 124 swapped this walkthrough to the Citizen Wallet PWA**
+> (`SorchaLocalWallet` target audience). The legacy HAIP filesystem-wallet
+> path is gone (FR-011). Phase 2 (Driving Licence) is currently a stub —
+> the umbrella citizen arc routes the credential-gated second service
+> through Spec 4, which redesigns the wallet-side presentation UX.
 
 > **Replaces `HaipVerifiedCitizen` and `HaipDrivingLicence`.** Those walkthroughs
-> will be deleted in Phase 7 of this feature, after the driving-licence chain
+> will be deleted in Phase 7 of that feature, after the driving-licence chain
 > and cross-peer smoke tests land.
 
 ## What it proves
@@ -26,8 +34,8 @@ receives an **AssuredIdentityCredential** in their chosen wallet.
 
 | Phase | What runs | Script |
 |---|---|---|
-| 1 | Citizen → verification analyst → `AssuredIdentityCredential` | `run-phase1-identity.ps1` |
-| 2 | Citizen → licensing officer (HAIP presentation) → `DrivingLicenceCredential` | `run-phase2-licence.ps1` |
+| 1 | Citizen → verification analyst → `AssuredIdentityCredential` lands in the PWA → welcome takeover fires | `run-phase1-identity.ps1` |
+| 2 | DEFERRED to Spec 4 (citizen-arc credential-gated second service). The stub script explains the deferral and exits. | `run-phase2-licence.ps1` |
 
 ## Unattended reviewer agents (PR 3 / US3)
 
@@ -93,6 +101,5 @@ walkthroughs/AssuredIdentity/
 │   └── assured-identity.json        # Three actions: submit, verify, claim
 ├── data/
 │   └── sample-portrait.jpg          # Optional pre-sized token for -IncludePortrait
-├── wallet/                          # HAIP filesystem wallet (produced by run-phase1)
 └── state.json                       # Per-run state, written by setup.ps1
 ```

--- a/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
+++ b/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
@@ -1,7 +1,7 @@
 {
   "id": "assured-identity-v1",
   "title": "Assured Identity",
-  "description": "Single canonical citizen-identity workflow. A public-org citizen submits a short 5-page wizard (name + DOB, address, contact, optional photo, review), a verification analyst (or background sorcha-agent) approves, and the AssuredIdentityCredential is delivered via the Wave 14b claim-card pattern. Feature 107 supersedes the earlier Features 103 / 106 demo blueprints.",
+  "description": "Single canonical citizen-identity workflow. A public-org citizen submits a short 5-page wizard (name + DOB, address, contact, optional photo, review), a verification analyst (or background sorcha-agent) approves, and the AssuredIdentityCredential is delivered to the citizen's Sorcha wallet. Feature 124 swapped this from the legacy HAIP filesystem wallet to the Citizen Wallet PWA (SorchaLocalWallet target audience).",
   "version": 1,
   "category": "identity",
   "tags": ["assured-identity", "identity", "haip", "oid4vci", "verifiable-credential", "credential-claim", "citizen-application", "core-primitives", "portrait"],
@@ -24,7 +24,7 @@
         "id": "citizen",
         "name": "Citizen",
         "organisation": "Public",
-        "description": "Submits an Assured Identity application and claims the credential into their Sorcha wallet or an external HAIP wallet"
+        "description": "Submits an Assured Identity application and receives the credential in their Citizen Wallet PWA"
       },
       {
         "id": "verification-analyst",
@@ -158,7 +158,7 @@
         ],
         "credentialIssuanceConfig": {
           "credentialType": "AssuredIdentityCredential",
-          "targetAudience": "HaipExternalWallet",
+          "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
           "claimMappings": [
             { "claimName": "givenName",   "sourceField": "/name/givenName" },
@@ -205,7 +205,7 @@
       {
         "id": 3,
         "title": "Claim your Assured Identity credential",
-        "description": "Your Assured Identity credential is ready. Click Claim to store it in your Sorcha wallet, or scan the QR code to load it into an external HAIP-compatible wallet. Declining will cancel the claim and no credential will be issued.",
+        "description": "Your Assured Identity credential is ready. Click Claim to deliver it to your Citizen Wallet PWA. Declining will cancel the claim and no credential will be issued.",
         "sender": "citizen",
         "requiredPriorActions": [2],
         "dataSchemas": [

--- a/walkthroughs/AssuredIdentity/run-agents.ps1
+++ b/walkthroughs/AssuredIdentity/run-agents.ps1
@@ -2,15 +2,15 @@
 .SYNOPSIS
     Launches autonomous actor agents for the AssuredIdentity walkthrough.
 .DESCRIPTION
-    Starts verification-analyst and licensing-officer agents in background, each in rules
-    mode (citizen is reference-only — script-driven), so the citizen-side run scripts can
-    drive the workflow end-to-end without a human at the analyst UI. Feature 107 PR 3 (US3).
+    Starts the verification-analyst agent in background rules mode (citizen
+    is reference-only — script-driven), so the citizen-side run scripts can
+    drive Phase 1 end-to-end without a human at the analyst UI. Feature 107
+    PR 3 (US3), updated by Feature 124.
 
-    verification-analyst auto-approves the identity application (Phase 1 Action 2).
-    licensing-officer auto-issues the driving licence (Phase 2 Action 3). The
-    verification step (Phase 2 Action 2) remains script-driven because it
-    creates the HAIP presentation request the citizen must respond to —
-    see README for the scope rationale.
+    verification-analyst auto-approves the identity application (Phase 1
+    Action 2). Phase 2 (Driving Licence) is currently deferred to Spec 4 of
+    the citizen arc — the licensing-officer agent is not launched because
+    there is no Phase 2 action for it to fire on.
 .PARAMETER StatePath
     Path to state.json. Default: auto-detected from walkthrough directory.
 .PARAMETER TimeoutMinutes
@@ -72,9 +72,11 @@ $expiry = (Get-Date).AddYears(10).ToString("yyyy-MM-dd")
 [Environment]::SetEnvironmentVariable("LICENCE_NUMBER", ("DL-ACME-{0:D5}" -f (Get-Random -Maximum 100000)))
 
 # ---------- Agents ----------
+# Feature 124 — Phase 2 (Driving Licence) deferred to Spec 4 of the citizen
+# arc; the licensing-officer agent is intentionally not launched here. Re-add
+# when Spec 4 lands the credential-gated second service flow.
 $actors = @(
     @{ File = "verification-analyst.json"; Name = "verification-analyst" }
-    @{ File = "licensing-officer.json";    Name = "licensing-officer"    }
 )
 
 Write-Host "`n=== AssuredIdentity Agent Launcher ===" -ForegroundColor Cyan

--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -2,15 +2,30 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
-# AssuredIdentity — Phase 1 (Identity issuance)
-# Feature 107. Creates the blueprint instance, submits the citizen's Assured
-# Identity application (Action 1), the verification analyst approves (Action 2),
-# and the citizen claims the AssuredIdentityCredential into their external
-# HAIP wallet via sorcha-agent haip receive.
+# AssuredIdentity — Phase 1 (Identity issuance to the Citizen Wallet PWA)
+# Feature 124 swapped this from the legacy HAIP filesystem-wallet path to the
+# Citizen Wallet PWA (SorchaLocalWallet target audience). The credential now
+# lands directly in the citizen's PWA via register-native delivery, so the
+# script no longer drives sorcha-agent haip receive.
+#
+# Script-driven beats (the operator runs this from a terminal while the
+# citizen's wallet is open on a phone/second browser):
+#   1. Citizen creates a blueprint instance
+#   2. Citizen submits Action 1 — application details
+#   3. Set the wallet's pending-application notice ("Assured Identity")
+#      — the PWA now shows the waiting-card on Home
+#   4. Verification analyst approves Action 2 → credential mints into the
+#      citizen's PWA register-natively
+#   5. Poll the citizen's wallet /credentials snapshot until the credential
+#      appears, then Clear the pending-application notice
+#
+# When the credential lands, the PWA's CredentialAvailable hub push (or its
+# poll-on-open path) fires the first-credential takeover (Feature 124 US3/US4).
 
 param(
     [switch]$ShowJson,
-    [switch]$IncludePortrait
+    [switch]$IncludePortrait,
+    [int]$DeliveryTimeoutSeconds = 60
 )
 
 $ErrorActionPreference = "Stop"
@@ -18,14 +33,12 @@ $ErrorActionPreference = "Stop"
 $modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
 Import-Module $modulePath -Force
 
-Write-WtBanner "AssuredIdentity — Phase 1 (Identity)"
+Write-WtBanner "AssuredIdentity — Phase 1 (Identity, PWA delivery)"
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $stateFile = Join-Path $scriptDir "state.json"
 if (-not (Test-Path $stateFile)) { Write-WtFail "No state.json. Run setup.ps1 first."; exit 1 }
 $state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
-
-$walletDir = Join-Path $scriptDir "wallet"
 
 # ============================================================================
 # Step 1: Authenticate both roles
@@ -128,9 +141,21 @@ $null = Invoke-SorchaAction `
     -PayloadData $payloadData
 
 # ============================================================================
-# Step 4: Verification Analyst approves Action 2
+# Step 4: Set the pending-application notice (Feature 124 US2 / FR-009)
 # ============================================================================
-Write-WtStep "Step 4: Verification Analyst verifies application (Action 2)"
+Write-WtStep "Step 4: Set pending-application notice on Citizen Wallet"
+
+Set-SorchaCitizenPendingApplication `
+    -WalletUrl $state.walletUrl `
+    -Label "Assured Identity" `
+    -Headers $citizenSession.Headers | Out-Null
+
+Write-WtInfo "PWA will now render the waiting-card on Home"
+
+# ============================================================================
+# Step 5: Verification Analyst approves Action 2
+# ============================================================================
+Write-WtStep "Step 5: Verification Analyst verifies application (Action 2)"
 
 $actionResponse = Invoke-SorchaAction `
     -BlueprintUrl $state.blueprintUrl `
@@ -146,51 +171,55 @@ $actionResponse = Invoke-SorchaAction `
     }
 
 if ($ShowJson) { $actionResponse | ConvertTo-Json -Depth 5 | Write-Host }
+Write-WtSuccess "Action 2 approved — credential issuance triggered (target: SorchaLocalWallet)"
 
-$credentialOffer = $actionResponse.credentialOffer
-if (-not $credentialOffer) {
-    Write-WtFail "Action 2 did not return a credentialOffer. HAIP response pipeline may be misconfigured."
+# ============================================================================
+# Step 6: Poll the citizen's wallet for the credential, then clear the notice
+# ============================================================================
+Write-WtStep "Step 6: Poll Citizen Wallet /credentials for AssuredIdentityCredential"
+
+$deadline = (Get-Date).AddSeconds($DeliveryTimeoutSeconds)
+$delivered = $false
+$credentialId = $null
+
+while ((Get-Date) -lt $deadline) {
+    try {
+        $snapshot = Invoke-SorchaApi -Method GET `
+            -Uri "$($state.walletUrl)/v1/wallet/credentials" `
+            -Headers $citizenSession.Headers
+        if ($snapshot.credentials -and $snapshot.credentials.Count -gt 0) {
+            $hit = $snapshot.credentials | Where-Object { $_.vct -match "AssuredIdentity" -or $_.displayLabel -match "Assured" } | Select-Object -First 1
+            if ($hit) {
+                $delivered = $true
+                $credentialId = $hit.id
+                break
+            }
+        }
+    } catch {
+        Write-WtWarn "  /credentials poll transient error: $($_.Exception.Message)"
+    }
+    Start-Sleep -Seconds 2
+}
+
+if (-not $delivered) {
+    # Best-effort clear so the wallet doesn't sit in a stale waiting-state on failure.
+    try { Clear-SorchaCitizenPendingApplication -WalletUrl $state.walletUrl -Headers $citizenSession.Headers } catch { }
+    Write-WtFail "AssuredIdentityCredential did not land in the citizen's wallet within $DeliveryTimeoutSeconds s."
     exit 1
 }
 
-$offerUri = $credentialOffer.credentialOfferUri
-Write-WtSuccess "Credential offer created: $($credentialOffer.offerId)"
-Write-WtInfo "Type: $($credentialOffer.credentialType)"
-Write-WtInfo "Expires: $($credentialOffer.expiresAt)"
-$truncatedUri = $offerUri.Substring(0, [Math]::Min(80, $offerUri.Length))
-Write-WtInfo "Offer URI: $truncatedUri..."
+Write-WtSuccess "AssuredIdentityCredential delivered to PWA (credentialId=$credentialId)"
 
-# ============================================================================
-# Step 5: sorcha-agent haip receive (simulates citizen's external wallet)
-# ============================================================================
-Write-WtStep "Step 5: sorcha-agent haip receive"
+Clear-SorchaCitizenPendingApplication `
+    -WalletUrl $state.walletUrl `
+    -Headers $citizenSession.Headers
 
-$agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
-
-& dotnet run --project $agentProject -- haip receive --offer-uri $offerUri --wallet-dir $walletDir
-if ($LASTEXITCODE -ne 0) {
-    Write-WtFail "sorcha-agent haip receive failed (exit $LASTEXITCODE)"
-    exit $LASTEXITCODE
-}
-
-# ============================================================================
-# Step 6: Verify Credential
-# ============================================================================
-Write-WtStep "Step 6: Verify Credential"
-
-$credFile = Join-Path $walletDir "credentials/AssuredIdentityCredential.sdjwt"
-if (Test-Path $credFile) {
-    $credSize = (Get-Item $credFile).Length
-    Write-WtSuccess "Credential stored: $credFile ($credSize bytes)"
-} else {
-    Write-WtFail "Credential file not found at $credFile"
-    exit 1
-}
-
+# Persist phase outcomes — no walletDir, no credentialPath; the credential
+# lives in the PWA's IndexedDB on the citizen's device, not on the operator
+# host. We only record the instance + credential id for cross-script use.
 $state | Add-Member -NotePropertyName "instanceId" -NotePropertyValue $instanceId -Force
-$state | Add-Member -NotePropertyName "credentialPath" -NotePropertyValue $credFile -Force
-$state | Add-Member -NotePropertyName "walletDir" -NotePropertyValue $walletDir -Force
+$state | Add-Member -NotePropertyName "credentialId" -NotePropertyValue $credentialId -Force
 $state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
 
 Write-WtBanner "AssuredIdentity — Phase 1 Complete"
-Write-WtSuccess "AssuredIdentityCredential issued to citizen wallet via blueprint action"
+Write-WtSuccess "Open the citizen's PWA — the first-credential welcome takeover should now fire."

--- a/walkthroughs/AssuredIdentity/run-phase2-licence.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase2-licence.ps1
@@ -2,18 +2,24 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
-# AssuredIdentity — Phase 2 (Driving Licence chain)
-# Feature 107 PR 2 (US2). Citizen submits a driving-licence application,
-# Acme Licensing Co. verifies the citizen's presented AssuredIdentityCredential via
-# HAIP OpenID4VP, then issues a DrivingLicenceCredential carrying the
-# holder's identity forward from the presentation.
+# AssuredIdentity — Phase 2 (Driving Licence) — DEFERRED
 #
-# Prerequisites: run-phase1-identity.ps1 must have run first so the
-# citizen's HAIP wallet-dir holds an AssuredIdentityCredential.
+# Phase 2 previously used the legacy HAIP filesystem wallet to (a) present
+# the AssuredIdentityCredential to the licensing officer via sorcha-agent
+# haip present and (b) receive the DrivingLicenceCredential into the same
+# filesystem wallet. Feature 124 swapped the AssuredIdentityCredential
+# delivery to the Citizen Wallet PWA — the filesystem-wallet path is gone
+# (FR-011) — and the HAIP presentation flow that Phase 2 depended on cannot
+# run scripted against the PWA.
+#
+# The umbrella citizen arc (`docs/superpowers/specs/2026-05-13-strathcarron-
+# citizen-arc.md`) sequences this into Spec 4 — "credential-gated second
+# service" — which will design the wallet-side ConsentSheet + verifier UX
+# from scratch. Until Spec 4 lands, Phase 2 stays as this stub: it explains
+# the deferral and exits cleanly so the walkthrough surface stays honest.
 
 param(
-    [switch]$ShowJson,
-    [switch]$IncludePortrait
+    [switch]$ShowJson
 )
 
 $ErrorActionPreference = "Stop"
@@ -21,272 +27,29 @@ $ErrorActionPreference = "Stop"
 $modulePath = Join-Path (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)) "modules/SorchaWalkthrough/SorchaWalkthrough.psm1"
 Import-Module $modulePath -Force
 
-Write-WtBanner "AssuredIdentity — Phase 2 (Driving Licence)"
+Write-WtBanner "AssuredIdentity — Phase 2 (Driving Licence) — DEFERRED to Spec 4"
 
-$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$stateFile = Join-Path $scriptDir "state.json"
-if (-not (Test-Path $stateFile)) { Write-WtFail "No state.json. Run setup.ps1 first."; exit 1 }
-$state = Get-Content -Path $stateFile -Raw | ConvertFrom-Json
+Write-WtInfo @"
+Phase 2 (Driving Licence) is currently deferred to a later spec in the
+Strathcarron citizen arc — the 'credential-gated second service' beat
+(Spec 4) owns the design for the wallet-side presentation UX that this
+flow needs.
 
-$walletDir = Join-Path $scriptDir "wallet"
-$identityCredPath = Join-Path $walletDir "credentials/AssuredIdentityCredential.sdjwt"
-if (-not (Test-Path $identityCredPath)) {
-    Write-WtFail "No AssuredIdentityCredential in the wallet. Run run-phase1-identity.ps1 first."
-    exit 1
-}
+What's deferred:
+  - Citizen presents AssuredIdentityCredential to the licensing officer
+  - Licensing officer issues DrivingLicenceCredential into the citizen's
+    wallet
 
-$agentProject = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) "src/Apps/Sorcha.Agent"
+What still works after Phase 1:
+  - The citizen holds an AssuredIdentityCredential in the Citizen Wallet
+    PWA (verify on the wallet device's Home).
 
-# ============================================================================
-# Step 1: Authenticate Citizen and Licensing Officer
-# ============================================================================
-Write-WtStep "Step 1: Authenticate Citizen and Licensing Officer"
+Run 'pwsh walkthroughs/AssuredIdentity/run-phase1-identity.ps1' to land
+the Assured Identity credential, then watch for Spec 4 to enable the
+Driving Licence flow against the PWA-resident credential.
 
-$citizenSession = Connect-SorchaUser `
-    -TenantUrl $state.tenantUrl `
-    -Email $state.roles.citizen.email `
-    -Password $state.roles.citizen.password `
-    -OrganizationId $state.roles.citizen.organizationId
-Write-WtSuccess "Authenticated as citizen"
+Umbrella context:
+  docs/superpowers/specs/2026-05-13-strathcarron-citizen-arc.md
+"@
 
-$licensingSession = Connect-SorchaUser `
-    -TenantUrl $state.tenantUrl `
-    -Email $state.roles.licensingOfficer.email `
-    -Password $state.roles.licensingOfficer.password `
-    -OrganizationId $state.roles.licensingOfficer.organizationId
-Write-WtSuccess "Authenticated as licensing officer"
-
-# ============================================================================
-# Step 2: Citizen creates the Driving Licence Blueprint instance
-# ============================================================================
-Write-WtStep "Step 2: Citizen creates Driving Licence Instance"
-
-$instanceBody = @{
-    blueprintId = $state.licenceBlueprintId
-    registerId  = $state.registerId
-    tenantId    = $state.publicOrgId
-    metadata    = @{ source = "walkthrough"; walkthrough = "AssuredIdentity"; phase = 2 }
-}
-
-$instance = Invoke-SorchaApi -Method POST `
-    -Uri "$($state.blueprintUrl)/instances/" `
-    -Body $instanceBody `
-    -Headers $citizenSession.Headers
-$instanceId = $instance.id
-Write-WtSuccess "Instance: $instanceId"
-if ($ShowJson) { $instance | ConvertTo-Json -Depth 5 | Write-Host }
-
-# ============================================================================
-# Step 3: Citizen submits vehicle class (Action 1)
-# ============================================================================
-Write-WtStep "Step 3: Citizen submits Driving Licence Application (Action 1)"
-
-$null = Invoke-SorchaAction `
-    -BlueprintUrl $state.blueprintUrl `
-    -InstanceId $instanceId `
-    -ActionId "1" `
-    -BlueprintId $state.licenceBlueprintId `
-    -SenderWallet $state.citizenWalletAddress `
-    -RegisterId $state.registerId `
-    -Token $citizenSession.Token `
-    -PayloadData @{
-        vehicleClass   = "Car (B)"
-        applicantNotes = "Standard car licence application"
-    }
-
-# ============================================================================
-# Step 4: Licensing officer verifies identity (Action 2 — HAIP presentation request)
-# ============================================================================
-Write-WtStep "Step 4: Licensing officer verifies applicant identity (Action 2)"
-
-$verifyResponse = Invoke-SorchaAction `
-    -BlueprintUrl $state.blueprintUrl `
-    -InstanceId $instanceId `
-    -ActionId "2" `
-    -BlueprintId $state.licenceBlueprintId `
-    -SenderWallet $state.licensingWalletAddress `
-    -RegisterId $state.registerId `
-    -Token $licensingSession.Token `
-    -PayloadData @{ verificationNotes = "Assured Identity presentation requested via HAIP" }
-
-if ($ShowJson) { $verifyResponse | ConvertTo-Json -Depth 5 | Write-Host }
-
-$presentationRequest = $verifyResponse.presentationRequest
-if (-not $presentationRequest) {
-    Write-WtFail "Action 2 did not return a presentationRequest. HAIP verifier pipeline may be misconfigured."
-    exit 1
-}
-Write-WtSuccess "Presentation request: $($presentationRequest.requestId)"
-Write-WtInfo "Credential type: $($presentationRequest.credentialType)"
-Write-WtInfo "Requested claims: $($presentationRequest.requestedClaims -join ', ')"
-
-# ============================================================================
-# Step 5: Citizen presents identity via sorcha-agent haip present
-# ============================================================================
-Write-WtStep "Step 5: sorcha-agent haip present"
-
-$discloseClaims = "givenName,familyName,dateOfBirth"
-if ($IncludePortrait) {
-    $discloseClaims = "givenName,familyName,dateOfBirth,portrait"
-}
-Write-WtInfo "Disclosing: $discloseClaims"
-
-$requestUri = "$($state.gatewayUrl)/api/v1/verifier/requests/$($presentationRequest.requestId)/request-object"
-
-& dotnet run --project $agentProject -- haip present `
-    --request-uri $requestUri `
-    --credential "AssuredIdentityCredential" `
-    --disclose $discloseClaims `
-    --wallet-dir $walletDir
-
-if ($LASTEXITCODE -ne 0) {
-    Write-WtFail "Presentation failed (exit $LASTEXITCODE)"
-    exit $LASTEXITCODE
-}
-Write-WtSuccess "Assured Identity presented and verified"
-
-# ============================================================================
-# Step 6: Wait for Action 3 (Issue Licence) to become current
-# ============================================================================
-Write-WtStep "Step 6: Wait for Action 3 to become current"
-
-$maxWait = 60
-$waited = 0
-$ready = $false
-while ($waited -lt $maxWait) {
-    $inst = Invoke-SorchaApi -Method GET `
-        -Uri "$($state.blueprintUrl)/instances/$instanceId" `
-        -Headers $licensingSession.Headers
-    if ($inst.currentActionIds -contains 3) {
-        $ready = $true
-        break
-    }
-    Start-Sleep -Seconds 1
-    $waited++
-}
-if (-not $ready) {
-    Write-WtWarn "Action 3 not yet current after ${waited}s — proceeding anyway"
-} else {
-    Write-WtInfo "Action 3 ready (waited ${waited}s)"
-}
-
-# ============================================================================
-# Step 7: Licensing officer issues Driving Licence (Action 3 — credential mint)
-# ============================================================================
-# Walkthrough-level carry-forward: the licensing officer's submission payload
-# includes holderName / holderDateOfBirth / holderPortrait drawn from the
-# citizen's persona state (which is the source of truth the citizen just
-# presented from their AssuredIdentityCredential). The claim mappings on
-# the blueprint reference these payload fields directly — see follow-up
-# issue #338 for proper server-side /presentedClaims/ plumbing.
-Write-WtStep "Step 7: Licensing officer issues Driving Licence (Action 3)"
-
-$today = (Get-Date).ToString("yyyy-MM-dd")
-$expiry = (Get-Date).AddYears(10).ToString("yyyy-MM-dd")
-
-$persona = $state.persona
-$licenceData = @{
-    licenceNumber     = "DL-ACME-$(Get-Random -Maximum 99999)"
-    vehicleClass      = "Car (B)"
-    issuedDate        = $today
-    expiryDate        = $expiry
-    holderName        = $persona.fullName
-    holderDateOfBirth = $persona.dateOfBirth
-}
-
-# Portrait carry-forward — optional. When -IncludePortrait was passed on
-# Phase 1, the Assured Identity token is at $persona.portraitTokenBase64.
-# The licensing officer reads the citizen's wallet-dir directly in a real browser
-# integration; here the walkthrough stashed it into persona state for
-# script-level simplicity.
-if ($IncludePortrait -and $state.persona.portraitTokenBase64) {
-    $licenceData.holderPortrait = $state.persona.portraitTokenBase64
-    Write-WtInfo "Portrait carried forward ($($state.persona.portraitTokenBase64.Length) base64 chars)"
-}
-
-$licenceResponse = Invoke-SorchaAction `
-    -BlueprintUrl $state.blueprintUrl `
-    -InstanceId $instanceId `
-    -ActionId "3" `
-    -BlueprintId $state.licenceBlueprintId `
-    -SenderWallet $state.licensingWalletAddress `
-    -RegisterId $state.registerId `
-    -Token $licensingSession.Token `
-    -PayloadData $licenceData
-
-if ($ShowJson) { $licenceResponse | ConvertTo-Json -Depth 5 | Write-Host }
-
-$credentialOffer = $licenceResponse.credentialOffer
-if (-not $credentialOffer) {
-    Write-WtFail "Action 3 did not return a credentialOffer. HAIP issuance pipeline may be misconfigured."
-    exit 1
-}
-Write-WtSuccess "Licence offer: $($credentialOffer.offerId)"
-
-# ============================================================================
-# Step 8: Citizen claims Driving Licence via sorcha-agent haip receive
-# ============================================================================
-Write-WtStep "Step 8: sorcha-agent haip receive (Driving Licence)"
-
-& dotnet run --project $agentProject -- haip receive `
-    --offer-uri $credentialOffer.credentialOfferUri `
-    --wallet-dir $walletDir
-
-if ($LASTEXITCODE -ne 0) {
-    Write-WtFail "Licence receive failed (exit $LASTEXITCODE)"
-    exit $LASTEXITCODE
-}
-
-# ============================================================================
-# Step 9: Verify both credentials in wallet + carry-forward correctness
-# ============================================================================
-Write-WtStep "Step 9: Verify wallet contents"
-
-$identityCred = Join-Path $walletDir "credentials/AssuredIdentityCredential.sdjwt"
-$licenceCred  = Join-Path $walletDir "credentials/DrivingLicenceCredential.sdjwt"
-
-if (-not (Test-Path $identityCred)) { Write-WtFail "Missing AssuredIdentityCredential"; exit 1 }
-if (-not (Test-Path $licenceCred))  { Write-WtFail "Missing DrivingLicenceCredential";  exit 1 }
-
-$identitySize = (Get-Item $identityCred).Length
-$licenceSize  = (Get-Item $licenceCred).Length
-Write-WtSuccess "Both credentials in wallet:"
-Write-WtInfo "  AssuredIdentityCredential: $identitySize bytes"
-Write-WtInfo "  DrivingLicenceCredential:  $licenceSize bytes"
-
-# Spot-check: licence SD-JWT carries the holderName disclosure. SD-JWT
-# disclosures are `~base64url(JSON-array)~` after the main JWT, so the
-# literal string "holderName" is only present after base64-decoding the
-# disclosure segments. Decode + scan for the expected claim names.
-$licenceBody = Get-Content $licenceCred -Raw
-$segments = $licenceBody.TrimEnd('~').Split('~')
-$decodedDisclosures = @()
-for ($i = 1; $i -lt $segments.Length; $i++) {
-    $seg = $segments[$i]
-    if ([string]::IsNullOrWhiteSpace($seg)) { continue }
-    $padded = $seg.Replace('-', '+').Replace('_', '/')
-    switch ($padded.Length % 4) {
-        2 { $padded += '==' }
-        3 { $padded += '=' }
-    }
-    try {
-        $json = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($padded))
-        $decodedDisclosures += $json
-    } catch { }
-}
-
-$decodedText = ($decodedDisclosures -join "`n")
-$expectedClaims = @("holderName", "holderDateOfBirth", "licenceNumber", "vehicleClass")
-$missing = $expectedClaims | Where-Object { $decodedText -notmatch $_ }
-if ($missing.Count -gt 0) {
-    Write-WtWarn "Licence missing expected claim disclosures: $($missing -join ', ')"
-} else {
-    Write-WtSuccess "Licence credential carries all expected claim disclosures (including holderName + holderDateOfBirth carry-forward)"
-}
-
-$state | Add-Member -NotePropertyName "licenceInstanceId" -NotePropertyValue $instanceId -Force
-$state | Add-Member -NotePropertyName "licenceCredentialPath" -NotePropertyValue $licenceCred -Force
-$state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
-
-Write-WtBanner "AssuredIdentity — Phase 2 Complete"
-Write-WtSuccess "DrivingLicenceCredential issued via credential-chain (AssuredIdentity -> Driving Licence)"
+exit 0

--- a/walkthroughs/AssuredIdentity/run.ps1
+++ b/walkthroughs/AssuredIdentity/run.ps1
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
-# AssuredIdentity — full two-phase orchestrator.
-# Runs setup.ps1 (idempotent) then Phase 1 (identity) then Phase 2
-# (driving licence). Logs total elapsed time so the SC-001 (under 3 min
-# for identity) and SC-002 (under 2 min for licence) success criteria
-# can be checked against real runs.
+# AssuredIdentity — orchestrator.
+# Runs setup.ps1 (idempotent) then Phase 1 (identity, PWA delivery). Phase 2
+# (driving licence) is currently a stub — Feature 124 deferred the
+# credential-gated second-service flow to Spec 4 of the citizen arc.
+# Logs total elapsed time so the SC-001 (under 3 min for identity) success
+# criterion can be checked against real runs.
 
 param(
     [ValidateSet('gateway', 'direct', 'aspire', 'n1')]
@@ -42,18 +43,11 @@ if ($LASTEXITCODE -ne 0) { throw "run-phase1-identity.ps1 failed (exit $LASTEXIT
 $phase1Elapsed = (Get-Date) - $phase1Start
 Write-WtInfo ("Phase 1 elapsed: {0:mm\:ss}" -f $phase1Elapsed)
 
-# Phase 2 — Driving Licence chain
-$phase2Start = Get-Date
-$phase2Args = @()
-if ($ShowJson)         { $phase2Args += '-ShowJson' }
-if ($IncludePortrait)  { $phase2Args += '-IncludePortrait' }
-& (Join-Path $scriptDir "run-phase2-licence.ps1") @phase2Args
-if ($LASTEXITCODE -ne 0) { throw "run-phase2-licence.ps1 failed (exit $LASTEXITCODE)" }
-$phase2Elapsed = (Get-Date) - $phase2Start
-Write-WtInfo ("Phase 2 elapsed: {0:mm\:ss}" -f $phase2Elapsed)
+# Phase 2 — deferred to Spec 4 of the citizen arc. The stub script logs the
+# deferral and exits 0; we surface its banner but skip the timing budget.
+& (Join-Path $scriptDir "run-phase2-licence.ps1")
 
 $totalElapsed = (Get-Date) - $totalStart
 Write-WtBanner "AssuredIdentity — Full Run Complete"
 Write-WtSuccess ("Total elapsed: {0:mm\:ss}" -f $totalElapsed)
 Write-WtInfo "SC-001 budget: Phase 1 under 3 min — $(if ($phase1Elapsed.TotalMinutes -lt 3) { 'OK' } else { 'OVER' })"
-Write-WtInfo "SC-002 budget: Phase 2 under 2 min — $(if ($phase2Elapsed.TotalMinutes -lt 2) { 'OK' } else { 'OVER' })"

--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -3,9 +3,16 @@
 # Copyright (c) 2026 Sorcha Contributors
 #
 # AssuredIdentity — Setup
-# Feature 107. Creates the Acme Verification Co. issuing organisation,
-# provisions its trust anchor + HAIP issuer enrolment, creates the citizen
-# public-org account, and publishes the AssuredIdentity blueprint.
+# Feature 107 + Feature 124. Creates the Acme Verification Co. issuing
+# organisation, provisions its trust anchor + HAIP issuer enrolment,
+# creates the citizen public-org account, and publishes the AssuredIdentity
+# blueprint (now configured to deliver into the Citizen Wallet PWA via
+# SorchaLocalWallet target audience).
+#
+# After setup, sign the citizen into the wallet host once on the demo
+# device: open http://localhost/wallet/, tap Settings, sign in with the
+# citizen credentials printed at the end of this script.
+#
 # Idempotent — safe to run multiple times.
 
 param(
@@ -391,7 +398,9 @@ $state = @{
     citizenWalletAddress      = $citizenWallet.Address
     registerId                = $register.RegisterId
     blueprintId               = $blueprint.BlueprintId
-    walletDir                 = (Join-Path $scriptDir "wallet")
+    # walletDir removed in Feature 124 — credential delivery now lands in the
+    # Citizen Wallet PWA (SorchaLocalWallet target audience), not in a
+    # filesystem wallet on the operator host.
     # PR 2 additions — licensing org, licensing wallet, Driving Licence blueprint id.
     licensingOrgId            = $licensingOrgId
     licensingWalletAddress    = $licensingWallet.Address
@@ -436,4 +445,19 @@ $state = @{
 
 $state | ConvertTo-Json -Depth 10 | Set-Content -Path $stateFile
 Write-WtSuccess "State saved to $stateFile"
+
+# Feature 124 — surface the citizen credentials so the operator can sign
+# the demo citizen into the PWA host before running phase 1.
+Write-WtInfo ""
+Write-WtInfo "Next step: sign the citizen into the wallet host."
+Write-WtInfo "  URL:       http://localhost/wallet/ (or your gateway equivalent)"
+Write-WtInfo "  Settings → Sign in"
+Write-WtInfo "  Email:     $citizenEmail"
+Write-WtInfo "  Password:  $citizenPassword"
+Write-WtInfo ""
+Write-WtInfo "Then enrol the device on the wallet PWA. In two terminals:"
+Write-WtInfo "  T1> pwsh walkthroughs/AssuredIdentity/run-agents.ps1"
+Write-WtInfo "  T2> pwsh walkthroughs/AssuredIdentity/run-phase1-identity.ps1"
+Write-WtInfo ""
+
 Write-WtBanner "AssuredIdentity — Setup Complete"

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psd1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psd1
@@ -43,6 +43,10 @@
 
         # Utilities
         'ConvertFrom-HexToBase64'
+
+        # Feature 124 — citizen pending-application notice helpers
+        'Set-SorchaCitizenPendingApplication'
+        'Clear-SorchaCitizenPendingApplication'
     )
 
     CmdletsToExport   = @()

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1882,3 +1882,63 @@ function Switch-SorchaOrganization {
         Headers        = @{ Authorization = "Bearer $token" }
     }
 }
+
+# ============================================================================
+# Set-SorchaCitizenPendingApplication / Clear-SorchaCitizenPendingApplication
+# Feature 124 — drives the wallet PWA's waiting-state UX from the walkthrough.
+# ============================================================================
+
+function Set-SorchaCitizenPendingApplication {
+    <#
+    .SYNOPSIS
+        Set the citizen's pending-application notice on the Wallet Service.
+    .DESCRIPTION
+        Calls PUT /api/v1/wallet/pending-applications with the supplied label.
+        Idempotent — calling with a new label replaces the prior one and
+        resets the TTL. The PWA reads this notice on every Home render to
+        decide whether to show the waiting-card.
+    .PARAMETER WalletUrl
+        The wallet service base URL (e.g. http://localhost/api).
+    .PARAMETER Label
+        Human-readable application label (1..80 chars). Plain text — no
+        credential content.
+    .PARAMETER Headers
+        Citizen-scope authorization headers (Bearer JWT carrying
+        platform_user_id claim).
+    #>
+    param(
+        [Parameter(Mandatory)][string]$WalletUrl,
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][hashtable]$Headers
+    )
+
+    $body = @{ label = $Label }
+    $response = Invoke-SorchaApi -Method PUT `
+        -Uri "$WalletUrl/v1/wallet/pending-applications" `
+        -Body $body `
+        -Headers $Headers
+    Write-WtInfo "Pending-application notice set: $Label"
+    return $response.notice
+}
+
+function Clear-SorchaCitizenPendingApplication {
+    <#
+    .SYNOPSIS
+        Clear the citizen's pending-application notice.
+    .DESCRIPTION
+        Calls DELETE /api/v1/wallet/pending-applications. Idempotent —
+        returns 204 whether or not a notice was present. The PWA drops
+        the waiting-card within one second of next Home render.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$WalletUrl,
+        [Parameter(Mandatory)][hashtable]$Headers
+    )
+
+    # Use RawResponse so we don't try to parse a 204 No Content body.
+    $null = Invoke-SorchaApi -Method DELETE `
+        -Uri "$WalletUrl/v1/wallet/pending-applications" `
+        -Headers $Headers `
+        -RawResponse
+    Write-WtInfo "Pending-application notice cleared"
+}


### PR DESCRIPTION
## Summary

PR-D of Feature 124. Swaps the AssuredIdentity walkthrough from the legacy HAIP filesystem-wallet path to the Citizen Wallet PWA, and adds the walkthrough-driven Set/Clear of the pending-application notice that lights up the wallet's waiting state. Tracks T039–T048.

## What's in

**Blueprint** (T039)
- \`assured-identity.json\` action 2 \`credentialIssuanceConfig.targetAudience\` flips from \`HaipExternalWallet\` → \`SorchaLocalWallet\`. HAIP-external phrasing stripped from action descriptions.

**Module helpers** (T040)
- \`Set-SorchaCitizenPendingApplication\` / \`Clear-SorchaCitizenPendingApplication\` in \`walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1\`, exported via the psd1 manifest. Both wrap \`/api/v1/wallet/pending-applications\` PUT/DELETE.

**Scripts**
- \`run-phase1-identity.ps1\` (T043) rewritten end-to-end: drops sorcha-agent haip receive, brackets action-2 approval with Set/Clear notice, polls \`/api/v1/wallet/credentials\` to confirm PWA delivery before clearing the notice.
- \`run-phase2-licence.ps1\` (T044) stubbed: Phase 2's HAIP presentation flow can't run scripted against the PWA — explicitly deferred to Spec 4 of the citizen arc (credential-gated second service).
- \`setup.ps1\` (T042) drops \`walletDir\` from saved state; final output surfaces the citizen sign-in URL + credentials so the operator can sign Sarah into the PWA on the demo device (FR-014).
- \`run-agents.ps1\` (T045): licensing-officer agent dropped (no Phase 2 action to fire on). Verification-analyst unchanged.
- \`run.ps1\` updated for the Phase 2 stub.
- \`README.md\` (T046): file tree drops \`wallet/\`, Phase table notes Phase 2 deferral.

**Cleanup** (T047)
- \`walkthroughs/AssuredIdentity/wallet/\` was never tracked in git (\`walkthroughs/*/wallet/\` is gitignored). The deletion is a tree-state no-op; operators clear local stale state on their own host.

## Out of scope

- **T041 Sign-CitizenInToWallet** — the PWA stores its JWT in IndexedDB via \`AuthService\`; a PowerShell-side helper cannot populate that from outside the browser. FR-014 is met by \`setup.ps1\` printing the citizen credentials at the end so the operator signs in once manually on the wallet device.
- **T048 multi-peer verification** — operator-run; \`run-multi-peer.ps1\` never referenced the filesystem wallet (R-005), so the removal should be a no-op. Will be exercised in PR-E's quickstart pass against SC-006.

## Verification

- PowerShell parse-check (\`[System.Management.Automation.Language.Parser]::ParseFile\`) clean on all six edited scripts + the module.
- Blueprint JSON validates; \`action 2 targetAudience == "SorchaLocalWallet"\` confirmed.
- \`dotnet test tests/Sorcha.Wallet.Service.Tests/\` — **768/768 pass**, 0 failures.
- \`dotnet test tests/Sorcha.Citizen.Wallet.Tests/\` — **57/57 pass**, 0 failures (no PWA code changes in this PR).

## Test plan

- [x] Scripts parse-check clean.
- [x] Blueprint JSON valid.
- [x] .NET tests green.
- [ ] PR-E quickstart: full setup + run-phase1-identity flow exercises the new Set/Clear notice and confirms credential delivery to PWA.
- [ ] PR-E: \`run-multi-peer.ps1\` still passes (SC-006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)