### PR TITLE
fix(register): serialise Status as string on /api/internal/registers

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -327,8 +327,19 @@ app.UseRateLimiting();
 // Internal discovery endpoint for service-to-service recovery (no auth)
 app.MapGet("/api/internal/registers", async (RegisterManager manager) =>
 {
+    // Status is serialised as the enum name (string) — the consumer-side
+    // InternalRegisterInfo.Status is typed string. Without the explicit
+    // ToString(), default System.Text.Json emits the underlying int and the
+    // client throws JsonException, which the catch-all returns as [],
+    // silently breaking bloom-filter fan-out for new wallet addresses.
     var allRegisters = await manager.GetAllRegistersAsync();
-    return Results.Ok(allRegisters.Select(r => new { r.Id, r.Name, r.Height, r.Status }).ToList());
+    return Results.Ok(allRegisters.Select(r => new
+    {
+        r.Id,
+        r.Name,
+        r.Height,
+        Status = r.Status.ToString()
+    }).ToList());
 })
 .WithName("InternalGetRegisters")
 .WithSummary("Internal: List all registers for service recovery")


### PR DESCRIPTION
## Summary

- `GET /api/internal/registers` emitted `Status` as the underlying int of the `RegisterStatus` enum; the client's `InternalRegisterInfo.Status` is typed `string`, so every `GetInternalRegistersAsync` call threw `JsonException` and the catch-all returned `[]`.
- Silent: the AssuredIdentity walkthrough on n1 minted the AssuredIdentityCredential register-side at docket 6, but the citizen never received it because `AddressRegistrationService.NotifyLocalAddressCreatedAsync` saw `[]` for the register list, the bloom filter never got the recipient address, `InboundTransactionRouter` skipped the notification, `InboundCredentialDetector` never extracted, `CitizenInboxProjector` never wrote, and no `CredentialAvailable` / inbox push fired.
- Fix is a one-line `r.Status.ToString()` on the response projection, scoped to this endpoint to avoid changing the wire shape of any other register-service API.

## Test plan

- [ ] CI green (Docker Publish builds `sorchadev/register-service:latest`).
- [ ] On n1 after pull + recreate of `register-service`: `docker logs sorcha-register-service` and `sorcha-wallet-service` no longer log `Failed to fetch internal registers`.
- [ ] Re-run `walkthroughs/AssuredIdentity/run-phase1-identity.ps1` against the citizen-wallet-paired account: `AssuredIdentityCredential` lands in the PWA, `CitizenCredentialEventLog` populates, and the welcome-takeover fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)