### PR TITLE
fix(ui): MainLayout direct snackbar bypass — Phase 4 of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -16,7 +16,6 @@
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
 
 src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Shared/TruncatedId.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -15,7 +15,6 @@
 @inject BlueprintHubConnection BlueprintHub
 @inject TenantHubConnection TenantHub
 @inject IInboxApiService InboxApi
-@inject ISnackbar Snackbar
 @inject ILocalizationService Loc
 
 <MudThemeProvider Theme="_theme" IsDarkMode="@_isDarkMode" />
@@ -419,14 +418,12 @@
 
     private void OnCredentialReceived(CredentialNotification notification)
     {
-        // Feature 118 T088 — the hub signal carries opaque IDs only; the snackbar
-        // surfaces a generic message and the user pulls full detail from
-        // /my-credentials (which fetches via /api/v1/wallets/{addr}/credentials).
-        InvokeAsync(() =>
-        {
-            Snackbar.Add("New credential received", Severity.Info);
-            StateHasChanged();
-        });
+        // Feature 118 T088 + Snackbar retirement Phase 4 — the hub signal
+        // carries opaque IDs only. WalletInboxWriter.WriteCredentialReceivedAsync
+        // produces the durable bell-drawer entry on the server side
+        // (Phase 2b); there's nothing for this layout handler to surface
+        // beyond keeping its own render fresh for the badge tick.
+        InvokeAsync(StateHasChanged);
     }
 
     private void OnPendingCredentialCountUpdated(int count)


### PR DESCRIPTION
## Summary

Phase 4 of the Snackbar retirement (Phases 0-3 landed in PRs #740-#747).

`MainLayout.OnCredentialReceived` was calling `Snackbar.Add("New credential received")` directly on the hub signal — a duplicate transient toast on top of the durable bell-drawer entry that `WalletInboxWriter.WriteCredentialReceivedAsync` already writes server-side (Phase 2b, PR #744). The toast was the original "kill everything except ephemeral UX" trigger.

Changes:
- Drop the `Snackbar.Add(...)` line; keep `InvokeAsync(StateHasChanged)` so the badge tick still re-renders.
- Drop `@inject ISnackbar Snackbar` — no other call sites remain in this file.
- Keep `<MudSnackbarProvider />` mounted — that's Phase 7's job, gated on full UAT.
- Allowlist: removes the `MainLayout.razor` entry.

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green (74 files; will be 69 once #747 lands)
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` — clean
- [ ] Manual: trigger a credential-received hub event, confirm bell badge updates with no toast (deferred to Phase 7 UAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)