### PR TITLE
docs: lock in notification-routing guidance — Phase 8 of Snackbar retirement

### DIFF
--- a/.claude/skills/blazor/SKILL.md
+++ b/.claude/skills/blazor/SKILL.md
@@ -172,6 +172,7 @@ public class ClientProductService : IProductService
 | Sync JS interop in Server | Blocks SignalR circuit | Use `IJSRuntime` async |
 | No error boundaries | One error crashes app | Use `<ErrorBoundary>` |
 | Forgetting prerender state | Double API calls | Use `[PersistentState]` |
+| `@inject ISnackbar` in new code | Toasts pull focus off the active surface; the action's own affordance is the right place for feedback. | Inject `IInlineFeedback` for actor's-own-action feedback (page-scoped banner), write a server-side inbox entry for workflow events that need durable history, or use the `CopyButton` primitive for clipboard affordances. |
 
 ## Performance Best Practices
 

--- a/.claude/skills/sorcha-ui/SKILL.md
+++ b/.claude/skills/sorcha-ui/SKILL.md
@@ -322,3 +322,17 @@ Test patterns (UI.Core.Tests):
 - "MudBlazor card table dialog"
 - "MudBlazor form validation"
 - "Browser storage state authentication"
+
+## Anti-Pattern: Don't Use ISnackbar
+
+The Sorcha UI has retired MudBlazor's `Snackbar.Add(...)` toast surface from every user-facing page and PWA component (PRs #740-#755). New code MUST NOT inject `ISnackbar` — a CI gate at `scripts/check-no-snackbar.ps1` enforces the ratchet via `.snackbar-allowlist`.
+
+Use one of three replacement surfaces:
+
+- **`IInlineFeedback`** for actor's-own-action feedback in the current page (success / error / info / warning). API: `Feedback.ShowSuccess(msg, detailHref?, autoDismissMs?)` / `ShowError` / `ShowInfo` / `ShowWarning`. Default 4s auto-dismiss; pass `autoDismissMs: 0` for errors that need explicit acknowledgement. Namespace `Sorcha.UI.Core.Services.Feedback`. Renders via `InlineFeedbackHost` mounted in `MainLayout`. Do NOT call from inside a dialog body — the host mounts in the layout, not in dialog surfaces.
+- **Server-side inbox writer** for workflow / lifecycle / security events that should live in the durable Feature 118 bell drawer across sessions. Existing writers: `WalletWorkflowInboxWriter`, `WalletInboxWriter`, `CitizenDeviceInboxWriter`, `TenantSecurityInboxWriter`, plus the membership writer. Always `try` / `LogError` / swallow — a writer failure must NOT roll back the underlying admin operation.
+- **`CopyButton` primitive** for clipboard affordances. `<CopyButton Value="@x" Label="Copy" />` for labelled buttons, `<CopyButton Value="@x" Variant="CopyButtonVariant.IconButton" Label="Copy hash" />` for icon-only inside lists. Morphs to "Copied ✓" for ~2s on success.
+
+**Dialog content** rule: dialog success closes with `MudDialog.Close(DialogResult.Ok(...))` so the parent renders inline feedback; dialog errors render an inline `<MudAlert Severity="Severity.Error" Dense="true" Class="mb-2">` at the top of `DialogContent`.
+
+Full architecture and migration history: `specs/118-notifications-architecture/MIGRATION.md` and Critical Pattern #12 in `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,24 @@ Hub events follow the **thin-signal contract** — opaque IDs and timestamps onl
 
 Full architecture: `specs/118-notifications-architecture/spec.md`. Design rationale: `docs/superpowers/specs/2026-05-05-notifications-architecture-design.md`.
 
+### 12. Notification Routing (Snackbar retirement)
+
+**Do NOT inject `ISnackbar` in new user-facing code.** The Sorcha UI has retired MudBlazor's `Snackbar.Add(...)` toast surface from every user-facing page and PWA component (PRs #740-#755). The remaining `MudSnackbarProvider` mount stays only for in-flight admin / designer pages still on the allowlist.
+
+**The three surfaces, by intent:**
+
+| Surface | Use when | Where |
+|---------|----------|-------|
+| `IInlineFeedback` | Actor's own-action feedback in the current page (success / error / info / warning). Default 4s auto-dismiss; pass `autoDismissMs: 0` for errors the user must acknowledge. | `Sorcha.UI.Core.Services.Feedback.IInlineFeedback` (scoped in Web, singleton in PWA). Renders via `InlineFeedbackHost.razor` mounted at the top of the content region. |
+| Server-side inbox writer | Workflow / lifecycle / security event that should appear in the durable bell drawer across sessions. Always wrap the writer call in `try` / `LogError` / swallow — a writer failure must NOT roll back the underlying operation. | `WalletWorkflowInboxWriter`, `WalletInboxWriter`, `CitizenDeviceInboxWriter`, `TenantSecurityInboxWriter`, plus `WriteOrgMembership*` on the membership writer. Bell drawer is Feature 118 / `MainLayout.razor`. |
+| `CopyButton` primitive | "Copy this value to clipboard" affordances. Use `Variant.Button` for labelled buttons, `Variant.IconButton` for icon-only triggers inside lists / detail views. The button morphs to "Copied ✓" for ~2s on success and reverts. | `Sorcha.UI.Core.Components.Forms.CopyButton` (in `Sorcha.UI.Components.User`). |
+
+**Dialog content** is its own micro-rule: dialog success closes the dialog with `MudDialog.Close(DialogResult.Ok(...))` and the parent surfaces inline feedback; dialog errors render an inline `<MudAlert Severity="Severity.Error" Dense="true" Class="mb-2">…</MudAlert>` inside the `DialogContent` body. Do NOT call `IInlineFeedback` from inside a dialog — `InlineFeedbackHost` mounts in the layout, not inside dialog surfaces.
+
+A CI gate at `scripts/check-no-snackbar.ps1` enforces the ratchet via `.snackbar-allowlist`. The allowlist may only shrink — any new `Snackbar.Add(` or `ISnackbar` reference outside the allowed paths fails the build.
+
+Full architecture: `specs/118-notifications-architecture/MIGRATION.md`.
+
 ---
 
 ## Key Documentation


### PR DESCRIPTION
## Summary

Phase 8 of the Snackbar retirement. Phases 0-6 shipped over PRs #740-#755; this PR locks the post-migration guidance into the docs that future contributors actually read.

**Updates:**
- **CLAUDE.md** — new Critical Pattern #12 (Notification Routing) explaining the three surfaces (`IInlineFeedback`, server-side inbox writers, `CopyButton`), the dialog success/error micro-rule, and the CI ratchet.
- **`.claude/skills/blazor/SKILL.md`** — anti-pattern row added to the Blazor "Anti-Patterns to Avoid" table.
- **`.claude/skills/sorcha-ui/SKILL.md`** — fuller "Don't Use ISnackbar" section at the bottom of the skill with the three surfaces and the dialog rule.

## Out of scope

The `MudSnackbarProvider` mount stays for now — 49 admin / designer pages remain on the allowlist by deliberate decision. The CI ratchet keeps the migrated user-facing surfaces from regressing; admin retirement is a future-round decision.

## Test plan

- [x] `pwsh ./scripts/check-no-snackbar.ps1` — green (49 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)