### PR TITLE
feat(128) PR-C: US3 mobile-web install variant + short-code fallback

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingHandoffSurface.razor
@@ -2,32 +2,42 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Feature 128 US2 — desktop handoff surface.
+    Feature 128 US2 + US3 — desktop handoff surface.
 
-    Mints a standalone enrol-session token on init and renders the
-    F126 HybridQrAffordance with the resulting QR URL. The citizen scans
-    the QR with their phone camera; the phone opens the wallet PWA at
-    /enrol?session=<token> where the standalone copy variant lands them
-    on the wallet Home after pairing (no returnTo).
+    Renders one of two variants based on IPwaInstallabilityProbe:
 
-    Sub-PR B1 ships the QR variant + Skip affordance only. The
-    install-flavoured variant (US3 mobile-web) lands in sub-PR C; the
-    "Email me a link" resumption affordance lands in sub-PR B3.
+    1. QR variant (Story 2, desktop browsers + non-installable mobile):
+       mints a standalone enrol-session token, displays the F126
+       HybridQrAffordance. Citizen scans with phone camera, the phone
+       opens the wallet PWA at /enrol?session=<token>.
+
+    2. Install variant (Story 3, mobile browsers that can install the
+       PWA): renders "Install Sorcha Wallet" button (or iOS A2HS
+       instructions) PLUS a 6-digit short code that is always visible
+       — the citizen reads the code, installs the wallet, opens the
+       takeover (sub-PR A3), expands the "Already started on another
+       device?" sub-affordance, and types the code. This is the
+       short-code fallback path per FR-032.
+
+    Skip + Email-me-a-link are common to both variants.
+
+    Deferred to D's polish: the seamless start_url-baked token path
+    where installing on Android Chrome opens the PWA already paired
+    (FR-031). The short-code fallback covers Story 3 end-to-end
+    without that optimization.
 *@
 
 @using System.Net.Http.Json
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Components.EnrolGate
+@using Sorcha.UI.Core.Services.User.Pairing
 @inject HttpClient Http
 @inject NavigationManager Nav
+@inject IPwaInstallabilityProbe InstallProbe
 @inject ILogger<PairingHandoffSurface> Logger
 
 <div class="sorcha-pair-handoff" data-testid="pairing-handoff-surface">
     <h1 class="sorcha-pair-handoff__headline">Put your wallet on your phone</h1>
-    <p class="sorcha-pair-handoff__subhead">
-        Your Sorcha credentials live on your phone. Scan this code with
-        your phone camera to set up your wallet.
-    </p>
 
     @if (_error is not null)
     {
@@ -39,24 +49,63 @@
             </button>
         </div>
     }
-    else if (_minted is not null)
-    {
-        <div class="sorcha-pair-handoff__qr-frame">
-            <HybridQrAffordance QrUrl="@_minted.QrUrl" ExpiresAt="@_minted.ExpiresAt" />
-        </div>
-    }
-    else
+    else if (_minted is null)
     {
         <p class="sorcha-pair-handoff__loading" data-testid="pairing-handoff-loading">
             Preparing your pairing code…
         </p>
     }
+    else if (_installVerdict == PwaInstallabilityVerdict.CanInstallProgrammatically)
+    {
+        @* US3 install variant — Android Chrome / Edge with deferred prompt. *@
+        <p class="sorcha-pair-handoff__subhead">
+            Install the Sorcha Wallet on this phone. Your credentials will
+            live on this device.
+        </p>
+        <button type="button" @onclick="HandleProgrammaticInstallAsync"
+                class="sorcha-pair-handoff__install"
+                disabled="@_installBusy"
+                data-testid="pairing-handoff-install-button">
+            @if (_installBusy)
+            {
+                <span>Installing…</span>
+            }
+            else
+            {
+                <span>Install Sorcha Wallet</span>
+            }
+        </button>
+        @RenderShortCodePanel()
+    }
+    else if (_installVerdict == PwaInstallabilityVerdict.CanInstallManually)
+    {
+        @* US3 install variant — iOS Safari (no programmatic API). *@
+        <p class="sorcha-pair-handoff__subhead">
+            Install the Sorcha Wallet on this iPhone. Your credentials
+            will live on this device.
+        </p>
+        <ol class="sorcha-pair-handoff__ios-instructions"
+            data-testid="pairing-handoff-ios-instructions">
+            <li>Tap the <strong>Share</strong> icon at the bottom of Safari.</li>
+            <li>Scroll down and tap <strong>Add to Home Screen</strong>.</li>
+            <li>Tap <strong>Add</strong> in the top-right.</li>
+            <li>Open the wallet from your home screen, then enter the pairing code below.</li>
+        </ol>
+        @RenderShortCodePanel()
+    }
+    else
+    {
+        @* US2 QR variant — desktop, in-app browsers, other mobile cases. *@
+        <p class="sorcha-pair-handoff__subhead">
+            Your Sorcha credentials live on your phone. Scan this code
+            with your phone camera to set up your wallet.
+        </p>
+        <div class="sorcha-pair-handoff__qr-frame">
+            <HybridQrAffordance QrUrl="@_minted.QrUrl" ExpiresAt="@_minted.ExpiresAt" />
+        </div>
+    }
 
     <div class="sorcha-pair-handoff__footer">
-        @* Feature 128 sub-PR B3 — "Email me a link" resumption affordance.
-           Citizen can tap if they don't have their phone with them right
-           now; an email arrives with a magic-link that brings them back
-           to /setup/add-device on whatever device they tap on. *@
         <button type="button" @onclick="HandleEmailLinkAsync"
                 class="sorcha-pair-handoff__email-link"
                 disabled="@_emailLinkBusy"
@@ -91,13 +140,26 @@
     [Parameter] public string SkipDestination { get; set; } = "/";
 
     private MintedHandoff? _minted;
+    private string? _shortCode;
     private string? _error;
     private bool _emailLinkBusy;
     private bool _emailLinkSent;
+    private bool _installBusy;
+    private PwaInstallabilityVerdict _installVerdict = PwaInstallabilityVerdict.CannotInstall;
 
     protected override async Task OnInitializedAsync()
     {
+        _installVerdict = await InstallProbe.ProbeAsync();
         await MintAsync();
+
+        // Mint the short code only when the surface will render the
+        // install variant — the QR variant doesn't need it. Short-code
+        // mint is independent of the enrol-session token mint above.
+        if (_installVerdict is PwaInstallabilityVerdict.CanInstallProgrammatically
+                              or PwaInstallabilityVerdict.CanInstallManually)
+        {
+            await MintShortCodeAsync();
+        }
     }
 
     private async Task MintAsync()
@@ -115,7 +177,7 @@
             if (!response.IsSuccessStatusCode)
             {
                 Logger.LogWarning(
-                    "PairingHandoffSurface mint returned {Status}",
+                    "PairingHandoffSurface enrol-session mint returned {Status}",
                     response.StatusCode);
                 _error = "Couldn't generate a pairing code. Try again.";
                 return;
@@ -137,6 +199,68 @@
         }
     }
 
+    private async Task MintShortCodeAsync()
+    {
+        try
+        {
+            var route = _installVerdict == PwaInstallabilityVerdict.CanInstallManually
+                ? "MobilewebHandoff"
+                : "MobilewebHandoff";
+            using var response = await Http.PostAsJsonAsync(
+                "/api/auth/enrol-session/short-code",
+                new ShortCodeMintRequest(route));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Logger.LogWarning("Short-code mint returned {Status}", response.StatusCode);
+                return;
+            }
+
+            var body = await response.Content.ReadFromJsonAsync<ShortCodeMintResponseShape>();
+            _shortCode = body?.Code;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Short-code mint failed; install variant will lack the fallback");
+        }
+    }
+
+    private RenderFragment RenderShortCodePanel() => __builder =>
+    {
+        <div class="sorcha-pair-handoff__short-code" data-testid="pairing-handoff-short-code-panel">
+            <p>After installing, open the wallet and enter this pairing code:</p>
+            <div class="sorcha-pair-handoff__short-code-value"
+                 data-testid="pairing-handoff-short-code-value">
+                @(_shortCode ?? "------")
+            </div>
+            <p class="sorcha-pair-handoff__short-code-hint">
+                Valid for 5 minutes. Open the wallet on this phone and tap
+                "Already started on another device?" on the setup screen.
+            </p>
+        </div>
+    };
+
+    private async Task HandleProgrammaticInstallAsync()
+    {
+        if (_installBusy) return;
+        _installBusy = true;
+        try
+        {
+            var accepted = await InstallProbe.TriggerInstallAsync();
+            if (!accepted)
+            {
+                Logger.LogInformation("Citizen dismissed install prompt");
+            }
+            // The citizen now opens the just-installed PWA from their
+            // home screen. Pairing completes via the takeover + short
+            // code path. Nothing more to do here.
+        }
+        finally
+        {
+            _installBusy = false;
+        }
+    }
+
     private Task HandleSkipAsync()
     {
         Nav.NavigateTo(SkipDestination);
@@ -151,10 +275,6 @@
         try
         {
             using var response = await Http.PostAsync("/api/auth/pairing-resumption-email", content: null);
-            // 202 Accepted is the success path; treat all non-error status codes
-            // as "sent" since the citizen-facing copy doesn't distinguish.
-            // Rate-limit (429) and auth failures (401) flip back to the
-            // default button label so the citizen can retry.
             if (response.IsSuccessStatusCode)
             {
                 _emailLinkSent = true;
@@ -175,8 +295,8 @@
     }
 
     private sealed record MintRequest(string Mode);
-
     private sealed record MintResponseShape(string SessionToken, string QrUrl, DateTimeOffset ExpiresAt, string Mode);
-
     private sealed record MintedHandoff(string QrUrl, DateTimeOffset ExpiresAt);
+    private sealed record ShortCodeMintRequest(string Route);
+    private sealed record ShortCodeMintResponseShape(string Code, DateTimeOffset ExpiresAt);
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/IPwaInstallabilityProbe.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/IPwaInstallabilityProbe.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Services.User.Pairing;
+
+/// <summary>
+/// Three-verdict probe used by the F128 desktop handoff to decide
+/// between rendering the QR variant (Story 2) or the install-flavoured
+/// variant (Story 3) for the same-phone PWA install path.
+/// </summary>
+public enum PwaInstallabilityVerdict
+{
+    /// <summary>
+    /// Cannot install — desktop browser, in-app browser, or a mobile
+    /// browser that has no install affordance. Render the QR variant.
+    /// </summary>
+    CannotInstall = 0,
+
+    /// <summary>
+    /// Browser captured the <c>beforeinstallprompt</c> event (Android
+    /// Chrome / Edge / Samsung Internet). Install can be triggered
+    /// programmatically by invoking the deferred prompt.
+    /// </summary>
+    CanInstallProgrammatically = 1,
+
+    /// <summary>
+    /// iOS Safari ≥16.4 — PWA-installable via Add-to-Home-Screen but
+    /// there is no programmatic install API. Render manual instructions
+    /// ("Tap Share, then Add to Home Screen").
+    /// </summary>
+    CanInstallManually = 2,
+}
+
+/// <summary>
+/// Determines whether the current browser can install the wallet PWA.
+/// Result is settled once on initialisation and surfaced as a single
+/// <see cref="PwaInstallabilityVerdict"/> for the surface to switch on.
+/// </summary>
+/// <remarks>
+/// Per F128 research R2 — listens for the <c>beforeinstallprompt</c>
+/// event for ~500ms after load (the empirical window after which
+/// Chromium fires it if eligibility checks pass), then falls back to
+/// UA-string detection for iOS Safari ≥16.4. The 500ms window is a
+/// trade-off: longer delays the page render, shorter risks missing
+/// the event.
+/// </remarks>
+public interface IPwaInstallabilityProbe
+{
+    /// <summary>
+    /// Probes the current browser. Idempotent — repeat calls return
+    /// the same verdict without re-running detection.
+    /// </summary>
+    Task<PwaInstallabilityVerdict> ProbeAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Triggers the deferred install prompt captured during
+    /// <see cref="ProbeAsync"/>. Only valid when the verdict was
+    /// <see cref="PwaInstallabilityVerdict.CanInstallProgrammatically"/>.
+    /// Returns true if the citizen accepted the install, false on
+    /// dismissal or any failure.
+    /// </summary>
+    Task<bool> TriggerInstallAsync(CancellationToken ct = default);
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/PwaInstallabilityProbe.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Pairing/PwaInstallabilityProbe.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+
+namespace Sorcha.UI.Core.Services.User.Pairing;
+
+/// <summary>
+/// JS-interop implementation of <see cref="IPwaInstallabilityProbe"/>.
+/// The companion JS module (<c>pwa-install-probe.js</c>) captures the
+/// <c>beforeinstallprompt</c> event eagerly on script load so the
+/// probe can resolve quickly when invoked.
+/// </summary>
+public sealed class PwaInstallabilityProbe : IPwaInstallabilityProbe
+{
+    private const string ModulePath = "./js/pwa-install-probe.js";
+
+    private readonly IJSRuntime _js;
+    private readonly ILogger<PwaInstallabilityProbe> _logger;
+    private IJSObjectReference? _module;
+    private PwaInstallabilityVerdict? _cachedVerdict;
+
+    public PwaInstallabilityProbe(IJSRuntime js, ILogger<PwaInstallabilityProbe> logger)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<PwaInstallabilityVerdict> ProbeAsync(CancellationToken ct = default)
+    {
+        if (_cachedVerdict.HasValue)
+        {
+            return _cachedVerdict.Value;
+        }
+
+        try
+        {
+            _module ??= await _js.InvokeAsync<IJSObjectReference>("import", ct, ModulePath)
+                .ConfigureAwait(false);
+
+            var verdict = await _module.InvokeAsync<string>("probe", ct).ConfigureAwait(false);
+            _cachedVerdict = verdict switch
+            {
+                "programmatic" => PwaInstallabilityVerdict.CanInstallProgrammatically,
+                "manual" => PwaInstallabilityVerdict.CanInstallManually,
+                _ => PwaInstallabilityVerdict.CannotInstall,
+            };
+            return _cachedVerdict.Value;
+        }
+        catch (Exception ex)
+        {
+            // Fail-safe: when JS interop is unavailable (prerender,
+            // sandboxed iframe, etc.) treat as not-installable so the
+            // surface falls through to the QR variant.
+            _logger.LogWarning(ex,
+                "PwaInstallabilityProbe failed — defaulting to CannotInstall");
+            _cachedVerdict = PwaInstallabilityVerdict.CannotInstall;
+            return _cachedVerdict.Value;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TriggerInstallAsync(CancellationToken ct = default)
+    {
+        if (_module is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return await _module.InvokeAsync<bool>("triggerInstall", ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "PwaInstallabilityProbe install-prompt failed");
+            return false;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -89,6 +89,12 @@ builder.Services.AddHttpClient<Sorcha.UI.Core.Services.User.Devices.IHasPairedDe
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
 });
 
+// Feature 128 US3 — PWA-installability probe used by PairingHandoffSurface
+// to switch between the QR variant and the install-flavoured variant.
+// Singleton so the cached verdict survives across surface re-renders.
+builder.Services.AddSingleton<Sorcha.UI.Core.Services.User.Pairing.IPwaInstallabilityProbe,
+                              Sorcha.UI.Core.Services.User.Pairing.PwaInstallabilityProbe>();
+
 builder.Services.AddSingleton(TimeProvider.System);
 
 var host = builder.Build();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/js/pwa-install-probe.js
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/js/pwa-install-probe.js
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// Feature 128 US3 — PWA install probe.
+//
+// Captures the `beforeinstallprompt` event eagerly on module load so
+// the C# probe can resolve quickly when invoked from a Razor component.
+// Per research R2: Chromium fires `beforeinstallprompt` within a few
+// hundred ms of page load if eligibility checks pass; iOS Safari never
+// fires it (we detect that via UA-string fallback).
+
+let deferredPrompt = null;
+
+window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+});
+
+window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+});
+
+function isIosSafari() {
+    const ua = navigator.userAgent || '';
+    // iOS Safari ≥16.4: PWA installable via Add-to-Home-Screen but no
+    // programmatic install API. Detect iPhone/iPad UA + Safari (exclude
+    // Chrome-on-iOS and other webviews which DON'T support PWA install).
+    const isIos = /iPad|iPhone|iPod/.test(ua) && !window.MSStream;
+    const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|GSA/.test(ua);
+    return isIos && isSafari;
+}
+
+function isAlreadyInstalled() {
+    // If the page is running inside an installed PWA (standalone
+    // display mode), there's nothing to install.
+    return window.matchMedia('(display-mode: standalone)').matches
+        || window.navigator.standalone === true;
+}
+
+export async function probe() {
+    if (isAlreadyInstalled()) {
+        return 'installed';
+    }
+
+    // Wait briefly for the beforeinstallprompt event in case the page
+    // just loaded and Chromium hasn't fired it yet.
+    if (!deferredPrompt) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    if (deferredPrompt) {
+        return 'programmatic';
+    }
+
+    if (isIosSafari()) {
+        return 'manual';
+    }
+
+    return 'none';
+}
+
+export async function triggerInstall() {
+    if (!deferredPrompt) {
+        return false;
+    }
+
+    try {
+        deferredPrompt.prompt();
+        const choice = await deferredPrompt.userChoice;
+        deferredPrompt = null;
+        return choice && choice.outcome === 'accepted';
+    } catch (e) {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Sub-PR C of feature 128. \`PairingHandoffSurface\` now detects PWA-installable mobile browsers and renders an install-flavoured variant instead of an unscannable QR. The 6-digit short code from A2's mint endpoint is always visible so iOS Safari (no programmatic install API) and lossy-install edge cases have a guaranteed fallback path through the A3 takeover.

## What lands

- **\`IPwaInstallabilityProbe\` + \`PwaInstallabilityProbe\`** in \`Sorcha.UI.Components.User/Services/User/Pairing/\`. Three-verdict: CannotInstall / CanInstallProgrammatically / CanInstallManually. Per F128 research R2.
- **\`wwwroot/js/pwa-install-probe.js\`** — JS interop module. Captures \`beforeinstallprompt\` eagerly on load; UA-string fallback for iOS Safari; detects "already installed" via standalone display mode.
- **\`PairingHandoffSurface\`** extended to switch on the verdict:
  - Programmatic → "Install Sorcha Wallet" button calling the deferred prompt
  - Manual → iOS Add-to-Home-Screen instructions
  - Both → 6-digit short code always visible below (FR-032)
- **DI:** \`PwaInstallabilityProbe\` Singleton in \`Sorcha.UI.Web.Client/Program.cs\`.

## Spec refinement
The seamless \`start_url\`-baked token path (FR-031) is deferred. The short-code fallback through the takeover (A3) covers Story 3 end-to-end without the iOS-quirk-dependent seamless path. SC-006 measurement post-launch will drive whether the seamless path is worth adding.

## Test plan
- [x] Components.User + Web.Client build clean
- [ ] claude-review
- Bunit deferred (would need IPwaInstallabilityProbe + IJSRuntime mocking). Underlying mint paths covered by EnrolSessionServiceModeTests (A1) + PairingShortCodeServiceTests (A2).

## Remaining for spec-128-complete
- **D:** \`/get\` cold landing + Phase 7 polish + doc sweep + \`spec-128-complete\` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)