### PR TITLE
docs(skills): codify today's PWA + DI + nginx lessons

### DIFF
--- a/.claude/skills/blazor/SKILL.md
+++ b/.claude/skills/blazor/SKILL.md
@@ -138,6 +138,63 @@ if (result is { Canceled: false })
 }
 ```
 
+### PWA navigation when mounted under a path prefix
+
+Blazor's `NavigationManager` treats paths with a **leading slash** as origin-relative (absolute), NOT base-href-relative. When the app is mounted under a prefix like `/wallet/` (via API Gateway `PathRemovePrefix` or similar) with `<base href="/wallet/" />` in `index.html`, this matters:
+
+```razor
+@* WRONG — resolves to https://host/enrol — 404 in production *@
+<MudButton OnClick="@(() => Nav.NavigateTo("/enrol"))">Enrol</MudButton>
+<MudLink Href="/settings">Settings</MudLink>
+
+@* RIGHT — resolves to https://host/wallet/enrol via base href *@
+<MudButton OnClick="@(() => Nav.NavigateTo("enrol"))">Enrol</MudButton>
+<MudLink Href="settings">Settings</MudLink>
+
+@* RIGHT — Home button: NavigateTo("") lands at base, NOT NavigateTo("/") *@
+<MudIconButton OnClick="@(() => Nav.NavigateTo(""))" />
+```
+
+**Why it ships broken**: localhost-dev often serves the PWA at the origin root (no prefix), so leading-slash calls *happen to work*. The bug only manifests when the PWA is served under a prefix in production. Citizen Wallet PWA hit this on n1 — see PR #698.
+
+**Test coverage**: every nav-triggering element must have a click+URL-assertion test. The page-object-without-clicks anti-pattern (see the **playwright** skill) is how this slips through CI.
+
+### nginx caching for Blazor WASM — fingerprinted vs entry-point assets
+
+Two classes of file live under `_framework/` and they need different cache policies:
+
+| Class | Example | URL stable? | Contents change? | Cache |
+|---|---|---|---|---|
+| Fingerprinted | `Sorcha.Citizen.Wallet.b0fgy5dpkq.wasm` | No (hash in URL) | No (hash *is* the contents key) | `immutable, max-age=31536000` ✅ |
+| Entry-point | `dotnet.js`, `blazor.webassembly.js` | Yes | **Yes** — embeds the fingerprint manifest of which wasm files to load | `no-cache, no-store, must-revalidate` ✅ |
+
+A nginx regex like `location ~* ^/_framework/.*\.(dll|wasm|js)$` that marks **everything** as `immutable` is the trap — it catches the non-fingerprinted entry points. On redeploy, the wasm fingerprints rotate but browsers holding the year-cached `dotnet.js` keep referencing dead hashes. Manifests as "the wallet won't navigate after a redeploy on a returning device." See PR #699.
+
+**Correct nginx pattern** (exact-match locations win over regex):
+
+```nginx
+# Non-fingerprinted entry points — revalidate every visit.
+location = /_framework/dotnet.js {
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    try_files $uri =404;
+}
+location = /_framework/blazor.webassembly.js {
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    try_files $uri =404;
+}
+
+# Fingerprinted assets — safe to cache forever.
+location ~* ^/_framework/.*\.(dll|wasm|js|json|blat|dat)$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+}
+```
+
+**Regression guard**: HTTP probe test that asserts `dotnet.js` does *not* contain `immutable` in `Cache-Control`. See `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletNginxCacheHeadersTests.cs`.
+
+**The one-time penalty**: existing browsers that visited before the fix landed still hold the year-cached `dotnet.js`. They keep showing broken nav until their cache TTL expires OR they hard-refresh. New visitors (and incognito sessions) are unaffected.
+
 ## See Also
 
 - [patterns](references/patterns.md) - Component and authentication patterns

--- a/.claude/skills/playwright/SKILL.md
+++ b/.claude/skills/playwright/SKILL.md
@@ -108,6 +108,53 @@ public async Task ResponsiveDesign_Works()
 }
 ```
 
+### Anti-pattern: locators declared but never clicked
+
+When a page object declares a locator (`EnrolDeviceButton`, `FooterNavSettings`) but **no test in the suite ever calls `.ClickAsync()` on it**, you are paying the cost of maintaining the locator without getting any coverage from it. The smell is easy to miss in review: the locator exists, the test compiles, CI is green — but the underlying user gesture has never been exercised end-to-end.
+
+This is exactly how the Citizen Wallet PWA shipped twelve broken navigation buttons (PR #698) past every CI gate. `CitizenWalletPage` declared `EnrolDeviceButton` + `PresentButton`, the test fixture imported them, but no test clicked them. The first time a real human clicked Enrol was on production — every nav button 404'd.
+
+**Discipline for new page objects**:
+1. Every nav-triggering locator gets a corresponding `Click_RoutesTo<Page>` test that asserts the URL after the click.
+2. Every state-mutating button gets a click + assert-on-resulting-state test.
+3. If a locator is for an assertion target only (e.g. `EmptyState`), document that — name it `*Indicator` / `*Banner` so future contributors don't expect it to be clicked.
+
+**Stable selector convention** — use `data-testid` attributes on every nav element rather than CSS path or text content. Pattern: kebab-case, scope-prefixed (`footer-nav-settings`, `home-present-button`, `credential-detail-back-button`). Survives MudBlazor markup churn; survives localisation.
+
+**Example test for a nav-button sweep** — one TestCaseSource covering N buttons:
+
+```csharp
+private static IEnumerable<TestCaseData> NavCases
+{
+    get
+    {
+        yield return new TestCaseData("footer-nav-devices", "devices").SetName("Footer Devices → /wallet/devices");
+        yield return new TestCaseData("footer-nav-settings", "settings").SetName("Footer Settings → /wallet/settings");
+        // ... one row per nav element
+    }
+}
+
+[Test, TestCaseSource(nameof(NavCases))]
+public async Task FooterNav_ClickRoutesToExpectedPage(string testId, string expectedSuffix)
+{
+    await NavigateToWalletAndWaitForBlazorAsync();
+    await Page.Locator($"[data-testid='{testId}']").ClickAsync();
+    await Page.WaitForURLAsync($"**/wallet/{expectedSuffix}*", new() { Timeout = 5000 });
+    Assert.That(new Uri(Page.Url).AbsolutePath,
+        Does.StartWith($"/wallet/{expectedSuffix}"));
+}
+```
+
+### Post-redeploy cache testing for PWAs
+
+A PWA with year-cached entry-point JS (`dotnet.js`, `blazor.webassembly.js` — see the **blazor** skill on this) only breaks on **return visits after a redeploy**. CI's normal "fresh browser context, fresh container" Playwright runs miss it entirely.
+
+Two cheap regression guards:
+
+1. **HTTP cache-header probes** — straight `HttpClient` against the live PWA, assert `dotnet.js` and `blazor.webassembly.js` carry `no-cache`/`must-revalidate` and *not* `immutable`. No browser needed, sub-second runtime. See `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletNginxCacheHeadersTests.cs`.
+
+2. **Browser context reuse across redeploy** — non-trivial Playwright dance: visit `/wallet/`, force fingerprint rotation (rebuild + recreate citizen-wallet container with a tagged content change), navigate again **without clearing browser state**, assert no wasm fetches 404. Phase 2 of issue #700.
+
 ## See Also
 
 - [patterns](references/patterns.md) - Locator strategies and assertions

--- a/.claude/skills/redis/SKILL.md
+++ b/.claude/skills/redis/SKILL.md
@@ -99,6 +99,21 @@ public async Task RevokeTokenAsync(string jti, DateTimeOffset expiresAt)
 }
 ```
 
+### `IDistributedCache` is a *separate* registration from `IConnectionMultiplexer`
+
+`builder.AddRedisClient("redis")` wires up `IConnectionMultiplexer` and `IDatabase` — sufficient for direct StackExchange.Redis use. It does **NOT** register `Microsoft.Extensions.Caching.Distributed.IDistributedCache`. Code that depends on `IDistributedCache` will throw `InvalidOperationException: Unable to resolve service for type 'IDistributedCache'` at the first request — not at boot.
+
+Add the distributed-cache overlay explicitly, sharing the same connection name:
+
+```csharp
+builder.AddRedisClient("redis");
+builder.AddRedisDistributedCache("redis");  // adds IDistributedCache → Redis
+```
+
+Requires the `Aspire.StackExchange.Redis.DistributedCaching` package alongside the base `Aspire.StackExchange.Redis`.
+
+**Unit-test trap that masks this**: tests that construct the SUT directly with `new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()))` bypass the DI graph entirely. The test passes; the container fails at runtime. If a service under test depends on `IDistributedCache`, also add a thin DI-startup test (or an integration test against a `TestHost`) that asserts the registration exists — not just one that mocks past it. Feature 124 PR #697 was the cautionary tale: 6 unit tests with `MemoryDistributedCache` green, production 500'd on every endpoint call.
+
 ## See Also
 
 - [patterns](references/patterns.md) - Caching, resilience, key naming

--- a/.claude/skills/sorcha-ui/SKILL.md
+++ b/.claude/skills/sorcha-ui/SKILL.md
@@ -226,6 +226,16 @@ PageTest (Playwright NUnit)
 | Docker tests | `tests/Sorcha.UI.E2E.Tests/Docker/` |
 | MudBlazor helpers | `tests/Sorcha.UI.E2E.Tests/PageObjects/Shared/MudBlazorHelpers.cs` |
 
+## Citizen Wallet PWA — path-prefix gotchas
+
+The Citizen Wallet PWA (`Sorcha.Citizen.Wallet`) mounts at **`/wallet/`** behind the API Gateway via `PathRemovePrefix`. Two rules apply only here, not to the main `Sorcha.UI.Web` app:
+
+1. **All `NavigateTo` / `Href` paths must be base-relative**, not origin-absolute. `NavigateTo("enrol")` ✓ — `NavigateTo("/enrol")` 404s in production. Home is `NavigateTo("")`, not `NavigateTo("/")`. Full rationale in the **blazor** skill → "PWA navigation when mounted under a path prefix". Twelve broken nav buttons shipped through CI as PR #698; the fix scope was global across `MainLayout.razor`, `Index.razor`, `Enrol.razor`, `CredentialDetail.razor`.
+
+2. **`nginx.conf` cache rules must exclude `dotnet.js` and `blazor.webassembly.js`** from the `immutable` regex. Those two files are NOT fingerprinted but DO change every build — caching them as immutable for a year breaks return-visits after every redeploy. Pattern in the **blazor** skill → "nginx caching for Blazor WASM" plus PR #699. Regression guard: `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletNginxCacheHeadersTests.cs`.
+
+PWA test coverage discipline (every nav element gets `data-testid` + click+URL test) is in the **playwright** skill. Issue #700 tracks the broader PWA test-coverage gap.
+
 ## See Also
 
 - [patterns](references/patterns.md) - Page implementation and test patterns


### PR DESCRIPTION
## Summary

Today's Feature 124 deployment uncovered four classes of latent bug, all of which a slightly tighter skill set would have warned about. Update the skill library so Spec 2 (and anyone else touching the PWA) starts from today's hard-won learning.

## Lessons + their new homes

| Lesson | Skill | Triggered by |
|---|---|---|
| Blazor `NavigateTo` / `Href` must be base-relative under a path-prefix mount | **blazor** § PWA navigation | PR #698 — twelve broken nav buttons |
| nginx must exclude `dotnet.js` / `blazor.webassembly.js` from immutable cache | **blazor** § nginx caching | PR #699 — return-visit-after-redeploy breakage |
| Page-object locators must have a corresponding click + URL assertion | **playwright** § Anti-pattern: locators declared but never clicked | The above two slipped through CI |
| Post-redeploy cache testing for PWAs (HTTP probe + context-reuse) | **playwright** § Post-redeploy cache testing | Issue #700 |
| `IDistributedCache` is a separate Aspire registration from `AddRedisClient` | **redis** § IDistributedCache | PR #697 — endpoints 500'd |
| Unit tests instantiating concrete deps bypass DI and mask the above | **redis** § (cautionary tale alongside the registration) | PR #697 |
| Citizen Wallet PWA path-prefix gotchas | **sorcha-ui** § (pointers to the above) | All four PRs |

## Diff stats

- \`blazor/SKILL.md\` — +57 lines (two new sections with full nginx pattern and NavigateTo cheat-sheet).
- \`playwright/SKILL.md\` — +47 lines (locator-without-click anti-pattern + post-redeploy testing section with TestCaseSource example).
- \`redis/SKILL.md\` — +15 lines.
- \`sorcha-ui/SKILL.md\` — +10 lines (cross-references the above with citizen-wallet-specific file paths).

## Verification

Markdown-only, no code changes, no test impact. The skill files are loaded by Claude Code when the matching skill is invoked.

## Related

- PR #697 (IDistributedCache wiring)
- PR #698 (NavigateTo leading-slash)
- PR #699 (nginx immutable on entry-point JS)
- PR #701 (nav-coverage Playwright)
- PR #702 (cache-header regression guard)
- Issue #700 (PWA test-coverage gap tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)