### PR TITLE
refactor(ui): retire ISnackbar from 4 admin surfaces (Snackbar Phase 9l)

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -15,11 +15,7 @@
 #
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
 
-src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Participants/ParticipantDetail.razor
@@ -3,6 +3,7 @@
 
 @using Sorcha.UI.Core.Models.Participants
 @using Sorcha.UI.Core.Services.Participants
+@using Sorcha.UI.Core.Services.Feedback
 
 @if (_loading)
 {
@@ -129,7 +130,7 @@ else
 
 @code {
     [Inject] private IParticipantApiService ParticipantService { get; set; } = default!;
-    [Inject] private ISnackbar Snackbar { get; set; } = default!;
+    [Inject] private IInlineFeedback Feedback { get; set; } = default!;
 
     [Parameter] public Guid OrganizationId { get; set; }
     [Parameter] public Guid ParticipantId { get; set; }
@@ -165,13 +166,13 @@ else
         var success = await ParticipantService.SuspendParticipantAsync(OrganizationId, ParticipantId);
         if (success)
         {
-            Snackbar.Add("Participant suspended", Severity.Success);
+            Feedback.ShowSuccess("Participant suspended");
             await LoadParticipantAsync();
             await OnParticipantChanged.InvokeAsync();
         }
         else
         {
-            Snackbar.Add("Failed to suspend participant", Severity.Error);
+            Feedback.ShowError("Failed to suspend participant", autoDismissMs: 0);
         }
     }
 
@@ -180,13 +181,13 @@ else
         var success = await ParticipantService.ReactivateParticipantAsync(OrganizationId, ParticipantId);
         if (success)
         {
-            Snackbar.Add("Participant reactivated", Severity.Success);
+            Feedback.ShowSuccess("Participant reactivated");
             await LoadParticipantAsync();
             await OnParticipantChanged.InvokeAsync();
         }
         else
         {
-            Snackbar.Add("Failed to reactivate participant", Severity.Error);
+            Feedback.ShowError("Failed to reactivate participant", autoDismissMs: 0);
         }
     }
 
@@ -195,12 +196,12 @@ else
         var success = await ParticipantService.DeactivateParticipantAsync(OrganizationId, ParticipantId);
         if (success)
         {
-            Snackbar.Add("Participant deactivated", Severity.Success);
+            Feedback.ShowSuccess("Participant deactivated");
             await OnParticipantChanged.InvokeAsync();
         }
         else
         {
-            Snackbar.Add("Failed to deactivate participant", Severity.Error);
+            Feedback.ShowError("Failed to deactivate participant", autoDismissMs: 0);
         }
     }
 
@@ -209,12 +210,12 @@ else
         var success = await ParticipantService.RevokeWalletLinkAsync(OrganizationId, ParticipantId, linkId);
         if (success)
         {
-            Snackbar.Add("Wallet link revoked", Severity.Success);
+            Feedback.ShowSuccess("Wallet link revoked");
             await LoadParticipantAsync();
         }
         else
         {
-            Snackbar.Add("Failed to revoke wallet link", Severity.Error);
+            Feedback.ShowError("Failed to revoke wallet link", autoDismissMs: 0);
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/IdpConfiguration.razor
@@ -8,9 +8,10 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
 @using Sorcha.UI.Core.Services.Identity
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IIdpConfigurationClientService IdpService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>IDP Configuration - Sorcha Platform</PageTitle>
 
@@ -168,7 +169,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to load IDP configurations: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to load IDP configurations: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -181,7 +182,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Discovery failed: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Discovery failed: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -197,21 +198,21 @@
                 ClientId = _newClientId,
                 ClientSecret = _newClientSecret
             });
-            Snackbar.Add("Identity provider added", Severity.Success);
+            Feedback.ShowSuccess("Identity provider added");
             _newPreset = "Custom"; _newDisplayName = ""; _newIssuer = ""; _newClientId = ""; _newClientSecret = "";
             _discoveryResult = null;
             await LoadIdpConfigsAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to add provider: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to add provider: {ex.Message}", autoDismissMs: 0);
         }
     }
 
     private async Task ToggleIdpAsync(Guid configId, bool enabled)
     {
         await IdpService.ToggleIdpAsync(_organizationId, configId, enabled);
-        Snackbar.Add(enabled ? "Provider enabled" : "Provider disabled", Severity.Info);
+        Feedback.ShowInfo(enabled ? "Provider enabled" : "Provider disabled");
         await LoadIdpConfigsAsync();
     }
 
@@ -219,15 +220,15 @@
     {
         var result = await IdpService.TestIdpConnectionAsync(_organizationId, configId);
         if (result.Success)
-            Snackbar.Add($"Connection successful ({result.ResponseTimeMs}ms)", Severity.Success);
+            Feedback.ShowSuccess($"Connection successful ({result.ResponseTimeMs}ms)");
         else
-            Snackbar.Add($"Connection failed: {result.Error}", Severity.Error);
+            Feedback.ShowError($"Connection failed: {result.Error}", autoDismissMs: 0);
     }
 
     private async Task DeleteIdpAsync(Guid configId)
     {
         await IdpService.DeleteIdpConfigurationAsync(_organizationId, configId);
-        Snackbar.Add("Provider deleted", Severity.Warning);
+        Feedback.ShowWarning("Provider deleted");
         await LoadIdpConfigsAsync();
     }
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Identity/UserManagement.razor
@@ -8,9 +8,10 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using System.Security.Claims
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IOrganizationAdminService OrgService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>User Management - Sorcha Platform</PageTitle>
 
@@ -205,12 +206,12 @@
         {
             await OrgService.UpdateOrganizationUserAsync(_organizationId, user.Id,
                 new UpdateUserDto { Roles = [nextRole] });
-            Snackbar.Add($"Role changed to {nextRole}", Severity.Success);
+            Feedback.ShowSuccess($"Role changed to {nextRole}");
             await ReloadUsersAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to change role: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to change role: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -220,12 +221,12 @@
         {
             await OrgService.UpdateOrganizationUserAsync(_organizationId, user.Id,
                 new UpdateUserDto { Status = "Suspended" });
-            Snackbar.Add("User suspended", Severity.Success);
+            Feedback.ShowSuccess("User suspended");
             await ReloadUsersAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to suspend user: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to suspend user: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -235,12 +236,12 @@
         {
             await OrgService.UpdateOrganizationUserAsync(_organizationId, user.Id,
                 new UpdateUserDto { Status = "Active" });
-            Snackbar.Add("User reactivated", Severity.Success);
+            Feedback.ShowSuccess("User reactivated");
             await ReloadUsersAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to reactivate user: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to reactivate user: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -250,12 +251,12 @@
         {
             await OrgService.UpdateOrganizationUserAsync(_organizationId, user.Id,
                 new UpdateUserDto { Status = "Active" });
-            Snackbar.Add("User unlocked", Severity.Success);
+            Feedback.ShowSuccess("User unlocked");
             await ReloadUsersAsync();
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Failed to unlock user: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Failed to unlock user: {ex.Message}", autoDismissMs: 0);
         }
     }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Admin/Settings/PlatformSettings.razor
@@ -6,9 +6,10 @@
 @attribute [Authorize(Roles = "SystemAdmin")]
 @using Microsoft.AspNetCore.Authorization
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 
 @inject IPlatformSettingsAdminService PlatformService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 
 <PageTitle>Platform Settings - Sorcha Platform</PageTitle>
 
@@ -161,16 +162,16 @@
             {
                 _publicOrgStatus = result.PublicOrgStatus;
                 _updatedAt = result.UpdatedAt.LocalDateTime.ToString("g");
-                Snackbar.Add("Public organisation setting updated", Severity.Success);
+                Feedback.ShowSuccess("Public organisation setting updated");
             }
             else
             {
-                Snackbar.Add("Failed to update public organisation setting", Severity.Error);
+                Feedback.ShowError("Failed to update public organisation setting", autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -182,7 +183,7 @@
     {
         if (_maxOrgsPerUser < 1 || _maxOrgsPerUser > 100)
         {
-            Snackbar.Add("Max organisations must be between 1 and 100", Severity.Warning);
+            Feedback.ShowWarning("Max organisations must be between 1 and 100");
             return;
         }
 
@@ -193,16 +194,16 @@
             if (result != null)
             {
                 _updatedAt = result.UpdatedAt.LocalDateTime.ToString("g");
-                Snackbar.Add("Organisation limit updated", Severity.Success);
+                Feedback.ShowSuccess("Organisation limit updated");
             }
             else
             {
-                Snackbar.Add("Failed to update organisation limit", Severity.Error);
+                Feedback.ShowError("Failed to update organisation limit", autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"Error: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"Error: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Migrates 33 \`Snackbar.Add\` call sites across four admin-facing surfaces to \`IInlineFeedback\`:

- \`Pages/Admin/Identity/UserManagement.razor\` (8 sites) — role-change, suspend, reactivate, unlock success/failure pairs.
- \`Pages/Admin/Identity/IdpConfiguration.razor\` (8 sites) — load, discovery, add, toggle (info), test-connection success/failure, delete (warning).
- \`Pages/Admin/Settings/PlatformSettings.razor\` (7 sites) — public-org toggle, max-orgs range warning + save, exception handlers.
- \`Components.User/Components/Participants/ParticipantDetail.razor\` (8 sites) — suspend, reactivate, deactivate, revoke-wallet-link.

Errors use \`autoDismissMs: 0\` (manual acknowledge); successes / warnings / info use the default 4s.

## Allowlist

4 files left after this PR (down from 8):

\`\`\`
Sorcha.UI.Web.Client/Pages/MyActions.razor                          (11)
Sorcha.UI.Web.Client/Pages/Settings.razor                           (28)
Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor      (1, paired)
Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs   (13, paired)
\`\`\`

## Test plan

- [x] \`dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client\` clean
- [x] \`scripts/check-no-snackbar.ps1\` reports 4 files (was 8)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)