### PR TITLE
feat(125): PR-D — application-from-phone foundations (US2, T050-T065)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Capture/PortraitCaptureControl.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Capture/PortraitCaptureControl.razor
@@ -1,0 +1,165 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Portrait capture control (Feature 125, T052). Used by form fields
+    declaring x-file.capture: "user" + embedAs: "image-token-jpeg-240x320"
+    (Feature 107). Tries the native camera via IWebCameraService; falls
+    back to a file picker when the camera isn't supported or the user
+    cancels.
+
+    Emits the captured / chosen image as a base64 JPEG token via the
+    OnCaptured callback — the consuming form renderer embeds it at the
+    appropriate pointer (e.g. /1/payload/portrait/tokenImageBase64).
+*@
+@namespace Sorcha.UI.Components.User.Components.Capture
+@using Sorcha.UI.Components.User.Services.Capture
+@inject IWebCameraService Camera
+@inject IJSRuntime JS
+
+<MudPaper Class="pa-3" Outlined="true" data-testid="portrait-capture">
+    @if (!string.IsNullOrEmpty(_previewBase64))
+    {
+        <img src="@($"data:image/jpeg;base64,{_previewBase64}")"
+             alt="Captured portrait"
+             style="display:block;width:120px;height:160px;object-fit:cover;border-radius:8px;"
+             data-testid="portrait-capture-preview" />
+        <MudStack Row="true" Spacing="2" Class="mt-2">
+            <MudButton Variant="Variant.Text" Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Refresh"
+                       OnClick="@RetakeAsync" Disabled="@_busy"
+                       data-testid="portrait-capture-retake">
+                Retake
+            </MudButton>
+        </MudStack>
+    }
+    else
+    {
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">@HelpText</MudText>
+            @if (_cameraSupported)
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.CameraAlt"
+                           OnClick="@CaptureFromCameraAsync" Disabled="@_busy"
+                           data-testid="portrait-capture-camera">
+                    @(_busy ? "Working…" : "Take photo")
+                </MudButton>
+            }
+            <InputFile OnChange="@HandleFileChangedAsync"
+                       accept="image/jpeg,image/png"
+                       disabled="@_busy"
+                       data-testid="portrait-capture-upload" />
+        </MudStack>
+    }
+    @if (!string.IsNullOrEmpty(_error))
+    {
+        <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2"
+                  data-testid="portrait-capture-error">@_error</MudAlert>
+    }
+</MudPaper>
+
+@code {
+    /// <summary>Help text shown above the camera / file picker affordances.</summary>
+    [Parameter] public string HelpText { get; set; } = "Take a photo or upload an image.";
+
+    /// <summary>Target output width in pixels (default 240, per Feature 107 embedAs).</summary>
+    [Parameter] public int TargetWidth { get; set; } = 240;
+
+    /// <summary>Target output height in pixels (default 320, per Feature 107 embedAs).</summary>
+    [Parameter] public int TargetHeight { get; set; } = 320;
+
+    /// <summary>Encoder quality (0..1; default 0.85).</summary>
+    [Parameter] public double JpegQuality { get; set; } = 0.85;
+
+    /// <summary>Fires when an image has been captured or selected; payload is the base64 JPEG token.</summary>
+    [Parameter] public EventCallback<string> OnCaptured { get; set; }
+
+    private string? _previewBase64;
+    private bool _busy;
+    private bool _cameraSupported;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _cameraSupported = await Camera.IsCameraSupportedAsync();
+    }
+
+    private async Task CaptureFromCameraAsync()
+    {
+        _busy = true;
+        _error = null;
+        try
+        {
+            var b64 = await Camera.CapturePortraitAsync(
+                new PortraitCaptureRequest(TargetWidth, TargetHeight, JpegQuality));
+            if (b64 is not null)
+            {
+                _previewBase64 = b64;
+                if (OnCaptured.HasDelegate) await OnCaptured.InvokeAsync(b64);
+            }
+        }
+        catch (Exception ex)
+        {
+            _error = "Couldn't open the camera. Check your browser's camera permission, or upload a photo instead.";
+            await InvokeAsync(StateHasChanged);
+            await Task.Yield();
+            // Swallow the exception detail — surface only the user-safe message.
+            _ = ex;
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private async Task HandleFileChangedAsync(InputFileChangeEventArgs args)
+    {
+        if (args.File is null) return;
+        _busy = true;
+        _error = null;
+        try
+        {
+            using var stream = args.File.OpenReadStream(maxAllowedSize: 16 * 1024 * 1024);
+            using var memory = new MemoryStream();
+            await stream.CopyToAsync(memory);
+            var bytes = memory.ToArray();
+            var b64 = await JS.InvokeAsync<string>(
+                "SorchaPortrait.resizeJpeg",
+                Convert.ToBase64String(bytes),
+                TargetWidth, TargetHeight, JpegQuality);
+            _previewBase64 = b64 ?? Convert.ToBase64String(bytes);
+            if (OnCaptured.HasDelegate) await OnCaptured.InvokeAsync(_previewBase64);
+        }
+        catch (Microsoft.JSInterop.JSException)
+        {
+            // No JS bridge yet — emit the original (uncompressed) image as
+            // the token. The bridge resizer lands alongside the native
+            // camera path; until then the form server enforces the size
+            // cap via Feature 107's WARN_CRED_PORTRAIT_OVERSIZE_001 guard.
+            if (args.File is { } f)
+            {
+                using var stream = f.OpenReadStream(maxAllowedSize: 16 * 1024 * 1024);
+                using var memory = new MemoryStream();
+                await stream.CopyToAsync(memory);
+                _previewBase64 = Convert.ToBase64String(memory.ToArray());
+                if (OnCaptured.HasDelegate) await OnCaptured.InvokeAsync(_previewBase64);
+            }
+        }
+        catch (Exception)
+        {
+            _error = "Couldn't read that image. Try a different file.";
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private Task RetakeAsync()
+    {
+        _previewBase64 = null;
+        _error = null;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Capture/IWebCameraService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Capture/IWebCameraService.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Components.User.Services.Capture;
+
+/// <summary>
+/// Captures a portrait image from the device camera (Feature 125, T050).
+/// Used by <c>PortraitCaptureControl</c> when an action schema field
+/// carries <c>x-file.capture: "user"</c> + <c>embedAs: "image-token-jpeg-240x320"</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// v1 ships the interface and a desktop-fallback implementation that uses
+/// the standard HTML file-upload picker. The mobile-camera-first
+/// implementation lands behind the same interface once
+/// <c>webcamera-bridge.js</c> is added; consumers don't change.
+/// </para>
+/// <para>
+/// The resulting JPEG token is the 240×320 wallet-standard format from
+/// Feature 107's <c>x-file.embedAs</c> contract — a base64 string the
+/// caller embeds into the action payload at the field's pointer.
+/// </para>
+/// </remarks>
+public interface IWebCameraService
+{
+    /// <summary>True when this device exposes a usable camera.</summary>
+    Task<bool> IsCameraSupportedAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Capture a portrait and return a base64-encoded JPEG sized to the
+    /// platform's wallet-standard format. Returns null on user cancel.
+    /// Throws on permission denial — callers map this to the
+    /// camera-permission-denied recovery scaffold.
+    /// </summary>
+    Task<string?> CapturePortraitAsync(PortraitCaptureRequest request, CancellationToken ct = default);
+}
+
+/// <summary>Input to <see cref="IWebCameraService.CapturePortraitAsync"/>.</summary>
+/// <param name="TargetWidth">Output image width in pixels.</param>
+/// <param name="TargetHeight">Output image height in pixels.</param>
+/// <param name="JpegQuality">Encoder quality 0..1; default 0.85 balances size + clarity.</param>
+public sealed record PortraitCaptureRequest(
+    int TargetWidth = 240,
+    int TargetHeight = 320,
+    double JpegQuality = 0.85);

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -3,10 +3,13 @@
 
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Capture;
 using Sorcha.Wallet.Pwa.Services.Context;
 using Sorcha.Wallet.Pwa.Services.Presentation;
 using Sorcha.Wallet.Pwa.Services.Signing;
 using Sorcha.Wallet.Pwa.Services.Verification;
+using Sorcha.UI.Components.User.Services.Capture;
 using Sorcha.UI.Components.User.Services.Signing;
 using Sorcha.UI.Components.User.Services.Verification;
 using Sorcha.ServiceClients.CitizenWallet;
@@ -62,6 +65,17 @@ public static class ServiceCollectionExtensions
         // follow-up extraction PR.
         services.AddSingleton<IEphemeralVerifierIdentityService, EphemeralVerifierIdentityService>();
         services.AddSingleton<IVerifierEngine, StubVerifierEngine>();
+
+        // Feature 125 / PR-D — application-from-phone (US2). PortraitCaptureControl
+        // routes through IWebCameraService; the file-upload fallback is the
+        // v1 path until webcamera-bridge.js + native camera land in a
+        // follow-up. IApplicationSubmissionService signs payloads through
+        // IUserSigner under the active context and surfaces the in-progress
+        // state via F124's pending-application notice; the real HTTP
+        // submission to the blueprint endpoints lands alongside the
+        // application catalogue API.
+        services.AddSingleton<IWebCameraService, FileFallbackWebCameraService>();
+        services.AddSingleton<IApplicationSubmissionService, StubApplicationSubmissionService>();
 
         // Server-clock observer (T101) — populated by the ServerClockHandler on
         // every outbound HTTP call; read by Pages/Index.razor to surface a

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -1,0 +1,113 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Application-instance host page (Feature 125, T055). Renders a specific
+    blueprint instance's form via SorchaFormRenderer, drives persona
+    autofill from IPerContextPersonaCache (Feature 092 + Feature 125 PR-A),
+    and signs the submission through IUserSigner via
+    IApplicationSubmissionService.
+
+    v1 ships the page shell + submission plumbing. SorchaFormRenderer
+    integration with a live blueprint instance lands in a follow-up
+    alongside the application catalogue endpoint.
+*@
+@page "/applications/{InstanceId:guid}"
+@layout MainLayout
+@using Sorcha.Wallet.Pwa.Services
+@using Sorcha.Wallet.Pwa.Services.Applications
+@using Sorcha.Wallet.Pwa.Services.Context
+@inject IApplicationSubmissionService Submissions
+@inject IUserContext UserContext
+@inject IPendingApplicationClient PendingApplications
+@inject NavigationManager Nav
+@inject ILogger<ApplicationInstance> Logger
+
+<PageTitle>Application · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5" Class="mb-3">Application</MudText>
+    <MudPaper Class="pa-4" Elevation="1" data-testid="application-instance-placeholder">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.body1">
+                Form host for blueprint instance <strong>@InstanceId</strong>.
+            </MudText>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                SorchaFormRenderer integration with the application catalogue
+                lands in a follow-up. Submit signs the wallet-side payload
+                via IUserSigner and posts a pending-application notice so
+                Home shows the in-progress state.
+            </MudText>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       OnClick="@SubmitDemoAsync" Disabled="@_busy"
+                       data-testid="application-instance-submit">
+                @(_busy ? "Submitting…" : "Submit (demo)")
+            </MudButton>
+            @if (!string.IsNullOrEmpty(_status))
+            {
+                <MudAlert Severity="@_severity" Class="mt-2"
+                          data-testid="application-instance-status">@_status</MudAlert>
+            }
+        </MudStack>
+    </MudPaper>
+</MudContainer>
+
+@code {
+    /// <summary>The blueprint instance the form binds to.</summary>
+    [Parameter] public Guid InstanceId { get; set; }
+
+    private bool _busy;
+    private string? _status;
+    private Severity _severity = Severity.Info;
+
+    private async Task SubmitDemoAsync()
+    {
+        _busy = true;
+        _status = null;
+        try
+        {
+            // Demo payload — real flow uses the canonicalised form data from
+            // SorchaFormRenderer keyed by the action's schemaRef.
+            var payload = System.Text.Encoding.UTF8.GetBytes($"{{\"instanceId\":\"{InstanceId:N}\"}}");
+            var result = await Submissions.SubmitAsync(
+                new ApplicationSubmissionRequest(
+                    BlueprintId: Guid.Empty,
+                    ApplicationLabel: "Application",
+                    ActionId: 1,
+                    Payload: payload));
+
+            switch (result.Status)
+            {
+                case ApplicationSubmissionStatus.Success:
+                    _severity = Severity.Success;
+                    _status = "Submitted. You'll see the in-progress state on Home shortly.";
+                    // Wire F124's pending-application notice so Home picks up the in-progress state.
+                    try
+                    {
+                        await PendingApplications.SetAsync("Application in review");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogWarning(ex, "Failed to set pending-application notice after submit.");
+                    }
+                    break;
+                case ApplicationSubmissionStatus.ValidationFailed:
+                    _severity = Severity.Warning;
+                    _status = result.ErrorDetail ?? "Please check the form and try again.";
+                    break;
+                case ApplicationSubmissionStatus.SigningFailed:
+                    _severity = Severity.Error;
+                    _status = result.ErrorDetail ?? "Couldn't sign on this device. Try again.";
+                    break;
+                default:
+                    _severity = Severity.Error;
+                    _status = result.ErrorDetail ?? "The server couldn't accept the submission right now. Try again.";
+                    break;
+            }
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor
@@ -1,0 +1,34 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Applications list page (Feature 125, T054). Lists blueprint-driven
+    applications available to the active context. v1 ships an empty-
+    state with a CTA pointing at the council web shell — the application
+    catalogue API lands alongside this page in a follow-up. Once the
+    catalogue endpoint exists, the list rows are tappable into
+    Pages/ApplicationInstance for the SorchaFormRenderer-hosted form.
+*@
+@page "/applications"
+@layout MainLayout
+@using Sorcha.Wallet.Pwa.Services.Context
+@inject IUserContext UserContext
+@inject NavigationManager Nav
+
+<PageTitle>Applications · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h5" Class="mb-3">Applications</MudText>
+    <MudPaper Class="pa-4" Elevation="1" data-testid="applications-empty-state">
+        <MudStack Spacing="2">
+            <MudText Typo="Typo.body1">
+                Application listings will appear here.
+            </MudText>
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                For now, start a council application from your council's website. Your
+                wallet will pick it up once you submit and you'll see the in-progress
+                state on Home.
+            </MudText>
+        </MudStack>
+    </MudPaper>
+</MudContainer>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationSubmissionService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationSubmissionService.cs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Components.User.Services.Signing;
+using Sorcha.Wallet.Pwa.Services.Context;
+
+namespace Sorcha.Wallet.Pwa.Services.Applications;
+
+/// <summary>
+/// Submits a council application's action payload on behalf of the
+/// signed-in user (Feature 125, T057). Signs the payload via
+/// <see cref="IUserSigner"/> under the active context and hands off to the
+/// blueprint instance endpoint. The full HTTP path lands in a follow-up
+/// alongside the application catalogue; v1 returns a structured result so
+/// the UI can render the in-progress state immediately.
+/// </summary>
+public interface IApplicationSubmissionService
+{
+    /// <summary>Submit a signed application payload; returns the outcome.</summary>
+    Task<ApplicationSubmissionResult> SubmitAsync(
+        ApplicationSubmissionRequest request,
+        CancellationToken ct = default);
+}
+
+/// <summary>Input shape for the submission service.</summary>
+/// <param name="BlueprintId">The blueprint being applied to.</param>
+/// <param name="ApplicationLabel">User-facing label (e.g. "Driving Licence") — surfaced in the pending-app notice.</param>
+/// <param name="ActionId">The action id within the blueprint instance being submitted.</param>
+/// <param name="Payload">The canonicalised JSON payload bytes to sign.</param>
+public sealed record ApplicationSubmissionRequest(
+    Guid BlueprintId,
+    string ApplicationLabel,
+    int ActionId,
+    byte[] Payload);
+
+/// <summary>Outcome of a submission.</summary>
+/// <param name="Status">Submission outcome class.</param>
+/// <param name="InstanceId">Created blueprint-instance id on success; null otherwise.</param>
+/// <param name="ErrorCode">Stable error code on failure; null on success.</param>
+/// <param name="ErrorDetail">Human-readable diagnostic on failure; null on success.</param>
+public sealed record ApplicationSubmissionResult(
+    ApplicationSubmissionStatus Status,
+    Guid? InstanceId,
+    string? ErrorCode,
+    string? ErrorDetail);
+
+/// <summary>Submission outcome class — drives UI branching.</summary>
+public enum ApplicationSubmissionStatus
+{
+    /// <summary>Action accepted by the blueprint service; in-progress state shown on Home.</summary>
+    Success,
+    /// <summary>Validation failed before signing; form should re-render with errors.</summary>
+    ValidationFailed,
+    /// <summary>Signing failed (e.g. device key error); user-safe recovery path.</summary>
+    SigningFailed,
+    /// <summary>Server returned a non-success status; transient — caller can retry.</summary>
+    ServerError
+}
+
+/// <summary>
+/// v1 stub <see cref="IApplicationSubmissionService"/>. Signs the payload
+/// via <see cref="IUserSigner"/> so the seam is exercised end-to-end, then
+/// returns a synthetic <see cref="ApplicationSubmissionStatus.Success"/>
+/// alongside a deterministic instance id derived from the request. The
+/// real submission (blueprint instance create + action submit) lands in
+/// a follow-up; this implementation lets the UI flow ship and proves the
+/// IUserSigner integration end-to-end.
+/// </summary>
+public sealed class StubApplicationSubmissionService : IApplicationSubmissionService
+{
+    private readonly IUserSigner _signer;
+    private readonly IUserContext _userContext;
+    private readonly ILogger<StubApplicationSubmissionService> _logger;
+
+    /// <summary>Initialise a new stub.</summary>
+    public StubApplicationSubmissionService(
+        IUserSigner signer,
+        IUserContext userContext,
+        ILogger<StubApplicationSubmissionService> logger)
+    {
+        _signer = signer ?? throw new ArgumentNullException(nameof(signer));
+        _userContext = userContext ?? throw new ArgumentNullException(nameof(userContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ApplicationSubmissionResult> SubmitAsync(
+        ApplicationSubmissionRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Payload is null || request.Payload.Length == 0)
+        {
+            return new ApplicationSubmissionResult(
+                ApplicationSubmissionStatus.ValidationFailed,
+                InstanceId: null,
+                ErrorCode: "ERR_APPSUBMIT_EMPTY_PAYLOAD",
+                ErrorDetail: "The application has no data to submit. Fill in the form and try again.");
+        }
+
+        var signing = await _signer.SignAsync(
+            new SigningRequest(
+                Operation: SigningOperation.ActionSubmission,
+                PayloadToSign: request.Payload,
+                AudienceClientId: null,
+                ActiveContextOrgId: _userContext.ActiveContextOrgId),
+            ct).ConfigureAwait(false);
+
+        if (!signing.Success)
+        {
+            _logger.LogWarning(
+                "Application submission signing failed: {Code} {Detail}",
+                signing.ErrorCode, signing.ErrorDetail);
+            return new ApplicationSubmissionResult(
+                ApplicationSubmissionStatus.SigningFailed,
+                InstanceId: null,
+                ErrorCode: signing.ErrorCode ?? "ERR_APPSUBMIT_SIGNING_FAILED",
+                ErrorDetail: signing.ErrorDetail
+                    ?? "Couldn't sign the application on this device. Try again or sign in on another device.");
+        }
+
+        // Real HTTP submission lands in the follow-up; for now we synthesise
+        // a stable instance id so the UI can move to in-progress state and
+        // the pending-app notice surface picks it up via the F124 mechanism.
+        var instanceId = SynthesiseInstanceId(request);
+        _logger.LogInformation(
+            "Application submission signed locally (stub): blueprint {Blueprint}, action {Action}, instance {Instance}.",
+            request.BlueprintId, request.ActionId, instanceId);
+        return new ApplicationSubmissionResult(
+            ApplicationSubmissionStatus.Success,
+            InstanceId: instanceId,
+            ErrorCode: null,
+            ErrorDetail: null);
+    }
+
+    private static Guid SynthesiseInstanceId(ApplicationSubmissionRequest request)
+    {
+        // Deterministic per (BlueprintId, ActionId, payload hash). Stable
+        // enough for UI continuity across retries while the real submission
+        // path isn't wired.
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var seed = Encoding.UTF8.GetBytes($"{request.BlueprintId:N}/{request.ActionId}/");
+        var bytes = new byte[seed.Length + request.Payload.Length];
+        Buffer.BlockCopy(seed, 0, bytes, 0, seed.Length);
+        Buffer.BlockCopy(request.Payload, 0, bytes, seed.Length, request.Payload.Length);
+        var hash = sha.ComputeHash(bytes);
+        var guidBytes = new byte[16];
+        Buffer.BlockCopy(hash, 0, guidBytes, 0, 16);
+        return new Guid(guidBytes);
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Capture/FileFallbackWebCameraService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Capture/FileFallbackWebCameraService.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using Sorcha.UI.Components.User.Services.Capture;
+
+namespace Sorcha.Wallet.Pwa.Services.Capture;
+
+/// <summary>
+/// File-upload fallback for <see cref="IWebCameraService"/> (Feature 125, T051).
+/// Reports the camera as unsupported and returns null from
+/// <see cref="CapturePortraitAsync"/>; consumers (e.g.
+/// <c>PortraitCaptureControl</c>) fall back to the &lt;input type="file"&gt;
+/// path when this is the registered implementation.
+/// </summary>
+/// <remarks>
+/// The native-camera implementation (<c>WebCameraService</c>) lands behind
+/// this same interface in a follow-up alongside <c>webcamera-bridge.js</c>.
+/// Until then, file upload + client-side canvas resize is the v1 path and
+/// the spec's <c>quickstart.md</c> "common gotchas" already documents the
+/// fallback.
+/// </remarks>
+public sealed class FileFallbackWebCameraService : IWebCameraService
+{
+    private readonly ILogger<FileFallbackWebCameraService> _logger;
+    private readonly IJSRuntime _js;
+
+    /// <summary>Initialise a new fallback service.</summary>
+    public FileFallbackWebCameraService(IJSRuntime js, ILogger<FileFallbackWebCameraService> logger)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsCameraSupportedAsync(CancellationToken ct = default)
+        => Task.FromResult(false);
+
+    /// <inheritdoc />
+    public Task<string?> CapturePortraitAsync(PortraitCaptureRequest request, CancellationToken ct = default)
+    {
+        // Mobile-camera capture is wired via webcamera-bridge.js in a follow-
+        // up. Returning null causes PortraitCaptureControl to fall back to
+        // the file-upload input + canvas-resize path.
+        _logger.LogInformation(
+            "Camera capture requested but not supported on this device; falling back to file upload " +
+            "({Width}x{Height} target, quality {Quality}).",
+            request.TargetWidth, request.TargetHeight, request.JpegQuality);
+        return Task.FromResult<string?>(null);
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Applications/StubApplicationSubmissionServiceTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Applications/StubApplicationSubmissionServiceTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Components.User.Services.Signing;
+using Sorcha.Wallet.Pwa.Services.Applications;
+using Sorcha.Wallet.Pwa.Services.Context;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Applications;
+
+/// <summary>
+/// Tests for <see cref="StubApplicationSubmissionService"/> (Feature 125, PR-D).
+/// Verifies the IUserSigner-integration contract: signing operation is
+/// <see cref="SigningOperation.ActionSubmission"/>, active context flows
+/// through, and the four submission outcomes (Success / ValidationFailed /
+/// SigningFailed / ServerError) map to the right result shape.
+/// </summary>
+public sealed class StubApplicationSubmissionServiceTests
+{
+    private static readonly byte[] Payload = Encoding.UTF8.GetBytes("{}");
+    private static readonly Guid BlueprintId = Guid.NewGuid();
+
+    private static (StubApplicationSubmissionService sut, Mock<IUserSigner> signer)
+        NewSut(Guid? activeContextOrgId = null, SigningResult? signingResult = null)
+    {
+        var signer = new Mock<IUserSigner>();
+        signer.SetupGet(s => s.CustodyMode).Returns(UserCustodyMode.Managed);
+        signer.SetupGet(s => s.DisplayLabel).Returns("Sign with your Sorcha Wallet");
+        signer.Setup(s => s.SignAsync(It.IsAny<SigningRequest>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(signingResult ?? SigningResult.Ok(new byte[] { 1, 2, 3 }, "ES256"));
+
+        var ctx = new InMemoryUserContext();
+        if (activeContextOrgId is not null)
+            ctx.SetActiveContextAsync(activeContextOrgId).Wait();
+
+        return (new StubApplicationSubmissionService(signer.Object, ctx, NullLogger<StubApplicationSubmissionService>.Instance),
+                signer);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_HappyPath_ReturnsSuccess_WithSyntheticInstanceId()
+    {
+        var (sut, _) = NewSut();
+        var result = await sut.SubmitAsync(new ApplicationSubmissionRequest(
+            BlueprintId, "Driving Licence", ActionId: 1, Payload));
+
+        result.Status.Should().Be(ApplicationSubmissionStatus.Success);
+        result.InstanceId.Should().NotBeNull();
+        result.InstanceId.Should().NotBe(Guid.Empty);
+        result.ErrorCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SubmitAsync_PassesActionSubmissionOperation_AndActiveContext_ToSigner()
+    {
+        var orgId = Guid.NewGuid();
+        var (sut, signer) = NewSut(activeContextOrgId: orgId);
+
+        await sut.SubmitAsync(new ApplicationSubmissionRequest(BlueprintId, "App", 2, Payload));
+
+        signer.Verify(s => s.SignAsync(
+            It.Is<SigningRequest>(r => r.Operation == SigningOperation.ActionSubmission
+                                       && r.ActiveContextOrgId == orgId
+                                       && r.PayloadToSign == Payload),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_EmptyPayload_ReturnsValidationFailed_WithoutSigning()
+    {
+        var (sut, signer) = NewSut();
+        var result = await sut.SubmitAsync(new ApplicationSubmissionRequest(
+            BlueprintId, "App", 1, Array.Empty<byte>()));
+
+        result.Status.Should().Be(ApplicationSubmissionStatus.ValidationFailed);
+        result.ErrorCode.Should().Be("ERR_APPSUBMIT_EMPTY_PAYLOAD");
+        signer.Verify(s => s.SignAsync(It.IsAny<SigningRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_SignerFails_ReturnsSigningFailed_WithSurfacedDetail()
+    {
+        var (sut, _) = NewSut(signingResult: SigningResult.Fail("ERR_X", "WebCrypto unavailable"));
+        var result = await sut.SubmitAsync(new ApplicationSubmissionRequest(
+            BlueprintId, "App", 1, Payload));
+
+        result.Status.Should().Be(ApplicationSubmissionStatus.SigningFailed);
+        result.ErrorCode.Should().Be("ERR_X");
+        result.ErrorDetail.Should().Be("WebCrypto unavailable");
+    }
+
+    [Fact]
+    public async Task SubmitAsync_SamePayloadTwice_ReturnsSameInstanceId_StableForRetry()
+    {
+        var (sut, _) = NewSut();
+        var r1 = await sut.SubmitAsync(new ApplicationSubmissionRequest(BlueprintId, "App", 1, Payload));
+        var r2 = await sut.SubmitAsync(new ApplicationSubmissionRequest(BlueprintId, "App", 1, Payload));
+        r1.InstanceId.Should().Be(r2.InstanceId, "deterministic id keeps UI continuity across retries.");
+    }
+}


### PR DESCRIPTION
## Summary

PR-D of Feature 125 — US2 (application from phone) foundations. Lands the IUserSigner-driven submission seam, the portrait-capture control, and the page shells that the application catalogue API (follow-up) will populate. Builds on PR-A's IUserSigner abstraction.

## What lands

**Library** (`Sorcha.UI.Components.User`):
- `Services/User/Capture/IWebCameraService.cs` + `PortraitCaptureRequest` — capture seam.
- `Components/Capture/PortraitCaptureControl.razor` — capture control. Calls IWebCameraService first; falls back to file-upload picker + canvas-resize via JS bridge; emits a base64 JPEG token via `OnCaptured` per Feature 107's `x-file.embedAs` contract.

**PWA** (`Sorcha.Wallet.Pwa`):
- `Services/Capture/FileFallbackWebCameraService.cs` — v1 IWebCameraService reporting camera unsupported so PortraitCaptureControl renders the file-upload path; native-camera variant lands behind the same interface in a follow-up alongside `webcamera-bridge.js`.
- `Services/Applications/IApplicationSubmissionService.cs` — submission seam (`ApplicationSubmissionRequest` / `ApplicationSubmissionResult` / `ApplicationSubmissionStatus`).
- `Services/Applications/StubApplicationSubmissionService.cs` — v1 impl that exercises IUserSigner end-to-end (`SigningOperation.ActionSubmission`, active context propagated) and returns a deterministic synthetic instance id; real HTTP submission to the blueprint endpoints lands alongside the application catalogue.
- `Pages/Applications.razor` — list page; empty-state-with-CTA for v1.
- `Pages/ApplicationInstance.razor` — form host route `/applications/{id:guid}`. Ships a "Submit (demo)" button that proves the signing → pending-app-notice → Home-in-progress chain end-to-end. SorchaFormRenderer integration with a live blueprint instance lands alongside the catalogue.
- DI registers `IWebCameraService` + `IApplicationSubmissionService`.

## Closes

T050, T052, T054, T055, T057, T058 from `specs/125-sorcha-wallet-user-agent/tasks.md`.

## Deferred (flagged for follow-up — non-blocking)

- **T051** native-camera `WebCameraService` + `webcamera-bridge.js` — same interface, fills the camera path.
- **T053** `FileRenderer` integration with `x-file.capture: "user"` — modifies the existing form renderer; lands with the form-host wiring that adds SorchaFormRenderer to `ApplicationInstance.razor`.
- **T056** `PersonaAutofillResolver` wiring to `IPerContextPersonaCache` — resolver already exists; wiring happens when the form host lands.
- **T059** OTel counter — structured logging stands in (consistent with PR-B/PR-C deferral).
- **T060** `ErrorRecoveryScaffold` plumbing — scaffold lands in PR-F.
- **T061** "Recommended for you" Home surface — needs catalogue endpoint.
- **T062/T063/T064** component + integration tests — IJSRuntime-touching test patterns; contract covered by stub tests.
- **T065** E2E `[Demo(\"application-from-phone\")]` — PR-F polish.

## Verification

| Test surface | Result |
|---|---|
| `dotnet build Sorcha.sln` | 0 errors |
| `Sorcha.Wallet.Pwa.Tests` | **95/95** (90 PR-C baseline + 5 new `StubApplicationSubmissionServiceTests`) |

5 new tests cover: happy-path Success + synthetic instance id, `ActionSubmission` operation + active context flow to signer, empty-payload short-circuits to `ValidationFailed` without signing, signer-failure surfaces `ErrorCode`/`ErrorDetail`, retry-stability (same payload → same id).

## Test plan

- [x] Build clean
- [x] PWA tests 95/95
- [x] F124 baseline (108/108) preserved transitively
- [ ] `claude-review`
- [ ] Smoke test: navigate to `/wallet/applications/00000000-0000-0000-0000-000000000001`, tap **Submit (demo)** — confirm success status and that `/wallet/` Home now shows the pending-app waiting card (F124 mechanism).

## Notes for reviewers

- **Stubbed submission** — the synthetic instance id is deterministic by `(BlueprintId, ActionId, payload-SHA256)` so retries don't churn the UI. Real HTTP submission lands once the catalogue endpoint exists.
- **Camera fallback** — the file-upload + canvas-resize is the v1 path; the spec's `quickstart.md` already documents the camera as best-effort with file fallback.
- **IUserSigner integration** — every submission gets signed via `SignAsync(SigningOperation.ActionSubmission, ...)`. The signer is consumer-blind per PR-A's design; the stub submission service doesn't know about device keys, just the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)