### PR TITLE
docs(131): UX-005 dashboard org-scoping — design, spec, plan, tasks

### DIFF
--- a/docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md
+++ b/docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md
@@ -1,0 +1,99 @@
+# UX-005 — Dashboard org-scoping (design)
+
+**Date:** 2026-05-18
+**Spec:** `specs/131-dashboard-org-scoping/`
+**Roadmap line:** M4 · "Dashboard org-scoped stats"
+**Driver:** an Administrator of org A sees totals across every org on the platform (their own + everyone else's) on Home.razor's stats cards. Same data leaks via the anonymous `GET /api/dashboard` endpoint on the gateway — anyone with HTTP access to the platform reads `TotalWallets` / `TotalOrganizations` / `TotalTransactions` without authentication.
+
+## Current state
+
+| Surface | Today |
+|---|---|
+| `Sorcha.ApiGateway/Program.cs:151` `GET /api/dashboard` | Anonymous. Returns `DashboardStatistics` aggregated from each backend `/api/stats`. |
+| Each backend `/api/stats` (Wallet, Blueprint, Register, Tenant `/api/organizations/stats`) | Anonymous. Returns platform-wide counts only. |
+| `Sorcha.ApiGateway/Services/DashboardStatisticsService.cs` | No org context anywhere in the call chain. |
+| `Sorcha.UI.Components.User/Services/User/DashboardService.cs:28` | Calls `/api/dashboard`. No org context. |
+| `Sorcha.UI.Web.Client/Pages/Home.razor:45` | Stats card grid gated to `Administrator,SystemAdmin,Auditor`. All cards render whatever the gateway returned. |
+
+## Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| **D1** | Path A — push org filter all the way through the call chain. | Backend filter is canonical; UI-only filter (Path B) wouldn't fix the gateway data-leak. |
+| **D2** | Org-scoped is the default for **every** role, including SystemAdmin. | Matches the org-switcher pattern: every other page in the UI honours `UserContext.ActiveContextOrgId`. Consistency wins. |
+| **D3** | SystemAdmin sees a `View: Org · Platform` toggle on the dashboard. Other roles never see it. | Platform-view is the SystemAdmin power-user case. Showing the toggle to org admins would imply they have a view they cannot access — bad affordance. |
+| **D4** | `ConnectedPeers` + `TotalOrganizations` only render in **platform view**. In org view they are hidden, not zeroed. | Both are infrastructure-wide signals an org admin has no agency over. Per Home.razor:174 comment, "Citizens have no agency over infrastructure health" — extend that principle to org admins. |
+| **D5** | Auth at the gateway endpoint, not at each backend `/api/stats`. | Backend stats stay anonymous-callable-with-`?orgId=`; the security boundary is the gateway. Avoids changing the s2s pattern for an internal-only metric surface. |
+| **D6** | Org id passes as `?orgId={guid}` query param on every backend `/api/stats`. Omitting the param = platform-wide (SystemAdmin platform view only). | Query param is more cache-friendly than headers and trivial to filter in EF. |
+| **D7** | `RecentTransactions` in org view = "transactions across registers the org is subscribed to". | Register-level data is org-scoped via `OrganizationRegisterSubscriptions`. Subset is correct and cheap to compute (Tenant already exposes the join). |
+| **D8** | `ActiveRegisters` in org view = `OrganizationRegisterSubscriptions` count with `Status=Active`. | Already the visible truth on the Registers page; same number on the dashboard avoids divergence. |
+| **D9** | `ActiveBlueprints` in org view = blueprints published by the org's own participants. | Blueprint publish is org-scoped via the publishing participant's org. |
+| **D10** | `TotalWallets` in org view = wallets with `Tenant = orgId`. | `wallet.Wallets.Tenant` already carries org id. |
+
+## Wire shape (after the change)
+
+```jsonc
+// org view (default)
+GET /api/dashboard
+Authorization: Bearer <user-jwt-with-org_id>
+
+200 OK
+{
+  "scope": "org",
+  "orgId": "0ce531bf-...",
+  "activeBlueprints": 3,
+  "totalWallets": 7,
+  "recentTransactions": 142,
+  "activeRegisters": 2,
+  // connectedPeers + totalOrganizations omitted
+  "timestamp": "2026-05-18T..."
+}
+
+// platform view (SystemAdmin only)
+GET /api/dashboard?scope=platform
+Authorization: Bearer <user-jwt-with-SystemAdmin-role>
+
+200 OK
+{
+  "scope": "platform",
+  "orgId": null,
+  "activeBlueprints": 41,
+  "totalWallets": 89,
+  "recentTransactions": 2,108,
+  "activeRegisters": 5,
+  "connectedPeers": 3,
+  "totalOrganizations": 5,
+  "timestamp": "..."
+}
+```
+
+`scope=platform` is honoured ONLY when the caller's JWT carries `SystemAdmin`. Other callers requesting it get an org-scoped response anyway (silent ignore — safer than 403).
+
+## Backend cost
+
+| Service | Change |
+|---|---|
+| Wallet | `IWalletRepository.CountAsync(string? tenantId)` overload; endpoint forwards param. |
+| Blueprint | Existing `/api/stats` already returns `blueprintCount`/`instanceCount` — add `?orgId=` filter via the publisher-participant→org join. |
+| Register | `/api/stats` filter: when `orgId` set, the count is "registers in `subscribedRegisterIds` for this org" — Register Service has no Tenant table so this needs a cross-service call to `Tenant.Service` for the subscription list. Cleaner: move the org-scoped read to Tenant Service, which already has `OrganizationRegisterSubscriptions`. Gateway picks the source per `scope`. |
+| Tenant | `/api/organizations/stats` already accepts an org context indirectly via the `/dashboard/{orgId}` endpoint (`DashboardService.GetDashboardAsync(orgId)`). New: a single composite stats endpoint that returns subscribed-register count + transaction roll-up for the org. |
+
+## Non-goals
+
+- No new metric surfaces. Same six cards, with scope discipline.
+- No caching strategy (current `/api/dashboard` is a fan-out per request; ~5 backend calls in parallel; fine for v1).
+- No realtime updates. Snapshot on page load + a Refresh button — current behaviour.
+- No history chart. Same point-in-time numbers.
+
+## Risk
+
+| Risk | Mitigation |
+|---|---|
+| Auditor role currently sees the same cards as Administrator; we're now scoping by org. Their view will change. | Acceptable — Auditors are org-scoped by definition. Org admins already expect this. |
+| Tests against `/api/dashboard` that don't carry a JWT will start 401-ing. | Inspect existing test fixtures; update any that exercise this surface. |
+| `?scope=platform` is JWT-claim-checked at the gateway; if claim extraction is wrong, SystemAdmin loses the platform view. | Existing `AuthorizationPolicies` already extract role claims; reuse them. |
+| Subscribed-register transaction count is a cross-service read (Register asks Tenant). Latency. | Acceptable — already five backend calls in parallel; one more isn't load-bearing. Cap timeout at 5 s (matches existing). |
+
+## Toggle UI
+
+`MudButtonGroup` with two buttons (Org / Platform), top-right of the stats grid, visible only when `IsInRole("SystemAdmin")`. Defaults to Org. Selection persists in `localStorage` keyed by user id so it survives reloads but doesn't bleed across users on a shared device.

--- a/specs/131-dashboard-org-scoping/plan.md
+++ b/specs/131-dashboard-org-scoping/plan.md
@@ -1,0 +1,64 @@
+# Plan — Dashboard org-scoping (UX-005, Feature 131)
+
+**Spec:** `spec.md`
+**Design:** `docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md`
+
+## Strategy
+
+Five layers, top-down. Land as **two PRs** to keep diffs reviewable; each PR self-contained and shippable.
+
+- **PR-A** — Backend stats endpoints accept `?orgId=` filter (Wallet, Blueprint, Register, Tenant). Includes unit tests. Behaviour without the param is unchanged, so this PR is a pure non-breaking extension and can ship independently.
+- **PR-B** — Gateway dashboard endpoint requires auth + scope-aware routing + UI toggle + UI card hiding. Depends on PR-A's filters being live.
+
+## Files
+
+### PR-A — backend filters
+
+| File | Change |
+|---|---|
+| `src/Services/Sorcha.Wallet.Service/Program.cs:315-333` | Accept `[FromQuery] Guid? orgId`. When set, call `IWalletRepository.CountAsync(tenantId: orgId.ToString())`. |
+| `src/Core/Sorcha.Wallet.Portable/Repositories/Interfaces/IWalletRepository.cs` | Overload `Task<int> CountAsync(string? tenantId = null, CancellationToken ct = default)`. |
+| `src/Core/Sorcha.Wallet.Portable/Repositories/EfCoreWalletRepository.cs` (or current impl) | Implement the overload; filter on `Tenant` column. |
+| `src/Services/Sorcha.Blueprint.Service/Program.cs:2322` (the `/api/stats` MapGet) | Accept `[FromQuery] Guid? orgId`. Filter via the publishing participant's `OrgId`. |
+| `src/Services/Sorcha.Blueprint.Service/Storage/IBlueprintStore.cs` (or whichever surface provides the count) | Add `CountByOrgAsync(Guid orgId)` if not present; reuse existing index. |
+| `src/Services/Sorcha.Register.Service/Program.cs:3105` | Accept `[FromQuery] Guid? orgId`. When set, return `{ registerCount = subscribedActive, transactionCount = sumAcrossSubscribed }`. Register Service calls Tenant Service via the existing service-to-service client for the subscription list (Register→Tenant cross-service hop). When unset, retain current platform-wide return. |
+| `src/Services/Sorcha.Tenant.Service/Endpoints/...` (org stats) | Already accepts org context via the dashboard service. Confirm `/api/organizations/stats` accepts `?orgId=` and returns `{ totalOrganizations = 1, totalUsers = orgUsers }` for that org; platform shape unchanged when omitted. |
+| `tests/Sorcha.Wallet.Service.Tests/.../StatsEndpointTests.cs` | Two cases: `?orgId=` filters; omitting returns platform total. |
+| `tests/Sorcha.Blueprint.Service.Tests/...` | Same pattern. |
+| `tests/Sorcha.Register.Service.Tests/...` | Same pattern + cross-service subscription read mock. |
+| `tests/Sorcha.Tenant.Service.Tests/...` | Confirm new shape. |
+
+### PR-B — gateway + UI
+
+| File | Change |
+|---|---|
+| `src/Services/Sorcha.ApiGateway/Program.cs:151` | `.RequireAuthorization()` on `/api/dashboard`. Accept `[FromQuery] string? scope`. Read `org_id` + role claims from `HttpContext.User`. Resolve effective scope: `platform` if `scope == "platform"` AND `IsInRole("SystemAdmin")`; else `org` with `orgId` from claim. Pass through to `DashboardStatisticsService`. |
+| `src/Services/Sorcha.ApiGateway/Services/DashboardStatisticsService.cs` | `GetDashboardStatisticsAsync(Guid? orgId, CancellationToken ct)`. Each fan-out method appends `?orgId={orgId}` to its backend call when set. |
+| `src/Services/Sorcha.ApiGateway/Services/DashboardStatisticsService.cs:198-212` (`DashboardStatistics` class) | Add `Scope` (string) + `OrgId` (Guid?). Keep `ConnectedPeers` + `TotalOrganizations` nullable; omit on serialize when null (default JsonIgnoreCondition.WhenWritingNull). |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/DashboardService.cs:28` | Accept `string? scope = null` param; forward `?scope=platform` when "platform". |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Dashboard/DashboardStatsViewModel.cs` | Add `Scope`, `OrgId`, `ConnectedPeers?`, `TotalOrganizations?` (nullable on the wire too). |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor` | Add scope-toggle `MudButtonGroup` (visible only when user is `SystemAdmin`). Bind selection to `localStorage` via `IJSRuntime` keyed by `platform_user_id`. Hide ConnectedPeers + TotalOrganizations cards when `_stats.Scope == "org"`. Reload stats on toggle change. |
+| `tests/Sorcha.ApiGateway.Tests/.../DashboardEndpointTests.cs` | Cases: anon → 401; non-admin → org scope; admin no-toggle → org scope; admin `?scope=platform` → platform scope; non-admin `?scope=platform` → org scope (silent ignore). |
+| `tests/Sorcha.UI.E2E.Tests/Docker/DashboardScopeTests.cs` (Playwright) | Smoke: SystemAdmin sees toggle, can flip; non-admin doesn't see toggle. |
+
+## PR ordering
+
+```
+PR-A backend filters  ──►  PR-B gateway + UI
+   (independent ship)         (depends on PR-A live)
+```
+
+PR-A is shippable in isolation — no caller uses `?orgId=` until PR-B. Risk: if PR-B is delayed, PR-A widens the API surface without exercising it. Acceptable; the contract is small.
+
+## Effort estimate
+
+- PR-A: ~4h (4 backends × ~30 min code + ~30 min test each; one cross-service hop for Register).
+- PR-B: ~5h (gateway claim extraction + UI toggle + localStorage + Playwright smoke).
+- Total: ~9h. Tracks the design's 8–10h estimate.
+
+## Verification
+
+- All four backends: unit tests pass with the `?orgId=` overload and the unscoped path.
+- Gateway: integration test pass for the four scope-resolution cases.
+- UI: Playwright smoke + manual run on n1 against `admin@sorcha.local` (SystemAdmin) and a freshly-created Administrator for org A (Acme Verification Co. exists from earlier walkthroughs).
+- SC-001 through SC-008 from `spec.md` validated on n1.

--- a/specs/131-dashboard-org-scoping/spec.md
+++ b/specs/131-dashboard-org-scoping/spec.md
@@ -1,0 +1,111 @@
+# Specification — Dashboard org-scoping (UX-005)
+
+**Feature:** 131
+**Status:** Draft
+**Roadmap:** v1 / Milestone M4
+**Design:** `docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md`
+
+## Problem statement
+
+The dashboard at `/` (Sorcha.UI.Web.Client/Pages/Home.razor) shows platform-wide totals to every signed-in admin/auditor. An Administrator of org A sees totals that include orgs B, C, D — wrong mental model and a soft data leak. The `GET /api/dashboard` endpoint that backs the cards is anonymous, so the same totals are readable by any unauthenticated HTTP caller — a hard data leak.
+
+## User stories
+
+### US1 · Org admin sees their own org's totals
+**As** an Administrator of org A
+**I want** the dashboard stats cards to count only my org's data
+**So that** my mental model of platform usage matches what I actually manage.
+
+**Acceptance:**
+- ActiveBlueprints reflects only blueprints published by participants in my org.
+- TotalWallets reflects only wallets with `Tenant = my-org-id`.
+- ActiveRegisters reflects only my org's `OrganizationRegisterSubscriptions` with `Status=Active`.
+- RecentTransactions reflects only transactions on registers I'm subscribed to.
+- ConnectedPeers and TotalOrganizations cards are hidden.
+- No platform-wide totals are visible anywhere on the page.
+
+### US2 · Auditor sees same scope as Administrator
+**As** an Auditor of org A
+**I want** to see exactly the same scope as my Administrator
+**So that** my read-only view is consistent with the actions I'm auditing.
+
+**Acceptance:** identical to US1; role differs but stats scope does not.
+
+### US3 · SystemAdmin defaults to org view, can toggle to platform
+**As** a SystemAdmin
+**I want** to default to the active context org and toggle to platform view explicitly
+**So that** my dashboard matches the rest of the UI when I'm acting as an org admin, and I can still see platform-wide health on demand.
+
+**Acceptance:**
+- On first load, the stats grid is org-scoped to my active context org (the org-switcher selection).
+- A `View: Org · Platform` toggle is present at top-right of the stats grid.
+- Selecting Platform reveals six cards (org-view's four plus ConnectedPeers and TotalOrganizations).
+- Toggle selection persists across reloads via localStorage keyed by my user id.
+
+### US4 · Unauthenticated callers cannot read totals
+**As** an outside HTTP caller
+**I want** `GET /api/dashboard` to refuse unauthenticated requests
+**So that** platform totals are not exfiltratable without an account.
+
+**Acceptance:**
+- `GET /api/dashboard` returns 401 without a valid bearer JWT.
+- Backend `/api/stats` endpoints stay anonymous (security boundary is the gateway).
+
+### US5 · SystemAdmin platform-view request is honoured only for SystemAdmin
+**As** the platform
+**I want** `?scope=platform` to be silently ignored for non-SystemAdmin callers
+**So that** an org admin cannot surface platform totals by guessing the URL.
+
+**Acceptance:**
+- `GET /api/dashboard?scope=platform` from a non-SystemAdmin JWT returns org-scoped data, with `scope: "org"` in the response.
+- Same request from SystemAdmin returns platform-scoped data with `scope: "platform"`.
+
+## Functional requirements
+
+| FR | Requirement |
+|---|---|
+| FR-001 | `GET /api/dashboard` MUST require a valid bearer JWT. |
+| FR-002 | The endpoint MUST honour `?scope=platform` only when the caller's JWT carries the `SystemAdmin` role; otherwise the response MUST be org-scoped to `org_id` from the JWT. |
+| FR-003 | Response MUST include `scope` ("org"\|"platform") and `orgId` (null when scope is platform) fields. |
+| FR-004 | Org-scoped responses MUST NOT include `connectedPeers` or `totalOrganizations`. |
+| FR-005 | Org-scoped `activeBlueprints` MUST be derived from blueprints whose publishing participant belongs to the caller's org. |
+| FR-006 | Org-scoped `totalWallets` MUST be derived from `wallet.Wallets` rows with `Tenant = orgId`. |
+| FR-007 | Org-scoped `activeRegisters` MUST equal the count of `OrganizationRegisterSubscriptions` rows for the org with `Status=Active`. |
+| FR-008 | Org-scoped `recentTransactions` MUST equal the sum of transaction counts on the org's subscribed registers (Status=Active). |
+| FR-009 | Platform-scoped responses retain the current six-card shape. |
+| FR-010 | Backend `/api/stats` endpoints MUST accept an optional `?orgId={guid}` query parameter. When present, they MUST filter their counts to that org's data. When absent, they MUST return platform-wide counts (preserving today's wire shape). |
+| FR-011 | The UI MUST hide the ConnectedPeers and TotalOrganizations cards when `scope == "org"`. |
+| FR-012 | The UI MUST render a `MudButtonGroup` scope toggle visible only when the caller is in role `SystemAdmin`. |
+| FR-013 | Toggle selection MUST persist in `localStorage` keyed by `platform_user_id` claim. |
+
+## Success criteria
+
+| SC | Criterion |
+|---|---|
+| SC-001 | `curl https://n1.sorcha.dev/api/dashboard` (no auth) returns 401. |
+| SC-002 | `admin@sorcha.local` (SystemAdmin) sees the toggle; org view returns 4 cards; platform view returns 6 cards. |
+| SC-003 | A non-SystemAdmin Administrator sees 4 cards and no toggle. |
+| SC-004 | `?scope=platform` requested by a non-SystemAdmin returns `scope: "org"` in the response body and the four org-scoped fields only. |
+| SC-005 | After a SystemAdmin selects Platform and reloads, the platform view is still rendered (localStorage persistence). |
+| SC-006 | Numbers in org view match the corresponding lists: `totalWallets` = `/api/wallets?orgId=...` count, `activeRegisters` = Registers page count, etc. |
+| SC-007 | No backend `/api/stats` endpoint has been moved off `AllowAnonymous`; gateway is the only auth gate. |
+| SC-008 | Page load time of the dashboard is within 10% of the pre-change baseline (parallel-fan-out preserved). |
+
+## Out of scope
+
+- Caching strategy (current snapshot-per-request retained).
+- Realtime updates / SignalR fan-out for stats.
+- Historical/time-series view.
+- Additional metric surfaces (e.g. presentation counts, credential issuances).
+- Auditor's separate "audit log" page — UX-004 is a separate task.
+
+## Dependencies
+
+- **Reads** `OrganizationRegisterSubscriptions` (Tenant Service) — already in production for UX-001.
+- **Reads** `wallet.Wallets.Tenant` column — already populated.
+- **Reads** JWT `org_id`, `platform_user_id`, `role` claims — standard Sorcha JWT shape.
+- **Touches** SystemAdmin's localStorage key shape — first time we use this; document the key.
+
+## Open questions
+
+None at design time. Three questions were resolved in the design session (Path A, org-by-default-toggle-to-platform, both-scoped).

--- a/specs/131-dashboard-org-scoping/tasks.md
+++ b/specs/131-dashboard-org-scoping/tasks.md
@@ -1,0 +1,87 @@
+# Tasks — Dashboard org-scoping (UX-005, Feature 131)
+
+**Spec:** `spec.md`
+**Plan:** `plan.md`
+
+## PR-A — Backend filters
+
+### Wallet Service
+
+- [ ] **T001** — Add `Task<int> CountAsync(string? tenantId = null, CancellationToken ct = default)` overload to `IWalletRepository`.
+- [ ] **T002** — Implement the overload in the EF Core repository; filter on `Tenant` column when set.
+- [ ] **T003** — Update `/api/stats` endpoint at `Sorcha.Wallet.Service/Program.cs:315` to accept `[FromQuery] Guid? orgId` and pass it as `tenantId.ToString()` when set.
+- [ ] **T004** — Unit tests in `Sorcha.Wallet.Service.Tests`: orgId-filter case + unscoped case.
+
+### Blueprint Service
+
+- [ ] **T005** — Confirm `BlueprintRecord` (or the equivalent storage row) carries an org id; add an index on it if missing.
+- [ ] **T006** — Add `CountByOrgAsync(Guid orgId)` to the blueprint count surface (or extend the existing count call to accept an optional org filter).
+- [ ] **T007** — Update `/api/stats` at `Sorcha.Blueprint.Service/Program.cs:2322` to accept `[FromQuery] Guid? orgId` and forward.
+- [ ] **T008** — Same shape for `instanceCount` + `activeInstanceCount` if applicable (filter via instance's blueprint→org link).
+- [ ] **T009** — Unit tests in `Sorcha.Blueprint.Service.Tests`.
+
+### Register Service
+
+- [ ] **T010** — In `Sorcha.Register.Service/Program.cs:3105`, accept `[FromQuery] Guid? orgId`.
+- [ ] **T011** — When orgId is set, Register Service calls Tenant Service (`ITenantSubscriptionClient.ListSubscribedRegistersAsync(orgId)` or the equivalent existing s2s client) for the org's subscribed active register ids; return `registerCount = subscribed.Count` and `transactionCount = sum of per-register transactionCount across subscribed`. Decision: Register→Tenant call shape, not gateway-orchestrated — keeps the gateway endpoint as a single fan-out and isolates the org-scoping logic inside Register Service. Tracked: Tenant becomes a downstream dep of Register for this endpoint; document in `Sorcha.Register.Service/README.md`.
+- [ ] **T012** — When orgId is null, return the existing platform-wide shape.
+- [ ] **T013** — Unit tests: mock the subscription client; verify cross-service read path; verify unscoped path.
+
+### Tenant Service
+
+- [ ] **T014** — Confirm `/api/organizations/stats` accepts `?orgId=` and returns `{ totalOrganizations = 1, totalUsers = orgUsers }` for that org. If not, extend.
+- [ ] **T015** — Unit tests for both shapes.
+
+### PR-A wrap
+
+- [ ] **T016** — Run full `dotnet test` for all four service test projects.
+- [ ] **T017** — Open PR-A, await CI green + claude-review, squash-merge.
+
+---
+
+## PR-B — Gateway + UI
+
+### Gateway
+
+- [ ] **T018** — In `Sorcha.ApiGateway/Program.cs:151` change `app.MapGet("/api/dashboard", …)` to `.RequireAuthorization()`. Accept `[FromQuery] string? scope` and `HttpContext`.
+- [ ] **T019** — Extract `org_id` (claim type from `Sorcha.ServiceDefaults.Auth`), `platform_user_id`, role from `HttpContext.User`. Compute effective scope: `platform` iff `scope=="platform" && context.User.IsInRole("SystemAdmin")`; else `org` with the claim's org id.
+- [ ] **T020** — Refactor `DashboardStatisticsService.GetDashboardStatisticsAsync` signature: `(Guid? orgId, CancellationToken ct)`. Append `?orgId={orgId}` to each backend call when set; omit when null.
+- [ ] **T021** — Extend `DashboardStatistics` DTO with `Scope` (string) + `OrgId` (Guid?). Mark `ConnectedPeers` + `TotalOrganizations` as nullable; configure `JsonIgnoreCondition.WhenWritingNull` on the response.
+- [ ] **T022** — Gateway integration tests in `Sorcha.ApiGateway.Tests`:
+  - anonymous → 401
+  - non-admin user → org scope; the two platform-only fields omitted
+  - SystemAdmin no toggle → org scope
+  - SystemAdmin `?scope=platform` → platform scope; all six fields populated
+  - non-admin `?scope=platform` → org scope (silent ignore); response `scope: "org"`
+
+### UI
+
+- [ ] **T023** — Update `IDashboardService.GetDashboardStatsAsync` signature to accept `string? scope = null`.
+- [ ] **T024** — Update `DashboardService` impl to forward `?scope=platform` to the gateway when "platform".
+- [ ] **T025** — Extend `DashboardStatsViewModel` (`Sorcha.UI.Components.User/Models/User/Dashboard/`): add `Scope`, `OrgId`, make `ConnectedPeers` + `TotalOrganizations` nullable.
+- [ ] **T026** — In `Sorcha.UI.Web.Client/Pages/Home.razor`:
+  - Render a `MudButtonGroup` scope toggle (`Org` / `Platform`) at the top-right of the stats grid, wrapped in `<AuthorizeView Roles="SystemAdmin">`.
+  - Bind toggle to `_scope` field; on change, reload stats and persist `_scope` in `localStorage["dashboard-scope-{platform_user_id}"]`.
+  - On `OnInitializedAsync`, read localStorage to restore prior selection.
+  - Hide ConnectedPeers + TotalOrganizations cards when `_stats.Scope == "org"`.
+- [ ] **T027** — Add `data-testid` attributes: `dashboard-scope-toggle`, `dashboard-scope-org`, `dashboard-scope-platform`, `dashboard-card-peers`, `dashboard-card-organizations`.
+- [ ] **T028** — Playwright smoke at `tests/Sorcha.UI.E2E.Tests/Docker/DashboardScopeTests.cs`:
+  - SystemAdmin sees toggle, can flip Org↔Platform, six-vs-four cards.
+  - Administrator does not see the toggle; sees four cards.
+- [ ] **T029** — Manual smoke on n1: `admin@sorcha.local` (SystemAdmin) flips toggle; `verification-admin@assured-identity.local` (Administrator of an org) sees scope-locked org view.
+
+### PR-B wrap
+
+- [ ] **T030** — Run full `dotnet test` + `dotnet test --filter Category=Dashboard` for E2E.
+- [ ] **T031** — Open PR-B, await CI + claude-review, squash-merge.
+- [ ] **T032** — n1 deploy: pull `sorchadev/ui-web:latest`, `sorchadev/api-gateway:latest`, `sorchadev/wallet-service:latest`, `sorchadev/blueprint-service:latest`, `sorchadev/register-service:latest`, `sorchadev/tenant-service:latest` (any service whose image changed). Recreate.
+- [ ] **T033** — On n1: validate SC-001 through SC-008 from `spec.md`. Mark UX-005 ✅ in MASTER-TASKS line 231.
+
+---
+
+## Definition of done
+
+- Tasks T001–T033 closed.
+- SC-001 through SC-008 in `spec.md` verified on n1.
+- MASTER-TASKS UX-005 row marked ✅ with PR refs.
+- Roadmap M4 line for UX-005 either struck (if combined with the docs-strike PR) or annotated with the PR refs.


### PR DESCRIPTION
## Summary

Specifies the v1 roadmap M4 line **UX-005 Dashboard org-scoped stats** as Feature 131. Four artefacts under `specs/131-dashboard-org-scoping/` plus a brainstorm design doc.

**Problem:** Home.razor's stats cards show platform-wide totals to any signed-in admin/auditor regardless of org. The backing `GET /api/dashboard` is anonymous — same totals leak to any unauthenticated HTTP caller.

**Decisions resolved during design:**
- Path A — push org filter through the call chain (not UI-only).
- Org-scoped by default for **every** role, including SystemAdmin. Matches the rest of the UI's org-switcher pattern.
- SystemAdmin gets a `View: Org · Platform` toggle, persisted in localStorage. Other roles never see it.
- `ConnectedPeers` and `TotalOrganizations` only render in platform view (hidden in org view, not zeroed).
- Auth at the gateway, not at backend `/api/stats` (stays anonymous-with-`?orgId=`).
- Register Service calls Tenant Service for the org's subscribed-register list (alternative was gateway orchestration).

**Files:**
- `docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md` — 10 design decisions, wire shape, risks.
- `specs/131-dashboard-org-scoping/spec.md` — 5 US, 13 FR, 8 SC.
- `specs/131-dashboard-org-scoping/plan.md` — two-PR strategy. PR-A: backend `?orgId=` filters on Wallet/Blueprint/Register/Tenant. PR-B: gateway auth + scope routing + UI toggle.
- `specs/131-dashboard-org-scoping/tasks.md` — T001–T033.

**Estimate:** ~9h total (PR-A ~4h, PR-B ~5h).

## Test plan

- [ ] CI green (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)