### PR TITLE
feat(ui): wallet pages → IInlineFeedback — Phase 5a of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -18,7 +18,6 @@
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/PendingActionToast.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
@@ -30,7 +29,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
@@ -44,9 +42,7 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
@@ -75,4 +71,3 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ExportDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ConditionEditor.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/CalculationEditor.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/RecoverWallet.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor
@@ -7,14 +7,15 @@
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Services.Authentication
 @using Sorcha.UI.Core.Services.Configuration
+@using Sorcha.UI.Core.Services.Feedback
+@using Sorcha.UI.Core.Components.Forms
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferences
 @inject IAuthenticationService AuthService
 @inject IConfigurationService ConfigService
 @inject CustomAuthenticationStateProvider AuthStateProvider
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
-@inject IJSRuntime JS
+@inject IInlineFeedback Feedback
 
 <PageTitle>Create Wallet - Sorcha Platform</PageTitle>
 
@@ -141,9 +142,7 @@
 
                 <MudDivider Class="my-4" />
 
-                <MudButton OnClick="CopyMnemonicAsync" Color="Color.Default" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.ContentCopy" Class="mb-4">
-                    Copy All Words
-                </MudButton>
+                <CopyButton Value="@MnemonicJoined" Label="Copy All Words" />
 
                 <MudAlert Severity="Severity.Error" Class="mb-4" Icon="@Icons.Material.Filled.Error">
                     <MudText Typo="Typo.body2">
@@ -242,15 +241,15 @@
         {
             response = await WalletService.CreateWalletAsync(request);
             currentStep = WizardStep.MnemonicDisplay;
-            Snackbar.Add($"Wallet '{request.Name}' created successfully!", Severity.Success);
+            Feedback.ShowSuccess($"Wallet '{request.Name}' created successfully!");
         }
         catch (HttpRequestException ex)
         {
-            Snackbar.Add($"Failed to create wallet: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to create wallet: {ex.Message}", autoDismissMs: 0);
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"An unexpected error occurred: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"An unexpected error occurred: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -258,15 +257,8 @@
         }
     }
 
-    private async Task CopyMnemonicAsync()
-    {
-        if (response?.MnemonicWords == null)
-            return;
-
-        var mnemonic = string.Join(" ", response.MnemonicWords);
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", mnemonic);
-        Snackbar.Add("Recovery phrase copied to clipboard", Severity.Info);
-    }
+    private string MnemonicJoined =>
+        response?.MnemonicWords is { Length: > 0 } words ? string.Join(" ", words) : string.Empty;
 
     private async Task NavigateToWallet()
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/RecoverWallet.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/RecoverWallet.razor
@@ -1,9 +1,10 @@
 @page "/wallets/recover"
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize]
+@using Sorcha.UI.Core.Services.Feedback
 @inject IWalletApiService WalletService
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Recover Wallet - Sorcha Platform</PageTitle>
 
@@ -220,7 +221,7 @@
         try
         {
             var wallet = await WalletService.RecoverWalletAsync(request);
-            Snackbar.Add($"Wallet '{wallet.Name}' recovered successfully!", Severity.Success);
+            Feedback.ShowSuccess($"Wallet '{wallet.Name}' recovered successfully!");
 
             // Clear sensitive data
             ClearWords();
@@ -242,12 +243,12 @@
             {
                 validationError = $"Failed to recover wallet: {ex.Message}";
             }
-            Snackbar.Add(validationError, Severity.Error);
+            Feedback.ShowError(validationError, autoDismissMs: 0);
         }
         catch (Exception ex)
         {
             validationError = $"An unexpected error occurred: {ex.Message}";
-            Snackbar.Add(validationError, Severity.Error);
+            Feedback.ShowError(validationError, autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
@@ -5,10 +5,11 @@
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize(Roles = "Administrator,SystemAdmin,Auditor")]
 @using Sorcha.UI.Core.Components.Wallets
+@using Sorcha.UI.Core.Services.Feedback
 @inject IWalletApiService WalletService
 @inject NavigationManager Navigation
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IJSRuntime JS
 
 <PageTitle>Wallet Administration - Sorcha Platform</PageTitle>
@@ -95,11 +96,11 @@
         try
         {
             await JS.InvokeVoidAsync("QrCodeHelper.copyToClipboard", wallet.Address);
-            Snackbar.Add($"Address for '{wallet.Name}' copied to clipboard", Severity.Success);
+            Feedback.ShowSuccess($"Address for '{wallet.Name}' copied to clipboard");
         }
         catch
         {
-            Snackbar.Add("Failed to copy address to clipboard", Severity.Error);
+            Feedback.ShowError("Failed to copy address to clipboard");
         }
     }
 
@@ -129,16 +130,16 @@
             if (success)
             {
                 wallets.Remove(wallet);
-                Snackbar.Add($"Wallet '{wallet.Name}' deleted successfully", Severity.Success);
+                Feedback.ShowSuccess($"Wallet '{wallet.Name}' deleted successfully");
             }
             else
             {
-                Snackbar.Add("Wallet not found", Severity.Warning);
+                Feedback.ShowWarning("Wallet not found");
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to delete wallet: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to delete wallet: {ex.Message}", autoDismissMs: 0);
         }
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletDetail.razor
@@ -3,14 +3,15 @@
 @attribute [Authorize]
 @using Sorcha.UI.Core.Models.Registers
 @using Sorcha.UI.Core.Components.Wallet
+@using Sorcha.UI.Core.Services.Feedback
+@using Sorcha.UI.Core.Components.Forms
 @implements IAsyncDisposable
 @inject IWalletApiService WalletService
 @inject ITransactionService TransactionService
 @inject WalletHubConnection HubConnection
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IDialogService DialogService
-@inject IJSRuntime JS
 
 <PageTitle>Wallet Details - Sorcha Platform</PageTitle>
 
@@ -46,7 +47,7 @@
                             <MudText Typo="Typo.body2" Color="Color.Secondary" Style="font-family: monospace;">
                                 @TruncateAddress(wallet.Address)
                             </MudText>
-                            <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="CopyWalletAddress" />
+                            <CopyButton Value="@wallet.Address" Variant="CopyButtonVariant.IconButton" Label="Copy address" />
                         </div>
                     </div>
                 </div>
@@ -80,7 +81,7 @@
                                         <td>
                                             <div class="d-flex align-center">
                                                 <code style="font-size: 0.85rem; word-break: break-all;">@wallet.Address</code>
-                                                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="CopyWalletAddress" />
+                                                <CopyButton Value="@wallet.Address" Variant="CopyButtonVariant.IconButton" Label="Copy address" />
                                             </div>
                                         </td>
                                     </tr>
@@ -112,7 +113,7 @@
                             <MudText Typo="Typo.h6" Class="mb-3">Public Key</MudText>
                             <div class="d-flex align-center mb-3">
                                 <code style="font-size: 0.75rem; word-break: break-all; max-height: 100px; overflow-y: auto; display: block; background: var(--mud-palette-background); padding: 8px; border-radius: 4px; flex-grow: 1;">@wallet.PublicKey</code>
-                                <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="CopyPublicKey" />
+                                <CopyButton Value="@wallet.PublicKey" Variant="CopyButtonVariant.IconButton" Label="Copy public key" />
                             </div>
                             <MudDivider Class="my-3" />
                             <MudText Typo="Typo.h6" Class="mb-3">Timestamps</MudText>
@@ -189,7 +190,7 @@
                                 <MudTd DataLabel="Address">
                                     <div class="d-flex align-center">
                                         <code style="font-size: 0.8rem;">@TruncateAddress(context.Address)</code>
-                                        <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="@(() => CopyAddressToClipboard(context.Address))" />
+                                        <CopyButton Value="@context.Address" Variant="CopyButtonVariant.IconButton" Label="Copy address" />
                                     </div>
                                 </MudTd>
                                 <MudTd DataLabel="Path"><code>@context.DerivationPath</code></MudTd>
@@ -205,7 +206,7 @@
                                     }
                                 </MudTd>
                                 <MudTd DataLabel="Actions">
-                                    <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="@(() => CopyAddressToClipboard(context.Address))" />
+                                    <CopyButton Value="@context.Address" Variant="CopyButtonVariant.IconButton" Label="Copy address" />
                                 </MudTd>
                             </RowTemplate>
                             <PagerContent>
@@ -303,7 +304,7 @@
                                 <MudText Typo="Typo.caption"><strong>Signature (Base64)</strong></MudText>
                                 <div class="d-flex align-center mb-2">
                                     <code style="font-size: 0.7rem; word-break: break-all; background: var(--mud-palette-surface); padding: 8px; border-radius: 4px; flex-grow: 1; max-height: 80px; overflow-y: auto;">@signatureResult.Signature</code>
-                                    <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="CopySignature" />
+                                    <CopyButton Value="@signatureResult.Signature" Variant="CopyButtonVariant.IconButton" Label="Copy signature" />
                                 </div>
 
                                 @if (!string.IsNullOrEmpty(signatureResult.PublicKey))
@@ -311,7 +312,7 @@
                                     <MudText Typo="Typo.caption"><strong>Public Key Used</strong></MudText>
                                     <div class="d-flex align-center mb-2">
                                         <code style="font-size: 0.7rem; word-break: break-all; background: var(--mud-palette-surface); padding: 8px; border-radius: 4px; flex-grow: 1; max-height: 60px; overflow-y: auto;">@signatureResult.PublicKey</code>
-                                        <MudIconButton Icon="@Icons.Material.Filled.ContentCopy" Size="Size.Small" OnClick="CopySignaturePublicKey" />
+                                        <CopyButton Value="@signatureResult.PublicKey" Variant="CopyButtonVariant.IconButton" Label="Copy public key" />
                                     </div>
                                 }
 
@@ -544,7 +545,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to load wallet: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to load wallet: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -562,7 +563,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to load addresses: {ex.Message}", Severity.Warning);
+            Feedback.ShowWarning($"Failed to load addresses: {ex.Message}");
         }
         finally
         {
@@ -612,11 +613,11 @@
             };
 
             signatureResult = await WalletService.SignDataAsync(Address, request);
-            Snackbar.Add("Data signed successfully!", Severity.Success);
+            Feedback.ShowSuccess("Data signed successfully!");
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to sign data: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to sign data: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -650,13 +651,13 @@
         try
         {
             await WalletService.RegisterAddressAsync(Address, registerRequest);
-            Snackbar.Add("Address registered successfully!", Severity.Success);
+            Feedback.ShowSuccess("Address registered successfully!");
             CloseRegisterAddressDialog();
             await LoadAddressesAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to register address: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to register address: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -689,54 +690,18 @@
             var success = await WalletService.DeleteWalletAsync(Address);
             if (success)
             {
-                Snackbar.Add($"Wallet deleted successfully", Severity.Success);
+                Feedback.ShowSuccess("Wallet deleted successfully");
                 Navigation.NavigateTo("wallets");
             }
             else
             {
-                Snackbar.Add("Wallet not found", Severity.Warning);
+                Feedback.ShowWarning("Wallet not found");
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to delete wallet: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to delete wallet: {ex.Message}", autoDismissMs: 0);
         }
-    }
-
-    // Copy helper methods - avoid lambda with string literals in Razor attributes
-    private async Task CopyWalletAddress()
-    {
-        if (wallet != null)
-            await CopyToClipboard(wallet.Address, "Address");
-    }
-
-    private async Task CopyPublicKey()
-    {
-        if (wallet != null)
-            await CopyToClipboard(wallet.PublicKey, "Public key");
-    }
-
-    private async Task CopySignature()
-    {
-        if (signatureResult != null)
-            await CopyToClipboard(signatureResult.Signature, "Signature");
-    }
-
-    private async Task CopySignaturePublicKey()
-    {
-        if (signatureResult?.PublicKey != null)
-            await CopyToClipboard(signatureResult.PublicKey, "Public key");
-    }
-
-    private async Task CopyAddressToClipboard(string address)
-    {
-        await CopyToClipboard(address, "Address");
-    }
-
-    private async Task CopyToClipboard(string text, string label)
-    {
-        await JS.InvokeVoidAsync("navigator.clipboard.writeText", text);
-        Snackbar.Add($"{label} copied to clipboard", Severity.Info);
     }
 
     private static string TruncateAddress(string address)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletList.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletList.razor
@@ -5,11 +5,12 @@
 @rendermode @(new InteractiveWebAssemblyRenderMode(prerender: false))
 @attribute [Authorize]
 @using Sorcha.UI.Core.Components.Wallets
+@using Sorcha.UI.Core.Services.Feedback
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferenceService
 @inject NavigationManager Navigation
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IJSRuntime JS
 
 <PageTitle>My Wallets - Sorcha Platform</PageTitle>
@@ -97,12 +98,12 @@
         {
             await WalletPreferenceService.SetDefaultWalletAsync(wallet.Address);
             defaultWalletAddress = wallet.Address;
-            Snackbar.Add($"'{wallet.Name}' set as default wallet", Severity.Success);
+            Feedback.ShowSuccess($"'{wallet.Name}' set as default wallet");
             StateHasChanged();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to set default wallet: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to set default wallet: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -129,11 +130,11 @@
         try
         {
             await JS.InvokeVoidAsync("QrCodeHelper.copyToClipboard", wallet.Address);
-            Snackbar.Add($"Address for '{wallet.Name}' copied to clipboard", Severity.Success);
+            Feedback.ShowSuccess($"Address for '{wallet.Name}' copied to clipboard");
         }
         catch
         {
-            Snackbar.Add("Failed to copy address to clipboard", Severity.Error);
+            Feedback.ShowError("Failed to copy address to clipboard");
         }
     }
 
@@ -171,16 +172,16 @@
                     defaultWalletAddress = null;
                 }
 
-                Snackbar.Add($"Wallet '{wallet.Name}' deleted successfully", Severity.Success);
+                Feedback.ShowSuccess($"Wallet '{wallet.Name}' deleted successfully");
             }
             else
             {
-                Snackbar.Add("Wallet not found", Severity.Warning);
+                Feedback.ShowWarning("Wallet not found");
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to delete wallet: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to delete wallet: {ex.Message}", autoDismissMs: 0);
         }
     }
 }


### PR DESCRIPTION
## Summary

Phase 5a of the Snackbar retirement (Phases 0-4 landed in PRs #740-#748).

Migrates the five wallet pages off `ISnackbar` onto `IInlineFeedback`:
- `CreateWallet.razor`
- `RecoverWallet.razor`
- `WalletList.razor`
- `WalletDetail.razor`
- `WalletAdmin.razor`

Phase 2a's `WalletWorkflowInboxWriter` already writes durable
bell-drawer entries for the underlying workflow events (created /
recovered / deleted / address-registered); this PR replaces the
ephemeral toast with the inline banner surface for in-page action
feedback. Any clipboard sites get the Phase 3 `CopyButton` primitive.

Allowlist: −5 entries.

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` — clean
- [x] `dotnet test tests/Sorcha.UI.Core.Tests` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)