### PR TITLE
feat(131,PR-A): Register ?registerIds= filter + Tenant org-summary endpoint

### DIFF
--- a/docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md
+++ b/docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md
@@ -1,99 +1,109 @@
-# UX-005 — Dashboard org-scoping (design)
+# UX-005 — Dashboard org-scoping (design, v2)
 
 **Date:** 2026-05-18
 **Spec:** `specs/131-dashboard-org-scoping/`
 **Roadmap line:** M4 · "Dashboard org-scoped stats"
-**Driver:** an Administrator of org A sees totals across every org on the platform (their own + everyone else's) on Home.razor's stats cards. Same data leaks via the anonymous `GET /api/dashboard` endpoint on the gateway — anyone with HTTP access to the platform reads `TotalWallets` / `TotalOrganizations` / `TotalTransactions` without authentication.
+**Driver:** an Administrator of org A sees totals across every org on the platform on Home.razor's stats cards. Same data leaks via the anonymous `GET /api/dashboard`.
+
+## v2 history note
+
+v1 of this design assumed Wallet and Blueprint Service stats could be filtered by `?orgId=`. **They can't** — neither schema carries an org id. `wallet.Wallets.Tenant` is per-installation (`system`/`default`); `Wallet.Owner` is a PlatformUserId. Blueprints carry an owner wallet address. Org-scoping wallets/blueprints would require cross-service joins through Tenant Service (org → users → wallets, org → participants → blueprints), which doubles the new HTTP surface and the implementation cost.
+
+v2 (this doc) **redefines the org-view card set** to use only data Tenant Service already has direct access to. SystemAdmin's platform view is unchanged.
 
 ## Current state
 
 | Surface | Today |
 |---|---|
-| `Sorcha.ApiGateway/Program.cs:151` `GET /api/dashboard` | Anonymous. Returns `DashboardStatistics` aggregated from each backend `/api/stats`. |
-| Each backend `/api/stats` (Wallet, Blueprint, Register, Tenant `/api/organizations/stats`) | Anonymous. Returns platform-wide counts only. |
-| `Sorcha.ApiGateway/Services/DashboardStatisticsService.cs` | No org context anywhere in the call chain. |
-| `Sorcha.UI.Components.User/Services/User/DashboardService.cs:28` | Calls `/api/dashboard`. No org context. |
-| `Sorcha.UI.Web.Client/Pages/Home.razor:45` | Stats card grid gated to `Administrator,SystemAdmin,Auditor`. All cards render whatever the gateway returned. |
+| `Sorcha.ApiGateway/Program.cs:151` `GET /api/dashboard` | Anonymous. Returns `DashboardStatistics` (6 platform-wide fields) aggregated from each backend `/api/stats`. |
+| Each backend `/api/stats` | Anonymous, platform-wide. |
+| `Sorcha.UI.Web.Client/Pages/Home.razor:45` | Stats card grid gated to `Administrator,SystemAdmin,Auditor`. All cards render the gateway's response. |
 
 ## Decisions
 
 | # | Decision | Why |
 |---|---|---|
-| **D1** | Path A — push org filter all the way through the call chain. | Backend filter is canonical; UI-only filter (Path B) wouldn't fix the gateway data-leak. |
-| **D2** | Org-scoped is the default for **every** role, including SystemAdmin. | Matches the org-switcher pattern: every other page in the UI honours `UserContext.ActiveContextOrgId`. Consistency wins. |
-| **D3** | SystemAdmin sees a `View: Org · Platform` toggle on the dashboard. Other roles never see it. | Platform-view is the SystemAdmin power-user case. Showing the toggle to org admins would imply they have a view they cannot access — bad affordance. |
-| **D4** | `ConnectedPeers` + `TotalOrganizations` only render in **platform view**. In org view they are hidden, not zeroed. | Both are infrastructure-wide signals an org admin has no agency over. Per Home.razor:174 comment, "Citizens have no agency over infrastructure health" — extend that principle to org admins. |
-| **D5** | Auth at the gateway endpoint, not at each backend `/api/stats`. | Backend stats stay anonymous-callable-with-`?orgId=`; the security boundary is the gateway. Avoids changing the s2s pattern for an internal-only metric surface. |
-| **D6** | Org id passes as `?orgId={guid}` query param on every backend `/api/stats`. Omitting the param = platform-wide (SystemAdmin platform view only). | Query param is more cache-friendly than headers and trivial to filter in EF. |
-| **D7** | `RecentTransactions` in org view = "transactions across registers the org is subscribed to". | Register-level data is org-scoped via `OrganizationRegisterSubscriptions`. Subset is correct and cheap to compute (Tenant already exposes the join). |
-| **D8** | `ActiveRegisters` in org view = `OrganizationRegisterSubscriptions` count with `Status=Active`. | Already the visible truth on the Registers page; same number on the dashboard avoids divergence. |
-| **D9** | `ActiveBlueprints` in org view = blueprints published by the org's own participants. | Blueprint publish is org-scoped via the publishing participant's org. |
-| **D10** | `TotalWallets` in org view = wallets with `Tenant = orgId`. | `wallet.Wallets.Tenant` already carries org id. |
+| **D1** | Two distinct response shapes — **org-scope** and **platform-scope** — keyed by a `scope` discriminator. | Org and platform are different mental models, not the same set of cards filtered differently. Forcing one shape muddles labels (e.g. "Total Organizations: 1" is wrong for an org admin). |
+| **D2** | Org-scoped is the default for **every** role, including SystemAdmin. | Matches the org-switcher pattern: every other page in the UI honours `UserContext.ActiveContextOrgId`. |
+| **D3** | SystemAdmin sees a `View: Org · Platform` toggle on the dashboard. Other roles never see it. | Platform view is the SystemAdmin power-user case. Showing the toggle to org admins would imply a view they cannot access. |
+| **D4** | Auth at the gateway endpoint, not at each backend `/api/stats`. | Backend stats stay anonymous-callable; security boundary is the gateway. Closes the latent data-leak (anyone hitting `/api/dashboard` reads platform totals today). |
+| **D5** | Gateway computes scope = `platform` iff `scope=="platform" && role==SystemAdmin`; else `org` with the JWT's `org_id`. | Single auth-decision site. `?scope=platform` from a non-admin is silently downgraded to org-scope. |
+| **D6** | Org-scope source: **Tenant Service** owns the aggregate. Gateway delegates the whole org-view fetch to one Tenant endpoint. | Tenant already holds users-per-org, invitations-per-org, subscriptions-per-org. Adding a transactions-across-subscribed-registers field there is one cross-service call (Tenant → Register). Cleaner than gateway orchestration of 3 backends. |
+| **D7** | Platform-scope source: existing 5-way fan-out from `DashboardStatisticsService`. Unchanged shape. | SystemAdmin behaviour preserved; existing tests still apply. |
+| **D8** | Org-view cards: **Active users in org · Pending invitations · Subscribed registers · Recent transactions across subscribed registers**. | All four already-available without schema changes. Wallets and blueprints stay platform-only. |
+| **D9** | Register Service accepts `?registerIds=a,b,c` (comma-sep) on `/api/stats`. Tenant Service uses this when building org-scope response. | One new query param on Register, no new endpoint. Sum scoped to the listed registers. |
+| **D10** | Toggle persists in `localStorage` keyed by `platform_user_id`. SystemAdmin selecting Platform stays Platform across reloads. | Matches the SystemAdmin's intent. Scoped to user so a shared device doesn't bleed selection. |
 
-## Wire shape (after the change)
+## Wire shape
 
 ```jsonc
-// org view (default)
+// org scope (default for everyone)
 GET /api/dashboard
-Authorization: Bearer <user-jwt-with-org_id>
+Authorization: Bearer <user-jwt>
 
 200 OK
 {
   "scope": "org",
   "orgId": "0ce531bf-...",
-  "activeBlueprints": 3,
-  "totalWallets": 7,
+  "activeUsers": 5,
+  "pendingInvitations": 2,
+  "subscribedRegisters": 3,
   "recentTransactions": 142,
-  "activeRegisters": 2,
-  // connectedPeers + totalOrganizations omitted
-  "timestamp": "2026-05-18T..."
+  "timestamp": "..."
 }
 
-// platform view (SystemAdmin only)
+// platform scope (SystemAdmin + ?scope=platform only)
 GET /api/dashboard?scope=platform
-Authorization: Bearer <user-jwt-with-SystemAdmin-role>
+Authorization: Bearer <systemadmin-jwt>
 
 200 OK
 {
   "scope": "platform",
   "orgId": null,
-  "activeBlueprints": 41,
+  "totalBlueprints": 41,
+  "totalBlueprintInstances": 0,
+  "activeBlueprintInstances": 0,
   "totalWallets": 89,
-  "recentTransactions": 2,108,
-  "activeRegisters": 5,
+  "totalRegisters": 5,
+  "totalTransactions": 2108,
+  "totalTenants": 5,
   "connectedPeers": 3,
-  "totalOrganizations": 5,
   "timestamp": "..."
 }
 ```
 
-`scope=platform` is honoured ONLY when the caller's JWT carries `SystemAdmin`. Other callers requesting it get an org-scoped response anyway (silent ignore — safer than 403).
+The UI knows by `scope` which card set to render; org-only fields are omitted in platform shape and vice versa.
 
 ## Backend cost
 
 | Service | Change |
 |---|---|
-| Wallet | `IWalletRepository.CountAsync(string? tenantId)` overload; endpoint forwards param. |
-| Blueprint | Existing `/api/stats` already returns `blueprintCount`/`instanceCount` — add `?orgId=` filter via the publisher-participant→org join. |
-| Register | `/api/stats` filter: when `orgId` set, the count is "registers in `subscribedRegisterIds` for this org" — Register Service has no Tenant table so this needs a cross-service call to `Tenant.Service` for the subscription list. Cleaner: move the org-scoped read to Tenant Service, which already has `OrganizationRegisterSubscriptions`. Gateway picks the source per `scope`. |
-| Tenant | `/api/organizations/stats` already accepts an org context indirectly via the `/dashboard/{orgId}` endpoint (`DashboardService.GetDashboardAsync(orgId)`). New: a single composite stats endpoint that returns subscribed-register count + transaction roll-up for the org. |
+| Tenant | Extend `DashboardService.GetDashboardAsync(orgId)` (or add a sibling method) to return: active-user count (already), pending-invitations (already), subscribed-registers count (new — count `OrganizationRegisterSubscriptions` with `Status=Active`), recent-transactions (new — call Register `/api/stats?registerIds=...` and sum). New endpoint or extended response on existing `/api/organizations/{orgId}/dashboard`. |
+| Register | Accept `?registerIds=a,b,c` on `/api/stats`. When set, `transactionCount` is the sum across the listed registers. `registerCount` becomes the listed count (defensive — Tenant already knows it, but consistent). Unset = current platform-wide shape. |
+| Wallet, Blueprint | **No change.** Wallets/blueprints not in the org view; platform view uses the existing endpoints. |
+| Gateway | `/api/dashboard`: `.RequireAuthorization()`. Extract `org_id`, `platform_user_id`, role. Resolve effective scope. Org → call Tenant `/api/organizations/{orgId}/dashboard-summary`, return as `scope=org` response. Platform → existing fan-out, return as `scope=platform`. |
 
-## Non-goals
+## UI
 
-- No new metric surfaces. Same six cards, with scope discipline.
-- No caching strategy (current `/api/dashboard` is a fan-out per request; ~5 backend calls in parallel; fine for v1).
-- No realtime updates. Snapshot on page load + a Refresh button — current behaviour.
-- No history chart. Same point-in-time numbers.
+`MudButtonGroup` toggle (`Org` / `Platform`), top-right of stats grid, wrapped in `<AuthorizeView Roles="SystemAdmin">`. Defaults to `Org`. Selection persists in `localStorage["dashboard-scope-{platform_user_id}"]`.
+
+Card grid is conditional on `_stats.Scope`:
+
+- **Org** — Active users (org icon), Pending invitations (mail icon), Subscribed registers (storage icon), Recent transactions (receipt icon). Four cards.
+- **Platform** — current six cards unchanged.
 
 ## Risk
 
 | Risk | Mitigation |
 |---|---|
-| Auditor role currently sees the same cards as Administrator; we're now scoping by org. Their view will change. | Acceptable — Auditors are org-scoped by definition. Org admins already expect this. |
 | Tests against `/api/dashboard` that don't carry a JWT will start 401-ing. | Inspect existing test fixtures; update any that exercise this surface. |
-| `?scope=platform` is JWT-claim-checked at the gateway; if claim extraction is wrong, SystemAdmin loses the platform view. | Existing `AuthorizationPolicies` already extract role claims; reuse them. |
-| Subscribed-register transaction count is a cross-service read (Register asks Tenant). Latency. | Acceptable — already five backend calls in parallel; one more isn't load-bearing. Cap timeout at 5 s (matches existing). |
+| Tenant→Register call adds latency to the org view path. | Acceptable — single call with N register ids; capped at 5s per existing fan-out timeout. Cache-friendly if a near-future iteration adds it. |
+| Auditor's view changes from platform-totals (current) to org-scoped (new). | Acceptable — Auditor scope is the org they audit. Confirm with operator in spec acceptance. |
 
-## Toggle UI
+## Non-goals
 
-`MudButtonGroup` with two buttons (Org / Platform), top-right of the stats grid, visible only when `IsInRole("SystemAdmin")`. Defaults to Org. Selection persists in `localStorage` keyed by user id so it survives reloads but doesn't bleed across users on a shared device.
+- No caching strategy (snapshot-per-request preserved).
+- No realtime SignalR fan-out.
+- No history / time-series.
+- No new metric surfaces (e.g. credential issuance counts).
+- No Wallet/Blueprint org-scoping. Deferred until either schema grows an `OrganizationId` column or we decide cross-service joins are worth the new HTTP surface.

--- a/specs/131-dashboard-org-scoping/plan.md
+++ b/specs/131-dashboard-org-scoping/plan.md
@@ -1,64 +1,65 @@
-# Plan — Dashboard org-scoping (UX-005, Feature 131)
+# Plan — Dashboard org-scoping (UX-005, Feature 131, v2)
 
 **Spec:** `spec.md`
 **Design:** `docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md`
 
 ## Strategy
 
-Five layers, top-down. Land as **two PRs** to keep diffs reviewable; each PR self-contained and shippable.
+Three layers, ordered. Two PRs.
 
-- **PR-A** — Backend stats endpoints accept `?orgId=` filter (Wallet, Blueprint, Register, Tenant). Includes unit tests. Behaviour without the param is unchanged, so this PR is a pure non-breaking extension and can ship independently.
-- **PR-B** — Gateway dashboard endpoint requires auth + scope-aware routing + UI toggle + UI card hiding. Depends on PR-A's filters being live.
+- **PR-A** — Backend support:
+  1. Register Service `/api/stats` accepts `?registerIds=`.
+  2. Tenant Service grows an org-summary surface (returns 4 org-scoped fields including `recentTransactions` via Tenant→Register cross-service call).
+  Behaviour without the new param/endpoint is unchanged. Shippable independently.
+- **PR-B** — Gateway + UI:
+  1. Gateway `/api/dashboard` requires auth; resolves scope; routes org→Tenant, platform→existing fan-out.
+  2. UI scope toggle, conditional card grid, localStorage persistence.
+  Depends on PR-A live.
 
 ## Files
 
-### PR-A — backend filters
+### PR-A — backend
 
 | File | Change |
 |---|---|
-| `src/Services/Sorcha.Wallet.Service/Program.cs:315-333` | Accept `[FromQuery] Guid? orgId`. When set, call `IWalletRepository.CountAsync(tenantId: orgId.ToString())`. |
-| `src/Core/Sorcha.Wallet.Portable/Repositories/Interfaces/IWalletRepository.cs` | Overload `Task<int> CountAsync(string? tenantId = null, CancellationToken ct = default)`. |
-| `src/Core/Sorcha.Wallet.Portable/Repositories/EfCoreWalletRepository.cs` (or current impl) | Implement the overload; filter on `Tenant` column. |
-| `src/Services/Sorcha.Blueprint.Service/Program.cs:2322` (the `/api/stats` MapGet) | Accept `[FromQuery] Guid? orgId`. Filter via the publishing participant's `OrgId`. |
-| `src/Services/Sorcha.Blueprint.Service/Storage/IBlueprintStore.cs` (or whichever surface provides the count) | Add `CountByOrgAsync(Guid orgId)` if not present; reuse existing index. |
-| `src/Services/Sorcha.Register.Service/Program.cs:3105` | Accept `[FromQuery] Guid? orgId`. When set, return `{ registerCount = subscribedActive, transactionCount = sumAcrossSubscribed }`. Register Service calls Tenant Service via the existing service-to-service client for the subscription list (Register→Tenant cross-service hop). When unset, retain current platform-wide return. |
-| `src/Services/Sorcha.Tenant.Service/Endpoints/...` (org stats) | Already accepts org context via the dashboard service. Confirm `/api/organizations/stats` accepts `?orgId=` and returns `{ totalOrganizations = 1, totalUsers = orgUsers }` for that org; platform shape unchanged when omitted. |
-| `tests/Sorcha.Wallet.Service.Tests/.../StatsEndpointTests.cs` | Two cases: `?orgId=` filters; omitting returns platform total. |
-| `tests/Sorcha.Blueprint.Service.Tests/...` | Same pattern. |
-| `tests/Sorcha.Register.Service.Tests/...` | Same pattern + cross-service subscription read mock. |
-| `tests/Sorcha.Tenant.Service.Tests/...` | Confirm new shape. |
+| `src/Services/Sorcha.Register.Service/Program.cs:3105` | Accept `[FromQuery] string? registerIds`. When non-empty (comma-split, validated as ids), return `{ registerCount = listed.Count, transactionCount = sumAcrossListed }`. When null, retain platform-wide shape. |
+| `src/Services/Sorcha.Tenant.Service/Services/IDashboardService.cs` | Add `Task<OrgSummaryResponse> GetOrgSummaryAsync(Guid orgId, CancellationToken ct)`. New DTO `OrgSummaryResponse { Guid OrgId, int ActiveUsers, int PendingInvitations, int SubscribedRegisters, int RecentTransactions, DateTimeOffset Timestamp }`. |
+| `src/Services/Sorcha.Tenant.Service/Services/DashboardService.cs` | Implement `GetOrgSummaryAsync`. Reuse existing user count + pending invitation count. Add `OrganizationRegisterSubscriptions` count query (Status=Active). Call `IRegisterServiceClient` with the subscribed register ids; sum `transactionCount`. |
+| `src/Services/Sorcha.Tenant.Service/Endpoints/DashboardEndpoints.cs` | Map `GET /api/organizations/{orgId:guid}/dashboard-summary` → `GetOrgSummaryAsync`. Policy `RequireAuthenticated` (any signed-in org member). |
+| `src/Common/Sorcha.ServiceClients.Http/Register/IRegisterServiceClient.cs` + impl | Add `Task<RegisterStatsResponse> GetStatsAsync(IReadOnlyList<string>? registerIds = null, CancellationToken ct = default)`. URL builder joins ids with `,`. |
+| `tests/Sorcha.Register.Service.Tests/...` | Two tests: `?registerIds=` filters to sum; unset returns platform shape. |
+| `tests/Sorcha.Tenant.Service.Tests/Services/DashboardServiceOrgSummaryTests.cs` | Cases: user count, invitations, subscriptions, mocked Register call for transactions, error path (Register down → recentTransactions = 0). |
 
 ### PR-B — gateway + UI
 
 | File | Change |
 |---|---|
-| `src/Services/Sorcha.ApiGateway/Program.cs:151` | `.RequireAuthorization()` on `/api/dashboard`. Accept `[FromQuery] string? scope`. Read `org_id` + role claims from `HttpContext.User`. Resolve effective scope: `platform` if `scope == "platform"` AND `IsInRole("SystemAdmin")`; else `org` with `orgId` from claim. Pass through to `DashboardStatisticsService`. |
-| `src/Services/Sorcha.ApiGateway/Services/DashboardStatisticsService.cs` | `GetDashboardStatisticsAsync(Guid? orgId, CancellationToken ct)`. Each fan-out method appends `?orgId={orgId}` to its backend call when set. |
-| `src/Services/Sorcha.ApiGateway/Services/DashboardStatisticsService.cs:198-212` (`DashboardStatistics` class) | Add `Scope` (string) + `OrgId` (Guid?). Keep `ConnectedPeers` + `TotalOrganizations` nullable; omit on serialize when null (default JsonIgnoreCondition.WhenWritingNull). |
-| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/DashboardService.cs:28` | Accept `string? scope = null` param; forward `?scope=platform` when "platform". |
-| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Dashboard/DashboardStatsViewModel.cs` | Add `Scope`, `OrgId`, `ConnectedPeers?`, `TotalOrganizations?` (nullable on the wire too). |
-| `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor` | Add scope-toggle `MudButtonGroup` (visible only when user is `SystemAdmin`). Bind selection to `localStorage` via `IJSRuntime` keyed by `platform_user_id`. Hide ConnectedPeers + TotalOrganizations cards when `_stats.Scope == "org"`. Reload stats on toggle change. |
-| `tests/Sorcha.ApiGateway.Tests/.../DashboardEndpointTests.cs` | Cases: anon → 401; non-admin → org scope; admin no-toggle → org scope; admin `?scope=platform` → platform scope; non-admin `?scope=platform` → org scope (silent ignore). |
-| `tests/Sorcha.UI.E2E.Tests/Docker/DashboardScopeTests.cs` (Playwright) | Smoke: SystemAdmin sees toggle, can flip; non-admin doesn't see toggle. |
+| `src/Services/Sorcha.ApiGateway/Program.cs:151` | `.RequireAuthorization()`. Accept `[FromQuery] string? scope` and `HttpContext`. Resolve effective scope. Org → call Tenant `/api/organizations/{orgId}/dashboard-summary`; map result to `DashboardResponse { scope:"org", orgId, activeUsers, pendingInvitations, subscribedRegisters, recentTransactions, timestamp }`. Platform → existing fan-out, decorate with `scope:"platform", orgId:null`. |
+| `src/Services/Sorcha.ApiGateway/Services/DashboardStatisticsService.cs` | Add `Scope` + `OrgId` to `DashboardStatistics`. Add `GetOrgSummaryAsync(Guid orgId, string? bearerToken)` that calls Tenant. |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/DashboardService.cs:28` | Accept `string? scope = null`; forward `?scope=platform` when provided. |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Dashboard/DashboardStatsViewModel.cs` | Add `Scope` (`"org"`\|`"platform"`), `OrgId` (Guid?), org-only fields (`ActiveUsers`, `PendingInvitations`, `SubscribedRegisters`, `RecentTransactions`) — all nullable so platform shape doesn't fill them. |
+| `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Home.razor` | (a) Add scope-toggle `MudButtonGroup` inside `<AuthorizeView Roles="SystemAdmin">`, top-right of the stats grid. (b) Bind to `_scope`, reload stats on change, persist in `localStorage`. (c) Replace single card grid with two `@if (_stats.Scope == "org")` / `@else` branches. Org branch: 4 cards. Platform branch: existing 6 cards. |
+| `tests/Sorcha.ApiGateway.Tests/...` | Anonymous→401; non-admin→org; admin no-toggle→org; admin scope=platform→platform; non-admin scope=platform→org (silent ignore). |
+| `tests/Sorcha.UI.E2E.Tests/Docker/DashboardScopeTests.cs` (Playwright) | Smoke: SystemAdmin sees toggle, can flip; Administrator (non-system) doesn't see toggle; both render expected card counts. |
 
 ## PR ordering
 
 ```
-PR-A backend filters  ──►  PR-B gateway + UI
-   (independent ship)         (depends on PR-A live)
+PR-A backend (Register filter + Tenant summary endpoint)
+        │  shippable independently — no caller uses it yet
+        ▼
+PR-B gateway + UI
 ```
-
-PR-A is shippable in isolation — no caller uses `?orgId=` until PR-B. Risk: if PR-B is delayed, PR-A widens the API surface without exercising it. Acceptable; the contract is small.
 
 ## Effort estimate
 
-- PR-A: ~4h (4 backends × ~30 min code + ~30 min test each; one cross-service hop for Register).
-- PR-B: ~5h (gateway claim extraction + UI toggle + localStorage + Playwright smoke).
-- Total: ~9h. Tracks the design's 8–10h estimate.
+- PR-A: ~4h (Register query-param parse, Tenant new method + endpoint + cross-service call + tests).
+- PR-B: ~5h (Gateway routing + UI toggle + localStorage + Playwright smoke).
+- Total: ~9h. Tracks prior estimate.
 
 ## Verification
 
-- All four backends: unit tests pass with the `?orgId=` overload and the unscoped path.
-- Gateway: integration test pass for the four scope-resolution cases.
-- UI: Playwright smoke + manual run on n1 against `admin@sorcha.local` (SystemAdmin) and a freshly-created Administrator for org A (Acme Verification Co. exists from earlier walkthroughs).
+- All target backends' unit tests pass with new param/endpoint and the unchanged unscoped path.
+- Gateway integration tests pass for the five scope-resolution cases.
+- Playwright smoke + manual run on n1: `admin@sorcha.local` (SystemAdmin) flips toggle and sees both views; `verification-admin@assured-identity.local` (Administrator of Acme Verification Co.) sees org view only.
 - SC-001 through SC-008 from `spec.md` validated on n1.

--- a/specs/131-dashboard-org-scoping/spec.md
+++ b/specs/131-dashboard-org-scoping/spec.md
@@ -1,46 +1,46 @@
 # Specification — Dashboard org-scoping (UX-005)
 
 **Feature:** 131
-**Status:** Draft
+**Status:** Draft (v2 — pivoted after Wallet/Blueprint schema review)
 **Roadmap:** v1 / Milestone M4
 **Design:** `docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md`
 
 ## Problem statement
 
-The dashboard at `/` (Sorcha.UI.Web.Client/Pages/Home.razor) shows platform-wide totals to every signed-in admin/auditor. An Administrator of org A sees totals that include orgs B, C, D — wrong mental model and a soft data leak. The `GET /api/dashboard` endpoint that backs the cards is anonymous, so the same totals are readable by any unauthenticated HTTP caller — a hard data leak.
+`Sorcha.UI.Web.Client/Pages/Home.razor` shows platform-wide totals on stats cards to every signed-in admin/auditor. An Administrator of org A sees totals that include orgs B, C, D — wrong mental model. The `GET /api/dashboard` endpoint backing the cards is anonymous, so the totals leak to any unauthenticated HTTP caller — a soft data exposure.
+
+## v2 pivot
+
+v1 of this spec proposed pushing `?orgId=` through Wallet and Blueprint Service `/api/stats` endpoints. Schema review showed `wallet.Wallets` and blueprint storage carry no direct org id (only user/owner-wallet linkage). v2 redefines the org-view card set to use only Tenant Service's existing org-scoped data plus a Register Service tx-count filter.
 
 ## User stories
 
-### US1 · Org admin sees their own org's totals
+### US1 · Org admin sees their org's own scope
 **As** an Administrator of org A
-**I want** the dashboard stats cards to count only my org's data
-**So that** my mental model of platform usage matches what I actually manage.
+**I want** the dashboard cards to reflect data about my org
+**So that** my mental model matches what I manage.
 
 **Acceptance:**
-- ActiveBlueprints reflects only blueprints published by participants in my org.
-- TotalWallets reflects only wallets with `Tenant = my-org-id`.
-- ActiveRegisters reflects only my org's `OrganizationRegisterSubscriptions` with `Status=Active`.
-- RecentTransactions reflects only transactions on registers I'm subscribed to.
-- ConnectedPeers and TotalOrganizations cards are hidden.
-- No platform-wide totals are visible anywhere on the page.
+- Card grid shows: Active users in org · Pending invitations · Subscribed registers · Recent transactions across subscribed registers. Four cards.
+- No platform-wide totals (Wallets, Blueprints, ConnectedPeers, TotalOrganizations) anywhere on the page.
 
 ### US2 · Auditor sees same scope as Administrator
 **As** an Auditor of org A
-**I want** to see exactly the same scope as my Administrator
-**So that** my read-only view is consistent with the actions I'm auditing.
+**I want** the same scope as my Administrator
+**So that** my read-only view is consistent.
 
-**Acceptance:** identical to US1; role differs but stats scope does not.
+**Acceptance:** identical to US1.
 
 ### US3 · SystemAdmin defaults to org view, can toggle to platform
 **As** a SystemAdmin
-**I want** to default to the active context org and toggle to platform view explicitly
-**So that** my dashboard matches the rest of the UI when I'm acting as an org admin, and I can still see platform-wide health on demand.
+**I want** the dashboard to default to my active context org and let me explicitly switch to platform view
+**So that** my normal usage matches the rest of the UI but I can still see platform health.
 
 **Acceptance:**
-- On first load, the stats grid is org-scoped to my active context org (the org-switcher selection).
+- First load: org-scoped to my active context org (the org-switcher selection).
 - A `View: Org · Platform` toggle is present at top-right of the stats grid.
-- Selecting Platform reveals six cards (org-view's four plus ConnectedPeers and TotalOrganizations).
-- Toggle selection persists across reloads via localStorage keyed by my user id.
+- Selecting Platform reveals six cards: Active Blueprints, Total Wallets, Recent Transactions, Active Registers, Connected Peers, Total Organizations.
+- Toggle selection persists across reloads via `localStorage["dashboard-scope-{platform_user_id}"]`.
 
 ### US4 · Unauthenticated callers cannot read totals
 **As** an outside HTTP caller
@@ -51,31 +51,31 @@ The dashboard at `/` (Sorcha.UI.Web.Client/Pages/Home.razor) shows platform-wide
 - `GET /api/dashboard` returns 401 without a valid bearer JWT.
 - Backend `/api/stats` endpoints stay anonymous (security boundary is the gateway).
 
-### US5 · SystemAdmin platform-view request is honoured only for SystemAdmin
+### US5 · `?scope=platform` honoured only for SystemAdmin
 **As** the platform
-**I want** `?scope=platform` to be silently ignored for non-SystemAdmin callers
+**I want** `?scope=platform` ignored for non-SystemAdmin callers
 **So that** an org admin cannot surface platform totals by guessing the URL.
 
 **Acceptance:**
-- `GET /api/dashboard?scope=platform` from a non-SystemAdmin JWT returns org-scoped data, with `scope: "org"` in the response.
-- Same request from SystemAdmin returns platform-scoped data with `scope: "platform"`.
+- `GET /api/dashboard?scope=platform` with non-SystemAdmin JWT returns org-scoped data; `scope` field in response is `"org"`.
+- Same request with SystemAdmin JWT returns platform-scoped data; `scope` is `"platform"`.
 
 ## Functional requirements
 
 | FR | Requirement |
 |---|---|
-| FR-001 | `GET /api/dashboard` MUST require a valid bearer JWT. |
-| FR-002 | The endpoint MUST honour `?scope=platform` only when the caller's JWT carries the `SystemAdmin` role; otherwise the response MUST be org-scoped to `org_id` from the JWT. |
-| FR-003 | Response MUST include `scope` ("org"\|"platform") and `orgId` (null when scope is platform) fields. |
-| FR-004 | Org-scoped responses MUST NOT include `connectedPeers` or `totalOrganizations`. |
-| FR-005 | Org-scoped `activeBlueprints` MUST be derived from blueprints whose publishing participant belongs to the caller's org. |
-| FR-006 | Org-scoped `totalWallets` MUST be derived from `wallet.Wallets` rows with `Tenant = orgId`. |
-| FR-007 | Org-scoped `activeRegisters` MUST equal the count of `OrganizationRegisterSubscriptions` rows for the org with `Status=Active`. |
-| FR-008 | Org-scoped `recentTransactions` MUST equal the sum of transaction counts on the org's subscribed registers (Status=Active). |
-| FR-009 | Platform-scoped responses retain the current six-card shape. |
-| FR-010 | Backend `/api/stats` endpoints MUST accept an optional `?orgId={guid}` query parameter. When present, they MUST filter their counts to that org's data. When absent, they MUST return platform-wide counts (preserving today's wire shape). |
-| FR-011 | The UI MUST hide the ConnectedPeers and TotalOrganizations cards when `scope == "org"`. |
-| FR-012 | The UI MUST render a `MudButtonGroup` scope toggle visible only when the caller is in role `SystemAdmin`. |
+| FR-001 | `GET /api/dashboard` MUST require a valid bearer JWT (`.RequireAuthorization()`). |
+| FR-002 | The endpoint MUST honour `?scope=platform` only when the caller's role includes `SystemAdmin`; otherwise the response MUST be org-scoped. |
+| FR-003 | The response MUST include `scope` (`"org"`\|`"platform"`) and `orgId` (Guid when org-scoped, null when platform-scoped). |
+| FR-004 | Org-scoped responses MUST include `activeUsers`, `pendingInvitations`, `subscribedRegisters`, `recentTransactions`. They MUST NOT include platform-only fields. |
+| FR-005 | Platform-scoped responses MUST preserve today's six fields (`totalBlueprints`, `totalBlueprintInstances`, `activeBlueprintInstances`, `totalWallets`, `totalRegisters`, `totalTransactions`, `totalTenants`, `connectedPeers`). |
+| FR-006 | `activeUsers` = count of `UserIdentity` rows with `OrganizationId = orgId` and `Status = Active`. |
+| FR-007 | `pendingInvitations` = count of `OrgInvitations` with `OrganizationId = orgId`, `Status = Pending`, `ExpiresAt > now`. |
+| FR-008 | `subscribedRegisters` = count of `OrganizationRegisterSubscriptions` with `OrganizationId = orgId`, `Status = Active`. |
+| FR-009 | `recentTransactions` = sum of `transactionCount` across the org's subscribed-active register ids, obtained by Tenant Service calling Register Service `/api/stats?registerIds=…`. |
+| FR-010 | Register Service `/api/stats` MUST accept an optional `?registerIds=a,b,c` (comma-separated). When set, `transactionCount` is the sum across those registers; `registerCount` is the count of registers in the param. When unset, behaviour is unchanged. |
+| FR-011 | The UI MUST render an org-view card grid (4 cards) when `scope == "org"` and a platform-view grid (6 cards) when `scope == "platform"`. |
+| FR-012 | The UI MUST render a `MudButtonGroup` scope toggle visible only when the caller's role includes `SystemAdmin`. |
 | FR-013 | Toggle selection MUST persist in `localStorage` keyed by `platform_user_id` claim. |
 
 ## Success criteria
@@ -83,29 +83,29 @@ The dashboard at `/` (Sorcha.UI.Web.Client/Pages/Home.razor) shows platform-wide
 | SC | Criterion |
 |---|---|
 | SC-001 | `curl https://n1.sorcha.dev/api/dashboard` (no auth) returns 401. |
-| SC-002 | `admin@sorcha.local` (SystemAdmin) sees the toggle; org view returns 4 cards; platform view returns 6 cards. |
+| SC-002 | `admin@sorcha.local` (SystemAdmin) sees the toggle. Org view renders 4 cards; Platform view renders 6 cards. |
 | SC-003 | A non-SystemAdmin Administrator sees 4 cards and no toggle. |
-| SC-004 | `?scope=platform` requested by a non-SystemAdmin returns `scope: "org"` in the response body and the four org-scoped fields only. |
-| SC-005 | After a SystemAdmin selects Platform and reloads, the platform view is still rendered (localStorage persistence). |
-| SC-006 | Numbers in org view match the corresponding lists: `totalWallets` = `/api/wallets?orgId=...` count, `activeRegisters` = Registers page count, etc. |
-| SC-007 | No backend `/api/stats` endpoint has been moved off `AllowAnonymous`; gateway is the only auth gate. |
-| SC-008 | Page load time of the dashboard is within 10% of the pre-change baseline (parallel-fan-out preserved). |
+| SC-004 | `?scope=platform` requested by a non-SystemAdmin returns `scope: "org"` and the four org-scoped fields. |
+| SC-005 | After a SystemAdmin selects Platform and reloads, Platform view is still rendered (localStorage persistence). |
+| SC-006 | Org-view `subscribedRegisters` matches the count visible on `/registers`. |
+| SC-007 | Org-view `activeUsers` matches the count on the `/admin/identity/org/{orgId}/dashboard` admin panel. |
+| SC-008 | No backend `/api/stats` endpoint has been moved off `AllowAnonymous`; gateway is the only auth gate. |
 
 ## Out of scope
 
-- Caching strategy (current snapshot-per-request retained).
-- Realtime updates / SignalR fan-out for stats.
+- Caching (snapshot-per-request retained).
+- Realtime updates.
 - Historical/time-series view.
-- Additional metric surfaces (e.g. presentation counts, credential issuances).
-- Auditor's separate "audit log" page — UX-004 is a separate task.
+- Wallet/Blueprint org-scoping. Deferred until schema decision or cross-service join is worth the surface cost.
+- Auditor's separate audit-log page (UX-004 is separate).
 
 ## Dependencies
 
-- **Reads** `OrganizationRegisterSubscriptions` (Tenant Service) — already in production for UX-001.
-- **Reads** `wallet.Wallets.Tenant` column — already populated.
-- **Reads** JWT `org_id`, `platform_user_id`, `role` claims — standard Sorcha JWT shape.
-- **Touches** SystemAdmin's localStorage key shape — first time we use this; document the key.
+- `OrganizationRegisterSubscriptions` (Tenant) — already used by `/registers`.
+- `Register Service /api/stats` — existing endpoint, extended with `?registerIds=`.
+- JWT `org_id`, `platform_user_id`, `role` claims — standard.
+- Existing `IDashboardService` in Tenant — extend with sibling method or extend response.
 
 ## Open questions
 
-None at design time. Three questions were resolved in the design session (Path A, org-by-default-toggle-to-platform, both-scoped).
+None at this revision.

--- a/specs/131-dashboard-org-scoping/tasks.md
+++ b/specs/131-dashboard-org-scoping/tasks.md
@@ -1,41 +1,36 @@
-# Tasks — Dashboard org-scoping (UX-005, Feature 131)
+# Tasks — Dashboard org-scoping (UX-005, Feature 131, v2)
 
 **Spec:** `spec.md`
 **Plan:** `plan.md`
 
-## PR-A — Backend filters
-
-### Wallet Service
-
-- [ ] **T001** — Add `Task<int> CountAsync(string? tenantId = null, CancellationToken ct = default)` overload to `IWalletRepository`.
-- [ ] **T002** — Implement the overload in the EF Core repository; filter on `Tenant` column when set.
-- [ ] **T003** — Update `/api/stats` endpoint at `Sorcha.Wallet.Service/Program.cs:315` to accept `[FromQuery] Guid? orgId` and pass it as `tenantId.ToString()` when set.
-- [ ] **T004** — Unit tests in `Sorcha.Wallet.Service.Tests`: orgId-filter case + unscoped case.
-
-### Blueprint Service
-
-- [ ] **T005** — Confirm `BlueprintRecord` (or the equivalent storage row) carries an org id; add an index on it if missing.
-- [ ] **T006** — Add `CountByOrgAsync(Guid orgId)` to the blueprint count surface (or extend the existing count call to accept an optional org filter).
-- [ ] **T007** — Update `/api/stats` at `Sorcha.Blueprint.Service/Program.cs:2322` to accept `[FromQuery] Guid? orgId` and forward.
-- [ ] **T008** — Same shape for `instanceCount` + `activeInstanceCount` if applicable (filter via instance's blueprint→org link).
-- [ ] **T009** — Unit tests in `Sorcha.Blueprint.Service.Tests`.
+## PR-A — Backend support
 
 ### Register Service
 
-- [ ] **T010** — In `Sorcha.Register.Service/Program.cs:3105`, accept `[FromQuery] Guid? orgId`.
-- [ ] **T011** — When orgId is set, Register Service calls Tenant Service (`ITenantSubscriptionClient.ListSubscribedRegistersAsync(orgId)` or the equivalent existing s2s client) for the org's subscribed active register ids; return `registerCount = subscribed.Count` and `transactionCount = sum of per-register transactionCount across subscribed`. Decision: Register→Tenant call shape, not gateway-orchestrated — keeps the gateway endpoint as a single fan-out and isolates the org-scoping logic inside Register Service. Tracked: Tenant becomes a downstream dep of Register for this endpoint; document in `Sorcha.Register.Service/README.md`.
-- [ ] **T012** — When orgId is null, return the existing platform-wide shape.
-- [ ] **T013** — Unit tests: mock the subscription client; verify cross-service read path; verify unscoped path.
+- [ ] **T001** — `Sorcha.Register.Service/Program.cs:3105` `/api/stats`: accept `[FromQuery] string? registerIds`. When non-empty, comma-split into list; defensive validation (drop empty entries, cap list length at 50).
+- [ ] **T002** — When `registerIds` is set, return `{ registerCount = listed.Count, transactionCount = sumAcrossListed }`. Use the existing transaction-count source filtered to the listed register ids. When unset, retain platform-wide shape.
+- [ ] **T003** — Unit tests: `?registerIds=a,b` filters; unset returns platform shape; over-50 ids → 400 (or capped — pick the documented behaviour and stick).
+
+### Service client extension
+
+- [ ] **T004** — `Sorcha.ServiceClients.Http/Register/IRegisterServiceClient.cs`: add `Task<RegisterStatsResponse> GetStatsAsync(IReadOnlyList<string>? registerIds = null, CancellationToken ct = default)`. New DTO carries `RegisterCount` + `TransactionCount`.
+- [ ] **T005** — Implementation builds the URL: when `registerIds` non-empty, append `?registerIds={joined}`. Use `Uri.EscapeDataString` per id.
+- [ ] **T006** — Client unit tests via `HttpMessageHandler` stub: verifies query-string shape on with/without ids.
 
 ### Tenant Service
 
-- [ ] **T014** — Confirm `/api/organizations/stats` accepts `?orgId=` and returns `{ totalOrganizations = 1, totalUsers = orgUsers }` for that org. If not, extend.
-- [ ] **T015** — Unit tests for both shapes.
+- [ ] **T007** — Define `OrgSummaryResponse` DTO in `Sorcha.Tenant.Service/Models/Dtos/`: `Guid OrgId, int ActiveUsers, int PendingInvitations, int SubscribedRegisters, int RecentTransactions, DateTimeOffset Timestamp`.
+- [ ] **T008** — Extend `IDashboardService` with `Task<OrgSummaryResponse> GetOrgSummaryAsync(Guid orgId, CancellationToken ct)`.
+- [ ] **T009** — Implement `GetOrgSummaryAsync` in `DashboardService`: query active-user count, pending-invitation count, active-subscribed-register list. For `RecentTransactions`, call `IRegisterServiceClient.GetStatsAsync(subscribedIds)` and use `transactionCount`. On client error, set `RecentTransactions = 0` and log warning (non-throwing).
+- [ ] **T010** — Inject `IRegisterServiceClient` into `DashboardService` (DI wiring confirmed in `ServiceCollectionExtensions.cs`).
+- [ ] **T011** — Map `GET /api/organizations/{orgId:guid}/dashboard-summary` in `DashboardEndpoints.cs`. Policy: `RequireAuthenticated` (any signed-in org member; the existing `/dashboard` endpoint requires Administrator — summary is broader because Auditors should be able to read it).
+- [ ] **T012** — Unit tests for `GetOrgSummaryAsync`: happy path; Register-client down → `RecentTransactions = 0`; zero subscribed registers → call still ok with empty list (Register handles empty `?registerIds=` as 0).
+- [ ] **T013** — Endpoint integration tests via WebApplicationFactory pattern: 401 anon; 200 authed; 200 includes all four fields.
 
 ### PR-A wrap
 
-- [ ] **T016** — Run full `dotnet test` for all four service test projects.
-- [ ] **T017** — Open PR-A, await CI green + claude-review, squash-merge.
+- [ ] **T014** — `dotnet test` for Register + Tenant test projects + service-clients tests; all green.
+- [ ] **T015** — Open PR-A, await CI + claude-review, squash-merge.
 
 ---
 
@@ -43,45 +38,47 @@
 
 ### Gateway
 
-- [ ] **T018** — In `Sorcha.ApiGateway/Program.cs:151` change `app.MapGet("/api/dashboard", …)` to `.RequireAuthorization()`. Accept `[FromQuery] string? scope` and `HttpContext`.
-- [ ] **T019** — Extract `org_id` (claim type from `Sorcha.ServiceDefaults.Auth`), `platform_user_id`, role from `HttpContext.User`. Compute effective scope: `platform` iff `scope=="platform" && context.User.IsInRole("SystemAdmin")`; else `org` with the claim's org id.
-- [ ] **T020** — Refactor `DashboardStatisticsService.GetDashboardStatisticsAsync` signature: `(Guid? orgId, CancellationToken ct)`. Append `?orgId={orgId}` to each backend call when set; omit when null.
-- [ ] **T021** — Extend `DashboardStatistics` DTO with `Scope` (string) + `OrgId` (Guid?). Mark `ConnectedPeers` + `TotalOrganizations` as nullable; configure `JsonIgnoreCondition.WhenWritingNull` on the response.
+- [ ] **T016** — `Sorcha.ApiGateway/Program.cs:151`: change `app.MapGet("/api/dashboard", …)` to `.RequireAuthorization()`. Accept `[FromQuery] string? scope` and `HttpContext`. Inject `DashboardStatisticsService`, `ITenantSummaryClient` (new — or extend existing tenant client).
+- [ ] **T017** — Extract `org_id`, `platform_user_id`, role claims from `HttpContext.User`. Compute effective scope: `platform` iff `scope == "platform" && context.User.IsInRole("SystemAdmin")`; else `org` with the JWT's `org_id` claim.
+- [ ] **T018** — Org scope path: call new `TenantSummaryClient.GetOrgSummaryAsync(orgId, bearerToken)` (forwards the user's JWT). Map result to `DashboardResponse { scope = "org", orgId, activeUsers, pendingInvitations, subscribedRegisters, recentTransactions, timestamp }`.
+- [ ] **T019** — Platform scope path: existing `DashboardStatisticsService.GetDashboardStatisticsAsync` (unchanged). Wrap result with `scope = "platform", orgId = null`.
+- [ ] **T020** — Extend `DashboardStatistics` DTO with `Scope`, `OrgId`. Make platform-only fields stay; add org-only nullable fields. JSON serializer: `JsonIgnoreCondition.WhenWritingNull` to keep the two wire shapes clean.
+- [ ] **T021** — `ITenantSummaryClient` + impl in `Sorcha.ApiGateway/Services/`. Typed HttpClient calling Tenant's `/api/organizations/{orgId}/dashboard-summary`. Forwards bearer token (so Tenant's `RequireAuthenticated` is satisfied). Returns `OrgSummaryResponse`.
 - [ ] **T022** — Gateway integration tests in `Sorcha.ApiGateway.Tests`:
   - anonymous → 401
-  - non-admin user → org scope; the two platform-only fields omitted
-  - SystemAdmin no toggle → org scope
-  - SystemAdmin `?scope=platform` → platform scope; all six fields populated
-  - non-admin `?scope=platform` → org scope (silent ignore); response `scope: "org"`
+  - non-admin user → `scope: "org"`; platform-only fields omitted
+  - SystemAdmin no toggle → `scope: "org"`
+  - SystemAdmin `?scope=platform` → `scope: "platform"`; org-only fields omitted
+  - non-admin `?scope=platform` → `scope: "org"` (silent ignore)
 
 ### UI
 
-- [ ] **T023** — Update `IDashboardService.GetDashboardStatsAsync` signature to accept `string? scope = null`.
-- [ ] **T024** — Update `DashboardService` impl to forward `?scope=platform` to the gateway when "platform".
-- [ ] **T025** — Extend `DashboardStatsViewModel` (`Sorcha.UI.Components.User/Models/User/Dashboard/`): add `Scope`, `OrgId`, make `ConnectedPeers` + `TotalOrganizations` nullable.
+- [ ] **T023** — Update `IDashboardService.GetDashboardStatsAsync` to accept `string? scope = null`.
+- [ ] **T024** — Update `DashboardService` (UI side) impl to forward `?scope=platform` when provided.
+- [ ] **T025** — Extend `DashboardStatsViewModel` (`Sorcha.UI.Components.User/Models/User/Dashboard/`): add `Scope` (string), `OrgId` (Guid?), and the org-only nullables (`ActiveUsers`, `PendingInvitations`, `SubscribedRegisters`, `RecentTransactions`). Make existing platform fields nullable.
 - [ ] **T026** — In `Sorcha.UI.Web.Client/Pages/Home.razor`:
-  - Render a `MudButtonGroup` scope toggle (`Org` / `Platform`) at the top-right of the stats grid, wrapped in `<AuthorizeView Roles="SystemAdmin">`.
-  - Bind toggle to `_scope` field; on change, reload stats and persist `_scope` in `localStorage["dashboard-scope-{platform_user_id}"]`.
-  - On `OnInitializedAsync`, read localStorage to restore prior selection.
-  - Hide ConnectedPeers + TotalOrganizations cards when `_stats.Scope == "org"`.
-- [ ] **T027** — Add `data-testid` attributes: `dashboard-scope-toggle`, `dashboard-scope-org`, `dashboard-scope-platform`, `dashboard-card-peers`, `dashboard-card-organizations`.
+  - Add `MudButtonGroup` scope toggle (Org / Platform) at top-right of stats heading, wrapped in `<AuthorizeView Roles="SystemAdmin">`.
+  - Bind toggle to `_scope`; on change, fetch stats with new scope and persist `_scope` in `localStorage["dashboard-scope-{platformUserId}"]`.
+  - In `OnInitializedAsync`, read localStorage to restore prior selection (SystemAdmin only).
+  - Two card-grid branches: `@if (_stats.Scope == "org") { 4 cards }` else `{ 6 cards (existing) }`.
+- [ ] **T027** — `data-testid`s: `dashboard-scope-toggle`, `dashboard-scope-org`, `dashboard-scope-platform`, plus card test ids for the four org-view cards.
 - [ ] **T028** — Playwright smoke at `tests/Sorcha.UI.E2E.Tests/Docker/DashboardScopeTests.cs`:
-  - SystemAdmin sees toggle, can flip Org↔Platform, six-vs-four cards.
-  - Administrator does not see the toggle; sees four cards.
-- [ ] **T029** — Manual smoke on n1: `admin@sorcha.local` (SystemAdmin) flips toggle; `verification-admin@assured-identity.local` (Administrator of an org) sees scope-locked org view.
+  - SystemAdmin sees toggle, can flip Org↔Platform, expected card counts.
+  - Administrator (non-system) doesn't see toggle; renders 4 org-view cards.
+- [ ] **T029** — Manual smoke on n1: `admin@sorcha.local` (SystemAdmin) toggles; `verification-admin@assured-identity.local` (org Administrator) sees 4 cards locked to org.
 
 ### PR-B wrap
 
-- [ ] **T030** — Run full `dotnet test` + `dotnet test --filter Category=Dashboard` for E2E.
+- [ ] **T030** — Full `dotnet test`. Run E2E filtered.
 - [ ] **T031** — Open PR-B, await CI + claude-review, squash-merge.
-- [ ] **T032** — n1 deploy: pull `sorchadev/ui-web:latest`, `sorchadev/api-gateway:latest`, `sorchadev/wallet-service:latest`, `sorchadev/blueprint-service:latest`, `sorchadev/register-service:latest`, `sorchadev/tenant-service:latest` (any service whose image changed). Recreate.
-- [ ] **T033** — On n1: validate SC-001 through SC-008 from `spec.md`. Mark UX-005 ✅ in MASTER-TASKS line 231.
+- [ ] **T032** — n1 deploy: pull `sorchadev/api-gateway:latest`, `sorchadev/tenant-service:latest`, `sorchadev/register-service:latest`, `sorchadev/ui-web:latest`. Recreate.
+- [ ] **T033** — Validate SC-001 through SC-008 on n1; flip UX-005 to ✅ in MASTER-TASKS line 231; strike the M4 line in `2026-05-16-v1-release-roadmap.md`.
 
 ---
 
 ## Definition of done
 
-- Tasks T001–T033 closed.
-- SC-001 through SC-008 in `spec.md` verified on n1.
-- MASTER-TASKS UX-005 row marked ✅ with PR refs.
-- Roadmap M4 line for UX-005 either struck (if combined with the docs-strike PR) or annotated with the PR refs.
+- T001–T033 closed.
+- SC-001 through SC-008 verified on n1.
+- MASTER-TASKS UX-005 marked ✅ with PR refs.
+- Roadmap M4 line for UX-005 struck or annotated.

--- a/src/Common/Sorcha.ServiceClients.Http/Register/IRegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/IRegisterServiceClient.cs
@@ -514,6 +514,29 @@ public interface IRegisterServiceClient
     Task<IReadOnlyList<string>> GetMyValidatedRegistersAsync(
         byte[] validatorPublicKey,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetch register-service statistics. Optional <paramref name="registerIds"/> scopes the counts
+    /// to the listed registers (used by Tenant Service to build org-scoped dashboard stats).
+    /// </summary>
+    /// <param name="registerIds">Optional register-id filter; null/empty returns platform-wide counts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Register count + transaction count, scoped per the filter.</returns>
+    Task<RegisterStatsResponse> GetStatsAsync(
+        IReadOnlyList<string>? registerIds = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Register-service statistics payload.
+/// </summary>
+public class RegisterStatsResponse
+{
+    /// <summary>Count of registers (platform-wide or, when filtered, the listed register count).</summary>
+    public int RegisterCount { get; set; }
+
+    /// <summary>Sum of transaction counts across the in-scope registers.</summary>
+    public int TransactionCount { get; set; }
 }
 
 /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/RegisterServiceClient.cs
@@ -1781,4 +1781,40 @@ public class RegisterServiceClient : IRegisterServiceClient
     }
 
     private sealed record MyValidatedRegistersResponse(IReadOnlyList<string> RegisterIds);
+
+    /// <inheritdoc />
+    public async Task<RegisterStatsResponse> GetStatsAsync(
+        IReadOnlyList<string>? registerIds = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Feature 131 — anonymous endpoint (no SetAuthHeaderAsync). When
+            // registerIds is non-empty, append as a comma-separated query string;
+            // entries are URL-encoded individually to defend against odd id chars.
+            var url = "api/stats";
+            if (registerIds is { Count: > 0 })
+            {
+                var joined = string.Join(",", registerIds.Select(Uri.EscapeDataString));
+                url = $"{url}?registerIds={joined}";
+            }
+
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "GetStatsAsync failed: {StatusCode}", response.StatusCode);
+                return new RegisterStatsResponse();
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<RegisterStatsResponse>(
+                JsonOptions, cancellationToken);
+            return payload ?? new RegisterStatsResponse();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch register statistics");
+            return new RegisterStatsResponse();
+        }
+    }
 }

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -3103,10 +3103,34 @@ static async IAsyncEnumerable<string> ExtractAddressStrings(IAsyncEnumerable<Sor
 // ===========================
 
 app.MapGet("/api/stats", async (
-    IRegisterRepository repository) =>
+    IRegisterRepository repository,
+    string? registerIds) =>
 {
     try
     {
+        // Feature 131 / UX-005 — optional ?registerIds=a,b,c filter. When set,
+        // counts are scoped to the listed registers; this lets Tenant Service
+        // build org-scoped dashboard stats by passing the org's subscribed
+        // register ids.
+        if (!string.IsNullOrWhiteSpace(registerIds))
+        {
+            var listed = registerIds
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Take(50)
+                .ToArray();
+            var listedTransactionCount = 0;
+            foreach (var id in listed)
+            {
+                var transactions = await repository.GetTransactionsAsync(id);
+                listedTransactionCount += transactions.Count();
+            }
+            return Results.Ok(new
+            {
+                registerCount = listed.Length,
+                transactionCount = listedTransactionCount
+            });
+        }
+
         var registerCount = await repository.CountRegistersAsync();
 
         // Sum docket heights across all registers as a transaction count proxy
@@ -3136,7 +3160,7 @@ app.MapGet("/api/stats", async (
 })
 .WithName("GetRegisterStats")
 .WithSummary("Get register statistics (public)")
-.WithDescription("Returns aggregate counts of registers and transactions. No authentication required.")
+.WithDescription("Returns aggregate counts of registers and transactions. Optional ?registerIds=a,b,c (comma-separated, max 50) filters the counts to the listed registers. No authentication required.")
 .WithTags("Statistics")
 .AllowAnonymous();
 

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/DashboardEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/DashboardEndpoints.cs
@@ -30,6 +30,19 @@ public static class DashboardEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden);
 
+        // Feature 131 / UX-005 — compact org-summary backing the API Gateway's
+        // /api/dashboard endpoint in org-scope. Broader-access than the
+        // Administrator-only /dashboard above (any signed-in org member can read
+        // the four card numbers).
+        app.MapGet("/api/organizations/{organizationId:guid}/dashboard-summary", GetOrgSummary)
+            .WithTags("Dashboard")
+            .RequireAuthorization()
+            .WithName("GetOrgDashboardSummary")
+            .WithSummary("Get the org-scoped dashboard summary")
+            .WithDescription("Returns active users, pending invitations, subscribed registers, and recent transactions across subscribed registers — the four cards rendered on Home.razor in org-scope view.")
+            .Produces<OrgSummaryResponse>()
+            .Produces(StatusCodes.Status401Unauthorized);
+
         return app;
     }
 
@@ -40,5 +53,14 @@ public static class DashboardEndpoints
     {
         var dashboard = await dashboardService.GetDashboardAsync(organizationId, cancellationToken);
         return TypedResults.Ok(dashboard);
+    }
+
+    private static async Task<Ok<OrgSummaryResponse>> GetOrgSummary(
+        Guid organizationId,
+        IDashboardService dashboardService,
+        CancellationToken cancellationToken)
+    {
+        var summary = await dashboardService.GetOrgSummaryAsync(organizationId, cancellationToken);
+        return TypedResults.Ok(summary);
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/OrgSummaryResponse.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/OrgSummaryResponse.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Tenant.Service.Models.Dtos;
+
+/// <summary>
+/// Compact, dashboard-card-shaped summary of an organization's state.
+/// Feature 131 / UX-005 — backs the org-scoped view of the API Gateway's
+/// <c>/api/dashboard</c> endpoint.
+/// </summary>
+/// <remarks>
+/// Distinct from <see cref="DashboardResponse"/>, which is the admin dashboard's
+/// richer per-org view (role breakdowns, recent logins, IDP status). This DTO is
+/// scoped to the four numbers visible on Home.razor's stats grid.
+/// </remarks>
+public record OrgSummaryResponse
+{
+    /// <summary>Organization id.</summary>
+    public Guid OrgId { get; init; }
+
+    /// <summary>Count of active <c>UserIdentity</c> rows in the org.</summary>
+    public int ActiveUsers { get; init; }
+
+    /// <summary>Count of pending, unexpired invitations in the org.</summary>
+    public int PendingInvitations { get; init; }
+
+    /// <summary>Count of <c>OrganizationRegisterSubscriptions</c> rows with Status=Active.</summary>
+    public int SubscribedRegisters { get; init; }
+
+    /// <summary>
+    /// Sum of transaction counts across the org's subscribed registers (Status=Active).
+    /// Best-effort: if the Register Service is unreachable, this is 0 and a warning is logged.
+    /// </summary>
+    public int RecentTransactions { get; init; }
+
+    /// <summary>Snapshot timestamp (UTC).</summary>
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/src/Services/Sorcha.Tenant.Service/Services/DashboardService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/DashboardService.cs
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
+using Sorcha.ServiceClients.Register;
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Models.Dtos;
@@ -16,10 +18,17 @@ namespace Sorcha.Tenant.Service.Services;
 public class DashboardService : IDashboardService
 {
     private readonly TenantDbContext _dbContext;
+    private readonly IRegisterServiceClient _registerClient;
+    private readonly ILogger<DashboardService> _logger;
 
-    public DashboardService(TenantDbContext dbContext)
+    public DashboardService(
+        TenantDbContext dbContext,
+        IRegisterServiceClient registerClient,
+        ILogger<DashboardService> logger)
     {
         _dbContext = dbContext;
+        _registerClient = registerClient;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -88,6 +97,61 @@ public class DashboardService : IDashboardService
             RecentLogins = recentLogins,
             PendingInvitationCount = pendingInvitationCount,
             IdpStatus = idpStatus
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<OrgSummaryResponse> GetOrgSummaryAsync(
+        Guid organizationId,
+        CancellationToken cancellationToken = default)
+    {
+        // Active users in org.
+        var activeUsers = await _dbContext.UserIdentities
+            .Where(u => u.OrganizationId == organizationId && u.Status == IdentityStatus.Active)
+            .CountAsync(cancellationToken);
+
+        // Pending invitations (unexpired).
+        var now = DateTimeOffset.UtcNow;
+        var pendingInvitations = await _dbContext.OrgInvitations
+            .Where(i => i.OrganizationId == organizationId
+                     && i.Status == InvitationStatus.Pending
+                     && i.ExpiresAt > now)
+            .CountAsync(cancellationToken);
+
+        // Subscribed registers (Status=Active). Capture the ids so we can ask
+        // Register Service for the transaction sum in one round-trip.
+        var subscribedRegisterIds = await _dbContext.OrganizationRegisterSubscriptions
+            .Where(s => s.OrganizationId == organizationId && s.Status == SubscriptionStatus.Active)
+            .Select(s => s.RegisterId)
+            .ToListAsync(cancellationToken);
+
+        // Recent transactions across the org's subscribed registers. Best-effort —
+        // a Register Service outage downgrades to 0 with a warning rather than
+        // failing the whole summary (the other three numbers are still useful).
+        var recentTransactions = 0;
+        if (subscribedRegisterIds.Count > 0)
+        {
+            try
+            {
+                var stats = await _registerClient.GetStatsAsync(subscribedRegisterIds, cancellationToken);
+                recentTransactions = stats.TransactionCount;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Register stats fetch failed for org {OrgId}; recentTransactions defaults to 0",
+                    organizationId);
+            }
+        }
+
+        return new OrgSummaryResponse
+        {
+            OrgId = organizationId,
+            ActiveUsers = activeUsers,
+            PendingInvitations = pendingInvitations,
+            SubscribedRegisters = subscribedRegisterIds.Count,
+            RecentTransactions = recentTransactions,
+            Timestamp = DateTimeOffset.UtcNow
         };
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/IDashboardService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IDashboardService.cs
@@ -14,4 +14,11 @@ public interface IDashboardService
     /// Gets dashboard statistics for an organization.
     /// </summary>
     Task<DashboardResponse> GetDashboardAsync(Guid organizationId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the compact org-summary used by the API Gateway's <c>/api/dashboard</c> endpoint
+    /// in org-scope (Feature 131 / UX-005). Includes active-user count, pending-invitation count,
+    /// subscribed-register count, and recent-transaction sum across the org's subscribed registers.
+    /// </summary>
+    Task<OrgSummaryResponse> GetOrgSummaryAsync(Guid organizationId, CancellationToken cancellationToken = default);
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Services/DashboardServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/DashboardServiceTests.cs
@@ -4,7 +4,11 @@
 using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 
+using Moq;
+
+using Sorcha.ServiceClients.Register;
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Models;
 using Sorcha.Tenant.Service.Services;
@@ -15,6 +19,7 @@ public class DashboardServiceTests : IDisposable
 {
     private readonly TenantDbContext _dbContext;
     private readonly DashboardService _service;
+    private readonly Mock<IRegisterServiceClient> _registerClient = new();
     private readonly Guid _orgId = Guid.NewGuid();
 
     public DashboardServiceTests()
@@ -24,7 +29,10 @@ public class DashboardServiceTests : IDisposable
             .Options;
 
         _dbContext = new TenantDbContext(options);
-        _service = new DashboardService(_dbContext);
+        _service = new DashboardService(
+            _dbContext,
+            _registerClient.Object,
+            NullLogger<DashboardService>.Instance);
     }
 
     [Fact]
@@ -200,6 +208,109 @@ public class DashboardServiceTests : IDisposable
             ProvisionedVia = provisionedVia,
             CreatedAt = DateTimeOffset.UtcNow
         };
+    }
+
+    // ---------------------------------------------------------------------
+    // Feature 131 / UX-005 — GetOrgSummaryAsync
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetOrgSummaryAsync_CountsActiveUsersAndPendingInvitations()
+    {
+        SeedUsers(active: 4, suspended: 1);
+        _dbContext.OrgInvitations.Add(new OrgInvitation
+        {
+            OrganizationId = _orgId, Email = "p@t.com", Token = "p1",
+            Status = InvitationStatus.Pending, ExpiresAt = DateTimeOffset.UtcNow.AddDays(3),
+            InvitedByUserId = Guid.NewGuid()
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetOrgSummaryAsync(_orgId);
+
+        result.OrgId.Should().Be(_orgId);
+        result.ActiveUsers.Should().Be(4);
+        result.PendingInvitations.Should().Be(1);
+        result.SubscribedRegisters.Should().Be(0);
+        result.RecentTransactions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetOrgSummaryAsync_CountsActiveSubscribedRegisters()
+    {
+        SeedUsers(active: 1);
+        _dbContext.OrganizationRegisterSubscriptions.AddRange(
+            new OrganizationRegisterSubscription
+            {
+                Id = Guid.NewGuid(), OrganizationId = _orgId, RegisterId = "reg-a",
+                Status = SubscriptionStatus.Active, SubscriptionType = SubscriptionType.Owner,
+                SubscribedAt = DateTimeOffset.UtcNow, SubscribedByUserId = Guid.NewGuid()
+            },
+            new OrganizationRegisterSubscription
+            {
+                Id = Guid.NewGuid(), OrganizationId = _orgId, RegisterId = "reg-b",
+                Status = SubscriptionStatus.Active, SubscriptionType = SubscriptionType.Public,
+                SubscribedAt = DateTimeOffset.UtcNow, SubscribedByUserId = Guid.NewGuid()
+            },
+            new OrganizationRegisterSubscription
+            {
+                Id = Guid.NewGuid(), OrganizationId = _orgId, RegisterId = "reg-c",
+                Status = SubscriptionStatus.Revoked, SubscriptionType = SubscriptionType.Owner,
+                SubscribedAt = DateTimeOffset.UtcNow, SubscribedByUserId = Guid.NewGuid()
+            });
+        await _dbContext.SaveChangesAsync();
+
+        _registerClient
+            .Setup(c => c.GetStatsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RegisterStatsResponse { RegisterCount = 2, TransactionCount = 17 });
+
+        var result = await _service.GetOrgSummaryAsync(_orgId);
+
+        result.SubscribedRegisters.Should().Be(2);     // active only
+        result.RecentTransactions.Should().Be(17);
+        _registerClient.Verify(
+            c => c.GetStatsAsync(
+                It.Is<IReadOnlyList<string>>(ids => ids.Count == 2
+                                                  && ids.Contains("reg-a")
+                                                  && ids.Contains("reg-b")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrgSummaryAsync_SkipsRegisterCallWhenNoSubscriptions()
+    {
+        SeedUsers(active: 1);
+
+        var result = await _service.GetOrgSummaryAsync(_orgId);
+
+        result.SubscribedRegisters.Should().Be(0);
+        result.RecentTransactions.Should().Be(0);
+        _registerClient.Verify(
+            c => c.GetStatsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrgSummaryAsync_RegisterClientThrows_DegradesToZeroTransactions()
+    {
+        SeedUsers(active: 1);
+        _dbContext.OrganizationRegisterSubscriptions.Add(new OrganizationRegisterSubscription
+        {
+            Id = Guid.NewGuid(), OrganizationId = _orgId, RegisterId = "reg-a",
+            Status = SubscriptionStatus.Active, SubscriptionType = SubscriptionType.Owner,
+            SubscribedAt = DateTimeOffset.UtcNow, SubscribedByUserId = Guid.NewGuid()
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _registerClient
+            .Setup(c => c.GetStatsAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("register down"));
+
+        var result = await _service.GetOrgSummaryAsync(_orgId);
+
+        result.SubscribedRegisters.Should().Be(1);
+        result.RecentTransactions.Should().Be(0); // graceful degrade
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

Backend support for Feature 131 / UX-005 (dashboard org-scoping). Two new pieces of internal HTTP surface; behaviour without the new params is unchanged, so this PR is shippable independently of PR-B (gateway + UI).

### Register Service
`/api/stats` accepts optional `?registerIds=a,b,c` (comma-separated, max 50). When set, `registerCount` and `transactionCount` are scoped to the listed registers. Unscoped behaviour preserved.

### Tenant Service
New endpoint `GET /api/organizations/{orgId}/dashboard-summary` returns:
```jsonc
{
  "orgId": "...",
  "activeUsers": 5,
  "pendingInvitations": 2,
  "subscribedRegisters": 3,
  "recentTransactions": 142,
  "timestamp": "..."
}
```
`recentTransactions` is computed by Tenant calling Register's new filtered endpoint with the org's `Status=Active` `OrganizationRegisterSubscriptions`. Register-client outage degrades to 0 with a logged warning rather than failing the whole summary.

Policy: `RequireAuthenticated` — any signed-in org member can read their org's four card numbers (broader than the existing `/dashboard` which is Administrator-only).

### Service-client glue
`IRegisterServiceClient.GetStatsAsync(registerIds?, ct)` added to `Sorcha.ServiceClients.Http` for Tenant's internal cross-service call.

## Test plan

- [x] 1113 `Sorcha.Tenant.Service.Tests` pass, including 4 new `DashboardServiceTests` cases:
  - `GetOrgSummaryAsync_CountsActiveUsersAndPendingInvitations`
  - `GetOrgSummaryAsync_CountsActiveSubscribedRegisters`
  - `GetOrgSummaryAsync_SkipsRegisterCallWhenNoSubscriptions`
  - `GetOrgSummaryAsync_RegisterClientThrows_DegradesToZeroTransactions`
- [x] Full solution `dotnet build Sorcha.sln -c Release` clean (0 errors).
- [ ] CI green.
- [ ] Manual: against n1 after deploy, `curl https://n1.sorcha.dev/api/stats?registerIds=64a2c817361a4a6ba0fd0020999b8cb1` returns scoped count.

## Spec / design

`specs/131-dashboard-org-scoping/` (spec + plan + tasks merged in #761) and `docs/superpowers/specs/2026-05-18-ux-005-dashboard-org-scoping-design.md`. Tasks T001–T015 done in this PR; T016–T033 (gateway + UI) follow in PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)