### PR TITLE
fix(blueprint): notify next participants after async-encrypted action (B-15)

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
@@ -408,6 +408,49 @@ public sealed class EncryptionBackgroundService : BackgroundService
             "Instance {InstanceId} advanced after encrypted action {ActionId}. Next actions: [{NextActions}]",
             workItem.InstanceId, workItem.ActionId,
             string.Join(", ", instance.CurrentActionIds));
+
+        // B-15 — notify the next-action participants and emit workflow-complete
+        // when the chain has run out. The inline ActionExecutionService path
+        // calls NotifyParticipantsAsync at step 15; the async-encrypted path
+        // skipped this, so a user awaiting an action from someone whose
+        // submission went through the encrypted pipeline never received the
+        // real-time SignalR push and saw "All Caught Up" until manual refresh.
+        // Try/catch swallow — a notification failure must NOT roll back the
+        // committed instance state.
+        try
+        {
+            var notificationService = scope.ServiceProvider.GetRequiredService<INotificationService>();
+            foreach (var nextAction in workItem.RoutingResult.NextActions)
+            {
+                string? walletAddress = null;
+                instance.ParticipantWallets?.TryGetValue(nextAction.ParticipantId, out walletAddress);
+
+                await notificationService.NotifyActionAvailableAsync(
+                    instance.Id,
+                    walletAddress,
+                    actionId: nextAction.ActionId.ToString(),
+                    ct: ct);
+            }
+
+            if (workItem.RoutingResult.NextActions.Count == 0)
+            {
+                var walletAddresses = instance.ParticipantWallets?.Values
+                    .Where(w => !string.IsNullOrEmpty(w))
+                    .Distinct()
+                    ?? [];
+
+                await notificationService.NotifyWorkflowCompletedAsync(
+                    instance.Id,
+                    walletAddresses!,
+                    ct);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "NotifyParticipantsAsync (async-encrypted path) failed for instance {InstanceId} after action {ActionId}; instance state is committed but next-participant SignalR push was missed",
+                workItem.InstanceId, workItem.ActionId);
+        }
     }
 
     private async Task StoreActivityEventAsync(


### PR DESCRIPTION
## Summary

Closes **B-15** from the v1 release roadmap (Release Blockers section).

The inline `ActionExecutionService.ExecuteAsync` path calls `NotifyParticipantsAsync` at step 15, pushing real-time `NotifyActionAvailableAsync` to the next action's wallet. The **async-encrypted pipeline** (`EncryptionBackgroundService.WaitForConfirmationAndAdvanceInstanceAsync`) advanced the instance state but skipped this step.

**Symptom:** when user A's submission goes through the encrypted path (Feature 085 file attachments, or any action that triggers async encryption), user B's "Pending Actions" page stays on "All Caught Up" until manual refresh — even though `currentActionIds` on the instance now lists their action.

**Source:** memory file `project_signalr_pending_actions.md` (53 days old, verified against current code).

## Fix

After `WaitForConfirmationAndAdvanceInstanceAsync` saves instance state, iterate `workItem.RoutingResult.NextActions` and call:
- `INotificationService.NotifyActionAvailableAsync(instanceId, walletAddress, actionId, ct)` per next action (resolving the wallet via `instance.ParticipantWallets`).
- `NotifyWorkflowCompletedAsync(instanceId, walletAddresses, ct)` when the chain ran out (`NextActions.Count == 0`).

Try/catch swallow — a notification failure must NOT roll back the already-committed instance state. Log at Warning.

Same pattern + same `INotificationService` API as the inline path's `NotifyParticipantsAsync`.

## Test plan

- [x] `dotnet build src/Services/Sorcha.Blueprint.Service -c Release` clean.
- [ ] CI green.
- [ ] After deploy, manual smoke on n1: submit a F085 file-attachment action as user A; observe user B's `/my-actions` page populate via SignalR push without manual refresh. (The previous broken state showed "All Caught Up" until refresh.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)