### PR TITLE
chore(samples): move strathcarron-portal out of root docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -669,29 +669,13 @@ services:
     depends_on:
       - api-gateway
 
-  # Feature 127: Strathcarron Council sample portal (Blazor WASM + nginx)
-  # Application-specific consumer artifact — lives in samples/ per the
-  # platform-vs-consumer boundary contract. Hosts the F126 driving-licence
-  # demo page (moved out of Sorcha.UI.Web.Client in F127 PR-A) and, once
-  # F127 PR-C lands, the Blue Badge credential-gated form.
+  # Feature 127: Strathcarron Council sample portal — NOT part of the platform
+  # deliverable. Its service definition lives in
+  # samples/strathcarron-portal/docker-compose.yml as an opt-in overlay. Run
+  # with both compose files together:
+  #   docker compose -f docker-compose.yml \
+  #                  -f samples/strathcarron-portal/docker-compose.yml up -d
   # See docs/superpowers/specs/2026-05-15-platform-consumer-boundary-design.md.
-  strathcarron-portal:
-    build:
-      context: .
-      dockerfile: samples/strathcarron-portal/Dockerfile
-    image: sorchadev/sample-strathcarron-portal:latest
-    container_name: sorcha-sample-strathcarron-portal
-    restart: unless-stopped
-    mem_limit: 128m
-    # Standalone consumer of the Sorcha platform — speaks to Sorcha only
-    # via the public API gateway. Reachable on the host at the chosen
-    # port (5400 by default; see docs/getting-started/PORT-CONFIGURATION.md).
-    ports:
-      - "${STRATHCARRON_PORTAL_PORT:-5400}:80"
-    networks:
-      - sorcha-network
-    depends_on:
-      - api-gateway
 
   # Feature 114: Reference verifier (Blazor Server)
   sorcha-verifier:

--- a/docs/getting-started/PORT-CONFIGURATION.md
+++ b/docs/getting-started/PORT-CONFIGURATION.md
@@ -52,11 +52,11 @@ Sorcha uses a standardized port configuration across all development and deploym
 
 ### Samples / Demo Consumers
 
-Samples in `samples/` are application-specific demo artifacts that run alongside the Sorcha stack and consume the platform's public APIs only (per the platform-vs-consumer boundary doc). They are NOT platform services.
+Samples in `samples/` are application-specific demo artifacts that run alongside the Sorcha stack and consume the platform's public APIs only (per the platform-vs-consumer boundary doc). They are NOT platform services and are NOT included in the root `docker-compose.yml`. Each sample ships its own compose file as an opt-in overlay.
 
-| Sample | Port | Purpose |
-|--------|------|---------|
-| **Strathcarron Portal** | 5400 | F127 demo — council citizen portal (Driving Licence + Blue Badge) consuming the shared `Sorcha.UI.Components.User` library. Reachable at `http://localhost:5400/`. Override the URL via the `STRATHCARRON_PORTAL_URL` env var. |
+| Sample | Port | Purpose | Invocation |
+|--------|------|---------|------------|
+| **Strathcarron Portal** | 5400 | F127 demo — council citizen portal (Driving Licence + Blue Badge) consuming the shared `Sorcha.UI.Components.User` library. Reachable at `http://localhost:5400/`. Override the host port via `STRATHCARRON_PORTAL_PORT`. | `docker compose -f docker-compose.yml -f samples/strathcarron-portal/docker-compose.yml up -d` |
 
 ---
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -15,15 +15,15 @@ Every csproj under `samples/`:
 - **MAY** `ProjectReference` `Sorcha.UI.Components.User` — the published consumer-facing component library.
 - **MAY** `ProjectReference` libraries intended for third-party consumption (`Sorcha.ServiceClients`, `Sorcha.CitizenWallet.Abstractions`, `Sorcha.Blueprint.Models`, etc.). If a real council would NuGet-install a library, samples can `ProjectReference` it.
 - **MUST NOT** `ProjectReference` anything else under `src/Apps/Sorcha.UI/` (e.g. `Sorcha.UI.Core`, `Sorcha.UI.Web.Client`). These are internal-only.
-- **MUST** build to its own container image and ship its own `docker-compose` entry.
+- **MUST** build to its own container image and ship its own `docker-compose.yml` overlay file (NOT a service block in the root `docker-compose.yml` — samples are opt-in, not part of the platform deliverable).
 
 CI grep gate (`scripts/check-samples-references.ps1`, wired into [`samples-boundary-check.yml`](../.github/workflows/samples-boundary-check.yml)) fails the build on a forbidden reference.
 
 ## What lives here
 
-| Folder | Purpose | Container image |
-|---|---|---|
-| [`strathcarron-portal/`](./strathcarron-portal/) | F127 demo — Strathcarron Council citizen portal hosting the Driving Licence form (F126) and Blue Badge form (F127). Reference for "what does a council consumer of Sorcha look like?" | `sorcha-sample-strathcarron-portal` |
+| Folder | Purpose | Container image | Run |
+|---|---|---|---|
+| [`strathcarron-portal/`](./strathcarron-portal/) | F127 demo — Strathcarron Council citizen portal hosting the Driving Licence form (F126) and Blue Badge form (F127). Reference for "what does a council consumer of Sorcha look like?" | `sorcha-sample-strathcarron-portal` | `docker compose -f docker-compose.yml -f samples/strathcarron-portal/docker-compose.yml up -d` |
 
 ## What does NOT live here
 

--- a/samples/strathcarron-portal/docker-compose.yml
+++ b/samples/strathcarron-portal/docker-compose.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+# Strathcarron Council sample portal — opt-in overlay onto the platform stack.
+#
+# This compose file is intentionally OUTSIDE the root docker-compose.yml so the
+# platform deliverable doesn't ship a consumer-side sample. The portal speaks
+# to Sorcha only via the public API gateway and is a reference for what a
+# third-party council deployment would look like.
+#
+# See docs/superpowers/specs/2026-05-15-platform-consumer-boundary-design.md.
+#
+# Recommended invocation — merge with the root stack so the network is shared:
+#   docker compose -f docker-compose.yml \
+#                  -f samples/strathcarron-portal/docker-compose.yml up -d
+#
+# Override the host port via STRATHCARRON_PORTAL_PORT (defaults to 5400).
+
+services:
+  strathcarron-portal:
+    build:
+      # Build context is the repo root so the Dockerfile can reach shared csproj
+      # references under src/Apps/Sorcha.UI/. Relative to this file.
+      context: ../..
+      dockerfile: samples/strathcarron-portal/Dockerfile
+    image: sorchadev/sample-strathcarron-portal:latest
+    container_name: sorcha-sample-strathcarron-portal
+    restart: unless-stopped
+    mem_limit: 128m
+    ports:
+      - "${STRATHCARRON_PORTAL_PORT:-5400}:80"
+    networks:
+      - sorcha-network
+    depends_on:
+      - api-gateway


### PR DESCRIPTION
## Summary
- The Strathcarron portal is a consumer-side sample per the platform-vs-consumer boundary contract. Shipping it as a service in the root `docker-compose.yml` meant every platform operator pulled a council-branded sample image they didn't need — contradicting the boundary the `samples/` tree was meant to draw.
- Moved to an opt-in overlay at `samples/strathcarron-portal/docker-compose.yml`. The Dockerfile and CI image build are unchanged — the image still publishes, it just no longer auto-starts with the platform stack.

## Run the demo
```
docker compose -f docker-compose.yml \
               -f samples/strathcarron-portal/docker-compose.yml up -d
```

## Files changed
- `docker-compose.yml` — 23-line service block replaced with a breadcrumb pointing at the overlay
- `samples/strathcarron-portal/docker-compose.yml` (new) — overlay file with `context: ../..` so the Dockerfile's repo-root paths still resolve
- `docs/getting-started/PORT-CONFIGURATION.md` — samples table shows the merged-compose invocation
- `samples/README.md` — boundary rule updated to "overlay file, not root service block"; table gains a Run column

## Test plan
- [x] `docker compose -f docker-compose.yml -f samples/strathcarron-portal/docker-compose.yml config --quiet` parses cleanly (exit 0)
- [ ] Merged stack `up -d` brings the portal up reachable at `http://localhost:5400/`
- [ ] CI image build for `sample-strathcarron-portal` still publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)