### PR TITLE
fix(gateway,ui): UX-007 — proxy /api/v1/me/* to tenant + silence AuthorizeView log spam

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Program.cs
@@ -14,6 +14,15 @@ using Sorcha.UI.Web.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
+// AuthorizeView role-mismatch evaluations log at Info per render — every
+// admin/designer nav block on MainLayout produces a "Authorization failed"
+// line for every non-matching role. For a Consumer that's ~100 lines per
+// page load. Silence the category; legitimate auth failures still surface
+// as HTTP 401s in the network log.
+builder.Logging.AddFilter(
+    "Microsoft.AspNetCore.Authorization.DefaultAuthorizationService",
+    LogLevel.Warning);
+
 // Register root components for standalone WASM
 builder.RootComponents.Add<Routes>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");

--- a/src/Services/Sorcha.ApiGateway/appsettings.json
+++ b/src/Services/Sorcha.ApiGateway/appsettings.json
@@ -351,6 +351,7 @@
       "tenant-participants":    { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/participants/{**catch-all}" } },
       "tenant-service-principals": { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/service-principals/{**catch-all}" } },
       "tenant-me":              { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/me/{**catch-all}" } },
+      "tenant-me-v1":           { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/v1/me/{**catch-all}" } },
       "tenant-address-lookup":  { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/address-lookup/{**catch-all}" } },
       "tenant-events":          { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/events/{**catch-all}" } },
       "tenant-preferences":     { "ClusterId": "tenant-cluster", "AuthorizationPolicy": "RequireAuthenticated", "Match": { "Path": "/api/preferences/{**catch-all}" } },


### PR DESCRIPTION
## Summary

Two browser-console issues surfaced on n1 (Consumer profile) that the original UX-007 task lumped together as "admin-endpoint hits when signed in as a Consumer". They're actually distinct, and only one is a real bug:

### A — `/api/v1/me/devices/has-any` 404 at the gateway (real bug, high impact)

F128's `HasPairedDeviceProbe` calls `GET /api/v1/me/devices/has-any`. The endpoint exists on **tenant-service** (`PlatformUserDeviceEndpoints.cs:60`, group prefix `/api/v1/me/devices`), but the API gateway's YARP routes only forwarded `/api/me/{**catch-all}` to tenant. No route matched the `/api/v1/me/...` prefix, so the gateway returned 404 before the request ever reached tenant.

Direct probes confirmed the diagnosis:

```
anon /api/v1/me/devices/has-any (via gateway): 404
direct wallet-service:8080/api/v1/me/devices/has-any: 404 (correct — wrong service)
direct tenant-service:8080/api/v1/me/devices/has-any: 401 (correct — auth required, endpoint exists)
```

**Result**: F128 PairingNagBanner has been broken on n1 for every signed-in user since F128 shipped. The probe silently caches an unchanged value and the nag-banner never renders. Adding the `tenant-me-v1` route fixes it.

### B — ~100 "Authorization failed" Info log lines per page load (log noise, not a bug)

`Microsoft.AspNetCore.Authorization.DefaultAuthorizationService[2]` logs every `AuthorizeView Roles="..."` mismatch at Info. MainLayout has ~6 admin/designer nav blocks; each renders multiple times during initial reactive cycles. The `wwwroot/appsettings.json` filter (`Microsoft.AspNetCore: Warning`) wasn't being honoured for this category by the WASM logger.

Added an explicit programmatic filter in `Program.cs`. Legitimate auth failures still surface in the network log as HTTP 401s — only the per-render local AuthorizeView noise goes away.

### Not in this PR

- WalletHub negotiate 401 — the trace shows the connection succeeds on retry (`WalletHub connected to https://n1.sorcha.dev/hubs/wallet`). It's a first-call cold-start race, not a real failure. If we want to remove the 401 noise, the right fix is lazy-start on first user-action, deferred for a separate PR.
- InboxPanel cold-open 401 on `/api/me/inbox?page=1&pageSize=50` — known race that PR #759 only partially fixed (it covered the drawer-open path, not OnInitializedAsync). Worth a small follow-up.

## Test plan

- [ ] CI green
- [ ] After merge + Docker Publish: `curl https://n1.sorcha.dev/api/v1/me/devices/has-any` returns 401 (was 404)
- [ ] Sign in to n1 as a Consumer; F128 nag-banner now decides based on real device data
- [ ] Browser console for the same session shows no "Authorization failed" Info entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)