### PR TITLE
feat(wallet): WalletWorkflowInboxWriter — wallet-lifecycle inbox entries (Phase 2a)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -496,6 +496,25 @@ public static class WalletEndpoints
                 }
             });
 
+            // Phase 2 of the Snackbar retirement — drop a durable "wallet created"
+            // inbox entry for the owner. Fire-and-forget; the writer itself
+            // catches transport errors so this is a hard no-op on failure.
+            var ownerUserIdentityIdForInbox = Guid.TryParse(owner, out var ownerIdGuid) ? ownerIdGuid : Guid.Empty;
+            var walletNameForInbox = request.Name ?? string.Empty;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var scope = serviceScopeFactory.CreateAsyncScope();
+                    var writer = scope.ServiceProvider.GetRequiredService<Sorcha.Wallet.Service.Services.Implementation.IWalletWorkflowInboxWriter>();
+                    await writer.WriteWalletCreatedAsync(walletAddress, walletNameForInbox, ownerUserIdentityIdForInbox, CancellationToken.None);
+                }
+                catch (Exception inboxEx)
+                {
+                    Console.Error.WriteLine($"Inbox-write failed for wallet-created {walletAddress}: {inboxEx.Message}");
+                }
+            });
+
             return Results.Created($"/api/v1/wallets/{wallet.Address}", response);
         }
         catch (ArgumentException ex)
@@ -524,6 +543,7 @@ public static class WalletEndpoints
     private static async Task<IResult> RecoverWallet(
         [FromBody] RecoverWalletRequest request,
         WalletManager walletManager,
+        IServiceScopeFactory serviceScopeFactory,
         HttpContext context,
         ILogger<Program> logger,
         CancellationToken cancellationToken = default)
@@ -547,6 +567,26 @@ public static class WalletEndpoints
                 tenant,
                 request.Passphrase,
                 cancellationToken);
+
+            // Phase 2 of the Snackbar retirement — drop a durable "wallet
+            // recovered" inbox entry for the owner. Fire-and-forget; the writer
+            // catches transport errors so recovery never fails because of inbox.
+            var ownerUserIdentityIdForInbox = Guid.TryParse(owner, out var ownerIdGuid) ? ownerIdGuid : Guid.Empty;
+            var walletAddressForInbox = wallet.Address;
+            var walletNameForInbox = request.Name ?? string.Empty;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var scope = serviceScopeFactory.CreateAsyncScope();
+                    var writer = scope.ServiceProvider.GetRequiredService<Sorcha.Wallet.Service.Services.Implementation.IWalletWorkflowInboxWriter>();
+                    await writer.WriteWalletRecoveredAsync(walletAddressForInbox, walletNameForInbox, ownerUserIdentityIdForInbox, CancellationToken.None);
+                }
+                catch (Exception inboxEx)
+                {
+                    Console.Error.WriteLine($"Inbox-write failed for wallet-recovered {walletAddressForInbox}: {inboxEx.Message}");
+                }
+            });
 
             return Results.Ok(wallet.ToDto());
         }
@@ -701,12 +741,39 @@ public static class WalletEndpoints
     private static async Task<IResult> DeleteWallet(
         string address,
         WalletManager walletManager,
+        IServiceScopeFactory serviceScopeFactory,
         ILogger<Program> logger,
         CancellationToken cancellationToken = default)
     {
         try
         {
+            // Phase 2 of the Snackbar retirement — capture owner + name BEFORE
+            // delete so the inbox entry carries the human-readable wallet name
+            // that the soft-deleted row may no longer expose to other queries.
+            var snapshotForInbox = await walletManager.GetWalletAsync(address, cancellationToken);
+
             await walletManager.DeleteWalletAsync(address, cancellationToken);
+
+            if (snapshotForInbox is not null)
+            {
+                var ownerUserIdentityIdForInbox = Guid.TryParse(snapshotForInbox.Owner, out var ownerIdGuid)
+                    ? ownerIdGuid : Guid.Empty;
+                var walletNameForInbox = snapshotForInbox.Name ?? string.Empty;
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await using var scope = serviceScopeFactory.CreateAsyncScope();
+                        var writer = scope.ServiceProvider.GetRequiredService<Sorcha.Wallet.Service.Services.Implementation.IWalletWorkflowInboxWriter>();
+                        await writer.WriteWalletDeletedAsync(address, walletNameForInbox, ownerUserIdentityIdForInbox, CancellationToken.None);
+                    }
+                    catch (Exception inboxEx)
+                    {
+                        Console.Error.WriteLine($"Inbox-write failed for wallet-deleted {address}: {inboxEx.Message}");
+                    }
+                });
+            }
+
             return Results.NoContent();
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("not found"))
@@ -1095,6 +1162,33 @@ public static class WalletEndpoints
                 catch (Exception bloomEx)
                 {
                     Console.Error.WriteLine($"Bloom fan-out failed for derived address {derivedAddr}: {bloomEx.Message}");
+                }
+            });
+
+            // Phase 2 of the Snackbar retirement — drop a durable "new derived
+            // address" inbox entry for the owning user. Look up the parent
+            // wallet to resolve the owner; the endpoint has no HttpContext.
+            // Fire-and-forget; the writer catches transport errors so the
+            // address registration is never affected by an inbox failure.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var scope = serviceScopeFactory.CreateAsyncScope();
+                    var manager = scope.ServiceProvider.GetRequiredService<WalletManager>();
+                    var parent = await manager.GetWalletAsync(address, CancellationToken.None);
+                    if (parent is null) return;
+
+                    var ownerUserIdentityId = Guid.TryParse(parent.Owner, out var ownerIdGuid)
+                        ? ownerIdGuid : Guid.Empty;
+                    if (ownerUserIdentityId == Guid.Empty) return;
+
+                    var writer = scope.ServiceProvider.GetRequiredService<Sorcha.Wallet.Service.Services.Implementation.IWalletWorkflowInboxWriter>();
+                    await writer.WriteAddressRegisteredAsync(address, derivedAddr, ownerUserIdentityId, CancellationToken.None);
+                }
+                catch (Exception inboxEx)
+                {
+                    Console.Error.WriteLine($"Inbox-write failed for address-registered {derivedAddr}: {inboxEx.Message}");
                 }
             });
 

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -65,6 +65,11 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Implementation.IWalletInboxWriter,
     Sorcha.Wallet.Service.Services.Implementation.WalletInboxWriter>();
 
+// Phase 2 of the Snackbar retirement — wallet-lifecycle events (created,
+// recovered, deleted, address registered) also drop durable inbox entries.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Implementation.IWalletWorkflowInboxWriter,
+    Sorcha.Wallet.Service.Services.Implementation.WalletWorkflowInboxWriter>();
+
 // Singleton TrustServiceClient — 5-min cert cache must survive across requests,
 // so the HttpClient is captured once. PooledConnectionLifetime caps connection
 // age at 2 min so DNS / mTLS rotation lands via connection recycling.

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/WalletWorkflowInboxWriter.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/WalletWorkflowInboxWriter.cs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceClients.Inbox;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Phase 2 of the Snackbar retirement plan — bridges wallet-lifecycle events
+/// (created, recovered, deleted, address registered) to the durable user
+/// inbox owned by Tenant Service. Companion to
+/// <see cref="IWalletInboxWriter"/> which covers credential events.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These events currently surface only as transient toasts in the UI; routing
+/// them through the inbox gives the wallet owner a durable record they can
+/// review later from any device. Severity is <c>Info</c> for create/recover/
+/// address; <c>Warning</c> for delete — the destructive operation warrants a
+/// more prominent treatment in the bell drawer.
+/// </para>
+/// <para>
+/// Fail-safe: every step short-circuits silently on <c>null</c> input or a
+/// failed PlatformUserId resolution; inbox-write exceptions are caught so
+/// wallet operations are never affected by an inbox-write failure. Matches
+/// the established <see cref="WalletInboxWriter"/> contract.
+/// </para>
+/// </remarks>
+public interface IWalletWorkflowInboxWriter
+{
+    /// <summary>Drop a "wallet created" entry for the owning user.</summary>
+    Task WriteWalletCreatedAsync(
+        string walletAddress,
+        string walletName,
+        Guid ownerUserIdentityId,
+        CancellationToken ct = default);
+
+    /// <summary>Drop a "wallet recovered" entry for the owning user.</summary>
+    Task WriteWalletRecoveredAsync(
+        string walletAddress,
+        string walletName,
+        Guid ownerUserIdentityId,
+        CancellationToken ct = default);
+
+    /// <summary>Drop a "wallet deleted" entry for the owning user. Severity is Warning.</summary>
+    Task WriteWalletDeletedAsync(
+        string walletAddress,
+        string walletName,
+        Guid ownerUserIdentityId,
+        CancellationToken ct = default);
+
+    /// <summary>Drop a "derived address registered" entry for the owning user.</summary>
+    /// <param name="derivedAddress">The newly-registered BIP44 child address.</param>
+    Task WriteAddressRegisteredAsync(
+        string walletAddress,
+        string derivedAddress,
+        Guid ownerUserIdentityId,
+        CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class WalletWorkflowInboxWriter : IWalletWorkflowInboxWriter
+{
+    private readonly IPlatformInboxClient _inbox;
+    private readonly ILogger<WalletWorkflowInboxWriter> _logger;
+
+    /// <summary>Initialises a new <see cref="WalletWorkflowInboxWriter"/>.</summary>
+    public WalletWorkflowInboxWriter(
+        IPlatformInboxClient inbox,
+        ILogger<WalletWorkflowInboxWriter> logger)
+    {
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public Task WriteWalletCreatedAsync(
+        string walletAddress, string walletName, Guid ownerUserIdentityId, CancellationToken ct = default)
+        => WriteAsync(
+            walletAddress: walletAddress,
+            ownerUserIdentityId: ownerUserIdentityId,
+            severity: "Info",
+            sourceTag: "wallet-created",
+            correlationKey: $"wallet:{walletAddress}",
+            detailHref: $"/api/v1/wallets/{walletAddress}",
+            title: BuildTitle("Wallet created", walletName),
+            summary: $"Wallet address: {walletAddress}",
+            iconKey: "wallet.created",
+            ct: ct);
+
+    /// <inheritdoc />
+    public Task WriteWalletRecoveredAsync(
+        string walletAddress, string walletName, Guid ownerUserIdentityId, CancellationToken ct = default)
+        => WriteAsync(
+            walletAddress: walletAddress,
+            ownerUserIdentityId: ownerUserIdentityId,
+            severity: "Info",
+            sourceTag: "wallet-recovered",
+            correlationKey: $"wallet:{walletAddress}:recovered",
+            detailHref: $"/api/v1/wallets/{walletAddress}",
+            title: BuildTitle("Wallet recovered", walletName),
+            summary: "Recovered from mnemonic phrase. Review your wallet to confirm everything is in order.",
+            iconKey: "wallet.recovered",
+            ct: ct);
+
+    /// <inheritdoc />
+    public Task WriteWalletDeletedAsync(
+        string walletAddress, string walletName, Guid ownerUserIdentityId, CancellationToken ct = default)
+        => WriteAsync(
+            walletAddress: walletAddress,
+            ownerUserIdentityId: ownerUserIdentityId,
+            severity: "Warning",
+            sourceTag: "wallet-deleted",
+            correlationKey: $"wallet:{walletAddress}:deleted",
+            // The wallet itself is gone; navigating to its detail URL would 404.
+            // Direct the user to the wallet listing instead so they can confirm
+            // the deletion and see their remaining wallets.
+            detailHref: "/api/v1/wallets",
+            title: BuildTitle("Wallet deleted", walletName),
+            summary: $"Wallet address: {walletAddress}. If this wasn't you, contact your administrator immediately.",
+            iconKey: "wallet.deleted",
+            ct: ct);
+
+    /// <inheritdoc />
+    public Task WriteAddressRegisteredAsync(
+        string walletAddress, string derivedAddress, Guid ownerUserIdentityId, CancellationToken ct = default)
+        => WriteAsync(
+            walletAddress: walletAddress,
+            ownerUserIdentityId: ownerUserIdentityId,
+            severity: "Info",
+            sourceTag: $"address-registered:{derivedAddress}",
+            correlationKey: $"wallet:{walletAddress}:address-registered:{derivedAddress}",
+            detailHref: $"/api/v1/wallets/{walletAddress}/addresses",
+            title: "New derived address",
+            summary: $"Address {derivedAddress} was registered under wallet {walletAddress}.",
+            iconKey: "wallet.address.registered",
+            ct: ct);
+
+    private async Task WriteAsync(
+        string walletAddress,
+        Guid ownerUserIdentityId,
+        string severity,
+        string sourceTag,
+        string correlationKey,
+        string detailHref,
+        string title,
+        string? summary,
+        string iconKey,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(walletAddress))
+        {
+            return;
+        }
+        if (ownerUserIdentityId == Guid.Empty)
+        {
+            _logger.LogDebug(
+                "Inbox skip — owner UserIdentity id is empty for {SourceTag} on wallet {Wallet}",
+                sourceTag, walletAddress);
+            return;
+        }
+
+        try
+        {
+            var platformUserId = await _inbox.ResolvePlatformUserIdAsync(ownerUserIdentityId, ct).ConfigureAwait(false);
+            if (platformUserId is null)
+            {
+                _logger.LogDebug(
+                    "Inbox skip — could not resolve PlatformUserId for UserIdentity {UserIdentityId} on {SourceTag}",
+                    ownerUserIdentityId, sourceTag);
+                return;
+            }
+
+            var sourceEventId = DeterministicSourceEventId($"sorcha.inbox.{sourceTag}:{walletAddress}");
+
+            var payload = new InboxWritePayload(
+                PlatformUserId: platformUserId.Value,
+                Category: "Workflow",
+                Severity: severity,
+                CorrelationKey: correlationKey,
+                DetailHref: detailHref,
+                SourceEventId: sourceEventId,
+                OccurredAt: DateTimeOffset.UtcNow,
+                Title: title,
+                Summary: summary,
+                IconKey: iconKey);
+
+            var outcome = await _inbox.WriteAsync(payload, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for {SourceTag} — Wallet={Wallet} EntryId={EntryId}",
+                outcome.Idempotent ? "idempotent" : "created",
+                sourceTag, walletAddress, outcome.EntryId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Inbox-write failed for {SourceTag} — Wallet={Wallet}",
+                sourceTag, walletAddress);
+        }
+    }
+
+    private static string BuildTitle(string action, string walletName)
+        => string.IsNullOrWhiteSpace(walletName) ? action : $"{action}: {walletName}";
+
+    /// <summary>
+    /// Hash a stable input string to a deterministic Guid. Matches the format
+    /// used by <see cref="WalletInboxWriter"/> so the (PlatformUserId, SourceEventId)
+    /// idempotency key collapses retries to the same row.
+    /// </summary>
+    private static Guid DeterministicSourceEventId(string input)
+    {
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Services/WalletWorkflowInboxWriterTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/WalletWorkflowInboxWriterTests.cs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.ServiceClients.Inbox;
+using Sorcha.Wallet.Service.Services.Implementation;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="WalletWorkflowInboxWriter"/> — Phase 2 of the
+/// Snackbar retirement plan. Companion to <see cref="WalletInboxWriterTests"/>;
+/// covers the four wallet-lifecycle events that currently surface as toasts:
+/// created, recovered, deleted, and address-registered.
+/// </summary>
+public class WalletWorkflowInboxWriterTests
+{
+    private readonly Mock<IPlatformInboxClient> _inbox = new();
+    private readonly WalletWorkflowInboxWriter _sut;
+    private readonly Guid _ownerUserIdentityId = Guid.NewGuid();
+    private readonly Guid _platformUserId = Guid.NewGuid();
+
+    public WalletWorkflowInboxWriterTests()
+    {
+        _sut = new WalletWorkflowInboxWriter(_inbox.Object, NullLogger<WalletWorkflowInboxWriter>.Instance);
+
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(_ownerUserIdentityId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_platformUserId);
+    }
+
+    [Fact]
+    public async Task WriteWalletCreatedAsync_HappyPath_PostsExpectedPayload()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "My Wallet", _ownerUserIdentityId);
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(_platformUserId);
+        captured.Category.Should().Be("Workflow");
+        captured.Severity.Should().Be("Info");
+        captured.CorrelationKey.Should().Be("wallet:WALLET-ADDR");
+        captured.DetailHref.Should().Be("/api/v1/wallets/WALLET-ADDR");
+        captured.Title.Should().Be("Wallet created: My Wallet");
+        captured.IconKey.Should().Be("wallet.created");
+    }
+
+    [Fact]
+    public async Task WriteWalletRecoveredAsync_HappyPath_PostsExpectedPayload()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteWalletRecoveredAsync("WALLET-ADDR", "My Wallet", _ownerUserIdentityId);
+
+        captured!.Severity.Should().Be("Info");
+        captured.Title.Should().Be("Wallet recovered: My Wallet");
+        captured.CorrelationKey.Should().Be("wallet:WALLET-ADDR:recovered");
+        captured.IconKey.Should().Be("wallet.recovered");
+    }
+
+    [Fact]
+    public async Task WriteWalletDeletedAsync_PostsWarningSeverity()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteWalletDeletedAsync("WALLET-ADDR", "Old Wallet", _ownerUserIdentityId);
+
+        // Destructive action gets a louder treatment in the bell drawer.
+        captured!.Severity.Should().Be("Warning");
+        captured.Title.Should().Be("Wallet deleted: Old Wallet");
+        // The wallet's resource URL would 404 after delete; direct to listing.
+        captured.DetailHref.Should().Be("/api/v1/wallets");
+        captured.IconKey.Should().Be("wallet.deleted");
+    }
+
+    [Fact]
+    public async Task WriteAddressRegisteredAsync_HappyPath_PostsExpectedPayload()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteAddressRegisteredAsync("PARENT-ADDR", "DERIVED-ADDR", _ownerUserIdentityId);
+
+        captured!.CorrelationKey.Should().Be("wallet:PARENT-ADDR:address-registered:DERIVED-ADDR");
+        captured.DetailHref.Should().Be("/api/v1/wallets/PARENT-ADDR/addresses");
+        captured.Title.Should().Be("New derived address");
+        captured.Summary.Should().Contain("DERIVED-ADDR");
+        captured.IconKey.Should().Be("wallet.address.registered");
+    }
+
+    [Fact]
+    public async Task BlankWalletAddress_ShortCircuits_WithNoCalls()
+    {
+        await _sut.WriteWalletCreatedAsync("", "Test", _ownerUserIdentityId);
+        await _sut.WriteWalletRecoveredAsync(" ", "Test", _ownerUserIdentityId);
+        await _sut.WriteWalletDeletedAsync(null!, "Test", _ownerUserIdentityId);
+        await _sut.WriteAddressRegisteredAsync("", "DERIVED", _ownerUserIdentityId);
+
+        _inbox.Verify(
+            i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _inbox.Verify(
+            i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EmptyOwnerUserIdentityId_ShortCircuits_WithoutResolving()
+    {
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "Test", Guid.Empty);
+
+        _inbox.Verify(
+            i => i.ResolvePlatformUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _inbox.Verify(
+            i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UnresolvedPlatformUserId_SkipsWrite()
+    {
+        var unknownOwner = Guid.NewGuid();
+        _inbox.Setup(i => i.ResolvePlatformUserIdAsync(unknownOwner, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "Test", unknownOwner);
+
+        _inbox.Verify(
+            i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DeterministicSourceEventId_CollapsesDuplicates()
+    {
+        var sourceIds = new List<Guid>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => sourceIds.Add(p.SourceEventId))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: true));
+
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "Same", _ownerUserIdentityId);
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "Same", _ownerUserIdentityId);
+
+        sourceIds.Should().HaveCount(2);
+        sourceIds[0].Should().Be(sourceIds[1]);
+    }
+
+    [Fact]
+    public async Task DifferentEventsForSameWallet_HaveDifferentSourceIds()
+    {
+        var sourceIds = new List<Guid>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => sourceIds.Add(p.SourceEventId))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "X", _ownerUserIdentityId);
+        await _sut.WriteWalletRecoveredAsync("WALLET-ADDR", "X", _ownerUserIdentityId);
+        await _sut.WriteWalletDeletedAsync("WALLET-ADDR", "X", _ownerUserIdentityId);
+
+        // Three distinct events on the same wallet → three distinct source ids.
+        sourceIds.Distinct().Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Tenant unavailable"));
+
+        var act = () => _sut.WriteWalletCreatedAsync("WALLET-ADDR", "Test", _ownerUserIdentityId);
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block wallet operations");
+    }
+
+    [Fact]
+    public async Task EmptyName_StillProducesUsableTitle()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteWalletCreatedAsync("WALLET-ADDR", "", _ownerUserIdentityId);
+
+        captured!.Title.Should().Be("Wallet created");
+    }
+
+    [Fact]
+    public async Task DetailHref_AlwaysStartsWithApi_PerInternalInboxValidation()
+    {
+        var captured = new List<InboxWritePayload>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured.Add(p))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteWalletCreatedAsync("W", "N", _ownerUserIdentityId);
+        await _sut.WriteWalletRecoveredAsync("W", "N", _ownerUserIdentityId);
+        await _sut.WriteWalletDeletedAsync("W", "N", _ownerUserIdentityId);
+        await _sut.WriteAddressRegisteredAsync("W", "D", _ownerUserIdentityId);
+
+        captured.Should().AllSatisfy(p => p.DetailHref.Should().StartWith("/api/"));
+    }
+}


### PR DESCRIPTION
## Summary

First of three Phase 2 PRs in the Snackbar retirement plan — wires durable inbox entries for the four wallet-lifecycle events that currently surface only as transient toasts. Once this lands plus the consuming UI migration in a later phase, citizens have a persistent record of every wallet operation they took, viewable from any device via the bell drawer.

## Events covered

| Event | Endpoint | Severity | DetailHref |
|---|---|---|---|
| Wallet created | \`POST /api/v1/wallets/\` | Info | \`/api/v1/wallets/{addr}\` |
| Wallet recovered | \`POST /api/v1/wallets/recover\` | Info | \`/api/v1/wallets/{addr}\` |
| Wallet deleted | \`DELETE /api/v1/wallets/{addr}\` | **Warning** | \`/api/v1/wallets\` (listing — the deleted resource URL would 404) |
| Derived address registered | \`POST /api/v1/wallets/{addr}/addresses\` | Info | \`/api/v1/wallets/{addr}/addresses\` |

All four use \`Category=Workflow\`. Severity bumps to Warning for delete since the destructive action warrants a more prominent treatment in the bell drawer.

## Implementation

Mirrors the established \`WalletInboxWriter\` pattern:
- \`IWalletWorkflowInboxWriter\` interface with one method per event
- Concrete class hashes a stable input → deterministic Guid so \`(PlatformUserId, SourceEventId)\` idempotency at the Tenant Service collapses retries
- Fail-safe: empty inputs short-circuit; failed \`PlatformUser\` resolutions log + skip; transport exceptions are caught and never propagated. Wallet operations are never blocked by inbox-write failures.
- DetailHref always \`/api/\`-prefixed per \`InternalInboxEndpoints.cs:53\` validation

Call sites use the fire-and-forget \`IServiceScopeFactory\` pattern (same shape as the bloom-filter fan-out in \`CreateWallet\`). \`DeleteWallet\` captures Owner + Name BEFORE the soft-delete so the inbox entry carries the wallet name. \`RegisterDerivedAddress\` looks up the parent wallet's Owner via \`WalletManager.GetWalletAsync\` since the endpoint has no \`HttpContext\` injected.

## Test coverage

12 new tests in \`WalletWorkflowInboxWriterTests\`. **780 total tests pass** in \`Sorcha.Wallet.Service.Tests\`.

- Happy-path per writer method
- Severity assertion for delete (Warning vs Info)
- Short-circuit on blank wallet address / empty owner id
- Skip on unresolved PlatformUserId
- Deterministic source-id collapses duplicates
- Different events on same wallet produce different source ids
- Inbox transport exceptions don't propagate
- Empty name still produces a usable title (\"Wallet created\" without trailing colon)
- All four methods produce \`/api/\`-prefixed DetailHrefs (validation guard)

## Test plan

- [x] All \`Sorcha.Wallet.Service.Tests\` pass locally (780/780)
- [x] Wallet Service builds clean
- [ ] CI: nuget-ci.yml green
- [ ] Manual smoke: create a wallet against the local Docker stack, confirm inbox entry appears (deferred — needs full stack)

## Independence

This is independent of:
- PR #741 (PWA inbox parity) — that just brings the inbox UI to a second client
- PR #742 (Phase 1: IInlineFeedback primitive) — that's the client-side toast replacement

Phase 2b (extend \`WalletInboxWriter\` with credential declined / deleted / presentation-submitted) and Phase 2c (extend \`TenantSecurityInboxWriter\` with device-revoked) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)