### PR TITLE
fix(walkthroughs): skip Docker check + brittle exit-code check for -Profile n1

### DIFF
--- a/walkthroughs/AssuredIdentity/run.ps1
+++ b/walkthroughs/AssuredIdentity/run.ps1
@@ -28,10 +28,13 @@ Write-WtBanner "AssuredIdentity — Full Run (Phases 1 + 2)"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $totalStart = Get-Date
 
-# Setup (idempotent)
+# Setup (idempotent). ErrorActionPreference=Stop already converts any
+# walkthrough-level failure into a thrown exception; don't double-check
+# $LASTEXITCODE because setup.ps1 inherits whatever the last native invocation
+# (docker info / curl probe) left in it, which is unreliable as a success
+# signal.
 Write-WtStep "Setup"
 & (Join-Path $scriptDir "setup.ps1") -Profile $Profile -SkipHealthCheck:$SkipHealthCheck -Force:$Force
-if ($LASTEXITCODE -ne 0) { throw "setup.ps1 failed (exit $LASTEXITCODE)" }
 
 # Phase 1 — Assured Identity issuance
 $phase1Start = Get-Date
@@ -39,7 +42,6 @@ $phase1Args = @()
 if ($ShowJson)         { $phase1Args += '-ShowJson' }
 if ($IncludePortrait)  { $phase1Args += '-IncludePortrait' }
 & (Join-Path $scriptDir "run-phase1-identity.ps1") @phase1Args
-if ($LASTEXITCODE -ne 0) { throw "run-phase1-identity.ps1 failed (exit $LASTEXITCODE)" }
 $phase1Elapsed = (Get-Date) - $phase1Start
 Write-WtInfo ("Phase 1 elapsed: {0:mm\:ss}" -f $phase1Elapsed)
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -297,13 +297,19 @@ function Initialize-SorchaEnvironment {
     }
 
     if (-not $SkipHealthCheck) {
-        # Check Docker
-        Write-WtInfo "Checking Docker availability..."
-        $dockerInfo = docker info 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            throw "Docker is not running. Start Docker Desktop and run: docker-compose up -d"
+        # Check Docker — only for local profiles. Remote profiles (n1) target a
+        # hosted environment where the local Docker daemon is irrelevant.
+        if ($Profile -ne 'n1') {
+            Write-WtInfo "Checking Docker availability..."
+            $dockerInfo = docker info 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Docker is not running. Start Docker Desktop and run: docker-compose up -d"
+            }
+            Write-WtSuccess "Docker is running"
         }
-        Write-WtSuccess "Docker is running"
+        else {
+            Write-WtInfo "Profile = n1 — skipping local Docker check"
+        }
 
         # Check API Gateway health
         Write-WtInfo "Checking API Gateway health..."


### PR DESCRIPTION
## Summary

Two small fixes uncovered while sweeping the walkthroughs against the live n1 deployment after the Snackbar Phase 6 deploy.

### 1. \`Initialize-SorchaEnvironment\` — skip Docker check for -Profile n1

The module unconditionally ran \`docker info\` to check the local daemon, even when the walkthrough targets a hosted environment (\`https://n1.sorcha.dev\`). On a machine without Docker Desktop running, every n1-profile walkthrough threw \`"Docker is not running"\` before doing anything.

Now only local profiles (\`gateway\`, \`direct\`, \`aspire\`) probe the Docker daemon; \`n1\` skips and logs \`"Profile = n1 — skipping local Docker check"\`.

### 2. \`AssuredIdentity/run.ps1\` — drop brittle \`$LASTEXITCODE\` check

The wrapper checked \`if ($LASTEXITCODE -ne 0) { throw }\` after each child script. Child scripts don't set \`$LASTEXITCODE\`; it inherits from whatever native process the child happened to invoke last (\`docker info\`, \`curl\` probe, etc.). Since the wrapper sets \`$ErrorActionPreference = "Stop"\`, any real failure inside the child throws and surfaces — the manual check only ever produced false positives.

After setup completed all 10 steps cleanly, the wrapper threw \`"setup.ps1 failed (exit )"\` because \`$LASTEXITCODE\` was empty.

## Walkthrough sweep findings (separate from this PR)

| Walkthrough | Result | Notes |
|---|---|---|
| AssuredIdentity | ✅ PASS | Setup + Phase 1 (Phase 2 deferred to Spec 4) — 11s total |
| HealthDeclaration | ✅ PASS | Setup-only (Feature 091 layout demo) |
| ForestryCertification | ✅ PASS | Both golden-path and decline scenarios |
| SelfBuildHouse | ✅ PASS | All 3 scenarios incl. credential issuance |
| ConstructionPermit | ❌ FAIL | Service-side: validator wedged on credential-issuance docket race; register stuck after first failure; not recoverable from walkthrough side |
| TradeFinance | ❌ FAIL | Service-side: 403 on Action 1 after register sign rate-limit (10/min) cleared — different root cause needs deeper investigation |
| PropertyInspection | skipped | Only ships \`run-agents.ps1\` — needs agent orchestration, no plain \`run.ps1\` |

The two service-side failures are out of scope for this PR (don't-touch-services constraint) and need separate diagnosis. Captured here for the record.

## Test plan

- [x] AssuredIdentity \`run.ps1 -Profile n1\` against the live n1 deploy completes end-to-end with no "Docker is not running" or "setup.ps1 failed (exit )" errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)