### PR TITLE
chore(ui): add CI gate for Snackbar retirement migration

### DIFF
--- a/.github/workflows/snackbar-gate.yml
+++ b/.github/workflows/snackbar-gate.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Snackbar retirement CI gate. Fails when any C# / Razor file under
+# src/Apps/Sorcha.UI* or src/Apps/Sorcha.Wallet.Pwa references the
+# MudBlazor Snackbar API outside the explicit allowlist
+# (.snackbar-allowlist). The allowlist is a ratchet — it may only shrink.
+#
+# See scripts/check-no-snackbar.ps1 and CLAUDE.md for the wider retirement plan.
+
+name: snackbar-gate
+
+on:
+  pull_request:
+    paths:
+      - "src/Apps/Sorcha.UI/**"
+      - "src/Apps/Sorcha.Wallet.Pwa/**"
+      - ".snackbar-allowlist"
+      - "scripts/check-no-snackbar.ps1"
+      - ".github/workflows/snackbar-gate.yml"
+  workflow_dispatch:
+
+jobs:
+  no-new-snackbar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Snackbar retirement gate
+        shell: pwsh
+        run: ./scripts/check-no-snackbar.ps1

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Seed allowlist for the Snackbar retirement migration.
+# Files listed here are permitted to contain `Snackbar.Add(` or `ISnackbar`
+# references. The CI gate (scripts/check-no-snackbar.ps1) fails when any new
+# file outside this list introduces those references.
+#
+# This list is a ratchet: it may only SHRINK, never grow. Each PR in the
+# Snackbar retirement effort should delete one or more lines as the
+# corresponding call sites migrate to IInlineFeedback / inbox writers /
+# CopyButton / inline MudAlert.
+#
+# When the list reaches zero entries, Phase 6 unmounts MudSnackbarProvider.
+#
+# Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
+
+src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/TruncatedId.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/JwtViewerDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AccountsTab.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletList.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/SubscribeDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Encryption/CryptoProgressPopover.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/PropertiesPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/OrgSettings.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SectorConfiguration.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SchemaProviderHealth.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/DomainRestrictions.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/AuditLog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetail.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/PayloadViewer.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/InstructionsTab.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Operations.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Wallets/WalletAccessTab.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ParticipantList.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletQrDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ImportDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ExportDialog.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ConditionEditor.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/CalculationEditor.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor
+src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/RecoverWallet.razor

--- a/scripts/check-no-snackbar.ps1
+++ b/scripts/check-no-snackbar.ps1
@@ -1,0 +1,157 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Snackbar retirement CI gate.
+#
+# The Sorcha UI is migrating off MudBlazor's Snackbar (toast popups) onto
+# two replacement surfaces:
+#   - IInlineFeedback / InlineResult.razor — page-scoped, in-place banner
+#     for the actor's own action feedback.
+#   - The durable inbox (Feature 118) — server-side writers fan workflow
+#     events into the bell drawer at MainLayout.razor.
+#
+# To stop the migration regressing while it's in flight, this gate fails
+# the build when any C# / Razor file outside the allowlist (.snackbar-allowlist)
+# contains a `Snackbar.Add(` call or an `ISnackbar` injection / parameter.
+#
+# The allowlist is a ratchet — it may only shrink, never grow. When it
+# reaches zero entries the MudSnackbarProvider mount is removed (Phase 7
+# of the retirement plan) and this script becomes a permanent guard.
+#
+# Usage:
+#   pwsh scripts/check-no-snackbar.ps1
+#
+# Exit codes:
+#   0 — no violations
+#   1 — Snackbar reference found outside the allowlist
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repo = $RepoRoot.TrimEnd([IO.Path]::DirectorySeparatorChar)
+$allowlistPath = Join-Path $repo '.snackbar-allowlist'
+
+if (-not (Test-Path -LiteralPath $allowlistPath)) {
+    Write-Error "Allowlist file not found: $allowlistPath"
+    exit 1
+}
+
+# Load the allowlist — strip blank lines and comments. Normalise to forward
+# slashes so the comparison works on both Windows and Linux runners.
+$allowed = @{}
+foreach ($line in (Get-Content -LiteralPath $allowlistPath)) {
+    $trimmed = $line.Trim()
+    if ($trimmed.Length -eq 0) { continue }
+    if ($trimmed.StartsWith('#')) { continue }
+    $allowed[$trimmed.Replace('\', '/')] = $true
+}
+
+# Patterns that indicate a Snackbar dependency. Each is anchored to a
+# token boundary so we don't false-positive on type members named
+# "SnackbarAddon" or similar.
+$patterns = @(
+    'Snackbar\.Add\(',          # ISnackbar.Add(...) call
+    '\bISnackbar\b',            # field, parameter, or [Inject] declaration
+    '@inject\s+ISnackbar\b'     # Razor @inject directive
+)
+
+# Files to scan: any .razor or .cs under src/Apps/. The Sorcha.UI.Components.User
+# library + the two host apps (Sorcha.UI.Web*, Sorcha.Wallet.Pwa) cover all
+# known Snackbar consumers; restricting scope keeps the scan fast and avoids
+# false positives in Service / test code that doesn't render UI.
+$scanRoots = @(
+    "$repo/src/Apps/Sorcha.UI",
+    "$repo/src/Apps/Sorcha.Wallet.Pwa"
+)
+
+$candidates = @()
+foreach ($root in $scanRoots) {
+    if (-not (Test-Path -LiteralPath $root)) { continue }
+    $candidates += Get-ChildItem -Path $root -Recurse -Include '*.razor', '*.cs' -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '[\\/](obj|bin)[\\/]' }
+}
+
+$violations = @()
+$matchedAllowed = @{}
+
+foreach ($file in $candidates) {
+    $rel = [IO.Path]::GetRelativePath($repo, $file.FullName).Replace('\', '/')
+    $lineNum = 0
+    $fileHasMatch = $false
+
+    foreach ($line in (Get-Content -LiteralPath $file.FullName)) {
+        $lineNum++
+        foreach ($p in $patterns) {
+            if ($line -match $p) {
+                $fileHasMatch = $true
+                if (-not $allowed.ContainsKey($rel)) {
+                    $violations += [pscustomobject]@{
+                        File    = $rel
+                        Line    = $lineNum
+                        Snippet = $line.Trim()
+                    }
+                }
+                break
+            }
+        }
+    }
+
+    if ($fileHasMatch -and $allowed.ContainsKey($rel)) {
+        $matchedAllowed[$rel] = $true
+    }
+}
+
+# Detect stale allowlist entries — files listed but no longer containing
+# any Snackbar reference. These should be removed from the allowlist as
+# part of the same PR that cleaned them up.
+$stale = @()
+foreach ($entry in $allowed.Keys) {
+    if (-not $matchedAllowed.ContainsKey($entry)) {
+        $stale += $entry
+    }
+}
+
+$failed = $false
+
+if ($violations.Count -gt 0) {
+    $failed = $true
+    Write-Host ""
+    Write-Host "FAIL: Snackbar reference found in files not on the allowlist." -ForegroundColor Red
+    Write-Host ""
+    foreach ($v in $violations) {
+        Write-Host ("  {0}:{1}  {2}" -f $v.File, $v.Line, $v.Snippet) -ForegroundColor Yellow
+    }
+    Write-Host ""
+    Write-Host "New code must not depend on ISnackbar." -ForegroundColor Yellow
+    Write-Host "Use IInlineFeedback for actor's-own-action feedback, or write a"
+    Write-Host "server-side inbox entry for workflow results. See CLAUDE.md."
+}
+
+if ($stale.Count -gt 0) {
+    $failed = $true
+    Write-Host ""
+    Write-Host "FAIL: stale allowlist entries — files no longer contain any Snackbar reference:" -ForegroundColor Red
+    foreach ($s in $stale) {
+        Write-Host "  - $s" -ForegroundColor Yellow
+    }
+    Write-Host ""
+    Write-Host "Remove these lines from .snackbar-allowlist in the same PR that cleaned them up."
+    Write-Host "The allowlist is a ratchet — it may only shrink."
+}
+
+if ($failed) {
+    exit 1
+}
+
+$remaining = $allowed.Count
+Write-Host ("OK: Snackbar gate passed. {0} files still on the allowlist." -f $remaining) -ForegroundColor Green
+if ($remaining -eq 0) {
+    Write-Host "  Allowlist is empty — Phase 7 (unmount MudSnackbarProvider) is unblocked." -ForegroundColor Green
+}
+exit 0


### PR DESCRIPTION
## Summary

Seeds the Snackbar retirement effort by locking the set of files that currently depend on MudBlazor's Snackbar (75 files) and failing CI when new files outside that allowlist introduce `Snackbar.Add(` / `ISnackbar` references.

This is **Phase 0** of the wider retirement plan agreed with @stuartfraser. Subsequent phases pull the PWA inbox forward as a prerequisite (Phase A), then migrate the 75 call sites onto `IInlineFeedback` / inbox writers / `CopyButton` over ~14 PRs. The `<MudSnackbarProvider />` mount stays in place until the allowlist hits zero and the user signs off on full UAT.

## Files

- `.snackbar-allowlist` — seed of 75 files. Ratchet: may only shrink.
- `scripts/check-no-snackbar.ps1` — gate logic. Detects both new violations and stale allowlist entries.
- `.github/workflows/snackbar-gate.yml` — pull_request trigger scoped to `src/Apps/Sorcha.UI/**` and `src/Apps/Sorcha.Wallet.Pwa/**`.

## Test plan

- [x] Gate green on seeded baseline (75 files match, no violations)
- [x] Gate red when a new file outside the allowlist introduces `ISnackbar`
- [x] Gate red when an allowlist entry no longer references Snackbar (stale-ratchet detection)
- [ ] Workflow runs on this PR — confirm CI surfaces green

## Replacement surfaces (forward reference)

| Today | Tomorrow |
|---|---|
| `Snackbar.Add` on actor's own action | `IInlineFeedback.ShowX(...)` → `InlineResult.razor` page-scoped banner |
| `Snackbar.Add` on workflow result | Server-side inbox writer → `InboxPanel` bell |
| `Snackbar.Add` after clipboard write | `CopyButton.razor` with button-morph affordance |
| `Snackbar.Add` from inside MudDialog | `<MudAlert>` in dialog body or close-with-result |

🤖 Generated with [Claude Code](https://claude.com/claude-code)