### PR TITLE
chore(skills): refresh .NET skill packs under .github/skills

### DIFF
--- a/.github/skills/.dotnet-skills-auto-state.json
+++ b/.github/skills/.dotnet-skills-auto-state.json
@@ -1,0 +1,24 @@
+{
+  "Version": 1,
+  "ProjectRoot": "C:\\Projects\\Sorcha",
+  "Skills": [
+    "aspire",
+    "aspnet-core",
+    "blazor",
+    "configuring-opentelemetry-dotnet",
+    "coverage-analysis",
+    "coverlet",
+    "entity-framework-core",
+    "grpc",
+    "mcp",
+    "microsoft-extensions",
+    "migrate-xunit-to-xunit-v3",
+    "minimal-api-file-upload",
+    "nunit",
+    "optimizing-ef-core-queries",
+    "signalr",
+    "worker-services",
+    "xunit"
+  ],
+  "UpdatedAt": "2026-05-16T12:56:37.6154032+00:00"
+}

--- a/.github/skills/aspire/SKILL.md
+++ b/.github/skills/aspire/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: aspire
+description: "Build, upgrade, and operate .NET Aspire 13.3.x application hosts with current CLI, AppHost, ServiceDefaults, integrations, dashboard, testing, and Azure deployment patterns for distributed apps. USE FOR: Aspire.AppHost.Sdk, Aspire.Hosting.*, DistributedApplication.CreateBuilder, WithReference, WaitFor, AddProject, AddRedis, AddPostgres, aspire run, aspire init, aspire. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Best for current Aspire 13.3.x tooling on .NET 10; use version-aware upgrade guidance for older 8.x or 9.x Aspire solutions."
+---
+
+# .NET Aspire
+
+## Trigger On
+
+- `Aspire.AppHost.Sdk`, `Aspire.Hosting.*`, `DistributedApplication.CreateBuilder`, `WithReference`, `WaitFor`, `AddProject`, `AddRedis`, `AddPostgres`, `aspire run`, `aspire init`, `aspire add`, or `aspire update`
+- `Aspire.Hosting.Testing`, `DistributedApplicationTestingBuilder`, or a test harness that mixes an Aspire AppHost with `WebApplicationFactory`
+- orchestrating multiple services and resources with an AppHost for local development or cloud deployment
+- setting up `ServiceDefaults`, service discovery, OpenTelemetry, health checks, or the Aspire Dashboard
+- choosing between official first-party Aspire integrations and `CommunityToolkit/Aspire`
+- upgrading older 8.x or 9.x Aspire solutions to the current CLI and AppHost SDK model
+- wiring polyglot services into an Aspire topology, especially when Go, Java, Python, or extra dev-time tools enter the picture
+
+## Workflow
+
+1. Classify the task first: new AppHost creation, existing-solution enlistment, integration wiring, testing and observability, deployment, or version upgrade.
+2. Prefer the current Aspire toolchain. For greenfield or modernized work, use the Aspire CLI and current AppHost SDK instead of writing new guidance around the deprecated legacy workload.
+3. Treat 13.3.x releases as servicing and feature updates for the current CLI-first app model, not a topology rewrite. Keep the Aspire CLI, `Aspire.AppHost.Sdk`, and closely coupled hosting or testing packages on the same line, then rerun the AppHost and deployment checks after `aspire update`.
+4. Keep the AppHost code-first and topology-focused. Model services, resources, dependencies, endpoints, lifetimes, and parameters there; keep business logic out.
+5. Keep `ServiceDefaults` narrow. It exists for telemetry, health checks, resilience, and service discovery, not shared domain models or general utility code.
+6. Prefer official first-party Aspire integrations when they cover the requirement. Use `CommunityToolkit/Aspire` only when the capability gap is real: unsupported language hosts, extra dev infrastructure, or extension packages the official project does not provide.
+7. Validate the whole distributed system, not one project in isolation. Local success means the AppHost starts cleanly, dependencies resolve through `WithReference`, the dashboard shows the expected resource graph, and end-to-end tests can exercise the topology.
+8. For integration tests, keep one shared AppHost fixture per test session. Use `Aspire.Hosting.Testing` to boot the distributed app, create `HttpClient` or SignalR clients from the AppHost, and layer `WebApplicationFactory` on top only when tests need direct Host DI, grains, or runtime services.
+9. When publishing, switch from local containers or emulators to managed resources deliberately and verify which services truly need external endpoints.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  A["Distributed-app task"] --> B{"Need code-first orchestration?"}
+  B -->|No| C["Stay in service-level skills such as ASP.NET Core, Worker, or Orleans"]
+  B -->|Yes| D["Create or update the AppHost"]
+  D --> E["Model resources and services with `WithReference` and `WaitFor`"]
+  E --> F{"Official Aspire integration exists?"}
+  F -->|Yes| G["Use first-party Aspire integration"]
+  F -->|No or gap remains| H["Evaluate `CommunityToolkit/Aspire`"]
+  G --> I["Apply `ServiceDefaults`, dashboard, and tests"]
+  H --> I
+  I --> J{"Publishing now?"}
+  J -->|No| K["Run locally with `aspire run` or the AppHost project"]
+  J -->|Yes| L["Choose `azd`, App Service, or the CLI deploy/publish pipeline"]
+```
+
+## Current Guidance
+
+- AppHost shape: prefer current SDK-style AppHost projects using `Aspire.AppHost.Sdk/<version>` or a file-based AppHost when that repo intentionally uses the single-file model. Recognize both as valid current patterns.
+- CLI entry points: use `aspire new` for starter projects, `aspire init` to add Aspire support to an existing solution or create a single-file AppHost, `aspire add` to add integrations or starter pieces, `aspire run` for local orchestration, `aspire start`/`aspire stop`/`aspire ps` for detached lifecycle management, `aspire describe` for live resource inspection, `aspire doctor` for environment diagnostics, `aspire secret` for user secrets, `aspire docs` for terminal documentation lookup, `aspire agent` for AI agent integration, `aspire deploy` for the current CLI deploy pipeline, `aspire restore` for AppHost and TypeScript resource refresh, and `aspire update` for version-aware upgrades. `aspire publish` still exists for explicit artifact-generation flows and remains preview-sensitive.
+- Patch posture: Aspire `13.2.2` is the current baseline release in the 13.2 line. Treat it as a current CLI and AppHost refresh, not a new topology model; align package versions, rerun `aspire update`, then revalidate local orchestration and the chosen deployment path.
+- App model wiring: use `WithReference(...)` for dependency and configuration flow, and `WaitFor(...)` for startup ordering. Use `WithExternalHttpEndpoints()` only when the resource truly needs an externally reachable endpoint for the chosen runtime or publish target.
+- ServiceDefaults boundaries: `AddServiceDefaults()` should stay focused on OpenTelemetry, health endpoints, service discovery, `HttpClient` resilience, and related cross-cutting infrastructure.
+- Testing model: prefer Aspire closed-box testing when you need to run the distributed application as a system. Use `DistributedApplicationTestingBuilder` plus a shared fixture for AppHost lifecycle, `App.CreateHttpClient(...)` for resource-bound clients, and a `WebApplicationFactory<TEntryPoint>` wrapper only when the test must resolve DI services or in-process runtime state from the hosted app. For UI flows, initialize Playwright once in the shared fixture, create a fresh browser context per test, and capture failure artifacts.
+- Dashboard usage: treat the Aspire Dashboard as the development observability surface. It is valuable in AppHost runs and standalone OTLP scenarios, but it is not a production monitoring replacement.
+- Upgrade posture: older 8.x or 9.x solutions need explicit migration work. Current guidance favors the Aspire CLI upgrade path and the newer AppHost SDK structure on `.NET 10`.
+
+## Selection Rules
+
+- Use first-party Aspire when the package and docs exist for the resource or platform, especially for core .NET, Azure, cache, database, messaging, Microsoft Foundry, and standard local-container flows.
+- Use `CommunityToolkit/Aspire` when you need polyglot app hosts beyond official coverage, extra dev-time tools around a resource, or community-maintained integrations such as SQLite, Java, Go, PowerShell, k6, MailPit, MinIO, or Meilisearch.
+- Prefer the smallest surface that solves the problem. Do not add a broad toolkit extension pack when an existing first-party integration plus a normal library already fits.
+- Treat toolkit packages as community-supported. Verify maturity, maintenance, external container images, and security or licensing assumptions before making them part of a production baseline.
+
+## Official Sources
+
+- [Aspire docs home](https://aspire.dev/docs/)
+- [What's new in Aspire 13.3](https://aspire.dev/whats-new/aspire-13-3/)
+- [AppHost](https://aspire.dev/get-started/app-host/)
+- [Service defaults](https://aspire.dev/fundamentals/service-defaults/)
+- [Integrations overview](https://aspire.dev/integrations/overview/)
+- [Build your first app](https://aspire.dev/get-started/first-app/)
+- [Aspire CLI reference](https://aspire.dev/reference/cli/commands/aspire/)
+- [Aspire 13.3 release](https://github.com/microsoft/aspire/releases/tag/v13.3.0)
+- [Testing overview](https://aspire.dev/testing/overview/)
+- [microsoft/aspire](https://github.com/microsoft/aspire)
+- [CommunityToolkit/Aspire](https://github.com/CommunityToolkit/Aspire)
+
+## Anti-Patterns
+
+- hardcoding service URLs or connection strings instead of using `WithReference`
+- putting business logic, data migrations, or large configuration transforms inside the AppHost
+- turning `ServiceDefaults` into a dumping ground for shared models or helpers
+- adding external HTTP endpoints everywhere instead of only where runtime or publish needs them
+- defaulting to `CommunityToolkit/Aspire` when first-party Aspire already covers the requirement
+- assuming the dashboard or local containers automatically mean production readiness
+- treating Aspire tests as a mocking framework; they run the application as a real distributed system
+
+## Deliver
+
+- a version-aware Aspire architecture or upgrade direction
+- the right AppHost, ServiceDefaults, integration, and CLI workflow
+- an explicit first-party versus `CommunityToolkit/Aspire` package decision
+- an end-to-end validation path for local orchestration, testing, and deployment
+
+## Validate
+
+- the AppHost starts cleanly via `aspire run` or the AppHost project
+- resources and projects are modeled with explicit `WithReference` and `WaitFor` relationships where needed
+- consuming apps resolve endpoints and connection strings without hardcoded values
+- `ServiceDefaults` contains only cross-cutting infrastructure concerns
+- dashboard, health checks, logs, and traces reflect the expected resource graph
+- Aspire-backed integration tests reuse a shared AppHost fixture instead of booting the distributed app inside each test
+- any `WebApplicationFactory` layer reuses connection strings and endpoints from the AppHost instead of duplicating local config
+- testing and deployment guidance matches the chosen runtime: local AppHost, standalone dashboard, ACA/App Service, or the CLI deploy/publish pipeline
+
+## References
+
+- [patterns.md](references/patterns.md) - Current CLI-first setup flows, AppHost patterns, `ServiceDefaults`, testing, and upgrade checkpoints
+- [testing.md](references/testing.md) - Shared AppHost fixtures, `DistributedApplicationTestingBuilder`, `WebApplicationFactory` integration, Playwright bootstrapping, and diagnostics
+- [deployment.md](references/deployment.md) - ACA, App Service, publish-mode, and manifest-oriented deployment guidance
+- [community-toolkit.md](references/community-toolkit.md) - Practical guide to `CommunityToolkit/Aspire` packages, capability gaps, and selection rules

--- a/.github/skills/aspire/manifest.json
+++ b/.github/skills/aspire/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.3.3",
+  "category": "Cloud",
+  "package_prefix": "Aspire"
+}

--- a/.github/skills/aspire/references/community-toolkit.md
+++ b/.github/skills/aspire/references/community-toolkit.md
@@ -1,0 +1,145 @@
+# `CommunityToolkit/Aspire` Reference
+
+Use this reference when official first-party Aspire integrations do not cover the scenario or when the user explicitly asks about `CommunityToolkit/Aspire`.
+
+Last verified against:
+
+- `CommunityToolkit/Aspire` release `v13.1.1` published on `2026-01-16`
+- the current repository README package index and Microsoft Learn Community Toolkit pages
+
+## Table of Contents
+
+- [When to use the toolkit](#when-to-use-the-toolkit)
+- [Selection rules](#selection-rules)
+- [Package families](#package-families)
+- [What not to do](#what-not-to-do)
+
+## When to use the toolkit
+
+Reach for `CommunityToolkit/Aspire` when you need one of these:
+
+- polyglot host integrations beyond first-party Aspire coverage
+- community-maintained resource integrations that official Aspire does not provide
+- extra development-time utilities around existing resource types
+- niche infrastructure or test-tool resources that should still live in the AppHost model
+
+Do not reach for it simply because it exists. First-party Aspire remains the default for core official scenarios.
+
+## Selection rules
+
+### Prefer first-party Aspire when
+
+- official Aspire already has the integration you need
+- the scenario is a mainstream database, cache, Azure resource, messaging broker, or normal .NET service topology
+- the repo benefits from staying as close as possible to Microsoft-maintained docs and examples
+
+### Prefer `CommunityToolkit/Aspire` when
+
+- you need to host non-.NET apps such as Go, Java, PowerShell, Deno, Bun, or Rust in the AppHost
+- you need SQLite-specific hosting or related EF and client wiring
+- you want extra dev-time tools such as MailPit, ngrok, k6, McpInspector, Adminer, or DbGate in the topology
+- you need community-maintained integrations such as Meilisearch, MinIO, RavenDB, SurrealDB, KurrentDB, LavinMQ, or Zitadel
+- you need extension packages around existing first-party resources, such as Redis, PostgreSQL, SQL Server, MySQL, MongoDB, Keycloak, Elasticsearch, or OpenTelemetry Collector support
+
+## Package families
+
+The toolkit surface is large. Keep the selection practical and grouped by problem type rather than trying to memorize every package name.
+
+### Polyglot and executable app hosting
+
+Use these when the AppHost must orchestrate non-.NET executable projects:
+
+- `CommunityToolkit.Aspire.Hosting.Golang`
+- `CommunityToolkit.Aspire.Hosting.Java`
+- `CommunityToolkit.Aspire.Hosting.Python.Extensions`
+- `CommunityToolkit.Aspire.Hosting.JavaScript.Extensions`
+- `CommunityToolkit.Aspire.Hosting.PowerShell`
+- `CommunityToolkit.Aspire.Hosting.Deno`
+- `CommunityToolkit.Aspire.Hosting.Bun`
+- `CommunityToolkit.Aspire.Hosting.Rust`
+
+These are especially important because current AppHost guidance explicitly points to toolkit integrations for Go and Java, while JavaScript has first-party coverage and Python often routes through the toolkit extension path.
+
+### Databases, object stores, and search
+
+Use these when the missing capability is a specific backing technology:
+
+- `CommunityToolkit.Aspire.Hosting.Sqlite`
+- `CommunityToolkit.Aspire.Microsoft.Data.Sqlite`
+- `CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite`
+- `CommunityToolkit.Aspire.Hosting.RavenDB`
+- `CommunityToolkit.Aspire.RavenDB.Client`
+- `CommunityToolkit.Aspire.Hosting.Meilisearch`
+- `CommunityToolkit.Aspire.Meilisearch`
+- `CommunityToolkit.Aspire.Hosting.Minio`
+- `CommunityToolkit.Aspire.Minio.Client`
+- `CommunityToolkit.Aspire.Hosting.KurrentDB`
+- `CommunityToolkit.Aspire.KurrentDB`
+- `CommunityToolkit.Aspire.Hosting.SurrealDb`
+- `CommunityToolkit.Aspire.SurrealDb`
+- `CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects`
+
+This family is often the fastest way to keep uncommon data dependencies inside the Aspire app model instead of documenting them as external setup steps.
+
+### Messaging, eventing, and feature flags
+
+- `CommunityToolkit.Aspire.Hosting.ActiveMQ`
+- `CommunityToolkit.Aspire.Hosting.LavinMQ`
+- `CommunityToolkit.Aspire.MassTransit.RabbitMQ`
+- `CommunityToolkit.Aspire.Hosting.Flagd`
+- `CommunityToolkit.Aspire.Hosting.GoFeatureFlag`
+- `CommunityToolkit.Aspire.GoFeatureFlag`
+- `CommunityToolkit.Aspire.Hosting.Dapr`
+- `CommunityToolkit.Aspire.Hosting.Azure.Dapr`
+- `CommunityToolkit.Aspire.Hosting.Azure.Dapr.Redis`
+
+Use this family when the distributed topology needs a real eventing, pub-sub, Dapr, or feature-flagged development story instead of a plain HTTP-only graph.
+
+### Platform extensions around existing resources
+
+These extend or deepen the official resource story:
+
+- `CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions`
+- `CommunityToolkit.Aspire.Hosting.SqlServer.Extensions`
+- `CommunityToolkit.Aspire.Hosting.Redis.Extensions`
+- `CommunityToolkit.Aspire.Hosting.MySql.Extensions`
+- `CommunityToolkit.Aspire.Hosting.MongoDB.Extensions`
+- `CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions`
+- `CommunityToolkit.Aspire.Hosting.Keycloak.Extensions`
+- `CommunityToolkit.Aspire.Hosting.Azure.Extensions`
+- `CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder`
+- `CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector`
+- `CommunityToolkit.Aspire.Hosting.Flyway`
+
+Choose these when first-party Aspire gets you most of the way there, but the real missing piece is a dev tool, extension, or advanced integration surface.
+
+### Dev-time utilities and diagnostics
+
+- `CommunityToolkit.Aspire.Hosting.MailPit`
+- `CommunityToolkit.Aspire.Hosting.PapercutSmtp`
+- `CommunityToolkit.Aspire.Hosting.Ngrok`
+- `CommunityToolkit.Aspire.Hosting.McpInspector`
+- `CommunityToolkit.Aspire.Hosting.DbGate`
+- `CommunityToolkit.Aspire.Hosting.Adminer`
+- `CommunityToolkit.Aspire.Hosting.k6`
+- `CommunityToolkit.Aspire.Hosting.Umami`
+
+Use these to keep development-only infrastructure visible in the AppHost instead of managing them out-of-band.
+
+### AI, file transfer, commerce, and identity
+
+- `CommunityToolkit.Aspire.Hosting.Ollama`
+- `CommunityToolkit.Aspire.OllamaSharp`
+- `CommunityToolkit.Aspire.Hosting.Sftp`
+- `CommunityToolkit.Aspire.Sftp`
+- `CommunityToolkit.Aspire.Hosting.Stripe`
+- `CommunityToolkit.Aspire.Hosting.Zitadel`
+
+These are useful when a distributed application needs more than the typical database and cache story.
+
+## What not to do
+
+- Do not add toolkit packages just because they look interesting. Tie each choice to a concrete gap.
+- Do not present community-maintained integrations as if they were automatically equivalent to first-party Aspire support.
+- Do not assume every package family is equally mature. Verify package recency, README quality, and real maintenance activity.
+- Do not let a dev-only tool become a hidden production dependency.

--- a/.github/skills/aspire/references/deployment.md
+++ b/.github/skills/aspire/references/deployment.md
@@ -1,0 +1,151 @@
+# .NET Aspire Deployment Reference
+
+Use this reference when the question is specifically about deployment shape, publish mode, Azure Container Apps, App Service, or manifest-oriented Aspire workflows.
+
+Current docs home and CLI reference now live on `aspire.dev`. The homepage and CLI docs emphasize `aspire deploy` as the current deployment command, while `aspire publish` remains a preview-oriented artifact-generation path.
+
+## Table of Contents
+
+- [Deployment defaults](#deployment-defaults)
+- [Azure Container Apps with `azd`](#azure-container-apps-with-azd)
+- [App Service-specific guidance](#app-service-specific-guidance)
+- [Publish-mode resource switching](#publish-mode-resource-switching)
+- [CLI deploy and preview publish flows](#cli-deploy-and-preview-publish-flows)
+- [Operational checks](#operational-checks)
+
+## Deployment defaults
+
+Current official guidance strongly favors Azure Developer CLI for the normal Azure path.
+
+Use this ordering by default:
+
+1. Local development and debugging with `aspire run`
+2. Azure Container Apps deployment with `azd`
+3. App Service only when the hosting constraints or team standards point there
+4. The CLI deploy or publish pipeline only when you explicitly need Aspire-managed deployment steps or artifact generation outside the normal `azd` flow
+
+Avoid inventing a custom deployment path before checking whether `azd` already covers the scenario.
+
+## Azure Container Apps with `azd`
+
+### Recommended path
+
+```bash
+azd init
+azd up
+```
+
+Why this path is the default:
+
+- `azd init` detects the AppHost and generates the right Azure-facing scaffolding
+- `azd up` provisions and deploys from the distributed application model
+- the workflow aligns with the official Aspire deployment tutorials
+
+### What `azd init` is doing
+
+In an Aspire solution, `azd init` typically:
+
+1. scans the current directory for the AppHost
+2. confirms the detected distributed application
+3. generates Azure deployment files such as `azure.yaml`
+4. creates environment-specific configuration under `.azure/`
+
+### Post-deploy dashboard access
+
+Use:
+
+```bash
+azd monitor
+```
+
+This is the preferred operational follow-up when the team wants the deployed Aspire Dashboard experience instead of hunting for URLs manually.
+
+## App Service-specific guidance
+
+App Service is valid, but it is not identical to ACA in how service-to-service traffic works.
+
+### Add the integration
+
+The current quickstart uses the Aspire App Service hosting integration:
+
+```bash
+aspire add azure-appservice
+```
+
+Then model the App Service environment in the AppHost:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureAppServiceEnvironment("app-service-env");
+
+var api = builder.AddProject<Projects.MyShop_Api>("api")
+    .WithExternalHttpEndpoints()
+    .WithHttpHealthCheck("/health");
+```
+
+Key point:
+
+- App Service currently needs externally reachable HTTP endpoints for service-to-service communication in this hosting model
+
+Do not copy a Container Apps mental model here and assume internal-only AppHost endpoints will just work.
+
+## Publish-mode resource switching
+
+Use publish-mode branching to move from local development resources to managed Azure services cleanly:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var database = builder.ExecutionContext.IsPublishMode
+    ? builder.AddAzurePostgresFlexibleServer("db").AddDatabase("catalog")
+    : builder.AddPostgres("db").AddDatabase("catalog");
+
+var cache = builder.ExecutionContext.IsPublishMode
+    ? builder.AddAzureRedis("cache")
+    : builder.AddRedis("cache");
+
+builder.AddProject<Projects.MyShop_Api>("api")
+    .WithReference(database)
+    .WithReference(cache)
+    .WaitFor(database)
+    .WaitFor(cache);
+```
+
+This is the normal way to express:
+
+- local containers or emulators for dev
+- managed Azure services for publish mode
+
+Do not keep separate hand-maintained topologies unless there is a real deployment-system constraint.
+
+## CLI deploy and preview publish flows
+
+The current Aspire CLI exposes two closely related preview-sensitive paths:
+
+- `aspire deploy` for running the deploy pipeline registered in the app model
+- `aspire publish` for explicit publish and artifact-generation scenarios
+
+Use `aspire deploy` when the task explicitly calls for:
+
+- driving the app model's deploy pipeline directly from the CLI
+- generating deploy output while letting the AppHost select and run dependent pipeline steps
+- validating a repo-specific Aspire deployment story outside `azd`
+
+Use `aspire publish` when the task explicitly calls for:
+
+- deployment artifact generation
+- manifest-oriented handoff to another toolchain
+- inspection of the publish output instead of a direct `azd` deployment
+
+Treat both flows as version-sensitive and preview-sensitive. Verify current docs and command behavior before encoding them into long-lived repo automation.
+
+## Operational checks
+
+Before calling a deployment story "done", verify:
+
+1. The local AppHost still runs after any publish-mode branching changes.
+2. Resources that must be external are explicitly external, and resources that should remain internal are not accidentally exposed.
+3. The dashboard, traces, and health endpoints reflect the expected topology after deployment.
+4. Environment-specific parameters and secrets are injected through the AppHost model or deployment tooling rather than copy-pasted config files.
+5. The team can explain why the target is ACA, App Service, `aspire deploy`, or `aspire publish`.

--- a/.github/skills/aspire/references/patterns.md
+++ b/.github/skills/aspire/references/patterns.md
@@ -1,0 +1,336 @@
+# .NET Aspire Patterns Reference
+
+Use this reference when the task is clearly about current Aspire application-host design, CLI-first workflows, `ServiceDefaults`, testing, or upgrade checkpoints.
+
+## Table of Contents
+
+- [CLI-first setup flows](#cli-first-setup-flows)
+- [AppHost shapes](#apphost-shapes)
+- [Current AppHost modeling patterns](#current-apphost-modeling-patterns)
+- [Dependency and configuration flow](#dependency-and-configuration-flow)
+- [ServiceDefaults boundaries](#servicedefaults-boundaries)
+- [Servicing patch posture](#servicing-patch-posture)
+- [Closed-box testing](#closed-box-testing)
+- [Upgrade checkpoints](#upgrade-checkpoints)
+- [Anti-patterns](#anti-patterns)
+
+## CLI-first setup flows
+
+### Create a new starter application
+
+Use the current Aspire CLI when the user wants a fresh distributed-app baseline:
+
+```bash
+aspire new aspire-starter --name MyShop
+cd MyShop
+aspire run
+```
+
+This gives you the modern baseline:
+
+- an AppHost for orchestration
+- a ServiceDefaults project for cross-cutting infrastructure
+- sample service projects wired into the AppHost
+- the Aspire Dashboard for local observability
+
+### Enlist an existing solution
+
+When the repo already has working services and you want to add orchestration instead of recreating the solution:
+
+```bash
+aspire init
+```
+
+Use `aspire init` when you need one of these:
+
+- an AppHost added to an existing solution
+- a file-based AppHost created quickly
+- Aspire support layered onto code that already exists
+
+### Add capabilities with the CLI
+
+Use the CLI to add official integrations or starter assets instead of hand-editing packages when the command exists:
+
+```bash
+aspire add <integration-or-starter>
+```
+
+Use `aspire add` when it improves repeatability, especially for:
+
+- common first-party integrations
+- starter resources that should match current Aspire conventions
+- reducing hand-written AppHost or project-file drift
+
+## Servicing patch posture
+
+Aspire `13.2.2` is the current baseline release in the 13.2 line, not a new application model. Treat 13.2.x updates as CLI and AppHost servicing work that should preserve the existing topology and only refine the toolchain surface.
+
+When you roll a 13.2.x patch:
+
+1. Keep the Aspire CLI and `Aspire.AppHost.Sdk` on the same patch line.
+2. Update adjacent Aspire packages that move with the AppHost, especially hosting and testing packages.
+3. Run `aspire update` before hand-editing package versions unless the repo intentionally pins them.
+4. Revalidate the AppHost start path, resource graph, dashboard, and any deployment scripts after the patch lands.
+5. Re-check the current CLI commands that changed in 13.2, especially `aspire start`/`aspire stop`/`aspire ps`, `aspire describe`, `aspire docs`, `aspire agent`, and `aspire restore`.
+
+Do not re-architect the AppHost just because a servicing release shipped.
+
+## AppHost shapes
+
+Current Aspire supports two valid AppHost styles.
+
+### Project-based AppHost
+
+Use this when the repo already uses the normal solution and project structure:
+
+```xml
+<Project Sdk="Aspire.AppHost.Sdk/<version>">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyShop.Api\MyShop.Api.csproj" />
+    <ProjectReference Include="..\MyShop.Web\MyShop.Web.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+Prefer the SDK-style AppHost in current projects. Do not create new 13-era examples that manually model the older AppHost package layout as if it were the default.
+
+### File-based AppHost
+
+Use this when a lightweight single-file orchestration layer is the better fit:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("db")
+    .AddDatabase("appdata");
+
+builder.AddProject<Projects.MyShop_Api>("api")
+    .WithReference(postgres)
+    .WaitFor(postgres);
+
+builder.Build().Run();
+```
+
+File-based AppHosts are useful for experimentation, smaller repos, and incremental adoption. They do not automatically include a ServiceDefaults project, so create one when the services need it.
+
+## Current AppHost modeling patterns
+
+### Minimal multi-service topology
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("postgres")
+    .AddDatabase("catalog")
+    .WithDataVolume();
+
+var cache = builder.AddRedis("cache");
+
+var api = builder.AddProject<Projects.MyShop_Api>("api")
+    .WithReference(postgres)
+    .WithReference(cache)
+    .WaitFor(postgres)
+    .WaitFor(cache);
+
+builder.AddProject<Projects.MyShop_Web>("web")
+    .WithReference(api);
+
+builder.Build().Run();
+```
+
+What matters:
+
+- infrastructure resources are modeled explicitly
+- consuming services get their config through `WithReference(...)`
+- startup ordering is intentional through `WaitFor(...)`
+- the AppHost stays at topology level
+
+### Persistent local resources
+
+If the slow path is repeated container bootstrap rather than code changes, keep state across local AppHost restarts:
+
+```csharp
+var postgres = builder.AddPostgres("postgres")
+    .WithDataVolume()
+    .WithLifetime(ContainerLifetime.Persistent)
+    .AddDatabase("catalog");
+```
+
+Use persistence deliberately. It is helpful for realistic local development, but it can hide initialization bugs if the team forgets the difference between a cold start and a reused container.
+
+### Publish-mode resource switching
+
+Use publish-mode branching when local development should use containers or emulators while published environments should use managed Azure resources:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var cache = builder.ExecutionContext.IsPublishMode
+    ? builder.AddAzureRedis("cache")
+    : builder.AddRedis("cache").WithDataVolume();
+
+var database = builder.ExecutionContext.IsPublishMode
+    ? builder.AddAzurePostgresFlexibleServer("db").AddDatabase("catalog")
+    : builder.AddPostgres("db").AddDatabase("catalog");
+
+builder.AddProject<Projects.MyShop_Api>("api")
+    .WithReference(cache)
+    .WithReference(database)
+    .WaitFor(cache)
+    .WaitFor(database);
+```
+
+This pattern is better than trying to maintain separate hand-written local and cloud topologies.
+
+## Dependency and configuration flow
+
+Official Aspire guidance treats integrations as two related but independent layers:
+
+- hosting integrations extend `IDistributedApplicationBuilder` and model resources in the AppHost
+- client integrations wire client libraries into DI, health checks, resiliency, and telemetry
+
+Use that split intentionally.
+
+### `WithReference` is the default wiring mechanism
+
+`WithReference(...)` is the normal way to pass endpoints, connection strings, credentials, or other configuration between resources.
+
+Use it instead of:
+
+- hardcoded URLs
+- copy-pasted connection strings
+- manually synchronized environment variables
+
+### `WaitFor` is for startup order, not configuration
+
+`WaitFor(...)` solves a different problem than `WithReference(...)`.
+
+- `WithReference(...)` injects configuration and expresses the dependency edge
+- `WaitFor(...)` delays startup until the dependency is ready or healthy
+
+Use both when the consuming service should not even begin until the dependency is available.
+
+### Named endpoints
+
+Use named endpoints when a service exposes more than one surface:
+
+```csharp
+var api = builder.AddProject<Projects.MyShop_Api>("api")
+    .WithHttpEndpoint(port: 5001, name: "public")
+    .WithHttpEndpoint(port: 5002, name: "internal");
+```
+
+Named endpoints are useful for:
+
+- separating public versus internal traffic
+- gRPC and HTTP on the same service
+- routing test-only or admin endpoints distinctly
+
+## ServiceDefaults boundaries
+
+The current ServiceDefaults template exists to centralize cross-cutting infrastructure, not shared business code.
+
+### Keep it focused
+
+Good content for `ServiceDefaults`:
+
+- OpenTelemetry logging, metrics, and tracing
+- health checks
+- service discovery
+- `HttpClient` resilience defaults
+- default endpoint mapping for health endpoints
+
+Bad content for `ServiceDefaults`:
+
+- domain models
+- repository implementations
+- DTOs
+- application-specific utilities unrelated to cross-cutting infrastructure
+
+### Typical structure
+
+```csharp
+public static class Extensions
+{
+    public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder)
+        where TBuilder : IHostApplicationBuilder
+    {
+        builder.ConfigureOpenTelemetry();
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddStandardResilienceHandler();
+            http.AddServiceDiscovery();
+        });
+
+        return builder;
+    }
+}
+```
+
+Current official guidance also keeps health endpoints and tracing filters aligned with these defaults. Do not fork this pattern casually unless the repo truly needs a custom shared-hosting baseline.
+
+## Closed-box testing
+
+Use Aspire testing when the requirement is to exercise the distributed system as a system instead of unit-testing a single component.
+
+Prefer Aspire testing for:
+
+- end-to-end flows across multiple services
+- verifying resource startup and wiring
+- validating service discovery and real HTTP or messaging paths
+- regression tests around the AppHost topology
+
+Do not reach for Aspire testing when:
+
+- a plain xUnit or NUnit test against one class is enough
+- the service logic can be verified entirely in-process
+- the AppHost topology is irrelevant to the assertion
+
+Testing is especially important for:
+
+- ensuring `WithReference(...)` and `WaitFor(...)` match the intended runtime graph
+- catching broken resource names or renamed endpoints
+- proving a version upgrade did not silently break orchestration
+
+Load `testing.md` when the repo mixes AppHost lifecycle, `DistributedApplicationTestingBuilder`, `WebApplicationFactory`, SignalR, or Playwright instead of using Aspire as a pure black-box API harness.
+
+## Upgrade checkpoints
+
+When modernizing older Aspire solutions, verify these points explicitly:
+
+1. The team is using the current Aspire CLI, and the upgrade path starts there.
+2. The AppHost project uses the current SDK-style layout rather than retaining older manual AppHost package wiring by inertia.
+3. The AppHost target framework is aligned with current tooling expectations for Aspire 13-era projects.
+4. The repo has removed assumptions about the old workload-based setup when those assumptions no longer apply.
+5. ServiceDefaults remains a narrow infrastructure project instead of having accumulated random shared code over time.
+
+Use:
+
+```bash
+aspire update
+```
+
+Pair the CLI upgrade with a review of:
+
+- AppHost project structure
+- project references
+- integration package versions
+- test coverage for the distributed topology
+- local run and dashboard behavior
+
+## Anti-Patterns
+
+- Treating the AppHost like an ordinary application project with business logic, service implementations, or repo-specific glue.
+- Using `WithEnvironment(...)` as the first answer when `WithReference(...)` or a normal integration already models the dependency correctly.
+- Assuming `WithExternalHttpEndpoints()` belongs on every web project. It should follow runtime needs, especially publish targets such as App Service.
+- Modeling a large topology with vague resource names like `service1` and `db2`, then expecting logs and traces to remain understandable.
+- Carrying an obsolete 8.x or 9.x setup pattern into new samples or new repos without a compatibility reason.

--- a/.github/skills/aspire/references/testing.md
+++ b/.github/skills/aspire/references/testing.md
@@ -1,0 +1,236 @@
+# .NET Aspire Testing Patterns
+
+Use this reference when the task is about AppHost-backed integration tests, `DistributedApplicationTestingBuilder`, mixing Aspire with `WebApplicationFactory`, Playwright UI automation, or practical diagnostics.
+
+These patterns are grounded in working production-style test harnesses used in `AIBase` and `WA.Storied.Agents`: one shared AppHost fixture per test session, optional `WebApplicationFactory` layering for Host DI/grains, and browser contexts created per test rather than per session.
+
+## Fixture Selection
+
+```mermaid
+flowchart LR
+  A["Test needs Aspire resources"] --> B{"Needs only external surfaces?"}
+  B -->|Yes| C["Shared AppHost fixture"]
+  C --> D["Create HttpClient / HubConnection from DistributedApplication"]
+  B -->|No, needs Host DI/grains| E["Shared AppHost fixture + WebApplicationFactory"]
+  E --> F["Resolve connection strings from AppHost into test host config"]
+  C --> G{"Needs UI automation?"}
+  G -->|Yes| H["Initialize Playwright once, create BrowserContext per test"]
+  G -->|No| I["Stay API/SignalR only"]
+```
+
+## Package Baseline
+
+Typical Aspire-backed integration suites need:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Aspire.Hosting.Testing" />
+  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+  <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+  <PackageReference Include="Microsoft.Playwright" />
+</ItemGroup>
+```
+
+Add the actual test framework package separately: `TUnit`, `xunit`, or `NUnit`.
+
+## Shared AppHost Fixture
+
+Boot the AppHost once, wait for the real resources, and hand out clients from the distributed app:
+
+```csharp
+using Aspire.Hosting.Testing;
+
+public sealed class AspireTestFixture : IAsyncDisposable
+{
+    private DistributedApplication? _app;
+
+    public DistributedApplication App =>
+        _app ?? throw new InvalidOperationException("App not initialized.");
+
+    public string ApiUrl { get; private set; } = string.Empty;
+
+    public async Task InitializeAsync()
+    {
+        var builder = await DistributedApplicationTestingBuilder.CreateAsync<Projects.My_AppHost>();
+
+        builder.Services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddConsole();
+            logging.SetMinimumLevel(LogLevel.Warning);
+            logging.AddFilter("Aspire.Hosting.Dcp", LogLevel.Warning);
+            logging.AddFilter("Aspire.Hosting.Backchannel", LogLevel.Critical);
+        });
+
+        _app = await builder.BuildAsync();
+        await _app.StartAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        await _app.ResourceNotifications.WaitForResourceHealthyAsync("api", cts.Token);
+
+        ApiUrl = _app.CreateHttpClient("api", "http").BaseAddress?.ToString()
+            ?? throw new InvalidOperationException("API URL was not resolved.");
+    }
+
+    public HttpClient CreateApiClient() => App.CreateHttpClient("api", "http");
+
+    public async Task DisposeAsync()
+    {
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+}
+```
+
+Use this shape when the test only needs the real distributed topology: API, SignalR, SSE, workers, or resource health.
+
+## Layer `WebApplicationFactory` On Top Of Aspire Infra
+
+When the test needs Host DI services, direct `IGrainFactory` access, or in-process runtime services, reuse the AppHost infrastructure and inject its connection strings into the web host:
+
+```csharp
+public sealed class TestApplication
+    : WebApplicationFactory<HostEntryPointMarker>, IAsyncDisposable
+{
+    private static readonly AspireTestFixture SharedFixture = new();
+    private readonly Dictionary<string, string?> _overrides = new(StringComparer.OrdinalIgnoreCase);
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment(Environments.Development);
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Logging:LogLevel:Default"] = "Warning",
+                ["Logging:LogLevel:Orleans"] = "Warning",
+                ["Logging:LogLevel:Aspire"] = "Warning",
+            });
+
+            config.AddInMemoryCollection(_overrides);
+        });
+    }
+
+    public async Task InitializeAsync()
+    {
+        await SharedFixture.InitializeAsync();
+
+        var tables = await SharedFixture.App.GetConnectionStringAsync("tables");
+        var blobs = await SharedFixture.App.GetConnectionStringAsync("blobs");
+
+        _overrides["ConnectionStrings:Tables"] = tables;
+        _overrides["ConnectionStrings:Blobs"] = blobs;
+
+        Environment.SetEnvironmentVariable("ConnectionStrings__Tables", tables);
+        Environment.SetEnvironmentVariable("ConnectionStrings__Blobs", blobs);
+
+        CreateClient();
+    }
+
+    public new HttpClient CreateClient()
+    {
+        var client = base.CreateClient();
+        client.Timeout = TimeSpan.FromMinutes(5);
+        return client;
+    }
+
+    public async Task DisposeAsync()
+    {
+        Dispose();
+        await SharedFixture.DisposeAsync();
+    }
+}
+```
+
+Rules that matter:
+
+- boot Aspire once, not per test
+- resolve connection strings and endpoints from `SharedFixture.App`, not from copied local config
+- keep `WebApplicationFactory` focused on DI/runtime access, not infrastructure provisioning
+- adapt the lifecycle surface to the active test framework: xUnit `IAsyncLifetime`, TUnit `IAsyncInitializer`, or the repo's own fixture abstraction
+
+## Playwright In The Shared Fixture
+
+Initialize the browser once, then create a fresh browser context per test:
+
+```csharp
+public async Task InitializePlaywrightAsync()
+{
+    await InitializeAsync();
+
+    var exitCode = Microsoft.Playwright.Program.Main(["install", "chromium"]);
+    if (exitCode != 0)
+    {
+        throw new InvalidOperationException($"Playwright install failed: {exitCode}");
+    }
+
+    Playwright ??= await Microsoft.Playwright.Playwright.CreateAsync();
+    Browser ??= await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+    {
+        Headless = true,
+        Args =
+        [
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+            "--window-size=1920,1080",
+        ],
+    });
+}
+
+public async Task<IBrowserContext> CreateBrowserContextAsync()
+{
+    await InitializePlaywrightAsync();
+
+    return await Browser!.NewContextAsync(new BrowserNewContextOptions
+    {
+        BaseURL = ApiUrl,
+        IgnoreHTTPSErrors = true,
+        ViewportSize = new ViewportSize { Width = 1920, Height = 1080 },
+        ScreenSize = new ScreenSize { Width = 1920, Height = 1080 },
+    });
+}
+```
+
+Do not share pages or browser contexts across tests. Reuse the browser process, not mutable browser state.
+
+## Diagnostics And Failure Capture
+
+Useful low-noise defaults:
+
+- `logging.ClearProviders(); logging.AddConsole();`
+- `logging.SetMinimumLevel(LogLevel.Warning);`
+- `logging.AddFilter("Aspire.Hosting.Dcp", LogLevel.Warning);`
+- `logging.AddFilter("Aspire.Hosting.Backchannel", LogLevel.Critical);`
+
+For failures:
+
+- dump server-side error logs from the shared fixture or `WebApplicationFactory` logger provider
+- capture Playwright screenshots and HTML into an `artifacts/` folder
+- include resource logs from the AppHost when a resource fails to become healthy
+
+Example pattern:
+
+```csharp
+try
+{
+    var response = await client.GetAsync("/health");
+    response.EnsureSuccessStatusCode();
+}
+catch
+{
+    Console.WriteLine(testApplication.GetHostLogDump(LogLevel.Error));
+    throw;
+}
+```
+
+## Practical Rules
+
+- Use plain service-level tests when the AppHost topology does not matter.
+- Use Aspire testing when the assertion depends on real resource wiring, service discovery, health, or cross-service flows.
+- Mix Aspire with `WebApplicationFactory` only when the test needs direct access to DI, grains, or in-process runtime services.
+- Keep one shared AppHost fixture per test session and one browser context per UI test.
+- Prefer explicit resource names and explicit `WaitForResourceHealthyAsync(...)` checks so failures point to the right resource quickly.

--- a/.github/skills/aspnet-core/SKILL.md
+++ b/.github/skills/aspnet-core/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: aspnet-core
+description: "Build, debug, modernize, or review ASP.NET Core applications with correct hosting, middleware, security, configuration, logging, and deployment patterns on current .NET. USE FOR: working on ASP.NET Core apps, services, or middleware; changing auth, routing, configuration, hosting, or deployment behavior; deciding between ASP.NET Core sub-stacks. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires an ASP.NET Core project or solution."
+---
+
+# ASP.NET Core
+
+## Trigger On
+
+- working on ASP.NET Core apps, services, or middleware
+- changing auth, routing, configuration, hosting, or deployment behavior
+- deciding between ASP.NET Core sub-stacks such as Blazor, Minimal APIs, or controller APIs
+- debugging request pipeline issues
+- modernizing legacy ASP.NET to ASP.NET Core
+
+## Documentation
+
+- [ASP.NET Core Overview](https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-10.0)
+- [ASP.NET Core Middleware](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-10.0)
+- [ASP.NET Core Best Practices](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/best-practices?view=aspnetcore-10.0)
+- [Configuration in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-10.0)
+- [Authentication and Authorization](https://learn.microsoft.com/en-us/aspnet/core/security/?view=aspnetcore-10.0)
+
+### References
+
+- [patterns.md](references/patterns.md) - Detailed middleware patterns, security patterns, configuration patterns, DI patterns, error handling patterns, and logging patterns
+- [anti-patterns.md](references/anti-patterns.md) - Common ASP.NET Core mistakes including HttpClient misuse, async anti-patterns, configuration errors, DI issues, middleware ordering problems, and security vulnerabilities
+
+## Workflow
+
+1. **Detect the real hosting shape first:**
+   - top-level `Program.cs` structure
+   - middleware order and registration
+   - auth model (Identity, JWT, OAuth, cookies)
+   - endpoint registrations and routing
+
+2. **Follow the correct middleware order:**
+   ```
+   ExceptionHandler → HttpsRedirection → Static Files → Routing
+   → CORS → Authentication → Authorization → Rate Limiting
+   → Response Caching → Custom Middleware → Endpoints
+   ```
+
+3. **Use built-in patterns correctly:**
+   - Prefer `IOptions<T>` / `IOptionsSnapshot<T>` for configuration
+   - Use `ILogger<T>` for structured logging
+   - Use `IHttpClientFactory` for HTTP clients (never `new HttpClient()`)
+   - Use `IHostedService` / `BackgroundService` for background work
+
+4. **Route specialized work to specific skills:**
+   - UI and components → `blazor`
+   - Real-time → `signalr`
+   - RPC → `grpc`
+   - New HTTP APIs → `minimal-apis` (prefer unless controllers needed)
+   - Controller APIs → `web-api`
+
+5. **Validate with build, tests, and targeted endpoint checks.**
+
+## Middleware Patterns
+
+### Correct Order Matters
+```csharp
+var app = builder.Build();
+
+app.UseExceptionHandler("/error");      // 1. Catch all exceptions
+app.UseHsts();                          // 2. Security headers
+app.UseHttpsRedirection();              // 3. HTTPS redirect
+app.UseStaticFiles();                   // 4. Serve static files
+app.UseRouting();                       // 5. Route matching
+app.UseCors();                          // 6. CORS policy
+app.UseAuthentication();                // 7. Who are you?
+app.UseAuthorization();                 // 8. Can you access?
+app.UseRateLimiter();                   // 9. Rate limiting
+app.UseResponseCaching();               // 10. Response cache
+app.MapControllers();                   // 11. Endpoints
+```
+
+### Custom Middleware Pattern
+```csharp
+public class RequestTimingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RequestTimingMiddleware> _logger;
+
+    public RequestTimingMiddleware(RequestDelegate next, ILogger<RequestTimingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var sw = Stopwatch.StartNew();
+        await _next(context);
+        _logger.LogInformation("Request {Path} completed in {Elapsed}ms",
+            context.Request.Path, sw.ElapsedMilliseconds);
+    }
+}
+```
+
+## Configuration Patterns
+
+### Strongly-Typed Options
+```csharp
+// appsettings.json
+{
+  "EmailSettings": {
+    "SmtpServer": "smtp.example.com",
+    "Port": 587
+  }
+}
+
+// Registration
+builder.Services.Configure<EmailSettings>(
+    builder.Configuration.GetSection("EmailSettings"));
+
+// Usage
+public class EmailService(IOptions<EmailSettings> options)
+{
+    private readonly EmailSettings _settings = options.Value;
+}
+```
+
+### Environment-Based Configuration
+```csharp
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: false)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
+    .AddEnvironmentVariables()
+    .AddUserSecrets<Program>(optional: true);
+```
+
+## Security Patterns
+
+### Authentication Setup
+```csharp
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+        };
+    });
+```
+
+### Authorization Policies
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOnly", policy =>
+        policy.RequireRole("Admin"));
+    options.AddPolicy("MinAge18", policy =>
+        policy.RequireClaim("Age", "18", "19", "20")); // simplified
+});
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| `new HttpClient()` | Socket exhaustion | `IHttpClientFactory` |
+| Sync-over-async (`Task.Result`) | Thread pool starvation | `await` properly |
+| Storing secrets in `appsettings.json` | Security risk | User Secrets, Key Vault |
+| Catching all exceptions silently | Hides bugs | Use `IExceptionHandler` |
+| `async void` in middleware | Crashes process | `async Task` |
+| Missing HTTPS redirect | Security risk | `UseHttpsRedirection()` |
+
+## Performance Best Practices
+
+1. **Use async/await everywhere** — avoid sync blocking calls
+2. **Pool DbContext properly** — use scoped lifetime
+3. **Enable response compression** — `UseResponseCompression()`
+4. **Use output caching** — `UseOutputCache()` for .NET 7+
+5. **Profile with diagnostic tools** — Visual Studio Diagnostic Tools, PerfView
+6. **Avoid allocations in hot paths** — use `Span<T>`, pooling
+
+## Deliver
+
+- production-credible ASP.NET Core code and config
+- a clear request pipeline and hosting story
+- verification that matches the affected endpoints and middleware
+- security headers and HTTPS configured correctly
+
+## Validate
+
+- middleware order is intentional and documented
+- security and configuration changes are explicit
+- endpoint behavior is covered by tests or smoke checks
+- no blocking calls in async context
+- secrets are not committed to source control
+- health checks are implemented for production readiness

--- a/.github/skills/aspnet-core/manifest.json
+++ b/.github/skills/aspnet-core/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "category": "Web",
+  "package_prefix": "Microsoft.AspNetCore"
+}

--- a/.github/skills/aspnet-core/references/anti-patterns.md
+++ b/.github/skills/aspnet-core/references/anti-patterns.md
@@ -1,0 +1,1126 @@
+# ASP.NET Core Anti-Patterns Reference
+
+This document catalogs common mistakes and anti-patterns in ASP.NET Core development, with explanations of why they are problematic and how to fix them.
+
+## Table of Contents
+
+- [HttpClient Anti-Patterns](#httpclient-anti-patterns)
+- [Async Anti-Patterns](#async-anti-patterns)
+- [Configuration and Secrets Anti-Patterns](#configuration-and-secrets-anti-patterns)
+- [Dependency Injection Anti-Patterns](#dependency-injection-anti-patterns)
+- [Middleware Anti-Patterns](#middleware-anti-patterns)
+- [Error Handling Anti-Patterns](#error-handling-anti-patterns)
+- [Security Anti-Patterns](#security-anti-patterns)
+- [Performance Anti-Patterns](#performance-anti-patterns)
+- [Controller Anti-Patterns](#controller-anti-patterns)
+- [Database and EF Core Anti-Patterns](#database-and-ef-core-anti-patterns)
+
+---
+
+## HttpClient Anti-Patterns
+
+### Creating HttpClient Instances Directly
+
+**Anti-Pattern:**
+```csharp
+public class WeatherService
+{
+    public async Task<Weather> GetWeatherAsync(string city)
+    {
+        using var client = new HttpClient(); // BAD: Creates new socket each time
+        var response = await client.GetAsync($"https://api.weather.com/{city}");
+        return await response.Content.ReadFromJsonAsync<Weather>();
+    }
+}
+```
+
+**Problem:** Creating `HttpClient` directly leads to socket exhaustion. Each `HttpClient` instance opens new TCP connections and disposing it does not immediately release sockets (they stay in TIME_WAIT state).
+
+**Correct Approach:**
+```csharp
+// Registration
+builder.Services.AddHttpClient<IWeatherService, WeatherService>(client =>
+{
+    client.BaseAddress = new Uri("https://api.weather.com/");
+});
+
+// Service
+public class WeatherService : IWeatherService
+{
+    private readonly HttpClient _client;
+
+    public WeatherService(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<Weather> GetWeatherAsync(string city)
+    {
+        var response = await _client.GetAsync(city);
+        return await response.Content.ReadFromJsonAsync<Weather>();
+    }
+}
+```
+
+### Using Static HttpClient Without Respecting DNS Changes
+
+**Anti-Pattern:**
+```csharp
+public static class ApiClient
+{
+    private static readonly HttpClient _client = new HttpClient
+    {
+        BaseAddress = new Uri("https://api.example.com/")
+    };
+
+    public static async Task<string> GetDataAsync()
+    {
+        return await _client.GetStringAsync("data");
+    }
+}
+```
+
+**Problem:** Static HttpClient instances cache DNS indefinitely. If the server's IP address changes, the client will continue to use the old IP.
+
+**Correct Approach:**
+```csharp
+// Use IHttpClientFactory which handles DNS rotation
+builder.Services.AddHttpClient("api", client =>
+{
+    client.BaseAddress = new Uri("https://api.example.com/");
+})
+.SetHandlerLifetime(TimeSpan.FromMinutes(5)); // Rotate handlers periodically
+```
+
+---
+
+## Async Anti-Patterns
+
+### Sync-Over-Async (Blocking on Async Code)
+
+**Anti-Pattern:**
+```csharp
+public class UserController : ControllerBase
+{
+    [HttpGet("{id}")]
+    public IActionResult GetUser(int id)
+    {
+        // BAD: Blocking on async code
+        var user = _userService.GetUserAsync(id).Result;
+        // Or equally bad:
+        var user2 = _userService.GetUserAsync(id).GetAwaiter().GetResult();
+        // Or:
+        var user3 = Task.Run(() => _userService.GetUserAsync(id)).Result;
+
+        return Ok(user);
+    }
+}
+```
+
+**Problem:** Blocking on async code can cause deadlocks (especially with synchronization contexts) and wastes thread pool threads. The thread waits instead of being released to handle other requests.
+
+**Correct Approach:**
+```csharp
+[HttpGet("{id}")]
+public async Task<IActionResult> GetUser(int id)
+{
+    var user = await _userService.GetUserAsync(id);
+    return Ok(user);
+}
+```
+
+### Async Void
+
+**Anti-Pattern:**
+```csharp
+public class LoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public LoggingMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async void Invoke(HttpContext context) // BAD: async void
+    {
+        await LogRequestAsync(context);
+        await _next(context);
+    }
+}
+```
+
+**Problem:** `async void` methods cannot be awaited, exceptions cannot be caught, and if an exception occurs it will crash the process.
+
+**Correct Approach:**
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    await LogRequestAsync(context);
+    await _next(context);
+}
+```
+
+### Not Using ConfigureAwait in Library Code
+
+**Anti-Pattern (in library/shared code):**
+```csharp
+public class DataService
+{
+    public async Task<Data> GetDataAsync()
+    {
+        var result = await _repository.QueryAsync(); // May capture unnecessary context
+        return ProcessData(result);
+    }
+}
+```
+
+**Problem:** In library code, not using `ConfigureAwait(false)` captures the synchronization context unnecessarily, which can cause performance issues and potential deadlocks when called from UI applications.
+
+**Correct Approach (for library code):**
+```csharp
+public async Task<Data> GetDataAsync()
+{
+    var result = await _repository.QueryAsync().ConfigureAwait(false);
+    return ProcessData(result);
+}
+```
+
+Note: In ASP.NET Core application code (controllers, services directly serving requests), this is less critical since ASP.NET Core does not have a synchronization context.
+
+### Async Over Sync
+
+**Anti-Pattern:**
+```csharp
+public Task<int> CalculateAsync(int value)
+{
+    return Task.Run(() => Calculate(value)); // BAD: Wrapping sync in Task.Run
+}
+
+public Task SaveAsync(Data data)
+{
+    Save(data);
+    return Task.CompletedTask; // BAD: Fake async
+}
+```
+
+**Problem:** Wrapping synchronous code in `Task.Run` wastes thread pool threads. Returning `Task.CompletedTask` after sync work is misleading and provides no benefit.
+
+**Correct Approach:**
+```csharp
+// Either keep it synchronous if there's nothing to await
+public int Calculate(int value)
+{
+    return value * 2;
+}
+
+// Or use truly async operations
+public async Task SaveAsync(Data data)
+{
+    await _dbContext.SaveChangesAsync();
+}
+```
+
+---
+
+## Configuration and Secrets Anti-Patterns
+
+### Storing Secrets in appsettings.json
+
+**Anti-Pattern:**
+```json
+{
+  "ConnectionStrings": {
+    "Database": "Server=prod.db.com;User=admin;Password=SuperSecret123!"
+  },
+  "Jwt": {
+    "Key": "MySuperSecretKey12345"
+  },
+  "ThirdPartyApi": {
+    "ApiKey": "sk-live-xxxxxxxxxxxxx"
+  }
+}
+```
+
+**Problem:** Secrets committed to source control are exposed to anyone with repository access. They persist in git history even if removed later.
+
+**Correct Approach:**
+```csharp
+// Development: User Secrets
+// In terminal: dotnet user-secrets set "Jwt:Key" "development-key"
+
+// Production: Environment variables or secret stores
+builder.Configuration
+    .AddEnvironmentVariables()
+    .AddAzureKeyVault(new Uri("https://myvault.vault.azure.net/"),
+        new DefaultAzureCredential());
+
+// appsettings.json should only contain non-sensitive defaults
+{
+  "ConnectionStrings": {
+    "Database": "" // Placeholder, real value from env/vault
+  }
+}
+```
+
+### Hardcoding Configuration Values
+
+**Anti-Pattern:**
+```csharp
+public class EmailService
+{
+    public async Task SendAsync(string to, string subject, string body)
+    {
+        using var client = new SmtpClient("smtp.company.com", 587); // BAD: Hardcoded
+        client.Credentials = new NetworkCredential("noreply@company.com", "password123");
+        // ...
+    }
+}
+```
+
+**Correct Approach:**
+```csharp
+public class EmailService
+{
+    private readonly EmailSettings _settings;
+
+    public EmailService(IOptions<EmailSettings> options)
+    {
+        _settings = options.Value;
+    }
+
+    public async Task SendAsync(string to, string subject, string body)
+    {
+        using var client = new SmtpClient(_settings.SmtpServer, _settings.Port);
+        // ...
+    }
+}
+```
+
+### Reading Configuration in Constructor
+
+**Anti-Pattern:**
+```csharp
+public class ReportService
+{
+    private readonly string _connectionString;
+
+    public ReportService(IConfiguration configuration)
+    {
+        // BAD: Reading raw configuration in constructor
+        _connectionString = configuration["ConnectionStrings:Reports"];
+    }
+}
+```
+
+**Problem:** Bypasses the options pattern, no validation, harder to test, service knows about configuration structure.
+
+**Correct Approach:**
+```csharp
+public class ReportService
+{
+    private readonly ReportSettings _settings;
+
+    public ReportService(IOptions<ReportSettings> options)
+    {
+        _settings = options.Value;
+    }
+}
+```
+
+---
+
+## Dependency Injection Anti-Patterns
+
+### Captive Dependency (Scoped in Singleton)
+
+**Anti-Pattern:**
+```csharp
+builder.Services.AddSingleton<ICacheService, CacheService>();
+builder.Services.AddScoped<IUserContext, HttpUserContext>();
+
+public class CacheService : ICacheService
+{
+    private readonly IUserContext _userContext; // BAD: Scoped in singleton
+
+    public CacheService(IUserContext userContext)
+    {
+        _userContext = userContext; // This instance will be captured forever
+    }
+}
+```
+
+**Problem:** A scoped service injected into a singleton is "captured" and reused for all requests, leading to stale data, wrong user context, and thread safety issues.
+
+**Correct Approach:**
+```csharp
+public class CacheService : ICacheService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public CacheService(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public async Task<T> GetOrCreateAsync<T>(string key, Func<Task<T>> factory)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var userContext = scope.ServiceProvider.GetRequiredService<IUserContext>();
+        // Use userContext safely within this scope
+    }
+}
+```
+
+### Service Locator Pattern
+
+**Anti-Pattern:**
+```csharp
+public class OrderService
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public OrderService(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public async Task ProcessOrderAsync(Order order)
+    {
+        // BAD: Service locator hides dependencies
+        var emailService = _serviceProvider.GetRequiredService<IEmailService>();
+        var inventoryService = _serviceProvider.GetRequiredService<IInventoryService>();
+        var paymentService = _serviceProvider.GetRequiredService<IPaymentService>();
+    }
+}
+```
+
+**Problem:** Hides dependencies, makes testing harder, class can request any service at any time, breaks explicit dependency declaration.
+
+**Correct Approach:**
+```csharp
+public class OrderService
+{
+    private readonly IEmailService _emailService;
+    private readonly IInventoryService _inventoryService;
+    private readonly IPaymentService _paymentService;
+
+    public OrderService(
+        IEmailService emailService,
+        IInventoryService inventoryService,
+        IPaymentService paymentService)
+    {
+        _emailService = emailService;
+        _inventoryService = inventoryService;
+        _paymentService = paymentService;
+    }
+}
+```
+
+### Circular Dependencies
+
+**Anti-Pattern:**
+```csharp
+public class ServiceA
+{
+    public ServiceA(ServiceB serviceB) { }
+}
+
+public class ServiceB
+{
+    public ServiceB(ServiceA serviceA) { } // BAD: Circular dependency
+}
+```
+
+**Problem:** Container cannot resolve circular dependencies. This indicates a design problem.
+
+**Correct Approach:**
+```csharp
+// Option 1: Extract shared logic into a third service
+public class SharedService { }
+public class ServiceA { public ServiceA(SharedService shared) { } }
+public class ServiceB { public ServiceB(SharedService shared) { } }
+
+// Option 2: Use lazy injection
+public class ServiceA
+{
+    private readonly Lazy<ServiceB> _serviceB;
+    public ServiceA(Lazy<ServiceB> serviceB) { _serviceB = serviceB; }
+}
+
+// Option 3: Use events/mediator pattern to decouple
+```
+
+---
+
+## Middleware Anti-Patterns
+
+### Wrong Middleware Order
+
+**Anti-Pattern:**
+```csharp
+var app = builder.Build();
+
+app.MapControllers();              // BAD: Endpoints before auth
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRouting();                  // BAD: Routing after endpoints
+app.UseExceptionHandler("/error"); // BAD: Exception handler last
+```
+
+**Problem:** Middleware order matters. Authentication before routing means route data is not available. Exception handler at the end will not catch exceptions from endpoints.
+
+**Correct Approach:**
+```csharp
+app.UseExceptionHandler("/error"); // First - catches all exceptions
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.UseAuthentication();           // After routing
+app.UseAuthorization();            // After authentication
+app.MapControllers();              // Last
+```
+
+### Blocking Operations in Middleware
+
+**Anti-Pattern:**
+```csharp
+public class ValidationMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public ValidationMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // BAD: Synchronous blocking read
+        using var reader = new StreamReader(context.Request.Body);
+        var body = reader.ReadToEnd();
+
+        // BAD: Blocking database call
+        var isValid = _validator.Validate(body).Result;
+
+        await _next(context);
+    }
+}
+```
+
+**Correct Approach:**
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    context.Request.EnableBuffering();
+    using var reader = new StreamReader(context.Request.Body, leaveOpen: true);
+    var body = await reader.ReadToEndAsync();
+    context.Request.Body.Position = 0;
+
+    var isValid = await _validator.ValidateAsync(body);
+
+    await _next(context);
+}
+```
+
+### Not Calling Next Unintentionally
+
+**Anti-Pattern:**
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    if (SomeCondition(context))
+    {
+        await _next(context);
+    }
+    // BAD: If condition is false, pipeline stops silently
+}
+```
+
+**Problem:** Pipeline stops without response, leading to hanging requests or empty responses.
+
+**Correct Approach:**
+```csharp
+public async Task InvokeAsync(HttpContext context)
+{
+    if (!SomeCondition(context))
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await context.Response.WriteAsJsonAsync(new { error = "Validation failed" });
+        return; // Explicit short-circuit with response
+    }
+
+    await _next(context);
+}
+```
+
+---
+
+## Error Handling Anti-Patterns
+
+### Swallowing Exceptions
+
+**Anti-Pattern:**
+```csharp
+public async Task<Order> GetOrderAsync(int id)
+{
+    try
+    {
+        return await _repository.GetByIdAsync(id);
+    }
+    catch (Exception)
+    {
+        return null; // BAD: Exception swallowed, bug hidden
+    }
+}
+```
+
+**Problem:** Hides bugs, makes debugging impossible, caller does not know something went wrong.
+
+**Correct Approach:**
+```csharp
+public async Task<Order?> GetOrderAsync(int id)
+{
+    try
+    {
+        return await _repository.GetByIdAsync(id);
+    }
+    catch (SqlException ex) when (ex.Number == 2) // Specific exception
+    {
+        _logger.LogWarning(ex, "Database timeout while getting order {OrderId}", id);
+        throw new ServiceUnavailableException("Database temporarily unavailable", ex);
+    }
+}
+```
+
+### Exposing Exception Details to Users
+
+**Anti-Pattern:**
+```csharp
+[HttpGet("{id}")]
+public async Task<IActionResult> GetUser(int id)
+{
+    try
+    {
+        return Ok(await _userService.GetByIdAsync(id));
+    }
+    catch (Exception ex)
+    {
+        // BAD: Stack trace and internal details exposed
+        return StatusCode(500, new
+        {
+            error = ex.Message,
+            stackTrace = ex.StackTrace,
+            innerException = ex.InnerException?.Message
+        });
+    }
+}
+```
+
+**Problem:** Exposes internal system details, potential security vulnerability, helps attackers understand system internals.
+
+**Correct Approach:**
+```csharp
+// Use global exception handler with environment-aware responses
+public class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly IHostEnvironment _environment;
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogError(exception, "Unhandled exception");
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Title = "An error occurred",
+            Detail = _environment.IsDevelopment() ? exception.Message : null
+        };
+
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+        return true;
+    }
+}
+```
+
+### Catch-All Without Logging
+
+**Anti-Pattern:**
+```csharp
+try
+{
+    await ProcessPaymentAsync(order);
+}
+catch (Exception)
+{
+    // BAD: No logging, no context
+    throw;
+}
+```
+
+**Correct Approach:**
+```csharp
+try
+{
+    await ProcessPaymentAsync(order);
+}
+catch (PaymentException ex)
+{
+    _logger.LogWarning(ex, "Payment failed for order {OrderId}: {Reason}",
+        order.Id, ex.Reason);
+    throw;
+}
+catch (Exception ex)
+{
+    _logger.LogError(ex, "Unexpected error processing payment for order {OrderId}",
+        order.Id);
+    throw;
+}
+```
+
+---
+
+## Security Anti-Patterns
+
+### Missing HTTPS Redirection
+
+**Anti-Pattern:**
+```csharp
+var app = builder.Build();
+app.MapControllers(); // BAD: No HTTPS enforcement
+app.Run();
+```
+
+**Correct Approach:**
+```csharp
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+}
+app.UseHttpsRedirection();
+app.MapControllers();
+```
+
+### Disabled CORS (Allow All)
+
+**Anti-Pattern:**
+```csharp
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+    {
+        policy.AllowAnyOrigin()    // BAD: Any site can access
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+```
+
+**Correct Approach:**
+```csharp
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("Production", policy =>
+    {
+        policy.WithOrigins(
+                "https://app.example.com",
+                "https://admin.example.com")
+              .WithMethods("GET", "POST", "PUT", "DELETE")
+              .WithHeaders("Authorization", "Content-Type")
+              .AllowCredentials();
+    });
+});
+```
+
+### SQL Injection via String Concatenation
+
+**Anti-Pattern:**
+```csharp
+public async Task<User> GetUserAsync(string username)
+{
+    // BAD: SQL injection vulnerability
+    var sql = $"SELECT * FROM Users WHERE Username = '{username}'";
+    return await _context.Users.FromSqlRaw(sql).FirstOrDefaultAsync();
+}
+```
+
+**Correct Approach:**
+```csharp
+public async Task<User> GetUserAsync(string username)
+{
+    // Parameterized query
+    return await _context.Users
+        .FromSqlInterpolated($"SELECT * FROM Users WHERE Username = {username}")
+        .FirstOrDefaultAsync();
+
+    // Or use LINQ
+    return await _context.Users
+        .Where(u => u.Username == username)
+        .FirstOrDefaultAsync();
+}
+```
+
+### Missing Authorization on Sensitive Endpoints
+
+**Anti-Pattern:**
+```csharp
+[HttpDelete("{id}")]
+public async Task<IActionResult> DeleteUser(int id) // BAD: No authorization
+{
+    await _userService.DeleteAsync(id);
+    return NoContent();
+}
+```
+
+**Correct Approach:**
+```csharp
+[Authorize(Policy = "AdminOnly")]
+[HttpDelete("{id}")]
+public async Task<IActionResult> DeleteUser(int id)
+{
+    await _userService.DeleteAsync(id);
+    return NoContent();
+}
+```
+
+### Storing Passwords in Plain Text
+
+**Anti-Pattern:**
+```csharp
+public async Task<User> CreateUserAsync(string email, string password)
+{
+    var user = new User
+    {
+        Email = email,
+        Password = password // BAD: Plain text password
+    };
+    await _context.SaveChangesAsync();
+    return user;
+}
+```
+
+**Correct Approach:**
+```csharp
+// Use ASP.NET Core Identity or proper password hashing
+public async Task<User> CreateUserAsync(string email, string password)
+{
+    var user = new User
+    {
+        Email = email,
+        PasswordHash = _passwordHasher.HashPassword(null, password)
+    };
+    await _context.SaveChangesAsync();
+    return user;
+}
+```
+
+---
+
+## Performance Anti-Patterns
+
+### Not Using Async I/O
+
+**Anti-Pattern:**
+```csharp
+[HttpGet]
+public IActionResult GetReport()
+{
+    // BAD: Synchronous database call blocks thread
+    var data = _context.Reports.ToList();
+    var file = File.ReadAllBytes("template.pdf"); // BAD: Sync file I/O
+    return Ok(GenerateReport(data, file));
+}
+```
+
+**Correct Approach:**
+```csharp
+[HttpGet]
+public async Task<IActionResult> GetReport()
+{
+    var data = await _context.Reports.ToListAsync();
+    var file = await File.ReadAllBytesAsync("template.pdf");
+    return Ok(GenerateReport(data, file));
+}
+```
+
+### Loading Entire Collections into Memory
+
+**Anti-Pattern:**
+```csharp
+public async Task<decimal> GetTotalRevenueAsync()
+{
+    // BAD: Loads all orders into memory
+    var orders = await _context.Orders.ToListAsync();
+    return orders.Sum(o => o.Total);
+}
+```
+
+**Correct Approach:**
+```csharp
+public async Task<decimal> GetTotalRevenueAsync()
+{
+    // Computed in database
+    return await _context.Orders.SumAsync(o => o.Total);
+}
+```
+
+### N+1 Query Problem
+
+**Anti-Pattern:**
+```csharp
+public async Task<List<OrderDto>> GetOrdersAsync()
+{
+    var orders = await _context.Orders.ToListAsync();
+
+    return orders.Select(o => new OrderDto
+    {
+        Id = o.Id,
+        // BAD: Each access triggers a separate query
+        CustomerName = o.Customer.Name,
+        Items = o.Items.Select(i => i.Name).ToList()
+    }).ToList();
+}
+```
+
+**Correct Approach:**
+```csharp
+public async Task<List<OrderDto>> GetOrdersAsync()
+{
+    return await _context.Orders
+        .Include(o => o.Customer)
+        .Include(o => o.Items)
+        .Select(o => new OrderDto
+        {
+            Id = o.Id,
+            CustomerName = o.Customer.Name,
+            Items = o.Items.Select(i => i.Name).ToList()
+        })
+        .ToListAsync();
+}
+```
+
+### Not Using Response Compression
+
+**Anti-Pattern:**
+```csharp
+var app = builder.Build();
+app.MapControllers(); // BAD: Large responses sent uncompressed
+```
+
+**Correct Approach:**
+```csharp
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+});
+
+builder.Services.Configure<BrotliCompressionProviderOptions>(options =>
+{
+    options.Level = CompressionLevel.Fastest;
+});
+
+app.UseResponseCompression();
+app.MapControllers();
+```
+
+---
+
+## Controller Anti-Patterns
+
+### Fat Controllers
+
+**Anti-Pattern:**
+```csharp
+[HttpPost]
+public async Task<IActionResult> CreateOrder(CreateOrderRequest request)
+{
+    // BAD: Business logic in controller
+    if (request.Items.Count == 0)
+        return BadRequest("Order must have items");
+
+    var customer = await _context.Customers.FindAsync(request.CustomerId);
+    if (customer == null)
+        return NotFound("Customer not found");
+
+    var order = new Order { CustomerId = request.CustomerId };
+
+    foreach (var item in request.Items)
+    {
+        var product = await _context.Products.FindAsync(item.ProductId);
+        if (product == null)
+            return BadRequest($"Product {item.ProductId} not found");
+
+        if (product.Stock < item.Quantity)
+            return BadRequest($"Insufficient stock for {product.Name}");
+
+        product.Stock -= item.Quantity;
+        order.Items.Add(new OrderItem
+        {
+            ProductId = product.Id,
+            Quantity = item.Quantity,
+            Price = product.Price
+        });
+    }
+
+    order.Total = order.Items.Sum(i => i.Price * i.Quantity);
+    _context.Orders.Add(order);
+    await _context.SaveChangesAsync();
+
+    await _emailService.SendOrderConfirmationAsync(customer.Email, order);
+
+    return CreatedAtAction(nameof(GetOrder), new { id = order.Id }, order);
+}
+```
+
+**Correct Approach:**
+```csharp
+[HttpPost]
+public async Task<IActionResult> CreateOrder(CreateOrderRequest request)
+{
+    var result = await _orderService.CreateOrderAsync(request);
+
+    return result.Match<IActionResult>(
+        success => CreatedAtAction(nameof(GetOrder), new { id = success.OrderId }, success),
+        notFound => NotFound(notFound.Message),
+        validation => BadRequest(validation.Errors));
+}
+```
+
+### Not Using Action Filters
+
+**Anti-Pattern:**
+```csharp
+[HttpPost]
+public async Task<IActionResult> Create(CreateRequest request)
+{
+    // BAD: Manual validation in every action
+    if (!ModelState.IsValid)
+    {
+        return BadRequest(ModelState);
+    }
+    // ...
+}
+```
+
+**Correct Approach:**
+```csharp
+// Configure globally
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.SuppressModelStateInvalidFilter = false; // Enable automatic validation
+});
+
+// Or use a filter
+public class ValidateModelAttribute : ActionFilterAttribute
+{
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        if (!context.ModelState.IsValid)
+        {
+            context.Result = new BadRequestObjectResult(context.ModelState);
+        }
+    }
+}
+```
+
+---
+
+## Database and EF Core Anti-Patterns
+
+### Using DbContext as Singleton
+
+**Anti-Pattern:**
+```csharp
+builder.Services.AddSingleton<MyDbContext>(); // BAD: DbContext is not thread-safe
+```
+
+**Problem:** `DbContext` is not thread-safe and tracks entities. Using it as singleton causes concurrency issues and memory leaks.
+
+**Correct Approach:**
+```csharp
+builder.Services.AddDbContext<MyDbContext>(options =>
+    options.UseSqlServer(connectionString));
+// Default is scoped lifetime
+```
+
+### Not Disposing DbContext (Manual Creation)
+
+**Anti-Pattern:**
+```csharp
+public class ReportService
+{
+    private readonly MyDbContext _context = new MyDbContext(); // BAD: Never disposed
+}
+```
+
+**Correct Approach:**
+```csharp
+public class ReportService
+{
+    private readonly MyDbContext _context;
+
+    public ReportService(MyDbContext context)
+    {
+        _context = context; // Injected, container manages lifetime
+    }
+}
+```
+
+### Tracking Entities When Not Needed
+
+**Anti-Pattern:**
+```csharp
+public async Task<List<ProductDto>> GetProductsAsync()
+{
+    // BAD: Tracking enabled for read-only query
+    var products = await _context.Products.ToListAsync();
+    return products.Select(p => new ProductDto { Name = p.Name }).ToList();
+}
+```
+
+**Correct Approach:**
+```csharp
+public async Task<List<ProductDto>> GetProductsAsync()
+{
+    return await _context.Products
+        .AsNoTracking()
+        .Select(p => new ProductDto { Name = p.Name })
+        .ToListAsync();
+}
+```
+
+### Lazy Loading in Web Applications
+
+**Anti-Pattern:**
+```csharp
+builder.Services.AddDbContext<MyDbContext>(options =>
+    options.UseLazyLoadingProxies() // BAD: Hidden N+1 queries
+           .UseSqlServer(connectionString));
+```
+
+**Problem:** Lazy loading causes unexpected database queries, N+1 problems, and makes it hard to track what data is being loaded.
+
+**Correct Approach:**
+```csharp
+// Use explicit loading with Include/ThenInclude
+var orders = await _context.Orders
+    .Include(o => o.Customer)
+    .Include(o => o.Items)
+        .ThenInclude(i => i.Product)
+    .ToListAsync();
+
+// Or use projection
+var orderDtos = await _context.Orders
+    .Select(o => new OrderDto
+    {
+        Id = o.Id,
+        CustomerName = o.Customer.Name
+    })
+    .ToListAsync();
+```

--- a/.github/skills/aspnet-core/references/patterns.md
+++ b/.github/skills/aspnet-core/references/patterns.md
@@ -1,0 +1,1057 @@
+# ASP.NET Core Patterns Reference
+
+This document provides detailed patterns for middleware, security, and configuration in ASP.NET Core applications.
+
+## Table of Contents
+
+- [Middleware Patterns](#middleware-patterns)
+- [Security Patterns](#security-patterns)
+- [Configuration Patterns](#configuration-patterns)
+- [Dependency Injection Patterns](#dependency-injection-patterns)
+- [Error Handling Patterns](#error-handling-patterns)
+- [Logging Patterns](#logging-patterns)
+
+---
+
+## Middleware Patterns
+
+### Pipeline Architecture
+
+The ASP.NET Core request pipeline consists of middleware components that process requests in sequence. Each middleware can:
+- Handle the request and short-circuit the pipeline
+- Pass the request to the next middleware
+- Execute code before and after the next middleware
+
+### Canonical Middleware Order
+
+```csharp
+var app = builder.Build();
+
+// 1. Exception handling - must be first to catch all exceptions
+app.UseExceptionHandler("/error");
+
+// 2. HSTS - HTTP Strict Transport Security header
+app.UseHsts();
+
+// 3. HTTPS redirection - before any content is served
+app.UseHttpsRedirection();
+
+// 4. Static files - serve before routing for performance
+app.UseStaticFiles();
+
+// 5. Routing - must precede authentication/authorization
+app.UseRouting();
+
+// 6. CORS - after routing, before auth
+app.UseCors("PolicyName");
+
+// 7. Authentication - identify the user
+app.UseAuthentication();
+
+// 8. Authorization - verify access rights
+app.UseAuthorization();
+
+// 9. Rate limiting - protect endpoints
+app.UseRateLimiter();
+
+// 10. Response caching - cache authorized responses
+app.UseResponseCaching();
+
+// 11. Output caching (.NET 7+) - server-side caching
+app.UseOutputCache();
+
+// 12. Custom middleware - business logic
+app.UseMiddleware<CustomMiddleware>();
+
+// 13. Endpoints - terminal middleware
+app.MapControllers();
+app.MapRazorPages();
+app.MapBlazorHub();
+```
+
+### Class-Based Middleware Pattern
+
+```csharp
+public class RequestTimingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RequestTimingMiddleware> _logger;
+
+    public RequestTimingMiddleware(RequestDelegate next, ILogger<RequestTimingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Request {Method} {Path} completed in {ElapsedMs}ms with status {StatusCode}",
+                context.Request.Method,
+                context.Request.Path,
+                stopwatch.ElapsedMilliseconds,
+                context.Response.StatusCode);
+        }
+    }
+}
+
+// Extension method for clean registration
+public static class RequestTimingMiddlewareExtensions
+{
+    public static IApplicationBuilder UseRequestTiming(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<RequestTimingMiddleware>();
+    }
+}
+```
+
+### Convention-Based Middleware with Dependencies
+
+```csharp
+public class TenantResolutionMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public TenantResolutionMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    // Scoped services can be injected into InvokeAsync
+    public async Task InvokeAsync(
+        HttpContext context,
+        ITenantService tenantService,
+        ILogger<TenantResolutionMiddleware> logger)
+    {
+        var tenantId = context.Request.Headers["X-Tenant-Id"].FirstOrDefault();
+
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsJsonAsync(new { error = "Tenant header required" });
+            return;
+        }
+
+        var tenant = await tenantService.GetTenantAsync(tenantId);
+        if (tenant is null)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsJsonAsync(new { error = "Tenant not found" });
+            return;
+        }
+
+        context.Items["Tenant"] = tenant;
+        logger.LogDebug("Resolved tenant {TenantId}", tenantId);
+
+        await _next(context);
+    }
+}
+```
+
+### Inline Middleware for Simple Cases
+
+```csharp
+// Use for simple, non-reusable middleware
+app.Use(async (context, next) =>
+{
+    context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+    await next(context);
+});
+
+// Terminal middleware (does not call next)
+app.Map("/health", app => app.Run(async context =>
+{
+    context.Response.ContentType = "application/json";
+    await context.Response.WriteAsJsonAsync(new { status = "healthy" });
+}));
+```
+
+### Conditional Middleware
+
+```csharp
+// Apply middleware only for specific paths
+app.UseWhen(
+    context => context.Request.Path.StartsWithSegments("/api"),
+    appBuilder => appBuilder.UseMiddleware<ApiLoggingMiddleware>());
+
+// Branch the pipeline
+app.MapWhen(
+    context => context.Request.Query.ContainsKey("debug"),
+    appBuilder => appBuilder.UseMiddleware<DebugMiddleware>());
+```
+
+### Short-Circuiting Middleware
+
+```csharp
+public class MaintenanceModeMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IOptions<MaintenanceOptions> _options;
+
+    public MaintenanceModeMiddleware(RequestDelegate next, IOptions<MaintenanceOptions> options)
+    {
+        _next = next;
+        _options = options;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (_options.Value.IsEnabled)
+        {
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            context.Response.Headers.RetryAfter = _options.Value.RetryAfterSeconds.ToString();
+            await context.Response.WriteAsJsonAsync(new
+            {
+                message = "Service under maintenance",
+                estimatedReturn = _options.Value.EstimatedReturn
+            });
+            return; // Short-circuit - do not call next
+        }
+
+        await _next(context);
+    }
+}
+```
+
+---
+
+## Security Patterns
+
+### JWT Authentication Setup
+
+```csharp
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = builder.Configuration["Jwt:Issuer"],
+        ValidAudience = builder.Configuration["Jwt:Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(
+            Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!)),
+        ClockSkew = TimeSpan.FromMinutes(1) // Reduce default 5-minute skew
+    };
+
+    options.Events = new JwtBearerEvents
+    {
+        OnAuthenticationFailed = context =>
+        {
+            if (context.Exception is SecurityTokenExpiredException)
+            {
+                context.Response.Headers.Append("Token-Expired", "true");
+            }
+            return Task.CompletedTask;
+        },
+        OnTokenValidated = context =>
+        {
+            // Add custom claims or perform additional validation
+            return Task.CompletedTask;
+        }
+    };
+});
+```
+
+### Cookie Authentication with Security Best Practices
+
+```csharp
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.Cookie.Name = "AppAuth";
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        options.Cookie.SameSite = SameSiteMode.Strict;
+        options.ExpireTimeSpan = TimeSpan.FromHours(8);
+        options.SlidingExpiration = true;
+        options.LoginPath = "/auth/login";
+        options.LogoutPath = "/auth/logout";
+        options.AccessDeniedPath = "/auth/access-denied";
+
+        options.Events = new CookieAuthenticationEvents
+        {
+            OnValidatePrincipal = async context =>
+            {
+                // Validate user still exists and is active
+                var userService = context.HttpContext.RequestServices
+                    .GetRequiredService<IUserService>();
+                var userId = context.Principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+                if (userId is null || !await userService.IsUserActiveAsync(userId))
+                {
+                    context.RejectPrincipal();
+                    await context.HttpContext.SignOutAsync();
+                }
+            }
+        };
+    });
+```
+
+### Policy-Based Authorization
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    // Simple role-based policy
+    options.AddPolicy("AdminOnly", policy =>
+        policy.RequireRole("Admin"));
+
+    // Claim-based policy
+    options.AddPolicy("VerifiedEmail", policy =>
+        policy.RequireClaim("email_verified", "true"));
+
+    // Multiple requirements (AND)
+    options.AddPolicy("SeniorAdmin", policy =>
+        policy.RequireRole("Admin")
+              .RequireClaim("experience_years", "5", "6", "7", "8", "9", "10"));
+
+    // Custom requirement
+    options.AddPolicy("MinimumAge", policy =>
+        policy.Requirements.Add(new MinimumAgeRequirement(18)));
+
+    // Resource-based authorization setup
+    options.AddPolicy("DocumentOwner", policy =>
+        policy.Requirements.Add(new DocumentOwnerRequirement()));
+});
+
+// Custom requirement
+public class MinimumAgeRequirement : IAuthorizationRequirement
+{
+    public int MinimumAge { get; }
+    public MinimumAgeRequirement(int minimumAge) => MinimumAge = minimumAge;
+}
+
+// Handler for custom requirement
+public class MinimumAgeHandler : AuthorizationHandler<MinimumAgeRequirement>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        MinimumAgeRequirement requirement)
+    {
+        var birthDateClaim = context.User.FindFirst("birth_date");
+        if (birthDateClaim is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (DateTime.TryParse(birthDateClaim.Value, out var birthDate))
+        {
+            var age = DateTime.Today.Year - birthDate.Year;
+            if (birthDate.Date > DateTime.Today.AddYears(-age)) age--;
+
+            if (age >= requirement.MinimumAge)
+            {
+                context.Succeed(requirement);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+// Register handler
+builder.Services.AddSingleton<IAuthorizationHandler, MinimumAgeHandler>();
+```
+
+### Resource-Based Authorization
+
+```csharp
+public class DocumentOwnerRequirement : IAuthorizationRequirement { }
+
+public class DocumentOwnerHandler : AuthorizationHandler<DocumentOwnerRequirement, Document>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        DocumentOwnerRequirement requirement,
+        Document resource)
+    {
+        var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (userId == resource.OwnerId)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+// Usage in controller
+public class DocumentsController : ControllerBase
+{
+    private readonly IAuthorizationService _authorizationService;
+
+    public DocumentsController(IAuthorizationService authorizationService)
+    {
+        _authorizationService = authorizationService;
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, DocumentUpdateDto dto)
+    {
+        var document = await _repository.GetByIdAsync(id);
+        if (document is null) return NotFound();
+
+        var authResult = await _authorizationService.AuthorizeAsync(
+            User, document, "DocumentOwner");
+
+        if (!authResult.Succeeded)
+        {
+            return Forbid();
+        }
+
+        // Proceed with update
+        return Ok();
+    }
+}
+```
+
+### Security Headers Middleware
+
+```csharp
+public class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public SecurityHeadersMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Prevent MIME type sniffing
+        context.Response.Headers.XContentTypeOptions = "nosniff";
+
+        // Prevent clickjacking
+        context.Response.Headers.XFrameOptions = "DENY";
+
+        // XSS protection (legacy browsers)
+        context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+
+        // Referrer policy
+        context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+
+        // Permissions policy
+        context.Response.Headers["Permissions-Policy"] =
+            "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
+
+        // Content Security Policy (customize based on your needs)
+        context.Response.Headers.ContentSecurityPolicy =
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:;";
+
+        await _next(context);
+    }
+}
+```
+
+### CORS Configuration
+
+```csharp
+builder.Services.AddCors(options =>
+{
+    // Named policy for specific origins
+    options.AddPolicy("AllowSpecificOrigins", policy =>
+    {
+        policy.WithOrigins(
+                "https://app.example.com",
+                "https://admin.example.com")
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+
+    // Policy for API clients
+    options.AddPolicy("ApiClients", policy =>
+    {
+        policy.WithOrigins(builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()!)
+            .WithHeaders("Authorization", "Content-Type", "X-Requested-With")
+            .WithMethods("GET", "POST", "PUT", "DELETE")
+            .SetPreflightMaxAge(TimeSpan.FromMinutes(10));
+    });
+});
+
+// Apply globally or per-endpoint
+app.UseCors("AllowSpecificOrigins");
+
+// Or per-controller
+[EnableCors("ApiClients")]
+public class ApiController : ControllerBase { }
+```
+
+### Rate Limiting (.NET 7+)
+
+```csharp
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    // Fixed window limiter
+    options.AddFixedWindowLimiter("fixed", opt =>
+    {
+        opt.Window = TimeSpan.FromMinutes(1);
+        opt.PermitLimit = 100;
+        opt.QueueLimit = 10;
+        opt.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
+    });
+
+    // Sliding window limiter
+    options.AddSlidingWindowLimiter("sliding", opt =>
+    {
+        opt.Window = TimeSpan.FromMinutes(1);
+        opt.SegmentsPerWindow = 6;
+        opt.PermitLimit = 100;
+    });
+
+    // Token bucket limiter
+    options.AddTokenBucketLimiter("token", opt =>
+    {
+        opt.TokenLimit = 100;
+        opt.ReplenishmentPeriod = TimeSpan.FromSeconds(10);
+        opt.TokensPerPeriod = 10;
+    });
+
+    // Per-user rate limiting
+    options.AddPolicy("per-user", context =>
+    {
+        var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+            ?? context.Connection.RemoteIpAddress?.ToString()
+            ?? "anonymous";
+
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: userId,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                Window = TimeSpan.FromMinutes(1),
+                PermitLimit = 60
+            });
+    });
+
+    options.OnRejected = async (context, token) =>
+    {
+        context.HttpContext.Response.ContentType = "application/json";
+        await context.HttpContext.Response.WriteAsJsonAsync(new
+        {
+            error = "Too many requests",
+            retryAfter = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+                ? retryAfter.TotalSeconds
+                : 60
+        }, token);
+    };
+});
+
+app.UseRateLimiter();
+
+// Apply to endpoints
+app.MapGet("/api/data", () => "data")
+    .RequireRateLimiting("per-user");
+```
+
+---
+
+## Configuration Patterns
+
+### Strongly-Typed Options with Validation
+
+```csharp
+public class EmailSettings
+{
+    public const string SectionName = "Email";
+
+    [Required]
+    public string SmtpServer { get; set; } = string.Empty;
+
+    [Range(1, 65535)]
+    public int Port { get; set; } = 587;
+
+    [Required, EmailAddress]
+    public string FromAddress { get; set; } = string.Empty;
+
+    public bool UseSsl { get; set; } = true;
+
+    [Range(1, 300)]
+    public int TimeoutSeconds { get; set; } = 30;
+}
+
+// Registration with validation
+builder.Services.AddOptions<EmailSettings>()
+    .Bind(builder.Configuration.GetSection(EmailSettings.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart(); // Fail fast on startup if invalid
+
+// Custom validation
+builder.Services.AddOptions<DatabaseSettings>()
+    .Bind(builder.Configuration.GetSection("Database"))
+    .Validate(settings =>
+    {
+        return !string.IsNullOrEmpty(settings.ConnectionString)
+            && settings.MaxPoolSize >= settings.MinPoolSize;
+    }, "Database configuration is invalid")
+    .ValidateOnStart();
+```
+
+### Options Interfaces Usage
+
+```csharp
+public class EmailService
+{
+    // IOptions<T> - singleton, read once at startup
+    public EmailService(IOptions<EmailSettings> options)
+    {
+        var settings = options.Value;
+    }
+}
+
+public class NotificationService
+{
+    // IOptionsSnapshot<T> - scoped, re-reads config per request
+    public NotificationService(IOptionsSnapshot<EmailSettings> options)
+    {
+        var settings = options.Value;
+    }
+}
+
+public class BackgroundEmailProcessor : BackgroundService
+{
+    // IOptionsMonitor<T> - singleton with change notifications
+    private readonly IOptionsMonitor<EmailSettings> _optionsMonitor;
+    private EmailSettings _currentSettings;
+
+    public BackgroundEmailProcessor(IOptionsMonitor<EmailSettings> optionsMonitor)
+    {
+        _optionsMonitor = optionsMonitor;
+        _currentSettings = optionsMonitor.CurrentValue;
+
+        _optionsMonitor.OnChange(settings =>
+        {
+            _currentSettings = settings;
+            // Handle configuration change
+        });
+    }
+}
+```
+
+### Multi-Environment Configuration
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// Configuration sources (later sources override earlier ones)
+builder.Configuration
+    .SetBasePath(builder.Environment.ContentRootPath)
+    .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+    .AddJsonFile("appsettings.local.json", optional: true, reloadOnChange: true) // Git-ignored local overrides
+    .AddEnvironmentVariables()
+    .AddCommandLine(args);
+
+// Development-only sources
+if (builder.Environment.IsDevelopment())
+{
+    builder.Configuration.AddUserSecrets<Program>();
+}
+
+// Production secret stores
+if (builder.Environment.IsProduction())
+{
+    builder.Configuration.AddAzureKeyVault(
+        new Uri($"https://{builder.Configuration["KeyVault:Name"]}.vault.azure.net/"),
+        new DefaultAzureCredential());
+}
+```
+
+### Named Options Pattern
+
+```csharp
+// appsettings.json
+{
+  "Storage": {
+    "Primary": {
+      "ConnectionString": "...",
+      "ContainerName": "primary"
+    },
+    "Backup": {
+      "ConnectionString": "...",
+      "ContainerName": "backup"
+    }
+  }
+}
+
+// Registration
+builder.Services.Configure<StorageSettings>("Primary",
+    builder.Configuration.GetSection("Storage:Primary"));
+builder.Services.Configure<StorageSettings>("Backup",
+    builder.Configuration.GetSection("Storage:Backup"));
+
+// Usage with IOptionsSnapshot
+public class StorageService
+{
+    private readonly StorageSettings _primarySettings;
+    private readonly StorageSettings _backupSettings;
+
+    public StorageService(IOptionsSnapshot<StorageSettings> options)
+    {
+        _primarySettings = options.Get("Primary");
+        _backupSettings = options.Get("Backup");
+    }
+}
+```
+
+### Post-Configure and Configure All
+
+```csharp
+// Post-configure runs after all Configure calls
+builder.Services.PostConfigure<EmailSettings>(settings =>
+{
+    // Apply defaults or computed values
+    if (string.IsNullOrEmpty(settings.FromAddress))
+    {
+        settings.FromAddress = "noreply@example.com";
+    }
+});
+
+// Configure all instances of an options type
+builder.Services.ConfigureAll<StorageSettings>(settings =>
+{
+    settings.TimeoutSeconds = 30; // Apply to all named instances
+});
+```
+
+---
+
+## Dependency Injection Patterns
+
+### Service Lifetimes
+
+```csharp
+// Singleton - one instance for application lifetime
+builder.Services.AddSingleton<ICacheService, MemoryCacheService>();
+
+// Scoped - one instance per HTTP request
+builder.Services.AddScoped<IUserContext, HttpUserContext>();
+builder.Services.AddScoped<IUnitOfWork, EfUnitOfWork>();
+
+// Transient - new instance every time
+builder.Services.AddTransient<IEmailBuilder, EmailBuilder>();
+```
+
+### Factory Pattern Registration
+
+```csharp
+// Simple factory
+builder.Services.AddScoped<IPaymentProcessor>(sp =>
+{
+    var config = sp.GetRequiredService<IOptions<PaymentSettings>>().Value;
+    return config.Provider switch
+    {
+        "Stripe" => new StripePaymentProcessor(config),
+        "PayPal" => new PayPalPaymentProcessor(config),
+        _ => throw new InvalidOperationException($"Unknown provider: {config.Provider}")
+    };
+});
+
+// Named factory with keyed services (.NET 8+)
+builder.Services.AddKeyedScoped<IPaymentProcessor, StripePaymentProcessor>("stripe");
+builder.Services.AddKeyedScoped<IPaymentProcessor, PayPalPaymentProcessor>("paypal");
+
+// Usage
+public class CheckoutService([FromKeyedServices("stripe")] IPaymentProcessor stripeProcessor)
+{
+    // ...
+}
+```
+
+### Decorator Pattern
+
+```csharp
+// Manual decoration
+builder.Services.AddScoped<IRepository, SqlRepository>();
+builder.Services.Decorate<IRepository, CachingRepository>();
+builder.Services.Decorate<IRepository, LoggingRepository>();
+
+// Extension method implementation
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection Decorate<TInterface, TDecorator>(
+        this IServiceCollection services)
+        where TDecorator : TInterface
+    {
+        var descriptor = services.Single(d => d.ServiceType == typeof(TInterface));
+
+        services.Add(new ServiceDescriptor(
+            typeof(TInterface),
+            sp =>
+            {
+                var inner = (TInterface)ActivatorUtilities.CreateInstance(
+                    sp,
+                    descriptor.ImplementationType!);
+                return ActivatorUtilities.CreateInstance<TDecorator>(sp, inner);
+            },
+            descriptor.Lifetime));
+
+        services.Remove(descriptor);
+        return services;
+    }
+}
+```
+
+### HttpClientFactory Patterns
+
+```csharp
+// Typed client
+builder.Services.AddHttpClient<IGitHubClient, GitHubClient>(client =>
+{
+    client.BaseAddress = new Uri("https://api.github.com/");
+    client.DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+    client.DefaultRequestHeaders.Add("User-Agent", "MyApp/1.0");
+})
+.AddPolicyHandler(GetRetryPolicy())
+.AddPolicyHandler(GetCircuitBreakerPolicy());
+
+// Named client
+builder.Services.AddHttpClient("weather", client =>
+{
+    client.BaseAddress = new Uri("https://api.weather.com/");
+    client.Timeout = TimeSpan.FromSeconds(30);
+});
+
+// Resilience policies with Polly
+static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .WaitAndRetryAsync(3, retryAttempt =>
+            TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+}
+
+static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .CircuitBreakerAsync(5, TimeSpan.FromSeconds(30));
+}
+```
+
+---
+
+## Error Handling Patterns
+
+### Global Exception Handler (.NET 8+)
+
+```csharp
+public class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+    private readonly IHostEnvironment _environment;
+
+    public GlobalExceptionHandler(
+        ILogger<GlobalExceptionHandler> logger,
+        IHostEnvironment environment)
+    {
+        _logger = logger;
+        _environment = environment;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var (statusCode, title) = exception switch
+        {
+            ValidationException => (StatusCodes.Status400BadRequest, "Validation Error"),
+            NotFoundException => (StatusCodes.Status404NotFound, "Not Found"),
+            UnauthorizedAccessException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
+            ForbiddenException => (StatusCodes.Status403Forbidden, "Forbidden"),
+            ConflictException => (StatusCodes.Status409Conflict, "Conflict"),
+            _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
+        };
+
+        _logger.LogError(exception, "Exception occurred: {Message}", exception.Message);
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Instance = httpContext.Request.Path,
+            Detail = _environment.IsDevelopment() ? exception.Message : null
+        };
+
+        if (exception is ValidationException validationException)
+        {
+            problemDetails.Extensions["errors"] = validationException.Errors;
+        }
+
+        httpContext.Response.StatusCode = statusCode;
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+        return true;
+    }
+}
+
+// Registration
+builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
+builder.Services.AddProblemDetails();
+
+app.UseExceptionHandler();
+```
+
+### Problem Details Configuration
+
+```csharp
+builder.Services.AddProblemDetails(options =>
+{
+    options.CustomizeProblemDetails = context =>
+    {
+        context.ProblemDetails.Instance = context.HttpContext.Request.Path;
+        context.ProblemDetails.Extensions["traceId"] = context.HttpContext.TraceIdentifier;
+        context.ProblemDetails.Extensions["timestamp"] = DateTime.UtcNow;
+
+        if (context.HttpContext.RequestServices.GetService<IHostEnvironment>()?.IsDevelopment() == true)
+        {
+            context.ProblemDetails.Extensions["machineName"] = Environment.MachineName;
+        }
+    };
+});
+```
+
+---
+
+## Logging Patterns
+
+### Structured Logging with Serilog
+
+```csharp
+builder.Host.UseSerilog((context, loggerConfig) =>
+{
+    loggerConfig
+        .ReadFrom.Configuration(context.Configuration)
+        .Enrich.FromLogContext()
+        .Enrich.WithMachineName()
+        .Enrich.WithEnvironmentName()
+        .Enrich.WithProperty("Application", "MyApp")
+        .WriteTo.Console(new JsonFormatter())
+        .WriteTo.Seq(context.Configuration["Seq:ServerUrl"]!);
+});
+
+// Request logging middleware
+app.UseSerilogRequestLogging(options =>
+{
+    options.MessageTemplate =
+        "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000}ms";
+
+    options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+    {
+        diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
+        diagnosticContext.Set("UserAgent", httpContext.Request.Headers.UserAgent.ToString());
+        diagnosticContext.Set("UserId", httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+    };
+});
+```
+
+### High-Performance Logging with Source Generators
+
+```csharp
+public static partial class LogMessages
+{
+    [LoggerMessage(
+        EventId = 1001,
+        Level = LogLevel.Information,
+        Message = "Processing order {OrderId} for customer {CustomerId}")]
+    public static partial void ProcessingOrder(
+        ILogger logger,
+        string orderId,
+        string customerId);
+
+    [LoggerMessage(
+        EventId = 1002,
+        Level = LogLevel.Warning,
+        Message = "Order {OrderId} processing delayed, retry attempt {Attempt}")]
+    public static partial void OrderProcessingDelayed(
+        ILogger logger,
+        string orderId,
+        int attempt);
+
+    [LoggerMessage(
+        EventId = 1003,
+        Level = LogLevel.Error,
+        Message = "Failed to process order {OrderId}")]
+    public static partial void OrderProcessingFailed(
+        ILogger logger,
+        string orderId,
+        Exception exception);
+}
+
+// Usage
+public class OrderProcessor
+{
+    private readonly ILogger<OrderProcessor> _logger;
+
+    public OrderProcessor(ILogger<OrderProcessor> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ProcessAsync(Order order)
+    {
+        LogMessages.ProcessingOrder(_logger, order.Id, order.CustomerId);
+
+        try
+        {
+            // Process order
+        }
+        catch (Exception ex)
+        {
+            LogMessages.OrderProcessingFailed(_logger, order.Id, ex);
+            throw;
+        }
+    }
+}
+```
+
+### Correlation and Scoped Logging
+
+```csharp
+public class CorrelationIdMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public CorrelationIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ILogger<CorrelationIdMiddleware> logger)
+    {
+        var correlationId = context.Request.Headers["X-Correlation-Id"].FirstOrDefault()
+            ?? Guid.NewGuid().ToString();
+
+        context.Response.Headers["X-Correlation-Id"] = correlationId;
+
+        using (logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId,
+            ["RequestPath"] = context.Request.Path.ToString()
+        }))
+        {
+            await _next(context);
+        }
+    }
+}
+```

--- a/.github/skills/blazor/SKILL.md
+++ b/.github/skills/blazor/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: blazor
+description: "Build and review Blazor applications across server, WebAssembly, web app, and hybrid scenarios with correct component design, state flow, rendering, and hosting choices. USE FOR: building interactive web UIs with C# instead of JavaScript; choosing between Server, WebAssembly, or Auto render modes; designing component hierarchies and state. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires Blazor project (.NET 6+, preferably .NET 8+ for unified model)."
+---
+
+# Blazor
+
+## Trigger On
+
+- building interactive web UIs with C# instead of JavaScript
+- choosing between Server, WebAssembly, or Auto render modes
+- designing component hierarchies and state management
+- handling prerendering and hydration
+- integrating with JavaScript when necessary
+
+## Documentation
+
+- [Blazor Overview](https://learn.microsoft.com/en-us/aspnet/core/blazor/?view=aspnetcore-10.0)
+- [Render Modes](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-10.0)
+- [Performance Best Practices](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-10.0)
+- [State Management](https://learn.microsoft.com/en-us/aspnet/core/blazor/state-management?view=aspnetcore-10.0)
+- [JS Interop](https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-10.0)
+
+### References
+
+- [patterns.md](references/patterns.md) - Detailed component patterns, state management strategies, and JS interop techniques
+- [anti-patterns.md](references/anti-patterns.md) - Common Blazor mistakes and how to avoid them
+
+## Render Modes (.NET 8+)
+
+| Mode | Where It Runs | Best For |
+|------|---------------|----------|
+| `Static` | Server (no interactivity) | SEO pages, marketing content |
+| `InteractiveServer` | Server via SignalR | Real-time apps, thin clients |
+| `InteractiveWebAssembly` | Browser via WASM | Offline-capable, client-heavy |
+| `InteractiveAuto` | Server first, then WASM | Best of both worlds |
+
+### Applying Render Modes
+
+```razor
+@* Per-component *@
+@rendermode InteractiveServer
+
+@* Or in App.razor for global *@
+<Routes @rendermode="InteractiveAuto" />
+```
+
+### InteractiveAuto Architecture
+
+```
+First Request:
+  Browser → Server (Interactive Server) → Fast response
+
+Subsequent Requests:
+  Browser → WASM (downloaded in background) → No server needed
+```
+
+## Workflow
+
+1. **Choose render mode based on requirements:**
+   - Need SEO? Start with Static or prerendering
+   - Need real-time? Use InteractiveServer
+   - Need offline? Use InteractiveWebAssembly
+   - Want both? Use InteractiveAuto
+
+2. **Design components for reusability:**
+   - Small, focused components
+   - Parameters for customization
+   - Events for communication
+
+3. **Handle state correctly:**
+   - Component state lives in component
+   - Shared state via services (DI)
+   - Persist state across prerender with `[PersistentState]`
+
+4. **Validate in both environments** (for Auto mode)
+
+## Component Patterns
+
+### Basic Component
+```razor
+@* Counter.razor *@
+<button @onclick="IncrementCount">
+    Clicked @count times
+</button>
+
+@code {
+    private int count = 0;
+
+    [Parameter]
+    public int InitialCount { get; set; } = 0;
+
+    protected override void OnInitialized()
+    {
+        count = InitialCount;
+    }
+
+    private void IncrementCount() => count++;
+}
+```
+
+### Parameter and Event Callbacks
+```razor
+@* Parent.razor *@
+<ChildComponent Value="@value" ValueChanged="@OnValueChanged" />
+
+@* ChildComponent.razor *@
+@code {
+    [Parameter] public string Value { get; set; } = "";
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+
+    private async Task UpdateValue(string newValue)
+    {
+        await ValueChanged.InvokeAsync(newValue);
+    }
+}
+```
+
+### State Persistence (.NET 8+)
+```razor
+@* Prevents double-fetch during prerender + hydration *@
+@code {
+    [PersistentState]
+    public List<Product> Products { get; set; } = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Only fetches once, persisted across prerender
+        Products ??= await Http.GetFromJsonAsync<List<Product>>("api/products");
+    }
+}
+```
+
+## Data Access Pattern for Auto Mode
+
+```csharp
+// Shared interface
+public interface IProductService
+{
+    Task<List<Product>> GetProductsAsync();
+}
+
+// Server implementation (direct DB access)
+public class ServerProductService : IProductService
+{
+    private readonly AppDbContext _db;
+    public async Task<List<Product>> GetProductsAsync()
+        => await _db.Products.ToListAsync();
+}
+
+// Client implementation (HTTP call)
+public class ClientProductService : IProductService
+{
+    private readonly HttpClient _http;
+    public async Task<List<Product>> GetProductsAsync()
+        => await _http.GetFromJsonAsync<List<Product>>("api/products");
+}
+
+// Registration
+// Server: builder.Services.AddScoped<IProductService, ServerProductService>();
+// Client: builder.Services.AddScoped<IProductService, ClientProductService>();
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| Large components | Hard to maintain, slow renders | Split into smaller components |
+| Direct DB access in WASM | No DB in browser | Use HTTP API |
+| Ignoring `ShouldRender` | Unnecessary re-renders | Override when needed |
+| Sync JS interop in Server | Blocks SignalR circuit | Use `IJSRuntime` async |
+| No error boundaries | One error crashes app | Use `<ErrorBoundary>` |
+| Forgetting prerender state | Double API calls | Use `[PersistentState]` |
+
+## Performance Best Practices
+
+1. **Virtualize large lists:**
+   ```razor
+   <Virtualize Items="@products" Context="product">
+       <ProductCard Product="@product" />
+   </Virtualize>
+   ```
+
+2. **Use `@key` for list diffing:**
+   ```razor
+   @foreach (var item in items)
+   {
+       <ItemComponent @key="item.Id" Item="@item" />
+   }
+   ```
+
+3. **Debounce rapid events:**
+   ```csharp
+   private Timer? _debounceTimer;
+
+   private void OnInput(ChangeEventArgs e)
+   {
+       _debounceTimer?.Dispose();
+       _debounceTimer = new Timer(_ => InvokeAsync(DoSearch), null, 300, Timeout.Infinite);
+   }
+   ```
+
+4. **Lazy load assemblies (WASM):**
+   ```csharp
+   var assemblies = await LazyAssemblyLoader
+       .LoadAssembliesAsync(["MyHeavyFeature.wasm"]);
+   ```
+
+## JS Interop
+
+### Calling JavaScript from C#
+```csharp
+@inject IJSRuntime JS
+
+await JS.InvokeVoidAsync("alert", "Hello from Blazor!");
+var result = await JS.InvokeAsync<string>("prompt", "Enter name:");
+```
+
+### Calling C# from JavaScript
+```csharp
+[JSInvokable]
+public static string GetMessage() => "Hello from C#!";
+```
+
+```javascript
+DotNet.invokeMethodAsync('MyAssembly', 'GetMessage')
+    .then(result => console.log(result));
+```
+
+## Deliver
+
+- interactive Blazor components with appropriate render mode
+- efficient state management and data flow
+- proper handling of prerendering scenarios
+- performant list rendering with virtualization
+
+## Validate
+
+- components render correctly in chosen mode
+- state persists correctly across prerender/hydration
+- no unnecessary re-renders (check with browser tools)
+- JS interop works in both Server and WASM
+- error boundaries catch component failures
+- Auto mode works in both environments

--- a/.github/skills/blazor/manifest.json
+++ b/.github/skills/blazor/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "category": "Web",
+  "package_prefix": "Microsoft.AspNetCore.Components"
+}

--- a/.github/skills/blazor/references/anti-patterns.md
+++ b/.github/skills/blazor/references/anti-patterns.md
@@ -1,0 +1,671 @@
+# Blazor Anti-Patterns
+
+## Component Design Anti-Patterns
+
+### Monolithic Components
+
+**Problem:** Creating large components that handle multiple concerns.
+
+```razor
+@* BAD: One component doing everything *@
+@code {
+    private List<Product> products = [];
+    private List<Category> categories = [];
+    private Cart cart = new();
+    private User? user;
+    private bool showFilters = false;
+    private string searchTerm = "";
+    private decimal minPrice;
+    private decimal maxPrice;
+    // ... 500 more lines of mixed concerns
+}
+```
+
+**Solution:** Split into focused components with single responsibilities.
+
+```razor
+@* GOOD: Composed from smaller components *@
+<ProductPage>
+    <ProductFilters />
+    <ProductGrid Products="@products" />
+    <CartSidebar />
+</ProductPage>
+```
+
+### Parameter Drilling
+
+**Problem:** Passing parameters through many component layers.
+
+```razor
+@* BAD: Drilling user through multiple levels *@
+<Layout User="@user">
+    <Sidebar User="@user">
+        <UserMenu User="@user">
+            <Avatar User="@user" />
+        </UserMenu>
+    </Sidebar>
+</Layout>
+```
+
+**Solution:** Use cascading values for widely-needed data.
+
+```razor
+@* GOOD: Cascading value *@
+<CascadingValue Value="@user">
+    <Layout>
+        <Sidebar>
+            <UserMenu />  @* Accesses user via [CascadingParameter] *@
+        </Sidebar>
+    </Layout>
+</CascadingValue>
+```
+
+### Mutable Parameter Objects
+
+**Problem:** Modifying parameter objects directly, bypassing change detection.
+
+```razor
+@* BAD: Mutating parameter object *@
+@code {
+    [Parameter] public Product Product { get; set; } = default!;
+
+    private void UpdatePrice()
+    {
+        Product.Price = 99.99m; // Parent won't know about this change
+    }
+}
+```
+
+**Solution:** Use events to notify parent of changes.
+
+```razor
+@* GOOD: Notify parent via callback *@
+@code {
+    [Parameter] public Product Product { get; set; } = default!;
+    [Parameter] public EventCallback<Product> ProductChanged { get; set; }
+
+    private async Task UpdatePrice()
+    {
+        var updated = Product with { Price = 99.99m };
+        await ProductChanged.InvokeAsync(updated);
+    }
+}
+```
+
+### Missing EditorRequired
+
+**Problem:** Forgetting to mark required parameters, leading to runtime errors.
+
+```razor
+@* BAD: No indication this is required *@
+@code {
+    [Parameter] public Product Product { get; set; } = default!;
+}
+```
+
+**Solution:** Use EditorRequired for mandatory parameters.
+
+```razor
+@* GOOD: Compiler warns if not provided *@
+@code {
+    [Parameter, EditorRequired] public Product Product { get; set; } = default!;
+}
+```
+
+## State Management Anti-Patterns
+
+### Global Static State
+
+**Problem:** Using static fields for state, causing cross-user data leakage in Server mode.
+
+```csharp
+// BAD: Static state is shared across ALL users in Server mode
+public static class AppState
+{
+    public static User? CurrentUser { get; set; }
+    public static List<CartItem> Cart { get; } = [];
+}
+```
+
+**Solution:** Use scoped services.
+
+```csharp
+// GOOD: Scoped per-circuit in Server mode
+public class AppState
+{
+    public User? CurrentUser { get; set; }
+    public List<CartItem> Cart { get; } = [];
+}
+
+// Registration
+services.AddScoped<AppState>();
+```
+
+### Forgetting to Dispose Event Subscriptions
+
+**Problem:** Memory leaks from event subscriptions.
+
+```razor
+@* BAD: Never unsubscribes *@
+@code {
+    protected override void OnInitialized()
+    {
+        CartService.OnChange += StateHasChanged;
+    }
+}
+```
+
+**Solution:** Implement IDisposable.
+
+```razor
+@* GOOD: Clean up subscriptions *@
+@implements IDisposable
+
+@code {
+    protected override void OnInitialized()
+    {
+        CartService.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        CartService.OnChange -= StateHasChanged;
+    }
+}
+```
+
+### Double Data Fetching with Prerendering
+
+**Problem:** Fetching data twice (once during prerender, once during interactive).
+
+```razor
+@* BAD: Fetches twice *@
+@code {
+    private List<Product> products = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        products = await Http.GetFromJsonAsync<List<Product>>("api/products") ?? [];
+    }
+}
+```
+
+**Solution:** Use PersistentState or PersistentComponentState.
+
+```razor
+@* GOOD: Data persists across prerender *@
+@code {
+    [PersistentState]
+    public List<Product> Products { get; set; } = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Products.Count == 0)
+        {
+            Products = await Http.GetFromJsonAsync<List<Product>>("api/products") ?? [];
+        }
+    }
+}
+```
+
+## Render Mode Anti-Patterns
+
+### Direct Database Access in WASM Components
+
+**Problem:** Trying to use DbContext in WebAssembly.
+
+```csharp
+// BAD: DbContext doesn't work in browser
+@inject AppDbContext Db
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        products = await Db.Products.ToListAsync(); // Will fail in WASM
+    }
+}
+```
+
+**Solution:** Use HTTP API abstraction.
+
+```csharp
+// GOOD: Works in both Server and WASM
+@inject IProductService ProductService
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        products = await ProductService.GetProductsAsync();
+    }
+}
+
+// Server implementation uses DbContext
+// Client implementation uses HttpClient
+```
+
+### Ignoring Render Mode Boundaries
+
+**Problem:** Assuming all components run in the same mode.
+
+```razor
+@* BAD: Child assumes parent's render mode *@
+<InteractiveParent>
+    <StaticChild />  @* May not behave as expected *@
+</InteractiveParent>
+```
+
+**Solution:** Explicitly set render modes and understand boundaries.
+
+```razor
+@* GOOD: Explicit render mode *@
+<div>
+    <StaticHeader />
+    <InteractiveContent @rendermode="InteractiveServer" />
+    <StaticFooter />
+</div>
+```
+
+### Auto Mode Without Dual Implementation
+
+**Problem:** Using Auto render mode without supporting both environments.
+
+```csharp
+// BAD: Only works on server
+services.AddScoped<IDataService, ServerOnlyDataService>();
+```
+
+**Solution:** Register environment-specific implementations.
+
+```csharp
+// Server project
+services.AddScoped<IDataService, ServerDataService>();
+
+// Client project
+services.AddScoped<IDataService, ClientDataService>();
+```
+
+## Performance Anti-Patterns
+
+### Missing @key on Lists
+
+**Problem:** Blazor recreates all list items on changes.
+
+```razor
+@* BAD: No key, poor diffing *@
+@foreach (var item in items)
+{
+    <ItemComponent Item="@item" />
+}
+```
+
+**Solution:** Use @key for efficient updates.
+
+```razor
+@* GOOD: Efficient list diffing *@
+@foreach (var item in items)
+{
+    <ItemComponent @key="item.Id" Item="@item" />
+}
+```
+
+### Rendering Large Lists Without Virtualization
+
+**Problem:** Rendering thousands of items at once.
+
+```razor
+@* BAD: Renders all 10,000 items *@
+@foreach (var item in allItems)
+{
+    <ItemRow Item="@item" />
+}
+```
+
+**Solution:** Use Virtualize component.
+
+```razor
+@* GOOD: Only renders visible items *@
+<Virtualize Items="@allItems" Context="item">
+    <ItemRow Item="@item" />
+</Virtualize>
+```
+
+### Unnecessary Re-renders
+
+**Problem:** Components re-render when they don't need to.
+
+```razor
+@* BAD: Re-renders on every parent change *@
+<ExpensiveComponent Data="@unchangingData" />
+```
+
+**Solution:** Override ShouldRender for expensive components.
+
+```razor
+@* GOOD: Controlled re-rendering *@
+@code {
+    private object? previousData;
+
+    [Parameter] public object? Data { get; set; }
+
+    protected override bool ShouldRender()
+    {
+        var shouldRender = !ReferenceEquals(Data, previousData);
+        previousData = Data;
+        return shouldRender;
+    }
+}
+```
+
+### Blocking Async Operations
+
+**Problem:** Using synchronous waits that block the render thread.
+
+```csharp
+// BAD: Blocks the thread
+protected override void OnInitialized()
+{
+    var data = Http.GetFromJsonAsync<Data>("api/data").Result; // BLOCKS!
+}
+```
+
+**Solution:** Use proper async patterns.
+
+```csharp
+// GOOD: Non-blocking
+protected override async Task OnInitializedAsync()
+{
+    var data = await Http.GetFromJsonAsync<Data>("api/data");
+}
+```
+
+## JavaScript Interop Anti-Patterns
+
+### Synchronous JS Calls in Server Mode
+
+**Problem:** Synchronous JS interop blocks the SignalR circuit.
+
+```csharp
+// BAD: Blocks in Server mode
+var result = ((IJSInProcessRuntime)JS).Invoke<string>("getValue");
+```
+
+**Solution:** Always use async JS interop.
+
+```csharp
+// GOOD: Non-blocking
+var result = await JS.InvokeAsync<string>("getValue");
+```
+
+### JS Interop During Prerendering
+
+**Problem:** Calling JS during prerender when there's no browser.
+
+```csharp
+// BAD: Fails during prerender
+protected override async Task OnInitializedAsync()
+{
+    await JS.InvokeVoidAsync("initializeMap"); // No JS runtime during prerender
+}
+```
+
+**Solution:** Call JS only after first interactive render.
+
+```csharp
+// GOOD: Only when interactive
+protected override async Task OnAfterRenderAsync(bool firstRender)
+{
+    if (firstRender)
+    {
+        await JS.InvokeVoidAsync("initializeMap");
+    }
+}
+```
+
+### Not Disposing JS Object References
+
+**Problem:** Memory leaks from JS object references.
+
+```csharp
+// BAD: Never disposed
+private IJSObjectReference? module;
+
+protected override async Task OnAfterRenderAsync(bool firstRender)
+{
+    if (firstRender)
+    {
+        module = await JS.InvokeAsync<IJSObjectReference>("import", "./module.js");
+    }
+}
+```
+
+**Solution:** Implement IAsyncDisposable.
+
+```csharp
+// GOOD: Proper cleanup
+@implements IAsyncDisposable
+
+private IJSObjectReference? module;
+
+public async ValueTask DisposeAsync()
+{
+    if (module is not null)
+    {
+        await module.DisposeAsync();
+    }
+}
+```
+
+### Large Data in JS Interop
+
+**Problem:** Passing large objects through JS interop serialization.
+
+```csharp
+// BAD: Serializes entire dataset
+await JS.InvokeVoidAsync("processData", hugeDataSet);
+```
+
+**Solution:** Use streaming or pass references.
+
+```csharp
+// GOOD: Stream large data
+using var streamRef = new DotNetStreamReference(dataStream);
+await JS.InvokeVoidAsync("processStream", streamRef);
+```
+
+## Form Handling Anti-Patterns
+
+### Missing Validation
+
+**Problem:** Forms without proper validation.
+
+```razor
+@* BAD: No validation *@
+<EditForm Model="@model" OnSubmit="Submit">
+    <InputText @bind-Value="model.Email" />
+    <button type="submit">Submit</button>
+</EditForm>
+```
+
+**Solution:** Add validators.
+
+```razor
+@* GOOD: With validation *@
+<EditForm Model="@model" OnValidSubmit="Submit">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+
+    <InputText @bind-Value="model.Email" />
+    <ValidationMessage For="() => model.Email" />
+
+    <button type="submit">Submit</button>
+</EditForm>
+```
+
+### Not Handling Form Submission State
+
+**Problem:** Double submissions and no loading indication.
+
+```razor
+@* BAD: Can submit multiple times *@
+<button type="submit">Submit</button>
+```
+
+**Solution:** Track and display submission state.
+
+```razor
+@* GOOD: Prevents double submit, shows status *@
+<button type="submit" disabled="@isSubmitting">
+    @(isSubmitting ? "Submitting..." : "Submit")
+</button>
+
+@code {
+    private bool isSubmitting = false;
+
+    private async Task Submit()
+    {
+        isSubmitting = true;
+        try
+        {
+            await SubmitFormAsync();
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+}
+```
+
+## Error Handling Anti-Patterns
+
+### No Error Boundaries
+
+**Problem:** One component error crashes the whole application.
+
+```razor
+@* BAD: Unhandled exception crashes circuit *@
+<RiskyComponent />
+```
+
+**Solution:** Wrap risky components in ErrorBoundary.
+
+```razor
+@* GOOD: Contained errors *@
+<ErrorBoundary>
+    <ChildContent>
+        <RiskyComponent />
+    </ChildContent>
+    <ErrorContent Context="ex">
+        <p>Something went wrong: @ex.Message</p>
+    </ErrorContent>
+</ErrorBoundary>
+```
+
+### Swallowing Exceptions
+
+**Problem:** Catching exceptions without proper handling.
+
+```csharp
+// BAD: Silent failure
+try
+{
+    await SaveDataAsync();
+}
+catch
+{
+    // Swallowed - user has no idea it failed
+}
+```
+
+**Solution:** Provide feedback and logging.
+
+```csharp
+// GOOD: User feedback and logging
+try
+{
+    await SaveDataAsync();
+    message = "Saved successfully";
+}
+catch (Exception ex)
+{
+    Logger.LogError(ex, "Failed to save data");
+    errorMessage = "Failed to save. Please try again.";
+}
+```
+
+## Security Anti-Patterns
+
+### Client-Side Authorization Only
+
+**Problem:** Relying solely on client-side security checks.
+
+```razor
+@* BAD: Client-side only - easily bypassed *@
+@if (isAdmin)
+{
+    <AdminPanel />
+}
+```
+
+**Solution:** Always validate on server.
+
+```csharp
+// GOOD: Server-side authorization
+[Authorize(Roles = "Admin")]
+public class AdminController : ControllerBase
+{
+    // Server validates every request
+}
+```
+
+### Exposing Sensitive Data in Component State
+
+**Problem:** Keeping secrets in component state visible to users.
+
+```razor
+@* BAD: API key visible in browser state *@
+@code {
+    private string apiKey = "secret-api-key-12345";
+}
+```
+
+**Solution:** Keep secrets server-side only.
+
+```csharp
+// GOOD: Server-side service holds secrets
+public class SecureService
+{
+    private readonly string _apiKey;
+
+    public SecureService(IConfiguration config)
+    {
+        _apiKey = config["ApiKey"]!;
+    }
+
+    public async Task CallApiAsync()
+    {
+        // Uses _apiKey internally, never exposed to client
+    }
+}
+```
+
+### Trusting Client Input
+
+**Problem:** Using client input without validation.
+
+```csharp
+// BAD: Direct use of user input
+var userId = userIdFromClient;
+var data = await Db.GetUserData(userId); // Can access any user's data
+```
+
+**Solution:** Validate against authenticated user.
+
+```csharp
+// GOOD: Validate ownership
+var authenticatedUserId = GetAuthenticatedUserId();
+if (requestedUserId != authenticatedUserId)
+{
+    throw new UnauthorizedAccessException();
+}
+```

--- a/.github/skills/blazor/references/patterns.md
+++ b/.github/skills/blazor/references/patterns.md
@@ -1,0 +1,705 @@
+# Blazor Component Patterns
+
+## Component Design Patterns
+
+### Smart vs Presentational Components
+
+Separate concerns by distinguishing between components that manage data and those that display it.
+
+**Presentational Component (Dumb)**
+```razor
+@* ProductCard.razor - Only displays data *@
+<div class="product-card">
+    <img src="@Product.ImageUrl" alt="@Product.Name" />
+    <h3>@Product.Name</h3>
+    <p>@Product.Price.ToString("C")</p>
+    <button @onclick="OnAddToCart">Add to Cart</button>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public Product Product { get; set; } = default!;
+    [Parameter] public EventCallback OnAddToCart { get; set; }
+}
+```
+
+**Smart Component (Container)**
+```razor
+@* ProductList.razor - Manages data and state *@
+@inject IProductService ProductService
+@inject ICartService CartService
+
+<div class="product-list">
+    @foreach (var product in products)
+    {
+        <ProductCard Product="@product" OnAddToCart="() => AddToCart(product)" />
+    }
+</div>
+
+@code {
+    private List<Product> products = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        products = await ProductService.GetProductsAsync();
+    }
+
+    private async Task AddToCart(Product product)
+    {
+        await CartService.AddAsync(product);
+    }
+}
+```
+
+### Templated Components
+
+Allow consumers to customize rendering with render fragments.
+
+```razor
+@* DataGrid.razor *@
+@typeparam TItem
+
+<table>
+    <thead>
+        <tr>@HeaderTemplate</tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Items)
+        {
+            <tr>@RowTemplate(item)</tr>
+        }
+    </tbody>
+</table>
+
+@code {
+    [Parameter, EditorRequired] public IEnumerable<TItem> Items { get; set; } = [];
+    [Parameter, EditorRequired] public RenderFragment HeaderTemplate { get; set; } = default!;
+    [Parameter, EditorRequired] public RenderFragment<TItem> RowTemplate { get; set; } = default!;
+}
+```
+
+**Usage:**
+```razor
+<DataGrid Items="@products">
+    <HeaderTemplate>
+        <th>Name</th>
+        <th>Price</th>
+    </HeaderTemplate>
+    <RowTemplate Context="product">
+        <td>@product.Name</td>
+        <td>@product.Price.ToString("C")</td>
+    </RowTemplate>
+</DataGrid>
+```
+
+### Generic Components
+
+Create type-safe reusable components.
+
+```razor
+@* SelectList.razor *@
+@typeparam TItem
+@typeparam TValue
+
+<select @onchange="OnSelectionChanged">
+    @foreach (var item in Items)
+    {
+        <option value="@ValueSelector(item)" selected="@(EqualityComparer<TValue>.Default.Equals(ValueSelector(item), SelectedValue))">
+            @DisplaySelector(item)
+        </option>
+    }
+</select>
+
+@code {
+    [Parameter, EditorRequired] public IEnumerable<TItem> Items { get; set; } = [];
+    [Parameter, EditorRequired] public Func<TItem, TValue> ValueSelector { get; set; } = default!;
+    [Parameter, EditorRequired] public Func<TItem, string> DisplaySelector { get; set; } = default!;
+    [Parameter] public TValue? SelectedValue { get; set; }
+    [Parameter] public EventCallback<TValue> SelectedValueChanged { get; set; }
+
+    private async Task OnSelectionChanged(ChangeEventArgs e)
+    {
+        var value = (TValue)Convert.ChangeType(e.Value, typeof(TValue))!;
+        await SelectedValueChanged.InvokeAsync(value);
+    }
+}
+```
+
+### Cascading Values Pattern
+
+Share data down the component tree without explicit parameter passing.
+
+```razor
+@* App.razor or Layout *@
+<CascadingValue Value="@theme" Name="AppTheme">
+    <CascadingValue Value="@currentUser">
+        @Body
+    </CascadingValue>
+</CascadingValue>
+
+@code {
+    private Theme theme = new() { IsDarkMode = false };
+    private User? currentUser;
+}
+```
+
+```razor
+@* Any nested component *@
+@code {
+    [CascadingParameter(Name = "AppTheme")]
+    public Theme Theme { get; set; } = default!;
+
+    [CascadingParameter]
+    public User? CurrentUser { get; set; }
+}
+```
+
+### Component Inheritance
+
+Share logic across related components.
+
+```csharp
+// BaseFormComponent.cs
+public abstract class BaseFormComponent<TModel> : ComponentBase
+{
+    [Parameter] public TModel? Model { get; set; }
+    [Parameter] public EventCallback<TModel> OnSubmit { get; set; }
+
+    protected bool IsSubmitting { get; set; }
+    protected string? ErrorMessage { get; set; }
+
+    protected async Task HandleSubmit()
+    {
+        IsSubmitting = true;
+        ErrorMessage = null;
+
+        try
+        {
+            await OnSubmit.InvokeAsync(Model);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsSubmitting = false;
+        }
+    }
+}
+```
+
+```razor
+@* ProductForm.razor *@
+@inherits BaseFormComponent<Product>
+
+<EditForm Model="@Model" OnValidSubmit="HandleSubmit">
+    <DataAnnotationsValidator />
+    @* Form fields *@
+    <button type="submit" disabled="@IsSubmitting">Save</button>
+    @if (ErrorMessage is not null)
+    {
+        <p class="error">@ErrorMessage</p>
+    }
+</EditForm>
+```
+
+## State Management Patterns
+
+### Component-Level State
+
+For isolated, component-specific state.
+
+```razor
+@code {
+    private int count = 0;
+    private string message = "";
+
+    private void Increment() => count++;
+}
+```
+
+### Service-Based Shared State
+
+For state shared across multiple components using DI.
+
+```csharp
+// CartState.cs
+public class CartState
+{
+    private readonly List<CartItem> _items = [];
+
+    public IReadOnlyList<CartItem> Items => _items.AsReadOnly();
+    public decimal Total => _items.Sum(i => i.Price * i.Quantity);
+
+    public event Action? OnChange;
+
+    public void AddItem(Product product, int quantity = 1)
+    {
+        var existing = _items.FirstOrDefault(i => i.ProductId == product.Id);
+        if (existing is not null)
+        {
+            existing.Quantity += quantity;
+        }
+        else
+        {
+            _items.Add(new CartItem(product.Id, product.Name, product.Price, quantity));
+        }
+        NotifyStateChanged();
+    }
+
+    public void RemoveItem(int productId)
+    {
+        _items.RemoveAll(i => i.ProductId == productId);
+        NotifyStateChanged();
+    }
+
+    private void NotifyStateChanged() => OnChange?.Invoke();
+}
+```
+
+```razor
+@* CartIcon.razor *@
+@inject CartState Cart
+@implements IDisposable
+
+<span class="cart-icon">
+    Cart (@Cart.Items.Count)
+</span>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Cart.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        Cart.OnChange -= StateHasChanged;
+    }
+}
+```
+
+### Fluxor Pattern (Redux-like)
+
+For complex applications needing predictable state management.
+
+```csharp
+// State
+public record CounterState(int Count);
+
+// Actions
+public record IncrementAction;
+public record DecrementAction;
+public record SetCountAction(int Value);
+
+// Reducer
+public static class CounterReducers
+{
+    [ReducerMethod]
+    public static CounterState OnIncrement(CounterState state, IncrementAction action)
+        => state with { Count = state.Count + 1 };
+
+    [ReducerMethod]
+    public static CounterState OnDecrement(CounterState state, DecrementAction action)
+        => state with { Count = state.Count - 1 };
+
+    [ReducerMethod]
+    public static CounterState OnSetCount(CounterState state, SetCountAction action)
+        => state with { Count = action.Value };
+}
+
+// Effects (side effects)
+public class CounterEffects
+{
+    [EffectMethod]
+    public async Task HandleSetCountAsync(SetCountAction action, IDispatcher dispatcher)
+    {
+        await Task.Delay(100); // Simulate async work
+        // Dispatch additional actions if needed
+    }
+}
+```
+
+```razor
+@inject IState<CounterState> CounterState
+@inject IDispatcher Dispatcher
+
+<p>Count: @CounterState.Value.Count</p>
+<button @onclick="Increment">+</button>
+
+@code {
+    private void Increment() => Dispatcher.Dispatch(new IncrementAction());
+}
+```
+
+### Persistent State (Prerendering)
+
+Handle state that must survive the prerender-to-interactive transition.
+
+```razor
+@inject PersistentComponentState ApplicationState
+
+@code {
+    private List<Product>? products;
+    private PersistingComponentStateSubscription persistingSubscription;
+
+    protected override async Task OnInitializedAsync()
+    {
+        persistingSubscription = ApplicationState.RegisterOnPersisting(PersistData);
+
+        if (!ApplicationState.TryTakeFromJson<List<Product>>("products", out var restored))
+        {
+            products = await FetchProducts();
+        }
+        else
+        {
+            products = restored;
+        }
+    }
+
+    private Task PersistData()
+    {
+        ApplicationState.PersistAsJson("products", products);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        persistingSubscription.Dispose();
+    }
+}
+```
+
+### .NET 8+ Simplified Persistent State
+
+```razor
+@code {
+    [PersistentState]
+    public List<Product> Products { get; set; } = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Products.Count == 0)
+        {
+            Products = await Http.GetFromJsonAsync<List<Product>>("api/products") ?? [];
+        }
+    }
+}
+```
+
+## JavaScript Interop Patterns
+
+### Module Isolation
+
+Encapsulate JS code in ES6 modules for better organization.
+
+```javascript
+// wwwroot/js/map.js
+export function initializeMap(elementId, options) {
+    const map = new MapLibrary(document.getElementById(elementId), options);
+    return DotNet.createJSObjectReference(map);
+}
+
+export function setMarker(map, lat, lng) {
+    map.addMarker({ lat, lng });
+}
+
+export function dispose(map) {
+    map.destroy();
+}
+```
+
+```razor
+@inject IJSRuntime JS
+@implements IAsyncDisposable
+
+<div id="map-container"></div>
+
+@code {
+    private IJSObjectReference? module;
+    private IJSObjectReference? mapInstance;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            module = await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./js/map.js");
+            mapInstance = await module.InvokeAsync<IJSObjectReference>(
+                "initializeMap", "map-container", new { zoom = 10 });
+        }
+    }
+
+    private async Task AddMarker(double lat, double lng)
+    {
+        if (module is not null && mapInstance is not null)
+        {
+            await module.InvokeVoidAsync("setMarker", mapInstance, lat, lng);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (module is not null)
+        {
+            if (mapInstance is not null)
+            {
+                await module.InvokeVoidAsync("dispose", mapInstance);
+            }
+            await module.DisposeAsync();
+        }
+    }
+}
+```
+
+### JS Interop Abstraction Service
+
+Wrap JS interop in a typed service for better testability.
+
+```csharp
+// ILocalStorage.cs
+public interface ILocalStorage
+{
+    Task<T?> GetItemAsync<T>(string key);
+    Task SetItemAsync<T>(string key, T value);
+    Task RemoveItemAsync(string key);
+}
+
+// LocalStorageService.cs
+public class LocalStorageService : ILocalStorage
+{
+    private readonly IJSRuntime _js;
+
+    public LocalStorageService(IJSRuntime js) => _js = js;
+
+    public async Task<T?> GetItemAsync<T>(string key)
+    {
+        var json = await _js.InvokeAsync<string?>("localStorage.getItem", key);
+        return json is null ? default : JsonSerializer.Deserialize<T>(json);
+    }
+
+    public async Task SetItemAsync<T>(string key, T value)
+    {
+        var json = JsonSerializer.Serialize(value);
+        await _js.InvokeVoidAsync("localStorage.setItem", key, json);
+    }
+
+    public async Task RemoveItemAsync(string key)
+    {
+        await _js.InvokeVoidAsync("localStorage.removeItem", key);
+    }
+}
+```
+
+### Handling JS Interop in Prerendering
+
+```razor
+@inject IJSRuntime JS
+
+@code {
+    private bool isInteractive = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            isInteractive = true;
+            StateHasChanged();
+
+            // Safe to call JS here
+            await JS.InvokeVoidAsync("console.log", "Component is interactive");
+        }
+    }
+}
+```
+
+### .NET to JS Streaming
+
+```csharp
+// Stream large data to JavaScript
+using var streamRef = new DotNetStreamReference(stream: myLargeDataStream);
+await JS.InvokeVoidAsync("receiveStream", streamRef);
+```
+
+```javascript
+async function receiveStream(streamRef) {
+    const data = await streamRef.arrayBuffer();
+    // Process data
+}
+```
+
+## Advanced Patterns
+
+### Dynamic Component Loading
+
+```razor
+<DynamicComponent Type="@componentType" Parameters="@parameters" />
+
+@code {
+    private Type? componentType;
+    private Dictionary<string, object>? parameters;
+
+    private void LoadComponent(string name)
+    {
+        componentType = name switch
+        {
+            "chart" => typeof(ChartComponent),
+            "table" => typeof(TableComponent),
+            _ => typeof(PlaceholderComponent)
+        };
+
+        parameters = new Dictionary<string, object>
+        {
+            { "Data", currentData }
+        };
+    }
+}
+```
+
+### Render Mode Boundary Pattern
+
+Isolate interactive components from static content.
+
+```razor
+@* StaticLayout.razor - No render mode *@
+<header>
+    <nav>Static navigation</nav>
+</header>
+
+<main>
+    @Body
+</main>
+
+<footer>Static footer</footer>
+```
+
+```razor
+@* InteractiveDashboard.razor *@
+@rendermode InteractiveServer
+
+<div class="dashboard">
+    <RealTimeChart />
+    <LiveNotifications />
+</div>
+```
+
+### Error Boundary Pattern
+
+```razor
+<ErrorBoundary @ref="errorBoundary">
+    <ChildContent>
+        <RiskyComponent />
+    </ChildContent>
+    <ErrorContent Context="exception">
+        <div class="error-panel">
+            <h3>Something went wrong</h3>
+            <p>@exception.Message</p>
+            <button @onclick="Recover">Try Again</button>
+        </div>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    private ErrorBoundary? errorBoundary;
+
+    private void Recover()
+    {
+        errorBoundary?.Recover();
+    }
+}
+```
+
+### Section Pattern (.NET 8+)
+
+Define content slots that can be filled from nested components.
+
+```razor
+@* MainLayout.razor *@
+<header>
+    <SectionOutlet SectionName="PageHeader" />
+</header>
+
+<main>@Body</main>
+
+<aside>
+    <SectionOutlet SectionName="Sidebar" />
+</aside>
+```
+
+```razor
+@* ProductPage.razor *@
+<SectionContent SectionName="PageHeader">
+    <h1>Products</h1>
+    <SearchBar />
+</SectionContent>
+
+<SectionContent SectionName="Sidebar">
+    <CategoryFilter />
+    <PriceRangeFilter />
+</SectionContent>
+
+<ProductGrid Products="@products" />
+```
+
+### Render Optimization with ShouldRender
+
+```razor
+@code {
+    private string? previousValue;
+
+    [Parameter] public string? Value { get; set; }
+
+    protected override bool ShouldRender()
+    {
+        // Only re-render if Value actually changed
+        var shouldRender = Value != previousValue;
+        previousValue = Value;
+        return shouldRender;
+    }
+}
+```
+
+### Form Validation Pattern
+
+```razor
+<EditForm Model="@model" OnValidSubmit="HandleSubmit" FormName="ProductForm">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+
+    <div class="form-group">
+        <label for="name">Name</label>
+        <InputText id="name" @bind-Value="model.Name" class="form-control" />
+        <ValidationMessage For="() => model.Name" />
+    </div>
+
+    <div class="form-group">
+        <label for="price">Price</label>
+        <InputNumber id="price" @bind-Value="model.Price" class="form-control" />
+        <ValidationMessage For="() => model.Price" />
+    </div>
+
+    <button type="submit" disabled="@isSubmitting">
+        @(isSubmitting ? "Saving..." : "Save")
+    </button>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private ProductModel model { get; set; } = new();
+
+    private bool isSubmitting = false;
+
+    private async Task HandleSubmit()
+    {
+        isSubmitting = true;
+        try
+        {
+            await ProductService.SaveAsync(model);
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+}
+```

--- a/.github/skills/configuring-opentelemetry-dotnet/SKILL.md
+++ b/.github/skills/configuring-opentelemetry-dotnet/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: configuring-opentelemetry-dotnet
+description: Configure OpenTelemetry distributed tracing, metrics, and logging in ASP.NET Core using the .NET OpenTelemetry SDK. Use when adding observability, setting up OTLP exporters, creating custom metrics/spans, or troubleshooting distributed trace correlation.
+license: MIT
+---
+
+# Configuring OpenTelemetry in .NET
+
+## When to Use
+
+- Adding distributed tracing to an ASP.NET Core application
+- Setting up OpenTelemetry exporters (OTLP is the primary protocol; Jaeger accepts OTLP natively; Prometheus OTLP ingestion requires explicit opt-in)
+- Creating custom metrics or trace spans for business operations
+- Troubleshooting distributed trace context propagation across services
+
+## When Not to Use
+
+- The user wants application-level logging only (use ILogger, Serilog)
+- The user is using Application Insights SDK directly (different API)
+- The user needs APM with a commercial vendor's proprietary SDK
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| ASP.NET Core project | Yes | The application to instrument |
+| Observability backend | No | Where to export: OTLP collector, Aspire dashboard, Jaeger (accepts OTLP natively) |
+
+## Workflow
+
+### Step 1: Install the correct packages
+
+**There are many OpenTelemetry NuGet packages. Install exactly these:**
+
+```bash
+# Core SDK + ASP.NET Core instrumentation + logging integration
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+
+# Exporter
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol  # OTLP exporter for traces, metrics, AND logs
+
+# Optional — dev/local debugging only (do NOT include in production deployments)
+# dotnet add package OpenTelemetry.Exporter.Console
+```
+
+**Do NOT install `OpenTelemetry` alone** — you need `OpenTelemetry.Extensions.Hosting` for proper DI integration.
+
+#### Optional: additional auto-instrumentation packages
+
+Install only the packages that match the libraries your application uses:
+
+```bash
+dotnet add package OpenTelemetry.Instrumentation.SqlClient           # SQL Server queries
+dotnet add package OpenTelemetry.Instrumentation.EntityFrameworkCore  # EF Core
+dotnet add package OpenTelemetry.Instrumentation.GrpcNetClient       # gRPC calls
+dotnet add package OpenTelemetry.Instrumentation.Runtime             # GC, thread pool metrics
+```
+
+### Step 2: Configure all signals in Program.cs
+
+```csharp
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Logs;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService(serviceName: builder.Environment.ApplicationName))
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation(options =>
+        {
+            // Filter out health check endpoints from traces
+            options.Filter = httpContext =>
+                !httpContext.Request.Path.StartsWithSegments("/healthz");
+        })
+        .AddHttpClientInstrumentation(options =>
+        {
+            options.RecordException = true;
+        })
+        // Optional: add SQL instrumentation if using SqlClient directly
+        // .AddSqlClientInstrumentation(options =>
+        // {
+        //     options.SetDbStatementForText = true;
+        //     options.RecordException = true;
+        // })
+        // Custom activity sources (must match ActivitySource names in your code)
+        .AddSource("MyApp.Orders")
+        .AddSource("MyApp.Payments")
+        .AddSource("MyApp.Messaging"))
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        // Optional: .AddRuntimeInstrumentation() for GC and thread pool metrics
+        //   (requires OpenTelemetry.Instrumentation.Runtime package)
+        // Custom meters (must match Meter names in your code)
+        .AddMeter("MyApp.Metrics"))
+    .WithLogging(logging =>
+    {
+        logging.IncludeScopes = true;
+        // logging.IncludeFormattedMessage = true;  // Enable if you need the formatted message string in log exports
+    })
+    // Single OTLP exporter for all signals — reads OTEL_EXPORTER_OTLP_ENDPOINT
+    // env var (defaults to http://localhost:4317). Override via environment variable
+    // or appsettings.json configuration.
+    .UseOtlpExporter();
+```
+
+### Step 3: Understanding log–trace correlation
+
+The `.WithLogging()` call in Step 2 integrates ILogger with OpenTelemetry:
+
+- Each log entry automatically includes TraceId and SpanId for correlation with traces
+- The service resource from `.ConfigureResource()` propagates to logs automatically
+- `UseOtlpExporter()` applies to logs alongside traces and metrics
+- No additional packages or separate `SetResourceBuilder` call needed
+
+### Step 4: Create custom spans (Activities) for business operations
+
+```csharp
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+public class OrderService
+{
+    // Create an ActivitySource matching what you registered in Step 2
+    private static readonly ActivitySource ActivitySource = new("MyApp.Orders");
+    private readonly ILogger<OrderService> _logger;
+
+    public OrderService(ILogger<OrderService> logger) => _logger = logger;
+
+    public async Task<Order> ProcessOrderAsync(CreateOrderRequest request)
+    {
+        // Start a new span
+        using var activity = ActivitySource.StartActivity("ProcessOrder");
+
+        // Add attributes (tags) to the span
+        activity?.SetTag("order.customer_id", request.CustomerId);
+        activity?.SetTag("order.item_count", request.Items.Count);
+
+        try
+        {
+            // Child span for validation
+            using (var validationActivity = ActivitySource.StartActivity("ValidateOrder"))
+            {
+                await ValidateOrderAsync(request);
+                validationActivity?.SetTag("validation.result", "passed");
+            }
+
+            // Child span for payment
+            using (var paymentActivity = ActivitySource.StartActivity("ProcessPayment",
+                ActivityKind.Client))  // Client = outgoing call
+            {
+                paymentActivity?.SetTag("payment.method", request.PaymentMethod);
+                await ProcessPaymentAsync(request);
+            }
+
+            var order = new Order { Id = Guid.NewGuid(), CustomerId = request.CustomerId, Status = "Completed" };
+
+            activity?.SetTag("order.status", "completed");
+            activity?.SetStatus(ActivityStatusCode.Ok);
+
+            return order;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            // Log via ILogger — OpenTelemetry captures this with trace correlation.
+            // Prefer logging over activity.RecordException() as OTel is deprecating
+            // span events for exception recording in favor of log-based exceptions.
+            _logger.LogError(ex, "Order processing failed for customer {CustomerId}", request.CustomerId);
+            throw;
+        }
+    }
+}
+```
+
+**Critical: `ActivitySource` name must match `AddSource("...")` in configuration.** Unmatched sources are silently ignored — this is the #1 debugging issue.
+
+### Step 5: Create custom metrics
+
+Use `IMeterFactory` (injected via DI) to create meters — this ensures proper lifetime management and testability.
+
+```csharp
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+public class OrderMetrics
+{
+    private readonly Counter<long> _ordersProcessed;
+    private readonly Histogram<double> _orderProcessingDuration;
+    private readonly UpDownCounter<int> _activeOrders;
+
+    public OrderMetrics(IMeterFactory meterFactory)
+    {
+        // Meter name must match AddMeter("...") in configuration
+        var meter = meterFactory.Create("MyApp.Metrics");
+
+        // Counter — use for things that only go up
+        _ordersProcessed = meter.CreateCounter<long>(
+            "orders.processed", "orders", "Total orders successfully processed");
+
+        // Histogram — use for measuring distributions (latency, sizes)
+        _orderProcessingDuration = meter.CreateHistogram<double>(
+            "orders.processing_duration", "ms", "Time to process an order");
+
+        // UpDownCounter — use for things that go up AND down
+        _activeOrders = meter.CreateUpDownCounter<int>(
+            "orders.active", "orders", "Currently processing orders");
+    }
+
+    public void RecordOrderProcessed(string region, double durationMs)
+    {
+        // Tags enable dimensional filtering (by region, status, etc.)
+        var tags = new TagList
+        {
+            { "region", region },
+            { "order.type", "standard" }
+        };
+
+        _ordersProcessed.Add(1, tags);
+        _orderProcessingDuration.Record(durationMs, tags);
+    }
+}
+```
+
+Register `OrderMetrics` in DI:
+
+```csharp
+builder.Services.AddSingleton<OrderMetrics>();
+```
+
+### Step 6: Configure context propagation for distributed scenarios
+
+Trace context propagation is automatic for HTTP calls when using `AddHttpClientInstrumentation()`. For non-HTTP scenarios:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
+
+// ActivitySource should be static — register via .AddSource("MyApp.Messaging") in Step 2
+private static readonly ActivitySource MessageSource = new("MyApp.Messaging");
+
+// Manual context propagation (e.g., across message queues)
+// On the SENDING side:
+var propagator = Propagators.DefaultTextMapPropagator;
+var activityContext = Activity.Current?.Context ?? default;
+var context = new PropagationContext(activityContext, Baggage.Current);
+var carrier = new Dictionary<string, string>();
+
+propagator.Inject(context, carrier, (dict, key, value) => dict[key] = value);
+// Send carrier dictionary as message headers
+
+// On the RECEIVING side:
+var parentContext = propagator.Extract(default, carrier,
+    (dict, key) => dict.TryGetValue(key, out var value) ? new[] { value } : Array.Empty<string>());
+
+Baggage.Current = parentContext.Baggage;
+using var activity = MessageSource.StartActivity("ProcessMessage",
+    ActivityKind.Consumer,
+    parentContext.ActivityContext);  // Links to parent trace!
+```
+
+## Validation
+
+- [ ] Traces appear in the observability backend (Jaeger, Aspire dashboard, etc.)
+- [ ] HTTP requests automatically create spans with correct verb, URL, status code
+- [ ] Custom `ActivitySource` names match `AddSource()` registrations
+- [ ] Custom `Meter` names match `AddMeter()` registrations
+- [ ] Logs include TraceId and SpanId for correlation
+- [ ] Health check endpoints are filtered from traces
+- [ ] Exception details appear on error spans
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| `ActivitySource.StartActivity` returns null | Source name doesn't match any `AddSource()` — names must match exactly |
+| Traces not appearing in exporter | Check OTLP endpoint: gRPC uses port 4317, HTTP uses 4318 |
+| Missing HTTP client spans | Ensure `AddHttpClientInstrumentation()` is registered; it works for both `IHttpClientFactory`/DI and `new HttpClient()` (use `IHttpClientFactory` for lifetime management) |
+| High cardinality tags | Don't use user IDs, request IDs, or UUIDs as metric tags — explodes storage |
+| OTLP gRPC vs HTTP mismatch | Default is gRPC (port 4317); if collector only accepts HTTP, set `OtlpExportProtocol.HttpProtobuf` |
+| `Meter` / `ActivitySource` lifecycle | `ActivitySource` should be static; create `Meter` via `IMeterFactory` from DI (not `new Meter()`) for proper lifetime management and testability |

--- a/.github/skills/configuring-opentelemetry-dotnet/manifest.json
+++ b/.github/skills/configuring-opentelemetry-dotnet/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.0",
+  "category": "Web",
+  "compatibility": "Requires an ASP.NET Core project or solution.",
+  "package_prefix": "OpenTelemetry"
+}

--- a/.github/skills/coverage-analysis/SKILL.md
+++ b/.github/skills/coverage-analysis/SKILL.md
@@ -1,0 +1,473 @@
+---
+name: coverage-analysis
+description: >
+  Automated, project-wide code coverage and CRAP (Change Risk Anti-Patterns)
+  score analysis for .NET projects with existing unit tests. Auto-detects
+  solution structure, runs coverage collection via `dotnet test` (supports both
+  Microsoft.Testing.Extensions.CodeCoverage and Coverlet), generates reports via
+  ReportGenerator, calculates CRAP scores per method, and surfaces risk
+  hotspots — complex code with low test coverage that is dangerous to modify.
+  Use when the user wants project-wide coverage analysis with risk
+  prioritization, coverage gap identification, CRAP score computation
+  across an entire solution, or to diagnose why coverage is stuck or
+  plateaued and identify what methods are blocking improvement.
+  DO NOT USE FOR: targeted single-method CRAP analysis (use crap-score skill),
+  writing tests, running tests without coverage collection, applying test
+  filters, producing TRX reports, or troubleshooting test execution (use
+  run-tests for all of these).
+license: MIT
+---
+
+# Coverage Analysis
+
+## Purpose
+
+Raw coverage percentages answer "what code was executed?" — they don't answer what you actually need to know:
+
+- **What tests should I write next?** — ranked by risk and impact
+- **Which uncovered code is risky vs. trivial?** — CRAP scores separate the two
+- **Why has coverage plateaued?** — identify the files blocking further gains
+- **Is this code safe to refactor?** — complex + uncovered = dangerous to change
+
+This skill bridges that gap: from a bare .NET solution to a prioritized risk hotspot list, with no manual tool configuration required.
+
+## When to Use
+
+Use this skill when the user mentions test coverage, coverage gaps, code risk, CRAP scores, where to add tests, why coverage plateaued, or wants to know which code is safest to refactor — even if they don't explicitly say "coverage analysis".
+
+## When Not to Use
+
+- **Targeted single-method CRAP analysis** — use the `crap-score` skill instead
+- **Writing or generating tests** — this skill identifies where tests are needed, not write them
+- **General test execution** unrelated to coverage or CRAP analysis
+- **Coverage reporting without CRAP context** — use `dotnet test` with coverage collection directly
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| Project/solution path | No | Current directory | Path to the .NET solution or project |
+| Line coverage threshold | No | 80% | Minimum acceptable line coverage |
+| Branch coverage threshold | No | 70% | Minimum acceptable branch coverage |
+| CRAP threshold | No | 30 | Maximum acceptable CRAP score before flagging |
+| Top N hotspots | No | 10 | Number of risk hotspots to surface |
+
+### Prerequisites
+
+- .NET SDK installed (`dotnet` on PATH)
+- At least one test project referencing the production code (xUnit, NUnit, or MSTest)
+- Internet access for `dotnet tool install` (ReportGenerator) on first run, or ReportGenerator already installed globally
+
+The skill auto-detects coverage provider state per test project and selects the least-invasive execution strategy:
+
+- unified Microsoft CodeCoverage when all projects use it,
+- unified Coverlet when no project uses Microsoft CodeCoverage,
+- per-project provider execution when the solution is truly mixed.
+
+No pre-existing runsettings files or manually installed tools required.
+
+## Workflow
+
+If the user provides a path to existing Cobertura XML (or coverage data is already present in `TestResults/`), skip Steps 3–4 (test execution and provider detection) but **still run Steps 5–6** (ReportGenerator and CRAP score computation). The Risk Hotspots table and CRAP scores are mandatory in every output — they are the skill's core value-add over raw coverage numbers.
+
+The workflow runs in four phases. Phases 2 and 3 each contain steps that can run in parallel to reduce total wall-clock time.
+
+### Phase 1 — Setup (sequential)
+
+#### Step 1: Locate the solution or project
+
+Given the user's path (default: current directory), find the entry point:
+
+```powershell
+$root = "<user-provided-path-or-current-directory>"
+
+# Prefer solution file; fall back to project file
+$sln = Get-ChildItem -Path $root -Filter "*.sln" -Recurse -Depth 2 -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if ($sln) {
+    Write-Host "ENTRY_TYPE:Solution"; Write-Host "ENTRY:$($sln.FullName)"
+} else {
+    $project = Get-ChildItem -Path $root -Filter "*.csproj" -Recurse -Depth 2 -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($project) {
+        Write-Host "ENTRY_TYPE:Project"; Write-Host "ENTRY:$($project.FullName)"
+    } else {
+        Write-Host "ENTRY_TYPE:NotFound"
+    }
+}
+
+# Test projects: search path first, then git root, then parent
+$searchRoots = @($root)
+$gitRoot = (git -C $root rev-parse --show-toplevel 2>$null)
+if ($gitRoot) { $gitRoot = [System.IO.Path]::GetFullPath($gitRoot) }
+if ($gitRoot -and $gitRoot -ne $root) { $searchRoots += $gitRoot }
+$parentPath = Split-Path $root -Parent
+if ($parentPath -and $parentPath -ne $root -and $parentPath -ne $gitRoot) { $searchRoots += $parentPath }
+
+$testProjects = @()
+foreach ($sr in $searchRoots) {
+    # Primary: match by .csproj content (test framework references)
+    $testProjects = @(Get-ChildItem -Path $sr -Filter "*.csproj" -Recurse -Depth 5 -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '([/\\]obj[/\\]|[/\\]bin[/\\])' } |
+        Where-Object { (Select-String -Path $_.FullName -Pattern 'Microsoft\.NET\.Test\.Sdk|xunit|nunit|MSTest\.TestAdapter|"MSTest"|MSTest\.TestFramework|TUnit' -Quiet) })
+    if ($testProjects.Count -gt 0) {
+        if ($sr -ne $root) { Write-Host "SEARCHED:$sr" }
+        break
+    }
+}
+
+# Fallback: match by file name convention
+if ($testProjects.Count -eq 0) {
+    foreach ($sr in $searchRoots) {
+        $testProjects = @(Get-ChildItem -Path $sr -Filter "*.csproj" -Recurse -Depth 5 -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '(?i)(test|spec)' })
+        if ($testProjects.Count -gt 0) {
+            if ($sr -ne $root) { Write-Host "SEARCHED:$sr" }
+            break
+        }
+    }
+}
+Write-Host "TEST_PROJECTS:$($testProjects.Count)"
+$testProjects | ForEach-Object { Write-Host "TEST_PROJECT:$($_.FullName)" }
+
+# Resolve the test output root (where coverage-analysis artifacts will be written)
+if ($testProjects.Count -eq 1) {
+    $testOutputRoot = $testProjects[0].DirectoryName
+} else {
+    # Multiple test projects — find their deepest common parent directory
+    $dirs = $testProjects | ForEach-Object { $_.DirectoryName }
+    $common = $dirs[0]
+    foreach ($d in $dirs[1..($dirs.Count-1)]) {
+        $sep = [System.IO.Path]::DirectorySeparatorChar
+        while (-not $d.StartsWith("$common$sep", [System.StringComparison]::OrdinalIgnoreCase) -and $d -ne $common) {
+            $prevCommon = $common
+            $common = Split-Path $common -Parent
+            # Terminate if we can no longer move up (at filesystem root or no parent)
+            if ([string]::IsNullOrEmpty($common) -or $common -eq $prevCommon) {
+                $common = $null
+                break
+            }
+        }
+    }
+    if ([string]::IsNullOrEmpty($common)) {
+        # Fallback when no common parent directory exists (e.g., projects on different drives)
+        if ($gitRoot) {
+            $testOutputRoot = $gitRoot
+        } else {
+            $testOutputRoot = $root
+        }
+    } else {
+        $testOutputRoot = $common
+    }
+}
+Write-Host "TEST_OUTPUT_ROOT:$testOutputRoot"
+```
+
+- If `ENTRY_TYPE:NotFound` and test projects were found → use the test projects directly as entry points (run `dotnet test` on each test `.csproj`).
+- If `ENTRY_TYPE:NotFound` and no test projects found → stop: `No .sln or test projects found under <path>. Provide the path to your .NET solution or project.`
+- If `TEST_PROJECTS:0` → stop: `No test projects found (expected projects with 'Test' or 'Spec' in the name). Ensure your solution has unit test projects before running coverage analysis.`
+
+#### Step 2: Create the output directory
+
+```powershell
+$coverageDir = Join-Path $testOutputRoot "TestResults" "coverage-analysis"
+if (Test-Path $coverageDir) { Remove-Item $coverageDir -Recurse -Force }
+New-Item -ItemType Directory -Path $coverageDir -Force | Out-Null
+Write-Host "COVERAGE_DIR:$coverageDir"
+```
+
+#### Step 2b: Recommend ignoring `TestResults/`
+
+```powershell
+$pattern = "**/TestResults/"
+$gitRoot = (git -C $testOutputRoot rev-parse --show-toplevel 2>$null)
+if ($gitRoot) { $gitRoot = [System.IO.Path]::GetFullPath($gitRoot) }
+if ($gitRoot) {
+    $gitignorePath = Join-Path $gitRoot ".gitignore"
+    $alreadyIgnored = $false
+    if (Test-Path $gitignorePath) {
+        $alreadyIgnored = (Select-String -Path $gitignorePath -Pattern '^\s*(\*\*/)?TestResults/?\s*$' -Quiet)
+    }
+    if ($alreadyIgnored) {
+        Write-Host "GITIGNORE_RECOMMENDATION:already-present"
+    } else {
+        Write-Host "GITIGNORE_RECOMMENDATION:$pattern"
+    }
+} else {
+    Write-Host "GITIGNORE_RECOMMENDATION:$pattern"
+}
+```
+
+### Phase 2 — Data collection (Steps 3 and 4 run in parallel)
+
+Steps 3 and 4 are independent — start both simultaneously. `dotnet test` is the slowest step, and ReportGenerator setup doesn't need coverage files, so running them concurrently cuts wall time significantly.
+
+#### Step 3: Detect coverage provider and run `dotnet test` with coverage collection
+
+Before running tests, detect which coverage provider the test projects use. Projects may reference
+`Microsoft.Testing.Extensions.CodeCoverage` (Microsoft's built-in provider, common on .NET 9+) or
+`coverlet.collector` (open-source, the default in xUnit templates). The provider determines which
+`dotnet test` arguments to use — both produce Cobertura XML.
+
+```powershell
+# Detect coverage provider per test project
+$coverageProvider = "unknown"  # will be set to "ms-codecoverage" or "coverlet"
+$msCodeCovProjects = @()
+$coverletProjects = @()
+$neitherProjects = @()
+
+foreach ($tp in $testProjects) {
+    $hasMsCodeCov = Select-String -Path $tp.FullName -Pattern 'Microsoft\.Testing\.Extensions\.CodeCoverage' -Quiet
+    $hasCoverlet = Select-String -Path $tp.FullName -Pattern 'coverlet\.collector' -Quiet
+    if ($hasMsCodeCov) { $msCodeCovProjects += $tp }
+    elseif ($hasCoverlet) { $coverletProjects += $tp }
+    else { $neitherProjects += $tp }
+}
+
+# Determine the provider strategy
+if ($msCodeCovProjects.Count -gt 0 -and $coverletProjects.Count -eq 0) {
+    $coverageProvider = "ms-codecoverage"
+    Write-Host "COVERAGE_PROVIDER:ms-codecoverage (ms:$($msCodeCovProjects.Count), none:$($neitherProjects.Count))"
+} elseif ($coverletProjects.Count -gt 0 -and $msCodeCovProjects.Count -eq 0) {
+    $coverageProvider = "coverlet"
+    Write-Host "COVERAGE_PROVIDER:coverlet (coverlet:$($coverletProjects.Count), none:$($neitherProjects.Count))"
+} elseif ($msCodeCovProjects.Count -gt 0 -and $coverletProjects.Count -gt 0) {
+    $coverageProvider = "mixed-project"
+    Write-Host "COVERAGE_PROVIDER:mixed-project (ms:$($msCodeCovProjects.Count), coverlet:$($coverletProjects.Count), none:$($neitherProjects.Count))"
+} else {
+    $coverageProvider = "coverlet"
+    Write-Host "COVERAGE_PROVIDER:none-detected — defaulting to coverlet"
+}
+```
+
+If any discovered test projects have no provider, add one based on the selected strategy:
+
+```powershell
+if ($coverageProvider -eq "ms-codecoverage" -and $neitherProjects.Count -gt 0) {
+    Write-Host "ADDING_MS_CODECOVERAGE:$($neitherProjects.Count) project(s)"
+    foreach ($tp in $neitherProjects) {
+        dotnet add $tp.FullName package Microsoft.Testing.Extensions.CodeCoverage --no-restore
+        Write-Host "  ADDED_MS_CODECOVERAGE:$($tp.FullName)"
+    }
+    foreach ($tp in $neitherProjects) {
+        dotnet restore $tp.FullName --quiet
+    }
+}
+
+if (($coverageProvider -eq "coverlet" -or $coverageProvider -eq "mixed-project") -and $neitherProjects.Count -gt 0) {
+    Write-Host "ADDING_COVERLET:$($neitherProjects.Count) project(s)"
+    foreach ($tp in $neitherProjects) {
+        dotnet add $tp.FullName package coverlet.collector --no-restore
+        Write-Host "  ADDED:$($tp.FullName)"
+    }
+    foreach ($tp in $neitherProjects) {
+        dotnet restore $tp.FullName --quiet
+    }
+}
+```
+
+Log each addition to the console so the developer sees what changed. Document the additions in the final report (see Output Format).
+
+Run one `dotnet test` per entry point for the selected strategy:
+
+- In `ms-codecoverage` or `coverlet` mode: run a single command for the solution entry (or one per test project if no `.sln` was found).
+- In `mixed-project` mode: run one command per test project, using that project's existing provider to avoid dual-provider conflicts.
+
+**Coverlet** (`coverlet.collector`):
+
+```powershell
+$rawDir = Join-Path "<COVERAGE_DIR>" "raw"
+dotnet test "<ENTRY>" `
+    --collect:"XPlat Code Coverage" `
+    --results-directory $rawDir `
+    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura `
+    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[*]*" `
+    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*.Tests]*,[*.Test]*,[*Tests]*,[*Test]*,[*.Specs]*,[*.Testing]*" `
+    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SkipAutoProps=true
+```
+
+**Microsoft CodeCoverage** (`Microsoft.Testing.Extensions.CodeCoverage`):
+
+The command syntax depends on the .NET SDK version. In .NET 9, Microsoft.Testing.Platform arguments
+must be passed after the `--` separator. In .NET 10+, `--coverage` is a top-level `dotnet test` flag.
+
+```powershell
+$rawDir = Join-Path "<COVERAGE_DIR>" "raw"
+
+# Detect SDK version for correct argument placement
+$sdkVersion = (dotnet --version 2>$null)
+$major = if ($sdkVersion -match '^(\d+)\.') { [int]$Matches[1] } else { 9 }
+
+if ($major -ge 10) {
+    # .NET 10+: --coverage is a first-class dotnet test flag
+    dotnet test "<ENTRY>" `
+        --results-directory $rawDir `
+        --coverage `
+        --coverage-output-format cobertura `
+        --coverage-output $rawDir
+} else {
+    # .NET 9: pass Microsoft.Testing.Platform arguments after the -- separator
+    dotnet test "<ENTRY>" `
+        --results-directory $rawDir `
+        -- --coverage --coverage-output-format cobertura --coverage-output $rawDir
+}
+```
+
+**Mixed-project mode** (`Microsoft.Testing.Extensions.CodeCoverage` + `coverlet.collector` in the same solution):
+
+```powershell
+$rawDir = Join-Path "<COVERAGE_DIR>" "raw"
+$sdkVersion = (dotnet --version 2>$null)
+$major = if ($sdkVersion -match '^(\d+)\.') { [int]$Matches[1] } else { 9 }
+
+foreach ($tp in $testProjects) {
+    $hasMsCodeCov = Select-String -Path $tp.FullName -Pattern 'Microsoft\.Testing\.Extensions\.CodeCoverage' -Quiet
+    if ($hasMsCodeCov) {
+        if ($major -ge 10) {
+            dotnet test $tp.FullName --results-directory $rawDir --coverage --coverage-output-format cobertura --coverage-output $rawDir
+        } else {
+            dotnet test $tp.FullName --results-directory $rawDir -- --coverage --coverage-output-format cobertura --coverage-output $rawDir
+        }
+    } else {
+        dotnet test $tp.FullName `
+            --collect:"XPlat Code Coverage" `
+            --results-directory $rawDir `
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura `
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[*]*" `
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[*.Tests]*,[*.Test]*,[*Tests]*,[*Test]*,[*.Specs]*,[*.Testing]*" `
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SkipAutoProps=true
+    }
+}
+```
+
+Exit code handling:
+
+- **0** — all tests passed, coverage collected
+- **1** — some tests failed (coverage still collected — proceed with a warning)
+- **Other** — build failure; stop and report the error
+
+After the run, locate coverage files:
+
+```powershell
+$coberturaFiles = Get-ChildItem -Path (Join-Path "<COVERAGE_DIR>" "raw") -Filter "coverage.cobertura.xml" -Recurse
+Write-Host "COBERTURA_COUNT:$($coberturaFiles.Count)"
+$coberturaFiles | ForEach-Object { Write-Host "COBERTURA:$($_.FullName)" }
+$vsCovFiles = Get-ChildItem -Path (Join-Path "<COVERAGE_DIR>" "raw") -Filter "*.coverage" -Recurse -ErrorAction SilentlyContinue
+if ($vsCovFiles) { Write-Host "VS_BINARY_COVERAGE:$($vsCovFiles.Count)" }
+```
+
+If `COBERTURA_COUNT` is 0:
+
+- If `VS_BINARY_COVERAGE` > 0: warn the user — *"Found .coverage files (VS binary format) but no Cobertura XML. These were likely produced by Visual Studio's built-in collector, which outputs a binary format by default. This skill needs Cobertura XML. Re-running with the detected provider configured for Cobertura output."* Then re-run the appropriate `dotnet test` command above (Coverlet or Microsoft CodeCoverage) with Cobertura format.
+- If no `.coverage` files either: stop and report — *"Coverage files not generated. Ensure `dotnet test` completed successfully and check the build output for errors."*
+
+#### Step 4: Verify or install ReportGenerator (parallel with Step 3)
+
+```powershell
+$rgAvailable = $false
+$rgCommand = Get-Command reportgenerator -ErrorAction SilentlyContinue
+if ($rgCommand) {
+    $rgAvailable = $true
+    Write-Host "RG_INSTALLED:already-present"
+} else {
+    $rgToolPath = Join-Path "<COVERAGE_DIR>" ".tools"
+    dotnet tool install dotnet-reportgenerator-globaltool --tool-path $rgToolPath
+    if ($LASTEXITCODE -eq 0) {
+        $env:PATH = "$rgToolPath$([System.IO.Path]::PathSeparator)$env:PATH"
+        $rgCommand = Get-Command reportgenerator -ErrorAction SilentlyContinue
+        if ($rgCommand) {
+            $rgAvailable = $true
+            Write-Host "RG_INSTALLED:true (tool-path: $rgToolPath)"
+        } else {
+            Write-Host "RG_INSTALLED:false"
+            Write-Host "RG_INSTALL_ERROR:reportgenerator-not-available"
+        }
+    } else {
+        Write-Host "RG_INSTALLED:false"
+        Write-Host "RG_INSTALL_ERROR:reportgenerator-not-available"
+    }
+}
+Write-Host "RG_AVAILABLE:$rgAvailable"
+```
+
+If installation fails (no internet), keep `RG_AVAILABLE:false` and continue with raw Cobertura XML parsing + script-based analysis in Step 6. Skip HTML/Text/CSV report generation in Step 5 and note this in the output.
+
+### Phase 3 — Analysis (Steps 5 and 6 run in parallel)
+
+Once Phase 2 completes (coverage files available, ReportGenerator ready), start Steps 5 and 6 simultaneously — both read from the same Cobertura XML and produce independent outputs.
+
+#### Step 5: Generate reports with ReportGenerator (parallel with Step 6)
+
+```powershell
+$reportsDir = Join-Path "<COVERAGE_DIR>" "reports"
+if ($rgAvailable) {
+    reportgenerator `
+        -reports:"<semicolon-separated COBERTURA paths>" `
+        -targetdir:$reportsDir `
+        -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary" `
+        -title:"Coverage Report" `
+        -tag:"coverage-analysis-skill"
+
+    Get-Content (Join-Path $reportsDir "Summary.txt") -ErrorAction SilentlyContinue
+} else {
+    Write-Host "REPORTGENERATOR_SKIPPED:true"
+}
+```
+
+#### Step 6: Calculate CRAP scores using the bundled script (parallel with Step 5)
+
+Run `scripts/Compute-CrapScores.ps1` (co-located with this SKILL.md). It reads all Cobertura XML files, applies `CRAP(m) = comp² × (1 − cov)³ + comp` per method, and returns the top-N hotspots as JSON.
+
+To locate the script: find the directory containing this skill's `SKILL.md` file (the skill loader provides this context), then resolve `scripts/Compute-CrapScores.ps1` relative to it. If the script path cannot be determined, calculate CRAP scores inline using the formula below.
+
+```powershell
+& "<skill-directory>/scripts/Compute-CrapScores.ps1" `
+    -CoberturaPath @(<all COBERTURA file paths as array>) `
+    -CrapThreshold <crap_threshold> `
+    -TopN <top_n>
+```
+
+Script outputs: `TOTAL_METHODS:<n>`, `FLAGGED_METHODS:<n>`, `HOTSPOTS:<json>` (top-N sorted by CrapScore descending).
+
+Also run `scripts/Extract-MethodCoverage.ps1` to get per-method coverage data for the Coverage Gaps table:
+
+```powershell
+& "<skill-directory>/scripts/Extract-MethodCoverage.ps1" `
+    -CoberturaPath @(<all COBERTURA file paths as array>) `
+    -CoverageThreshold <line_threshold> `
+    -BranchThreshold <branch_threshold> `
+    -Filter below-threshold
+```
+
+Script outputs: JSON array of methods below the coverage threshold, sorted by coverage ascending. Use this data to populate the Coverage Gaps by File table in the report.
+
+### Phase 4 — Output (sequential)
+
+#### Step 7: Build the output report
+
+Compose the analysis and save it to `TestResults/coverage-analysis/coverage-analysis.md` under the test project directory. Print the full report to the console.
+
+After saving the file, automatically open `TestResults/coverage-analysis/coverage-analysis.md` in the editor so the user can review it immediately.
+
+- In editor-hosted environments (VS Code, Visual Studio, or other IDE hosts): open the file in the current host session/editor context after writing it.
+- Do not launch a different app instance via hardcoded shell commands (for example `code`, `start`, or platform-specific open commands) unless the host has no native open-file mechanism.
+- In CLI or non-editor environments: print the absolute report path and clearly state that the file was generated.
+
+Do not ask for confirmation before opening the report file.
+
+Use `references/output-format.md` verbatim for all fixed headings, table structures, symbols, and emoji in the generated report. Use `references/guidelines.md` for execution constraints, prioritization rules, and style.
+
+## Validation
+
+- Verify that at least one `coverage.cobertura.xml` file was generated after `dotnet test`
+- Confirm `TestResults/coverage-analysis/coverage-analysis.md` was written and contains data
+- Spot-check one method's CRAP score: `comp² × (1 − cov)³ + comp` — a method with 100% coverage should have CRAP = complexity
+- If ReportGenerator ran, verify `TestResults/coverage-analysis/reports/index.html` exists
+
+## Common Pitfalls
+
+- **No Cobertura XML generated** — the test project may lack a coverage provider. The skill auto-adds one, but if `dotnet add package` fails (offline/proxy), coverage collection silently produces nothing. Check for `.coverage` binary files as a fallback indicator.
+- **Test failures (exit code 1)** — coverage is still collected from passing tests. Do not abort; proceed with partial data and note the failures in the summary.
+- **ReportGenerator install failure** — if `dotnet tool install` fails (no internet), skip HTML/CSV report generation and continue with raw Cobertura XML analysis + script-based CRAP scores. Note the skip in the report.
+- **Method name mismatches in Cobertura** — async methods, lambdas, and local functions may have compiler-generated names. The scripts use the Cobertura method name/signature directly; verify against source if results look unexpected.
+- **Mixed coverage providers** — when a solution contains both Coverlet and Microsoft CodeCoverage projects, the skill runs per-project to avoid dual-provider conflicts. This is slower but correct.

--- a/.github/skills/coverage-analysis/manifest.json
+++ b/.github/skills/coverage-analysis/manifest.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1.0",
+  "category": "Testing",
+  "compatibility": "Requires a .NET test project or solution.",
+  "packages": [
+    "coverlet.collector",
+    "coverlet.msbuild"
+  ]
+}

--- a/.github/skills/coverage-analysis/references/guidelines.md
+++ b/.github/skills/coverage-analysis/references/guidelines.md
@@ -1,0 +1,59 @@
+# Guidelines
+
+**Don't modify source or production code.** The only permitted project file modifications are adding a coverage provider package to test projects that currently have no provider: `coverlet.collector` (coverlet/mixed modes) or `Microsoft.Testing.Extensions.CodeCoverage` (ms-codecoverage mode). Do not add a second provider to projects that already have one. Always log package additions and document revert commands in the report. Write all other output to `TestResults/coverage-analysis/` under the test project directory.
+
+**Always show and open the generated markdown report.** After writing `TestResults/coverage-analysis/coverage-analysis.md`, print its contents to the console and open the file in the current host editor/session automatically (when an editor is available).
+
+**Don't generate new tests during the initial analysis run.** This skill surfaces where tests are needed. Test generation is a separate follow-up step outside the scope of this skill.
+
+**Use inline `dotnet test` arguments, not runsettings files.** Runsettings files require the developer to already know what they're doing — the whole point of this skill is that they shouldn't have to. Inline data collector args produce the same result with zero configuration.
+
+**Show the risk hotspots table even when all thresholds pass.** A project at 90% line coverage can still have a method with cyclomatic complexity 20 and 0% branch coverage. The thresholds measure averages; the hotspot table finds outliers. Don't hide it just because the summary looks green.
+
+**Always compute and surface CRAP scores.** The Risk Hotspots table is mandatory in every analysis output, whether analyzing pre-existing data, freshly collected data, or diagnosing a plateau. Never skip CRAP score computation — it is the primary differentiator between this skill and raw `dotnet test` coverage output.
+
+**Continue past test failures (exit code 1).** If some tests fail, coverage is still collected from the passing tests — partial data is better than no data. Note the failures in the summary and proceed. Aborting would leave the developer with nothing actionable.
+
+**Run `dotnet test` only once per entry point during normal flow.** When a solution is found, run it once against the solution. When no solution is found, run it once per test project. A single recovery rerun is allowed only if the first run produced no Cobertura XML and only `.coverage` binary output.
+
+**CRAP threshold of 30 is the default for a reason.** Scores above 30 are widely cited (by the original researchers) as "needs immediate attention." Scores between 15 and 30 are moderate — flag them in the table but don't make them sound catastrophic. Scores ≤ 5 are generally fine.
+
+**Priority assignment for coverage gaps:**
+
+- **HIGH** — file has both a CRAP score above threshold AND coverage below threshold (the double failure is what makes it urgent)
+- **MED** — coverage below threshold OR CRAP score above threshold, but not both
+- **LOW** — coverage below threshold with all methods having complexity ≤ 2 (trivial code — missing coverage here is unlikely to hide real bugs)
+
+---
+
+## Coverage Intelligence — Going Beyond the Numbers
+
+**Prioritize uncovered code that is** complex (cyclomatic complexity > 5), on critical paths (auth, payment, data access, error handling), or changed frequently. **Deprioritize** trivial getters (complexity 1–2), generated files (EF migrations, `*.Designer.cs`, `*.g.cs`), and DI/configuration glue code.
+
+**Coverage plateau diagnosis** — if coverage has stopped increasing, check for: `[Exclude]` attributes hiding large code sections, tests that execute code but assert nothing (inflated coverage without verification), or integration code that needs external dependencies (databases, file system).
+
+**AI-generated test quality** — coverage delta alone is insufficient. Flag methods where CRAP score is still above threshold after coverage increased (tests may be happy-path only), and methods covered by a single test with no branch variation.
+
+---
+
+## Style
+
+- **Keep risk hotspots prominent and immediately after the summary section** — developers should find the highest-risk methods quickly
+- **Quantify recommendations** — "adding 3 tests for `ProcessOrder` would cut the CRAP score from 48 to ~6"
+- **Be direct** — skip preamble, get to the table
+- **Emoji for visual scanning in generated output** (defined in `references/output-format.md`):
+
+  | Symbol | Meaning |
+  |--------|---------|
+  | 🔥 | hotspots |
+  | 📋 | gaps |
+  | 💡 | recommendations |
+  | 📁 | reports |
+  | ✅ | passing |
+  | ❌ | failing |
+  | ⚠️ | warning |
+  | 🔴 | HIGH priority |
+  | 🟡 | MED priority |
+  | 🟢 | LOW priority |
+
+- **Always use Unicode emoji in generated output** — never shortcodes like `:x:` or `:fire:`

--- a/.github/skills/coverage-analysis/references/output-format.md
+++ b/.github/skills/coverage-analysis/references/output-format.md
@@ -1,0 +1,83 @@
+# Output Format
+
+Copy the template below **verbatim** for all fixed elements (headings, table headers, emoji, symbols). Only replace `<placeholder>` values with actual data. Do not substitute emoji with text equivalents, do not change `·` to `-`, do not change `×` to `x`, and do not drop section emoji prefixes.
+
+```markdown
+# Coverage Analysis - <ProjectName>
+
+| Metric | Value |
+|--------|-------|
+| **Date** | <YYYY-MM-DD> |
+| **Line Coverage** | <N>% |
+| **Branch Coverage** | <N>% |
+| **Risk Hotspots** | <N> (CRAP > <crap_threshold>) |
+| **Tests** | <N> passed · <N> failed |
+
+## Summary
+
+| Metric | Value | Threshold | Status |
+|--------|-------|-----------|--------|
+| **Line Coverage** | <N>% | <line_threshold>% | ✅ / ❌ |
+| **Branch Coverage** | <N>% | <branch_threshold>% | ✅ / ❌ |
+| **Methods Analyzed** | <N> | — | — |
+| **Risk Hotspots** | <N> | 0 | ✅ / ⚠️ |
+| **Test Result** | <Passed / N tests failed> | — | ✅ / ⚠️ |
+
+> Coverage collected from **<N> of <M> test project(s)**.
+> Reports saved to: `<coverageDir>/reports/`
+
+If any coverage provider package was added to test projects, include this note after the summary:
+
+> ℹ️ **Coverage provider package updates**
+> - `coverlet.collector` added to `<K>` project(s): `<TestProject1.csproj>`, `<TestProject2.csproj>`
+> - `Microsoft.Testing.Extensions.CodeCoverage` added to `<M>` project(s): `<TestProject3.csproj>`
+>
+> To revert: `git checkout -- <path-to-each-modified-csproj>`
+
+If all test projects already had a coverage provider, omit this note.
+
+---
+
+## 🔥 Risk Hotspots (Top <N> by CRAP Score)
+
+Methods flagged as high-risk: complex code with low test coverage that is dangerous to change.
+
+| Rank | Method | Class | File | Complexity | Coverage | CRAP Score |
+|------|--------|-------|------|-----------|---------|-----------|
+| 1 | `<method>` | `<class>` | `<file>` | <N> | <N>% | **<score>** |
+| … | … | … | … | … | … | … |
+
+> **CRAP Score** = `Complexity² × (1 − Coverage)³ + Complexity`.
+> Scores above <crap_threshold> are flagged. A score ≤ 5 is considered safe.
+
+---
+
+## 📋 Coverage Gaps by File
+
+Files below the line or branch coverage threshold, ordered by uncovered lines descending:
+
+| File | Line Coverage | Branch Coverage | Uncovered Lines | Priority |
+|------|--------------|----------------|----------------|---------|
+| `<file>` | <N>% | <N>% | <N> | 🔴 HIGH / 🟡 MED / 🟢 LOW |
+| … | … | … | … | … |
+
+---
+
+## 💡 Recommendations
+
+1. **Write tests for the top risk hotspot first** — `<method>` in `<class>` has a CRAP score of <N> (complexity <N>, <N>% coverage). Reducing it to 80% coverage would drop the score to ~<projected>.
+2. **Focus on `<file>`** — <N> uncovered lines, below threshold. <Brief reasoning.>
+3. **<Up to 5 actionable items total, ordered by expected risk reduction.>**
+
+---
+
+## 📁 Reports
+
+| Report | Path |
+|--------|------|
+| HTML (browsable) | `<coverageDir>/reports/index.html` |
+| Text summary | `<coverageDir>/reports/Summary.txt` |
+| GitHub markdown | `<coverageDir>/reports/SummaryGithub.md` |
+| CSV data | `<coverageDir>/reports/Summary.csv` |
+| Raw data | `<coverageDir>/raw/` |
+```

--- a/.github/skills/coverage-analysis/scripts/Compute-CrapScores.ps1
+++ b/.github/skills/coverage-analysis/scripts/Compute-CrapScores.ps1
@@ -1,0 +1,113 @@
+# Compute-CrapScores.ps1
+#
+# Reads a Cobertura XML coverage file and calculates CRAP scores per method.
+# Uses Alberto Savoia's original CRAP formula:
+#   CRAP(m) = comp(m)^2 * (1 - cov(m))^3 + comp(m)
+#
+# Usage:
+#   .\Compute-CrapScores.ps1 -CoberturaPath <path1>,<path2>,... [-CrapThreshold <int>] [-TopN <int>]
+#
+# Outputs:
+#   - Hotspot rows (top N by CRAP score) as a JSON array to stdout (HOTSPOTS:<json>)
+#   - Summary counts as TOTAL_METHODS:<n> and FLAGGED_METHODS:<n>
+
+param(
+    [Parameter(Mandatory)][string[]]$CoberturaPath,
+    [int]$CrapThreshold = 30,
+    [int]$TopN = 10
+)
+
+# Merge methods across all Cobertura files using a stable key (Class|Method|Signature|File).
+# Line hits are accumulated so a line is counted as covered if any test project covered it.
+$methodMap = @{}
+
+foreach ($filePath in $CoberturaPath) {
+    if (-not (Test-Path $filePath)) {
+        Write-Error "Cobertura file not found: $filePath"
+        exit 2
+    }
+
+    try {
+        [xml]$cobertura = Get-Content $filePath -Encoding UTF8 -ErrorAction Stop
+    } catch {
+        Write-Error "Failed to parse Cobertura XML: $filePath. $_"
+        exit 2
+    }
+
+    foreach ($package in $cobertura.coverage.packages.package) {
+        foreach ($class in $package.classes.class) {
+            $className = $class.name
+            $fileName  = $class.filename
+
+            foreach ($method in $class.methods.method) {
+                $key = "$className|$($method.name)|$($method.signature)|$fileName"
+
+                # Cyclomatic complexity is stored as an XML attribute in Cobertura format
+                $complexity = if ($null -ne $method.complexity) { [int]$method.complexity } else { 1 }
+                if ($complexity -lt 1) { $complexity = 1 }
+
+                if (-not $methodMap.ContainsKey($key)) {
+                    $methodMap[$key] = @{
+                        Class      = $className
+                        Method     = $method.name
+                        Signature  = $method.signature
+                        File       = $fileName
+                        Complexity = $complexity
+                        LineHits   = @{}
+                    }
+                }
+
+                # Accumulate hit counts per line number across files
+                foreach ($line in $method.lines.line) {
+                    $lineNo = $line.number
+                    $hits   = [int]$line.hits
+                    if ($methodMap[$key].LineHits.ContainsKey($lineNo)) {
+                        $methodMap[$key].LineHits[$lineNo] += $hits
+                    } else {
+                        $methodMap[$key].LineHits[$lineNo] = $hits
+                    }
+                }
+            }
+        }
+    }
+}
+
+$results = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($entry in $methodMap.Values) {
+    $totalLines   = $entry.LineHits.Count
+    $coveredLines = ($entry.LineHits.Values | Where-Object { $_ -gt 0 } | Measure-Object).Count
+    $lineCoverage = if ($totalLines -gt 0) { $coveredLines / $totalLines } else { 0.0 }
+
+    $complexity = $entry.Complexity
+
+    # Alberto Savoia's CRAP formula: comp^2 * (1 - cov)^3 + comp
+    # The cubic exponent on (1-cov) sharply penalizes low coverage:
+    # at 0% coverage the risk multiplier is 1.0; at 50% it drops to 0.125.
+    # Higher scores = more complex AND less covered = riskier to change
+    $uncovered = 1.0 - $lineCoverage
+    $crapScore = [Math]::Round(($complexity * $complexity * [Math]::Pow($uncovered, 3)) + $complexity, 2)
+
+    $results.Add([PSCustomObject]@{
+        Class        = $entry.Class
+        Method       = $entry.Method
+        Signature    = $entry.Signature
+        File         = $entry.File
+        TotalLines   = $totalLines
+        CoveredLines = $coveredLines
+        LineCoverage = [Math]::Round($lineCoverage * 100, 1)
+        Complexity   = $complexity
+        CrapScore    = $crapScore
+    })
+}
+
+$hotspots = $results | Sort-Object CrapScore -Descending | Select-Object -First $TopN
+$flagged  = $results | Where-Object { $_.CrapScore -gt $CrapThreshold }
+
+Write-Host "TOTAL_METHODS:$($results.Count)"
+Write-Host "FLAGGED_METHODS:$($flagged.Count)"
+if ($hotspots) {
+    Write-Output "HOTSPOTS:$(@($hotspots) | ConvertTo-Json -Compress)"
+} else {
+    Write-Output "HOTSPOTS:[]"
+}

--- a/.github/skills/coverage-analysis/scripts/Extract-MethodCoverage.ps1
+++ b/.github/skills/coverage-analysis/scripts/Extract-MethodCoverage.ps1
@@ -1,0 +1,193 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string[]]$CoberturaPath,
+    
+    [Parameter(Mandatory=$false)]
+    [int]$CoverageThreshold = 80,
+
+    [Parameter(Mandatory=$false)]
+    [int]$BranchThreshold = 70,
+    
+    [Parameter(Mandatory=$false)]
+    [ValidateSet('uncovered', 'below-threshold', 'all')]
+    [string]$Filter = 'all'
+)
+
+<#
+.SYNOPSIS
+Extract method-level coverage from Cobertura XML and output as JSON.
+
+.DESCRIPTION
+Parses one or more Cobertura code coverage XML files and extracts per-method coverage metrics:
+- Method name and class
+- Line coverage percentage
+- Branch coverage percentage  
+- Lines covered / total
+- Branches covered / total
+- Complexity (if available)
+
+When multiple files are provided, line hits are merged across files so a line is counted
+as covered if any test project covered it.
+
+Filters by coverage status (uncovered, below threshold, or all).
+Output is JSON for easy post-processing into tables, CSV, or other formats.
+
+.PARAMETER CoberturaPath
+Path(s) to Cobertura coverage.cobertura.xml file(s). Accepts multiple paths for multi-test-project merging.
+
+.PARAMETER CoverageThreshold
+Minimum acceptable line coverage percentage. Methods below this threshold are flagged (default: 80).
+
+.PARAMETER BranchThreshold
+Minimum acceptable branch coverage percentage for methods that contain branches (default: 70).
+
+.PARAMETER Filter
+Which methods to include:
+  'uncovered' - methods with 0% coverage only
+  'below-threshold' - methods with line coverage < CoverageThreshold OR branch coverage < BranchThreshold (for methods with branches)
+  'all' - all methods (default)
+
+.EXAMPLE
+PS> & .\Extract-MethodCoverage.ps1 -CoberturaPath "coverage.cobertura.xml" -CoverageThreshold 80 -BranchThreshold 70 -Filter uncovered
+Outputs a JSON array of uncovered methods.
+
+.EXAMPLE
+PS> & .\Extract-MethodCoverage.ps1 -CoberturaPath @("tests1/coverage.cobertura.xml","tests2/coverage.cobertura.xml")
+Merges coverage from multiple test projects and outputs combined method-level metrics.
+
+.OUTPUTS
+Writes JSON array to stdout.
+Sets exit code 0 on success, 2 on missing/invalid file.
+#>
+
+foreach ($p in $CoberturaPath) {
+    if (-not (Test-Path $p)) {
+        Write-Error "Cobertura file not found: $p"
+        exit 2
+    }
+}
+
+# Merge methods across all Cobertura files using a stable key (Class|Method|Signature|File).
+# Line hits and branch data are accumulated so coverage reflects all test projects.
+$methodMap = @{}
+
+foreach ($p in $CoberturaPath) {
+    try {
+        [xml]$xml = Get-Content $p -Encoding UTF8 -ErrorAction Stop
+    } catch {
+        Write-Error "Failed to parse Cobertura XML: $_"
+        exit 2
+    }
+
+    foreach ($package in $xml.coverage.packages.package) {
+        foreach ($class in $package.classes.class) {
+            $className = $class.name
+            $classFilename = $class.filename
+            
+            foreach ($method in $class.methods.method) {
+                $key = "$className|$($method.name)|$($method.signature)|$classFilename"
+                
+                if (-not $methodMap.ContainsKey($key)) {
+                    $complexity = if ($null -ne $method.complexity) { [int]$method.complexity } else { 1 }
+                    if ($complexity -lt 1) { $complexity = 1 }
+                    $methodMap[$key] = @{
+                        Class          = $className
+                        Method         = $method.name
+                        Signature      = $method.signature
+                        File           = $classFilename
+                        Complexity     = $complexity
+                        LineHits       = @{}
+                        BranchData     = @{}
+                    }
+                }
+
+                # Accumulate line hits across files
+                foreach ($line in $method.lines.line) {
+                    $lineNo = $line.number
+                    $hits   = [int]$line.hits
+                    if ($methodMap[$key].LineHits.ContainsKey($lineNo)) {
+                        $methodMap[$key].LineHits[$lineNo] += $hits
+                    } else {
+                        $methodMap[$key].LineHits[$lineNo] = $hits
+                    }
+
+                    # Accumulate branch data
+                    if ($line.branch -eq 'true' -and $line.'condition-coverage') {
+                        if ($line.'condition-coverage' -match '\((\d+)/(\d+)\)') {
+                            $covered = [int]$Matches[1]
+                            $total   = [int]$Matches[2]
+                            if ($methodMap[$key].BranchData.ContainsKey($lineNo)) {
+                                # Merge branch coverage across files by accumulating covered branches (capped at total)
+                                $existingCovered = $methodMap[$key].BranchData[$lineNo].Covered
+                                $existingTotal = $methodMap[$key].BranchData[$lineNo].Total
+                                if ($existingTotal -ne $total) {
+                                    Write-Warning ("Branch total mismatch for {0} at line {1}: {2} vs {3}" -f $key, $lineNo, $existingTotal, $total)
+                                }
+                                $mergedTotal = [Math]::Max($existingTotal, $total)
+                                $mergedCovered = [Math]::Min($existingCovered + $covered, $mergedTotal)
+                                $methodMap[$key].BranchData[$lineNo] = @{ Covered = $mergedCovered; Total = $mergedTotal }
+                            } else {
+                                $methodMap[$key].BranchData[$lineNo] = @{ Covered = $covered; Total = $total }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+$methods = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($entry in $methodMap.Values) {
+    $totalLines = $entry.LineHits.Count
+    $coveredLineCount = ($entry.LineHits.Values | Where-Object { $_ -gt 0 } | Measure-Object).Count
+    $lineCoveragePercent = if ($totalLines -gt 0) { [math]::Round(($coveredLineCount / $totalLines) * 100, 1) } else { 0 }
+
+    $branchesTotal = 0
+    $branchesCovered = 0
+    foreach ($bd in $entry.BranchData.Values) {
+        $branchesCovered += $bd.Covered
+        $branchesTotal   += $bd.Total
+    }
+    $branchCoveragePercent = if ($branchesTotal -gt 0) { [math]::Round(($branchesCovered / $branchesTotal) * 100, 1) } else { 0 }
+
+    # Apply filter
+    if ($Filter -eq 'uncovered' -and $lineCoveragePercent -gt 0) { continue }
+    if ($Filter -eq 'below-threshold') {
+        $lineOk = $lineCoveragePercent -ge $CoverageThreshold
+        $branchOk = ($branchesTotal -eq 0) -or ($branchCoveragePercent -ge $BranchThreshold)
+        if ($lineOk -and $branchOk) { continue }
+    }
+    
+    $methods.Add([PSCustomObject]@{
+        Class               = $entry.Class
+        Method              = $entry.Method
+        Signature           = $entry.Signature
+        File                = $entry.File
+        Complexity          = $entry.Complexity
+        LineCoverage        = $lineCoveragePercent
+        BranchCoverage      = $branchCoveragePercent
+        CoveredLines        = $coveredLineCount
+        TotalLines          = $totalLines
+        UncoveredLines      = ($totalLines - $coveredLineCount)
+        CoveredBranches     = $branchesCovered
+        TotalBranches       = $branchesTotal
+    })
+}
+# Sort by uncovered lines descending, then by line coverage ascending
+$sorted = $methods | Sort-Object -Property @{Expression='UncoveredLines';Descending=$true}, @{Expression='LineCoverage';Descending=$false}, Class, Method
+
+# Output as JSON (empty array guard for zero results)
+if ($sorted.Count -eq 0) {
+    Write-Output "[]"
+} else {
+    $json = @($sorted) | ConvertTo-Json
+    Write-Output $json
+}
+
+# Summary
+Write-Host "METHODS_FILTERED:$($methods.Count)" -ForegroundColor Green
+$uncovered = $methods | Where-Object { $_.LineCoverage -eq 0 } | Measure-Object | Select-Object -ExpandProperty Count
+Write-Host "UNCOVERED_METHODS:$uncovered" -ForegroundColor $(if ($uncovered -gt 0) { 'Yellow' } else { 'Green' })
+exit 0

--- a/.github/skills/coverlet/SKILL.md
+++ b/.github/skills/coverlet/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: coverlet
+description: "Use the open-source free `coverlet` toolchain for .NET code coverage. Use when a repo needs line and branch coverage, collector versus MSBuild driver selection, or CI-safe coverage commands. USE FOR: coverlet setup; CI line or branch coverage; choosing between collector and MSBuild drivers. DO NOT USE FOR: coverage report rendering by itself; repos that intentionally use a different coverage engine. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires a .NET test project or solution; respects the repo's `AGENTS.md` commands first."
+---
+
+# Coverlet for .NET
+
+## Trigger On
+
+- the repo uses or wants `coverlet`
+- CI needs line or branch coverage for .NET tests
+- the team needs to choose between `coverlet.collector`, `coverlet.msbuild`, or `coverlet.console`
+
+## Value
+
+- produce a concrete project delta: code, docs, config, tests, CI, or review artifact
+- reduce ambiguity through explicit planning, verification, and final validation skills
+- leave reusable project context so future tasks are faster and safer
+
+## Do Not Use For
+
+- coverage report rendering by itself
+- repos that intentionally use a different coverage engine
+
+## Inputs
+
+- the nearest `AGENTS.md`
+- active runner model: VSTest or Microsoft.Testing.Platform
+- target test projects
+
+## Quick Start
+
+1. Read the nearest `AGENTS.md` and confirm scope and constraints.
+2. Run this skill's `Workflow` through the `Ralph Loop` until outcomes are acceptable.
+3. Return the `Required Result Format` with concrete artifacts and verification evidence.
+
+## Workflow
+
+1. Choose the driver deliberately:
+   - `coverlet.collector` for VSTest `dotnet test --collect`
+   - `coverlet.msbuild` for MSBuild property-driven runs
+   - `coverlet.console` for standalone scenarios
+2. Add coverage packages only to test projects.
+3. Do not mix `coverlet.collector` and `coverlet.msbuild` in the same test project.
+4. Pair raw coverage collection with `ReportGenerator` only when humans need rendered reports.
+
+## Bootstrap When Missing
+
+If coverage is not configured yet:
+
+1. Detect current state:
+   - `rg -n "coverlet\\.(collector|msbuild)|CollectCoverage|XPlat Code Coverage" -g '*.csproj' -g '*.props' -g '*.targets' .`
+   - `dotnet tool list --local`
+   - `dotnet tool list --global`
+   - `command -v coverlet`
+2. Install exactly one driver path:
+   - VSTest collector: `dotnet add TEST_PROJECT.csproj package coverlet.collector`
+   - MSBuild driver: `dotnet add TEST_PROJECT.csproj package coverlet.msbuild`
+   - Console tool: `dotnet new tool-manifest` (if missing) and `dotnet tool install coverlet.console`
+3. Record one concrete local and CI command in `AGENTS.md`:
+   - collector: `dotnet test TEST_PROJECT.csproj --collect:"XPlat Code Coverage"`
+   - msbuild: `dotnet test TEST_PROJECT.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura`
+   - console: `dotnet tool run coverlet TEST_ASSEMBLY.dll --target "dotnet" --targetargs "test TEST_PROJECT.csproj --no-build"`
+4. Run the chosen command once and return `status: configured` or `status: improved`.
+5. If another coverage engine already owns coverage for this repo, return `status: not_applicable`.
+
+## Deliver
+
+- explicit coverage driver selection
+- reproducible coverage commands for local and CI runs
+
+## Validate
+
+- coverage driver matches the runner model
+- coverage files are stable and consumable by downstream reporting
+
+## Ralph Loop
+
+Use the Ralph Loop for every task, including docs, architecture, testing, and tooling work.
+
+1. Plan first (mandatory):
+   - analyze current state
+   - define target outcome, constraints, and risks
+   - write a detailed execution plan
+   - list final validation skills to run at the end, with order and reason
+2. Execute one planned step and produce a concrete delta.
+3. Review the result and capture findings with actionable next fixes.
+4. Apply fixes in small batches and rerun the relevant checks or review steps.
+5. Update the plan after each iteration.
+6. Repeat until outcomes are acceptable or only explicit exceptions remain.
+7. If a dependency is missing, bootstrap it or return `status: not_applicable` with explicit reason and fallback path.
+
+### Required Result Format
+
+- `status`: `complete` | `clean` | `improved` | `configured` | `not_applicable` | `blocked`
+- `plan`: concise plan and current iteration step
+- `actions_taken`: concrete changes made
+- `validation_skills`: final skills run, or skipped with reasons
+- `verification`: commands, checks, or review evidence summary
+- `remaining`: top unresolved items or `none`
+
+For setup-only requests with no execution, return `status: configured` and exact next commands.
+
+## Load References
+
+- [references/commands.md](references/commands.md)
+- [references/patterns.md](references/patterns.md)
+- [references/coverlet.md](references/coverlet.md)
+
+## Example Requests
+
+- "Add Coverlet to this .NET solution."
+- "Choose the right Coverlet driver for CI."

--- a/.github/skills/coverlet/manifest.json
+++ b/.github/skills/coverlet/manifest.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "category": "Testing",
+  "packages": [
+    "coverlet.collector",
+    "coverlet.msbuild"
+  ]
+}

--- a/.github/skills/coverlet/references/commands.md
+++ b/.github/skills/coverlet/references/commands.md
@@ -1,0 +1,309 @@
+# Coverlet Commands Reference
+
+## Coverlet Drivers Overview
+
+Coverlet provides three drivers for collecting code coverage. Choose exactly one per test project.
+
+| Driver | Package | Use Case |
+|--------|---------|----------|
+| Collector | `coverlet.collector` | VSTest integration via `--collect` |
+| MSBuild | `coverlet.msbuild` | MSBuild property-driven coverage |
+| Console | `coverlet.console` | Standalone CLI tool |
+
+---
+
+## Collector Driver (`coverlet.collector`)
+
+### Installation
+
+```bash
+dotnet add <TEST_PROJECT>.csproj package coverlet.collector
+```
+
+### Basic Command
+
+```bash
+dotnet test <TEST_PROJECT>.csproj --collect:"XPlat Code Coverage"
+```
+
+### Output Location
+
+Coverage files are written to `TestResults/<guid>/coverage.cobertura.xml` by default.
+
+### Common Options
+
+```bash
+# Specify output directory
+dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+# With runsettings file
+dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+```
+
+### Runsettings Configuration
+
+Create `coverlet.runsettings`:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura,opencover</Format>
+          <Exclude>[*]*.Generated.*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**/Migrations/*.cs</ExcludeByFile>
+          <IncludeDirectory>../src/*</IncludeDirectory>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SkipAutoProps>true</SkipAutoProps>
+          <DeterministicReport>true</DeterministicReport>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>
+```
+
+---
+
+## MSBuild Driver (`coverlet.msbuild`)
+
+### Installation
+
+```bash
+dotnet add <TEST_PROJECT>.csproj package coverlet.msbuild
+```
+
+### Basic Command
+
+```bash
+dotnet test <TEST_PROJECT>.csproj /p:CollectCoverage=true
+```
+
+### Output Formats
+
+```bash
+# Cobertura (default for CI)
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+
+# OpenCover format
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+
+# Multiple formats
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=\"opencover,cobertura\"
+
+# JSON format
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=json
+
+# LCOV format
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
+```
+
+### Output Location
+
+```bash
+# Custom output file
+dotnet test /p:CollectCoverage=true /p:CoverletOutput=./coverage/
+
+# With specific filename
+dotnet test /p:CollectCoverage=true /p:CoverletOutput=./coverage/coverage.xml
+```
+
+### MSBuild Properties
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `CollectCoverage` | Enable coverage collection | `false` |
+| `CoverletOutputFormat` | Output format(s) | `json` |
+| `CoverletOutput` | Output path | `./` |
+| `Threshold` | Minimum coverage percentage | none |
+| `ThresholdType` | `line`, `branch`, `method` | `line` |
+| `ThresholdStat` | `minimum`, `total`, `average` | `minimum` |
+| `ExcludeByFile` | Files to exclude | none |
+| `ExcludeByAttribute` | Attributes to exclude | none |
+| `Exclude` | Filter expressions | none |
+| `Include` | Filter expressions | none |
+| `IncludeDirectory` | Source directories | none |
+| `UseSourceLink` | Use SourceLink URIs | `false` |
+| `SingleHit` | Count hits as 0 or 1 | `false` |
+| `IncludeTestAssembly` | Include test assembly | `false` |
+| `SkipAutoProps` | Skip auto-properties | `false` |
+| `DeterministicReport` | Deterministic output | `false` |
+| `MergeWith` | Merge with existing file | none |
+
+### Coverage Thresholds
+
+```bash
+# Fail if line coverage below 80%
+dotnet test /p:CollectCoverage=true /p:Threshold=80
+
+# Fail if branch coverage below 70%
+dotnet test /p:CollectCoverage=true /p:Threshold=70 /p:ThresholdType=branch
+
+# Multiple threshold types
+dotnet test /p:CollectCoverage=true /p:Threshold=\"80,70,90\" /p:ThresholdType=\"line,branch,method\"
+
+# Average instead of minimum
+dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdStat=average
+```
+
+### Merging Coverage
+
+```bash
+# Merge with existing coverage file
+dotnet test /p:CollectCoverage=true /p:MergeWith="./coverage/previous.json"
+
+# Typical multi-project merge workflow
+dotnet test Project1.Tests.csproj /p:CollectCoverage=true /p:CoverletOutput=./coverage/
+dotnet test Project2.Tests.csproj /p:CollectCoverage=true /p:CoverletOutput=./coverage/ /p:MergeWith="./coverage/coverage.json"
+```
+
+### Directory.Build.props Configuration
+
+Set defaults across all test projects:
+
+```xml
+<Project>
+  <PropertyGroup Condition="'$(CollectCoverage)' == 'true'">
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <CoverletOutput>$(MSBuildThisFileDirectory)coverage/</CoverletOutput>
+    <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverage</ExcludeByAttribute>
+    <ExcludeByFile>**/Migrations/*.cs</ExcludeByFile>
+    <SkipAutoProps>true</SkipAutoProps>
+    <DeterministicReport>true</DeterministicReport>
+  </PropertyGroup>
+</Project>
+```
+
+---
+
+## Console Tool (`coverlet.console`)
+
+### Installation
+
+```bash
+# As local tool (recommended)
+dotnet new tool-manifest  # if not present
+dotnet tool install coverlet.console
+
+# As global tool
+dotnet tool install --global coverlet.console
+```
+
+### Basic Command
+
+```bash
+# Local tool
+dotnet tool run coverlet <TEST_ASSEMBLY>.dll --target "dotnet" --targetargs "test <TEST_PROJECT>.csproj --no-build"
+
+# Global tool
+coverlet <TEST_ASSEMBLY>.dll --target "dotnet" --targetargs "test <TEST_PROJECT>.csproj --no-build"
+```
+
+### Common Options
+
+```bash
+coverlet <TEST_ASSEMBLY>.dll \
+  --target "dotnet" \
+  --targetargs "test <TEST_PROJECT>.csproj --no-build" \
+  --output ./coverage/ \
+  --format cobertura \
+  --exclude "[*]*.Migrations.*" \
+  --exclude-by-attribute "Obsolete,GeneratedCode" \
+  --threshold 80 \
+  --threshold-type line
+```
+
+### Console Tool Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--target` | Executable to run tests |
+| `--targetargs` | Arguments for target executable |
+| `--output` | Output path |
+| `--format` | Output format(s) |
+| `--threshold` | Minimum coverage |
+| `--threshold-type` | `line`, `branch`, `method` |
+| `--threshold-stat` | `minimum`, `total`, `average` |
+| `--exclude` | Filter expressions |
+| `--include` | Filter expressions |
+| `--exclude-by-file` | File patterns to exclude |
+| `--exclude-by-attribute` | Attributes to exclude |
+| `--include-directory` | Source directories |
+| `--use-source-link` | Use SourceLink |
+| `--single-hit` | Count hits as 0 or 1 |
+| `--include-test-assembly` | Include test assembly |
+| `--skip-auto-props` | Skip auto-properties |
+| `--merge-with` | Merge with existing file |
+| `--verbosity` | `quiet`, `minimal`, `normal`, `detailed` |
+
+---
+
+## CI Integration Examples
+
+### GitHub Actions
+
+```yaml
+- name: Run tests with coverage
+  run: dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+- name: Upload coverage
+  uses: codecov/codecov-action@v4
+  with:
+    directory: ./coverage
+    files: "**/*.cobertura.xml"
+```
+
+### Azure Pipelines
+
+```yaml
+- task: DotNetCoreCLI@2
+  inputs:
+    command: test
+    arguments: '--collect:"XPlat Code Coverage" --results-directory $(Build.SourcesDirectory)/coverage'
+
+- task: PublishCodeCoverageResults@2
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.SourcesDirectory)/coverage/**/coverage.cobertura.xml'
+```
+
+### GitLab CI
+
+```yaml
+test:
+  script:
+    - dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
+  artifacts:
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/**/coverage.cobertura.xml
+```
+
+---
+
+## ReportGenerator Integration
+
+Generate HTML reports from coverage files:
+
+```bash
+# Install
+dotnet tool install dotnet-reportgenerator-globaltool
+
+# Generate HTML report
+reportgenerator \
+  -reports:"./coverage/**/coverage.cobertura.xml" \
+  -targetdir:"./coverage/report" \
+  -reporttypes:Html
+
+# Multiple formats
+reportgenerator \
+  -reports:"./coverage/**/coverage.cobertura.xml" \
+  -targetdir:"./coverage/report" \
+  -reporttypes:"Html;Badges;TextSummary"
+```

--- a/.github/skills/coverlet/references/coverlet.md
+++ b/.github/skills/coverlet/references/coverlet.md
@@ -1,0 +1,71 @@
+# Coverlet
+
+## Open/Free Status
+
+- open source
+- free to use
+
+## Install
+
+VSTest collector:
+
+```bash
+dotnet add package coverlet.collector
+```
+
+MSBuild driver:
+
+```bash
+dotnet add package coverlet.msbuild
+```
+
+Console tool:
+
+```bash
+dotnet tool install --global coverlet.console
+```
+
+## Verify First
+
+Before installing a coverage driver, check what the repo already uses:
+
+```bash
+rg -n "coverlet\\.(collector|msbuild)|CollectCoverage|XPlat Code Coverage" -g '*.csproj' -g '*.props' -g '*.targets' .
+dotnet tool list --local
+dotnet tool list --global
+command -v coverlet
+```
+
+## Common Usage
+
+Collector:
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+MSBuild:
+
+```bash
+dotnet test /p:CollectCoverage=true
+```
+
+Console:
+
+```bash
+coverlet /path/to/test-assembly.dll --target "dotnet" --targetargs "test /path/to/test-project --no-build"
+```
+
+## CI Fit
+
+- add coverage packages only to test projects
+- do not combine `coverlet.collector` and `coverlet.msbuild` in one test project
+- render the resulting files with `ReportGenerator` if humans need HTML or Markdown output
+
+## When Not To Use
+
+- when the repo already standardized on another coverage engine
+
+## Sources
+
+- [Coverlet](https://github.com/coverlet-coverage/coverlet)

--- a/.github/skills/coverlet/references/patterns.md
+++ b/.github/skills/coverlet/references/patterns.md
@@ -1,0 +1,325 @@
+# Coverlet Coverage Patterns Reference
+
+## Filter Expression Syntax
+
+Coverlet uses filter expressions to include or exclude assemblies and types from coverage.
+
+### Basic Syntax
+
+```
+[<ASSEMBLY_FILTER>]<TYPE_FILTER>
+```
+
+- `*` matches any sequence of characters
+- `?` matches any single character
+- Assembly filter is enclosed in `[]`
+- Type filter follows the assembly filter
+
+### Examples
+
+| Pattern | Description |
+|---------|-------------|
+| `[*]*` | All types in all assemblies |
+| `[MyApp]*` | All types in MyApp assembly |
+| `[MyApp]MyApp.Services.*` | All types in Services namespace |
+| `[*]MyApp.Models.User` | Specific type in any assembly |
+| `[MyApp.?]*` | Assemblies matching MyApp.* |
+| `[MyApp.*]*.Tests.*` | Test types in MyApp.* assemblies |
+
+---
+
+## Common Exclusion Patterns
+
+### Generated Code
+
+```bash
+# MSBuild
+/p:Exclude="[*]*.Generated.*,[*]*.Designer.*,[*]*.g.cs"
+
+# Runsettings
+<Exclude>[*]*.Generated.*,[*]*.Designer.*</Exclude>
+
+# Console
+--exclude "[*]*.Generated.*" --exclude "[*]*.Designer.*"
+```
+
+### Entity Framework Migrations
+
+```bash
+# By file path
+/p:ExcludeByFile="**/Migrations/*.cs"
+
+# By namespace
+/p:Exclude="[*]*.Migrations.*"
+```
+
+### Auto-Generated Properties
+
+```bash
+# Skip auto-properties (getters/setters)
+/p:SkipAutoProps=true
+```
+
+### Test Assemblies
+
+```bash
+# Exclude test projects from coverage
+/p:Exclude="[*.Tests]*,[*.UnitTests]*,[*.IntegrationTests]*"
+
+# Do not include test assembly itself
+/p:IncludeTestAssembly=false
+```
+
+### Third-Party Code
+
+```bash
+# Exclude specific vendor namespaces
+/p:Exclude="[*]AutoMapper.*,[*]FluentValidation.*"
+```
+
+---
+
+## Attribute-Based Exclusions
+
+### Built-in .NET Attributes
+
+```bash
+/p:ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute"
+```
+
+### ExcludeFromCodeCoverage Attribute
+
+Apply `[ExcludeFromCodeCoverage]` to types or members:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+[ExcludeFromCodeCoverage]
+public class GeneratedDto
+{
+    public string Name { get; set; }
+}
+
+public class Service
+{
+    [ExcludeFromCodeCoverage]
+    public void DebugOnlyMethod()
+    {
+        // Not covered
+    }
+}
+```
+
+Then exclude:
+
+```bash
+/p:ExcludeByAttribute="ExcludeFromCodeCoverage"
+```
+
+### Custom Exclusion Attributes
+
+Define a custom attribute:
+
+```csharp
+[AttributeUsage(AttributeTargets.All)]
+public sealed class ExcludeFromCoverageAttribute : Attribute { }
+```
+
+Apply and exclude:
+
+```bash
+/p:ExcludeByAttribute="ExcludeFromCoverageAttribute"
+```
+
+---
+
+## File-Based Exclusions
+
+### ExcludeByFile Patterns
+
+```bash
+# Single pattern
+/p:ExcludeByFile="**/Migrations/*.cs"
+
+# Multiple patterns
+/p:ExcludeByFile="**/Migrations/*.cs,**/Generated/*.cs,**/obj/**/*.cs"
+```
+
+### Common File Exclusions
+
+| Pattern | Description |
+|---------|-------------|
+| `**/Migrations/*.cs` | EF Core migrations |
+| `**/Generated/*.cs` | Generated code folders |
+| `**/obj/**/*.cs` | Build output |
+| `**/*.Designer.cs` | Designer files |
+| `**/*.g.cs` | Source generators |
+| `**/GlobalSuppressions.cs` | Analyzer suppressions |
+| `**/AssemblyInfo.cs` | Assembly metadata |
+
+---
+
+## Include Patterns
+
+### Limiting Coverage Scope
+
+```bash
+# Only specific assemblies
+/p:Include="[MyApp.Core]*,[MyApp.Services]*"
+
+# Only specific namespaces
+/p:Include="[MyApp]*MyApp.Domain.*"
+```
+
+### Source Directory Inclusion
+
+For projects with source code in non-standard locations:
+
+```bash
+/p:IncludeDirectory="../src/*,../lib/*"
+```
+
+---
+
+## Combined Pattern Examples
+
+### Typical Application Coverage
+
+```bash
+dotnet test /p:CollectCoverage=true \
+  /p:CoverletOutputFormat=cobertura \
+  /p:Exclude="[*.Tests]*,[*.IntegrationTests]*,[*]*.Migrations.*,[*]*.Generated.*" \
+  /p:ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverage" \
+  /p:ExcludeByFile="**/Migrations/*.cs,**/*.Designer.cs" \
+  /p:SkipAutoProps=true
+```
+
+### Runsettings Example
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+
+          <!-- Assembly and type exclusions -->
+          <Exclude>
+            [*.Tests]*,
+            [*.IntegrationTests]*,
+            [*]*.Migrations.*,
+            [*]*.Generated.*
+          </Exclude>
+
+          <!-- Attribute exclusions -->
+          <ExcludeByAttribute>
+            Obsolete,
+            GeneratedCodeAttribute,
+            CompilerGeneratedAttribute,
+            ExcludeFromCodeCoverage
+          </ExcludeByAttribute>
+
+          <!-- File path exclusions -->
+          <ExcludeByFile>
+            **/Migrations/*.cs,
+            **/*.Designer.cs,
+            **/*.g.cs,
+            **/GlobalSuppressions.cs
+          </ExcludeByFile>
+
+          <!-- Additional options -->
+          <SkipAutoProps>true</SkipAutoProps>
+          <DeterministicReport>true</DeterministicReport>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>
+```
+
+### Directory.Build.props Example
+
+```xml
+<Project>
+  <PropertyGroup Condition="'$(CollectCoverage)' == 'true'">
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <CoverletOutput>$(MSBuildThisFileDirectory)coverage/</CoverletOutput>
+
+    <!-- Exclusions -->
+    <Exclude>[*.Tests]*,[*.IntegrationTests]*,[*]*.Migrations.*</Exclude>
+    <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverage</ExcludeByAttribute>
+    <ExcludeByFile>**/Migrations/*.cs,**/*.Designer.cs</ExcludeByFile>
+
+    <!-- Options -->
+    <SkipAutoProps>true</SkipAutoProps>
+    <DeterministicReport>true</DeterministicReport>
+    <IncludeTestAssembly>false</IncludeTestAssembly>
+  </PropertyGroup>
+</Project>
+```
+
+---
+
+## Framework-Specific Patterns
+
+### ASP.NET Core
+
+```bash
+/p:Exclude="[*]*.Migrations.*,[*]Program,[*]Startup" \
+/p:ExcludeByFile="**/Migrations/*.cs,**/wwwroot/**"
+```
+
+### Blazor
+
+```bash
+/p:Exclude="[*]*.Migrations.*,[*]App,[*]*.razor.g.cs" \
+/p:ExcludeByFile="**/*.razor.g.cs,**/*.razor.css.g.cs"
+```
+
+### Worker Services
+
+```bash
+/p:Exclude="[*]Program,[*]*.Worker" \
+/p:ExcludeByAttribute="ExcludeFromCodeCoverage"
+```
+
+---
+
+## Troubleshooting Patterns
+
+### Verify Exclusions Work
+
+Run with verbose output to see what is being excluded:
+
+```bash
+# Console tool
+coverlet ... --verbosity detailed
+
+# Check generated coverage file for excluded types
+```
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Pattern not matching | Check assembly name vs namespace |
+| Wildcards not working | Ensure proper escaping in shell |
+| Files still covered | Use absolute paths in ExcludeByFile |
+| Attributes ignored | Check attribute full name |
+
+### Debug Filter Expressions
+
+Test patterns incrementally:
+
+```bash
+# Start broad
+/p:Exclude="[*]*"  # Excludes everything
+
+# Narrow down
+/p:Exclude="[MyApp.Tests]*"  # Exclude specific assembly
+
+# Verify with coverage report
+```

--- a/.github/skills/entity-framework-core/SKILL.md
+++ b/.github/skills/entity-framework-core/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: entity-framework-core
+description: "Design, tune, or review EF Core data access with proper modeling, migrations, query translation, performance, and lifetime management for modern .NET applications. USE FOR: DbContext, migrations, model configuration, EF queries, tracking, loading, performance, transactions, and EF6 migration decisions. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires EF Core 7+ (preferably 8/9 for latest features)."
+---
+
+# Entity Framework Core
+
+## Trigger On
+
+- working on `DbContext`, migrations, model configuration, or EF queries
+- reviewing tracking, loading, performance, or transaction behavior
+- porting data access from EF6 or custom repositories to EF Core
+- optimizing slow database queries
+
+## Documentation
+
+- [EF Core Overview](https://learn.microsoft.com/en-us/ef/core/)
+- [Performance](https://learn.microsoft.com/en-us/ef/core/performance/)
+- [Efficient Querying](https://learn.microsoft.com/en-us/ef/core/performance/efficient-querying)
+- [Migrations](https://learn.microsoft.com/en-us/ef/core/managing-schemas/migrations/)
+- [What's New in EF Core 9](https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-9.0/whatsnew)
+
+### References
+
+- [patterns.md](references/patterns.md) - Query patterns, tracking strategies, loading strategies, projections, compiled queries, pagination, and temporal tables
+- [anti-patterns.md](references/anti-patterns.md) - Common EF Core mistakes including N+1 queries, large contexts, generic repositories, and missing indexes
+
+## Workflow
+
+1. **Prefer EF Core for new development** unless a documented gap requires Dapper or raw SQL
+2. **Keep `DbContext` lifetime scoped** — align with unit of work
+3. **Review query translation** — check generated SQL, avoid N+1
+4. **Treat migrations as first-class** — reviewable, not throwaway
+5. **Be deliberate about provider behavior** — cross-provider but not identical
+6. **Validate with query inspection** — not just in-memory mental model
+
+## DbContext Patterns
+
+### Basic Configuration
+```csharp
+public class AppDbContext : DbContext
+{
+    public DbSet<Product> Products => Set<Product>();
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+    }
+}
+
+// Entity Configuration (Fluent API)
+public class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> builder)
+    {
+        builder.HasKey(p => p.Id);
+        builder.Property(p => p.Name).HasMaxLength(200).IsRequired();
+        builder.HasIndex(p => p.Sku).IsUnique();
+        builder.HasMany(p => p.OrderItems).WithOne(oi => oi.Product);
+    }
+}
+```
+
+### Registration with DI
+```csharp
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString)
+           .EnableSensitiveDataLogging()  // Dev only
+           .EnableDetailedErrors());      // Dev only
+
+// Or with pooling (better performance)
+builder.Services.AddDbContextPool<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
+```
+
+## Query Patterns
+
+### Use AsNoTracking for Read-Only
+```csharp
+// Bad - tracks entities unnecessarily
+var products = await db.Products.ToListAsync();
+
+// Good - no tracking overhead
+var products = await db.Products
+    .AsNoTracking()
+    .ToListAsync();
+```
+
+### Project to DTOs
+```csharp
+// Bad - loads entire entity graph
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .Include(o => o.Customer)
+    .ToListAsync();
+
+// Good - loads only needed data
+var orders = await db.Orders
+    .Select(o => new OrderDto
+    {
+        Id = o.Id,
+        CustomerName = o.Customer.Name,
+        ItemCount = o.Items.Count,
+        Total = o.Items.Sum(i => i.Price)
+    })
+    .ToListAsync();
+```
+
+### Avoid N+1 Queries
+```csharp
+// Bad - N+1 problem
+foreach (var order in orders)
+{
+    var items = await db.OrderItems
+        .Where(i => i.OrderId == order.Id)
+        .ToListAsync();
+}
+
+// Good - eager loading
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .ToListAsync();
+
+// Good - split query for large graphs
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .AsSplitQuery()
+    .ToListAsync();
+```
+
+### Compiled Queries (EF Core 9)
+```csharp
+// Pre-compiled for frequently used queries
+private static readonly Func<AppDbContext, int, Task<Product?>> GetProductById =
+    EF.CompileAsyncQuery((AppDbContext db, int id) =>
+        db.Products.FirstOrDefault(p => p.Id == id));
+
+// Usage
+var product = await GetProductById(db, productId);
+```
+
+## Migration Patterns
+
+### Creating Migrations
+```bash
+# Add migration
+dotnet ef migrations add AddProductIndex
+
+# Apply to database
+dotnet ef database update
+
+# Generate SQL script
+dotnet ef migrations script --idempotent -o migrate.sql
+```
+
+### Data Migrations
+```csharp
+public partial class AddProductIndex : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_Products_Sku",
+            table: "Products",
+            column: "Sku",
+            unique: true);
+
+        // Data migration (if needed)
+        migrationBuilder.Sql(@"
+            UPDATE Products
+            SET NormalizedName = UPPER(Name)
+            WHERE NormalizedName IS NULL");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_Products_Sku",
+            table: "Products");
+    }
+}
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| `ToList()` then filter | Loads all data to memory | Filter in query |
+| Multiple DbContext per request | Transaction issues | Scoped lifetime |
+| Lazy loading everywhere | N+1 queries | Explicit Include |
+| Generic repository wrapper | Removes query power | Use DbContext directly |
+| Ignoring generated SQL | Hidden performance issues | Log and review |
+| `SaveChanges()` in loops | Many roundtrips | Batch then save |
+
+## Performance Best Practices
+
+1. **Index frequently queried columns:**
+   ```csharp
+   builder.HasIndex(p => p.CreatedAt);
+   builder.HasIndex(p => new { p.Category, p.Status });
+   ```
+
+2. **Use pagination:**
+   ```csharp
+   var page = await db.Products
+       .OrderBy(p => p.Id)
+       .Skip(pageSize * pageNumber)
+       .Take(pageSize)
+       .ToListAsync();
+   ```
+
+3. **Batch updates (EF Core 7+):**
+   ```csharp
+   await db.Products
+       .Where(p => p.Category == "Obsolete")
+       .ExecuteDeleteAsync();
+
+   await db.Products
+       .Where(p => p.Category == "Sale")
+       .ExecuteUpdateAsync(p => p.SetProperty(x => x.Price, x => x.Price * 0.9m));
+   ```
+
+4. **Minimize network roundtrips:**
+   ```csharp
+   // Bad - 3 roundtrips
+   var product = await db.Products.FindAsync(id);
+   var reviews = await db.Reviews.Where(r => r.ProductId == id).ToListAsync();
+   var related = await db.Products.Where(p => p.Category == product.Category).ToListAsync();
+
+   // Good - 1 roundtrip
+   var data = await db.Products
+       .Where(p => p.Id == id)
+       .Select(p => new
+       {
+           Product = p,
+           Reviews = p.Reviews,
+           Related = db.Products.Where(r => r.Category == p.Category).Take(5)
+       })
+       .FirstOrDefaultAsync();
+   ```
+
+## Concurrency Patterns
+
+```csharp
+public class Product
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+
+    [ConcurrencyCheck]
+    public int Version { get; set; }
+
+    // Or use RowVersion
+    [Timestamp]
+    public byte[] RowVersion { get; set; }
+}
+
+// Handle concurrency conflicts
+try
+{
+    await db.SaveChangesAsync();
+}
+catch (DbUpdateConcurrencyException ex)
+{
+    var entry = ex.Entries.Single();
+    var databaseValues = await entry.GetDatabaseValuesAsync();
+    // Resolve conflict...
+}
+```
+
+## Deliver
+
+- EF Core models and queries that match the domain
+- safer migrations and lifetime management
+- performance-aware data access decisions
+- proper indexing and query optimization
+
+## Validate
+
+- query behavior is intentional (check SQL logs)
+- migrations are reviewable and correct
+- no N+1 queries in common paths
+- indexes exist for filtered/sorted columns
+- DbContext lifetime is scoped properly
+- concurrency is handled for critical entities

--- a/.github/skills/entity-framework-core/manifest.json
+++ b/.github/skills/entity-framework-core/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "category": "Data",
+  "package_prefix": "Microsoft.EntityFrameworkCore"
+}

--- a/.github/skills/entity-framework-core/references/anti-patterns.md
+++ b/.github/skills/entity-framework-core/references/anti-patterns.md
@@ -1,0 +1,549 @@
+# EF Core Anti-Patterns
+
+## N+1 Query Problem
+
+### The Problem
+
+Loading related data in a loop causes one query per iteration:
+
+```csharp
+// BAD: N+1 queries - 1 for orders + N for items
+var orders = await db.Orders.ToListAsync();
+foreach (var order in orders)
+{
+    // Each iteration executes a new query
+    order.Items = await db.OrderItems
+        .Where(i => i.OrderId == order.Id)
+        .ToListAsync();
+}
+```
+
+### The Solution
+
+Use eager loading, projection, or explicit loading:
+
+```csharp
+// GOOD: Single query with Include
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .ToListAsync();
+
+// GOOD: Split query for large graphs
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .Include(o => o.Payments)
+    .AsSplitQuery()
+    .ToListAsync();
+
+// GOOD: Projection to DTO
+var orderDtos = await db.Orders
+    .Select(o => new OrderDto
+    {
+        Id = o.Id,
+        Items = o.Items.Select(i => new OrderItemDto { ... }).ToList()
+    })
+    .ToListAsync();
+```
+
+## Large DbContext with Too Many DbSets
+
+### The Problem
+
+A single DbContext with dozens of DbSets becomes hard to maintain and test:
+
+```csharp
+// BAD: Monolithic context
+public class AppDbContext : DbContext
+{
+    public DbSet<User> Users { get; set; }
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<Product> Products { get; set; }
+    public DbSet<Inventory> Inventory { get; set; }
+    public DbSet<Shipment> Shipments { get; set; }
+    public DbSet<Invoice> Invoices { get; set; }
+    // ... 50 more DbSets
+}
+```
+
+### The Solution
+
+Split into bounded contexts:
+
+```csharp
+// GOOD: Bounded contexts
+public class OrderingDbContext : DbContext
+{
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<OrderItem> OrderItems { get; set; }
+}
+
+public class InventoryDbContext : DbContext
+{
+    public DbSet<Product> Products { get; set; }
+    public DbSet<StockLevel> StockLevels { get; set; }
+}
+```
+
+## Loading Full Entities When You Need Subsets
+
+### The Problem
+
+Fetching entire entity graphs when only a few properties are needed:
+
+```csharp
+// BAD: Loads everything including large blobs
+var products = await db.Products
+    .Include(p => p.Images)
+    .Include(p => p.Reviews)
+    .Include(p => p.Specifications)
+    .ToListAsync();
+
+// Then only using name and price
+var displayList = products.Select(p => $"{p.Name}: {p.Price}");
+```
+
+### The Solution
+
+Project to DTOs or anonymous types:
+
+```csharp
+// GOOD: Only fetch what you need
+var products = await db.Products
+    .Select(p => new { p.Name, p.Price })
+    .ToListAsync();
+
+var displayList = products.Select(p => $"{p.Name}: {p.Price}");
+```
+
+## Client-Side Evaluation Without Awareness
+
+### The Problem
+
+Filtering happens in memory instead of database:
+
+```csharp
+// BAD: Custom method forces client evaluation
+var activeProducts = await db.Products
+    .Where(p => IsProductActive(p))  // Cannot translate to SQL
+    .ToListAsync();
+
+// BAD: Complex string operations may not translate
+var products = await db.Products
+    .Where(p => p.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+    .ToListAsync();
+```
+
+### The Solution
+
+Use translatable expressions or explicit client evaluation:
+
+```csharp
+// GOOD: Use EF.Functions for database operations
+var products = await db.Products
+    .Where(p => EF.Functions.Like(p.Name, $"%{searchTerm}%"))
+    .ToListAsync();
+
+// GOOD: Explicit about client evaluation
+var allProducts = await db.Products.ToListAsync();
+var activeProducts = allProducts.Where(p => IsProductActive(p));
+```
+
+## SaveChanges in Loops
+
+### The Problem
+
+Calling SaveChanges repeatedly causes many database roundtrips:
+
+```csharp
+// BAD: N roundtrips
+foreach (var product in products)
+{
+    product.Price *= 1.1m;
+    await db.SaveChangesAsync();  // Roundtrip each iteration
+}
+```
+
+### The Solution
+
+Batch changes and save once:
+
+```csharp
+// GOOD: Single roundtrip
+foreach (var product in products)
+{
+    product.Price *= 1.1m;
+}
+await db.SaveChangesAsync();
+
+// BETTER: Use ExecuteUpdate for bulk operations (EF Core 7+)
+await db.Products
+    .Where(p => p.Category == category)
+    .ExecuteUpdateAsync(s => s.SetProperty(p => p.Price, p => p.Price * 1.1m));
+```
+
+## Incorrect DbContext Lifetime
+
+### The Problem
+
+Long-lived or singleton DbContext causes memory leaks and stale data:
+
+```csharp
+// BAD: Singleton - accumulates tracked entities
+services.AddSingleton<AppDbContext>();
+
+// BAD: Static or field-level context
+public class ProductService
+{
+    private static readonly AppDbContext _db = new AppDbContext();
+}
+```
+
+### The Solution
+
+Use scoped lifetime aligned with unit of work:
+
+```csharp
+// GOOD: Scoped lifetime (default for AddDbContext)
+services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+// GOOD: Pooled for better performance
+services.AddDbContextPool<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+// For background services, create scope explicitly
+public class BackgroundProcessor : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        // Use db within this scope
+    }
+}
+```
+
+## Generic Repository Anti-Pattern
+
+### The Problem
+
+Wrapping DbContext in a generic repository hides EF Core's power:
+
+```csharp
+// BAD: Generic repository loses query composition
+public interface IRepository<T>
+{
+    Task<T> GetByIdAsync(int id);
+    Task<IEnumerable<T>> GetAllAsync();
+    Task AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(T entity);
+}
+
+// Usage - can't compose queries efficiently
+var products = await _productRepo.GetAllAsync();
+var filtered = products.Where(p => p.Price > 100);  // Client-side!
+```
+
+### The Solution
+
+Use DbContext directly or create specific query methods:
+
+```csharp
+// GOOD: Direct DbContext usage
+var products = await db.Products
+    .Where(p => p.Price > 100)
+    .OrderBy(p => p.Name)
+    .Take(20)
+    .ToListAsync();
+
+// GOOD: Specific repository with meaningful methods
+public class ProductRepository
+{
+    private readonly AppDbContext _db;
+
+    public async Task<List<Product>> GetExpensiveProductsAsync(decimal minPrice)
+    {
+        return await _db.Products
+            .Where(p => p.Price >= minPrice)
+            .OrderByDescending(p => p.Price)
+            .ToListAsync();
+    }
+}
+```
+
+## Ignoring Query Translation
+
+### The Problem
+
+Not verifying that LINQ translates to efficient SQL:
+
+```csharp
+// May not translate as expected
+var results = await db.Products
+    .Where(p => SomeComplexMethod(p))
+    .ToListAsync();
+// Could load ALL products to memory!
+```
+
+### The Solution
+
+Enable logging and verify SQL:
+
+```csharp
+// In development
+services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString)
+           .EnableSensitiveDataLogging()
+           .EnableDetailedErrors()
+           .LogTo(Console.WriteLine, LogLevel.Information));
+
+// In tests - use ToQueryString()
+var query = db.Products.Where(p => p.Price > 100);
+var sql = query.ToQueryString();
+Console.WriteLine(sql);
+```
+
+## Lazy Loading Without Understanding
+
+### The Problem
+
+Enabling lazy loading without realizing the N+1 implications:
+
+```csharp
+// Configuration enables lazy loading
+services.AddDbContext<AppDbContext>(o => o.UseLazyLoadingProxies());
+
+// BAD: Hidden N+1 queries in views/serialization
+@foreach (var order in orders)
+{
+    <p>@order.Customer.Name</p>  // Query per iteration!
+    @foreach (var item in order.Items)  // Another query per order!
+    {
+        <p>@item.Product.Name</p>  // Yet another query!
+    }
+}
+```
+
+### The Solution
+
+Disable lazy loading and use explicit strategies:
+
+```csharp
+// GOOD: Explicit eager loading for known needs
+var orders = await db.Orders
+    .Include(o => o.Customer)
+    .Include(o => o.Items)
+        .ThenInclude(i => i.Product)
+    .ToListAsync();
+
+// Or project to view model
+var orderViews = await db.Orders
+    .Select(o => new OrderViewModel
+    {
+        CustomerName = o.Customer.Name,
+        Items = o.Items.Select(i => new ItemViewModel
+        {
+            ProductName = i.Product.Name
+        }).ToList()
+    })
+    .ToListAsync();
+```
+
+## Missing Indexes
+
+### The Problem
+
+Queries filter on columns without indexes:
+
+```csharp
+// If no index on Email, this scans entire table
+var user = await db.Users
+    .FirstOrDefaultAsync(u => u.Email == email);
+
+// Composite filter without composite index
+var orders = await db.Orders
+    .Where(o => o.CustomerId == customerId && o.Status == status)
+    .ToListAsync();
+```
+
+### The Solution
+
+Add indexes for queried columns:
+
+```csharp
+public class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.HasIndex(u => u.Email).IsUnique();
+    }
+}
+
+public class OrderConfiguration : IEntityTypeConfiguration<Order>
+{
+    public void Configure(EntityTypeBuilder<Order> builder)
+    {
+        // Composite index matches query pattern
+        builder.HasIndex(o => new { o.CustomerId, o.Status });
+
+        // Filtered index for common queries
+        builder.HasIndex(o => o.CreatedAt)
+            .HasFilter("[Status] = 'Pending'");
+    }
+}
+```
+
+## Unbounded Queries
+
+### The Problem
+
+Queries that can return unlimited results:
+
+```csharp
+// BAD: Could return millions of rows
+var products = await db.Products.ToListAsync();
+
+// BAD: User-controlled search without limits
+var results = await db.Products
+    .Where(p => p.Name.Contains(searchTerm))
+    .ToListAsync();
+```
+
+### The Solution
+
+Always apply limits and pagination:
+
+```csharp
+// GOOD: Bounded results
+var products = await db.Products
+    .Take(100)
+    .ToListAsync();
+
+// GOOD: Paginated
+var results = await db.Products
+    .Where(p => p.Name.Contains(searchTerm))
+    .OrderBy(p => p.Name)
+    .Skip(page * pageSize)
+    .Take(pageSize)
+    .ToListAsync();
+```
+
+## Mixing Tracked and Untracked Entities
+
+### The Problem
+
+Attaching or mixing entities from different tracking contexts:
+
+```csharp
+// BAD: Entity from one context used in another
+var product = await db1.Products.FindAsync(id);
+db2.Products.Update(product);  // Confusion and potential errors
+await db2.SaveChangesAsync();
+
+// BAD: Mixing tracked and untracked
+var product = await db.Products.AsNoTracking().FirstAsync(p => p.Id == id);
+product.Price = newPrice;
+await db.SaveChangesAsync();  // Nothing saved - not tracked!
+```
+
+### The Solution
+
+Be consistent with tracking and context usage:
+
+```csharp
+// GOOD: Clear ownership
+var product = await db.Products.FindAsync(id);
+product.Price = newPrice;
+await db.SaveChangesAsync();
+
+// GOOD: Explicit attach for disconnected scenarios
+var product = GetProductFromDto(dto);  // Untracked
+db.Products.Update(product);  // Marks all as modified
+await db.SaveChangesAsync();
+
+// BETTER: Only update changed properties
+var product = await db.Products.FindAsync(dto.Id);
+product.Price = dto.Price;  // Only this is marked modified
+await db.SaveChangesAsync();
+```
+
+## Not Using Transactions for Multi-Step Operations
+
+### The Problem
+
+Multiple SaveChanges without transaction can leave data inconsistent:
+
+```csharp
+// BAD: Partial failure possible
+order.Status = OrderStatus.Completed;
+await db.SaveChangesAsync();
+
+inventory.Quantity -= order.Quantity;
+await db.SaveChangesAsync();  // If this fails, order status is wrong
+
+payment.Status = PaymentStatus.Captured;
+await db.SaveChangesAsync();
+```
+
+### The Solution
+
+Use explicit transactions:
+
+```csharp
+// GOOD: All-or-nothing
+using var transaction = await db.Database.BeginTransactionAsync();
+try
+{
+    order.Status = OrderStatus.Completed;
+    await db.SaveChangesAsync();
+
+    inventory.Quantity -= order.Quantity;
+    await db.SaveChangesAsync();
+
+    payment.Status = PaymentStatus.Captured;
+    await db.SaveChangesAsync();
+
+    await transaction.CommitAsync();
+}
+catch
+{
+    await transaction.RollbackAsync();
+    throw;
+}
+
+// BETTER: Single SaveChanges when possible
+order.Status = OrderStatus.Completed;
+inventory.Quantity -= order.Quantity;
+payment.Status = PaymentStatus.Captured;
+await db.SaveChangesAsync();  // All in one transaction
+```
+
+## String-Based Includes
+
+### The Problem
+
+Using string-based includes loses compile-time safety:
+
+```csharp
+// BAD: Typos not caught at compile time
+var orders = await db.Orders
+    .Include("Cusotmer")  // Typo - runtime error
+    .Include("Items.Prodcut")  // Another typo
+    .ToListAsync();
+```
+
+### The Solution
+
+Use strongly-typed lambda expressions:
+
+```csharp
+// GOOD: Compile-time safety
+var orders = await db.Orders
+    .Include(o => o.Customer)
+    .Include(o => o.Items)
+        .ThenInclude(i => i.Product)
+    .ToListAsync();
+```

--- a/.github/skills/entity-framework-core/references/patterns.md
+++ b/.github/skills/entity-framework-core/references/patterns.md
@@ -1,0 +1,377 @@
+# EF Core Query Patterns
+
+## Query Tracking Strategies
+
+### No-Tracking Queries
+
+Use `AsNoTracking()` for read-only scenarios to reduce memory overhead and improve performance:
+
+```csharp
+// Single query
+var products = await db.Products
+    .AsNoTracking()
+    .Where(p => p.IsActive)
+    .ToListAsync();
+
+// Context-wide default (useful for read-heavy contexts)
+db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+```
+
+### No-Tracking with Identity Resolution
+
+When you need consistent object references without change tracking:
+
+```csharp
+var orders = await db.Orders
+    .AsNoTrackingWithIdentityResolution()
+    .Include(o => o.Customer)
+    .Include(o => o.Items)
+    .ToListAsync();
+// Same customer object returned for orders with same customer
+```
+
+### Tracking Queries
+
+Use tracking only when you intend to modify entities:
+
+```csharp
+var product = await db.Products.FindAsync(id);
+product.Price = newPrice;
+await db.SaveChangesAsync();
+```
+
+## Loading Strategies
+
+### Eager Loading
+
+Load related data in a single query using `Include()`:
+
+```csharp
+// Single level
+var orders = await db.Orders
+    .Include(o => o.Customer)
+    .ToListAsync();
+
+// Nested includes
+var orders = await db.Orders
+    .Include(o => o.Items)
+        .ThenInclude(i => i.Product)
+            .ThenInclude(p => p.Category)
+    .ToListAsync();
+
+// Multiple includes
+var orders = await db.Orders
+    .Include(o => o.Customer)
+    .Include(o => o.ShippingAddress)
+    .Include(o => o.Items)
+    .ToListAsync();
+```
+
+### Filtered Includes (EF Core 5+)
+
+Include only specific related entities:
+
+```csharp
+var orders = await db.Orders
+    .Include(o => o.Items.Where(i => i.Quantity > 0))
+    .ToListAsync();
+
+// With ordering and limiting
+var customers = await db.Customers
+    .Include(c => c.Orders
+        .OrderByDescending(o => o.CreatedAt)
+        .Take(5))
+    .ToListAsync();
+```
+
+### Split Queries
+
+Avoid cartesian explosion with large entity graphs:
+
+```csharp
+// Without split - one large query with cartesian product
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .Include(o => o.Payments)
+    .ToListAsync();
+
+// With split - multiple smaller queries
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .Include(o => o.Payments)
+    .AsSplitQuery()
+    .ToListAsync();
+
+// Configure as default
+optionsBuilder.UseSqlServer(connectionString, o => o.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
+```
+
+### Explicit Loading
+
+Load related data on demand after the principal entity:
+
+```csharp
+var order = await db.Orders.FindAsync(orderId);
+
+// Load collection
+await db.Entry(order)
+    .Collection(o => o.Items)
+    .LoadAsync();
+
+// Load reference
+await db.Entry(order)
+    .Reference(o => o.Customer)
+    .LoadAsync();
+
+// Query into loaded navigation
+var highValueItems = await db.Entry(order)
+    .Collection(o => o.Items)
+    .Query()
+    .Where(i => i.Price > 100)
+    .ToListAsync();
+```
+
+### Lazy Loading
+
+Requires proxy setup and virtual navigation properties:
+
+```csharp
+// Setup
+services.AddDbContext<AppDbContext>(options =>
+    options.UseLazyLoadingProxies()
+           .UseSqlServer(connectionString));
+
+// Entity
+public class Order
+{
+    public int Id { get; set; }
+    public virtual Customer Customer { get; set; }  // virtual required
+    public virtual ICollection<OrderItem> Items { get; set; }
+}
+```
+
+**Warning:** Lazy loading often leads to N+1 queries. Prefer explicit strategies.
+
+## Projection Patterns
+
+### Project to DTOs
+
+Always project when you need a subset of data:
+
+```csharp
+var orderSummaries = await db.Orders
+    .Where(o => o.Status == OrderStatus.Pending)
+    .Select(o => new OrderSummaryDto
+    {
+        OrderId = o.Id,
+        CustomerName = o.Customer.Name,
+        ItemCount = o.Items.Count,
+        Total = o.Items.Sum(i => i.Quantity * i.UnitPrice),
+        CreatedAt = o.CreatedAt
+    })
+    .ToListAsync();
+```
+
+### Anonymous Projections
+
+For internal use without creating DTOs:
+
+```csharp
+var stats = await db.Products
+    .GroupBy(p => p.Category)
+    .Select(g => new
+    {
+        Category = g.Key,
+        Count = g.Count(),
+        AvgPrice = g.Average(p => p.Price),
+        MaxPrice = g.Max(p => p.Price)
+    })
+    .ToListAsync();
+```
+
+### Conditional Projection
+
+```csharp
+var products = await db.Products
+    .Select(p => new ProductDto
+    {
+        Id = p.Id,
+        Name = p.Name,
+        DisplayPrice = p.IsOnSale ? p.SalePrice : p.RegularPrice,
+        StockStatus = p.Stock > 10 ? "In Stock" : p.Stock > 0 ? "Low Stock" : "Out of Stock"
+    })
+    .ToListAsync();
+```
+
+## Compiled Queries
+
+Pre-compile frequently used queries for better performance:
+
+```csharp
+public static class CompiledQueries
+{
+    public static readonly Func<AppDbContext, int, Task<Product?>> GetProductById =
+        EF.CompileAsyncQuery((AppDbContext db, int id) =>
+            db.Products.FirstOrDefault(p => p.Id == id));
+
+    public static readonly Func<AppDbContext, string, IAsyncEnumerable<Product>> GetProductsByCategory =
+        EF.CompileAsyncQuery((AppDbContext db, string category) =>
+            db.Products.Where(p => p.Category == category));
+
+    public static readonly Func<AppDbContext, decimal, int, IAsyncEnumerable<Product>> GetExpensiveProducts =
+        EF.CompileAsyncQuery((AppDbContext db, decimal minPrice, int take) =>
+            db.Products
+                .Where(p => p.Price >= minPrice)
+                .OrderByDescending(p => p.Price)
+                .Take(take));
+}
+
+// Usage
+var product = await CompiledQueries.GetProductById(db, productId);
+
+await foreach (var p in CompiledQueries.GetProductsByCategory(db, "Electronics"))
+{
+    // Process product
+}
+```
+
+## Raw SQL Patterns
+
+### FromSql for Entity Queries
+
+```csharp
+var products = await db.Products
+    .FromSql($"SELECT * FROM Products WHERE Price > {minPrice}")
+    .ToListAsync();
+
+// Composable - can add LINQ operators
+var products = await db.Products
+    .FromSql($"SELECT * FROM Products WHERE Category = {category}")
+    .Where(p => p.IsActive)
+    .OrderBy(p => p.Name)
+    .ToListAsync();
+```
+
+### SqlQuery for Arbitrary Results (EF Core 8+)
+
+```csharp
+var totals = await db.Database
+    .SqlQuery<decimal>($"SELECT SUM(Price) FROM Products WHERE Category = {category}")
+    .ToListAsync();
+
+var stats = await db.Database
+    .SqlQuery<CategoryStats>($@"
+        SELECT Category, COUNT(*) as ProductCount, AVG(Price) as AvgPrice
+        FROM Products
+        GROUP BY Category")
+    .ToListAsync();
+```
+
+### ExecuteSql for Non-Query Operations
+
+```csharp
+var affected = await db.Database
+    .ExecuteSqlAsync($"UPDATE Products SET Price = Price * {multiplier} WHERE Category = {category}");
+```
+
+## Pagination Patterns
+
+### Offset-Based Pagination
+
+```csharp
+public async Task<PagedResult<T>> GetPageAsync<T>(
+    IQueryable<T> query,
+    int pageNumber,
+    int pageSize)
+{
+    var totalCount = await query.CountAsync();
+    var items = await query
+        .Skip(pageNumber * pageSize)
+        .Take(pageSize)
+        .ToListAsync();
+
+    return new PagedResult<T>
+    {
+        Items = items,
+        TotalCount = totalCount,
+        PageNumber = pageNumber,
+        PageSize = pageSize,
+        TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize)
+    };
+}
+```
+
+### Keyset Pagination (Better for Large Datasets)
+
+```csharp
+// More efficient for deep pages - uses index instead of offset
+public async Task<List<Product>> GetNextPageAsync(int lastId, int pageSize)
+{
+    return await db.Products
+        .Where(p => p.Id > lastId)
+        .OrderBy(p => p.Id)
+        .Take(pageSize)
+        .ToListAsync();
+}
+
+// Bidirectional keyset pagination
+public async Task<List<Product>> GetPreviousPageAsync(int firstId, int pageSize)
+{
+    return await db.Products
+        .Where(p => p.Id < firstId)
+        .OrderByDescending(p => p.Id)
+        .Take(pageSize)
+        .OrderBy(p => p.Id)  // Restore ascending order
+        .ToListAsync();
+}
+```
+
+## Global Query Filters
+
+Apply filters automatically to all queries:
+
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+{
+    // Soft delete filter
+    modelBuilder.Entity<Product>()
+        .HasQueryFilter(p => !p.IsDeleted);
+
+    // Multi-tenant filter
+    modelBuilder.Entity<Order>()
+        .HasQueryFilter(o => o.TenantId == _tenantId);
+}
+
+// Bypass when needed
+var allProducts = await db.Products
+    .IgnoreQueryFilters()
+    .ToListAsync();
+```
+
+## Temporal Tables (EF Core 6+)
+
+Query historical data:
+
+```csharp
+// Configure temporal table
+modelBuilder.Entity<Product>()
+    .ToTable("Products", b => b.IsTemporal());
+
+// Query as of specific time
+var historicalProducts = await db.Products
+    .TemporalAsOf(specificDateTime)
+    .ToListAsync();
+
+// Query between time range
+var productHistory = await db.Products
+    .TemporalBetween(startDate, endDate)
+    .Where(p => p.Id == productId)
+    .ToListAsync();
+
+// Get all changes
+var allChanges = await db.Products
+    .TemporalAll()
+    .Where(p => p.Id == productId)
+    .OrderBy(p => EF.Property<DateTime>(p, "PeriodStart"))
+    .ToListAsync();
+```

--- a/.github/skills/grpc/SKILL.md
+++ b/.github/skills/grpc/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: grpc
+description: "Build or review gRPC services and clients in .NET. USE FOR: ASP.NET Core gRPC, protobuf contracts, unary or streaming RPC, gRPC client factory, interceptors, deadlines, cancellation, channel reuse, backend service integration. DO NOT USE FOR: broad browser-facing APIs without gRPC-Web tradeoff review, SignalR realtime hubs, plain REST APIs. INVOKES: dotnet build/test and focused service or client smoke checks when code changes."
+compatibility: "Requires ASP.NET Core gRPC or gRPC client projects."
+---
+
+# gRPC for .NET
+
+## Trigger On
+
+- building backend-to-backend RPC services or clients
+- adding protobuf contracts, streaming calls, or interceptors
+- deciding between gRPC, HTTP APIs, and SignalR
+- optimizing gRPC performance, deadlines, cancellation, or connection reuse
+- integrating service-to-service communication in microservices
+
+## Do Not Use For
+
+- public browser-first APIs unless gRPC-Web limitations are explicitly acceptable
+- SignalR hub design, realtime UI fan-out, or websocket-style client collaboration
+- generic ASP.NET Core minimal APIs or REST controllers with no protobuf/RPC requirement
+- non-.NET gRPC work unless the user asks for cross-stack contract guidance
+
+## Load References
+
+- [references/patterns.md](references/patterns.md) for proto design, streaming implementations, interceptors, health checks, load balancing, and client factory setup.
+- [references/anti-patterns.md](references/anti-patterns.md) for common channel, deadline, streaming, message-size, and exception-handling mistakes.
+
+## Workflow
+
+1. Validate the architecture fit before touching code.
+   - prefer gRPC for backend RPC, strong contracts, low-latency calls, or streaming
+   - prefer REST or minimal APIs for broad browser compatibility and loosely coupled public APIs
+   - prefer SignalR for browser/client realtime fan-out and UI collaboration
+2. Treat `.proto` files as the source of truth.
+   - keep package names, `csharp_namespace`, service names, and versioning deliberate
+   - reserve removed field numbers and avoid reusing tags
+   - use wrapper types or explicit messages when optionality matters
+3. Choose the RPC shape from the interaction model.
+   - unary for request/response
+   - server streaming for large or progressive result sets
+   - client streaming for uploads or batches
+   - bidirectional streaming for coordinated two-way flows
+4. Wire server and client behavior together.
+   - register services with `AddGrpc`
+   - use `AddGrpcClient` or long-lived `GrpcChannel` reuse
+   - set deadlines and propagate cancellation
+   - convert domain failures to appropriate `RpcException` status codes
+5. Add observability and resilience where the boundary justifies it.
+   - logging or exception interceptors
+   - OpenTelemetry traces and status-code metrics
+   - retry policy only for safe idempotent calls
+6. Validate with the repo's normal build and tests, plus a focused smoke call when runnable.
+
+```mermaid
+flowchart LR
+  A["RPC requirement"] --> B["proto contract"]
+  B --> C["server implementation"]
+  B --> D["client factory or channel"]
+  C --> E["deadlines / cancellation / status codes"]
+  D --> E
+  E --> F["build, tests, smoke call"]
+```
+
+## Examples
+
+Use client factory for normal app integration:
+
+```csharp
+builder.Services.AddGrpcClient<Greeter.GreeterClient>(options =>
+{
+    options.Address = new Uri("https://localhost:5001");
+});
+```
+
+Always set a deadline and pass cancellation:
+
+```csharp
+var response = await client.SayHelloAsync(
+    new HelloRequest { Name = name },
+    deadline: DateTime.UtcNow.AddSeconds(5),
+    cancellationToken: cancellationToken);
+```
+
+For streaming, check cancellation inside the read/write loop and keep message sizes bounded. Load [references/patterns.md](references/patterns.md) before writing detailed streaming code.
+
+## Anti-Patterns
+
+- creating a new `GrpcChannel` per call
+- omitting deadlines and relying only on client-side cancellation
+- ignoring `ServerCallContext.CancellationToken` in streaming handlers
+- sending large single messages instead of chunking or streaming
+- using gRPC as the default public browser API
+- swallowing exceptions inside interceptors
+- retrying non-idempotent calls without explicit policy
+
+## Deliver
+
+- stable protobuf contracts and generated-code ownership
+- service and client code that match the RPC shape
+- explicit deadline, cancellation, retry, and status-code behavior
+- tests or smoke checks for serialization and call behavior
+- documentation of browser, transport, or deployment constraints when relevant
+
+## Validate
+
+- `dotnet build` succeeds after contract or generated-code changes
+- tests or smoke checks exercise at least one server/client call
+- streaming methods respect cancellation and bounded message sizes
+- channels are reused through client factory or a long-lived channel
+- status-code handling is intentional and observable
+- browser constraints are documented if gRPC-Web is involved

--- a/.github/skills/grpc/manifest.json
+++ b/.github/skills/grpc/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "category": "Web",
+  "package_prefix": "Grpc"
+}

--- a/.github/skills/grpc/references/anti-patterns.md
+++ b/.github/skills/grpc/references/anti-patterns.md
@@ -1,0 +1,898 @@
+# gRPC Anti-Patterns Reference
+
+This document catalogs common mistakes when building gRPC services and clients in .NET, with explanations and corrections.
+
+## Connection and Channel Anti-Patterns
+
+### Creating a New Channel Per Call
+
+```csharp
+// WRONG: Creating channel per call
+public async Task<string> GetGreetingAsync(string name)
+{
+    using var channel = GrpcChannel.ForAddress("https://localhost:5001");
+    var client = new Greeter.GreeterClient(channel);
+    var reply = await client.SayHelloAsync(new HelloRequest { Name = name });
+    return reply.Message;
+}
+```
+
+**Why it's bad:**
+- HTTP/2 connection establishment is expensive (TLS handshake, SETTINGS exchange)
+- Prevents connection pooling and multiplexing
+- Kills performance under load
+- Causes connection churn on the server
+
+**Correct approach:**
+```csharp
+// CORRECT: Use client factory for channel reuse
+builder.Services.AddGrpcClient<Greeter.GreeterClient>(options =>
+{
+    options.Address = new Uri("https://localhost:5001");
+});
+
+// Or manage singleton channel manually
+public class GrpcClientService
+{
+    private static readonly GrpcChannel _channel =
+        GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions
+        {
+            HttpHandler = new SocketsHttpHandler
+            {
+                EnableMultipleHttp2Connections = true,
+                PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
+                KeepAlivePingDelay = TimeSpan.FromSeconds(60),
+                KeepAlivePingTimeout = TimeSpan.FromSeconds(30)
+            }
+        });
+
+    private readonly Greeter.GreeterClient _client = new(_channel);
+
+    public Task<HelloReply> SayHelloAsync(HelloRequest request) =>
+        _client.SayHelloAsync(request).ResponseAsync;
+}
+```
+
+### Disposing Channel After Every Call
+
+```csharp
+// WRONG: Disposing channel immediately
+public async Task DoWorkAsync()
+{
+    var channel = GrpcChannel.ForAddress("https://localhost:5001");
+    try
+    {
+        var client = new Greeter.GreeterClient(channel);
+        await client.SayHelloAsync(new HelloRequest { Name = "World" });
+    }
+    finally
+    {
+        await channel.ShutdownAsync(); // Kills connection reuse
+    }
+}
+```
+
+**Why it's bad:**
+- ShutdownAsync closes all HTTP/2 connections
+- Subsequent calls must re-establish connections
+- Negates HTTP/2 multiplexing benefits
+
+**Correct approach:**
+```csharp
+// CORRECT: Channel lives for application lifetime
+public class ChannelManager : IAsyncDisposable
+{
+    private readonly GrpcChannel _channel;
+
+    public ChannelManager(string address)
+    {
+        _channel = GrpcChannel.ForAddress(address);
+    }
+
+    public GrpcChannel Channel => _channel;
+
+    public async ValueTask DisposeAsync()
+    {
+        await _channel.ShutdownAsync();
+    }
+}
+
+// Register as singleton
+builder.Services.AddSingleton(sp =>
+    new ChannelManager("https://localhost:5001"));
+```
+
+## Deadline and Timeout Anti-Patterns
+
+### Missing Deadlines on Client Calls
+
+```csharp
+// WRONG: No deadline set
+var response = await client.ProcessOrderAsync(new OrderRequest { OrderId = orderId });
+```
+
+**Why it's bad:**
+- Calls can hang indefinitely if server is slow or network fails
+- No way to enforce timeout at the gRPC level
+- Can cause thread/connection exhaustion under load
+
+**Correct approach:**
+```csharp
+// CORRECT: Always set a deadline
+var deadline = DateTime.UtcNow.AddSeconds(10);
+var response = await client.ProcessOrderAsync(
+    new OrderRequest { OrderId = orderId },
+    deadline: deadline);
+
+// Or use CallOptions for more control
+var options = new CallOptions(deadline: DateTime.UtcNow.AddSeconds(10));
+var response = await client.ProcessOrderAsync(new OrderRequest { OrderId = orderId }, options);
+```
+
+### Using CancellationToken Instead of Deadline
+
+```csharp
+// WRONG: CancellationToken alone doesn't signal the server
+var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+var response = await client.ProcessOrderAsync(request, cancellationToken: cts.Token);
+```
+
+**Why it's bad:**
+- CancellationToken only cancels client-side
+- Server continues processing, wasting resources
+- Deadline is transmitted to server, CancellationToken is not
+
+**Correct approach:**
+```csharp
+// CORRECT: Use deadline AND cancellation token
+var deadline = DateTime.UtcNow.AddSeconds(10);
+var response = await client.ProcessOrderAsync(
+    request,
+    deadline: deadline,
+    cancellationToken: cancellationToken);
+```
+
+### Mismatched Client/Server Deadlines
+
+```csharp
+// WRONG: Server deadline longer than client
+// Client sets 5 second deadline
+var deadline = DateTime.UtcNow.AddSeconds(5);
+var response = await client.ProcessAsync(request, deadline: deadline);
+
+// Server handler takes up to 30 seconds
+public override async Task<Response> Process(Request request, ServerCallContext context)
+{
+    await LongRunningOperation(TimeSpan.FromSeconds(30)); // Client already timed out
+    return new Response();
+}
+```
+
+**Why it's bad:**
+- Server wastes resources after client has given up
+- Results are computed but never delivered
+- No coordinated timeout behavior
+
+**Correct approach:**
+```csharp
+// CORRECT: Server respects incoming deadline
+public override async Task<Response> Process(Request request, ServerCallContext context)
+{
+    // Check remaining time before expensive operations
+    var remaining = context.Deadline - DateTime.UtcNow;
+    if (remaining < TimeSpan.FromSeconds(1))
+    {
+        throw new RpcException(new Status(StatusCode.DeadlineExceeded, "Insufficient time"));
+    }
+
+    using var cts = CancellationTokenSource.CreateLinkedTokenSource(context.CancellationToken);
+    cts.CancelAfter(remaining - TimeSpan.FromMilliseconds(100)); // Buffer for response
+
+    await ProcessWithTimeoutAsync(request, cts.Token);
+    return new Response();
+}
+```
+
+## Streaming Anti-Patterns
+
+### Ignoring Cancellation in Streaming Handlers
+
+```csharp
+// WRONG: Not checking cancellation
+public override async Task StreamData(
+    DataRequest request,
+    IServerStreamWriter<DataChunk> responseStream,
+    ServerCallContext context)
+{
+    var items = await GetAllItemsAsync(); // Could be millions
+    foreach (var item in items)
+    {
+        await responseStream.WriteAsync(item); // Continues even if client disconnects
+    }
+}
+```
+
+**Why it's bad:**
+- Server continues processing after client disconnects
+- Wastes CPU, memory, and network resources
+- Can cause resource exhaustion under load
+
+**Correct approach:**
+```csharp
+// CORRECT: Check cancellation regularly
+public override async Task StreamData(
+    DataRequest request,
+    IServerStreamWriter<DataChunk> responseStream,
+    ServerCallContext context)
+{
+    await foreach (var item in GetItemsAsync(context.CancellationToken))
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
+        await responseStream.WriteAsync(item, context.CancellationToken);
+    }
+}
+```
+
+### Not Completing Client Streams
+
+```csharp
+// WRONG: Forgetting to complete the request stream
+public async Task UploadDataAsync(IEnumerable<DataChunk> chunks)
+{
+    using var call = _client.UploadData();
+
+    foreach (var chunk in chunks)
+    {
+        await call.RequestStream.WriteAsync(chunk);
+    }
+
+    // Missing: await call.RequestStream.CompleteAsync();
+    var response = await call.ResponseAsync; // Hangs forever
+}
+```
+
+**Why it's bad:**
+- Server waits indefinitely for more messages
+- Call never completes
+- Resources are held until timeout
+
+**Correct approach:**
+```csharp
+// CORRECT: Always complete client streams
+public async Task UploadDataAsync(IEnumerable<DataChunk> chunks)
+{
+    using var call = _client.UploadData();
+
+    foreach (var chunk in chunks)
+    {
+        await call.RequestStream.WriteAsync(chunk);
+    }
+
+    await call.RequestStream.CompleteAsync(); // Signal end of stream
+    var response = await call.ResponseAsync;
+}
+```
+
+### Blocking on Bidirectional Streams
+
+```csharp
+// WRONG: Sequential read/write in bidirectional stream
+public async Task ChatAsync()
+{
+    using var call = _client.Chat();
+
+    while (true)
+    {
+        var message = await GetNextMessageAsync();
+        await call.RequestStream.WriteAsync(message);
+
+        // Blocks until response arrives - can't send another message until then
+        var response = await call.ResponseStream.MoveNext();
+    }
+}
+```
+
+**Why it's bad:**
+- Serializes what should be concurrent operations
+- Loses bidirectional streaming benefits
+- Can deadlock if server expects multiple requests before responding
+
+**Correct approach:**
+```csharp
+// CORRECT: Concurrent read and write
+public async Task ChatAsync(CancellationToken ct)
+{
+    using var call = _client.Chat();
+
+    var readTask = Task.Run(async () =>
+    {
+        await foreach (var response in call.ResponseStream.ReadAllAsync(ct))
+        {
+            ProcessResponse(response);
+        }
+    }, ct);
+
+    var writeTask = Task.Run(async () =>
+    {
+        await foreach (var message in GetMessagesAsync(ct))
+        {
+            await call.RequestStream.WriteAsync(message);
+        }
+        await call.RequestStream.CompleteAsync();
+    }, ct);
+
+    await Task.WhenAll(readTask, writeTask);
+}
+```
+
+## Message Size Anti-Patterns
+
+### Sending Large Messages
+
+```csharp
+// WRONG: Sending multi-MB payloads
+message FileUploadRequest {
+  bytes content = 1; // Could be hundreds of MB
+  string filename = 2;
+}
+
+public async Task UploadFileAsync(byte[] fileContent)
+{
+    await _client.UploadFileAsync(new FileUploadRequest
+    {
+        Content = ByteString.CopyFrom(fileContent), // LOH allocation
+        Filename = "large-file.zip"
+    });
+}
+```
+
+**Why it's bad:**
+- Large messages cause Large Object Heap allocations
+- Memory fragmentation and GC pressure
+- Can exceed default message size limits (4MB)
+- Single-request timeout affects entire transfer
+
+**Correct approach:**
+```csharp
+// CORRECT: Use streaming for large data
+service FileService {
+  rpc UploadFile (stream FileChunk) returns (UploadResponse);
+}
+
+message FileChunk {
+  oneof data {
+    FileMetadata metadata = 1;
+    bytes chunk = 2;
+  }
+}
+
+public async Task UploadFileAsync(string filePath, CancellationToken ct)
+{
+    using var call = _client.UploadFile();
+
+    // Send metadata first
+    await call.RequestStream.WriteAsync(new FileChunk
+    {
+        Metadata = new FileMetadata { Filename = Path.GetFileName(filePath) }
+    });
+
+    // Stream file in chunks
+    await using var stream = File.OpenRead(filePath);
+    var buffer = new byte[64 * 1024]; // 64KB chunks
+    int bytesRead;
+
+    while ((bytesRead = await stream.ReadAsync(buffer, ct)) > 0)
+    {
+        await call.RequestStream.WriteAsync(new FileChunk
+        {
+            Chunk = ByteString.CopyFrom(buffer, 0, bytesRead)
+        });
+    }
+
+    await call.RequestStream.CompleteAsync();
+    var response = await call.ResponseAsync;
+}
+```
+
+## Error Handling Anti-Patterns
+
+### Swallowing Exceptions
+
+```csharp
+// WRONG: Swallowing exceptions returns OK status
+public override async Task<OrderResponse> CreateOrder(OrderRequest request, ServerCallContext context)
+{
+    try
+    {
+        await _repository.CreateOrderAsync(request);
+        return new OrderResponse { Success = true };
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Order creation failed");
+        return new OrderResponse { Success = false }; // Client sees OK status
+    }
+}
+```
+
+**Why it's bad:**
+- Client receives OK status despite failure
+- Error details lost in response message
+- Client retry logic doesn't trigger
+- Breaks gRPC error handling conventions
+
+**Correct approach:**
+```csharp
+// CORRECT: Convert exceptions to appropriate status codes
+public override async Task<OrderResponse> CreateOrder(OrderRequest request, ServerCallContext context)
+{
+    try
+    {
+        await _repository.CreateOrderAsync(request);
+        return new OrderResponse { Success = true };
+    }
+    catch (ValidationException ex)
+    {
+        throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));
+    }
+    catch (DuplicateOrderException ex)
+    {
+        throw new RpcException(new Status(StatusCode.AlreadyExists, ex.Message));
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Order creation failed");
+        throw new RpcException(new Status(StatusCode.Internal, "An error occurred"));
+    }
+}
+```
+
+### Using Wrong Status Codes
+
+```csharp
+// WRONG: Using Internal for everything
+catch (KeyNotFoundException)
+{
+    throw new RpcException(new Status(StatusCode.Internal, "Not found")); // Should be NotFound
+}
+catch (UnauthorizedAccessException)
+{
+    throw new RpcException(new Status(StatusCode.Internal, "Access denied")); // Should be PermissionDenied
+}
+catch (ArgumentException)
+{
+    throw new RpcException(new Status(StatusCode.Internal, "Bad argument")); // Should be InvalidArgument
+}
+```
+
+**Why it's bad:**
+- Clients can't distinguish error types
+- Retry policies may retry non-retryable errors
+- Metrics and monitoring lose granularity
+
+**Correct approach:**
+```csharp
+// CORRECT: Map to appropriate gRPC status codes
+public static class ExceptionMapping
+{
+    public static RpcException ToRpcException(Exception ex) => ex switch
+    {
+        ArgumentException e => new RpcException(new Status(StatusCode.InvalidArgument, e.Message)),
+        KeyNotFoundException e => new RpcException(new Status(StatusCode.NotFound, e.Message)),
+        UnauthorizedAccessException e => new RpcException(new Status(StatusCode.PermissionDenied, e.Message)),
+        InvalidOperationException e => new RpcException(new Status(StatusCode.FailedPrecondition, e.Message)),
+        NotImplementedException e => new RpcException(new Status(StatusCode.Unimplemented, e.Message)),
+        OperationCanceledException e => new RpcException(new Status(StatusCode.Cancelled, e.Message)),
+        TimeoutException e => new RpcException(new Status(StatusCode.DeadlineExceeded, e.Message)),
+        _ => new RpcException(new Status(StatusCode.Internal, "An internal error occurred"))
+    };
+}
+```
+
+### Leaking Sensitive Information in Error Details
+
+```csharp
+// WRONG: Including stack trace and internal details
+catch (Exception ex)
+{
+    throw new RpcException(new Status(
+        StatusCode.Internal,
+        $"Failed: {ex.Message}\n{ex.StackTrace}\nConnection: {_connectionString}"));
+}
+```
+
+**Why it's bad:**
+- Exposes internal implementation details
+- May leak sensitive data (connection strings, paths)
+- Security vulnerability
+
+**Correct approach:**
+```csharp
+// CORRECT: Log details server-side, return safe message
+catch (Exception ex)
+{
+    var errorId = Guid.NewGuid();
+    _logger.LogError(ex, "Error {ErrorId}: {Message}", errorId, ex.Message);
+
+    var message = _environment.IsDevelopment()
+        ? ex.Message
+        : $"An error occurred. Reference: {errorId}";
+
+    throw new RpcException(new Status(StatusCode.Internal, message));
+}
+```
+
+## Interceptor Anti-Patterns
+
+### Blocking in Interceptors
+
+```csharp
+// WRONG: Synchronous blocking in async interceptor
+public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+    TRequest request,
+    ClientInterceptorContext<TRequest, TResponse> context,
+    AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+{
+    // Blocking call - ties up thread pool
+    var token = _tokenService.GetTokenAsync().Result; // NEVER do this
+
+    var headers = context.Options.Headers ?? new Metadata();
+    headers.Add("authorization", $"Bearer {token}");
+
+    return continuation(request, context);
+}
+```
+
+**Why it's bad:**
+- Blocks thread pool threads
+- Can cause thread pool starvation
+- Degrades application throughput
+
+**Correct approach:**
+```csharp
+// CORRECT: Handle async properly in interceptor
+public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+    TRequest request,
+    ClientInterceptorContext<TRequest, TResponse> context,
+    AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+{
+    // Get token synchronously if possible, or wrap the response
+    var call = continuation(request, context);
+
+    return new AsyncUnaryCall<TResponse>(
+        AddAuthAndCallAsync(request, context, call.ResponseAsync),
+        call.ResponseHeadersAsync,
+        call.GetStatus,
+        call.GetTrailers,
+        call.Dispose);
+}
+
+private async Task<TResponse> AddAuthAndCallAsync<TRequest, TResponse>(
+    TRequest request,
+    ClientInterceptorContext<TRequest, TResponse> context,
+    Task<TResponse> responseTask)
+{
+    // Can await safely here
+    var token = await _tokenService.GetTokenAsync();
+    // Note: Headers are already sent at this point, so this pattern
+    // requires restructuring to modify context before continuation
+    return await responseTask;
+}
+```
+
+### Incomplete Interceptor Implementation
+
+```csharp
+// WRONG: Only implementing UnaryServerHandler
+public class AuthInterceptor : Interceptor
+{
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthAsync(context);
+        return await continuation(request, context);
+    }
+
+    // Missing: ServerStreamingServerHandler, ClientStreamingServerHandler,
+    // DuplexStreamingServerHandler - streaming calls bypass auth!
+}
+```
+
+**Why it's bad:**
+- Streaming calls bypass the interceptor logic
+- Security holes in streaming endpoints
+- Inconsistent behavior
+
+**Correct approach:**
+```csharp
+// CORRECT: Implement all relevant interceptor methods
+public class AuthInterceptor : Interceptor
+{
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthAsync(context);
+        return await continuation(request, context);
+    }
+
+    public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthAsync(context);
+        await continuation(request, responseStream, context);
+    }
+
+    public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        ServerCallContext context,
+        ClientStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthAsync(context);
+        return await continuation(requestStream, context);
+    }
+
+    public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthAsync(context);
+        await continuation(requestStream, responseStream, context);
+    }
+}
+```
+
+## Proto Design Anti-Patterns
+
+### Using Primitives for Optional Fields
+
+```protobuf
+// WRONG: Primitives have default values, not null
+message SearchRequest {
+  int32 page_size = 1;    // 0 means unset OR 0?
+  bool include_deleted = 2; // false means unset OR false?
+}
+```
+
+**Why it's bad:**
+- Can't distinguish "not set" from "set to default value"
+- Forces awkward conventions (e.g., -1 means unset)
+- Proto3 removed "required" and made all fields optional with defaults
+
+**Correct approach:**
+```protobuf
+// CORRECT: Use wrapper types for optional primitives
+import "google/protobuf/wrappers.proto";
+
+message SearchRequest {
+  google.protobuf.Int32Value page_size = 1;    // null means unset
+  google.protobuf.BoolValue include_deleted = 2; // null means unset
+}
+
+// Or use explicit presence with optional keyword (proto3 optional)
+message SearchRequest {
+  optional int32 page_size = 1;
+  optional bool include_deleted = 2;
+}
+```
+
+### Reusing Field Numbers
+
+```protobuf
+// VERSION 1
+message User {
+  string id = 1;
+  string email = 2;
+  string phone = 3; // Later removed
+}
+
+// VERSION 2 - WRONG
+message User {
+  string id = 1;
+  string email = 2;
+  string address = 3; // Reused field 3 - breaks wire compatibility
+}
+```
+
+**Why it's bad:**
+- Old clients deserialize address bytes as phone string
+- Silent data corruption
+- Breaks backward compatibility
+
+**Correct approach:**
+```protobuf
+// VERSION 2 - CORRECT
+message User {
+  string id = 1;
+  string email = 2;
+  reserved 3;
+  reserved "phone";
+  string address = 4; // New field number
+}
+```
+
+### Flat Request Messages
+
+```protobuf
+// WRONG: Flat request makes evolution difficult
+service OrderService {
+  rpc CreateOrder (CreateOrderRequest) returns (CreateOrderResponse);
+}
+
+message CreateOrderRequest {
+  string customer_id = 1;
+  string product_id = 2;
+  int32 quantity = 3;
+  string shipping_street = 4;
+  string shipping_city = 5;
+  string shipping_country = 6;
+  // Adding billing address requires many new fields
+}
+```
+
+**Why it's bad:**
+- Hard to add related groups of fields
+- No reuse across messages
+- Field explosion over time
+
+**Correct approach:**
+```protobuf
+// CORRECT: Nested messages for structured data
+message CreateOrderRequest {
+  string customer_id = 1;
+  OrderDetails order = 2;
+  Address shipping_address = 3;
+  Address billing_address = 4; // Easy to add
+}
+
+message OrderDetails {
+  repeated OrderItem items = 1;
+}
+
+message OrderItem {
+  string product_id = 1;
+  int32 quantity = 2;
+}
+
+message Address {
+  string street = 1;
+  string city = 2;
+  string country = 3;
+  string postal_code = 4;
+}
+```
+
+## Configuration Anti-Patterns
+
+### Not Configuring HTTP/2 Limits
+
+```csharp
+// WRONG: Using defaults that may not match your workload
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddGrpc(); // Default limits
+```
+
+**Why it's bad:**
+- Default stream limits may be too low for your traffic
+- Window sizes may cause unnecessary backpressure
+- Keep-alive not configured for long-lived connections
+
+**Correct approach:**
+```csharp
+// CORRECT: Configure HTTP/2 settings appropriately
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.Http2.MaxStreamsPerConnection = 250;
+    options.Limits.Http2.InitialConnectionWindowSize = 1024 * 1024; // 1MB
+    options.Limits.Http2.InitialStreamWindowSize = 768 * 1024; // 768KB
+    options.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(30);
+    options.Limits.Http2.KeepAlivePingTimeout = TimeSpan.FromSeconds(10);
+});
+```
+
+### Ignoring Keep-Alive Configuration
+
+```csharp
+// WRONG: No keep-alive configuration
+var channel = GrpcChannel.ForAddress("https://server:5001");
+```
+
+**Why it's bad:**
+- Connections may be silently closed by proxies/load balancers
+- First call after idle period fails
+- No detection of dead connections
+
+**Correct approach:**
+```csharp
+// CORRECT: Configure keep-alive
+var channel = GrpcChannel.ForAddress("https://server:5001", new GrpcChannelOptions
+{
+    HttpHandler = new SocketsHttpHandler
+    {
+        KeepAlivePingDelay = TimeSpan.FromSeconds(60),
+        KeepAlivePingTimeout = TimeSpan.FromSeconds(30),
+        PooledConnectionIdleTimeout = Timeout.InfiniteTimeSpan,
+        EnableMultipleHttp2Connections = true
+    }
+});
+```
+
+## Testing Anti-Patterns
+
+### Testing with Real Network Calls
+
+```csharp
+// WRONG: Integration test depends on real server
+[Fact]
+public async Task CreateOrder_WithValidData_ReturnsSuccess()
+{
+    var channel = GrpcChannel.ForAddress("https://localhost:5001");
+    var client = new Orders.OrdersClient(channel);
+
+    var response = await client.CreateOrderAsync(new CreateOrderRequest
+    {
+        CustomerId = "test-customer"
+    });
+
+    Assert.True(response.Success);
+}
+```
+
+**Why it's bad:**
+- Tests depend on external server
+- Flaky due to network issues
+- Slow test execution
+- Can't test edge cases easily
+
+**Correct approach:**
+```csharp
+// CORRECT: Use TestServer or mocks
+[Fact]
+public async Task CreateOrder_WithValidData_ReturnsSuccess()
+{
+    await using var factory = new WebApplicationFactory<Program>();
+    using var channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+    {
+        HttpHandler = factory.Server.CreateHandler()
+    });
+
+    var client = new Orders.OrdersClient(channel);
+
+    var response = await client.CreateOrderAsync(new CreateOrderRequest
+    {
+        CustomerId = "test-customer"
+    });
+
+    Assert.True(response.Success);
+}
+
+// Or use Moq with generated client interface
+[Fact]
+public async Task ProcessOrder_CallsService()
+{
+    var mockClient = new Mock<IOrdersClient>();
+    mockClient
+        .Setup(x => x.CreateOrderAsync(It.IsAny<CreateOrderRequest>(), null, null, default))
+        .Returns(new AsyncUnaryCall<CreateOrderResponse>(
+            Task.FromResult(new CreateOrderResponse { Success = true }),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { }));
+
+    var service = new OrderProcessor(mockClient.Object);
+    await service.ProcessAsync();
+
+    mockClient.Verify(x => x.CreateOrderAsync(
+        It.Is<CreateOrderRequest>(r => r.CustomerId == "expected"),
+        null, null, default), Times.Once);
+}
+```

--- a/.github/skills/grpc/references/patterns.md
+++ b/.github/skills/grpc/references/patterns.md
@@ -1,0 +1,772 @@
+# gRPC Patterns Reference
+
+This document provides detailed patterns for gRPC services in .NET, covering proto design, streaming implementations, and interceptor patterns.
+
+## Proto File Patterns
+
+### Service Definition Best Practices
+
+```protobuf
+syntax = "proto3";
+
+package mycompany.orders.v1;
+
+option csharp_namespace = "MyCompany.Orders.V1";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/empty.proto";
+
+// Version services explicitly for breaking changes
+service OrderService {
+  // Unary RPC for simple request-response
+  rpc CreateOrder (CreateOrderRequest) returns (CreateOrderResponse);
+
+  // Server streaming for large result sets
+  rpc ListOrders (ListOrdersRequest) returns (stream OrderItem);
+
+  // Client streaming for batch uploads
+  rpc UploadOrders (stream CreateOrderRequest) returns (UploadOrdersResponse);
+
+  // Bidirectional streaming for real-time sync
+  rpc SyncOrders (stream OrderSyncMessage) returns (stream OrderSyncMessage);
+}
+```
+
+### Message Design Patterns
+
+```protobuf
+// Use wrapper types for optional primitives
+message OrderFilter {
+  google.protobuf.StringValue customer_id = 1;
+  google.protobuf.Int32Value min_quantity = 2;
+  google.protobuf.BoolValue is_active = 3;
+}
+
+// Wrap request fields in objects for extensibility
+message CreateOrderRequest {
+  OrderDetails order = 1;
+  RequestMetadata metadata = 2;
+}
+
+message OrderDetails {
+  string customer_id = 1;
+  repeated OrderLineItem items = 2;
+  ShippingAddress address = 3;
+}
+
+// Use oneof for mutually exclusive fields
+message PaymentMethod {
+  oneof method {
+    CreditCard credit_card = 1;
+    BankTransfer bank_transfer = 2;
+    DigitalWallet digital_wallet = 3;
+  }
+}
+
+// Reserve removed field numbers to prevent reuse
+message Order {
+  string id = 1;
+  string customer_id = 2;
+  // Field 3 was deprecated_field
+  reserved 3;
+  reserved "deprecated_field";
+  OrderStatus status = 4;
+}
+
+// Use enums with explicit zero value as unknown/default
+enum OrderStatus {
+  ORDER_STATUS_UNSPECIFIED = 0;
+  ORDER_STATUS_PENDING = 1;
+  ORDER_STATUS_CONFIRMED = 2;
+  ORDER_STATUS_SHIPPED = 3;
+  ORDER_STATUS_DELIVERED = 4;
+  ORDER_STATUS_CANCELLED = 5;
+}
+```
+
+### Pagination Pattern
+
+```protobuf
+message ListOrdersRequest {
+  int32 page_size = 1;
+  string page_token = 2;
+  OrderFilter filter = 3;
+}
+
+message ListOrdersResponse {
+  repeated Order orders = 1;
+  string next_page_token = 2;
+  int32 total_count = 3;
+}
+```
+
+## Streaming Patterns
+
+### Server Streaming with Backpressure
+
+```csharp
+public override async Task StreamOrders(
+    ListOrdersRequest request,
+    IServerStreamWriter<Order> responseStream,
+    ServerCallContext context)
+{
+    var batchSize = 100;
+    var lastId = string.Empty;
+
+    while (!context.CancellationToken.IsCancellationRequested)
+    {
+        var orders = await _repository.GetOrdersBatchAsync(
+            lastId,
+            batchSize,
+            context.CancellationToken);
+
+        if (orders.Count == 0)
+            break;
+
+        foreach (var order in orders)
+        {
+            // WriteAsync handles backpressure automatically
+            await responseStream.WriteAsync(order, context.CancellationToken);
+            lastId = order.Id;
+        }
+
+        // Optional: yield control to prevent starvation
+        await Task.Yield();
+    }
+}
+```
+
+### Client Streaming with Batching
+
+```csharp
+public override async Task<UploadOrdersResponse> UploadOrders(
+    IAsyncStreamReader<CreateOrderRequest> requestStream,
+    ServerCallContext context)
+{
+    var batch = new List<CreateOrderRequest>();
+    var batchSize = 100;
+    var totalProcessed = 0;
+    var errors = new List<string>();
+
+    await foreach (var request in requestStream.ReadAllAsync(context.CancellationToken))
+    {
+        batch.Add(request);
+
+        if (batch.Count >= batchSize)
+        {
+            var result = await ProcessBatchAsync(batch, context.CancellationToken);
+            totalProcessed += result.SuccessCount;
+            errors.AddRange(result.Errors);
+            batch.Clear();
+        }
+    }
+
+    // Process remaining items
+    if (batch.Count > 0)
+    {
+        var result = await ProcessBatchAsync(batch, context.CancellationToken);
+        totalProcessed += result.SuccessCount;
+        errors.AddRange(result.Errors);
+    }
+
+    return new UploadOrdersResponse
+    {
+        ProcessedCount = totalProcessed,
+        ErrorCount = errors.Count,
+        Errors = { errors.Take(10) }
+    };
+}
+```
+
+### Bidirectional Streaming with Concurrent Processing
+
+```csharp
+public override async Task SyncOrders(
+    IAsyncStreamReader<OrderSyncMessage> requestStream,
+    IServerStreamWriter<OrderSyncMessage> responseStream,
+    ServerCallContext context)
+{
+    var pendingResponses = Channel.CreateUnbounded<OrderSyncMessage>();
+
+    // Writer task - sends responses as they become available
+    var writerTask = Task.Run(async () =>
+    {
+        await foreach (var response in pendingResponses.Reader.ReadAllAsync(context.CancellationToken))
+        {
+            await responseStream.WriteAsync(response, context.CancellationToken);
+        }
+    }, context.CancellationToken);
+
+    // Reader task - processes incoming messages concurrently
+    try
+    {
+        await foreach (var message in requestStream.ReadAllAsync(context.CancellationToken))
+        {
+            // Process each message asynchronously
+            _ = ProcessAndQueueResponseAsync(message, pendingResponses.Writer, context.CancellationToken);
+        }
+    }
+    finally
+    {
+        pendingResponses.Writer.Complete();
+        await writerTask;
+    }
+}
+
+private async Task ProcessAndQueueResponseAsync(
+    OrderSyncMessage message,
+    ChannelWriter<OrderSyncMessage> writer,
+    CancellationToken ct)
+{
+    try
+    {
+        var response = await ProcessSyncMessageAsync(message, ct);
+        await writer.WriteAsync(response, ct);
+    }
+    catch (Exception ex)
+    {
+        await writer.WriteAsync(new OrderSyncMessage
+        {
+            CorrelationId = message.CorrelationId,
+            Error = ex.Message
+        }, ct);
+    }
+}
+```
+
+### Streaming with Heartbeats
+
+```csharp
+public override async Task Subscribe(
+    SubscribeRequest request,
+    IServerStreamWriter<Event> responseStream,
+    ServerCallContext context)
+{
+    var subscription = await _eventBus.SubscribeAsync(request.Topic, context.CancellationToken);
+    var heartbeatInterval = TimeSpan.FromSeconds(30);
+    var lastActivity = DateTime.UtcNow;
+
+    using var heartbeatTimer = new PeriodicTimer(heartbeatInterval);
+
+    // Start heartbeat task
+    var heartbeatTask = Task.Run(async () =>
+    {
+        while (await heartbeatTimer.WaitForNextTickAsync(context.CancellationToken))
+        {
+            if (DateTime.UtcNow - lastActivity > heartbeatInterval)
+            {
+                await responseStream.WriteAsync(new Event { IsHeartbeat = true }, context.CancellationToken);
+            }
+        }
+    }, context.CancellationToken);
+
+    try
+    {
+        await foreach (var evt in subscription.ReadAllAsync(context.CancellationToken))
+        {
+            await responseStream.WriteAsync(evt, context.CancellationToken);
+            lastActivity = DateTime.UtcNow;
+        }
+    }
+    finally
+    {
+        await heartbeatTask;
+    }
+}
+```
+
+## Interceptor Patterns
+
+### Authentication Interceptor (Server)
+
+```csharp
+public class AuthenticationInterceptor : Interceptor
+{
+    private readonly ITokenValidator _tokenValidator;
+    private readonly ILogger<AuthenticationInterceptor> _logger;
+
+    // Methods that don't require authentication
+    private static readonly HashSet<string> AnonymousMethods = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "/grpc.health.v1.Health/Check",
+        "/mycompany.auth.v1.AuthService/Login"
+    };
+
+    public AuthenticationInterceptor(
+        ITokenValidator tokenValidator,
+        ILogger<AuthenticationInterceptor> logger)
+    {
+        _tokenValidator = tokenValidator;
+        _logger = logger;
+    }
+
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthenticationAsync(context);
+        return await continuation(request, context);
+    }
+
+    public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateAuthenticationAsync(context);
+        await continuation(request, responseStream, context);
+    }
+
+    private async Task ValidateAuthenticationAsync(ServerCallContext context)
+    {
+        if (AnonymousMethods.Contains(context.Method))
+            return;
+
+        var authHeader = context.RequestHeaders.GetValue("authorization");
+        if (string.IsNullOrEmpty(authHeader))
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated, "Missing authorization header"));
+        }
+
+        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated, "Invalid authorization scheme"));
+        }
+
+        var token = authHeader.Substring(7);
+        var principal = await _tokenValidator.ValidateTokenAsync(token, context.CancellationToken);
+
+        if (principal == null)
+        {
+            throw new RpcException(new Status(StatusCode.Unauthenticated, "Invalid or expired token"));
+        }
+
+        // Store principal for downstream use
+        context.UserState["ClaimsPrincipal"] = principal;
+    }
+}
+```
+
+### Authentication Interceptor (Client)
+
+```csharp
+public class ClientAuthInterceptor : Interceptor
+{
+    private readonly ITokenProvider _tokenProvider;
+
+    public ClientAuthInterceptor(ITokenProvider tokenProvider)
+    {
+        _tokenProvider = tokenProvider;
+    }
+
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        var newContext = AddAuthHeader(context);
+        return continuation(request, newContext);
+    }
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        var newContext = AddAuthHeader(context);
+        return continuation(request, newContext);
+    }
+
+    private ClientInterceptorContext<TRequest, TResponse> AddAuthHeader<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context)
+        where TRequest : class
+        where TResponse : class
+    {
+        var token = _tokenProvider.GetToken();
+        if (string.IsNullOrEmpty(token))
+            return context;
+
+        var headers = context.Options.Headers ?? new Metadata();
+        headers.Add("authorization", $"Bearer {token}");
+
+        return new ClientInterceptorContext<TRequest, TResponse>(
+            context.Method,
+            context.Host,
+            context.Options.WithHeaders(headers));
+    }
+}
+```
+
+### Retry Interceptor with Circuit Breaker
+
+```csharp
+public class RetryInterceptor : Interceptor
+{
+    private readonly ILogger<RetryInterceptor> _logger;
+    private readonly RetryPolicy _policy;
+
+    private static readonly HashSet<StatusCode> RetryableStatusCodes = new()
+    {
+        StatusCode.Unavailable,
+        StatusCode.Aborted,
+        StatusCode.DeadlineExceeded,
+        StatusCode.ResourceExhausted
+    };
+
+    public RetryInterceptor(ILogger<RetryInterceptor> logger, RetryPolicy policy)
+    {
+        _logger = logger;
+        _policy = policy;
+    }
+
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        var call = continuation(request, context);
+
+        return new AsyncUnaryCall<TResponse>(
+            RetryAsync(call.ResponseAsync, request, context, continuation),
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            call.Dispose);
+    }
+
+    private async Task<TResponse> RetryAsync<TRequest, TResponse>(
+        Task<TResponse> responseTask,
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+        where TRequest : class
+        where TResponse : class
+    {
+        var attempt = 0;
+        var delay = _policy.InitialBackoff;
+
+        while (true)
+        {
+            try
+            {
+                return await responseTask;
+            }
+            catch (RpcException ex) when (ShouldRetry(ex, attempt))
+            {
+                attempt++;
+                _logger.LogWarning(
+                    "Retry attempt {Attempt} for {Method} after {Status}",
+                    attempt, context.Method.FullName, ex.StatusCode);
+
+                await Task.Delay(delay);
+                delay = TimeSpan.FromTicks(Math.Min(
+                    (long)(delay.Ticks * _policy.BackoffMultiplier),
+                    _policy.MaxBackoff.Ticks));
+
+                var call = continuation(request, context);
+                responseTask = call.ResponseAsync;
+            }
+        }
+    }
+
+    private bool ShouldRetry(RpcException ex, int attempt)
+    {
+        return attempt < _policy.MaxAttempts
+            && RetryableStatusCodes.Contains(ex.StatusCode);
+    }
+}
+
+public record RetryPolicy(
+    int MaxAttempts = 3,
+    TimeSpan InitialBackoff = default,
+    TimeSpan MaxBackoff = default,
+    double BackoffMultiplier = 2.0)
+{
+    public TimeSpan InitialBackoff { get; init; } = InitialBackoff == default
+        ? TimeSpan.FromMilliseconds(100)
+        : InitialBackoff;
+
+    public TimeSpan MaxBackoff { get; init; } = MaxBackoff == default
+        ? TimeSpan.FromSeconds(5)
+        : MaxBackoff;
+}
+```
+
+### Validation Interceptor
+
+```csharp
+public class ValidationInterceptor : Interceptor
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public ValidationInterceptor(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateRequestAsync(request, context.CancellationToken);
+        return await continuation(request, context);
+    }
+
+    private async Task ValidateRequestAsync<TRequest>(TRequest request, CancellationToken ct)
+    {
+        var validator = _serviceProvider.GetService<IValidator<TRequest>>();
+        if (validator == null)
+            return;
+
+        var result = await validator.ValidateAsync(request, ct);
+        if (!result.IsValid)
+        {
+            var errors = string.Join("; ", result.Errors.Select(e => e.ErrorMessage));
+            throw new RpcException(new Status(StatusCode.InvalidArgument, errors));
+        }
+    }
+}
+```
+
+### Metrics Interceptor
+
+```csharp
+public class MetricsInterceptor : Interceptor
+{
+    private readonly IMeterFactory _meterFactory;
+    private readonly Histogram<double> _requestDuration;
+    private readonly Counter<long> _requestCount;
+
+    public MetricsInterceptor(IMeterFactory meterFactory)
+    {
+        _meterFactory = meterFactory;
+        var meter = _meterFactory.Create("GrpcServer");
+
+        _requestDuration = meter.CreateHistogram<double>(
+            "grpc.server.request.duration",
+            unit: "ms",
+            description: "Duration of gRPC requests");
+
+        _requestCount = meter.CreateCounter<long>(
+            "grpc.server.request.count",
+            description: "Number of gRPC requests");
+    }
+
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        var sw = Stopwatch.StartNew();
+        var status = StatusCode.OK;
+
+        try
+        {
+            return await continuation(request, context);
+        }
+        catch (RpcException ex)
+        {
+            status = ex.StatusCode;
+            throw;
+        }
+        finally
+        {
+            sw.Stop();
+            RecordMetrics(context.Method, status, sw.Elapsed.TotalMilliseconds);
+        }
+    }
+
+    private void RecordMetrics(string method, StatusCode status, double duration)
+    {
+        var tags = new TagList
+        {
+            { "grpc.method", method },
+            { "grpc.status_code", status.ToString() }
+        };
+
+        _requestDuration.Record(duration, tags);
+        _requestCount.Add(1, tags);
+    }
+}
+```
+
+## Deadline Propagation
+
+```csharp
+public class DeadlinePropagationInterceptor : Interceptor
+{
+    private readonly TimeSpan _bufferTime = TimeSpan.FromMilliseconds(100);
+
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        var newContext = PropagateDeadline(context);
+        return continuation(request, newContext);
+    }
+
+    private ClientInterceptorContext<TRequest, TResponse> PropagateDeadline<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context)
+        where TRequest : class
+        where TResponse : class
+    {
+        // Check if there's an incoming deadline from the current call context
+        if (ServerCallContext.Current?.Deadline is { } incomingDeadline)
+        {
+            var remaining = incomingDeadline - DateTime.UtcNow;
+
+            // Apply buffer to leave time for response processing
+            var adjustedRemaining = remaining - _bufferTime;
+
+            if (adjustedRemaining > TimeSpan.Zero)
+            {
+                var newOptions = context.Options.WithDeadline(DateTime.UtcNow + adjustedRemaining);
+                return new ClientInterceptorContext<TRequest, TResponse>(
+                    context.Method,
+                    context.Host,
+                    newOptions);
+            }
+        }
+
+        return context;
+    }
+}
+```
+
+## Health Check Implementation
+
+```csharp
+public class HealthServiceImpl : Health.HealthBase
+{
+    private readonly IEnumerable<IHealthCheck> _healthChecks;
+    private readonly ConcurrentDictionary<string, HealthCheckResponse.Types.ServingStatus> _statusMap = new();
+
+    public HealthServiceImpl(IEnumerable<IHealthCheck> healthChecks)
+    {
+        _healthChecks = healthChecks;
+    }
+
+    public override async Task<HealthCheckResponse> Check(
+        HealthCheckRequest request,
+        ServerCallContext context)
+    {
+        var service = request.Service;
+
+        if (string.IsNullOrEmpty(service))
+        {
+            // Overall health check
+            var allHealthy = await CheckAllServicesAsync(context.CancellationToken);
+            return new HealthCheckResponse
+            {
+                Status = allHealthy
+                    ? HealthCheckResponse.Types.ServingStatus.Serving
+                    : HealthCheckResponse.Types.ServingStatus.NotServing
+            };
+        }
+
+        if (_statusMap.TryGetValue(service, out var status))
+        {
+            return new HealthCheckResponse { Status = status };
+        }
+
+        throw new RpcException(new Status(StatusCode.NotFound, $"Service '{service}' not found"));
+    }
+
+    public override async Task Watch(
+        HealthCheckRequest request,
+        IServerStreamWriter<HealthCheckResponse> responseStream,
+        ServerCallContext context)
+    {
+        var lastStatus = HealthCheckResponse.Types.ServingStatus.Unknown;
+
+        while (!context.CancellationToken.IsCancellationRequested)
+        {
+            var currentStatus = await GetServiceStatusAsync(request.Service, context.CancellationToken);
+
+            if (currentStatus != lastStatus)
+            {
+                await responseStream.WriteAsync(new HealthCheckResponse { Status = currentStatus });
+                lastStatus = currentStatus;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), context.CancellationToken);
+        }
+    }
+
+    private async Task<bool> CheckAllServicesAsync(CancellationToken ct)
+    {
+        foreach (var check in _healthChecks)
+        {
+            var result = await check.CheckHealthAsync(new HealthCheckContext(), ct);
+            if (result.Status != HealthStatus.Healthy)
+                return false;
+        }
+        return true;
+    }
+
+    private async Task<HealthCheckResponse.Types.ServingStatus> GetServiceStatusAsync(
+        string service,
+        CancellationToken ct)
+    {
+        // Implementation depends on service-specific health checks
+        return HealthCheckResponse.Types.ServingStatus.Serving;
+    }
+}
+```
+
+## Load Balancing Client Configuration
+
+```csharp
+// Configure DNS-based load balancing
+var channel = GrpcChannel.ForAddress("dns:///my-service.example.com", new GrpcChannelOptions
+{
+    ServiceConfig = new ServiceConfig
+    {
+        LoadBalancingConfigs = { new RoundRobinConfig() },
+        MethodConfigs =
+        {
+            new MethodConfig
+            {
+                Names = { MethodName.Default },
+                RetryPolicy = new RetryPolicy
+                {
+                    MaxAttempts = 3,
+                    InitialBackoff = TimeSpan.FromMilliseconds(100),
+                    MaxBackoff = TimeSpan.FromSeconds(2),
+                    BackoffMultiplier = 1.5,
+                    RetryableStatusCodes = { StatusCode.Unavailable }
+                }
+            }
+        }
+    },
+    Credentials = ChannelCredentials.SecureSsl
+});
+```
+
+## Compression Configuration
+
+```csharp
+// Server-side compression
+builder.Services.AddGrpc(options =>
+{
+    options.ResponseCompressionAlgorithm = "gzip";
+    options.ResponseCompressionLevel = CompressionLevel.Optimal;
+    options.CompressionProviders = new List<ICompressionProvider>
+    {
+        new GzipCompressionProvider(CompressionLevel.Optimal)
+    };
+});
+
+// Client-side compression
+var callOptions = new CallOptions(
+    headers: new Metadata
+    {
+        { "grpc-accept-encoding", "gzip" }
+    },
+    writeOptions: new WriteOptions(WriteFlags.NoCompress));
+```

--- a/.github/skills/mcp/SKILL.md
+++ b/.github/skills/mcp/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: mcp
+description: "Build or consume Model Context Protocol (MCP) servers and clients in .NET using the official MCP C# SDK, including stdio, Streamable HTTP, tools, prompts, resources, and capability negotiation. USE FOR: .NET MCP servers or clients; stdio versus HTTP transport choices; tools, resources, prompts, completions, and capability negotiation. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires the official MCP C# SDK packages (`ModelContextProtocol.Core`, `ModelContextProtocol`, or `ModelContextProtocol.AspNetCore`) on .NET 8+; current guidance targets the v1.1.x SDK."
+---
+
+# MCP C# SDK for .NET
+
+## Trigger On
+
+- building or consuming MCP servers from a .NET application or library
+- choosing between stdio and HTTP transport for MCP
+- exposing tools, resources, prompts, completions, or logging to an MCP host
+- connecting a .NET app to an existing MCP server and passing discovered tools into `IChatClient`
+- bootstrapping a minimal MCP client/server from the `.NET AI` quickstarts or publishing a server to the MCP Registry
+- implementing capability-aware flows such as roots, sampling, elicitation, subscriptions, or session resumption
+
+## Use This Skill Instead Of
+
+- Use `mcp` when **protocol interoperability** is the requirement.
+- Use `microsoft-extensions-ai` when you only need model/provider abstraction or local tool orchestration without the MCP wire protocol.
+- Use `microsoft-agent-framework` when the main problem is agent orchestration; combine it with `mcp` only when those agents must consume or expose MCP endpoints.
+- Use the `.NET AI` quickstarts for the very first vertical slice, then come back here to harden transport, capability negotiation, publishing, and host interoperability.
+
+## Documentation
+
+- [MCP C# SDK overview](https://csharp.sdk.modelcontextprotocol.io/)
+- [Getting Started](https://csharp.sdk.modelcontextprotocol.io/concepts/getting-started.html)
+- [API reference](https://csharp.sdk.modelcontextprotocol.io/api/ModelContextProtocol.html)
+- [Conceptual docs](https://csharp.sdk.modelcontextprotocol.io/concepts/index.html)
+- [Versioning policy](https://csharp.sdk.modelcontextprotocol.io/versioning.html)
+- [Experimental APIs](https://csharp.sdk.modelcontextprotocol.io/experimental.html)
+- [MCP C# SDK repository](https://github.com/modelcontextprotocol/csharp-sdk)
+- [Model Context Protocol specification](https://modelcontextprotocol.io/specification/)
+
+## References
+
+Load only what the task needs:
+
+- [references/patterns.md](references/patterns.md) - current server/client patterns, transports, capabilities, filters, and chat-client integration
+- [references/security.md](references/security.md) - safe error handling, auth boundaries, stdio logging hygiene, and defensive tool/resource patterns
+
+## Package Selection
+
+| Package | Choose when |
+|---------|-------------|
+| `ModelContextProtocol.Core` | You only need a client or low-level server APIs and want the smallest dependency set. |
+| `ModelContextProtocol` | You want the main SDK package with hosting, DI, attribute discovery, and stdio server support. Start here for most projects. |
+| `ModelContextProtocol.AspNetCore` | You are hosting a remote MCP server in ASP.NET Core over HTTP. This includes the main package. |
+
+## Transport Selection
+
+| Transport | Use when | Notes |
+|-----------|----------|-------|
+| `StdioClientTransport` / `WithStdioServerTransport()` | The MCP server should run as a local child process. | Best for local tooling and editor/agent integrations. |
+| `HttpClientTransport` + `HttpTransportMode.StreamableHttp` | The server is remote or should be reachable over HTTP. | Recommended HTTP transport; supports streaming and session resumption. |
+| `HttpTransportMode.Sse` | You must connect to an older SSE-only server. | Legacy compatibility only; do not choose this for new servers. |
+
+```mermaid
+flowchart LR
+    A["Need MCP interoperability in .NET"] --> B{"Role?"}
+    B -->|"Expose MCP surface"| C{"Where will it run?"}
+    B -->|"Consume an MCP server"| D{"Transport?"}
+    C -->|"Local child process"| E["ModelContextProtocol\nAddMcpServer()\nWithStdioServerTransport()"]
+    C -->|"Remote HTTP endpoint"| F["ModelContextProtocol.AspNetCore\nAddMcpServer()\nWithHttpTransport()\nMapMcp()"]
+    D -->|"stdio"| G["StdioClientTransport\nMcpClient.CreateAsync()"]
+    D -->|"HTTP"| H["HttpClientTransport\nAutoDetect or StreamableHttp"]
+    E --> I["Register tools/resources/prompts"]
+    F --> I
+    G --> J["Check ServerCapabilities\nbefore optional features"]
+    H --> J
+```
+
+## Workflow
+
+1. Pick the package and transport first.
+   - Local child-process server: `ModelContextProtocol` + `WithStdioServerTransport()`.
+   - Remote server: `ModelContextProtocol.AspNetCore` + `WithHttpTransport()` + `MapMcp()`.
+   - Client-only app: start with `ModelContextProtocol` or `ModelContextProtocol.Core`.
+   - Registry distribution: pair a minimal server with the MCP Registry publishing flow only after the server contract is stable.
+
+2. Model the MCP surface explicitly.
+   - Tools: `[McpServerToolType]` + `[McpServerTool]`
+   - Resources: `[McpServerResourceType]` + `[McpServerResource]`
+   - Prompts: `[McpServerPromptType]` + `[McpServerPrompt]`
+   - Use custom handlers or filters only for cross-cutting behavior, protocol extensions, or advanced routing.
+
+3. Prefer attribute discovery for straightforward servers.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddConsole(options =>
+{
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();
+
+[McpServerToolType]
+public static class EchoTool
+{
+    [McpServerTool, Description("Echoes the message back to the client.")]
+    public static string Echo(string message) => $"hello {message}";
+}
+```
+
+4. For HTTP servers, use the ASP.NET Core transport and map the endpoint directly.
+
+```csharp
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport()
+    .WithToolsFromAssembly();
+
+var app = builder.Build();
+app.MapMcp("/mcp");
+app.Run();
+
+[McpServerToolType]
+public static class EchoTool
+{
+    [McpServerTool, Description("Echoes the message back to the client.")]
+    public static string Echo(string message) => $"hello {message}";
+}
+```
+
+5. When consuming a server, use `McpClient.CreateAsync(...)` and stay capability-aware.
+
+```csharp
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+var transport = new StdioClientTransport(new StdioClientTransportOptions
+{
+    Name = "Everything",
+    Command = "npx",
+    Arguments = ["-y", "@modelcontextprotocol/server-everything"],
+});
+
+await using var client = await McpClient.CreateAsync(transport);
+
+IList<McpClientTool> tools = await client.ListToolsAsync();
+
+if (client.ServerCapabilities.Prompts is not null)
+{
+    var prompts = await client.ListPromptsAsync();
+}
+```
+
+6. Treat optional features as negotiated capabilities, not assumptions.
+   - Client capabilities: configure `McpClientOptions.Capabilities` for roots, sampling, and elicitation.
+   - Server capabilities are inferred from registered features.
+   - Check `client.ServerCapabilities` before using completions, logging, prompt list-change notifications, or resource subscriptions.
+   - Use `client.NegotiatedProtocolVersion` or `server.NegotiatedProtocolVersion` only when version-specific behavior matters.
+
+7. Keep HTTP guidance current.
+   - Streamable HTTP is the recommended transport for remote servers.
+   - `MapMcp()` also serves SSE compatibility endpoints for older clients.
+   - HTTP clients can use `AutoDetect` by default, or force `StreamableHttp` / `Sse`.
+   - Session resumption is available for Streamable HTTP through `McpClient.ResumeSessionAsync(...)`.
+
+8. Treat the `.NET AI` MCP quickstarts as bootstrap examples.
+   - `build-mcp-client` and `build-mcp-server` are good starting points when the surrounding app is still MEAI-centric.
+   - `publish-mcp-registry` is the distribution step, not the design step. Stabilize the protocol surface before publishing.
+
+9. Respect current error and serialization rules.
+   - Tool exceptions normally come back as `CallToolResult.IsError == true`.
+   - Throw `McpProtocolException` only for protocol-level JSON-RPC failures.
+   - `McpClientTool` inherits from `AIFunction`, so discovered tools can be passed directly into `IChatClient`.
+   - Experimental APIs use `MCPEXP...` diagnostics; suppress them intentionally, not globally by accident.
+   - If you use a custom `JsonSerializerContext`, prepend `McpJsonUtilities.DefaultOptions.TypeInfoResolver` so MCP protocol types keep the SDK's contract.
+
+## Anti-Patterns To Avoid
+
+| Anti-pattern | Why it causes trouble | Better approach |
+|--------------|-----------------------|-----------------|
+| Picking HTTP transport for a purely local child-process scenario | Adds unnecessary hosting, auth, and deployment surface | Use stdio for local/editor-hosted integrations |
+| Treating SSE as the default remote transport | Locks new work to legacy behavior | Prefer Streamable HTTP and keep SSE only for backward compatibility |
+| Writing tools without `[Description]` metadata | Hosts and models lose schema clarity | Describe tool purpose and parameters explicitly |
+| Returning huge binary/text payloads from every tool call | Bloats context and slows hosts | Return focused content and move large data to resources |
+| Logging to stdout on stdio servers | Corrupts the protocol stream | Send logs to stderr |
+| Assuming prompts/resources/logging/completions exist | Breaks against partial implementations | Check negotiated capabilities first |
+| Using filters for normal business logic | Makes handlers opaque and hard to reason about | Keep filters for cross-cutting policy, audit, or protocol plumbing |
+
+## Deliver
+
+- a correctly packaged MCP server or client that matches the deployment topology
+- explicit tool/resource/prompt definitions with descriptions and bounded payloads
+- capability-aware handling for optional MCP features
+- validation notes for transport, auth boundary, and host/client interoperability
+
+## Validate
+
+- chosen package matches the topology: `Core`, `ModelContextProtocol`, or `AspNetCore`
+- stdio servers do not write logs or diagnostics to stdout
+- HTTP servers use `MapMcp()` and are tested at the final route, for example `/mcp`
+- tools, resources, and prompts use current `[McpServer*]` attributes or documented handler/filter alternatives
+- client code checks `ServerCapabilities` before using subscriptions, completions, logging, or prompt/resource list-change flows
+- Streamable HTTP is the default for new remote servers; SSE is used only for legacy compatibility
+- experimental APIs and custom serialization settings are reviewed intentionally rather than copied blindly

--- a/.github/skills/mcp/manifest.json
+++ b/.github/skills/mcp/manifest.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.1.1",
+  "category": "AI",
+  "packages": [
+    "ModelContextProtocol",
+    "ModelContextProtocol.AspNetCore"
+  ]
+}

--- a/.github/skills/mcp/references/patterns.md
+++ b/.github/skills/mcp/references/patterns.md
@@ -1,0 +1,361 @@
+# MCP C# SDK Patterns
+
+Use this file when the task needs concrete current patterns from the official MCP C# SDK rather than high-level routing guidance.
+
+## Package and Transport Matrix
+
+| Scenario | Package | Transport / API |
+|----------|---------|-----------------|
+| Minimal client or low-level host | `ModelContextProtocol.Core` | `McpClient`, low-level server APIs |
+| Typical client or stdio server | `ModelContextProtocol` | `StdioClientTransport`, `WithStdioServerTransport()` |
+| ASP.NET Core server | `ModelContextProtocol.AspNetCore` | `WithHttpTransport()`, `MapMcp()` |
+| Remote client over HTTP | `ModelContextProtocol` or `Core` | `HttpClientTransport` |
+
+## Minimal stdio server
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.AddConsole(options =>
+{
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();
+
+[McpServerToolType]
+public static class EchoTools
+{
+    [McpServerTool, Description("Echoes the message back to the caller.")]
+    public static string Echo([Description("Message to echo")] string message)
+        => $"hello {message}";
+}
+```
+
+Use `WithTools<T>()`, `WithResources<T>()`, and `WithPrompts<T>()` when you want explicit registration instead of assembly scanning.
+
+## Minimal ASP.NET Core server
+
+```csharp
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport()
+    .WithTools<WeatherTools>()
+    .WithResources<WeatherResources>()
+    .WithPrompts<WeatherPrompts>();
+
+var app = builder.Build();
+app.MapMcp("/mcp");
+app.Run();
+
+[McpServerToolType]
+public static class WeatherTools
+{
+    [McpServerTool, Description("Returns the current weather for a city.")]
+    public static string GetCurrentWeather(
+        [Description("City name")] string city)
+        => $"Current weather for {city}: sunny";
+}
+```
+
+Notes:
+
+- `MapMcp()` serves Streamable HTTP and legacy SSE endpoints.
+- New remote clients should connect to the mapped route directly and prefer Streamable HTTP.
+- Only point SSE clients to `{route}/sse`.
+
+## Stdio client pattern
+
+```csharp
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+var transport = new StdioClientTransport(new StdioClientTransportOptions
+{
+    Name = "Everything",
+    Command = "npx",
+    Arguments = ["-y", "@modelcontextprotocol/server-everything"],
+});
+
+await using var client = await McpClient.CreateAsync(transport);
+
+IList<McpClientTool> tools = await client.ListToolsAsync();
+
+CallToolResult result = await client.CallToolAsync(
+    "echo",
+    new Dictionary<string, object?> { ["message"] = "Hello MCP!" });
+
+Console.WriteLine(result.Content.OfType<TextContentBlock>().First().Text);
+```
+
+## HTTP client pattern
+
+```csharp
+using ModelContextProtocol.Client;
+
+var transport = new HttpClientTransport(new HttpClientTransportOptions
+{
+    Endpoint = new Uri("https://example.com/mcp"),
+    TransportMode = HttpTransportMode.StreamableHttp,
+    ConnectionTimeout = TimeSpan.FromSeconds(30),
+    AdditionalHeaders = new Dictionary<string, string>
+    {
+        ["Authorization"] = "Bearer <token>"
+    }
+});
+
+await using var client = await McpClient.CreateAsync(transport);
+```
+
+For mixed environments, `HttpTransportMode.AutoDetect` is the default. It tries Streamable HTTP first and falls back to SSE when needed.
+
+## Session resumption
+
+Use this only for Streamable HTTP sessions:
+
+```csharp
+var transport = new HttpClientTransport(new HttpClientTransportOptions
+{
+    Endpoint = new Uri("https://example.com/mcp"),
+    KnownSessionId = previousSessionId
+});
+
+await using var client = await McpClient.ResumeSessionAsync(
+    transport,
+    new ResumeClientSessionOptions
+    {
+        ServerCapabilities = previousServerCapabilities,
+        ServerInfo = previousServerInfo
+    });
+```
+
+## Tool pattern
+
+```csharp
+[McpServerToolType]
+public sealed class BuildTools(IBuildService builds)
+{
+    [McpServerTool, Description("Queues a build for the requested branch.")]
+    public async Task<string> QueueBuildAsync(
+        [Description("Git branch to build")] string branch,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(branch))
+        {
+            throw new McpProtocolException("Branch is required.", McpErrorCode.InvalidParams);
+        }
+
+        var buildId = await builds.QueueAsync(branch, cancellationToken);
+        return $"queued:{buildId}";
+    }
+}
+```
+
+Guidance:
+
+- `string` results are wrapped as `TextContentBlock`.
+- Use `ImageContentBlock`, `AudioContentBlock`, or `EmbeddedResourceBlock` when the tool returns richer content.
+- Use `[Description]` on the method and parameters so hosts can build better schemas.
+- Methods can accept `McpServer`, `ClaimsPrincipal`, `IProgress<ProgressNotificationValue>`, and DI-registered services in addition to normal arguments.
+
+## Resource pattern
+
+```csharp
+[McpServerResourceType]
+public static class RepoResources
+{
+    [McpServerResource(
+        UriTemplate = "repo://readme",
+        Name = "Repository README",
+        MimeType = "text/markdown")]
+    [Description("Returns the repository overview document.")]
+    public static string ReadReadme()
+        => File.ReadAllText("README.md");
+
+    [McpServerResource(UriTemplate = "repo://files/{path}", Name = "Repository File")]
+    [Description("Returns a file under the approved repository root.")]
+    public static TextResourceContents ReadFile(string path)
+    {
+        var fullPath = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, path));
+        var root = Path.GetFullPath(Environment.CurrentDirectory);
+
+        if (!fullPath.StartsWith(root, StringComparison.Ordinal))
+        {
+            throw new McpException("Requested file is outside the repository root.");
+        }
+
+        return new TextResourceContents
+        {
+            Uri = $"repo://files/{path}",
+            MimeType = "text/plain",
+            Text = File.ReadAllText(fullPath)
+        };
+    }
+}
+```
+
+Use resource templates when the URI contains parameters. Clients can enumerate them with `ListResourceTemplatesAsync()` and materialize them with `ReadResourceAsync(...)`.
+
+## Prompt pattern
+
+```csharp
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Protocol;
+
+[McpServerPromptType]
+public static class ReviewPrompts
+{
+    [McpServerPrompt, Description("Builds a code-review prompt.")]
+    public static IEnumerable<ChatMessage> CodeReview(
+        [Description("Programming language")] string language,
+        [Description("Code to review")] string code) =>
+        [
+            new(ChatRole.User, $"Review this {language} code:\n\n```{language}\n{code}\n```")
+        ];
+
+    [McpServerPrompt, Description("Builds a document-review prompt with an embedded resource.")]
+    public static IEnumerable<PromptMessage> ReviewDocument(
+        [Description("Document identifier")] string id)
+        =>
+        [
+            new()
+            {
+                Role = Role.User,
+                Content = new TextContentBlock
+                {
+                    Text = "Review the attached document."
+                }
+            },
+            new()
+            {
+                Role = Role.User,
+                Content = new EmbeddedResourceBlock
+                {
+                    Resource = new TextResourceContents
+                    {
+                        Uri = $"docs://documents/{id}",
+                        MimeType = "text/plain",
+                        Text = LoadDocument(id)
+                    }
+                }
+            }
+        ];
+}
+```
+
+Use `ChatMessage` for normal text/image flows and `PromptMessage` when you need protocol-specific content such as embedded resources.
+
+## Capability-aware client pattern
+
+```csharp
+var options = new McpClientOptions
+{
+    Capabilities = new ClientCapabilities
+    {
+        Roots = new RootsCapability { ListChanged = true },
+        Sampling = new SamplingCapability(),
+        Elicitation = new ElicitationCapability
+        {
+            Form = new FormElicitationCapability(),
+            Url = new UrlElicitationCapability()
+        }
+    }
+};
+
+await using var client = await McpClient.CreateAsync(transport, options);
+
+if (client.ServerCapabilities.Resources is { Subscribe: true })
+{
+    await client.SubscribeToResourceAsync("repo://readme");
+}
+
+if (client.ServerCapabilities.Logging is not null)
+{
+    await client.SetLoggingLevelAsync(LoggingLevel.Info);
+}
+```
+
+Check `client.ServerCapabilities` before using:
+
+- resource subscriptions
+- prompt/resource list-change notifications
+- completions
+- logging
+- any feature that is optional in the spec
+
+## Passing MCP tools into a chat client
+
+`McpClientTool` inherits from `AIFunction`, so discovered tools can be passed directly into `IChatClient`:
+
+```csharp
+IList<McpClientTool> tools = await client.ListToolsAsync();
+
+IChatClient chatClient = ...;
+var response = await chatClient.GetResponseAsync(
+    "Use the MCP tools to answer the question.",
+    new() { Tools = [.. tools] });
+```
+
+## Filters for cross-cutting behavior
+
+Use filters for audit, custom JSON-RPC routing, or policy, not for normal domain logic:
+
+```csharp
+builder.Services
+    .AddMcpServer()
+    .WithMessageFilters(messageFilters =>
+    {
+        messageFilters.AddIncomingFilter(next => async (context, cancellationToken) =>
+        {
+            if (context.JsonRpcMessage is JsonRpcRequest request)
+            {
+                Console.Error.WriteLine($"Incoming MCP method: {request.Method}");
+            }
+
+            await next(context, cancellationToken);
+        });
+    })
+    .WithRequestFilters(requestFilters =>
+    {
+        requestFilters.AddCallToolFilter(next => async (context, cancellationToken) =>
+        {
+            Console.Error.WriteLine($"Executing tool: {context.Params?.Name}");
+            return await next(context, cancellationToken);
+        });
+    })
+    .WithTools<WeatherTools>();
+```
+
+## Experimental APIs and serialization
+
+When using experimental MCP APIs:
+
+- suppress only the relevant `MCPEXP...` diagnostic ids
+- avoid blanket `NoWarn` entries for unrelated code
+- if you supply a custom `JsonSerializerContext`, prepend `McpJsonUtilities.DefaultOptions.TypeInfoResolver` so MCP protocol types continue to serialize with the SDK's contract
+
+## Validation Checklist
+
+- client and server transport choices match the deployment topology
+- stdio servers keep stdout protocol-clean
+- HTTP endpoints are tested at the real final route
+- tool/resource/prompt descriptions are explicit
+- optional features are guarded by capability checks
+- filter usage is cross-cutting rather than replacing normal handlers
+
+static string LoadDocument(string id) => $"Document {id}";

--- a/.github/skills/mcp/references/security.md
+++ b/.github/skills/mcp/references/security.md
@@ -1,0 +1,193 @@
+# MCP C# SDK Security Notes
+
+Use this file when the task involves safe server/client design, auth boundaries, or data exposure rules for MCP.
+
+## Security Priorities
+
+1. Keep the MCP transport clean and predictable.
+2. Limit what tools and resources can reach.
+3. Return safe protocol errors instead of leaking internals.
+4. Authenticate and authorize at the transport boundary.
+5. Make optional capabilities explicit.
+
+## stdio hygiene
+
+For stdio servers, anything written to stdout can corrupt the protocol stream. Route logs to stderr:
+
+```csharp
+builder.Logging.AddConsole(options =>
+{
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+```
+
+Do not:
+
+- write banner text to stdout
+- print debug tracing with `Console.WriteLine`
+- mix app startup messaging into the MCP pipe
+
+## Parameter validation
+
+Treat every tool/resource/prompt argument as untrusted input.
+
+```csharp
+[McpServerToolType]
+public sealed class FileTools(IFileSystem files)
+{
+    [McpServerTool, Description("Reads a text file below the approved workspace root.")]
+    public async Task<string> ReadTextFileAsync(
+        [Description("Relative path below the workspace root")] string relativePath,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            throw new McpProtocolException("Path is required.", McpErrorCode.InvalidParams);
+        }
+
+        var root = Path.GetFullPath("/path/to/approved/workspace");
+        var fullPath = Path.GetFullPath(Path.Combine(root, relativePath));
+
+        if (!fullPath.StartsWith(root, StringComparison.Ordinal))
+        {
+            throw new McpException("Requested path is outside the allowed workspace.");
+        }
+
+        return await files.File.ReadAllTextAsync(fullPath, cancellationToken);
+    }
+}
+```
+
+Patterns:
+
+- normalize paths before checking the root
+- whitelist supported operations and file types
+- clamp numeric limits and pagination inputs
+- reject blank or ambiguous identifiers early
+
+## Error boundaries
+
+Use the right exception type for the right kind of failure:
+
+- `McpProtocolException` for JSON-RPC or contract-level failures such as invalid parameters
+- `McpException` for domain errors whose message is safe to surface
+- ordinary exceptions only for unexpected faults; they will be converted into generic tool errors
+
+This distinction matters because tool failures are exposed differently from protocol failures.
+
+## Authorization
+
+For HTTP servers, prefer normal ASP.NET Core auth middleware and endpoint policy around `MapMcp()`:
+
+- bearer tokens, cookies, or mutual TLS belong at the HTTP boundary
+- rate limiting belongs in ASP.NET Core middleware or infrastructure, not ad hoc inside every tool
+- map unauthenticated requests to standard HTTP auth behavior before MCP handlers run
+
+Inside MCP handlers, use injected principals for per-operation authorization:
+
+```csharp
+[McpServerToolType]
+public sealed class DeploymentTools(IDeploymentService deployments)
+{
+    [McpServerTool, Description("Cancels a deployment owned by the current user.")]
+    public async Task<string> CancelDeploymentAsync(
+        [Description("Deployment identifier")] string deploymentId,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken = default)
+    {
+        if (!user.Identity?.IsAuthenticated ?? true)
+        {
+            throw new McpException("Authentication is required.");
+        }
+
+        await deployments.CancelAsync(deploymentId, user, cancellationToken);
+        return $"Cancelled deployment {deploymentId}.";
+    }
+}
+```
+
+## Capability minimization
+
+Only enable features you are prepared to support safely:
+
+- roots: only if the client should disclose filesystem roots
+- sampling: only if the server should request LLM completions from the client
+- elicitation: only if the server is allowed to prompt the user for more input
+- resource subscriptions: only if you can track and notify subscribers correctly
+
+Do not assume a host/client supports these features. Capability negotiation is part of the security boundary.
+
+## Tool and resource output discipline
+
+Keep payloads small and deliberate.
+
+Prefer:
+
+- summaries plus identifiers
+- paginated lists
+- direct resources for large text or binary data
+- explicit MIME types
+
+Avoid:
+
+- dumping whole databases or repositories into one tool result
+- returning secrets or internal stack traces
+- embedding large binary payloads when a resource URI is enough
+
+## Remote transport guidance
+
+For remote servers:
+
+- prefer Streamable HTTP
+- use HTTPS
+- pass auth via standard HTTP headers or ASP.NET Core auth
+- use SSE only for legacy compatibility
+
+For local-only integrations:
+
+- prefer stdio
+- keep environment variables explicit
+- avoid inheriting more process privileges than the child server needs
+
+## Filters as policy points
+
+Filters are appropriate for audit, tracing, and global policy checks:
+
+```csharp
+builder.Services
+    .AddMcpServer()
+    .WithRequestFilters(filters =>
+    {
+        filters.AddCallToolFilter(next => async (context, cancellationToken) =>
+        {
+            var toolName = context.Params?.Name;
+            if (toolName is "delete_all_data")
+            {
+                throw new McpException("This tool is disabled in the current environment.");
+            }
+
+            return await next(context, cancellationToken);
+        });
+    });
+```
+
+Do not hide primary business rules in filters if the tool handler itself can express them clearly.
+
+## Experimental APIs
+
+Experimental MCP APIs can change outside normal patch-level expectations. Before adopting them:
+
+- suppress only the specific `MCPEXP...` diagnostic you intend to accept
+- document why the suppression exists
+- isolate experimental usage behind an internal abstraction if the project needs a stable surface
+
+If you use source-generated JSON serialization, prepend `McpJsonUtilities.DefaultOptions.TypeInfoResolver` so MCP protocol types keep the SDK's serialization contract, including experimental fields when required by the wire protocol.
+
+## Review Checklist
+
+- stdout remains protocol-clean for stdio servers
+- every externally supplied argument is validated and normalized
+- auth happens at the HTTP boundary and is rechecked inside sensitive handlers
+- sensitive operations are scoped to the caller's identity or allowed root
+- optional capabilities are enabled intentionally rather than by accident
+- tool/resource outputs exclude secrets, internal stack traces, and oversized payloads

--- a/.github/skills/microsoft-extensions/SKILL.md
+++ b/.github/skills/microsoft-extensions/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: microsoft-extensions
+description: "Use the Microsoft.Extensions stack correctly across Generic Host, dependency injection, configuration, logging, options, HttpClientFactory, and other shared infrastructure patterns. USE FOR: wiring dependency injection, configuration, logging, or options; introducing Generic Host patterns into non-web .NET apps; cleaning up service registration, typed HTTP. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Relevant to console apps, workers, ASP.NET Core apps, functions, and reusable libraries."
+---
+
+# Microsoft.Extensions for .NET
+
+## Trigger On
+
+- wiring dependency injection, configuration, logging, or options
+- introducing Generic Host patterns into non-web .NET apps
+- cleaning up service registration, typed HTTP clients, or shared infrastructure code
+
+## Workflow
+
+1. Prefer the Generic Host for apps that need configuration, DI, logging, hosted services, or coordinated startup.
+2. Keep service registration predictable: composition at the edge, concrete implementations hidden behind interfaces only where that abstraction buys flexibility.
+3. Use options binding for structured configuration and validate configuration at startup when bad settings would fail later at runtime.
+4. Prefer `IHttpClientFactory` and typed or named clients for outbound HTTP instead of ad-hoc singleton or per-call `HttpClient` usage.
+5. Use logging categories and config-driven log levels rather than scattered ad-hoc logging behavior.
+6. Avoid building mini-frameworks over Microsoft.Extensions unless the repo genuinely needs reusable composition primitives.
+
+## Deliver
+
+- clean host wiring and service registration
+- configuration and logging that are observable and testable
+- infrastructure code that fits naturally with the .NET stack
+
+## Validate
+
+- service lifetimes are correct
+- configuration is strongly typed where it matters
+- host setup remains easy to debug and reason about
+
+## References
+
+- [patterns.md](references/patterns.md) - DI patterns, Configuration patterns, Options pattern, Logging patterns, HttpClientFactory patterns, Hosted Service patterns
+- [anti-patterns.md](references/anti-patterns.md) - Common mistakes with DI, configuration, options, logging, HttpClient, and hosted services

--- a/.github/skills/microsoft-extensions/manifest.json
+++ b/.github/skills/microsoft-extensions/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "category": "Core",
+  "package_prefix": "Microsoft.Extensions"
+}

--- a/.github/skills/microsoft-extensions/references/anti-patterns.md
+++ b/.github/skills/microsoft-extensions/references/anti-patterns.md
@@ -1,0 +1,606 @@
+# Microsoft.Extensions Anti-Patterns
+
+## Dependency Injection Anti-Patterns
+
+### Service Locator Pattern
+
+**Problem**: Resolving services manually instead of using constructor injection.
+
+```csharp
+// BAD: Service locator
+public class OrderService(IServiceProvider serviceProvider)
+{
+    public async Task ProcessAsync(Order order)
+    {
+        // Hidden dependency, hard to test, breaks DI benefits
+        var repository = serviceProvider.GetRequiredService<IOrderRepository>();
+        await repository.SaveAsync(order);
+    }
+}
+
+// GOOD: Explicit constructor injection
+public class OrderService(IOrderRepository repository)
+{
+    public async Task ProcessAsync(Order order)
+    {
+        await repository.SaveAsync(order);
+    }
+}
+```
+
+**Exception**: `IServiceProvider` is acceptable in factory classes or hosted services that need to create scopes.
+
+### Captive Dependencies
+
+**Problem**: A singleton service captures a scoped or transient dependency.
+
+```csharp
+// BAD: Singleton captures scoped DbContext
+services.AddSingleton<ICacheService, CacheService>();
+services.AddDbContext<AppDbContext>(); // Scoped by default
+
+public class CacheService(AppDbContext dbContext) : ICacheService
+{
+    // dbContext is now captive - same instance for entire app lifetime
+    // This causes threading issues and stale data
+}
+
+// GOOD: Use IServiceScopeFactory for scoped dependencies
+public class CacheService(IServiceScopeFactory scopeFactory) : ICacheService
+{
+    public async Task RefreshAsync()
+    {
+        using var scope = scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        // Use dbContext within this scope
+    }
+}
+```
+
+### Constructor Over-Injection
+
+**Problem**: Too many dependencies indicate a class is doing too much.
+
+```csharp
+// BAD: 8+ dependencies suggest SRP violation
+public class OrderProcessor(
+    IOrderRepository orderRepository,
+    ICustomerRepository customerRepository,
+    IInventoryService inventoryService,
+    IPaymentService paymentService,
+    IShippingService shippingService,
+    INotificationService notificationService,
+    ILogger<OrderProcessor> logger,
+    IOptions<OrderSettings> options,
+    IAuditService auditService,
+    IMetricsService metricsService)
+{
+    // This class is doing too much
+}
+
+// GOOD: Split into focused services or use aggregates
+public class OrderProcessor(
+    IOrderWorkflow workflow,
+    ILogger<OrderProcessor> logger,
+    IOptions<OrderSettings> options)
+{
+    public async Task ProcessAsync(Order order)
+    {
+        await workflow.ExecuteAsync(order);
+    }
+}
+```
+
+### Registering Implementations Instead of Interfaces
+
+**Problem**: Registering concrete types makes testing and swapping implementations difficult.
+
+```csharp
+// BAD: Hard to mock in tests
+services.AddScoped<OrderService>();
+
+// GOOD: Register interface to implementation
+services.AddScoped<IOrderService, OrderService>();
+```
+
+### Inappropriate Lifetimes
+
+**Problem**: Using wrong service lifetimes.
+
+```csharp
+// BAD: Transient for expensive-to-create services
+services.AddTransient<IExpensiveService, ExpensiveService>();
+
+// BAD: Singleton for services with request-specific state
+services.AddSingleton<IUserContext, UserContext>();
+
+// GOOD: Match lifetime to actual requirements
+services.AddSingleton<IExpensiveService, ExpensiveService>(); // Create once
+services.AddScoped<IUserContext, UserContext>(); // Per-request state
+```
+
+---
+
+## Configuration Anti-Patterns
+
+### Magic Strings Everywhere
+
+**Problem**: Configuration keys scattered as strings throughout the code.
+
+```csharp
+// BAD: Magic strings
+var connectionString = configuration["ConnectionStrings:DefaultConnection"];
+var timeout = int.Parse(configuration["HttpClient:Timeout"]);
+
+// GOOD: Strongly typed configuration
+public class HttpClientSettings
+{
+    public const string SectionName = "HttpClient";
+    public int Timeout { get; init; } = 30;
+}
+
+services.Configure<HttpClientSettings>(configuration.GetSection(HttpClientSettings.SectionName));
+```
+
+### No Validation
+
+**Problem**: Invalid configuration discovered at runtime instead of startup.
+
+```csharp
+// BAD: Fails at runtime when service is first used
+public class EmailService(IOptions<EmailSettings> options)
+{
+    public void Send(string to, string subject, string body)
+    {
+        // Crashes here if SmtpHost is null
+        using var client = new SmtpClient(options.Value.SmtpHost);
+    }
+}
+
+// GOOD: Validate at startup
+services.AddOptions<EmailSettings>()
+    .BindConfiguration("Email")
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+```
+
+### Secrets in Configuration Files
+
+**Problem**: Sensitive data in appsettings.json checked into source control.
+
+```json
+// BAD: appsettings.json in source control
+{
+  "Database": {
+    "ConnectionString": "Server=prod;Password=actualPassword123"
+  }
+}
+```
+
+**Solutions**:
+- Use User Secrets for local development
+- Use environment variables for production
+- Use Azure Key Vault, AWS Secrets Manager, or similar
+- Use `appsettings.Development.json` (gitignored) for local overrides
+
+### Ignoring Configuration Hierarchy
+
+**Problem**: Not understanding that later sources override earlier ones.
+
+```csharp
+// Configuration sources (later overrides earlier):
+// 1. appsettings.json
+// 2. appsettings.{Environment}.json
+// 3. Environment variables
+// 4. Command-line arguments
+
+// BAD: Adding JSON after environment variables reverses expected precedence
+builder.Configuration.AddJsonFile("override.json"); // Now overrides env vars!
+
+// GOOD: Understand and maintain intended precedence
+builder.Configuration.AddJsonFile("defaults.json", optional: true);
+// Environment variables and command-line args still win
+```
+
+---
+
+## Options Pattern Anti-Patterns
+
+### Using IOptions When Reload Is Needed
+
+**Problem**: `IOptions<T>` never reloads after startup.
+
+```csharp
+// BAD: IOptions won't see configuration changes
+public class FeatureService(IOptions<FeatureFlags> options)
+{
+    public bool IsEnabled(string feature) =>
+        options.Value.EnabledFeatures.Contains(feature);
+    // This never updates even if config file changes
+}
+
+// GOOD: Use IOptionsMonitor for live updates
+public class FeatureService(IOptionsMonitor<FeatureFlags> options)
+{
+    public bool IsEnabled(string feature) =>
+        options.CurrentValue.EnabledFeatures.Contains(feature);
+}
+```
+
+### Mutable Options Classes
+
+**Problem**: Options objects that can be modified after binding.
+
+```csharp
+// BAD: Mutable options
+public class ApiSettings
+{
+    public string BaseUrl { get; set; } = "";
+    public int Timeout { get; set; }
+}
+
+// GOOD: Immutable options with init-only setters
+public class ApiSettings
+{
+    public required string BaseUrl { get; init; }
+    public int Timeout { get; init; } = 30;
+}
+```
+
+### Complex Logic in Options Classes
+
+**Problem**: Adding business logic to configuration POCOs.
+
+```csharp
+// BAD: Options class with logic
+public class RetrySettings
+{
+    public int MaxAttempts { get; init; }
+    public int BaseDelayMs { get; init; }
+
+    // Don't put business logic here
+    public TimeSpan GetDelay(int attempt) =>
+        TimeSpan.FromMilliseconds(BaseDelayMs * Math.Pow(2, attempt));
+}
+
+// GOOD: Keep options as pure data; logic belongs in services
+public class RetrySettings
+{
+    public int MaxAttempts { get; init; } = 3;
+    public int BaseDelayMs { get; init; } = 100;
+}
+
+public class RetryPolicy(IOptions<RetrySettings> options)
+{
+    public TimeSpan GetDelay(int attempt) =>
+        TimeSpan.FromMilliseconds(options.Value.BaseDelayMs * Math.Pow(2, attempt));
+}
+```
+
+---
+
+## Logging Anti-Patterns
+
+### String Interpolation in Log Messages
+
+**Problem**: String interpolation defeats structured logging and always allocates.
+
+```csharp
+// BAD: String interpolation
+logger.LogInformation($"Processing order {order.Id} for customer {order.CustomerId}");
+
+// GOOD: Message templates
+logger.LogInformation("Processing order {OrderId} for customer {CustomerId}",
+    order.Id, order.CustomerId);
+```
+
+### Logging Sensitive Data
+
+**Problem**: Accidentally logging PII, credentials, or secrets.
+
+```csharp
+// BAD: Logging sensitive data
+logger.LogDebug("User login: {Email} with password {Password}", email, password);
+logger.LogInformation("Processing payment for card {CardNumber}", cardNumber);
+
+// GOOD: Redact or omit sensitive data
+logger.LogDebug("User login attempt for {Email}", email);
+logger.LogInformation("Processing payment for card ending in {CardLast4}",
+    cardNumber[^4..]);
+```
+
+### Incorrect Log Levels
+
+**Problem**: Using wrong log levels makes filtering difficult.
+
+```csharp
+// BAD: Using Information for errors
+logger.LogInformation("Failed to connect to database: {Error}", ex.Message);
+
+// BAD: Using Error for normal operations
+logger.LogError("Request completed successfully");
+
+// BAD: Using Debug for critical failures
+logger.LogDebug("Payment processing failed: {Error}", ex.Message);
+
+// GOOD: Match level to severity
+logger.LogDebug("Entering method {MethodName}", nameof(ProcessAsync));
+logger.LogInformation("Order {OrderId} processed successfully", orderId);
+logger.LogWarning("Retry attempt {Attempt} of {MaxAttempts}", attempt, max);
+logger.LogError(ex, "Payment {PaymentId} failed", paymentId);
+logger.LogCritical("Database connection pool exhausted");
+```
+
+### Missing Exception in Log
+
+**Problem**: Logging exception message but not the exception itself.
+
+```csharp
+// BAD: Loses stack trace and exception type
+catch (Exception ex)
+{
+    logger.LogError("Operation failed: {Message}", ex.Message);
+}
+
+// GOOD: Pass exception as first parameter
+catch (Exception ex)
+{
+    logger.LogError(ex, "Operation failed for order {OrderId}", orderId);
+}
+```
+
+### Logging Inside Tight Loops
+
+**Problem**: Excessive logging in hot paths kills performance.
+
+```csharp
+// BAD: Logging every iteration
+foreach (var item in items) // Could be millions
+{
+    logger.LogDebug("Processing item {ItemId}", item.Id);
+    Process(item);
+}
+
+// GOOD: Log summary or use conditional logging
+logger.LogInformation("Processing {Count} items", items.Count);
+foreach (var item in items)
+{
+    Process(item);
+}
+logger.LogInformation("Completed processing {Count} items", items.Count);
+```
+
+---
+
+## HttpClient Anti-Patterns
+
+### Creating HttpClient Directly
+
+**Problem**: Not using `IHttpClientFactory` leads to socket exhaustion.
+
+```csharp
+// BAD: Creates new HttpClient per request
+public async Task<string> GetDataAsync(string url)
+{
+    using var client = new HttpClient(); // Socket exhaustion risk
+    return await client.GetStringAsync(url);
+}
+
+// BAD: Singleton HttpClient ignores DNS changes
+private static readonly HttpClient _client = new();
+
+// GOOD: Use IHttpClientFactory
+public class ApiClient(HttpClient httpClient)
+{
+    public Task<string> GetDataAsync(string path) =>
+        httpClient.GetStringAsync(path);
+}
+```
+
+### Not Disposing HttpResponseMessage
+
+**Problem**: Leaking connections by not disposing responses.
+
+```csharp
+// BAD: Response not disposed
+public async Task<string?> GetValueAsync(string url)
+{
+    var response = await httpClient.GetAsync(url);
+    if (!response.IsSuccessStatusCode)
+        return null; // Response not disposed!
+    return await response.Content.ReadAsStringAsync();
+}
+
+// GOOD: Always dispose response
+public async Task<string?> GetValueAsync(string url)
+{
+    using var response = await httpClient.GetAsync(url);
+    if (!response.IsSuccessStatusCode)
+        return null;
+    return await response.Content.ReadAsStringAsync();
+}
+```
+
+### Ignoring Cancellation Tokens
+
+**Problem**: Not passing cancellation tokens to async operations.
+
+```csharp
+// BAD: No cancellation support
+public async Task<Data> GetDataAsync()
+{
+    var response = await httpClient.GetAsync("api/data");
+    return await response.Content.ReadFromJsonAsync<Data>();
+}
+
+// GOOD: Support cancellation throughout
+public async Task<Data?> GetDataAsync(CancellationToken cancellationToken = default)
+{
+    using var response = await httpClient.GetAsync("api/data", cancellationToken);
+    response.EnsureSuccessStatusCode();
+    return await response.Content.ReadFromJsonAsync<Data>(cancellationToken);
+}
+```
+
+---
+
+## Hosted Service Anti-Patterns
+
+### Blocking in ExecuteAsync
+
+**Problem**: Blocking the hosted service startup.
+
+```csharp
+// BAD: Blocks application startup
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    while (!stoppingToken.IsCancellationRequested)
+    {
+        Thread.Sleep(1000); // Blocks thread!
+        await ProcessAsync();
+    }
+}
+
+// GOOD: Use async delays
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    while (!stoppingToken.IsCancellationRequested)
+    {
+        await ProcessAsync(stoppingToken);
+        await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+    }
+}
+```
+
+### Not Handling Exceptions
+
+**Problem**: Unhandled exceptions crash the hosted service silently.
+
+```csharp
+// BAD: Unhandled exception stops the service
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    while (!stoppingToken.IsCancellationRequested)
+    {
+        await DoWorkAsync(stoppingToken); // Exception kills the loop
+    }
+}
+
+// GOOD: Handle exceptions and continue
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    while (!stoppingToken.IsCancellationRequested)
+    {
+        try
+        {
+            await DoWorkAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Expected during shutdown
+            break;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error in background processing");
+            await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+        }
+    }
+}
+```
+
+### Injecting Scoped Services Directly
+
+**Problem**: Scoped services injected into singleton hosted services.
+
+```csharp
+// BAD: Scoped DbContext in singleton BackgroundService
+public class DataSyncService(AppDbContext dbContext) : BackgroundService
+{
+    // dbContext is now a captive dependency with wrong lifetime
+}
+
+// GOOD: Create scope for each unit of work
+public class DataSyncService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<DataSyncService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            using var scope = scopeFactory.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            await SyncDataAsync(dbContext, stoppingToken);
+            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+        }
+    }
+}
+```
+
+---
+
+## Generic Host Anti-Patterns
+
+### Long-Running StartAsync
+
+**Problem**: Blocking application startup in `IHostedService.StartAsync`.
+
+```csharp
+// BAD: Blocks entire application startup
+public class WarmupService : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await LoadEntireCacheAsync(); // Takes 30 seconds!
+    }
+}
+
+// GOOD: Start work in background, return quickly
+public class WarmupService(ILogger<WarmupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Starting cache warmup");
+        await LoadEntireCacheAsync(stoppingToken);
+        logger.LogInformation("Cache warmup complete");
+    }
+}
+```
+
+### Ignoring Application Lifetime Events
+
+**Problem**: Not cleaning up resources during shutdown.
+
+```csharp
+// BAD: No graceful shutdown handling
+public class WorkerService : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessBatchAsync(); // May be interrupted mid-batch
+        }
+    }
+}
+
+// GOOD: Handle shutdown gracefully
+public class WorkerService(
+    IHostApplicationLifetime lifetime,
+    ILogger<WorkerService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        lifetime.ApplicationStopping.Register(() =>
+            logger.LogInformation("Shutdown requested, finishing current batch..."));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessBatchAsync(stoppingToken);
+        }
+
+        logger.LogInformation("Graceful shutdown complete");
+    }
+}
+```

--- a/.github/skills/microsoft-extensions/references/patterns.md
+++ b/.github/skills/microsoft-extensions/references/patterns.md
@@ -1,0 +1,540 @@
+# Microsoft.Extensions Patterns
+
+## Dependency Injection Patterns
+
+### Constructor Injection with Primary Constructors
+
+Primary constructors (C# 12+) provide a concise way to declare dependencies:
+
+```csharp
+public class OrderService(
+    IOrderRepository repository,
+    ILogger<OrderService> logger,
+    IOptions<OrderSettings> options)
+{
+    public async Task<Order> GetOrderAsync(int id)
+    {
+        logger.LogDebug("Fetching order {OrderId}", id);
+        return await repository.GetByIdAsync(id);
+    }
+}
+```
+
+### Service Registration Extensions
+
+Encapsulate related registrations in extension methods:
+
+```csharp
+public static class OrderingServiceExtensions
+{
+    public static IServiceCollection AddOrdering(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<OrderSettings>(configuration.GetSection("Ordering"));
+        services.AddScoped<IOrderRepository, OrderRepository>();
+        services.AddScoped<IOrderService, OrderService>();
+        return services;
+    }
+}
+```
+
+Usage in `Program.cs`:
+
+```csharp
+builder.Services.AddOrdering(builder.Configuration);
+```
+
+### Keyed Services (C# 12+ / .NET 8+)
+
+Register and resolve multiple implementations by key:
+
+```csharp
+// Registration
+services.AddKeyedScoped<IPaymentProcessor, StripeProcessor>("stripe");
+services.AddKeyedScoped<IPaymentProcessor, PayPalProcessor>("paypal");
+
+// Injection via primary constructor
+public class CheckoutService(
+    [FromKeyedServices("stripe")] IPaymentProcessor stripeProcessor,
+    [FromKeyedServices("paypal")] IPaymentProcessor paypalProcessor)
+{
+    public Task ProcessAsync(string provider, decimal amount) =>
+        provider switch
+        {
+            "stripe" => stripeProcessor.ChargeAsync(amount),
+            "paypal" => paypalProcessor.ChargeAsync(amount),
+            _ => throw new ArgumentException($"Unknown provider: {provider}")
+        };
+}
+```
+
+### Factory Pattern with DI
+
+When you need runtime parameters to create services:
+
+```csharp
+public interface IConnectionFactory
+{
+    IConnection Create(string connectionString);
+}
+
+public class ConnectionFactory(ILogger<ConnectionFactory> logger) : IConnectionFactory
+{
+    public IConnection Create(string connectionString)
+    {
+        logger.LogDebug("Creating connection to {ConnectionString}", connectionString);
+        return new Connection(connectionString);
+    }
+}
+```
+
+### Decorator Pattern
+
+Wrap existing services with additional behavior:
+
+```csharp
+public class CachingOrderRepository(
+    IOrderRepository inner,
+    IMemoryCache cache,
+    ILogger<CachingOrderRepository> logger) : IOrderRepository
+{
+    public async Task<Order?> GetByIdAsync(int id)
+    {
+        var cacheKey = $"order:{id}";
+        if (cache.TryGetValue(cacheKey, out Order? cached))
+        {
+            logger.LogDebug("Cache hit for order {OrderId}", id);
+            return cached;
+        }
+
+        var order = await inner.GetByIdAsync(id);
+        if (order is not null)
+        {
+            cache.Set(cacheKey, order, TimeSpan.FromMinutes(5));
+        }
+        return order;
+    }
+}
+```
+
+Registration with Scrutor or manual:
+
+```csharp
+services.AddScoped<IOrderRepository, OrderRepository>();
+services.Decorate<IOrderRepository, CachingOrderRepository>();
+```
+
+---
+
+## Configuration Patterns
+
+### Strongly Typed Configuration
+
+Define a POCO for your settings:
+
+```csharp
+public class EmailSettings
+{
+    public const string SectionName = "Email";
+
+    public required string SmtpHost { get; init; }
+    public int SmtpPort { get; init; } = 587;
+    public required string FromAddress { get; init; }
+    public bool UseSsl { get; init; } = true;
+}
+```
+
+Register and bind:
+
+```csharp
+services.Configure<EmailSettings>(configuration.GetSection(EmailSettings.SectionName));
+```
+
+### Configuration Validation at Startup
+
+Use `ValidateDataAnnotations` or `ValidateOnStart` to fail fast:
+
+```csharp
+public class DatabaseSettings
+{
+    [Required]
+    public required string ConnectionString { get; init; }
+
+    [Range(1, 100)]
+    public int MaxPoolSize { get; init; } = 10;
+}
+
+// Registration with validation
+services.AddOptions<DatabaseSettings>()
+    .BindConfiguration("Database")
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+```
+
+### Custom Validation Logic
+
+```csharp
+services.AddOptions<ApiSettings>()
+    .BindConfiguration("Api")
+    .Validate(settings =>
+    {
+        if (string.IsNullOrEmpty(settings.BaseUrl))
+            return false;
+        return Uri.TryCreate(settings.BaseUrl, UriKind.Absolute, out _);
+    }, "BaseUrl must be a valid absolute URI")
+    .ValidateOnStart();
+```
+
+### Environment-Specific Configuration
+
+Standard configuration layering:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+// Already loaded by CreateApplicationBuilder:
+// 1. appsettings.json
+// 2. appsettings.{Environment}.json
+// 3. Environment variables
+// 4. Command-line args
+
+// Add additional sources if needed
+builder.Configuration.AddJsonFile("secrets.json", optional: true);
+```
+
+### Configuration Sections Binding
+
+Bind nested sections:
+
+```csharp
+public class AppSettings
+{
+    public required DatabaseSettings Database { get; init; }
+    public required EmailSettings Email { get; init; }
+    public required CacheSettings Cache { get; init; }
+}
+
+// Bind entire hierarchy
+var settings = configuration.Get<AppSettings>();
+```
+
+---
+
+## Options Pattern
+
+### IOptions vs IOptionsSnapshot vs IOptionsMonitor
+
+| Interface | Lifetime | Reloads | Use Case |
+|-----------|----------|---------|----------|
+| `IOptions<T>` | Singleton | No | Static configuration |
+| `IOptionsSnapshot<T>` | Scoped | Per request | Web apps with reloadable config |
+| `IOptionsMonitor<T>` | Singleton | Yes (notifications) | Long-running services |
+
+### Using IOptionsMonitor for Live Updates
+
+```csharp
+public class FeatureFlagService(IOptionsMonitor<FeatureFlags> optionsMonitor)
+{
+    public bool IsEnabled(string featureName) =>
+        optionsMonitor.CurrentValue.EnabledFeatures.Contains(featureName);
+
+    public IDisposable OnChange(Action<FeatureFlags> listener) =>
+        optionsMonitor.OnChange(listener);
+}
+```
+
+### Named Options
+
+Configure multiple instances of the same type:
+
+```csharp
+services.Configure<StorageOptions>("blob", configuration.GetSection("Storage:Blob"));
+services.Configure<StorageOptions>("table", configuration.GetSection("Storage:Table"));
+
+// Injection
+public class StorageService(IOptionsSnapshot<StorageOptions> options)
+{
+    public string GetBlobConnectionString() =>
+        options.Get("blob").ConnectionString;
+
+    public string GetTableConnectionString() =>
+        options.Get("table").ConnectionString;
+}
+```
+
+### Post-Configure
+
+Apply transformations after binding:
+
+```csharp
+services.PostConfigure<ApiSettings>(settings =>
+{
+    settings.BaseUrl = settings.BaseUrl.TrimEnd('/');
+});
+```
+
+---
+
+## Logging Patterns
+
+### Structured Logging
+
+Use message templates with named placeholders:
+
+```csharp
+public class PaymentService(ILogger<PaymentService> logger)
+{
+    public async Task ProcessPaymentAsync(Payment payment)
+    {
+        logger.LogInformation(
+            "Processing payment {PaymentId} for {Amount:C} from {CustomerId}",
+            payment.Id, payment.Amount, payment.CustomerId);
+
+        try
+        {
+            await ProcessAsync(payment);
+            logger.LogInformation("Payment {PaymentId} processed successfully", payment.Id);
+        }
+        catch (PaymentException ex)
+        {
+            logger.LogError(ex,
+                "Payment {PaymentId} failed: {ErrorCode}",
+                payment.Id, ex.ErrorCode);
+            throw;
+        }
+    }
+}
+```
+
+### High-Performance Logging with Source Generators
+
+Define log messages at compile time:
+
+```csharp
+public static partial class Log
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "Processing order {OrderId} with {ItemCount} items")]
+    public static partial void ProcessingOrder(ILogger logger, int orderId, int itemCount);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Order {OrderId} processing failed")]
+    public static partial void OrderProcessingFailed(ILogger logger, int orderId, Exception exception);
+}
+
+// Usage
+public class OrderProcessor(ILogger<OrderProcessor> logger)
+{
+    public void Process(Order order)
+    {
+        Log.ProcessingOrder(logger, order.Id, order.Items.Count);
+    }
+}
+```
+
+### Logging Scopes
+
+Add contextual data to all logs within a scope:
+
+```csharp
+public class RequestProcessor(ILogger<RequestProcessor> logger)
+{
+    public async Task ProcessAsync(Request request)
+    {
+        using (logger.BeginScope(new Dictionary<string, object>
+        {
+            ["RequestId"] = request.Id,
+            ["UserId"] = request.UserId,
+            ["CorrelationId"] = request.CorrelationId
+        }))
+        {
+            logger.LogInformation("Starting request processing");
+            await DoWorkAsync(request);
+            logger.LogInformation("Request processing completed");
+        }
+    }
+}
+```
+
+### Category-Based Filtering
+
+Configure log levels per category in `appsettings.json`:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "MyApp.DataAccess": "Debug",
+      "MyApp.Services": "Information"
+    }
+  }
+}
+```
+
+---
+
+## HttpClientFactory Patterns
+
+### Typed Clients
+
+```csharp
+public class GitHubClient(HttpClient httpClient, ILogger<GitHubClient> logger)
+{
+    public async Task<User?> GetUserAsync(string username)
+    {
+        logger.LogDebug("Fetching GitHub user {Username}", username);
+        return await httpClient.GetFromJsonAsync<User>($"users/{username}");
+    }
+}
+
+// Registration
+services.AddHttpClient<GitHubClient>(client =>
+{
+    client.BaseAddress = new Uri("https://api.github.com/");
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("MyApp/1.0");
+});
+```
+
+### Resilience with Polly
+
+```csharp
+services.AddHttpClient<ExternalApiClient>()
+    .AddStandardResilienceHandler();
+
+// Or custom policies
+services.AddHttpClient<ExternalApiClient>()
+    .AddResilienceHandler("custom", builder =>
+    {
+        builder.AddRetry(new HttpRetryStrategyOptions
+        {
+            MaxRetryAttempts = 3,
+            BackoffType = DelayBackoffType.Exponential
+        });
+        builder.AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+        {
+            SamplingDuration = TimeSpan.FromSeconds(30),
+            FailureRatio = 0.5,
+            MinimumThroughput = 10
+        });
+    });
+```
+
+### Named Clients
+
+```csharp
+services.AddHttpClient("github", client =>
+{
+    client.BaseAddress = new Uri("https://api.github.com/");
+});
+
+// Usage via factory
+public class MultiApiService(IHttpClientFactory clientFactory)
+{
+    public async Task<string> GetDataAsync()
+    {
+        var client = clientFactory.CreateClient("github");
+        return await client.GetStringAsync("zen");
+    }
+}
+```
+
+---
+
+## Hosted Service Patterns
+
+### Background Worker
+
+```csharp
+public class QueueProcessor(
+    IServiceScopeFactory scopeFactory,
+    ILogger<QueueProcessor> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Queue processor starting");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            using var scope = scopeFactory.CreateScope();
+            var queue = scope.ServiceProvider.GetRequiredService<IMessageQueue>();
+
+            if (await queue.TryDequeueAsync(stoppingToken) is { } message)
+            {
+                await ProcessMessageAsync(message, scope.ServiceProvider, stoppingToken);
+            }
+            else
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+            }
+        }
+    }
+}
+```
+
+### Timed Background Service
+
+```csharp
+public class HealthCheckService(
+    ILogger<HealthCheckService> logger,
+    IOptions<HealthCheckOptions> options) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(options.Value.Interval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await PerformHealthCheckAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Health check failed");
+            }
+        }
+    }
+}
+```
+
+---
+
+## Generic Host Patterns
+
+### Minimal Console App
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddHostedService<WorkerService>();
+builder.Services.AddOrdering(builder.Configuration);
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+### Graceful Shutdown
+
+```csharp
+public class GracefulWorker(
+    IHostApplicationLifetime lifetime,
+    ILogger<GracefulWorker> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        lifetime.ApplicationStarted.Register(() =>
+            logger.LogInformation("Application started"));
+
+        lifetime.ApplicationStopping.Register(() =>
+            logger.LogInformation("Application stopping, draining work..."));
+
+        // Work loop
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await DoWorkAsync(stoppingToken);
+        }
+    }
+}
+```

--- a/.github/skills/migrate-xunit-to-xunit-v3/SKILL.md
+++ b/.github/skills/migrate-xunit-to-xunit-v3/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: migrate-xunit-to-xunit-v3
+description: >
+  Migrates .NET test projects from xUnit.net v2 to xUnit.net v3.
+  USE FOR: upgrading xunit to xunit.v3.
+  DO NOT USE FOR: migrating between test frameworks (MSTest/NUnit to
+  xUnit.net), migrating from VSTest to Microsoft.Testing.Platform
+  (use migrate-vstest-to-mtp).
+license: MIT
+---
+
+# xunit.v3 Migration
+
+Migrate .NET test projects from xUnit.net v2 to xUnit.net v3. The outcome is a solution where all test projects reference `xunit.v3.*` packages, compiles cleanly, and all tests pass with the same results as before migration.
+
+## When to Use
+
+- Upgrading test projects from `xunit` (v2) packages to `xunit.v3`
+- Resolving compilation errors after updating xunit package references to v3
+
+## When Not to Use
+
+- Migrating between test frameworks (e.g., MSTest or NUnit to xUnit.net) — different effort entirely
+- Migrating from VSTest to Microsoft.Testing.Platform — use `migrate-vstest-to-mtp`
+- The projects already reference `xunit.v3` — migration is done
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Test project or solution | Yes | The .NET project or solution containing xUnit.net v2 test projects |
+
+## Workflow
+
+> **Commit strategy:** Commit after each major step so the migration is reviewable and bisectable. Separate project file changes from code changes.
+
+### Step 1: Identify xUnit.net projects
+
+Search for test projects referencing xUnit.net v2 packages:
+
+- `xunit`
+- `xunit.abstractions`
+- `xunit.assert`
+- `xunit.core`
+- `xunit.extensibility.core`
+- `xunit.extensibility.execution`
+- `xunit.runner.visualstudio`
+
+Make sure to check the package references in project files, MSBuild props and targets files, like `Directory.Build.props`, `Directory.Build.targets`, and `Directory.Packages.props`.
+
+### Step 2: Verify compatibility
+
+1. Verify target framework compatibility: xUnit.net v3 requires **.NET 8+** or **.NET Framework 4.7.2+**. For test library projects, .NET Standard 2.0 is also supported.
+2. If any of the test projects have non-compatible target frameworks, STOP here and DON'T do anything. Only tell the user to upgrade the target framework first before migrating xUnit.net.
+3. Verify project compatibility: xUnit.net v3 only supports SDK-style projects. If any test projects are non-SDK-style, STOP here and DON'T do anything. Only tell the user to migrate to SDK-style projects first before migrating xUnit.net.
+
+### Step 3: Establish a baseline
+
+Run `dotnet test` to establish a baseline of test pass/fail counts. When running `dotnet test`, ensure that:
+
+- You run `dotnet test` without any additional arguments (i.e., don't pass `--no-restore` or `--no-build`).
+- Ensure you redirect the command output to a file and read the output from that file.
+
+### Step 4: Update package references
+
+1. Update any `PackageReference` or `PackageVersion` items for the new package names, based on the following mapping:
+
+    - `xunit` → `xunit.v3`
+    - `xunit.abstractions` → Remove entirely
+    - `xunit.assert` → `xunit.v3.assert`
+    - `xunit.core` → `xunit.v3.core`
+    - `xunit.extensibility.core` and `xunit.extensibility.execution` → `xunit.v3.extensibility.core` (if both are referenced in a project consolidate to only a single entry as the two packages are merged)
+
+2. Update all `xunit.v3.*` packages to the latest correct version available on NuGet. Also update `xunit.runner.visualstudio` to the latest version.
+
+### Step 5: Set `OutputType` to `Exe`
+
+In each test project (excluding test library projects), set `OutputType` to `Exe` in the project file:
+
+```xml
+<PropertyGroup>
+  <OutputType>Exe</OutputType>
+</PropertyGroup>
+```
+
+Depending on the solution in hand, there might be a centralized place where this can be added. For example:
+
+- If all test projects share (or can share) a common `Directory.Build.props`, add the `<OutputType>Exe</OutputType>` property there. Note that the OutputType should not be added to `Directory.Build.targets`.
+- If all test projects share a name pattern (e.g., `*.Tests.csproj`), add a conditional property group in `Directory.Build.props` that applies only to those projects, like `<OutputType Condition="$(MSBuildProjectName.EndsWith('.Tests'))">Exe</OutputType>`. Adjust the condition as needed to target only test projects.
+- Otherwise, add the `<OutputType>Exe</OutputType>` property to each test project file individually.
+
+### Step 6: Remove `Xunit.Abstractions` usings
+
+Find any `using Xunit.Abstractions;` directives in C# files and remove them completely.
+
+### Step 7: Address `async void` breaking change
+
+In xUnit.net v3, `async void` test methods are no longer supported and will fail to compile. Search for any test methods declared with `async void` and change them to `async Task`. Test methods can be identified via the `[Fact]` or `[Theory]` attributes or other test attributes.
+
+### Step 8: Address breaking change of attributes
+
+In xUnit.net v3, some attributes were updated so that they accept a `System.Type` instead of two strings (fully qualified type name and assembly name). These attributes are:
+
+- `CollectionBehaviorAttribute`
+- `TestCaseOrdererAttribute`
+- `TestCollectionOrdererAttribute`
+- `TestFrameworkAttribute`
+
+For example, `[assembly: CollectionBehavior("MyNamespace.MyCollectionFactory", "MyAssembly")]` must be converted to `[assembly: CollectionBehavior(typeof(MyNamespace.MyCollectionFactory))]`.
+
+### Step 9: Inheriting from FactAttribute or TheoryAttribute
+
+Identify if there are any custom attributes that inherit from `FactAttribute` or `TheoryAttribute`. These custom user-defined attributes must now provide source information. For example, if the attribute looked like this:
+
+```csharp
+internal sealed class MyFactAttribute : FactAttribute
+{
+    public MyFactAttribute()
+    {
+    }
+}
+```
+
+it must be changed to this:
+
+```csharp
+internal sealed class MyFactAttribute : FactAttribute
+{
+    public MyFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1
+    ) : base(sourceFilePath, sourceLineNumber)
+    {
+    }
+}
+```
+
+### Step 10: Inheriting from BeforeAfterTestAttribute
+
+Identify if there are any custom attributes that inherit from `BeforeAfterTestAttribute`. These custom user-defined attributes must update their method signatures. Previously, they would have `Before`/`After` overrides that look like this:
+
+```csharp
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        // Possibly some custom logic here
+        base.Before(methodUnderTest);
+        // Possibly some custom logic here
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+        // Possibly some custom logic here
+        base.After(methodUnderTest);
+        // Possibly some custom logic here
+    }
+```
+
+it must be changed to this:
+
+```csharp
+    public override void Before(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        // Possibly some custom logic here
+        base.Before(methodUnderTest, test);
+        // Possibly some custom logic here
+    }
+
+    public override void After(MethodInfo methodUnderTest, IXunitTest test)
+    {
+        // Possibly some custom logic here
+        base.After(methodUnderTest, test);
+        // Possibly some custom logic here
+    }
+```
+
+### Step 11: Address new xUnit analyzer warnings
+
+xunit.v3 introduced new analyzer warnings. You should attempt to address them.
+
+One of the most notable warnings is [xUnit1051: Calls to methods which accept CancellationToken should use TestContext.Current.CancellationToken](https://xunit.net/xunit.analyzers/rules/xUnit1051). Identify the calls to such methods, if any, and pass the cancellation token.
+
+### Step 12: Test platform selection
+
+You should keep the same test platform that was used with xunit 2.
+
+Note that xunit 2 is always VSTest except if the user used YTest.MTP.XUnit2.
+
+- If user had a reference to YTest.MTP.XUnit2:
+  - Remove the reference to YTest.MTP.XUnit2 completely.
+  - Add `<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>` to Directory.Build.props under an unconditional PropertyGroup.
+- If user didn't have a reference to YTest.MTP.XUnit2:
+  - Add `<IsTestingPlatformApplication>false</IsTestingPlatformApplication>` to Directory.Build.props under an unconditional PropertyGroup.
+
+### Step 13: Migrate `Xunit.SkippableFact`
+
+If there are any package references to `Xunit.SkippableFact`, remove all these package references entirely.
+
+Then, follow these steps to eliminate usages of APIs coming from the removed package reference:
+
+- Update any `SkippableFact` attribute to the regular `Fact` attribute.
+- Update any `SkippableTheory` attribute to the regular `Theory` attribute.
+- Change `Skip.If` method calls to `Assert.SkipWhen`.
+- Change `Skip.IfNot` method calls to `Assert.SkipUnless`.
+
+### Step 14: Update `Xunit.Combinatorial` NuGet package
+
+Find package references of `Xunit.Combinatorial` and update them from 1.x to the latest 2.x version available.
+
+### Step 15: Update `Xunit.StaFact` NuGet package
+
+Find package references of `Xunit.StaFact` and update them from 1.x to the latest 3.x version available.
+
+### Step 16: Build the solution
+
+Now, build the solution to identify any remaining compilation errors that might not have been addressed by previous instructions.
+Fix any straightforward errors that show up, and keep iterating and fixing more.
+
+You can also look into <https://xunit.net/docs/getting-started/v3/migration-extensibility> and <https://xunit.net/docs/getting-started/v3/migration> to help with the remaining compilation errors.
+
+You can fix as much as you can, and it's okay if not everything is fixed. Just tell the user that there are remaining errors that need to be manually addressed.

--- a/.github/skills/migrate-xunit-to-xunit-v3/manifest.json
+++ b/.github/skills/migrate-xunit-to-xunit-v3/manifest.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1.0",
+  "category": "Testing",
+  "compatibility": "Requires a .NET test project or solution.",
+  "packages": [
+    "xunit",
+    "xunit.v3"
+  ]
+}

--- a/.github/skills/minimal-api-file-upload/SKILL.md
+++ b/.github/skills/minimal-api-file-upload/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: minimal-api-file-upload
+description: File upload endpoints in ASP.NET minimal APIs (.NET 8+)
+license: MIT
+---
+
+# Implementing File Uploads in ASP.NET Core Minimal APIs
+
+## When to Use
+- File upload endpoints in ASP.NET Core minimal APIs (.NET 8+)
+- Handling IFormFile or IFormFileCollection parameters
+- When you need size limits, content type validation, or streaming large files
+
+## When Not to Use
+- MVC controllers → `[FromForm] IFormFile` works directly with attributes
+- Simple JSON body → no file upload needed
+- Very large files (> 1GB) → use streaming with `MultipartReader` instead
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| File parameter(s) | Yes | IFormFile or IFormFileCollection |
+| Size limits | Yes | Max file/request size |
+| Allowed types | No | Content type or extension restrictions |
+
+## Workflow
+
+### Step 1: CRITICAL — Understand IFormFile Binding in Minimal APIs
+
+```csharp
+// In .NET 8+ minimal APIs, IFormFile binds automatically from multipart/form-data
+// when it is the only complex parameter.
+app.MapPost("/upload", (IFormFile file) => ...);
+
+// CRITICAL: When you mix files with other form fields, use [FromForm] on all
+// form-bound parameters (or group them into a single [FromForm] DTO).
+app.MapPost("/upload-with-metadata",
+    ([FromForm] IFormFile file, [FromForm] string description) =>
+{
+    return Results.Ok(new { file.FileName, Description = description });
+});
+
+// Multiple files: IFormFileCollection also binds automatically from multipart/form-data.
+// You only need [FromForm] if you mix it with other form fields, as shown above.
+app.MapPost("/upload-multiple", (IFormFileCollection files) =>
+{
+    return Results.Ok(files.Select(f => new { f.FileName, f.Length }));
+});
+```
+
+### Step 2: CRITICAL — File Size Limits Are Separate from Request Size Limits
+
+```csharp
+// CRITICAL: There are TWO different size limits and you need to configure BOTH
+
+// 1. Request body size limit (Kestrel level) — default is 30MB
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = 10 * 1024 * 1024; // 10 MB
+});
+
+// 2. Form options — multipart body length limit — default is 128MB
+builder.Services.Configure<FormOptions>(options =>
+{
+    options.MultipartBodyLengthLimit = 10 * 1024 * 1024; // 10 MB
+    options.ValueLengthLimit = 1024 * 1024; // 1 MB for form values
+    options.MultipartHeadersLengthLimit = 16384; // 16 KB for section headers
+});
+
+// COMMON MISTAKE: Only increasing Kestrel MaxRequestBodySize
+// upload still fails because FormOptions.MultipartBodyLengthLimit is exceeded
+
+// COMMON MISTAKE: Only increasing FormOptions
+// upload fails with "Request body too large" from Kestrel before reaching form parsing
+
+// CRITICAL: Per-endpoint override with RequestSizeLimit attribute
+app.MapPost("/upload-large", [RequestSizeLimit(200_000_000)] (IFormFile file) =>
+{
+    return Results.Ok(new { file.FileName, file.Length });
+});
+
+// CRITICAL: To disable the limit entirely (for streaming):
+app.MapPost("/upload-unlimited", [DisableRequestSizeLimit] async (HttpContext context) =>
+{
+    // Handle manually
+});
+```
+
+### Step 3: CRITICAL — Anti-Forgery Auto-Validates Form Uploads in .NET 8+
+
+```csharp
+// CRITICAL: In .NET 8+ with UseAntiforgery(), ALL form-bound endpoints
+// automatically validate anti-forgery tokens, INCLUDING file uploads
+
+builder.Services.AddAntiforgery();
+var app = builder.Build();
+app.UseAntiforgery();
+
+// This endpoint now REQUIRES an anti-forgery token:
+app.MapPost("/upload", (IFormFile file) => Results.Ok(file.FileName));
+// Without the token → 400 Bad Request
+
+// CRITICAL: For API-only file uploads (no anti-forgery needed), opt out:
+app.MapPost("/api/upload", (IFormFile file) => Results.Ok(file.FileName))
+    .DisableAntiforgery();  // CRITICAL: Must explicitly opt out
+
+// COMMON MISTAKE: Getting 400 errors on file uploads and not realizing
+// it's because UseAntiforgery() is in the pipeline
+
+// WARNING: DisableAntiforgery() is safe for unauthenticated endpoints and
+// endpoints using JWT bearer authentication. However, for endpoints
+// authenticated with cookies, disabling antiforgery removes CSRF protection
+// and exposes the endpoint to cross-site request forgery attacks.
+// For cookie-authenticated endpoints, include a valid antiforgery token instead.
+```
+
+### Step 4: CRITICAL — Validate File Content, Not Just Extension
+
+```csharp
+app.MapPost("/upload", async (IFormFile file) =>
+{
+    // CRITICAL: Check content type AND file signature (magic bytes)
+    // NEVER trust file extension alone — it can be spoofed
+
+    // Allow only JPEG/PNG by default. To support more (e.g., GIF),
+    // add the MIME type here AND validate its magic bytes below.
+    var allowedTypes = new[] { "image/jpeg", "image/png" };
+    if (!allowedTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
+        return Results.BadRequest("File type not allowed");
+
+    // CRITICAL: Check magic bytes for file type verification
+    using var stream = file.OpenReadStream();
+    var header = new byte[8];
+    var bytesRead = await stream.ReadAsync(header, 0, header.Length);
+    if (bytesRead < 4)
+        return Results.BadRequest("File content is too short or invalid");
+
+    // JPEG: FF D8 FF
+    // PNG: 89 50 4E 47
+    var isJpeg = header[0] == 0xFF && header[1] == 0xD8 && header[2] == 0xFF;
+    var isPng = header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47;
+
+    // Determine the actual content type from magic bytes
+    string? detectedContentType = isJpeg ? "image/jpeg" : isPng ? "image/png" : null;
+    if (detectedContentType is null)
+        return Results.BadRequest("File content is not a supported image format (only JPEG and PNG are allowed).");
+
+    // Ensure the declared Content-Type matches what the magic bytes detected
+    if (!string.Equals(file.ContentType, detectedContentType, StringComparison.OrdinalIgnoreCase))
+        return Results.BadRequest("File content type does not match the declared ContentType header.");
+
+    // CRITICAL: Never use the user-provided filename directly for the save path — it can
+    // contain path traversal characters (e.g., "../../../etc/passwd").
+    // Generate a safe filename; derive the extension from validated content, not user input.
+    var extension = detectedContentType == "image/jpeg" ? ".jpg" : ".png";
+    var safeFileName = $"{Guid.NewGuid()}{extension}";
+    // NEVER: var path = Path.Combine("uploads", file.FileName);     // Path traversal!
+
+    var filePath = Path.Combine("uploads", safeFileName);
+    Directory.CreateDirectory("uploads");
+    stream.Position = 0;
+    using var fileStream = File.Create(filePath);
+    await stream.CopyToAsync(fileStream);
+
+    return Results.Ok(new { FileName = safeFileName, file.Length });
+});
+```
+
+### Step 5: CRITICAL — Streaming Large Files Without Buffering
+
+```csharp
+// CRITICAL: IFormFile relies on multipart form parsing that buffers content in memory
+// (up to a threshold) then spills to temp files on disk. For very large uploads,
+// this overhead is unnecessary if you can process the data in chunks.
+// Use MultipartReader to stream directly — e.g., to a final storage location —
+// without buffering the entire file first.
+
+app.MapPost("/upload-stream",
+    [DisableRequestSizeLimit]
+    async (HttpContext context) =>
+{
+    // Extract the multipart boundary from the Content-Type header
+    var contentType = context.Request.ContentType;
+    if (contentType == null)
+        return Results.BadRequest("Missing Content-Type");
+
+    // Safely parse the Content-Type header to avoid FormatException from MediaTypeHeaderValue.Parse
+    if (!MediaTypeHeaderValue.TryParse(contentType, out var mediaType))
+        return Results.BadRequest("Invalid Content-Type");
+
+    var boundary = HeaderUtilities.RemoveQuotes(mediaType.Boundary).Value;
+    if (string.IsNullOrWhiteSpace(boundary))
+        return Results.BadRequest("Not a multipart request");
+
+    var reader = new MultipartReader(boundary, context.Request.Body);
+
+    // CRITICAL: ReadNextSectionAsync returns null when there are no more sections
+    while (await reader.ReadNextSectionAsync() is { } section)
+    {
+        // Parse Content-Disposition to identify file sections
+        if (!ContentDispositionHeaderValue.TryParse(section.ContentDisposition, out var contentDisposition))
+            continue;
+
+        if (contentDisposition.DispositionType.Equals("form-data")
+            && !string.IsNullOrEmpty(contentDisposition.FileName.Value))
+        {
+            // Sanitize the user-provided filename to prevent path traversal
+            var originalFileName = contentDisposition.FileName.Value ?? string.Empty;
+            var sanitizedFileName = Path.GetFileName(originalFileName.Trim('"'));
+            var safeFile = $"{Guid.NewGuid()}";
+
+            // CRITICAL: Stream directly to disk — avoids buffering in memory
+            Directory.CreateDirectory("uploads");
+            using var fileStream = File.Create(Path.Combine("uploads", safeFile));
+            await section.Body.CopyToAsync(fileStream);
+        }
+    }
+
+    return Results.Ok("Uploaded");
+}).DisableAntiforgery();
+
+// COMMON MISTAKE: Using IFormFile for very large files
+// Multipart form parsing can buffer large uploads and consume memory/disk.
+// Use MultipartReader for streaming directly to storage.
+```
+
+## Common Mistakes
+
+1. **Only configuring one size limit**: Must configure BOTH Kestrel `MaxRequestBodySize` AND `FormOptions.MultipartBodyLengthLimit`.
+2. **400 errors from anti-forgery**: In .NET 8+, `UseAntiforgery()` auto-validates form uploads. Use `.DisableAntiforgery()` for API endpoints (safe for JWT/unauthenticated; do NOT disable for cookie-authenticated endpoints).
+3. **Trusting file.FileName**: User-provided filename can contain path traversal. Generate a safe filename with `Guid.NewGuid()` and derive the extension from validated content.
+4. **Trusting Content-Type only**: Content type is client-spoofable. Always check magic bytes for actual file type verification.
+5. **Using IFormFile for very large files**: Multipart form parsing buffers with a memory threshold and spills to temp files. Use `MultipartReader` to stream data in chunks directly to storage without buffering the entire file.
+6. **Deriving file extension from user input**: Prefer deriving the extension from the validated content type or magic bytes rather than `Path.GetExtension(file.FileName)`. If the original extension must be preserved, validate it against the detected content type.

--- a/.github/skills/minimal-api-file-upload/manifest.json
+++ b/.github/skills/minimal-api-file-upload/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.0",
+  "category": "Web",
+  "compatibility": "Requires an ASP.NET Core project or solution.",
+  "package_prefix": "Microsoft.AspNetCore"
+}

--- a/.github/skills/nunit/SKILL.md
+++ b/.github/skills/nunit/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: nunit
+description: "Write, run, or repair .NET tests that use NUnit. Use when a repo uses `NUnit`, `[Test]`, `[TestCase]`, `[TestFixture]`, or NUnit3TestAdapter for VSTest or Microsoft.Testing.Platform execution. USE FOR: writing or reviewing NUnit tests; using [Test], [TestCase], [TestFixture], [SetUp], [TearDown] attributes; configuring NUnit3TestAdapter or NUnit.Analyzers. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires NUnit 3.x or 4.x packages and appropriate test adapter."
+---
+
+# NUnit Testing
+
+## Trigger On
+
+- writing or reviewing NUnit tests
+- using `[Test]`, `[TestCase]`, `[TestFixture]`, `[SetUp]`, `[TearDown]` attributes
+- configuring NUnit3TestAdapter or NUnit.Analyzers
+- migrating between NUnit versions
+- integrating NUnit with CI pipelines
+
+## Documentation
+
+- [NUnit Documentation](https://docs.nunit.org/)
+- [NUnit GitHub](https://github.com/nunit/nunit)
+- [NUnit3TestAdapter](https://github.com/nunit/nunit3-vs-adapter)
+- [NUnit Analyzers](https://github.com/nunit/nunit.analyzers)
+
+## Workflow
+
+1. Detect whether the project uses NUnit 3.x or 4.x and which runner path is active: VSTest, Microsoft.Testing.Platform, IDE runner, or CI wrapper.
+2. Keep test fixtures small, prefer focused assertions with `Assert.That`, and use `TestCase` or `TestCaseSource` only when parameterization improves signal.
+3. Add `NUnit3TestAdapter`, `Microsoft.NET.Test.Sdk`, and `NUnit.Analyzers` when CLI discovery or analyzer coverage is missing.
+4. Validate with the repo's real test command before changing assertion style or lifecycle hooks.
+
+### References
+
+- [patterns.md](references/patterns.md) — Test patterns, assertions, parameterized tests, lifecycle
+- [anti-patterns.md](references/anti-patterns.md) — Common NUnit mistakes and fixes
+
+## Package Selection
+
+| Package | Purpose |
+|---------|---------|
+| `NUnit` | Core testing framework |
+| `NUnit3TestAdapter` | VSTest adapter for `dotnet test` |
+| `NUnit.Analyzers` | Roslyn analyzers for NUnit best practices |
+| `Microsoft.NET.Test.Sdk` | Required for test discovery |
+
+## Project Setup
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="NUnit" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+```
+
+## Test Patterns
+
+### Basic Test Structure
+
+```csharp
+[TestFixture]
+public class CalculatorTests
+{
+    private Calculator _calculator;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _calculator = new Calculator();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _calculator?.Dispose();
+    }
+
+    [Test]
+    public void Add_TwoPositiveNumbers_ReturnsSum()
+    {
+        var result = _calculator.Add(2, 3);
+
+        Assert.That(result, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Divide_ByZero_ThrowsException()
+    {
+        Assert.Throws<DivideByZeroException>(() => _calculator.Divide(10, 0));
+    }
+}
+```
+
+### Parameterized Tests with TestCase
+
+```csharp
+[TestFixture]
+public class ValidationTests
+{
+    [TestCase("", false)]
+    [TestCase("a", false)]
+    [TestCase("ab", false)]
+    [TestCase("abc", true)]
+    [TestCase("valid@email.com", true)]
+    public void IsValid_VariousInputs_ReturnsExpected(string input, bool expected)
+    {
+        var result = Validator.IsValid(input);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [TestCase(1, 2, ExpectedResult = 3)]
+    [TestCase(-1, 1, ExpectedResult = 0)]
+    [TestCase(100, 200, ExpectedResult = 300)]
+    public int Add_TestCases_ReturnsExpectedResult(int a, int b)
+    {
+        return _calculator.Add(a, b);
+    }
+}
+```
+
+### TestCaseSource for Complex Data
+
+```csharp
+[TestFixture]
+public class OrderTests
+{
+    private static IEnumerable<TestCaseData> OrderTestCases()
+    {
+        yield return new TestCaseData(
+            new Order { Items = new[] { new Item { Price = 10 }, new Item { Price = 20 } } },
+            30m
+        ).SetName("TwoItems_CalculatesTotal");
+
+        yield return new TestCaseData(
+            new Order { Items = Array.Empty<Item>() },
+            0m
+        ).SetName("EmptyOrder_ReturnsZero");
+
+        yield return new TestCaseData(
+            new Order { Items = new[] { new Item { Price = 100 } }, DiscountPercent = 10 },
+            90m
+        ).SetName("WithDiscount_AppliesDiscount");
+    }
+
+    [TestCaseSource(nameof(OrderTestCases))]
+    public void CalculateTotal_VariousOrders_ReturnsExpected(Order order, decimal expected)
+    {
+        var result = order.CalculateTotal();
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}
+```
+
+### Constraint-Based Assertions
+
+```csharp
+[Test]
+public void AssertionExamples()
+{
+    // Equality
+    Assert.That(actual, Is.EqualTo(expected));
+    Assert.That(actual, Is.Not.EqualTo(other));
+
+    // Comparison
+    Assert.That(value, Is.GreaterThan(5));
+    Assert.That(value, Is.LessThanOrEqualTo(10));
+    Assert.That(value, Is.InRange(1, 100));
+
+    // String
+    Assert.That(str, Does.StartWith("Hello"));
+    Assert.That(str, Does.Contain("world"));
+    Assert.That(str, Does.Match(@"\d{3}-\d{4}"));
+    Assert.That(str, Is.EqualTo("HELLO").IgnoreCase);
+
+    // Collection
+    Assert.That(list, Has.Count.EqualTo(5));
+    Assert.That(list, Contains.Item("expected"));
+    Assert.That(list, Is.All.GreaterThan(0));
+    Assert.That(list, Is.Unique);
+    Assert.That(list, Is.Ordered);
+    Assert.That(list, Has.Exactly(3).Items.GreaterThan(10));
+
+    // Type
+    Assert.That(obj, Is.InstanceOf<MyClass>());
+    Assert.That(obj, Is.AssignableTo<IMyInterface>());
+
+    // Null
+    Assert.That(obj, Is.Null);
+    Assert.That(obj, Is.Not.Null);
+
+    // Boolean
+    Assert.That(condition, Is.True);
+    Assert.That(condition, Is.False);
+
+    // Exception
+    Assert.That(() => DoSomething(), Throws.TypeOf<InvalidOperationException>());
+    Assert.That(() => DoSomething(), Throws.Exception.With.Message.Contains("error"));
+
+    // Async
+    Assert.That(async () => await DoAsync(), Throws.Nothing);
+}
+```
+
+### Async Test Support
+
+```csharp
+[TestFixture]
+public class AsyncServiceTests
+{
+    private IAsyncService _service;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = new AsyncService();
+    }
+
+    [Test]
+    public async Task GetDataAsync_ValidId_ReturnsData()
+    {
+        var result = await _service.GetDataAsync(1);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Id, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void GetDataAsync_InvalidId_ThrowsException()
+    {
+        Assert.ThrowsAsync<NotFoundException>(
+            async () => await _service.GetDataAsync(-1));
+    }
+
+    [Test]
+    public async Task ProcessAsync_CancellationRequested_ThrowsOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await _service.ProcessAsync(cts.Token));
+    }
+}
+```
+
+### OneTimeSetUp and OneTimeTearDown
+
+```csharp
+[TestFixture]
+public class IntegrationTests
+{
+    private static TestServer _server;
+    private HttpClient _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        // Runs once before all tests in fixture
+        _server = new TestServer(new WebHostBuilder().UseStartup<Startup>());
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        // Runs once after all tests in fixture
+        _server?.Dispose();
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        // Runs before each test
+        _client = _server.CreateClient();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // Runs after each test
+        _client?.Dispose();
+    }
+
+    [Test]
+    public async Task GetEndpoint_ReturnsSuccess()
+    {
+        var response = await _client.GetAsync("/api/data");
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+    }
+}
+```
+
+## Categories and Filtering
+
+```csharp
+[TestFixture]
+[Category("Integration")]
+public class DatabaseTests
+{
+    [Test]
+    [Category("Slow")]
+    public void SlowDatabaseTest() { }
+
+    [Test]
+    [Category("Fast")]
+    public void FastDatabaseTest() { }
+}
+
+// Run specific categories:
+// dotnet test --filter "Category=Fast"
+// dotnet test --filter "Category!=Slow"
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| Multiple asserts without clear purpose | Hard to identify which assertion failed | One logical assertion per test or use `Assert.Multiple` |
+| Test interdependence | Tests fail unpredictably | Each test should be independent |
+| Hardcoded test data | Brittle tests | Use `TestCase` or `TestCaseSource` |
+| Testing implementation details | Breaks on refactoring | Test behavior, not internals |
+| Missing `[SetUp]`/`[TearDown]` cleanup | Resource leaks | Always clean up resources |
+| Classic Assert syntax | Less readable | Use constraint model (`Assert.That`) |
+
+## Running Tests
+
+```bash
+# Run all tests
+dotnet test
+
+# Run with verbosity
+dotnet test --logger "console;verbosity=detailed"
+
+# Filter by name
+dotnet test --filter "FullyQualifiedName~CalculatorTests"
+
+# Filter by category
+dotnet test --filter "Category=Unit"
+
+# Run in parallel
+dotnet test -- NUnit.NumberOfTestWorkers=4
+```
+
+## Deliver
+
+- NUnit tests following the Arrange-Act-Assert pattern
+- Parameterized tests with `[TestCase]` and `[TestCaseSource]`
+- Constraint-based assertions with `Assert.That`
+- Proper test lifecycle management
+
+## Validate
+
+- Tests are independent and isolated
+- No hardcoded test data where parameterization is appropriate
+- Async tests use `async Task` not `async void`
+- Resources are properly disposed in `[TearDown]` or `[OneTimeTearDown]`
+- NUnit.Analyzers enabled to catch common issues

--- a/.github/skills/nunit/manifest.json
+++ b/.github/skills/nunit/manifest.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "category": "Testing",
+  "packages": [
+    "NUnit",
+    "NUnit3TestAdapter"
+  ]
+}

--- a/.github/skills/nunit/references/anti-patterns.md
+++ b/.github/skills/nunit/references/anti-patterns.md
@@ -1,0 +1,466 @@
+# NUnit Anti-Patterns Reference
+
+## Test Structure Anti-Patterns
+
+### Multiple Unrelated Assertions
+
+```csharp
+// WRONG - Tests multiple unrelated things
+[Test]
+public void UserService_Works()
+{
+    var user = _service.CreateUser("test@example.com");
+    Assert.That(user, Is.Not.Null);
+
+    var updated = _service.UpdateUser(user.Id, "new@example.com");
+    Assert.That(updated.Email, Is.EqualTo("new@example.com"));
+
+    _service.DeleteUser(user.Id);
+    var deleted = _service.GetUser(user.Id);
+    Assert.That(deleted, Is.Null);
+}
+
+// CORRECT - One test per behavior
+[Test]
+public void CreateUser_ValidEmail_ReturnsUser()
+{
+    var user = _service.CreateUser("test@example.com");
+    Assert.That(user, Is.Not.Null);
+}
+
+[Test]
+public void UpdateUser_NewEmail_UpdatesEmail()
+{
+    var user = _service.CreateUser("test@example.com");
+    var updated = _service.UpdateUser(user.Id, "new@example.com");
+    Assert.That(updated.Email, Is.EqualTo("new@example.com"));
+}
+
+[Test]
+public void DeleteUser_ExistingUser_RemovesUser()
+{
+    var user = _service.CreateUser("test@example.com");
+    _service.DeleteUser(user.Id);
+    Assert.That(_service.GetUser(user.Id), Is.Null);
+}
+```
+
+### Test Interdependence
+
+```csharp
+// WRONG - Tests depend on execution order
+[TestFixture]
+public class OrderDependentTests
+{
+    private static int _sharedCounter = 0;
+
+    [Test, Order(1)]
+    public void First_IncrementsCounter()
+    {
+        _sharedCounter++;
+        Assert.That(_sharedCounter, Is.EqualTo(1));
+    }
+
+    [Test, Order(2)]
+    public void Second_DependsOnFirst()
+    {
+        // Fails if First doesn't run first
+        Assert.That(_sharedCounter, Is.EqualTo(1));
+    }
+}
+
+// CORRECT - Independent tests
+[TestFixture]
+public class IndependentTests
+{
+    private int _counter;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _counter = 0; // Fresh state for each test
+    }
+
+    [Test]
+    public void Increment_FromZero_ReturnsOne()
+    {
+        _counter++;
+        Assert.That(_counter, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Increment_Twice_ReturnsTwo()
+    {
+        _counter++;
+        _counter++;
+        Assert.That(_counter, Is.EqualTo(2));
+    }
+}
+```
+
+### Classic Assert Instead of Constraint Model
+
+```csharp
+// WRONG - Classic assert syntax (less readable, deprecated in NUnit 4)
+[Test]
+public void ClassicAsserts()
+{
+    Assert.AreEqual(expected, actual);
+    Assert.IsTrue(condition);
+    Assert.IsNotNull(obj);
+    Assert.IsInstanceOf<MyClass>(obj);
+    Assert.Throws<Exception>(() => DoSomething());
+}
+
+// CORRECT - Constraint model
+[Test]
+public void ConstraintAsserts()
+{
+    Assert.That(actual, Is.EqualTo(expected));
+    Assert.That(condition, Is.True);
+    Assert.That(obj, Is.Not.Null);
+    Assert.That(obj, Is.InstanceOf<MyClass>());
+    Assert.That(() => DoSomething(), Throws.TypeOf<Exception>());
+}
+```
+
+## Async Anti-Patterns
+
+### Async Void Tests
+
+```csharp
+// WRONG - async void cannot be awaited
+[Test]
+public async void GetDataAsync_BadPattern()
+{
+    var result = await _service.GetDataAsync();
+    Assert.That(result, Is.Not.Null);
+    // Test might complete before assertion runs!
+}
+
+// CORRECT - async Task
+[Test]
+public async Task GetDataAsync_GoodPattern()
+{
+    var result = await _service.GetDataAsync();
+    Assert.That(result, Is.Not.Null);
+}
+```
+
+### Blocking on Async Code
+
+```csharp
+// WRONG - Blocking can cause deadlocks
+[Test]
+public void GetData_Blocking()
+{
+    var result = _service.GetDataAsync().Result; // Deadlock risk
+    Assert.That(result, Is.Not.Null);
+}
+
+// WRONG - GetAwaiter().GetResult() is just as bad
+[Test]
+public void GetData_GetAwaiter()
+{
+    var result = _service.GetDataAsync().GetAwaiter().GetResult();
+    Assert.That(result, Is.Not.Null);
+}
+
+// CORRECT - Use async/await
+[Test]
+public async Task GetData_Async()
+{
+    var result = await _service.GetDataAsync();
+    Assert.That(result, Is.Not.Null);
+}
+```
+
+## Setup/Teardown Anti-Patterns
+
+### Heavy OneTimeSetUp
+
+```csharp
+// WRONG - Too much work in OneTimeSetUp
+[TestFixture]
+public class HeavySetupTests
+{
+    private List<User> _allUsers;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        // Creates 10000 users - slow and wasteful
+        _allUsers = new List<User>();
+        for (int i = 0; i < 10000; i++)
+        {
+            _allUsers.Add(await _service.CreateUserAsync($"user{i}@test.com"));
+        }
+    }
+
+    [Test]
+    public void TestOne()
+    {
+        // Only needs 1 user
+        Assert.That(_allUsers[0].Email, Does.StartWith("user"));
+    }
+}
+
+// CORRECT - Create only what each test needs
+[TestFixture]
+public class EfficientSetupTests
+{
+    [Test]
+    public async Task TestOne()
+    {
+        var user = await _service.CreateUserAsync("user@test.com");
+        Assert.That(user.Email, Does.StartWith("user"));
+    }
+}
+```
+
+### Missing Teardown for Resources
+
+```csharp
+// WRONG - Resource leak
+[TestFixture]
+public class LeakyTests
+{
+    private HttpClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _client = new HttpClient();
+    }
+
+    [Test]
+    public async Task Test()
+    {
+        var response = await _client.GetAsync("https://api.example.com");
+        // _client is never disposed!
+    }
+}
+
+// CORRECT - Proper cleanup
+[TestFixture]
+public class CleanTests
+{
+    private HttpClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _client = new HttpClient();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client?.Dispose();
+    }
+
+    [Test]
+    public async Task Test()
+    {
+        var response = await _client.GetAsync("https://api.example.com");
+    }
+}
+```
+
+## Assertion Anti-Patterns
+
+### Swallowing Exceptions
+
+```csharp
+// WRONG - Exception is caught, test passes incorrectly
+[Test]
+public void BadExceptionHandling()
+{
+    try
+    {
+        _service.DoSomethingThatShouldThrow();
+        // Test passes even if exception not thrown!
+    }
+    catch (Exception)
+    {
+        // Silently swallowed
+    }
+}
+
+// CORRECT - Use Assert.Throws
+[Test]
+public void GoodExceptionHandling()
+{
+    Assert.Throws<InvalidOperationException>(
+        () => _service.DoSomethingThatShouldThrow());
+}
+```
+
+### Assert.Pass() Abuse
+
+```csharp
+// WRONG - Using Assert.Pass to skip actual assertions
+[Test]
+public void SkippedTest()
+{
+    if (!FeatureFlag.IsEnabled)
+    {
+        Assert.Pass("Feature not enabled"); // Hides untested code
+    }
+
+    // Never reaches actual test
+    var result = _service.NewFeature();
+    Assert.That(result, Is.Not.Null);
+}
+
+// CORRECT - Use Assume or Ignore
+[Test]
+public void ConditionalTest()
+{
+    Assume.That(FeatureFlag.IsEnabled, "Feature must be enabled");
+
+    var result = _service.NewFeature();
+    Assert.That(result, Is.Not.Null);
+}
+
+// Or use explicit Ignore
+[Test]
+[Ignore("Feature not yet implemented")]
+public void FutureFeatureTest()
+{
+    var result = _service.NewFeature();
+    Assert.That(result, Is.Not.Null);
+}
+```
+
+### Weak Assertions
+
+```csharp
+// WRONG - Assertion passes but doesn't verify behavior
+[Test]
+public void WeakAssertion()
+{
+    var result = _service.GetUsers();
+    Assert.That(result, Is.Not.Null); // Only checks not null
+    // Doesn't verify content, count, or correctness
+}
+
+// CORRECT - Specific assertions
+[Test]
+public void StrongAssertion()
+{
+    var result = _service.GetActiveUsers();
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Has.Count.GreaterThan(0));
+        Assert.That(result, Is.All.Property("IsActive").True);
+    });
+}
+```
+
+## Test Data Anti-Patterns
+
+### Hardcoded Magic Values
+
+```csharp
+// WRONG - Magic numbers without context
+[Test]
+public void ProcessOrder_MagicNumbers()
+{
+    var order = new Order { Quantity = 5, Price = 10.99m };
+    var result = _calculator.CalculateTotal(order);
+    Assert.That(result, Is.EqualTo(54.95m)); // Where does 54.95 come from?
+}
+
+// CORRECT - Clear calculation or named constants
+[Test]
+public void ProcessOrder_ClearCalculation()
+{
+    const int quantity = 5;
+    const decimal pricePerUnit = 10.99m;
+    const decimal expectedTotal = quantity * pricePerUnit;
+
+    var order = new Order { Quantity = quantity, Price = pricePerUnit };
+    var result = _calculator.CalculateTotal(order);
+
+    Assert.That(result, Is.EqualTo(expectedTotal));
+}
+```
+
+### DateTime.Now in Tests
+
+```csharp
+// WRONG - Non-deterministic test
+[Test]
+public void CreateUser_SetsCreatedAt()
+{
+    var user = _service.CreateUser("test@example.com");
+    Assert.That(user.CreatedAt, Is.EqualTo(DateTime.Now)); // Race condition!
+}
+
+// CORRECT - Use tolerance or inject time
+[Test]
+public void CreateUser_SetsCreatedAt_WithTolerance()
+{
+    var before = DateTime.UtcNow;
+    var user = _service.CreateUser("test@example.com");
+    var after = DateTime.UtcNow;
+
+    Assert.That(user.CreatedAt, Is.InRange(before, after));
+}
+
+// BETTER - Inject clock abstraction
+[Test]
+public void CreateUser_SetsCreatedAt_WithClock()
+{
+    var fixedTime = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+    var clock = Substitute.For<IClock>();
+    clock.UtcNow.Returns(fixedTime);
+
+    var service = new UserService(clock);
+    var user = service.CreateUser("test@example.com");
+
+    Assert.That(user.CreatedAt, Is.EqualTo(fixedTime));
+}
+```
+
+## Mocking Anti-Patterns
+
+### Over-Mocking
+
+```csharp
+// WRONG - Mocking everything, testing nothing
+[Test]
+public void OverMockedTest()
+{
+    var mockRepo = Substitute.For<IRepository>();
+    var mockLogger = Substitute.For<ILogger>();
+    var mockCache = Substitute.For<ICache>();
+    var mockValidator = Substitute.For<IValidator>();
+
+    mockValidator.Validate(Arg.Any<User>()).Returns(true);
+    mockRepo.Save(Arg.Any<User>()).Returns(true);
+
+    var service = new UserService(mockRepo, mockLogger, mockCache, mockValidator);
+    var result = service.CreateUser("test@example.com");
+
+    Assert.That(result, Is.True);
+    // What did we actually test? Just that mocks return what we told them to.
+}
+
+// CORRECT - Use real objects where possible
+[Test]
+public void BetterTest()
+{
+    var realValidator = new UserValidator();
+    var mockRepo = Substitute.For<IRepository>();
+
+    var service = new UserService(mockRepo, NullLogger.Instance, realValidator);
+    var result = service.CreateUser("test@example.com");
+
+    // Now we're actually testing validation + service integration
+    mockRepo.Received(1).Save(Arg.Is<User>(u => u.Email == "test@example.com"));
+}
+```

--- a/.github/skills/nunit/references/patterns.md
+++ b/.github/skills/nunit/references/patterns.md
@@ -1,0 +1,373 @@
+# NUnit Patterns Reference
+
+## Test Organization Patterns
+
+### Fixture Per Feature
+
+```csharp
+[TestFixture]
+public class UserRegistrationTests
+{
+    [Test]
+    public void Register_ValidUser_CreatesAccount() { }
+
+    [Test]
+    public void Register_DuplicateEmail_ReturnsError() { }
+}
+
+[TestFixture]
+public class UserAuthenticationTests
+{
+    [Test]
+    public void Login_ValidCredentials_ReturnsToken() { }
+
+    [Test]
+    public void Login_InvalidPassword_ReturnsUnauthorized() { }
+}
+```
+
+### Nested Test Fixtures
+
+```csharp
+[TestFixture]
+public class OrderServiceTests
+{
+    [TestFixture]
+    public class WhenCreatingOrder
+    {
+        [Test]
+        public void WithValidItems_CreatesOrder() { }
+
+        [Test]
+        public void WithEmptyCart_ThrowsException() { }
+    }
+
+    [TestFixture]
+    public class WhenCancellingOrder
+    {
+        [Test]
+        public void BeforeShipment_RefundsPayment() { }
+
+        [Test]
+        public void AfterShipment_ThrowsException() { }
+    }
+}
+```
+
+## Data-Driven Testing Patterns
+
+### Values Attribute for Simple Types
+
+```csharp
+[Test]
+public void IsPositive_VariousNumbers_ReturnsExpected(
+    [Values(1, 5, 100, int.MaxValue)] int positive,
+    [Values(-1, -100, int.MinValue)] int negative)
+{
+    Assert.That(MathHelper.IsPositive(positive), Is.True);
+    Assert.That(MathHelper.IsPositive(negative), Is.False);
+}
+
+[Test]
+public void ParseBoolean_VariousStrings(
+    [Values("true", "True", "TRUE", "1", "yes")] string trueValue)
+{
+    Assert.That(Parser.ParseBoolean(trueValue), Is.True);
+}
+```
+
+### Range Attribute
+
+```csharp
+[Test]
+public void CalculateDiscount_QuantityRange(
+    [Range(1, 10)] int quantity)
+{
+    var discount = _service.CalculateDiscount(quantity);
+    Assert.That(discount, Is.GreaterThanOrEqualTo(0));
+}
+```
+
+### Combinatorial and Pairwise
+
+```csharp
+// Tests all combinations (3 x 3 x 2 = 18 tests)
+[Test, Combinatorial]
+public void TestAllCombinations(
+    [Values("small", "medium", "large")] string size,
+    [Values("red", "green", "blue")] string color,
+    [Values(true, false)] bool express)
+{
+    var order = CreateOrder(size, color, express);
+    Assert.That(order, Is.Not.Null);
+}
+
+// Tests pairwise combinations (fewer tests, still good coverage)
+[Test, Pairwise]
+public void TestPairwiseCombinations(
+    [Values("small", "medium", "large")] string size,
+    [Values("red", "green", "blue")] string color,
+    [Values(true, false)] bool express)
+{
+    var order = CreateOrder(size, color, express);
+    Assert.That(order, Is.Not.Null);
+}
+```
+
+### TestCaseSource with Named Tests
+
+```csharp
+private static IEnumerable<TestCaseData> EdgeCaseTestData()
+{
+    yield return new TestCaseData(null)
+        .SetName("NullInput")
+        .SetDescription("Verifies null handling");
+
+    yield return new TestCaseData("")
+        .SetName("EmptyString")
+        .SetDescription("Verifies empty string handling");
+
+    yield return new TestCaseData("   ")
+        .SetName("WhitespaceOnly")
+        .SetDescription("Verifies whitespace handling");
+}
+
+[TestCaseSource(nameof(EdgeCaseTestData))]
+public void Validate_EdgeCases_HandlesGracefully(string input)
+{
+    Assert.DoesNotThrow(() => _validator.Validate(input));
+}
+```
+
+## Assertion Patterns
+
+### Multiple Assertions
+
+```csharp
+[Test]
+public void CreateUser_ValidInput_SetsAllProperties()
+{
+    var user = _service.CreateUser("john@example.com", "John Doe");
+
+    Assert.Multiple(() =>
+    {
+        Assert.That(user.Email, Is.EqualTo("john@example.com"));
+        Assert.That(user.Name, Is.EqualTo("John Doe"));
+        Assert.That(user.CreatedAt, Is.EqualTo(DateTime.UtcNow).Within(1).Seconds);
+        Assert.That(user.IsActive, Is.True);
+        Assert.That(user.Id, Is.Not.EqualTo(Guid.Empty));
+    });
+}
+```
+
+### Custom Constraints
+
+```csharp
+public class ValidEmailConstraint : Constraint
+{
+    public override ConstraintResult ApplyTo<TActual>(TActual actual)
+    {
+        var email = actual as string;
+        var isValid = !string.IsNullOrEmpty(email)
+            && email.Contains("@")
+            && email.Contains(".");
+
+        return new ConstraintResult(this, actual, isValid);
+    }
+
+    public override string Description => "a valid email address";
+}
+
+public static class Is2
+{
+    public static ValidEmailConstraint ValidEmail => new ValidEmailConstraint();
+}
+
+[Test]
+public void User_Email_IsValid()
+{
+    var user = new User { Email = "test@example.com" };
+    Assert.That(user.Email, Is2.ValidEmail);
+}
+```
+
+### Fluent Collection Assertions
+
+```csharp
+[Test]
+public void GetActiveUsers_ReturnsCorrectCollection()
+{
+    var users = _service.GetActiveUsers();
+
+    Assert.That(users, Has.Count.GreaterThan(0)
+        .And.All.Property("IsActive").EqualTo(true)
+        .And.None.Property("Email").Null
+        .And.Some.Property("Role").EqualTo("Admin"));
+}
+
+[Test]
+public void GetProducts_SortedByPrice()
+{
+    var products = _service.GetProductsSortedByPrice();
+
+    Assert.That(products.Select(p => p.Price), Is.Ordered.Ascending);
+}
+```
+
+## Setup and Lifecycle Patterns
+
+### Dependency Injection in Tests
+
+```csharp
+[TestFixture]
+public class ServiceTests
+{
+    private ServiceProvider _serviceProvider;
+    private IMyService _service;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IMyService, MyService>();
+        services.AddSingleton<ILogger, TestLogger>();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _service = _serviceProvider.GetRequiredService<IMyService>();
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _serviceProvider?.Dispose();
+    }
+}
+```
+
+### Test Context Access
+
+```csharp
+[TestFixture]
+public class ContextAwareTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        var testName = TestContext.CurrentContext.Test.Name;
+        var testDirectory = TestContext.CurrentContext.TestDirectory;
+
+        Console.WriteLine($"Running: {testName}");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        var result = TestContext.CurrentContext.Result.Outcome.Status;
+
+        if (result == TestStatus.Failed)
+        {
+            // Capture screenshot, logs, etc.
+            CaptureFailureArtifacts();
+        }
+    }
+}
+```
+
+## Parallel Execution Patterns
+
+### Fixture-Level Parallelism
+
+```csharp
+[TestFixture]
+[Parallelizable(ParallelScope.Fixtures)]
+public class ParallelFixtureTests
+{
+    [Test]
+    public void Test1() { }
+
+    [Test]
+    public void Test2() { }
+}
+```
+
+### Test-Level Parallelism
+
+```csharp
+[TestFixture]
+[Parallelizable(ParallelScope.Children)]
+public class ParallelTestsWithinFixture
+{
+    // Each test runs in parallel
+    [Test]
+    public void Test1() { }
+
+    [Test]
+    public void Test2() { }
+
+    [Test]
+    public void Test3() { }
+}
+```
+
+### Non-Parallelizable Tests
+
+```csharp
+[TestFixture]
+[NonParallelizable]
+public class SequentialTests
+{
+    // Tests that must run sequentially (shared resource, etc.)
+}
+```
+
+## Retry and Timeout Patterns
+
+### Retry Flaky Tests
+
+```csharp
+[Test]
+[Retry(3)]
+public void FlakyNetworkTest()
+{
+    // Will retry up to 3 times if fails
+    var result = _httpClient.GetAsync("https://api.example.com").Result;
+    Assert.That(result.IsSuccessStatusCode, Is.True);
+}
+```
+
+### Test Timeout
+
+```csharp
+[Test]
+[Timeout(5000)] // 5 seconds
+public void LongRunningTest()
+{
+    // Test will fail if takes longer than 5 seconds
+    _service.ProcessLargeDataSet();
+}
+```
+
+## Theory Tests (NUnit 4)
+
+```csharp
+[TestFixture]
+public class TheoryTests
+{
+    [Theory]
+    public void Sqrt_PositiveNumber_ReturnsPositive(double value)
+    {
+        Assume.That(value > 0);
+        var result = Math.Sqrt(value);
+        Assert.That(result, Is.GreaterThan(0));
+    }
+
+    [Datapoint] public double Zero = 0;
+    [Datapoint] public double One = 1;
+    [Datapoint] public double Pi = Math.PI;
+    [Datapoint] public double Negative = -1;
+}
+```

--- a/.github/skills/optimizing-ef-core-queries/SKILL.md
+++ b/.github/skills/optimizing-ef-core-queries/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: optimizing-ef-core-queries
+description: Optimize Entity Framework Core queries by fixing N+1 problems, choosing correct tracking modes, using compiled queries, and avoiding common performance traps. Use when EF Core queries are slow, generating excessive SQL, or causing high database load.
+license: MIT
+---
+
+# Optimizing EF Core Queries
+
+## When to Use
+
+- EF Core queries are slow or generating too many SQL statements
+- Database CPU/IO is high due to ORM inefficiency
+- N+1 query patterns are detected in logs
+- Large result sets cause memory pressure
+
+## When Not to Use
+
+- The user is using Dapper or raw ADO.NET (not EF Core)
+- The performance issue is database-side (missing indexes, bad schema)
+- The user is building a new data access layer from scratch
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Slow EF Core queries | Yes | The LINQ queries or DbContext usage to optimize |
+| SQL output or logs | No | EF Core generated SQL or query execution logs |
+
+## Workflow
+
+### Step 1: Enable query logging to see the actual SQL
+
+```csharp
+// In Program.cs or DbContext configuration:
+optionsBuilder
+    .UseSqlServer(connectionString)
+    .LogTo(Console.WriteLine, LogLevel.Information)
+    .EnableSensitiveDataLogging()  // shows parameter values (dev only!)
+    .EnableDetailedErrors();
+```
+
+Or use the `Microsoft.EntityFrameworkCore` log category:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+    }
+  }
+}
+```
+
+### Step 2: Fix N+1 query patterns
+
+**The #1 EF Core performance killer.** Happens when loading related entities in a loop.
+
+**Before (N+1 — 1 query for orders + N queries for items):**
+```csharp
+var orders = await db.Orders.ToListAsync();
+foreach (var order in orders)
+{
+    // Each access triggers a lazy-load query!
+    var items = order.Items.Count;
+}
+```
+
+**After (eager loading — 1 or 2 queries total):**
+```csharp
+// Option 1: Include (JOIN)
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .ToListAsync();
+
+// Option 2: Split query (separate SQL, avoids cartesian explosion)
+var orders = await db.Orders
+    .Include(o => o.Items)
+    .AsSplitQuery()
+    .ToListAsync();
+
+// Option 3: Explicit projection (best - only fetches needed columns)
+var orderSummaries = await db.Orders
+    .Select(o => new OrderSummary
+    {
+        OrderId = o.Id,
+        Total = o.Items.Sum(i => i.Price),
+        ItemCount = o.Items.Count
+    })
+    .ToListAsync();
+```
+
+**When to use Split vs Single query:**
+
+| Scenario | Use |
+|----------|-----|
+| 1 level of Include | Single query (default) |
+| Multiple Includes (Cartesian risk) | `AsSplitQuery()` |
+| Include with large child collections | `AsSplitQuery()` |
+| Need transaction consistency | Single query |
+
+### Step 3: Use NoTracking for read-only queries
+
+**Change tracking overhead is significant.** Disable it when you don't need to update entities:
+
+```csharp
+// Per-query
+var products = await db.Products
+    .AsNoTracking()
+    .Where(p => p.IsActive)
+    .ToListAsync();
+
+// Global default for read-heavy apps
+services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString)
+           .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking));
+```
+
+**Use `AsNoTrackingWithIdentityResolution()` when the query returns duplicate entities to avoid duplicated objects in memory.**
+
+### Step 4: Use compiled queries for hot paths
+
+```csharp
+// Define once as static
+private static readonly Func<AppDbContext, int, Task<Order?>> GetOrderById =
+    EF.CompileAsyncQuery((AppDbContext db, int id) =>
+        db.Orders
+            .Include(o => o.Items)
+            .FirstOrDefault(o => o.Id == id));
+
+// Use repeatedly — skips query compilation overhead
+var order = await GetOrderById(db, orderId);
+```
+
+### Step 5: Avoid common query traps
+
+| Trap | Problem | Fix |
+|------|---------|-----|
+| `ToList()` before `Where()` | Loads entire table into memory | Filter first: `.Where().ToList()` |
+| `Count()` to check existence | Scans all rows | Use `.Any()` instead |
+| `.Select()` after `.Include()` | Include is ignored with projection | Remove Include, use Select only |
+| `string.Contains()` in Where | May not translate, falls to client eval | Use `EF.Functions.Like()` for SQL LIKE |
+| Calling `.ToList()` inside `Select()` | Causes nested queries | Use projection with `Select` all the way |
+
+### Step 6: Use raw SQL or FromSql for complex queries
+
+When LINQ can't express it efficiently:
+
+```csharp
+var results = await db.Orders
+    .FromSqlInterpolated($@"
+        SELECT o.* FROM Orders o
+        INNER JOIN (
+            SELECT OrderId, SUM(Price) as Total
+            FROM OrderItems
+            GROUP BY OrderId
+            HAVING SUM(Price) > {minTotal}
+        ) t ON o.Id = t.OrderId")
+    .AsNoTracking()
+    .ToListAsync();
+```
+
+## Validation
+
+- [ ] SQL logging shows expected number of queries (no N+1)
+- [ ] Read-only queries use `AsNoTracking()`
+- [ ] Hot-path queries use compiled queries
+- [ ] No client-side evaluation warnings in logs
+- [ ] Include/split strategy matches data shape
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| Lazy loading silently creating N+1 | Remove `Microsoft.EntityFrameworkCore.Proxies` or disable lazy loading |
+| Global query filters forgotten in perf analysis | Check `HasQueryFilter` in model config; use `IgnoreQueryFilters()` if needed |
+| `DbContext` kept alive too long | DbContext should be scoped (per-request); don't cache it |
+| Batch updates fetching then saving | EF Core 7+: use `ExecuteUpdateAsync` / `ExecuteDeleteAsync` for bulk operations |
+| String interpolation in `FromSqlRaw` | SQL injection risk — use `FromSqlInterpolated` (parameterized) |

--- a/.github/skills/optimizing-ef-core-queries/manifest.json
+++ b/.github/skills/optimizing-ef-core-queries/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.0",
+  "category": "Data",
+  "compatibility": "Requires a .NET repository using Entity Framework Core or similar data-access patterns.",
+  "package_prefix": "Microsoft.EntityFrameworkCore"
+}

--- a/.github/skills/signalr/SKILL.md
+++ b/.github/skills/signalr/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: signalr
+description: "Implement or review SignalR hubs, streaming, reconnection, transport, and real-time delivery patterns in ASP.NET Core applications. USE FOR: building chat, notification, collaboration, or live-update features; debugging hub lifetime, connection state, or transport issues; deciding whether SignalR or another. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires ASP.NET Core SignalR server or client code."
+---
+
+# SignalR
+
+## Trigger On
+
+- building chat, notification, collaboration, or live-update features
+- debugging hub lifetime, connection state, or transport issues
+- deciding whether SignalR or another transport better fits the scenario
+- implementing real-time broadcasting to groups of connected clients
+- scaling SignalR across multiple servers
+
+## Documentation
+
+- [ASP.NET Core SignalR Overview](https://learn.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-10.0)
+- [SignalR Hubs](https://learn.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-10.0)
+- [SignalR API Design Considerations](https://learn.microsoft.com/en-us/aspnet/core/signalr/api-design?view=aspnetcore-10.0)
+- [SignalR Production Hosting and Scaling](https://learn.microsoft.com/en-us/aspnet/core/signalr/scale?view=aspnetcore-10.0)
+- [SignalR Configuration](https://learn.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-10.0)
+
+### References
+
+- [patterns.md](references/patterns.md) - Detailed hub patterns, streaming, groups, presence, and advanced messaging techniques
+- [anti-patterns.md](references/anti-patterns.md) - Common SignalR mistakes and how to avoid them
+
+## Workflow
+
+1. Use SignalR for broadcast-style or connection-oriented real-time features; do not force gRPC into hub-style fan-out scenarios.
+2. Model hub contracts intentionally and keep hub methods thin, delegating durable work elsewhere.
+3. Plan for reconnection, backpressure, auth, and fan-out costs instead of treating real-time messaging as stateless request/response.
+4. Use groups, presence, and connection metadata deliberately so scale-out behavior is understandable.
+5. If Native AOT or trimming is in play, validate supported protocols and serialization choices explicitly.
+6. Test connection behavior and failure modes, not just happy-path message delivery.
+
+## Hub Patterns
+
+### Strongly-Typed Hub (Recommended)
+```csharp
+// Define the client interface
+public interface IChatClient
+{
+    Task ReceiveMessage(string user, string message);
+    Task UserJoined(string user);
+    Task UserLeft(string user);
+}
+
+// Implement the strongly-typed hub
+public class ChatHub : Hub<IChatClient>
+{
+    public async Task SendMessage(string user, string message)
+    {
+        // Compiler checks client method calls
+        await Clients.All.ReceiveMessage(user, message);
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        await Clients.Others.UserJoined(Context.User?.Identity?.Name ?? "Anonymous");
+        await base.OnConnectedAsync();
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        await Clients.Others.UserLeft(Context.User?.Identity?.Name ?? "Anonymous");
+        await base.OnDisconnectedAsync(exception);
+    }
+}
+```
+
+### Using Groups for Targeted Messaging
+```csharp
+public class NotificationHub : Hub<INotificationClient>
+{
+    public async Task JoinGroup(string groupName)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+        await Clients.Group(groupName).UserJoined(Context.User?.Identity?.Name);
+    }
+
+    public async Task LeaveGroup(string groupName)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+    }
+
+    public async Task SendToGroup(string groupName, string message)
+    {
+        await Clients.Group(groupName).ReceiveNotification(message);
+    }
+}
+```
+
+### Hub Method with Custom Object Parameters (API Versioning)
+```csharp
+// Use custom objects to avoid breaking changes
+public class SendMessageRequest
+{
+    public string Message { get; set; } = string.Empty;
+    public string? Recipient { get; set; }  // Added later without breaking clients
+    public int? Priority { get; set; }       // Added later without breaking clients
+}
+
+public class ChatHub : Hub<IChatClient>
+{
+    public async Task SendMessage(SendMessageRequest request)
+    {
+        // Handle both old and new clients
+        if (request.Recipient != null)
+        {
+            await Clients.User(request.Recipient).ReceiveMessage(request.Message);
+        }
+        else
+        {
+            await Clients.All.ReceiveMessage(request.Message);
+        }
+    }
+}
+```
+
+## Client Patterns
+
+### JavaScript Client with Automatic Reconnection
+```javascript
+const connection = new signalR.HubConnectionBuilder()
+    .withUrl("/chatHub")
+    .withAutomaticReconnect([0, 2000, 5000, 10000, 30000]) // Retry delays
+    .configureLogging(signalR.LogLevel.Information)
+    .build();
+
+// Handle reconnection events
+connection.onreconnecting(error => {
+    console.log("Reconnecting...", error);
+    updateUIForReconnecting();
+});
+
+connection.onreconnected(connectionId => {
+    console.log("Reconnected with ID:", connectionId);
+    // Rejoin groups - reconnection does not restore group membership
+    rejoinGroups();
+    updateUIForConnected();
+});
+
+connection.onclose(error => {
+    console.log("Connection closed", error);
+    updateUIForDisconnected();
+});
+
+async function start() {
+    try {
+        await connection.start();
+        console.log("SignalR Connected");
+    } catch (err) {
+        console.log(err);
+        setTimeout(start, 5000);
+    }
+}
+
+start();
+```
+
+### .NET Client with Reconnection
+```csharp
+var connection = new HubConnectionBuilder()
+    .WithUrl("https://localhost:5001/chatHub", options =>
+    {
+        options.AccessTokenProvider = () => Task.FromResult(GetAccessToken());
+    })
+    .WithAutomaticReconnect()
+    .Build();
+
+connection.Reconnecting += error =>
+{
+    _logger.LogWarning("Connection lost. Reconnecting: {Error}", error?.Message);
+    return Task.CompletedTask;
+};
+
+connection.Reconnected += connectionId =>
+{
+    _logger.LogInformation("Reconnected with ID: {ConnectionId}", connectionId);
+    // Rejoin groups after reconnection
+    return RejoinGroupsAsync();
+};
+
+connection.Closed += async error =>
+{
+    _logger.LogError("Connection closed: {Error}", error?.Message);
+    await Task.Delay(Random.Shared.Next(0, 5) * 1000);
+    await connection.StartAsync();
+};
+
+await connection.StartAsync();
+```
+
+## Server Configuration
+
+### Hub Registration with Authentication
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSignalR(options =>
+{
+    options.EnableDetailedErrors = builder.Environment.IsDevelopment();
+    options.MaximumReceiveMessageSize = 64 * 1024; // 64 KB
+    options.StreamBufferCapacity = 10;
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+    options.ClientTimeoutInterval = TimeSpan.FromSeconds(30);
+})
+.AddMessagePackProtocol(); // Binary protocol for performance
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = context =>
+            {
+                // Read token from query string for WebSocket connections
+                var accessToken = context.Request.Query["access_token"];
+                var path = context.HttpContext.Request.Path;
+                if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/hubs"))
+                {
+                    context.Token = accessToken;
+                }
+                return Task.CompletedTask;
+            }
+        };
+    });
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapHub<ChatHub>("/hubs/chat");
+```
+
+### Sending Messages from Outside a Hub
+```csharp
+public class NotificationService
+{
+    private readonly IHubContext<NotificationHub, INotificationClient> _hubContext;
+
+    public NotificationService(IHubContext<NotificationHub, INotificationClient> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task NotifyAllAsync(string message)
+    {
+        await _hubContext.Clients.All.ReceiveNotification(message);
+    }
+
+    public async Task NotifyUserAsync(string userId, string message)
+    {
+        await _hubContext.Clients.User(userId).ReceiveNotification(message);
+    }
+
+    public async Task NotifyGroupAsync(string groupName, string message)
+    {
+        await _hubContext.Clients.Group(groupName).ReceiveNotification(message);
+    }
+}
+```
+
+## Scaling with Redis Backplane
+
+```csharp
+builder.Services.AddSignalR()
+    .AddStackExchangeRedis(connectionString, options =>
+    {
+        options.Configuration.ChannelPrefix = RedisChannel.Literal("MyApp");
+    });
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| Storing state in Hub properties | Hub instances are created per method call | Use `IMemoryCache`, database, or external store |
+| Instantiating Hub directly | Bypasses SignalR infrastructure | Use `IHubContext<THub>` for external messaging |
+| Not awaiting `SendAsync` calls | Messages may not be sent before hub method completes | Always `await` async hub calls |
+| Adding method parameters without versioning | Breaking change for existing clients | Use custom object parameters |
+| Ignoring reconnection group loss | Clients lose group membership on reconnect | Re-add to groups in `OnConnectedAsync` or client reconnect handler |
+| Large payloads over SignalR | Memory pressure, bandwidth issues | Use REST/gRPC for bulk data, SignalR for notifications |
+| Missing backplane in multi-server | Messages only reach clients on same server | Use Redis backplane or Azure SignalR Service |
+| Exposing ORM entities directly | May serialize sensitive data | Use DTOs with explicit properties |
+| Not validating incoming messages | Security risk after initial auth | Validate every hub method input |
+
+## Best Practices
+
+### Connection Management
+1. **Enable automatic reconnection** with exponential backoff delays
+2. **Handle group rejoining** explicitly after reconnection (connection ID changes)
+3. **Implement heartbeat monitoring** on the client to detect stale connections
+4. **Use sticky sessions** when scaling across multiple servers (unless using Azure SignalR Service)
+
+### Performance
+1. **Use MessagePack protocol** for smaller message sizes and faster serialization
+2. **Throttle high-frequency events** like typing indicators or mouse movements
+3. **Batch messages** when possible instead of many small sends
+4. **Set appropriate buffer sizes** based on expected message throughput
+
+### Security
+1. **Authenticate at connection time** using JWT tokens via query string
+2. **Authorize hub methods** using `[Authorize]` attribute
+3. **Validate all incoming messages** even after authentication
+4. **Use HTTPS** for all SignalR connections
+
+### API Design
+1. **Use strongly-typed hubs** to catch client method name typos at compile time
+2. **Use custom object parameters** to enable backward-compatible API evolution
+3. **Version hub names** (e.g., `ChatHubV2`) for breaking changes
+4. **Keep hub methods thin** and delegate business logic to services
+
+### Observability
+1. **Log connection events** (connect, disconnect, reconnect)
+2. **Track transport type** used by each connection
+3. **Monitor message delivery** latency and failure rates
+4. **Integrate with Application Insights** or other APM tools
+
+## Deliver
+
+- clear hub contracts and connection behavior
+- real-time delivery that matches the product scenario
+- validation for reconnection and authorization flows
+- appropriate scale-out strategy for multi-server deployments
+
+## Validate
+
+- SignalR is the correct transport for the use case
+- hub methods remain orchestration-oriented
+- group and auth behavior are explicit and tested
+- reconnection and group membership are handled correctly
+- backplane is configured for multi-server scenarios
+- message validation is implemented in hub methods

--- a/.github/skills/signalr/manifest.json
+++ b/.github/skills/signalr/manifest.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "category": "Web",
+  "package_prefix": "Microsoft.AspNetCore.SignalR"
+}

--- a/.github/skills/signalr/references/anti-patterns.md
+++ b/.github/skills/signalr/references/anti-patterns.md
@@ -1,0 +1,818 @@
+# SignalR Anti-Patterns
+
+This reference documents common SignalR mistakes and how to avoid them.
+
+## Hub Instance Anti-Patterns
+
+### Storing State in Hub Properties
+
+Hub instances are transient and created per invocation:
+
+```csharp
+// BAD: State is lost between calls
+public class BadHub : Hub
+{
+    private List<string> _messages = new(); // Created fresh every call
+    private int _messageCount = 0;          // Always 0
+
+    public Task SendMessage(string message)
+    {
+        _messages.Add(message);  // Lost immediately
+        _messageCount++;         // Always 1
+        return Task.CompletedTask;
+    }
+}
+
+// GOOD: Use external state management
+public class GoodHub : Hub
+{
+    private readonly IMessageStore _store;
+    private readonly IMemoryCache _cache;
+
+    public GoodHub(IMessageStore store, IMemoryCache cache)
+    {
+        _store = store;
+        _cache = cache;
+    }
+
+    public async Task SendMessage(string message)
+    {
+        await _store.AddMessageAsync(message);
+        _cache.Set("lastMessage", message);
+    }
+}
+
+// GOOD: Use Context.Items for per-connection state
+public class ConnectionStateHub : Hub
+{
+    public Task SetConnectionData(string key, object value)
+    {
+        Context.Items[key] = value;
+        return Task.CompletedTask;
+    }
+
+    public object? GetConnectionData(string key)
+    {
+        return Context.Items.TryGetValue(key, out var value) ? value : null;
+    }
+}
+```
+
+### Instantiating Hub Directly
+
+Never create hub instances manually:
+
+```csharp
+// BAD: Bypasses SignalR infrastructure
+public class BadService
+{
+    public async Task NotifyUsers()
+    {
+        var hub = new ChatHub(); // No context, no clients, no groups
+        await hub.Clients.All.ReceiveMessage("test"); // NullReferenceException
+    }
+}
+
+// GOOD: Use IHubContext<THub>
+public class GoodService
+{
+    private readonly IHubContext<ChatHub, IChatClient> _hubContext;
+
+    public GoodService(IHubContext<ChatHub, IChatClient> hubContext)
+    {
+        _hubContext = hubContext;
+    }
+
+    public async Task NotifyUsers()
+    {
+        await _hubContext.Clients.All.ReceiveMessage("test");
+    }
+}
+```
+
+## Async Anti-Patterns
+
+### Not Awaiting SendAsync Calls
+
+Fire-and-forget messaging loses errors and ordering:
+
+```csharp
+// BAD: No await means method may complete before message is sent
+public class BadHub : Hub<IChatClient>
+{
+    public Task SendMessage(string message)
+    {
+        Clients.All.ReceiveMessage(message); // Not awaited!
+        return Task.CompletedTask;
+    }
+}
+
+// BAD: Multiple unawaited calls have undefined ordering
+public class AlsoBadHub : Hub<IChatClient>
+{
+    public Task NotifyAll()
+    {
+        Clients.All.Message1(); // Which arrives first?
+        Clients.All.Message2(); // Unknown!
+        return Task.CompletedTask;
+    }
+}
+
+// GOOD: Always await async calls
+public class GoodHub : Hub<IChatClient>
+{
+    public async Task SendMessage(string message)
+    {
+        await Clients.All.ReceiveMessage(message);
+    }
+
+    public async Task NotifyAll()
+    {
+        await Clients.All.Message1();
+        await Clients.All.Message2(); // Guaranteed order
+    }
+}
+```
+
+### Blocking Async Code
+
+Blocking calls cause thread pool starvation:
+
+```csharp
+// BAD: Blocking on async
+public class BadHub : Hub
+{
+    private readonly IDataService _dataService;
+
+    public string GetData()
+    {
+        // Blocks thread pool thread
+        return _dataService.GetDataAsync().Result;
+    }
+
+    public void SendBlocking()
+    {
+        // Potential deadlock
+        Clients.All.SendAsync("Method").Wait();
+    }
+}
+
+// GOOD: Async all the way
+public class GoodHub : Hub
+{
+    private readonly IDataService _dataService;
+
+    public async Task<string> GetData()
+    {
+        return await _dataService.GetDataAsync();
+    }
+
+    public async Task Send()
+    {
+        await Clients.All.SendAsync("Method");
+    }
+}
+```
+
+## Connection Management Anti-Patterns
+
+### Ignoring Group Loss on Reconnection
+
+Group membership is tied to connection ID, which changes on reconnect:
+
+```csharp
+// BAD: Assumes groups persist across reconnection
+public class BadHub : Hub
+{
+    public async Task JoinRoom(string roomId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, roomId);
+        // Client reconnects with new connection ID = no longer in group
+    }
+}
+
+// GOOD: Track groups and rejoin on connect
+public class GoodHub : Hub
+{
+    private readonly IGroupMembershipStore _store;
+
+    public GoodHub(IGroupMembershipStore store) => _store = store;
+
+    public override async Task OnConnectedAsync()
+    {
+        var userId = Context.User!.GetUserId();
+        var groups = await _store.GetUserGroupsAsync(userId);
+
+        foreach (var group in groups)
+        {
+            await Groups.AddToGroupAsync(Context.ConnectionId, group);
+        }
+
+        await base.OnConnectedAsync();
+    }
+
+    public async Task JoinRoom(string roomId)
+    {
+        var userId = Context.User!.GetUserId();
+
+        // Persist membership
+        await _store.AddUserToGroupAsync(userId, roomId);
+
+        // Add current connection
+        await Groups.AddToGroupAsync(Context.ConnectionId, roomId);
+    }
+}
+```
+
+Client-side handling is also required:
+
+```javascript
+// BAD: No reconnection handling
+connection.start();
+
+// GOOD: Rejoin groups after reconnection
+connection.onreconnected(async (connectionId) => {
+    console.log("Reconnected with ID:", connectionId);
+    // Rejoin all rooms
+    for (const roomId of joinedRooms) {
+        await connection.invoke("JoinRoom", roomId);
+    }
+});
+```
+
+### Not Handling Connection Lifecycle
+
+Ignoring connect/disconnect events loses cleanup opportunities:
+
+```csharp
+// BAD: No lifecycle handling
+public class BadHub : Hub
+{
+    public Task JoinGame(string gameId)
+    {
+        // What happens when they disconnect mid-game?
+        return Groups.AddToGroupAsync(Context.ConnectionId, gameId);
+    }
+}
+
+// GOOD: Handle lifecycle events
+public class GoodHub : Hub
+{
+    private readonly IGameService _gameService;
+
+    public GoodHub(IGameService gameService) => _gameService = gameService;
+
+    public async Task JoinGame(string gameId)
+    {
+        Context.Items["GameId"] = gameId;
+        await _gameService.AddPlayerAsync(gameId, Context.User!.GetUserId());
+        await Groups.AddToGroupAsync(Context.ConnectionId, gameId);
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        if (Context.Items.TryGetValue("GameId", out var gameIdObj) && gameIdObj is string gameId)
+        {
+            await _gameService.RemovePlayerAsync(gameId, Context.User!.GetUserId());
+            await Clients.Group(gameId).PlayerLeft(Context.User!.GetUserId());
+        }
+        await base.OnDisconnectedAsync(exception);
+    }
+}
+```
+
+## Security Anti-Patterns
+
+### Not Validating Hub Method Inputs
+
+Authentication does not equal authorization or validation:
+
+```csharp
+// BAD: No validation after auth
+[Authorize]
+public class BadHub : Hub
+{
+    public async Task SendToGroup(string groupId, string message)
+    {
+        // Is user allowed in this group? Unknown!
+        // Is message content safe? Unknown!
+        await Clients.Group(groupId).ReceiveMessage(message);
+    }
+
+    public async Task GetUserData(string userId)
+    {
+        // Can caller access this user's data? Not checked!
+        var data = await _userService.GetDataAsync(userId);
+        await Clients.Caller.ReceiveData(data);
+    }
+}
+
+// GOOD: Validate every hub method
+[Authorize]
+public class GoodHub : Hub
+{
+    private readonly IAuthorizationService _authService;
+    private readonly IValidator<SendMessageRequest> _validator;
+
+    public async Task SendToGroup(string groupId, SendMessageRequest request)
+    {
+        // Check authorization
+        var canSend = await _authService.CanSendToGroupAsync(Context.User!, groupId);
+        if (!canSend)
+        {
+            throw new HubException("Not authorized for this group");
+        }
+
+        // Validate content
+        var validation = await _validator.ValidateAsync(request);
+        if (!validation.IsValid)
+        {
+            throw new HubException($"Invalid message: {validation.Errors.First().ErrorMessage}");
+        }
+
+        await Clients.Group(groupId).ReceiveMessage(request.Message);
+    }
+
+    public async Task GetUserData(string userId)
+    {
+        // Verify caller can access this data
+        var callerId = Context.User!.GetUserId();
+        if (userId != callerId && !Context.User.IsInRole("Admin"))
+        {
+            throw new HubException("Not authorized to access this user's data");
+        }
+
+        var data = await _userService.GetDataAsync(userId);
+        await Clients.Caller.ReceiveData(data);
+    }
+}
+```
+
+### Exposing Internal Exceptions
+
+Internal errors leak implementation details:
+
+```csharp
+// BAD: Exceptions leak to client
+public class BadHub : Hub
+{
+    public async Task ProcessOrder(OrderRequest request)
+    {
+        // SqlException details visible to client
+        // Stack traces visible to client
+        await _orderService.ProcessAsync(request);
+    }
+}
+
+// GOOD: Wrap exceptions
+public class GoodHub : Hub
+{
+    private readonly ILogger<GoodHub> _logger;
+
+    public async Task ProcessOrder(OrderRequest request)
+    {
+        try
+        {
+            await _orderService.ProcessAsync(request);
+        }
+        catch (ValidationException ex)
+        {
+            throw new HubException($"Validation error: {ex.Message}");
+        }
+        catch (BusinessRuleException ex)
+        {
+            throw new HubException(ex.UserFriendlyMessage);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing order");
+            throw new HubException("An error occurred processing your order");
+        }
+    }
+}
+```
+
+## Scaling Anti-Patterns
+
+### Missing Backplane for Multi-Server
+
+Without a backplane, messages only reach local connections:
+
+```csharp
+// BAD: Single-server assumption
+builder.Services.AddSignalR();
+// Users on Server B never receive messages from Server A
+
+// GOOD: Use backplane for multi-server
+builder.Services.AddSignalR()
+    .AddStackExchangeRedis(connectionString, options =>
+    {
+        options.Configuration.ChannelPrefix = RedisChannel.Literal("MyApp");
+    });
+
+// OR: Use Azure SignalR Service
+builder.Services.AddSignalR()
+    .AddAzureSignalR(connectionString);
+```
+
+### Storing Connection State In-Memory for Scale-Out
+
+In-memory state does not scale:
+
+```csharp
+// BAD: In-memory state with scale-out
+public class BadPresenceTracker
+{
+    // Only tracks connections on this server
+    private readonly ConcurrentDictionary<string, string> _connections = new();
+}
+
+// GOOD: Distributed state
+public class GoodPresenceTracker
+{
+    private readonly IDistributedCache _cache;
+    // OR
+    private readonly IConnectionMultiplexer _redis;
+    // OR
+    private readonly IDatabase _database;
+}
+```
+
+## Performance Anti-Patterns
+
+### Large Payloads Over SignalR
+
+SignalR is optimized for small, frequent messages:
+
+```csharp
+// BAD: Large file transfer over SignalR
+public class BadHub : Hub
+{
+    public async Task UploadFile(byte[] fileData) // 50MB payload
+    {
+        await _fileService.SaveAsync(fileData);
+    }
+
+    public async Task<byte[]> DownloadFile(string fileId)
+    {
+        return await _fileService.GetAsync(fileId); // Returns 50MB
+    }
+}
+
+// GOOD: Use SignalR for signaling, HTTP for bulk data
+public class GoodHub : Hub
+{
+    public async Task<string> RequestUploadUrl()
+    {
+        // Return pre-signed URL for direct upload
+        return await _blobService.GetUploadUrlAsync();
+    }
+
+    public async Task NotifyUploadComplete(string fileId)
+    {
+        await Clients.Others.FileUploaded(fileId);
+    }
+
+    public async Task<string> RequestDownloadUrl(string fileId)
+    {
+        return await _blobService.GetDownloadUrlAsync(fileId);
+    }
+}
+```
+
+### No Throttling for High-Frequency Events
+
+Unthrottled events overwhelm clients and servers:
+
+```csharp
+// BAD: Every keystroke sends a message
+public class BadHub : Hub
+{
+    public async Task UserTyping()
+    {
+        await Clients.Others.UserIsTyping(Context.User!.Identity!.Name!);
+    }
+}
+
+// GOOD: Throttle high-frequency events
+public class GoodHub : Hub
+{
+    private readonly IThrottler _throttler;
+
+    public async Task UserTyping()
+    {
+        var key = $"typing:{Context.ConnectionId}";
+        if (await _throttler.ShouldThrottleAsync(key, TimeSpan.FromSeconds(2)))
+        {
+            return; // Skip if sent within last 2 seconds
+        }
+
+        await Clients.Others.UserIsTyping(Context.User!.Identity!.Name!);
+    }
+}
+```
+
+### Not Using Streaming for Large Result Sets
+
+Loading everything into memory wastes resources:
+
+```csharp
+// BAD: Load all records into memory
+public class BadHub : Hub
+{
+    public async Task<List<LogEntry>> GetLogs(DateTime from, DateTime to)
+    {
+        // Loads potentially millions of records
+        return await _logService.GetAllLogsAsync(from, to);
+    }
+}
+
+// GOOD: Stream results
+public class GoodHub : Hub
+{
+    public async IAsyncEnumerable<LogEntry> StreamLogs(
+        DateTime from,
+        DateTime to,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var log in _logService.StreamLogsAsync(from, to, cancellationToken))
+        {
+            yield return log;
+        }
+    }
+}
+```
+
+## API Design Anti-Patterns
+
+### Using Dynamic Hubs
+
+Dynamic invocations lose compile-time safety:
+
+```csharp
+// BAD: Dynamic client invocation
+public class BadHub : Hub
+{
+    public async Task SendMessage(string message)
+    {
+        // Typos not caught at compile time
+        await Clients.All.SendAsync("RecieveMessage", message); // Typo!
+    }
+}
+
+// GOOD: Strongly-typed hub
+public interface IChatClient
+{
+    Task ReceiveMessage(string message);
+}
+
+public class GoodHub : Hub<IChatClient>
+{
+    public async Task SendMessage(string message)
+    {
+        // Compile-time checking
+        await Clients.All.ReceiveMessage(message);
+    }
+}
+```
+
+### Breaking API Changes
+
+Changing method signatures breaks existing clients:
+
+```csharp
+// BAD: Breaking change
+public class HubV1 : Hub
+{
+    // Original
+    public Task SendMessage(string message) => ...;
+
+    // Changed to add parameter - breaks existing clients!
+    public Task SendMessage(string message, string category) => ...;
+}
+
+// GOOD: Use request objects for evolution
+public class SendMessageRequest
+{
+    public string Message { get; set; } = "";
+    public string? Category { get; set; }  // Added later, optional
+    public int? Priority { get; set; }      // Added later, optional
+}
+
+public class GoodHub : Hub<IChatClient>
+{
+    public async Task SendMessage(SendMessageRequest request)
+    {
+        // Handles both old and new clients
+        var category = request.Category ?? "general";
+        await ProcessMessageAsync(request.Message, category);
+    }
+}
+```
+
+### Exposing ORM Entities
+
+Direct entity exposure leaks implementation and sensitive data:
+
+```csharp
+// BAD: Exposing EF entities
+public class BadHub : Hub
+{
+    public async Task<User> GetUser(string userId)
+    {
+        // May include navigation properties, password hashes, etc.
+        return await _dbContext.Users.FindAsync(userId);
+    }
+}
+
+// GOOD: Use DTOs
+public class GoodHub : Hub
+{
+    public async Task<UserDto> GetUser(string userId)
+    {
+        var user = await _dbContext.Users.FindAsync(userId);
+        return new UserDto
+        {
+            Id = user.Id,
+            DisplayName = user.DisplayName,
+            AvatarUrl = user.AvatarUrl
+            // No password hash, no internal fields
+        };
+    }
+}
+```
+
+## Diagnostic Anti-Patterns
+
+### No Logging for Connection Events
+
+Silent connections make debugging impossible:
+
+```csharp
+// BAD: No visibility
+public class BadHub : Hub
+{
+    // No logging, no metrics
+}
+
+// GOOD: Log important events
+public class GoodHub : Hub
+{
+    private readonly ILogger<GoodHub> _logger;
+
+    public GoodHub(ILogger<GoodHub> logger) => _logger = logger;
+
+    public override async Task OnConnectedAsync()
+    {
+        _logger.LogInformation(
+            "Client connected: {ConnectionId}, User: {User}, Transport: {Transport}",
+            Context.ConnectionId,
+            Context.User?.Identity?.Name ?? "anonymous",
+            Context.Features.Get<IHttpTransportFeature>()?.TransportType);
+
+        await base.OnConnectedAsync();
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        if (exception != null)
+        {
+            _logger.LogWarning(exception,
+                "Client disconnected with error: {ConnectionId}",
+                Context.ConnectionId);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Client disconnected: {ConnectionId}",
+                Context.ConnectionId);
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+}
+```
+
+### Not Monitoring Message Delivery
+
+Assuming messages always arrive:
+
+```csharp
+// BAD: Fire and forget without tracking
+public class BadHub : Hub
+{
+    public async Task Broadcast(string message)
+    {
+        await Clients.All.ReceiveMessage(message);
+        // Did everyone get it? Unknown!
+    }
+}
+
+// GOOD: Track delivery metrics
+public class GoodHub : Hub
+{
+    private readonly IMetrics _metrics;
+    private readonly ILogger<GoodHub> _logger;
+
+    public async Task Broadcast(string message)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await Clients.All.ReceiveMessage(message);
+            _metrics.RecordBroadcast(stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            _metrics.RecordBroadcastFailure();
+            _logger.LogError(ex, "Broadcast failed");
+            throw;
+        }
+    }
+}
+```
+
+## Testing Anti-Patterns
+
+### Not Testing Reconnection Scenarios
+
+Only testing happy paths misses critical failures:
+
+```csharp
+// BAD: Only test message sending
+[Fact]
+public async Task CanSendMessage()
+{
+    await _connection.InvokeAsync("SendMessage", "hello");
+    // What about reconnection? Disconnection?
+}
+
+// GOOD: Test connection lifecycle
+[Fact]
+public async Task ReconnectionRestoresGroupMembership()
+{
+    await _connection.InvokeAsync("JoinRoom", "test-room");
+
+    // Simulate network failure
+    await _connection.StopAsync();
+    await _connection.StartAsync();
+
+    // Verify group membership restored
+    var isInRoom = await _connection.InvokeAsync<bool>("IsInRoom", "test-room");
+    Assert.True(isInRoom);
+}
+
+[Fact]
+public async Task DisconnectionCleansUpResources()
+{
+    await _connection.InvokeAsync("JoinGame", "game-1");
+    await _connection.StopAsync();
+
+    // Verify cleanup occurred
+    var game = await _gameService.GetGameAsync("game-1");
+    Assert.DoesNotContain(_userId, game.Players);
+}
+```
+
+### Not Testing Under Load
+
+Performance issues only appear at scale:
+
+```csharp
+// GOOD: Load test SignalR
+[Fact]
+public async Task HandlesHighMessageVolume()
+{
+    var connections = new List<HubConnection>();
+    var receivedCounts = new ConcurrentDictionary<string, int>();
+
+    // Create many connections
+    for (int i = 0; i < 100; i++)
+    {
+        var connection = CreateConnection();
+        var connId = $"conn-{i}";
+        receivedCounts[connId] = 0;
+
+        connection.On<string>("ReceiveMessage", msg =>
+        {
+            receivedCounts.AddOrUpdate(connId, 1, (_, c) => c + 1);
+        });
+
+        await connection.StartAsync();
+        connections.Add(connection);
+    }
+
+    // Send many messages
+    var sendTasks = Enumerable.Range(0, 1000)
+        .Select(i => connections[i % connections.Count].InvokeAsync("SendMessage", $"msg-{i}"));
+
+    await Task.WhenAll(sendTasks);
+    await Task.Delay(5000); // Allow delivery
+
+    // Verify delivery
+    foreach (var count in receivedCounts.Values)
+    {
+        Assert.Equal(1000, count);
+    }
+}
+```

--- a/.github/skills/signalr/references/patterns.md
+++ b/.github/skills/signalr/references/patterns.md
@@ -1,0 +1,733 @@
+# SignalR Hub Patterns
+
+This reference provides detailed patterns for implementing SignalR hubs, streaming, groups, and connection management.
+
+## Hub Design Patterns
+
+### Hub per Feature
+
+Separate hubs by domain feature rather than creating one monolithic hub:
+
+```csharp
+// Good: Feature-focused hubs
+app.MapHub<ChatHub>("/hubs/chat");
+app.MapHub<NotificationHub>("/hubs/notifications");
+app.MapHub<CollaborationHub>("/hubs/collaboration");
+app.MapHub<PresenceHub>("/hubs/presence");
+
+// Bad: One hub for everything
+app.MapHub<ApplicationHub>("/hubs/app"); // Too broad
+```
+
+### Hub Method Delegation Pattern
+
+Keep hub methods thin and delegate to services:
+
+```csharp
+public class OrderHub : Hub<IOrderClient>
+{
+    private readonly IOrderService _orderService;
+    private readonly IValidator<PlaceOrderRequest> _validator;
+    private readonly ILogger<OrderHub> _logger;
+
+    public OrderHub(
+        IOrderService orderService,
+        IValidator<PlaceOrderRequest> validator,
+        ILogger<OrderHub> logger)
+    {
+        _orderService = orderService;
+        _validator = validator;
+        _logger = logger;
+    }
+
+    public async Task<OrderResult> PlaceOrder(PlaceOrderRequest request)
+    {
+        // 1. Validate
+        var validation = await _validator.ValidateAsync(request);
+        if (!validation.IsValid)
+        {
+            return OrderResult.Failed(validation.Errors);
+        }
+
+        // 2. Delegate to service
+        var order = await _orderService.PlaceOrderAsync(
+            request,
+            Context.User!.GetUserId());
+
+        // 3. Broadcast (orchestration only)
+        await Clients.Group($"order-watchers-{order.CustomerId}")
+            .OrderPlaced(order.ToDto());
+
+        return OrderResult.Success(order.Id);
+    }
+}
+```
+
+### Connection Context Pattern
+
+Use connection items for per-connection state:
+
+```csharp
+public class GameHub : Hub<IGameClient>
+{
+    public async Task JoinGame(string gameId)
+    {
+        // Store per-connection state
+        Context.Items["GameId"] = gameId;
+        Context.Items["JoinedAt"] = DateTime.UtcNow;
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"game-{gameId}");
+        await Clients.Group($"game-{gameId}").PlayerJoined(Context.User!.Identity!.Name!);
+    }
+
+    public async Task MakeMove(MoveRequest move)
+    {
+        // Retrieve per-connection state
+        var gameId = Context.Items["GameId"] as string
+            ?? throw new HubException("Not in a game");
+
+        // Process move...
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        if (Context.Items.TryGetValue("GameId", out var gameIdObj) && gameIdObj is string gameId)
+        {
+            await Clients.Group($"game-{gameId}").PlayerLeft(Context.User!.Identity!.Name!);
+        }
+        await base.OnDisconnectedAsync(exception);
+    }
+}
+```
+
+## Streaming Patterns
+
+### Server-to-Client Streaming
+
+Use `IAsyncEnumerable<T>` for server-to-client streams:
+
+```csharp
+public class DataHub : Hub<IDataClient>
+{
+    private readonly IDataService _dataService;
+
+    public DataHub(IDataService dataService) => _dataService = dataService;
+
+    // Client calls: connection.stream("StreamData", query)
+    public async IAsyncEnumerable<DataItem> StreamData(
+        DataQuery query,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (var item in _dataService.GetDataStreamAsync(query, cancellationToken))
+        {
+            // Check cancellation between yields
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+    }
+
+    // Alternative with ChannelReader for more control
+    public ChannelReader<StockQuote> StreamStockQuotes(
+        string[] symbols,
+        CancellationToken cancellationToken)
+    {
+        var channel = Channel.CreateUnbounded<StockQuote>();
+
+        _ = WriteQuotesToChannelAsync(channel.Writer, symbols, cancellationToken);
+
+        return channel.Reader;
+    }
+
+    private async Task WriteQuotesToChannelAsync(
+        ChannelWriter<StockQuote> writer,
+        string[] symbols,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                foreach (var symbol in symbols)
+                {
+                    var quote = await GetQuoteAsync(symbol);
+                    await writer.WriteAsync(quote, cancellationToken);
+                }
+                await Task.Delay(1000, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when client disconnects
+        }
+        finally
+        {
+            writer.Complete();
+        }
+    }
+}
+```
+
+### Client-to-Server Streaming
+
+Accept `ChannelReader<T>` or `IAsyncEnumerable<T>` for client uploads:
+
+```csharp
+public class UploadHub : Hub<IUploadClient>
+{
+    public async Task UploadChunks(
+        string fileName,
+        ChannelReader<byte[]> stream)
+    {
+        var totalBytes = 0L;
+
+        await foreach (var chunk in stream.ReadAllAsync(Context.ConnectionAborted))
+        {
+            // Process each chunk
+            await ProcessChunkAsync(fileName, chunk);
+            totalBytes += chunk.Length;
+
+            // Report progress back to client
+            await Clients.Caller.UploadProgress(totalBytes);
+        }
+
+        await Clients.Caller.UploadComplete(fileName, totalBytes);
+    }
+
+    // IAsyncEnumerable variant
+    public async Task StreamMessages(IAsyncEnumerable<ChatMessage> stream)
+    {
+        await foreach (var message in stream)
+        {
+            // Validate each message
+            if (string.IsNullOrWhiteSpace(message.Content))
+                continue;
+
+            // Broadcast to group
+            await Clients.Group(message.RoomId).ReceiveMessage(message);
+        }
+    }
+}
+```
+
+### Bidirectional Streaming
+
+Combine both patterns for full-duplex streams:
+
+```csharp
+public class CollaborationHub : Hub<ICollaborationClient>
+{
+    public async IAsyncEnumerable<DocumentChange> Collaborate(
+        string documentId,
+        IAsyncEnumerable<DocumentEdit> edits,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        // Join the document group to receive others' changes
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"doc-{documentId}");
+
+        // Start a background task to process incoming edits
+        var editProcessor = ProcessEditsAsync(documentId, edits, cancellationToken);
+
+        // Stream out all changes from other users
+        var changeChannel = GetChangeChannel(documentId);
+
+        await foreach (var change in changeChannel.ReadAllAsync(cancellationToken))
+        {
+            // Skip changes from this connection
+            if (change.ConnectionId != Context.ConnectionId)
+            {
+                yield return change;
+            }
+        }
+
+        await editProcessor;
+    }
+}
+```
+
+## Group Patterns
+
+### Hierarchical Groups
+
+Model group membership hierarchically:
+
+```csharp
+public class OrganizationHub : Hub<IOrgClient>
+{
+    public async Task JoinOrganization(string orgId)
+    {
+        // Hierarchical group structure
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"org-{orgId}");
+    }
+
+    public async Task JoinTeam(string orgId, string teamId)
+    {
+        // More specific group
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"org-{orgId}-team-{teamId}");
+    }
+
+    public async Task JoinProject(string orgId, string teamId, string projectId)
+    {
+        // Most specific group
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"org-{orgId}-team-{teamId}-project-{projectId}");
+    }
+
+    public async Task NotifyOrganization(string orgId, Notification notification)
+    {
+        // Reaches everyone in the org
+        await Clients.Group($"org-{orgId}").ReceiveNotification(notification);
+    }
+
+    public async Task NotifyTeam(string orgId, string teamId, Notification notification)
+    {
+        // Reaches only team members
+        await Clients.Group($"org-{orgId}-team-{teamId}").ReceiveNotification(notification);
+    }
+}
+```
+
+### Group Membership Tracking
+
+Track group membership for presence features:
+
+```csharp
+public class PresenceHub : Hub<IPresenceClient>
+{
+    private readonly IGroupMembershipService _membership;
+
+    public PresenceHub(IGroupMembershipService membership) => _membership = membership;
+
+    public async Task JoinRoom(string roomId)
+    {
+        var userId = Context.User!.GetUserId();
+        var connectionId = Context.ConnectionId;
+
+        // Track in persistent store
+        await _membership.AddMemberAsync(roomId, userId, connectionId);
+
+        // Add to SignalR group
+        await Groups.AddToGroupAsync(connectionId, roomId);
+
+        // Get current members and notify
+        var members = await _membership.GetMembersAsync(roomId);
+        await Clients.Caller.RoomMembers(members);
+        await Clients.OthersInGroup(roomId).UserJoined(userId);
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        var userId = Context.User!.GetUserId();
+        var connectionId = Context.ConnectionId;
+
+        // Find and clean up all rooms this connection was in
+        var rooms = await _membership.GetRoomsForConnectionAsync(connectionId);
+        foreach (var roomId in rooms)
+        {
+            await _membership.RemoveMemberAsync(roomId, connectionId);
+
+            // Check if user has other connections in this room
+            var hasOtherConnections = await _membership.UserHasConnectionsInRoomAsync(roomId, userId);
+            if (!hasOtherConnections)
+            {
+                await Clients.Group(roomId).UserLeft(userId);
+            }
+        }
+
+        await base.OnDisconnectedAsync(exception);
+    }
+}
+```
+
+### Excluding Connections from Group Sends
+
+Use exclusion lists for targeted broadcasts:
+
+```csharp
+public class BroadcastHub : Hub<IBroadcastClient>
+{
+    public async Task SendToGroupExcept(
+        string groupName,
+        string message,
+        string[] excludeConnectionIds)
+    {
+        await Clients
+            .GroupExcept(groupName, excludeConnectionIds)
+            .ReceiveMessage(message);
+    }
+
+    public async Task SendToAllExceptCaller(string message)
+    {
+        // Built-in exclusion of caller
+        await Clients.Others.ReceiveMessage(message);
+    }
+
+    public async Task SendToGroupExceptCaller(string groupName, string message)
+    {
+        // Exclude caller from group send
+        await Clients.OthersInGroup(groupName).ReceiveMessage(message);
+    }
+}
+```
+
+## User-Based Targeting
+
+### Multi-Connection Users
+
+Handle users with multiple connections:
+
+```csharp
+public class UserHub : Hub<IUserClient>
+{
+    public async Task SendToUser(string userId, Message message)
+    {
+        // Reaches all connections for this user
+        await Clients.User(userId).ReceiveMessage(message);
+    }
+
+    public async Task SendToUsers(string[] userIds, Message message)
+    {
+        await Clients.Users(userIds).ReceiveMessage(message);
+    }
+}
+```
+
+### Custom User ID Provider
+
+Map connections to custom user identifiers:
+
+```csharp
+public class TenantUserIdProvider : IUserIdProvider
+{
+    public string? GetUserId(HubConnectionContext connection)
+    {
+        var tenantId = connection.User?.FindFirst("tenant_id")?.Value;
+        var userId = connection.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (tenantId != null && userId != null)
+        {
+            // Namespace user IDs by tenant for multi-tenant apps
+            return $"{tenantId}:{userId}";
+        }
+
+        return userId;
+    }
+}
+
+// Registration
+builder.Services.AddSingleton<IUserIdProvider, TenantUserIdProvider>();
+```
+
+## Presence Patterns
+
+### Connection Counting
+
+Track user presence across connections:
+
+```csharp
+public class PresenceTracker
+{
+    private readonly ConcurrentDictionary<string, HashSet<string>> _userConnections = new();
+
+    public bool AddConnection(string userId, string connectionId)
+    {
+        var connections = _userConnections.GetOrAdd(userId, _ => new HashSet<string>());
+        lock (connections)
+        {
+            var wasEmpty = connections.Count == 0;
+            connections.Add(connectionId);
+            return wasEmpty; // True if this is the first connection
+        }
+    }
+
+    public bool RemoveConnection(string userId, string connectionId)
+    {
+        if (_userConnections.TryGetValue(userId, out var connections))
+        {
+            lock (connections)
+            {
+                connections.Remove(connectionId);
+                if (connections.Count == 0)
+                {
+                    _userConnections.TryRemove(userId, out _);
+                    return true; // User is now offline
+                }
+            }
+        }
+        return false;
+    }
+
+    public string[] GetOnlineUsers() => _userConnections.Keys.ToArray();
+}
+```
+
+### Presence with Redis (Scale-Out)
+
+Distributed presence for multi-server deployments:
+
+```csharp
+public class RedisPresenceService : IPresenceService
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly string _serverInstance;
+
+    public RedisPresenceService(IConnectionMultiplexer redis)
+    {
+        _redis = redis;
+        _serverInstance = $"{Environment.MachineName}-{Process.GetCurrentProcess().Id}";
+    }
+
+    public async Task<bool> UserConnectedAsync(string userId, string connectionId)
+    {
+        var db = _redis.GetDatabase();
+        var key = $"presence:{userId}";
+
+        var wasEmpty = !(await db.KeyExistsAsync(key));
+
+        await db.HashSetAsync(key, connectionId, _serverInstance);
+        await db.KeyExpireAsync(key, TimeSpan.FromMinutes(30));
+
+        return wasEmpty;
+    }
+
+    public async Task<bool> UserDisconnectedAsync(string userId, string connectionId)
+    {
+        var db = _redis.GetDatabase();
+        var key = $"presence:{userId}";
+
+        await db.HashDeleteAsync(key, connectionId);
+        var remaining = await db.HashLengthAsync(key);
+
+        return remaining == 0;
+    }
+
+    public async Task<string[]> GetOnlineUsersAsync()
+    {
+        var server = _redis.GetServer(_redis.GetEndPoints().First());
+        var keys = server.Keys(pattern: "presence:*");
+
+        return keys.Select(k => k.ToString().Replace("presence:", "")).ToArray();
+    }
+}
+```
+
+## Request-Response Pattern
+
+### Hub Methods with Return Values
+
+Return results directly from hub methods:
+
+```csharp
+public class QueryHub : Hub<IQueryClient>
+{
+    private readonly IQueryService _queryService;
+
+    public QueryHub(IQueryService queryService) => _queryService = queryService;
+
+    public async Task<SearchResult> Search(SearchRequest request)
+    {
+        // Validate
+        if (string.IsNullOrEmpty(request.Query))
+        {
+            throw new HubException("Query is required");
+        }
+
+        // Execute and return
+        return await _queryService.SearchAsync(request, Context.ConnectionAborted);
+    }
+
+    public async Task<PagedResult<Item>> GetItems(int page, int pageSize)
+    {
+        if (pageSize > 100)
+        {
+            throw new HubException("Page size cannot exceed 100");
+        }
+
+        return await _queryService.GetItemsAsync(page, pageSize);
+    }
+}
+```
+
+### Error Handling
+
+Use `HubException` for client-visible errors:
+
+```csharp
+public class RobustHub : Hub<IRobustClient>
+{
+    public async Task<OperationResult> PerformOperation(OperationRequest request)
+    {
+        try
+        {
+            // Business logic...
+            return OperationResult.Success();
+        }
+        catch (ValidationException ex)
+        {
+            // Client sees this message
+            throw new HubException($"Validation failed: {ex.Message}");
+        }
+        catch (NotFoundException ex)
+        {
+            throw new HubException($"Not found: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error in PerformOperation");
+            // Generic message for unexpected errors
+            throw new HubException("An unexpected error occurred");
+        }
+    }
+}
+```
+
+## Acknowledgment Pattern
+
+### Message Acknowledgments
+
+Track message delivery acknowledgments:
+
+```csharp
+public interface IReliableClient
+{
+    Task ReceiveMessage(string messageId, Message message);
+    Task MessageAcknowledged(string messageId);
+}
+
+public class ReliableHub : Hub<IReliableClient>
+{
+    private readonly IPendingMessageStore _pendingStore;
+
+    public ReliableHub(IPendingMessageStore pendingStore) => _pendingStore = pendingStore;
+
+    public async Task SendReliable(string recipientId, Message message)
+    {
+        var messageId = Guid.NewGuid().ToString();
+
+        // Store pending message
+        await _pendingStore.StorePendingAsync(messageId, recipientId, message);
+
+        // Attempt delivery
+        await Clients.User(recipientId).ReceiveMessage(messageId, message);
+
+        // Notify sender
+        await Clients.Caller.MessageAcknowledged(messageId);
+    }
+
+    public async Task AcknowledgeMessage(string messageId)
+    {
+        // Mark as delivered
+        await _pendingStore.MarkDeliveredAsync(messageId);
+    }
+
+    // Background job retries unacknowledged messages
+}
+```
+
+## Batching Pattern
+
+### Message Batching for High Throughput
+
+Batch messages to reduce overhead:
+
+```csharp
+public class BatchingHub : Hub<IBatchingClient>
+{
+    private readonly IBatchService _batchService;
+
+    public BatchingHub(IBatchService batchService) => _batchService = batchService;
+
+    public async Task StartBatchedUpdates(string subscriptionId)
+    {
+        var channel = Channel.CreateBounded<Update>(new BoundedChannelOptions(1000)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
+
+        // Register this connection for updates
+        _batchService.RegisterSubscription(subscriptionId, Context.ConnectionId, channel.Writer);
+
+        // Background batching loop
+        _ = Task.Run(async () =>
+        {
+            var batch = new List<Update>();
+            var batchTimeout = TimeSpan.FromMilliseconds(100);
+
+            while (!Context.ConnectionAborted.IsCancellationRequested)
+            {
+                batch.Clear();
+
+                // Collect items for up to 100ms or 50 items
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(Context.ConnectionAborted);
+                cts.CancelAfter(batchTimeout);
+
+                try
+                {
+                    while (batch.Count < 50 && await channel.Reader.WaitToReadAsync(cts.Token))
+                    {
+                        if (channel.Reader.TryRead(out var item))
+                        {
+                            batch.Add(item);
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Timeout or disconnect - send what we have
+                }
+
+                if (batch.Count > 0)
+                {
+                    await Clients.Caller.ReceiveBatch(batch.ToArray());
+                }
+            }
+        });
+    }
+}
+```
+
+## Throttling Pattern
+
+### Rate Limiting Hub Methods
+
+Implement per-connection rate limiting:
+
+```csharp
+public class ThrottledHub : Hub<IThrottledClient>
+{
+    private readonly IRateLimiter _rateLimiter;
+
+    public ThrottledHub(IRateLimiter rateLimiter) => _rateLimiter = rateLimiter;
+
+    public async Task SendMessage(string message)
+    {
+        var key = $"hub:{Context.ConnectionId}:sendMessage";
+
+        if (!await _rateLimiter.TryAcquireAsync(key, maxRequests: 10, window: TimeSpan.FromSeconds(1)))
+        {
+            throw new HubException("Rate limit exceeded. Please slow down.");
+        }
+
+        await Clients.All.ReceiveMessage(Context.User!.Identity!.Name!, message);
+    }
+}
+
+// Using System.Threading.RateLimiting
+public class SlidingWindowRateLimiter : IRateLimiter
+{
+    private readonly ConcurrentDictionary<string, RateLimiter> _limiters = new();
+
+    public async ValueTask<bool> TryAcquireAsync(string key, int maxRequests, TimeSpan window)
+    {
+        var limiter = _limiters.GetOrAdd(key, _ =>
+            new SlidingWindowRateLimiter(new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = maxRequests,
+                Window = window,
+                SegmentsPerWindow = 4,
+                AutoReplenishment = true
+            }));
+
+        using var lease = await limiter.AcquireAsync();
+        return lease.IsAcquired;
+    }
+}
+```

--- a/.github/skills/worker-services/SKILL.md
+++ b/.github/skills/worker-services/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: worker-services
+description: "Build long-running .NET background services with `BackgroundService`, Generic Host, graceful shutdown, configuration, logging, and deployment patterns suited to workers and daemons. USE FOR: background services; scheduled workers; hosted services; worker extraction; graceful shutdown, health checks, and service hosting review. DO NOT USE FOR: unrelated stacks; generic tasks that do not need this specific guidance. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires a worker, hosted service, or background-processing scenario."
+---
+
+# .NET Worker Services
+
+## Trigger On
+
+- building long-running background services or scheduled workers
+- adding hosted services to an app or extracting them into a worker process
+- reviewing graceful shutdown, cancellation, queue processing, or health behavior
+
+## Documentation
+
+- [Worker Services in .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/workers)
+- [Background tasks with hosted services in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-10.0)
+- [Create Windows Service using BackgroundService](https://learn.microsoft.com/en-us/dotnet/core/extensions/windows-service)
+- [App health checks in .NET](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/diagnostic-health-checks)
+- [Health checks in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-10.0)
+
+### References
+
+- [patterns.md](references/patterns.md) - BackgroundService patterns, graceful shutdown, and health check implementations
+- [anti-patterns.md](references/anti-patterns.md) - Common worker service mistakes and how to avoid them
+
+## Workflow
+
+1. **Use BackgroundService as your base class:**
+   - Provides standard `StartAsync`/`StopAsync` handling
+   - Focus on implementing `ExecuteAsync` only
+   - Proper cancellation token management built-in
+
+2. **Handle scoped dependencies correctly:**
+   - Create service scopes for scoped services
+   - No scope is created by default in hosted services
+
+3. **Implement graceful shutdown:**
+   - Propagate cancellation tokens throughout
+   - Complete work promptly when token fires
+   - Avoid ungraceful shutdown at timeout
+
+4. **Keep execution loop thin:**
+   - Move business logic to testable services
+   - Handle exceptions to prevent service crashes
+   - Use `PeriodicTimer` for scheduled work
+
+5. **Add observability:**
+   - Use health checks for readiness/liveness
+   - Expose metrics and structured logging
+   - Consider distributed locks for multi-instance
+
+## Basic BackgroundService Pattern
+
+### Simple Worker
+```csharp
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Worker starting");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                _logger.LogInformation("Worker running at: {Time}", DateTimeOffset.Now);
+                await DoWorkAsync(stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Graceful shutdown, not an error
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in worker iteration");
+                // Continue or break based on error severity
+            }
+        }
+
+        _logger.LogInformation("Worker stopping");
+    }
+
+    private async Task DoWorkAsync(CancellationToken cancellationToken)
+    {
+        // Business logic here
+    }
+}
+```
+
+### Using PeriodicTimer (Recommended)
+```csharp
+public class TimedWorker : BackgroundService
+{
+    private readonly ILogger<TimedWorker> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeSpan _period = TimeSpan.FromMinutes(1);
+
+    public TimedWorker(ILogger<TimedWorker> logger, IServiceScopeFactory scopeFactory)
+    {
+        _logger = logger;
+        _scopeFactory = scopeFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(_period);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var processor = scope.ServiceProvider.GetRequiredService<IDataProcessor>();
+                await processor.ProcessAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing scheduled task");
+            }
+        }
+    }
+}
+```
+
+## Handling Scoped Dependencies
+
+### Correct Pattern with Scope Factory
+```csharp
+public class ScopedWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ScopedWorker> _logger;
+
+    public ScopedWorker(IServiceScopeFactory scopeFactory, ILogger<ScopedWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Create scope for each unit of work
+            await using var scope = _scopeFactory.CreateAsyncScope();
+
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var service = scope.ServiceProvider.GetRequiredService<IScopedService>();
+
+            await service.ProcessAsync(dbContext, stoppingToken);
+            await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+        }
+    }
+}
+```
+
+## Queue Processing Pattern
+
+### Message Queue Worker
+```csharp
+public class QueueWorker : BackgroundService
+{
+    private readonly ILogger<QueueWorker> _logger;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IBackgroundTaskQueue _taskQueue;
+
+    public QueueWorker(
+        ILogger<QueueWorker> logger,
+        IServiceScopeFactory scopeFactory,
+        IBackgroundTaskQueue taskQueue)
+    {
+        _logger = logger;
+        _scopeFactory = scopeFactory;
+        _taskQueue = taskQueue;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Queue Worker started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var workItem = await _taskQueue.DequeueAsync(stoppingToken);
+
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                await workItem(scope.ServiceProvider, stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing queued work item");
+                // Handle poison message - retry, dead-letter, etc.
+            }
+        }
+    }
+}
+
+// Task queue interface
+public interface IBackgroundTaskQueue
+{
+    ValueTask QueueBackgroundWorkItemAsync(
+        Func<IServiceProvider, CancellationToken, ValueTask> workItem);
+
+    ValueTask<Func<IServiceProvider, CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken);
+}
+```
+
+## Health Checks for Workers
+
+### Adding Health Check Endpoint
+```csharp
+// Program.cs
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddHostedService<Worker>();
+
+// Add health checks
+builder.Services.AddHealthChecks()
+    .AddCheck<WorkerHealthCheck>("worker_health")
+    .AddResourceUtilizationHealthCheck();
+
+// Add HTTP endpoint for health checks
+builder.Services.AddHealthChecksUI();
+
+// Or use simple TCP listener for Kubernetes
+builder.Services.AddSingleton<TcpHealthProbeService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<TcpHealthProbeService>());
+
+var host = builder.Build();
+host.Run();
+```
+
+### Custom Health Check
+```csharp
+public class WorkerHealthCheck : IHealthCheck
+{
+    private readonly WorkerState _workerState;
+
+    public WorkerHealthCheck(WorkerState workerState)
+    {
+        _workerState = workerState;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (_workerState.LastSuccessfulRun > DateTime.UtcNow.AddMinutes(-5))
+        {
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"Last successful run: {_workerState.LastSuccessfulRun}"));
+        }
+
+        return Task.FromResult(HealthCheckResult.Unhealthy(
+            $"No successful run since: {_workerState.LastSuccessfulRun}"));
+    }
+}
+
+// Shared state
+public class WorkerState
+{
+    public DateTime LastSuccessfulRun { get; set; } = DateTime.UtcNow;
+    public bool IsProcessing { get; set; }
+}
+```
+
+## Graceful Shutdown Pattern
+
+### Proper Shutdown Handling
+```csharp
+public class GracefulWorker : BackgroundService
+{
+    private readonly ILogger<GracefulWorker> _logger;
+    private int _currentWorkItemId;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Worker starting");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _currentWorkItemId = GetNextWorkItemId();
+
+            try
+            {
+                // Pass cancellation token to all async operations
+                await ProcessWorkItemAsync(_currentWorkItemId, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation(
+                    "Shutdown requested, stopping after work item {Id}", _currentWorkItemId);
+                break;
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Worker stopping gracefully");
+        await base.StopAsync(cancellationToken);
+        _logger.LogInformation("Worker stopped");
+    }
+}
+```
+
+## Windows Service Deployment
+
+### Configuring as Windows Service
+```csharp
+// Program.cs
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddWindowsService(options =>
+{
+    options.ServiceName = "My Worker Service";
+});
+
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
+host.Run();
+```
+
+### Project File Settings
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>
+```
+
+## Best Practices
+
+1. **Use BackgroundService as base class** - Handles `StartAsync`/`StopAsync` boilerplate and cancellation management
+2. **Create scopes for scoped dependencies** - Use `IServiceScopeFactory` to resolve scoped services like DbContext
+3. **Propagate cancellation tokens everywhere** - Pass to all async methods for responsive shutdown
+4. **Wrap work in try-catch** - Unhandled exceptions stop the service completely
+5. **Use PeriodicTimer for timed tasks** - Cleaner than `Task.Delay` with proper cancellation support
+6. **Add health checks** - Essential for Kubernetes liveness/readiness probes
+7. **Avoid blocking StartAsync** - Long initialization delays other hosted services
+8. **Call base methods when overriding** - Always call `await base.StartAsync()` and `await base.StopAsync()`
+9. **Publish as single file for Windows Service** - Reduces deployment complexity and errors
+10. **Consider scaling requirements** - Separate worker projects if independent scaling is needed
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| Ad-hoc `while(true)` loops | No graceful shutdown, poor lifecycle | Use `BackgroundService` |
+| Ignoring cancellation token | Ungraceful shutdown, resource leaks | Propagate token to all async calls |
+| Injecting scoped services directly | Captive dependencies, memory leaks | Use `IServiceScopeFactory` |
+| Unhandled exceptions in `ExecuteAsync` | Silently stops the worker | Wrap in try-catch, log, continue |
+| Long-running `StartAsync` | Blocks other services from starting | Move work to `ExecuteAsync` |
+| `async void` methods | Crashes process on exception | Use `async Task` |
+| Missing health checks | No visibility into worker status | Implement `IHealthCheck` |
+| Polling with tight loops | CPU waste, no responsiveness | Use `PeriodicTimer` or event-driven |
+| Not overriding `StopAsync` | Missed cleanup opportunity | Override for graceful cleanup |
+| Singleton DbContext | Not thread-safe, stale data | Create scopes per operation |
+
+## Deliver
+
+- well-behaved worker processes and hosted services
+- predictable startup and shutdown behavior
+- proper scoped dependency handling
+- health checks for production observability
+- retry and poison-message handling for queue work
+
+## Validate
+
+- cancellation token propagated and shutdown honored
+- scoped services resolved within proper scopes
+- exception handling prevents service crashes
+- health checks report accurate worker status
+- runtime behavior visible through logs or telemetry
+- no blocking calls in async context

--- a/.github/skills/worker-services/manifest.json
+++ b/.github/skills/worker-services/manifest.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "category": "Core",
+  "packages": [
+    "Microsoft.Extensions.Hosting"
+  ]
+}

--- a/.github/skills/worker-services/references/anti-patterns.md
+++ b/.github/skills/worker-services/references/anti-patterns.md
@@ -1,0 +1,888 @@
+# Worker Services Anti-Patterns Reference
+
+This reference documents common mistakes when building .NET worker services and provides corrective guidance.
+
+---
+
+## Lifecycle and Initialization Anti-Patterns
+
+### 1. Blocking in StartAsync
+
+**Problem:** Long-running operations in `StartAsync` block other hosted services from starting.
+
+```csharp
+// BAD: Blocks host startup
+public class BadWorker : BackgroundService
+{
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        // This blocks all other hosted services from starting
+        await LoadLargeDatasetAsync();
+        await WarmupCachesAsync();
+        await base.StartAsync(cancellationToken);
+    }
+}
+```
+
+**Correction:** Move initialization to `ExecuteAsync`:
+
+```csharp
+// GOOD: Non-blocking startup
+public class GoodWorker : BackgroundService
+{
+    private bool _initialized;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Initialize in ExecuteAsync, not StartAsync
+        await LoadLargeDatasetAsync(stoppingToken);
+        await WarmupCachesAsync(stoppingToken);
+        _initialized = true;
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await DoWorkAsync(stoppingToken);
+        }
+    }
+}
+```
+
+### 2. Forgetting to Call Base Methods
+
+**Problem:** Not calling base class methods breaks lifecycle management.
+
+```csharp
+// BAD: Missing base.StartAsync
+public class BadWorker : BackgroundService
+{
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await InitializeAsync();
+        // Missing: await base.StartAsync(cancellationToken);
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await CleanupAsync();
+        // Missing: await base.StopAsync(cancellationToken);
+    }
+}
+```
+
+**Correction:** Always call base methods:
+
+```csharp
+// GOOD: Proper base method calls
+public class GoodWorker : BackgroundService
+{
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await InitializeAsync();
+        await base.StartAsync(cancellationToken);
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await CleanupAsync();
+        await base.StopAsync(cancellationToken);
+    }
+}
+```
+
+### 3. Using async void
+
+**Problem:** `async void` methods crash the process on unhandled exceptions.
+
+```csharp
+// BAD: async void crashes process
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            ProcessItemAsync(); // Fire and forget
+        }
+    }
+
+    private async void ProcessItemAsync() // DANGEROUS
+    {
+        await DoWorkThatMightFailAsync(); // Unhandled exception = process crash
+    }
+}
+```
+
+**Correction:** Use `async Task` and handle exceptions:
+
+```csharp
+// GOOD: async Task with proper handling
+public class GoodWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessItemAsync(stoppingToken);
+        }
+    }
+
+    private async Task ProcessItemAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await DoWorkThatMightFailAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing item");
+        }
+    }
+}
+```
+
+---
+
+## Cancellation and Shutdown Anti-Patterns
+
+### 4. Ignoring Cancellation Token
+
+**Problem:** Not propagating cancellation tokens causes ungraceful shutdown.
+
+```csharp
+// BAD: Ignoring cancellation
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (true) // Never checks stoppingToken
+        {
+            await ProcessAsync(); // No cancellation token passed
+            await Task.Delay(5000); // No cancellation token
+        }
+    }
+}
+```
+
+**Correction:** Propagate cancellation everywhere:
+
+```csharp
+// GOOD: Proper cancellation
+public class GoodWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessAsync(stoppingToken);
+                await Task.Delay(5000, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break; // Graceful exit
+            }
+        }
+    }
+}
+```
+
+### 5. Swallowing OperationCanceledException
+
+**Problem:** Catching and ignoring `OperationCanceledException` during shutdown hides issues.
+
+```csharp
+// BAD: Swallowing cancellation
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await DoWorkAsync(stoppingToken);
+            }
+            catch (Exception ex) // Catches OperationCanceledException too
+            {
+                _logger.LogError(ex, "Error"); // Logs cancellation as error
+                // Continues loop even on shutdown
+            }
+        }
+    }
+}
+```
+
+**Correction:** Handle cancellation separately:
+
+```csharp
+// GOOD: Proper exception handling
+public class GoodWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await DoWorkAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Shutdown requested");
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during work");
+            }
+        }
+    }
+}
+```
+
+### 6. No Shutdown Timeout Configuration
+
+**Problem:** Default 30-second shutdown timeout may be too short for draining work.
+
+```csharp
+// BAD: Relying on default timeout
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<LongRunningWorker>();
+// Default ShutdownTimeout is 30 seconds
+```
+
+**Correction:** Configure appropriate timeout:
+
+```csharp
+// GOOD: Configured shutdown timeout
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromMinutes(2);
+});
+builder.Services.AddHostedService<LongRunningWorker>();
+```
+
+---
+
+## Dependency Injection Anti-Patterns
+
+### 7. Injecting Scoped Services Directly
+
+**Problem:** Injecting scoped services into singleton `BackgroundService` creates captive dependencies.
+
+```csharp
+// BAD: Captive dependency
+public class BadWorker : BackgroundService
+{
+    private readonly AppDbContext _dbContext; // Singleton captures scoped service
+
+    public BadWorker(AppDbContext dbContext) // Direct injection
+    {
+        _dbContext = dbContext;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // DbContext is never refreshed, connection may be stale
+            var items = await _dbContext.Items.ToListAsync(stoppingToken);
+        }
+    }
+}
+```
+
+**Correction:** Use `IServiceScopeFactory`:
+
+```csharp
+// GOOD: Proper scoped service handling
+public class GoodWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public GoodWorker(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var items = await dbContext.Items.ToListAsync(stoppingToken);
+        }
+    }
+}
+```
+
+### 8. Singleton DbContext
+
+**Problem:** Using `DbContext` as singleton causes thread-safety issues and stale data.
+
+```csharp
+// BAD: Singleton DbContext registration
+builder.Services.AddSingleton<AppDbContext>(); // Thread-unsafe, stale tracking
+builder.Services.AddHostedService<Worker>();
+```
+
+**Correction:** Register as scoped and use scope factory:
+
+```csharp
+// GOOD: Scoped DbContext
+builder.Services.AddDbContext<AppDbContext>();
+builder.Services.AddHostedService<Worker>();
+
+// In worker, create scopes for each unit of work
+```
+
+### 9. Service Locator in Constructor
+
+**Problem:** Resolving services in constructor can fail if service isn't registered.
+
+```csharp
+// BAD: Service resolution in constructor
+public class BadWorker : BackgroundService
+{
+    private readonly ISpecialService _service;
+
+    public BadWorker(IServiceProvider provider)
+    {
+        _service = provider.GetRequiredService<ISpecialService>(); // May throw
+    }
+}
+```
+
+**Correction:** Use proper constructor injection or scope factory:
+
+```csharp
+// GOOD: Explicit dependency
+public class GoodWorker : BackgroundService
+{
+    private readonly ISpecialService _service;
+
+    public GoodWorker(ISpecialService service) // Fails at startup if not registered
+    {
+        _service = service;
+    }
+}
+```
+
+---
+
+## Loop and Timing Anti-Patterns
+
+### 10. Tight Polling Loop
+
+**Problem:** Polling without delay wastes CPU and may overload resources.
+
+```csharp
+// BAD: CPU-burning tight loop
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var hasWork = await CheckForWorkAsync();
+            if (hasWork)
+            {
+                await ProcessAsync();
+            }
+            // No delay - burns CPU when idle
+        }
+    }
+}
+```
+
+**Correction:** Add appropriate delays or use event-driven patterns:
+
+```csharp
+// GOOD: Appropriate delay
+public class GoodWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var hasWork = await CheckForWorkAsync(stoppingToken);
+            if (hasWork)
+            {
+                await ProcessAsync(stoppingToken);
+            }
+            else
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+            }
+        }
+    }
+}
+```
+
+### 11. Task.Delay Instead of PeriodicTimer
+
+**Problem:** `Task.Delay` doesn't account for processing time, causing drift.
+
+```csharp
+// BAD: Interval drift
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessAsync(); // Takes variable time
+            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+            // Actual interval is 5 minutes + processing time
+        }
+    }
+}
+```
+
+**Correction:** Use `PeriodicTimer` for consistent intervals:
+
+```csharp
+// GOOD: Consistent intervals with PeriodicTimer
+public class GoodWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMinutes(5));
+
+        // Run immediately, then on schedule
+        await ProcessAsync(stoppingToken);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await ProcessAsync(stoppingToken);
+        }
+    }
+}
+```
+
+### 12. Ad-hoc while(true) Without BackgroundService
+
+**Problem:** Raw `while(true)` loops lack proper lifecycle management.
+
+```csharp
+// BAD: Manual loop without BackgroundService
+public class BadService : IHostedService
+{
+    private Task? _executingTask;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _executingTask = Task.Run(async () =>
+        {
+            while (true) // No way to stop
+            {
+                await DoWorkAsync();
+                await Task.Delay(5000);
+            }
+        });
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Cannot stop the loop
+        return Task.CompletedTask;
+    }
+}
+```
+
+**Correction:** Use `BackgroundService`:
+
+```csharp
+// GOOD: BackgroundService with proper lifecycle
+public class GoodService : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await DoWorkAsync(stoppingToken);
+            await Task.Delay(5000, stoppingToken);
+        }
+    }
+}
+```
+
+---
+
+## Exception Handling Anti-Patterns
+
+### 13. Unhandled Exceptions in ExecuteAsync
+
+**Problem:** Unhandled exceptions silently stop the worker without notification.
+
+```csharp
+// BAD: No exception handling
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessAsync(stoppingToken); // Exception stops worker silently
+        }
+    }
+}
+```
+
+**Correction:** Wrap in try-catch with logging:
+
+```csharp
+// GOOD: Exception handling with logging
+public class GoodWorker : BackgroundService
+{
+    private readonly ILogger<GoodWorker> _logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in worker iteration");
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken); // Backoff
+            }
+        }
+    }
+}
+```
+
+### 14. Retrying Forever Without Backoff
+
+**Problem:** Immediate retry on failure can overwhelm resources.
+
+```csharp
+// BAD: No backoff
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ConnectAndProcessAsync(stoppingToken);
+            }
+            catch (Exception)
+            {
+                // Immediately retry - can overwhelm network/service
+            }
+        }
+    }
+}
+```
+
+**Correction:** Implement exponential backoff:
+
+```csharp
+// GOOD: Exponential backoff
+public class GoodWorker : BackgroundService
+{
+    private readonly ILogger<GoodWorker> _logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var backoff = TimeSpan.FromSeconds(1);
+        var maxBackoff = TimeSpan.FromMinutes(5);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ConnectAndProcessAsync(stoppingToken);
+                backoff = TimeSpan.FromSeconds(1); // Reset on success
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Connection failed, retrying in {Delay}", backoff);
+                await Task.Delay(backoff, stoppingToken);
+                backoff = TimeSpan.FromTicks(Math.Min(backoff.Ticks * 2, maxBackoff.Ticks));
+            }
+        }
+    }
+}
+```
+
+---
+
+## Observability Anti-Patterns
+
+### 15. No Health Checks
+
+**Problem:** Workers without health checks are invisible to orchestrators like Kubernetes.
+
+```csharp
+// BAD: No health visibility
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
+var host = builder.Build();
+host.Run();
+```
+
+**Correction:** Add health checks:
+
+```csharp
+// GOOD: Health check integration
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddSingleton<WorkerState>();
+builder.Services.AddHostedService<Worker>();
+builder.Services.AddHealthChecks()
+    .AddCheck<WorkerHealthCheck>("worker");
+builder.Services.AddHostedService<TcpHealthProbeService>();
+
+var host = builder.Build();
+host.Run();
+```
+
+### 16. Console.WriteLine Instead of Structured Logging
+
+**Problem:** `Console.WriteLine` loses structure and is hard to aggregate.
+
+```csharp
+// BAD: Unstructured output
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Console.WriteLine("Worker started at " + DateTime.Now);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            Console.WriteLine("Processing item " + itemId);
+        }
+    }
+}
+```
+
+**Correction:** Use `ILogger` with structured data:
+
+```csharp
+// GOOD: Structured logging
+public class GoodWorker : BackgroundService
+{
+    private readonly ILogger<GoodWorker> _logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Worker started at {StartTime}", DateTime.UtcNow);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Processing item {ItemId}", itemId);
+        }
+    }
+}
+```
+
+### 17. Missing Correlation IDs
+
+**Problem:** Log entries without correlation IDs are hard to trace across operations.
+
+```csharp
+// BAD: No correlation
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var items = await FetchItemsAsync();
+            foreach (var item in items)
+            {
+                _logger.LogInformation("Processing item"); // Which item?
+                await ProcessAsync(item);
+            }
+        }
+    }
+}
+```
+
+**Correction:** Add correlation/operation context:
+
+```csharp
+// GOOD: Correlation and context
+public class GoodWorker : BackgroundService
+{
+    private readonly ILogger<GoodWorker> _logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var batchId = Guid.NewGuid().ToString("N")[..8];
+            using var scope = _logger.BeginScope(new { BatchId = batchId });
+
+            var items = await FetchItemsAsync(stoppingToken);
+            _logger.LogInformation("Fetched {Count} items", items.Count);
+
+            foreach (var item in items)
+            {
+                using var itemScope = _logger.BeginScope(new { ItemId = item.Id });
+                _logger.LogInformation("Processing item");
+                await ProcessAsync(item, stoppingToken);
+            }
+        }
+    }
+}
+```
+
+---
+
+## Concurrency Anti-Patterns
+
+### 18. Shared Mutable State Without Synchronization
+
+**Problem:** Multiple workers accessing shared state causes race conditions.
+
+```csharp
+// BAD: Unsynchronized shared state
+public class BadWorker : BackgroundService
+{
+    private int _processedCount; // Shared mutable state
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var tasks = Enumerable.Range(0, 4)
+            .Select(_ => ProcessLoopAsync(stoppingToken));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task ProcessLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await ProcessAsync();
+            _processedCount++; // Race condition
+        }
+    }
+}
+```
+
+**Correction:** Use thread-safe operations:
+
+```csharp
+// GOOD: Thread-safe counter
+public class GoodWorker : BackgroundService
+{
+    private int _processedCount;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var tasks = Enumerable.Range(0, 4)
+            .Select(_ => ProcessLoopAsync(stoppingToken));
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task ProcessLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await ProcessAsync(cancellationToken);
+            Interlocked.Increment(ref _processedCount);
+        }
+    }
+}
+```
+
+### 19. Unbounded Parallelism
+
+**Problem:** Processing items without limiting concurrency can exhaust resources.
+
+```csharp
+// BAD: Unbounded parallelism
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var items = await GetItemsAsync();
+        var tasks = items.Select(item => ProcessAsync(item)); // Starts ALL at once
+        await Task.WhenAll(tasks); // May exhaust connections, memory
+    }
+}
+```
+
+**Correction:** Use bounded parallelism:
+
+```csharp
+// GOOD: Bounded parallelism
+public class GoodWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var items = await GetItemsAsync(stoppingToken);
+        await Parallel.ForEachAsync(
+            items,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = 4,
+                CancellationToken = stoppingToken
+            },
+            async (item, ct) => await ProcessAsync(item, ct));
+    }
+}
+```
+
+### 20. No Distributed Locking for Multi-Instance
+
+**Problem:** Multiple worker instances process the same items without coordination.
+
+```csharp
+// BAD: No coordination between instances
+public class BadWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Multiple instances may process same items
+            var items = await FetchPendingItemsAsync();
+            foreach (var item in items)
+            {
+                await ProcessAsync(item);
+            }
+        }
+    }
+}
+```
+
+**Correction:** Implement distributed locking or partitioning:
+
+```csharp
+// GOOD: Distributed lock
+public class GoodWorker : BackgroundService
+{
+    private readonly IDistributedLockProvider _lockProvider;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var items = await FetchPendingItemsAsync(stoppingToken);
+            foreach (var item in items)
+            {
+                await using var @lock = await _lockProvider.TryAcquireLockAsync(
+                    $"item:{item.Id}", TimeSpan.FromMinutes(5), stoppingToken);
+
+                if (@lock != null)
+                {
+                    await ProcessAsync(item, stoppingToken);
+                }
+            }
+        }
+    }
+}
+```

--- a/.github/skills/worker-services/references/patterns.md
+++ b/.github/skills/worker-services/references/patterns.md
@@ -1,0 +1,720 @@
+# Worker Services Patterns Reference
+
+This reference covers BackgroundService patterns, graceful shutdown implementation, and health check patterns for .NET worker services.
+
+## BackgroundService Patterns
+
+### 1. Basic Worker Pattern
+
+The simplest pattern for periodic work:
+
+```csharp
+public class BasicWorker : BackgroundService
+{
+    private readonly ILogger<BasicWorker> _logger;
+
+    public BasicWorker(ILogger<BasicWorker> logger) => _logger = logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Processing at {Time}", DateTimeOffset.Now);
+            await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+        }
+    }
+}
+```
+
+### 2. Scoped Dependency Pattern
+
+Create a new scope for each unit of work to properly handle scoped dependencies like DbContext:
+
+```csharp
+public class ScopedDependencyWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ScopedDependencyWorker> _logger;
+
+    public ScopedDependencyWorker(IServiceScopeFactory scopeFactory, ILogger<ScopedDependencyWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var processor = scope.ServiceProvider.GetRequiredService<IDataProcessor>();
+
+            await processor.ProcessBatchAsync(dbContext, stoppingToken);
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+        }
+    }
+}
+```
+
+### 3. PeriodicTimer Pattern
+
+Preferred over `Task.Delay` for scheduled work with cleaner cancellation semantics:
+
+```csharp
+public class PeriodicTimerWorker : BackgroundService
+{
+    private readonly TimeSpan _interval = TimeSpan.FromMinutes(5);
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<PeriodicTimerWorker> _logger;
+
+    public PeriodicTimerWorker(IServiceScopeFactory scopeFactory, ILogger<PeriodicTimerWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Run immediately on startup
+        await RunIterationAsync(stoppingToken);
+
+        using var timer = new PeriodicTimer(_interval);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await RunIterationAsync(stoppingToken);
+        }
+    }
+
+    private async Task RunIterationAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var service = scope.ServiceProvider.GetRequiredService<IScheduledService>();
+            await service.ExecuteAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in scheduled iteration");
+        }
+    }
+}
+```
+
+### 4. Queue Consumer Pattern
+
+Process items from a queue with proper backpressure and error handling:
+
+```csharp
+public class QueueConsumerWorker : BackgroundService
+{
+    private readonly IBackgroundTaskQueue _queue;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<QueueConsumerWorker> _logger;
+
+    public QueueConsumerWorker(
+        IBackgroundTaskQueue queue,
+        IServiceScopeFactory scopeFactory,
+        ILogger<QueueConsumerWorker> logger)
+    {
+        _queue = queue;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Queue Consumer starting");
+
+        await foreach (var workItem in _queue.DequeueAllAsync(stoppingToken))
+        {
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                await workItem.ExecuteAsync(scope.ServiceProvider, stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing work item {Id}", workItem.Id);
+                await HandleFailedItemAsync(workItem, ex);
+            }
+        }
+    }
+
+    private Task HandleFailedItemAsync(IWorkItem workItem, Exception exception)
+    {
+        // Implement retry, dead-letter, or alerting logic
+        return Task.CompletedTask;
+    }
+}
+```
+
+### 5. Parallel Worker Pattern
+
+Process multiple items concurrently with controlled parallelism:
+
+```csharp
+public class ParallelWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ParallelWorker> _logger;
+    private readonly int _maxDegreeOfParallelism = Environment.ProcessorCount;
+
+    public ParallelWorker(IServiceScopeFactory scopeFactory, ILogger<ParallelWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var channel = Channel.CreateBounded<WorkItem>(new BoundedChannelOptions(100)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        });
+
+        // Start producer
+        var producer = ProduceItemsAsync(channel.Writer, stoppingToken);
+
+        // Start consumers
+        var consumers = Enumerable.Range(0, _maxDegreeOfParallelism)
+            .Select(_ => ConsumeItemsAsync(channel.Reader, stoppingToken))
+            .ToArray();
+
+        await Task.WhenAll(consumers.Prepend(producer));
+    }
+
+    private async Task ProduceItemsAsync(ChannelWriter<WorkItem> writer, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var source = scope.ServiceProvider.GetRequiredService<IWorkItemSource>();
+
+                await foreach (var item in source.GetItemsAsync(cancellationToken))
+                {
+                    await writer.WriteAsync(item, cancellationToken);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+            }
+        }
+        finally
+        {
+            writer.Complete();
+        }
+    }
+
+    private async Task ConsumeItemsAsync(ChannelReader<WorkItem> reader, CancellationToken cancellationToken)
+    {
+        await foreach (var item in reader.ReadAllAsync(cancellationToken))
+        {
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var processor = scope.ServiceProvider.GetRequiredService<IWorkItemProcessor>();
+                await processor.ProcessAsync(item, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing item {Id}", item.Id);
+            }
+        }
+    }
+}
+```
+
+### 6. Event-Driven Worker Pattern
+
+React to external events instead of polling:
+
+```csharp
+public class EventDrivenWorker : BackgroundService
+{
+    private readonly IMessageSubscriber _subscriber;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<EventDrivenWorker> _logger;
+
+    public EventDrivenWorker(
+        IMessageSubscriber subscriber,
+        IServiceScopeFactory scopeFactory,
+        ILogger<EventDrivenWorker> logger)
+    {
+        _subscriber = subscriber;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _subscriber.SubscribeAsync<OrderCreatedEvent>(
+            async (message, ct) =>
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var handler = scope.ServiceProvider.GetRequiredService<IOrderHandler>();
+                await handler.HandleAsync(message, ct);
+            },
+            stoppingToken);
+
+        // Keep alive until cancellation
+        await Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+}
+```
+
+---
+
+## Graceful Shutdown Patterns
+
+### 1. Basic Graceful Shutdown
+
+Respond to cancellation token and complete current work:
+
+```csharp
+public class GracefulShutdownWorker : BackgroundService
+{
+    private readonly ILogger<GracefulShutdownWorker> _logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Worker started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessCurrentBatchAsync(stoppingToken);
+                await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Shutdown requested, completing gracefully");
+                break;
+            }
+        }
+
+        _logger.LogInformation("Worker completed shutdown");
+    }
+}
+```
+
+### 2. StopAsync Override for Cleanup
+
+Override StopAsync for explicit cleanup operations:
+
+```csharp
+public class CleanupWorker : BackgroundService
+{
+    private readonly ILogger<CleanupWorker> _logger;
+    private readonly IExternalConnection _connection;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _connection.ConnectAsync(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await _connection.ProcessMessagesAsync(stoppingToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Stopping worker, disconnecting...");
+
+        try
+        {
+            await _connection.DisconnectAsync(cancellationToken);
+            _logger.LogInformation("Disconnected cleanly");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during disconnect, may have leaked resources");
+        }
+
+        await base.StopAsync(cancellationToken);
+    }
+}
+```
+
+### 3. Work-in-Progress Tracking
+
+Track ongoing work to ensure completion before shutdown:
+
+```csharp
+public class TrackedWorkWorker : BackgroundService
+{
+    private readonly ILogger<TrackedWorkWorker> _logger;
+    private readonly SemaphoreSlim _workTracker = new(0, int.MaxValue);
+    private int _activeWorkItems;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var channel = Channel.CreateUnbounded<WorkItem>();
+
+        // Start processor
+        var processor = ProcessItemsAsync(channel.Reader, stoppingToken);
+
+        // Produce items until cancelled
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var items = await FetchItemsAsync(stoppingToken);
+            foreach (var item in items)
+            {
+                Interlocked.Increment(ref _activeWorkItems);
+                await channel.Writer.WriteAsync(item, stoppingToken);
+            }
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+
+        channel.Writer.Complete();
+        await processor;
+    }
+
+    private async Task ProcessItemsAsync(ChannelReader<WorkItem> reader, CancellationToken cancellationToken)
+    {
+        await foreach (var item in reader.ReadAllAsync(cancellationToken))
+        {
+            try
+            {
+                await ProcessItemAsync(item, cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeWorkItems);
+                _workTracker.Release();
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Waiting for {Count} work items to complete", _activeWorkItems);
+
+        // Wait for all work to complete or timeout
+        var timeout = Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+        while (_activeWorkItems > 0 && !timeout.IsCompleted)
+        {
+            await Task.WhenAny(_workTracker.WaitAsync(cancellationToken), timeout);
+        }
+
+        if (_activeWorkItems > 0)
+        {
+            _logger.LogWarning("Shutdown with {Count} items still processing", _activeWorkItems);
+        }
+
+        await base.StopAsync(cancellationToken);
+    }
+}
+```
+
+### 4. Configurable Shutdown Timeout
+
+Configure host shutdown timeout for long-running operations:
+
+```csharp
+// Program.cs
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(60);
+});
+
+builder.Services.AddHostedService<LongRunningWorker>();
+```
+
+### 5. Two-Phase Shutdown
+
+Implement soft and hard shutdown phases:
+
+```csharp
+public class TwoPhaseShutdownWorker : BackgroundService
+{
+    private readonly ILogger<TwoPhaseShutdownWorker> _logger;
+    private volatile bool _softShutdownRequested;
+    private readonly CancellationTokenSource _internalCts = new();
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            stoppingToken, _internalCts.Token);
+
+        stoppingToken.Register(() => _softShutdownRequested = true);
+
+        while (!linkedCts.Token.IsCancellationRequested)
+        {
+            if (_softShutdownRequested)
+            {
+                _logger.LogInformation("Soft shutdown: finishing current batch");
+                // Complete current iteration but don't start new work
+            }
+
+            await ProcessBatchAsync(linkedCts.Token);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Phase 1: Soft shutdown (stop accepting new work)
+        _softShutdownRequested = true;
+
+        // Give time for graceful completion
+        await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+
+        // Phase 2: Hard shutdown (cancel internal operations)
+        _internalCts.Cancel();
+
+        await base.StopAsync(cancellationToken);
+    }
+}
+```
+
+---
+
+## Health Check Patterns
+
+### 1. Basic Worker Health Check
+
+Track last successful execution time:
+
+```csharp
+public class WorkerHealthCheck : IHealthCheck
+{
+    private readonly WorkerState _state;
+    private readonly TimeSpan _maxAge = TimeSpan.FromMinutes(5);
+
+    public WorkerHealthCheck(WorkerState state) => _state = state;
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var timeSinceLastRun = DateTime.UtcNow - _state.LastSuccessfulRun;
+
+        if (timeSinceLastRun > _maxAge)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"No successful run in {timeSinceLastRun.TotalMinutes:F1} minutes"));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy(
+            $"Last run: {_state.LastSuccessfulRun:O}"));
+    }
+}
+
+public class WorkerState
+{
+    public DateTime LastSuccessfulRun { get; set; } = DateTime.UtcNow;
+    public int ConsecutiveFailures { get; set; }
+    public bool IsProcessing { get; set; }
+}
+```
+
+### 2. Liveness vs Readiness Health Checks
+
+Separate liveness (is the process alive) from readiness (can it accept work):
+
+```csharp
+// Liveness: Is the worker process running and not deadlocked?
+public class WorkerLivenessCheck : IHealthCheck
+{
+    private readonly WorkerState _state;
+    private readonly TimeSpan _maxProcessingTime = TimeSpan.FromMinutes(10);
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (_state.IsProcessing && _state.ProcessingStarted < DateTime.UtcNow - _maxProcessingTime)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                "Worker appears stuck - processing for too long"));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy());
+    }
+}
+
+// Readiness: Is the worker ready to handle new work?
+public class WorkerReadinessCheck : IHealthCheck
+{
+    private readonly WorkerState _state;
+    private readonly IDbConnectionFactory _dbFactory;
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // Check dependencies are available
+        try
+        {
+            await using var connection = await _dbFactory.CreateConnectionAsync(cancellationToken);
+            await connection.OpenAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Database unavailable", ex);
+        }
+
+        if (_state.ConsecutiveFailures > 5)
+        {
+            return HealthCheckResult.Degraded("Multiple consecutive failures");
+        }
+
+        return HealthCheckResult.Healthy();
+    }
+}
+```
+
+### 3. Health Check Registration
+
+```csharp
+// Program.cs
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddSingleton<WorkerState>();
+builder.Services.AddHostedService<Worker>();
+
+builder.Services.AddHealthChecks()
+    .AddCheck<WorkerLivenessCheck>("liveness", tags: ["live"])
+    .AddCheck<WorkerReadinessCheck>("readiness", tags: ["ready"])
+    .AddCheck<WorkerHealthCheck>("worker", tags: ["worker"]);
+
+// For workers without ASP.NET Core, expose via TCP
+builder.Services.AddHostedService<TcpHealthProbeService>();
+```
+
+### 4. TCP Health Probe for Kubernetes
+
+Expose health without HTTP for pure workers:
+
+```csharp
+public class TcpHealthProbeService : BackgroundService
+{
+    private readonly HealthCheckService _healthCheckService;
+    private readonly ILogger<TcpHealthProbeService> _logger;
+    private readonly int _port;
+
+    public TcpHealthProbeService(
+        HealthCheckService healthCheckService,
+        ILogger<TcpHealthProbeService> logger,
+        IConfiguration configuration)
+    {
+        _healthCheckService = healthCheckService;
+        _logger = logger;
+        _port = configuration.GetValue<int>("HealthProbe:TcpPort", 8080);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var listener = new TcpListener(IPAddress.Any, _port);
+        listener.Start();
+        _logger.LogInformation("Health probe listening on port {Port}", _port);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var client = await listener.AcceptTcpClientAsync(stoppingToken);
+            _ = HandleClientAsync(client, stoppingToken);
+        }
+
+        listener.Stop();
+    }
+
+    private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            var result = await _healthCheckService.CheckHealthAsync(cancellationToken);
+            var response = result.Status == HealthStatus.Healthy ? "HTTP/1.1 200 OK\r\n\r\n" : "HTTP/1.1 503 Service Unavailable\r\n\r\n";
+            var bytes = Encoding.UTF8.GetBytes(response);
+            await client.GetStream().WriteAsync(bytes, cancellationToken);
+        }
+    }
+}
+```
+
+### 5. Startup Health Check
+
+Report unhealthy during initialization:
+
+```csharp
+public class StartupHealthCheck : IHealthCheck
+{
+    private volatile bool _isReady;
+
+    public bool IsReady
+    {
+        get => _isReady;
+        set => _isReady = value;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (_isReady)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy("Startup complete"));
+        }
+
+        return Task.FromResult(HealthCheckResult.Unhealthy("Still starting up"));
+    }
+}
+
+public class InitializingWorker : BackgroundService
+{
+    private readonly StartupHealthCheck _startupCheck;
+    private readonly ILogger<InitializingWorker> _logger;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Initializing...");
+        await InitializeAsync(stoppingToken);
+        _startupCheck.IsReady = true;
+        _logger.LogInformation("Initialization complete, starting work");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await DoWorkAsync(stoppingToken);
+        }
+    }
+}
+```
+
+### 6. Circuit Breaker Health Check
+
+Track error rates and circuit state:
+
+```csharp
+public class CircuitBreakerHealthCheck : IHealthCheck
+{
+    private readonly CircuitBreakerState _state;
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_state.State switch
+        {
+            CircuitState.Closed => HealthCheckResult.Healthy("Circuit closed"),
+            CircuitState.HalfOpen => HealthCheckResult.Degraded("Circuit half-open, testing recovery"),
+            CircuitState.Open => HealthCheckResult.Unhealthy($"Circuit open until {_state.ResetTime:O}"),
+            _ => HealthCheckResult.Unhealthy("Unknown circuit state")
+        });
+    }
+}
+
+public class CircuitBreakerState
+{
+    public CircuitState State { get; set; } = CircuitState.Closed;
+    public DateTime ResetTime { get; set; }
+    public int FailureCount { get; set; }
+}
+
+public enum CircuitState { Closed, Open, HalfOpen }
+```

--- a/.github/skills/xunit/SKILL.md
+++ b/.github/skills/xunit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: xunit
+description: "Write, run, or repair .NET tests that use xUnit with the right package, CLI, and runner guidance. USE FOR: xUnit v2 or xUnit v3 projects; adding, running, debugging, or repairing xUnit tests; choosing between VSTest and Microsoft.Testing.Platform. DO NOT USE FOR: TUnit projects; MSTest projects. INVOKES: inspect the repository context, edit targeted files, and run relevant build, test, lint, or validation commands when changes are made."
+compatibility: "Requires a .NET solution or project with xUnit packages; respects the repo's `AGENTS.md` commands first."
+---
+
+# xUnit.net
+
+## Trigger On
+
+- the repo uses xUnit v2 or xUnit v3
+- you need to add, run, debug, or repair xUnit tests
+- the team is unsure whether a project is using VSTest or Microsoft.Testing.Platform
+
+## Value
+
+- produce a concrete project delta: code, docs, config, tests, CI, or review artifact
+- reduce ambiguity through explicit planning, verification, and final validation skills
+- leave reusable project context so future tasks are faster and safer
+
+## Do Not Use For
+
+- TUnit projects
+- MSTest projects
+- generic test strategy with no xUnit-specific mechanics
+
+## Inputs
+
+- the nearest `AGENTS.md`
+- the test project file and package references
+- the active runner model for the test project
+
+## Quick Start
+
+1. Read the nearest `AGENTS.md` and confirm scope and constraints.
+2. Run this skill's `Workflow` through the `Ralph Loop` until outcomes are acceptable.
+3. Return the `Required Result Format` with concrete artifacts and verification evidence.
+
+## Workflow
+
+1. Detect the active xUnit model before changing commands:
+   - `xunit` usually means v2
+   - `xunit.v3` means v3
+   - `xunit.runner.visualstudio` plus `Microsoft.NET.Test.Sdk` usually means VSTest compatibility is enabled
+   - `TestingPlatformDotnetTestSupport` or `UseMicrosoftTestingPlatformRunner` means Microsoft.Testing.Platform is in play
+2. Read the repo's real `test` command from `AGENTS.md`. If the repo has no explicit command yet, start with `dotnet test PROJECT_OR_SOLUTION`.
+3. Keep the runner model consistent:
+   - xUnit v2 usually runs through VSTest
+   - xUnit v3 can run as a standalone executable with `dotnet run`
+   - xUnit v3 can also integrate with Microsoft.Testing.Platform
+   - do not mix VSTest-only switches into Microsoft.Testing.Platform runs
+4. Run the narrowest useful scope first:
+   - one project
+   - one class
+   - one trait
+   - one method
+5. Prefer `[Theory]` for stable data-driven coverage and `[Fact]` for single-path invariant checks.
+6. Keep `xunit.analyzers` enabled when present. Fix analyzer findings instead of muting them casually.
+
+## Bootstrap When Missing
+
+If xUnit is requested but not configured:
+
+1. Detect current framework first:
+   - `rg -n "xunit(\\.v3)?|xunit\\.runner\\.visualstudio|TestingPlatformDotnetTestSupport|UseMicrosoftTestingPlatformRunner|TUnit|MSTest" -g '*.csproj' .`
+2. If the repo currently uses `TUnit` or `MSTest`, do not auto-migrate. Return `status: not_applicable` unless migration is explicitly requested.
+3. For explicit xUnit adoption, add packages to the target test project:
+   - `dotnet add TEST_PROJECT.csproj package xunit.v3`
+   - optional VSTest bridge: `dotnet add TEST_PROJECT.csproj package xunit.runner.visualstudio`
+4. Add repo test commands and runner notes to `AGENTS.md`.
+5. Run `dotnet test TEST_PROJECT.csproj` or repo-defined xUnit command and return `status: configured` or `status: improved`.
+
+
+## Deliver
+
+- xUnit tests that match the repo's active xUnit version and runner
+- commands that work in local and CI runs
+- focused verification before broader suite execution
+
+## Validate
+
+- the chosen CLI matches the active runner model
+- test filters or focused runs are valid for that runner
+- tests use deterministic inputs and assertions
+- xUnit-specific analyzers remain active unless the repo documents an exception
+
+## Ralph Loop
+
+Use the Ralph Loop for every task, including docs, architecture, testing, and tooling work.
+
+1. Plan first (mandatory):
+   - analyze current state
+   - define target outcome, constraints, and risks
+   - write a detailed execution plan
+   - list final validation skills to run at the end, with order and reason
+2. Execute one planned step and produce a concrete delta.
+3. Review the result and capture findings with actionable next fixes.
+4. Apply fixes in small batches and rerun the relevant checks or review steps.
+5. Update the plan after each iteration.
+6. Repeat until outcomes are acceptable or only explicit exceptions remain.
+7. If a dependency is missing, bootstrap it or return `status: not_applicable` with explicit reason and fallback path.
+
+### Required Result Format
+
+- `status`: `complete` | `clean` | `improved` | `configured` | `not_applicable` | `blocked`
+- `plan`: concise plan and current iteration step
+- `actions_taken`: concrete changes made
+- `validation_skills`: final skills run, or skipped with reasons
+- `verification`: commands, checks, or review evidence summary
+- `remaining`: top unresolved items or `none`
+
+For setup-only requests with no execution, return `status: configured` and exact next commands.
+
+## Load References
+
+- [references/xunit.md](references/xunit.md)
+- [references/patterns.md](references/patterns.md)
+- [references/anti-patterns.md](references/anti-patterns.md)
+
+## Example Requests
+
+- "Run this xUnit suite correctly."
+- "Fix our xUnit v3 test command."
+- "Add an xUnit regression test and keep CI compatible."

--- a/.github/skills/xunit/manifest.json
+++ b/.github/skills/xunit/manifest.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "category": "Testing",
+  "packages": [
+    "xunit",
+    "xunit.v3"
+  ]
+}

--- a/.github/skills/xunit/references/anti-patterns.md
+++ b/.github/skills/xunit/references/anti-patterns.md
@@ -1,0 +1,674 @@
+# xUnit Anti-Patterns
+
+Avoid these common testing mistakes.
+
+## Test Interdependence
+
+Tests must not depend on execution order or shared mutable state.
+
+Bad:
+
+```csharp
+public class UserServiceTests
+{
+    private static int _testUserId;
+
+    [Fact]
+    public void CreateUser_ValidData_ReturnsId()
+    {
+        var service = new UserService();
+        _testUserId = service.CreateUser("test@example.com"); // sets static state
+        Assert.True(_testUserId > 0);
+    }
+
+    [Fact]
+    public void GetUser_ExistingId_ReturnsUser()
+    {
+        var service = new UserService();
+        var user = service.GetUser(_testUserId); // depends on other test running first
+        Assert.NotNull(user);
+    }
+}
+```
+
+Good:
+
+```csharp
+public class UserServiceTests
+{
+    [Fact]
+    public void CreateUser_ValidData_ReturnsId()
+    {
+        // Arrange
+        var service = new UserService();
+
+        // Act
+        var userId = service.CreateUser("test@example.com");
+
+        // Assert
+        Assert.True(userId > 0);
+    }
+
+    [Fact]
+    public void GetUser_ExistingId_ReturnsUser()
+    {
+        // Arrange
+        var service = new UserService();
+        var userId = service.CreateUser("test@example.com"); // each test creates its own data
+
+        // Act
+        var user = service.GetUser(userId);
+
+        // Assert
+        Assert.NotNull(user);
+    }
+}
+```
+
+## Excessive Mocking
+
+Over-mocking creates brittle tests that verify implementation rather than behavior.
+
+Bad:
+
+```csharp
+public class OrderServiceTests
+{
+    [Fact]
+    public void PlaceOrder_Valid_CallsAllMethods()
+    {
+        // Arrange
+        var loggerMock = new Mock<ILogger<OrderService>>();
+        var repoMock = new Mock<IOrderRepository>();
+        var validatorMock = new Mock<IOrderValidator>();
+        var pricingMock = new Mock<IPricingService>();
+        var inventoryMock = new Mock<IInventoryService>();
+        var notificationMock = new Mock<INotificationService>();
+
+        validatorMock.Setup(v => v.Validate(It.IsAny<Order>())).Returns(true);
+        pricingMock.Setup(p => p.CalculateTotal(It.IsAny<Order>())).Returns(100m);
+        inventoryMock.Setup(i => i.Reserve(It.IsAny<Order>())).Returns(true);
+        repoMock.Setup(r => r.Save(It.IsAny<Order>())).Returns(1);
+
+        var service = new OrderService(loggerMock.Object, repoMock.Object,
+            validatorMock.Object, pricingMock.Object, inventoryMock.Object, notificationMock.Object);
+
+        // Act
+        service.PlaceOrder(new Order());
+
+        // Assert - verifying every internal call creates coupling to implementation
+        validatorMock.Verify(v => v.Validate(It.IsAny<Order>()), Times.Once);
+        pricingMock.Verify(p => p.CalculateTotal(It.IsAny<Order>()), Times.Once);
+        inventoryMock.Verify(i => i.Reserve(It.IsAny<Order>()), Times.Once);
+        repoMock.Verify(r => r.Save(It.IsAny<Order>()), Times.Once);
+        notificationMock.Verify(n => n.Send(It.IsAny<string>()), Times.Once);
+    }
+}
+```
+
+Good:
+
+```csharp
+public class OrderServiceTests
+{
+    [Fact]
+    public void PlaceOrder_ValidOrder_ReturnsOrderId()
+    {
+        // Arrange - use real implementations where cheap, mock only external boundaries
+        var repository = new InMemoryOrderRepository();
+        var notificationService = Substitute.For<INotificationService>();
+        var service = new OrderService(repository, notificationService);
+        var order = new Order { CustomerId = 1, Items = [new OrderItem { ProductId = 1, Quantity = 1 }] };
+
+        // Act
+        var orderId = service.PlaceOrder(order);
+
+        // Assert - verify observable outcomes
+        Assert.True(orderId > 0);
+        var savedOrder = repository.GetById(orderId);
+        Assert.NotNull(savedOrder);
+        Assert.Equal(OrderStatus.Placed, savedOrder.Status);
+    }
+}
+```
+
+## Testing Implementation Instead of Behavior
+
+Tests should verify what the code does, not how it does it.
+
+Bad:
+
+```csharp
+public class CacheTests
+{
+    [Fact]
+    public void Get_CacheMiss_CallsUnderlyingStore()
+    {
+        // Arrange
+        var storeMock = new Mock<IDataStore>();
+        storeMock.Setup(s => s.Get("key")).Returns("value");
+        var cache = new Cache(storeMock.Object);
+
+        // Act
+        cache.Get("key");
+        cache.Get("key");
+
+        // Assert - tests internal caching logic, not behavior
+        storeMock.Verify(s => s.Get("key"), Times.Once);
+    }
+}
+```
+
+Good:
+
+```csharp
+public class CacheTests
+{
+    [Fact]
+    public void Get_SameKey_ReturnsSameValue()
+    {
+        // Arrange
+        var store = new InMemoryDataStore();
+        store.Set("key", "value");
+        var cache = new Cache(store);
+
+        // Act
+        var result1 = cache.Get("key");
+        var result2 = cache.Get("key");
+
+        // Assert - verifies behavior: caching returns consistent results
+        Assert.Equal("value", result1);
+        Assert.Equal("value", result2);
+        Assert.Same(result1, result2); // if reference equality matters
+    }
+
+    [Fact]
+    public void Get_AfterExpiry_ReturnsUpdatedValue()
+    {
+        // Arrange
+        var store = new InMemoryDataStore();
+        store.Set("key", "original");
+        var timeProvider = new FakeTimeProvider();
+        var cache = new Cache(store, timeProvider, ttl: TimeSpan.FromMinutes(5));
+
+        // Act
+        var result1 = cache.Get("key");
+        store.Set("key", "updated");
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+        var result2 = cache.Get("key");
+
+        // Assert
+        Assert.Equal("original", result1);
+        Assert.Equal("updated", result2);
+    }
+}
+```
+
+## Ignoring Test Isolation
+
+Each test must run in isolation without affecting others.
+
+Bad:
+
+```csharp
+public class ConfigurationTests
+{
+    [Fact]
+    public void SetGlobalConfig_UpdatesEnvironment()
+    {
+        Environment.SetEnvironmentVariable("APP_MODE", "test"); // pollutes other tests
+        var config = new AppConfiguration();
+        Assert.Equal("test", config.Mode);
+    }
+}
+```
+
+Good:
+
+```csharp
+public class ConfigurationTests : IDisposable
+{
+    private readonly string? _originalValue;
+
+    public ConfigurationTests()
+    {
+        _originalValue = Environment.GetEnvironmentVariable("APP_MODE");
+    }
+
+    [Fact]
+    public void SetGlobalConfig_UpdatesEnvironment()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("APP_MODE", "test");
+        var config = new AppConfiguration();
+
+        // Assert
+        Assert.Equal("test", config.Mode);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("APP_MODE", _originalValue);
+    }
+}
+```
+
+Even better - inject configuration:
+
+```csharp
+public class ConfigurationTests
+{
+    [Fact]
+    public void AppConfiguration_TestMode_ReturnsTestBehavior()
+    {
+        // Arrange
+        var settings = new Dictionary<string, string?> { ["APP_MODE"] = "test" };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        var config = new AppConfiguration(configuration);
+
+        // Assert
+        Assert.Equal("test", config.Mode);
+    }
+}
+```
+
+## Non-Deterministic Tests
+
+Tests must produce the same result every time.
+
+Bad:
+
+```csharp
+public class TimestampTests
+{
+    [Fact]
+    public void CreateRecord_SetsTimestamp()
+    {
+        // Arrange
+        var service = new RecordService();
+
+        // Act
+        var record = service.CreateRecord("data");
+
+        // Assert - fails intermittently when clock rolls over
+        Assert.Equal(DateTime.Now.Date, record.CreatedAt.Date);
+    }
+}
+
+public class RandomTests
+{
+    [Fact]
+    public void GenerateId_ReturnsUniqueId()
+    {
+        var service = new IdGenerator();
+        var id1 = service.Generate();
+        var id2 = service.Generate();
+        Assert.NotEqual(id1, id2); // usually passes, sometimes fails
+    }
+}
+```
+
+Good:
+
+```csharp
+public class TimestampTests
+{
+    [Fact]
+    public void CreateRecord_SetsTimestampFromProvider()
+    {
+        // Arrange
+        var fixedTime = new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider(fixedTime);
+        var service = new RecordService(timeProvider);
+
+        // Act
+        var record = service.CreateRecord("data");
+
+        // Assert
+        Assert.Equal(fixedTime, record.CreatedAt);
+    }
+}
+
+public class RandomTests
+{
+    [Fact]
+    public void GenerateId_WithSeed_ReturnsExpectedId()
+    {
+        // Arrange
+        var randomProvider = new SeededRandomProvider(42);
+        var service = new IdGenerator(randomProvider);
+
+        // Act
+        var id = service.Generate();
+
+        // Assert
+        Assert.Equal("expected-seeded-value", id);
+    }
+
+    [Fact]
+    public void GenerateId_ReturnsValidFormat()
+    {
+        // Arrange
+        var service = new IdGenerator();
+
+        // Act
+        var id = service.Generate();
+
+        // Assert - verify format rather than specific value
+        Assert.Matches(@"^[a-f0-9]{32}$", id);
+    }
+}
+```
+
+## Swallowing Exceptions
+
+Tests must not catch exceptions without re-throwing or asserting.
+
+Bad:
+
+```csharp
+public class FileServiceTests
+{
+    [Fact]
+    public void ReadFile_MissingFile_HandlesGracefully()
+    {
+        try
+        {
+            var service = new FileService();
+            var content = service.ReadFile("/nonexistent/path");
+            Assert.NotNull(content);
+        }
+        catch
+        {
+            // test passes either way - hides real failures
+        }
+    }
+}
+```
+
+Good:
+
+```csharp
+public class FileServiceTests
+{
+    [Fact]
+    public void ReadFile_MissingFile_ThrowsFileNotFoundException()
+    {
+        // Arrange
+        var service = new FileService();
+
+        // Act & Assert
+        var exception = Assert.Throws<FileNotFoundException>(
+            () => service.ReadFile("/nonexistent/path"));
+        Assert.Contains("nonexistent", exception.FileName);
+    }
+
+    [Fact]
+    public void TryReadFile_MissingFile_ReturnsFalse()
+    {
+        // Arrange
+        var service = new FileService();
+
+        // Act
+        var success = service.TryReadFile("/nonexistent/path", out var content);
+
+        // Assert
+        Assert.False(success);
+        Assert.Null(content);
+    }
+}
+```
+
+## Magic Numbers and Strings
+
+Unexplained literals reduce test clarity.
+
+Bad:
+
+```csharp
+public class DiscountTests
+{
+    [Fact]
+    public void CalculateDiscount_ReturnsExpected()
+    {
+        var service = new DiscountService();
+        var discount = service.Calculate(150, 3, true);
+        Assert.Equal(22.5m, discount);
+    }
+}
+```
+
+Good:
+
+```csharp
+public class DiscountTests
+{
+    [Fact]
+    public void CalculateDiscount_GoldMemberWithBulkOrder_AppliesCombinedDiscount()
+    {
+        // Arrange
+        const decimal orderTotal = 150m;
+        const int itemCount = 3;
+        const bool isGoldMember = true;
+        const decimal expectedBulkDiscount = 15m;      // 10% for 3+ items
+        const decimal expectedMemberDiscount = 7.5m;   // 5% gold member bonus
+        const decimal expectedTotalDiscount = 22.5m;
+
+        var service = new DiscountService();
+
+        // Act
+        var discount = service.Calculate(orderTotal, itemCount, isGoldMember);
+
+        // Assert
+        Assert.Equal(expectedTotalDiscount, discount);
+    }
+}
+```
+
+## Asserting Too Much or Too Little
+
+Each test should verify one logical concept.
+
+Bad - too many assertions:
+
+```csharp
+public class UserRegistrationTests
+{
+    [Fact]
+    public void RegisterUser_ValidData_EverythingWorks()
+    {
+        var service = new UserService();
+        var result = service.Register("test@example.com", "password123");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.User);
+        Assert.Equal("test@example.com", result.User.Email);
+        Assert.True(result.User.IsActive);
+        Assert.NotNull(result.User.CreatedAt);
+        Assert.True(result.EmailSent);
+        Assert.Equal(1, service.GetUserCount());
+        Assert.NotNull(service.GetUserByEmail("test@example.com"));
+        // continues for 20 more assertions
+    }
+}
+```
+
+Bad - too few assertions:
+
+```csharp
+public class UserRegistrationTests
+{
+    [Fact]
+    public void RegisterUser_ValidData_Succeeds()
+    {
+        var service = new UserService();
+        var result = service.Register("test@example.com", "password123");
+        Assert.True(result.Success); // what about the user? was it actually created?
+    }
+}
+```
+
+Good:
+
+```csharp
+public class UserRegistrationTests
+{
+    [Fact]
+    public void RegisterUser_ValidData_CreatesActiveUser()
+    {
+        // Arrange
+        var service = new UserService();
+        const string email = "test@example.com";
+
+        // Act
+        var result = service.Register(email, "password123");
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.User);
+        Assert.Equal(email, result.User.Email);
+        Assert.True(result.User.IsActive);
+    }
+
+    [Fact]
+    public void RegisterUser_ValidData_SendsWelcomeEmail()
+    {
+        // Arrange
+        var emailService = Substitute.For<IEmailService>();
+        var service = new UserService(emailService);
+
+        // Act
+        service.Register("test@example.com", "password123");
+
+        // Assert
+        emailService.Received(1).SendWelcomeEmail("test@example.com");
+    }
+
+    [Fact]
+    public void RegisterUser_ValidData_PersistsUser()
+    {
+        // Arrange
+        var repository = new InMemoryUserRepository();
+        var service = new UserService(repository);
+
+        // Act
+        var result = service.Register("test@example.com", "password123");
+
+        // Assert
+        var persistedUser = repository.GetByEmail("test@example.com");
+        Assert.NotNull(persistedUser);
+        Assert.Equal(result.User.Id, persistedUser.Id);
+    }
+}
+```
+
+## Async Void Tests
+
+xUnit does not properly await `async void` test methods.
+
+Bad:
+
+```csharp
+public class AsyncTests
+{
+    [Fact]
+    public async void FetchData_ReturnsData() // async void - xUnit won't wait
+    {
+        var service = new DataService();
+        var data = await service.FetchAsync();
+        Assert.NotEmpty(data); // may not execute before test completes
+    }
+}
+```
+
+Good:
+
+```csharp
+public class AsyncTests
+{
+    [Fact]
+    public async Task FetchData_ReturnsData() // async Task - xUnit awaits properly
+    {
+        // Arrange
+        var service = new DataService();
+
+        // Act
+        var data = await service.FetchAsync();
+
+        // Assert
+        Assert.NotEmpty(data);
+    }
+}
+```
+
+## Constructor Abuse
+
+Test constructors are for shared setup, not test-specific logic.
+
+Bad:
+
+```csharp
+public class PaymentTests
+{
+    private readonly PaymentResult _result;
+
+    public PaymentTests()
+    {
+        var service = new PaymentService();
+        _result = service.ProcessPayment(new Payment { Amount = 100 }); // runs for every test
+    }
+
+    [Fact]
+    public void ProcessPayment_ValidAmount_Succeeds() => Assert.True(_result.Success);
+
+    [Fact]
+    public void ProcessPayment_ValidAmount_ReturnsTransactionId() => Assert.NotNull(_result.TransactionId);
+}
+```
+
+Good:
+
+```csharp
+public class PaymentTests(PaymentFixture fixture) : IClassFixture<PaymentFixture>
+{
+    [Fact]
+    public void ProcessPayment_ValidAmount_Succeeds()
+    {
+        // Arrange
+        var service = new PaymentService(fixture.Gateway);
+        var payment = new Payment { Amount = 100 };
+
+        // Act
+        var result = service.ProcessPayment(payment);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public void ProcessPayment_ValidAmount_ReturnsTransactionId()
+    {
+        // Arrange
+        var service = new PaymentService(fixture.Gateway);
+        var payment = new Payment { Amount = 100 };
+
+        // Act
+        var result = service.ProcessPayment(payment);
+
+        // Assert
+        Assert.NotNull(result.TransactionId);
+    }
+}
+
+public class PaymentFixture
+{
+    public IPaymentGateway Gateway { get; } = new TestPaymentGateway();
+}
+```
+
+## Sources
+
+- [xUnit.net Patterns](https://xunit.net/docs/comparisons)
+- [Unit Testing Best Practices](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices)

--- a/.github/skills/xunit/references/patterns.md
+++ b/.github/skills/xunit/references/patterns.md
@@ -1,0 +1,392 @@
+# xUnit Testing Patterns
+
+## Arrange-Act-Assert (AAA)
+
+Structure every test method in three distinct phases:
+
+```csharp
+public class CalculatorTests
+{
+    [Fact]
+    public void Add_TwoPositiveNumbers_ReturnsSum()
+    {
+        // Arrange
+        var calculator = new Calculator();
+        var a = 5;
+        var b = 3;
+
+        // Act
+        var result = calculator.Add(a, b);
+
+        // Assert
+        Assert.Equal(8, result);
+    }
+}
+```
+
+Keep the phases visually separated. Avoid mixing setup, execution, and verification in the same block.
+
+## Class Fixtures
+
+Use class fixtures to share expensive setup across all tests in a class. Primary constructors inject the fixture directly:
+
+```csharp
+public class DatabaseFixture : IAsyncLifetime
+{
+    public IDbConnection Connection { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        Connection = new SqliteConnection("Data Source=:memory:");
+        await Connection.OpenAsync();
+        await SeedTestDataAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Connection.DisposeAsync();
+    }
+
+    private async Task SeedTestDataAsync()
+    {
+        // seed shared test data
+    }
+}
+
+public class UserRepositoryTests(DatabaseFixture fixture) : IClassFixture<DatabaseFixture>
+{
+    [Fact]
+    public async Task GetUser_ExistingId_ReturnsUser()
+    {
+        // Arrange
+        var repository = new UserRepository(fixture.Connection);
+
+        // Act
+        var user = await repository.GetUserAsync(1);
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal("TestUser", user.Name);
+    }
+}
+```
+
+## Collection Fixtures
+
+Share expensive resources across multiple test classes:
+
+```csharp
+public class IntegrationTestFixture : IAsyncLifetime
+{
+    public HttpClient Client { get; private set; } = null!;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new WebApplicationFactory<Program>();
+        Client = _factory.CreateClient();
+        await Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client.Dispose();
+        await _factory.DisposeAsync();
+    }
+}
+
+[CollectionDefinition("Integration")]
+public class IntegrationTestCollection : ICollectionFixture<IntegrationTestFixture>;
+
+[Collection("Integration")]
+public class OrdersApiTests(IntegrationTestFixture fixture)
+{
+    [Fact]
+    public async Task GetOrders_ReturnsOk()
+    {
+        // Act
+        var response = await fixture.Client.GetAsync("/api/orders");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+}
+
+[Collection("Integration")]
+public class ProductsApiTests(IntegrationTestFixture fixture)
+{
+    [Fact]
+    public async Task GetProducts_ReturnsOk()
+    {
+        // Act
+        var response = await fixture.Client.GetAsync("/api/products");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+}
+```
+
+## Theory Data Patterns
+
+### InlineData for Simple Cases
+
+```csharp
+public class ValidationTests
+{
+    [Theory]
+    [InlineData("", false)]
+    [InlineData("a", false)]
+    [InlineData("ab", false)]
+    [InlineData("abc", true)]
+    [InlineData("valid-password-123", true)]
+    public void IsValidPassword_VariousInputs_ReturnsExpected(string password, bool expected)
+    {
+        // Arrange
+        var validator = new PasswordValidator(minLength: 3);
+
+        // Act
+        var result = validator.IsValid(password);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+}
+```
+
+### MemberData for Complex Objects
+
+```csharp
+public class OrderProcessorTests
+{
+    public static TheoryData<Order, decimal> OrderDiscountData => new()
+    {
+        { new Order { Total = 100m, CustomerTier = CustomerTier.Standard }, 0m },
+        { new Order { Total = 100m, CustomerTier = CustomerTier.Silver }, 5m },
+        { new Order { Total = 100m, CustomerTier = CustomerTier.Gold }, 10m },
+        { new Order { Total = 500m, CustomerTier = CustomerTier.Gold }, 75m }
+    };
+
+    [Theory]
+    [MemberData(nameof(OrderDiscountData))]
+    public void CalculateDiscount_VariousOrders_ReturnsExpectedDiscount(Order order, decimal expectedDiscount)
+    {
+        // Arrange
+        var processor = new OrderProcessor();
+
+        // Act
+        var discount = processor.CalculateDiscount(order);
+
+        // Assert
+        Assert.Equal(expectedDiscount, discount);
+    }
+}
+```
+
+### ClassData for Reusable Data Sets
+
+```csharp
+public class EdgeCaseStringData : TheoryData<string?>
+{
+    public EdgeCaseStringData()
+    {
+        Add(null);
+        Add("");
+        Add(" ");
+        Add("\t");
+        Add("\n");
+        Add("   \t\n   ");
+    }
+}
+
+public class StringUtilityTests
+{
+    [Theory]
+    [ClassData(typeof(EdgeCaseStringData))]
+    public void IsNullOrWhitespace_EdgeCases_ReturnsTrue(string? input)
+    {
+        // Act
+        var result = string.IsNullOrWhiteSpace(input);
+
+        // Assert
+        Assert.True(result);
+    }
+}
+```
+
+## Mocking with NSubstitute
+
+Prefer NSubstitute for readable substitute configuration:
+
+```csharp
+public class OrderServiceTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task PlaceOrder_ValidOrder_SendsNotification()
+    {
+        // Arrange
+        var notificationService = Substitute.For<INotificationService>();
+        var orderRepository = Substitute.For<IOrderRepository>();
+        orderRepository.SaveAsync(Arg.Any<Order>()).Returns(Task.FromResult(true));
+
+        var service = new OrderService(orderRepository, notificationService);
+        var order = new Order { CustomerId = 1, Items = [new OrderItem { ProductId = 1, Quantity = 2 }] };
+
+        // Act
+        await service.PlaceOrderAsync(order);
+
+        // Assert
+        await notificationService.Received(1).SendOrderConfirmationAsync(Arg.Is<Order>(o => o.CustomerId == 1));
+        output.WriteLine("Order placed and notification sent");
+    }
+
+    [Fact]
+    public async Task PlaceOrder_RepositoryFails_ThrowsException()
+    {
+        // Arrange
+        var notificationService = Substitute.For<INotificationService>();
+        var orderRepository = Substitute.For<IOrderRepository>();
+        orderRepository.SaveAsync(Arg.Any<Order>()).ThrowsAsync(new DataException("Connection failed"));
+
+        var service = new OrderService(orderRepository, notificationService);
+        var order = new Order { CustomerId = 1 };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<DataException>(() => service.PlaceOrderAsync(order));
+        await notificationService.DidNotReceive().SendOrderConfirmationAsync(Arg.Any<Order>());
+    }
+}
+```
+
+## Mocking with Moq
+
+Use Moq when the project already depends on it:
+
+```csharp
+public class PaymentProcessorTests
+{
+    [Fact]
+    public async Task ProcessPayment_ValidCard_ReturnsSuccess()
+    {
+        // Arrange
+        var gatewayMock = new Mock<IPaymentGateway>();
+        gatewayMock
+            .Setup(g => g.ChargeAsync(It.IsAny<string>(), It.Is<decimal>(d => d > 0)))
+            .ReturnsAsync(new PaymentResult { Success = true, TransactionId = "TX123" });
+
+        var processor = new PaymentProcessor(gatewayMock.Object);
+
+        // Act
+        var result = await processor.ProcessPaymentAsync("4111111111111111", 99.99m);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal("TX123", result.TransactionId);
+        gatewayMock.Verify(g => g.ChargeAsync("4111111111111111", 99.99m), Times.Once);
+    }
+}
+```
+
+## Output and Diagnostics
+
+Use `ITestOutputHelper` for test diagnostics:
+
+```csharp
+public class DiagnosticTests(ITestOutputHelper output)
+{
+    [Fact]
+    public void ComplexCalculation_LargeInput_CompletesWithinTimeout()
+    {
+        // Arrange
+        var calculator = new ComplexCalculator();
+        var input = GenerateLargeInput();
+        output.WriteLine($"Testing with input size: {input.Length}");
+
+        var stopwatch = Stopwatch.StartNew();
+
+        // Act
+        var result = calculator.Process(input);
+
+        // Assert
+        stopwatch.Stop();
+        output.WriteLine($"Completed in {stopwatch.ElapsedMilliseconds}ms");
+        Assert.True(stopwatch.ElapsedMilliseconds < 5000, "Calculation took too long");
+    }
+
+    private static int[] GenerateLargeInput() => Enumerable.Range(0, 100_000).ToArray();
+}
+```
+
+## Async Test Patterns
+
+xUnit handles async tests natively:
+
+```csharp
+public class AsyncServiceTests
+{
+    [Fact]
+    public async Task FetchData_ValidEndpoint_ReturnsData()
+    {
+        // Arrange
+        var service = new DataService();
+
+        // Act
+        var data = await service.FetchDataAsync("/api/items");
+
+        // Assert
+        Assert.NotEmpty(data);
+    }
+
+    [Fact]
+    public async Task FetchData_Timeout_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var service = new DataService();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => service.FetchDataAsync("/api/slow-endpoint", cts.Token));
+    }
+}
+```
+
+## Trait-Based Organization
+
+Use traits sparingly for CI filtering:
+
+```csharp
+public class IntegrationTests
+{
+    [Fact]
+    [Trait("Category", "Integration")]
+    [Trait("Database", "SqlServer")]
+    public async Task CreateUser_ValidData_PersistsToDatabase()
+    {
+        // integration test implementation
+    }
+}
+
+public class UnitTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ValidateEmail_InvalidFormat_ReturnsFalse()
+    {
+        // unit test implementation
+    }
+}
+```
+
+Run filtered:
+
+```bash
+dotnet test --filter "Category=Unit"
+dotnet test --filter "Category!=Integration"
+```
+
+## Sources
+
+- [xUnit.net v3 Getting Started](https://xunit.net/docs/getting-started/v3/getting-started)
+- [xUnit.net Shared Context](https://xunit.net/docs/shared-context)
+- [NSubstitute Documentation](https://nsubstitute.github.io/help/getting-started/)

--- a/.github/skills/xunit/references/xunit.md
+++ b/.github/skills/xunit/references/xunit.md
@@ -1,0 +1,98 @@
+# xUnit in MCAF
+
+## Open/Free Status
+
+- open source
+- free to use
+
+## Install
+
+xUnit v3 package setup:
+
+```bash
+dotnet add package xunit.v3
+```
+
+VSTest compatibility package when the repo intentionally uses that runner:
+
+```bash
+dotnet add package xunit.runner.visualstudio
+```
+
+## Verify First
+
+Before adding packages, check what the repo already references:
+
+```bash
+rg -n "xunit(\\.v3)?|xunit\\.runner\\.visualstudio|TestingPlatformDotnetTestSupport|UseMicrosoftTestingPlatformRunner" -g '*.csproj' .
+```
+
+Use this reference when the repository already chose xUnit and you need framework-specific commands, package checks, or CI guardrails.
+
+## Detect the xUnit Model
+
+Use the project file as the source of truth:
+
+```bash
+rg -n "xunit\\.v3|xunit.runner.visualstudio|Microsoft\\.NET\\.Test\\.Sdk|TestingPlatformDotnetTestSupport|UseMicrosoftTestingPlatformRunner" -g '*.csproj' .
+```
+
+Typical markers:
+
+- xUnit v2: `xunit`
+- xUnit v3: `xunit.v3`
+- VSTest compatibility: `xunit.runner.visualstudio` and `Microsoft.NET.Test.Sdk`
+- Microsoft.Testing.Platform support: `TestingPlatformDotnetTestSupport` or `UseMicrosoftTestingPlatformRunner`
+
+## Common Commands
+
+Start with the repo's `test` command from `AGENTS.md`. If the repo has not documented one yet, these are the safe defaults:
+
+```bash
+dotnet test MySolution.sln
+dotnet test tests/MyProject.Tests/MyProject.Tests.csproj
+dotnet test tests/MyProject.Tests/MyProject.Tests.csproj --no-build
+```
+
+Focused VSTest-style run:
+
+```bash
+dotnet test tests/MyProject.Tests/MyProject.Tests.csproj --filter "FullyQualifiedName~Namespace.TypeName"
+```
+
+xUnit v3 standalone runner:
+
+```bash
+dotnet run --project tests/MyProject.Tests/MyProject.Tests.csproj
+```
+
+xUnit v3 with Microsoft.Testing.Platform-style class filtering:
+
+```bash
+dotnet run --project tests/MyProject.Tests/MyProject.Tests.csproj -- --filter-class Namespace.TypeName
+```
+
+If the project enables `TestingPlatformDotnetTestSupport`, `dotnet test` can forward into Microsoft.Testing.Platform. Keep those switches consistent with the runner the project actually uses.
+
+## CI Notes
+
+- Use one runner model per project. Do not mix VSTest-only flags and Microsoft.Testing.Platform flags in the same command.
+- Build first, then use `--no-build` for repeat test runs.
+- Keep coverage driver aligned with the runner:
+  - VSTest: `coverlet.collector` or `--collect:"XPlat Code Coverage"`
+  - Microsoft.Testing.Platform: `coverlet.MTP`
+- Keep xUnit analyzers on:
+  - xUnit v2 2.3+ usually brings them through the main `xunit` package
+  - xUnit v3 brings analyzer guidance through the main package set unless the repo split packages explicitly
+
+## Good Defaults
+
+- prefer `[Theory]` plus stable inline or member data for variant-heavy behavior
+- use traits only when the repo already relies on them for filtering
+- avoid runner rewrites in the same change as behavior work unless the current command is already broken
+
+## Sources
+
+- [xUnit.net v3 getting started](https://xunit.net/docs/getting-started/v3/getting-started)
+- [xUnit.net v3 Microsoft Testing Platform support](https://xunit.net/docs/getting-started/v3/microsoft-testing-platform)
+- [xunit/xunit.analyzers](https://github.com/xunit/xunit.analyzers)


### PR DESCRIPTION
Auto-generated mirror of the `.claude/skills/` refresh from #731, landed under `.github/skills/` for GitHub-native skill consumers (Copilot etc.). Same 17 packs.

Doc-only sweep — no source code, tests, or runtime configuration touched. **No testing required** — merging via --admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)