### PR TITLE
fix(127): PR-E — deploy fixes from local Docker stack run (5 real bugs)

### DIFF
--- a/samples/strathcarron-portal/Dockerfile
+++ b/samples/strathcarron-portal/Dockerfile
@@ -10,34 +10,28 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-# Central package management + build-prop hierarchies that the
-# referenced platform projects participate in.
+# Central package management + build-prop hierarchies.
 COPY ["Directory.Packages.props", "."]
-COPY ["src/Apps/Directory.Build.props", "src/Apps/"]
-COPY ["src/Common/Directory.Build.props", "src/Common/"]
-COPY ["src/Core/Directory.Build.props", "src/Core/"]
+COPY ["samples/Directory.Build.props", "samples/"]
 
-# Sample csproj.
-COPY ["samples/strathcarron-portal/Sorcha.Sample.StrathcarronPortal.csproj", "samples/strathcarron-portal/"]
-# Allowed platform-side csprojs the sample references (per boundary rule).
-COPY ["src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Sorcha.UI.Components.User.csproj", "src/Apps/Sorcha.UI/Sorcha.UI.Components.User/"]
-COPY ["src/Common/Sorcha.CitizenWallet.Abstractions/Sorcha.CitizenWallet.Abstractions.csproj", "src/Common/Sorcha.CitizenWallet.Abstractions/"]
-COPY ["src/Common/Sorcha.ServiceClients.Http/Sorcha.ServiceClients.Http.csproj", "src/Common/Sorcha.ServiceClients.Http/"]
-# Any transitive csprojs Sorcha.UI.Components.User or the ServiceClients
-# bring along are restored implicitly via `dotnet restore`.
+# The sample's ProjectReferences (and their transitive ProjectReferences)
+# fan out across src/Apps/Sorcha.UI/, src/Common/, src/Core/. Rather than
+# enumerate every transitively-referenced csproj (which is a moving target
+# as the platform evolves), COPY the relevant src/ subtrees in their
+# entirety before restore. Slightly worse layer caching; far more
+# robust against transitive-reference changes.
+COPY src/ src/
+COPY samples/strathcarron-portal/ samples/strathcarron-portal/
 
 RUN dotnet restore "samples/strathcarron-portal/Sorcha.Sample.StrathcarronPortal.csproj"
-
-# Copy full source for build (samples/ + the src/ subtrees the sample
-# touches).
-COPY samples/ samples/
-COPY src/ src/
 
 WORKDIR /src/samples/strathcarron-portal
 RUN dotnet publish "Sorcha.Sample.StrathcarronPortal.csproj" -c Release -o /app/publish
 
-# Runtime — nginx serving the published WASM bundle.
+# Runtime — nginx serving the published WASM bundle with SPA fallback.
 FROM nginx:alpine AS final
 COPY --from=build /app/publish/wwwroot/ /usr/share/nginx/html/
+COPY samples/strathcarron-portal/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/samples/strathcarron-portal/nginx.conf
+++ b/samples/strathcarron-portal/nginx.conf
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# nginx config for the Strathcarron Council sample portal (F127).
+# Blazor WASM served as a SPA — deep routes fall back to index.html so
+# client-side routing handles /services/driving-licence, /services/blue-badge etc.
+
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Blazor's two non-fingerprinted entry-point JS files must always
+    # revalidate so a portal redeploy lands cleanly on next visit.
+    location = /_framework/dotnet.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri =404;
+    }
+    location = /_framework/blazor.webassembly.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri =404;
+    }
+
+    # Hashed Blazor assets — immutable, cache for a year.
+    location ~* ^/_framework/.*\.(dll|wasm|js|json|blat|dat)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri =404;
+    }
+
+    # SPA fallback — Blazor handles client-side routing for
+    # /services/driving-licence, /services/blue-badge, etc.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.OutputCaching;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http;
 using Polly;
 using Polly.Extensions.Http;
@@ -228,6 +229,25 @@ builder.Services.AddSingleton<Sorcha.Blueprint.Service.Services.Implementation.P
 // container; they cannot live in their originating service's process.
 builder.Services.AddSingleton<Sorcha.PresentationLifecycle.Abstractions.IPresentationConsumer,
     Sorcha.Blueprint.Service.Services.Implementation.HaipPresentationConsumer>();
+
+// Feature 127 — Sorcha.Verifier.Engine dependencies the SorchaWalletPresentationConsumer
+// consumes. The full verifier-DID resolution stack lands in Spec 5 alongside
+// the production IIssuerKeyResolver; for now the JWK-registry resolver covers
+// the dev/demo path and the OptOut resolver is the fallback for tests that
+// don't populate the registry.
+builder.Services.AddHttpClient<Sorcha.Verifier.Engine.IStatusListCache,
+    Sorcha.Verifier.Engine.StatusListCache>();
+builder.Services.TryAddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>();
+builder.Services.AddSingleton<Sorcha.Verifier.Engine.IIssuerKeyResolver>(sp =>
+    sp.GetRequiredService<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>());
+builder.Services.AddSingleton<Sorcha.Verifier.Engine.IVerifiablePresentationValidator>(sp =>
+    new Sorcha.Verifier.Engine.VerifiablePresentationValidator(
+        sp.GetRequiredService<Sorcha.Verifier.Engine.IStatusListCache>(),
+        sp.GetRequiredService<Sorcha.Verifier.Engine.IIssuerKeyResolver>(),
+        sp.GetRequiredService<TimeProvider>(),
+        sp.GetRequiredService<ILogger<Sorcha.Verifier.Engine.VerifiablePresentationValidator>>(),
+        requireIssuerSignature: builder.Configuration.GetValue<bool?>("IssuerSignature:Required") ?? true));
 
 // Feature 127 — Sorcha-wallet consumer. Verifies SD-JWT presentations posted
 // by the citizen's Sorcha wallet via Sorcha.Verifier.Engine. The first

--- a/walkthroughs/initialize-secrets.ps1
+++ b/walkthroughs/initialize-secrets.ps1
@@ -196,6 +196,18 @@ $secrets = [ordered]@{
         adminName       = $platformName
         DefaultPassword = $platformPassword
     }
+    "strathcarron-cold-start" = @{
+        adminEmail      = $platformEmail
+        adminPassword   = $platformPassword
+        adminName       = $platformName
+        DefaultPassword = $platformPassword
+    }
+    "strathcarron-blue-badge" = @{
+        adminEmail      = $platformEmail
+        adminPassword   = $platformPassword
+        adminName       = $platformName
+        DefaultPassword = $platformPassword
+    }
     "council" = @{
         sysAdminEmail               = $platformEmail
         sysAdminPassword            = $platformPassword

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1246,7 +1246,13 @@ function Publish-SorchaBlueprint {
     }
 
     $templateJson = Get-Content -Path $TemplatePath -Raw | ConvertFrom-Json -Depth 30
-    $blueprint = $templateJson.template
+    # Templates may be wrapped (`{ "template": {...} }`) or flat (the
+    # blueprint object at the top level). Tolerate both.
+    if ($templateJson.PSObject.Properties.Name -contains "template" -and $null -ne $templateJson.template) {
+        $blueprint = $templateJson.template
+    } else {
+        $blueprint = $templateJson
+    }
 
     # Feature 103: identify open starting-action senders. The publish-time
     # guardrail (VAL_BP_010) rejects any blueprint where an open starting
@@ -1274,9 +1280,11 @@ function Publish-SorchaBlueprint {
         }
     }
 
-    # Generate unique ID
+    # Generate unique ID. Use Add-Member -Force so this is robust whether
+    # the template carries a placeholder `id` or omits it entirely (most
+    # templates do — the id is generated here per-publish).
     $timestamp = Get-Date -Format "yyyyMMddHHmmss"
-    $blueprint.id = "$IdPrefix-$timestamp"
+    $blueprint | Add-Member -NotePropertyName "id" -NotePropertyValue "$IdPrefix-$timestamp" -Force
 
     # Create blueprint
     Write-WtInfo "Creating blueprint..."


### PR DESCRIPTION
## Summary

The operator brought up a clean local Docker stack to try the F127 tests. Five real bugs surfaced that the unit/bunit/FakeTimeProvider test layer never caught. All fixed here.

## Bugs caught and fixed

### 1. Sample Dockerfile didn't COPY transitive ProjectReferences

`dotnet restore` skipped Sorcha.Blueprint.Models / Sorcha.Register.Models / Sorcha.Tenant.Models / Sorcha.Blueprint.Schemas.Client (and others). My original Dockerfile enumerated the sample's direct ProjectReferences but not their fan-out — every chained csproj is a moving target as the platform evolves. Fixed by COPYing `src/` in its entirety before restore. Worse layer caching, far more robust.

### 2. nginx returned 404 on deep routes (no SPA fallback)

`http://localhost:8082/services/driving-licence` and `/services/blue-badge` both 404'd because the default `nginx:alpine` config doesn't know about Blazor's client-side routing. Added `samples/strathcarron-portal/nginx.conf` with the SPA fallback + the standard Blazor cache-header treatment (dotnet.js + blazor.webassembly.js no-cache, hashed framework assets immutable+1y). Ported from the existing wallet PWA nginx config.

### 3. Blueprint Service failed to start: missing IVerifiablePresentationValidator

PR-B registered `SorchaWalletPresentationConsumer` in DI but never registered the `Sorcha.Verifier.Engine` services it depends on. Container crashed on startup with:

```
Unable to resolve service for type 'Sorcha.Verifier.Engine.IVerifiablePresentationValidator'
while attempting to activate 'SorchaWalletPresentationConsumer'.
```

Now registered using the JWK-registry-only resolver path (the F125 verifier-desk pattern minus the DID-backed resolver — that's Spec 5 work). Validator honours `IssuerSignature:Required` config (default `true` per F120 FR-019). **The integration tests deferred from PR-D (T041 / T042 / T043) would have caught this** — confirming the operator-gated WAF tests are real value, not just nice-to-have.

### 4. Walkthrough secrets missing entries for the new walkthroughs

Both `setup-cold-start-demo.ps1` and `setup-blue-badge-demo.ps1` failed instantly with:
```
No secrets found for walkthrough 'strathcarron-cold-start' in walkthroughs/.secrets/passwords.json
```
Added registry entries via `walkthroughs/initialize-secrets.ps1` using the platform seed-admin pattern matching the other council-flavoured walkthroughs.

### 5. `Publish-SorchaBlueprint` helper hit PowerShell strict-mode twice

(a) `$blueprint = $templateJson.template` — crashes on the flat-shape templates F126 and F127 use (no top-level `template` wrapper). Helper now tolerates both shapes.
(b) `$blueprint.id = "..."` — strict-mode rejects assigning a property that doesn't exist on the deserialised object. Now uses `Add-Member -Force` so the helper is robust whether the template carries a placeholder `id` or omits it (most templates do — id is generated per-publish).

## Verified post-fix

All 13 platform containers come up healthy (gateway, blueprint, wallet, register, tenant, validator, peer, haip, postgres, mongodb, redis, aspire-dashboard, ui-web, wallet-pwa, verifier, strathcarron-portal).

- `http://localhost:8082/` → 200 (sample landing page)
- `/services/driving-licence` → 200 (SPA fallback confirmed)
- `/services/blue-badge` → 200 (SPA fallback confirmed)
- `http://localhost/api/health` → 200 (gateway)

> Note: this dev session forced the portal onto host port 8082 because Docker Desktop was holding stale 5400 bindings from earlier retries. The `STRATHCARRON_PORTAL_PORT` env-var override in the compose file worked cleanly. No code change needed for 5400 — that's a Docker Desktop quirk, not a Sorcha bug.

## Known REMAINING after this PR

The F126 driving-licence blueprint publish fails with `InvalidJsonRequestBody` from the Blueprint Service. The blueprint JSON shape against the current API contract is the suspect — likely a pre-existing walkthrough/contract divergence rather than F127 scope. **Needs operator pickup**: closer look at what the Blueprint Service expects vs what the F126 / F127 JSON sends.

## Test plan

- [ ] CI builds the sample image with the new Dockerfile + nginx.conf.
- [ ] CI `docker-ci` matrix for `sample-strathcarron-portal` passes.
- [ ] Blueprint Service starts cleanly in the docker-ci suite (the DI registration fix is load-bearing for every other consumer that touches this stack).
- [ ] Operator follow-up — investigate the InvalidJsonRequestBody on the F126 blueprint publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)