### PR TITLE
feat(128) PR-A1: mode discriminator on enrol-session primitive

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/EnrolSessionRedeemer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/EnrolSessionRedeemer.cs
@@ -49,7 +49,8 @@ public sealed class EnrolSessionRedeemer : IEnrolSessionRedeemer
                     body.AccessToken,
                     body.ExpiresIn,
                     body.DisplayName ?? "",
-                    body.Email ?? "");
+                    body.Email ?? "",
+                    ParseMode(body.Mode));
             }
 
             var error = await TryReadErrorAsync(response, ct).ConfigureAwait(false);
@@ -94,7 +95,13 @@ public sealed class EnrolSessionRedeemer : IEnrolSessionRedeemer
         }
     }
 
+    private static EnrolRedeemMode ParseMode(string? wire) => wire switch
+    {
+        "Standalone" or "standalone" => EnrolRedeemMode.Standalone,
+        _ => EnrolRedeemMode.Gated,
+    };
+
     private sealed record RedeemRequest(string SessionToken);
-    private sealed record RedeemSuccessShape(string AccessToken, int ExpiresIn, string? DisplayName, string? Email);
+    private sealed record RedeemSuccessShape(string AccessToken, int ExpiresIn, string? DisplayName, string? Email, string? Mode);
     private sealed record ErrorShape(string? Code, string? Message);
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/IEnrolSessionRedeemer.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Enrolment/IEnrolSessionRedeemer.cs
@@ -19,6 +19,18 @@ public enum EnrolRedeemErrorCode
 }
 
 /// <summary>
+/// Discriminates the intent behind a redeemed enrol-session, echoed from the
+/// server. F128 — drives the redeem page's copy + post-pair destination.
+/// F126 tokens (and any in-flight token at deployment time) default to
+/// <see cref="Gated"/>.
+/// </summary>
+public enum EnrolRedeemMode
+{
+    Gated = 0,
+    Standalone = 1,
+}
+
+/// <summary>
 /// Outcome of a redeem call — success carries the citizen access token +
 /// the bound user's identifying details (which feed the confirmation
 /// dialog); failure carries a structured error code.
@@ -29,14 +41,20 @@ public sealed record EnrolRedeemResult(
     int ExpiresInSeconds,
     string? DisplayName,
     string? Email,
+    EnrolRedeemMode Mode,
     EnrolRedeemErrorCode? ErrorCode,
     string? ErrorMessage)
 {
-    public static EnrolRedeemResult Ok(string accessToken, int expiresIn, string displayName, string email) =>
-        new(true, accessToken, expiresIn, displayName, email, null, null);
+    public static EnrolRedeemResult Ok(
+        string accessToken,
+        int expiresIn,
+        string displayName,
+        string email,
+        EnrolRedeemMode mode) =>
+        new(true, accessToken, expiresIn, displayName, email, mode, null, null);
 
     public static EnrolRedeemResult Fail(EnrolRedeemErrorCode code, string message) =>
-        new(false, null, 0, null, null, code, message);
+        new(false, null, 0, null, null, EnrolRedeemMode.Gated, code, message);
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/EnrolSessionEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/EnrolSessionEndpoints.cs
@@ -28,11 +28,13 @@ public static class EnrolSessionEndpoints
             .WithName("MintEnrolSession")
             .WithSummary("Mint a one-time enrolment session token for the signed-in caller.")
             .WithDescription(
-                "Returns a JWT scoped to 'enrol', a QR URL embedding the token, and the absolute "
-                + "expiry timestamp. The caller must be authenticated. Used by council pages to "
-                + "render the enrolment QR/link/paste affordance on the wallet-pairing surface.")
+                "Returns a JWT scoped to 'enrol', a QR URL embedding the token, the absolute "
+                + "expiry timestamp, and the mode discriminator. The caller must be authenticated. "
+                + "Request body is optional — omit (or send `mode: gated`) for F126 council-page "
+                + "callers; send `mode: standalone` for F128 cold-start callers.")
             .RequireAuthorization()
             .RequireRateLimiting(RateLimitPolicies.PlatformAuth)
+            .Accepts<MintEnrolSessionRequest>("application/json")
             .Produces<MintEnrolSessionResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized);
 
@@ -57,6 +59,7 @@ public static class EnrolSessionEndpoints
     internal static async Task<Results<Ok<MintEnrolSessionResponse>, UnauthorizedHttpResult>> MintAsync(
         ClaimsPrincipal principal,
         IEnrolSessionService service,
+        [FromBody] MintEnrolSessionRequest? request,
         CancellationToken ct)
     {
         var platformUserId = ResolvePlatformUserId(principal);
@@ -65,7 +68,8 @@ public static class EnrolSessionEndpoints
             return TypedResults.Unauthorized();
         }
 
-        var response = await service.MintAsync(platformUserId.Value, ct).ConfigureAwait(false);
+        var mode = request?.Mode ?? EnrolSessionMode.Gated;
+        var response = await service.MintAsync(platformUserId.Value, mode, ct).ConfigureAwait(false);
         return TypedResults.Ok(response);
     }
 

--- a/src/Services/Sorcha.Tenant.Service/Models/EnrolSessionDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/EnrolSessionDtos.cs
@@ -6,13 +6,52 @@ using System.Text.Json.Serialization;
 namespace Sorcha.Tenant.Service.Models;
 
 /// <summary>
+/// Discriminates the intent behind an enrol-session token. Determines the copy
+/// + post-redeem destination on the wallet PWA's redeem page, and the
+/// <c>mode</c> dimension on pairing telemetry. The cryptographic ceremony is
+/// identical across modes.
+/// </summary>
+/// <remarks>
+/// Feature 128 — see <c>specs/128-cold-start-onboarding/data-model.md</c>.
+/// <see cref="Gated"/> is the default to preserve F126 council-page semantics
+/// for callers that pre-date this discriminator.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<EnrolSessionMode>))]
+public enum EnrolSessionMode
+{
+    /// <summary>
+    /// Council-page-flavoured (F126). The PWA's redeem page honours any
+    /// <c>?returnTo=</c> query parameter and routes the citizen back to the
+    /// gating application after pairing.
+    /// </summary>
+    Gated = 0,
+
+    /// <summary>
+    /// Standalone (F128). The PWA's redeem page ignores any <c>?returnTo=</c>
+    /// query parameter and routes the citizen to the wallet Home after pairing.
+    /// Used by the four cold-start routes (desktop-handoff, mobileweb-handoff,
+    /// pwa-takeover, cold-landing).
+    /// </summary>
+    Standalone = 1,
+}
+
+/// <summary>
+/// Wire shape of the <c>POST /api/auth/enrol-session</c> request body.
+/// Empty body (or omitted <see cref="Mode"/>) defaults to
+/// <see cref="EnrolSessionMode.Gated"/> for back-compat with F126 callers.
+/// </summary>
+public sealed record MintEnrolSessionRequest(
+    EnrolSessionMode? Mode = null);
+
+/// <summary>
 /// Wire shape of a successful <c>POST /api/auth/enrol-session</c> response.
-/// Feature 126 — Sorcha Wallet enrolment inside a council application wizard.
+/// Feature 126 — extended in Feature 128 with the <see cref="Mode"/> echo.
 /// </summary>
 public sealed record MintEnrolSessionResponse(
     string SessionToken,
     string QrUrl,
-    DateTimeOffset ExpiresAt);
+    DateTimeOffset ExpiresAt,
+    EnrolSessionMode Mode);
 
 /// <summary>
 /// Wire shape of the <c>POST /api/auth/enrol-session/redeem</c> request body.
@@ -24,11 +63,17 @@ public sealed record RedeemEnrolSessionRequest(string SessionToken);
 /// The <see cref="DisplayName"/> and <see cref="Email"/> are surfaced by the
 /// wallet PWA's confirmation dialog before the device-pairing call.
 /// </summary>
+/// <remarks>
+/// Feature 128 — extended with <see cref="Mode"/> echo so the redeem page can
+/// choose between gated copy (route back to <c>?returnTo=</c>) and standalone
+/// copy (route to PWA Home).
+/// </remarks>
 public sealed record RedeemEnrolSessionResponse(
     string AccessToken,
     int ExpiresIn,
     string DisplayName,
-    string Email);
+    string Email,
+    EnrolSessionMode Mode);
 
 /// <summary>
 /// Discriminated error codes for redeem failures. Mapped 1:1 to HTTP status:

--- a/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionMetrics.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionMetrics.cs
@@ -41,17 +41,29 @@ public sealed class EnrolSessionMetrics : IDisposable
             description: "Latency from device registration to pairing-completion signal delivery.");
     }
 
-    /// <summary>Records a successful mint with a purpose tag (e.g. <c>tier3_first_qr</c>, <c>regenerate</c>).</summary>
-    public void RecordMint(string purpose) =>
-        _sessionMinted.Add(1, KeyValuePair.Create<string, object?>("purpose", purpose));
+    /// <summary>
+    /// Records a successful mint with a purpose tag (e.g. <c>tier3_first_qr</c>,
+    /// <c>regenerate</c>) and a F128 <paramref name="mode"/> tag
+    /// (<c>gated</c> | <c>standalone</c>).
+    /// </summary>
+    public void RecordMint(string purpose, string mode) =>
+        _sessionMinted.Add(
+            1,
+            KeyValuePair.Create<string, object?>("purpose", purpose),
+            KeyValuePair.Create<string, object?>("mode", mode));
 
     /// <summary>
     /// Records a redeem attempt with an outcome tag — one of
     /// <c>success</c>, <c>expired</c>, <c>replay</c>, <c>scope_mismatch</c>,
-    /// <c>signature_fail</c>, <c>malformed</c>.
+    /// <c>signature_fail</c>, <c>malformed</c> — and the F128
+    /// <paramref name="mode"/> tag (<c>gated</c> | <c>standalone</c> |
+    /// <c>unknown</c> for failures that surface before the mode claim is read).
     /// </summary>
-    public void RecordRedeem(string outcome) =>
-        _sessionRedeemed.Add(1, KeyValuePair.Create<string, object?>("outcome", outcome));
+    public void RecordRedeem(string outcome, string mode) =>
+        _sessionRedeemed.Add(
+            1,
+            KeyValuePair.Create<string, object?>("outcome", outcome),
+            KeyValuePair.Create<string, object?>("mode", mode));
 
     /// <summary>Records the pairing-signal latency in seconds, tagged by transport (<c>signalr</c> / <c>polling</c>).</summary>
     public void RecordPairingSignalLatency(double seconds, string path) =>

--- a/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/EnrolSessionService.cs
@@ -41,6 +41,13 @@ public sealed class EnrolSessionService : IEnrolSessionService
     /// <summary>Token scope claim value identifying these tokens.</summary>
     public const string EnrolScope = "enrol";
 
+    /// <summary>
+    /// JWT claim carrying the <see cref="EnrolSessionMode"/> discriminator
+    /// (F128). Persisted in-token so single-use enforcement is unchanged
+    /// (only the JTI is tracked server-side).
+    /// </summary>
+    public const string PairModeClaim = "pair_mode";
+
     /// <summary>Cache key prefix for the single-use JTI registry.</summary>
     public const string JtiRegistryKeyPrefix = "sorcha:enrol-session:";
 
@@ -105,7 +112,10 @@ public sealed class EnrolSessionService : IEnrolSessionService
     }
 
     /// <inheritdoc />
-    public async Task<MintEnrolSessionResponse> MintAsync(Guid platformUserId, CancellationToken ct)
+    public async Task<MintEnrolSessionResponse> MintAsync(
+        Guid platformUserId,
+        EnrolSessionMode mode,
+        CancellationToken ct)
     {
         if (platformUserId == Guid.Empty)
         {
@@ -116,11 +126,14 @@ public sealed class EnrolSessionService : IEnrolSessionService
         var now = _timeProvider.GetUtcNow();
         var expiresAt = now.Add(SessionTokenLifetime);
 
+        var modeWire = ModeToWire(mode);
+
         var claims = new List<Claim>
         {
             new(JwtRegisteredClaimNames.Sub, platformUserId.ToString()),
             new(JwtRegisteredClaimNames.Jti, jti),
             new("scope", EnrolScope),
+            new(PairModeClaim, modeWire),
         };
 
         var descriptor = new SecurityTokenDescriptor
@@ -145,20 +158,33 @@ public sealed class EnrolSessionService : IEnrolSessionService
 
         var qrUrl = $"{_councilOrigin.TrimEnd('/')}/wallet/enrol?session={jwt}";
 
-        _metrics.RecordMint("tier3_first_qr");
+        _metrics.RecordMint("tier3_first_qr", modeWire);
         _logger.LogInformation(
-            "Minted enrol-session token (jti={Jti}, platformUserId={PlatformUserId}, exp={Exp:O})",
-            jti, platformUserId, expiresAt);
+            "Minted enrol-session token (jti={Jti}, platformUserId={PlatformUserId}, mode={Mode}, exp={Exp:O})",
+            jti, platformUserId, modeWire, expiresAt);
 
-        return new MintEnrolSessionResponse(jwt, qrUrl, expiresAt);
+        return new MintEnrolSessionResponse(jwt, qrUrl, expiresAt, mode);
     }
+
+    private static string ModeToWire(EnrolSessionMode mode) => mode switch
+    {
+        EnrolSessionMode.Gated => "gated",
+        EnrolSessionMode.Standalone => "standalone",
+        _ => "gated",
+    };
+
+    private static EnrolSessionMode ModeFromClaim(string? wire) => wire switch
+    {
+        "standalone" => EnrolSessionMode.Standalone,
+        _ => EnrolSessionMode.Gated,
+    };
 
     /// <inheritdoc />
     public async Task<RedeemResult> RedeemAsync(string sessionToken, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(sessionToken))
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Session token is required.");
         }
 
@@ -171,12 +197,12 @@ public sealed class EnrolSessionService : IEnrolSessionService
         }
         catch (ArgumentException)
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token could not be parsed.");
         }
         catch (SecurityTokenException)
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token could not be parsed.");
         }
 
@@ -201,12 +227,12 @@ public sealed class EnrolSessionService : IEnrolSessionService
         }
         catch (SecurityTokenInvalidSignatureException)
         {
-            _metrics.RecordRedeem("signature_fail");
+            _metrics.RecordRedeem("signature_fail", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.InvalidSignature, "Signature did not validate.");
         }
         catch (SecurityTokenException)
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token failed validation.");
         }
 
@@ -214,21 +240,21 @@ public sealed class EnrolSessionService : IEnrolSessionService
         var expClaim = principal.FindFirst(JwtRegisteredClaimNames.Exp)?.Value;
         if (expClaim is null || !long.TryParse(expClaim, NumberStyles.Integer, CultureInfo.InvariantCulture, out var expEpoch))
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token is missing exp claim.");
         }
 
         var expiresAt = DateTimeOffset.FromUnixTimeSeconds(expEpoch);
         if (_timeProvider.GetUtcNow() >= expiresAt)
         {
-            _metrics.RecordRedeem("expired");
+            _metrics.RecordRedeem("expired", ModeToWire(ModeFromClaim(principal.FindFirst(PairModeClaim)?.Value)));
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.Expired, "Session token has expired.");
         }
 
         var scope = principal.FindFirst("scope")?.Value;
         if (!string.Equals(scope, EnrolScope, StringComparison.Ordinal))
         {
-            _metrics.RecordRedeem("scope_mismatch");
+            _metrics.RecordRedeem("scope_mismatch", ModeToWire(ModeFromClaim(principal.FindFirst(PairModeClaim)?.Value)));
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.ScopeMismatch, "Token scope does not permit enrolment.");
         }
 
@@ -236,7 +262,7 @@ public sealed class EnrolSessionService : IEnrolSessionService
         var jti = principal.FindFirst(JwtRegisteredClaimNames.Jti)?.Value;
         if (string.IsNullOrEmpty(sub) || !Guid.TryParse(sub, out var platformUserId) || string.IsNullOrEmpty(jti))
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             return RedeemResult.Fail(RedeemEnrolSessionErrorCode.MalformedToken, "Token is missing required claims.");
         }
 
@@ -246,7 +272,7 @@ public sealed class EnrolSessionService : IEnrolSessionService
         var sentinel = await _cache.GetAndRemoveAsync(cacheKey, ct).ConfigureAwait(false);
         if (sentinel is null)
         {
-            _metrics.RecordRedeem("replay");
+            _metrics.RecordRedeem("replay", ModeToWire(ModeFromClaim(principal.FindFirst(PairModeClaim)?.Value)));
             _logger.LogWarning(
                 "Enrol-session redeem replay detected (jti={Jti}, platformUserId={PlatformUserId})",
                 jti, platformUserId);
@@ -257,7 +283,7 @@ public sealed class EnrolSessionService : IEnrolSessionService
         var user = await _platformUserService.GetByIdAsync(platformUserId, ct).ConfigureAwait(false);
         if (user is null)
         {
-            _metrics.RecordRedeem("malformed");
+            _metrics.RecordRedeem("malformed", "unknown");
             _logger.LogWarning(
                 "Enrol-session redeem failed — PlatformUser not found (jti={Jti}, platformUserId={PlatformUserId})",
                 jti, platformUserId);
@@ -266,16 +292,22 @@ public sealed class EnrolSessionService : IEnrolSessionService
 
         var (accessToken, expiresInSeconds) = IssueCitizenAccessToken(user);
 
-        _metrics.RecordRedeem("success");
+        // Read mode from claim. Tokens minted before F128 lack this claim and
+        // fall through to the Gated default — preserving F126 behaviour for
+        // any in-flight token at the time of deployment.
+        var mode = ModeFromClaim(principal.FindFirst(PairModeClaim)?.Value);
+
+        _metrics.RecordRedeem("success", ModeToWire(mode));
         _logger.LogInformation(
-            "Enrol-session redeemed successfully (jti={Jti}, platformUserId={PlatformUserId})",
-            jti, platformUserId);
+            "Enrol-session redeemed successfully (jti={Jti}, platformUserId={PlatformUserId}, mode={Mode})",
+            jti, platformUserId, ModeToWire(mode));
 
         return RedeemResult.Ok(new RedeemEnrolSessionResponse(
             AccessToken: accessToken,
             ExpiresIn: expiresInSeconds,
             DisplayName: user.DisplayName ?? user.Email,
-            Email: user.Email));
+            Email: user.Email,
+            Mode: mode));
     }
 
     private (string AccessToken, int ExpiresInSeconds) IssueCitizenAccessToken(PlatformUser user)

--- a/src/Services/Sorcha.Tenant.Service/Services/IEnrolSessionService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IEnrolSessionService.cs
@@ -31,7 +31,17 @@ public interface IEnrolSessionService
     /// Mints a fresh session token bound to <paramref name="platformUserId"/>.
     /// 10-minute lifetime, single-use, scope <c>"enrol"</c>.
     /// </summary>
-    Task<MintEnrolSessionResponse> MintAsync(Guid platformUserId, CancellationToken ct);
+    /// <param name="platformUserId">The Sorcha account to bind the token to.</param>
+    /// <param name="mode">
+    /// Discriminator that drives the redeem-page copy + post-pair destination.
+    /// Defaults to <see cref="EnrolSessionMode.Gated"/> for F126 back-compat;
+    /// F128 callers pass <see cref="EnrolSessionMode.Standalone"/>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<MintEnrolSessionResponse> MintAsync(
+        Guid platformUserId,
+        EnrolSessionMode mode,
+        CancellationToken ct);
 
     /// <summary>
     /// Validates and consumes <paramref name="sessionToken"/>. Returns the bound

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/EnrolSessionEndpointsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/EnrolSessionEndpointsTests.cs
@@ -26,7 +26,7 @@ public sealed class EnrolSessionEndpointsTests
         var service = new Mock<IEnrolSessionService>(MockBehavior.Strict);
 
         var principal = new ClaimsPrincipal(new ClaimsIdentity()); // no platform_user_id
-        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, CancellationToken.None);
+        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, null, CancellationToken.None);
 
         result.Result.Should().BeOfType<UnauthorizedHttpResult>();
         service.VerifyNoOtherCalls();
@@ -39,17 +39,18 @@ public sealed class EnrolSessionEndpointsTests
         var minted = new MintEnrolSessionResponse(
             "jwt-string",
             $"https://strathcarron.gov/wallet/enrol?session=jwt-string",
-            DateTimeOffset.UtcNow.AddMinutes(10));
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            EnrolSessionMode.Gated);
 
         var service = new Mock<IEnrolSessionService>();
-        service.Setup(s => s.MintAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(minted);
+        service.Setup(s => s.MintAsync(pu, EnrolSessionMode.Gated, It.IsAny<CancellationToken>())).ReturnsAsync(minted);
 
         var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
         {
             new Claim("platform_user_id", pu.ToString())
         }));
 
-        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, CancellationToken.None);
+        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, null, CancellationToken.None);
 
         result.Result.Should().BeOfType<Ok<MintEnrolSessionResponse>>();
         var ok = (Ok<MintEnrolSessionResponse>)result.Result;
@@ -65,7 +66,7 @@ public sealed class EnrolSessionEndpointsTests
             new Claim("platform_user_id", "not-a-guid")
         }));
 
-        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, CancellationToken.None);
+        var result = await EnrolSessionEndpoints.MintAsync(principal, service.Object, null, CancellationToken.None);
 
         result.Result.Should().BeOfType<UnauthorizedHttpResult>();
         service.VerifyNoOtherCalls();
@@ -75,7 +76,7 @@ public sealed class EnrolSessionEndpointsTests
     public async Task RedeemAsync_Happy_Path_Returns_Ok()
     {
         var service = new Mock<IEnrolSessionService>();
-        var redeemed = new RedeemEnrolSessionResponse("access-jwt", 3600, "Sarah", "sarah@example.test");
+        var redeemed = new RedeemEnrolSessionResponse("access-jwt", 3600, "Sarah", "sarah@example.test", EnrolSessionMode.Gated);
         service.Setup(s => s.RedeemAsync("the-token", It.IsAny<CancellationToken>()))
             .ReturnsAsync(RedeemResult.Ok(redeemed));
 

--- a/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionServiceModeTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionServiceModeTests.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Sorcha.AtomicCache;
+using Sorcha.Tenant.Service.Extensions;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// Feature 128 — covers the <c>mode</c> discriminator round-trip on the
+/// enrol-session JWT (claim persistence, response echo) and the back-compat
+/// default for F126-era callers.
+/// </summary>
+public sealed class EnrolSessionServiceModeTests
+{
+    private readonly Mock<IPlatformUserService> _platformUserService = new();
+    private readonly InMemoryAtomicDistributedCache _cache = new();
+    private readonly FakeTimeProvider _time = new();
+    private readonly EnrolSessionMetrics _metrics;
+    private readonly EnrolSessionService _service;
+
+    public EnrolSessionServiceModeTests()
+    {
+        var jwt = new JwtConfiguration
+        {
+            SigningKey = "test-signing-key-please-be-at-least-32-bytes-long-aaaaa",
+            Issuer = "sorcha-test",
+            Audiences = ["sorcha:citizen-wallet"],
+            AccessTokenLifetimeMinutes = 60,
+        };
+        var jwtOptions = Options.Create(jwt);
+        var config = new ConfigurationBuilder().Build();
+
+        _metrics = new EnrolSessionMetrics(new TestMeterFactory());
+        _service = new EnrolSessionService(
+            jwtOptions, _cache, _platformUserService.Object, _metrics,
+            config, _time, NullLogger<EnrolSessionService>.Instance);
+    }
+
+    [Fact]
+    public async Task MintAsync_With_Standalone_Mode_Echoes_Standalone_In_Response()
+    {
+        var pu = Guid.NewGuid();
+        _time.SetUtcNow(DateTimeOffset.UtcNow);
+
+        var response = await _service.MintAsync(pu, EnrolSessionMode.Standalone, CancellationToken.None);
+
+        response.Mode.Should().Be(EnrolSessionMode.Standalone);
+        response.SessionToken.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task MintAsync_With_Gated_Mode_Echoes_Gated_In_Response()
+    {
+        var pu = Guid.NewGuid();
+        _time.SetUtcNow(DateTimeOffset.UtcNow);
+
+        var response = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
+
+        response.Mode.Should().Be(EnrolSessionMode.Gated);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Returns_Standalone_Mode_When_Token_Minted_Standalone()
+    {
+        var pu = Guid.NewGuid();
+        var user = new PlatformUser { Id = pu, Email = "s@e.test", DisplayName = "S" };
+        _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Standalone, CancellationToken.None);
+        var redeem = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+
+        redeem.IsSuccess.Should().BeTrue();
+        redeem.Success!.Mode.Should().Be(EnrolSessionMode.Standalone);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Returns_Gated_Mode_When_Token_Minted_Gated()
+    {
+        var pu = Guid.NewGuid();
+        var user = new PlatformUser { Id = pu, Email = "s@e.test", DisplayName = "S" };
+        _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
+        var redeem = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
+
+        redeem.IsSuccess.Should().BeTrue();
+        redeem.Success!.Mode.Should().Be(EnrolSessionMode.Gated);
+    }
+
+    [Fact]
+    public async Task RedeemAsync_Mode_Is_Bound_To_Mint_Not_Tampered_From_Redeem_Side()
+    {
+        // Mode is encoded as a signed JWT claim. There is no redeem-side input
+        // to "set" the mode — the only mode source of truth is what was minted.
+        // This test re-asserts that property by demonstrating that minting two
+        // tokens with different modes returns the corresponding mode on redeem.
+        var pu = Guid.NewGuid();
+        var user = new PlatformUser { Id = pu, Email = "s@e.test", DisplayName = "S" };
+        _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var gatedMint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
+        var standaloneMint = await _service.MintAsync(pu, EnrolSessionMode.Standalone, CancellationToken.None);
+
+        var gatedRedeem = await _service.RedeemAsync(gatedMint.SessionToken, CancellationToken.None);
+        var standaloneRedeem = await _service.RedeemAsync(standaloneMint.SessionToken, CancellationToken.None);
+
+        gatedRedeem.Success!.Mode.Should().Be(EnrolSessionMode.Gated);
+        standaloneRedeem.Success!.Mode.Should().Be(EnrolSessionMode.Standalone);
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = DateTimeOffset.UtcNow;
+        public void SetUtcNow(DateTimeOffset value) => _now = value;
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class TestMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+        public void Dispose() { }
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/EnrolSessionServiceTests.cs
@@ -54,7 +54,7 @@ public sealed class EnrolSessionServiceTests
         var now = DateTimeOffset.UtcNow;
         _time.SetUtcNow(now);
 
-        var response = await _service.MintAsync(pu, CancellationToken.None);
+        var response = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
 
         response.SessionToken.Should().NotBeNullOrWhiteSpace();
         response.QrUrl.Should().Contain($"session={response.SessionToken}");
@@ -68,7 +68,7 @@ public sealed class EnrolSessionServiceTests
         var user = new PlatformUser { Id = pu, Email = "sarah@example.test", DisplayName = "Sarah Example" };
         _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
 
-        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
         var redeem = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
 
         redeem.IsSuccess.Should().BeTrue();
@@ -85,7 +85,7 @@ public sealed class EnrolSessionServiceTests
         var user = new PlatformUser { Id = pu, Email = "s@e.test", DisplayName = "S" };
         _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>())).ReturnsAsync(user);
 
-        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
         var first = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
         first.IsSuccess.Should().BeTrue();
 
@@ -99,7 +99,7 @@ public sealed class EnrolSessionServiceTests
     {
         var pu = Guid.NewGuid();
         _time.SetUtcNow(DateTimeOffset.UtcNow);
-        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
 
         _time.Advance(TimeSpan.FromMinutes(11));
 
@@ -128,7 +128,7 @@ public sealed class EnrolSessionServiceTests
     public async Task RedeemAsync_Tampered_Signature_Returns_InvalidSignature()
     {
         var pu = Guid.NewGuid();
-        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
         var tampered = mint.SessionToken.Substring(0, mint.SessionToken.Length - 4) + "AAAA";
 
         var result = await _service.RedeemAsync(tampered, CancellationToken.None);
@@ -145,7 +145,7 @@ public sealed class EnrolSessionServiceTests
         _platformUserService.Setup(p => p.GetByIdAsync(pu, It.IsAny<CancellationToken>()))
             .ReturnsAsync((PlatformUser?)null);
 
-        var mint = await _service.MintAsync(pu, CancellationToken.None);
+        var mint = await _service.MintAsync(pu, EnrolSessionMode.Gated, CancellationToken.None);
         var result = await _service.RedeemAsync(mint.SessionToken, CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();


### PR DESCRIPTION
## Summary

Sub-PR A1 of feature 128 (cold-start onboarding). Establishes the **\`mode: gated | standalone\`** discriminator on the existing F126 \`enrol-session\` primitive. All subsequent F128 sub-PRs (short-code transport, has-any aggregate, takeover, handoff, etc.) build on this.

- F126 council-page callers preserved unchanged — omitted \`mode\` defaults to \`Gated\`.
- Discriminator persisted as a signed JWT claim (\`pair_mode\`), not a server-side cache record.
- Mode echoed on redeem response; PWA \`EnrolRedeemResult\` surfaces it.
- Telemetry counters (\`sorcha_enrol_session_minted_total\`, \`sorcha_enrol_session_redeemed_total\`) gain a \`mode\` dimension for the F128 SC-005 contract.

## Spec refinement (worth flagging)

vs the brainstorm contracts at \`specs/128-cold-start-onboarding/contracts/rest-endpoints.md\`:
- The discriminator is a JWT claim (signed), not a separate cache record. Simpler and inherits single-use enforcement for free.
- \`returnTo\` is NOT on the mint API — it stays a URL query concern on the redeem side (matching today's F126). Mode/returnTo coherence enforcement deferred to the redeem page (\`Enrol.razor\`) in a follow-up sub-PR.
- Rationale: the F114 cryptographic ceremony is identical across modes; the discriminator is for UX + telemetry, not security.

Spec / plan / contracts will be updated in a doc-sweep sub-PR (D + polish phase) once the implementation lands.

## Test plan

- [x] Full solution builds clean (0 errors)
- [x] 1089/1097 Tenant tests pass (F126 baseline 1084 + 5 new mode tests, 8 pre-existing skips)
- [x] 111/111 Wallet PWA tests pass
- [x] New \`EnrolSessionServiceModeTests\` covers mint+redeem round-trip on both modes + immutability-from-redeem-side
- [ ] claude-review

## Sub-PR cadence (planned)

This is the first of several sub-PRs in F128. Per the F124/F125/F126 pattern, sub-PRs land into the feature branch \`128-cold-start-onboarding\` and the feature branch squash-merges to master with the \`spec-128-complete\` tag at the end.

Planned subsequent sub-PRs:
- A2: short-code transport + has-any aggregate + HasPairedDeviceProbe + CitizenWalletHubConnection \`OnDeviceEnrolled\`
- A3: US1 PairingTakeover (the operator-flagged irritant fix)
- B: US2 desktop handoff + nag-banner + Add-my-phone + email resumption
- C: US3 mobile-web install variant + seamless redeem
- D: US4 cold landing + Phase 7 polish + doc sweep + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)