### PR TITLE
chore(deps): NuGet sweep + JsonLogic dedupe

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,17 +7,17 @@
     <!-- AI / MCP -->
     <PackageVersion Include="Anthropic.SDK" Version="5.10.0" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.8" />
     <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
     <!-- .NET Aspire -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.2.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.3" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.3.3" />
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
@@ -42,86 +42,85 @@
     <!-- Authentication -->
     <PackageVersion Include="Fido2.AspNet" Version="4.0.0" />
     <!-- Testing - Assertions -->
-    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.78.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server.Reflection" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <!-- SD-JWT -->
     <PackageVersion Include="HeroSD-JWT" Version="1.1.7" />
     <!-- JSON Processing -->
     <PackageVersion Include="JsonE.Net" Version="3.0.1" />
     <PackageVersion Include="JsonLogic" Version="6.0.1" />
-    <PackageVersion Include="JsonLogic.Net" Version="1.1.11" />
     <PackageVersion Include="JsonPath.Net" Version="3.0.2" />
     <PackageVersion Include="JsonSchema.Net" Version="9.1.3" />
     <PackageVersion Include="JsonSchema.Net.Generation" Version="7.1.3" />
     <!-- Microsoft ASP.NET Core -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.4.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.8" />
     <!-- Microsoft Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
     <!-- Microsoft Extensions - Caching -->
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
     <!-- Microsoft Extensions - Configuration -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <!-- Microsoft Extensions - DI -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <!-- Microsoft Extensions - Health -->
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
     <!-- Microsoft Extensions - Hosting -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <!-- Microsoft Extensions - HTTP -->
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
     <!-- Microsoft Extensions - Logging -->
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <!-- Microsoft Extensions - Options -->
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <!-- Microsoft Extensions - Service Discovery -->
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
     <!-- Microsoft Extensions - Time Provider (test fakes) -->
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
     <!-- Microsoft JSInterop -->
-    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.8" />
     <!-- Testing - SDK -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <!-- Testing - Playwright -->
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
     <!-- Source Link -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <!-- MongoDB -->
     <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
     <!-- Testing - Mocking -->
@@ -136,7 +135,7 @@
     <!-- Crypto - BLS -->
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
     <!-- Email -->
-    <PackageVersion Include="MailKit" Version="4.15.1" />
+    <PackageVersion Include="MailKit" Version="4.16.0" />
     <!-- JSON Serialization -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- PostgreSQL -->
@@ -147,13 +146,13 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.14.0-beta.1" />
     <!-- OTP -->
     <PackageVersion Include="Otp.NET" Version="1.4.1" />
@@ -168,7 +167,7 @@
     <PackageVersion Include="Refit" Version="10.1.6" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
     <!-- OpenAPI -->
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.13" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.14" />
     <!-- Email Templates -->
     <PackageVersion Include="Scriban" Version="5.12.0" />
     <!-- Logging -->
@@ -182,20 +181,20 @@
     <!-- Console UI -->
     <PackageVersion Include="Spectre.Console" Version="0.54.0" />
     <!-- Redis -->
-    <PackageVersion Include="StackExchange.Redis" Version="2.12.4" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <!-- CLI -->
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <!-- JWT -->
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <!-- Security -->
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.8" />
     <!-- Rate Limiting -->
-    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.5" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.8" />
     <!-- Testing - Containers -->
     <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MongoDb" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.2.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <!-- Testing - xUnit -->
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Apps/Sorcha.McpServer/Sorcha.McpServer.csproj
+++ b/src/Apps/Sorcha.McpServer/Sorcha.McpServer.csproj
@@ -29,8 +29,7 @@
 
     <!-- Schema and Logic Processing -->
     <PackageReference Include="JsonSchema.Net" />
-    <PackageReference Include="JsonLogic.Net" />
-    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="JsonLogic" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 

--- a/src/Apps/Sorcha.McpServer/Tools/Designer/JsonLogicTestTool.cs
+++ b/src/Apps/Sorcha.McpServer/Tools/Designer/JsonLogicTestTool.cs
@@ -4,10 +4,10 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json;
-using JsonLogic.Net;
+using System.Text.Json.Nodes;
+using Json.Logic;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
-using Newtonsoft.Json.Linq;
 using Sorcha.McpServer.Infrastructure;
 using Sorcha.McpServer.Services;
 
@@ -16,6 +16,14 @@ namespace Sorcha.McpServer.Tools.Designer;
 /// <summary>
 /// Designer tool for testing JSON Logic expressions.
 /// </summary>
+/// <remarks>
+/// Backed by the same json-everything <c>Json.Logic</c> engine that
+/// <c>Sorcha.Blueprint.Engine.Implementation.JsonLogicEvaluator</c> uses at
+/// runtime, so test results in the designer match what a deployed blueprint
+/// would compute. Prior implementation used the unrelated <c>JsonLogic.Net</c>
+/// package; consolidated on the json-everything family to remove a duplicate
+/// dependency and a Newtonsoft.Json bridge layer.
+/// </remarks>
 [McpServerToolType]
 public sealed class JsonLogicTestTool
 {
@@ -23,7 +31,6 @@ public sealed class JsonLogicTestTool
     private readonly IMcpAuthorizationService _authService;
     private readonly IMcpErrorHandler _errorHandler;
     private readonly ILogger<JsonLogicTestTool> _logger;
-    private readonly JsonLogicEvaluator _evaluator;
 
     public JsonLogicTestTool(
         IMcpSessionService sessionService,
@@ -35,7 +42,6 @@ public sealed class JsonLogicTestTool
         _authService = authService;
         _errorHandler = errorHandler;
         _logger = logger;
-        _evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
     }
 
     /// <summary>
@@ -52,7 +58,6 @@ public sealed class JsonLogicTestTool
         [Description("The data to evaluate the rule against")] string dataJson,
         CancellationToken cancellationToken = default)
     {
-        // Authorization check
         if (!_authService.CanInvokeTool("sorcha_jsonlogic_test"))
         {
             return Task.FromResult(new JsonLogicTestResult
@@ -63,7 +68,6 @@ public sealed class JsonLogicTestTool
             });
         }
 
-        // Validate inputs
         if (string.IsNullOrWhiteSpace(ruleJson))
         {
             return Task.FromResult(new JsonLogicTestResult
@@ -90,13 +94,12 @@ public sealed class JsonLogicTestTool
 
         try
         {
-            // Parse rule using Newtonsoft.Json (required by JsonLogic.Net)
-            JToken rule;
+            Rule? rule;
             try
             {
-                rule = JToken.Parse(ruleJson);
+                rule = JsonSerializer.Deserialize<Rule>(ruleJson);
             }
-            catch (Newtonsoft.Json.JsonReaderException ex)
+            catch (JsonException ex)
             {
                 stopwatch.Stop();
                 return Task.FromResult(new JsonLogicTestResult
@@ -108,13 +111,24 @@ public sealed class JsonLogicTestTool
                 });
             }
 
-            // Parse data using Newtonsoft.Json
-            object? data;
+            if (rule is null)
+            {
+                stopwatch.Stop();
+                return Task.FromResult(new JsonLogicTestResult
+                {
+                    Status = "Error",
+                    Message = "Rule JSON deserialised to null.",
+                    CheckedAt = DateTimeOffset.UtcNow,
+                    ResponseTimeMs = (int)stopwatch.ElapsedMilliseconds
+                });
+            }
+
+            JsonNode? dataNode;
             try
             {
-                data = JToken.Parse(dataJson);
+                dataNode = JsonNode.Parse(dataJson);
             }
-            catch (Newtonsoft.Json.JsonReaderException ex)
+            catch (JsonException ex)
             {
                 stopwatch.Stop();
                 return Task.FromResult(new JsonLogicTestResult
@@ -126,73 +140,15 @@ public sealed class JsonLogicTestTool
                 });
             }
 
-            // Evaluate the rule
-            var result = _evaluator.Apply(rule, data);
+            var resultNode = rule.Apply(dataNode);
 
             stopwatch.Stop();
 
-            // Serialize result
-            var resultJson = result != null
-                ? Newtonsoft.Json.JsonConvert.SerializeObject(result, Newtonsoft.Json.Formatting.Indented)
-                : "null";
+            var resultJson = resultNode is null
+                ? "null"
+                : resultNode.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
 
-            // Determine result type - handle both native types and JToken types
-            string resultType;
-            bool isTruthy;
-
-            if (result == null)
-            {
-                resultType = "null";
-                isTruthy = false;
-            }
-            else if (result is JValue jValue)
-            {
-                resultType = jValue.Type switch
-                {
-                    JTokenType.Null => "null",
-                    JTokenType.Boolean => "boolean",
-                    JTokenType.String => "string",
-                    JTokenType.Integer or JTokenType.Float => "number",
-                    _ => "object"
-                };
-                isTruthy = jValue.Type switch
-                {
-                    JTokenType.Null => false,
-                    JTokenType.Boolean => jValue.Value<bool>(),
-                    JTokenType.Integer => jValue.Value<long>() != 0,
-                    JTokenType.Float => jValue.Value<double>() != 0,
-                    JTokenType.String => !string.IsNullOrEmpty(jValue.Value<string>()),
-                    _ => true
-                };
-            }
-            else if (result is JArray)
-            {
-                resultType = "array";
-                isTruthy = true;
-            }
-            else if (result is JObject)
-            {
-                resultType = "object";
-                isTruthy = true;
-            }
-            else
-            {
-                resultType = result switch
-                {
-                    bool => "boolean",
-                    string => "string",
-                    int or long or float or double or decimal => "number",
-                    System.Collections.IEnumerable => "array",
-                    _ => "object"
-                };
-                isTruthy = result switch
-                {
-                    false => false,
-                    0 => false,
-                    "" => false,
-                    _ => true
-                };
-            }
+            var (resultType, isTruthy) = ClassifyResult(resultNode);
 
             _logger.LogInformation(
                 "JSON Logic evaluation completed in {ElapsedMs}ms. Result type: {ResultType}",
@@ -221,6 +177,73 @@ public sealed class JsonLogicTestTool
                 CheckedAt = DateTimeOffset.UtcNow,
                 ResponseTimeMs = (int)stopwatch.ElapsedMilliseconds
             });
+        }
+    }
+
+    /// <summary>
+    /// Maps a <see cref="JsonNode"/> result to (resultType, isTruthy) using
+    /// the same truthiness rules JSON Logic itself applies: null/false/0/""
+    /// are falsy, empty arrays are falsy, everything else is truthy.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="JsonNode.GetValueKind"/> rather than a chain of
+    /// <c>TryGetValue&lt;T&gt;</c> calls because Json.Logic's arithmetic
+    /// operations can wrap results as <see cref="decimal"/> internally, and
+    /// the typed gets don't cross numeric-CLR-type boundaries — e.g. a
+    /// <c>JsonValue&lt;decimal&gt;(15m)</c> returns false for
+    /// <c>TryGetValue&lt;long&gt;</c>. <c>GetValueKind</c> classifies via the
+    /// underlying JSON shape and is stable across all numeric wrappings.
+    /// </remarks>
+    private static (string resultType, bool isTruthy) ClassifyResult(JsonNode? node)
+    {
+        if (node is null)
+        {
+            return ("null", false);
+        }
+
+        var kind = node.GetValueKind();
+        switch (kind)
+        {
+            case JsonValueKind.Null:
+                return ("null", false);
+            case JsonValueKind.True:
+                return ("boolean", true);
+            case JsonValueKind.False:
+                return ("boolean", false);
+            case JsonValueKind.String:
+                var s = node.GetValue<string>();
+                return ("string", !string.IsNullOrEmpty(s));
+            case JsonValueKind.Number:
+                // Json.Logic wraps numeric results as JsonValue<decimal/long/int/double>
+                // depending on the operator. Try each in turn — typed GetValue<T> on
+                // a JsonValue only succeeds when the requested T matches the underlying
+                // CLR type exactly, so a chain is the simplest robust path.
+                var value = node.AsValue();
+                if (value.TryGetValue<decimal>(out var dec))
+                {
+                    return ("number", dec != 0m);
+                }
+                if (value.TryGetValue<long>(out var lng))
+                {
+                    return ("number", lng != 0L);
+                }
+                if (value.TryGetValue<double>(out var dbl))
+                {
+                    return ("number", dbl != 0.0);
+                }
+                if (value.TryGetValue<int>(out var intv))
+                {
+                    return ("number", intv != 0);
+                }
+                // Last-resort round-trip via JSON text — handles any future numeric
+                // wrapping (BigInteger, etc.) without code change.
+                return ("number", node.ToJsonString() is not ("0" or "0.0"));
+            case JsonValueKind.Array:
+                return ("array", ((JsonArray)node).Count > 0);
+            case JsonValueKind.Object:
+                return ("object", true);
+            default:
+                return ("object", true);
         }
     }
 }


### PR DESCRIPTION
## Summary

Single-shot bump of every package that has a newer stable version plus consolidation onto json-everything's `JsonLogic` (removing the duplicate `JsonLogic.Net` dependency).

## Bumps

**Microsoft .NET 10 patch-line servicing** (38 packages): `10.0.5 → 10.0.8` — ASP.NET Core, EF Core, Extensions.\*, Bcl.Memory, JSInterop, System.Security.Cryptography.ProtectedData, System.Threading.RateLimiting.

**Microsoft Extensions** (transitively required by new Aspire):
- `Microsoft.Extensions.Http.Resilience` 10.4.0 → 10.6.0
- `Microsoft.Extensions.ServiceDiscovery` 10.4.0 → 10.6.0

**Aspire family**: 13.2.0 → 13.3.3 (AppHost, Hosting.MongoDB/PostgreSQL/Redis/Testing, StackExchange.Redis.\*)

**gRPC family**: 2.76.0 → 2.80.0 (+ Grpc.Tools 2.78 → 2.80)

**OpenTelemetry family**: 1.15.0 → 1.15.3 (Instrumentation.AspNetCore 1.15.2 + Http/Runtime 1.15.1 — current per-package stables). Closes three moderate-severity advisories (`GHSA-g94r-2vxg-569j`, `GHSA-q834-8qmm-v933`, `GHSA-88hf-wf7h-7w4m`).

**Other:**
- `Microsoft.NET.Test.Sdk` 18.3.0 → 18.5.1
- `Microsoft.SourceLink.GitHub` 10.0.201 → 10.0.300
- `FluentAssertions` 8.9.0 → 8.10.0
- `Scalar.AspNetCore` 2.13.13 → 2.14.14
- `StackExchange.Redis` 2.12.4 → 2.13.1
- `Testcontainers.Redis` 4.2.0 → 4.11.0 (aligns with the rest of the family)
- `MailKit` 4.15.1 → 4.16.0 (closes `GHSA-9j88-vvj5-vhgr` moderate)

## JsonLogic consolidation

The codebase was carrying two unrelated JsonLogic libraries:
- `Json.Logic` (json-everything) — used by `Sorcha.Blueprint.Engine` and `Sorcha.Agent`. **The canonical runtime evaluator.**
- `JsonLogic.Net` (different author) — used by exactly one file: `Sorcha.McpServer/Tools/Designer/JsonLogicTestTool.cs`.

The designer tool now uses the same `Json.Logic` engine the deployed Blueprint Engine uses, so designer-side rule tests match production semantics byte-for-byte. `JsonLogic.Net` and `Newtonsoft.Json` (only carried because `JsonLogic.Net` needed it) are removed from the McpServer project.

Result-classifier rewritten around `JsonNode.GetValueKind()` rather than chained `TryGetValue<T>` — `Json.Logic` wraps arithmetic results as `JsonValue<decimal>`, and typed gets don't cross numeric CLR-type boundaries. `GetValueKind` classifies via the JSON shape and is stable across wrappings.

550/550 McpServer tests pass post-migration. Full solution builds 0 errors.

## What's NOT in this PR

- **Scriban 5.12.0 (High CVE `GHSA-wgh7-7m3c-fx25`)** — 5.12.0 IS latest, no fix upstream. Practical risk is near-zero (Feature 112 templates are embedded resources, never user-loaded). Track as a GitHub issue for upstream watch.
- **Snappier 1.0.0 + SharpCompress 0.30.1** — transitive from MongoDB.Driver in test projects only. Needs a MongoDB.Driver bump or pinning override; separate PR.
- **coverlet.collector 8.0.1 → 10.0.1** — major bump, separate PR.
- **OpenTelemetry.Instrumentation.StackExchangeRedis 1.14.0-beta.1** — no stable channel found at audit time.

## Test plan

- [x] `dotnet build Sorcha.sln` — 0 errors (1390 warnings, all preexisting XML-doc churn)
- [x] McpServer tests — 550/550 pass post-migration
- [ ] CI passes (will tell us how the bumps affect the full suite + every service's Docker build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)