### PR TITLE
feat(ui): designer pages → IInlineFeedback — Phase 5c of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -53,7 +53,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.r
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/PropertiesPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
@@ -66,15 +65,12 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/AuditLog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/InstructionsTab.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Operations.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Wallets/WalletAccessTab.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ParticipantList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/InstructionsTab.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/InstructionsTab.razor
@@ -2,6 +2,7 @@
 @using Sorcha.Blueprint.Models
 @using Sorcha.Blueprint.Schemas.Client
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using System.Text.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
@@ -135,7 +136,7 @@
     public EventCallback<Blueprint> OnInstructionsChanged { get; set; }
 
     [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
+    private IInlineFeedback Feedback { get; set; } = null!;
 
     private string _overview = string.Empty;
     private List<string> _staleInstructions = [];
@@ -167,7 +168,7 @@
 
         await JS.InvokeVoidAsync("sorcha.downloadFile", fileName, "application/json", json);
 
-        Snackbar.Add("Instruction strings exported", MudBlazor.Severity.Success);
+        Feedback.ShowSuccess("Instruction strings exported");
     }
 
     private async Task ImportStrings(IBrowserFile? file)
@@ -185,11 +186,11 @@
             await OnInstructionsChanged.InvokeAsync(Blueprint);
             DetectStaleInstructions();
             StateHasChanged();
-            Snackbar.Add("Translations imported successfully", MudBlazor.Severity.Success);
+            Feedback.ShowSuccess("Translations imported successfully");
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Import failed: {ex.Message}", MudBlazor.Severity.Error);
+            Feedback.ShowError($"Import failed: {ex.Message}", autoDismissMs: 0);
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ParticipantList.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ParticipantList.razor
@@ -3,6 +3,7 @@
 
 @using MudBlazor
 @using Sorcha.UI.Core.Models.Designer
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.Blueprint.Models
 
 <div class="participant-list">
@@ -79,7 +80,7 @@
     private IDialogService DialogService { get; set; } = null!;
 
     [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
+    private IInlineFeedback Feedback { get; set; } = null!;
 
     [Parameter]
     public List<Participant> Participants { get; set; } = [];
@@ -122,7 +123,7 @@
         {
             var participant = savedModel.ToParticipant();
             await OnParticipantAdded.InvokeAsync(participant);
-            Snackbar.Add($"Participant '{participant.Name}' added", Severity.Success);
+            Feedback.ShowSuccess($"Participant '{participant.Name}' added");
         }
     }
 
@@ -155,7 +156,7 @@
         {
             var updatedParticipant = savedModel.ToParticipant();
             await OnParticipantUpdated.InvokeAsync(updatedParticipant);
-            Snackbar.Add($"Participant '{updatedParticipant.Name}' updated", Severity.Success);
+            Feedback.ShowSuccess($"Participant '{updatedParticipant.Name}' updated");
         }
     }
 
@@ -170,7 +171,7 @@
         if (confirm == true)
         {
             await OnParticipantDeleted.InvokeAsync(participant);
-            Snackbar.Add($"Participant '{participant.Name}' deleted", Severity.Warning);
+            Feedback.ShowWarning($"Participant '{participant.Name}' deleted");
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/PropertiesPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/PropertiesPanel.razor
@@ -1,6 +1,7 @@
 @using MudBlazor
 @using Sorcha.UI.Core.Models.Designer
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Models.SchemaLibrary
 @using Sorcha.Blueprint.Models
 @using System.Text.Json
@@ -495,7 +496,7 @@
     private IDialogService DialogService { get; set; } = null!;
 
     [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
+    private IInlineFeedback Feedback { get; set; } = null!;
 
     [Inject]
     private ISchemaLibraryApiService SchemaLibraryApi { get; set; } = null!;
@@ -618,7 +619,7 @@
             var participant = savedModel.ToParticipant();
             Blueprint.Participants.Add(participant);
             editedBlueprint.Participants = Blueprint.Participants;
-            Snackbar.Add($"Participant '{participant.Name}' added", Severity.Success);
+            Feedback.ShowSuccess($"Participant '{participant.Name}' added");
             StateHasChanged();
         }
     }
@@ -655,7 +656,7 @@
             {
                 Blueprint.Participants[index] = updatedParticipant;
                 editedBlueprint.Participants = Blueprint.Participants;
-                Snackbar.Add($"Participant '{updatedParticipant.Name}' updated", Severity.Success);
+                Feedback.ShowSuccess($"Participant '{updatedParticipant.Name}' updated");
                 StateHasChanged();
             }
         }
@@ -673,7 +674,7 @@
         {
             Blueprint.Participants.Remove(participant);
             editedBlueprint.Participants = Blueprint.Participants;
-            Snackbar.Add($"Participant '{participant.Name}' deleted", Severity.Warning);
+            Feedback.ShowWarning($"Participant '{participant.Name}' deleted");
             StateHasChanged();
         }
     }
@@ -737,7 +738,7 @@
         if (result is not null && !result.Canceled && result.Data is ConditionModel savedModel)
         {
             editedAction.Condition = savedModel.ToJsonLogic();
-            Snackbar.Add("Routing condition updated", Severity.Success);
+            Feedback.ShowSuccess("Routing condition updated");
             StateHasChanged();
         }
     }
@@ -788,7 +789,7 @@
             {
                 editedAction.Calculations ??= [];
                 editedAction.Calculations[savedModel.TargetFieldPath] = jsonLogic;
-                Snackbar.Add($"Calculation '{savedModel.TargetFieldPath}' added", Severity.Success);
+                Feedback.ShowSuccess($"Calculation '{savedModel.TargetFieldPath}' added");
                 StateHasChanged();
             }
         }
@@ -828,7 +829,7 @@
 
                 editedAction.Calculations ??= [];
                 editedAction.Calculations[savedModel.TargetFieldPath] = jsonLogic;
-                Snackbar.Add($"Calculation '{savedModel.TargetFieldPath}' updated", Severity.Success);
+                Feedback.ShowSuccess($"Calculation '{savedModel.TargetFieldPath}' updated");
                 StateHasChanged();
             }
         }
@@ -845,7 +846,7 @@
         if (confirm == true && editedAction.Calculations != null)
         {
             editedAction.Calculations.Remove(fieldName);
-            Snackbar.Add($"Calculation '{fieldName}' deleted", Severity.Warning);
+            Feedback.ShowWarning($"Calculation '{fieldName}' deleted");
             StateHasChanged();
         }
     }
@@ -923,7 +924,7 @@
                 var schemas = editedAction.DataSchemas?.ToList() ?? [];
                 schemas.Add(detail.Content);
                 editedAction.DataSchemas = schemas;
-                Snackbar.Add($"Schema '{detail.Title}' added to action", Severity.Success);
+                Feedback.ShowSuccess($"Schema '{detail.Title}' added to action");
                 StateHasChanged();
             }
         }
@@ -936,7 +937,7 @@
         var schemas = editedAction.DataSchemas.ToList();
         schemas.Remove(schema);
         editedAction.DataSchemas = schemas;
-        Snackbar.Add("Schema removed from action", Severity.Warning);
+        Feedback.ShowWarning("Schema removed from action");
         StateHasChanged();
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Wallets/WalletAccessTab.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Wallets/WalletAccessTab.razor
@@ -3,8 +3,9 @@
 
 @using Sorcha.UI.Core.Models
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IWalletAccessService AccessService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IDialogService DialogService
 
 <MudPaper Elevation="0" Class="pa-4">
@@ -119,14 +120,14 @@
         var result = await AccessService.GrantAccessAsync(WalletAddress, _form);
         if (result != null)
         {
-            Snackbar.Add($"Access granted to {_form.Subject}", Severity.Success);
+            Feedback.ShowSuccess($"Access granted to {_form.Subject}");
             _form = new GrantAccessFormModel();
             _showGrantForm = false;
             await LoadGrantsAsync();
         }
         else
         {
-            Snackbar.Add("Failed to grant access. You may not have permission.", Severity.Error);
+            Feedback.ShowError("Failed to grant access. You may not have permission.", autoDismissMs: 0);
         }
     }
 
@@ -145,12 +146,12 @@
         var success = await AccessService.RevokeAccessAsync(WalletAddress, subject);
         if (success)
         {
-            Snackbar.Add($"Access revoked for {subject}", Severity.Success);
+            Feedback.ShowSuccess($"Access revoked for {subject}");
             await LoadGrantsAsync();
         }
         else
         {
-            Snackbar.Add("Failed to revoke access", Severity.Error);
+            Feedback.ShowError("Failed to revoke access", autoDismissMs: 0);
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 5c of the Snackbar retirement (Phases 0-4 landed in PRs #740-#748).

Migrates four designer / admin authoring pages off `ISnackbar` onto `IInlineFeedback`:
- `PropertiesPanel.razor`
- `ParticipantList.razor`
- `InstructionsTab.razor`
- `WalletAccessTab.razor`

Designer events stay inline-only per the Phase A5 audit — authoring actions don't need durable inbox history.

Allowlist: −4 entries.

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Core` — clean
- [x] `dotnet test tests/Sorcha.UI.Core.Tests` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)