### PR TITLE
fix(wallet-pwa): strip leading slash from NavigateTo / Href so nav respects /wallet/ base href

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/MainLayout.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/MainLayout.razor
@@ -21,20 +21,20 @@
         <MudSpacer />
         <MudIconButton Icon="@Icons.Material.Filled.QrCodeScanner"
                        Color="Color.Inherit"
-                       OnClick="@(() => Nav.NavigateTo("/present"))"
+                       OnClick="@(() => Nav.NavigateTo("present"))"
                        aria-label="Present a credential" />
     </MudAppBar>
     <MudMainContent Class="pb-16">
         @Body
     </MudMainContent>
     <MudAppBar Bottom="true" Fixed="true" Elevation="4" Color="Color.Surface" Class="d-flex justify-space-around">
-        <MudIconButton Icon="@Icons.Material.Filled.Home" OnClick="@(() => Nav.NavigateTo("/"))"
+        <MudIconButton Icon="@Icons.Material.Filled.Home" OnClick="@(() => Nav.NavigateTo(""))"
                        aria-label="Home" />
-        <MudIconButton Icon="@Icons.Material.Filled.PhoneIphone" OnClick="@(() => Nav.NavigateTo("/devices"))"
+        <MudIconButton Icon="@Icons.Material.Filled.PhoneIphone" OnClick="@(() => Nav.NavigateTo("devices"))"
                        aria-label="Devices" />
-        <MudIconButton Icon="@Icons.Material.Filled.History" OnClick="@(() => Nav.NavigateTo("/activity"))"
+        <MudIconButton Icon="@Icons.Material.Filled.History" OnClick="@(() => Nav.NavigateTo("activity"))"
                        aria-label="Activity" />
-        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="@(() => Nav.NavigateTo("/settings"))"
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="@(() => Nav.NavigateTo("settings"))"
                        aria-label="Settings" />
     </MudAppBar>
 </MudLayout>

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/CredentialDetail.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/CredentialDetail.razor
@@ -20,7 +20,7 @@
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
     <MudButton StartIcon="@Icons.Material.Filled.ArrowBack"
-               OnClick="@(() => Nav.NavigateTo("/"))" Class="mb-2">
+               OnClick="@(() => Nav.NavigateTo(""))" Class="mb-2">
         Back
     </MudButton>
 
@@ -80,7 +80,7 @@
 
         <MudButton Color="Color.Primary" Variant="Variant.Filled"
                    StartIcon="@Icons.Material.Filled.QrCodeScanner"
-                   OnClick="@(() => Nav.NavigateTo("/present"))" FullWidth="true">
+                   OnClick="@(() => Nav.NavigateTo("present"))" FullWidth="true">
             Present this credential
         </MudButton>
     }

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Enrol.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Enrol.razor
@@ -42,7 +42,7 @@
             {
                 <MudAlert Severity="Severity.Warning" Class="mb-3">
                     You need to sign in first.
-                    <MudLink Href="/settings">Open Settings</MudLink> to sign in,
+                    <MudLink Href="settings">Open Settings</MudLink> to sign in,
                     then come back here.
                 </MudAlert>
             }
@@ -126,7 +126,7 @@
                     </MudAlert>
                 }
                 <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                           OnClick="@(() => Nav.NavigateTo("/"))">
+                           OnClick="@(() => Nav.NavigateTo(""))">
                     Open wallet
                 </MudButton>
             }

--- a/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
+++ b/src/Apps/Sorcha.Citizen.Wallet/Pages/Index.razor
@@ -81,7 +81,7 @@
             </MudAlert>
             <MudButton Variant="Variant.Filled" Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.PhoneIphone"
-                       OnClick="@(() => Nav.NavigateTo("/enrol"))" FullWidth="true" Class="mb-2"
+                       OnClick="@(() => Nav.NavigateTo("enrol"))" FullWidth="true" Class="mb-2"
                        data-testid="enrol-device-button">
                 Enrol this device
             </MudButton>
@@ -93,7 +93,7 @@
             @foreach (var c in _credentials)
             {
                 <MudCard Class="mb-3" Style="cursor:pointer;"
-                         @onclick="@(() => Nav.NavigateTo($"/credentials/{c.Id}"))"
+                         @onclick="@(() => Nav.NavigateTo($"credentials/{c.Id}"))"
                          data-testid="@($"credential-card-{c.Id}")">
                     <MudCardContent>
                         <MudText Typo="Typo.subtitle1">@(c.DisplayLabel ?? c.Vct)</MudText>
@@ -110,7 +110,7 @@
     <MudStack Row="true" Spacing="2" Class="mt-4">
         <MudButton Color="Color.Primary" Variant="Variant.Filled"
                    StartIcon="@Icons.Material.Filled.QrCodeScanner"
-                   OnClick="@(() => Nav.NavigateTo("/present"))"
+                   OnClick="@(() => Nav.NavigateTo("present"))"
                    Disabled="@(_credentials is null || _credentials.Count == 0)">
             Present a credential
         </MudButton>


### PR DESCRIPTION
## Summary

Every navigation button in the citizen wallet PWA was producing a 404 — clicking *Enrol this device* on https://n1.sorcha.dev/wallet/ went to https://n1.sorcha.dev/enrol (404). Same reproduces locally: \`http://127.0.0.1/enrol\` → 404 while \`http://127.0.0.1/wallet/enrol\` → 200.

## Root cause

Blazor's \`NavigationManager.NavigateTo(\"/enrol\")\` treats a leading-slash path as **origin-relative** (absolute), not base-href-relative. With the PWA mounted under \`/wallet/\` behind the API Gateway (and \`<base href=\"/wallet/\" />\` in \`index.html\`), every \`NavigateTo(\"/<page>\")\` lands on the wrong place — the gateway has no route for \`/<page>\` at the root.

Only trailing-segment paths (\`NavigateTo(\"enrol\")\`) resolve against the base. \`NavigateTo(\"\")\` resolves to the base path itself (= Home).

## Fix

Twelve sites across four files — strip leading slash on every \`NavigateTo\` and one \`Href\`:

- \`MainLayout.razor\` (5): top-bar Present icon + bottom-nav Home / Devices / Activity / Settings.
- \`Pages/Index.razor\` (3): *Enrol this device*, credential-card tap-through, *Present a credential*.
- \`Pages/CredentialDetail.razor\` (2): Back + *Present*.
- \`Pages/Enrol.razor\` (2): *Open Settings* MudLink + *Open wallet* on the Done step.

\`NavigateTo(\"/\")\` → \`NavigateTo(\"\")\` so Home lands at \`/wallet/\` instead of \`/\`.

## Why it slipped through

\`tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletPushTests.cs\` exists but covers Home page render + the demo-mint helper, not any navigation click. The Feature 124 sub-PR CI gates ran those tests cleanly. The bug surfaced the moment a real human (you) clicked *Enrol this device* on n1.

## How it was found

\`chrome-devtools\` MCP driving the actual \`https://n1.sorcha.dev/wallet/\` URL. The Enrol button click resolved to \`chrome-error://chromewebdata/\` with HTTP 404 on \`https://n1.sorcha.dev/enrol\`. Reproduced locally with curl.

## Verification

- \`dotnet build src/Apps/Sorcha.Citizen.Wallet/\` clean (0 errors).
- Local \`docker compose up -d --force-recreate sorcha-citizen-wallet\` → \`http://localhost/wallet/\` and \`http://localhost/wallet/enrol\` both 200.
- Will re-run chrome-devtools against n1 once this is merged + deployed.

## Follow-up (separate PR)

The Playwright suite should grow a click-each-nav-button test that catches this class of regression. Tracking as a TODO; not blocking the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)