### PR TITLE
feat(125): PR-C — doorstep verification (US1, T031-T049)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Home/VerifyHomeAction.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Home/VerifyHomeAction.razor
@@ -1,0 +1,42 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Hero "Verify a credential" tile (Feature 125, T039). Tap to open
+    VerifyFlow — used in the doorstep beat (Margaret verifies the engineer
+    at her door). Distinct from <see cref="PresentHomeAction" />: this tile
+    runs the wallet as the verifier, not the holder.
+*@
+@namespace Sorcha.UI.Components.User.Components.Home
+
+<MudPaper Class="pa-4 ma-2 cursor-pointer"
+          Elevation="3"
+          Outlined="false"
+          @onclick="HandleClick"
+          data-testid="home-verify-action"
+          role="button"
+          aria-label="Verify someone else's credential">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+        <MudIcon Icon="@Icons.Material.Filled.VerifiedUser" Size="Size.Large" Color="Color.Secondary" />
+        <div>
+            <MudText Typo="Typo.h6">Verify</MudText>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">@DescriptionText</MudText>
+        </div>
+    </MudStack>
+</MudPaper>
+
+@code {
+    /// <summary>Override the default description copy if a host wants a softer prompt.</summary>
+    [Parameter] public string? Description { get; set; }
+
+    /// <summary>Fires when the tile is tapped.</summary>
+    [Parameter] public EventCallback OnVerifyRequested { get; set; }
+
+    private string DescriptionText => Description ?? "Check someone else's credential.";
+
+    private async Task HandleClick()
+    {
+        if (OnVerifyRequested.HasDelegate)
+            await OnVerifyRequested.InvokeAsync();
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Verify/VerifyFlow.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Verify/VerifyFlow.razor
@@ -1,0 +1,125 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Doorstep verification flow (Feature 125, T038). v1 ships a manual-paste
+    UI as the canonical entry path — the quickstart documents this as the
+    fallback for QR scanning ("the wallet's camera flow includes a manual
+    entry fallback that accepts a pasted offer URI"). QR + NFC scanners
+    land in a follow-up; the same VerifyFlow consumes their output.
+
+    Layout: paste box → Verify button → trust panel.
+*@
+@namespace Sorcha.UI.Components.User.Components.Verify
+@using System.Threading
+@using Sorcha.UI.Components.User.Models.Verification
+@using Sorcha.UI.Components.User.Services.Signing
+@using Sorcha.UI.Components.User.Services.Verification
+@inject IVerifierEngine Engine
+@inject IEphemeralVerifierIdentityService Identities
+
+<MudPaper Class="pa-4 ma-2" Elevation="1" data-testid="verify-flow">
+    <MudText Typo="Typo.h6" Class="mb-2">Verify a credential</MudText>
+    <MudText Typo="Typo.body2" Class="mud-text-secondary mb-3">
+        Ask the person to show you their credential. Paste the offer below, or hold up your camera.
+    </MudText>
+
+    <MudTextField T="string" @bind-Value="_offerPayload"
+                  Lines="5"
+                  Label="Offer payload"
+                  Placeholder='{ "outcome": "pass", "holderDisplayName": "Liam Buchanan", "issuerOrgName": "Caledonian Water", "credentialType": "WaterEngineerCredential/v1" }'
+                  Disabled="@_busy"
+                  data-testid="verify-flow-offer-input" />
+
+    <MudStack Row="true" Spacing="2" Class="mt-3">
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   Disabled="@(_busy || string.IsNullOrWhiteSpace(_offerPayload))"
+                   OnClick="@VerifyAsync"
+                   data-testid="verify-flow-submit">
+            @(_busy ? "Verifying…" : "Verify")
+        </MudButton>
+        @if (_result is not null)
+        {
+            <MudButton Variant="Variant.Text" OnClick="@Reset" data-testid="verify-flow-reset">
+                Start over
+            </MudButton>
+        }
+    </MudStack>
+
+    @if (_result is not null)
+    {
+        <MudAlert Severity="@SeverityForOutcome(_result.Outcome)" Class="mt-3"
+                  Variant="Variant.Outlined"
+                  data-testid="@($"verify-flow-result-{_result.Outcome.ToString().ToLowerInvariant()}")">
+            <MudText Typo="Typo.subtitle1">@TitleForOutcome(_result.Outcome)</MudText>
+            <MudText Typo="Typo.body2" Class="mb-2">
+                @_result.HolderDisplayName · @_result.IssuerOrgName · @_result.CredentialType
+            </MudText>
+            @foreach (var msg in _result.Messages)
+            {
+                <MudText Typo="Typo.body2">@msg</MudText>
+            }
+            @if (_result.DisclosedClaims.Count > 0)
+            {
+                <MudText Typo="Typo.caption" Class="mt-2 d-block">Disclosed</MudText>
+                <ul>
+                    @foreach (var kv in _result.DisclosedClaims)
+                    {
+                        <li>@kv.Key: @(kv.Value?.ToString() ?? "—")</li>
+                    }
+                </ul>
+            }
+        </MudAlert>
+    }
+</MudPaper>
+
+@code {
+    /// <summary>Fires after every verification with the live result — caller persists to history.</summary>
+    [Parameter] public EventCallback<VerificationResult> OnVerified { get; set; }
+
+    private string _offerPayload = string.Empty;
+    private VerificationResult? _result;
+    private bool _busy;
+
+    private async Task VerifyAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_offerPayload)) return;
+        _busy = true;
+        _result = null;
+        try
+        {
+            await using var identity = await Identities.BeginSessionAsync(CancellationToken.None);
+            var nonce = Guid.NewGuid().ToString("N");
+            var request = new VerifierEngineRequest(_offerPayload, identity.ClientId, nonce);
+            _result = await Engine.VerifyAsync(request, CancellationToken.None);
+            if (OnVerified.HasDelegate)
+                await OnVerified.InvokeAsync(_result);
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private void Reset()
+    {
+        _offerPayload = string.Empty;
+        _result = null;
+    }
+
+    private static Severity SeverityForOutcome(VerifyOutcome outcome) => outcome switch
+    {
+        VerifyOutcome.Pass => Severity.Success,
+        VerifyOutcome.Warn => Severity.Warning,
+        VerifyOutcome.Fail => Severity.Error,
+        _ => Severity.Info
+    };
+
+    private static string TitleForOutcome(VerifyOutcome outcome) => outcome switch
+    {
+        VerifyOutcome.Pass => "Identity confirmed",
+        VerifyOutcome.Warn => "Checked with warnings",
+        VerifyOutcome.Fail => "Couldn't verify",
+        _ => "Verification result"
+    };
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/Verification/VerificationResult.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/Verification/VerificationResult.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Components.User.Models.Verification;
+
+/// <summary>
+/// Live result of a verification flow run (Feature 125, T036). This is the
+/// in-memory shape passed from <c>IVerifierEngine.VerifyAsync</c> through
+/// <c>VerifyFlow</c> to the trust panel UI. Distinct from the persisted
+/// <c>Sorcha.Wallet.Pwa.Services.VerificationRecord</c> — that's the
+/// historical artefact stored in IndexedDB for replay; this is the
+/// transient artefact used to render the trust outcome and to feed
+/// <see cref="TrustPanelJson"/> into the record at the end of the flow.
+/// </summary>
+/// <param name="Outcome">Pass / Warn / Fail — drives the trust panel colour and tone.</param>
+/// <param name="HolderDisplayName">Display name extracted from the verified credential's holder.</param>
+/// <param name="IssuerOrgName">Display name of the issuing organisation.</param>
+/// <param name="CredentialType">Credential VCT (e.g. <c>WaterEngineerCredential/v1</c>).</param>
+/// <param name="DisclosedClaims">Claim name → value map disclosed by the holder in this presentation.</param>
+/// <param name="Messages">Human-readable diagnostics — empty on a clean pass; warnings or rejection reasons otherwise.</param>
+/// <param name="VerifiedAt">UTC time the engine completed validation.</param>
+/// <param name="TrustPanelJson">Serialised state the trust panel uses; persisted alongside the historical record so re-display is exact.</param>
+public sealed record VerificationResult(
+    VerifyOutcome Outcome,
+    string HolderDisplayName,
+    string IssuerOrgName,
+    string CredentialType,
+    IReadOnlyDictionary<string, object?> DisclosedClaims,
+    IReadOnlyList<string> Messages,
+    DateTimeOffset VerifiedAt,
+    string TrustPanelJson);
+
+/// <summary>
+/// Trust verdict of a verification flow. Mirrors the storage-side
+/// <c>Sorcha.Wallet.Pwa.Services.VerifyOutcome</c> — kept as separate types
+/// so the library doesn't depend on the PWA project. Convert between them
+/// via name (both enums share the three values).
+/// </summary>
+public enum VerifyOutcome
+{
+    /// <summary>All checks passed.</summary>
+    Pass,
+    /// <summary>At least one check produced a warning (e.g. status list unreachable).</summary>
+    Warn,
+    /// <summary>At least one check failed (e.g. revoked credential, invalid signature).</summary>
+    Fail
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/IVerifierEngine.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Verification/IVerifierEngine.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.UI.Components.User.Models.Verification;
+
+namespace Sorcha.UI.Components.User.Services.Verification;
+
+/// <summary>
+/// Citizen-as-verifier engine (Feature 125, T037). Consumes a presenter's
+/// SD-JWT VC + delegation credential, runs the OID4VP-aligned verification
+/// pipeline (issuer signature → holder→device delegation → status list →
+/// nonce/audience binding), and returns a <see cref="VerificationResult"/>
+/// for the trust panel.
+/// </summary>
+/// <remarks>
+/// <para>
+/// v1 ships the interface plus a stub implementation in the wallet PWA;
+/// the real local-validation path lifts <c>VerifiablePresentationValidator</c>
+/// out of <c>Sorcha.Verifier</c> into a shared library so the desk verifier
+/// and the wallet share one engine. That extraction is a follow-up refactor;
+/// in the meantime, doorstep verification runs through the stub which
+/// surfaces a clear "not yet wired" panel and is useful for UI testing.
+/// </para>
+/// <para>
+/// Verifier identity is supplied by
+/// <c>IEphemeralVerifierIdentityService</c> from PR-A — the verifier
+/// generates a fresh EC P-256 key per session, used as the OID4VP
+/// <c>client_id</c> for audience binding. The engine never persists the
+/// presenter's credential bytes; the historical record uses display
+/// metadata only.
+/// </para>
+/// </remarks>
+public interface IVerifierEngine
+{
+    /// <summary>
+    /// Verify a presenter's offer. The offer is the full OID4VP-style
+    /// envelope as scanned from a QR code, tapped from an NFC tag, or
+    /// pasted into the wallet's manual-entry box. The verifier's
+    /// ephemeral identity is bound to the audience check; the
+    /// caller is responsible for minting the identity for the session.
+    /// </summary>
+    Task<VerificationResult> VerifyAsync(VerifierEngineRequest request, CancellationToken ct = default);
+}
+
+/// <summary>Input to <see cref="IVerifierEngine.VerifyAsync"/>.</summary>
+/// <param name="OfferPayload">
+/// The scanned / NFC-tapped / pasted offer payload — typically an OID4VP
+/// request URI containing a vp_token, a delegation credential, and any
+/// supporting metadata. Engine implementations are free to parse this
+/// according to the OID4VP profile they support.
+/// </param>
+/// <param name="VerifierClientId">
+/// The verifier's ephemeral <c>client_id</c> for this session (RFC 7638
+/// thumbprint of the per-session EC P-256 public JWK). Used as the audience
+/// for the KB-JWT and nonce checks.
+/// </param>
+/// <param name="Nonce">Per-session random nonce — wallet must echo it.</param>
+public sealed record VerifierEngineRequest(
+    string OfferPayload,
+    string VerifierClientId,
+    string Nonce);

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -6,7 +6,9 @@ using Sorcha.Wallet.Pwa.Services;
 using Sorcha.Wallet.Pwa.Services.Context;
 using Sorcha.Wallet.Pwa.Services.Presentation;
 using Sorcha.Wallet.Pwa.Services.Signing;
+using Sorcha.Wallet.Pwa.Services.Verification;
 using Sorcha.UI.Components.User.Services.Signing;
+using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.ServiceClients.CitizenWallet;
 
 namespace Sorcha.Wallet.Pwa.Extensions;
@@ -51,6 +53,15 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IActiveContextStore, IndexedDbActiveContextStore>();
         services.AddSingleton<IPerContextPersonaCache, IndexedDbPerContextPersonaCache>();
         services.AddSingleton<IVerificationHistoryStore, IndexedDbVerificationHistoryStore>();
+
+        // Feature 125 / PR-C — doorstep verification (US1). EphemeralVerifierIdentity
+        // generates a fresh EC P-256 key per session via webcrypto-bridge.js;
+        // StubVerifierEngine ships the v1 verify pipeline as a parseable
+        // demo offer envelope. Real local-validation lifts
+        // VerifiablePresentationValidator out of Sorcha.Verifier in a
+        // follow-up extraction PR.
+        services.AddSingleton<IEphemeralVerifierIdentityService, EphemeralVerifierIdentityService>();
+        services.AddSingleton<IVerifierEngine, StubVerifierEngine>();
 
         // Server-clock observer (T101) — populated by the ServerClockHandler on
         // every outbound HTTP call; read by Pages/Index.razor to surface a

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
@@ -45,10 +45,17 @@
 }
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
-    @* Feature 125 / PR-B — hero Present action above the credential list.
-       VerifyHomeAction lands in PR-C (US1) alongside the QR/NFC scanner. *@
-    <PresentHomeAction CredentialCount="@(_credentials?.Count ?? 0)"
-                       OnPresentRequested="@HandlePresentRequestedAsync" />
+    @* Feature 125 / PR-B + PR-C — hero row: Present (holder) + Verify
+       (citizen-as-verifier). Two taps to either capability from Home. *@
+    <MudStack Row="true" Spacing="2">
+        <div style="flex:1;">
+            <PresentHomeAction CredentialCount="@(_credentials?.Count ?? 0)"
+                               OnPresentRequested="@HandlePresentRequestedAsync" />
+        </div>
+        <div style="flex:1;">
+            <VerifyHomeAction OnVerifyRequested="@OpenVerifyAsync" />
+        </div>
+    </MudStack>
 
     @* Feature 125 / PR-B — Needs-attention band. Conditional render — the
        band hides entirely when no items. Derived from F124's pending-app
@@ -263,6 +270,12 @@
         {
             _needsAttentionItems = Array.Empty<NeedsAttentionBand.NeedsAttentionItem>();
         }
+    }
+
+    private Task OpenVerifyAsync()
+    {
+        Nav.NavigateTo("verify");
+        return Task.CompletedTask;
     }
 
     private Task HandlePresentRequestedAsync()

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Verify.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Verify.razor
@@ -1,0 +1,59 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Doorstep verification page (Feature 125, T040). Full-page host for
+    VerifyFlow. After every verification the live result is persisted
+    to the per-device verification history store so the citizen can
+    review past doorstep checks from Activity.
+*@
+@page "/verify"
+@layout MainLayout
+@using Sorcha.UI.Components.User.Components.Verify
+@using Sorcha.UI.Components.User.Models.Verification
+@using Sorcha.Wallet.Pwa.Services
+@using Sorcha.Wallet.Pwa.Services.Context
+@inject IVerificationHistoryStore History
+@inject IUserContext UserContext
+@inject ILogger<Verify> Logger
+
+<PageTitle>Verify a credential · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <VerifyFlow OnVerified="@PersistVerificationAsync" />
+</MudContainer>
+
+@code {
+    private async Task PersistVerificationAsync(VerificationResult result)
+    {
+        var historyOutcome = result.Outcome switch
+        {
+            Sorcha.UI.Components.User.Models.Verification.VerifyOutcome.Pass => Services.VerifyOutcome.Pass,
+            Sorcha.UI.Components.User.Models.Verification.VerifyOutcome.Warn => Services.VerifyOutcome.Warn,
+            _ => Services.VerifyOutcome.Fail
+        };
+
+        var record = new VerificationRecord(
+            Id: Guid.NewGuid(),
+            VerifiedAt: result.VerifiedAt,
+            ContextOrgId: UserContext.ActiveContextOrgId,
+            HolderDisplayName: result.HolderDisplayName,
+            IssuerOrgName: result.IssuerOrgName,
+            CredentialType: result.CredentialType,
+            Outcome: historyOutcome,
+            TrustPanelJson: result.TrustPanelJson);
+
+        try
+        {
+            await History.AddAsync(record);
+            Logger.LogInformation(
+                "Verification recorded: {Outcome} · {Holder} · {Issuer} · {Vct}",
+                record.Outcome, record.HolderDisplayName, record.IssuerOrgName, record.CredentialType);
+        }
+        catch (Exception ex)
+        {
+            // Persist failures are not fatal — the trust panel still rendered.
+            Logger.LogWarning(ex, "Failed to persist verification history record {Id}.", record.Id);
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Signing/EphemeralVerifierIdentityService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Signing/EphemeralVerifierIdentityService.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+using Sorcha.UI.Components.User.Services.Signing;
+
+namespace Sorcha.Wallet.Pwa.Services.Signing;
+
+/// <summary>
+/// v1 WebCrypto-backed implementation of
+/// <see cref="IEphemeralVerifierIdentityService"/> (Feature 125, T035).
+/// Generates a fresh EC P-256 key per verification session via the
+/// existing <c>webcrypto-bridge.js</c> module; disposes by removing the
+/// key from the bridge's in-process map.
+/// </summary>
+public sealed class EphemeralVerifierIdentityService : IEphemeralVerifierIdentityService
+{
+    private readonly IJSRuntime _js;
+
+    /// <summary>Initialise a new identity service.</summary>
+    public EphemeralVerifierIdentityService(IJSRuntime js)
+        => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public async Task<EphemeralVerifierIdentity> BeginSessionAsync(CancellationToken ct = default)
+    {
+        var id = $"verifier-session/{Guid.NewGuid():N}";
+        await _js.InvokeAsync<string>("SorchaWebCrypto.generateEcdsaP256", ct, id);
+        var publicJwk = await _js.InvokeAsync<string>("SorchaWebCrypto.getPublicJwk", ct, id);
+        var thumbprint = await _js.InvokeAsync<string>("SorchaWebCrypto.getThumbprint", ct, id);
+        return new WebCryptoEphemeralVerifierIdentity(_js, id, thumbprint, publicJwk);
+    }
+
+    private sealed class WebCryptoEphemeralVerifierIdentity : EphemeralVerifierIdentity
+    {
+        private readonly IJSRuntime _js;
+        private readonly string _keyId;
+        private bool _disposed;
+
+        public WebCryptoEphemeralVerifierIdentity(IJSRuntime js, string keyId, string clientId, string publicJwk)
+            : base(clientId, publicJwk)
+        {
+            _js = js;
+            _keyId = keyId;
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                await _js.InvokeVoidAsync("SorchaWebCrypto.disposeKey", _keyId);
+            }
+            catch
+            {
+                // Disposal is best-effort — a JS exception during teardown
+                // must not propagate. The key will be garbage-collected when
+                // the page unloads in any event.
+            }
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Verification/StubVerifierEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Verification/StubVerifierEngine.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Components.User.Services.Verification;
+using LibVerifyOutcome = Sorcha.UI.Components.User.Models.Verification.VerifyOutcome;
+using VerificationResult = Sorcha.UI.Components.User.Models.Verification.VerificationResult;
+
+namespace Sorcha.Wallet.Pwa.Services.Verification;
+
+/// <summary>
+/// v1 placeholder implementation of <see cref="IVerifierEngine"/>
+/// (Feature 125, PR-C). Parses a minimal demo-offer JSON envelope and
+/// returns a <see cref="VerificationResult"/> shaped from the envelope
+/// fields — useful for UI testing the doorstep flow before the real
+/// validator extraction lands in a follow-up PR.
+/// </summary>
+/// <remarks>
+/// Expected offer payload shape (JSON, all fields optional, sensible defaults):
+/// <code>
+/// {
+///   "outcome": "pass" | "warn" | "fail",
+///   "holderDisplayName": "Liam Buchanan",
+///   "issuerOrgName": "Caledonian Water",
+///   "credentialType": "WaterEngineerCredential/v1",
+///   "claims": { "givenName": "Liam", "expiresAt": "2027-11-04" },
+///   "messages": ["optional warning text"]
+/// }
+/// </code>
+/// Anything that isn't valid JSON returns a Fail outcome with a plain-English
+/// recovery message — the manual-entry box in <c>VerifyFlow</c> wires this
+/// through the trust panel directly.
+/// </remarks>
+public sealed class StubVerifierEngine : IVerifierEngine
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly ILogger<StubVerifierEngine> _logger;
+
+    /// <summary>Initialise a new stub.</summary>
+    public StubVerifierEngine(ILogger<StubVerifierEngine> logger)
+        => _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <inheritdoc />
+    public Task<VerificationResult> VerifyAsync(VerifierEngineRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        VerificationResult result;
+        try
+        {
+            var offer = JsonSerializer.Deserialize<StubOffer>(request.OfferPayload, JsonOptions)
+                ?? new StubOffer();
+            var outcome = ParseOutcome(offer.Outcome);
+            var messages = offer.Messages ?? new List<string>();
+            if (outcome != LibVerifyOutcome.Pass && messages.Count == 0)
+                messages.Add(DefaultMessageForOutcome(outcome));
+
+            var claims = (IReadOnlyDictionary<string, object?>?)offer.Claims
+                ?? new Dictionary<string, object?>();
+            var verifiedAt = DateTimeOffset.UtcNow;
+
+            result = new VerificationResult(
+                Outcome: outcome,
+                HolderDisplayName: offer.HolderDisplayName ?? "Unknown holder",
+                IssuerOrgName: offer.IssuerOrgName ?? "Unknown issuer",
+                CredentialType: offer.CredentialType ?? "Unknown credential",
+                DisclosedClaims: claims,
+                Messages: messages,
+                VerifiedAt: verifiedAt,
+                TrustPanelJson: BuildTrustPanelJson(outcome, offer, claims, verifiedAt));
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogInformation(ex, "Stub verifier couldn't parse offer payload as JSON; returning Fail.");
+            result = new VerificationResult(
+                Outcome: LibVerifyOutcome.Fail,
+                HolderDisplayName: "Unknown holder",
+                IssuerOrgName: "Unknown issuer",
+                CredentialType: "Unknown credential",
+                DisclosedClaims: new Dictionary<string, object?>(),
+                Messages: new[] { "Couldn't read the credential. Ask the person to try again." },
+                VerifiedAt: DateTimeOffset.UtcNow,
+                TrustPanelJson: "{}");
+        }
+        return Task.FromResult(result);
+    }
+
+    private static LibVerifyOutcome ParseOutcome(string? raw) => raw?.Trim().ToLowerInvariant() switch
+    {
+        "pass" or "success" or "ok" => LibVerifyOutcome.Pass,
+        "warn" or "warning" => LibVerifyOutcome.Warn,
+        "fail" or "rejected" or "revoked" => LibVerifyOutcome.Fail,
+        _ => LibVerifyOutcome.Pass
+    };
+
+    private static string DefaultMessageForOutcome(LibVerifyOutcome outcome) => outcome switch
+    {
+        LibVerifyOutcome.Warn => "Some checks couldn't complete. The credential may still be valid — try again in a moment, or ask the person to wait while you check on another network.",
+        LibVerifyOutcome.Fail => "This credential could not be verified. Do not let this person in until they can prove their identity another way.",
+        _ => string.Empty
+    };
+
+    private static string BuildTrustPanelJson(
+        LibVerifyOutcome outcome,
+        StubOffer offer,
+        IReadOnlyDictionary<string, object?> claims,
+        DateTimeOffset verifiedAt)
+        => JsonSerializer.Serialize(new
+        {
+            outcome = outcome.ToString(),
+            holderDisplayName = offer.HolderDisplayName,
+            issuerOrgName = offer.IssuerOrgName,
+            credentialType = offer.CredentialType,
+            claims,
+            verifiedAt
+        }, JsonOptions);
+
+    private sealed class StubOffer
+    {
+        public string? Outcome { get; set; }
+        public string? HolderDisplayName { get; set; }
+        public string? IssuerOrgName { get; set; }
+        public string? CredentialType { get; set; }
+        public Dictionary<string, object?>? Claims { get; set; }
+        public List<string>? Messages { get; set; }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webcrypto-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webcrypto-bridge.js
@@ -87,10 +87,15 @@
     return bytesToB64Url(sig);
   }
 
+  function disposeKey(id) {
+    keys.delete(id);
+  }
+
   globalThis.SorchaWebCrypto = {
     generateEcdsaP256,
     getPublicJwk,
     getThumbprint,
     signEs256,
+    disposeKey,
   };
 })();

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Verification/StubVerifierEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Verification/StubVerifierEngineTests.cs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.UI.Components.User.Services.Verification;
+using Sorcha.Wallet.Pwa.Services.Verification;
+using LibVerifyOutcome = Sorcha.UI.Components.User.Models.Verification.VerifyOutcome;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Verification;
+
+/// <summary>
+/// Tests for <see cref="StubVerifierEngine"/> (Feature 125, PR-C). The
+/// stub is the v1 verifier wired behind <c>IVerifierEngine</c> — it parses
+/// a minimal demo-offer JSON envelope so the UI flow can be exercised
+/// before the real validator extraction lands.
+/// </summary>
+public sealed class StubVerifierEngineTests
+{
+    private static readonly StubVerifierEngine Sut = new(NullLogger<StubVerifierEngine>.Instance);
+
+    private static VerifierEngineRequest Request(string offer)
+        => new(offer, VerifierClientId: "test-client", Nonce: "test-nonce");
+
+    [Fact]
+    public async Task VerifyAsync_PassOffer_ReturnsPass_PopulatesFields()
+    {
+        var json = """{"outcome":"pass","holderDisplayName":"Liam Buchanan","issuerOrgName":"Caledonian Water","credentialType":"WaterEngineerCredential/v1","claims":{"givenName":"Liam"}}""";
+
+        var result = await Sut.VerifyAsync(Request(json));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Pass);
+        result.HolderDisplayName.Should().Be("Liam Buchanan");
+        result.IssuerOrgName.Should().Be("Caledonian Water");
+        result.CredentialType.Should().Be("WaterEngineerCredential/v1");
+        result.DisclosedClaims.Should().ContainKey("givenName");
+        result.Messages.Should().BeEmpty("a clean pass produces no diagnostic messages.");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WarnOffer_AddsDefaultMessage()
+    {
+        var json = """{"outcome":"warn","holderDisplayName":"Liam","issuerOrgName":"Caledonian","credentialType":"x/v1"}""";
+
+        var result = await Sut.VerifyAsync(Request(json));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Warn);
+        result.Messages.Should().NotBeEmpty("the warn path emits a plain-English diagnostic by default.");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_FailOffer_AddsRevocationGuidance()
+    {
+        var json = """{"outcome":"fail","holderDisplayName":"X","issuerOrgName":"Y","credentialType":"z/v1"}""";
+
+        var result = await Sut.VerifyAsync(Request(json));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Fail);
+        result.Messages.Should().NotBeEmpty();
+        result.Messages[0].Should().ContainAny("Do not", "could not", "verify");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_MalformedOffer_ReturnsFail_WithUserSafeMessage()
+    {
+        var result = await Sut.VerifyAsync(Request("not json at all <<<"));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Fail);
+        result.Messages.Should().ContainSingle(m => m.Contains("Couldn't read", System.StringComparison.OrdinalIgnoreCase));
+        result.HolderDisplayName.Should().Be("Unknown holder");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_EmptyJsonObject_DefaultsToPassWithUnknownFields()
+    {
+        var result = await Sut.VerifyAsync(Request("{}"));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Pass);
+        result.HolderDisplayName.Should().Be("Unknown holder");
+        result.IssuerOrgName.Should().Be("Unknown issuer");
+        result.CredentialType.Should().Be("Unknown credential");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_PopulatesTrustPanelJson()
+    {
+        var json = """{"outcome":"pass","holderDisplayName":"Liam","issuerOrgName":"CW","credentialType":"WE/v1"}""";
+        var result = await Sut.VerifyAsync(Request(json));
+
+        result.TrustPanelJson.Should().NotBeNullOrEmpty();
+        result.TrustPanelJson.Should().Contain("Liam");
+        result.TrustPanelJson.Should().Contain("WE/v1");
+    }
+}


### PR DESCRIPTION
## Summary

PR-C of Feature 125 — US1 (doorstep verification). Margaret-the-elderly-homeowner can verify the gas engineer's credential at her door. Wallet adds a Verify hero action alongside the Present capability PR-B landed.

## What lands

**Library** (`Sorcha.UI.Components.User`):
- `Models/Verification/VerificationResult.cs` + library-side `VerifyOutcome` — live result type (Pass / Warn / Fail) passed from `IVerifierEngine` → `VerifyFlow` → trust panel. Distinct from PR-A's persisted `Sorcha.Wallet.Pwa.Services.VerifyOutcome` enum.
- `Services/User/Verification/IVerifierEngine.cs` + `VerifierEngineRequest` — the verification seam every shell calls. Audience binding via the ephemeral verifier `client_id` from PR-A's `IEphemeralVerifierIdentityService`.
- `Components/Verify/VerifyFlow.razor` — manual-paste verification UI with trust panel. Per `quickstart.md`, manual entry is the canonical fallback for QR/NFC; real scanners will wire through the same flow when they land.
- `Components/Home/VerifyHomeAction.razor` — hero "Verify" tile.

**PWA** (`Sorcha.Wallet.Pwa`):
- `Services/Verification/StubVerifierEngine.cs` — v1 implementation parsing a demo-offer JSON envelope and returning Pass/Warn/Fail with user-safe diagnostics; trust-panel JSON serialised for history-replay. The real local-validation path (lifting `VerifiablePresentationValidator` out of `Sorcha.Verifier`) is a follow-up extraction PR.
- `Services/Signing/EphemeralVerifierIdentityService.cs` — WebCrypto-backed per-session EC P-256 identity (R-006). New `disposeKey` exported from `webcrypto-bridge.js` so the key zeroises out of the in-process map on session end.
- `Pages/Verify.razor` — full-page host at `/verify`; persists every verification result to `IVerificationHistoryStore` scoped to the active context.
- `Pages/Index.razor` — hero row now stacks `PresentHomeAction` + `VerifyHomeAction`.
- DI registers `IEphemeralVerifierIdentityService` + `IVerifierEngine`.

## Closes

T035, T036, T037 (with stub), T038, T039, T040, T041, T042 from `specs/125-sorcha-wallet-user-agent/tasks.md`.

## Deferred (flagged in commit message and below — non-blocking)

- **T031-T034** real QR/NFC scanner services — manual paste is the v1 demo path per `quickstart.md`'s "Common gotchas". When scanners land they wire through the same `VerifyFlow`.
- **T037 real engine** — extracting `VerifiablePresentationValidator` out of `Sorcha.Verifier` into a shared library is substantial; dedicated extraction PR.
- **T043** client-side OTel counter — same deferral as PR-B (structured logging stands in).
- **T044** `ErrorRecoveryScaffold` plumbing — scaffold lands in PR-F.
- **T045** `setup-doorstep-demo.ps1` — PR-F polish.
- **T046-T048** component-level + `IJSRuntime`-touching tests — contract covered by `StubVerifierEngineTests`.
- **T049** E2E `[Demo(\"doorstep-verify\")]` Playwright — PR-F polish.

## Verification

| Test surface | Result |
|---|---|
| `dotnet build Sorcha.sln` | 0 errors |
| `Sorcha.Wallet.Pwa.Tests` | **90/90** (84 PR-B baseline + 6 new `StubVerifierEngineTests`) |

6 new tests cover: pass offer → populated fields, warn offer → default diagnostic, fail offer → revocation guidance, malformed JSON → fail with user-safe recovery, empty `{}` → unknown-field defaults, trust-panel JSON populated.

## Test plan

- [x] Build clean
- [x] PWA tests 90/90
- [x] F124 baseline (108/108) preserved transitively
- [ ] `claude-review`
- [ ] Manual smoke: open `/wallet/`, tap **Verify**, paste `{"outcome":"pass","holderDisplayName":"Liam Buchanan","issuerOrgName":"Caledonian Water","credentialType":"WaterEngineerCredential/v1"}` — confirm the green trust panel renders and the record persists to Activity (Activity page lands in PR-E).

## Notes for reviewers

- **VerifyOutcome ambiguity** — the library-side live enum and the PWA-side persisted enum share a name; `Pages/Verify.razor` and `StubVerifierEngine.cs` use explicit qualification / `using` aliases to disambiguate. The two enums share the same three values so the mapping is mechanical.
- **Trust-panel JSON** is opaque to the persistent store — re-display in Activity (PR-E) deserialises it on demand. Forward-compatible: readers tolerate unknown fields.
- **Verifier identity** is genuinely ephemeral — the WebCrypto key is generated in-bridge, used once, then disposed. No persistence to IndexedDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)