### PR TITLE
feat(pwa): Devices → IInlineFeedback — Phase 5f of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -15,7 +15,6 @@
 #
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
 
-src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
@@ -17,9 +17,10 @@
 @layout MainLayout
 @using Sorcha.CitizenWallet.Abstractions.Models
 @using Sorcha.ServiceClients.CitizenWallet
+@using Sorcha.UI.Core.Services.Feedback
 @inject ICitizenWalletClient WalletClient
 @inject IDialogService Dialogs
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject ILogger<Devices> Logger
 
 <PageTitle>Devices</PageTitle>
@@ -155,18 +156,18 @@
                 // Optimistic UI update — server already accepted the change.
                 var idx = _devices!.FindIndex(d => d.DeviceId == device.DeviceId);
                 _devices[idx] = device with { Label = newLabel };
-                Snackbar.Add("Device renamed.", Severity.Success);
+                Feedback.ShowSuccess("Device renamed.");
             }
             else
             {
-                Snackbar.Add("Device not found.", Severity.Warning);
+                Feedback.ShowWarning("Device not found.");
                 await LoadAsync();
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Rename device failed");
-            Snackbar.Add($"Rename failed: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Rename failed: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -192,18 +193,18 @@
             {
                 var idx = _devices!.FindIndex(d => d.DeviceId == device.DeviceId);
                 _devices[idx] = device with { Status = DeviceStatus.Revoked, RevokedAt = DateTimeOffset.UtcNow };
-                Snackbar.Add("Device revoked.", Severity.Success);
+                Feedback.ShowSuccess("Device revoked.");
             }
             else
             {
-                Snackbar.Add("Device not found.", Severity.Warning);
+                Feedback.ShowWarning("Device not found.");
                 await LoadAsync();
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Revoke device failed");
-            Snackbar.Add($"Revoke failed: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Revoke failed: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Phase 5f of the Snackbar retirement (Phases 0-4 landed in PRs #740-#748).

Migrates `src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor` off `ISnackbar` onto `IInlineFeedback`. Phase 2c's `CitizenDeviceInboxWriter` already writes durable security-inbox entries for device-revoke events; this PR covers the actor's in-page action feedback.

Allowlist: -1 entry.

## Test plan

- [x] \`pwsh ./scripts/check-no-snackbar.ps1\` — green
- [x] \`dotnet build src/Apps/Sorcha.Wallet.Pwa\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)