### PR TITLE
fix(124): wire IDistributedCache in wallet-service for pending-application store

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -210,6 +210,12 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.IFileReasse
 // Add Redis for notification rate limiting and pub/sub
 builder.AddRedisClient("redis");
 
+// Feature 124 — IDistributedCache backing for RedisPendingApplicationStore.
+// Re-uses the same "redis" connection registered above; Aspire wires the
+// StackExchange.Redis distributed-cache implementation on top of the
+// existing IConnectionMultiplexer.
+builder.AddRedisDistributedCache("redis");
+
 // Add service clients for inter-service communication
 builder.Services.AddServiceClients(builder.Configuration);
 

--- a/src/Services/Sorcha.Wallet.Service/Sorcha.Wallet.Service.csproj
+++ b/src/Services/Sorcha.Wallet.Service/Sorcha.Wallet.Service.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Aspire.StackExchange.Redis" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />

--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -448,16 +448,16 @@ Write-WtSuccess "State saved to $stateFile"
 
 # Feature 124 — surface the citizen credentials so the operator can sign
 # the demo citizen into the PWA host before running phase 1.
-Write-WtInfo ""
+Write-Host ""
 Write-WtInfo "Next step: sign the citizen into the wallet host."
 Write-WtInfo "  URL:       http://localhost/wallet/ (or your gateway equivalent)"
 Write-WtInfo "  Settings → Sign in"
 Write-WtInfo "  Email:     $citizenEmail"
 Write-WtInfo "  Password:  $citizenPassword"
-Write-WtInfo ""
+Write-Host ""
 Write-WtInfo "Then enrol the device on the wallet PWA. In two terminals:"
 Write-WtInfo "  T1> pwsh walkthroughs/AssuredIdentity/run-agents.ps1"
 Write-WtInfo "  T2> pwsh walkthroughs/AssuredIdentity/run-phase1-identity.ps1"
-Write-WtInfo ""
+Write-Host ""
 
 Write-WtBanner "AssuredIdentity — Setup Complete"


### PR DESCRIPTION
## Summary

Feature 124 PR-A's research note (R-001) assumed \`IDistributedCache\` was already wired in \`Sorcha.Wallet.Service\`. It wasn't — the service had the Aspire Redis client (\`AddRedisClient\`) but not the distributed-cache overlay (\`AddRedisDistributedCache\`).

Production hit **500 InvalidOperationException** on every PUT/GET/DELETE of \`/api/v1/wallet/pending-applications\` because the DI container couldn't resolve \`IDistributedCache\` to construct \`RedisPendingApplicationStore\`. Unit tests passed because they constructed \`MemoryDistributedCache\` directly via \`Options.Create\`, never exercising the DI graph.

Caught immediately by the post-merge quickstart smoke probe.

## Fix

- Add \`Aspire.StackExchange.Redis.DistributedCaching\` package reference to \`Sorcha.Wallet.Service.csproj\`.
- Call \`builder.AddRedisDistributedCache("redis")\` in \`Program.cs\` right after the existing \`AddRedisClient("redis")\` so both consume the same Aspire-managed connection.

## Verification

End-to-end smoke against a freshly-rebuilt wallet-service container:

\`\`\`
GET     /pending-applications  → 200 { "notice": null }
PUT     { "label": "Assured Identity" }  → 200 with notice envelope
GET     /pending-applications  → 200 with notice present
PUT     { "label": "Driving Licence" }   → 200 replaced
DELETE  /pending-applications  → 204
GET     /pending-applications  → 200 { "notice": null }
DELETE  /pending-applications  → 204 (idempotent re-delete)
\`\`\`

## Drive-by

\`setup.ps1\`'s three trailing \`Write-WtInfo ""\` calls (added in PR-D for visual spacing around the sign-in instructions) failed parameter validation because the helper rejects empty strings. Swapped to \`Write-Host ""\` — same blank-line effect, no validation gate.

## Test plan

- [x] Wallet-service builds clean.
- [x] All six smoke probes return 2xx with correct payloads.
- [ ] Existing wallet-service test suite still green (will run on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)