### PR TITLE
fix(wallet-pwa): nginx — don't mark dotnet.js / blazor.webassembly.js as immutable

### DIFF
--- a/src/Apps/Sorcha.Citizen.Wallet/nginx.conf
+++ b/src/Apps/Sorcha.Citizen.Wallet/nginx.conf
@@ -10,6 +10,22 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Blazor's two non-fingerprinted entry-point JS files. These are the
+    # ONLY files in /_framework/ that aren't content-hashed in their URL,
+    # which means a browser that caches them as immutable will hold a
+    # stale reference table pointing at fingerprinted wasm names that no
+    # longer exist on the server — every navigation then fetches dead URLs.
+    # Must always revalidate so a wallet redeploy lands cleanly on next visit.
+    # Exact-match locations win over the regex below them.
+    location = /_framework/dotnet.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri =404;
+    }
+    location = /_framework/blazor.webassembly.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri =404;
+    }
+
     # Hashed Blazor assets — immutable, can cache for a year.
     location ~* ^/_framework/.*\.(dll|wasm|js|json|blat|dat)$ {
         expires 1y;


### PR DESCRIPTION
## Summary

The PWA's nginx regex \`location ~* ^/_framework/.*\.(dll|wasm|js|json|blat|dat)$\` caught two non-fingerprinted Blazor entry-point JS files (\`dotnet.js\`, \`blazor.webassembly.js\`) and stamped them \`Cache-Control: public, immutable, max-age=31536000\`.

## Why this is broken

Every other file in \`/_framework/\` is content-hashed (e.g. \`Sorcha.Citizen.Wallet.b0fgy5dpkq.wasm\`) — immutable cache is correct for those. The two entry-point JS files are different: stable URLs but the contents change on every build, because **\`dotnet.js\` embeds the manifest of which fingerprinted wasm files to load**.

When the PWA redeploys, wasm hashes change. But a browser holding the year-cached \`dotnet.js\` keeps requesting the **old** hashes, which now 404. The cached \`dotnet.js\` outlives its referenced wasm.

## Repro

Reproduced on n1 today during the F124 deployment:
- Container's \`dotnet.js\` references \`Sorcha.Citizen.Wallet.b0fgy5dpkq.wasm\` ✓ (matches what nginx has).
- Browser disk-cache served an older \`dotnet.js\` that referenced \`Sorcha.Citizen.Wallet.z2b9rlfmbv.wasm\` — that hash 404s on the server.

Repro path:
1. Visit \`/wallet/\` → browser caches everything for a year.
2. Operator pushes a new PWA build to the same host.
3. Browser returns → uses cached \`dotnet.js\` → its embedded fingerprint table is stale → all wasm fetches 404 → wallet doesn't navigate / boot.

## Fix

Two exact-match \`location =\` blocks above the regex (exact match wins in nginx) that send \`no-cache, no-store, must-revalidate\` for \`dotnet.js\` and \`blazor.webassembly.js\`. Fingerprinted assets keep their immutable year-long cache.

## Why this slipped

- Bug requires a **return visit after redeploy** to manifest. First visits and CI smoke probes hit fresh browsers.
- Local docker dev typically rebuilds from a fresh state.
- Browser cache TTL is the gate. We've been getting away with it because nothing in CI does a deploy → re-visit cycle.

## Verification

Once merged + Docker Publish completes + n1 pulls, I'll re-run chrome-devtools against \`https://n1.sorcha.dev/wallet/\` after a hard reload and confirm the Enrol button (fixed in #698) lands at the correct \`/wallet/enrol\` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)