### PR TITLE
refactor(ui): retire ISnackbar from Invitations + DesignerToolbar (Snackbar Phase 9k)

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -20,8 +20,6 @@ src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/Invitations.razor
@@ -8,9 +8,10 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
 @using Sorcha.UI.Core.Services.Identity
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IInvitationClientService InvitationService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Invitations - Sorcha Platform</PageTitle>
 
@@ -156,7 +157,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to load invitations: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to load invitations: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -174,27 +175,27 @@
                 Role = _newRole,
                 ExpiryDays = _newExpiryDays
             });
-            Snackbar.Add($"Invitation sent to {_newEmail}", Severity.Success);
+            Feedback.ShowSuccess($"Invitation sent to {_newEmail}");
             _newEmail = "";
             await LoadInvitationsAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to send invitation: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to send invitation: {ex.Message}", autoDismissMs: 0);
         }
     }
 
     private async Task RevokeAsync(Guid invitationId)
     {
         await InvitationService.RevokeInvitationAsync(_organizationId, invitationId);
-        Snackbar.Add("Invitation revoked", Severity.Warning);
+        Feedback.ShowWarning("Invitation revoked");
         await LoadInvitationsAsync();
     }
 
     private async Task ResendAsync(Guid invitationId)
     {
         await InvitationService.ResendInvitationAsync(_organizationId, invitationId);
-        Snackbar.Add("Invitation resent", Severity.Success);
+        Feedback.ShowSuccess("Invitation resent");
         await LoadInvitationsAsync();
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/DesignerToolbar.razor.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
 using Sorcha.UI.Core.Services;
+using Sorcha.UI.Core.Services.Feedback;
 
 namespace Sorcha.UI.Web.Client.Pages.DesignerShell;
 
@@ -20,7 +21,7 @@ public partial class DesignerToolbar : ComponentBase, IDisposable
     private bool _saving;
 
     [Inject] private IBlueprintApiService BlueprintApi { get; set; } = default!;
-    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private IInlineFeedback Feedback { get; set; } = default!;
     [Inject] private ILogger<DesignerToolbar> Logger { get; set; } = default!;
 
     /// <summary>Inline-edit binding for the blueprint title; marks the context dirty on change.</summary>
@@ -82,17 +83,17 @@ public partial class DesignerToolbar : ComponentBase, IDisposable
             if (result is not null)
             {
                 Context.MarkClean();
-                Snackbar.Add($"Blueprint '{Context.Blueprint.Title}' saved successfully", Severity.Success);
+                Feedback.ShowSuccess($"Blueprint '{Context.Blueprint.Title}' saved successfully");
             }
             else
             {
-                Snackbar.Add("Save failed — please try again", Severity.Warning);
+                Feedback.ShowWarning("Save failed — please try again");
             }
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to save blueprint");
-            Snackbar.Add($"Error saving blueprint: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error saving blueprint: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -103,7 +104,7 @@ public partial class DesignerToolbar : ComponentBase, IDisposable
     private void OnLoadClicked()
     {
         // TODO(US1 follow-up): open LoadBlueprintDialog and call Context.SetBlueprint(...).
-        Snackbar.Add("Load dialog wiring is scheduled for a follow-up PR", Severity.Info);
+        Feedback.ShowInfo("Load dialog wiring is scheduled for a follow-up PR");
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

Migrates 11 `Snackbar.Add` call sites across two admin/designer surfaces to `IInlineFeedback`:

- `Pages/Admin/Identity/Invitations.razor` (6 sites): load failure, send success, send failure, revoke, resend, plus the `ISnackbar` injection.
- `Pages/Designer/DesignerToolbar.razor.cs` (5 sites): save success, save-failed warning, save-error exception, load-stub info, plus the `ISnackbar` injection.

Errors use `autoDismissMs: 0` (manual acknowledge) per the Phase 9 convention established in PRs #766/#767/#768. Successes / warnings / info use the default 4s.

`AiDesignerPane.razor` deliberately not included — its `.razor.cs` partner has 13 paired call sites; both will land together in Phase 9l to avoid splitting a coupled partial class across PRs.

## Allowlist

8 files left after this PR (down from 10):

```
Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor   (9)
Sorcha.UI.Web.Client/Pages/MyActions.razor                                  (11)
Sorcha.UI.Web.Client/Pages/Settings.razor                                   (28)
Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor              (1, paired)
Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs           (13, paired)
Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor              (9)
Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor            (8)
Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor            (9)
```

## Test plan

- [x] `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` clean
- [x] `scripts/check-no-snackbar.ps1` reports 8 files (was 10)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)