### PR TITLE
fix(ci): snackbar-gate skips comment lines

### DIFF
--- a/scripts/check-no-snackbar.ps1
+++ b/scripts/check-no-snackbar.ps1
@@ -87,6 +87,17 @@ foreach ($file in $candidates) {
 
     foreach ($line in (Get-Content -LiteralPath $file.FullName)) {
         $lineNum++
+
+        # Skip comment-only lines so XML docs and inline comments that mention
+        # ISnackbar (e.g. "replacement for ISnackbar") don't trigger the gate.
+        # The retirement plan explicitly documents the replacement surface;
+        # narrative references to the old API in prose aren't actual usage.
+        # Covered shapes:
+        #   C# // line comment, /// XML doc, /* block, * continuation, */ end
+        #   Razor @* block-comment line
+        $trimmedForCommentCheck = $line.TrimStart()
+        if ($trimmedForCommentCheck -match '^(//|/\*|\*|@\*)') { continue }
+
         foreach ($p in $patterns) {
             if ($line -match $p) {
                 $fileHasMatch = $true


### PR DESCRIPTION
Phase 1 PR (#742) hit a gate false-positive: XML doc comments saying "replacement for ISnackbar" matched the pattern. Adds a comment-line skip so narrative references in /// XML docs, // line comments, /* */ block comments, and Razor @* comments don't trigger.

Pattern matchers unchanged — Snackbar.Add(), [Inject] ISnackbar, @inject ISnackbar all still fail the gate.

Verified green locally on master baseline.