### PR TITLE
refactor: extract VerifiablePresentationValidator → Sorcha.Verifier.Engine; wire real engine into wallet PWA

### DIFF
--- a/Sorcha.sln
+++ b/Sorcha.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.0.11205.157
@@ -264,6 +264,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sorcha.Validator.Service.Tests", "tests\Sorcha.Validator.Service.Tests\Sorcha.Validator.Service.Tests.csproj", "{147FFC46-B2C1-4882-AD8C-4971246BECB7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sorcha.Register.Service.Tests", "tests\Sorcha.Register.Service.Tests\Sorcha.Register.Service.Tests.csproj", "{1DE87EF3-6C25-479F-9C99-E52A6E8A7857}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sorcha.Verifier.Engine", "src\Common\Sorcha.Verifier.Engine\Sorcha.Verifier.Engine.csproj", "{90291A53-A836-43C8-9073-66A3E333CCD1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1475,6 +1477,18 @@ Global
 		{1DE87EF3-6C25-479F-9C99-E52A6E8A7857}.Release|x64.Build.0 = Release|Any CPU
 		{1DE87EF3-6C25-479F-9C99-E52A6E8A7857}.Release|x86.ActiveCfg = Release|Any CPU
 		{1DE87EF3-6C25-479F-9C99-E52A6E8A7857}.Release|x86.Build.0 = Release|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Debug|x64.Build.0 = Debug|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Debug|x86.Build.0 = Debug|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Release|x64.ActiveCfg = Release|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Release|x64.Build.0 = Release|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Release|x86.ActiveCfg = Release|Any CPU
+		{90291A53-A836-43C8-9073-66A3E333CCD1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1586,5 +1600,6 @@ Global
 		{CD0765A6-3A03-490A-9ABD-95B422A67C5B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{147FFC46-B2C1-4882-AD8C-4971246BECB7} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{1DE87EF3-6C25-479F-9C99-E52A6E8A7857} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{90291A53-A836-43C8-9073-66A3E333CCD1} = {BFF2DF6E-AA54-47C7-211F-79ACCBB4577C}
 	EndGlobalSection
 EndGlobal

--- a/src/Apps/Sorcha.Verifier/Components/_Imports.razor
+++ b/src/Apps/Sorcha.Verifier/Components/_Imports.razor
@@ -8,5 +8,6 @@
 @using Sorcha.Verifier
 @using Sorcha.Verifier.Components
 @using Sorcha.Verifier.Services
-@using Sorcha.Verifier.Services.Models
-@using Models = Sorcha.Verifier.Services.Models
+@using Sorcha.Verifier.Engine
+@using Sorcha.Verifier.Engine.Models
+@using Models = Sorcha.Verifier.Engine.Models

--- a/src/Apps/Sorcha.Verifier/Endpoints/DemoMintEndpoint.cs
+++ b/src/Apps/Sorcha.Verifier/Endpoints/DemoMintEndpoint.cs
@@ -8,7 +8,8 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Sorcha.Verifier.Services;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing;using Sorcha.Verifier.Engine;
+
 
 namespace Sorcha.Verifier.Endpoints;
 

--- a/src/Apps/Sorcha.Verifier/Endpoints/PresentationResponseEndpoints.cs
+++ b/src/Apps/Sorcha.Verifier/Endpoints/PresentationResponseEndpoints.cs
@@ -7,7 +7,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Sorcha.Verifier.Services;
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;using Sorcha.Verifier.Engine;
+
 
 namespace Sorcha.Verifier.Endpoints;
 

--- a/src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs
@@ -5,7 +5,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Sorcha.Verifier.Services;
-using Sorcha.ServiceClients.Http.Extensions;
+using Sorcha.ServiceClients.Http.Extensions;using Sorcha.Verifier.Engine;
+
 
 namespace Sorcha.Verifier.Extensions;
 

--- a/src/Apps/Sorcha.Verifier/Services/IPresentationRequestBuilder.cs
+++ b/src/Apps/Sorcha.Verifier/Services/IPresentationRequestBuilder.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;
 
 namespace Sorcha.Verifier.Services;
 

--- a/src/Apps/Sorcha.Verifier/Services/IVerifierSessionStore.cs
+++ b/src/Apps/Sorcha.Verifier/Services/IVerifierSessionStore.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;
 
 namespace Sorcha.Verifier.Services;
 

--- a/src/Apps/Sorcha.Verifier/Services/InMemoryVerifierSessionStore.cs
+++ b/src/Apps/Sorcha.Verifier/Services/InMemoryVerifierSessionStore.cs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Collections.Concurrent;
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;
 
 namespace Sorcha.Verifier.Services;
 

--- a/src/Apps/Sorcha.Verifier/Services/PresentationRequestBuilder.cs
+++ b/src/Apps/Sorcha.Verifier/Services/PresentationRequestBuilder.cs
@@ -6,7 +6,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using System.Web;
 using Microsoft.Extensions.Logging;
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;
 
 namespace Sorcha.Verifier.Services;
 

--- a/src/Apps/Sorcha.Verifier/Sorcha.Verifier.csproj
+++ b/src/Apps/Sorcha.Verifier/Sorcha.Verifier.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.ServiceDefaults\Sorcha.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\Common\Sorcha.Verifier.Engine\Sorcha.Verifier.Engine.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -64,7 +64,21 @@ public static class ServiceCollectionExtensions
         // VerifiablePresentationValidator out of Sorcha.Verifier in a
         // follow-up extraction PR.
         services.AddSingleton<IEphemeralVerifierIdentityService, EphemeralVerifierIdentityService>();
-        services.AddSingleton<IVerifierEngine, StubVerifierEngine>();
+
+        // Real validator + adapter (Feature 126, replaces the PR-C stub).
+        // VerifiablePresentationValidator was extracted to Sorcha.Verifier.Engine
+        // so the wallet runs the same OID4VP pipeline as the desk verifier.
+        // StubVerifierEngine stays in the assembly for tests / debug staging
+        // but is no longer DI-registered.
+        services.AddSingleton<Sorcha.Verifier.Engine.IStatusListCache, Sorcha.Verifier.Engine.StatusListCache>();
+        services.AddSingleton<Sorcha.Verifier.Engine.IIssuerKeyResolver, Sorcha.Verifier.Engine.OptOutIssuerKeyResolver>();
+        services.AddSingleton<Sorcha.Verifier.Engine.IVerifiablePresentationValidator>(sp =>
+            new Sorcha.Verifier.Engine.VerifiablePresentationValidator(
+                sp.GetRequiredService<Sorcha.Verifier.Engine.IStatusListCache>(),
+                sp.GetRequiredService<Sorcha.Verifier.Engine.IIssuerKeyResolver>(),
+                sp.GetRequiredService<TimeProvider>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Sorcha.Verifier.Engine.VerifiablePresentationValidator>>()));
+        services.AddSingleton<IVerifierEngine, RealVerifierEngine>();
 
         // Feature 125 / PR-D — application-from-phone (US2). PortraitCaptureControl
         // routes through IWebCameraService; the file-upload fallback is the

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Verification/RealVerifierEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Verification/RealVerifierEngine.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Components.User.Services.Verification;
+using Sorcha.Verifier.Engine;
+using Sorcha.Verifier.Engine.Models;
+using LibVerifyOutcome = Sorcha.UI.Components.User.Models.Verification.VerifyOutcome;
+using LibVerificationResult = Sorcha.UI.Components.User.Models.Verification.VerificationResult;
+
+namespace Sorcha.Wallet.Pwa.Services.Verification;
+
+/// <summary>
+/// Production <see cref="IVerifierEngine"/> for the citizen-as-verifier
+/// wallet flow (Feature 126, follow-up to Feature 125 PR-C). Wraps the
+/// extracted <see cref="IVerifiablePresentationValidator"/> so the wallet
+/// runs the same OID4VP-aligned pipeline the desk verifier
+/// (<c>Sorcha.Verifier</c>) uses — issuer signature → holder→device
+/// delegation → status list → nonce/audience binding.
+/// </summary>
+/// <remarks>
+/// Offer payload (JSON, pasted into <c>VerifyFlow</c> or surfaced from a
+/// future QR/NFC scanner):
+/// <code>
+/// {
+///   "vpToken": "&lt;SD-JWT VC w/ KB-JWT&gt;",
+///   "delegationCredential": "&lt;holder→device delegation JWT&gt;",
+///   "requiredVct": "&lt;expected credential type URI&gt;",
+///   "requiredClaims": ["givenName","familyName"],
+///   "purpose": "Doorstep verification",
+///   "holderDisplayName": "&lt;optional, used when validator can't extract it from the credential&gt;",
+///   "issuerOrgName":  "&lt;optional&gt;"
+/// }
+/// </code>
+/// Unrecognised JSON returns a Fail outcome with a plain-English recovery
+/// message. The <c>StubVerifierEngine</c> remains available for tests /
+/// pre-real-engine staging.
+/// </remarks>
+public sealed class RealVerifierEngine : IVerifierEngine
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly IVerifiablePresentationValidator _validator;
+    private readonly ILogger<RealVerifierEngine> _logger;
+
+    /// <summary>Initialise a new engine wired to the shared validator.</summary>
+    public RealVerifierEngine(IVerifiablePresentationValidator validator, ILogger<RealVerifierEngine> logger)
+    {
+        _validator = validator ?? throw new ArgumentNullException(nameof(validator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<LibVerificationResult> VerifyAsync(
+        VerifierEngineRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        OfferEnvelope? offer;
+        try
+        {
+            offer = JsonSerializer.Deserialize<OfferEnvelope>(request.OfferPayload, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogInformation(ex, "Verifier offer was not valid JSON; returning Fail.");
+            return Fail("Couldn't read the credential. Ask the person to try again, or scan a different code.");
+        }
+
+        if (offer is null || string.IsNullOrWhiteSpace(offer.VpToken))
+        {
+            return Fail("This doesn't look like a credential offer. Ask the person to show their credential again.");
+        }
+
+        var session = new VerifierSession
+        {
+            SessionId = $"wallet-verify/{Guid.NewGuid():N}",
+            ClientId = request.VerifierClientId,
+            Nonce = request.Nonce,
+            RequiredVct = offer.RequiredVct ?? string.Empty,
+            RequiredClaims = (IReadOnlyList<string>?)offer.RequiredClaims ?? Array.Empty<string>(),
+            Purpose = offer.Purpose ?? "Doorstep verification",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5)
+        };
+
+        VerificationOutcome outcome;
+        try
+        {
+            outcome = await _validator.ValidateAsync(
+                session, offer.VpToken, offer.DelegationCredential, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Verifier pipeline threw unexpectedly; returning Fail.");
+            return Fail("We couldn't complete the verification. Try again in a moment.");
+        }
+
+        return Map(outcome, offer, request);
+    }
+
+    private static LibVerificationResult Fail(string message) =>
+        new(
+            Outcome: LibVerifyOutcome.Fail,
+            HolderDisplayName: "Unknown holder",
+            IssuerOrgName: "Unknown issuer",
+            CredentialType: "Unknown credential",
+            DisclosedClaims: new Dictionary<string, object?>(),
+            Messages: new[] { message },
+            VerifiedAt: DateTimeOffset.UtcNow,
+            TrustPanelJson: "{}");
+
+    private static LibVerificationResult Map(
+        VerificationOutcome outcome, OfferEnvelope offer, VerifierEngineRequest request)
+    {
+        var liveOutcome = outcome.Accepted
+            ? LibVerifyOutcome.Pass
+            : LibVerifyOutcome.Fail;
+
+        var holderDisplay = offer.HolderDisplayName
+            ?? (outcome.DisclosedClaims.TryGetValue("givenName", out var gn) ? gn?.ToString() : null)
+            ?? "Verified holder";
+        var issuer = offer.IssuerOrgName ?? "Unknown issuer";
+        var credentialType = offer.RequiredVct ?? "Unknown credential";
+
+        var messages = outcome.Errors;
+        if (outcome.Accepted && messages.Count == 0)
+            messages = Array.Empty<string>();
+
+        var trustPanelJson = JsonSerializer.Serialize(new
+        {
+            outcome = liveOutcome.ToString(),
+            holderDisplayName = holderDisplay,
+            issuerOrgName = issuer,
+            credentialType,
+            claims = outcome.DisclosedClaims,
+            verifiedAt = outcome.CompletedAt,
+            sessionId = $"wallet-verify/{request.Nonce}"
+        }, JsonOptions);
+
+        return new LibVerificationResult(
+            Outcome: liveOutcome,
+            HolderDisplayName: holderDisplay,
+            IssuerOrgName: issuer,
+            CredentialType: credentialType,
+            DisclosedClaims: outcome.DisclosedClaims,
+            Messages: messages,
+            VerifiedAt: outcome.CompletedAt,
+            TrustPanelJson: trustPanelJson);
+    }
+
+    private sealed class OfferEnvelope
+    {
+        [JsonPropertyName("vpToken")] public string? VpToken { get; set; }
+        [JsonPropertyName("delegationCredential")] public string? DelegationCredential { get; set; }
+        [JsonPropertyName("requiredVct")] public string? RequiredVct { get; set; }
+        [JsonPropertyName("requiredClaims")] public List<string>? RequiredClaims { get; set; }
+        [JsonPropertyName("purpose")] public string? Purpose { get; set; }
+        [JsonPropertyName("holderDisplayName")] public string? HolderDisplayName { get; set; }
+        [JsonPropertyName("issuerOrgName")] public string? IssuerOrgName { get; set; }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Sorcha.Wallet.Pwa.csproj
+++ b/src/Apps/Sorcha.Wallet.Pwa/Sorcha.Wallet.Pwa.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Common\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
+    <ProjectReference Include="..\..\Common\Sorcha.Verifier.Engine\Sorcha.Verifier.Engine.csproj" />
     <ProjectReference Include="..\Sorcha.UI\Sorcha.UI.Components.User\Sorcha.UI.Components.User.csproj" />
   </ItemGroup>
 

--- a/src/Common/Sorcha.Verifier.Engine/CompositeIssuerKeyResolver.cs
+++ b/src/Common/Sorcha.Verifier.Engine/CompositeIssuerKeyResolver.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json;
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// Composite resolver that tries each underlying <see cref="IIssuerKeyResolver"/>

--- a/src/Common/Sorcha.Verifier.Engine/DidResolverBackedIssuerKeyResolver.cs
+++ b/src/Common/Sorcha.Verifier.Engine/DidResolverBackedIssuerKeyResolver.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.ServiceClients.Did;
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// Production <see cref="IIssuerKeyResolver"/> — resolves the credential's

--- a/src/Common/Sorcha.Verifier.Engine/IIssuerKeyResolver.cs
+++ b/src/Common/Sorcha.Verifier.Engine/IIssuerKeyResolver.cs
@@ -4,7 +4,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// Resolves the issuer's public signing key for a credential, given the

--- a/src/Common/Sorcha.Verifier.Engine/IStatusListCache.cs
+++ b/src/Common/Sorcha.Verifier.Engine/IStatusListCache.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// Verifier-side cache of signed Token Status List 2024 JWTs (Feature 114, T072).

--- a/src/Common/Sorcha.Verifier.Engine/IVerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/IVerifiablePresentationValidator.cs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// Validates a wallet-submitted vp_token against an open <see cref="VerifierSession"/>.

--- a/src/Common/Sorcha.Verifier.Engine/Models/VerifierSession.cs
+++ b/src/Common/Sorcha.Verifier.Engine/Models/VerifierSession.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-namespace Sorcha.Verifier.Services.Models;
+namespace Sorcha.Verifier.Engine.Models;
 
 /// <summary>
 /// In-memory verifier session — the link between a generated presentation request

--- a/src/Common/Sorcha.Verifier.Engine/Sorcha.Verifier.Engine.csproj
+++ b/src/Common/Sorcha.Verifier.Engine/Sorcha.Verifier.Engine.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sorcha.ServiceClients.Http\Sorcha.ServiceClients.Http.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sorcha.Verifier.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Common/Sorcha.Verifier.Engine/StatusListCache.cs
+++ b/src/Common/Sorcha.Verifier.Engine/StatusListCache.cs
@@ -8,7 +8,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// Default <see cref="IStatusListCache"/>. In-memory cache keyed by status list

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -6,9 +6,9 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Sorcha.Verifier.Services.Models;
+using Sorcha.Verifier.Engine.Models;
 
-namespace Sorcha.Verifier.Services;
+namespace Sorcha.Verifier.Engine;
 
 /// <summary>
 /// v1 reference verifier validator. Performs the offline chain check the citizen

--- a/tests/Sorcha.Verifier.Tests/Services/DidResolverBackedIssuerKeyResolverTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/DidResolverBackedIssuerKeyResolverTests.cs
@@ -13,7 +13,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sorcha.Verifier.Services;
 using Sorcha.ServiceClients.Did;
-using Xunit;
+using Xunit;using Sorcha.Verifier.Engine;
+
 
 namespace Sorcha.Verifier.Tests.Services;
 

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListCacheTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListCacheTests.cs
@@ -17,7 +17,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Moq.Protected;
 using Sorcha.Verifier.Services;
-using Xunit;
+using Xunit;using Sorcha.Verifier.Engine;
+
 
 namespace Sorcha.Verifier.Tests.Services;
 

--- a/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
@@ -9,8 +9,9 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sorcha.Verifier.Services;
-using Sorcha.Verifier.Services.Models;
-using Xunit;
+using Sorcha.Verifier.Engine.Models;
+using Xunit;using Sorcha.Verifier.Engine;
+
 
 namespace Sorcha.Verifier.Tests.Services;
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Verification/RealVerifierEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Verification/RealVerifierEngineTests.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Components.User.Services.Verification;
+using Sorcha.Verifier.Engine;
+using Sorcha.Verifier.Engine.Models;
+using Sorcha.Wallet.Pwa.Services.Verification;
+using LibVerifyOutcome = Sorcha.UI.Components.User.Models.Verification.VerifyOutcome;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Verification;
+
+/// <summary>
+/// Tests for <see cref="RealVerifierEngine"/> — the adapter that wraps
+/// <see cref="IVerifiablePresentationValidator"/> behind the citizen-as-
+/// verifier <see cref="IVerifierEngine"/> contract. Mocks the validator
+/// so the adapter logic (offer parsing, session build, outcome mapping,
+/// trust-panel JSON) can be exercised without standing up the real
+/// validator pipeline.
+/// </summary>
+public sealed class RealVerifierEngineTests
+{
+    private static VerifierEngineRequest Request(string offer)
+        => new(offer, VerifierClientId: "ephemeral-thumbprint", Nonce: "n-123");
+
+    private static RealVerifierEngine NewSut(VerificationOutcome outcome, out Mock<IVerifiablePresentationValidator> validator)
+    {
+        validator = new Mock<IVerifiablePresentationValidator>();
+        validator.Setup(v => v.ValidateAsync(It.IsAny<VerifierSession>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(outcome);
+        return new RealVerifierEngine(validator.Object, NullLogger<RealVerifierEngine>.Instance);
+    }
+
+    private static VerificationOutcome Accept(IReadOnlyDictionary<string, object?>? claims = null) =>
+        new()
+        {
+            Accepted = true,
+            DisclosedClaims = claims ?? new Dictionary<string, object?>(),
+            Errors = Array.Empty<string>(),
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+
+    private static VerificationOutcome Reject(string reason) =>
+        new()
+        {
+            Accepted = false,
+            DisclosedClaims = new Dictionary<string, object?>(),
+            Errors = new[] { reason },
+            CompletedAt = DateTimeOffset.UtcNow
+        };
+
+    [Fact]
+    public async Task VerifyAsync_MalformedJson_ReturnsFail_WithoutCallingValidator()
+    {
+        var sut = NewSut(Accept(), out var validator);
+        var result = await sut.VerifyAsync(Request("not json at all"));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Fail);
+        result.Messages.Should().ContainSingle(m => m.Contains("Couldn't read", System.StringComparison.OrdinalIgnoreCase));
+        validator.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_MissingVpToken_ReturnsFail_WithoutCallingValidator()
+    {
+        var sut = NewSut(Accept(), out var validator);
+        var result = await sut.VerifyAsync(Request("""{"requiredVct":"x/v1"}"""));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Fail);
+        result.Messages.Should().NotBeEmpty();
+        validator.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_AcceptedOutcome_MapsToPass_PreservesDisplayFields()
+    {
+        var claims = new Dictionary<string, object?> { ["givenName"] = "Liam", ["familyName"] = "Buchanan" };
+        var sut = NewSut(Accept(claims), out var validator);
+        var offer = """
+            {"vpToken":"vp.token.here","delegationCredential":"d.c.here","requiredVct":"WaterEngineerCredential/v1","purpose":"Doorstep verification","holderDisplayName":"Liam Buchanan","issuerOrgName":"Caledonian Water"}
+            """;
+
+        var result = await sut.VerifyAsync(Request(offer));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Pass);
+        result.HolderDisplayName.Should().Be("Liam Buchanan");
+        result.IssuerOrgName.Should().Be("Caledonian Water");
+        result.CredentialType.Should().Be("WaterEngineerCredential/v1");
+        result.DisclosedClaims.Should().ContainKey("givenName");
+        result.TrustPanelJson.Should().NotBeNullOrEmpty();
+        result.TrustPanelJson.Should().Contain("Liam Buchanan");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_RejectedOutcome_MapsToFail_SurfacesValidatorErrors()
+    {
+        var sut = NewSut(Reject("Status list bit set — credential revoked."), out _);
+        var offer = """{"vpToken":"vp","delegationCredential":"dc","requiredVct":"x/v1"}""";
+
+        var result = await sut.VerifyAsync(Request(offer));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Fail);
+        result.Messages.Should().ContainSingle()
+            .Which.Should().Contain("revoked");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_PropagatesNonceAndClientId_ToValidatorSession()
+    {
+        var sut = NewSut(Accept(), out var validator);
+        var offer = """{"vpToken":"vp","delegationCredential":"dc","requiredVct":"x/v1","purpose":"Test"}""";
+
+        await sut.VerifyAsync(Request(offer));
+
+        validator.Verify(v => v.ValidateAsync(
+            It.Is<VerifierSession>(s =>
+                s.ClientId == "ephemeral-thumbprint"
+                && s.Nonce == "n-123"
+                && s.RequiredVct == "x/v1"
+                && s.Purpose == "Test"),
+            "vp",
+            "dc",
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ValidatorThrows_ReturnsFail_DoesNotPropagate()
+    {
+        var validator = new Mock<IVerifiablePresentationValidator>();
+        validator.Setup(v => v.ValidateAsync(It.IsAny<VerifierSession>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                 .ThrowsAsync(new InvalidOperationException("pipeline blew up"));
+        var sut = new RealVerifierEngine(validator.Object, NullLogger<RealVerifierEngine>.Instance);
+        var offer = """{"vpToken":"vp","delegationCredential":"dc"}""";
+
+        var result = await sut.VerifyAsync(Request(offer));
+
+        result.Outcome.Should().Be(LibVerifyOutcome.Fail);
+        result.Messages[0].Should().NotContain("pipeline blew up", "validator exception detail must not leak to the user.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Feature 125 PR-C deferral that left `StubVerifierEngine` as the v1 verifier in the wallet PWA. Lifts the OID4VP-aligned verification pipeline out of `Sorcha.Verifier` (Blazor Server desk app) into a new shared library `Sorcha.Verifier.Engine` so the wallet runs the same validator the desk verifier runs — citizens can verify credentials at the doorstep against the real chain, not a scripted stub.

## What lands

**New library** `src/Common/Sorcha.Verifier.Engine` (8 files moved, 1016 lines):
- `VerifiablePresentationValidator` + `IVerifiablePresentationValidator`
- `IIssuerKeyResolver` + `OptOutIssuerKeyResolver` + `JwkRegistryIssuerKeyResolver`
- `DidResolverBackedIssuerKeyResolver` + `CompositeIssuerKeyResolver`
- `IStatusListCache` + `StatusListCache`
- `Models/VerifierSession` + `VerificationOutcome`

Namespaces flipped from `Sorcha.Verifier.Services.*` to `Sorcha.Verifier.Engine.*` so the project name is the new public address.

**`Sorcha.Verifier`** — added ProjectReference to the engine library; consumer files gained `using Sorcha.Verifier.Engine;` for the moved types. `_Imports.razor` model alias updated. `IPresentationRequestBuilder`, `InMemoryVerifierSessionStore`, `QrRenderer` stay in the desk app (desk-only).

**`Sorcha.Wallet.Pwa`**:
- `Services/Verification/RealVerifierEngine.cs` — adapter wrapping `IVerifiablePresentationValidator` behind PR-C's `IVerifierEngine` contract. Parses a JSON offer envelope `{ vpToken, delegationCredential, requiredVct, requiredClaims, purpose, holderDisplayName, issuerOrgName }`, builds a `VerifierSession` with the caller's ephemeral `client_id` + nonce, runs the pipeline, maps `Accepted`/`Errors` → `Pass`/`Fail` + plain-English messages. Validator exceptions return Fail without leaking detail.
- DI swaps `StubVerifierEngine` → `RealVerifierEngine`; registers `IStatusListCache`, `IIssuerKeyResolver` (OptOut for v1), and the validator with `TimeProvider.System`.
- `StubVerifierEngine` retained in the assembly for offline UI-flow demos; no longer DI-registered.

## Verification

| Test surface | Result |
|---|---|
| `dotnet build Sorcha.sln` | 0 errors |
| `Sorcha.Verifier.Tests` | **30/30** (validator behaviour preserved across the namespace move) |
| `Sorcha.Wallet.Pwa.Tests` | **103/103** (97 PR-F baseline + 6 new `RealVerifierEngineTests`) |

6 new tests cover: malformed JSON → Fail without calling validator, missing `vpToken` → Fail without calling validator, Accepted outcome → Pass with display fields + trust-panel JSON, Rejected outcome → Fail surfacing validator errors, session `ClientId` + `Nonce` + `Purpose` flow through to the validator, validator exception → Fail with user-safe message.

## Test plan

- [x] Build clean
- [x] Sorcha.Verifier.Tests 30/30
- [x] Sorcha.Wallet.Pwa.Tests 103/103
- [ ] `claude-review`
- [ ] Smoke: at `https://n1.sorcha.dev/wallet/verify`, paste a real OID4VP offer envelope (vpToken + delegationCredential from a working presenter wallet) — confirm the trust panel reflects the validator's verdict.

## Notes for reviewers

- **WASM viability** — validator uses only `System.Security.Cryptography`, `System.Text.Json`, and `Microsoft.Extensions.Logging.Abstractions`. ECDsa.Create and friends are WASM-friendly. No platform-specific dependencies.
- **`OptOutIssuerKeyResolver` is the v1 default** in the PWA; production hardening swaps in `DidResolverBackedIssuerKeyResolver` against the tenant DID document registry (already wired in the desk verifier). Per F114's documented behaviour matrix the OptOut resolver accepts on holder→device chain alone when the issuer key can't be resolved — fail-open, intentional for v1 demo.
- **Stub retained** — useful for offline UI-flow demos where a real presenter wallet isn't available. Removable once QR/NFC scanners + a presenter-wallet flow ship.
- **Namespace flip** is the biggest reviewer surface — `Sorcha.Verifier.Services.*` → `Sorcha.Verifier.Engine.*` for moved types. 12 consumer files updated; remaining `Sorcha.Verifier.Services.*` types (session store, request builder, QR renderer) keep their namespace and stay in the desk-app project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)