### PR TITLE
fix(128): close base-href and OAuth-callback gaps from #775

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/BlueprintChat.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/BlueprintChat.razor
@@ -12,6 +12,6 @@
     protected override void OnInitialized()
     {
         var suffix = string.IsNullOrEmpty(ExistingBlueprintId) ? string.Empty : "/" + ExistingBlueprintId;
-        Navigation.NavigateTo($"/designer/blueprint{suffix}?tab=ai", replace: true, forceLoad: false);
+        Navigation.NavigateTo($"designer/blueprint{suffix}?tab=ai", replace: true, forceLoad: false);
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer.razor
@@ -7,5 +7,5 @@
 
 @code {
     protected override void OnInitialized()
-        => Navigation.NavigateTo("/designer/blueprint?tab=diagram", replace: true, forceLoad: false);
+        => Navigation.NavigateTo("designer/blueprint?tab=diagram", replace: true, forceLoad: false);
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/AcceptInvitation.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Registers/AcceptInvitation.razor
@@ -56,6 +56,6 @@
 
         // Whether accepted or cancelled, return the user to the Registers page.
         // The panel there picks up the new subscription on its next load.
-        Navigation.NavigateTo("/registers");
+        Navigation.NavigateTo("registers");
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/Login.cshtml.cs
@@ -297,17 +297,16 @@ public class LoginModel : PageModel
     {
         // Feature 128 US2 — when the citizen has no paired device and no
         // explicit ReturnUrl override, route them to /app/setup/add-device so
-        // the WASM client lands on the pairing handoff page (FR-020).
-        // The /app prefix is load-bearing: the Sorcha.UI.Web.Client is hosted
-        // under <base href="/app/"> and NavigationManager.NavigateTo treats
-        // a slash-prefixed path as origin-absolute, bypassing the base href.
-        // Without /app the gateway has no matching route and serves 404.
-        // Citizens who already have a paired device follow the existing
-        // ReturnUrl / "" behaviour unchanged (FR-026).
+        // the WASM client lands on the pairing handoff page (FR-020). The
+        // routing-gate contract is shared with the OIDC and Social callbacks
+        // via SetupAddDeviceRoutingGate; the /app/ prefix rationale lives
+        // there. Citizens who already have a paired device follow the
+        // existing ReturnUrl / "" behaviour unchanged (FR-026).
         var returnUrl = IsValidReturnUrl(ReturnUrl, _returnToAllowlist) ? ReturnUrl : "";
-        if (string.IsNullOrEmpty(returnUrl) && ShouldRouteToSetupAddDevice(tokens.AccessToken))
+        if (string.IsNullOrEmpty(returnUrl)
+            && SetupAddDeviceRoutingGate.ShouldRoute(tokens.AccessToken, _deviceService, _logger))
         {
-            returnUrl = "/app/setup/add-device";
+            returnUrl = SetupAddDeviceRoutingGate.SetupAddDevicePath;
         }
 
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
@@ -317,40 +316,6 @@ public class LoginModel : PageModel
             fragment += $"&returnUrl={Uri.EscapeDataString(returnUrl!)}";
         }
         return Redirect($"/app/#{fragment}");
-    }
-
-    /// <summary>
-    /// Reads <c>platform_user_id</c> from the freshly-issued access token and
-    /// queries <see cref="IPlatformUserDeviceService.HasAnyAsync"/>. Returns
-    /// true when the citizen has zero active paired devices — the F128
-    /// auto-route trigger. Non-fatal: any failure (token parse, DB error)
-    /// is logged and falls through to the existing redirect behaviour.
-    /// </summary>
-    private bool ShouldRouteToSetupAddDevice(string accessToken)
-    {
-        try
-        {
-            var handler = new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
-            var jwt = handler.ReadJwtToken(accessToken);
-            var raw = jwt.Claims.FirstOrDefault(c => c.Type == "platform_user_id")?.Value;
-            if (!Guid.TryParse(raw, out var platformUserId))
-            {
-                return false;
-            }
-
-            // Block synchronously on the aggregate read; this is one cheap
-            // DB hit on the post-login path, and the call site is already
-            // synchronous so refactoring all three sites to async-everything
-            // is more invasive than warranted.
-            var (hasAny, _) = _deviceService.HasAnyAsync(platformUserId).GetAwaiter().GetResult();
-            return !hasAny;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "F128 setup-add-device routing check failed — falling through to default redirect");
-            return false;
-        }
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/OidcCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/OidcCallback.cshtml.cs
@@ -32,6 +32,7 @@ public class OidcCallbackModel : PageModel
     private readonly IOrganizationRepository _organizationRepository;
     private readonly TenantDbContext _dbContext;
     private readonly ILogger<OidcCallbackModel> _logger;
+    private readonly IPlatformUserDeviceService _deviceService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OidcCallbackModel"/> class.
@@ -44,7 +45,8 @@ public class OidcCallbackModel : PageModel
         IIdentityRepository identityRepository,
         IOrganizationRepository organizationRepository,
         TenantDbContext dbContext,
-        ILogger<OidcCallbackModel> logger)
+        ILogger<OidcCallbackModel> logger,
+        IPlatformUserDeviceService deviceService)
     {
         _oidcExchangeService = oidcExchangeService;
         _oidcProvisioningService = oidcProvisioningService;
@@ -54,6 +56,7 @@ public class OidcCallbackModel : PageModel
         _organizationRepository = organizationRepository;
         _dbContext = dbContext;
         _logger = logger;
+        _deviceService = deviceService;
     }
 
     /// <summary>
@@ -217,7 +220,7 @@ public class OidcCallbackModel : PageModel
                 "OIDC login completed for org {OrgSubdomain}: userId={UserId}, isFirstLogin={IsFirstLogin}",
                 orgSubdomain, user.Id, isFirstLogin);
 
-            return RedirectToApp(tokenResponse);
+            return await RedirectToAppAsync(tokenResponse, ct);
         }
         catch (InvalidOperationException ex)
         {
@@ -333,13 +336,20 @@ public class OidcCallbackModel : PageModel
         _logger.LogInformation(
             "OIDC profile completion succeeded for user {UserId}", user.Id);
 
-        return RedirectToApp(tokenResponse);
+        return await RedirectToAppAsync(tokenResponse, ct);
     }
 
-    private IActionResult RedirectToApp(TokenResponse tokens)
+    private async Task<IActionResult> RedirectToAppAsync(TokenResponse tokens, CancellationToken ct)
     {
+        // Feature 128 US2 — same FR-020 routing-gate contract as Login.cshtml.cs.
+        // OIDC flow has no user-provided ReturnUrl, so the gate is the only
+        // decision point.
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
                        $"&refresh={Uri.EscapeDataString(tokens.RefreshToken)}";
+        if (await SetupAddDeviceRoutingGate.ShouldRouteAsync(tokens.AccessToken, _deviceService, _logger, ct))
+        {
+            fragment += $"&returnUrl={Uri.EscapeDataString(SetupAddDeviceRoutingGate.SetupAddDevicePath)}";
+        }
         return Redirect($"/app/#{fragment}");
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SetupAddDeviceRoutingGate.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SetupAddDeviceRoutingGate.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.IdentityModel.Tokens.Jwt;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Pages.Auth;
+
+/// <summary>
+/// Feature 128 US2 post-login routing gate — single source of truth for the
+/// FR-020/FR-026 contract: when a citizen has zero paired devices and no
+/// explicit ReturnUrl override, the fragment redirect MUST route them to
+/// <c>/app/setup/add-device</c> so the WASM client lands on the pairing
+/// handoff page.
+///
+/// The <c>/app/</c> prefix is load-bearing — Sorcha.UI.Web.Client is hosted
+/// under <c>&lt;base href="/app/"&gt;</c> and <c>NavigationManager.NavigateTo</c>
+/// treats a slash-prefixed path as origin-absolute, bypassing the base href.
+/// Without the prefix the gateway has no matching route and serves 404.
+/// </summary>
+internal static class SetupAddDeviceRoutingGate
+{
+    /// <summary>
+    /// The fragment <c>returnUrl</c> value to inject when the gate fires.
+    /// </summary>
+    public const string SetupAddDevicePath = "/app/setup/add-device";
+
+    /// <summary>
+    /// Reads <c>platform_user_id</c> from the freshly-issued access token and
+    /// queries <see cref="IPlatformUserDeviceService.HasAnyAsync"/>. Returns
+    /// true when the citizen has zero active paired devices — the F128
+    /// auto-route trigger. Non-fatal: any failure (token parse, DB error)
+    /// is logged and falls through to the existing redirect behaviour.
+    /// </summary>
+    public static async Task<bool> ShouldRouteAsync(
+        string accessToken,
+        IPlatformUserDeviceService deviceService,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(accessToken);
+            var raw = jwt.Claims.FirstOrDefault(c => c.Type == "platform_user_id")?.Value;
+            if (!Guid.TryParse(raw, out var platformUserId))
+            {
+                return false;
+            }
+
+            var (hasAny, _) = await deviceService.HasAnyAsync(platformUserId, ct).ConfigureAwait(false);
+            return !hasAny;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "F128 setup-add-device routing check failed — falling through to default redirect");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Sync wrapper around <see cref="ShouldRouteAsync"/> for callers on
+    /// synchronous code paths (Login.cshtml.cs's <c>RedirectToApp</c>).
+    /// </summary>
+    public static bool ShouldRoute(
+        string accessToken,
+        IPlatformUserDeviceService deviceService,
+        ILogger logger)
+        => ShouldRouteAsync(accessToken, deviceService, logger, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+}

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
@@ -28,6 +28,7 @@ public class SocialCallbackModel : PageModel
     private readonly IWelcomeEmailDispatcher _welcomeDispatcher;
     private readonly TenantDbContext _db;
     private readonly ILogger<SocialCallbackModel> _logger;
+    private readonly IPlatformUserDeviceService _deviceService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SocialCallbackModel"/> class.
@@ -40,7 +41,8 @@ public class SocialCallbackModel : PageModel
         ITokenService tokenService,
         IWelcomeEmailDispatcher welcomeDispatcher,
         TenantDbContext db,
-        ILogger<SocialCallbackModel> logger)
+        ILogger<SocialCallbackModel> logger,
+        IPlatformUserDeviceService deviceService)
     {
         _socialLoginService = socialLoginService;
         _platformUserService = platformUserService;
@@ -50,6 +52,7 @@ public class SocialCallbackModel : PageModel
         _welcomeDispatcher = welcomeDispatcher;
         _db = db;
         _logger = logger;
+        _deviceService = deviceService;
     }
 
     /// <summary>
@@ -200,9 +203,17 @@ public class SocialCallbackModel : PageModel
         // Idempotent + non-throwing by design.
         await _welcomeDispatcher.SendIfPendingAsync(platformUser, ct);
 
-        // Redirect to app with token in fragment
+        // Redirect to app with token in fragment.
+        // Feature 128 US2 — same FR-020 routing-gate contract as Login.cshtml.cs.
+        // Social flow has no user-provided ReturnUrl, so the gate is the only
+        // decision point. The /app/ prefix is load-bearing — see
+        // SetupAddDeviceRoutingGate XML doc.
         var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
                        $"&refresh={Uri.EscapeDataString(tokens.RefreshToken)}";
+        if (await SetupAddDeviceRoutingGate.ShouldRouteAsync(tokens.AccessToken, _deviceService, _logger, ct))
+        {
+            fragment += $"&returnUrl={Uri.EscapeDataString(SetupAddDeviceRoutingGate.SetupAddDevicePath)}";
+        }
         return Redirect($"/app/#{fragment}");
     }
 

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/Auth/SetupAddDeviceRoutingGateTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/Auth/SetupAddDeviceRoutingGateTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Sorcha.Tenant.Service.Pages.Auth;
+using Sorcha.Tenant.Service.Services;
+
+namespace Sorcha.Tenant.Service.Tests.Pages.Auth;
+
+/// <summary>
+/// Tests for <see cref="SetupAddDeviceRoutingGate"/>. The gate is the shared
+/// source of truth for the F128 FR-020/FR-026 routing decision across three
+/// post-login fragment-redirect sites (Login, OidcCallback, SocialCallback).
+/// </summary>
+public sealed class SetupAddDeviceRoutingGateTests
+{
+    private readonly Mock<IPlatformUserDeviceService> _deviceService = new();
+
+    [Fact]
+    public async Task ShouldRouteAsync_Returns_True_When_Token_Has_Pid_And_Zero_Devices()
+    {
+        var pid = Guid.NewGuid();
+        _deviceService
+            .Setup(d => d.HasAnyAsync(pid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((false, (DateTimeOffset?)null));
+
+        var result = await SetupAddDeviceRoutingGate.ShouldRouteAsync(
+            BuildToken(pid), _deviceService.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ShouldRouteAsync_Returns_False_When_Citizen_Has_At_Least_One_Device()
+    {
+        var pid = Guid.NewGuid();
+        _deviceService
+            .Setup(d => d.HasAnyAsync(pid, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, DateTimeOffset.UtcNow));
+
+        var result = await SetupAddDeviceRoutingGate.ShouldRouteAsync(
+            BuildToken(pid), _deviceService.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldRouteAsync_Returns_False_When_Token_Has_No_PlatformUserId_Claim()
+    {
+        var result = await SetupAddDeviceRoutingGate.ShouldRouteAsync(
+            BuildToken(platformUserId: null),
+            _deviceService.Object,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        result.Should().BeFalse();
+        _deviceService.Verify(
+            d => d.HasAnyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ShouldRouteAsync_Returns_False_And_Logs_When_Token_Is_Garbage()
+    {
+        var result = await SetupAddDeviceRoutingGate.ShouldRouteAsync(
+            "not-a-valid-jwt",
+            _deviceService.Object,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldRouteAsync_Returns_False_When_DeviceService_Throws()
+    {
+        var pid = Guid.NewGuid();
+        _deviceService
+            .Setup(d => d.HasAnyAsync(pid, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var result = await SetupAddDeviceRoutingGate.ShouldRouteAsync(
+            BuildToken(pid), _deviceService.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetupAddDevicePath_Carries_The_Load_Bearing_App_Prefix()
+    {
+        // Pinning constant — F128 #775 root cause was the missing /app/ prefix
+        // causing NavigationManager.NavigateTo to resolve as origin-absolute and
+        // bypass the WASM client's base href. Pin the prefix here so a careless
+        // edit can't silently regress it.
+        SetupAddDeviceRoutingGate.SetupAddDevicePath.Should().Be("/app/setup/add-device");
+    }
+
+    private static string BuildToken(Guid? platformUserId)
+    {
+        var claims = new List<Claim>();
+        if (platformUserId is { } pid)
+        {
+            claims.Add(new Claim("platform_user_id", pid.ToString()));
+        }
+        var token = new JwtSecurityToken(
+            issuer: "test",
+            audience: "test",
+            claims: claims,
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(5));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/OidcCallbackModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/OidcCallbackModelTests.cs
@@ -29,6 +29,7 @@ public class OidcCallbackModelTests : IDisposable
     private readonly Mock<ITotpService> _totpService = new();
     private readonly Mock<IIdentityRepository> _identityRepo = new();
     private readonly Mock<IOrganizationRepository> _orgRepo = new();
+    private readonly Mock<IPlatformUserDeviceService> _deviceService = new();
     private readonly TenantDbContext _dbContext;
 
     public OidcCallbackModelTests()
@@ -54,7 +55,8 @@ public class OidcCallbackModelTests : IDisposable
             _identityRepo.Object,
             _orgRepo.Object,
             _dbContext,
-            NullLogger<OidcCallbackModel>.Instance);
+            NullLogger<OidcCallbackModel>.Instance,
+            _deviceService.Object);
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
@@ -27,6 +27,7 @@ public class SocialCallbackModelTests : IDisposable
     private readonly Mock<IOrganizationRepository> _orgRepo = new();
     private readonly Mock<ITokenService> _tokenService = new();
     private readonly Mock<ITransactionalEmailService> _transactionalEmail = new();
+    private readonly Mock<IPlatformUserDeviceService> _deviceService = new();
     private readonly TenantDbContext _dbContext;
 
     public SocialCallbackModelTests()
@@ -54,7 +55,8 @@ public class SocialCallbackModelTests : IDisposable
             _tokenService.Object,
             dispatcher,
             _dbContext,
-            NullLogger<SocialCallbackModel>.Instance);
+            NullLogger<SocialCallbackModel>.Instance,
+            _deviceService.Object);
 
         var httpContext = new DefaultHttpContext();
         model.PageContext = new PageContext(new ActionContext(


### PR DESCRIPTION
## Summary

Audit follow-up to PR #775. The base-href bug class and the F128 zero-device routing-gate contract had five sibling sites missed by the original fix.

### Base-href bugs (identical to #775)

`NavigateTo` with leading slash → resolves outside `<base href="/app/">` → forceLoad fallback → gateway 404:

- `Sorcha.UI.Web.Client/Pages/Designer.razor:10` — legacy `/designer` shim
- `Sorcha.UI.Web.Client/Pages/BlueprintChat.razor:15` — legacy `/designer/chat` shim
- `Sorcha.UI.Web.Client/Pages/Registers/AcceptInvitation.razor:59` — post-dialog redirect

Fix: drop leading slash so the path is base-href-relative.

### F128 contract gap

The post-login zero-device routing gate (FR-020/FR-026) existed only in `Login.cshtml.cs` (email/password). OAuth flows skipped it entirely — a zero-device citizen signing in via Google/Microsoft/OIDC landed on default home, not `/setup/add-device`. Citizen onboarding is the cohort most likely to use social sign-in, so this was arguably a bigger hole than the one #775 closed.

- `Pages/Auth/OidcCallback.cshtml.cs` — wired the gate
- `Pages/Auth/SocialCallback.cshtml.cs` — wired the gate

### Shared helper

Extracted Login.cshtml.cs's private routing-gate method into `SetupAddDeviceRoutingGate` — a static helper with one source of truth for the FR-020/FR-026 decision plus the load-bearing `/app/` prefix rationale. Three callers now share one definition; the next person fixing one won't miss the others.

### Tests

- 6 new in `SetupAddDeviceRoutingGateTests` (happy path, has-device, missing claim, malformed token, downstream throw, pinning test for the `/app/setup/add-device` constant)
- `OidcCallbackModelTests` + `SocialCallbackModelTests` updated to wire the new `IPlatformUserDeviceService` mock
- Full Tenant Service suite: **1119 passed, 0 failed**

## Test plan

- [x] `dotnet test tests/Sorcha.Tenant.Service.Tests` green locally
- [ ] CI passes
- [ ] After merge + Docker Publish: verify zero-device citizen signing in via social/OIDC also lands on `/app/setup/add-device` (currently confirmed only for email/password)

🤖 Generated with [Claude Code](https://claude.com/claude-code)