### PR TITLE
feat(myactions): post-action IssuanceSummaryPanel dialog (Feature 062 follow-up)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Workflows/ActionSubmissionResultViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Workflows/ActionSubmissionResultViewModel.cs
@@ -54,6 +54,13 @@ public record ActionSubmissionResultViewModel
     public bool HasAsyncOperation => IsAsync && !string.IsNullOrEmpty(OperationId);
 
     /// <summary>
+    /// Rich summary of a credential issued by this action — drives the
+    /// IssuanceSummaryPanel dialog on MyActions.razor. Null when the action
+    /// has no credentialIssuanceConfig or the issuance failed.
+    /// </summary>
+    public IssuedCredentialInfo? IssuedCredential { get; init; }
+
+    /// <summary>
     /// HAIP credential offer URI when the action issues a credential to an external wallet.
     /// Present when TargetAudience is HaipExternalWallet.
     /// </summary>
@@ -69,6 +76,28 @@ public record ActionSubmissionResultViewModel
     /// Whether this result includes a HAIP external wallet interaction.
     /// </summary>
     public bool HasHaipInteraction => CredentialOffer is not null || PresentationRequest is not null;
+}
+
+/// <summary>
+/// Compact, human-readable summary of a credential just issued by an action
+/// execution. Mirrors <c>Sorcha.Blueprint.Service.Models.Responses.IssuedCredentialResponse</c>
+/// — drives the IssuanceSummaryPanel dialog on MyActions.razor.
+/// </summary>
+public record IssuedCredentialInfo
+{
+    public string CredentialId { get; init; } = string.Empty;
+    public string CredentialType { get; init; } = string.Empty;
+    public string IssuedToDid { get; init; } = string.Empty;
+    public string IssuedToName { get; init; } = string.Empty;
+    public string SignedByOrg { get; init; } = string.Empty;
+    public string ProcessedByName { get; init; } = string.Empty;
+    public string ProcessedByRole { get; init; } = string.Empty;
+    public int TotalClaims { get; init; }
+    public int DisclosableClaims { get; init; }
+    public string UsagePolicy { get; init; } = "Reusable";
+    public DateTimeOffset? ExpiresAt { get; init; }
+    public string BlueprintName { get; init; } = string.Empty;
+    public string ActionName { get; init; } = string.Empty;
 }
 
 /// <summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -525,19 +525,20 @@
                             "Credential Verification", requestParams, requestOptions);
                     }
 
-                    // TODO: When the Blueprint Service surfaces credential issuance data in the
-                    // ActionSubmissionResultViewModel (e.g. an IssuedCredential property), show
-                    // the IssuanceSummaryPanel dialog here:
-                    //
-                    // if (submitResult.IssuedCredential is not null)
-                    // {
-                    //     var summaryParams = new DialogParameters<IssuanceSummaryPanel>
-                    //     {
-                    //         { x => x.Summary, MapToIssuanceSummary(submitResult.IssuedCredential, action) }
-                    //     };
-                    //     var summaryOptions = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true };
-                    //     await DialogService.ShowAsync<IssuanceSummaryPanel>("Credential Issued", summaryParams, summaryOptions);
-                    // }
+                    // Feature 062 follow-up — when the action minted a credential, show the
+                    // IssuanceSummaryPanel after any HAIP-side QR dialogs close. The server
+                    // populates submitResult.IssuedCredential from
+                    // ActionSubmissionResponse.IssuedCredential (Sorcha.Blueprint.Service).
+                    if (submitResult.IssuedCredential is not null)
+                    {
+                        var summaryParams = new DialogParameters<IssuanceSummaryPanel>
+                        {
+                            { x => x.Summary, MapToIssuanceSummary(submitResult.IssuedCredential) }
+                        };
+                        var summaryOptions = new DialogOptions { MaxWidth = MaxWidth.Small, FullWidth = true };
+                        await DialogService.ShowAsync<IssuanceSummaryPanel>(
+                            "Credential Issued", summaryParams, summaryOptions);
+                    }
                 }
                 else
                 {
@@ -639,4 +640,27 @@
 
         return ValueTask.CompletedTask;
     }
+
+    /// <summary>
+    /// Maps the server-supplied <see cref="IssuedCredentialInfo"/> to the dialog's
+    /// <see cref="IssuanceSummaryViewModel"/>. The server populates every human-readable
+    /// field (recipient name, issuing org, processed-by) using JWT claims +
+    /// participant-lookup; the UI is a pure pass-through.
+    /// </summary>
+    private static IssuanceSummaryViewModel MapToIssuanceSummary(IssuedCredentialInfo info) =>
+        new()
+        {
+            CredentialType = info.CredentialType,
+            IssuedToDid = info.IssuedToDid,
+            IssuedToName = info.IssuedToName,
+            SignedByOrg = info.SignedByOrg,
+            ProcessedByName = info.ProcessedByName,
+            ProcessedByRole = info.ProcessedByRole,
+            TotalClaims = info.TotalClaims,
+            DisclosableClaims = info.DisclosableClaims,
+            UsagePolicy = info.UsagePolicy,
+            ExpiresAt = info.ExpiresAt,
+            BlueprintName = info.BlueprintName,
+            ActionName = info.ActionName
+        };
 }

--- a/src/Services/Sorcha.Blueprint.Service/Models/Responses/ActionSubmissionResponse.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/Responses/ActionSubmissionResponse.cs
@@ -51,9 +51,20 @@ public record ActionSubmissionResponse
     public List<string>? Warnings { get; init; }
 
     /// <summary>
-    /// Credential ID if a verifiable credential was issued by this action
+    /// Credential ID if a verifiable credential was issued by this action.
     /// </summary>
+    /// <remarks>
+    /// Retained for backwards-compatible clients. New consumers should prefer
+    /// the richer <see cref="IssuedCredential"/> object when present.
+    /// </remarks>
     public string? IssuedCredentialId { get; init; }
+
+    /// <summary>
+    /// Rich summary of the credential issued by this action. Present whenever
+    /// the action has a credentialIssuanceConfig and the issuance succeeded.
+    /// Powers the post-action IssuanceSummaryPanel dialog on the UI side.
+    /// </summary>
+    public IssuedCredentialResponse? IssuedCredential { get; init; }
 
     /// <summary>
     /// Operation ID for async encryption tracking (non-null when IsAsync is true).
@@ -96,6 +107,53 @@ public record ActionSubmissionResponse
     /// writes the PresentationOutcome that advances the action on success.
     /// </summary>
     public bool AwaitingPresentation { get; init; }
+}
+
+/// <summary>
+/// Compact, human-readable summary of a credential just issued by an action
+/// execution. Populated alongside the legacy <see cref="ActionSubmissionResponse.IssuedCredentialId"/>
+/// when the action's credentialIssuanceConfig fires successfully.
+/// </summary>
+public record IssuedCredentialResponse
+{
+    /// <summary>Unique credential identifier (urn:uuid:... shape).</summary>
+    public required string CredentialId { get; init; }
+
+    /// <summary>Credential type (e.g. "AssuredIdentityCredential").</summary>
+    public required string CredentialType { get; init; }
+
+    /// <summary>Recipient DID (typically a Sorcha wallet address; falls back to whatever the engine produced).</summary>
+    public required string IssuedToDid { get; init; }
+
+    /// <summary>Best-effort display name for the recipient. Falls back to a truncated DID when no participant lookup matched.</summary>
+    public required string IssuedToName { get; init; }
+
+    /// <summary>Display name of the signing organisation (from the issuance config, or a truncated issuer DID fallback).</summary>
+    public required string SignedByOrg { get; init; }
+
+    /// <summary>Display name of the user who processed the action (caller of the submit endpoint).</summary>
+    public required string ProcessedByName { get; init; }
+
+    /// <summary>Role of the user who processed the action (first role claim, or "Member" as a generic fallback).</summary>
+    public required string ProcessedByRole { get; init; }
+
+    /// <summary>Total number of claims in the issued credential.</summary>
+    public required int TotalClaims { get; init; }
+
+    /// <summary>Number of claims marked selectively disclosable in the blueprint's credentialIssuanceConfig.</summary>
+    public required int DisclosableClaims { get; init; }
+
+    /// <summary>Human-readable usage policy (e.g. "Reusable", "Single-use", "Up to N presentations").</summary>
+    public required string UsagePolicy { get; init; }
+
+    /// <summary>Expiry timestamp, if any.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>Blueprint title that drove the issuance.</summary>
+    public required string BlueprintName { get; init; }
+
+    /// <summary>Title of the specific action within the blueprint.</summary>
+    public required string ActionName { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1047,6 +1047,11 @@ public class ActionExecutionService : IActionExecutionService
         }
 
         // 16. Build response
+        var issuedCredentialResponse = issuedCredential is null
+            ? null
+            : await BuildIssuedCredentialResponseAsync(
+                issuedCredential, blueprint, actionDef, caller, cancellationToken);
+
         var response = new ActionSubmissionResponse
         {
             TransactionId = confirmedTxId,
@@ -1062,6 +1067,7 @@ public class ActionExecutionService : IActionExecutionService
             IsComplete = routingResult.NextActions.Count == 0,
             Warnings = validationResult.Warnings,
             IssuedCredentialId = issuedCredential?.CredentialId,
+            IssuedCredential = issuedCredentialResponse,
             CredentialOffer = haipOfferResult != null
                 ? new HaipCredentialOfferResponse
                 {
@@ -2516,6 +2522,101 @@ public class ActionExecutionService : IActionExecutionService
                 instance.Id);
         }
     }
+
+    /// <summary>
+    /// Build the post-action <see cref="IssuedCredentialResponse"/> summary. Best-effort lookups
+    /// — a participant-lookup failure degrades to a truncated DID rather than failing the response.
+    /// </summary>
+    private async Task<IssuedCredentialResponse> BuildIssuedCredentialResponseAsync(
+        Sorcha.ServiceClients.Wallet.CredentialIssuanceResult issuedCredential,
+        BlueprintModel blueprint,
+        ActionModel actionDef,
+        ClaimsPrincipal? caller,
+        CancellationToken cancellationToken)
+    {
+        var issuedToName = await ResolveRecipientNameAsync(issuedCredential.SubjectDid, cancellationToken);
+        var processedByName = caller?.FindFirst("name")?.Value
+                              ?? caller?.FindFirst(ClaimTypes.Name)?.Value
+                              ?? "Unknown";
+        var processedByRole = caller?.FindFirst("role")?.Value
+                              ?? caller?.FindFirst(ClaimTypes.Role)?.Value
+                              ?? "Member";
+
+        // Org name comes from the caller's JWT (org_name claim) — same source used by
+        // the credential mint path. Falls back to a truncated issuer DID when missing.
+        var signedByOrg = caller?.FindFirst("org_name")?.Value;
+        if (string.IsNullOrEmpty(signedByOrg))
+        {
+            signedByOrg = TruncateDid(issuedCredential.IssuerDid);
+        }
+
+        var disclosableCount = actionDef.CredentialIssuanceConfig?.Disclosable?.Count() ?? 0;
+
+        return new IssuedCredentialResponse
+        {
+            CredentialId = issuedCredential.CredentialId,
+            CredentialType = string.IsNullOrEmpty(issuedCredential.Type)
+                ? actionDef.CredentialIssuanceConfig?.CredentialType ?? "Credential"
+                : issuedCredential.Type,
+            IssuedToDid = issuedCredential.SubjectDid,
+            IssuedToName = issuedToName,
+            SignedByOrg = signedByOrg,
+            ProcessedByName = processedByName,
+            ProcessedByRole = processedByRole,
+            TotalClaims = issuedCredential.Claims.Count,
+            DisclosableClaims = disclosableCount,
+            UsagePolicy = FormatUsagePolicy(
+                actionDef.CredentialIssuanceConfig?.UsagePolicy ?? UsagePolicy.Reusable,
+                actionDef.CredentialIssuanceConfig?.MaxPresentations),
+            ExpiresAt = issuedCredential.ExpiresAt,
+            BlueprintName = string.IsNullOrEmpty(blueprint.Title) ? blueprint.Id : blueprint.Title,
+            ActionName = string.IsNullOrEmpty(actionDef.Title) ? actionDef.Id.ToString() : actionDef.Title
+        };
+    }
+
+    private async Task<string> ResolveRecipientNameAsync(string subjectDid, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subjectDid))
+        {
+            return "Unknown recipient";
+        }
+
+        // SubjectDid is usually a wallet address (ws11q...). Try the participant lookup;
+        // fall back to a truncated DID display when no participant has linked it.
+        try
+        {
+            var participant = await _participantClient.GetByWalletAddressAsync(subjectDid, cancellationToken);
+            if (participant is not null && !string.IsNullOrEmpty(participant.DisplayName))
+            {
+                return participant.DisplayName;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "Participant lookup failed for credential subject {SubjectDid} — falling back to truncated DID",
+                subjectDid);
+        }
+
+        return TruncateDid(subjectDid);
+    }
+
+    private static string TruncateDid(string did)
+    {
+        if (string.IsNullOrEmpty(did)) return "(unknown)";
+        if (did.Length <= 16) return did;
+        return $"{did[..8]}…{did[^4..]}";
+    }
+
+    private static string FormatUsagePolicy(UsagePolicy policy, int? maxPresentations) => policy switch
+    {
+        UsagePolicy.Reusable => "Reusable",
+        UsagePolicy.SingleUse => "Single-use",
+        UsagePolicy.LimitedUse => maxPresentations is > 0
+            ? $"Up to {maxPresentations} presentations"
+            : "Limited use",
+        _ => policy.ToString()
+    };
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Closes the TODO at `MyActions.razor:528`. When a workflow action mints a credential, the user submitting it now sees an IssuanceSummaryPanel dialog with the full human-readable summary.

### Server (Sorcha.Blueprint.Service)
- New `IssuedCredentialResponse` record with 13 fields (CredentialId, CredentialType, IssuedToDid, IssuedToName, SignedByOrg, ProcessedByName, ProcessedByRole, TotalClaims, DisclosableClaims, UsagePolicy, ExpiresAt, BlueprintName, ActionName).
- `ActionSubmissionResponse.IssuedCredential` added; the legacy `IssuedCredentialId` string preserved for backwards-compatible clients.
- `ActionExecutionService.BuildIssuedCredentialResponseAsync` populates all fields. Recipient name via `IParticipantServiceClient.GetByWalletAddressAsync` (degrades to truncated DID on miss); `SignedByOrg` / `ProcessedBy*` from JWT claims (`org_name`, `name`, `role`); `BlueprintName` / `ActionName` from blueprint + actionDef; `UsagePolicy` formatted from the enum + `MaxPresentations`.

### UI (Sorcha.UI.Components.User + Sorcha.UI.Web.Client)
- New `IssuedCredentialInfo` record mirrors the server shape on `ActionSubmissionResultViewModel`. Auto-binds via `JsonDefaults.Api` (case-insensitive).
- `MyActions.razor` TODO replaced with the dialog show. New private `MapToIssuanceSummary` helper is a pure pass-through — the server already shaped the human-readable fields.

## Test plan

- [x] 721 existing `ActionExecutionService` tests pass.
- [x] Full `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client -c Release` + `dotnet build src/Services/Sorcha.Blueprint.Service -c Release` clean.
- [ ] CI green.
- [ ] After deploy, manual smoke on n1: re-run AssuredIdentity Phase 1 → verification analyst approves Action 2 → IssuanceSummaryPanel dialog shows with citizen name + Acme Verification Co. + 4 claims + ExpiresAt set.

## Deferred test

A focused unit test for the populate path would either need internal-visibility expose or an extracted static utility — both add scope outside this PR's surface. Happy to follow up if claude-review flags it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)