### PR TITLE
refactor(ui): retire ISnackbar from Settings.razor — allowlist now empty (Snackbar Phase 9o)

### DIFF
--- a/.snackbar-allowlist
+++ b/.snackbar-allowlist
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Sorcha Contributors
 #
-# Seed allowlist for the Snackbar retirement migration.
-# Files listed here are permitted to contain `Snackbar.Add(` or `ISnackbar`
-# references. The CI gate (scripts/check-no-snackbar.ps1) fails when any new
-# file outside this list introduces those references.
+# Snackbar retirement allowlist — now empty.
 #
-# This list is a ratchet: it may only SHRINK, never grow. Each PR in the
-# Snackbar retirement effort should delete one or more lines as the
-# corresponding call sites migrate to IInlineFeedback / inbox writers /
-# CopyButton / inline MudAlert.
+# Phase 9o (PR closing this work) cleared the last entry (Settings.razor).
+# Every user-facing toast has migrated to one of:
+#   - IInlineFeedback (actor's own-action feedback in the current page)
+#   - Server-side inbox writers (durable bell-drawer entries via F118)
+#   - CopyButton primitive (clipboard "Copied ✓" affordance)
+#   - Inline MudAlert (dialog body errors, per F118 §12)
 #
-# When the list reaches zero entries, Phase 6 unmounts MudSnackbarProvider.
+# Phase 6 follow-up: unmount <MudSnackbarProvider /> from the two MainLayouts.
+# That deserves its own PR (it changes runtime behaviour — any stray
+# Snackbar.Add slipping past the gate would silently no-op).
+#
+# The CI gate (scripts/check-no-snackbar.ps1) stays active. With an empty
+# allowlist, any new `Snackbar.Add(` or `ISnackbar` reference fails the
+# build — preventing regressions.
 #
 # Paths are repo-relative, forward-slashes, case-sensitive on Linux CI.
-
-src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
@@ -12,6 +12,7 @@
 @using Sorcha.UI.Core.Services.Admin
 @using Sorcha.UI.Core.Services.Configuration
 @using Sorcha.UI.Core.Components.Configuration
+@using Sorcha.UI.Core.Services.Feedback
 @using Sorcha.UI.Web.Client.Components.Settings
 @inject IUserPreferencesService PreferencesService
 @inject IConfigurationService ConfigService
@@ -19,7 +20,7 @@
 @inject IPushNotificationService PushService
 @inject IJSRuntime JSRuntime
 @inject IDialogService DialogService
-@inject ISnackbar Snackbar
+@inject IInlineFeedback Feedback
 @inject NavigationManager Navigation
 @inject ILocalizationService Loc
 @inject IThemeService ThemeService
@@ -627,7 +628,7 @@
                 {
                     _pushPermissionDenied = true;
                     _pushEnabled = false;
-                    Snackbar.Add("Browser notifications permission denied", Severity.Warning);
+                    Feedback.ShowWarning("Browser notifications permission denied");
                     return;
                 }
                 _pushPermissionDenied = false;
@@ -640,12 +641,14 @@
                 };
                 var success = await PushService.SubscribeAsync(request);
                 _pushEnabled = success;
-                Snackbar.Add(success ? "Push notifications enabled" : "Failed to enable push notifications",
-                    success ? Severity.Success : Severity.Error);
+                if (success)
+                    Feedback.ShowSuccess("Push notifications enabled");
+                else
+                    Feedback.ShowError("Failed to enable push notifications", autoDismissMs: 0);
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"Push error: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"Push error: {ex.Message}", autoDismissMs: 0);
             }
         }
         else
@@ -654,12 +657,14 @@
             {
                 var success = await PushService.UnsubscribeAsync("browser-push-endpoint");
                 _pushEnabled = !success ? _pushEnabled : false;
-                Snackbar.Add(success ? "Push notifications disabled" : "Failed to disable push notifications",
-                    success ? Severity.Success : Severity.Error);
+                if (success)
+                    Feedback.ShowSuccess("Push notifications disabled");
+                else
+                    Feedback.ShowError("Failed to disable push notifications", autoDismissMs: 0);
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"Push error: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"Push error: {ex.Message}", autoDismissMs: 0);
             }
         }
     }
@@ -682,7 +687,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -697,7 +702,7 @@
             "Dark" => "settings.theme.dark",
             _ => "settings.theme.system"
         };
-        Snackbar.Add($"{Loc.T("settings.theme")}: {Loc.T(themeKey)}", Severity.Success);
+        Feedback.ShowSuccess($"{Loc.T("settings.theme")}: {Loc.T(themeKey)}");
     }
 
     private async Task OnTimeFormatChanged(string format)
@@ -705,7 +710,7 @@
         _preferences.TimeFormat = format;
         await SavePreferencesAsync(new UpdateUserPreferencesRequest { TimeFormat = format });
         var formatKey = format == "UTC" ? "settings.timeFormat.utc" : "settings.timeFormat.local";
-        Snackbar.Add($"{Loc.T("settings.timeFormat")}: {Loc.T(formatKey)}", Severity.Success);
+        Feedback.ShowSuccess($"{Loc.T("settings.timeFormat")}: {Loc.T(formatKey)}");
     }
 
     private async Task OnLanguageChanged(string languageCode)
@@ -713,28 +718,28 @@
         _preferences.Language = languageCode;
         await Loc.SetLanguageAsync(languageCode);
         var langName = _supportedLanguages.FirstOrDefault(l => l.Code == languageCode).Name ?? languageCode;
-        Snackbar.Add($"{Loc.T("settings.language")}: {langName}", Severity.Success);
+        Feedback.ShowSuccess($"{Loc.T("settings.language")}: {langName}");
     }
 
     private async Task OnNotificationsChanged(bool enabled)
     {
         _preferences.NotificationsEnabled = enabled;
         await SavePreferencesAsync(new UpdateUserPreferencesRequest { NotificationsEnabled = enabled });
-        Snackbar.Add(enabled ? Loc.T("settings.notifications.enabledSuccess") : Loc.T("settings.notifications.disabledSuccess"), Severity.Success);
+        Feedback.ShowSuccess(enabled ? Loc.T("settings.notifications.enabledSuccess") : Loc.T("settings.notifications.disabledSuccess"));
     }
 
     private async Task OnNotificationMethodChanged(string method)
     {
         _preferences.NotificationMethod = method;
         await SavePreferencesAsync(new UpdateUserPreferencesRequest { NotificationMethod = method });
-        Snackbar.Add(Loc.T("settings.notifications.saved"), Severity.Success);
+        Feedback.ShowSuccess(Loc.T("settings.notifications.saved"));
     }
 
     private async Task OnNotificationFrequencyChanged(string frequency)
     {
         _preferences.NotificationFrequency = frequency;
         await SavePreferencesAsync(new UpdateUserPreferencesRequest { NotificationFrequency = frequency });
-        Snackbar.Add(Loc.T("settings.notifications.saved"), Severity.Success);
+        Feedback.ShowSuccess(Loc.T("settings.notifications.saved"));
     }
 
     private async Task SavePreferencesAsync(UpdateUserPreferencesRequest request)
@@ -745,7 +750,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -763,12 +768,12 @@
             }
             else
             {
-                Snackbar.Add(Loc.T("settings.twoFactor.setupFailed"), Severity.Error);
+                Feedback.ShowError(Loc.T("settings.twoFactor.setupFailed"), autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -785,16 +790,16 @@
                 _preferences.TwoFactorEnabled = true;
                 _showTotpSetup = false;
                 _totpVerificationCode = string.Empty;
-                Snackbar.Add(Loc.T("settings.twoFactor.enabledSuccess"), Severity.Success);
+                Feedback.ShowSuccess(Loc.T("settings.twoFactor.enabledSuccess"));
             }
             else
             {
-                Snackbar.Add(Loc.T("settings.twoFactor.invalidCode"), Severity.Error);
+                Feedback.ShowError(Loc.T("settings.twoFactor.invalidCode"), autoDismissMs: 0);
             }
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -818,16 +823,16 @@
                     _totpSecret = string.Empty;
                     _totpQrUri = string.Empty;
                     _totpBackupCodes.Clear();
-                    Snackbar.Add(Loc.T("settings.twoFactor.disabledSuccess"), Severity.Info);
+                    Feedback.ShowInfo(Loc.T("settings.twoFactor.disabledSuccess"));
                 }
                 else
                 {
-                    Snackbar.Add(Loc.T("settings.twoFactor.disableFailed"), Severity.Error);
+                    Feedback.ShowError(Loc.T("settings.twoFactor.disableFailed"), autoDismissMs: 0);
                 }
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
             }
         }
     }
@@ -843,7 +848,7 @@
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
         finally
         {
@@ -862,11 +867,11 @@
                 ApiConfiguration.ConfigureFromProfile(profile);
             }
             await LoadProfilesAsync();
-            Snackbar.Add(Loc.T("settings.connections.activatedSuccess", profileName), Severity.Success);
+            Feedback.ShowSuccess(Loc.T("settings.connections.activatedSuccess", profileName));
         }
         catch (Exception ex)
         {
-            Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
     }
 
@@ -934,16 +939,16 @@
                 if (deleted)
                 {
                     await LoadProfilesAsync();
-                    Snackbar.Add(Loc.T("settings.connections.deletedSuccess", profile.Name), Severity.Info);
+                    Feedback.ShowInfo(Loc.T("settings.connections.deletedSuccess", profile.Name));
                 }
                 else
                 {
-                    Snackbar.Add(Loc.T("settings.connections.cannotDelete"), Severity.Warning);
+                    Feedback.ShowWarning(Loc.T("settings.connections.cannotDelete"));
                 }
             }
             catch (Exception ex)
             {
-                Snackbar.Add($"{Loc.T("common.error")}: {ex.Message}", Severity.Error);
+                Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
             }
         }
     }


### PR DESCRIPTION
## Summary

Migrates the final 28 \`Snackbar.Add\` call sites in \`Pages/Settings.razor\` to \`IInlineFeedback\`.

After this PR merges the \`.snackbar-allowlist\` contains **zero file entries**. The CI gate stays active to prevent regressions — any new \`Snackbar.Add\` or \`ISnackbar\` reference fails the build.

## What was migrated

- **Push notifications**: permission-denied warning, enable/disable success/failure (ternary \`Snackbar.Add(condition ? a : b, condition ? Success : Error)\` calls expanded to explicit branches so Error severity gets \`autoDismissMs: 0\`), exception errors.
- **User preferences**: theme/time-format/language change success, notifications toggle success, save errors, generic load error.
- **TOTP cluster**: setup failed, verify success/invalid-code, disable success/failure, exception errors.
- **Connection profiles**: load error, activate success, delete success / cannot-delete warning, exception error.

Errors use \`autoDismissMs: 0\` (manual acknowledge); successes / warnings / info use the default 4s.

## Snackbar Phase 9 summary

This PR closes Phase 9 of the Snackbar retirement effort. Across the phase the allowlist went **49 → 0** files:

| PR | Phase | Files retired |
|---|---|---|
| #740…#755 | Phase 8 and earlier | bulk PWA + web-page migrations |
| #766 | 9a–9g | 34 surfaces |
| #767 | 9h | 3 dialog surfaces |
| #768 | 9i | MyProfile.razor |
| #769 | 9j | TransactionDetailPanel via CopyButton |
| #780 | 9k | Invitations + DesignerToolbar |
| #781 | 9l | 4 admin surfaces (UserManagement, IdpConfiguration, PlatformSettings, ParticipantDetail) |
| #782 | 9m | MyActions.razor |
| #783 | 9n | AiDesignerPane partial-class pair |
| **this** | **9o** | **Settings.razor — last file** |

## Phase 6 follow-up

Unmount \`<MudSnackbarProvider />\` from the two MainLayouts (web \`Components/Layout/MainLayout.razor\` and PWA \`MainLayout.razor\`). Worth its own PR — it changes runtime behaviour: any stray \`Snackbar.Add\` slipping past the CI gate would silently no-op rather than throw, so the swap deserves a clean retrospective commit.

## Test plan

- [x] \`dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client\` clean
- [x] \`scripts/check-no-snackbar.ps1\` reports 0 files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)