### PR TITLE
feat(ui): MyCredentials → IInlineFeedback — Phase 5b of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -20,7 +20,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OperationNotificationListener.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyCredentials.razor
@@ -13,13 +13,14 @@
 @using Sorcha.UI.Core.Models.Wallet
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Wallet
 @using Sorcha.UI.Core.Models.Workflows
 @inject ICredentialApiService CredentialApi
 @inject IWalletApiService WalletApi
 @inject IWorkflowService WorkflowService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject WalletHubConnection WalletHub
 @implements IDisposable
 
@@ -321,12 +322,12 @@
         if (localSuccess)
         {
             _pendingCredentials.Remove(credential);
-            Snackbar.Add("Credential accepted", Severity.Success);
+            Feedback.ShowSuccess("Credential accepted");
             await LoadAllAsync();
         }
         else
         {
-            Snackbar.Add("Failed to accept credential. Please try again.", Severity.Error);
+            Feedback.ShowError("Failed to accept credential. Please try again.", autoDismissMs: 0);
             StateHasChanged();
         }
     }
@@ -377,12 +378,12 @@
         if (localSuccess)
         {
             _pendingCredentials.Remove(credential);
-            Snackbar.Add("Credential declined.", Severity.Info);
+            Feedback.ShowInfo("Credential declined.");
             StateHasChanged();
         }
         else
         {
-            Snackbar.Add("Failed to decline credential. Please try again.", Severity.Error);
+            Feedback.ShowError("Failed to decline credential. Please try again.", autoDismissMs: 0);
             StateHasChanged();
         }
     }
@@ -394,7 +395,7 @@
 
         if (detail == null)
         {
-            Snackbar.Add("Could not load credential details.", Severity.Error);
+            Feedback.ShowError("Could not load credential details.", autoDismissMs: 0);
             return;
         }
 
@@ -407,12 +408,12 @@
                         _selectedWallet, credential.CredentialId);
                     if (deleted)
                     {
-                        Snackbar.Add("Credential deleted.", Severity.Success);
+                        Feedback.ShowSuccess("Credential deleted.");
                         await LoadAllAsync();
                     }
                     else
                     {
-                        Snackbar.Add("Failed to delete credential.", Severity.Error);
+                        Feedback.ShowError("Failed to delete credential.", autoDismissMs: 0);
                     }
                 })
             }
@@ -430,7 +431,7 @@
 
     private Task OnPresentCredential(CredentialCardViewModel credential)
     {
-        Snackbar.Add("Verifiable credential presentation is planned for a future release.", Severity.Info);
+        Feedback.ShowInfo("Verifiable credential presentation is planned for a future release.");
         return Task.CompletedTask;
     }
 
@@ -439,7 +440,7 @@
         var detail = await CredentialApi.GetPresentationRequestDetailAsync(request.RequestId);
         if (detail == null)
         {
-            Snackbar.Add("Could not load request details.", Severity.Error);
+            Feedback.ShowError("Could not load request details.", autoDismissMs: 0);
             return;
         }
 
@@ -448,13 +449,13 @@
             { x => x.Request, detail },
             { x => x.OnSubmitted, EventCallback.Factory.Create<PresentationSubmitResult>(this, async result =>
                 {
-                    Snackbar.Add($"Presentation {result.Status}.", Severity.Success);
+                    Feedback.ShowSuccess($"Presentation {result.Status}.");
                     await LoadAllAsync();
                 })
             },
             { x => x.OnDenied, EventCallback.Factory.Create(this, async () =>
                 {
-                    Snackbar.Add("Request denied.", Severity.Info);
+                    Feedback.ShowInfo("Request denied.");
                     await LoadAllAsync();
                 })
             }


### PR DESCRIPTION
## Summary

Phase 5b of the Snackbar retirement (Phases 0-4 landed in PRs #740-#748).

Migrates `MyCredentials.razor` off `ISnackbar` onto `IInlineFeedback`. Phase 2b's `WalletInboxWriter` already writes durable bell-drawer entries for credential lifecycle events — this PR covers the in-page action feedback for user-triggered accept / decline / delete operations.

Allowlist: −1 entry.

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` — clean
- [x] `dotnet test tests/Sorcha.UI.Core.Tests` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)