### PR TITLE
feat(128) PR-B2: PairingNagBanner + Add-my-phone menu entry

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor
@@ -1,0 +1,86 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Feature 128 US2 (FR-024) — persistent dismissable banner.
+
+    Renders above the Sorcha Web main content when the signed-in citizen
+    has zero paired devices. Citizen can dismiss for the session (the
+    flag is local-only — not persisted server-side so a fresh browser
+    surfaces the banner again as a safety net). CTA navigates to
+    /setup/add-device which hosts the handoff page from sub-PR B1.
+
+    Hidden once IHasPairedDeviceProbe reports HasAnyDevice == true,
+    which flips when the citizen completes pairing on any device (local
+    or remote via the F128 hub event, sub-PR A3).
+*@
+
+@using Microsoft.Extensions.Logging
+@using Sorcha.UI.Core.Services.User.Devices
+@inject IHasPairedDeviceProbe Probe
+@inject NavigationManager Nav
+@inject ILogger<PairingNagBanner> Logger
+@implements IDisposable
+
+@if (_visible)
+{
+    <MudAlert Severity="Severity.Info"
+              ShowCloseIcon="true"
+              CloseIconClicked="HandleDismiss"
+              Class="mb-3"
+              data-testid="pairing-nag-banner">
+        <div class="d-flex align-center" style="gap: 12px;">
+            <span style="flex: 1;">
+                You haven't paired a phone yet — your Sorcha credentials
+                live on your phone, so set one up to start receiving them.
+            </span>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="HandleSetUpNow"
+                       data-testid="pairing-nag-banner-cta">
+                Pair my phone
+            </MudButton>
+        </div>
+    </MudAlert>
+}
+
+@code {
+    private bool _dismissed;
+    private bool _visible;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Probe.Changed += HandleProbeChanged;
+        await Probe.EnsureLoadedAsync();
+        UpdateVisibility();
+    }
+
+    private void HandleProbeChanged()
+    {
+        UpdateVisibility();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void UpdateVisibility()
+    {
+        // Show only when the probe has resolved AND reports no paired device
+        // AND the citizen hasn't dismissed this session.
+        _visible = !_dismissed && Probe.HasAnyDevice == false;
+    }
+
+    private void HandleDismiss()
+    {
+        _dismissed = true;
+        _visible = false;
+    }
+
+    private void HandleSetUpNow()
+    {
+        Nav.NavigateTo("/setup/add-device");
+    }
+
+    public void Dispose()
+    {
+        Probe.Changed -= HandleProbeChanged;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -253,6 +253,14 @@
 
     <MudMainContent>
         <MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="my-4" Style="padding-bottom: 40px;">
+            @* Feature 128 US2 (FR-024) — nag-banner for signed-in citizens
+               with zero paired devices. Self-gates on IHasPairedDeviceProbe;
+               dismissable per-session. *@
+            <AuthorizeView>
+                <Authorized>
+                    <Sorcha.UI.Core.Components.Pairing.PairingNagBanner />
+                </Authorized>
+            </AuthorizeView>
             @Body
         </MudContainer>
     </MudMainContent>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
@@ -32,14 +32,28 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject ILogger<MyDevices> Logger
+@inject NavigationManager Nav
 
 <PageTitle>My Devices - Sorcha Platform</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
-    <MudText Typo="Typo.h4" Class="mb-2">
-        <MudIcon Icon="@Icons.Material.Filled.Devices" Class="mr-2" />
-        My Devices
-    </MudText>
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2">
+        <MudText Typo="Typo.h4">
+            <MudIcon Icon="@Icons.Material.Filled.Devices" Class="mr-2" />
+            My Devices
+        </MudText>
+        <MudSpacer />
+        @* Feature 128 US2 (FR-025) — "Add my phone" affordance, visible
+           regardless of paired-device count so a citizen can always add
+           another device from here. Routes to the F128 handoff page. *@
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.AddToHomeScreen"
+                   OnClick="@(() => Nav.NavigateTo("/setup/add-device"))"
+                   data-testid="my-devices-add-my-phone">
+            Add my phone
+        </MudButton>
+    </MudStack>
     <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
         Wallet devices you've enrolled. Lost your phone? Revoke it here so
         verifiers reject any further presentations from that device.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -78,6 +78,17 @@ builder.Services.AddHttpClient<IEnrolPairingSignal, EnrolPairingSignal>(client =
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 });
+
+// Feature 128 — shared has-any-device probe. Drives the PairingNagBanner
+// on every MainLayout render for signed-in citizens with zero paired
+// devices (FR-024). The same probe is also registered in the PWA
+// (Sorcha.Wallet.Pwa) where it drives the takeover trigger (sub-PR A3).
+builder.Services.AddHttpClient<Sorcha.UI.Core.Services.User.Devices.IHasPairedDeviceProbe,
+                               Sorcha.UI.Core.Services.User.Devices.HasPairedDeviceProbe>(client =>
+{
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+});
+
 builder.Services.AddSingleton(TimeProvider.System);
 
 var host = builder.Build();


### PR DESCRIPTION
## Summary

Sub-PR B2 of feature 128. Two recovery affordances for citizens who skipped the post-signup handoff (B1) or arrived at the web wallet without a paired device.

## What lands

1. **\`PairingNagBanner.razor\`** — new component in \`Sorcha.UI.Components.User/Components/Pairing/\`. Renders above MainContent in \`Sorcha.UI.Web.Client\` for signed-in citizens whose \`IHasPairedDeviceProbe\` reports \`HasAnyDevice == false\`. Dismissable per-session. CTA → \`/setup/add-device\`. **FR-024.**
2. **"Add my phone"** button on \`MyDevices.razor\`. Visible regardless of paired-device count so a citizen with an existing phone can add another. **FR-025.**

DI: \`IHasPairedDeviceProbe\` registered in \`Sorcha.UI.Web.Client/Program.cs\` — same shared service that drives the PWA takeover trigger (A3).

## Test plan
- [x] Components.User + UI.Web.Client build clean
- [x] No regression risk to existing tests
- [ ] claude-review

## Remaining for spec-128-complete
- **B3:** Email-resumption ("Email me a link") — F112 template + endpoint + service
- **C:** Mobile-web install variant + seamless redeem
- **D:** \`/get\` cold landing + Phase 7 polish + doc sweep + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)