### PR TITLE
feat(pwa): bring durable inbox to Citizen Wallet PWA (Feature 118 / Phase A)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
@@ -6,6 +6,7 @@
 @inject TenantHubConnection TenantHub
 @inject NavigationManager Navigation
 @inject ILogger<InboxPanel> Logger
+@using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Services
 @using MudBlazor
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/_Imports.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/_Imports.razor
@@ -20,6 +20,7 @@
 @using Sorcha.UI.Core.Components.Designer
 @using Sorcha.UI.Core.Components.Admin
 @using Sorcha.UI.Core.Components.Encryption
+@using Sorcha.UI.Core.Components.Inbox
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Models.Chat
 @using Sorcha.UI.Web.Client.Components.Chat

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Sorcha.Wallet.Pwa.Services.Verification;
 using Sorcha.UI.Components.User.Services.Capture;
 using Sorcha.UI.Components.User.Services.Signing;
 using Sorcha.UI.Components.User.Services.Verification;
+using Sorcha.UI.Core.Services;
 using Sorcha.ServiceClients.CitizenWallet;
 
 namespace Sorcha.Wallet.Pwa.Extensions;
@@ -170,6 +171,25 @@ public static class ServiceCollectionExtensions
             gatewayBaseAddress,
             sp.GetRequiredService<IAccessTokenStore>(),
             sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<CitizenWalletHubConnection>>()));
+
+        // Feature 118 / Phase A — durable inbox surface. The PWA mirrors the
+        // main web app: an HTTP client for /api/me/inbox/* under the bearer-
+        // and clock-handler chain, plus a TenantHubConnection singleton for
+        // realtime InboxEntryAdded / InboxUnreadCountUpdated nudges.
+        services.AddHttpClient<IInboxApiService, InboxApiService>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
+        services.AddSingleton(sp => new TenantHubConnection(
+            gatewayBaseAddress,
+            accessTokenProvider: async () =>
+            {
+                var record = await sp.GetRequiredService<IAccessTokenStore>().GetAsync();
+                return record?.AccessToken;
+            },
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<TenantHubConnection>>(),
+            sp.GetService<IInboxApiService>()));
 
         return services;
     }

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -114,6 +114,7 @@
     private bool _inboxPanelOpen;
     private int _inboxUnreadCount;
     private bool _inboxHubStarted;
+    private bool _inboxInitInFlight;
 
     protected override async Task OnInitializedAsync()
     {
@@ -125,23 +126,51 @@
         await InitialiseInboxAsync();
     }
 
+    /// <summary>
+    /// IAccessTokenStore has no Changed event, so the SPA login flow (which
+    /// writes the token in place without rebuilding the layout) needs a
+    /// poll hook. OnAfterRenderAsync fires after every render; we re-attempt
+    /// the inbox wake-up if the hub hasn't started and the token now exists.
+    /// Once <see cref="_inboxHubStarted"/> flips true, the guard short-circuits
+    /// so this is cheap on subsequent renders. <see cref="_inboxInitInFlight"/>
+    /// prevents a re-entrant init when several renders queue between an
+    /// access-token write and the hub coming online.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_inboxHubStarted || _inboxInitInFlight) return;
+
+        var record = await AccessTokens.GetAsync();
+        if (record is null) return;
+
+        _inboxInitInFlight = true;
+        try
+        {
+            await InitialiseInboxAsync();
+        }
+        finally
+        {
+            _inboxInitInFlight = false;
+        }
+    }
+
     private void ToggleInboxPanel() => _inboxPanelOpen = !_inboxPanelOpen;
 
     /// <summary>
     /// Feature 118 / Phase A — bring the bell badge live. Cold-loads the
     /// unread count via REST, then subscribes to TenantHub for realtime
     /// updates. Hub failures are swallowed — the bell stays accurate on
-    /// the next REST refresh.
+    /// the next REST refresh. Idempotent: skips when already started.
     /// </summary>
     private async Task InitialiseInboxAsync()
     {
-        // Cold load — the badge surfaces from the first render even if the
-        // hub takes a moment to connect.
+        if (_inboxHubStarted) return;
+
         var record = await AccessTokens.GetAsync();
         if (record is null)
         {
-            // Anonymous PWA visit (pre-enrolment). Bell stays at zero; the
-            // hub will be started post-enrolment when a token exists.
+            // Anonymous PWA visit (pre-enrolment). Bell stays at zero. The
+            // OnAfterRenderAsync poll wakes it up once a token is written.
             return;
         }
 
@@ -163,6 +192,9 @@
         catch (Exception)
         {
             // Hub may be unavailable — auto-reconnect handles transient outages.
+            // Don't flip _inboxHubStarted so the OnAfterRenderAsync poll
+            // keeps retrying until the hub comes online.
+            TenantHub.OnInboxUnreadCountUpdated -= OnInboxUnreadCountUpdated;
         }
 
         await InvokeAsync(StateHasChanged);

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -13,6 +13,8 @@
 *@
 @using Sorcha.UI.Components.User.Components.Context
 @using Sorcha.UI.Components.User.Components.Onboarding
+@using Sorcha.UI.Core.Components.Inbox
+@using Sorcha.UI.Core.Services
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Context
 @using Sorcha.Wallet.Pwa.Services.Onboarding
@@ -22,6 +24,9 @@
 @inject IUserContext UserContext
 @inject IUserOrgMembershipsClient MembershipsClient
 @inject IWalletFlagsStore WalletFlags
+@inject IInboxApiService InboxApi
+@inject TenantHubConnection TenantHub
+@inject IAccessTokenStore AccessTokens
 
 <MudThemeProvider />
 <MudPopoverProvider />
@@ -44,6 +49,23 @@
                              Memberships="@_chipMemberships"
                              OnContextSelected="@OnContextSelectedAsync" />
         <MudSpacer />
+        @* Feature 118 / Phase A — durable inbox bell. Same surface as the
+           main web app's MainLayout.razor; backed by the same /api/me/inbox
+           REST endpoints and TenantHub realtime signals. *@
+        <MudIconButton Icon="@Icons.Material.Filled.Notifications"
+                       Color="Color.Inherit"
+                       OnClick="@ToggleInboxPanel"
+                       data-testid="topbar-inbox-button"
+                       aria-label="Inbox"
+                       Title="Inbox">
+            @if (_inboxUnreadCount > 0)
+            {
+                <MudBadge Content="@_inboxUnreadCount"
+                          Color="Color.Primary"
+                          Overlap="true"
+                          data-testid="topbar-inbox-badge" />
+            }
+        </MudIconButton>
         <MudIconButton Icon="@Icons.Material.Filled.QrCodeScanner"
                        Color="Color.Inherit"
                        OnClick="@(() => Nav.NavigateTo("present"))"
@@ -75,6 +97,12 @@
                        ShouldRun="@_tourShouldRun"
                        OnCompleted="@PersistTourDismissedAsync"
                        OnDismissedEarly="@PersistTourDismissedAsync" />
+
+    @* Feature 118 / Phase A — durable inbox drawer. Mirrors the main web
+       app's MainLayout mount. Subscribes to TenantHub.OnInboxEntryAdded
+       internally for realtime refresh; the bell badge above is driven by
+       OnInboxUnreadCountUpdated wired up below. *@
+    <InboxPanel @bind-IsOpen="_inboxPanelOpen" />
 </MudLayout>
 
 @code {
@@ -83,6 +111,9 @@
         Array.Empty<ContextChipSwitcher.ContextChipMembership>();
     private string _activeLabel = "Personal";
     private bool _tourShouldRun;
+    private bool _inboxPanelOpen;
+    private int _inboxUnreadCount;
+    private bool _inboxHubStarted;
 
     protected override async Task OnInitializedAsync()
     {
@@ -91,6 +122,56 @@
         await ReloadMembershipsAsync();
         UpdateActiveLabel();
         await EvaluateTourEligibilityAsync();
+        await InitialiseInboxAsync();
+    }
+
+    private void ToggleInboxPanel() => _inboxPanelOpen = !_inboxPanelOpen;
+
+    /// <summary>
+    /// Feature 118 / Phase A — bring the bell badge live. Cold-loads the
+    /// unread count via REST, then subscribes to TenantHub for realtime
+    /// updates. Hub failures are swallowed — the bell stays accurate on
+    /// the next REST refresh.
+    /// </summary>
+    private async Task InitialiseInboxAsync()
+    {
+        // Cold load — the badge surfaces from the first render even if the
+        // hub takes a moment to connect.
+        var record = await AccessTokens.GetAsync();
+        if (record is null)
+        {
+            // Anonymous PWA visit (pre-enrolment). Bell stays at zero; the
+            // hub will be started post-enrolment when a token exists.
+            return;
+        }
+
+        try
+        {
+            _inboxUnreadCount = await InboxApi.GetUnreadCountAsync();
+        }
+        catch (Exception)
+        {
+            // Non-critical UI element — silent on transport failure.
+        }
+
+        TenantHub.OnInboxUnreadCountUpdated += OnInboxUnreadCountUpdated;
+        try
+        {
+            await TenantHub.StartAsync();
+            _inboxHubStarted = true;
+        }
+        catch (Exception)
+        {
+            // Hub may be unavailable — auto-reconnect handles transient outages.
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private Task OnInboxUnreadCountUpdated(int unreadCount, DateTimeOffset occurredAt, string traceId)
+    {
+        _inboxUnreadCount = unreadCount;
+        return InvokeAsync(StateHasChanged);
     }
 
     private async Task EvaluateTourEligibilityAsync()
@@ -147,10 +228,14 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         UserContext.OnContextChanged -= HandleContextChanged;
-        return ValueTask.CompletedTask;
+        if (_inboxHubStarted)
+        {
+            TenantHub.OnInboxUnreadCountUpdated -= OnInboxUnreadCountUpdated;
+            await TenantHub.DisposeAsync();
+        }
     }
 }
 

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaInboxTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaInboxTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+using Sorcha.UI.E2E.Tests.PageObjects;
+
+namespace Sorcha.UI.E2E.Tests.Docker.CitizenWallet;
+
+/// <summary>
+/// Feature 118 / Phase A — verifies the durable inbox surface in the Citizen
+/// Wallet PWA wires up correctly. The bell + drawer relocate to the shared
+/// <c>Sorcha.UI.Components.User</c> library and mount in the PWA's
+/// <c>MainLayout.razor</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Anonymous-state coverage only. The PWA holds its bearer token in IndexedDB
+/// (<see cref="Sorcha.Wallet.Pwa.Services.IAccessTokenStore"/>), which
+/// Playwright's <c>StorageState</c> does not capture — so an automated
+/// citizen-authenticated test would require driving the full enrol flow or
+/// stuffing the IndexedDB record directly via JS interop. Both are deferred to
+/// the broader Citizen Wallet test-fixture work tracked in issue #700.
+/// </para>
+/// <para>
+/// The realtime sync path — server issues credential → bell badge increments
+/// in &lt;3s — is exercised by the manual UAT at Phase A5 of the Snackbar
+/// retirement plan. The placeholder test <see cref="InboxBell_BadgeIncrementsOnServerIssuance"/>
+/// documents the hook for the eventual automated version.
+/// </para>
+/// </remarks>
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+[Category("Docker")]
+[Category("CitizenWallet")]
+[Category("Inbox")]
+public class PwaInboxTests : AuthenticatedCitizenWalletTestBase
+{
+    private CitizenWalletPage Wallet => new(Page);
+
+    [Test]
+    [Retry(2)]
+    public async Task InboxBell_RendersInPwaAppBar()
+    {
+        await NavigateToWalletAndWaitForBlazorAsync();
+        await Wallet.WaitForReadyAsync();
+
+        // The bell button must be present in the app bar regardless of auth
+        // state — it's a layout fixture, not a feature gate. Anonymous
+        // visitors see the bell at zero so the surface is discoverable from
+        // the first render.
+        await Assertions.Expect(Wallet.TopBarInboxButton).ToBeVisibleAsync();
+    }
+
+    [Test]
+    [Retry(2)]
+    public async Task InboxBell_HasZeroBadge_WhenAnonymous()
+    {
+        await NavigateToWalletAndWaitForBlazorAsync();
+        await Wallet.WaitForReadyAsync();
+
+        // The badge is conditional — only rendered when _inboxUnreadCount > 0.
+        // Anonymous state: the layout skips the cold-load + hub start, so the
+        // badge element should not be in the DOM.
+        var badgeCount = await Wallet.TopBarInboxBadge.CountAsync();
+        Assert.That(badgeCount, Is.EqualTo(0),
+            "Anonymous PWA visit should not render an unread badge — " +
+            "InitialiseInboxAsync short-circuits when IAccessTokenStore.GetAsync() returns null.");
+    }
+
+    [Test]
+    [Retry(2)]
+    public async Task InboxBell_Click_OpensDrawer()
+    {
+        await NavigateToWalletAndWaitForBlazorAsync();
+        await Wallet.WaitForReadyAsync();
+
+        await Wallet.TopBarInboxButton.ClickAsync();
+
+        // The drawer's "Inbox" header text appears when MudDrawer.Open is true.
+        // Using a text-anchored locator keeps the test independent of the
+        // drawer's class structure (Temporary variant injects a backdrop +
+        // animation classes that vary by MudBlazor minor version).
+        var drawerHeader = Page.Locator(".mud-drawer:has-text('Inbox')").First;
+        await Assertions.Expect(drawerHeader).ToBeVisibleAsync(
+            new() { Timeout = 3000 });
+    }
+
+    [Test]
+    [Retry(2)]
+    public async Task InboxDrawer_ShowsEmptyState_WhenAnonymousAndNoEntries()
+    {
+        await NavigateToWalletAndWaitForBlazorAsync();
+        await Wallet.WaitForReadyAsync();
+        await Wallet.TopBarInboxButton.ClickAsync();
+
+        // Anonymous citizens hit /api/me/inbox without a bearer token; the
+        // gateway returns 401 → InboxApiService.ListAsync logs + returns null
+        // → InboxPanel's _entries stays empty → empty-state MudAlert renders.
+        // This is the correct fallback shape — the panel never crashes a
+        // pre-enrolment session.
+        var emptyState = Page.Locator(".mud-alert:has-text('Your inbox is empty')").First;
+        await Assertions.Expect(emptyState).ToBeVisibleAsync(
+            new() { Timeout = 3000 });
+    }
+
+    /// <summary>
+    /// Placeholder for the realtime sync test. Asserts that a server-issued
+    /// credential lands in the PWA inbox panel within 3 seconds via the
+    /// <c>TenantHub.OnInboxEntryAdded</c> path. Requires an authenticated
+    /// citizen fixture (IndexedDB token plus a server-side credential-
+    /// issuance probe), so currently runs as part of the Phase A5 manual UAT.
+    /// </summary>
+    [Test]
+    [Ignore("Phase A5 / issue #700 — needs an authenticated-citizen IndexedDB fixture. " +
+            "Manual UAT covers this path until the fixture lands.")]
+    public Task InboxBell_BadgeIncrementsOnServerIssuance()
+    {
+        // Outline of the eventual automated path:
+        //   1. Provision a citizen via /api/auth/register (or a test-only
+        //      seeding endpoint) and capture { platformUserId, accessToken }.
+        //   2. Page.EvaluateAsync — write { AccessToken, ExpiresAt, Email }
+        //      into the indexeddb-bridge under key 'sorcha:access-token'.
+        //   3. Reload the PWA; InitialiseInboxAsync now picks up the token
+        //      and starts TenantHub.
+        //   4. Trigger /api/test/inbox-write (or issue a credential via
+        //      WalletInboxWriter) for { platformUserId } → expect a single
+        //      InboxEntryAdded.
+        //   5. Wait <=3s for TopBarInboxBadge to render with content "1".
+        //   6. Open the drawer, assert the entry's title is visible.
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletPage.cs
+++ b/tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletPage.cs
@@ -55,6 +55,12 @@ public class CitizenWalletPage
     /// <summary>Top-bar Present icon (MainLayout AppBar).</summary>
     public ILocator TopBarPresentButton => _page.Locator("[data-testid='topbar-present-button']");
 
+    /// <summary>Top-bar Inbox bell icon (MainLayout AppBar, Feature 118 / Phase A).</summary>
+    public ILocator TopBarInboxButton => _page.Locator("[data-testid='topbar-inbox-button']");
+
+    /// <summary>Unread-count badge on the inbox bell. Absent when unread count is zero.</summary>
+    public ILocator TopBarInboxBadge => _page.Locator("[data-testid='topbar-inbox-badge']");
+
     /// <summary>Footer Home nav button.</summary>
     public ILocator FooterNavHome => _page.Locator("[data-testid='footer-nav-home']");
 


### PR DESCRIPTION
## Summary

- Mirrors the main web app's inbox bell + panel + realtime hub events in the Citizen Wallet PWA so citizens have a durable, server-anchored notification surface.
- Prerequisite for the wider Snackbar retirement (PR #740): the PWA's `Devices.razor` cannot migrate off Snackbar until citizens have somewhere durable to receive workflow events.
- Three small changes, ~110 lines total: relocate `InboxPanel.razor` to the shared library, register DI in the PWA, wire the layout.

## Changes

### 1. Move `InboxPanel.razor` to the shared library

Was: `Sorcha.UI.Web.Client/Components/Layout/InboxPanel.razor` (host-only)
Now: `Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor` (shared)

The PWA references `Sorcha.UI.Components.User` but cannot reference `Sorcha.UI.Web.Client`. Placement follows the F122 audience-tag convention — InboxPanel is user-facing, so it lives in the User library. Namespace stays `Sorcha.UI.Core.Components.Inbox` (subject-level), matching the convention that audience is folder metadata not part of the type's address. Web.Client picks it up via a single `@using` line added to `_Imports.razor`.

### 2. Register `IInboxApiService` + `TenantHubConnection` in PWA DI

`Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs`:
- `AddHttpClient<IInboxApiService, InboxApiService>` under the existing `BearerTokenHandler` + `ServerClockHandler` chain.
- `TenantHubConnection` as Singleton (matches the existing `CitizenWalletHubConnection` lifetime — one live socket per tab). Access-token provider projects `AccessTokenRecord.AccessToken` out of `IAccessTokenStore`.

### 3. Wire the PWA layout

`Sorcha.Wallet.Pwa/MainLayout.razor`:
- Notification bell in the app bar with unread-count `MudBadge`. Sits between `ContextChipSwitcher` and the QR-scanner button.
- `<InboxPanel @bind-IsOpen=\"_inboxPanelOpen\" />` drawer at end of `MudLayout`.
- `InitialiseInboxAsync` cold-loads `GetUnreadCountAsync`, then subscribes to `OnInboxUnreadCountUpdated` and starts the hub. Skipped for anonymous visitors — bell stays at zero pre-enrolment.
- `DisposeAsync` unsubscribes and disposes the hub.

`data-testid` hooks (`topbar-inbox-button`, `topbar-inbox-badge`) follow the sorcha-ui skill's selector-resilience pattern.

## Test plan

- [x] `Sorcha.UI.Web` builds (server host)
- [x] `Sorcha.UI.Web.Client` builds (Web WASM client)
- [x] `Sorcha.Wallet.Pwa` builds (PWA)
- [ ] **Playwright E2E** lands in follow-up PR (Phase A4 in the retirement plan)
- [ ] **Manual sync verification** end-to-end against full Docker stack (Phase A5 sign-off gate)

## Follow-up

The follow-up PR (Phase A4) adds:
- `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaInboxTests.cs` covering: bell renders → server issues credential → badge increments in <3s → entry visible in panel → mark-read → badge decrements → mark-all-read → badge zeros.
- Then Phase A5 = manual UAT sign-off before the web Snackbar retirement begins.

## Related

- PR #740 — Snackbar retirement CI gate (must merge first; the wider plan ratchets off the seeded allowlist)
- Feature 118 spec: `specs/118-notifications-architecture/`
- Audience-tag convention: `src/Apps/Sorcha.UI/Sorcha.UI.Core/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)