### PR TITLE
refactor(ui): retire ISnackbar from MyActions.razor (Snackbar Phase 9m)

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -15,7 +15,6 @@
 #
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
 
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor
 src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyActions.razor
@@ -18,12 +18,13 @@
 @using Sorcha.UI.Core.Services.Forms
 @using Sorcha.UI.Core.Services.Wallet
 @using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.Feedback
 @inject IWorkflowService WorkflowService
 @inject IBlueprintApiService BlueprintApiService
 @inject IWalletApiService WalletService
 @inject IWalletPreferenceService WalletPreferenceService
 @inject BlueprintHubConnection BlueprintHub
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject IDialogService DialogService
 @inject ILogger<MyActions> Logger
 @inject IJSRuntime JSRuntime
@@ -374,7 +375,7 @@
             catch (Exception ex)
             {
                 Logger.LogWarning(ex, "Failed to load schema for action {ActionId} on blueprint {BlueprintId}", action.ActionId, action.BlueprintId);
-                Snackbar.Add("Failed to load action form — please try again.", Severity.Error);
+                Feedback.ShowError("Failed to load action form — please try again.", autoDismissMs: 0);
                 return;
             }
         }
@@ -443,20 +444,20 @@
                     action.InstanceId, action.ActionId, "declined");
                 if (rejected)
                 {
-                    Snackbar.Add("Action declined", Severity.Info);
+                    Feedback.ShowInfo("Action declined");
                     _actions.Remove(action);
                     RebuildGroups();
                     StateHasChanged();
                 }
                 else
                 {
-                    Snackbar.Add("Failed to decline action. Please try again.", Severity.Error);
+                    Feedback.ShowError("Failed to decline action. Please try again.", autoDismissMs: 0);
                 }
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error rejecting action {ActionId}", action.ActionId);
-                Snackbar.Add("An error occurred while declining the action.", Severity.Error);
+                Feedback.ShowError("An error occurred while declining the action.", autoDismissMs: 0);
             }
             return;
         }
@@ -481,12 +482,12 @@
                     // Async encryption — show progress indicator
                     _activeEncryptionOperationId = submitResult.OperationId;
                     _activeEncryptionRequest = executeRequest;
-                    Snackbar.Add("Encryption started — tracking progress...", Severity.Info);
+                    Feedback.ShowInfo("Encryption started — tracking progress...");
                     StateHasChanged();
                 }
                 else if (submitResult != null)
                 {
-                    Snackbar.Add("Action submitted successfully", Severity.Success);
+                    Feedback.ShowSuccess("Action submitted successfully");
                     _actions.Remove(action);
                     RebuildGroups();
                     StateHasChanged();
@@ -542,13 +543,13 @@
                 }
                 else
                 {
-                    Snackbar.Add("Failed to submit action. Please try again.", Severity.Error);
+                    Feedback.ShowError("Failed to submit action. Please try again.", autoDismissMs: 0);
                 }
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error submitting action {ActionId}", action.ActionId);
-                Snackbar.Add("An error occurred while submitting the action.", Severity.Error);
+                Feedback.ShowError("An error occurred while submitting the action.", autoDismissMs: 0);
             }
         }
     }
@@ -557,7 +558,7 @@
     {
         _activeEncryptionOperationId = null;
         _activeEncryptionRequest = null;
-        Snackbar.Add("Encryption completed successfully!", Severity.Success);
+        Feedback.ShowSuccess("Encryption completed successfully!");
         await LoadActionsAsync();
         await InvokeAsync(StateHasChanged);
     }
@@ -565,7 +566,7 @@
     private Task HandleEncryptionFailed()
     {
         // Keep the progress indicator visible so user can see error and retry
-        Snackbar.Add("Encryption failed. See details above.", Severity.Error);
+        Feedback.ShowError("Encryption failed. See details above.", autoDismissMs: 0);
         return InvokeAsync(StateHasChanged);
     }
 


### PR DESCRIPTION
## Summary

Migrates 11 \`Snackbar.Add\` call sites in \`Pages/MyActions.razor\` to \`IInlineFeedback\`:

- Form-load failure (error, manual ack)
- Decline path: success info, failure error, exception error
- Submit path: async-encryption start info, sync success, generic failure error, exception error
- Background encryption completion success, failure error

Errors use \`autoDismissMs: 0\` (manual acknowledge); successes / info use the default 4s.

Touches the same file as PR #770 — the \`IssuanceSummaryPanel\` dialog flow stays inside the MudDialog surface unchanged (it already uses \`DialogService.ShowAsync\`, not a transient toast).

## Allowlist

3 files left after this PR (down from 4):

\`\`\`
Sorcha.UI.Web.Client/Pages/Settings.razor                           (28)
Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor      (1, paired)
Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs   (13, paired)
\`\`\`

## Test plan

- [x] \`dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client\` clean
- [x] \`scripts/check-no-snackbar.ps1\` reports 3 files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)