### PR TITLE
refactor(ui): retire ISnackbar from 34 surfaces (Snackbar Phase 9a–9g)

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -31,7 +31,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.ra
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
@@ -42,15 +41,9 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/OrgSettings.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SectorConfiguration.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SchemaProviderHealth.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/DomainRestrictions.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/AuditLog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -15,30 +15,25 @@
 #
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
 
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -28,7 +28,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
@@ -41,9 +40,7 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/OrgSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SectorConfiguration.razor
@@ -56,11 +53,9 @@ src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.ra
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Operations.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -22,15 +22,11 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razo
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -29,13 +29,8 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razo
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -30,15 +30,12 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor

--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -15,12 +15,10 @@
 #
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
 
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AccountsTab.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
@@ -28,8 +26,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
@@ -45,7 +41,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.ra
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrgSelectorPanel.razor
@@ -2,9 +2,10 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IOrganizationAdminService OrganizationService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudExpansionPanels data-testid="org-selector-panel">
     <MudExpansionPanel @bind-IsExpanded="_isExpanded"
@@ -93,7 +94,7 @@
 
         if (result is { Canceled: false, Data: OrganizationDto newOrg })
         {
-            Snackbar.Add($"Organisation '{newOrg.Name}' created successfully.", Severity.Success);
+            Feedback.ShowSuccess($"Organisation '{newOrg.Name}' created successfully.");
             await OnOrganizationSelected.InvokeAsync(newOrg);
             _isExpanded = false;
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationConfiguration.razor
@@ -4,9 +4,10 @@
 @using MudBlazor.Utilities
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IOrganizationAdminService OrganizationService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudStack Spacing="4" Class="mt-2">
     @* Security Policies *@
@@ -195,16 +196,16 @@
             var result = await OrganizationService.UpdateOrganizationAsync(Organization.Id, request);
             if (result != null)
             {
-                Snackbar.Add("Branding saved successfully", Severity.Success);
+                Feedback.ShowSuccess("Branding saved successfully");
             }
             else
             {
-                Snackbar.Add("Failed to save branding", Severity.Error);
+                Feedback.ShowError("Failed to save branding", autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error saving branding: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error saving branding: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationDashboard.razor
@@ -4,12 +4,13 @@
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Models.Participants
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Participants
 
 @inject IOrganizationAdminService OrganizationService
 @inject IParticipantApiService ParticipantService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudStack Spacing="4">
     @if (IsSystemAdmin)
@@ -148,7 +149,7 @@
         var detail = await ParticipantService.GetParticipantAsync(Organization.Id, participant.Id);
         if (detail == null)
         {
-            Snackbar.Add("Could not load participant details", Severity.Error);
+            Feedback.ShowError("Could not load participant details", autoDismissMs: 0);
             return;
         }
 
@@ -167,7 +168,7 @@
 
         if (!result!.Canceled)
         {
-            Snackbar.Add("Participant published to register", Severity.Success);
+            Feedback.ShowSuccess("Participant published to register");
             await LoadStatsAsync();
             StateHasChanged();
         }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/OrganizationList.razor
@@ -2,9 +2,10 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IOrganizationAdminService OrganizationService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudStack Spacing="4">
     @if (!CompactMode)
@@ -163,7 +164,7 @@
         if (result is { Canceled: false, Data: OrganizationDto newOrg })
         {
             _organizations.Insert(0, newOrg);
-            Snackbar.Add($"Organization '{newOrg.Name}' created successfully.", Severity.Success);
+            Feedback.ShowSuccess($"Organization '{newOrg.Name}' created successfully.");
             StateHasChanged();
         }
     }
@@ -193,7 +194,7 @@
             {
                 _organizations[index] = updatedOrg;
             }
-            Snackbar.Add($"Organization '{updatedOrg.Name}' updated successfully.", Severity.Success);
+            Feedback.ShowSuccess($"Organization '{updatedOrg.Name}' updated successfully.");
             StateHasChanged();
         }
     }
@@ -218,13 +219,13 @@
                     {
                         _organizations[index] = organization with { Status = "Deleted" };
                     }
-                    Snackbar.Add($"Organization '{organization.Name}' deactivated.", Severity.Warning);
+                    Feedback.ShowWarning($"Organization '{organization.Name}' deactivated.");
                     StateHasChanged();
                 }
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"Failed to deactivate: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"Failed to deactivate: {ex.Message}", autoDismissMs: 0);
             }
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/ServiceHealthDashboard.razor
@@ -3,10 +3,11 @@
 
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IHealthCheckService HealthService
 @inject IOrganizationAdminService OrganizationService
 @inject IAlertService AlertService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @implements IDisposable
 
 <MudStack Spacing="4">
@@ -224,14 +225,20 @@
             {
                 if (alert.Severity >= AlertSeverity.Warning)
                 {
-                    var severity = alert.Severity switch
+                    var msg = $"{alert.Source}: {alert.Message}";
+                    switch (alert.Severity)
                     {
-                        AlertSeverity.Critical => MudBlazor.Severity.Error,
-                        AlertSeverity.Error => MudBlazor.Severity.Error,
-                        AlertSeverity.Warning => MudBlazor.Severity.Warning,
-                        _ => MudBlazor.Severity.Info
-                    };
-                    Snackbar.Add($"{alert.Source}: {alert.Message}", severity);
+                        case AlertSeverity.Critical:
+                        case AlertSeverity.Error:
+                            Feedback.ShowError(msg, autoDismissMs: 0);
+                            break;
+                        case AlertSeverity.Warning:
+                            Feedback.ShowWarning(msg);
+                            break;
+                        default:
+                            Feedback.ShowInfo(msg);
+                            break;
+                    }
                 }
             }
             StateHasChanged();

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/UserList.razor
@@ -2,9 +2,10 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IOrganizationAdminService OrganizationService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudStack Spacing="4">
     <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
@@ -202,17 +203,17 @@
             var verified = await OrganizationService.VerifyEmailAsync(Organization.Id, user.Id);
             if (verified)
             {
-                Snackbar.Add($"Email verified for '{user.DisplayName}'.", Severity.Success);
+                Feedback.ShowSuccess($"Email verified for '{user.DisplayName}'.");
                 await LoadUsersAsync();
             }
             else
             {
-                Snackbar.Add("Email is already verified.", Severity.Info);
+                Feedback.ShowInfo("Email is already verified.");
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to verify email: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to verify email: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -234,7 +235,7 @@
         {
             _users.Insert(0, newUser);
             ApplyStatusFilter();
-            Snackbar.Add($"User '{newUser.DisplayName}' added successfully.", Severity.Success);
+            Feedback.ShowSuccess($"User '{newUser.DisplayName}' added successfully.");
             StateHasChanged();
         }
     }
@@ -259,7 +260,7 @@
             var index = _users.FindIndex(u => u.Id == updatedUser.Id);
             if (index >= 0) _users[index] = updatedUser;
             ApplyStatusFilter();
-            Snackbar.Add($"User '{updatedUser.DisplayName}' updated successfully.", Severity.Success);
+            Feedback.ShowSuccess($"User '{updatedUser.DisplayName}' updated successfully.");
             StateHasChanged();
         }
     }
@@ -283,13 +284,13 @@
                     var index = _users.FindIndex(u => u.Id == user.Id);
                     if (index >= 0) _users[index] = user with { Status = "Removed" };
                     ApplyStatusFilter();
-                    Snackbar.Add($"User '{user.DisplayName}' removed.", Severity.Warning);
+                    Feedback.ShowWarning($"User '{user.DisplayName}' removed.");
                     StateHasChanged();
                 }
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"Failed to remove user: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"Failed to remove user: {ex.Message}", autoDismissMs: 0);
             }
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorConsentPanel.razor
@@ -2,10 +2,11 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Models.Admin
 @inject IValidatorAdminService ValidatorService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 @if (_isLoading && !_hasEverLoaded)
 {
@@ -207,12 +208,11 @@ else
 
         if (conflictCount > 0)
         {
-            Snackbar.Add($"Approved {succeeded} validator(s). {conflictCount} failed — maximum validator count may have been reached.",
-                Severity.Warning);
+            Feedback.ShowWarning($"Approved {succeeded} validator(s). {conflictCount} failed — maximum validator count may have been reached.");
         }
         else
         {
-            Snackbar.Add($"Successfully approved {succeeded} validator(s).", Severity.Success);
+            Feedback.ShowSuccess($"Successfully approved {succeeded} validator(s).");
         }
 
         await LoadConsentQueueAsync();
@@ -249,8 +249,15 @@ else
         }
 
         _isProcessing = false;
-        Snackbar.Add($"Rejected {succeeded} of {selected.Count} validator(s).",
-            succeeded == selected.Count ? Severity.Info : Severity.Warning);
+        var msg = $"Rejected {succeeded} of {selected.Count} validator(s).";
+        if (succeeded == selected.Count)
+        {
+            Feedback.ShowInfo(msg);
+        }
+        else
+        {
+            Feedback.ShowWarning(msg);
+        }
 
         await LoadConsentQueueAsync();
     }
@@ -263,12 +270,12 @@ else
         try
         {
             var approved = await ValidatorService.RefreshApprovedValidatorsAsync(registerId);
-            Snackbar.Add($"Refreshed from chain — {approved.Count} approved validator(s) found.", Severity.Success);
+            Feedback.ShowSuccess($"Refreshed from chain — {approved.Count} approved validator(s) found.");
             await LoadConsentQueueAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to refresh from chain: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to refresh from chain: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorRegistryPanel.razor
@@ -2,10 +2,11 @@
 @* Copyright (c) 2026 Sorcha Contributors *@
 
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Models.Admin
 @inject IValidatorAdminService ValidatorService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudText Typo="Typo.h6" Class="mb-2">
     <MudIcon Icon="@Icons.Material.Filled.AdminPanelSettings" Class="mr-1" />
@@ -107,8 +108,14 @@ else
         {
             var success = await ValidatorService.SuspendValidatorAsync(
                 item.RegisterId, item.ValidatorId, "admin", result.Data as string ?? "Suspended by admin");
-            Snackbar.Add(success ? "Validator suspended" : "Failed to suspend — may be the last active validator",
-                success ? Severity.Warning : Severity.Error);
+            if (success)
+            {
+                Feedback.ShowWarning("Validator suspended");
+            }
+            else
+            {
+                Feedback.ShowError("Failed to suspend — may be the last active validator", autoDismissMs: 0);
+            }
             if (success) await LoadValidatorsAsync();
         }
         finally
@@ -124,8 +131,14 @@ else
         {
             var success = await ValidatorService.ReactivateValidatorAsync(
                 item.RegisterId, item.ValidatorId, "admin");
-            Snackbar.Add(success ? "Validator reactivated" : "Failed to reactivate — validator may not be suspended",
-                success ? Severity.Success : Severity.Error);
+            if (success)
+            {
+                Feedback.ShowSuccess("Validator reactivated");
+            }
+            else
+            {
+                Feedback.ShowError("Failed to reactivate — validator may not be suspended", autoDismissMs: 0);
+            }
             if (success) await LoadValidatorsAsync();
         }
         finally
@@ -150,8 +163,14 @@ else
         {
             var success = await ValidatorService.RevokeValidatorAsync(
                 item.RegisterId, item.ValidatorId, "admin", result.Data as string ?? "Revoked by admin");
-            Snackbar.Add(success ? "Validator permanently revoked" : "Failed to revoke",
-                success ? Severity.Warning : Severity.Error);
+            if (success)
+            {
+                Feedback.ShowWarning("Validator permanently revoked");
+            }
+            else
+            {
+                Feedback.ShowError("Failed to revoke", autoDismissMs: 0);
+            }
             if (success) await LoadValidatorsAsync();
         }
         finally

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Admin/Validator/ValidatorThresholdPanel.razor
@@ -3,9 +3,10 @@
 
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IValidatorAdminService ValidatorService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudStack Spacing="4" Class="pa-4">
     @if (_isLoading)
@@ -169,12 +170,12 @@
             try
             {
                 await ValidatorService.SetupThresholdAsync(request);
-                Snackbar.Add("Threshold signing configured successfully", Severity.Success);
+                Feedback.ShowSuccess("Threshold signing configured successfully");
                 await LoadAsync();
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"Failed to setup threshold: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"Failed to setup threshold: {ex.Message}", autoDismissMs: 0);
             }
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/BlueprintJsonView.razor
@@ -59,7 +59,7 @@
     public Blueprint? Blueprint { get; set; }
 
     [Inject]
-    private ISnackbar? Snackbar { get; set; }
+    private Sorcha.UI.Core.Services.Feedback.IInlineFeedback Feedback { get; set; } = null!;
 
     private string jsonText = string.Empty;
     private JsonElement? jsonElement;
@@ -89,12 +89,12 @@
         try
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", jsonText);
-            Snackbar?.Add("JSON copied to clipboard", Severity.Success);
+            Feedback.ShowSuccess("JSON copied to clipboard");
         }
         catch
         {
             // Fallback for browsers that block clipboard API (e.g., non-HTTPS)
-            Snackbar?.Add("Unable to copy to clipboard — check browser permissions", Severity.Warning);
+            Feedback.ShowWarning("Unable to copy to clipboard — check browser permissions");
         }
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Designer/OfflineSyncIndicator.razor
@@ -4,6 +4,7 @@
 @using MudBlazor
 @using Sorcha.UI.Core.Models.Designer
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @implements IDisposable
 
 @if (_pendingCount > 0)
@@ -57,7 +58,7 @@ else
     private IDialogService DialogService { get; set; } = null!;
 
     [Inject]
-    private ISnackbar Snackbar { get; set; } = null!;
+    private IInlineFeedback Feedback { get; set; } = null!;
 
     private int _pendingCount;
     private bool _syncing;
@@ -90,17 +91,17 @@ else
 
         if (e.SuccessCount > 0)
         {
-            Snackbar.Add($"Synced {e.SuccessCount} item(s) successfully", Severity.Success);
+            Feedback.ShowSuccess($"Synced {e.SuccessCount} item(s) successfully");
         }
 
         if (e.FailedCount > 0)
         {
-            Snackbar.Add($"{e.FailedCount} item(s) failed to sync", Severity.Warning);
+            Feedback.ShowWarning($"{e.FailedCount} item(s) failed to sync");
         }
 
         if (e.ConflictCount > 0)
         {
-            Snackbar.Add($"{e.ConflictCount} conflict(s) need resolution", Severity.Error);
+            Feedback.ShowError($"{e.ConflictCount} conflict(s) need resolution", autoDismissMs: 0);
         }
 
         InvokeAsync(StateHasChanged);
@@ -149,13 +150,13 @@ else
                     localCopy.UpdatedAt = DateTimeOffset.UtcNow;
                     await StorageService.SaveBlueprintAsync(localCopy);
                     await SyncService.RemoveFromQueueAsync(queueItem.Id);
-                    Snackbar.Add("Local version saved to server", Severity.Success);
+                    Feedback.ShowSuccess("Local version saved to server");
                     break;
 
                 case ConflictResolution.KeepServer:
                     // Discard local changes, use server version
                     await SyncService.RemoveFromQueueAsync(queueItem.Id);
-                    Snackbar.Add("Server version kept, local changes discarded", Severity.Info);
+                    Feedback.ShowInfo("Server version kept, local changes discarded");
                     break;
 
                 case ConflictResolution.KeepBoth:
@@ -168,13 +169,13 @@ else
                     duplicate.Version = 1;
                     await StorageService.SaveBlueprintAsync(duplicate);
                     await SyncService.RemoveFromQueueAsync(queueItem.Id);
-                    Snackbar.Add($"Copy created: {duplicate.Title}", Severity.Success);
+                    Feedback.ShowSuccess($"Copy created: {duplicate.Title}");
                     break;
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to resolve conflict: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to resolve conflict: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -205,7 +206,7 @@ else
                     break;
                 case "clear":
                     await SyncService.ClearQueueAsync();
-                    Snackbar.Add("Sync queue cleared", Severity.Info);
+                    Feedback.ShowInfo("Sync queue cleared");
                     break;
             }
         }
@@ -222,7 +223,7 @@ else
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Sync failed: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Sync failed: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InvitationsPanel.razor
@@ -5,12 +5,13 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.JSInterop
 @using Sorcha.ServiceClients.Invitation
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IRegisterInvitationServiceClient InvitationClient
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IDialogService DialogService
 @inject IJSRuntime JS
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudExpansionPanel MaxHeight="480"
                    Expanded="@Expanded"
@@ -246,7 +247,7 @@
         try
         {
             await InvitationClient.RevokeAsync(_orgId, invitation.InvitationId);
-            Snackbar.Add("Invitation revoked", Severity.Success);
+            Feedback.ShowSuccess("Invitation revoked");
             await LoadAsync();
             // Badge tracks the cross-tab pending count. After a mutation we need a fresh
             // "all" snapshot — otherwise the chip stays at the pre-revoke value until the
@@ -258,11 +259,11 @@
         }
         catch (InvitationApiException ex)
         {
-            Snackbar.Add(ex.Message, Severity.Error);
+            Feedback.ShowError(ex.Message, autoDismissMs: 0);
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Unexpected error: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Unexpected error: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialClaimCard.razor
@@ -4,10 +4,11 @@
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Forms
 @implements IDisposable
 @inject IHaipLocalReceiveService LocalReceive
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject ILogger<CredentialClaimCard> Logger
 
 @*
@@ -256,7 +257,7 @@
         }
         if (string.IsNullOrWhiteSpace(LocalWalletAddress))
         {
-            Snackbar.Add("No wallet address available. Please sign in again.", Severity.Error);
+            Feedback.ShowError("No wallet address available. Please sign in again.", autoDismissMs: 0);
             return;
         }
 
@@ -272,7 +273,7 @@
                 Offer.CredentialOfferUri.Length > 32
                     ? Offer.CredentialOfferUri[..32] + "..."
                     : Offer.CredentialOfferUri);
-            Snackbar.Add("Could not claim credential. The offer is malformed.", Severity.Error);
+            Feedback.ShowError("Could not claim credential. The offer is malformed.", autoDismissMs: 0);
             return;
         }
 
@@ -290,13 +291,11 @@
                     "Local receive failed: code={Code} message={Message}",
                     result.ErrorCode,
                     result.ErrorMessage ?? "Unknown error");
-                Snackbar.Add("Could not claim credential. Please try again.", Severity.Error);
+                Feedback.ShowError("Could not claim credential. Please try again.", autoDismissMs: 0);
                 return;
             }
 
-            Snackbar.Add(
-                $"{result.CredentialType ?? Offer.CredentialType ?? "Credential"} stored in your wallet",
-                Severity.Success);
+            Feedback.ShowSuccess($"{result.CredentialType ?? Offer.CredentialType ?? "Credential"} stored in your wallet");
 
             _state = State.Claimed;
             SafeStateHasChanged();
@@ -317,7 +316,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Credential claim threw an unexpected error");
-            Snackbar.Add("Could not claim credential. Please try again.", Severity.Error);
+            Feedback.ShowError("Could not claim credential. Please try again.", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Credentials/CredentialOfferQrCard.razor
@@ -4,11 +4,12 @@
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Services
 @using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Services.Feedback
 @implements IDisposable
 @inject IQrPresentationService QrService
 @inject IHaipOfferService HaipService
 @inject IHaipLocalReceiveService LocalReceive
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject ILogger<CredentialOfferQrCard> Logger
 
 <MudCard Elevation="3" Class="credential-offer-qr-card pa-4">
@@ -259,9 +260,7 @@
             var result = await LocalReceive.ReceiveLocallyAsync(CredentialOfferUri, LocalWalletAddress);
             if (result.Success)
             {
-                Snackbar.Add(
-                    $"{result.CredentialType ?? "Credential"} received and stored in your local wallet",
-                    Severity.Success);
+                Feedback.ShowSuccess($"{result.CredentialType ?? "Credential"} received and stored in your local wallet");
                 _status = HaipOfferStates.Exchanged;
                 StateHasChanged();
                 if (OnLocalReceived.HasDelegate)
@@ -277,13 +276,13 @@
             {
                 var detail = result.ErrorMessage ?? "Unknown error";
                 Logger.LogWarning("Local receive failed: {Code} {Message}", result.ErrorCode, detail);
-                Snackbar.Add($"Could not receive locally: {detail}", Severity.Error);
+                Feedback.ShowError($"Could not receive locally: {detail}", autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Local receive threw an unexpected error");
-            Snackbar.Add($"Could not receive locally: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Could not receive locally: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/OrgSwitcher.razor
@@ -6,6 +6,7 @@
 @using Sorcha.UI.Core.Services.Admin
 @using Sorcha.UI.Core.Services.Authentication
 @using Sorcha.UI.Core.Services.Configuration
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Models.Authentication
 
 @inject IOrgSwitcherService OrgSwitcherService
@@ -13,7 +14,7 @@
 @inject IConfigurationService ConfigurationService
 @inject CustomAuthenticationStateProvider AuthStateProvider
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 @if (_organizations.Count > 1)
 {
@@ -69,7 +70,7 @@
             var tokenResponse = await OrgSwitcherService.SwitchOrgAsync(org.OrganizationId);
             if (tokenResponse is null)
             {
-                Snackbar.Add("Failed to switch organisation.", Severity.Error);
+                Feedback.ShowError("Failed to switch organisation.", autoDismissMs: 0);
                 return;
             }
 
@@ -81,14 +82,14 @@
             // Notify auth state changed
             AuthStateProvider.NotifyAuthenticationStateChanged();
 
-            Snackbar.Add($"Switched to {org.OrganizationName}", Severity.Success);
+            Feedback.ShowSuccess($"Switched to {org.OrganizationName}");
 
             // Force full page reload to refresh all data contexts
             Navigation.NavigateTo("dashboard", forceLoad: true);
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error switching organisation: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error switching organisation: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AccountsTab.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AccountsTab.razor
@@ -5,10 +5,11 @@
 
 @using Sorcha.UI.Core.Models
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Web.Client.Components.Settings.AuthMethods
 @inject IAuthMethodsClientService AuthMethodsClient
 @inject ILocalizationService Loc
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <MudText Typo="Typo.h6" Class="mb-1">
     @Loc.T("settings.accounts.title")
@@ -80,7 +81,7 @@ else
             _methods = await AuthMethodsClient.GetAuthMethodsAsync();
             if (_methods is null)
             {
-                Snackbar.Add(Loc.T("settings.accounts.loadFailed"), Severity.Error);
+                Feedback.ShowError(Loc.T("settings.accounts.loadFailed"), autoDismissMs: 0);
             }
         }
         finally

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/EventsAdmin.razor
@@ -8,8 +8,9 @@
 @using MudBlazor
 @using Sorcha.UI.Core.Models.Admin
 @using Sorcha.UI.Core.Services.Admin
+@using Sorcha.UI.Core.Services.Feedback
 @inject IEventAdminService EventAdminService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IDialogService DialogService
 
 <PageTitle>Events - Sorcha Platform</PageTitle>
@@ -125,7 +126,7 @@
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to load events", Severity.Error);
+            Feedback.ShowError("Failed to load events", autoDismissMs: 0);
             return new TableData<SystemEventViewModel>
             {
                 TotalItems = 0,
@@ -174,7 +175,7 @@
             var success = await EventAdminService.DeleteEventAsync(evt.Id);
             if (success)
             {
-                Snackbar.Add("Event deleted", Severity.Success);
+                Feedback.ShowSuccess("Event deleted");
                 if (_table is not null)
                 {
                     await _table.ReloadServerData();
@@ -182,12 +183,12 @@
             }
             else
             {
-                Snackbar.Add("Failed to delete event", Severity.Error);
+                Feedback.ShowError("Failed to delete event", autoDismissMs: 0);
             }
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to delete event", Severity.Error);
+            Feedback.ShowError("Failed to delete event", autoDismissMs: 0);
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/AuditLog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/AuditLog.razor
@@ -8,9 +8,10 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IAuditService AuditService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Audit Log - Sorcha Platform</PageTitle>
 
@@ -174,7 +175,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to load audit events: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to load audit events: {ex.Message}", autoDismissMs: 0);
         }
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/DomainRestrictions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/DomainRestrictions.razor
@@ -7,10 +7,11 @@
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Identity
 
 @inject IDomainRestrictionClientService DomainService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Domain Restrictions - Sorcha Platform</PageTitle>
 
@@ -143,7 +144,7 @@
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"Failed to load restrictions: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"Failed to load restrictions: {ex.Message}", autoDismissMs: 0);
             }
         }
 
@@ -177,13 +178,18 @@
         {
             var domainsToSave = _restrictionsEnabled ? _domains.ToArray() : [];
             var success = await DomainService.UpdateRestrictionsAsync(_organizationId, domainsToSave);
-            Snackbar.Add(
-                success ? "Domain restrictions saved" : "Failed to save domain restrictions",
-                success ? Severity.Success : Severity.Error);
+            if (success)
+            {
+                Feedback.ShowSuccess("Domain restrictions saved");
+            }
+            else
+            {
+                Feedback.ShowError("Failed to save domain restrictions", autoDismissMs: 0);
+            }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/IssuedCredentials.razor
@@ -9,10 +9,11 @@
 @using Sorcha.UI.Core.Components.Admin
 @using Sorcha.UI.Core.Models.Credentials
 @using Sorcha.UI.Core.Services.Credentials
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IIssuedCredentialService IssuedCredentialService
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Issued Credentials - Sorcha Platform</PageTitle>
 
@@ -147,12 +148,12 @@
                 "Refresh" => "refreshed",
                 _ => action.ToLowerInvariant()
             };
-            Snackbar.Add($"Credential {pastTense} successfully.", Severity.Success);
+            Feedback.ShowSuccess($"Credential {pastTense} successfully.");
             await LoadCredentialsAsync();
         }
         else
         {
-            Snackbar.Add(operationResult.ErrorMessage ?? $"Failed to {action.ToLowerInvariant()} credential.", Severity.Error);
+            Feedback.ShowError(operationResult.ErrorMessage ?? $"Failed to {action.ToLowerInvariant()} credential.", autoDismissMs: 0);
         }
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/OrganizationUserDetail.razor
@@ -8,10 +8,11 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IOrganizationAdminService OrganizationService
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>User Detail - Sorcha Platform</PageTitle>
 
@@ -205,12 +206,12 @@
                 _user = updated;
                 _editDisplayName = updated.DisplayName;
                 _editRole = updated.Roles.FirstOrDefault() ?? "Consumer";
-                Snackbar.Add("User updated successfully.", Severity.Success);
+                Feedback.ShowSuccess("User updated successfully.");
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to update user: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to update user: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -223,17 +224,17 @@
             var verified = await OrganizationService.VerifyEmailAsync(OrgId, UserId);
             if (verified)
             {
-                Snackbar.Add("Email verified successfully.", Severity.Success);
+                Feedback.ShowSuccess("Email verified successfully.");
                 _user = await OrganizationService.GetOrganizationUserAsync(OrgId, UserId);
             }
             else
             {
-                Snackbar.Add("Email is already verified.", Severity.Info);
+                Feedback.ShowInfo("Email is already verified.");
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to verify email: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to verify email: {ex.Message}", autoDismissMs: 0);
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SchemaProviderHealth.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SchemaProviderHealth.razor
@@ -8,8 +8,9 @@
 @using MudBlazor
 @using Sorcha.UI.Core.Models.SchemaLibrary
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject ISchemaLibraryApiService SchemaLibraryApi
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Schema Providers - Sorcha Platform</PageTitle>
 
@@ -134,7 +135,7 @@
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to load provider statuses", Severity.Error);
+            Feedback.ShowError("Failed to load provider statuses", autoDismissMs: 0);
         }
         finally
         {
@@ -151,16 +152,16 @@
             var triggered = await SchemaLibraryApi.RefreshProviderAsync(providerName);
             if (triggered)
             {
-                Snackbar.Add($"Refresh triggered for {providerName}. Status will update on next page load.", Severity.Success);
+                Feedback.ShowSuccess($"Refresh triggered for {providerName}. Status will update on next page load.");
             }
             else
             {
-                Snackbar.Add($"Refresh for {providerName} was rejected (may be in backoff)", Severity.Warning);
+                Feedback.ShowWarning($"Refresh for {providerName} was rejected (may be in backoff)");
             }
         }
         catch (Exception)
         {
-            Snackbar.Add($"Failed to refresh {providerName}", Severity.Error);
+            Feedback.ShowError($"Failed to refresh {providerName}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SectorConfiguration.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/SectorConfiguration.razor
@@ -7,8 +7,9 @@
 @using Microsoft.AspNetCore.Authorization
 @using MudBlazor
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject ISchemaLibraryApiService SchemaLibraryApi
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Schema Sectors - Sorcha Platform</PageTitle>
 
@@ -104,7 +105,7 @@
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to load sector configuration", Severity.Error);
+            Feedback.ShowError("Failed to load sector configuration", autoDismissMs: 0);
         }
         finally
         {
@@ -145,11 +146,11 @@
         {
             string[]? sectors = _allEnabled ? null : _enabledSectors.ToArray();
             await SchemaLibraryApi.UpdateSectorPreferencesAsync(sectors);
-            Snackbar.Add("Sector preferences saved successfully", Severity.Success);
+            Feedback.ShowSuccess("Sector preferences saved successfully");
         }
         catch (Exception)
         {
-            Snackbar.Add("Failed to save sector preferences", Severity.Error);
+            Feedback.ShowError("Failed to save sector preferences", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/OrgSettings.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/OrgSettings.razor
@@ -8,10 +8,11 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IOrganizationAdminService OrgService
 @inject IAuditService AuditService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Organization Settings - Sorcha Platform</PageTitle>
 
@@ -151,7 +152,7 @@
     {
         if (_retentionMonths < 1 || _retentionMonths > 120)
         {
-            Snackbar.Add("Retention must be between 1 and 120 months", Severity.Warning);
+            Feedback.ShowWarning("Retention must be between 1 and 120 months");
             return;
         }
 
@@ -159,12 +160,18 @@
         try
         {
             var success = await AuditService.UpdateRetentionAsync(_organizationId, _retentionMonths);
-            Snackbar.Add(success ? "Retention updated" : "Failed to update retention",
-                success ? Severity.Success : Severity.Error);
+            if (success)
+            {
+                Feedback.ShowSuccess("Retention updated");
+            }
+            else
+            {
+                Feedback.ShowError("Failed to update retention", autoDismissMs: 0);
+            }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
@@ -12,9 +12,10 @@
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Components.Designer
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IBlueprintApiService BlueprintApi
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject NavigationManager Navigation
 
 <PageTitle>My Blueprints - Sorcha Platform</PageTitle>
@@ -249,7 +250,7 @@
 
         if (result is { Canceled: false })
         {
-            Snackbar.Add($"Blueprint '{blueprint.Title}' published successfully", Severity.Success);
+            Feedback.ShowSuccess($"Blueprint '{blueprint.Title}' published successfully");
             await LoadBlueprintsAsync();
         }
     }
@@ -270,7 +271,7 @@
         var fullBlueprint = await BlueprintApi.GetBlueprintDetailAsync(blueprint.Id);
         if (fullBlueprint is null)
         {
-            Snackbar.Add("Could not load blueprint details", Severity.Warning);
+            Feedback.ShowWarning("Could not load blueprint details");
             return;
         }
 
@@ -297,17 +298,17 @@
                 var success = await BlueprintApi.DeleteBlueprintAsync(blueprint.Id);
                 if (success)
                 {
-                    Snackbar.Add($"Blueprint '{blueprint.Title}' deleted", Severity.Success);
+                    Feedback.ShowSuccess($"Blueprint '{blueprint.Title}' deleted");
                     await LoadBlueprintsAsync();
                 }
                 else
                 {
-                    Snackbar.Add("Failed to delete blueprint", Severity.Error);
+                    Feedback.ShowError("Failed to delete blueprint", autoDismissMs: 0);
                 }
             }
             catch
             {
-                Snackbar.Add("Error deleting blueprint", Severity.Error);
+                Feedback.ShowError("Error deleting blueprint", autoDismissMs: 0);
             }
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/CreateOrganization.razor
@@ -4,8 +4,9 @@
 @using Microsoft.AspNetCore.Authorization
 @using MudBlazor
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IOrgProvisioningClientService OrgService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject NavigationManager Navigation
 
 <PageTitle>Create Organisation</PageTitle>
@@ -92,7 +93,7 @@
                 _success = true;
                 _resultName = result.OrganizationName;
                 _resultSubdomain = result.Subdomain;
-                Snackbar.Add("Organisation created!", Severity.Success);
+                Feedback.ShowSuccess("Organisation created!");
             }
             else
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
@@ -27,10 +27,11 @@
 @using Microsoft.Extensions.Logging
 @using MudBlazor
 @using Sorcha.CitizenWallet.Abstractions.Models
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject HttpClient Http
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject ILogger<MyDevices> Logger
 @inject NavigationManager Nav
 
@@ -183,30 +184,28 @@
                         RevokedAt = DateTimeOffset.UtcNow
                     };
                 }
-                Snackbar.Add("Device revoked.", Severity.Success);
+                Feedback.ShowSuccess("Device revoked.");
             }
             else if (response.StatusCode == HttpStatusCode.NotFound)
             {
-                Snackbar.Add("Device not found.", Severity.Warning);
+                Feedback.ShowWarning("Device not found.");
                 await LoadAsync();
             }
             else if (response.StatusCode == HttpStatusCode.BadGateway)
             {
                 // Tenant row IS revoked but Wallet S2S failed. Caller should retry.
-                Snackbar.Add(
-                    "Device marked revoked, but the wallet status-list flip failed. Try again to complete revocation.",
-                    Severity.Warning);
+                Feedback.ShowWarning("Device marked revoked, but the wallet status-list flip failed. Try again to complete revocation.");
                 await LoadAsync();
             }
             else
             {
-                Snackbar.Add($"Revoke failed (HTTP {(int)response.StatusCode}).", Severity.Error);
+                Feedback.ShowError($"Revoke failed (HTTP {(int)response.StatusCode}).", autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Revoke /api/v1/me/devices/{DeviceId} failed", device.DeviceId);
-            Snackbar.Add($"Revoke failed: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Revoke failed: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/NewSubmissionWorkspace.razor
@@ -11,6 +11,7 @@
 @using Sorcha.UI.Core.Models.Wallet
 @using Sorcha.UI.Core.Models.Workflows
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Forms
 @using Sorcha.UI.Core.Services.Wallet
 @inject NavigationStateService NavState
@@ -20,7 +21,7 @@
 @inject IWalletPreferenceService WalletPreferenceService
 @inject IEncryptionOperationTracker EncryptionTracker
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject NavigationManager Navigation
 @inject ILogger<NewSubmissionWorkspace> Logger
 
@@ -204,7 +205,7 @@
             var message = result.IsComplete
                 ? "Submission completed successfully!"
                 : $"Submission started — instance {result.InstanceId[..Math.Min(8, result.InstanceId.Length)]}...";
-            Snackbar.Add(message, Severity.Success);
+            Feedback.ShowSuccess(message);
 
             // HAIP external wallet interactions — show QR dialog before navigating away
             if (result.CredentialOffer is { } offer)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Operations.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Operations.razor
@@ -11,10 +11,11 @@
 @using Sorcha.UI.Core.Services.Admin
 @using Sorcha.UI.Core.Services.Wallet
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject IOperationStatusService OperationService
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferenceService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject ILogger<Operations> Logger
 
 <PageTitle>Encryption Operations - Sorcha Platform</PageTitle>
@@ -147,7 +148,7 @@
             var result = await OperationService.ListOperationsAsync(_walletAddress, page, pageSize, ct);
             if (result == null)
             {
-                Snackbar.Add("Failed to load operations", Severity.Error);
+                Feedback.ShowError("Failed to load operations", autoDismissMs: 0);
                 return new TableData<OperationHistoryItem> { Items = [], TotalItems = 0 };
             }
 
@@ -156,7 +157,7 @@
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Error loading operations page {Page}", page);
-            Snackbar.Add("Failed to load operations", Severity.Error);
+            Feedback.ShowError("Failed to load operations", autoDismissMs: 0);
             return new TableData<OperationHistoryItem> { Items = [], TotalItems = 0 };
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Detail.razor
@@ -5,6 +5,7 @@
 @using Sorcha.UI.Core.Components.Participants
 @using Sorcha.UI.Core.Models.Participants
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Core.Services.Participants
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
@@ -35,7 +36,7 @@
     [Inject] private IParticipantApiService ParticipantService { get; set; } = default!;
     [Inject] private IOrganizationAdminService OrganizationService { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
-    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private IInlineFeedback Feedback { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     private ParticipantDetail? _detail;
@@ -94,7 +95,7 @@
         var org = await OrganizationService.GetOrganizationAsync(OrganizationId);
         if (org == null)
         {
-            Snackbar.Add("Could not load organization details", Severity.Error);
+            Feedback.ShowError("Could not load organization details", autoDismissMs: 0);
             return;
         }
 
@@ -113,7 +114,7 @@
 
         if (!result!.Canceled)
         {
-            Snackbar.Add("Participant published to register", Severity.Success);
+            Feedback.ShowSuccess("Participant published to register");
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/Index.razor
@@ -9,6 +9,7 @@
 @using Sorcha.UI.Core.Components.Registers
 @using Sorcha.UI.Core.Models.Registers
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @implements IAsyncDisposable
 
 @inject IRegisterReadService RegisterService
@@ -16,7 +17,7 @@
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject RegisterHubConnection HubConnection
 
 @* Filter state for client-side filtering *@
@@ -499,7 +500,7 @@
     {
         await LoadRegistersAsync();
         StateHasChanged();
-        Snackbar.Add("Successfully subscribed to register.", Severity.Success);
+        Feedback.ShowSuccess("Successfully subscribed to register.");
     }
 
     private async Task ConfirmUnsubscribe(RegisterViewModel register)
@@ -515,12 +516,12 @@
             var success = await SubscriptionService.UnsubscribeAsync(_orgId, register.Id);
             if (success)
             {
-                Snackbar.Add($"Unsubscribed from \"{register.Name}\".", Severity.Success);
+                Feedback.ShowSuccess($"Unsubscribed from \"{register.Name}\".");
                 await LoadRegistersAsync();
             }
             else
             {
-                Snackbar.Add("Failed to unsubscribe. Please try again.", Severity.Error);
+                Feedback.ShowError("Failed to unsubscribe. Please try again.", autoDismissMs: 0);
             }
         }
     }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaDetail.razor
@@ -3,10 +3,11 @@
 @attribute [Authorize]
 @using Sorcha.UI.Core.Models.SchemaLibrary
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.Blueprint.Schemas.Client
 @inject ISchemaLibraryApiService SchemaApiService
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IJSRuntime JSRuntime
 
 <PageTitle>@(_detail?.Title ?? "Schema Detail") - Sorcha Platform</PageTitle>
@@ -274,7 +275,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error loading schema: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error loading schema: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -287,11 +288,11 @@
         try
         {
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", _contentJson);
-            Snackbar.Add("Schema JSON copied to clipboard", Severity.Success);
+            Feedback.ShowSuccess("Schema JSON copied to clipboard");
         }
         catch
         {
-            Snackbar.Add("Failed to copy to clipboard", Severity.Warning);
+            Feedback.ShowWarning("Failed to copy to clipboard");
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/SchemaLibrary.razor
@@ -4,9 +4,10 @@
 @using Sorcha.UI.Core.Components
 @using Sorcha.UI.Core.Models.SchemaLibrary
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject ISchemaLibraryApiService SchemaApiService
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Schema Library - Sorcha Platform</PageTitle>
 
@@ -170,7 +171,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error loading schemas: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error loading schemas: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Templates.razor
@@ -11,10 +11,11 @@
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Components.Designer
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject ITemplateApiService TemplateApi
 @inject IBlueprintApiService BlueprintApi
 @inject ISystemRegisterService RegisterService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject NavigationManager Navigation
 
 <PageTitle>Catalogue - Sorcha Platform</PageTitle>
@@ -355,18 +356,18 @@
             var saved = await BlueprintApi.SaveBlueprintAsync(_previewBlueprint);
             if (saved is not null)
             {
-                Snackbar.Add($"Blueprint created from '{_selectedTemplate.Title}'", Severity.Success);
+                Feedback.ShowSuccess($"Blueprint created from '{_selectedTemplate.Title}'");
                 _ = TemplateApi.IncrementUsageAsync(_selectedTemplate.Id);
                 Navigation.NavigateTo($"blueprints?highlight={saved.Id}");
             }
             else
             {
-                Snackbar.Add("Failed to save blueprint from template", Severity.Error);
+                Feedback.ShowError("Failed to save blueprint from template", autoDismissMs: 0);
             }
         }
         catch
         {
-            Snackbar.Add("Error saving blueprint from template", Severity.Error);
+            Feedback.ShowError("Error saving blueprint from template", autoDismissMs: 0);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Seven batches of Phase 9 — thirty-four user-facing surfaces migrate off `ISnackbar` to `IInlineFeedback` per CLAUDE.md §12. Drops **34 entries** from `.snackbar-allowlist` (**49 → 15**, 69% retired).

| Batch | Scope | Files | Calls |
|---|---|---|---|
| 9a | Five small single-page surfaces | 5 | 12 |
| 9b | Seven admin/schema pages | 7 | 15 |
| 9c | Component + page surfaces (OrgSwitcher, Credential*, AccountsTab, MyDevices) | 5 | 21 |
| 9d | Mid-size admin/designer pages (Templates, Blueprints, Registers/Index, EventsAdmin, OrganizationUserDetail) | 5 | 25 |
| 9e | Sorcha.UI.Core components (OrgSelectorPanel, BlueprintJsonView, OfflineSyncIndicator) | 3 | 13 |
| 9f | Admin components (ServiceHealthDashboard, OrganizationDashboard, OrganizationConfiguration, Validator{Threshold,Registry}Panel) | 5 | 16 |
| 9g | Admin components (InvitationsPanel, OrganizationList, UserList, ValidatorConsentPanel) | 4 | 22 |

**~124 call sites cleared.** Errors carry `autoDismissMs: 0` (explicit acknowledgement per §12); success/info/warning use the 4 s auto-dismiss default. Ternary-shape `Snackbar.Add(success ? ... : ...)` calls expanded to explicit branches. Dynamic-severity `switch` expressions flattened to per-severity `Feedback.Show*` calls.

## Skipped — saved for later phases

- **Dialogs** (`AcceptInvitationDialog`, `InviteOrganisationDialog`, `TemplateEvaluator`) — need the §12 dialog-content rule (inline `<MudAlert>` inside `DialogContent`, not `IInlineFeedback`). Bigger pattern shift.
- **`TransactionDetailPanel.razor`** — 7 calls, all clipboard-copy confirmations. Per §12 these should migrate to `<CopyButton>` primitive, not `IInlineFeedback`.
- **The big surfaces** (`Settings.razor` ×28, `MyActions.razor` ×11, `IdpConfiguration.razor` ×9, `UserManagement.razor` ×9, `MyProfile.razor` ×8, `PlatformSettings.razor` ×8) — each warrants its own focused PR with manual smoke testing.
- **Designer code-behind** (`AiDesignerPane.razor.cs` ×13, `DesignerToolbar.razor.cs` ×5) — designer surface in flux per the open in-code TODOs.

## Test plan

- [x] `scripts/check-no-snackbar.ps1` passes locally (15 files still on allowlist).
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client -c Release` clean across all seven batches.
- [ ] CI green.
- [ ] Manual smoke on n1 after deploy — touch a sampling of migrated surfaces (create org, suspend a validator, switch org, audit log error).

## Scope correction (from earlier session)

My earlier estimate said Phase 9 was "two paths, ~33 calls, ~6h". Reality was ~170 calls across 49 files. This PR clears 69% of the surface in ~2.5h of mechanical work. The remaining 15 files each need judgment — dialog body rewrites, CopyButton extraction, large-page test surface — so the final 5-or-so PRs will be smaller and slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)