### PR TITLE
refactor(ui): retire ISnackbar from 3 dialog surfaces (Snackbar Phase 9h)

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -21,12 +21,9 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyProfile.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/TransactionDetailPanel.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/AcceptInvitationDialog.razor
@@ -8,7 +8,6 @@
 @inject IRegisterInvitationServiceClient InvitationClient
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject NavigationManager Navigation
-@inject ISnackbar Snackbar
 
 <MudDialog>
     <TitleContent>
@@ -147,11 +146,13 @@
         _isSubmitting = true;
         try
         {
+            // Feature 118 §12 dialog rule — success is conveyed by the inline
+            // MudAlert in DialogContent (rendered when _result is non-null).
+            // The parent picks up the DialogResult.Ok payload on Close.
             _result = await InvitationClient.AcceptAsync(orgId, new AcceptInvitationRequest
             {
                 InvitationToken = _token.Trim(),
             });
-            Snackbar.Add($"Joined register {_result.RegisterName ?? _result.RegisterId}", Severity.Success);
         }
         catch (InvitationApiException ex)
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Registers/InviteOrganisationDialog.razor
@@ -11,7 +11,6 @@
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject NavigationManager Navigation
 @inject IJSRuntime JS
-@inject ISnackbar Snackbar
 
 <MudDialog>
     <TitleContent>
@@ -97,6 +96,16 @@
                 <MudText Typo="Typo.caption" Color="Color.Secondary">
                     Expires @_result.ExpiresAt.ToString("yyyy-MM-dd HH:mm") UTC
                 </MudText>
+
+                @* Feature 118 §12 dialog rule — clipboard-fail surfaces as an
+                   inline MudAlert; success is implicit (the value is already in
+                   the field, the user just clicked Copy). *@
+                @if (_copyError is not null)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" data-testid="invite-copy-warning">
+                        @_copyError
+                    </MudAlert>
+                }
             }
         </MudStack>
     </DialogContent>
@@ -137,6 +146,7 @@
     private int _expiresInDays = 7;
     private string? _didError;
     private string? _submitError;
+    private string? _copyError;
     private bool _isSubmitting;
     private InvitationCreatedResponse? _result;
 
@@ -224,17 +234,20 @@
 
     // navigator.clipboard throws when the page isn't served over HTTPS or the user denies
     // the permission prompt. Silently failing leaves the admin thinking the token was
-    // copied when it wasn't — surface the failure with instructions to copy manually.
+    // copied when it wasn't — surface the failure with an inline MudAlert in
+    // DialogContent (the dialog body can't host IInlineFeedback). Success is implicit:
+    // the value is already visible in the read-only field above the Copy button.
     private async Task CopyToClipboardAsync(string value, string successMessage)
     {
+        _ = successMessage; // success path is now signalled by the field-stays-on-screen UX
         try
         {
             await JS.InvokeVoidAsync("navigator.clipboard.writeText", value);
-            Snackbar.Add(successMessage, Severity.Success);
+            _copyError = null;
         }
         catch
         {
-            Snackbar.Add("Clipboard unavailable — select the field above and copy manually.", Severity.Warning);
+            _copyError = "Clipboard unavailable — select the field above and copy manually.";
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Templates/TemplateEvaluator.razor
@@ -5,7 +5,6 @@
 @using Sorcha.UI.Core.Services
 
 @inject ITemplateApiService TemplateApi
-@inject ISnackbar Snackbar
 @inject NavigationManager Navigation
 
 <MudDialog>
@@ -73,6 +72,14 @@
             {
                 <MudAlert Severity="Severity.Error" Class="mt-2">@_validationError</MudAlert>
             }
+            else if (_validationSuccess)
+            {
+                @* Feature 118 §12 dialog rule — inline validation feedback;
+                   the dialog body can't host IInlineFeedback. *@
+                <MudAlert Severity="Severity.Success" Dense="true" Class="mt-2">
+                    Parameters are valid
+                </MudAlert>
+            }
         }
     </DialogContent>
     <DialogActions>
@@ -101,6 +108,7 @@
 
     private Dictionary<string, object> _parameters = new();
     private string? _validationError;
+    private bool _validationSuccess;
     private bool _processing;
 
     protected override void OnParametersSet()
@@ -121,6 +129,7 @@
     {
         _parameters[name] = value;
         _validationError = null;
+        _validationSuccess = false; // any edit invalidates the prior "valid" badge
     }
 
     private string GetStringValue(string name, object? defaultValue) =>
@@ -146,13 +155,14 @@
 
         _processing = true;
         _validationError = null;
+        _validationSuccess = false;
 
         try
         {
             var isValid = await TemplateApi.ValidateParametersAsync(Template.Id, _parameters);
             if (isValid)
             {
-                Snackbar.Add("Parameters are valid", Severity.Success);
+                _validationSuccess = true;
             }
             else
             {
@@ -181,7 +191,9 @@
             var result = await TemplateApi.EvaluateTemplateAsync(Template.Id, _parameters);
             if (result != null)
             {
-                Snackbar.Add("Template evaluated successfully. Opening in Designer.", Severity.Success);
+                // Feature 118 §12 dialog rule — close with the result payload;
+                // Templates.razor surfaces the "Blueprint created from …" success
+                // via IInlineFeedback after the dialog returns.
                 MudDialog?.Close(DialogResult.Ok(result));
             }
             else


### PR DESCRIPTION
## Summary

Three dialog flows migrate off `ISnackbar` per CLAUDE.md §12 dialog rule — inline `<MudAlert>` inside `DialogContent`, **not** `IInlineFeedback` (the host doesn't mount inside dialog surfaces).

| File | Migration shape |
|---|---|
| `Components/Registers/AcceptInvitationDialog.razor` | Success snackbar was redundant with the inline `<MudAlert Severity="Severity.Success">` already in `DialogContent` when `_result is not null`. Dropped. |
| `Components/Registers/InviteOrganisationDialog.razor` | Clipboard-success snackbar dropped (the value sits in the read-only field next to the Copy button — copy success is implicit). Clipboard-fail warning becomes an inline `<MudAlert Severity="Severity.Warning">` toggled by a new `_copyError` field. |
| `Components/Templates/TemplateEvaluator.razor` | "Parameters are valid" success becomes an inline `<MudAlert Severity="Severity.Success">` via a new `_validationSuccess` field (cleared on any edit). "Template evaluated successfully" snackbar dropped — `Templates.razor` (the parent) already surfaces "Blueprint created from …" via `IInlineFeedback` after the dialog returns. |

## Coordination with PR #766

This PR branches off master, so the allowlist starts from the original 49-line state. PR #766 removes 34 *different* lines (mechanical migrations). Both PRs touch only `.snackbar-allowlist` outside their own scope and remove distinct lines — Git should auto-resolve the merge.

After both land: 49 - 34 (#766) - 3 (#767) = **12 files remaining** on the allowlist.

## Test plan

- [x] `scripts/check-no-snackbar.ps1` passes locally.
- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client -c Release` clean.
- [ ] CI green.
- [ ] After deploy, manual smoke: accept an invitation (dialog shows success table), generate an invitation (Copy button error path triggers inline warning), evaluate a template (Validate shows green badge; Use Template closes and parent shows success banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)