### PR TITLE
feat(wallet): CitizenDeviceInboxWriter — device-revoke security inbox entry (Phase 2c)

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -165,6 +165,7 @@ public static class CitizenWalletEndpoints
         HttpContext context,
         IPlatformUserDeviceClient deviceClient,
         IDeviceRevocationService revocation,
+        Sorcha.Wallet.Service.Services.Implementation.ICitizenDeviceInboxWriter inboxWriter,
         ILogger<Program> logger,
         CancellationToken ct)
     {
@@ -200,6 +201,16 @@ public static class CitizenWalletEndpoints
                 "(platformUser={PlatformUserId}) after a successful GetByIdAsync — concurrent revoke?",
                 deviceId, platformUserId);
         }
+
+        // Phase 2c of the Snackbar retirement — drop a durable Category=Security
+        // inbox entry on the citizen. Fail-safe: writer catches transport errors.
+        // Idempotent on (platformUserId, deviceId) so concurrent revokes from
+        // web + PWA produce a single inbox entry.
+        await inboxWriter.WriteDeviceRevokedAsync(
+            platformUserId: platformUserId.Value,
+            deviceId: deviceId,
+            deviceLabel: device.Label,
+            ct: ct).ConfigureAwait(false);
 
         return Results.NoContent();
     }

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -65,6 +65,11 @@ builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.INotificati
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Implementation.IWalletInboxWriter,
     Sorcha.Wallet.Service.Services.Implementation.WalletInboxWriter>();
 
+// Phase 2c of the Snackbar retirement — citizen-wallet device revocation
+// drops a Category=Security inbox entry on the owning citizen.
+builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Implementation.ICitizenDeviceInboxWriter,
+    Sorcha.Wallet.Service.Services.Implementation.CitizenDeviceInboxWriter>();
+
 // Singleton TrustServiceClient — 5-min cert cache must survive across requests,
 // so the HttpClient is captured once. PooledConnectionLifetime caps connection
 // age at 2 min so DNS / mTLS rotation lands via connection recycling.

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenDeviceInboxWriter.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenDeviceInboxWriter.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceClients.Inbox;
+
+namespace Sorcha.Wallet.Service.Services.Implementation;
+
+/// <summary>
+/// Phase 2c of the Snackbar retirement plan — bridges citizen-wallet device
+/// lifecycle events to the durable user inbox owned by Tenant Service. Today
+/// only the revoke path is wired; rename is a UX-only event with no inbox
+/// surface.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Distinct from <see cref="WalletInboxWriter"/> because the citizen-wallet
+/// device path already knows the caller's <c>PlatformUserId</c> from the JWT
+/// claims (see <c>CitizenWalletEndpoints.ResolveCitizenContext</c>); there's
+/// no participant-lookup step. Keeping it separate also avoids dragging the
+/// participant client into a service that doesn't need it.
+/// </para>
+/// <para>
+/// Severity is <see cref="InboxSeverity.Warning"/> — device revocation is a
+/// security-relevant event that the citizen may want to confirm later. The
+/// surface mirrors <c>TenantSecurityInboxWriter.WriteBackupCodeUsedAsync</c>
+/// which uses the same severity for the same audit-trail reason.
+/// </para>
+/// <para>
+/// Fail-safe: empty inputs short-circuit, transport exceptions are caught.
+/// Device revocation must never fail because of an inbox-write outage.
+/// </para>
+/// </remarks>
+public interface ICitizenDeviceInboxWriter
+{
+    /// <summary>Drop a Category=Security entry for a revoked citizen device.</summary>
+    /// <param name="platformUserId">The wallet-owner's cross-org platform user id (from JWT claims).</param>
+    /// <param name="deviceId">The revoked device's id.</param>
+    /// <param name="deviceLabel">Human-readable device label, or <c>null</c> if unavailable.</param>
+    Task WriteDeviceRevokedAsync(
+        Guid platformUserId,
+        Guid deviceId,
+        string? deviceLabel,
+        CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class CitizenDeviceInboxWriter : ICitizenDeviceInboxWriter
+{
+    private readonly IPlatformInboxClient _inbox;
+    private readonly ILogger<CitizenDeviceInboxWriter> _logger;
+
+    /// <summary>Initialises a new <see cref="CitizenDeviceInboxWriter"/>.</summary>
+    public CitizenDeviceInboxWriter(
+        IPlatformInboxClient inbox,
+        ILogger<CitizenDeviceInboxWriter> logger)
+    {
+        _inbox = inbox ?? throw new ArgumentNullException(nameof(inbox));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task WriteDeviceRevokedAsync(
+        Guid platformUserId,
+        Guid deviceId,
+        string? deviceLabel,
+        CancellationToken ct = default)
+    {
+        if (platformUserId == Guid.Empty || deviceId == Guid.Empty)
+        {
+            return;
+        }
+
+        try
+        {
+            var displayLabel = string.IsNullOrWhiteSpace(deviceLabel) ? "your device" : deviceLabel;
+            var sourceEventId = DeterministicSourceEventId(platformUserId, deviceId);
+
+            var payload = new InboxWritePayload(
+                PlatformUserId: platformUserId,
+                Category: "Security",
+                Severity: "Warning",
+                CorrelationKey: $"security:device-revoked:{platformUserId:N}:{deviceId:N}",
+                // The revoked device's resource is intentionally still readable
+                // (Tenant retains the row with Status=Revoked). Point at the
+                // device listing so the citizen can see their remaining devices
+                // and confirm which one was removed.
+                DetailHref: "/api/v1/me/devices",
+                SourceEventId: sourceEventId,
+                OccurredAt: DateTimeOffset.UtcNow,
+                Title: $"Device revoked: {displayLabel}",
+                Summary: "If this wasn't you, change your password and review your remaining devices in Settings → Devices.",
+                IconKey: "security.device-revoked");
+
+            var outcome = await _inbox.WriteAsync(payload, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for device-revoked — PlatformUserId={UserId} DeviceId={DeviceId} EntryId={EntryId}",
+                outcome.Idempotent ? "idempotent" : "created",
+                platformUserId, deviceId, outcome.EntryId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Inbox-write failed for device-revoked — PlatformUserId={UserId} DeviceId={DeviceId}",
+                platformUserId, deviceId);
+        }
+    }
+
+    /// <summary>
+    /// Deterministic id from <c>(platformUserId, deviceId)</c> so duplicate
+    /// revoke attempts (e.g. concurrent web + PWA revoke race) collapse to a
+    /// single inbox entry via the <c>(PlatformUserId, SourceEventId)</c>
+    /// idempotency key at Tenant Service.
+    /// </summary>
+    private static Guid DeterministicSourceEventId(Guid platformUserId, Guid deviceId)
+    {
+        var input = $"sorcha.inbox.security.device-revoked:{platformUserId:N}:{deviceId:N}";
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletRevokeEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletRevokeEndpointTests.cs
@@ -26,6 +26,10 @@ public sealed class CitizenWalletRevokeEndpointTests
 
     private readonly Mock<IPlatformUserDeviceClient> _deviceClient = new();
     private readonly Mock<IDeviceRevocationService> _revocation = new();
+    // Phase 2c — RevokeDevice now drops a Category=Security inbox entry via
+    // ICitizenDeviceInboxWriter. The mock lets the existing assertions pass
+    // untouched (writer is fail-safe and irrelevant to status-code paths).
+    private readonly Mock<Sorcha.Wallet.Service.Services.Implementation.ICitizenDeviceInboxWriter> _inboxWriter = new();
 
     private static HttpContext BuildHttpContext(
         Guid? platformUserId = null,
@@ -55,6 +59,7 @@ public sealed class CitizenWalletRevokeEndpointTests
             context,
             _deviceClient.Object,
             _revocation.Object,
+            _inboxWriter.Object,
             NullLogger<Program>.Instance,
             CancellationToken.None
         ]);

--- a/tests/Sorcha.Wallet.Service.Tests/Services/CitizenDeviceInboxWriterTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/CitizenDeviceInboxWriterTests.cs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.ServiceClients.Inbox;
+using Sorcha.Wallet.Service.Services.Implementation;
+
+namespace Sorcha.Wallet.Service.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="CitizenDeviceInboxWriter"/> — Phase 2c of the
+/// Snackbar retirement plan. Covers the citizen-device revoke path; the
+/// rest of Phase 2c (wiring TenantSecurityInboxWriter's existing methods to
+/// their 2FA/password/backup-code endpoints) is rolled into task #14 because
+/// it lives entirely in Tenant Service and overlaps the admin-paths audit.
+/// </summary>
+public class CitizenDeviceInboxWriterTests
+{
+    private readonly Mock<IPlatformInboxClient> _inbox = new();
+    private readonly CitizenDeviceInboxWriter _sut;
+    private readonly Guid _platformUserId = Guid.NewGuid();
+    private readonly Guid _deviceId = Guid.NewGuid();
+
+    public CitizenDeviceInboxWriterTests()
+    {
+        _sut = new CitizenDeviceInboxWriter(_inbox.Object, NullLogger<CitizenDeviceInboxWriter>.Instance);
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_HappyPath_PostsExpectedPayload()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, "Alice's iPhone");
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(_platformUserId);
+        captured.Category.Should().Be("Security");
+        captured.Severity.Should().Be("Warning");
+        captured.Title.Should().Be("Device revoked: Alice's iPhone");
+        captured.DetailHref.Should().Be("/api/v1/me/devices");
+        captured.IconKey.Should().Be("security.device-revoked");
+        captured.Summary.Should().Contain("If this wasn't you");
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_NoLabel_FallsBackToGenericTitle()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, deviceLabel: null);
+
+        captured!.Title.Should().Be("Device revoked: your device");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task WriteDeviceRevokedAsync_BlankLabel_FallsBackToGenericTitle(string? label)
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, label);
+
+        captured!.Title.Should().Be("Device revoked: your device");
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_EmptyPlatformUserId_ShortCircuits()
+    {
+        await _sut.WriteDeviceRevokedAsync(Guid.Empty, _deviceId, "Phone");
+
+        _inbox.Verify(
+            i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_EmptyDeviceId_ShortCircuits()
+    {
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, Guid.Empty, "Phone");
+
+        _inbox.Verify(
+            i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_DeterministicSourceId_CollapsesDuplicates()
+    {
+        var sourceIds = new List<Guid>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => sourceIds.Add(p.SourceEventId))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: true));
+
+        // Simulate the documented concurrent web + PWA race — same (user, device)
+        // pair, two writes. They MUST collapse to the same SourceEventId.
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, "Phone");
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, "Phone");
+
+        sourceIds.Should().HaveCount(2);
+        sourceIds[0].Should().Be(sourceIds[1]);
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_DifferentDevices_HaveDifferentSourceIds()
+    {
+        var sourceIds = new List<Guid>();
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => sourceIds.Add(p.SourceEventId))
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, Guid.NewGuid(), "Phone A");
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, Guid.NewGuid(), "Phone B");
+
+        sourceIds.Distinct().Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Tenant unavailable"));
+
+        var act = () => _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, "Phone");
+
+        await act.Should().NotThrowAsync(
+            "device revocation must never fail because of an inbox-write outage");
+    }
+
+    [Fact]
+    public async Task WriteDeviceRevokedAsync_DetailHrefStartsWithApi_PerInternalInboxValidation()
+    {
+        InboxWritePayload? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWritePayload>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWritePayload, CancellationToken>((p, _) => captured = p)
+            .ReturnsAsync(new InboxWriteOutcome(Guid.NewGuid(), Idempotent: false));
+
+        await _sut.WriteDeviceRevokedAsync(_platformUserId, _deviceId, "Phone");
+
+        captured!.DetailHref.Should().StartWith("/api/");
+    }
+}


### PR DESCRIPTION
## Summary

Third Phase 2 PR in the Snackbar retirement plan. Adds the device-revoke inbox entry that lands on the citizen when their PWA-initiated device revoke completes. Category=Security, Severity=Warning — audit-trail event the citizen may want to confirm later.

## Scope reduction from original plan

This PR ships **only the new device-revoke path**. Wiring TenantSecurityInboxWriter's four existing-but-unused methods (2FA enable/disable, password reset, backup code used) to their endpoints in Tenant Service is **rolled into task #14** (admin notification paths audit) — those endpoints live entirely in Tenant Service and overlap the same audit territory. Better to handle them together with the other admin-path fixes than scatter them across PRs.

## Implementation

- New \`ICitizenDeviceInboxWriter\` / \`CitizenDeviceInboxWriter\` sibling to \`WalletInboxWriter\`. Distinct because the citizen-wallet device path already has \`platformUserId\` from the JWT claim — no participant-lookup step needed (different from credential flows).
- DI registration in \`Program.cs\` (scoped).
- \`RevokeDevice\` handler awaits writer post-revoke; fail-safe so a writer outage never blocks the revoke itself.
- Deterministic source-id on \`(platformUserId, deviceId)\` so concurrent web + PWA revokes collapse to a single inbox entry — handles the documented race where web + PWA hit the revoke path simultaneously.

## Test coverage

9 new tests + 1 reflection-helper fix on \`CitizenWalletRevokeEndpointTests\`. **779 total pass** in \`Sorcha.Wallet.Service.Tests\`.

- Happy path: severity / title / DetailHref / icon
- Label fallback to \"your device\" when blank or null
- Short-circuit on empty platformUserId or deviceId
- Deterministic source-id collapses duplicates
- Different devices produce different source ids
- Transport exceptions don't propagate
- DetailHref \`/api/\`-prefixed (InternalInboxEndpoints validation)

## Stack status

Five PRs now open across the retirement effort, all independent:

| PR | Phase | Scope |
|---|---|---|
| #741 | A | PWA inbox parity |
| #742 | 1 | IInlineFeedback primitive |
| #743 | 2a | WalletWorkflowInboxWriter |
| #744 | 2b | WalletInboxWriter extended (3 credential events) |
| **this** | **2c** | **CitizenDeviceInboxWriter (device revoke)** |

Phase 2 done modulo the four-call-site wire-up rolled into task #14. Next up is Phase 3 (CopyButton.razor primitive) or Phase 5 page migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)