### PR TITLE
feat(126): Sorcha Wallet enrolment inside a council application wizard — PR-A cold-start

### DIFF
--- a/docs/superpowers/specs/2026-05-15-spec-3-enrol-inside-wizard-design.md
+++ b/docs/superpowers/specs/2026-05-15-spec-3-enrol-inside-wizard-design.md
@@ -1,0 +1,343 @@
+# Spec 3 — Enrolment inside a council application wizard
+
+**Date:** 2026-05-15
+**Status:** Design locked — awaiting plan-phase.
+**Umbrella:** [`2026-05-13-strathcarron-citizen-arc.md`](2026-05-13-strathcarron-citizen-arc.md)
+**Spec 1 precedent:** [`2026-05-13-spec-1-assured-identity-on-pwa-design.md`](2026-05-13-spec-1-assured-identity-on-pwa-design.md)
+**Spec 2 precedent:** [`2026-05-14-spec-2-sorcha-wallet-user-agent-design.md`](2026-05-14-spec-2-sorcha-wallet-user-agent-design.md)
+
+## Purpose
+
+Take a citizen from "I clicked an Apply button on a council page" to "I'm filling out the form, with a Sorcha account and an enrolled wallet device ready to receive whatever this council issues." Designed so that:
+
+- Cold-start citizens (no Sorcha account, no PWA, no device) get onboarded as a side-effect of the council form they came for — not a separate "set up your wallet first" detour.
+- Returning citizens see zero friction beyond a sign-in screen.
+- The capability shows up wherever a council places an application form. The library houses the gate; councils consume it.
+
+This is the third sub-spec of the Strathcarron citizen arc. Spec 1 (Feature 124) gave the PWA a credential to receive; Spec 2 (Feature 125) gave the PWA the full user-agent shape. Spec 3 is the front door — without it, every citizen has to discover the wallet some other way, which the umbrella expressly rejects.
+
+## Decisions captured (brainstorm summary)
+
+The 2026-05-15 brainstorm settled five decisions. Each is restated below as a locked premise of this spec.
+
+| # | Decision | Where in spec |
+|---|----------|---------------|
+| 1 | **Placement is preflight for first-time citizens, no-op for returning citizens.** Wallet acquisition happens before the form, not after. Returning citizens (Tier 1) skip the gate entirely. | §2, §3 |
+| 2 | **Wallet is mandatory in v1.** No email-pickup fallback. The wallet is the only credential delivery surface. | §2, §11 |
+| 3 | **Web-first signup with signed-in QR for enrolment.** Account creation happens on the council page (existing Feature 116 flow). The QR/link that follows carries a short-lived one-time auth token so the PWA opens already-authenticated. | §4 |
+| 4 | **Web-shell submission in v1; PWA-hosted form continuation is a deliberate future evolution.** The council page owns the form; the PWA is the delivery surface. The capability to "continue on your phone" stays available for Spec 4/5 to exercise once the F125 `ApplicationInstance.razor` form host matures. | §6 |
+| 5 | **Hybrid SignalR with polling fallback** for cross-device "phone enrolled" coordination. Same philosophy as the umbrella's Decision #3 hybrid QR — one mechanism, two resolution paths. | §5, §8 |
+
+## §1 — What ships
+
+Three citizen tiers, three flows, one library-housed gate component the council page consumes.
+
+### Tier 1 — Returning citizen (account ✓, device ✓)
+
+The desired-state path. Sign in, fill, submit, watch wallet.
+
+### Tier 2 — Mini-gate (account ✓, device ✗)
+
+Edge case but real. Signed up but never enrolled, or lost their phone. Sign in, see the hybrid QR/link/paste, enrol, then fill the form.
+
+### Tier 3 — Cold-start (account ✗, device ✗)
+
+The umbrella's defining beat. Preflight signup → enrol → form → submit → watch wallet. Once per citizen per arc.
+
+### Library component + Tenant Service surface
+
+- **`EnrolGateComponent`** in `Sorcha.UI.Components.User` — composes signup + hybrid QR + tier-aware copy. Drop-in for any council page that wants the gate.
+- **Two new Tenant Service endpoints** — `POST /api/auth/enrol-session` and `POST /api/auth/enrol-session/redeem` for the QR token mechanics.
+- **One new `TenantHub` event** — `DeviceEnrolled(platformUserId, deviceId)` so the council page transitions instantly when the phone completes enrolment.
+- **One small extension to existing Feature 116 signup endpoints** — `?returnTo=` query parameter so signup can route back to the council page cleanly.
+
+## §2 — The cold-start preflight, step by step
+
+Sarah arrives at `https://strathcarron.gov/services/driving-licence`. Not signed in, no Sorcha account, no PWA.
+
+### Step 1 — Preflight page
+
+Council page renders the gate's Tier 3 surface:
+
+- **"Sign in or create your account"** — primary affordance. Single button → existing Feature 116 signup/sign-in flow (email/password, social, or passkey). The `returnTo` query parameter carries the council page URL so signup redirects back here on success.
+- **"What is this?"** — secondary affordance. Short plain-English explainer with the umbrella's Sorcha Wallet positioning.
+
+No QR yet. The wallet conversation only starts after the user has committed to creating an account. Avoids "scan this QR" without context, which is the classic phishing red flag.
+
+### Step 2 — Signup completes; redirect back
+
+Sarah completes the F116 signup flow. Council page knows she's back via the OAuth-style redirect with her session JWT. Now signed in, zero devices.
+
+### Step 3 — Wallet enrolment gate
+
+Tier evaluates to 2 (account ✓, device ✗) — render the hybrid QR/link/paste:
+
+- **QR code** with "Sorcha Wallet" tagline below. Scan with phone camera.
+- **"Open on this device"** tap-able link. For same-device mobile users; renders prominently when `MediaQueryService.IsMobile` is true.
+- **"Copy link"** button as third fallback. For "I'll set this up later on my work laptop" or accessibility paths.
+
+All three resolve the same URL:
+
+```
+https://strathcarron.gov/wallet/enrol?session=<one-time-token>
+```
+
+Below the QR: a status line — **"Waiting for your phone…"** — which flips to **"Phone ready ✓ — continuing"** when the SignalR `DeviceEnrolled` event fires.
+
+### Step 4 — Device enrolled; back-channel notification
+
+PWA completes the F114 enrolment ceremony. Tenant Service raises `DeviceEnrolled` on `TenantHub`. Council page subscribed to the per-platform-user group; transitions to Step 5.
+
+### Step 5 — Continue with the application
+
+Council page resumes the application form. Sarah fills, submits.
+
+### Step 6 — Watch your wallet
+
+Council page success screen: **"Your application is in. Watch your wallet for the credential — it usually arrives within a few seconds."** Hub event from the wallet service's credential push (Feature 114 / US4) is also observable from the council page, so the success screen transitions to **"Credential received ✓ — open your wallet to see it"** when the credential lands. PWA's F124 welcome takeover fires on the phone simultaneously.
+
+Three steps where the user actually does something (signup, phone enrolment, form completion). Steps 4 and 6 are passive transitions.
+
+## §3 — Returning citizen + mini-gate flows
+
+### Tier-detection mechanic
+
+The council page's entry-point probes:
+
+```
+GET /api/auth/whoami       → 200 {platformUserId} if signed in, 401 otherwise
+GET /api/me/devices        → active-device list ([] = no devices)
+```
+
+Both endpoints exist today. The gate decides:
+
+| `/whoami` | `/me/devices.Count` | Tier | Render |
+|---|---|---|---|
+| 401 | — | 3 (cold-start) | Preflight signup screen (§2 Step 1) |
+| 200 | 0 | 2 (mini-gate) | Hybrid QR/link/paste — no signup involved |
+| 200 | ≥1 | 1 (fast path) | Form |
+
+### Tier 1 — Returning citizen
+
+One sign-in screen (existing F116), then straight to the form. No QR, no "you'll need a wallet" copy. When she submits, the credential lands in her existing PWA via the F124 SorchaLocalWallet path; success page shows the standard "Watch your wallet" hint.
+
+**Total user steps from arrival to form: sign in.**
+
+### Tier 2 — Mini-gate
+
+Sign in. Wallet enrolment gate (same hybrid QR as Tier 3 Step 3, no signup). SignalR `DeviceEnrolled` fires; form continues.
+
+**Total user steps: sign in + enrol device.**
+
+### Tier-specific copy
+
+Tier 2 cannot say "you'll need a wallet for this" the way Tier 3 does — Sarah might already have a Sorcha Wallet account on another (lost) device. The mini-gate copy is closer to **"Let's pair this device with your wallet."** Tier-aware copy is a load-bearing UX call — designed into the gate component, not bolted on by the consuming page.
+
+### Tier transitions are one-way
+
+A citizen who hits Tier 3 today is Tier 1 tomorrow. No "you've graduated" ceremony. Each visit probes the two endpoints and renders the right thing.
+
+## §4 — The QR / session-token mechanic
+
+### Token shape
+
+Short-lived JWT signed by Tenant Service:
+
+```json
+{
+  "sub": "<platformUserId>",
+  "scope": "enrol",
+  "jti": "<uuid>",
+  "iat": <epoch>,
+  "exp": <iat + 600>
+}
+```
+
+10-minute TTL. Signed with the same Tenant Service signing key the existing auth JWTs use. One-time use enforced by Redis `SET NX` on the JTI at redeem.
+
+### Token redemption
+
+PWA loads with `?session=<token>` in URL. PWA POSTs the session token to:
+
+```
+POST /api/auth/enrol-session/redeem
+```
+
+Tenant Service validates signature + expiry + scope, atomically marks `jti` consumed in Redis, returns `{ accessToken, expiresIn, displayName, email }`. PWA stores the token in `IAccessTokenStore` and proceeds with the existing F114 enrolment ceremony.
+
+The `displayName` + `email` fields feed the redeem-confirmation dialog (see §7 — friend-scans-by-mistake mitigation).
+
+### Token minting
+
+Council page calls a separate endpoint at Step 3 to mint the session token:
+
+```
+POST /api/auth/enrol-session
+→ { sessionToken, qrUrl, expiresAt }
+```
+
+Auth required (the caller must already be signed in). Mints a token bound to the caller's PlatformUserId.
+
+### Why no `?form=` parameter
+
+In v1 cold-start, the PWA doesn't need to know about the form. The PWA enrols; the council page (which has the form open) reacts to `DeviceEnrolled`. URL stays clean: `https://strathcarron.gov/wallet/enrol?session=<token>`. The `?form=` evolution is reserved for Spec 4/5 when "continue on your phone" lights up.
+
+## §5 — Cross-device coordination
+
+### Hub event
+
+```
+TenantHub.DeviceEnrolled(Guid platformUserId, Guid deviceId)
+```
+
+Raised by `PlatformUserDeviceService.RegisterAsync` after a new active device lands. Published to the per-platform-user group via the existing `TenantHubGroups.User(platformUserId)` builder.
+
+### Subscription on the council page
+
+Council page joins the per-user group via the existing `TenantHubConnection` shim. On `DeviceEnrolled`, transitions out of the waiting state.
+
+### Polling fallback
+
+If `TenantHubConnection.StartAsync()` doesn't establish within 2 s, the gate falls back to polling `GET /api/me/devices` every 3 s for up to 60 s. After 60 s of polling failure, the gate surfaces a manual recovery affordance — **"Trouble hearing from your phone — tap *I've enrolled* to continue, or refresh this page"**.
+
+Both paths are equivalent functionally; SignalR is the smoother polish.
+
+## §6 — Web-shell submission; PWA-hosted continuation is a future capability
+
+The application form lives in the council page (`Sorcha.UI.Web.Client`). Submission happens on the web shell. The wallet is the delivery target.
+
+The F125 `ApplicationInstance.razor` exists in the PWA today as a stub for a future evolution where the citizen chooses to continue on their phone. Spec 3 v1 deliberately does NOT exercise that path — the cold-start gate's job is to get the citizen a wallet, not to relocate the form. The capability stays available for Spec 4/5 to light up when the application catalogue API + persona autofill wiring matures.
+
+This keeps Spec 3's scope tight and avoids two parallel form-submission paths in v1.
+
+## §7 — Failure paths
+
+| What goes wrong | Council-page behaviour | PWA behaviour |
+|---|---|---|
+| **Session token expires** (10 min, citizen distracted) | Status line flips to **"QR expired — let's get you a new one"** with a regenerate button that calls `POST /api/auth/enrol-session` again | If PWA opens an expired token URL, render an `ErrorRecoveryScaffold` (Feature 125 PR-F) — "This link has expired. Open the council page on your other device for a new code." |
+| **Session token already consumed** (race condition, PWA reload) | No change — still waiting on `DeviceEnrolled` | If redeem fails with `already_used`, the PWA already holds a citizen JWT — proceed to enrolment if not already enrolled, or surface "you're already set up" if enrolled |
+| **PWA install dismissed** | Status line stays "Waiting for your phone…" | Browser PWA loads; user dismisses the "add to home screen" prompt — in-browser session works fine for enrolment, only the home-screen icon defers |
+| **Phone offline during enrolment** | Stuck on waiting | PWA surfaces `ErrorRecoveryScaffold` — "Couldn't reach Sorcha — check your connection"; retry on reconnect |
+| **SignalR fails to connect within 2 s** | Silently falls back to polling — no UX change | n/a |
+| **Polling fails too (60 s of no device seen)** | Status flips to manual recovery — **"Trouble hearing from your phone — tap *I've enrolled* to continue, or refresh this page"** | n/a |
+| **User abandons signup** (closes browser at signup screen) | Next visit: not signed in → Tier 3 path from scratch | n/a |
+| **User abandons enrolment** (signed up, never enrolled) | Next visit: signed in + 0 devices → Tier 2 mini-gate | n/a |
+| **Council form was halfway filled** before the gate fired | Form state persists in browser `sessionStorage` — restored after the gate clears | n/a |
+| **Two browser tabs open concurrently** for the same Sorcha account | Each tab's `TenantHubConnection` subscription receives the event — both transition. Idempotent. | n/a |
+| **Friend scans the QR by mistake** | Council page transitions to "Phone ready ✓" as soon as `DeviceEnrolled` fires for Sarah's platformUserId — regardless of whose physical phone got enrolled. The **PWA-side confirmation dialog before redeem** is the mitigation; see below. | PWA renders **"You're about to enrol this device for `sarah@example.com` (Sarah Example). If that's not you, close this page."** Confirmation gate before the redeem completes; cancel returns to the friend's existing PWA state with no side-effects. |
+
+### Friend-scans-by-mistake — the load-bearing concern
+
+The session token is a bearer credential; anyone who scans it gets a JWT for `sub: <originalUserId>`. The v1 mitigation: **confirmation dialog inside the PWA before redeem completes**, surfacing the email and display-name the token resolves to. Combined with 10-minute TTL and one-time JTI, that's the v1 trust model.
+
+Future hardening (not v1): bind the token to the originating browser's session via a server-set HttpOnly cookie presented alongside the token at redeem. Breaks "scan with a friend's phone" recovery, which the umbrella doesn't currently want to support but might in a later spec.
+
+## §8 — New server surface
+
+### Two new Tenant Service endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/auth/enrol-session` | Mint a new one-time enrolment session token for the signed-in caller. Returns `{ sessionToken, qrUrl, expiresAt }`. |
+| `POST` | `/api/auth/enrol-session/redeem` | Redeem a session token for a full citizen JWT. Atomic single-use via Redis `SET NX` on JTI. Returns `{ accessToken, expiresIn, displayName, email }`. |
+
+Both rate-limited per the existing `RateLimitPolicies.PlatformAuth` standard.
+
+### One new hub event on existing `TenantHub`
+
+| Event | Payload | Trigger |
+|---|---|---|
+| `DeviceEnrolled` | `(Guid platformUserId, Guid deviceId)` | `PlatformUserDeviceService.RegisterAsync` success; published to per-user group |
+
+### One extension to existing Feature 116 signup endpoints
+
+`?returnTo=<url>` query parameter on the signup/sign-in routes. On success, redirect to the supplied URL instead of the default dashboard. Validated against an allowlist of trusted return domains — no open redirects.
+
+That's the full new server surface. Composes with existing F116 (signup), F114 (device enrolment), F118 (hubs). No new microservices.
+
+## §9 — Library component growth
+
+### `EnrolGateComponent` in `Sorcha.UI.Components.User`
+
+Single component that composes signup + hybrid QR + tier-aware copy. Drop-in for any council page that wants the gate.
+
+```razor
+<EnrolGateComponent CouncilName="Strathcarron Council"
+                    OnReady="@HandleCitizenReady" />
+```
+
+Internally evaluates the citizen tier (via `/whoami` + `/me/devices` probes), renders the right surface (signup / mini-gate / fast-through), handles the hub event subscription, manages the session-token lifecycle. The consuming page's only job is to render `EnrolGateComponent` and react to `OnReady`.
+
+### Sub-components
+
+- `EnrolGate.SignupGate` — Tier 3 preflight surface.
+- `EnrolGate.WalletPairingGate` — Tier 2 mini-gate (and the post-signup step of Tier 3).
+- `EnrolGate.HybridQrAffordance` — the QR + tap-link + copy-link surface. Reusable in other contexts; placed in the library for that reason.
+- `EnrolmentRedeemConfirmDialog` (in `Sorcha.Wallet.Pwa`) — PWA-side confirmation surface for the friend-scans-by-mistake path.
+
+### What's PWA-local vs library-shared
+
+PWA-local:
+- `EnrolmentRedeemConfirmDialog` (PWA-specific UX moment)
+- The session-token redeem call (PWA-specific HTTP client)
+
+Library-shared:
+- Everything in `EnrolGateComponent` and its sub-components
+- The tier-detection mechanic
+- The hub-subscription wiring (consumes the existing `TenantHubConnection`)
+
+## §10 — Testing strategy
+
+| Layer | Coverage |
+|---|---|
+| **Tenant Service unit** | `EnrolSessionService.MintAsync` (token claims, TTL, signature). `RedeemAsync` (single-use via Redis SET NX, expired rejected, scope-mismatch rejected, consumed-token rejected on re-redeem). |
+| **Tenant Service integration** | `POST /api/auth/enrol-session` (auth required, valid JWT structure). `POST /api/auth/enrol-session/redeem` (happy path, replay → 409, expired → 410). |
+| **Hub event** | `TenantHubTests.DeviceEnrolled` — group filtering, payload shape. |
+| **Council-page component** | `EnrolGateComponent` — renders Tier 1 / Tier 2 / Tier 3 from probe results, renders correct copy per tier, transitions on `DeviceEnrolled` hub event, falls back to polling when hub fails, shows regenerate button on token expiry. |
+| **PWA flow** | `EnrolSessionRedeemerTests` (the redeem path), `EnrolmentRedeemConfirmDialogTests`. |
+| **E2E (Playwright)** | `[Demo("cold-start-enrolment")]` — full Tier 3 walk on Docker stack: council page arrival → preflight → signup → QR → simulated phone enrolment via second browser context → council form continues → submission → credential lands in PWA. |
+| **Walkthrough script** | `walkthroughs/Strathcarron/setup-cold-start-demo.ps1` — pre-creates the Strathcarron council org with the cold-start-enabled application; gives the operator a reset-able fresh-citizen email for demos. |
+
+## §11 — Out of scope / deferred
+
+- **Email-pickup fallback** — deferred per Q2. v1 wallet is mandatory; the wallet-less path is a future graceful-degradation spec.
+- **PWA-hosted form continuation** — deferred per Q4. F125's `ApplicationInstance.razor` stub stays a stub for cold-start; Spec 4/5 picks it up when the application catalogue lands.
+- **Application catalogue API** — Spec 3 designs the gate; the form behind it is whatever blueprint-driven form already exists. "List available applications" is Spec 4.
+- **Cross-council single-sign-on UX polish** — the existing Sorcha auth already handles this; no new design needed here.
+- **Multi-tenant council onboarding** — Spec 3 assumes Strathcarron is the council. Onboarding additional councils onto the gate is a roadmap item.
+- **Token binding via HttpOnly cookie** — future hardening for the friend-scans-by-mistake path; v1 mitigation is the confirmation dialog.
+
+## §12 — Success criteria
+
+| ID | Criterion | How to verify |
+|---|---|---|
+| **SC-3-001** | Cold-start citizen (Tier 3, fresh browser) gets from "click apply" to "form ready to fill" in ≤ 90 s, 95th-percentile across 10 manual runs | Demo runbook with stopwatch |
+| **SC-3-002** | Returning citizen (Tier 1) sees no QR, no enrolment gate — only a sign-in screen — when they revisit | E2E test: enrol-then-revisit |
+| **SC-3-003** | Mini-gate (Tier 2) shows the QR without re-prompting signup | E2E test: signup-then-revoke-device-then-revisit |
+| **SC-3-004** | Cross-device hub event reaches the desktop within 2 s of `PlatformUserDeviceService.RegisterAsync` success in 95% of runs | Hub telemetry + E2E timing assertion |
+| **SC-3-005** | Expired session token returns a clear "let's get you a new one" affordance — no dead-end | Manual test with clock-skewed token |
+| **SC-3-006** | Friend-scans-by-mistake confirmation dialog renders the original user's email/display name before redeem completes | Component test of `EnrolmentRedeemConfirmDialog` |
+| **SC-3-007** | Walkthrough script `setup-cold-start-demo.ps1` produces a working cold-start state on n1 within 30 s of invocation | Quickstart runbook |
+| **SC-3-008** | Existing Feature 124 + Feature 125 test suites stay green (no regressions) | Standard CI |
+
+## §13 — Open items for plan-phase
+
+Locked during brainstorm; restated for the speckit plan step:
+
+1. **`EnrolGateComponent` lives in `Sorcha.UI.Components.User`** (library), not in the council web shell. Drop-in for any council page that wants the gate.
+2. **`EnrolSessionService` lives in `Sorcha.Tenant.Service`** — no new common library needed.
+3. **Feature 116 signup endpoints gain a `?returnTo=<url>` query parameter** — validated against a trusted-return-domain allowlist; no open redirects.
+
+## References
+
+- Umbrella: `docs/superpowers/specs/2026-05-13-strathcarron-citizen-arc.md`
+- Spec 1 design: `docs/superpowers/specs/2026-05-13-spec-1-assured-identity-on-pwa-design.md`
+- Spec 2 design: `docs/superpowers/specs/2026-05-14-spec-2-sorcha-wallet-user-agent-design.md`
+- Spec 2 implementation tag: `spec-125-complete` at `6c698ff6` (master)
+- Feature 114 (Citizen Wallet PWA — device enrolment): `specs/114-citizen-wallet-pwa/`
+- Feature 116 (Account linking — signup/sign-in flows): `specs/116-account-linking/`
+- Feature 118 (Notification hubs — `TenantHub`): `specs/118-notifications-architecture/`
+- Feature 124 (Spec 1): `specs/124-assured-identity-pwa/`
+- Feature 125 (Spec 2): `specs/125-sorcha-wallet-user-agent/`
+- sorcha-architecture skill: § "Citizen Wallet PWA (Feature 114)", § "Platform Organisation Topology", § "AssuredIdentity on the PWA (Feature 124)"
+- sorcha-ui skill: § "Citizen Wallet PWA — path-prefix gotchas"

--- a/specs/126-enrol-inside-wizard/checklists/requirements.md
+++ b/specs/126-enrol-inside-wizard/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Sorcha Wallet enrolment inside a council application wizard
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Five locked decisions from the 2026-05-15 brainstorm are captured in `docs/superpowers/specs/2026-05-15-spec-3-enrol-inside-wizard-design.md` and reflected in this spec's FRs.
+- No [NEEDS CLARIFICATION] markers were needed: every gap was closed by an explicit design decision or a reasonable default documented in the Assumptions section.
+- Success criteria are deliberately user-facing (e.g. "under 90 seconds", "in 100% of cases", "no surface other than a sign-in screen") and avoid implementation language (e.g. SignalR, JWT, Redis). The technical mechanics live in the design doc.
+- Three layers of design discipline: the umbrella locks the arc's invariants, the design doc locks the five spec-level decisions, the spec locks the requirements + success criteria. Each layer is testable against the next.

--- a/specs/126-enrol-inside-wizard/contracts/enrol-session.openapi.yaml
+++ b/specs/126-enrol-inside-wizard/contracts/enrol-session.openapi.yaml
@@ -1,0 +1,167 @@
+openapi: 3.1.0
+info:
+  title: Enrolment Session API
+  version: "1.0.0"
+  description: |
+    Feature 126 — the two-endpoint server surface that backs the
+    council-page enrolment gate. Mint a one-time-use session token
+    bound to the signed-in citizen's account; redeem it from the
+    wallet device to acquire a full citizen access token for the
+    F114 device-pairing ceremony.
+
+    The token is a short-lived (≤10 min) JWT with `scope: "enrol"`,
+    signed by the existing Tenant Service signing key. Single-use is
+    enforced by atomic Redis `SET NX` on the JTI at redeem.
+
+    Security: the token is a bearer credential. The friend-scans-by-
+    mistake mitigation is a confirmation dialog on the wallet device
+    that displays the bound user's email + display name before any
+    device-pairing happens — see the response shape of the redeem
+    endpoint.
+
+servers:
+  - url: https://{host}/api
+    description: API gateway path
+    variables:
+      host:
+        default: localhost
+
+security:
+  - tenantUserJwt: []
+
+paths:
+  /auth/enrol-session:
+    post:
+      operationId: MintEnrolSession
+      summary: Mint a new one-time enrolment session token for the signed-in caller.
+      description: |
+        Requires the caller to be authenticated. Returns a JWT with
+        `scope: "enrol"`, a fully-formed QR URL embedding that token,
+        and the absolute expiry timestamp.
+      tags:
+        - EnrolSession
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties: {}
+      responses:
+        "200":
+          description: New session minted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MintEnrolSessionResponse"
+        "401":
+          description: Caller is not authenticated.
+
+  /auth/enrol-session/redeem:
+    post:
+      operationId: RedeemEnrolSession
+      summary: Redeem a session token for a full citizen access token.
+      description: |
+        Called by the wallet device after the citizen has opened the
+        enrolment URL. Single-use. Returns the bound user's display
+        name and email for the wallet's confirmation dialog.
+      tags:
+        - EnrolSession
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RedeemEnrolSessionRequest"
+      responses:
+        "200":
+          description: Token redeemed; full citizen access token returned along with the bound user's identifying details.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RedeemEnrolSessionResponse"
+        "400":
+          description: Malformed token, wrong scope, signature invalid, or token claims missing.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RedeemEnrolSessionErrorBody"
+        "409":
+          description: Token has already been consumed (replay detected).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RedeemEnrolSessionErrorBody"
+        "410":
+          description: Token expired.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RedeemEnrolSessionErrorBody"
+
+components:
+  securitySchemes:
+    tenantUserJwt:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    MintEnrolSessionResponse:
+      type: object
+      required: [sessionToken, qrUrl, expiresAt]
+      properties:
+        sessionToken:
+          type: string
+          description: The signed JWT to be embedded in the QR URL. Single-use; ≤10 minute lifetime.
+        qrUrl:
+          type: string
+          format: uri
+          description: Template `{ConfiguredCouncilOrigin}/wallet/enrol?session={sessionToken}`.
+        expiresAt:
+          type: string
+          format: date-time
+          description: UTC absolute expiry of `sessionToken`.
+
+    RedeemEnrolSessionRequest:
+      type: object
+      required: [sessionToken]
+      properties:
+        sessionToken:
+          type: string
+
+    RedeemEnrolSessionResponse:
+      type: object
+      required: [accessToken, expiresIn, displayName, email]
+      properties:
+        accessToken:
+          type: string
+          description: Full citizen access token bound to the same `platformUserId` the session token carried.
+        expiresIn:
+          type: integer
+          description: Seconds until `accessToken` expires.
+        displayName:
+          type: string
+          description: Display name on the bound user's `PlatformUser`. Surfaced by the wallet PWA's confirmation dialog.
+          example: "Sarah Example"
+        email:
+          type: string
+          format: email
+          description: Email address on the bound user's `PlatformUser`.
+          example: "sarah@example.com"
+
+    RedeemEnrolSessionErrorBody:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          enum:
+            - malformed_token
+            - invalid_signature
+            - scope_mismatch
+            - already_used
+            - expired
+        message:
+          type: string

--- a/specs/126-enrol-inside-wizard/data-model.md
+++ b/specs/126-enrol-inside-wizard/data-model.md
@@ -1,0 +1,200 @@
+# Phase 1 Data Model — Sorcha Wallet enrolment inside a council application wizard
+
+**Feature**: 126-enrol-inside-wizard
+**Date**: 2026-05-15
+
+This feature adds **zero new persisted entities**. It introduces one transient cache entry (the single-use JTI registry), one new event payload, and two HTTP wire shapes. All persistent state lives in entities that already exist (PlatformUser + PlatformUserDevice from Feature 114).
+
+## Transient: Enrolment Session JTI registry
+
+**Storage**: `IAtomicDistributedCache` (Sorcha.AtomicCache from Feature 113). Redis-backed in production, in-memory in tests.
+
+**Key**: `sorcha:enrol-session:{jti}` where `{jti}` is the JWT's claim.
+
+**Value** (JSON):
+
+```json
+{
+  "platformUserId": "<guid>",
+  "consumedAt": "<UTC ISO 8601>",
+  "displayName": "<string>",
+  "email": "<string>"
+}
+```
+
+**TTL**: matches the token's `exp` (10 minutes from mint). Redis cleans expired keys automatically; no background sweep.
+
+**Lifecycle**:
+- **Mint**: `EnrolSessionService.MintAsync` issues a JWT but does NOT write to the cache. The cache entry only exists once a redeem succeeds.
+- **Redeem attempt**: `EnrolSessionService.RedeemAsync` validates the JWT (signature, expiry, scope), then calls `IAtomicDistributedCache.TrySetAsync(key, value, ttl, ifNotExists: true)`. First writer wins. Subsequent attempts read the existing entry's `consumedAt` to surface a replay-detected response.
+
+**Invariants**:
+- A given `jti` is consumed at most once. Replay attempts return HTTP 409 with a deterministic body shape.
+- The cache entry's `displayName` and `email` are echoed from `PlatformUser` at redeem time so the PWA confirmation dialog has fresh data even if the user updated their profile between mint and redeem.
+
+## Transient: One-time JWT (session token)
+
+**Shape** (signed by Tenant Service signing key, same as auth JWTs):
+
+```json
+{
+  "sub": "<platformUserId guid>",
+  "scope": "enrol",
+  "jti": "<uuid>",
+  "iat": <epoch>,
+  "exp": <iat + 600>
+}
+```
+
+**Lifecycle**:
+- Created by `EnrolSessionService.MintAsync` for the calling user's `platformUserId`. Returned to caller (the council page, which uses it to compose the QR URL).
+- Sent by the PWA in the body of `POST /api/auth/enrol-session/redeem`.
+- Validated, JTI consumed, response returned. JWT itself isn't persisted anywhere — the JTI registry is the only ledger.
+
+**Invariants**:
+- The token's `scope` MUST be exactly `"enrol"`. Tokens with any other scope MUST be rejected by the redeem endpoint with HTTP 400.
+- `exp` MUST be ≥ 60 seconds from now AND ≤ 10 minutes from `iat`. Tokens outside that band MUST be rejected.
+
+## Wire shape: `POST /api/auth/enrol-session` (mint)
+
+**Request body** (signed-in caller; no extra parameters in v1):
+
+```json
+{}
+```
+
+**Response 200**:
+
+```json
+{
+  "sessionToken": "<JWT string>",
+  "qrUrl": "<full URL embedding the token>",
+  "expiresAt": "<UTC ISO 8601>"
+}
+```
+
+The `qrUrl` template is `{ConfiguredCouncilOrigin}/wallet/enrol?session={sessionToken}`. The configured council origin is per-deployment configuration; v1 ships Strathcarron's origin.
+
+## Wire shape: `POST /api/auth/enrol-session/redeem`
+
+**Request body**:
+
+```json
+{
+  "sessionToken": "<JWT string>"
+}
+```
+
+**Response 200** (successful redeem):
+
+```json
+{
+  "accessToken": "<full citizen JWT>",
+  "expiresIn": <seconds>,
+  "displayName": "<string>",
+  "email": "<string>"
+}
+```
+
+**Response 400** — malformed token, wrong scope, signature invalid.
+**Response 409** — token already consumed (replay).
+**Response 410** — token expired.
+
+## Wire shape: `TenantHub.DeviceEnrolled` (new hub event)
+
+**Payload** (server-to-client, typed via `ITenantHubClient`):
+
+```csharp
+Task DeviceEnrolled(Guid platformUserId, Guid deviceId);
+```
+
+**Publishing**:
+- Source: `PlatformUserDeviceService.RegisterAsync` after the new `PlatformUserDevice` row commits.
+- Group: `TenantHubGroups.User(platformUserId)`.
+- Idempotent: subsequent calls for the same `(platformUserId, deviceId)` republish (no-op for the citizen UX; downstream subscribers tolerate the repeat).
+
+**Subscribing**:
+- Council page: hub connection joins the `User(platformUserId)` group at component init, transitions out of the waiting state on `DeviceEnrolled`.
+- PWA (optional in v1; future-proofing): can subscribe to react to "another device just got enrolled on my account" — not used by the gate but available for future surfaces (the "your account just got a new device" notification path).
+
+## Validation rules from requirements
+
+| Requirement | Validation |
+|---|---|
+| FR-009 | Session token `exp` claim ≤ `iat + 600`. Enforced on mint; revalidated on redeem. |
+| FR-010 | Redeem response MUST include `displayName` + `email` for the confirmation dialog. |
+| FR-011 | PWA's `EnrolmentRedeemConfirmDialog` MUST present a Cancel affordance that closes the dialog without invoking the device-pairing call. |
+| FR-012 | `IAtomicDistributedCache.TrySetAsync` with `ifNotExists: true` enforces single use. |
+| FR-014 | Hub event published synchronously inside the `RegisterAsync` transaction's success path. |
+| FR-024 | Endpoints registered on the gateway with `RequireHttps` configured at the gateway level. |
+| FR-025 | `AuthEndpoints.Login` + `AuthEndpoints.Signup` validate `?returnTo=` against `ReturnToAllowlistOptions.Hosts` before issuing the redirect; non-matches fall back to the default landing URL. |
+
+## State transitions
+
+### Citizen tier (derived, not stored)
+
+```
+   ┌── Tier 3 (no account) ──→ signup → Tier 2 ──→ pair → Tier 1 ──┐
+   │                                                                  │
+   └──── one-way; computed on every visit from /whoami + /me/devices ─┘
+```
+
+No persistent "onboarding state" enum. Tier is the answer to two probes, not a stored value.
+
+### Session token
+
+```
+   minted ─→ in-flight (≤10 min) ─→ redeemed (JTI in cache) ─→ rejected (any further use)
+                  │
+                  └─→ expired ─→ rejected with 410
+```
+
+### Pairing-completion signal (council page state)
+
+```
+   waiting ─SignalR connected─→ subscribed ─DeviceEnrolled event─→ advanced
+       │                            │
+       │ (timeout 2 s)              │ (timeout 60 s after polling started)
+       ▼                            ▼
+   polling ─/me/devices ≥ 1─→ advanced
+       │
+       │ (60 s no result)
+       ▼
+   manual recovery affordance shown
+```
+
+## Entity-relationship view
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Tenant DB (existing, unchanged)                                  │
+│                                                                   │
+│  PlatformUser ─────one-to-many──── PlatformUserDevice            │
+│        ▲                                  ▲                       │
+│        │  (FR-005: Feature 116 signup     │  (FR-013: Feature 114 │
+│        │   creates this)                   │   device-pairing      │
+│        │                                   │   ceremony creates    │
+│        │                                   │   this)               │
+└────────┼───────────────────────────────────┼─────────────────────┘
+         │                                   │
+         │ minted via                        │ created by
+         │                                   │
+┌────────┴───────────────────────────────────┴─────────────────────┐
+│ Redis (IAtomicDistributedCache)                                  │
+│                                                                   │
+│  sorcha:enrol-session:{jti}  ─→  { platformUserId,               │
+│                                    consumedAt,                    │
+│                                    displayName,                    │
+│                                    email }                         │
+│                                                                   │
+│  TTL = 10 min (matches token exp)                                 │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+## Cross-cutting invariants
+
+- **Tier is derived, never persisted.** The truth lives in `PlatformUser` (account-exists) + `PlatformUserDevice` (device-exists). Any caching on the council-page side is presentation-only.
+- **Session token never re-mintable post-redeem.** Citizens regenerate (mint a new one) rather than re-using.
+- **Return-to validation runs server-side.** The council page MAY display the requested return URL pre-validation; the actual redirect goes through the validator on every request.
+- **Confirmation dialog data flows in-band.** `displayName` + `email` come back in the redeem response so the PWA dialog doesn't need a separate user-info lookup. No extra round-trip.
+- **No new EF migrations.** Spec 3 is additive at the wire surface; the EF schema is untouched.

--- a/specs/126-enrol-inside-wizard/plan.md
+++ b/specs/126-enrol-inside-wizard/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Sorcha Wallet enrolment inside a council application wizard
+
+**Branch**: `126-enrol-inside-wizard` | **Date**: 2026-05-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/126-enrol-inside-wizard/spec.md`
+
+## Summary
+
+Take a citizen from "click Apply on a council page" to "form ready, account + wallet ready to receive credentials" — in one continuous experience, with no separate "set up a wallet first" detour. Three citizen tiers (cold-start, mini-gate, fast-path) detected transparently from `/whoami` + `/me/devices` probes; the cold-start tier walks the citizen through Feature 116 signup, then a hybrid QR/link/paste affordance opens a one-time-use enrolment URL on the wallet device, which runs the existing Feature 114 device-pairing ceremony with a PWA-side confirmation dialog as the friend-scans-by-mistake mitigation. Cross-device coordination uses the existing TenantHub (Feature 118) with `DeviceEnrolled` as a new event; polling on `/me/devices` is the fallback when the hub doesn't connect.
+
+Technical approach is **library-first**: a single new `EnrolGateComponent` in `Sorcha.UI.Components.User` handles all three tiers internally, so any council page can host the gate with one element. Server-side surface is small — two new endpoints + one new hub event + a `?returnTo=` extension on existing F116 signup. Reuses everything Spec 1 + Spec 2 already shipped.
+
+## Technical Context
+
+**Language/Version**: .NET 10 / C# 14 (per project constitution + active Sorcha CLAUDE.md; constitution table is slightly stale at C# 13, not a violation).
+**Primary Dependencies**: ASP.NET Core Minimal APIs (server), Blazor WebAssembly (PWA shell), Blazor Server-shell (council page in `Sorcha.UI.Web`), MudBlazor (UI primitives), Microsoft.AspNetCore.SignalR (`TenantHub` from Feature 118), Microsoft.AspNetCore.SignalR.Client (council page + PWA subscriptions), `Sorcha.UI.Components.User` (existing shared component library), QRCoder (server-side QR rendering — already used by `Sorcha.Verifier`).
+**Storage**: Redis via `IDistributedCache` for the one-time session-token JTI registry (single-use enforcement; ≤10 min TTL aligns with the existing atomic-distributed-cache pattern from Feature 113). No new EF entities — `PlatformUserDevice` and `PlatformUser` already exist (F114 + F116).
+**Testing**: xUnit + FluentAssertions + Moq for unit tests across `Sorcha.Tenant.Service.Tests`, `Sorcha.Wallet.Pwa.Tests`, `Sorcha.UI.Core.Tests`. Playwright under `tests/Sorcha.UI.E2E.Tests/Docker/Enrolment/` for the cold-start cross-device walk and the friend-scans-by-mistake confirmation.
+**Target Platform**: Linux containers for Tenant Service + dependants; Mobile Safari + Chrome PWA for the wallet; desktop browsers for the council page.
+**Project Type**: Web — multi-service backend + Blazor WASM PWA + Blazor Server-shell council page. Existing Sorcha multi-project layout.
+**Performance Goals**:
+- Tier-detection probes (`/whoami` + `/me/devices`) complete in under 200 ms p95.
+- Pairing-completion signal reaches the council page within 2 s of pairing in 95% of attempts (SC-004 / FR-014).
+- Cold-start journey from "click Apply" to "form ready" completes in under 90 s in 95% of attempts (SC-001).
+- Session-token mint + redeem each under 300 ms p95.
+**Constraints**:
+- Zero regression in Feature 124 + Feature 125 test suites (SC-009 baseline).
+- No new microservice — surface fits in `Sorcha.Tenant.Service` + `Sorcha.UI.Components.User` + small additions to `Sorcha.UI.Web` + `Sorcha.Wallet.Pwa`.
+- Session token MUST be one-time-use; replay MUST fail closed.
+- Return-to redirect MUST validate against an allowlist; open redirects MUST fail closed.
+**Scale/Scope**: One council (Strathcarron) in v1. Concurrent enrolments expected in the dozens — well within existing platform limits. Polling fallback uses existing `/me/devices` endpoint with the existing rate limits.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Microservices-First | PASS | No new service. Tenant Service gets two endpoints + one hub event; existing dependency chain unchanged. EnrolGateComponent lives in the shared library, consumed by the web shell — dependencies flow downward only. |
+| II. Security First | PASS | Session token is a signed JWT (Tenant Service signing key, same as existing auth JWTs). One-time-use via Redis `SET NX` on JTI. Confirmation dialog before redeem mitigates friend-scans-by-mistake. Return-to allowlist prevents open redirects. All new inputs validated via FluentValidation. Token never logged. |
+| III. API Documentation | PASS | Two new endpoints use Scalar + `.WithName` / `.WithSummary` / `.WithDescription` / `.Produces` per existing pattern. OpenAPI contract committed to `contracts/enrol-session.openapi.yaml`. |
+| IV. Testing Requirements | PASS | Target >85% on new code. Unit tests for `EnrolSessionService.MintAsync` + `RedeemAsync`, integration tests for the two endpoints, component tests for `EnrolGateComponent`, Playwright E2E for the three citizen tiers + the friend-scans-by-mistake mitigation. xUnit + FluentAssertions + Moq throughout. All deterministic. |
+| V. Code Quality | PASS | C# 14, async/await, DI, nullable enabled. No new compiler warnings. |
+| VI. Blueprint Creation Standards | N/A | No new blueprints. |
+| VII. Domain-Driven Design | PASS | Uses ubiquitous language: Citizen, Wallet, Device, Pairing. New terms — "enrolment session token", "citizen tier" — consistent with existing PlatformUser / PlatformUserDevice vocabulary. |
+| VIII. Observability by Default | PASS | OpenTelemetry counters: `sorcha_enrol_session_minted_total`, `sorcha_enrol_session_redeemed_total{outcome ∈ {success, expired, replay, scope_mismatch}}`, `sorcha_enrol_pairing_signal_latency_seconds` histogram. Structured logs on all new server-side surfaces. Health checks unaffected. |
+
+**Verdict**: No violations. Complexity Tracking section omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/126-enrol-inside-wizard/
+├── plan.md              # This file (/speckit.plan command output)
+├── spec.md              # Feature spec (already in place)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── enrol-session.openapi.yaml      # Phase 1 output — new server-side contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already in place)
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+Multi-project Sorcha layout. Feature touches four areas:
+
+```text
+src/
+├── Services/
+│   └── Sorcha.Tenant.Service/
+│       ├── Endpoints/
+│       │   └── EnrolSessionEndpoints.cs            # NEW — POST /api/auth/enrol-session, POST /api/auth/enrol-session/redeem
+│       ├── Services/
+│       │   ├── IEnrolSessionService.cs             # NEW — interface
+│       │   ├── EnrolSessionService.cs              # NEW — mint + redeem implementation
+│       │   └── EnrolSessionMetrics.cs              # NEW — OpenTelemetry meters
+│       ├── Models/
+│       │   ├── EnrolSessionDtos.cs                 # NEW — request/response shapes
+│       │   └── ReturnToAllowlistOptions.cs         # NEW — configuration shape
+│       ├── Hubs/
+│       │   ├── TenantHub.cs                        # EXTEND — add DeviceEnrolled event method
+│       │   ├── ITenantHubClient.cs                 # EXTEND — add DeviceEnrolled client method
+│       │   └── TenantHubGroups.cs                  # CHECK — User(platformUserId) group already exists per F118 conventions
+│       ├── Services/PlatformUserDeviceService.cs   # EXTEND — fire DeviceEnrolled on RegisterAsync success
+│       └── Endpoints/AuthEndpoints.cs              # EXTEND — ?returnTo= query param + allowlist validation on signup
+│
+├── Apps/
+│   ├── Sorcha.UI/
+│   │   └── Sorcha.UI.Components.User/
+│   │       ├── Components/
+│   │       │   └── EnrolGate/
+│   │       │       ├── EnrolGateComponent.razor          # NEW — top-level gate; tier detection + branching
+│   │       │       ├── PreflightSignupSurface.razor      # NEW — Tier 3 signup explainer
+│   │       │       ├── WalletPairingSurface.razor        # NEW — Tier 2 / Tier 3 post-signup
+│   │       │       └── HybridQrAffordance.razor          # NEW — QR + tap link + copy link, shared across surfaces
+│   │       └── Services/
+│   │           └── User/
+│   │               └── Enrolment/
+│   │                   ├── ITierProbeService.cs          # NEW — wraps /whoami + /me/devices probes
+│   │                   ├── HttpTierProbeService.cs       # NEW — production impl
+│   │                   ├── IEnrolPairingSignal.cs        # NEW — abstracts SignalR + polling fallback
+│   │                   └── EnrolPairingSignal.cs         # NEW — uses TenantHubConnection + IPollingFallback
+│   │
+│   ├── Sorcha.UI/Sorcha.UI.Web.Client/
+│   │   └── Pages/
+│   │       └── CouncilApplication.razor             # NEW (or extension) — example council application page that hosts EnrolGateComponent
+│   │
+│   └── Sorcha.Wallet.Pwa/
+│       ├── Pages/
+│       │   └── Enrol.razor                          # EXTEND — accept ?session= query, swap for full JWT via redeem endpoint
+│       ├── Components/
+│       │   └── EnrolmentRedeemConfirmDialog.razor   # NEW — confirmation surface before redeem
+│       └── Services/
+│           └── Enrolment/
+│               ├── IEnrolSessionRedeemer.cs         # NEW — interface for the redeem HTTP call
+│               └── EnrolSessionRedeemer.cs          # NEW — implementation
+
+tests/
+├── Sorcha.Tenant.Service.Tests/
+│   ├── Services/
+│   │   └── EnrolSessionServiceTests.cs                  # NEW — mint claims, redeem single-use, expired/scope-mismatch rejection
+│   ├── Endpoints/
+│   │   └── EnrolSessionEndpointsTests.cs                # NEW — happy path, replay 409, expired 410
+│   └── Hubs/
+│       └── TenantHubDeviceEnrolledTests.cs              # NEW — group filtering + payload shape
+├── Sorcha.UI.Core.Tests/
+│   ├── Components/
+│   │   └── EnrolGate/
+│   │       ├── EnrolGateComponentTests.cs               # NEW — tier rendering, hub-event transition, polling fallback
+│   │       └── HybridQrAffordanceTests.cs               # NEW — mobile prominence, three resolution paths
+│   └── Services/
+│       └── User/
+│           └── Enrolment/
+│               └── EnrolPairingSignalTests.cs           # NEW — SignalR-or-polling, manual recovery after 60 s
+├── Sorcha.Wallet.Pwa.Tests/
+│   ├── Components/
+│   │   └── EnrolmentRedeemConfirmDialogTests.cs         # NEW — renders bound email + name, cancel leaves no side-effects
+│   └── Services/
+│       └── Enrolment/
+│           └── EnrolSessionRedeemerTests.cs             # NEW — happy path, already-used handling, expired handling
+└── Sorcha.UI.E2E.Tests/Docker/Enrolment/
+    ├── ColdStartEnrolmentTests.cs                       # NEW — [Demo("cold-start-enrolment")] — full Tier 3 walk
+    ├── ReturningCitizenFastPathTests.cs                 # NEW — Tier 1 verification
+    ├── MiniGateEnrolmentTests.cs                        # NEW — Tier 2 verification
+    └── StrangerScansQrTests.cs                          # NEW — friend-scans-by-mistake mitigation
+
+walkthroughs/Strathcarron/
+└── setup-cold-start-demo.ps1                            # NEW — pre-creates Strathcarron council org + a reset-able fresh-citizen email
+```
+
+**Structure Decision**: Existing Sorcha multi-project layout, web-application shape. Library-first growth: `EnrolGateComponent` in `Sorcha.UI.Components.User` is the contract any council page consumes. Server surface lives in `Sorcha.Tenant.Service` per locked decision #2 from the brainstorm. No new project required.
+
+## Complexity Tracking
+
+No constitution violations. Section omitted.

--- a/specs/126-enrol-inside-wizard/quickstart.md
+++ b/specs/126-enrol-inside-wizard/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart — Sorcha Wallet enrolment inside a council application wizard
+
+**Feature**: 126-enrol-inside-wizard
+**Audience**: Demo presenters, operators, reviewers running Spec 3 end-to-end.
+
+This document is the runbook for demonstrating the cold-start onboarding gate against the local Docker stack (or n1.sorcha.dev). It assumes the implementation has merged and the operator wants to walk a fresh citizen through Tier 3 and observe Tier 2 + Tier 1 paths.
+
+## Prerequisites
+
+- Docker Desktop running, `docker compose up -d` completed cleanly.
+- Secrets initialised: `pwsh walkthroughs/initialize-secrets.ps1`.
+- PowerShell 7.5+ (`pwsh`).
+- A primary device — a desktop browser, plus a second device or browser profile acting as the citizen's phone wallet.
+
+## One-time setup
+
+```powershell
+pwsh walkthroughs/Strathcarron/setup-cold-start-demo.ps1
+```
+
+This script (added in PR-A of the implementation plan):
+
+- Provisions the Strathcarron Council org if absent.
+- Publishes a `DrivingLicence` blueprint with `targetAudience: "SorchaLocalWallet"` on its credential-issuance action.
+- Generates three reset-able test-citizen email addresses for the three tiers:
+  - `cold-start-<random>@example.test` — Tier 3 (no account)
+  - `mini-gate-<random>@example.test` — Tier 2 (account, no device)
+  - `returning-<random>@example.test` — Tier 1 (account + paired device)
+- For Tier 2 + Tier 1, pre-creates the platform user via the Feature 116 signup endpoints; for Tier 1, also runs the Feature 114 device-pairing ceremony so the test account starts with one active device.
+
+Re-running the script resets all three test accounts to their target tier.
+
+## Walk 1 — Cold-start (Tier 3, headline beat)
+
+**Scenario**: A citizen with no Sorcha account and no wallet wants to apply for a driving licence.
+
+In two windows:
+
+1. **Desktop council page**: `http://localhost/strathcarron/services/driving-licence` (or the n1 equivalent).
+2. **Phone wallet**: a second browser profile, mobile viewport (DevTools), no Sorcha cookies, no installed PWA.
+
+Walk:
+
+1. On the desktop, the page renders the **preflight signup surface** — short "you'll need an account and a wallet" copy + a single "Sign in or create your account" button. **No QR yet.**
+2. Click the signup button → Feature 116 signup flow → use the script-provided cold-start email + a generated password.
+3. After signup completion, the desktop redirects back to the council page (return-to allowlist validated). Page now renders the **wallet-pairing surface** with the hybrid QR + tap-link + copy-link.
+4. On the phone, scan the QR (or copy the URL into the phone browser).
+5. The wallet PWA loads, then immediately presents the **`EnrolmentRedeemConfirmDialog`**: *"You're about to enrol this device for `cold-start-XYZ@example.test`. If that's not you, close this page."* Confirm.
+6. The PWA runs the Feature 114 device-pairing ceremony.
+7. On the desktop, within 2 seconds of pairing completion, the council page transitions out of the waiting state — the **`DeviceEnrolled`** SignalR event has fired — and renders the application form.
+8. Fill the form. Submit.
+9. The success screen says "Watch your wallet for your credential." On the phone, the Feature 124 welcome takeover fires when the credential lands.
+
+**Stopwatch checkpoints** (SC-001 target: <90 s):
+
+- Preflight visible: t = 0
+- Form ready: t ≤ 90 s
+
+Variations:
+
+- **Same-device cold-start** — use the phone browser as the desktop too. The page detects the mobile viewport and renders the tap-link more prominently than the QR. Tap-link opens the PWA on the same phone; pairing completes; switch back to the browser tab (form ready).
+- **Stranger scans by mistake** — share the QR URL with a different browser profile / device. The confirmation dialog appears displaying the cold-start citizen's email + name. Cancel; verify no device row appears on the cold-start account (`GET /me/devices` returns empty).
+- **Session token expires** — leave the QR alone for 11 minutes. Click "I've enrolled — continue" or wait for the auto status. The page surfaces "QR expired — let's get you a new one" with a regenerate button. Regenerate; new QR works.
+
+## Walk 2 — Returning citizen (Tier 1, fast path)
+
+**Scenario**: A citizen who already onboarded comes back for a second service.
+
+In one window:
+
+1. **Desktop council page**: signed-out, using the Tier-1 test email.
+
+Walk:
+
+1. Page renders a **sign-in screen** (no QR, no preflight explainer).
+2. Sign in with the Tier-1 credentials.
+3. Page drops directly into the application form — no intermediate "wallet setup" surface.
+
+Stopwatch (SC-002 target: <30 s from click-Apply to form-ready, almost all of which is the sign-in form filling):
+
+- Sign-in visible: t = 0
+- Form ready: t ≤ 30 s.
+
+## Walk 3 — Mini-gate (Tier 2, lost-phone recovery)
+
+**Scenario**: A citizen whose account exists but who has no active device (lost phone, never enrolled, all devices revoked).
+
+In two windows:
+
+1. **Desktop council page**: signed-out, using the Tier-2 test email.
+2. **Phone wallet**: fresh browser profile.
+
+Walk:
+
+1. Page renders the **sign-in screen** (Tier-2 same starting point as Tier-1).
+2. Sign in. Page detects zero active devices, renders the **wallet-pairing surface** — same hybrid QR/link/paste as Tier-3 step 3, but **no signup mention**. Copy: "Let's pair this device with your wallet."
+3. Scan QR on phone, confirm in the dialog, complete pairing.
+4. Desktop transitions to the application form.
+
+## Verify the success criteria
+
+| Criterion | How to verify |
+|-----------|----------------|
+| **SC-001** | Stopwatch Walk 1; should complete in <90 s in 9.5/10 attempts. |
+| **SC-002** | Walk 2; no QR / no enrolment surface visible at any point. |
+| **SC-003** | Walk 3; no signup-related copy or button visible at any point. |
+| **SC-004** | Devtools network tab: hub event arrives within 2 s of pairing. Or check OpenTelemetry: `sorcha_enrol_pairing_signal_latency_seconds{path=signalr}` p95 < 2 s. |
+| **SC-005** | Block SignalR hub via browser devtools (block `/hubs/tenant` WebSocket); verify polling fallback fires within 6 s. |
+| **SC-006** | Wait 11 minutes during Walk 1's pairing surface; verify regenerate affordance one-click reachable. |
+| **SC-007** | Run Walk 1 ten times with fresh test citizens (re-run `setup-cold-start-demo.ps1`); record completion rate. |
+| **SC-008** | Run "stranger scans" variation; verify `GET /me/devices` on the bound account returns 0 active devices after cancel. |
+| **SC-009** | `dotnet test` — Feature 124 + Feature 125 suites still green. |
+
+## Common gotchas
+
+- **Council page sits forever on "Waiting for your phone"**. Likely the SignalR connection didn't establish; check devtools network tab for `/hubs/tenant`. The polling fallback should kick in after 2 s — if it doesn't, the council page's `IEnrolPairingSignal` registration is missing.
+- **Confirmation dialog doesn't render the citizen's name**. The redeem response's `displayName` is null; check the `PlatformUser.DisplayName` field for the test account.
+- **Session token rejected with `expired`** despite being fresh. Tenant Service clock skew vs. browser/device clock — verify the `TimeProvider` injection.
+- **Open-redirect attempt succeeds**. The `ReturnToAllowlist` configuration is missing or empty; council origins must be added to `Auth:ReturnToAllowlist:Hosts` in `appsettings.json` / `appsettings.Production.json`.
+
+## Tear down
+
+```powershell
+pwsh walkthroughs/Strathcarron/teardown.ps1
+```
+
+Clears the three test accounts and any partial enrolment state. Use `docker compose down` afterwards to bring the platform down fully.
+
+## What's next
+
+After Spec 3 ships:
+
+- **Spec 4** (credential-gated second service — Blue Badge) — exercises the multi-context UI in F125 with a citizen who now has more than one credential.
+- **Spec 5** (MyStrathcarron portal + third-party verifiers) — third-party verifier UX builds on the wallet established here.
+- **F125 follow-ups** — PWA-hosted form continuation (Q4 option C), wallet-wide scaffold sweeps, audit scripts.

--- a/specs/126-enrol-inside-wizard/research.md
+++ b/specs/126-enrol-inside-wizard/research.md
@@ -1,0 +1,220 @@
+# Phase 0 Research — Sorcha Wallet enrolment inside a council application wizard
+
+**Feature**: 126-enrol-inside-wizard
+**Date**: 2026-05-15
+**Status**: Complete — no NEEDS CLARIFICATION items remain.
+
+This document captures the design decisions feeding plan.md, along with the alternatives considered. Most decisions were settled during the 2026-05-15 brainstorm (captured in `docs/superpowers/specs/2026-05-15-spec-3-enrol-inside-wizard-design.md`); a few smaller details — token wire format, return-to validation algorithm, polling cadence specifics — are resolved here.
+
+## R-001 — Tier-detection mechanic
+
+**Decision**: Two probes from the council page's entry-point.
+
+- `GET /api/auth/whoami` → 200 with `{ platformUserId }` if signed in, 401 otherwise.
+- `GET /api/me/devices` → active-device list (empty array = no devices).
+
+Result drives the rendered tier:
+
+| `/whoami` | `/me/devices.Count` | Tier | Rendered |
+|---|---|---|---|
+| 401 | — | 3 (cold-start) | `PreflightSignupSurface` |
+| 200 | 0 | 2 (mini-gate) | `WalletPairingSurface` |
+| 200 | ≥1 | 1 (fast path) | Application form |
+
+**Rationale**: Both endpoints already exist (F114 + the existing tenant auth surface). No new server-side classification logic. Tier is recomputed on every visit, so transitions are one-way and immediate.
+
+**Alternatives considered**:
+- *A persisted "onboarding state" enum on `PlatformUser`* — rejected. The state IS the data (`HasAccount` + `HasDevice`). Persisting a redundant flag risks drift.
+- *Single combined endpoint `GET /api/me/onboarding-tier`* — rejected. It would couple the council page to a server-side product concept, when the actual question is two existing facts.
+
+## R-002 — Session token wire format
+
+**Decision**: JWT signed by Tenant Service with the existing auth signing key. Claims:
+
+```json
+{
+  "sub": "<platformUserId>",
+  "scope": "enrol",
+  "jti": "<uuid>",
+  "iat": <epoch>,
+  "exp": <iat + 600>
+}
+```
+
+Single-use enforced by atomic Redis `SET NX` on the `jti` at redeem; key TTL matches the token's `exp` so the cache cleans itself.
+
+**Rationale**:
+- JWT lets the redeem endpoint validate signature + expiry + scope statelessly. Token contents are not secret (the `sub` is just a user id); the security property is "one redeem succeeds" via the JTI registry.
+- 10 min TTL balances "citizen got distracted" against "stale tokens linger". Matches industry-standard short-lived bearer tokens.
+- `scope: "enrol"` is a hard guard against the redeem endpoint accidentally accepting normal access tokens, and vice versa.
+
+**Alternatives considered**:
+- *Opaque random string with a Redis lookup* — rejected. Adds a stateful lookup for every redeem just to retrieve `sub`; the JWT puts that in the token.
+- *Longer TTL with shorter "active" window* — rejected. Two timers add complexity; 10 min is plenty.
+- *Cookie-bound token (HttpOnly cookie carries the bearer; URL has only an opaque handle)* — flagged for future hardening; defers v1.
+
+## R-003 — Single-use enforcement mechanic
+
+**Decision**: `IAtomicDistributedCache` from `Sorcha.AtomicCache` (the existing Feature 113 primitive). `SET NX` on `sorcha:enrol-session:{jti}` at redeem. The value carries `consumed-at` + the `displayName/email` that need to flow back to the PWA confirmation dialog.
+
+**Rationale**:
+- `IAtomicDistributedCache` is the established Sorcha primitive for "first writer wins" semantics (HAIP nonces, pre-auth codes). Reuse is correct here.
+- Persisting consumer-confirmation data alongside the JTI lets the redeem call return everything in one round-trip.
+- TTL on the Redis key auto-cleans expired tokens; no background sweep needed.
+
+**Alternatives considered**:
+- *Database table `EnrolSessionRedemptions`* — rejected. Adds an EF migration for state that's strictly transient.
+- *In-process dictionary* — rejected. Multi-replica Tenant Service would race.
+
+## R-004 — Return-to allowlist validation
+
+**Decision**: Configuration-driven allowlist of trusted return-to hosts, matched as exact-host or `*.host` suffix. Validation runs on signup endpoint entry before issuing the redirect.
+
+```json
+{
+  "Auth": {
+    "ReturnToAllowlist": {
+      "Hosts": [
+        "strathcarron.gov",
+        "*.strathcarron.gov",
+        "localhost",
+        "n1.sorcha.dev"
+      ]
+    }
+  }
+}
+```
+
+Matcher: parse the supplied `returnTo` URL with `Uri.TryCreate`; reject if scheme isn't `https` (allow `http://localhost` for dev); compare `Uri.Host` against the allowlist. Suffix matches require a leading-dot prefix on the candidate (`api.strathcarron.gov` matches `*.strathcarron.gov`).
+
+**Rationale**:
+- Configuration-driven so operators can add councils without code changes.
+- Suffix matching with `*.` prefix is the standard OWASP pattern for safe subdomain trust.
+- Exact-host requirement (no path prefix matching) avoids the "what counts as the same site" classic open-redirect bug class.
+
+**Alternatives considered**:
+- *Regex matching* — rejected; foot-gun for the operator config.
+- *Same-origin-only* (council page must share an origin with the auth server) — rejected; the existing setup has the auth flow on the tenant-service host and council pages on their own host.
+
+## R-005 — Pairing-completion real-time signal
+
+**Decision**: New `TenantHub` event `DeviceEnrolled(Guid platformUserId, Guid deviceId)`. Raised by `PlatformUserDeviceService.RegisterAsync` after a successful insert. Published to the per-user group via the existing `TenantHubGroups.User(platformUserId)` builder. Subscribers (council page) join the group at component init and dispose on detach.
+
+**Rationale**:
+- `TenantHub` already exists (Feature 118); existing per-user group convention applies.
+- Per-user filtering means the council page only sees events for its own session — no cross-citizen leakage.
+- Single canonical raising point (`RegisterAsync` success) avoids duplicate or missing events when a device is added via different surfaces (idempotent on `(PlatformUserId, DevicePublicJwkThumbprint)` per the F114 design).
+
+**Alternatives considered**:
+- *Webhook from Wallet Service back to the council page* — rejected. The council page is a browser, not a backend; no webhook target.
+- *Server-sent events* — rejected. SignalR is the established platform pattern; SSE would be a new transport for one event.
+- *Tenant Service-only event (don't reuse F118 hub)* — rejected. The hub primitive is exactly right for this.
+
+## R-006 — Polling fallback cadence
+
+**Decision**: If `TenantHubConnection.StartAsync()` doesn't reach `Connected` within 2 seconds, the council page silently falls back to polling `GET /me/devices` every 3 seconds. Manual recovery affordance shows after 60 seconds of polling without success.
+
+**Rationale**:
+- 2 s connect timeout matches typical SignalR connection budgets on shaky networks before the user notices a stall.
+- 3 s polling cadence is well within the existing `/me/devices` rate limit (`RateLimitPolicies.Api` permits hundreds/min).
+- 60 s ceiling matches the spec's FR-016 — covers the "phone enrolment is taking longer than expected" without leaving the citizen forever stuck.
+
+**Alternatives considered**:
+- *Exponential backoff polling* — rejected. The work happens in a narrow window; constant cadence is simpler and the rate-limit budget tolerates it.
+- *Short hub-connect timeout (e.g. 500 ms)* — rejected. Some users on cold-start mobile networks legitimately take ≥1 s to establish a fresh SignalR connection.
+
+## R-007 — PWA-side confirmation dialog placement
+
+**Decision**: New `EnrolmentRedeemConfirmDialog.razor` in the wallet PWA (`Sorcha.Wallet.Pwa/Components/`). Renders on `Pages/Enrol.razor` BEFORE calling the redeem endpoint. Displays the bound user's `email` + `displayName`, both of which are returned by the redeem endpoint in the same response payload (so the dialog has the info without a separate lookup). User cancel from this dialog leaves no state on the wallet device.
+
+**Rationale**:
+- Confirmation lives in the PWA, not on the council page, because the citizen holding the phone is the relevant decision-maker.
+- Showing the bound user's email/name is the load-bearing mitigation per the design doc §7; cancelling MUST be a no-op (no device registered, no friction on the original user re-minting).
+- Co-locating with `Pages/Enrol.razor` keeps the F114 enrolment ceremony's entry path single — the dialog gates the entry to the existing ceremony.
+
+**Note on subtle redeem semantics**: The redeem call DOES consume the JTI (one-time-use property is preserved). If the user cancels after seeing the dialog, the original user's QR is "spent" — they need to regenerate. This is by design: a redeem call has happened; the only thing not happening is the device registration. Re-minting is one click on the council page (FR-017 / FR-018).
+
+**Alternatives considered**:
+- *Confirmation on the council page before showing the QR* — rejected. The council-page user already knows it's their session; they're not the actor at risk of mistaken pairing.
+- *Two-step redeem (probe + commit)* — rejected. Adds API surface; the one-time-use property is the v1 trust model and a "probe" that doesn't consume the JTI weakens it.
+
+## R-008 — Form-data preservation across the gate
+
+**Decision**: Council page persists in-progress form state to browser `sessionStorage` keyed by `(applicationFormId, browserSessionId)`. Restored after the gate clears. Cleared on submission or when the citizen explicitly cancels.
+
+**Rationale**:
+- `sessionStorage` survives tab navigation within a session but doesn't outlive a closed-tab — appropriate for the "within one session" scope of FR-019.
+- No server-side persistence for partial form state — keeps Spec 3 narrowly scoped (the F125 application catalogue, when it ships, may add server-side resume).
+- Keyed by both form id and session id so two tabs of the same form don't trample each other.
+
+**Alternatives considered**:
+- *No preservation — citizen re-enters the form after the gate* — rejected. UX regression vs. just walking the gate before starting the form.
+- *Server-side draft persistence* — deferred. Belongs with the application catalogue work in Spec 4.
+
+## R-009 — Council page integration surface
+
+**Decision**: Council pages consume `EnrolGateComponent` as a wrapper:
+
+```razor
+<EnrolGateComponent CouncilName="Strathcarron Council" OnReady="@HandleCitizenReady">
+    <!-- the form goes here; renders only after gate clears -->
+    <DrivingLicenceForm />
+</EnrolGateComponent>
+```
+
+The component owns tier detection, signup redirect handling, QR/link rendering, hub subscription, polling fallback, and emits a single `OnReady` event when the citizen reaches Tier 1.
+
+**Rationale**:
+- One drop-in element per council page; consumers don't reason about tiers.
+- ChildContent slot lets the form live in the consuming page (D from the brainstorm), keeping the gate component reusable across applications.
+
+**Alternatives considered**:
+- *EnrolGateComponent renders the form too* — rejected. Couples gate state with form lifecycle; F125 form rendering belongs in `SorchaFormRenderer`, not the gate.
+- *Per-tier components on the council page* — rejected. Pushes tier branching to every consumer.
+
+## R-010 — Observability — counters + spans
+
+**Decision**: OpenTelemetry meters on a new `Sorcha.Enrolment` meter:
+
+- `sorcha_enrol_session_minted_total` (counter, tag `purpose ∈ {tier3_first_qr, tier2_first_qr, regenerate}`)
+- `sorcha_enrol_session_redeemed_total` (counter, tag `outcome ∈ {success, expired, replay, scope_mismatch, signature_fail}`)
+- `sorcha_enrol_pairing_signal_latency_seconds` (histogram, tag `path ∈ {signalr, polling}`) — measured server-side as `(now - registerAsyncCompletedAt)` at the point the signal goes out.
+
+Activity sources: `Sorcha.Enrolment.SessionMint`, `Sorcha.Enrolment.SessionRedeem`, parented to the existing HTTP request span where applicable.
+
+**Rationale**:
+- Three metrics covering the meaningful health signals (mint volume, redeem outcomes, signal latency) without metric sprawl.
+- Outcome tagging on redeem surfaces the replay / scope / expiry failure modes operators care about.
+- Latency histogram supports the SC-004 / FR-014 95th-percentile claim.
+
+**Alternatives considered**:
+- *Per-tier counters* — rejected. Tier breakdown emerges from `purpose` tagging on mint without doubling counter count.
+- *No latency histogram* (just success counter) — rejected. SC-004 specifically measures latency.
+
+## R-011 — Spec 1 / Spec 2 baseline preservation
+
+**Decision**: Spec 3 adds endpoints + a hub event + a library component + a PWA dialog + a council-page composition. It does NOT modify:
+
+- The Feature 114 device-pairing ceremony (`POST /api/v1/wallet/devices/enrol`) — the PWA still calls this after redeeming the session token.
+- The Feature 124 first-credential welcome takeover — fires unchanged when the issued credential lands.
+- The Feature 125 hero-row / multi-context UI on the wallet home — independent surface.
+- The Feature 125 `ApplicationInstance.razor` form host — stays a stub for the future "continue on your phone" evolution.
+
+**Rationale**:
+- SC-009 demands zero regression in existing test suites.
+- Each preserved surface is governed by its own spec; touching them creates a multi-spec change set with weak invariants.
+
+**Alternatives considered**:
+- *Lift `Pages/Enrol.razor` (PWA) into the gate flow as a hosted component* — rejected for v1. Keeps the route-based separation clear.
+
+## All NEEDS CLARIFICATION resolved
+
+Zero `NEEDS CLARIFICATION` markers in `plan.md`'s Technical Context. The brainstorm + the Spec 1/2 precedents answered all the load-bearing questions; this research closes the remaining detail-level gaps.
+
+## Open items for Phase 1 design
+
+Carried forward into the data-model + contracts, not litigated further here:
+
+- Exact OpenAPI shape for the two new endpoints. Resolved in `contracts/enrol-session.openapi.yaml`.
+- Exact wire shape of the redeem response (carries `displayName` + `email` for the PWA confirmation dialog). Resolved in `data-model.md`.
+- Quickstart runbook for the cold-start journey on the Docker stack. Resolved in `quickstart.md`.

--- a/specs/126-enrol-inside-wizard/spec.md
+++ b/specs/126-enrol-inside-wizard/spec.md
@@ -1,0 +1,202 @@
+# Feature Specification: Sorcha Wallet enrolment inside a council application wizard
+
+**Feature Branch**: `126-enrol-inside-wizard`
+**Created**: 2026-05-15
+**Status**: Draft
+**Input**: User description: "Spec 3 of the Strathcarron citizen arc — Sorcha Wallet enrolment inside a council application wizard. Lands the cold-start onboarding gate that turns a council-page visitor into a Sorcha-account-holding, wallet-enrolled citizen as a side-effect of the application form they came for. Returning citizens see only a sign-in screen."
+
+**Authoritative design**: [`docs/superpowers/specs/2026-05-15-spec-3-enrol-inside-wizard-design.md`](../../docs/superpowers/specs/2026-05-15-spec-3-enrol-inside-wizard-design.md)
+**Umbrella context**: [`docs/superpowers/specs/2026-05-13-strathcarron-citizen-arc.md`](../../docs/superpowers/specs/2026-05-13-strathcarron-citizen-arc.md)
+**Predecessor specs**: Feature 124 (Spec 1) shipped 2026-05-14 as `spec-124-complete`; Feature 125 (Spec 2) shipped 2026-05-14 as `spec-125-complete`.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Sarah onboards from scratch via a council form (Priority: P1)
+
+Sarah has never used Sorcha before. She lands on the Strathcarron Council website looking to apply for a driving licence and taps "Apply". The page tells her plainly that she'll need a Sorcha account and a wallet on her phone for the council to deliver her credential — and walks her through both as part of starting the application. She signs up with her email, sees a QR code on the council page, scans it with her phone, and her phone walks her through pairing the wallet to her new account. The council page reacts the moment her phone is ready, drops her into the application form, and she completes the rest of the application normally. After she submits, the council page tells her to watch her phone; the credential lands in the wallet within seconds.
+
+**Why this priority**: This is the umbrella's defining beat — "Sarah-from-cold-start acquires a wallet as a side-effect of the council form she came for." Without it, every citizen has to discover the wallet some other way, and the citizen arc doesn't hold together. Tier 3 is the only path through which Spec 3's load-bearing decisions (preflight gate, hybrid QR, wallet-mandatory, cross-device coordination) all visibly land at once.
+
+**Independent Test**: A fresh-state browser session (no Sorcha cookies, no PWA installed) arrives at the council page, completes signup, scans/taps/pastes the enrolment link, completes the device-pairing ceremony on a phone or second browser context, returns to the council page to find it has advanced to the form, fills the form, submits, and observes the credential arriving in the wallet. End-to-end, single session.
+
+**Acceptance Scenarios**:
+
+1. **Given** Sarah has no Sorcha account and no wallet, **When** she clicks "Apply" on a council form, **Then** the page renders a preflight explaining she'll need an account and a wallet, with a single clear "Sign in or create your account" call to action — and no QR code is shown until she completes signup.
+2. **Given** Sarah has just completed signup, **When** she lands back on the council page, **Then** the page shows a QR code, a tap-able link (prominent on mobile), and a "Copy link" fallback — all resolving the same single-use enrolment URL.
+3. **Given** Sarah scans the QR from her phone, **When** her phone's wallet asks her to confirm "You're about to enrol this device for `sarah@example.com`", **Then** she sees her own email and name surfaced before the device is paired, so a stranger scanning by mistake would recognise it as not theirs.
+4. **Given** Sarah completes pairing on her phone, **When** the desktop council page has been waiting, **Then** the page transitions within 2 seconds to the application form without requiring her to click anything.
+5. **Given** Sarah submits the completed application, **When** the success screen renders, **Then** it tells her to watch her wallet, and the credential appears in her wallet within seconds (matching the F124 first-credential welcome takeover).
+
+---
+
+### User Story 2 — Returning citizen fast-path (Priority: P1)
+
+Sarah comes back to the council a week later to apply for a different service. She still has her phone, still has her account, the wallet is still paired. The council page recognises her immediately — she signs in once and goes straight to the form. No QR, no enrolment screen, no "you'll need a wallet" copy. The credential for the new service lands in her existing wallet the same way it did the first time.
+
+**Why this priority**: This story proves the gate doesn't impose friction on the common case. A cold-start beat that breaks the returning experience would be a net regression. P1 because every citizen becomes a returning citizen on their second visit.
+
+**Independent Test**: A pre-enrolled test account (one with a registered wallet device) arrives at the council page, signs in once, lands straight on the form with no enrolment surface visible, completes and submits, and observes credential delivery to the existing wallet.
+
+**Acceptance Scenarios**:
+
+1. **Given** Sarah has a Sorcha account with at least one active device, **When** she arrives at the council page signed-out, **Then** she sees a sign-in screen — not a QR code, not an enrolment gate, not a "what is this" explainer.
+2. **Given** Sarah has signed in, **When** the council page evaluates her state, **Then** it drops her directly into the application form without an intermediate "wallet setup" step.
+3. **Given** Sarah completes the application, **When** the credential is issued, **Then** it lands in the same wallet she enrolled previously without her needing to re-pair anything.
+
+---
+
+### User Story 3 — Lost-phone mini-gate (Priority: P2)
+
+Sarah's phone was lost last week. She got into the council page on her work laptop, signed in (she remembers her password), and wants to apply for something — but her account has no active device anymore. The page recognises this and shows her the enrolment QR alone (no signup gate, because she already has an account). She enrols her new phone, returns to the council form, and continues.
+
+**Why this priority**: Real-world wallet users will lose phones. Without a clean mini-gate, lost-phone recovery is a confusing "you have an account but the page thinks you don't" loop. P2 because it's a real edge case but happens much less than first-time onboarding.
+
+**Independent Test**: A test account with all devices revoked attempts a council application. The page shows the wallet-pairing gate without re-prompting signup; pairing a new device transitions to the form.
+
+**Acceptance Scenarios**:
+
+1. **Given** Sarah has an account but zero active devices, **When** she arrives at the council page signed in, **Then** the page shows the enrolment QR with copy like "Let's pair this device with your wallet" — explicitly not "Sign up to get a wallet".
+2. **Given** Sarah completes pairing the replacement device, **When** the council page receives the device-paired signal, **Then** the page advances to the application form within 2 seconds.
+
+---
+
+### User Story 4 — Stranger scans the QR by mistake (Priority: P2)
+
+Sarah's QR is showing on her desktop screen. Her brother, curious, scans it with his phone before she can stop him. Instead of silently pairing his phone to her account, the wallet on his phone surfaces a clear "You're about to enrol this device for Sarah Example (`sarah@example.com`). If that's not you, close this page." He recognises that's his sister's email and closes the page — no device is registered.
+
+**Why this priority**: The session token is a bearer credential; whoever scans it gets to act on the bound account. Without the confirmation gate, accidental scans turn into account compromise. P2 because the abuse path requires physical proximity to the QR, but the mitigation is cheap and the failure mode is catastrophic.
+
+**Independent Test**: Generate a session-token URL on one browser/account. Open the URL on a second browser. Verify the confirmation dialog renders the bound user's identifying details. Verify cancelling the confirmation leaves no device registered against either account.
+
+**Acceptance Scenarios**:
+
+1. **Given** Sarah's QR is showing on her desktop, **When** any device opens the enrolment URL, **Then** the wallet shows a confirmation surface naming the email and display name of the account the link is bound to — before any device-pairing happens.
+2. **Given** the wallet shows the confirmation, **When** the person holding the phone chooses "this isn't me / close this page", **Then** no device gets registered against the bound account and the original user can mint a fresh QR.
+3. **Given** the wallet shows the confirmation, **When** the person holding the phone confirms it IS them, **Then** the device-pairing ceremony continues normally.
+
+---
+
+### User Story 5 — Same-device tap-link (Priority: P3)
+
+Sarah is on her phone's browser when she arrives at the council page. The page detects she's on mobile and renders the tap-able link more prominently than the QR (which she can't easily scan with the device she's already on). She taps the link, her phone's wallet opens, she confirms it's her, the pairing happens, and the browser tab she came from transitions to the form when she switches back.
+
+**Why this priority**: Increasing share of users are mobile-only. The umbrella's Decision #3 hybrid universal QR is meant to handle this without a separate "phone user" flow. P3 because the underlying mechanism is the same as the cross-device case; this story is mostly a copy-and-emphasis concern.
+
+**Independent Test**: A mobile-emulated browser session arrives at the council page; the tap-link is prominent (above or replacing the QR), tapping it opens the same enrolment URL and proceeds through the same confirmation + pairing flow.
+
+**Acceptance Scenarios**:
+
+1. **Given** the council page detects a mobile viewport, **When** the enrolment gate renders, **Then** the tap-able "Open on this device" link is more prominent than the QR (or the QR is hidden by default behind a "show QR" expander).
+2. **Given** Sarah taps the link on her phone, **When** her wallet opens with the enrolment URL, **Then** the confirmation + pairing flow proceeds identically to the cross-device case.
+
+---
+
+### Edge Cases
+
+- **Citizen distracted; session token expires before pairing completes.** The council page shows a clear "QR expired — let's get you a new one" with a regenerate button. No dead end.
+- **PWA install prompt dismissed.** Wallet still works in the browser tab and pairing proceeds; only the home-screen icon is deferred.
+- **Phone offline during pairing.** Wallet surfaces a "Couldn't reach Sorcha — check your connection" message with retry; council page stays in the waiting state.
+- **Real-time pairing-completion signal fails to establish.** Council page silently falls back to checking the citizen's device state every few seconds; if that also fails for a minute, surfaces a manual "I've enrolled — continue" button.
+- **Citizen abandons signup mid-flow.** Next visit: not signed in, restart from Tier 3.
+- **Citizen completes signup but never enrols a device.** Next visit: signed in with zero devices, mini-gate (Tier 2) takes over — no signup repetition.
+- **Council form was partially filled before the gate fired.** Form state is preserved in the browser; restored when the gate clears.
+- **Two browser tabs of the same council form, same Sorcha account.** Both subscribe to the same pairing-completion signal; both advance idempotently.
+- **Citizen opens enrolment URL more than once on the same phone.** Token's one-time-use property is enforced; the wallet either finishes the pairing it was already doing or surfaces "you're already set up" — no duplicate device row.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Tier detection and routing
+
+- **FR-001**: The council application page MUST detect whether the visiting citizen has a Sorcha account and whether that account has at least one active wallet device, and render exactly one of three surfaces accordingly: cold-start preflight (no account), wallet-pairing mini-gate (account but no device), or the application form (account + at least one device).
+- **FR-002**: Tier detection MUST be transparent to the citizen — they MUST never be asked to declare "I'm new" or "I'm returning"; the page MUST infer it.
+- **FR-003**: A citizen who starts as cold-start and completes onboarding MUST be treated as a returning citizen on their next visit (one-way transition).
+
+#### Cold-start preflight
+
+- **FR-004**: The cold-start preflight MUST present a plain-English explanation of why a wallet is needed before any QR code, scan affordance, or wallet-pairing surface is shown.
+- **FR-005**: The cold-start preflight MUST offer signup via the platform's existing supported methods (email/password, social, or passkey) — this feature MUST NOT introduce a separate "council-only" account.
+- **FR-006**: After signup completion, the citizen MUST be returned to the same council application page they started from — not the platform's default landing surface.
+
+#### Hybrid enrolment affordance
+
+- **FR-007**: The wallet-pairing surface (Tier 2 mini-gate and Tier 3 post-signup) MUST present the same enrolment URL in three equivalent forms: a scannable QR code, a tap-able link, and a copyable text string.
+- **FR-008**: On mobile viewports, the tap-able link MUST be visually more prominent than the QR.
+- **FR-009**: The enrolment URL MUST carry a short-lived (no more than 10 minutes) one-time-use session token bound to the signed-in citizen's account.
+- **FR-010**: When the citizen opens the enrolment URL on a wallet-capable device, the wallet MUST display a confirmation surface naming the email and display name of the account the token is bound to, before any device-pairing operation begins.
+- **FR-011**: The confirmation surface MUST allow the recipient to cancel without registering a device against the bound account.
+- **FR-012**: When the session token is consumed (whether by completed pairing or by an attempted second use), subsequent attempts to use the same token MUST be rejected.
+
+#### Cross-device coordination
+
+- **FR-013**: When pairing completes on the citizen's wallet device, the council page MUST advance to the application form without requiring manual action from the citizen.
+- **FR-014**: The pairing-completion signal MUST reach the council page within 2 seconds of pairing in 95% of attempts.
+- **FR-015**: When the real-time signal fails to establish or fails to fire, the council page MUST silently fall back to a polling check on the citizen's device state.
+- **FR-016**: When both the real-time signal and the polling fallback fail to surface pairing completion within 60 seconds, the council page MUST present a clear manual recovery affordance ("I've enrolled — continue").
+
+#### Session-token expiry and regeneration
+
+- **FR-017**: If the session token expires before pairing completes, the council page MUST present a clear regenerate affordance with copy that explains what happened in plain English.
+- **FR-018**: A regenerate request MUST produce a freshly-minted token without requiring the citizen to repeat signup or any earlier step.
+
+#### Form continuity
+
+- **FR-019**: Form data entered before the gate fired (within the same browser session) MUST be preserved across the gate transition.
+- **FR-020**: Submission of the application MUST happen on the council page (web shell), not via the citizen's wallet device, in this feature's v1 scope.
+- **FR-021**: The application's success screen MUST tell the citizen to watch their wallet, and MUST update to reflect credential arrival when the wallet receives the credential.
+
+#### Account + device-state preservation
+
+- **FR-022**: A citizen who completes signup but abandons before pairing MUST be able to return later and resume from the wallet-pairing gate (Tier 2), without re-doing signup.
+- **FR-023**: A citizen who abandons during the cold-start preflight MUST be able to return later and restart from the preflight, with no orphaned account or partial-state record blocking them.
+
+#### Security
+
+- **FR-024**: The enrolment URL MUST be served over HTTPS only.
+- **FR-025**: Signup redirects after completion MUST be validated against an allowlist of trusted return-to domains — open redirects MUST be rejected.
+
+### Key Entities
+
+- **Enrolment Session Token**: A short-lived (≤10 min) one-time-use bearer token bound to a specific Sorcha account, used by the wallet to authenticate itself for an upcoming pairing operation. Distinct from the citizen's normal access token; specific to this single-use enrolment moment.
+- **Citizen Tier**: A derived state — not stored — indicating whether the visiting citizen needs cold-start onboarding, mini-gate pairing, or no gate at all. Recomputed on every visit from account-state + device-state probes.
+- **Pairing-Completion Signal**: The event surfacing "a new wallet device has been registered against this account", consumed by the council page to advance its state. Has a primary (real-time push) path and a fallback (polling) path; same logical event, two transports.
+- **Trusted Return-To Domain Allowlist**: The set of domains that signup may redirect to on completion. Council pages are added by platform operators; citizens cannot extend it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A cold-start citizen (no prior Sorcha account or device) completes the journey from "click Apply" to "form ready to fill" in under 90 seconds in 95% of attempts (excluding citizen-driven distractions like leaving the page).
+- **SC-002**: A returning citizen with a paired device completes the journey from "click Apply" to "form ready to fill" with no surface other than a single sign-in screen in 100% of cases.
+- **SC-003**: A mini-gate citizen (account but no device) completes pairing and reaches the form without seeing any signup or "create account" surface in 100% of cases.
+- **SC-004**: The pairing-completion signal reaches the council page within 2 seconds of pairing completion in 95% of attempts.
+- **SC-005**: When the real-time signal fails, the polling fallback surfaces pairing completion within 6 seconds in 95% of attempts.
+- **SC-006**: An expired session token never leaves the citizen on a dead-end screen — a regenerate affordance MUST be reachable in one click in 100% of cases.
+- **SC-007**: Across 10 independent walks of the cold-start journey by different test citizens, all 10 complete successfully end-to-end (preflight → signup → pairing → form → submission → credential delivery).
+- **SC-008**: A "stranger scans the QR" simulation (an unintended second party opens the enrolment URL) results in zero device registrations against the bound account when the unintended party cancels the confirmation, in 100% of attempts.
+- **SC-009**: Existing Feature 124 and Feature 125 test suites remain green after this feature's changes (no regressions in the wallet's credential-arrival or multi-context behaviour).
+
+## Out of Scope
+
+These items are explicitly deferred from this feature; tracked for later specs or follow-up PRs.
+
+- **Email-pickup fallback for citizens who refuse to enrol a wallet.** v1 keeps the wallet mandatory; a future spec may add a clearly second-class wallet-less delivery path if accessibility/equity testing flags an exclusion problem.
+- **Wallet-hosted form continuation.** The PWA's `ApplicationInstance` form-hosting capability (built in Feature 125) is NOT used in this feature's v1 cold-start path; submission stays on the web shell. A future spec may add "continue on your phone" as a citizen-driven choice.
+- **A "list of available applications" surface for citizens.** This feature designs the gate; the form behind it is whatever application is consumed via a council page. Citizen-facing application catalogues are out of scope.
+- **Multi-tenant council onboarding UX.** This feature assumes a single council (Strathcarron) consuming the gate. Onboarding additional councils onto the same machinery is a later roadmap item.
+- **Server-set cookie binding for the session token.** Future hardening for the friend-scans-by-mistake path; v1 mitigation is the confirmation dialog.
+- **Form-data preservation across DIFFERENT browser sessions.** Form data preserved across the gate transition within one session is in scope; resuming a half-filled form weeks later on a different browser is not.
+- **Cross-council single-sign-on UX polish.** The existing Sorcha auth handles cross-council session sharing; no new design needed.
+
+## Assumptions
+
+Captured for plan-phase reference; each is a reasonable default the spec adopts unless contradicted.
+
+- **The umbrella's invariants hold.** The hybrid universal QR (Decision #3) is the only entry-point mechanism. Email/password is the durable account anchor (Decision #6); social and passkey are equivalent entry points. No new account model is introduced by this spec.
+- **Strathcarron is the demo council.** Production deployments may onboard additional councils, but Spec 3's success criteria assume the Strathcarron council page is the one consuming the gate.
+- **The wallet's first-credential welcome takeover from Feature 124 fires unchanged.** Spec 3 doesn't redesign the credential-arrival moment; it ensures the moment can happen by getting a wallet into the citizen's hands.
+- **Citizens have one phone they use for this.** Multi-device enrolment (one citizen pairing multiple phones in one cold-start session) is unusual and not specifically designed for in v1.
+- **Existing Feature 116 signup endpoints are extended (not rewritten).** Adding a return-to parameter is an additive change; signup mechanics, password rules, social provider configuration, etc., all remain as they are.
+- **Real-time pairing-completion signal uses an existing platform mechanism.** No new transport is introduced; the implementation reuses the platform's existing real-time push surface.
+- **Citizens read the confirmation dialog before tapping through.** The friend-scans-by-mistake mitigation depends on the recipient noticing that the displayed email and name are not theirs. Citizens who reflexively tap through any confirmation prompt are not protected; this is an accepted v1 limitation.

--- a/specs/126-enrol-inside-wizard/tasks.md
+++ b/specs/126-enrol-inside-wizard/tasks.md
@@ -1,0 +1,344 @@
+---
+description: "Task list for Feature 126 — Sorcha Wallet enrolment inside a council application wizard"
+---
+
+# Tasks: Sorcha Wallet enrolment inside a council application wizard
+
+**Input**: Design documents from `/specs/126-enrol-inside-wizard/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md (all present)
+
+**Tests**: Tests ARE included. Sorcha's constitution requires >85% coverage on new code (Principle IV), the spec defines measurable success criteria requiring automated verification (SC-007, SC-008, SC-009), and FR-014 / FR-024 / FR-025 mandate specific test coverage.
+
+**Organization**: Tasks are grouped by user story. Each story's checkpoint is a fully working, independently testable increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps to user stories from spec.md (US1–US5)
+- All file paths are repo-rooted
+
+## Path Conventions
+
+Sorcha multi-project layout. Paths in this document are repo-rooted:
+- Tenant Service: `src/Services/Sorcha.Tenant.Service/`
+- Shared library: `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/`
+- Council web shell: `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/`
+- PWA: `src/Apps/Sorcha.Wallet.Pwa/`
+- Tenant tests: `tests/Sorcha.Tenant.Service.Tests/`
+- Library tests: `tests/Sorcha.UI.Core.Tests/`
+- PWA tests: `tests/Sorcha.Wallet.Pwa.Tests/`
+- E2E tests: `tests/Sorcha.UI.E2E.Tests/Docker/Enrolment/`
+- Walkthroughs: `walkthroughs/Strathcarron/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm prerequisites and stand up the demo scaffold every story relies on.
+
+- [ ] T001 Verify the Feature 124 + Feature 125 test suites pass on the freshly-created `126-enrol-inside-wizard` branch as the SC-009 regression baseline. Record the counts in tasks.md as a baseline comment.
+- [ ] T002 [P] Create `walkthroughs/Strathcarron/` directory if absent and a stub `setup-cold-start-demo.ps1` script with parameters but no body — fleshed out across Phases 3-5.
+- [ ] T003 [P] Add `Auth:ReturnToAllowlist:Hosts` configuration block to `src/Services/Sorcha.Tenant.Service/appsettings.json` + `appsettings.Development.json` with the development hosts (`localhost`, `n1.sorcha.dev`, `strathcarron.gov`, `*.strathcarron.gov`).
+
+**Checkpoint**: Build clean, baseline recorded, configuration template in place. Ready for foundational work.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Server-side enrolment-session machinery, hub event, return-to validation, library-side tier probe. Every user story below depends on at least one of these.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### Server-side: enrolment session endpoints
+
+- [ ] T004 [P] Create `EnrolSessionDtos.cs` in `src/Services/Sorcha.Tenant.Service/Models/` with the request/response shapes from `contracts/enrol-session.openapi.yaml`: `MintEnrolSessionResponse`, `RedeemEnrolSessionRequest`, `RedeemEnrolSessionResponse`, `RedeemEnrolSessionErrorBody`, `RedeemEnrolSessionErrorCode` enum.
+- [ ] T005 Create `IEnrolSessionService.cs` + `EnrolSessionService.cs` in `src/Services/Sorcha.Tenant.Service/Services/`. Methods: `Task<MintEnrolSessionResponse> MintAsync(Guid platformUserId, CancellationToken ct)` + `Task<RedeemResult> RedeemAsync(string sessionToken, CancellationToken ct)`. Uses `IAtomicDistributedCache` from `Sorcha.AtomicCache` for single-use enforcement per research §R-003.
+- [ ] T006 Wire JWT mint + signature validation in `EnrolSessionService` using the existing Tenant Service signing key (`ITokenService` injection). Claims per `data-model.md`: `{ sub, scope: "enrol", jti, iat, exp = iat + 600 }`. Verify on redeem: signature, expiry, scope; reject with the corresponding `RedeemEnrolSessionErrorCode`.
+- [ ] T007 Add `EnrolSessionMetrics.cs` in `src/Services/Sorcha.Tenant.Service/Services/` exposing the three OpenTelemetry instruments per research §R-010 on a new `Sorcha.Enrolment` meter: `sorcha_enrol_session_minted_total`, `sorcha_enrol_session_redeemed_total{outcome}`, `sorcha_enrol_pairing_signal_latency_seconds` histogram.
+- [ ] T008 Create `EnrolSessionEndpoints.cs` in `src/Services/Sorcha.Tenant.Service/Endpoints/`. Maps `POST /api/auth/enrol-session` (auth required, mints) and `POST /api/auth/enrol-session/redeem` (anonymous; consumes). Both rate-limited by `RateLimitPolicies.PlatformAuth`. Scalar OpenAPI annotations per existing pattern.
+- [ ] T009 Register `IEnrolSessionService` + `EnrolSessionMetrics` in `Program.cs` for Sorcha.Tenant.Service. Add `app.MapEnrolSessionEndpoints()` call.
+- [ ] T010 Add `AddAtomicDistributedCache(builder.Configuration, "Tenant")` to `Sorcha.Tenant.Service/Program.cs` if not already registered (re-use of Feature 113 primitive).
+
+### Server-side: TenantHub.DeviceEnrolled event
+
+- [ ] T011 [P] Extend `ITenantHubClient.cs` in `src/Services/Sorcha.Tenant.Service/Hubs/` with `Task DeviceEnrolled(Guid platformUserId, Guid deviceId)` method.
+- [ ] T012 [P] Extend `TenantHubGroups.cs` to expose the existing per-user group helper (or add one) — `User(Guid platformUserId)` returning a stable group name like `"user:{platformUserId:N}"`.
+- [ ] T013 Wire `DeviceEnrolled` publishing into `PlatformUserDeviceService.RegisterAsync` after a successful `await _db.SaveChangesAsync(ct)`. Inject `IHubContext<TenantHub, ITenantHubClient>`; call `Clients.Group(TenantHubGroups.User(platformUserId)).DeviceEnrolled(platformUserId, device.Id)`. Wrap in try/log/swallow so a hub failure cannot fail the device registration.
+
+### Server-side: ?returnTo= on Feature 116 signup endpoints
+
+- [ ] T014 [P] Create `ReturnToAllowlistOptions.cs` in `src/Services/Sorcha.Tenant.Service/Models/` with `IReadOnlyList<string> Hosts { get; init; }` and an `IsAllowed(string returnTo)` helper that parses the URL, applies the matcher rules from research §R-004 (https-only except `http://localhost`, exact-host or `*.host` suffix). Bind to `Auth:ReturnToAllowlist`.
+- [ ] T015 Extend `AuthEndpoints.Login` + `AuthEndpoints.Signup` (whichever handle the post-completion redirect) in `src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs` to accept an optional `?returnTo=<url>` query parameter. Validate via `ReturnToAllowlistOptions.IsAllowed`. On match, redirect to the supplied URL after success; on miss, fall back to the existing default landing redirect. Log the rejection at `Information` level (not warning — citizen-driven, not adversarial by default).
+
+### Library-side: tier probe + pairing-signal abstractions
+
+- [ ] T016 [P] Create `ITierProbeService.cs` in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/` with `Task<CitizenTier> ProbeAsync(CancellationToken ct)` and `enum CitizenTier { ColdStart, MiniGate, FastPath }`.
+- [ ] T017 [P] Create `HttpTierProbeService.cs` in the same folder. Calls `GET /api/auth/whoami` + `GET /api/me/devices`; returns `ColdStart` on 401, `MiniGate` when device count is 0, `FastPath` when ≥1. 200 ms timeout on both calls.
+- [ ] T018 [P] Create `IEnrolPairingSignal.cs` + `EnrolPairingSignal.cs` in the same folder. `event Func<Guid, Task>? OnDeviceEnrolled;` plus `Task StartAsync(Guid platformUserId, CancellationToken ct)` + `Task StopAsync()`. Wraps `TenantHubConnection` (primary) with a polling fallback that calls `GET /me/devices` every 3 s if hub doesn't connect within 2 s. Per research §R-006.
+
+### Library-side: EnrolGateComponent skeleton
+
+- [ ] T019 Create the folder structure `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/` and an `EnrolGateComponent.razor` shell that injects `ITierProbeService` + `IEnrolPairingSignal`, holds the tier state, renders a `<RenderFragment>` ChildContent only when Tier 1 reached. No tier-specific UI yet — that's T021-T023.
+
+### DI registration (library + PWA)
+
+- [ ] T020 Register `ITierProbeService` → `HttpTierProbeService` and `IEnrolPairingSignal` → `EnrolPairingSignal` in the council web shell's `Program.cs` (`src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs`). HttpClient configured against the API gateway.
+
+### Cross-cutting tests (foundational)
+
+- [ ] T021 [P] Tests: `EnrolSessionServiceTests.cs` in `tests/Sorcha.Tenant.Service.Tests/Services/` — mint claims, redeem single-use via `InMemoryAtomicDistributedCache`, expired token rejection, scope-mismatch rejection, replay rejection.
+- [ ] T022 [P] Tests: `EnrolSessionEndpointsTests.cs` in `tests/Sorcha.Tenant.Service.Tests/Endpoints/` — `POST /api/auth/enrol-session` happy path + auth required, `POST /api/auth/enrol-session/redeem` happy path (200) + replay (409) + expired (410) + scope-mismatch (400).
+- [ ] T023 [P] Tests: `TenantHubDeviceEnrolledTests.cs` in `tests/Sorcha.Tenant.Service.Tests/Hubs/` — group-filtering (only the target user's group receives), payload shape, idempotent re-firing for the same `(platformUserId, deviceId)`.
+- [ ] T024 [P] Tests: `ReturnToAllowlistOptionsTests.cs` in `tests/Sorcha.Tenant.Service.Tests/Models/` — exact host match, `*.host` suffix match, `http://localhost` allowed, every other non-https rejected, malformed URL rejected, host not on allowlist rejected.
+- [ ] T025 [P] Tests: `HttpTierProbeServiceTests.cs` in `tests/Sorcha.UI.Core.Tests/Services/User/Enrolment/` — 401 → ColdStart, 200 + empty devices → MiniGate, 200 + ≥1 device → FastPath.
+- [ ] T026 [P] Tests: `EnrolPairingSignalTests.cs` in `tests/Sorcha.UI.Core.Tests/Services/User/Enrolment/` — SignalR path fires `OnDeviceEnrolled`, polling fallback fires after 2 s hub failure, manual recovery after 60 s.
+- [ ] T027 Re-run full Tenant Service + UI.Core test suites. Confirm SC-009 baseline holds; all new foundational tests green.
+
+**Checkpoint**: Server endpoints work, hub event fires, allowlist enforces, library probes + signals work. The wallet PWA + council page can compile against the new interfaces.
+
+---
+
+## Phase 3: User Story 1 — Sarah onboards from scratch (Priority: P1) 🎯 MVP
+
+**Goal**: Cold-start citizen (Tier 3) completes the journey from "click Apply" to "form ready" with no prior Sorcha account or device.
+
+**Independent Test**: Fresh-state browser session arrives at the council page → preflight signup surface → completes F116 signup → wallet-pairing surface renders → scans QR / taps link on phone → confirmation dialog → device-pairing ceremony → council page transitions to form within 2 s → fills + submits → credential lands in PWA wallet.
+
+### Implementation for User Story 1
+
+- [ ] T028 [P] [US1] Create `PreflightSignupSurface.razor` in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/`. Renders the plain-English explainer + "Sign in or create your account" button that links to the F116 signup flow with `?returnTo=<currentUrl>`. No QR code at this stage (FR-004).
+- [ ] T029 [P] [US1] Create `HybridQrAffordance.razor` in the same folder. Takes `QrUrl` + `ExpiresAt` parameters, renders the QR via `QRCoder` (server-side rendered to base64), the tap-able link prominent on mobile (`MediaQueryService.IsMobile`), and a copy-link affordance.
+- [ ] T030 [P] [US1] Create `WalletPairingSurface.razor` in the same folder. Consumes `HybridQrAffordance`. Calls the mint endpoint at component init via injected HttpClient to obtain the session token; subscribes to `IEnrolPairingSignal.OnDeviceEnrolled`; renders the "Waiting for your phone…" status line and updates to "Phone ready ✓" on event fire.
+- [ ] T031 [US1] Extend `EnrolGateComponent.razor` (skeleton from T019) to branch on `CitizenTier` and render `PreflightSignupSurface` for `ColdStart` then `WalletPairingSurface` for the post-signup return. Emits `OnReady` callback when Tier transitions to `FastPath`.
+- [ ] T032 [US1] Create `Pages/CouncilApplicationDrivingLicence.razor` (or extend an existing page) in `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/` that hosts `EnrolGateComponent` wrapping a `DrivingLicenceForm` placeholder. Demonstrates the consumer-side API.
+- [ ] T033 [US1] Create `IEnrolSessionRedeemer.cs` + `EnrolSessionRedeemer.cs` in `src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/`. Calls `POST /api/auth/enrol-session/redeem` with the session token; returns `RedeemEnrolSessionResponse` on success, structured `RedeemEnrolSessionErrorCode` on failure.
+- [ ] T034 [US1] Create `EnrolmentRedeemConfirmDialog.razor` in `src/Apps/Sorcha.Wallet.Pwa/Components/`. Takes `DisplayName` + `Email` parameters; renders the confirmation copy from FR-010 + spec acceptance scenario US1 #3; emits `OnConfirm` + `OnCancel` callbacks.
+- [ ] T035 [US1] Extend `Pages/Enrol.razor` in `src/Apps/Sorcha.Wallet.Pwa/Pages/` to accept `?session=<token>` query parameter. On load: call `IEnrolSessionRedeemer.RedeemAsync` → render `EnrolmentRedeemConfirmDialog` with returned `displayName` + `email` → on Confirm, store the returned access token via `IAccessTokenStore` and proceed with the existing F114 enrolment ceremony → on Cancel, navigate to a "this isn't me" landing.
+- [ ] T036 [US1] Register `IEnrolSessionRedeemer` in `Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs` as a typed HttpClient targeting the API gateway with `ServerClockHandler` (no `BearerTokenHandler` — the redeem call is anonymous).
+- [ ] T037 [US1] Add structured logging (Serilog) to `EnrolSessionService.MintAsync` + `RedeemAsync` per Sorcha conventions — no token contents in logs, only metadata (PlatformUserId, jti, outcome).
+- [ ] T038 [US1] Flesh out `walkthroughs/Strathcarron/setup-cold-start-demo.ps1` per `quickstart.md` Walk 1: provision Strathcarron Council org, publish `DrivingLicence` blueprint with `targetAudience: "SorchaLocalWallet"`, generate `cold-start-<random>@example.test` test citizen.
+- [ ] T039 [US1] Add the `?form=current` form-state preservation per FR-019: `EnrolGateComponent` writes the consumer page's form state (via a parameter `FormStatePersistenceKey`) into `sessionStorage` before the gate fires; restores on `OnReady`.
+
+### Tests for User Story 1
+
+- [ ] T040 [P] [US1] Tests: `PreflightSignupSurfaceTests.cs` in `tests/Sorcha.UI.Core.Tests/Components/EnrolGate/` — renders explainer copy, signup link carries `?returnTo`, NO QR code rendered.
+- [ ] T041 [P] [US1] Tests: `WalletPairingSurfaceTests.cs` in `tests/Sorcha.UI.Core.Tests/Components/EnrolGate/` — calls mint at init, subscribes to `OnDeviceEnrolled`, transitions status line on event fire.
+- [ ] T042 [P] [US1] Tests: `HybridQrAffordanceTests.cs` in `tests/Sorcha.UI.Core.Tests/Components/EnrolGate/` — QR rendered, tap-link prominent on mobile viewport (mock `MediaQueryService`), copy-link button copies to clipboard via JS interop mock.
+- [ ] T043 [P] [US1] Tests: `EnrolSessionRedeemerTests.cs` in `tests/Sorcha.Wallet.Pwa.Tests/Services/Enrolment/` — happy path 200 returns `{ accessToken, displayName, email }`, 409 surfaces `AlreadyUsed`, 410 surfaces `Expired`, 400 surfaces `MalformedToken`/`ScopeMismatch`/`InvalidSignature`.
+- [ ] T044 [P] [US1] Tests: `EnrolmentRedeemConfirmDialogTests.cs` in `tests/Sorcha.Wallet.Pwa.Tests/Components/` — renders `DisplayName` + `Email`, `OnConfirm`/`OnCancel` fire with no extra effects.
+- [ ] T045 [US1] E2E: `ColdStartEnrolmentTests.cs` in `tests/Sorcha.UI.E2E.Tests/Docker/Enrolment/`. Tagged `[Demo("cold-start-enrolment")]`. Walks Walk 1 from `quickstart.md` against the Docker stack: arrival → preflight → signup → QR scan via second browser context → confirmation dialog confirms → device pairs → council page advances → form fills → submission → credential lands in PWA. Stopwatch asserts SC-001 (<90 s).
+
+**Checkpoint**: Demo Beat 1 (cold-start onboarding) shippable. Tier 3 → Tier 1 transition works end-to-end. SC-001 + SC-007 verifiable.
+
+---
+
+## Phase 4: User Story 2 — Returning citizen fast-path (Priority: P1)
+
+**Goal**: Returning citizen (Tier 1) lands on the form immediately after a single sign-in screen.
+
+**Independent Test**: Pre-enrolled test account arrives at council page → sign-in → form (no QR, no enrolment surface).
+
+### Implementation for User Story 2
+
+- [ ] T046 [US2] Extend `EnrolGateComponent.razor` branching: when `ITierProbeService.ProbeAsync` returns `FastPath`, render `ChildContent` directly (the consumer page's form) and fire `OnReady` immediately. No intermediate UI.
+- [ ] T047 [US2] Extend `setup-cold-start-demo.ps1` to provision the Tier 1 test citizen: signup via F116 + run the F114 device-pairing ceremony so the account starts with one active device. Email: `returning-<random>@example.test`.
+
+### Tests for User Story 2
+
+- [ ] T048 [P] [US2] Tests: `EnrolGateComponentTests.cs` in `tests/Sorcha.UI.Core.Tests/Components/EnrolGate/` — when probe returns `FastPath`, `OnReady` fires synchronously and `ChildContent` renders.
+- [ ] T049 [US2] E2E: `ReturningCitizenFastPathTests.cs` in `tests/Sorcha.UI.E2E.Tests/Docker/Enrolment/`. Walks Walk 2 from `quickstart.md` — verifies SC-002 (no QR, no enrolment surface visible) and stopwatch asserts <30 s click-Apply-to-form-ready.
+
+**Checkpoint**: Fast-path verifiable. SC-002 + SC-007 verifiable.
+
+---
+
+## Phase 5: User Story 3 — Lost-phone mini-gate (Priority: P2)
+
+**Goal**: Citizen with account but no active device (Tier 2) sees the wallet-pairing surface without a signup re-prompt.
+
+**Independent Test**: Test account with all devices revoked arrives at council page → sign-in → mini-gate (QR with "Let's pair this device" copy) → pairing → form.
+
+### Implementation for User Story 3
+
+- [ ] T050 [US3] Extend `WalletPairingSurface.razor` to accept a `TierMode` parameter (`MiniGate` vs `PostSignup`) that selects copy. MiniGate copy: "Let's pair this device with your wallet" (FR-003 per-tier copy spec). PostSignup copy: "Almost there — open your wallet to receive your credential." Same hybrid QR component underneath.
+- [ ] T051 [US3] Wire `EnrolGateComponent.razor` to render `WalletPairingSurface` with `TierMode="MiniGate"` when probe returns `MiniGate`.
+- [ ] T052 [US3] Extend `setup-cold-start-demo.ps1` to provision the Tier 2 test citizen: F116 signup completed, no device-pairing run. Email: `mini-gate-<random>@example.test`.
+
+### Tests for User Story 3
+
+- [ ] T053 [P] [US3] Tests: extend `EnrolGateComponentTests.cs` (T048) — when probe returns `MiniGate`, renders `WalletPairingSurface` with `TierMode="MiniGate"`; no signup surface visible.
+- [ ] T054 [P] [US3] Tests: extend `WalletPairingSurfaceTests.cs` (T041) — MiniGate mode renders the right copy; PostSignup mode renders the other copy; same QR underneath.
+- [ ] T055 [US3] E2E: `MiniGateEnrolmentTests.cs` in `tests/Sorcha.UI.E2E.Tests/Docker/Enrolment/`. Walks Walk 3 from `quickstart.md` — verifies SC-003 (no signup surface visible at any point) and pairing-to-form transition.
+
+**Checkpoint**: Mini-gate verifiable. SC-003 verifiable. Lost-phone recovery path covered.
+
+---
+
+## Phase 6: User Story 4 — Stranger scans QR (Priority: P2)
+
+**Goal**: An unintended second party who opens the enrolment URL sees the confirmation dialog with the bound user's email + display name; cancelling leaves no device registered.
+
+**Independent Test**: Generate session-token URL on Browser A's account, open the URL on Browser B → confirmation dialog renders Browser A's user details → cancel → `GET /me/devices` on Browser A's account returns empty.
+
+### Implementation for User Story 4
+
+- [ ] T056 [US4] Tighten the confirmation copy in `EnrolmentRedeemConfirmDialog.razor` to exactly match the spec wording: "You're about to enrol this device for `{email}` ({displayName}). If that's not you, close this page." Add a "this isn't me" button alongside Confirm; route the citizen back to a `/wallet/cancelled-enrolment` landing on Cancel.
+- [ ] T057 [US4] Create `Pages/CancelledEnrolment.razor` in `src/Apps/Sorcha.Wallet.Pwa/Pages/` — empty-state-with-CTA from Feature 125 PR-F's `EmptyStateWithCta` component. Copy: "Looks like that link wasn't for you. Close this page when you're done."
+
+### Tests for User Story 4
+
+- [ ] T058 [P] [US4] Tests: extend `EnrolmentRedeemConfirmDialogTests.cs` (T044) — Cancel button fires `OnCancel`, NOT `OnConfirm`. Confirm copy includes the exact "if that's not you, close this page" wording.
+- [ ] T059 [P] [US4] Tests: extend `EnrolSessionEndpointsTests.cs` (T022) — redeem on Browser B's session returns the BOUND user's `displayName` + `email`, NOT the redeemer's. The redeem call does NOT register a device on Browser B's auth context.
+- [ ] T060 [US4] E2E: `StrangerScansQrTests.cs` in `tests/Sorcha.UI.E2E.Tests/Docker/Enrolment/`. Mints a session URL on browser context A, opens it on browser context B (a different signed-in account). Verifies the confirmation dialog renders A's details; Cancel; verifies `GET /me/devices` on account A returns 0 active devices. Verifies SC-008.
+
+**Checkpoint**: Friend-scans-by-mistake mitigation verifiable. SC-008 covered.
+
+---
+
+## Phase 7: User Story 5 — Same-device tap-link (Priority: P3)
+
+**Goal**: Citizen on a mobile browser sees the tap-link more prominently than the QR; tapping the link opens the same enrolment URL on the same device.
+
+**Independent Test**: Mobile-emulated browser session arrives at the council page during the wallet-pairing surface; the tap-link is the dominant affordance; tapping it proceeds through the same confirmation + pairing flow.
+
+### Implementation for User Story 5
+
+- [ ] T061 [US5] Update `HybridQrAffordance.razor` (T029) to render the tap-link above the QR on mobile viewports, with the QR collapsed into a "Show QR code" expander; on desktop, QR is dominant and the tap-link sits below it. Driven by `MediaQueryService.IsMobile`.
+- [ ] T062 [US5] Add layout-adaptation parameters to `HybridQrAffordance.razor` (`Layout` + sensible defaults) per the Feature 125 §10 form-factor convention.
+
+### Tests for User Story 5
+
+- [ ] T063 [P] [US5] Tests: extend `HybridQrAffordanceTests.cs` (T042) — mobile viewport renders tap-link as the dominant affordance, QR behind an expander; desktop viewport renders QR dominantly with tap-link below; explicit `Layout` parameter overrides the auto-detection.
+
+**Checkpoint**: Same-device path universal. SC-001 demonstrably works on a mobile-only session.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: SC verification, documentation propagation, audits.
+
+### Failure-path polish
+
+- [ ] T064 [P] Add the regenerate affordance to `WalletPairingSurface.razor`: status flips to "QR expired — let's get you a new one" when the session token's `expiresAt` passes without `OnDeviceEnrolled` firing; calls `POST /api/auth/enrol-session` to mint a fresh token. Per FR-017 / FR-018.
+- [ ] T065 [P] Add the manual-recovery affordance to `WalletPairingSurface.razor`: after 60 s of no `OnDeviceEnrolled` (covering both SignalR + polling failure), surfaces "I've enrolled — continue" button that re-runs the tier probe and advances if the probe now reports `FastPath`. Per FR-016 / SC-005.
+- [ ] T066 [P] Add the `ErrorRecoveryScaffold` (from Feature 125 PR-F) to `Pages/Enrol.razor` for the redeem error paths (`expired`, `already_used`, `malformed_token`) so each surfaces a user-safe recovery action.
+
+### Tests for the polish phase
+
+- [ ] T067 [P] Tests: extend `WalletPairingSurfaceTests.cs` — regenerate-on-expiry path, manual-recovery affordance after 60 s.
+- [ ] T068 [P] Tests: extend `EnrolPairingSignalTests.cs` (T026) — manual-recovery affordance surfaces after 60 s of no signal.
+
+### Documentation propagation
+
+- [ ] T069 [P] Update `.claude/skills/sorcha-architecture/SKILL.md` with a new section: "Council application enrolment gate (Feature 126)". Document the three citizen tiers, the EnrolGateComponent, the two new Tenant Service endpoints, the new `TenantHub.DeviceEnrolled` event, the `?returnTo=` allowlist mechanic, and the session-token security properties.
+- [ ] T070 [P] Update `.claude/skills/sorcha-ui/SKILL.md` with the new library components (`EnrolGateComponent`, `PreflightSignupSurface`, `WalletPairingSurface`, `HybridQrAffordance`) and the form-data preservation convention (sessionStorage keyed by form id + browser session id).
+- [ ] T071 [P] Update `docs/reference/API-DOCUMENTATION.md` with the two new enrolment endpoints (link to `contracts/enrol-session.openapi.yaml`).
+- [ ] T072 [P] Update `.specify/MASTER-TASKS.md` with the Feature 126 entry under "Completed Features (not in themes above)".
+- [ ] T073 [P] Add an `### EnrolGate (Feature 126)` section to `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/README.md` explaining the component's consumer-side API + the `OnReady` callback contract.
+
+### Audits
+
+- [ ] T074 Run `dotnet test` across all touched test projects. Confirm SC-009: F124 + F125 baselines preserved; all new Feature 126 tests green.
+- [ ] T075 Manual smoke-test against `n1.sorcha.dev/strathcarron`: walk all three demo journeys from `quickstart.md`. Verify SC-001 + SC-002 + SC-003 timings.
+- [ ] T076 Build clean: `dotnet build Sorcha.sln` with 0 errors. No new compiler warnings on Release builds (Constitution V).
+
+### Final verification
+
+- [ ] T077 Run the full `specs/126-enrol-inside-wizard/quickstart.md` runbook end-to-end. Record SC-001..SC-009 outcomes in the PR description or as a follow-up comment.
+- [ ] T078 Tag the merge commit `spec-126-complete` once master receives the feature.
+- [ ] T079 Update `MEMORY.md > Current Branch` section with the Feature 126 shipped state.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No prerequisites — runs first.
+- **Foundational (Phase 2)**: Depends on Setup. **BLOCKS all user stories.** Within Phase 2:
+  - T004 (DTOs) before T005 (service impl) before T006 (JWT mint/redeem) before T008 (endpoints).
+  - T011–T012 (hub interface + groups) before T013 (publishing wiring).
+  - T014 (allowlist options) before T015 (signup endpoint extension).
+  - T016 (tier probe interface) before T017 (HTTP impl).
+  - T018 (pairing signal) independent of all others.
+  - T019 (gate skeleton) independent.
+  - T020 (DI) depends on T017 + T018.
+  - T021–T026 ([P] tests) can run as soon as their target lands.
+  - T027 (regression run) is the gate to leave Phase 2.
+- **User Stories (Phase 3–7)**: All depend on Foundational completion. Within each story, `[P]` markers indicate parallel execution.
+- **Polish (Phase 8)**: Depends on the user stories whose behaviour it polishes; tests + docs can run in parallel.
+
+### User Story Dependencies
+
+- **US1 (Cold-start)**: depends on full Phase 2. Independent of US2/US3/US4/US5.
+- **US2 (Fast path)**: depends on T031 (EnrolGateComponent tier branching) from US1. Tier-1 branch is the smallest add.
+- **US3 (Mini-gate)**: depends on T030 (WalletPairingSurface) from US1. Adds a TierMode parameter.
+- **US4 (Stranger scans)**: depends on T034 (EnrolmentRedeemConfirmDialog) from US1. Adds cancel-routing.
+- **US5 (Same-device)**: depends on T029 (HybridQrAffordance) from US1. Adds mobile-prominence parameters.
+
+### Parallel Opportunities
+
+- **Phase 2 parallel batch (after T009)**: T011, T012, T014, T016, T017, T018, T021, T023, T024, T025, T026 — eleven tasks across different files.
+- **US1 parallel batch**: T028, T029, T030, T040, T041, T042, T043, T044 — eight tasks across different files. T031 + T032 + T033 + T034 + T035 sequential due to integration.
+- **US3 parallel batch**: T053, T054 — two test tasks; T050 + T051 sequential.
+- **US4 parallel batch**: T058, T059 — two test tasks; T056 + T057 sequential.
+- **Polish parallel batch**: T064, T065, T066, T067, T068, T069, T070, T071, T072, T073 — ten tasks across different files.
+
+---
+
+## PR-shaped delivery
+
+Single PR covers Phase 1 + Phase 2 + US1 (the headline beat) as the MVP increment. Subsequent PRs layer US2 → US3 → US4 → US5 → Polish.
+
+| PR | Phase coverage | Tasks |
+|---|---|---|
+| **PR-A** | Phase 1 + Phase 2 + Phase 3 (US1) | T001–T045. Foundations + cold-start MVP. |
+| **PR-B** | Phase 4 (US2) + Phase 5 (US3) | T046–T055. Fast-path + mini-gate. |
+| **PR-C** | Phase 6 (US4) + Phase 7 (US5) | T056–T063. Security mitigation + mobile prominence. |
+| **PR-D** | Phase 8 polish | T064–T079. Failure-path polish + docs + final verification. |
+
+PR-A gates on SC-001 + SC-007 + SC-009. PR-B gates on SC-002 + SC-003. PR-C gates on SC-008. PR-D gates on SC-005 + SC-006 + the final quickstart walk.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+The smallest demoable MVP is the cold-start journey (US1) plus the foundational server surface. After PR-A, you can demonstrate Beat 1 (Sarah onboards from scratch) end-to-end.
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: US1 cold-start
+4. **STOP and VALIDATE**: Walk the cold-start journey on Docker (`quickstart.md` Walk 1).
+
+US2 (fast-path), US3 (mini-gate), US4 (stranger-scans), US5 (same-device), Polish layer on after the MVP.
+
+### Incremental Delivery
+
+1. After PR-A: cold-start onboarding works; the headline beat demoable. SC-001 / SC-007 / SC-009 verifiable.
+2. After PR-B: fast-path + mini-gate visible. SC-002 / SC-003 verifiable.
+3. After PR-C: friend-scans-by-mistake mitigation + mobile prominence. SC-008 verifiable.
+4. After PR-D: polish, audits, docs, n1 deploy. SC-004 / SC-005 / SC-006 verifiable.
+
+### Parallel Team Strategy
+
+With two developers:
+
+1. Both drive Phase 2 (Foundational) together — server-side endpoints + library probe primitives are the cornerstone.
+2. After PR-A merges:
+   - Developer A: PR-B (US2 + US3) — both add small branches to existing components.
+   - Developer B: PR-C (US4 + US5) — security mitigation + mobile polish.
+3. Either developer takes PR-D (polish).
+
+---
+
+## Notes
+
+- All file paths are exact. No `src/[location]/[file]` placeholders remain.
+- Pre-release migration squash is N/A — Feature 126 adds no EF entities.
+- Each E2E test is tagged with a Demo attribute so the demo verification can run only those tests as a group (e.g., `dotnet test --filter "Demo"`).
+- The `?returnTo=` allowlist (T014/T015) is a small extension to the existing Feature 116 signup endpoints; the F116 mechanics themselves stay untouched.
+- The session-token redeem call is anonymous (no `BearerTokenHandler` on the redeem HttpClient) — the token IS the authentication for that single call.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/EnrolGateComponent.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/EnrolGateComponent.razor
@@ -1,0 +1,77 @@
+@namespace Sorcha.UI.Core.Components.EnrolGate
+@using Sorcha.UI.Core.Services.User.Enrolment
+@inject ITierProbeService TierProbe
+@inject IEnrolPairingSignal PairingSignal
+
+@*
+    Feature 126 — top-level enrolment gate component.
+    Consumers wrap a form in this; ChildContent only renders once the citizen
+    has reached the FastPath tier (signed in + at least one wallet device).
+
+    PR-A skeleton: tier branching renders placeholder text for ColdStart /
+    MiniGate. Tier-specific surfaces (PreflightSignupSurface,
+    WalletPairingSurface) replace those placeholders in Phase 3 (T031) and
+    Phase 5 (T051).
+*@
+
+@if (_isProbing)
+{
+    <p class="enrol-gate__probing">Checking your account…</p>
+}
+else
+{
+    switch (_tier)
+    {
+        case CitizenTier.FastPath:
+            @ChildContent
+            break;
+        case CitizenTier.MiniGate:
+            <p class="enrol-gate__placeholder enrol-gate__placeholder--mini-gate">
+                Let's pair this device with your wallet. (Phase 5)
+            </p>
+            break;
+        case CitizenTier.ColdStart:
+            <p class="enrol-gate__placeholder enrol-gate__placeholder--cold-start">
+                You'll need an account and a wallet to continue. (Phase 3)
+            </p>
+            break;
+    }
+}
+
+@code {
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Display name for the council whose page is hosting the gate. Used by
+    /// tier-specific copy in Phase 3+.
+    /// </summary>
+    [Parameter] public string CouncilName { get; set; } = "this council";
+
+    /// <summary>
+    /// Fired once the citizen reaches <see cref="CitizenTier.FastPath"/>, with
+    /// the bound platform user id when available. Consumers typically use this
+    /// to restore form state.
+    /// </summary>
+    [Parameter] public EventCallback<Guid?> OnReady { get; set; }
+
+    private bool _isProbing = true;
+    private CitizenTier _tier = CitizenTier.ColdStart;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _isProbing = true;
+        try
+        {
+            _tier = await TierProbe.ProbeAsync(CancellationToken.None);
+        }
+        finally
+        {
+            _isProbing = false;
+        }
+
+        if (_tier == CitizenTier.FastPath && OnReady.HasDelegate)
+        {
+            await OnReady.InvokeAsync(null);
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/EnrolGateComponent.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/EnrolGateComponent.razor
@@ -1,22 +1,24 @@
 @namespace Sorcha.UI.Core.Components.EnrolGate
 @using Sorcha.UI.Core.Services.User.Enrolment
 @inject ITierProbeService TierProbe
-@inject IEnrolPairingSignal PairingSignal
+@inject HttpClient Http
 
 @*
     Feature 126 — top-level enrolment gate component.
-    Consumers wrap a form in this; ChildContent only renders once the citizen
-    has reached the FastPath tier (signed in + at least one wallet device).
 
-    PR-A skeleton: tier branching renders placeholder text for ColdStart /
-    MiniGate. Tier-specific surfaces (PreflightSignupSurface,
-    WalletPairingSurface) replace those placeholders in Phase 3 (T031) and
-    Phase 5 (T051).
+    Probes citizen tier on init; renders the matching surface:
+      ColdStart → PreflightSignupSurface (signup; QR comes after)
+      MiniGate  → WalletPairingSurface (TierMode.MiniGate copy)
+      FastPath  → ChildContent (the application form)
+
+    After pairing completes in MiniGate / cold-start flows, re-probes
+    once; the council page advances when tier transitions to FastPath
+    and OnReady fires.
 *@
 
 @if (_isProbing)
 {
-    <p class="enrol-gate__probing">Checking your account…</p>
+    <p class="enrol-gate__probing" data-testid="enrol-gate-probing">Checking your account…</p>
 }
 else
 {
@@ -25,15 +27,25 @@ else
         case CitizenTier.FastPath:
             @ChildContent
             break;
+
         case CitizenTier.MiniGate:
-            <p class="enrol-gate__placeholder enrol-gate__placeholder--mini-gate">
-                Let's pair this device with your wallet. (Phase 5)
-            </p>
+            <WalletPairingSurface PlatformUserId="@_platformUserId"
+                                  Mode="WalletPairingSurface.TierMode.MiniGate"
+                                  OnPaired="HandlePairedAsync" />
             break;
+
         case CitizenTier.ColdStart:
-            <p class="enrol-gate__placeholder enrol-gate__placeholder--cold-start">
-                You'll need an account and a wallet to continue. (Phase 3)
-            </p>
+            @if (!_postSignup)
+            {
+                <PreflightSignupSurface CouncilName="@CouncilName"
+                                        ServiceLabel="@ServiceLabel" />
+            }
+            else
+            {
+                <WalletPairingSurface PlatformUserId="@_platformUserId"
+                                      Mode="WalletPairingSurface.TierMode.PostSignup"
+                                      OnPaired="HandlePairedAsync" />
+            }
             break;
     }
 }
@@ -41,37 +53,87 @@ else
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
-    /// <summary>
-    /// Display name for the council whose page is hosting the gate. Used by
-    /// tier-specific copy in Phase 3+.
-    /// </summary>
+    /// <summary>Display name for the council whose page is hosting the gate.</summary>
     [Parameter] public string CouncilName { get; set; } = "this council";
 
     /// <summary>
-    /// Fired once the citizen reaches <see cref="CitizenTier.FastPath"/>, with
-    /// the bound platform user id when available. Consumers typically use this
-    /// to restore form state.
+    /// Friendly label for the service the citizen is applying for — fed
+    /// through to <see cref="PreflightSignupSurface"/>.
+    /// </summary>
+    [Parameter] public string ServiceLabel { get; set; } = "application";
+
+    /// <summary>
+    /// Fired once the citizen reaches <see cref="CitizenTier.FastPath"/>,
+    /// either at first probe or after pairing completes.
     /// </summary>
     [Parameter] public EventCallback<Guid?> OnReady { get; set; }
 
     private bool _isProbing = true;
     private CitizenTier _tier = CitizenTier.ColdStart;
+    private Guid _platformUserId = Guid.Empty;
+    private bool _postSignup;
 
     protected override async Task OnInitializedAsync()
     {
+        await ProbeAndPossiblyAdvanceAsync(initial: true);
+    }
+
+    private async Task HandlePairedAsync()
+    {
+        // Pairing-completion signal arrived. Re-probe to confirm the
+        // device is visible to the platform, then transition to
+        // FastPath on success.
+        await ProbeAndPossiblyAdvanceAsync(initial: false);
+    }
+
+    private async Task ProbeAndPossiblyAdvanceAsync(bool initial)
+    {
         _isProbing = true;
+        StateHasChanged();
         try
         {
             _tier = await TierProbe.ProbeAsync(CancellationToken.None);
+            if (_tier != CitizenTier.ColdStart)
+            {
+                _platformUserId = await ResolveBoundPlatformUserIdAsync();
+            }
+
+            // If we were in ColdStart and now the citizen is signed in,
+            // they've completed F116 signup and returned via ?returnUrl.
+            // Switch into the post-signup wallet-pairing branch.
+            if (!initial || _tier == CitizenTier.MiniGate)
+            {
+                _postSignup = _tier == CitizenTier.MiniGate || _tier == CitizenTier.FastPath;
+            }
+            else if (_tier != CitizenTier.ColdStart)
+            {
+                _postSignup = true;
+            }
         }
         finally
         {
             _isProbing = false;
+            StateHasChanged();
         }
 
         if (_tier == CitizenTier.FastPath && OnReady.HasDelegate)
         {
-            await OnReady.InvokeAsync(null);
+            await OnReady.InvokeAsync(_platformUserId == Guid.Empty ? null : _platformUserId);
         }
     }
+
+    private async Task<Guid> ResolveBoundPlatformUserIdAsync()
+    {
+        try
+        {
+            var whoami = await Http.GetFromJsonAsync<WhoamiShape>("/api/auth/whoami");
+            return whoami?.PlatformUserId ?? Guid.Empty;
+        }
+        catch
+        {
+            return Guid.Empty;
+        }
+    }
+
+    private sealed record WhoamiShape(Guid? PlatformUserId);
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/HybridQrAffordance.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/HybridQrAffordance.razor
@@ -1,0 +1,75 @@
+@namespace Sorcha.UI.Core.Components.EnrolGate
+@using Sorcha.UI.Core.Services
+@inject IQrPresentationService QrService
+@inject IJSRuntime JSRuntime
+
+@*
+    Feature 126 — three equivalent resolutions of the enrolment URL:
+    QR (scan from another device), tap-able link (same-device mobile),
+    copy-link (accessibility / "I'll set this up later" fallback).
+
+    Phase 7 (T061) will adapt prominence by viewport — mobile gets the
+    tap-link up top, desktop keeps the QR dominant. This PR-A skeleton
+    renders all three side-by-side; tier-aware layout follows.
+*@
+
+<div class="enrol-hybrid-qr" data-testid="enrol-hybrid-qr">
+    @if (!string.IsNullOrEmpty(QrUrl))
+    {
+        <div class="enrol-hybrid-qr__qr" aria-label="Enrolment QR code">
+            @((MarkupString)_qrSvg)
+        </div>
+
+        <p class="enrol-hybrid-qr__tap">
+            <a href="@QrUrl" class="enrol-hybrid-qr__link" data-testid="enrol-tap-link">
+                Open on this device
+            </a>
+        </p>
+
+        <button type="button"
+                class="enrol-hybrid-qr__copy"
+                data-testid="enrol-copy-link"
+                @onclick="CopyToClipboardAsync">
+            @(_copied ? "Copied ✓" : "Copy link")
+        </button>
+    }
+</div>
+
+@code {
+    /// <summary>The fully-formed enrolment URL embedding the session token.</summary>
+    [Parameter, EditorRequired] public string QrUrl { get; set; } = "";
+
+    /// <summary>Absolute expiry of the embedded session token — surfaced for diagnostics; not rendered.</summary>
+    [Parameter] public DateTimeOffset ExpiresAt { get; set; }
+
+    /// <summary>QR image side length in pixels per module. 6 = ~250 px QR for a standard URL.</summary>
+    [Parameter] public int PixelsPerModule { get; set; } = 6;
+
+    private string _qrSvg = "";
+    private bool _copied;
+
+    protected override void OnParametersSet()
+    {
+        if (!string.IsNullOrEmpty(QrUrl))
+        {
+            _qrSvg = QrService.GenerateSvgFromUri(QrUrl, PixelsPerModule);
+        }
+    }
+
+    private async Task CopyToClipboardAsync()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", QrUrl);
+            _copied = true;
+            StateHasChanged();
+        }
+        catch
+        {
+            // Clipboard API may be unavailable (insecure context, denied
+            // permission) — silently skip rather than crash the UI. The
+            // copy-link button remains visible so the user can long-press
+            // and copy manually.
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/PreflightSignupSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/PreflightSignupSurface.razor
@@ -1,0 +1,50 @@
+@namespace Sorcha.UI.Core.Components.EnrolGate
+@inject NavigationManager Navigation
+
+@*
+    Feature 126 — Tier 3 cold-start preflight surface.
+
+    Renders a plain-English explainer of why the citizen needs an account
+    and a wallet, with a single "Sign in or create your account" CTA that
+    routes to the F116 signup flow with ?returnTo=<currentUrl>. No QR is
+    rendered at this stage (FR-004 — wallet conversation only begins after
+    the citizen has committed to creating an account).
+*@
+
+<div class="enrol-preflight" data-testid="enrol-preflight">
+    <h2 class="enrol-preflight__heading">Before you start your @ServiceLabel</h2>
+
+    <p class="enrol-preflight__explainer">
+        @CouncilName uses your Sorcha Wallet to deliver the credential
+        you'll receive at the end of this application. You'll need a
+        Sorcha account and a wallet on your phone before we begin the form.
+    </p>
+
+    <a href="@SignupUrl"
+       class="enrol-preflight__cta"
+       data-testid="enrol-signup-cta">
+        Sign in or create your account
+    </a>
+
+    <details class="enrol-preflight__more">
+        <summary>What is Sorcha Wallet?</summary>
+        <p>
+            Sorcha Wallet is a free app that holds credentials councils and
+            other organisations issue you — like a driving licence or a
+            blue badge — under your control on your own phone.
+        </p>
+    </details>
+</div>
+
+@code {
+    /// <summary>Display name of the council hosting this page.</summary>
+    [Parameter] public string CouncilName { get; set; } = "this council";
+
+    /// <summary>Friendly label for the service the citizen is applying for. E.g. "driving licence application".</summary>
+    [Parameter] public string ServiceLabel { get; set; } = "application";
+
+    /// <summary>Base URL of the Sorcha signup page. Defaults to <c>/auth/signup</c> on the same origin.</summary>
+    [Parameter] public string SignupBaseUrl { get; set; } = "/auth/signup";
+
+    private string SignupUrl => $"{SignupBaseUrl}?returnUrl={Uri.EscapeDataString(Navigation.Uri)}";
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/WalletPairingSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/EnrolGate/WalletPairingSurface.razor
@@ -1,0 +1,162 @@
+@namespace Sorcha.UI.Core.Components.EnrolGate
+@using System.Net.Http.Json
+@using Sorcha.UI.Core.Services.User.Enrolment
+@inject HttpClient Http
+@inject IEnrolPairingSignal PairingSignal
+@implements IAsyncDisposable
+
+@*
+    Feature 126 — Tier 2 (mini-gate) and Tier 3 (post-signup) shared
+    wallet-pairing surface. Calls POST /api/auth/enrol-session at init to
+    obtain the session token + QR URL; renders the hybrid affordance and
+    a status line that flips when DeviceEnrolled fires (or polling
+    surfaces an active device).
+*@
+
+<div class="enrol-pairing" data-testid="enrol-pairing">
+    @if (_minting)
+    {
+        <p class="enrol-pairing__status">Generating your one-time enrolment code…</p>
+    }
+    else if (_mintError is not null)
+    {
+        <p class="enrol-pairing__status enrol-pairing__status--error" data-testid="enrol-mint-error">
+            @_mintError
+        </p>
+        <button type="button" @onclick="MintAsync" class="enrol-pairing__retry">Try again</button>
+    }
+    else if (_minted is not null)
+    {
+        <h2 class="enrol-pairing__heading">@HeadingText</h2>
+        <p class="enrol-pairing__subheading">@SubheadingText</p>
+
+        <HybridQrAffordance QrUrl="@_minted.QrUrl" ExpiresAt="@_minted.ExpiresAt" />
+
+        <p class="enrol-pairing__status" data-testid="enrol-pairing-status">@_statusText</p>
+
+        @if (_manualRecovery)
+        {
+            <button type="button"
+                    class="enrol-pairing__manual"
+                    data-testid="enrol-manual-recovery"
+                    @onclick="OnManualRecoveryClicked">
+                I've enrolled — continue
+            </button>
+        }
+    }
+</div>
+
+@code {
+    /// <summary>
+    /// Bound platform user id — passed from the parent EnrolGateComponent
+    /// after the whoami probe. Required so the pairing signal subscribes
+    /// to the correct hub group.
+    /// </summary>
+    [Parameter, EditorRequired] public Guid PlatformUserId { get; set; }
+
+    /// <summary>
+    /// Tier-aware copy mode. <c>MiniGate</c> renders "Let's pair this
+    /// device with your wallet" — appropriate when the citizen already
+    /// has an account. <c>PostSignup</c> renders "Almost there — open
+    /// your wallet to receive your credential" for the cold-start path.
+    /// </summary>
+    [Parameter] public TierMode Mode { get; set; } = TierMode.PostSignup;
+
+    /// <summary>Fired when a wallet device for this user has been enrolled.</summary>
+    [Parameter] public EventCallback OnPaired { get; set; }
+
+    private MintEnrolSessionResponseShape? _minted;
+    private bool _minting = true;
+    private string? _mintError;
+    private string _statusText = "Waiting for your phone…";
+    private bool _manualRecovery;
+
+    private string HeadingText => Mode == TierMode.MiniGate
+        ? "Let's pair this device with your wallet"
+        : "Almost there — open your wallet";
+
+    private string SubheadingText => Mode == TierMode.MiniGate
+        ? "Scan the code with your phone (or tap the link if you're on mobile)."
+        : "Scan the code with your phone to receive the credential we'll issue.";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await MintAsync();
+        if (_minted is not null)
+        {
+            PairingSignal.OnDeviceEnrolled += HandleDeviceEnrolled;
+            PairingSignal.OnManualRecoveryRequired += HandleManualRecovery;
+            await PairingSignal.StartAsync(PlatformUserId, CancellationToken.None);
+        }
+    }
+
+    private async Task MintAsync()
+    {
+        _minting = true;
+        _mintError = null;
+        _manualRecovery = false;
+        StateHasChanged();
+
+        try
+        {
+            using var response = await Http.PostAsJsonAsync("/api/auth/enrol-session", new { });
+            if (!response.IsSuccessStatusCode)
+            {
+                _mintError = "Couldn't generate an enrolment code — try again or refresh the page.";
+                return;
+            }
+            _minted = await response.Content.ReadFromJsonAsync<MintEnrolSessionResponseShape>();
+        }
+        catch (Exception)
+        {
+            _mintError = "Couldn't reach Sorcha — check your connection.";
+        }
+        finally
+        {
+            _minting = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task HandleDeviceEnrolled(Guid deviceId)
+    {
+        _statusText = "Phone ready ✓ — continuing";
+        StateHasChanged();
+        if (OnPaired.HasDelegate)
+        {
+            await OnPaired.InvokeAsync();
+        }
+    }
+
+    private void HandleManualRecovery()
+    {
+        _manualRecovery = true;
+        _statusText = "Trouble hearing from your phone — tap below if you've enrolled, or refresh this page.";
+        StateHasChanged();
+    }
+
+    private async Task OnManualRecoveryClicked()
+    {
+        if (OnPaired.HasDelegate)
+        {
+            await OnPaired.InvokeAsync();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        PairingSignal.OnDeviceEnrolled -= HandleDeviceEnrolled;
+        PairingSignal.OnManualRecoveryRequired -= HandleManualRecovery;
+        try { await PairingSignal.StopAsync(); } catch { /* tolerate dispose errors */ }
+    }
+
+    /// <summary>Local DTO mirroring <c>MintEnrolSessionResponse</c> on the Tenant Service.</summary>
+    public sealed record MintEnrolSessionResponseShape(string SessionToken, string QrUrl, DateTimeOffset ExpiresAt);
+
+    /// <summary>Tier-aware copy mode for the pairing surface.</summary>
+    public enum TierMode
+    {
+        MiniGate,
+        PostSignup,
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TenantHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TenantHubConnection.cs
@@ -41,6 +41,13 @@ public sealed class TenantHubConnection : IAsyncDisposable
     /// <summary>Fires when the server emits <c>InboxUnreadCountUpdated(unreadCount, occurredAt, traceId)</c>.</summary>
     public event Func<int, DateTimeOffset, string, Task>? OnInboxUnreadCountUpdated;
 
+    /// <summary>
+    /// Fires when the server emits <c>DeviceEnrolled(platformUserId, deviceId)</c>.
+    /// Feature 126 — the council page subscribes to this to advance out of the
+    /// "Waiting for your phone…" state when the citizen finishes pairing.
+    /// </summary>
+    public event Func<Guid, Guid, Task>? OnDeviceEnrolled;
+
     /// <summary>Connection-state changes for the inline reconnect indicator.</summary>
     public event Action<ConnectionState>? OnConnectionStateChanged;
 
@@ -109,6 +116,15 @@ public sealed class TenantHubConnection : IAsyncDisposable
                 if (OnInboxUnreadCountUpdated is not null)
                 {
                     await OnInboxUnreadCountUpdated(unreadCount, occurredAt, traceId);
+                }
+            });
+
+            _hubConnection.On<Guid, Guid>("DeviceEnrolled", async (platformUserId, deviceId) =>
+            {
+                _logger.LogDebug("Device enrolled: platformUser={PlatformUserId}, device={DeviceId}", platformUserId, deviceId);
+                if (OnDeviceEnrolled is not null)
+                {
+                    await OnDeviceEnrolled(platformUserId, deviceId);
                 }
             });
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/EnrolPairingSignal.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/EnrolPairingSignal.cs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Services;
+
+namespace Sorcha.UI.Core.Services.User.Enrolment;
+
+/// <summary>
+/// <see cref="IEnrolPairingSignal"/> backed by <see cref="TenantHubConnection"/>
+/// for the SignalR path and a periodic <c>/api/v1/me/devices</c> poll for the
+/// fallback path. Cadence comes from research §R-006:
+/// <list type="bullet">
+///   <item><description>2 s hub-connect timeout before polling engages</description></item>
+///   <item><description>3 s polling cadence</description></item>
+///   <item><description>60 s ceiling before manual-recovery affordance fires</description></item>
+/// </list>
+/// </summary>
+public sealed class EnrolPairingSignal : IEnrolPairingSignal, IAsyncDisposable
+{
+    private static readonly TimeSpan HubConnectWindow = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan PollingCadence = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan ManualRecoveryWindow = TimeSpan.FromSeconds(60);
+
+    private readonly TenantHubConnection _hub;
+    private readonly HttpClient _http;
+    private readonly TimeProvider _time;
+    private readonly ILogger<EnrolPairingSignal> _logger;
+
+    private Guid _platformUserId;
+    private CancellationTokenSource? _cts;
+    private Task? _pollingLoop;
+    private Task? _manualRecoveryTimer;
+    private bool _signalReceived;
+
+    public event Func<Guid, Task>? OnDeviceEnrolled;
+    public event Action? OnFallbackEngaged;
+    public event Action? OnManualRecoveryRequired;
+
+    public EnrolPairingSignal(
+        TenantHubConnection hub,
+        HttpClient http,
+        TimeProvider timeProvider,
+        ILogger<EnrolPairingSignal> logger)
+    {
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _time = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task StartAsync(Guid platformUserId, CancellationToken ct)
+    {
+        if (platformUserId == Guid.Empty)
+        {
+            throw new ArgumentException("PlatformUserId must be non-empty.", nameof(platformUserId));
+        }
+
+        _platformUserId = platformUserId;
+        _signalReceived = false;
+
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        _hub.OnDeviceEnrolled += HandleHubDeviceEnrolled;
+
+        // Manual-recovery timer runs regardless of transport — fires after 60 s
+        // unless a signal has arrived.
+        _manualRecoveryTimer = StartManualRecoveryTimerAsync(_cts.Token);
+
+        // Try to connect the hub; if it doesn't connect within 2 s, engage polling.
+        var hubStart = _hub.StartAsync(_cts.Token);
+        var deadline = Task.Delay(HubConnectWindow, _cts.Token);
+        var winner = await Task.WhenAny(hubStart, deadline).ConfigureAwait(false);
+
+        // Even if hub connects, kick off polling at the same cadence so a
+        // late-arriving signal doesn't get lost when the hub's WS later flaps.
+        // The polling loop is a no-op once a signal is received.
+        _pollingLoop = PollingLoopAsync(winner == hubStart ? null : "hub-timeout", _cts.Token);
+
+        await hubStart.ConfigureAwait(false);
+    }
+
+    public Task StopAsync() => StopInternalAsync();
+
+    private async Task StopInternalAsync()
+    {
+        _hub.OnDeviceEnrolled -= HandleHubDeviceEnrolled;
+        try
+        {
+            _cts?.Cancel();
+        }
+        catch (ObjectDisposedException) { }
+
+        if (_pollingLoop is not null)
+        {
+            try { await _pollingLoop.ConfigureAwait(false); } catch { /* expected on cancel */ }
+            _pollingLoop = null;
+        }
+        if (_manualRecoveryTimer is not null)
+        {
+            try { await _manualRecoveryTimer.ConfigureAwait(false); } catch { /* expected on cancel */ }
+            _manualRecoveryTimer = null;
+        }
+        _cts?.Dispose();
+        _cts = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopInternalAsync().ConfigureAwait(false);
+        GC.SuppressFinalize(this);
+    }
+
+    private Task HandleHubDeviceEnrolled(Guid platformUserId, Guid deviceId)
+    {
+        if (platformUserId != _platformUserId)
+        {
+            return Task.CompletedTask;
+        }
+        return RaiseDeviceEnrolledAsync(deviceId);
+    }
+
+    private async Task RaiseDeviceEnrolledAsync(Guid deviceId)
+    {
+        if (_signalReceived) return;
+        _signalReceived = true;
+        var handler = OnDeviceEnrolled;
+        if (handler is not null)
+        {
+            try { await handler.Invoke(deviceId).ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "OnDeviceEnrolled handler threw"); }
+        }
+    }
+
+    private async Task PollingLoopAsync(string? engageReason, CancellationToken ct)
+    {
+        if (engageReason is not null)
+        {
+            _logger.LogInformation("Enrol pairing-signal polling engaged ({Reason})", engageReason);
+            OnFallbackEngaged?.Invoke();
+        }
+
+        try
+        {
+            while (!ct.IsCancellationRequested && !_signalReceived)
+            {
+                try
+                {
+                    using var response = await _http.GetAsync("/api/v1/me/devices", ct).ConfigureAwait(false);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var payload = await response.Content
+                            .ReadFromJsonAsync<DeviceListProbeShape>(ct)
+                            .ConfigureAwait(false);
+                        var active = payload?.ActiveCount
+                            ?? payload?.Devices?.Count(d => string.Equals(d.Status, "active", StringComparison.OrdinalIgnoreCase))
+                            ?? 0;
+                        if (active > 0)
+                        {
+                            await RaiseDeviceEnrolledAsync(Guid.Empty).ConfigureAwait(false);
+                            return;
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { return; }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Enrol pairing-signal poll failed; will retry");
+                }
+
+                try { await Task.Delay(PollingCadence, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { return; }
+            }
+        }
+        finally
+        {
+            // intentional no-op
+        }
+    }
+
+    private async Task StartManualRecoveryTimerAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(ManualRecoveryWindow, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { return; }
+
+        if (!_signalReceived)
+        {
+            _logger.LogInformation("Enrol pairing-signal manual-recovery window elapsed");
+            OnManualRecoveryRequired?.Invoke();
+        }
+    }
+
+    private sealed record DeviceListProbeShape(int? ActiveCount, IReadOnlyList<DeviceProbeRow>? Devices);
+    private sealed record DeviceProbeRow(string? Status);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/HttpTierProbeService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/HttpTierProbeService.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.UI.Core.Services.User.Enrolment;
+
+/// <summary>
+/// HTTP <see cref="ITierProbeService"/> backed by two parallel calls to
+/// <c>GET /api/auth/whoami</c> and <c>GET /api/me/devices</c> on the API gateway.
+/// Each probe times out at 200 ms; whichever finishes first informs the result.
+/// </summary>
+public sealed class HttpTierProbeService : ITierProbeService
+{
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromMilliseconds(200);
+    private readonly HttpClient _http;
+    private readonly ILogger<HttpTierProbeService> _logger;
+
+    public HttpTierProbeService(HttpClient http, ILogger<HttpTierProbeService> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<CitizenTier> ProbeAsync(CancellationToken ct)
+    {
+        var whoami = await TryWhoamiAsync(ct).ConfigureAwait(false);
+        if (!whoami)
+        {
+            return CitizenTier.ColdStart;
+        }
+
+        var deviceCount = await TryDeviceCountAsync(ct).ConfigureAwait(false);
+        return deviceCount > 0 ? CitizenTier.FastPath : CitizenTier.MiniGate;
+    }
+
+    private async Task<bool> TryWhoamiAsync(CancellationToken outer)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(outer);
+        cts.CancelAfter(ProbeTimeout);
+        try
+        {
+            using var response = await _http.GetAsync("/api/auth/whoami", cts.Token).ConfigureAwait(false);
+            return response.StatusCode == HttpStatusCode.OK;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Tier probe — /api/auth/whoami failed; treating as ColdStart");
+            return false;
+        }
+    }
+
+    private async Task<int> TryDeviceCountAsync(CancellationToken outer)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(outer);
+        cts.CancelAfter(ProbeTimeout);
+        try
+        {
+            using var response = await _http.GetAsync("/api/v1/me/devices", cts.Token).ConfigureAwait(false);
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return 0;
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<DeviceListProbeShape>(cts.Token).ConfigureAwait(false);
+            return payload?.ActiveCount ?? payload?.Devices?.Count(d => string.Equals(d.Status, "active", StringComparison.OrdinalIgnoreCase)) ?? 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Tier probe — /api/v1/me/devices failed; treating as MiniGate (best effort)");
+            return 0;
+        }
+    }
+
+    private sealed record DeviceListProbeShape(int? ActiveCount, IReadOnlyList<DeviceProbeRow>? Devices);
+    private sealed record DeviceProbeRow(string? Status);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/IEnrolPairingSignal.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/IEnrolPairingSignal.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.User.Enrolment;
+
+/// <summary>
+/// Surfaces the pairing-completion signal (Feature 126 cross-device coordination).
+/// Wraps the SignalR hub event with a polling fallback so the council page
+/// can advance to the form whether the websocket is healthy or not.
+/// </summary>
+public interface IEnrolPairingSignal
+{
+    /// <summary>
+    /// Fires when a wallet device has been registered for the bound platform
+    /// user, regardless of which transport carried the signal.
+    /// </summary>
+    event Func<Guid, Task>? OnDeviceEnrolled;
+
+    /// <summary>
+    /// Fires when the polling fallback engages (after 2 s with no successful
+    /// SignalR connection) — useful for diagnostics and connection-state UI.
+    /// </summary>
+    event Action? OnFallbackEngaged;
+
+    /// <summary>
+    /// Fires when neither path has surfaced a signal within 60 s — the council
+    /// page should render the manual-recovery affordance (FR-016 / SC-005).
+    /// </summary>
+    event Action? OnManualRecoveryRequired;
+
+    /// <summary>
+    /// Starts listening for pairing-completion signals for
+    /// <paramref name="platformUserId"/>.
+    /// </summary>
+    Task StartAsync(Guid platformUserId, CancellationToken ct);
+
+    /// <summary>Stops listening and disposes any transport resources.</summary>
+    Task StopAsync();
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/ITierProbeService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Enrolment/ITierProbeService.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.User.Enrolment;
+
+/// <summary>
+/// The three citizen tiers used by Feature 126's enrolment gate. Derived from
+/// <c>GET /api/auth/whoami</c> and <c>GET /api/me/devices</c> on every visit;
+/// never persisted.
+/// </summary>
+public enum CitizenTier
+{
+    /// <summary>Visitor is signed in and has at least one active wallet device — render the form directly.</summary>
+    FastPath = 1,
+
+    /// <summary>Visitor is signed in but has no active wallet device — render the wallet-pairing surface.</summary>
+    MiniGate = 2,
+
+    /// <summary>Visitor has no Sorcha account — render the preflight signup surface.</summary>
+    ColdStart = 3,
+}
+
+/// <summary>
+/// Probes the platform for the visiting citizen's tier. Used by the
+/// <c>EnrolGateComponent</c> on render.
+/// </summary>
+public interface ITierProbeService
+{
+    /// <summary>
+    /// Probes <c>whoami</c> and <c>/me/devices</c> and returns the citizen tier.
+    /// Implementations should apply a short (≤200 ms) timeout on each probe
+    /// so the gate component never blocks on a slow round-trip.
+    /// </summary>
+    Task<CitizenTier> ProbeAsync(CancellationToken ct);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CouncilApplicationDrivingLicence.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CouncilApplicationDrivingLicence.razor
@@ -1,0 +1,87 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 126 / T032 — example council application page that demonstrates
+    how a consuming web shell hosts EnrolGateComponent. Stand-in for the
+    real Strathcarron driving-licence form (which lives in the council's
+    own deployment); this page is enough to exercise the cold-start
+    journey end-to-end on the development stack.
+
+    The form below is intentionally minimal — the umbrella's defining beat
+    is the gate that gets the citizen a wallet, not the form behind it.
+    Spec 4/5 picks up the catalogue + form-rendering polish.
+*@
+@page "/strathcarron/services/driving-licence"
+@layout Sorcha.UI.Web.Client.Components.Layout.MainLayout
+@using Sorcha.UI.Core.Components.EnrolGate
+
+<PageTitle>Strathcarron Council — Driving Licence Application</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudText Typo="Typo.h4" Class="mb-2">Apply for a driving licence</MudText>
+    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+        Strathcarron Council — sample application
+    </MudText>
+
+    <EnrolGateComponent CouncilName="Strathcarron Council"
+                        ServiceLabel="driving licence application"
+                        OnReady="HandleCitizenReadyAsync">
+        @* ChildContent renders only once the citizen has a paired wallet
+           device (Tier 1 / FastPath). *@
+        <MudPaper Class="pa-4" Elevation="1">
+            <MudText Typo="Typo.h6" Class="mb-3">Driving licence application</MudText>
+
+            <MudTextField @bind-Value="_fullName" Label="Full name"
+                          Variant="Variant.Outlined" Margin="Margin.Dense"
+                          Class="mb-3" />
+
+            <MudDatePicker @bind-Date="_dateOfBirth" Label="Date of birth"
+                           Variant="Variant.Outlined" Margin="Margin.Dense"
+                           Class="mb-3" />
+
+            <MudTextField @bind-Value="_address" Label="Home address"
+                          Variant="Variant.Outlined" Margin="Margin.Dense"
+                          Lines="3" Class="mb-4" />
+
+            @if (_submitted)
+            {
+                <MudAlert Severity="Severity.Success" Class="mb-3">
+                    Your application is in. Watch your wallet — your credential will
+                    arrive within a few seconds.
+                </MudAlert>
+            }
+            else
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           OnClick="SubmitAsync"
+                           Disabled="@(string.IsNullOrWhiteSpace(_fullName))"
+                           data-testid="driving-licence-submit">
+                    Submit application
+                </MudButton>
+            }
+        </MudPaper>
+    </EnrolGateComponent>
+</MudContainer>
+
+@code {
+    private string _fullName = "";
+    private DateTime? _dateOfBirth;
+    private string _address = "";
+    private bool _submitted;
+    private Guid? _platformUserId;
+
+    private Task HandleCitizenReadyAsync(Guid? platformUserId)
+    {
+        _platformUserId = platformUserId;
+        return Task.CompletedTask;
+    }
+
+    private Task SubmitAsync()
+    {
+        // Demo stand-in — real submission against the blueprint application
+        // endpoints lands with Spec 4's application-catalogue work.
+        _submitted = true;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -8,6 +8,7 @@ using MudBlazor.Services;
 using Sorcha.Blueprint.Schemas.Client;
 using Sorcha.UI.Core.Extensions;
 using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.User.Enrolment;
 using Sorcha.UI.Web.Client;
 using Sorcha.UI.Web.Client.Services;
 
@@ -65,6 +66,19 @@ builder.Services.AddScoped<SchemaLibraryService>(sp =>
 
     return schemaLibrary;
 });
+
+// Feature 126 — council enrolment gate services. ITierProbeService hits the
+// API gateway directly via a typed HttpClient; IEnrolPairingSignal layers
+// SignalR (via TenantHubConnection) with a 3-s /me/devices poll as fallback.
+builder.Services.AddHttpClient<ITierProbeService, HttpTierProbeService>(client =>
+{
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+});
+builder.Services.AddHttpClient<IEnrolPairingSignal, EnrolPairingSignal>(client =>
+{
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+});
+builder.Services.AddSingleton(TimeProvider.System);
 
 var host = builder.Build();
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Components/EnrolmentRedeemConfirmDialog.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Components/EnrolmentRedeemConfirmDialog.razor
@@ -1,0 +1,57 @@
+@namespace Sorcha.Wallet.Pwa.Components
+
+@*
+    Feature 126 — friend-scans-by-mistake mitigation. Surfaces the bound
+    user's display name + email BEFORE the device-pairing call runs, so an
+    unintended recipient can cancel without registering a device against
+    someone else's account.
+
+    Per spec acceptance scenario US1 #3 + FR-010 + FR-011 / US4. Cancel
+    routes the citizen to /wallet/cancelled-enrolment (lands in PR-C);
+    Confirm proceeds to the F114 device-pairing ceremony in Enrol.razor.
+*@
+
+<div class="enrol-confirm" role="dialog" aria-modal="true" data-testid="enrol-confirm-dialog">
+    <h2 class="enrol-confirm__heading">Is this you?</h2>
+
+    <p class="enrol-confirm__body">
+        You're about to enrol this device for <strong>@Email</strong>
+        @if (!string.IsNullOrWhiteSpace(DisplayName))
+        {
+            <span> (@DisplayName)</span>
+        }.
+    </p>
+
+    <p class="enrol-confirm__warning">
+        If that's not you, close this page.
+    </p>
+
+    <div class="enrol-confirm__actions">
+        <button type="button"
+                class="enrol-confirm__confirm"
+                data-testid="enrol-confirm-yes"
+                @onclick="OnConfirm">
+            Yes, that's me — continue
+        </button>
+        <button type="button"
+                class="enrol-confirm__cancel"
+                data-testid="enrol-confirm-no"
+                @onclick="OnCancel">
+            This isn't me
+        </button>
+    </div>
+</div>
+
+@code {
+    /// <summary>Display name of the bound platform user — surfaced for recognition.</summary>
+    [Parameter] public string? DisplayName { get; set; }
+
+    /// <summary>Email of the bound platform user — surfaced as the primary recognition key.</summary>
+    [Parameter, EditorRequired] public string Email { get; set; } = "";
+
+    /// <summary>Fires when the citizen confirms they are the bound user.</summary>
+    [Parameter] public EventCallback OnConfirm { get; set; }
+
+    /// <summary>Fires when the citizen indicates this isn't them. Routes to cancelled-enrolment landing.</summary>
+    [Parameter] public EventCallback OnCancel { get; set; }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Sorcha.Wallet.Pwa.Services;
 using Sorcha.Wallet.Pwa.Services.Applications;
 using Sorcha.Wallet.Pwa.Services.Capture;
 using Sorcha.Wallet.Pwa.Services.Context;
+using Sorcha.Wallet.Pwa.Services.Enrolment;
 using Sorcha.Wallet.Pwa.Services.Presentation;
 using Sorcha.Wallet.Pwa.Services.Signing;
 using Sorcha.Wallet.Pwa.Services.Verification;
@@ -102,6 +103,14 @@ public static class ServiceCollectionExtensions
         // the server clock — sign-in is a great moment to capture initial drift.
         services.AddTransient<BearerTokenHandler>();
         services.AddHttpClient<IAuthService, AuthService>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<ServerClockHandler>();
+
+        // Feature 126 — enrolment-session redeem client. Anonymous: the
+        // session token in the request body is the credential. Still
+        // observes the server clock so a clock-skew banner can surface
+        // before the citizen confirms.
+        services.AddHttpClient<IEnrolSessionRedeemer, EnrolSessionRedeemer>(c =>
             c.BaseAddress = new Uri(gatewayBaseAddress))
             .AddHttpMessageHandler<ServerClockHandler>();
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/CancelledEnrolment.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/CancelledEnrolment.razor
@@ -1,0 +1,30 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 126 / US4 — friend-scans-by-mistake landing. Reached when a
+    citizen cancels out of EnrolmentRedeemConfirmDialog because the bound
+    user's email isn't theirs. No device has been registered against the
+    bound account; the citizen can safely close the page.
+*@
+@page "/cancelled-enrolment"
+@layout MainLayout
+@inject NavigationManager Nav
+
+<PageTitle>Enrolment cancelled</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    <MudPaper Class="pa-4" Elevation="1">
+        <MudText Typo="Typo.h5" Class="mb-3">That wasn't for you</MudText>
+        <MudText Typo="Typo.body2" Class="mb-4">
+            No problem — we didn't register this device. The original code
+            stays unused, and the person who shared it can generate a fresh
+            one. You can safely close this page.
+        </MudText>
+        <MudButton Variant="Variant.Outlined" Color="Color.Default"
+                   OnClick="@(() => Nav.NavigateTo(""))"
+                   data-testid="cancelled-back-to-wallet">
+            Back to wallet
+        </MudButton>
+    </MudPaper>
+</MudContainer>

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Enrol.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Enrol.razor
@@ -15,8 +15,12 @@
 @layout MainLayout
 @using Microsoft.JSInterop
 @using Sorcha.Wallet.Pwa.Services
+@using Sorcha.Wallet.Pwa.Services.Enrolment
+@using Sorcha.Wallet.Pwa.Components
 @inject IAuthService Auth
 @inject IEnrolmentService Enrolment
+@inject IAccessTokenStore AccessTokenStore
+@inject IEnrolSessionRedeemer Redeemer
 @inject IJSRuntime Js
 @inject NavigationManager Nav
 @inject ILogger<Enrol> Logger
@@ -24,6 +28,26 @@
 <PageTitle>Enrol this device</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
+    @if (_redeemError is not null)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-3" data-testid="enrol-redeem-error">
+            @_redeemError
+        </MudAlert>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   OnClick="@(() => Nav.NavigateTo(""))">
+            Back to wallet
+        </MudButton>
+    }
+    else if (_awaitingConfirm)
+    {
+        <EnrolmentRedeemConfirmDialog
+            DisplayName="@_redeemed?.DisplayName"
+            Email="@(_redeemed?.Email ?? string.Empty)"
+            OnConfirm="HandleConfirmAsync"
+            OnCancel="HandleCancelAsync" />
+    }
+    else
+    {
     <MudText Typo="Typo.h5" Class="mb-3">Enrol this device</MudText>
 
     <MudStepper @ref="_stepper" Linear="true" NonLinear="false">
@@ -133,6 +157,7 @@
             }
         </MudStep>
     </MudStepper>
+    }
 </MudContainer>
 
 @code {
@@ -145,10 +170,87 @@
     private string? _error;
     private EnrolmentResult? _result;
 
+    // Feature 126 — session-redeem flow state.
+    private bool _awaitingConfirm;
+    private EnrolRedeemResult? _redeemed;
+    private string? _redeemError;
+
     protected override async Task OnInitializedAsync()
     {
+        // Feature 126: if the URL carries ?session=<token>, redeem it for a
+        // citizen access token before the normal enrolment flow proceeds.
+        // Surface the bound user's display name + email in a confirmation
+        // dialog before any device-pairing call runs — the friend-scans-by-
+        // mistake mitigation. Once confirmed, the redeemed access token is
+        // persisted via IAccessTokenStore and the existing stepper flow
+        // takes over with the citizen already signed in.
+        var sessionToken = TryReadSessionToken();
+        if (!string.IsNullOrEmpty(sessionToken))
+        {
+            var result = await Redeemer.RedeemAsync(sessionToken);
+            if (result.IsSuccess)
+            {
+                _redeemed = result;
+                _awaitingConfirm = true;
+                return;
+            }
+
+            _redeemError = result.ErrorCode switch
+            {
+                EnrolRedeemErrorCode.Expired => "This link has expired. Open the council page on your other device for a new code.",
+                EnrolRedeemErrorCode.AlreadyUsed => "This link has already been used. If you're trying to set up another device, generate a fresh code from the council page.",
+                EnrolRedeemErrorCode.Network => "Couldn't reach Sorcha. Check your connection and try again.",
+                _ => "This enrolment link couldn't be redeemed.",
+            };
+            return;
+        }
+
         _signedInEmail = await Auth.GetSignedInEmailAsync();
         _signedIn = _signedInEmail is not null;
+    }
+
+    private string? TryReadSessionToken()
+    {
+        var uri = new Uri(Nav.Uri);
+        if (string.IsNullOrEmpty(uri.Query)) return null;
+        var query = uri.Query.TrimStart('?');
+        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = part.IndexOf('=');
+            if (eq < 0) continue;
+            var key = Uri.UnescapeDataString(part[..eq]);
+            if (string.Equals(key, "session", StringComparison.Ordinal))
+            {
+                return Uri.UnescapeDataString(part[(eq + 1)..]);
+            }
+        }
+        return null;
+    }
+
+    private async Task HandleConfirmAsync()
+    {
+        if (_redeemed is null || _redeemed.AccessToken is null)
+        {
+            return;
+        }
+
+        var expiresAt = DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, _redeemed.ExpiresInSeconds));
+        await AccessTokenStore.SetAsync(new AccessTokenRecord(
+            _redeemed.AccessToken, expiresAt, _redeemed.Email));
+
+        // Drop the dialog and re-resolve signed-in state. The existing
+        // stepper renders the welcome step with the citizen now signed in.
+        _awaitingConfirm = false;
+        _signedInEmail = _redeemed.Email;
+        _signedIn = true;
+        StateHasChanged();
+    }
+
+    private void HandleCancelAsync()
+    {
+        // Friend-scans-by-mistake path: no device registered. Route to a
+        // landing that makes the "this wasn't for me" outcome clear.
+        Nav.NavigateTo("cancelled-enrolment");
     }
 
     private async Task EnrolAsync()

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/EnrolSessionRedeemer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/EnrolSessionRedeemer.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.Wallet.Pwa.Services.Enrolment;
+
+/// <summary>
+/// HTTP implementation of <see cref="IEnrolSessionRedeemer"/>. Uses a typed
+/// HttpClient configured against the API gateway. No bearer-token handler
+/// is wired — the session token in the request body is the credential.
+/// </summary>
+public sealed class EnrolSessionRedeemer : IEnrolSessionRedeemer
+{
+    private readonly HttpClient _http;
+    private readonly ILogger<EnrolSessionRedeemer> _logger;
+
+    public EnrolSessionRedeemer(HttpClient http, ILogger<EnrolSessionRedeemer> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EnrolRedeemResult> RedeemAsync(string sessionToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(sessionToken))
+        {
+            return EnrolRedeemResult.Fail(EnrolRedeemErrorCode.MalformedToken, "Missing session token.");
+        }
+
+        try
+        {
+            using var response = await _http.PostAsJsonAsync(
+                "/api/auth/enrol-session/redeem",
+                new RedeemRequest(sessionToken),
+                ct).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadFromJsonAsync<RedeemSuccessShape>(cancellationToken: ct)
+                    .ConfigureAwait(false);
+                if (body is null || string.IsNullOrEmpty(body.AccessToken))
+                {
+                    return EnrolRedeemResult.Fail(EnrolRedeemErrorCode.MalformedToken, "Response missing access token.");
+                }
+                return EnrolRedeemResult.Ok(
+                    body.AccessToken,
+                    body.ExpiresIn,
+                    body.DisplayName ?? "",
+                    body.Email ?? "");
+            }
+
+            var error = await TryReadErrorAsync(response, ct).ConfigureAwait(false);
+            return response.StatusCode switch
+            {
+                HttpStatusCode.Conflict => EnrolRedeemResult.Fail(EnrolRedeemErrorCode.AlreadyUsed, error?.Message ?? "Already used."),
+                HttpStatusCode.Gone => EnrolRedeemResult.Fail(EnrolRedeemErrorCode.Expired, error?.Message ?? "Expired."),
+                _ when error?.Code is not null => EnrolRedeemResult.Fail(MapCode(error.Code), error.Message ?? error.Code),
+                _ => EnrolRedeemResult.Fail(EnrolRedeemErrorCode.MalformedToken, "Redeem failed."),
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Network error redeeming enrol-session token");
+            return EnrolRedeemResult.Fail(EnrolRedeemErrorCode.Network, "Couldn't reach Sorcha.");
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return EnrolRedeemResult.Fail(EnrolRedeemErrorCode.Network, "Couldn't reach Sorcha.");
+        }
+    }
+
+    private static EnrolRedeemErrorCode MapCode(string code) => code switch
+    {
+        "malformed_token" => EnrolRedeemErrorCode.MalformedToken,
+        "invalid_signature" => EnrolRedeemErrorCode.InvalidSignature,
+        "scope_mismatch" => EnrolRedeemErrorCode.ScopeMismatch,
+        "already_used" => EnrolRedeemErrorCode.AlreadyUsed,
+        "expired" => EnrolRedeemErrorCode.Expired,
+        _ => EnrolRedeemErrorCode.MalformedToken,
+    };
+
+    private static async Task<ErrorShape?> TryReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadFromJsonAsync<ErrorShape>(cancellationToken: ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed record RedeemRequest(string SessionToken);
+    private sealed record RedeemSuccessShape(string AccessToken, int ExpiresIn, string? DisplayName, string? Email);
+    private sealed record ErrorShape(string? Code, string? Message);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/IEnrolSessionRedeemer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/IEnrolSessionRedeemer.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Pwa.Services.Enrolment;
+
+/// <summary>
+/// Discriminated error codes mirroring the Tenant Service redeem endpoint's
+/// <c>RedeemEnrolSessionErrorCode</c>. PWA confirmation dialog + error
+/// surfaces switch on these.
+/// </summary>
+public enum EnrolRedeemErrorCode
+{
+    MalformedToken,
+    InvalidSignature,
+    ScopeMismatch,
+    AlreadyUsed,
+    Expired,
+    Network,
+}
+
+/// <summary>
+/// Outcome of a redeem call — success carries the citizen access token +
+/// the bound user's identifying details (which feed the confirmation
+/// dialog); failure carries a structured error code.
+/// </summary>
+public sealed record EnrolRedeemResult(
+    bool IsSuccess,
+    string? AccessToken,
+    int ExpiresInSeconds,
+    string? DisplayName,
+    string? Email,
+    EnrolRedeemErrorCode? ErrorCode,
+    string? ErrorMessage)
+{
+    public static EnrolRedeemResult Ok(string accessToken, int expiresIn, string displayName, string email) =>
+        new(true, accessToken, expiresIn, displayName, email, null, null);
+
+    public static EnrolRedeemResult Fail(EnrolRedeemErrorCode code, string message) =>
+        new(false, null, 0, null, null, code, message);
+}
+
+/// <summary>
+/// PWA-side client for <c>POST /api/auth/enrol-session/redeem</c>. Feature 126.
+/// Anonymous — the session token IS the credential for this single call.
+/// </summary>
+public interface IEnrolSessionRedeemer
+{
+    Task<EnrolRedeemResult> RedeemAsync(string sessionToken, CancellationToken ct = default);
+}

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/EnrolSessionEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/EnrolSessionEndpoints.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Sorcha.ServiceDefaults;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Endpoints;
+
+/// <summary>
+/// Enrolment-session HTTP surface for Feature 126.
+/// </summary>
+public static class EnrolSessionEndpoints
+{
+    /// <summary>
+    /// Maps <c>POST /api/auth/enrol-session</c> and
+    /// <c>POST /api/auth/enrol-session/redeem</c>.
+    /// </summary>
+    public static IEndpointRouteBuilder MapEnrolSessionEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/auth")
+            .WithTags("EnrolSession");
+
+        group.MapPost("/enrol-session", MintAsync)
+            .WithName("MintEnrolSession")
+            .WithSummary("Mint a one-time enrolment session token for the signed-in caller.")
+            .WithDescription(
+                "Returns a JWT scoped to 'enrol', a QR URL embedding the token, and the absolute "
+                + "expiry timestamp. The caller must be authenticated. Used by council pages to "
+                + "render the enrolment QR/link/paste affordance on the wallet-pairing surface.")
+            .RequireAuthorization()
+            .RequireRateLimiting(RateLimitPolicies.PlatformAuth)
+            .Produces<MintEnrolSessionResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+
+        group.MapPost("/enrol-session/redeem", RedeemAsync)
+            .WithName("RedeemEnrolSession")
+            .WithSummary("Redeem a one-time enrolment session token.")
+            .WithDescription(
+                "Anonymous (the token is the credential). Single-use: subsequent attempts to "
+                + "redeem the same token return 409. Returns the bound user's display name and "
+                + "email so the wallet PWA can surface a confirmation dialog before any device-"
+                + "pairing happens.")
+            .AllowAnonymous()
+            .RequireRateLimiting(RateLimitPolicies.PlatformAuth)
+            .Produces<RedeemEnrolSessionResponse>(StatusCodes.Status200OK)
+            .Produces<RedeemEnrolSessionErrorBody>(StatusCodes.Status400BadRequest)
+            .Produces<RedeemEnrolSessionErrorBody>(StatusCodes.Status409Conflict)
+            .Produces<RedeemEnrolSessionErrorBody>(StatusCodes.Status410Gone);
+
+        return app;
+    }
+
+    private static async Task<Results<Ok<MintEnrolSessionResponse>, UnauthorizedHttpResult>> MintAsync(
+        ClaimsPrincipal principal,
+        IEnrolSessionService service,
+        CancellationToken ct)
+    {
+        var platformUserId = ResolvePlatformUserId(principal);
+        if (platformUserId is null)
+        {
+            return TypedResults.Unauthorized();
+        }
+
+        var response = await service.MintAsync(platformUserId.Value, ct).ConfigureAwait(false);
+        return TypedResults.Ok(response);
+    }
+
+    private static async Task<IResult> RedeemAsync(
+        [FromBody] RedeemEnrolSessionRequest request,
+        IEnrolSessionService service,
+        CancellationToken ct)
+    {
+        if (request is null || string.IsNullOrWhiteSpace(request.SessionToken))
+        {
+            return TypedResults.BadRequest(new RedeemEnrolSessionErrorBody(
+                RedeemEnrolSessionErrorCode.MalformedToken,
+                "Session token is required."));
+        }
+
+        var result = await service.RedeemAsync(request.SessionToken, ct).ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            return TypedResults.Ok(result.Success);
+        }
+
+        return result.Error!.Code switch
+        {
+            RedeemEnrolSessionErrorCode.Expired => Results.Json(result.Error, statusCode: StatusCodes.Status410Gone),
+            RedeemEnrolSessionErrorCode.AlreadyUsed => Results.Json(result.Error, statusCode: StatusCodes.Status409Conflict),
+            _ => Results.Json(result.Error, statusCode: StatusCodes.Status400BadRequest),
+        };
+    }
+
+    private static Guid? ResolvePlatformUserId(ClaimsPrincipal principal)
+    {
+        var raw = principal.FindFirst("platform_user_id")?.Value;
+        return Guid.TryParse(raw, out var parsed) ? parsed : null;
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/EnrolSessionEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/EnrolSessionEndpoints.cs
@@ -54,7 +54,7 @@ public static class EnrolSessionEndpoints
         return app;
     }
 
-    private static async Task<Results<Ok<MintEnrolSessionResponse>, UnauthorizedHttpResult>> MintAsync(
+    internal static async Task<Results<Ok<MintEnrolSessionResponse>, UnauthorizedHttpResult>> MintAsync(
         ClaimsPrincipal principal,
         IEnrolSessionService service,
         CancellationToken ct)
@@ -69,7 +69,7 @@ public static class EnrolSessionEndpoints
         return TypedResults.Ok(response);
     }
 
-    private static async Task<IResult> RedeemAsync(
+    internal static async Task<IResult> RedeemAsync(
         [FromBody] RedeemEnrolSessionRequest request,
         IEnrolSessionService service,
         CancellationToken ct)

--- a/src/Services/Sorcha.Tenant.Service/Hubs/ITenantHubClient.cs
+++ b/src/Services/Sorcha.Tenant.Service/Hubs/ITenantHubClient.cs
@@ -43,5 +43,22 @@ public interface ITenantHubClient
     /// <param name="traceId">W3C trace-id for correlating across the bridge.</param>
     Task InboxUnreadCountUpdated(int unreadCount, DateTimeOffset occurredAt, string traceId);
 
+    /// <summary>
+    /// A new wallet device has been enrolled against the user's account.
+    /// Thin-signal: opaque IDs only; clients fetch full device detail via
+    /// <c>GET /api/v1/me/devices/{deviceId}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Published from <c>PlatformUserDeviceService.RegisterAsync</c> to the
+    /// <see cref="TenantHubGroups.User"/> group of the bound platform user.
+    /// Feature 126 — the council page subscribes to this event to advance
+    /// out of the "Waiting for your phone…" state when the citizen finishes
+    /// pairing on their wallet device. Idempotent: re-firing for the same
+    /// <c>(platformUserId, deviceId)</c> pair is a no-op for the council page.
+    /// </remarks>
+    /// <param name="platformUserId">Platform user that owns the device.</param>
+    /// <param name="deviceId">Id of the newly registered <c>PlatformUserDevice</c>.</param>
+    Task DeviceEnrolled(Guid platformUserId, Guid deviceId);
+
     // Membership / Security / System announcement events follow in a later phase.
 }

--- a/src/Services/Sorcha.Tenant.Service/Models/EnrolSessionDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/EnrolSessionDtos.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Tenant.Service.Models;
+
+/// <summary>
+/// Wire shape of a successful <c>POST /api/auth/enrol-session</c> response.
+/// Feature 126 — Sorcha Wallet enrolment inside a council application wizard.
+/// </summary>
+public sealed record MintEnrolSessionResponse(
+    string SessionToken,
+    string QrUrl,
+    DateTimeOffset ExpiresAt);
+
+/// <summary>
+/// Wire shape of the <c>POST /api/auth/enrol-session/redeem</c> request body.
+/// </summary>
+public sealed record RedeemEnrolSessionRequest(string SessionToken);
+
+/// <summary>
+/// Wire shape of a successful <c>POST /api/auth/enrol-session/redeem</c> response.
+/// The <see cref="DisplayName"/> and <see cref="Email"/> are surfaced by the
+/// wallet PWA's confirmation dialog before the device-pairing call.
+/// </summary>
+public sealed record RedeemEnrolSessionResponse(
+    string AccessToken,
+    int ExpiresIn,
+    string DisplayName,
+    string Email);
+
+/// <summary>
+/// Discriminated error codes for redeem failures. Mapped 1:1 to HTTP status:
+/// <see cref="MalformedToken"/> / <see cref="InvalidSignature"/> /
+/// <see cref="ScopeMismatch"/> → 400, <see cref="AlreadyUsed"/> → 409,
+/// <see cref="Expired"/> → 410.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<RedeemEnrolSessionErrorCode>))]
+public enum RedeemEnrolSessionErrorCode
+{
+    MalformedToken,
+    InvalidSignature,
+    ScopeMismatch,
+    AlreadyUsed,
+    Expired,
+}
+
+/// <summary>
+/// Wire shape of an unsuccessful <c>POST /api/auth/enrol-session/redeem</c> response.
+/// </summary>
+public sealed record RedeemEnrolSessionErrorBody(RedeemEnrolSessionErrorCode Code, string Message);

--- a/src/Services/Sorcha.Tenant.Service/Models/ReturnToAllowlistOptions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/ReturnToAllowlistOptions.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Tenant.Service.Models;
+
+/// <summary>
+/// Configuration shape for the trusted-return-to-URL allowlist used by
+/// Feature 116 signup endpoints when honouring <c>?returnTo=</c>.
+/// Feature 126 — research §R-004.
+/// </summary>
+/// <remarks>
+/// Matcher rules:
+/// <list type="bullet">
+///   <item><description>Scheme MUST be <c>https</c>, except <c>http://localhost</c> for dev.</description></item>
+///   <item><description>Host MUST be an exact match in <see cref="Hosts"/>, OR match a wildcard entry
+///   prefixed with <c>*.</c> as a suffix match (<c>api.strathcarron.gov</c> matches <c>*.strathcarron.gov</c>).</description></item>
+///   <item><description>Open-redirects fail closed — any malformed URL or unmatched host returns <c>false</c>.</description></item>
+/// </list>
+/// </remarks>
+public sealed class ReturnToAllowlistOptions
+{
+    /// <summary>Configuration section key.</summary>
+    public const string SectionName = "Auth:ReturnToAllowlist";
+
+    /// <summary>
+    /// The allowlisted hosts. Exact-host entries match the URI's <c>Host</c>
+    /// case-insensitively; entries prefixed with <c>*.</c> match any host
+    /// ending with the suffix (e.g. <c>*.strathcarron.gov</c> matches
+    /// <c>api.strathcarron.gov</c> but NOT <c>strathcarron.gov</c> itself).
+    /// </summary>
+    public IReadOnlyList<string> Hosts { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="returnTo"/> is a well-formed,
+    /// HTTPS-only (or <c>http://localhost</c>) absolute URL whose host matches
+    /// an entry in <see cref="Hosts"/>. Returns <c>false</c> for any malformed
+    /// input or unmatched host — fail closed.
+    /// </summary>
+    public bool IsAllowed(string? returnTo)
+    {
+        if (string.IsNullOrWhiteSpace(returnTo))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(returnTo, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        var isHttps = string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase);
+        var isLocalhostHttp = string.Equals(uri.Scheme, "http", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
+
+        if (!isHttps && !isLocalhostHttp)
+        {
+            return false;
+        }
+
+        foreach (var entry in Hosts)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+            {
+                continue;
+            }
+
+            if (entry.StartsWith("*.", StringComparison.Ordinal))
+            {
+                var suffix = entry.Substring(1); // ".strathcarron.gov"
+                if (uri.Host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            else if (string.Equals(uri.Host, entry, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -26,6 +26,7 @@ public class LoginModel : PageModel
     private readonly ILogger<LoginModel> _logger;
     private readonly DemoEnvironmentSettings _demoSettings;
     private readonly ISocialLoginService _socialLoginService;
+    private readonly ReturnToAllowlistOptions _returnToAllowlist;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginModel"/> class.
@@ -38,7 +39,8 @@ public class LoginModel : PageModel
         IOrganizationRepository organizationRepository,
         ILogger<LoginModel> logger,
         IOptions<DemoEnvironmentSettings> demoSettings,
-        ISocialLoginService socialLoginService)
+        ISocialLoginService socialLoginService,
+        IOptions<ReturnToAllowlistOptions> returnToAllowlist)
     {
         _loginService = loginService;
         _totpService = totpService;
@@ -48,6 +50,7 @@ public class LoginModel : PageModel
         _logger = logger;
         _demoSettings = demoSettings.Value;
         _socialLoginService = socialLoginService;
+        _returnToAllowlist = returnToAllowlist?.Value ?? new ReturnToAllowlistOptions();
     }
 
     /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
@@ -289,7 +292,7 @@ public class LoginModel : PageModel
 
     private IActionResult RedirectToApp(TokenResponse tokens)
     {
-        var returnUrl = IsValidReturnUrl(ReturnUrl) ? ReturnUrl : "";
+        var returnUrl = IsValidReturnUrl(ReturnUrl, _returnToAllowlist) ? ReturnUrl : "";
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
                        $"&refresh={Uri.EscapeDataString(tokens.RefreshToken)}";
         if (!string.IsNullOrEmpty(returnUrl))
@@ -299,9 +302,21 @@ public class LoginModel : PageModel
         return Redirect($"/app/#{fragment}");
     }
 
-    private static bool IsValidReturnUrl(string? url)
+    /// <summary>
+    /// Validates the return URL — accepts (a) internal relative paths and (b)
+    /// absolute URLs whose host matches the Feature 126 return-to allowlist
+    /// (so council pages can carry the citizen back to e.g. strathcarron.gov
+    /// after F116 signup completes).
+    /// </summary>
+    internal static bool IsValidReturnUrl(string? url, ReturnToAllowlistOptions allowlist)
     {
         if (string.IsNullOrEmpty(url)) return false;
-        return url.StartsWith('/') && !url.StartsWith("//");
+
+        // Internal relative path — the existing behaviour. Reject "//host" as
+        // a protocol-relative URL footgun.
+        if (url.StartsWith('/') && !url.StartsWith("//")) return true;
+
+        // Absolute URL — must match the allowlist. Open redirects fail closed.
+        return allowlist.IsAllowed(url);
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Signup.cshtml.cs
@@ -20,6 +20,7 @@ public class SignupModel : PageModel
     private readonly ILogger<SignupModel> _logger;
     private readonly DemoEnvironmentSettings _demoSettings;
     private readonly ISocialLoginService _socialLoginService;
+    private readonly ReturnToAllowlistOptions _returnToAllowlist;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SignupModel"/> class.
@@ -28,12 +29,14 @@ public class SignupModel : PageModel
         IRegistrationService registrationService,
         ILogger<SignupModel> logger,
         IOptions<DemoEnvironmentSettings> demoSettings,
-        ISocialLoginService socialLoginService)
+        ISocialLoginService socialLoginService,
+        IOptions<ReturnToAllowlistOptions> returnToAllowlist)
     {
         _registrationService = registrationService;
         _logger = logger;
         _demoSettings = demoSettings.Value;
         _socialLoginService = socialLoginService;
+        _returnToAllowlist = returnToAllowlist?.Value ?? new ReturnToAllowlistOptions();
     }
 
     /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
@@ -186,11 +189,29 @@ public class SignupModel : PageModel
     }
 
     /// <summary>
-    /// Validates a return URL to prevent open redirects.
+    /// Validates a return URL to prevent open redirects. Accepts internal
+    /// relative paths; rejects protocol-relative and absolute URLs.
     /// </summary>
+    /// <remarks>
+    /// Existing callers/tests use this signature; the Feature 126 overload
+    /// <see cref="IsValidReturnUrl(string?, ReturnToAllowlistOptions)"/> adds
+    /// allowlist-aware support for absolute council-page URLs.
+    /// </remarks>
     internal static bool IsValidReturnUrl(string? url)
     {
         if (string.IsNullOrEmpty(url)) return false;
         return url.StartsWith('/') && !url.StartsWith("//");
+    }
+
+    /// <summary>
+    /// Feature 126 — validates a return URL against the relative-only rules
+    /// PLUS the configured external-host allowlist. Council pages
+    /// (strathcarron.gov, *.strathcarron.gov, etc.) hit this path; everything
+    /// else falls back to the relative-only rule.
+    /// </summary>
+    internal static bool IsValidReturnUrl(string? url, ReturnToAllowlistOptions allowlist)
+    {
+        if (IsValidReturnUrl(url)) return true;
+        return allowlist.IsAllowed(url);
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Program.cs
+++ b/src/Services/Sorcha.Tenant.Service/Program.cs
@@ -5,9 +5,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.HttpOverrides;
 using Sorcha.AddressLookup;
+using Sorcha.AtomicCache.Extensions;
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Endpoints;
 using Sorcha.Tenant.Service.Hubs;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
 using Sorcha.ServiceClients.Extensions;
 using Sorcha.ServiceDefaults.Hubs;
 using Sorcha.ServiceDefaults.Storage;
@@ -145,6 +148,14 @@ builder.Services.AddHttpClient<Sorcha.Tenant.Service.Services.IPersonaCryptoClie
     client.BaseAddress = new Uri(walletBase);
 });
 
+// Feature 126: enrolment-session service + atomic single-use JTI registry.
+// AddAtomicDistributedCache is idempotent across services (Feature 113 primitive).
+builder.Services.AddAtomicDistributedCache(builder.Configuration, "Tenant");
+builder.Services.AddSingleton<EnrolSessionMetrics>();
+builder.Services.AddScoped<IEnrolSessionService, EnrolSessionService>();
+builder.Services.Configure<ReturnToAllowlistOptions>(
+    builder.Configuration.GetSection(ReturnToAllowlistOptions.SectionName));
+
 // Feature 103 US3: address lookup service + providers. postcodes.io is
 // registered as the default-on provider (no key, no rate limit, MIT). OS
 // Places is conditionally registered when Tenant:AddressLookup:OsPlaces:ApiKey
@@ -234,6 +245,7 @@ app.MapEventEndpoints();
 app.MapRegisterSubscriptionEndpoints();
 app.MapRegisterInvitationEndpoints();
 app.MapTrustEndpoints();
+app.MapEnrolSessionEndpoints();
 app.MapRazorPages();
 
 // Feature 118 — map TenantHub at /hubs/tenant (US2). Routed via API Gateway.

--- a/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionMetrics.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionMetrics.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// OpenTelemetry instruments for Feature 126 enrolment-session flow.
+/// Exposed on the <c>Sorcha.Enrolment</c> meter per research §R-010.
+/// </summary>
+public sealed class EnrolSessionMetrics : IDisposable
+{
+    /// <summary>The meter name surfaced on dashboards.</summary>
+    public const string MeterName = "Sorcha.Enrolment";
+
+    private readonly Meter _meter;
+
+    private readonly Counter<long> _sessionMinted;
+    private readonly Counter<long> _sessionRedeemed;
+    private readonly Histogram<double> _pairingSignalLatency;
+
+    public EnrolSessionMetrics(IMeterFactory factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _meter = factory.Create(MeterName);
+
+        _sessionMinted = _meter.CreateCounter<long>(
+            "sorcha_enrol_session_minted_total",
+            unit: "count",
+            description: "Enrolment session tokens minted, tagged by purpose.");
+
+        _sessionRedeemed = _meter.CreateCounter<long>(
+            "sorcha_enrol_session_redeemed_total",
+            unit: "count",
+            description: "Enrolment session redeem attempts, tagged by outcome.");
+
+        _pairingSignalLatency = _meter.CreateHistogram<double>(
+            "sorcha_enrol_pairing_signal_latency_seconds",
+            unit: "s",
+            description: "Latency from device registration to pairing-completion signal delivery.");
+    }
+
+    /// <summary>Records a successful mint with a purpose tag (e.g. <c>tier3_first_qr</c>, <c>regenerate</c>).</summary>
+    public void RecordMint(string purpose) =>
+        _sessionMinted.Add(1, KeyValuePair.Create<string, object?>("purpose", purpose));
+
+    /// <summary>
+    /// Records a redeem attempt with an outcome tag — one of
+    /// <c>success</c>, <c>expired</c>, <c>replay</c>, <c>scope_mismatch</c>,
+    /// <c>signature_fail</c>, <c>malformed</c>.
+    /// </summary>
+    public void RecordRedeem(string outcome) =>
+        _sessionRedeemed.Add(1, KeyValuePair.Create<string, object?>("outcome", outcome));
+
+    /// <summary>Records the pairing-signal latency in seconds, tagged by transport (<c>signalr</c> / <c>polling</c>).</summary>
+    public void RecordPairingSignalLatency(double seconds, string path) =>
+        _pairingSignalLatency.Record(seconds, KeyValuePair.Create<string, object?>("path", path));
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionService.cs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Sorcha.AtomicCache;
+using Sorcha.Tenant.Service.Extensions;
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// Mints and redeems one-time enrolment session tokens.
+/// Feature 126 — see <c>specs/126-enrol-inside-wizard/data-model.md</c>
+/// and <c>research.md §R-002/§R-003</c>.
+/// </summary>
+/// <remarks>
+/// Implementation notes:
+/// <list type="bullet">
+///   <item><description>The session JWT is signed with the same key as
+///   <see cref="TokenService"/> (HMAC-SHA256 over the configured signing
+///   key). It is identified by <c>scope: "enrol"</c> — the redeem endpoint
+///   rejects any token whose scope is not exactly that.</description></item>
+///   <item><description>Single-use is enforced by writing a sentinel value
+///   to <see cref="IAtomicDistributedCache"/> at mint time and consuming it
+///   atomically at redeem time via <see cref="IAtomicDistributedCache.GetAndRemoveAsync"/>.
+///   Absent-entry at redeem with a still-valid JWT means
+///   <see cref="RedeemEnrolSessionErrorCode.AlreadyUsed"/>.</description></item>
+///   <item><description>The redeem response's <c>displayName</c> + <c>email</c>
+///   are sourced fresh from <see cref="IPlatformUserService.GetByIdAsync"/>
+///   at redeem time, so they reflect the user's current profile rather than
+///   a stale cache from mint.</description></item>
+/// </list>
+/// </remarks>
+public sealed class EnrolSessionService : IEnrolSessionService
+{
+    /// <summary>Token scope claim value identifying these tokens.</summary>
+    public const string EnrolScope = "enrol";
+
+    /// <summary>Cache key prefix for the single-use JTI registry.</summary>
+    public const string JtiRegistryKeyPrefix = "sorcha:enrol-session:";
+
+    /// <summary>Token TTL — 10 minutes. Matches data-model.md §"One-time JWT (session token)".</summary>
+    public static readonly TimeSpan SessionTokenLifetime = TimeSpan.FromMinutes(10);
+
+    private readonly JwtConfiguration _jwtConfig;
+    private readonly IAtomicDistributedCache _cache;
+    private readonly IPlatformUserService _platformUserService;
+    private readonly EnrolSessionMetrics _metrics;
+    private readonly ILogger<EnrolSessionService> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly JwtSecurityTokenHandler _handler = new() { MapInboundClaims = false };
+    private readonly SymmetricSecurityKey _signingKey;
+    private readonly SigningCredentials _signingCreds;
+
+    /// <summary>Configuration key for the QR-URL council origin template.</summary>
+    public const string CouncilOriginConfigKey = "EnrolSession:CouncilOrigin";
+
+    private readonly string _councilOrigin;
+
+    public EnrolSessionService(
+        IOptions<JwtConfiguration> jwtOptions,
+        IAtomicDistributedCache cache,
+        IPlatformUserService platformUserService,
+        EnrolSessionMetrics metrics,
+        IConfiguration configuration,
+        TimeProvider timeProvider,
+        ILogger<EnrolSessionService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(jwtOptions);
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(platformUserService);
+        ArgumentNullException.ThrowIfNull(metrics);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _jwtConfig = jwtOptions.Value;
+        _cache = cache;
+        _platformUserService = platformUserService;
+        _metrics = metrics;
+        _timeProvider = timeProvider;
+        _logger = logger;
+
+        if (string.IsNullOrEmpty(_jwtConfig.SigningKey))
+        {
+            throw new InvalidOperationException(
+                "JwtSettings:SigningKey must be configured for EnrolSessionService to mint and validate session tokens.");
+        }
+
+        var keyBytes = Encoding.UTF8.GetBytes(_jwtConfig.SigningKey);
+        if (keyBytes.Length < 32)
+        {
+            Array.Resize(ref keyBytes, 32);
+        }
+        _signingKey = new SymmetricSecurityKey(keyBytes);
+        _signingCreds = new SigningCredentials(_signingKey, SecurityAlgorithms.HmacSha256);
+
+        _councilOrigin = configuration[CouncilOriginConfigKey]
+            ?? "https://strathcarron.gov";
+    }
+
+    /// <inheritdoc />
+    public async Task<MintEnrolSessionResponse> MintAsync(Guid platformUserId, CancellationToken ct)
+    {
+        if (platformUserId == Guid.Empty)
+        {
+            throw new ArgumentException("PlatformUserId must be non-empty.", nameof(platformUserId));
+        }
+
+        var jti = Guid.NewGuid().ToString("N");
+        var now = _timeProvider.GetUtcNow();
+        var expiresAt = now.Add(SessionTokenLifetime);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, platformUserId.ToString()),
+            new(JwtRegisteredClaimNames.Jti, jti),
+            new("scope", EnrolScope),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            IssuedAt = now.UtcDateTime,
+            NotBefore = now.UtcDateTime,
+            Expires = expiresAt.UtcDateTime,
+            Issuer = _jwtConfig.Issuer,
+            // Distinct audience so the standard auth pipeline never accepts these
+            // as a normal access token even by accident.
+            Audience = "sorcha:enrol-session",
+            SigningCredentials = _signingCreds,
+        };
+
+        var token = _handler.CreateToken(descriptor);
+        var jwt = _handler.WriteToken(token);
+
+        // Pre-write the sentinel so RedeemAsync's GetAndRemoveAsync enforces single-use.
+        var cacheKey = JtiRegistryKeyPrefix + jti;
+        await _cache.SetAsync(cacheKey, "pending", SessionTokenLifetime, ct).ConfigureAwait(false);
+
+        var qrUrl = $"{_councilOrigin.TrimEnd('/')}/wallet/enrol?session={jwt}";
+
+        _metrics.RecordMint("tier3_first_qr");
+        _logger.LogInformation(
+            "Minted enrol-session token (jti={Jti}, platformUserId={PlatformUserId}, exp={Exp:O})",
+            jti, platformUserId, expiresAt);
+
+        return new MintEnrolSessionResponse(jwt, qrUrl, expiresAt);
+    }
+
+    /// <inheritdoc />
+    public async Task<RedeemResult> RedeemAsync(string sessionToken, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(sessionToken))
+        {
+            _metrics.RecordRedeem("malformed");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Session token is required.");
+        }
+
+        // Parse without validation first so we can surface a clean
+        // malformed-vs-signature-fail distinction.
+        JwtSecurityToken parsed;
+        try
+        {
+            parsed = _handler.ReadJwtToken(sessionToken);
+        }
+        catch (ArgumentException)
+        {
+            _metrics.RecordRedeem("malformed");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token could not be parsed.");
+        }
+        catch (SecurityTokenException)
+        {
+            _metrics.RecordRedeem("malformed");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token could not be parsed.");
+        }
+
+        // Validate signature, issuer, audience — but NOT lifetime. We re-check
+        // expiry below using the injected TimeProvider so tests can drive
+        // expired-token paths deterministically.
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = _jwtConfig.Issuer,
+            ValidateAudience = true,
+            ValidAudience = "sorcha:enrol-session",
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = _signingKey,
+            ValidateLifetime = false,
+        };
+
+        ClaimsPrincipal principal;
+        try
+        {
+            principal = _handler.ValidateToken(sessionToken, validationParameters, out _);
+        }
+        catch (SecurityTokenInvalidSignatureException)
+        {
+            _metrics.RecordRedeem("signature_fail");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.InvalidSignature, "Signature did not validate.");
+        }
+        catch (SecurityTokenException)
+        {
+            _metrics.RecordRedeem("malformed");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token failed validation.");
+        }
+
+        // Explicit expiry check via TimeProvider.
+        var expClaim = principal.FindFirst(JwtRegisteredClaimNames.Exp)?.Value;
+        if (expClaim is null || !long.TryParse(expClaim, NumberStyles.Integer, CultureInfo.InvariantCulture, out var expEpoch))
+        {
+            _metrics.RecordRedeem("malformed");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token is missing exp claim.");
+        }
+
+        var expiresAt = DateTimeOffset.FromUnixTimeSeconds(expEpoch);
+        if (_timeProvider.GetUtcNow() >= expiresAt)
+        {
+            _metrics.RecordRedeem("expired");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.Expired, "Session token has expired.");
+        }
+
+        var scope = principal.FindFirst("scope")?.Value;
+        if (!string.Equals(scope, EnrolScope, StringComparison.Ordinal))
+        {
+            _metrics.RecordRedeem("scope_mismatch");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.ScopeMismatch, "Token scope does not permit enrolment.");
+        }
+
+        var sub = principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value;
+        var jti = principal.FindFirst(JwtRegisteredClaimNames.Jti)?.Value;
+        if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var platformUserId) || string.IsNullOrEmpty(jti))
+        {
+            _metrics.RecordRedeem("malformed");
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token is missing required claims.");
+        }
+
+        // Atomic single-use consume. Absent → already used (or expired but our
+        // cache TTL is wider than the JWT TTL so this is replay).
+        var cacheKey = JtiRegistryKeyPrefix + jti;
+        var sentinel = await _cache.GetAndRemoveAsync(cacheKey, ct).ConfigureAwait(false);
+        if (sentinel is null)
+        {
+            _metrics.RecordRedeem("replay");
+            _logger.LogWarning(
+                "Enrol-session redeem replay detected (jti={Jti}, platformUserId={PlatformUserId})",
+                jti, platformUserId);
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.AlreadyUsed, "Session token has already been used.");
+        }
+
+        // Look up fresh user details for the PWA confirmation dialog.
+        var user = await _platformUserService.GetByIdAsync(platformUserId, ct).ConfigureAwait(false);
+        if (user is null)
+        {
+            _metrics.RecordRedeem("malformed");
+            _logger.LogWarning(
+                "Enrol-session redeem failed — PlatformUser not found (jti={Jti}, platformUserId={PlatformUserId})",
+                jti, platformUserId);
+            return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Bound user no longer exists.");
+        }
+
+        var (accessToken, expiresInSeconds) = IssueCitizenAccessToken(user);
+
+        _metrics.RecordRedeem("success");
+        _logger.LogInformation(
+            "Enrol-session redeemed successfully (jti={Jti}, platformUserId={PlatformUserId})",
+            jti, platformUserId);
+
+        return RedeemResult.Ok(new RedeemEnrolSessionResponse(
+            AccessToken: accessToken,
+            ExpiresIn: expiresInSeconds,
+            DisplayName: user.DisplayName ?? user.Email,
+            Email: user.Email));
+    }
+
+    private (string AccessToken, int ExpiresInSeconds) IssueCitizenAccessToken(PlatformUser user)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var lifetimeMinutes = _jwtConfig.AccessTokenLifetimeMinutes;
+        var expires = now.AddMinutes(lifetimeMinutes);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new("name", user.DisplayName ?? user.Email),
+            new("platform_user_id", user.Id.ToString()),
+            new("token_use", "access"),
+        };
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            IssuedAt = now.UtcDateTime,
+            NotBefore = now.UtcDateTime,
+            Expires = expires.UtcDateTime,
+            Issuer = _jwtConfig.Issuer,
+            Audience = _jwtConfig.Audiences.FirstOrDefault() ?? "sorcha:citizen-wallet",
+            SigningCredentials = _signingCreds,
+        };
+
+        var token = _handler.CreateToken(descriptor);
+        var jwt = _handler.WriteToken(token);
+        var expiresIn = (int)((expires - now).TotalSeconds);
+        return (jwt, expiresIn);
+    }
+}

--- a/src/Services/Sorcha.Tenant.Service/Services/IEnrolSessionService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IEnrolSessionService.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Services;
+
+/// <summary>
+/// Result of an <see cref="IEnrolSessionService.RedeemAsync"/> attempt.
+/// Discriminated union: either <see cref="Success"/> is non-null (HTTP 200)
+/// or <see cref="Error"/> is non-null (HTTP 400/409/410).
+/// </summary>
+public sealed record RedeemResult(
+    RedeemEnrolSessionResponse? Success,
+    RedeemEnrolSessionErrorBody? Error)
+{
+    public static RedeemResult Ok(RedeemEnrolSessionResponse response) => new(response, null);
+    public static RedeemResult Fail(RedeemEnrolSessionErrorCode code, string message) =>
+        new(null, new RedeemEnrolSessionErrorBody(code, message));
+
+    public bool IsSuccess => Success is not null;
+}
+
+/// <summary>
+/// Mints and redeems one-time enrolment session tokens binding a Sorcha
+/// account to an upcoming wallet device-pairing call. Feature 126.
+/// </summary>
+public interface IEnrolSessionService
+{
+    /// <summary>
+    /// Mints a fresh session token bound to <paramref name="platformUserId"/>.
+    /// 10-minute lifetime, single-use, scope <c>"enrol"</c>.
+    /// </summary>
+    Task<MintEnrolSessionResponse> MintAsync(Guid platformUserId, CancellationToken ct);
+
+    /// <summary>
+    /// Validates and consumes <paramref name="sessionToken"/>. Returns the bound
+    /// user's identifying details + a freshly minted full citizen access token
+    /// on first redeem; subsequent redeems return <see cref="RedeemEnrolSessionErrorCode.AlreadyUsed"/>.
+    /// </summary>
+    Task<RedeemResult> RedeemAsync(string sessionToken, CancellationToken ct);
+}

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserDeviceService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserDeviceService.cs
@@ -17,14 +17,21 @@ namespace Sorcha.Tenant.Service.Services;
 public sealed class PlatformUserDeviceService : IPlatformUserDeviceService
 {
     private readonly TenantDbContext _db;
-    private readonly IHubContext<TenantHub, ITenantHubClient>? _hubContext;
+    private readonly IHubContext<TenantHub>? _hubContext;
     private readonly ILogger<PlatformUserDeviceService> _logger;
 
     /// <summary>Initialises a new instance of the <see cref="PlatformUserDeviceService"/> class.</summary>
+    /// <remarks>
+    /// Uses the untyped <see cref="IHubContext{THub}"/> overload to match
+    /// <see cref="InboxService"/>'s thin-signal emit pattern (Feature 118).
+    /// Subscribers wire on the method name <c>DeviceEnrolled</c> per the
+    /// typed <see cref="ITenantHubClient"/> contract — wire shape is the same
+    /// either way.
+    /// </remarks>
     public PlatformUserDeviceService(
         TenantDbContext db,
         ILogger<PlatformUserDeviceService> logger,
-        IHubContext<TenantHub, ITenantHubClient>? hubContext = null)
+        IHubContext<TenantHub>? hubContext = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -96,6 +103,12 @@ public sealed class PlatformUserDeviceService : IPlatformUserDeviceService
                 "thumbprint={Thumbprint}) — idempotent enrolment retry",
                 existing.Id, platformUserId, devicePublicJwkThumbprint);
 
+            // Feature 126: republish on idempotent retry so a council page
+            // that missed the original event (refresh, hub disconnect during
+            // first enrolment) still advances. Subscribers tolerate the
+            // repeat — data-model.md §"DeviceEnrolled" calls this out.
+            await PublishDeviceEnrolledAsync(platformUserId, existing.Id, ct).ConfigureAwait(false);
+
             return existing;
         }
 
@@ -144,7 +157,7 @@ public sealed class PlatformUserDeviceService : IPlatformUserDeviceService
         {
             await _hubContext.Clients
                 .Group(TenantHubGroups.User(platformUserId))
-                .DeviceEnrolled(platformUserId, deviceId)
+                .SendAsync("DeviceEnrolled", platformUserId, deviceId, ct)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserDeviceService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserDeviceService.cs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Hubs;
 using Sorcha.Tenant.Service.Models;
 
 namespace Sorcha.Tenant.Service.Services;
@@ -15,13 +17,21 @@ namespace Sorcha.Tenant.Service.Services;
 public sealed class PlatformUserDeviceService : IPlatformUserDeviceService
 {
     private readonly TenantDbContext _db;
+    private readonly IHubContext<TenantHub, ITenantHubClient>? _hubContext;
     private readonly ILogger<PlatformUserDeviceService> _logger;
 
     /// <summary>Initialises a new instance of the <see cref="PlatformUserDeviceService"/> class.</summary>
-    public PlatformUserDeviceService(TenantDbContext db, ILogger<PlatformUserDeviceService> logger)
+    public PlatformUserDeviceService(
+        TenantDbContext db,
+        ILogger<PlatformUserDeviceService> logger,
+        IHubContext<TenantHub, ITenantHubClient>? hubContext = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        // Hub context is optional so unit tests without SignalR wiring can
+        // construct the service directly. Production registration is via
+        // AddSorchaHub which guarantees the hub context exists.
+        _hubContext = hubContext;
     }
 
     /// <inheritdoc />
@@ -115,7 +125,35 @@ public sealed class PlatformUserDeviceService : IPlatformUserDeviceService
             "platform={Platform}, statusList={StatusListId}#{StatusListIndex}, exp={Exp:O})",
             device.Id, platformUserId, platform, statusListId, statusListIndex, delegationExpiresAt);
 
+        // Feature 126: notify any subscribed council pages that this user's
+        // wallet device is now enrolled. Try/log/swallow — a hub-publish
+        // failure must not fail the device registration.
+        await PublishDeviceEnrolledAsync(platformUserId, device.Id, ct).ConfigureAwait(false);
+
         return device;
+    }
+
+    private async Task PublishDeviceEnrolledAsync(Guid platformUserId, Guid deviceId, CancellationToken ct)
+    {
+        if (_hubContext is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _hubContext.Clients
+                .Group(TenantHubGroups.User(platformUserId))
+                .DeviceEnrolled(platformUserId, deviceId)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to publish TenantHub.DeviceEnrolled (platformUser={PlatformUserId}, device={DeviceId}) — registration committed regardless",
+                platformUserId, deviceId);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Services/Sorcha.Tenant.Service/Sorcha.Tenant.Service.csproj
+++ b/src/Services/Sorcha.Tenant.Service/Sorcha.Tenant.Service.csproj
@@ -49,6 +49,7 @@
     <ProjectReference Include="..\..\Common\Sorcha.ServiceDefaults\Sorcha.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.Tenant.Models\Sorcha.Tenant.Models.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.AddressLookup\Sorcha.AddressLookup.csproj" />
+    <ProjectReference Include="..\..\Common\Sorcha.AtomicCache\Sorcha.AtomicCache.csproj" />
     <ProjectReference Include="..\..\Common\Sorcha.CitizenWallet.Abstractions\Sorcha.CitizenWallet.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Services/Sorcha.Tenant.Service/appsettings.Development.json
+++ b/src/Services/Sorcha.Tenant.Service/appsettings.Development.json
@@ -58,6 +58,17 @@
     "ZipkinEndpoint": "http://localhost:9411/api/v2/spans"
   },
 
+  "Auth": {
+    "ReturnToAllowlist": {
+      "Hosts": [
+        "localhost",
+        "n1.sorcha.dev",
+        "strathcarron.gov",
+        "*.strathcarron.gov"
+      ]
+    }
+  },
+
   "Security": {
     "Lockout": {
       "Tier1Threshold": 50,

--- a/src/Services/Sorcha.Tenant.Service/appsettings.json
+++ b/src/Services/Sorcha.Tenant.Service/appsettings.json
@@ -88,5 +88,16 @@
     "DefaultCaValidityYears": 10,
     "DefaultOrgCertValidityYears": 2,
     "CrlRefreshHours": 24
+  },
+
+  "Auth": {
+    "ReturnToAllowlist": {
+      "Hosts": [
+        "localhost",
+        "n1.sorcha.dev",
+        "strathcarron.gov",
+        "*.strathcarron.gov"
+      ]
+    }
   }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/EnrolSessionEndpointsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/EnrolSessionEndpointsTests.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using Sorcha.Tenant.Service.Endpoints;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+/// <summary>
+/// Handler-level tests for <see cref="EnrolSessionEndpoints"/>. Exercises the
+/// platform_user_id claim resolution + DTO error-code-to-HTTP-status mapping
+/// without spinning up a full WebApplicationFactory. The actual mint/redeem
+/// semantics are covered by <c>EnrolSessionServiceTests</c>.
+/// </summary>
+public sealed class EnrolSessionEndpointsTests
+{
+    [Fact]
+    public async Task MintAsync_Anonymous_Caller_Returns_Unauthorized()
+    {
+        var service = new Mock<IEnrolSessionService>(MockBehavior.Strict);
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity()); // no platform_user_id
+        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedHttpResult>();
+        service.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task MintAsync_With_PlatformUserId_Claim_Returns_Ok()
+    {
+        var pu = Guid.NewGuid();
+        var minted = new MintEnrolSessionResponse(
+            "jwt-string",
+            $"https://strathcarron.gov/wallet/enrol?session=jwt-string",
+            DateTimeOffset.UtcNow.AddMinutes(10));
+
+        var service = new Mock<IEnrolSessionService>();
+        service.Setup(s => s.MintAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(minted);
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("platform_user_id", pu.ToString())
+        }));
+
+        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, CancellationToken.None);
+
+        result.Result.Should().BeOfType<Ok<MintEnrolSessionResponse>>();
+        var ok = (Ok<MintEnrolSessionResponse>)result.Result;
+        ok.Value!.SessionToken.Should().Be("jwt-string");
+    }
+
+    [Fact]
+    public async Task MintAsync_With_Malformed_PlatformUserId_Returns_Unauthorized()
+    {
+        var service = new Mock<IEnrolSessionService>(MockBehavior.Strict);
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("platform_user_id", "not-a-guid")
+        }));
+
+        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, CancellationToken.None);
+
+        result.Result.Should().BeOfType<UnauthorizedHttpResult>();
+        service.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Happy_Path_Returns_Ok()
+    {
+        var service = new Mock<IEnrolSessionService>();
+        var redeemed = new RedeemEnrolSessionResponse("access-jwt", 3600, "Sarah", "sarah@example.test");
+        service.Setup(s => s.RedeemAsync("the-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RedeemResult.Ok(redeemed));
+
+        var result = await EnrolSessionEndpoints.RedeemAsync(
+            new RedeemEnrolSessionRequest("the-token"), service.Object, CancellationToken.None);
+
+        var ok = result.Should().BeOfType<Ok<RedeemEnrolSessionResponse>>().Subject;
+        ok.Value!.AccessToken.Should().Be("access-jwt");
+        ok.Value.DisplayName.Should().Be("Sarah");
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Replay_Maps_To_409()
+    {
+        var service = new Mock<IEnrolSessionService>();
+        service.Setup(s => s.RedeemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RedeemResult.Fail(RedeemEnrolSessionErrorCode.AlreadyUsed, "already used"));
+
+        var result = await EnrolSessionEndpoints.RedeemAsync(
+            new RedeemEnrolSessionRequest("the-token"), service.Object, CancellationToken.None);
+
+        AssertJsonStatus(result, StatusCodes.Status409Conflict, RedeemEnrolSessionErrorCode.AlreadyUsed);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Expired_Maps_To_410()
+    {
+        var service = new Mock<IEnrolSessionService>();
+        service.Setup(s => s.RedeemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RedeemResult.Fail(RedeemEnrolSessionErrorCode.Expired, "expired"));
+
+        var result = await EnrolSessionEndpoints.RedeemAsync(
+            new RedeemEnrolSessionRequest("the-token"), service.Object, CancellationToken.None);
+
+        AssertJsonStatus(result, StatusCodes.Status410Gone, RedeemEnrolSessionErrorCode.Expired);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Scope_Mismatch_Maps_To_400()
+    {
+        var service = new Mock<IEnrolSessionService>();
+        service.Setup(s => s.RedeemAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RedeemResult.Fail(RedeemEnrolSessionErrorCode.ScopeMismatch, "scope mismatch"));
+
+        var result = await EnrolSessionEndpoints.RedeemAsync(
+            new RedeemEnrolSessionRequest("the-token"), service.Object, CancellationToken.None);
+
+        AssertJsonStatus(result, StatusCodes.Status400BadRequest, RedeemEnrolSessionErrorCode.ScopeMismatch);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Empty_Token_Returns_400_Without_Calling_Service()
+    {
+        var service = new Mock<IEnrolSessionService>(MockBehavior.Strict);
+
+        var result = await EnrolSessionEndpoints.RedeemAsync(
+            new RedeemEnrolSessionRequest(""), service.Object, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequest<RedeemEnrolSessionErrorBody>>();
+        service.VerifyNoOtherCalls();
+    }
+
+    private static void AssertJsonStatus(IResult result, int expectedStatus, RedeemEnrolSessionErrorCode expectedCode)
+    {
+        // Results.Json returns a JsonHttpResult<T> with the StatusCode property set.
+        var status = result.GetType().GetProperty("StatusCode")?.GetValue(result) as int?;
+        status.Should().Be(expectedStatus);
+
+        var value = result.GetType().GetProperty("Value")?.GetValue(result);
+        value.Should().BeOfType<RedeemEnrolSessionErrorBody>();
+        ((RedeemEnrolSessionErrorBody)value!).Code.Should().Be(expectedCode);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Hubs/TenantHubDeviceEnrolledTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Hubs/TenantHubDeviceEnrolledTests.cs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Hubs;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Hubs;
+
+/// <summary>
+/// Feature 126 — verifies <see cref="PlatformUserDeviceService.RegisterAsync"/>
+/// emits <c>DeviceEnrolled(platformUserId, deviceId)</c> on the per-user
+/// TenantHub group with the thin-signal payload contract (opaque IDs only).
+/// </summary>
+public sealed class TenantHubDeviceEnrolledTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly TenantDbContext _db;
+
+    private readonly Mock<IHubContext<TenantHub>> _hub = new();
+    private readonly Mock<IHubClients> _clients = new();
+    private readonly Mock<IClientProxy> _group = new();
+    private readonly List<(string Method, object?[] Args)> _emits = new();
+
+    public TenantHubDeviceEnrolledTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<TenantDbContext>().UseSqlite(_connection).Options;
+        _db = new TenantDbContext(options);
+        _db.Database.EnsureCreated();
+
+        _hub.Setup(h => h.Clients).Returns(_clients.Object);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_group.Object);
+        _group
+            .Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((m, a, _) => _emits.Add((m, a)))
+            .Returns(Task.CompletedTask);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _connection.Dispose();
+    }
+
+    private async Task<Guid> SeedPlatformUserAsync()
+    {
+        var pu = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = $"u-{Guid.NewGuid():N}@test.com",
+            DisplayName = "Test User",
+        };
+        _db.PlatformUsers.Add(pu);
+        await _db.SaveChangesAsync();
+        return pu.Id;
+    }
+
+    [Fact]
+    public async Task RegisterAsync_NewDevice_Emits_DeviceEnrolled_On_User_Group_With_Thin_Payload()
+    {
+        var platformUserId = await SeedPlatformUserAsync();
+        var service = new PlatformUserDeviceService(_db, NullLogger<PlatformUserDeviceService>.Instance, _hub.Object);
+
+        var device = await service.RegisterAsync(
+            platformUserId,
+            label: "Sarah's phone",
+            devicePublicJwkThumbprint: new string('a', 43),
+            devicePublicJwkJson: """{"kty":"OKP"}""",
+            platform: "iOS",
+            userAgent: "WalletPWA/1",
+            delegationExpiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            delegationCredentialJti: "jti-123",
+            statusListId: 1,
+            statusListIndex: 1);
+
+        _clients.Verify(c => c.Group(TenantHubGroups.User(platformUserId)), Times.Once,
+            "publish must target the bound platform user's group, never SystemAll or another user");
+
+        _emits.Should().ContainSingle(e => e.Method == "DeviceEnrolled");
+        var fire = _emits.Single(e => e.Method == "DeviceEnrolled");
+        fire.Args.Should().HaveCount(2, "thin-signal: platformUserId + deviceId, no domain payload");
+        fire.Args[0].Should().BeOfType<Guid>().Which.Should().Be(platformUserId);
+        fire.Args[1].Should().BeOfType<Guid>().Which.Should().Be(device.Id);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Idempotent_Reregistration_Still_Emits()
+    {
+        // Idempotent re-register (same thumbprint) keeps the original deviceId.
+        // The current behaviour re-publishes on every successful Register call;
+        // this is intentional and the council page tolerates the repeat
+        // (DeviceEnrolled handler is idempotent on the consumer side).
+        var platformUserId = await SeedPlatformUserAsync();
+        var service = new PlatformUserDeviceService(_db, NullLogger<PlatformUserDeviceService>.Instance, _hub.Object);
+        var thumbprint = new string('b', 43);
+
+        var first = await service.RegisterAsync(
+            platformUserId, "phone", thumbprint, """{"kty":"OKP"}""", "iOS", "ua",
+            DateTimeOffset.UtcNow.AddDays(30), "jti-1", 1, 1);
+        _emits.Clear();
+
+        var second = await service.RegisterAsync(
+            platformUserId, "phone", thumbprint, """{"kty":"OKP"}""", "iOS", "ua",
+            DateTimeOffset.UtcNow.AddDays(30), "jti-2", 1, 2);
+
+        second.Id.Should().Be(first.Id, "idempotent upsert preserves deviceId");
+        _emits.Should().ContainSingle(e => e.Method == "DeviceEnrolled");
+        _emits.Single().Args[1].Should().Be(first.Id);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_Hub_Publish_Failure_Does_Not_Fail_Registration()
+    {
+        var platformUserId = await SeedPlatformUserAsync();
+        _group.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("hub fell over"));
+
+        var service = new PlatformUserDeviceService(_db, NullLogger<PlatformUserDeviceService>.Instance, _hub.Object);
+
+        var device = await service.RegisterAsync(
+            platformUserId, "phone", new string('c', 43), """{"kty":"OKP"}""", "iOS", "ua",
+            DateTimeOffset.UtcNow.AddDays(30), "jti-x", 1, 1);
+
+        device.Should().NotBeNull("hub publish failure must not cascade to the device write");
+        var persisted = await _db.PlatformUserDevices.SingleOrDefaultAsync(d => d.Id == device.Id);
+        persisted.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_With_No_HubContext_Skips_Publish_Cleanly()
+    {
+        // Unit-test path — hub context not provided. Registration must still
+        // succeed without throwing.
+        var service = new PlatformUserDeviceService(_db, NullLogger<PlatformUserDeviceService>.Instance);
+        var pu = await SeedPlatformUserAsync();
+
+        var device = await service.RegisterAsync(
+            pu, "phone", new string('d', 43), """{"kty":"OKP"}""", "iOS", "ua",
+            DateTimeOffset.UtcNow.AddDays(30), "jti-y", 1, 1);
+
+        device.Should().NotBeNull();
+        _emits.Should().BeEmpty();
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Models/ReturnToAllowlistOptionsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Models/ReturnToAllowlistOptionsTests.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Tenant.Service.Models;
+
+namespace Sorcha.Tenant.Service.Tests.Models;
+
+/// <summary>
+/// Feature 126 — return-to allowlist validator. Covers research §R-004's
+/// matcher rules: HTTPS-only (with localhost http exception), exact-host or
+/// <c>*.host</c> suffix match, fail-closed on every malformed input.
+/// </summary>
+public sealed class ReturnToAllowlistOptionsTests
+{
+    private static ReturnToAllowlistOptions WithHosts(params string[] hosts) =>
+        new() { Hosts = hosts };
+
+    [Fact]
+    public void IsAllowed_ExactHttpsHost_Matches() =>
+        WithHosts("strathcarron.gov").IsAllowed("https://strathcarron.gov/services/driving-licence")
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsAllowed_WildcardSubdomain_Matches() =>
+        WithHosts("*.strathcarron.gov").IsAllowed("https://api.strathcarron.gov/page")
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsAllowed_WildcardSubdomain_DoesNotMatch_BareApex() =>
+        WithHosts("*.strathcarron.gov").IsAllowed("https://strathcarron.gov/page")
+            .Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_HttpLocalhost_Allowed_For_Dev() =>
+        WithHosts("localhost").IsAllowed("http://localhost/wallet").Should().BeTrue();
+
+    [Fact]
+    public void IsAllowed_HttpNonLocalhost_Rejected() =>
+        WithHosts("strathcarron.gov").IsAllowed("http://strathcarron.gov/page").Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_MalformedUrl_Rejected() =>
+        WithHosts("strathcarron.gov").IsAllowed("not-a-url").Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_NullOrEmpty_Rejected()
+    {
+        var opts = WithHosts("strathcarron.gov");
+        opts.IsAllowed(null).Should().BeFalse();
+        opts.IsAllowed("").Should().BeFalse();
+        opts.IsAllowed("   ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAllowed_UnknownHost_Rejected() =>
+        WithHosts("strathcarron.gov").IsAllowed("https://attacker.example/redirect")
+            .Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_HostMatch_CaseInsensitive() =>
+        WithHosts("Strathcarron.gov").IsAllowed("https://strathcarron.gov/page")
+            .Should().BeTrue();
+
+    [Fact]
+    public void IsAllowed_EmptyAllowlist_Rejects_All() =>
+        WithHosts().IsAllowed("https://strathcarron.gov/page").Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_RelativeUrl_Rejected() =>
+        WithHosts("strathcarron.gov").IsAllowed("/page").Should().BeFalse();
+
+    [Fact]
+    public void IsAllowed_FileScheme_Rejected() =>
+        WithHosts("strathcarron.gov").IsAllowed("file:///etc/passwd").Should().BeFalse();
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
@@ -39,7 +39,8 @@ public class LoginModelTests
             _orgRepo.Object,
             NullLogger<LoginModel>.Instance,
             Options.Create(new DemoEnvironmentSettings()),
-            _socialLoginService.Object);
+            _socialLoginService.Object,
+            Options.Create(new ReturnToAllowlistOptions()));
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SignupModelTests.cs
@@ -29,7 +29,8 @@ public class SignupModelTests
             _registrationService.Object,
             NullLogger<SignupModel>.Instance,
             Options.Create(new DemoEnvironmentSettings()),
-            _socialLoginService.Object);
+            _socialLoginService.Object,
+            Options.Create(new ReturnToAllowlistOptions()));
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(

--- a/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionServiceTests.cs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Sorcha.AtomicCache;
+using Sorcha.Tenant.Service.Extensions;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="EnrolSessionService"/>. Covers mint claims, single-use
+/// redeem semantics, expired-token rejection, scope-mismatch, and replay.
+/// </summary>
+public sealed class EnrolSessionServiceTests
+{
+    private const string SigningKey = "test-signing-key-must-be-at-least-32-bytes-long-padded-out";
+
+    private readonly InMemoryAtomicDistributedCache _cache = new();
+    private readonly FakeTimeProvider _time = new();
+    private readonly Mock<IPlatformUserService> _platformUserService = new();
+    private readonly EnrolSessionMetrics _metrics;
+    private readonly EnrolSessionService _service;
+
+    public EnrolSessionServiceTests()
+    {
+        var jwt = new JwtConfiguration
+        {
+            Issuer = "https://test.sorcha",
+            Audiences = new[] { "sorcha:citizen-wallet" },
+            SigningKey = SigningKey,
+            AccessTokenLifetimeMinutes = 60,
+        };
+        var jwtOptions = Options.Create(jwt);
+        var config = new ConfigurationBuilder().Build();
+
+        _metrics = new EnrolSessionMetrics(new TestMeterFactory());
+        _service = new EnrolSessionService(
+            jwtOptions, _cache, _platformUserService.Object, _metrics,
+            config, _time, NullLogger<EnrolSessionService>.Instance);
+    }
+
+    [Fact]
+    public async Task MintAsync_Issues_JWT_With_Enrol_Scope_And_10_Minute_TTL()
+    {
+        var pu = Guid.NewGuid();
+        var now = DateTimeOffset.UtcNow;
+        _time.SetUtcNow(now);
+
+        var response = await _service.MintAsync(pu, CancellationToken.None);
+
+        response.SessionToken.Should().NotBeNullOrWhiteSpace();
+        response.QrUrl.Should().Contain($"session={response.SessionToken}");
+        response.ExpiresAt.Should().BeCloseTo(now.AddMinutes(10), TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Happy_Path_Returns_DisplayName_And_Email()
+    {
+        var pu = Guid.NewGuid();
+        var user = new PlatformUser { Id = pu, Email = "sarah@example.test", DisplayName = "Sarah Example" };
+        _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var redeem = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+
+        redeem.IsSuccess.Should().BeTrue();
+        redeem.Success!.DisplayName.Should().Be("Sarah Example");
+        redeem.Success.Email.Should().Be("sarah@example.test");
+        redeem.Success.AccessToken.Should().NotBeNullOrWhiteSpace();
+        redeem.Success.ExpiresIn.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Replay_Returns_AlreadyUsed()
+    {
+        var pu = Guid.NewGuid();
+        var user = new PlatformUser { Id = pu, Email = "s@e.test", DisplayName = "S" };
+        _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var first = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+        first.IsSuccess.Should().BeTrue();
+
+        var second = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+        second.IsSuccess.Should().BeFalse();
+        second.Error!.Code.Should().Be(RedeemEnrolSessionErrorCode.AlreadyUsed);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Expired_Token_Returns_Expired()
+    {
+        var pu = Guid.NewGuid();
+        _time.SetUtcNow(DateTimeOffset.UtcNow);
+        var mint = await _service.MintAsync(pu, CancellationToken.None);
+
+        _time.Advance(TimeSpan.FromMinutes(11));
+
+        var result = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be(RedeemEnrolSessionErrorCode.Expired);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Malformed_Token_Returns_MalformedToken()
+    {
+        var result = await _service.RedeemAsync("not-a-jwt", CancellationToken.None);
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be(RedeemEnrolSessionErrorCode.MalformedToken);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Empty_Token_Returns_MalformedToken()
+    {
+        var result = await _service.RedeemAsync("", CancellationToken.None);
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be(RedeemEnrolSessionErrorCode.MalformedToken);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Tampered_Signature_Returns_InvalidSignature()
+    {
+        var pu = Guid.NewGuid();
+        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var tampered = mint.SessionToken.Substring(0, mint.SessionToken.Length - 4) + "AAAA";
+
+        var result = await _service.RedeemAsync(tampered, CancellationToken.None);
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().BeOneOf(
+            RedeemEnrolSessionErrorCode.InvalidSignature,
+            RedeemEnrolSessionErrorCode.MalformedToken);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_When_PlatformUser_Missing_Returns_MalformedToken()
+    {
+        var pu = Guid.NewGuid();
+        _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformUser?)null);
+
+        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var result = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be(RedeemEnrolSessionErrorCode.MalformedToken);
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UtcNow;
+        public void SetUtcNow(DateTimeOffset value) => _now = value;
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+        public void Dispose() { }
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Sorcha.Tenant.Service.Tests.csproj
+++ b/tests/Sorcha.Tenant.Service.Tests/Sorcha.Tenant.Service.Tests.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Services\Sorcha.Tenant.Service\Sorcha.Tenant.Service.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.AtomicCache\Sorcha.AtomicCache.csproj" />
     <ProjectReference Include="..\..\src\Common\Sorcha.Tenant.Models\Sorcha.Tenant.Models.csproj" />
     <ProjectReference Include="..\..\src\Common\Sorcha.ServiceClients\Sorcha.ServiceClients.csproj" />
   </ItemGroup>

--- a/tests/Sorcha.UI.Core.Tests/Components/EnrolGate/EnrolGateComponentTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/EnrolGate/EnrolGateComponentTests.cs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Core.Components.EnrolGate;
+using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.User.Enrolment;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.EnrolGate;
+
+/// <summary>
+/// bunit component tests for Feature 126's EnrolGate surfaces. Verifies
+/// tier branching, the FastPath / OnReady contract, and the
+/// PreflightSignupSurface + HybridQrAffordance render contracts that
+/// downstream consumers + the cold-start E2E rely on.
+/// </summary>
+public sealed class EnrolGateComponentTests : BunitContext
+{
+    private readonly Mock<ITierProbeService> _probe = new();
+    private readonly Mock<IEnrolPairingSignal> _signal = new();
+    private readonly Mock<IQrPresentationService> _qr = new();
+
+    public EnrolGateComponentTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(_probe.Object);
+        Services.AddSingleton(_signal.Object);
+        Services.AddSingleton(_qr.Object);
+        // HttpClient that immediately returns a synthetic whoami payload —
+        // EnrolGateComponent.ResolveBoundPlatformUserIdAsync calls
+        // GET /api/auth/whoami when tier != ColdStart.
+        Services.AddSingleton(new HttpClient(new StubHandler())
+        {
+            BaseAddress = new Uri("http://test.local")
+        });
+
+        _qr.Setup(q => q.GenerateSvgFromUri(It.IsAny<string>(), It.IsAny<int>()))
+            .Returns("<svg data-testid=\"stub-qr\"/>");
+
+        // EnrolPairingSignal is started by WalletPairingSurface — make it a no-op.
+        _signal.Setup(s => s.StartAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _signal.Setup(s => s.StopAsync()).Returns(Task.CompletedTask);
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"platformUserId\":\"00000000-0000-0000-0000-000000000001\",\"sessionToken\":\"jwt\",\"qrUrl\":\"http://x/?session=jwt\",\"expiresAt\":\"2030-01-01T00:00:00Z\"}",
+                    System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    [Fact]
+    public void FastPath_Tier_Renders_ChildContent_And_Fires_OnReady()
+    {
+        _probe.Setup(p => p.ProbeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(CitizenTier.FastPath);
+        Guid? readyForUser = null;
+        var readyFired = false;
+
+        var cut = Render<EnrolGateComponent>(parameters => parameters
+            .Add(p => p.CouncilName, "Strathcarron Council")
+            .Add(p => p.OnReady, EventCallback.Factory.Create<Guid?>(this, (Guid? id) =>
+            {
+                readyForUser = id;
+                readyFired = true;
+            }))
+            .AddChildContent("<div data-testid=\"form-rendered\">application form</div>"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("data-testid=\"form-rendered\"");
+            readyFired.Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public void ColdStart_Tier_Renders_PreflightSignupSurface()
+    {
+        _probe.Setup(p => p.ProbeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(CitizenTier.ColdStart);
+
+        var cut = Render<EnrolGateComponent>(parameters => parameters
+            .Add(p => p.CouncilName, "Strathcarron Council")
+            .Add(p => p.ServiceLabel, "driving licence application"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("enrol-preflight");
+            cut.Markup.Should().Contain("Strathcarron Council");
+            cut.Markup.Should().Contain("driving licence application");
+            // FR-004 — no QR before signup.
+            cut.Markup.Should().NotContain("enrol-hybrid-qr");
+        });
+    }
+
+    [Fact]
+    public void MiniGate_Tier_Renders_WalletPairingSurface_Without_Signup_Copy()
+    {
+        _probe.Setup(p => p.ProbeAsync(It.IsAny<CancellationToken>())).ReturnsAsync(CitizenTier.MiniGate);
+
+        var cut = Render<EnrolGateComponent>(parameters => parameters
+            .Add(p => p.CouncilName, "Strathcarron Council"));
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Should().Contain("enrol-pairing");
+            // SC-003 — mini-gate citizen sees no signup surface at any point.
+            cut.Markup.Should().NotContain("Sign in or create your account");
+        });
+    }
+}
+
+/// <summary>
+/// Focused tests for <see cref="PreflightSignupSurface"/> — Tier 3 preflight
+/// surface that links to the F116 signup flow with ?returnUrl=&lt;currentUrl&gt;.
+/// </summary>
+public sealed class PreflightSignupSurfaceTests : BunitContext
+{
+    [Fact]
+    public void Renders_Signup_Link_With_ReturnUrl_Pointing_At_Current_Page()
+    {
+        // bunit's FakeNavigationManager defaults to http://localhost/ as the base.
+        var cut = Render<PreflightSignupSurface>(parameters => parameters
+            .Add(p => p.CouncilName, "Strathcarron Council")
+            .Add(p => p.ServiceLabel, "driving licence application"));
+
+        cut.Markup.Should().Contain("data-testid=\"enrol-signup-cta\"");
+        cut.Markup.Should().Contain("Strathcarron Council");
+        cut.Markup.Should().Contain("/auth/signup?returnUrl=");
+        // FR-004 — no QR rendered at this stage.
+        cut.Markup.Should().NotContain("enrol-hybrid-qr");
+    }
+
+    [Fact]
+    public void Defaults_CouncilName_When_Not_Set()
+    {
+        var cut = Render<PreflightSignupSurface>();
+        cut.Markup.Should().Contain("this council");
+    }
+}
+
+/// <summary>
+/// Focused tests for <see cref="HybridQrAffordance"/> — QR + tap-link + copy-link.
+/// </summary>
+public sealed class HybridQrAffordanceTests : BunitContext
+{
+    private readonly Mock<IQrPresentationService> _qr = new();
+
+    public HybridQrAffordanceTests()
+    {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(_qr.Object);
+        _qr.Setup(q => q.GenerateSvgFromUri(It.IsAny<string>(), It.IsAny<int>()))
+            .Returns("<svg data-testid=\"stub-qr-svg\"/>");
+    }
+
+    [Fact]
+    public void Renders_Qr_Tap_Link_And_Copy_Button_With_TestIds()
+    {
+        var cut = Render<HybridQrAffordance>(parameters => parameters
+            .Add(p => p.QrUrl, "https://strathcarron.gov/wallet/enrol?session=jwt-123")
+            .Add(p => p.ExpiresAt, DateTimeOffset.UtcNow.AddMinutes(10)));
+
+        cut.Markup.Should().Contain("stub-qr-svg", "QR SVG goes through IQrPresentationService");
+        cut.Markup.Should().Contain("data-testid=\"enrol-tap-link\"");
+        cut.Markup.Should().Contain("data-testid=\"enrol-copy-link\"");
+        cut.Markup.Should().Contain("https://strathcarron.gov/wallet/enrol?session=jwt-123");
+    }
+
+    [Fact]
+    public void Empty_QrUrl_Renders_Nothing()
+    {
+        var cut = Render<HybridQrAffordance>(parameters => parameters
+            .Add(p => p.QrUrl, ""));
+
+        cut.Markup.Should().NotContain("data-testid=\"enrol-tap-link\"");
+        cut.Markup.Should().NotContain("data-testid=\"enrol-copy-link\"");
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Services/User/Enrolment/HttpTierProbeServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Services/User/Enrolment/HttpTierProbeServiceTests.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.UI.Core.Services.User.Enrolment;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Services.User.Enrolment;
+
+/// <summary>
+/// Tests for <see cref="HttpTierProbeService"/> — covers the three citizen-tier
+/// branches and the failure-tolerant probe semantics from research §R-001.
+/// </summary>
+public sealed class HttpTierProbeServiceTests
+{
+    [Fact]
+    public async Task ProbeAsync_Whoami401_Returns_ColdStart()
+    {
+        var handler = new StubHandler((req, _) => req.RequestUri!.AbsolutePath switch
+        {
+            "/api/auth/whoami" => new HttpResponseMessage(HttpStatusCode.Unauthorized),
+            _ => new HttpResponseMessage(HttpStatusCode.OK),
+        });
+        var probe = CreateProbe(handler);
+
+        var tier = await probe.ProbeAsync(CancellationToken.None);
+
+        tier.Should().Be(CitizenTier.ColdStart);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_Whoami200_NoDevices_Returns_MiniGate()
+    {
+        var handler = new StubHandler((req, _) => req.RequestUri!.AbsolutePath switch
+        {
+            "/api/auth/whoami" => Ok("{\"platformUserId\":\"00000000-0000-0000-0000-000000000001\"}"),
+            "/api/v1/me/devices" => Ok("{\"activeCount\":0,\"devices\":[]}"),
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+        });
+        var probe = CreateProbe(handler);
+
+        var tier = await probe.ProbeAsync(CancellationToken.None);
+
+        tier.Should().Be(CitizenTier.MiniGate);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_Whoami200_WithDevices_Returns_FastPath()
+    {
+        var handler = new StubHandler((req, _) => req.RequestUri!.AbsolutePath switch
+        {
+            "/api/auth/whoami" => Ok("{\"platformUserId\":\"00000000-0000-0000-0000-000000000001\"}"),
+            "/api/v1/me/devices" => Ok("{\"activeCount\":2,\"devices\":[{\"status\":\"active\"},{\"status\":\"active\"}]}"),
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+        });
+        var probe = CreateProbe(handler);
+
+        var tier = await probe.ProbeAsync(CancellationToken.None);
+
+        tier.Should().Be(CitizenTier.FastPath);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_DevicesEndpoint_Falls_Back_To_Active_Filter_When_ActiveCount_Missing()
+    {
+        var handler = new StubHandler((req, _) => req.RequestUri!.AbsolutePath switch
+        {
+            "/api/auth/whoami" => Ok("{\"platformUserId\":\"00000000-0000-0000-0000-000000000001\"}"),
+            // No activeCount field — counted from device list.
+            "/api/v1/me/devices" => Ok("{\"devices\":[{\"status\":\"active\"},{\"status\":\"revoked\"}]}"),
+            _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+        });
+        var probe = CreateProbe(handler);
+
+        var tier = await probe.ProbeAsync(CancellationToken.None);
+
+        tier.Should().Be(CitizenTier.FastPath);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_Whoami_Network_Error_Treated_As_ColdStart()
+    {
+        var handler = new StubHandler((req, _) => throw new HttpRequestException("network down"));
+        var probe = CreateProbe(handler);
+
+        var tier = await probe.ProbeAsync(CancellationToken.None);
+
+        tier.Should().Be(CitizenTier.ColdStart);
+    }
+
+    [Fact]
+    public async Task ProbeAsync_Devices_Network_Error_Treated_As_MiniGate()
+    {
+        var handler = new StubHandler((req, _) => req.RequestUri!.AbsolutePath switch
+        {
+            "/api/auth/whoami" => Ok("{\"platformUserId\":\"00000000-0000-0000-0000-000000000001\"}"),
+            _ => throw new HttpRequestException("devices endpoint down"),
+        });
+        var probe = CreateProbe(handler);
+
+        var tier = await probe.ProbeAsync(CancellationToken.None);
+
+        tier.Should().Be(CitizenTier.MiniGate);
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
+
+    private static HttpTierProbeService CreateProbe(HttpMessageHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("http://test.local") },
+            NullLogger<HttpTierProbeService>.Instance);
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _responder;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder) =>
+            _responder = responder;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(_responder(request, cancellationToken));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Enrolment/EnrolSessionRedeemerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Enrolment/EnrolSessionRedeemerTests.cs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Wallet.Pwa.Services.Enrolment;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services.Enrolment;
+
+/// <summary>
+/// Tests for the PWA-side <see cref="EnrolSessionRedeemer"/>. Verifies wire
+/// decoding of the success body and the four documented error mappings
+/// from <see cref="RedeemEnrolSessionErrorCode"/> on the Tenant Service.
+/// </summary>
+public sealed class EnrolSessionRedeemerTests
+{
+    [Fact]
+    public async Task RedeemAsync_Success_Parses_Access_Token_Email_DisplayName()
+    {
+        var handler = new StubHandler((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/auth/enrol-session/redeem");
+            return Ok("""
+                {
+                  "accessToken": "citizen-jwt",
+                  "expiresIn": 3600,
+                  "displayName": "Sarah Example",
+                  "email": "sarah@example.test"
+                }
+                """);
+        });
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeTrue();
+        result.AccessToken.Should().Be("citizen-jwt");
+        result.ExpiresInSeconds.Should().Be(3600);
+        result.DisplayName.Should().Be("Sarah Example");
+        result.Email.Should().Be("sarah@example.test");
+    }
+
+    [Fact]
+    public async Task RedeemAsync_409_AlreadyUsed_Maps_To_AlreadyUsed()
+    {
+        var handler = new StubHandler((_, _) => Json(HttpStatusCode.Conflict, "already_used", "Token has already been used."));
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.AlreadyUsed);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_410_Expired_Maps_To_Expired()
+    {
+        var handler = new StubHandler((_, _) => Json(HttpStatusCode.Gone, "expired", "Expired."));
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.Expired);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_400_Scope_Mismatch_Maps_To_ScopeMismatch()
+    {
+        var handler = new StubHandler((_, _) => Json(HttpStatusCode.BadRequest, "scope_mismatch", "Wrong scope."));
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.ScopeMismatch);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_400_Malformed_Maps_To_MalformedToken()
+    {
+        var handler = new StubHandler((_, _) => Json(HttpStatusCode.BadRequest, "malformed_token", "Bad token."));
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.MalformedToken);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Network_Failure_Maps_To_Network()
+    {
+        var handler = new StubHandler((_, _) => throw new HttpRequestException("connection refused"));
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.Network);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Empty_Token_Returns_MalformedToken_Without_Calling_Server()
+    {
+        var called = false;
+        var handler = new StubHandler((_, _) => { called = true; return Ok("{}"); });
+
+        var result = await Create(handler).RedeemAsync("");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.MalformedToken);
+        called.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Success_Missing_AccessToken_Maps_To_MalformedToken()
+    {
+        var handler = new StubHandler((_, _) => Ok("""{"expiresIn":3600,"displayName":"X","email":"x@y.test"}"""));
+
+        var result = await Create(handler).RedeemAsync("session-jwt");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(EnrolRedeemErrorCode.MalformedToken);
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json") };
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string code, string message) =>
+        new(status)
+        {
+            Content = new StringContent(
+                $$"""{"code":"{{code}}","message":"{{message}}"}""",
+                System.Text.Encoding.UTF8, "application/json")
+        };
+
+    private static EnrolSessionRedeemer Create(HttpMessageHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("http://test.local") },
+            NullLogger<EnrolSessionRedeemer>.Instance);
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _responder;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> responder) =>
+            _responder = responder;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(_responder(request, cancellationToken));
+    }
+}

--- a/walkthroughs/Strathcarron/setup-cold-start-demo.ps1
+++ b/walkthroughs/Strathcarron/setup-cold-start-demo.ps1
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+<#
+.SYNOPSIS
+    Provisions the Strathcarron Council demo environment for the Feature 126
+    cold-start enrolment walkthroughs.
+
+.DESCRIPTION
+    Stub created in PR-A (T002). Body fleshed out across Phases 3-5:
+      - Phase 3 (US1): Strathcarron org provisioning + DrivingLicence blueprint
+        publish + cold-start-<random>@example.test test citizen.
+      - Phase 4 (US2): Tier 1 returning-<random>@example.test test citizen
+        (signup + F114 device-pairing pre-run).
+      - Phase 5 (US3): Tier 2 mini-gate-<random>@example.test test citizen
+        (signup only, no device).
+
+    Re-running this script resets all three test accounts to their target tier.
+
+.PARAMETER ApiBase
+    The API gateway base URL. Defaults to http://localhost.
+
+.PARAMETER Profile
+    'local' for Docker Compose, 'n1' for n1.sorcha.dev.
+
+.EXAMPLE
+    pwsh walkthroughs/Strathcarron/setup-cold-start-demo.ps1
+    pwsh walkthroughs/Strathcarron/setup-cold-start-demo.ps1 -Profile n1
+#>
+[CmdletBinding()]
+param(
+    [string]$ApiBase = 'http://localhost',
+    [ValidateSet('local', 'n1')]
+    [string]$Profile = 'local'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Strathcarron cold-start demo setup — Profile: $Profile, ApiBase: $ApiBase"
+Write-Host "Stub: full implementation lands across Phases 3-5 (T038, T047, T052)."


### PR DESCRIPTION
Spec 3 of the Strathcarron citizen arc — council-page cold-start onboarding gate.

Lands the bulk of `specs/126-enrol-inside-wizard/tasks.md` Phase 1 + Phase 2 + Phase 3 (US1). Subsequent PRs (B-D) layer US2 / US3 / US4 / US5 + polish on top of this foundation.

## Summary

- Two new Tenant Service endpoints: `POST /api/auth/enrol-session` (mint) + `POST /api/auth/enrol-session/redeem` (anonymous single-use redeem). 10-min JWT with `scope: "enrol"`, signed with the existing auth signing key; single-use via `IAtomicDistributedCache.GetAndRemoveAsync` (Feature 113 primitive).
- One new `TenantHub` event: `DeviceEnrolled(platformUserId, deviceId)` fired from `PlatformUserDeviceService.RegisterAsync` (including idempotent re-register). Per-user group filtering; try/log/swallow on publish failure.
- `?returnTo=` allowlist wired into the existing Razor signup/login pages via `ReturnToAllowlistOptions` (HTTPS-only-except-localhost, exact-host or `*.host` suffix). Bound from `Auth:ReturnToAllowlist:Hosts` in `appsettings`.
- New shared library surface in `Sorcha.UI.Components.User`: `EnrolGateComponent`, `PreflightSignupSurface`, `WalletPairingSurface`, `HybridQrAffordance`, plus `ITierProbeService` / `HttpTierProbeService` and `IEnrolPairingSignal` / `EnrolPairingSignal`. `TenantHubConnection` gains an `OnDeviceEnrolled` event.
- PWA wire-up: `Pages/Enrol.razor` extended to accept `?session=<token>`, runs `IEnrolSessionRedeemer.RedeemAsync`, renders `EnrolmentRedeemConfirmDialog`, stores the citizen JWT via `IAccessTokenStore`, then chains into the existing F114 device-pairing ceremony. New `Pages/CancelledEnrolment.razor` landing for the friend-scans-by-mistake cancel path.
- Example consumer page: `Sorcha.UI.Web.Client/Pages/CouncilApplicationDrivingLicence.razor` at `/strathcarron/services/driving-licence` hosts `EnrolGateComponent` wrapping a minimal driving-licence form. Stand-in for the real Strathcarron deployment.
- OpenTelemetry: new `Sorcha.Enrolment` meter with three instruments per research §R-010 (mint counter, redeem counter tagged by outcome, pairing-signal latency histogram).

## End-to-end cold-start journey (demo-able)

1. Browse `/strathcarron/services/driving-licence` → `EnrolGateComponent` probes `/whoami` + `/me/devices` → `ColdStart` → renders `PreflightSignupSurface`.
2. Click signup → F116 flow with allowlist-validated `?returnUrl=` → land back signed-in.
3. Component re-probes → `MiniGate` → `WalletPairingSurface` mints, renders QR + tap-link + copy-link.
4. Scan QR on phone → `Pages/Enrol.razor` parses `?session=`, calls `RedeemAsync`.
5. `EnrolmentRedeemConfirmDialog` shows the bound user's email + name.
6. Confirm → access token persisted → existing F114 stepper picks up signed-in state.
7. Pair device → `TenantHub.DeviceEnrolled` fires → council page's `EnrolPairingSignal` triggers → re-probe → `FastPath` → form `ChildContent` renders.
8. Fill + submit → "Watch your wallet for your credential" success copy.

Cancel from the confirmation dialog routes to `/cancelled-enrolment`; no device registered.

## Test plan

- Unit (Tenant Service): `EnrolSessionServiceTests` (8), `ReturnToAllowlistOptionsTests` (12), `EnrolSessionEndpointsTests` (8), `TenantHubDeviceEnrolledTests` (4) — 32 new tests.
- Unit (UI.Core): `HttpTierProbeServiceTests` (6), `EnrolGateComponentTests` + sub-component tests (7) — 13 new tests.
- Unit (Wallet.Pwa): `EnrolSessionRedeemerTests` (8) — 8 new tests.
- Regression: Tenant 1084/1092 (8 pre-existing skips), UI.Core 1186/1186, Wallet.Pwa 111/111, Verifier 30/30, CitizenWallet.Abstractions 21/21 — SC-009 baseline preserved.
- Build clean across Tenant Service, Components.User, UI.Web.Client, Wallet.Pwa.

## Deferred to follow-up PRs (PR-B/C/D)

- `EnrolPairingSignal` timer-bound tests (T026) — needs a `TimeProvider.CreateTimer` refactor for deterministic test driving of the 2 s/3 s/60 s windows. Hub-event path is exercised end-to-end via `TenantHubDeviceEnrolledTests` + component tests.
- Walkthrough body (`walkthroughs/Strathcarron/setup-cold-start-demo.ps1` stub only; T038 / T047 / T052 fill it in across PRs B and C).
- Form-state preservation across the gate via `sessionStorage` (T039, FR-019) — not load-bearing for v1's cold-start; the form lives inside `ChildContent` and only renders post-gate.
- Phase 4 (US2 returning-citizen fast-path), Phase 5 (US3 mini-gate), Phase 6 (US4 stranger-scans), Phase 7 (US5 same-device prominence) — separate PRs per the plan.
- Cold-start E2E Playwright walk (T045) and the demo-tagged tests (T049 / T055 / T060) — Phase 8 polish.
- Documentation propagation to skill files / API docs / MASTER-TASKS (T069-T073) — Phase 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)