### PR TITLE
chore(ui): share MudTheme between Web Client and Wallet PWA

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Theme/SorchaMudTheme.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Theme/SorchaMudTheme.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using MudBlazor;
+
+namespace Sorcha.UI.Core.Theme;
+
+/// <summary>
+/// Canonical Sorcha <see cref="MudTheme"/> — single source of truth for
+/// palette, surfaces, and (eventually) typography shared by every host
+/// that mounts MudBlazor. Web (<c>Sorcha.UI.Web.Client</c>) and PWA
+/// (<c>Sorcha.Wallet.Pwa</c>) both bind their <c>MudThemeProvider</c> to
+/// <see cref="Default"/> so the citizen sees a consistent identity moving
+/// between the multi-tenant app and the wallet.
+/// </summary>
+/// <remarks>
+/// The instance is built once at type-init and exposed read-only. Do not
+/// mutate the returned <see cref="MudTheme"/> — MudBlazor reads palette
+/// properties on every render and a mutation would propagate to every
+/// host sharing the singleton.
+/// </remarks>
+public static class SorchaMudTheme
+{
+    /// <summary>
+    /// The default theme. Lifted verbatim from the original
+    /// <c>Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor</c>
+    /// private field so existing Web appearance is byte-identical.
+    /// </summary>
+    public static MudTheme Default { get; } = Build();
+
+    private static MudTheme Build() => new()
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#667eea",
+            Secondary = "#764ba2",
+            AppbarBackground = "#667eea",
+        },
+        PaletteDark = new PaletteDark
+        {
+            Primary = "#667eea",
+            Secondary = "#764ba2",
+            AppbarBackground = "#1e1e1e",
+            Surface = "#1e1e1e",
+            Background = "#121212",
+            DrawerBackground = "#1e1e1e",
+            TextPrimary = "#e0e0e0",
+            TextSecondary = "#b0b0b0",
+            LinesDefault = "#333333",
+        }
+    };
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 @using MudBlazor
 @using Sorcha.UI.Core.Services.Authentication
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Theme
 @using Sorcha.UI.Core.Components.Shared
 @using Sorcha.UI.Core.Models.Credentials
 @using Sorcha.UI.Core.Models.Registers
@@ -17,7 +18,7 @@
 @inject IInboxApiService InboxApi
 @inject ILocalizationService Loc
 
-<MudThemeProvider Theme="_theme" IsDarkMode="@_isDarkMode" />
+<MudThemeProvider Theme="SorchaMudTheme.Default" IsDarkMode="@_isDarkMode" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
@@ -402,28 +403,6 @@
         _badgeWiggle = false;
         await InvokeAsync(StateHasChanged);
     }
-
-    private readonly MudTheme _theme = new()
-    {
-        PaletteLight = new PaletteLight()
-        {
-            Primary = "#667eea",
-            Secondary = "#764ba2",
-            AppbarBackground = "#667eea",
-        },
-        PaletteDark = new PaletteDark()
-        {
-            Primary = "#667eea",
-            Secondary = "#764ba2",
-            AppbarBackground = "#1e1e1e",
-            Surface = "#1e1e1e",
-            Background = "#121212",
-            DrawerBackground = "#1e1e1e",
-            TextPrimary = "#e0e0e0",
-            TextSecondary = "#b0b0b0",
-            LinesDefault = "#333333",
-        }
-    };
 
     private void ToggleDrawer()
     {

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -15,6 +15,7 @@
 @using Sorcha.UI.Components.User.Components.Onboarding
 @using Sorcha.UI.Core.Components.Inbox
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Theme
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Context
 @using Sorcha.Wallet.Pwa.Services.Onboarding
@@ -28,7 +29,7 @@
 @inject TenantHubConnection TenantHub
 @inject IAccessTokenStore AccessTokens
 
-<MudThemeProvider />
+<MudThemeProvider Theme="SorchaMudTheme.Default" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />


### PR DESCRIPTION
## Summary

Audit follow-up to today's theme-divergence question.

The PWA's `<MudThemeProvider />` had no `Theme` prop and was rendering with MudBlazor's stock Material defaults (purple Primary `#594AE2`, pink Secondary `#FF4081`). The Web Client's hand-tuned indigo-blue palette (Primary `#667eea`, Secondary `#764ba2`) only applied to one of the two hosts a citizen actually sees. Same MudBlazor controls, different default colors.

This lifts the palette into a single static `SorchaMudTheme.Default` in `Sorcha.UI.Components.User` and binds both hosts' `MudThemeProvider` to it.

### What changes visually

| Host | Before | After |
|---|---|---|
| `Sorcha.UI.Web.Client` (App, `/app/`) | Indigo-blue palette | Identical — bytes lifted verbatim |
| `Sorcha.Wallet.Pwa` (Wallet, `/wallet/`) | MudBlazor stock purple/pink | Indigo-blue, matches the App |
| `Sorcha.Verifier` (`/verify/`) | MudBlazor stock — unchanged | Unchanged (see Scope) |

### Scope kept narrow

- **No dark-mode in PWA.** `IThemeService` (the Web Client's dark-mode source) depends on `IUserPreferencesService` and a server-persisted preference. The PWA doesn't register either, and the citizen-wallet JWT audience may not accept the existing preferences endpoint. Doing it properly needs a local-first design (IndexedDB-backed preference + JS interop for `prefers-color-scheme`). Worth its own PR.
- **Verifier untouched.** `Sorcha.Verifier` doesn't `ProjectReference` `Sorcha.UI.Components.User`. Pulling that whole graph in just for one theme constant is a bad trade for an org-facing test tool that isn't part of the citizen visual identity.

### Mutation guard

`SorchaMudTheme.Default` is a single instance shared across hosts. Its XML doc warns not to mutate — `PaletteLight`/`PaletteDark` are settable on MudBlazor's side and a stray mutation would propagate to every host sharing the singleton. No mutations exist today; the doc is the seatbelt.

## Test plan

- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.sln` clean — 0 errors
- [ ] CI passes
- [ ] After merge + Docker Publish: load `/app/` and `/wallet/` side by side on n1 — appbar / primary buttons / nav highlight should now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)