### PR TITLE
fix(ui): refetch InboxPanel on drawer open

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
@@ -120,6 +120,7 @@
     private readonly List<InboxEntryDto> _entries = new();
     private bool _loading;
     private bool _disposed;
+    private bool _wasOpen;
     private string _selectedCategory = string.Empty;
 
     private static readonly string[] CategoryFilters =
@@ -136,6 +137,24 @@
     {
         TenantHub.OnInboxEntryAdded += OnInboxEntryAddedAsync;
         await LoadAsync();
+    }
+
+    // Re-fetch when the drawer opens. The OnInitializedAsync LoadAsync can race
+    // a not-yet-loaded access token on cold open (PWA reads it from IndexedDB),
+    // and entries written before TenantHub connected are never replayed via
+    // OnInboxEntryAdded — so without this, the panel shows stale-empty until
+    // the user hits the Refresh button.
+    protected override async Task OnParametersSetAsync()
+    {
+        if (IsOpen && !_wasOpen)
+        {
+            _wasOpen = true;
+            await LoadAsync();
+        }
+        else if (!IsOpen && _wasOpen)
+        {
+            _wasOpen = false;
+        }
     }
 
     private async Task OnCategoryChanged(string? category)


### PR DESCRIPTION
## Summary

`InboxPanel.OnInitializedAsync` runs a single `LoadAsync()` on instantiation. Two race conditions leave it stuck on stale-empty until the user clicks the panel's own Refresh button:

1. **PWA cold open** — the initial `LoadAsync()` can race the access-token read from IndexedDB. `BearerTokenHandler` ships the request with no `Authorization` header; tenant-service returns 401; `InboxApiService.ListAsync` swallows it as `null` and `_entries` stays empty.
2. **Entries written before connection** — `TenantHub.OnInboxEntryAdded` only re-fetches for entries posted *while* the user is connected. Inbox entries written before the hub joins the user group (e.g. credentials issued just before the citizen first opened the PWA) are never replayed.

Reproduced on n1 with the AssuredIdentity walkthrough: credential issued at 11:29, citizen opened the PWA at 11:32, bell drawer was empty until manual Refresh — even though 11 entries existed server-side.

## Fix

Add `OnParametersSetAsync` to re-fetch on the false → true `IsOpen` transition. Targeted, no other behavioural change.

## Test plan

- [ ] CI green.
- [ ] On n1: as Alex (`alex.macleod@assured-identity.local`) reload `/wallet/`, click the bell — drawer populates without hitting Refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)