### PR TITLE
feat(128) PR-B1: desktop handoff surface + post-login routing

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
@@ -1,0 +1,127 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 128 US2 — desktop handoff surface.
+
+    Mints a standalone enrol-session token on init and renders the
+    F126 HybridQrAffordance with the resulting QR URL. The citizen scans
+    the QR with their phone camera; the phone opens the wallet PWA at
+    /enrol?session=<token> where the standalone copy variant lands them
+    on the wallet Home after pairing (no returnTo).
+
+    Sub-PR B1 ships the QR variant + Skip affordance only. The
+    install-flavoured variant (US3 mobile-web) lands in sub-PR C; the
+    "Email me a link" resumption affordance lands in sub-PR B3.
+*@
+
+@using System.Net.Http.Json
+@using Microsoft.Extensions.Logging
+@using Sorcha.UI.Core.Components.EnrolGate
+@inject HttpClient Http
+@inject NavigationManager Nav
+@inject ILogger<PairingHandoffSurface> Logger
+
+<div class="sorcha-pair-handoff" data-testid="pairing-handoff-surface">
+    <h1 class="sorcha-pair-handoff__headline">Put your wallet on your phone</h1>
+    <p class="sorcha-pair-handoff__subhead">
+        Your Sorcha credentials live on your phone. Scan this code with
+        your phone camera to set up your wallet.
+    </p>
+
+    @if (_error is not null)
+    {
+        <div class="sorcha-pair-handoff__error" role="alert" data-testid="pairing-handoff-error">
+            <p>@_error</p>
+            <button type="button" @onclick="MintAsync" class="sorcha-pair-handoff__retry"
+                    data-testid="pairing-handoff-retry">
+                Try again
+            </button>
+        </div>
+    }
+    else if (_minted is not null)
+    {
+        <div class="sorcha-pair-handoff__qr-frame">
+            <HybridQrAffordance QrUrl="@_minted.QrUrl" ExpiresAt="@_minted.ExpiresAt" />
+        </div>
+    }
+    else
+    {
+        <p class="sorcha-pair-handoff__loading" data-testid="pairing-handoff-loading">
+            Preparing your pairing code…
+        </p>
+    }
+
+    <div class="sorcha-pair-handoff__footer">
+        <button type="button" @onclick="HandleSkipAsync"
+                class="sorcha-pair-handoff__skip"
+                data-testid="pairing-handoff-skip">
+            Skip for now
+        </button>
+    </div>
+</div>
+
+@code {
+    /// <summary>
+    /// Where to navigate after the citizen clicks Skip. Defaults to the
+    /// web wallet root.
+    /// </summary>
+    [Parameter] public string SkipDestination { get; set; } = "/";
+
+    private MintedHandoff? _minted;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await MintAsync();
+    }
+
+    private async Task MintAsync()
+    {
+        _error = null;
+        _minted = null;
+        StateHasChanged();
+
+        try
+        {
+            using var response = await Http.PostAsJsonAsync(
+                "/api/auth/enrol-session",
+                new MintRequest("standalone"));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Logger.LogWarning(
+                    "PairingHandoffSurface mint returned {Status}",
+                    response.StatusCode);
+                _error = "Couldn't generate a pairing code. Try again.";
+                return;
+            }
+
+            var body = await response.Content.ReadFromJsonAsync<MintResponseShape>();
+            if (body is null || string.IsNullOrEmpty(body.QrUrl))
+            {
+                _error = "Couldn't generate a pairing code. Try again.";
+                return;
+            }
+
+            _minted = new MintedHandoff(body.QrUrl, body.ExpiresAt);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "PairingHandoffSurface mint failed");
+            _error = "Couldn't reach Sorcha. Check your connection and try again.";
+        }
+    }
+
+    private Task HandleSkipAsync()
+    {
+        Nav.NavigateTo(SkipDestination);
+        return Task.CompletedTask;
+    }
+
+    private sealed record MintRequest(string Mode);
+
+    private sealed record MintResponseShape(string SessionToken, string QrUrl, DateTimeOffset ExpiresAt, string Mode);
+
+    private sealed record MintedHandoff(string QrUrl, DateTimeOffset ExpiresAt);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Setup/AddDevice.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Setup/AddDevice.razor
@@ -1,0 +1,18 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 128 US2 — desktop handoff page. Auto-routed after first
+    sign-in when the citizen has no paired devices (Login.cshtml.cs
+    sets the returnUrl to /setup/add-device when has-any-device == false).
+    Also reachable manually from the "Add my phone" menu entry (sub-PR B2).
+*@
+
+@page "/setup/add-device"
+@using Microsoft.AspNetCore.Authorization
+@using Sorcha.UI.Core.Components.Pairing
+@attribute [Authorize]
+
+<PageTitle>Set up your wallet — Sorcha</PageTitle>
+
+<PairingHandoffSurface SkipDestination="/" />

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -27,6 +27,7 @@ public class LoginModel : PageModel
     private readonly DemoEnvironmentSettings _demoSettings;
     private readonly ISocialLoginService _socialLoginService;
     private readonly ReturnToAllowlistOptions _returnToAllowlist;
+    private readonly IPlatformUserDeviceService _deviceService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LoginModel"/> class.
@@ -40,7 +41,8 @@ public class LoginModel : PageModel
         ILogger<LoginModel> logger,
         IOptions<DemoEnvironmentSettings> demoSettings,
         ISocialLoginService socialLoginService,
-        IOptions<ReturnToAllowlistOptions> returnToAllowlist)
+        IOptions<ReturnToAllowlistOptions> returnToAllowlist,
+        IPlatformUserDeviceService deviceService)
     {
         _loginService = loginService;
         _totpService = totpService;
@@ -51,6 +53,7 @@ public class LoginModel : PageModel
         _demoSettings = demoSettings.Value;
         _socialLoginService = socialLoginService;
         _returnToAllowlist = returnToAllowlist?.Value ?? new ReturnToAllowlistOptions();
+        _deviceService = deviceService;
     }
 
     /// <summary>Demo-environment banner flag — when true the page shows the warning notice.</summary>
@@ -292,7 +295,17 @@ public class LoginModel : PageModel
 
     private IActionResult RedirectToApp(TokenResponse tokens)
     {
+        // Feature 128 US2 — when the citizen has no paired device and no
+        // explicit ReturnUrl override, route them to /setup/add-device so
+        // the WASM client lands on the pairing handoff page (FR-020).
+        // Citizens who already have a paired device follow the existing
+        // ReturnUrl / "" behaviour unchanged (FR-026).
         var returnUrl = IsValidReturnUrl(ReturnUrl, _returnToAllowlist) ? ReturnUrl : "";
+        if (string.IsNullOrEmpty(returnUrl) && ShouldRouteToSetupAddDevice(tokens.AccessToken))
+        {
+            returnUrl = "/setup/add-device";
+        }
+
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
                        $"&refresh={Uri.EscapeDataString(tokens.RefreshToken)}";
         if (!string.IsNullOrEmpty(returnUrl))
@@ -300,6 +313,40 @@ public class LoginModel : PageModel
             fragment += $"&returnUrl={Uri.EscapeDataString(returnUrl!)}";
         }
         return Redirect($"/app/#{fragment}");
+    }
+
+    /// <summary>
+    /// Reads <c>platform_user_id</c> from the freshly-issued access token and
+    /// queries <see cref="IPlatformUserDeviceService.HasAnyAsync"/>. Returns
+    /// true when the citizen has zero active paired devices — the F128
+    /// auto-route trigger. Non-fatal: any failure (token parse, DB error)
+    /// is logged and falls through to the existing redirect behaviour.
+    /// </summary>
+    private bool ShouldRouteToSetupAddDevice(string accessToken)
+    {
+        try
+        {
+            var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(accessToken);
+            var raw = jwt.Claims.FirstOrDefault(c => c.Type == "platform_user_id")?.Value;
+            if (!Guid.TryParse(raw, out var platformUserId))
+            {
+                return false;
+            }
+
+            // Block synchronously on the aggregate read; this is one cheap
+            // DB hit on the post-login path, and the call site is already
+            // synchronous so refactoring all three sites to async-everything
+            // is more invasive than warranted.
+            var (hasAny, _) = _deviceService.HasAnyAsync(platformUserId).GetAwaiter().GetResult();
+            return !hasAny;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "F128 setup-add-device routing check failed — falling through to default redirect");
+            return false;
+        }
     }
 
     /// <summary>

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/LoginModelTests.cs
@@ -28,6 +28,7 @@ public class LoginModelTests
     private readonly Mock<IIdentityRepository> _identityRepo = new();
     private readonly Mock<IOrganizationRepository> _orgRepo = new();
     private readonly Mock<ISocialLoginService> _socialLoginService = new();
+    private readonly Mock<IPlatformUserDeviceService> _deviceService = new();
 
     private LoginModel CreateModel()
     {
@@ -40,7 +41,8 @@ public class LoginModelTests
             NullLogger<LoginModel>.Instance,
             Options.Create(new DemoEnvironmentSettings()),
             _socialLoginService.Object,
-            Options.Create(new ReturnToAllowlistOptions()));
+            Options.Create(new ReturnToAllowlistOptions()),
+            _deviceService.Object);
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(


### PR DESCRIPTION
## Summary

Sub-PR B1 of feature 128 — primary US2 happy path. Citizen signs in with zero paired devices → lands on \`/setup/add-device\` → sees QR → scans with phone → wallet pairs.

## What lands

1. **\`PairingHandoffSurface.razor\`** in \`Sorcha.UI.Components.User/Components/Pairing/\`. Mints a standalone enrol-session token (using the A1 mode discriminator), renders the existing F126 \`HybridQrAffordance\`, Skip button with retry-on-error.
2. **\`/setup/add-device\` page** in \`Sorcha.UI.Web.Client/Pages/Setup/\`. Authenticated. Hosts the surface.
3. **\`Login.cshtml.cs\`** \`RedirectToApp\` gate. Parses platform_user_id from the freshly-issued access token, queries \`IPlatformUserDeviceService.HasAnyAsync\` (A2 endpoint), routes to \`/setup/add-device\` when zero paired AND no explicit ReturnUrl override. Non-fatal — any failure falls through to the existing redirect. **Covers FR-020 + FR-026.**

## Deferred to subsequent sub-PRs

- **B2:** \`PairingNagBanner\` + "Add my phone" menu entry in MyDevices
- **B3:** Email-resumption ("Email me a link" affordance) — F112 template + endpoint + service
- **C:** Mobile-web install-flavoured variant + seamless redeem
- **D:** \`/get\` cold landing + Phase 7 polish + doc sweep + \`spec-128-complete\` tag

## Test plan

- [x] Full solution builds clean
- [x] Tenant 1097/1105 (\`LoginModelTests\` updated for the new constructor parameter; 8 pre-existing skips)
- [x] Wallet PWA, Wallet Service, UI.Core unchanged
- [ ] claude-review

## Note on testing

Bunit test for \`PairingHandoffSurface\` deferred — \`Sorcha.UI.Core.Tests\` HttpClient-mocking + \`NavigationManager\` + \`ILogger\` triple-injection setup is non-trivial for a Razor component; the underlying mint path is covered by \`EnrolSessionServiceModeTests\` (A1). Manual smoke + the post-login routing exercise integration verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)