### PR TITLE
fix(128): prefix /app on post-login setup/add-device redirect

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor
@@ -76,7 +76,7 @@
 
     private void HandleSetUpNow()
     {
-        Nav.NavigateTo("/setup/add-device");
+        Nav.NavigateTo("setup/add-device");
     }
 
     public void Dispose()

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
@@ -50,7 +50,7 @@
         <MudButton Variant="Variant.Filled"
                    Color="Color.Primary"
                    StartIcon="@Icons.Material.Filled.AddToHomeScreen"
-                   OnClick="@(() => Nav.NavigateTo("/setup/add-device"))"
+                   OnClick="@(() => Nav.NavigateTo("setup/add-device"))"
                    data-testid="my-devices-add-my-phone">
             Add my phone
         </MudButton>

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PairingResumptionEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PairingResumptionEndpoints.cs
@@ -132,7 +132,10 @@ public static class PairingResumptionEndpoints
             return Results.Redirect("/auth/login?reason=resumption-expired");
         }
 
-        var returnUrl = Uri.EscapeDataString("/setup/add-device");
+        // /app prefix required — the WASM client lives under <base href="/app/">
+        // and NavigateTo treats slash-prefixed paths as origin-absolute,
+        // bypassing the base href. See Login.cshtml.cs:RedirectToApp.
+        var returnUrl = Uri.EscapeDataString("/app/setup/add-device");
         var emailHint = Uri.EscapeDataString(user.Email);
         return Results.Redirect($"/auth/login?returnUrl={returnUrl}&email={emailHint}&reason=pairing-resumption");
     }

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -296,14 +296,18 @@ public class LoginModel : PageModel
     private IActionResult RedirectToApp(TokenResponse tokens)
     {
         // Feature 128 US2 — when the citizen has no paired device and no
-        // explicit ReturnUrl override, route them to /setup/add-device so
+        // explicit ReturnUrl override, route them to /app/setup/add-device so
         // the WASM client lands on the pairing handoff page (FR-020).
+        // The /app prefix is load-bearing: the Sorcha.UI.Web.Client is hosted
+        // under <base href="/app/"> and NavigationManager.NavigateTo treats
+        // a slash-prefixed path as origin-absolute, bypassing the base href.
+        // Without /app the gateway has no matching route and serves 404.
         // Citizens who already have a paired device follow the existing
         // ReturnUrl / "" behaviour unchanged (FR-026).
         var returnUrl = IsValidReturnUrl(ReturnUrl, _returnToAllowlist) ? ReturnUrl : "";
         if (string.IsNullOrEmpty(returnUrl) && ShouldRouteToSetupAddDevice(tokens.AccessToken))
         {
-            returnUrl = "/setup/add-device";
+            returnUrl = "/app/setup/add-device";
         }
 
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +


### PR DESCRIPTION
## Summary
Reported: signing in as a zero-device citizen redirected to `https://n1.sorcha.dev/setup/add-device` and 404'd at the gateway.

Root cause: the F128 post-login routing gate hardcoded paths in the Sorcha.UI.Web.Client URL space without the `/app/` prefix. Two distinct sub-bugs share the cause.

### Server-side (the 404 in the report)
`Login.cshtml.cs` and `PairingResumptionEndpoints.cs` emit `returnUrl = "/setup/add-device"` in the URL fragment sent to the WASM client. The Web Client mounts under `<base href="/app/">`, but `NavigationManager.NavigateTo` treats a slash-prefixed path as **origin-absolute**, bypassing the base href. The browser lands at `/setup/add-device`, which the gateway has no route for (only `/app/{**catch-all}`) — 404.

Fix: emit `/app/setup/add-device` so `NavigateTo` resolves to the gateway-correct path.

### Client-side (sibling bug, same root cause)
`MyDevices.razor`'s "Add my phone" button and `PairingNagBanner`'s "Set up now" button both called `Nav.NavigateTo("/setup/add-device")`. Same bypass-the-base-href bug.

Fix: drop the leading slash so the path is base-href-relative.

## PWA unaffected
The Citizen Wallet PWA (`Sorcha.Wallet.Pwa`, mounted at `/wallet/`) consistently uses base-href-relative navigation (`Nav.NavigateTo("present")`, `Nav.NavigateTo("devices")`, etc.) so it doesn't hit this class of bug. The bug is confined to the Web Client's F128 paths.

## Files changed
- `src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs` — server emits `/app/setup/add-device`
- `src/Services/Sorcha.Tenant.Service/Endpoints/PairingResumptionEndpoints.cs` — magic-link redeem emits the prefixed path
- `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor` — base-href-relative navigation
- `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingNagBanner.razor` — base-href-relative navigation

Each Login.cshtml.cs / PairingResumptionEndpoints.cs change carries an inline comment explaining the `/app` prefix is load-bearing, so the next reader doesn't undo it.

## Test plan
- [x] `dotnet build` clean on `Sorcha.Tenant.Service` and `Sorcha.UI.Web.Client` (0 errors).
- [ ] Manual: sign in as a zero-device citizen against deployed stack → lands on `/app/setup/add-device` (the pairing handoff page) rather than 404.
- [ ] Manual: click "Add my phone" on `/app/my-devices` → same handoff page.
- [ ] Manual: redeem a pairing-resumption magic link → 302 to `/auth/login?returnUrl=%2Fapp%2Fsetup%2Fadd-device&...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)