### PR TITLE
feat(ui): dialog toasts → inline alerts — Phase 5d of Snackbar retirement

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -33,7 +33,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/SubscribeDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
@@ -42,7 +41,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
@@ -66,8 +64,4 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.raz
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ImportDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ExportDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ConditionEditor.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/CalculationEditor.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Configuration/ProfileEditorDialog.razor
@@ -5,7 +5,6 @@
 @using Sorcha.UI.Core.Models.Configuration
 @using Sorcha.UI.Core.Services.Configuration
 @inject IConfigurationService ConfigService
-@inject ISnackbar Snackbar
 
 <MudDialog>
     <TitleContent>
@@ -266,7 +265,6 @@
             }
 
             await ConfigService.SaveProfileAsync(profile);
-            Snackbar.Add($"Profile '{profile.Name}' {(IsNew ? "created" : "updated")} successfully", Severity.Success);
             MudDialog.Close(DialogResult.Ok(profile));
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/CalculationEditor.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/CalculationEditor.razor
@@ -291,9 +291,6 @@
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = null!;
 
-    [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
-
     [Parameter]
     public CalculationModel Model { get; set; } = new();
 
@@ -517,7 +514,6 @@
     {
         if (!IsValid())
         {
-            Snackbar.Add(_validationError ?? "Validation failed", Severity.Warning);
             StateHasChanged();
             return;
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ConditionEditor.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ConditionEditor.razor
@@ -135,9 +135,6 @@
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = null!;
 
-    [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
-
     [Parameter]
     public ConditionModel Model { get; set; } = new();
 
@@ -246,7 +243,6 @@
     {
         if (!ValidateCondition())
         {
-            Snackbar.Add(_validationError ?? "Validation failed", Severity.Warning);
             StateHasChanged();
             return;
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ExportDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ExportDialog.razor
@@ -14,6 +14,11 @@
         </MudText>
     </TitleContent>
     <DialogContent>
+        @if (!string.IsNullOrEmpty(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mb-2">@_errorMessage</MudAlert>
+        }
+
         <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
             Export "@Blueprint.Title" as a file for backup or sharing.
         </MudText>
@@ -82,15 +87,13 @@
     [Inject]
     private IJSRuntime JS { get; set; } = null!;
 
-    [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
-
     [Parameter]
     public Blueprint Blueprint { get; set; } = new();
 
     private ExportFormat SelectedFormat { get; set; } = ExportFormat.Json;
     private string FileName { get; set; } = string.Empty;
     private bool _exporting;
+    private string? _errorMessage;
 
     protected override void OnInitialized()
     {
@@ -101,6 +104,7 @@
     private async Task Export()
     {
         _exporting = true;
+        _errorMessage = null;
         StateHasChanged();
 
         try
@@ -124,12 +128,11 @@
             // Download the file using JavaScript
             await DownloadFile(fullFileName, content, mimeType);
 
-            Snackbar.Add($"Blueprint exported to {fullFileName}", Severity.Success);
             MudDialog.Close(DialogResult.Ok(fullFileName));
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Export failed: {ex.Message}", Severity.Error);
+            _errorMessage = $"Export failed: {ex.Message}";
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ImportDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/ImportDialog.razor
@@ -137,9 +137,6 @@
     [Inject]
     private BlueprintSerializationService SerializationService { get; set; } = null!;
 
-    [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
-
     private IBrowserFile? _selectedFile;
     private ImportValidationResult? _validationResult;
     private bool _loading;
@@ -180,7 +177,6 @@
     {
         if (_validationResult?.IsValid == true && _validationResult.Blueprint != null)
         {
-            Snackbar.Add($"Blueprint '{_validationResult.Blueprint.Title}' imported successfully", Severity.Success);
             MudDialog.Close(DialogResult.Ok(_validationResult.Blueprint));
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/SubscribeDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/SubscribeDialog.razor
@@ -3,7 +3,6 @@
 
 @using Sorcha.UI.Core.Services
 @using Microsoft.Extensions.Logging
-@inject ISnackbar Snackbar
 @inject ILogger<SubscribeDialog> Logger
 
 <MudDialog>
@@ -14,6 +13,12 @@
         </MudStack>
     </TitleContent>
     <DialogContent>
+        @if (!string.IsNullOrEmpty(_subscribeFeedback))
+        {
+            <MudAlert Severity="@_subscribeFeedbackSeverity" Dense="true" Class="mb-2" ShowCloseIcon="true" CloseIconClicked="@(() => _subscribeFeedback = null)">
+                @_subscribeFeedback
+            </MudAlert>
+        }
         @if (_loading)
         {
             <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" />
@@ -135,6 +140,8 @@
     private bool _loading = true;
     private string? _errorMessage;
     private string? _subscribingRegisterId;
+    private string? _subscribeFeedback;
+    private Severity _subscribeFeedbackSeverity = Severity.Info;
 
     protected override async Task OnInitializedAsync()
     {
@@ -173,17 +180,20 @@
             {
                 SubscribedRegisterIds.Add(registerId);
                 await OnSubscribed.InvokeAsync();
-                Snackbar.Add("Successfully subscribed to register", Severity.Success);
+                _subscribeFeedback = "Successfully subscribed to register";
+                _subscribeFeedbackSeverity = Severity.Success;
             }
             else
             {
-                Snackbar.Add("Failed to subscribe to register", Severity.Error);
+                _subscribeFeedback = "Failed to subscribe to register";
+                _subscribeFeedbackSeverity = Severity.Error;
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Subscribe to register {RegisterId} failed", registerId);
-            Snackbar.Add("Subscription failed. Please try again.", Severity.Error);
+            _subscribeFeedback = "Subscription failed. Please try again.";
+            _subscribeFeedbackSeverity = Severity.Error;
         }
         finally
         {


### PR DESCRIPTION
## Summary

Phase 5d of the Snackbar retirement (Phases 0-4 landed in PRs #740-#748).

Replaces redundant `Snackbar.Add` calls inside dialog bodies with the right surface for the context:
- Success that should close the dialog → `MudDialog.Close(...)` with the parent rendering inline feedback.
- Errors that need acknowledgement → inline `<MudAlert>` at the top of `DialogContent`.

`ConditionEditor` / `CalculationEditor` already had inline `MudAlert` — just drops the duplicate toasts.

Files:
- `ConditionEditor.razor`, `CalculationEditor.razor` (Designer)
- `ImportDialog.razor`, `ExportDialog.razor` (Designer)
- `ProfileEditorDialog.razor` (Configuration)
- `SubscribeDialog.razor` (Registers)

Allowlist: −6 entries (now 63).

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Core` — clean
- [x] `dotnet test tests/Sorcha.UI.Core.Tests` — 1233/1233 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)