### PR TITLE
fix(tenant): wire missing inbox writes on admin paths — Task #14

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
@@ -470,6 +470,7 @@ public static class OrganizationEndpoints
         ChangeUserRoleRequest request,
         IIdentityRepository identityRepository,
         TenantDbContext dbContext,
+        ITenantMembershipInboxWriter membershipInbox,
         ClaimsPrincipal user,
         CancellationToken cancellationToken)
     {
@@ -517,6 +518,20 @@ public static class OrganizationEndpoints
             }
         });
         await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Feature 118 — drop a "your role in {org} changed" inbox entry for the affected user.
+        // Only fires when the target identity is linked to a PlatformUser (PlatformUserId != Empty).
+        // Writer is fail-safe (try/log/swallow internally) — an inbox failure must never
+        // roll back the just-committed role change.
+        if (targetUser.PlatformUserId != Guid.Empty)
+        {
+            await membershipInbox.WriteOrgMembershipRoleChangedAsync(
+                targetUser.PlatformUserId,
+                organizationId,
+                previousRole,
+                request.Role.ToString(),
+                cancellationToken).ConfigureAwait(false);
+        }
 
         return TypedResults.Ok();
     }

--- a/src/Services/Sorcha.Tenant.Service/Services/OrgProvisioningService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrgProvisioningService.cs
@@ -19,6 +19,7 @@ public class OrgProvisioningService : IOrgProvisioningService
     private readonly IOrganizationService _orgService;
     private readonly IPlatformSettingsService _settingsService;
     private readonly IInvitationService _invitationService;
+    private readonly ITenantMembershipInboxWriter _membershipInbox;
     private readonly ILogger<OrgProvisioningService> _logger;
 
     /// <summary>
@@ -29,12 +30,14 @@ public class OrgProvisioningService : IOrgProvisioningService
         IOrganizationService orgService,
         IPlatformSettingsService settingsService,
         IInvitationService invitationService,
+        ITenantMembershipInboxWriter membershipInbox,
         ILogger<OrgProvisioningService> logger)
     {
         _db = db;
         _orgService = orgService;
         _settingsService = settingsService;
         _invitationService = invitationService;
+        _membershipInbox = membershipInbox;
         _logger = logger;
     }
 
@@ -204,6 +207,12 @@ public class OrgProvisioningService : IOrgProvisioningService
             _logger.LogInformation(
                 "Organisation provisioned: {OrgId} ({Subdomain}) by platform user {UserId} (total orgs: {Count})",
                 org.Id, org.Subdomain, platformUserId, platformUser.CreatedOrgsCount);
+
+            // Feature 118 — drop a "welcome to {org}" inbox entry for the founding owner.
+            // Writer is fail-safe (try/log/swallow internally) — an inbox failure here
+            // must never roll back the just-committed org.
+            await _membershipInbox.WriteOrgMembershipAddedAsync(
+                platformUserId, org.Id, UserRole.Administrator.ToString(), ct).ConfigureAwait(false);
 
             return new OrgProvisioningResult
             {
@@ -394,6 +403,15 @@ public class OrgProvisioningService : IOrgProvisioningService
                 _logger.LogInformation(
                     "Organisation provisioned by system admin: {OrgId} ({Subdomain}), admin={AdminEmail}, direct={Direct}",
                     org.Id, org.Subdomain, adminEmail, adminDirectlyAdded);
+
+                // Feature 118 — if the admin was a known platform user we attached directly,
+                // drop a "welcome to {org}" inbox entry. New invitees get their entry when
+                // they accept the invitation (handled in PlatformUserService).
+                if (adminDirectlyAdded && existingUser is not null)
+                {
+                    await _membershipInbox.WriteOrgMembershipAddedAsync(
+                        existingUser.Id, org.Id, role.ToString(), ct).ConfigureAwait(false);
+                }
 
                 return new AdminProvisionResult
                 {

--- a/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
@@ -21,6 +21,7 @@ public partial class OrganizationService : IOrganizationService
     private readonly IIdentityRepository _identityRepository;
     private readonly TenantDbContext _dbContext;
     private readonly IWalletServiceClient _walletClient;
+    private readonly ITenantMembershipInboxWriter _membershipInbox;
     private readonly ILogger<OrganizationService> _logger;
 
     // Reserved subdomains that cannot be used
@@ -38,12 +39,14 @@ public partial class OrganizationService : IOrganizationService
         IIdentityRepository identityRepository,
         TenantDbContext dbContext,
         IWalletServiceClient walletClient,
+        ITenantMembershipInboxWriter membershipInbox,
         ILogger<OrganizationService> logger)
     {
         _organizationRepository = organizationRepository ?? throw new ArgumentNullException(nameof(organizationRepository));
         _identityRepository = identityRepository ?? throw new ArgumentNullException(nameof(identityRepository));
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
+        _membershipInbox = membershipInbox ?? throw new ArgumentNullException(nameof(membershipInbox));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -269,15 +272,21 @@ public partial class OrganizationService : IOrganizationService
 
             if (existingMembership == null)
             {
+                var newMembershipRole = request.Roles.Any(r => r == UserRole.Administrator)
+                    ? UserRole.Administrator.ToString() : UserRole.Consumer.ToString();
                 _dbContext.PlatformUserOrgMemberships.Add(new PlatformUserOrgMembership
                 {
                     PlatformUserId = platformUser.Id,
                     OrganizationId = organizationId,
-                    Role = request.Roles.Any(r => r == UserRole.Administrator)
-                        ? UserRole.Administrator.ToString() : UserRole.Consumer.ToString(),
+                    Role = newMembershipRole,
                     JoinedAt = DateTimeOffset.UtcNow
                 });
                 await _dbContext.SaveChangesAsync(cancellationToken);
+
+                // Feature 118 — drop a "welcome to {org}" inbox entry once the membership
+                // is committed. Writer is fail-safe (try/log/swallow internally).
+                await _membershipInbox.WriteOrgMembershipAddedAsync(
+                    platformUser.Id, organizationId, newMembershipRole, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Services/Sorcha.Tenant.Service/Services/TenantMembershipInboxWriter.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/TenantMembershipInboxWriter.cs
@@ -22,6 +22,18 @@ public interface ITenantMembershipInboxWriter
         Guid organizationId,
         string role,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Write a "your role in {org} changed" inbox entry. Severity is <see cref="InboxSeverity.Info"/>
+    /// but each role change produces a fresh entry — the timestamp is folded into the deterministic
+    /// SourceEventId so successive promotions / demotions stay visible.
+    /// </summary>
+    Task WriteOrgMembershipRoleChangedAsync(
+        Guid platformUserId,
+        Guid organizationId,
+        string previousRole,
+        string newRole,
+        CancellationToken ct = default);
 }
 
 /// <inheritdoc />
@@ -85,6 +97,70 @@ public sealed class TenantMembershipInboxWriter : ITenantMembershipInboxWriter
                 "Inbox-write failed for org membership added — PlatformUserId={UserId} OrgId={OrgId}",
                 platformUserId, organizationId);
         }
+    }
+
+    /// <inheritdoc />
+    public async Task WriteOrgMembershipRoleChangedAsync(
+        Guid platformUserId,
+        Guid organizationId,
+        string previousRole,
+        string newRole,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var orgName = await _db.Organizations
+                .AsNoTracking()
+                .Where(o => o.Id == organizationId)
+                .Select(o => o.Name)
+                .FirstOrDefaultAsync(ct)
+                .ConfigureAwait(false)
+                ?? "your organisation";
+
+            var occurredAt = DateTimeOffset.UtcNow;
+            var sourceEventId = DeterministicRoleChangeSourceEventId(platformUserId, organizationId, newRole, occurredAt);
+            var summary = string.IsNullOrWhiteSpace(previousRole)
+                ? $"You are now {newRole}."
+                : $"You changed from {previousRole} to {newRole}.";
+
+            var request = new InboxWriteRequest(
+                PlatformUserId: platformUserId,
+                Category: InboxCategory.Membership,
+                Severity: InboxSeverity.Info,
+                CorrelationKey: $"membership:{organizationId:N}",
+                DetailHref: $"/api/me/organizations/{organizationId:D}",
+                SourceEventId: sourceEventId,
+                OccurredAt: occurredAt,
+                Title: $"Your role in {orgName} changed",
+                Summary: summary,
+                IconKey: "membership.role-changed");
+
+            var result = await _inbox.WriteAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Inbox entry {Outcome} for org membership role change — PlatformUserId={UserId} OrgId={OrgId} PreviousRole={Previous} NewRole={New} EntryId={EntryId}",
+                result.IsIdempotent ? "idempotent" : "created",
+                platformUserId, organizationId, previousRole, newRole, result.Entry.Id);
+        }
+        catch (Exception ex)
+        {
+            // Inbox-write failure must not block the role-change operation.
+            _logger.LogWarning(ex,
+                "Inbox-write failed for org membership role change — PlatformUserId={UserId} OrgId={OrgId} NewRole={New}",
+                platformUserId, organizationId, newRole);
+        }
+    }
+
+    private static Guid DeterministicRoleChangeSourceEventId(Guid platformUserId, Guid organizationId, string newRole, DateTimeOffset occurredAt)
+    {
+        // Fold the timestamp (to the second) so back-to-back role changes don't collapse onto the
+        // same SourceEventId — each one should be its own line in the inbox.
+        var input = $"sorcha.inbox.org-membership-role-changed:{platformUserId:N}:{organizationId:N}:{newRole}:{occurredAt.ToUnixTimeSeconds()}";
+        var bytes = System.Security.Cryptography.SHA1.HashData(System.Text.Encoding.UTF8.GetBytes(input));
+        var guidBytes = new byte[16];
+        Array.Copy(bytes, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50);
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80);
+        return new Guid(guidBytes);
     }
 
     private static Guid DeterministicSourceEventId(Guid platformUserId, Guid organizationId)

--- a/tests/Sorcha.Tenant.Service.Tests/Services/DomainRestrictionTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/DomainRestrictionTests.cs
@@ -55,6 +55,7 @@ public class DomainRestrictionTests : IDisposable
             _identityRepoMock.Object,
             _dbContext,
             new Mock<IWalletServiceClient>().Object,
+            Mock.Of<ITenantMembershipInboxWriter>(),
             _loggerMock.Object);
     }
 

--- a/tests/Sorcha.Tenant.Service.Tests/Services/OrgProvisioningServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/OrgProvisioningServiceTests.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Tenant.Service.Data;
+using Sorcha.Tenant.Service.Models;
+using Sorcha.Tenant.Service.Models.Dtos;
+using Sorcha.Tenant.Service.Services;
+using Sorcha.Tenant.Service.Tests.Helpers;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+/// <summary>
+/// Task #14 — verifies <see cref="OrgProvisioningService.ProvisionAsync"/> fires the
+/// membership-inbox writer for the founding owner after the org row commits.
+/// </summary>
+public sealed class OrgProvisioningServiceTests : IDisposable
+{
+    private readonly TenantDbContext _db;
+    private readonly Mock<IOrganizationService> _orgService = new();
+    private readonly Mock<IPlatformSettingsService> _settings = new();
+    private readonly Mock<IInvitationService> _invitations = new();
+    private readonly Mock<ITenantMembershipInboxWriter> _membershipInbox = new();
+    private readonly OrgProvisioningService _sut;
+
+    public OrgProvisioningServiceTests()
+    {
+        _db = InMemoryDbContextFactory.Create();
+        _orgService.Setup(s => s.ValidateSubdomainAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, (string?)null));
+        _settings.Setup(s => s.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PlatformSettings { MaxOrgsPerUser = 10 });
+
+        _sut = new OrgProvisioningService(
+            _db,
+            _orgService.Object,
+            _settings.Object,
+            _invitations.Object,
+            _membershipInbox.Object,
+            NullLogger<OrgProvisioningService>.Instance);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task ProvisionAsync_HappyPath_FiresMembershipInboxWriterForFoundingOwner()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        _db.PlatformUsers.Add(new PlatformUser
+        {
+            Id = userId,
+            Email = "owner@example.com",
+            DisplayName = "Founding Owner",
+            EmailVerified = true,
+            EmailVerifiedAt = DateTimeOffset.UtcNow.AddDays(-1),
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        var request = new ProvisionOrgRequest
+        {
+            Name = "Founding Org",
+            Subdomain = "founding",
+            Description = null
+        };
+
+        // Act
+        var result = await _sut.ProvisionAsync(userId, request, CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        _membershipInbox.Verify(
+            w => w.WriteOrgMembershipAddedAsync(
+                userId,
+                result.OrganizationId!.Value,
+                UserRole.Administrator.ToString(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/OrganizationServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/OrganizationServiceTests.cs
@@ -20,6 +20,7 @@ public class OrganizationServiceTests : IDisposable
     private readonly Mock<IOrganizationRepository> _orgRepoMock;
     private readonly Mock<IIdentityRepository> _identityRepoMock;
     private readonly Mock<IWalletServiceClient> _walletClientMock;
+    private readonly Mock<ITenantMembershipInboxWriter> _membershipInboxMock;
     private readonly Mock<ILogger<OrganizationService>> _loggerMock;
     private readonly Guid _testOrgId = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
@@ -29,6 +30,7 @@ public class OrganizationServiceTests : IDisposable
         _orgRepoMock = new Mock<IOrganizationRepository>();
         _identityRepoMock = new Mock<IIdentityRepository>();
         _walletClientMock = new Mock<IWalletServiceClient>();
+        _membershipInboxMock = new Mock<ITenantMembershipInboxWriter>();
         _loggerMock = new Mock<ILogger<OrganizationService>>();
 
         // Seed test organization
@@ -56,6 +58,7 @@ public class OrganizationServiceTests : IDisposable
             _identityRepoMock.Object,
             _dbContext,
             _walletClientMock.Object,
+            _membershipInboxMock.Object,
             _loggerMock.Object);
     }
 
@@ -612,5 +615,76 @@ public class OrganizationServiceTests : IDisposable
             .ToList();
 
         auditEntries.Should().BeEmpty();
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // Task #14 — AddUserToOrganizationAsync fires the membership-inbox writer
+    // ══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task AddUserToOrganizationAsync_ExistingPlatformUser_FiresMembershipInboxWriter()
+    {
+        // Arrange
+        var platformUser = SeedPlatformUser(Guid.NewGuid(), "newmember@test.com", emailVerified: true);
+
+        _orgRepoMock.Setup(r => r.GetByIdAsync(_testOrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Organization { Id = _testOrgId, Name = "Test Organization", Subdomain = "testorg" });
+
+        _identityRepoMock.Setup(r => r.CreateUserAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserIdentity u, CancellationToken _) => u);
+
+        var service = CreateService();
+        var request = new Sorcha.Tenant.Service.Models.Dtos.AddUserToOrganizationRequest
+        {
+            Email = "newmember@test.com",
+            DisplayName = "New Member",
+            ExternalIdpSubject = "ext-sub-123",
+            Roles = [UserRole.Consumer]
+        };
+
+        // Act
+        await service.AddUserToOrganizationAsync(_testOrgId, request);
+
+        // Assert — inbox writer fired for the linked platform user
+        _membershipInboxMock.Verify(
+            w => w.WriteOrgMembershipAddedAsync(
+                platformUser.Id,
+                _testOrgId,
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AddUserToOrganizationAsync_NoLinkedPlatformUser_DoesNotFireInboxWriter()
+    {
+        // Arrange — adding an identity for an email that has no PlatformUser yet
+        // (pre-registration). No membership row is created, so no inbox entry should fire.
+        _orgRepoMock.Setup(r => r.GetByIdAsync(_testOrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Organization { Id = _testOrgId, Name = "Test Organization", Subdomain = "testorg" });
+
+        _identityRepoMock.Setup(r => r.CreateUserAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserIdentity u, CancellationToken _) => u);
+
+        var service = CreateService();
+        var request = new Sorcha.Tenant.Service.Models.Dtos.AddUserToOrganizationRequest
+        {
+            Email = "noone@test.com",
+            DisplayName = "Nobody",
+            ExternalIdpSubject = "ext-sub-none",
+            Roles = [UserRole.Consumer]
+        };
+
+        // Act
+        await service.AddUserToOrganizationAsync(_testOrgId, request);
+
+        // Assert
+        _membershipInboxMock.Verify(
+            w => w.WriteOrgMembershipAddedAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Services/TenantMembershipInboxWriterTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/TenantMembershipInboxWriterTests.cs
@@ -98,4 +98,47 @@ public sealed class TenantMembershipInboxWriterTests : IDisposable
         await act.Should().NotThrowAsync(
             "inbox-write failures must never block the org membership operation");
     }
+
+    // ── Task #14 — WriteOrgMembershipRoleChangedAsync ─────────────
+
+    [Fact]
+    public async Task WriteOrgMembershipRoleChangedAsync_LooksUpOrgName_AndPostsExpectedPayload()
+    {
+        _db.Organizations.Add(new Organization
+        {
+            Id = _orgId,
+            Name = "Acme Inc.",
+            Subdomain = "acme",
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await _db.SaveChangesAsync();
+
+        InboxWriteRequest? captured = null;
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<InboxWriteRequest, CancellationToken>((r, _) => captured = r)
+            .ReturnsAsync((InboxWriteRequest r, CancellationToken _) =>
+                new InboxWriteResult(new InboxEntry { Id = Guid.NewGuid() }, IsIdempotent: false));
+
+        await _sut.WriteOrgMembershipRoleChangedAsync(_userId, _orgId, "Consumer", "Administrator");
+
+        captured.Should().NotBeNull();
+        captured!.PlatformUserId.Should().Be(_userId);
+        captured.Category.Should().Be(InboxCategory.Membership);
+        captured.Severity.Should().Be(InboxSeverity.Info);
+        captured.Title.Should().Be("Your role in Acme Inc. changed");
+        captured.Summary.Should().Be("You changed from Consumer to Administrator.");
+        captured.IconKey.Should().Be("membership.role-changed");
+    }
+
+    [Fact]
+    public async Task WriteOrgMembershipRoleChangedAsync_InboxThrows_DoesNotPropagate()
+    {
+        _inbox.Setup(i => i.WriteAsync(It.IsAny<InboxWriteRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("inbox down"));
+
+        var act = () => _sut.WriteOrgMembershipRoleChangedAsync(_userId, _orgId, "Consumer", "Administrator");
+
+        await act.Should().NotThrowAsync(
+            "inbox-write failures must never block the role-change operation");
+    }
 }


### PR DESCRIPTION
## Summary

Task #14 of the Snackbar retirement (separate from Phase 5/6/7/8).

Three admin operations were bypassing the existing membership-inbox writer, and the change-role endpoint had no inbox write at all. The four `TenantSecurityInboxWriter` methods (2FA enable/disable, password reset, backup code used) are already wired from earlier phases (`TotpService`, `PasswordResetService`) — verified by grep + the existing call sites and test fixtures.

**Membership writes** (existing writer + one new method, four new call sites):
- `OrgProvisioningService.ProvisionAsync` — fires `WriteOrgMembershipAddedAsync` for the founding owner after the org row commits
- `OrgProvisioningService.AdminProvisionAsync` — fires the same write on the direct-add path when the admin email matches an existing PlatformUser
- `OrganizationService.AddUserToOrganizationAsync` — fires after the membership row commits
- `OrganizationEndpoints.ChangeUserRole` — adds a new `WriteOrgMembershipRoleChangedAsync` writer method (timestamp-folded SourceEventId so successive role changes don't collapse) and fires it when the target identity is linked to a PlatformUser

Each writer call is fail-safe at the writer level — `try` / `LogWarning` / swallow inside the writer — so an inbox failure must not roll back the underlying admin operation. Same pattern as the existing `PlatformUserService` wiring.

## Test plan

- [x] `dotnet build src/Services/Sorcha.Tenant.Service` — clean (0 errors)
- [x] `dotnet test tests/Sorcha.Tenant.Service.Tests` — 1109 passed, 0 failed (5 new tests added)
- [ ] Manual smoke: change a user's role on a dev org, confirm bell entry lands (deferred to Phase 7 UAT)

New tests:
- `OrgProvisioningServiceTests` — happy-path founding-owner wiring
- `OrganizationServiceTests.AddUserToOrganizationAsync_ExistingPlatformUser_FiresMembershipInboxWriter` (happy-path)
- `OrganizationServiceTests.AddUserToOrganizationAsync_NoLinkedPlatformUser_DoesNotFireInboxWriter` (negative-path — no membership, no write)
- `TenantMembershipInboxWriterTests.WriteOrgMembershipRoleChangedAsync_LooksUpOrgName_AndPostsExpectedPayload` (happy-path)
- `TenantMembershipInboxWriterTests.WriteOrgMembershipRoleChangedAsync_InboxThrows_DoesNotPropagate` (proves writer failure can't break the admin operation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)