### PR TITLE
docs: strike completed UI items from v1 roadmap + MASTER-TASKS

### DIFF
--- a/.specify/MASTER-TASKS.md
+++ b/.specify/MASTER-TASKS.md
@@ -224,8 +224,8 @@ These are the **Tier 1** trust improvements identified in the transaction archit
 
 | # | Task | Priority | Effort | Status | Notes |
 |---|------|----------|--------|--------|-------|
-| UX-001 | Register subscription scoping — org-based register access + UI consolidation | P1 | 24h | 📋 | #113 — New Submission shows only subscribed registers; merge Available Registers into Registers page |
-| UX-002 | Rename UserRole.Member → UserRole.Consumer across codebase | P1 | 8h | 📋 | #112 — Enum, DB migration, JWT claims, docs, permission presets |
+| UX-001 | Register subscription scoping — org-based register access + UI consolidation | P1 | 24h | ✅ | #113 (closed) — `Registers/Index.razor` + `NewSubmissions.razor` both filter via `IRegisterSubscriptionService.GetMySubscribedRegistersAsync()`; `SubscribeDialog` + `InvitationsPanel` merged in. Auto-subscribe on register creation + system-admin↔system-register bootstrap verified on n1 2026-05-18 |
+| UX-002 | Rename UserRole.Member → UserRole.Consumer across codebase | P1 | 8h | ✅ | #112 (closed) — landed in `aee79106`. Remaining `Member` symbols belong to other domains (`ParticipantRole.Member`, `StandardMember` permission flag, `RosterMember`) |
 | UX-003 | Blueprint register filter + role-based nav/page auth | P1 | 8h | ✅ | #111 — Fixed register filter, nav gating, dashboard scoping, page-level [Authorize(Roles)] |
 | UX-004 | Auditor role access review — determine read-only access scope | P2 | 4h | 📋 | Auditors currently have no nav items for Registers/Participants; decide if read-only access needed |
 | UX-005 | Dashboard org-scoped stats for multi-tenant deployments | P2 | 8h | 📋 | Currently global counts; need per-org stats for Consumer/Auditor users |

--- a/docs/superpowers/specs/2026-05-16-v1-release-roadmap.md
+++ b/docs/superpowers/specs/2026-05-16-v1-release-roadmap.md
@@ -181,15 +181,17 @@ Sequenced as four overlapping milestones. Each milestone is independently demoab
 **Goal:** Public users have correct mental model of their data, register access, and roles.
 **Demoable outcome:** A new Consumer signs up, sees only registers they're subscribed to, with role nomenclature that matches the docs.
 
-- `UX-001` Register subscription scoping (`gh#113`)
-- `UX-002` `UserRole.Member → UserRole.Consumer` rename (`gh#112`)
 - `UX-004` Auditor read-only access scope decision
 - `UX-005` Dashboard org-scoped stats
 - `UX-007` Public-user page hitting admin-only endpoint (latent auth-boundary bug — fix and silence)
 - `GAP-020` Multi-org `ConstructionPermit` walkthrough completion (the run path; setup already passes)
-- `GAP-019` admin user provisioning across orgs (closes the `GAP-020` blocker)
 - `SEC-004` OWASP Top 10 review + light pentest pass against the hardened build
 - **V1-quality interleaved:** `OPS-009` CI/CD release pipeline (tags, changelog, artifact signing).
+
+> **Already shipped before this roadmap was finalised — kept here as audit trail:**
+> - `UX-001` Register subscription scoping (`gh#113`, closed) — `Registers/Index.razor` + `NewSubmissions.razor` both filter by `IRegisterSubscriptionService.GetMySubscribedRegistersAsync()`; `SubscribeDialog` and `InvitationsPanel` ship the merged "Available Registers" + invite surfaces. Auto-subscribe on register creation + system-admin↔system-register bootstrap verified on n1 2026-05-18.
+> - `UX-002` `UserRole.Member → UserRole.Consumer` rename (`gh#112`, closed) — landed in `aee79106`. Remaining `Member` symbols in `src/` belong to other domains (`ParticipantRole.Member`, `StandardMember` permission flag, `RosterMember`).
+> - `GAP-019` admin user provisioning (Feature 077) — `POST /api/platform/users` + `PUT /api/platform/users/{id}/password` ship in `PlatformManagementEndpoints.cs`. The remaining walkthrough plumbing is `GAP-020`'s problem, listed above.
 
 ### Milestone M5 (parallel track if 2 engineers) — Strathcarron Spec 5
 - Spec 5 is the natural close of the citizen arc. Lands `IIssuerKeyResolver` production hardening (DID-resolver-backed), verifier-DID resolution in `SorchaWalletPresentationConsumer` (currently emits `did:sorcha:org:UNKNOWN`), and the recovery UX entry point.


### PR DESCRIPTION
## Summary

UX-001, UX-002, GAP-019 are all already shipped — the v1 roadmap was audited from MASTER-TASKS but didn't cross-check against `src/`. This PR strikes the three from M4 with an audit-trail block, and flips UX-001 / UX-002 to ✅ in MASTER-TASKS.

| ID | Proof of completion |
|---|---|
| UX-001 (#113) | `Registers/Index.razor:390` + `NewSubmissions.razor:280` filter by `IRegisterSubscriptionService.GetMySubscribedRegistersAsync()`. `SubscribeDialog` + `InvitationsPanel` ship the merged Available-Registers / invite surfaces. n1 invariants verified 2026-05-18 — `OrganizationRegisterSubscriptions` rows confirm system-admin↔system-register and auto-subscribe-on-create. |
| UX-002 (#112) | Commit `aee79106`. Zero hits for `UserRole.Member` in `src/`. |
| GAP-019 (Feature 077) | `POST /api/platform/users` + `PUT /api/platform/users/{id}/password` ship in `PlatformManagementEndpoints.cs`. Already ✅ in MASTER-TASKS; only the roadmap was stale. |

UX-003 (#111) was already ✅ in MASTER-TASKS — no change needed.

## Test plan

- [ ] CI green (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)