### PR TITLE
feat(ui): CopyButton primitive — Phase 3 of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -19,8 +19,6 @@ src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/TruncatedId.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/JwtViewerDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
@@ -68,8 +66,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/DomainRestrictions.
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/AuditLog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetail.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/PayloadViewer.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/InstructionsTab.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
@@ -80,7 +76,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdP
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ParticipantList.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletQrDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/CopyButton.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/CopyButton.razor
@@ -1,0 +1,151 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using MudBlazor
+@implements IDisposable
+@inject IJSRuntime JS
+
+@*
+    Phase 3 of the Snackbar retirement — copy-to-clipboard primitive that uses
+    the button-morph pattern instead of a transient Snackbar.
+
+    On click: writes Value to the clipboard via navigator.clipboard. Label
+    morphs to "Copied ✓" (or a check icon, for the IconButton variant) for
+    ~2 seconds then reverts. On failure, morphs to "Failed" / error icon
+    for the same window.
+
+    Variants:
+      - Button (default): renders a MudButton with optional Label text.
+      - IconButton: renders a MudIconButton with a content-copy icon.
+
+    Use this everywhere a "copy this value" affordance is needed instead of
+    wiring a transient toast after a clipboard call. The button itself IS
+    the feedback surface.
+*@
+
+@if (Variant == CopyButtonVariant.IconButton)
+{
+    <MudTooltip Text="@CurrentTooltip" Arrow="true" Placement="Placement.Top">
+        <MudIconButton Icon="@CurrentIcon"
+                       Color="@CurrentColor"
+                       Size="@Size"
+                       OnClick="HandleCopy"
+                       Disabled="@(string.IsNullOrEmpty(Value))"
+                       aria-label="@(_state == CopyState.Idle ? (Label ?? "Copy") : CurrentTooltip)"
+                       data-testid="copy-button" />
+    </MudTooltip>
+}
+else
+{
+    <MudButton StartIcon="@CurrentIcon"
+               Color="@CurrentColor"
+               Variant="MudBlazor.Variant.Text"
+               Size="@Size"
+               OnClick="HandleCopy"
+               Disabled="@(string.IsNullOrEmpty(Value))"
+               data-testid="copy-button">
+        @CurrentLabel
+    </MudButton>
+}
+
+@code {
+    private enum CopyState { Idle, Copied, Failed }
+
+    [Parameter, EditorRequired]
+    public string? Value { get; set; }
+
+    /// <summary>Optional label for the Button variant. Defaults to "Copy".</summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>Button or IconButton. Defaults to Button.</summary>
+    [Parameter]
+    public CopyButtonVariant Variant { get; set; } = CopyButtonVariant.Button;
+
+    /// <summary>MudBlazor size. Defaults to Small.</summary>
+    [Parameter]
+    public Size Size { get; set; } = Size.Small;
+
+    /// <summary>Idle-state color. Morph to Success/Error overrides this temporarily.</summary>
+    [Parameter]
+    public Color Color { get; set; } = Color.Default;
+
+    /// <summary>Morph window in milliseconds. Defaults to 2000.</summary>
+    [Parameter]
+    public int MorphMs { get; set; } = 2000;
+
+    private CopyState _state = CopyState.Idle;
+    private System.Timers.Timer? _resetTimer;
+    private bool _disposed;
+
+    private string CurrentIcon => _state switch
+    {
+        CopyState.Copied => Icons.Material.Filled.Check,
+        CopyState.Failed => Icons.Material.Filled.ErrorOutline,
+        _ => Icons.Material.Filled.ContentCopy,
+    };
+
+    private Color CurrentColor => _state switch
+    {
+        CopyState.Copied => Color.Success,
+        CopyState.Failed => Color.Error,
+        _ => Color,
+    };
+
+    private string CurrentLabel => _state switch
+    {
+        CopyState.Copied => "Copied",
+        CopyState.Failed => "Failed",
+        _ => Label ?? "Copy",
+    };
+
+    private string CurrentTooltip => _state switch
+    {
+        CopyState.Copied => "Copied to clipboard",
+        CopyState.Failed => "Copy failed — clipboard unavailable",
+        _ => Label ?? "Copy to clipboard",
+    };
+
+    private async Task HandleCopy()
+    {
+        if (string.IsNullOrEmpty(Value)) return;
+
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", Value);
+            EnterState(CopyState.Copied);
+        }
+        catch
+        {
+            // navigator.clipboard throws on insecure contexts or when the user
+            // denies the permission prompt. Surface the failure via the morph
+            // so the user knows to copy manually rather than silently failing.
+            EnterState(CopyState.Failed);
+        }
+    }
+
+    private void EnterState(CopyState state)
+    {
+        _state = state;
+        StateHasChanged();
+
+        _resetTimer?.Stop();
+        _resetTimer?.Dispose();
+        _resetTimer = new System.Timers.Timer(MorphMs) { AutoReset = false };
+        _resetTimer.Elapsed += (_, _) =>
+        {
+            if (_disposed) return;
+            _state = CopyState.Idle;
+            InvokeAsync(StateHasChanged);
+        };
+        _resetTimer.Start();
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _resetTimer?.Stop();
+        _resetTimer?.Dispose();
+        _resetTimer = null;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/CopyButtonVariant.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/CopyButtonVariant.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Components.Forms;
+
+/// <summary>Visual variant for <c>CopyButton</c>.</summary>
+public enum CopyButtonVariant
+{
+    /// <summary>MudButton with an icon and a label (default).</summary>
+    Button,
+    /// <summary>MudIconButton — icon only, with the label surfaced via tooltip.</summary>
+    IconButton,
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/JwtViewerDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/JwtViewerDialog.razor
@@ -3,9 +3,7 @@
 
 @using System.IdentityModel.Tokens.Jwt
 @using System.Security.Claims
-
-@inject IJSRuntime JSRuntime
-@inject ISnackbar Snackbar
+@using Sorcha.UI.Core.Components.Forms
 
 <MudDialog Style="max-width: 700px;">
     <TitleContent>
@@ -93,13 +91,11 @@
                     <div style="word-break: break-all; font-family: monospace; font-size: 0.75rem; line-height: 1.4; padding: 8px; background: var(--mud-palette-background-grey); border-radius: 4px; max-height: 180px; overflow: auto;">
                         @AccessToken
                     </div>
-                    <MudButton OnClick="CopyRawToken"
-                               Variant="Variant.Text"
-                               Size="Size.Small"
-                               StartIcon="@Icons.Material.Filled.ContentCopy"
-                               Class="mt-2">
-                        Copy Token
-                    </MudButton>
+                    <div class="mt-2">
+                        <CopyButton Value="@AccessToken"
+                                    Label="Copy Token"
+                                    Size="Size.Small" />
+                    </div>
                 </MudExpansionPanel>
             </MudExpansionPanels>
         }
@@ -229,20 +225,6 @@
         if (ts.TotalMinutes < 1) return $"{ts.Seconds}s";
         if (ts.TotalHours < 1) return $"{ts.Minutes}m {ts.Seconds}s";
         return $"{(int)ts.TotalHours}h {ts.Minutes}m";
-    }
-
-    private async Task CopyRawToken()
-    {
-        try
-        {
-            var success = await JSRuntime.InvokeAsync<bool>("clipboardInterop.copyText", AccessToken);
-            Snackbar.Add(success ? "Token copied to clipboard" : "Failed to copy", success ? Severity.Success : Severity.Error,
-                config => config.VisibleStateDuration = 2000);
-        }
-        catch
-        {
-            Snackbar.Add("Failed to copy to clipboard", Severity.Error);
-        }
     }
 
     private void Close()

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/TruncatedId.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/TruncatedId.razor
@@ -2,8 +2,8 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using MudBlazor
+@implements IDisposable
 @inject IJSRuntime JS
-@inject ISnackbar Snackbar
 
 @if (string.IsNullOrEmpty(Value))
 {
@@ -15,7 +15,7 @@ else if (Value.Length <= MaxLength)
 }
 else
 {
-    <MudTooltip Text="@Value" Arrow="true" Placement="Placement.Top">
+    <MudTooltip Text="@_tooltipText" Arrow="true" Placement="Placement.Top">
         <MudText Typo="Typo.body2"
                  Class="@($"truncated-id {Class}")"
                  Style="@($"font-family: monospace; cursor: pointer; {Style}")"
@@ -46,6 +46,14 @@ else
         return $"{start}...{end}";
     }
 
+    // Tooltip morph is the inline feedback channel — no Snackbar / IInlineFeedback
+    // dependency since the trigger IS the tooltip target. Reverts after MorphMs.
+    private const int MorphMs = 1500;
+    private string _tooltipText => _showCopied ? "Copied ✓" : (Value ?? string.Empty);
+    private bool _showCopied;
+    private System.Timers.Timer? _resetTimer;
+    private bool _disposed;
+
     private async Task CopyToClipboard()
     {
         if (string.IsNullOrEmpty(Value)) return;
@@ -53,16 +61,36 @@ else
         try
         {
             await JS.InvokeVoidAsync("navigator.clipboard.writeText", Value);
-            Snackbar.Add("Copied to clipboard", Severity.Success, config =>
-            {
-                config.VisibleStateDuration = 1500;
-                config.ShowTransitionDuration = 200;
-                config.HideTransitionDuration = 200;
-            });
+            ShowCopiedTooltip();
         }
         catch
         {
-            Snackbar.Add("Failed to copy", Severity.Error);
+            // Silent fail — the truncated text fallback is to manually
+            // hover the tooltip and select the full value. No Snackbar.
         }
+    }
+
+    private void ShowCopiedTooltip()
+    {
+        _showCopied = true;
+        StateHasChanged();
+        _resetTimer?.Stop();
+        _resetTimer?.Dispose();
+        _resetTimer = new System.Timers.Timer(MorphMs) { AutoReset = false };
+        _resetTimer.Elapsed += (_, _) =>
+        {
+            if (_disposed) return;
+            _showCopied = false;
+            InvokeAsync(StateHasChanged);
+        };
+        _resetTimer.Start();
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        _resetTimer?.Stop();
+        _resetTimer?.Dispose();
+        _resetTimer = null;
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/PayloadViewer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/PayloadViewer.razor
@@ -5,10 +5,9 @@
 @using Sorcha.UI.Core.Models.Registers
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Components.Shared
+@using Sorcha.UI.Core.Components.Forms
 
 @inject IPayloadDecoderService Decoder
-@inject IJSRuntime JSRuntime
-@inject ISnackbar Snackbar
 @inject ICurrentUserWalletService CurrentUserWalletService
 @inject IBlueprintSchemaService BlueprintSchemaService
 
@@ -38,12 +37,12 @@
              PanelClass="pa-0">
         <MudTabPanel Text="Raw" data-testid="tab-raw">
             <div class="payload-code-container" data-testid="raw-content">
-                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                               Size="Size.Small"
-                               Class="copy-button"
-                               OnClick="CopyRaw"
-                               aria-label="Copy raw payload"
-                               data-testid="copy-raw" />
+                <span class="copy-button">
+                    <CopyButton Value="@_rawContent"
+                                Variant="CopyButtonVariant.IconButton"
+                                Size="Size.Small"
+                                Label="Copy raw payload" />
+                </span>
                 <pre class="payload-monospace">@_rawContent</pre>
             </div>
         </MudTabPanel>
@@ -72,12 +71,12 @@
                 }
                 else
                 {
-                    <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                                   Size="Size.Small"
-                                   Class="copy-button"
-                                   OnClick="CopyDecoded"
-                                   aria-label="Copy decoded payload"
-                                   data-testid="copy-decoded" />
+                    <span class="copy-button">
+                        <CopyButton Value="@_displayContent"
+                                    Variant="CopyButtonVariant.IconButton"
+                                    Size="Size.Small"
+                                    Label="Copy decoded payload" />
+                    </span>
                     @if (_schemaFields is not null && _isJson && _jsonElement.HasValue)
                     {
                         <div class="payload-monospace payload-wrap" data-testid="decoded-annotated">
@@ -110,12 +109,12 @@
                 }
                 else if (_isJson && _jsonElement.HasValue)
                 {
-                    <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                                   Size="Size.Small"
-                                   Class="copy-button"
-                                   OnClick="CopyTree"
-                                   aria-label="Copy JSON payload"
-                                   data-testid="copy-tree" />
+                    <span class="copy-button">
+                        <CopyButton Value="@(_prettyJson ?? _decodedContent ?? string.Empty)"
+                                    Variant="CopyButtonVariant.IconButton"
+                                    Size="Size.Small"
+                                    Label="Copy JSON payload" />
+                    </span>
                     <JsonTreeView JsonElement="@_jsonElement" RootName="payload" SchemaFields="@_schemaFields" />
                 }
                 else
@@ -421,56 +420,6 @@
         }
     }
 
-    private async Task CopyRaw()
-    {
-        await CopyToClipboardAsync(_rawContent);
-    }
-
-    private async Task CopyDecoded()
-    {
-        await CopyToClipboardAsync(_displayContent);
-    }
-
-    private async Task CopyTree()
-    {
-        await CopyToClipboardAsync(_prettyJson ?? _decodedContent ?? string.Empty);
-    }
-
-    private async Task CopyToClipboardAsync(string text)
-    {
-        try
-        {
-            var success = await JSRuntime.InvokeAsync<bool>("clipboardInterop.copyText", text);
-            if (success)
-            {
-                Snackbar.Add("Copied to clipboard", Severity.Success, config =>
-                {
-                    config.VisibleStateDuration = 1500;
-                    config.ShowCloseIcon = false;
-                });
-            }
-            else
-            {
-                Snackbar.Add("Failed to copy to clipboard", Severity.Error);
-            }
-        }
-        catch
-        {
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
-                Snackbar.Add("Copied to clipboard", Severity.Success, config =>
-                {
-                    config.VisibleStateDuration = 1500;
-                    config.ShowCloseIcon = false;
-                });
-            }
-            catch
-            {
-                Snackbar.Add("Failed to copy to clipboard", Severity.Error);
-            }
-        }
-    }
 }
 
 <style>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetail.razor
@@ -2,10 +2,7 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.UI.Core.Models.Registers
-@using Microsoft.JSInterop
-
-@inject IJSRuntime JSRuntime
-@inject ISnackbar Snackbar
+@using Sorcha.UI.Core.Components.Forms
 
 <div data-testid="transaction-detail">
     @* Transaction ID Section *@
@@ -16,11 +13,10 @@
                 <MudText Typo="Typo.body2" Class="monospace-text" Style="word-break: break-all;" data-testid="tx-id">
                     @Transaction.TxId
                 </MudText>
-                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                               Size="Size.Small"
-                               OnClick="CopyTxId"
-                               aria-label="Copy transaction ID"
-                               data-testid="copy-tx-id" />
+                <CopyButton Value="@Transaction.TxId"
+                            Variant="CopyButtonVariant.IconButton"
+                            Size="Size.Small"
+                            Label="Copy transaction ID" />
             </MudStack>
         </MudStack>
 
@@ -102,11 +98,10 @@
                 <MudText Typo="Typo.body2" Class="monospace-text" Style="word-break: break-all;" data-testid="sender-wallet">
                     @Transaction.SenderWallet
                 </MudText>
-                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                               Size="Size.Small"
-                               OnClick="CopySenderWallet"
-                               aria-label="Copy sender wallet"
-                               data-testid="copy-sender-wallet" />
+                <CopyButton Value="@Transaction.SenderWallet"
+                            Variant="CopyButtonVariant.IconButton"
+                            Size="Size.Small"
+                            Label="Copy sender wallet" />
             </MudStack>
         </MudStack>
 
@@ -123,11 +118,10 @@
                         <MudText Typo="Typo.body2" Class="monospace-text" Style="word-break: break-all;" data-testid="recipient-wallet">
                             @recipient
                         </MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                                       Size="Size.Small"
-                                       OnClick="@(() => CopyRecipientWallet(recipient))"
-                                       aria-label="Copy recipient wallet"
-                                       data-testid="copy-recipient-wallet" />
+                        <CopyButton Value="@recipient"
+                                    Variant="CopyButtonVariant.IconButton"
+                                    Size="Size.Small"
+                                    Label="Copy recipient wallet" />
                     </MudStack>
                 }
             </MudStack>
@@ -141,11 +135,10 @@
             <MudText Typo="Typo.body2" Class="monospace-text signature-text" data-testid="signature">
                 @Transaction.Signature
             </MudText>
-            <MudIconButton Icon="@Icons.Material.Filled.ContentCopy"
-                           Size="Size.Small"
-                           OnClick="CopySignature"
-                           aria-label="Copy signature"
-                           data-testid="copy-signature" />
+            <CopyButton Value="@Transaction.Signature"
+                        Variant="CopyButtonVariant.IconButton"
+                        Size="Size.Small"
+                        Label="Copy signature" />
         </MudStack>
 
         @* Action ID (if applicable) *@
@@ -203,62 +196,6 @@
         _ => Color.Default
     };
 
-    private async Task CopyTxId()
-    {
-        await CopyToClipboardAsync(Transaction.TxId);
-    }
-
-    private async Task CopySenderWallet()
-    {
-        await CopyToClipboardAsync(Transaction.SenderWallet);
-    }
-
-    private async Task CopyRecipientWallet(string recipient)
-    {
-        await CopyToClipboardAsync(recipient);
-    }
-
-    private async Task CopySignature()
-    {
-        await CopyToClipboardAsync(Transaction.Signature);
-    }
-
-    private async Task CopyToClipboardAsync(string text)
-    {
-        try
-        {
-            var success = await JSRuntime.InvokeAsync<bool>("clipboardInterop.copyText", text);
-            if (success)
-            {
-                Snackbar.Add("Copied to clipboard", Severity.Success, config =>
-                {
-                    config.VisibleStateDuration = 1500;
-                    config.ShowCloseIcon = false;
-                });
-            }
-            else
-            {
-                Snackbar.Add("Failed to copy to clipboard", Severity.Error);
-            }
-        }
-        catch
-        {
-            // Fallback to navigator.clipboard for compatibility
-            try
-            {
-                await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", text);
-                Snackbar.Add("Copied to clipboard", Severity.Success, config =>
-                {
-                    config.VisibleStateDuration = 1500;
-                    config.ShowCloseIcon = false;
-                });
-            }
-            catch
-            {
-                Snackbar.Add("Failed to copy to clipboard", Severity.Error);
-            }
-        }
-    }
 }
 
 <style>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletQrDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletQrDialog.razor
@@ -1,8 +1,8 @@
 @* SPDX-License-Identifier: MIT *@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
+@using Sorcha.UI.Core.Components.Forms
 @inject IJSRuntime JS
-@inject ISnackbar Snackbar
 
 <MudDialog>
     <TitleContent>
@@ -25,12 +25,10 @@
                 @WalletAddress
             </MudText>
 
-            <MudButton StartIcon="@Icons.Material.Filled.ContentCopy"
-                       Color="Color.Primary"
-                       Variant="Variant.Outlined"
-                       OnClick="CopyAddressAsync">
-                Copy Address
-            </MudButton>
+            <CopyButton Value="@WalletAddress"
+                        Label="Copy Address"
+                        Color="Color.Primary"
+                        Size="Size.Medium" />
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -62,19 +60,6 @@
             {
                 // QR library may not be loaded — fail silently
             }
-        }
-    }
-
-    private async Task CopyAddressAsync()
-    {
-        try
-        {
-            await JS.InvokeVoidAsync("QrCodeHelper.copyToClipboard", WalletAddress);
-            Snackbar.Add("Address copied to clipboard", Severity.Success);
-        }
-        catch
-        {
-            Snackbar.Add("Failed to copy address", Severity.Error);
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 3 of the Snackbar retirement effort (PRs #740–#746 landed Phase 0 + A + 1 + 2 already).

Adds `CopyButton.razor` — a button-morph clipboard primitive (Button or IconButton variant) that replaces the "clipboard write + \`Snackbar.Add\`" pattern with self-contained inline feedback: green check ("Copied") for 2s on success, red error icon ("Failed") on failure, then reverts.

Migrates the five files whose Snackbar usage was 100% clipboard-related:

| File | Sites | Notes |
|---|---|---|
| `TruncatedId.razor` | 2 | Non-button trigger — uses tooltip-morph variant inline (text element click) |
| `JwtViewerDialog.razor` | 2 | "Copy Token" button → CopyButton |
| `PayloadViewer.razor` | 4 | Raw / Decoded / Tree IconButtons → CopyButton (IconButton variant) |
| `TransactionDetail.razor` | 4 | TxId / Sender / Recipient / Signature → CopyButton (IconButton variant) |
| `WalletQrDialog.razor` | 2 | "Copy Address" button → CopyButton |

Allowlist: **75 → 70 entries**.

Files with mixed copy + non-copy Snackbar usage (`TransactionDetailPanel`, `SchemaDetail`, `WalletList`, `WalletAdmin`, `WalletDetail`, `CreateWallet`) intentionally stay on the allowlist for now — they'll be drained in Phase 5 alongside their other Snackbar calls via `IInlineFeedback` + inbox writers.

Outliers per the phase plan stay untouched: `SecretDisplayDialog`, `HybridQrAffordance`, `ExportContentDialog`.

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green (70 files)
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` — clean
- [x] `dotnet build src/Apps/Sorcha.Wallet.Pwa` — clean
- [x] `dotnet test tests/Sorcha.UI.Core.Tests` — 1233 passed
- [ ] Manual click-test in Docker (deferred to Phase 7 UAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)