### PR TITLE
feat(walkthroughs): Wait-SorchaActorReady — bridge script cadence to docket sealing

### DIFF
--- a/.claude/skills/walkthrough-builder/SKILL.md
+++ b/.claude/skills/walkthrough-builder/SKILL.md
@@ -20,6 +20,64 @@ Each participant runs as an independent `sorcha-agent` process. Actors are state
 
 **Always prefer the actor-based model for new walkthroughs.**
 
+## Cadence: gating script execution on docket-sealing (REQUIRED)
+
+Script-based walkthroughs race ahead of the validator's docket-build cycle. The `/actions/execute` HTTP response only means "tx accepted into mempool" — the tx is not yet sealed. If the next action submits during the validator's post-seal cleanup window, you can trigger the **docket-monitoring race** (P0 bug — see issue #787) that wedges the register permanently. **This is not theoretical** — it happened to ConstructionPermit on 2026-05-19 and required filing a P0 bug to fix at the validator level.
+
+Real-world actor flow doesn't race because each participant waits for SignalR notification of an inbound sealed transaction before responding. That natural latency (docket dwell + notification + actor cognition) gives the validator ~3-5 seconds between consecutive actions. Scripts do it in 50 ms.
+
+### The fix: `Wait-SorchaActorReady` and the `-WaitForSeal` switch
+
+The shared module provides a `Wait-SorchaActorReady` cmdlet and an opt-in `-WaitForSeal` switch on `Invoke-SorchaAction`. **Every walkthrough script that calls `Invoke-SorchaAction` MUST pass `-WaitForSeal`.** The CI gate doesn't enforce this (yet) but PR reviewers should.
+
+```powershell
+# Required shape for script-based walkthroughs:
+$response = Invoke-SorchaAction `
+    -BlueprintUrl $state.blueprintUrl `
+    -InstanceId $instanceId `
+    -ActionId "1" `
+    -BlueprintId $state.blueprintId `
+    -SenderWallet $wallet `
+    -RegisterId $state.registerId `
+    -Token $session.Token `
+    -PayloadData $payload `
+    -WaitForSeal            # <-- bridges script cadence to docket cadence
+```
+
+`Invoke-SorchaAction -WaitForSeal` polls the F079 lifecycle endpoint (`/api/registers/{registerId}/transactions/{txId}/status`) for the submitted tx until `Active` / `Revoked` / `Superseded`. Timeout 90s by default; override via `-WaitForSealTimeoutSeconds`. The lifecycle endpoint is auth-gated by `CanReadTransactions` — the helper passes the same `Authorization` header used for the submit.
+
+### Other modes
+
+`Wait-SorchaActorReady` supports four modes for the rest of the cadence gates that show up in walkthrough authoring:
+
+| Mode | What it gates on | Use when |
+|---|---|---|
+| `AfterSubmit` | tx sealed in a docket | After every `Invoke-SorchaAction` (use `-WaitForSeal` for the ergonomic form) |
+| `AwaitingInbox` | `instance.currentActionIds` contains the named action | Between actor switches in a script — the equivalent of an actor receiving a SignalR inbox notification |
+| `ParticipantSealed` | participant publish tx sealed | After `Publish-SorchaParticipant` in setup.ps1, before saving `state.json` |
+| `BlueprintSealed` | blueprint publish tx sealed | After `Publish-SorchaBlueprint` in setup.ps1, before saving `state.json` |
+
+### Don't save state.json until publishes seal
+
+A second class of failure (TradeFinance on 2026-05-19) was setup.ps1 saving `state.json` immediately after blueprint/participant publish HTTP responses — same issue, the tx hadn't sealed yet. `run.ps1` then starts instantly, tries to execute Action 1, the auth check looks up the participant record, gets a 404 because the tx hasn't sealed, and returns 403.
+
+**In setup.ps1**, after each `Publish-SorchaBlueprint` / `Publish-SorchaParticipant` call, capture the response's `transactionId` and wait for it:
+
+```powershell
+$publishResult = Publish-SorchaBlueprint ...
+if ($publishResult.transactionId) {
+    Wait-SorchaActorReady -Mode BlueprintSealed `
+        -TxId $publishResult.transactionId `
+        -RegisterId $registerId `
+        -Headers $session.Headers `
+        -GatewayUrl $sorchaEnv.GatewayUrl
+}
+```
+
+### Agents (Sorcha.Agent) don't need this
+
+The autonomous agent already gates on SignalR — its `SignalRInboxListener` subscribes to `BlueprintHub.ActionAvailable` and only acts when notified. **Do not retrofit `-WaitForSeal` into agent code paths.** This helper is for script-based walkthroughs only (the two execution models converge on the same cadence: agents do it via SignalR events, scripts do it via polling).
+
 ## Project Locations
 
 ```
@@ -460,6 +518,8 @@ await orgCard.First.ClickAsync();
 | Walkthrough: org subdomain taken | Re-running setup without volume reset | Use `docker compose down -v` for clean slate, or use `-Force` flag |
 | Walkthrough: Action N fails 400 for the same participant on every scenario | Late-bound participant reuse hitting VAL_BP_002 via a broken Tier 3 chain lookup (incident 2026-04-20) | Check validator logs for "no prior in-instance binding". Confirm `GET /api/query/instance/{id}/transactions/{registerId}` returns 200 with a non-empty list. If empty, inspect MongoDB: `MetaData.InstanceId` must be non-null on sealed txs. See `n1-deploy` skill → "Validator-pipeline changes — end-to-end probe". |
 | Walkthrough: re-running after n1 reset but setup keeps state from last run | State files (state.json) persist between resets, pointing at deleted registers/users | Before re-running: `find walkthroughs -name state.json -delete`. The script's idempotency only works against state that still exists server-side. |
+| Walkthrough: Action N times out at 60s on `/actions/execute` with "Transaction not confirmed" | Script raced ahead of docket-seal; the previous action's tx is mid-cleanup at the validator and the new tx triggers the docket-monitoring race (P0 issue #787). Register is now wedged — restart won't help; new txs on this register never seal. | Pass `-WaitForSeal` on every `Invoke-SorchaAction` call (see "Cadence" section above). Existing wedged register needs the underlying validator bug fixed, or the register replaced (the wedge survives validator restart because the stuck tx is persisted in the mempool). |
+| Walkthrough: Action 1 returns 403 immediately (6 ms response) on a fresh setup, no rate-limit warning | setup.ps1 saved state.json before the participant/blueprint publish txs had sealed; run.ps1 starts instantly, auth check looks up the participant record, 404 upstream becomes 403 at auth layer | Add `Wait-SorchaActorReady -Mode BlueprintSealed` / `ParticipantSealed` in setup.ps1 after each publish, before writing state.json. |
 
 ## Running against n1 (ground-truth verification)
 

--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -138,7 +138,8 @@ $null = Invoke-SorchaAction `
     -SenderWallet $state.citizenWalletAddress `
     -RegisterId $state.registerId `
     -Token $citizenSession.Token `
-    -PayloadData $payloadData
+    -PayloadData $payloadData `
+    -WaitForSeal
 
 # ============================================================================
 # Step 4: Set the pending-application notice (Feature 124 US2 / FR-009)
@@ -168,7 +169,8 @@ $actionResponse = Invoke-SorchaAction `
     -PayloadData @{
         decision          = "approved"
         verificationNotes = "Identity verified against submitted persona."
-    }
+    } `
+    -WaitForSeal
 
 if ($ShowJson) { $actionResponse | ConvertTo-Json -Depth 5 | Write-Host }
 Write-WtSuccess "Action 2 approved — credential issuance triggered (target: SorchaLocalWallet)"

--- a/walkthroughs/ConstructionPermit/run.ps1
+++ b/walkthroughs/ConstructionPermit/run.ps1
@@ -151,18 +151,20 @@ foreach ($sid in $scenariosToRun) {
 
         try {
             if ($isRejectionAction) {
-                $null = Invoke-SorchaAction `
+                $response = Invoke-SorchaAction `
                     -BlueprintUrl $state.blueprintUrl -InstanceId $instanceId `
                     -ActionId $actionIdStr -BlueprintId $state.blueprintId `
                     -SenderWallet $senderWallet -RegisterId $state.registerId `
                     -Token $senderToken `
-                    -Reject -RejectionReason $scenarioData.rejectionReason
+                    -Reject -RejectionReason $scenarioData.rejectionReason `
+                    -WaitForSeal
             } else {
                 $response = Invoke-SorchaAction `
                     -BlueprintUrl $state.blueprintUrl -InstanceId $instanceId `
                     -ActionId $actionIdStr -BlueprintId $state.blueprintId `
                     -SenderWallet $senderWallet -RegisterId $state.registerId `
-                    -Token $senderToken -PayloadData $payloadData
+                    -Token $senderToken -PayloadData $payloadData `
+                    -WaitForSeal
 
                 if ($response.calculatedValues) {
                     foreach ($calc in $response.calculatedValues.PSObject.Properties) {
@@ -170,6 +172,7 @@ foreach ($sid in $scenariosToRun) {
                     }
                 }
             }
+
             $actionsOk++
             $prevActionId = $actionId
             Write-WtInfo "  ($sender via per-user token)"

--- a/walkthroughs/ForestryCertification/run.ps1
+++ b/walkthroughs/ForestryCertification/run.ps1
@@ -78,7 +78,8 @@ $null = Invoke-SorchaAction `
     -SenderWallet $state.wallets.salesMgr `
     -RegisterId $state.registerId `
     -Token $salesSession.Token `
-    -PayloadData $action1Payload
+    -PayloadData $action1Payload `
+    -WaitForSeal
 Write-WtSuccess "Action 1 submitted (batch $($action1Payload.batchId))"
 
 # ============================================================================
@@ -96,7 +97,8 @@ $action2Response = Invoke-SorchaAction `
     -SenderWallet $state.wallets.auditor `
     -RegisterId $state.registerId `
     -Token $auditorSession.Token `
-    -PayloadData $action2Payload
+    -PayloadData $action2Payload `
+    -WaitForSeal
 
 if ($ShowJson) { $action2Response | ConvertTo-Json -Depth 5 | Write-Host }
 

--- a/walkthroughs/FormCoverage/run.ps1
+++ b/walkthroughs/FormCoverage/run.ps1
@@ -111,7 +111,8 @@ for ($i = 1; $i -le $Rounds; $i++) {
             -SenderWallet $submitterWallet `
             -RegisterId $state.registerId `
             -Token $submitterToken `
-            -PayloadData $payload1
+            -PayloadData $payload1 `
+            -WaitForSeal
         Write-WtInfo "  Submit action ok"
     } catch {
         Write-WtFail "  Submit failed: $($_.Exception.Message)"
@@ -159,7 +160,8 @@ for ($i = 1; $i -le $Rounds; $i++) {
             -SenderWallet $reviewerWallet `
             -RegisterId $state.registerId `
             -Token $reviewerToken `
-            -PayloadData $payload2
+            -PayloadData $payload2 `
+            -WaitForSeal
         Write-WtInfo "  Acknowledge action ok"
     } catch {
         Write-WtFail "  Acknowledge failed: $($_.Exception.Message)"

--- a/walkthroughs/PayloadTests/run.ps1
+++ b/walkthroughs/PayloadTests/run.ps1
@@ -376,7 +376,8 @@ for ($round = 1; $round -le $Rounds; $round++) {
             -PayloadData @{
                 message    = "Round $round test file ($FileSize)"
                 attachment = $fileRef
-            }
+            } `
+            -WaitForSeal
 
         # Action execution is async — the initial response may have an empty transactionId.
         # Poll the instance until action 1 becomes current (action 0 has been sealed).
@@ -439,7 +440,8 @@ for ($round = 1; $round -le $Rounds; $round++) {
             -Token $receiverAuth.Token `
             -PayloadData @{
                 acknowledged = $true
-            }
+            } `
+            -WaitForSeal
 
         Write-WtSuccess "Receiver acknowledged"
         $stepsPassed++

--- a/walkthroughs/PingPongN1/run.ps1
+++ b/walkthroughs/PingPongN1/run.ps1
@@ -229,7 +229,8 @@ for ($round = 1; $round -le $Rounds; $round++) {
             -SenderWallet $state.n1.pongWallet `
             -RegisterId $register.RegisterId `
             -PayloadData @{ message = "pong #$round (n1 initiating)"; counter = $round; fromHost = "n1" } `
-            -Token $pongSession.Token
+            -Token $pongSession.Token `
+            -WaitForSeal
         $pongTx = $pongResp.transactionId
         $roundState.PongSent = $true
         Write-WtSuccess "Round ${round}: action 0 sent on n1 (tx=$pongTx)"
@@ -287,7 +288,8 @@ for ($round = 1; $round -le $Rounds; $round++) {
             -SenderWallet $state.local.pingWallet `
             -RegisterId $register.RegisterId `
             -PayloadData @{ message = "ping #$round (local replying)"; counter = $round; fromHost = "local" } `
-            -Token $pingSession.Token
+            -Token $pingSession.Token `
+            -WaitForSeal
         $pingTx = $pingResp.transactionId
         $roundState.PingSent = $true
         Write-WtSuccess "Round ${round}: action 1 sent on local (tx=$pingTx)"

--- a/walkthroughs/SelfBuildHouse/run.ps1
+++ b/walkthroughs/SelfBuildHouse/run.ps1
@@ -155,7 +155,8 @@ function Invoke-BlueprintScenario {
                     -ActionId $actionIdStr -BlueprintId $BlueprintId `
                     -SenderWallet $senderWallet -RegisterId $RegisterId `
                     -Token $senderToken `
-                    -Reject -RejectionReason $RejectionReason
+                    -Reject -RejectionReason $RejectionReason `
+                    -WaitForSeal
                 Write-WtWarn "    Action $actionIdStr ($sender) -> REJECTED"
             } else {
                 $presentations = @()
@@ -169,7 +170,8 @@ function Invoke-BlueprintScenario {
                     -ActionId $actionIdStr -BlueprintId $BlueprintId `
                     -SenderWallet $senderWallet -RegisterId $RegisterId `
                     -Token $senderToken -PayloadData $payloadData `
-                    -CredentialPresentations $presentations
+                    -CredentialPresentations $presentations `
+                    -WaitForSeal
 
                 Write-WtSuccess "    Action $actionIdStr ($sender) -> OK"
 

--- a/walkthroughs/TradeFinance/run.ps1
+++ b/walkthroughs/TradeFinance/run.ps1
@@ -164,7 +164,8 @@ function Invoke-BlueprintScenario {
                     -ActionId $actionIdStr -BlueprintId $BlueprintId `
                     -SenderWallet $senderWallet -RegisterId $RegisterId `
                     -Token $senderToken `
-                    -Reject -RejectionReason $RejectionReason
+                    -Reject -RejectionReason $RejectionReason `
+                    -WaitForSeal
                 Write-WtWarn "    Action $actionIdStr ($sender) -> REJECTED"
             } else {
                 # For the first action with credential presentations, send directly with presentations
@@ -191,7 +192,8 @@ function Invoke-BlueprintScenario {
                         -BlueprintUrl $blueprintUrl -InstanceId $instanceId `
                         -ActionId $actionIdStr -BlueprintId $BlueprintId `
                         -SenderWallet $senderWallet -RegisterId $RegisterId `
-                        -Token $senderToken -PayloadData $payloadData
+                        -Token $senderToken -PayloadData $payloadData `
+                        -WaitForSeal
 
                     Write-WtSuccess "    Action $actionIdStr ($sender) -> OK"
                 }
@@ -262,7 +264,8 @@ function Invoke-DisputedProcurement {
                 -BlueprintUrl $blueprintUrl -InstanceId $instanceId `
                 -ActionId $actionIdStr -BlueprintId $BlueprintId `
                 -SenderWallet $senderWallet -RegisterId $RegisterId `
-                -Token $senderToken -PayloadData $payloadData
+                -Token $senderToken -PayloadData $payloadData `
+                -WaitForSeal
 
             Write-WtSuccess "    Action $actionIdStr ($sender) -> OK"
 
@@ -298,7 +301,8 @@ function Invoke-DisputedProcurement {
             -BlueprintUrl $blueprintUrl -InstanceId $instanceId `
             -ActionId "6" -BlueprintId $BlueprintId `
             -SenderWallet $senderWallet -RegisterId $RegisterId `
-            -Token $senderToken -PayloadData $payloadData
+            -Token $senderToken -PayloadData $payloadData `
+            -WaitForSeal
         Write-WtWarn "    Action 6 ($sender) -> DISPUTED"
         $actionsOk++
     } catch {
@@ -323,7 +327,8 @@ function Invoke-DisputedProcurement {
             -BlueprintUrl $blueprintUrl -InstanceId $instanceId `
             -ActionId "5" -BlueprintId $BlueprintId `
             -SenderWallet $senderWallet -RegisterId $RegisterId `
-            -Token $senderToken -PayloadData $payloadData
+            -Token $senderToken -PayloadData $payloadData `
+            -WaitForSeal
 
         Write-WtSuccess "    Action 5 ($sender) -> RESUBMITTED"
 
@@ -358,7 +363,8 @@ function Invoke-DisputedProcurement {
             -BlueprintUrl $blueprintUrl -InstanceId $instanceId `
             -ActionId "6" -BlueprintId $BlueprintId `
             -SenderWallet $senderWallet -RegisterId $RegisterId `
-            -Token $senderToken -PayloadData $payloadData
+            -Token $senderToken -PayloadData $payloadData `
+            -WaitForSeal
 
         Write-WtSuccess "    Action 6 ($sender) -> APPROVED"
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1376,7 +1376,15 @@ function Invoke-SorchaAction {
         [hashtable]$PayloadData = @{},
         [array]$CredentialPresentations = @(),
         [switch]$Reject,
-        [string]$RejectionReason = ""
+        [string]$RejectionReason = "",
+        # Wait for the submitted tx to seal before returning. This is the
+        # actor-cadence bridge: real participants see SignalR-notified
+        # inbound transactions, scripts see immediate HTTP responses; without
+        # this gate the next action can submit during the validator's post-
+        # seal cleanup and trigger the docket-monitoring race. Default off
+        # for back-compat; new scripts should always set it.
+        [switch]$WaitForSeal,
+        [int]$WaitForSealTimeoutSeconds = 90
     )
 
     $executeHeaders = @{
@@ -1397,6 +1405,17 @@ function Invoke-SorchaAction {
             -Headers $executeHeaders
 
         Write-WtSuccess "Action $ActionId REJECTED"
+
+        if ($WaitForSeal -and $response.transactionId) {
+            $gatewayUrl = $BlueprintUrl -replace '/api$', ''
+            Wait-SorchaActorReady -Mode AfterSubmit `
+                -TxId $response.transactionId `
+                -RegisterId $RegisterId `
+                -Headers $executeHeaders `
+                -GatewayUrl $gatewayUrl `
+                -TimeoutSeconds $WaitForSealTimeoutSeconds
+        }
+
         return $response
     } else {
         $actionBody = @{
@@ -1419,6 +1438,17 @@ function Invoke-SorchaAction {
 
         $nextAction = if ($response.nextAction) { $response.nextAction } else { "complete" }
         Write-WtSuccess "Action $ActionId executed (next: $nextAction)"
+
+        if ($WaitForSeal -and $response.transactionId) {
+            $gatewayUrl = $BlueprintUrl -replace '/api$', ''
+            Wait-SorchaActorReady -Mode AfterSubmit `
+                -TxId $response.transactionId `
+                -RegisterId $RegisterId `
+                -Headers $executeHeaders `
+                -GatewayUrl $gatewayUrl `
+                -TimeoutSeconds $WaitForSealTimeoutSeconds
+        }
+
         return $response
     }
 }
@@ -1955,4 +1985,186 @@ function Clear-SorchaCitizenPendingApplication {
         -Headers $Headers `
         -RawResponse
     Write-WtInfo "Pending-application notice cleared"
+}
+
+# ============================================================================
+# Wait-SorchaActorReady — Bridge script cadence and docket-sealing cadence
+# ============================================================================
+
+function Wait-SorchaActorReady {
+    <#
+    .SYNOPSIS
+        Pauses a walkthrough script until the platform is in a state where the
+        next step can proceed safely.
+
+    .DESCRIPTION
+        Walkthroughs that submit actions back-to-back can race ahead of the
+        validator's docket-build cycle. In real-world actor flows each
+        participant waits for a SignalR notification that an inbound
+        transaction has sealed before proceeding, adding several seconds of
+        natural latency between consecutive actions. Scripts move in
+        milliseconds and exercise concurrency bugs (notably: stuck
+        transactions when a credential-issuance tx arrives during the
+        validator's post-seal cleanup window).
+
+        Four modes covering the cases where script cadence needs to gate
+        on platform state:
+
+          AfterSubmit         my outgoing tx is sealed (status = Active /
+                              Revoked / Superseded)
+          AwaitingInbox       the named action is ready for the named actor
+                              (the script equivalent of an inbox
+                              notification — polls instance.currentActionIds)
+          ParticipantSealed   a participant publish tx is sealed
+          BlueprintSealed     a blueprint publish tx is sealed
+
+        AfterSubmit / ParticipantSealed / BlueprintSealed share the polling
+        shape against /api/registers/{registerId}/transactions/{txId}/status
+        (Feature 079 lifecycle endpoint, anonymous). AwaitingInbox polls
+        /api/instances/{instanceId} for currentActionIds containment
+        (authenticated).
+
+        For agents (Sorcha.Agent), the same conceptual surface is provided
+        by their SignalR inbox listeners. Agents do not need this helper.
+
+    .PARAMETER Mode
+        Which condition to wait for.
+
+    .PARAMETER TxId
+        Transaction ID. Required for AfterSubmit / ParticipantSealed /
+        BlueprintSealed.
+
+    .PARAMETER RegisterId
+        Register where the transaction seals. Required for all sealed-* modes
+        and for AwaitingInbox.
+
+    .PARAMETER InstanceId
+        Workflow instance ID. Required for AwaitingInbox.
+
+    .PARAMETER ActionId
+        Action ID to wait for. Required for AwaitingInbox.
+
+    .PARAMETER Headers
+        Auth headers for API calls. Required for all four modes — the F079
+        lifecycle status endpoint is gated by the CanReadTransactions policy,
+        and the instance GET is also authenticated.
+
+    .PARAMETER GatewayUrl
+        Base URL of the API gateway (e.g., http://localhost or
+        https://n1.sorcha.dev).
+
+    .PARAMETER TimeoutSeconds
+        Maximum seconds to wait. Default 90. Throws on timeout.
+
+    .PARAMETER IntervalSeconds
+        Poll interval. Default 1s.
+
+    .EXAMPLE
+        $resp = Invoke-SorchaAction ...
+        Wait-SorchaActorReady -Mode AfterSubmit -TxId $resp.transactionId `
+            -RegisterId $registerId -GatewayUrl $env.GatewayUrl
+
+    .EXAMPLE
+        # Between actor switches in a script:
+        Wait-SorchaActorReady -Mode AwaitingInbox -InstanceId $inst `
+            -ActionId 6 -RegisterId $registerId -Headers $planningHeaders `
+            -GatewayUrl $env.GatewayUrl
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('AfterSubmit', 'AwaitingInbox', 'ParticipantSealed', 'BlueprintSealed')]
+        [string]$Mode,
+
+        [string]$TxId,
+        [string]$RegisterId,
+        [string]$InstanceId,
+        [int]$ActionId,
+        [hashtable]$Headers,
+
+        [Parameter(Mandatory)]
+        [string]$GatewayUrl,
+
+        [int]$TimeoutSeconds = 90,
+        [int]$IntervalSeconds = 1
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $start = Get-Date
+    $attempt = 0
+
+    $sealedModes = @('AfterSubmit', 'ParticipantSealed', 'BlueprintSealed')
+    if ($sealedModes -contains $Mode) {
+        if (-not $TxId)       { throw "Wait-SorchaActorReady[$Mode]: -TxId is required" }
+        if (-not $RegisterId) { throw "Wait-SorchaActorReady[$Mode]: -RegisterId is required" }
+        if (-not $Headers)    { throw "Wait-SorchaActorReady[$Mode]: -Headers is required (lifecycle endpoint is auth-gated by CanReadTransactions policy)" }
+
+        $url = "$GatewayUrl/api/registers/$RegisterId/transactions/$TxId/status"
+        $shortTx = if ($TxId.Length -ge 10) { $TxId.Substring(0, 10) } else { $TxId }
+
+        while ((Get-Date) -lt $deadline) {
+            $attempt++
+            try {
+                $r = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipCertificateCheck -ErrorAction Stop
+                if ($r.StatusCode -eq 200) {
+                    $body = $r.Content | ConvertFrom-Json
+                    # TransactionLifecycleStatus serializes as int (Active=0,
+                    # Revoked=1, Superseded=2) on n1; accept both numeric and
+                    # string forms for resilience.
+                    $statusLabel = switch ($body.status) {
+                        0 { 'Active' }
+                        1 { 'Revoked' }
+                        2 { 'Superseded' }
+                        default { "$($body.status)" }
+                    }
+                    if ($statusLabel -in @('Active', 'Revoked', 'Superseded')) {
+                        $elapsed = ((Get-Date) - $start).TotalSeconds
+                        Write-WtInfo ("  Wait[$Mode] tx=$shortTx... -> $statusLabel in {0:N1}s ($attempt polls)" -f $elapsed)
+                        return
+                    }
+                }
+            }
+            catch {
+                # 404 expected during pre-seal window — keep polling silently.
+                $status = $null
+                if ($_.Exception.PSObject.Properties.Name -contains 'Response' -and $_.Exception.Response) {
+                    $status = $_.Exception.Response.StatusCode.value__
+                }
+                if ($status -and $status -ne 404) {
+                    Write-WtWarn "  Wait[$Mode] poll error ($status): $($_.Exception.Message)"
+                }
+            }
+            Start-Sleep -Seconds $IntervalSeconds
+        }
+        throw "Wait-SorchaActorReady[$Mode] timed out after ${TimeoutSeconds}s — tx $TxId on register $RegisterId never reached a sealed status"
+    }
+
+    if ($Mode -eq 'AwaitingInbox') {
+        if (-not $InstanceId) { throw "Wait-SorchaActorReady[AwaitingInbox]: -InstanceId is required" }
+        if (-not $PSBoundParameters.ContainsKey('ActionId')) {
+            throw "Wait-SorchaActorReady[AwaitingInbox]: -ActionId is required"
+        }
+        if (-not $Headers) { throw "Wait-SorchaActorReady[AwaitingInbox]: -Headers is required (the instance GET is authenticated)" }
+
+        $url = "$GatewayUrl/api/instances/$InstanceId"
+
+        while ((Get-Date) -lt $deadline) {
+            $attempt++
+            try {
+                $r = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipCertificateCheck -ErrorAction Stop
+                if ($r.StatusCode -eq 200) {
+                    $inst = $r.Content | ConvertFrom-Json
+                    if ($inst.currentActionIds -contains $ActionId) {
+                        $elapsed = ((Get-Date) - $start).TotalSeconds
+                        Write-WtInfo ("  Wait[Inbox] action $ActionId ready on instance $InstanceId in {0:N1}s ($attempt polls)" -f $elapsed)
+                        return
+                    }
+                }
+            }
+            catch {
+                Write-WtWarn "  Wait[Inbox] poll error: $($_.Exception.Message)"
+            }
+            Start-Sleep -Seconds $IntervalSeconds
+        }
+        throw "Wait-SorchaActorReady[AwaitingInbox] timed out after ${TimeoutSeconds}s — action $ActionId never became ready on instance $InstanceId"
+    }
 }


### PR DESCRIPTION
## Summary

Script-based walkthroughs submit actions in milliseconds; real-world actors wait for SignalR-notified sealed transactions before responding, giving the validator several seconds between consecutive actions. That natural cadence keeps the validator's docket-build cycle uncontended. The script cadence does not — it exercises a P0 validator race (issue #787) where a credential-issuance tx arriving during the validator's docket-seal cleanup lands in the unverified pool just as docket-build monitoring is torn down, **wedging the register permanently**.

This PR ships a polling-based wait helper that gates script execution on platform state, eliminating the race exposure from walkthrough runs.

**The underlying validator bug still exists** and is tracked in #787 (with a belt-and-braces fix proposal). This PR is the walkthrough-side mitigation — it stops walkthroughs from triggering the wedge but doesn't fix production traffic that doesn't gate on seal.

## What ships

### \`Wait-SorchaActorReady\` cmdlet (new)

One cmdlet, four modes covering the cadence gates that show up in walkthrough authoring:

| Mode | What it gates on | Used by |
|---|---|---|
| \`AfterSubmit\` | my outgoing tx is sealed | scripts after every \`Invoke-SorchaAction\` |
| \`AwaitingInbox\` | the named action is ready for the named actor (instance.currentActionIds) | scripts switching actors |
| \`ParticipantSealed\` | a participant publish tx is sealed | setup.ps1 before saving state.json |
| \`BlueprintSealed\` | a blueprint publish tx is sealed | setup.ps1 before saving state.json |

All four are PowerShell-native polling. Sealed-* modes poll the F079 lifecycle endpoint (\`/api/registers/{registerId}/transactions/{txId}/status\`, auth-gated by \`CanReadTransactions\`). AwaitingInbox polls the instance state.

SignalR-primary variants can be added later behind the same API without changing callers. Agents (\`Sorcha.Agent\`) already get SignalR via their inbox listeners — this helper is for scripts only.

### \`Invoke-SorchaAction -WaitForSeal\` (new switch)

Opt-in switch (defaults off for back-compat) that calls \`Wait-SorchaActorReady -Mode AfterSubmit\` internally after submission. 90s timeout, override via \`-WaitForSealTimeoutSeconds\`.

### Retrofit

All 17 \`Invoke-SorchaAction\` call sites across 7 walkthroughs now pass \`-WaitForSeal\`:

  - \`AssuredIdentity/run-phase1-identity.ps1\` (2)
  - \`ConstructionPermit/run.ps1\` (2)
  - \`ForestryCertification/run.ps1\` (2)
  - \`FormCoverage/run.ps1\` (2)
  - \`PayloadTests/run.ps1\` (2)
  - \`PingPongN1/run.ps1\` (2)
  - \`SelfBuildHouse/run.ps1\` (2)
  - \`TradeFinance/run.ps1\` (5)

### Skill update

\`.claude/skills/walkthrough-builder/SKILL.md\` — new top-level "Cadence: gating script execution on docket-sealing (REQUIRED)" section documenting the helper, the \`-WaitForSeal\` switch, and the setup-time pattern. Two new entries in the troubleshooting table with the specific fingerprint of each failure mode (60s timeout on \`/actions/execute\` + 6 ms 403 on \`Action 1\` after fresh setup).

## Smoke results on n1

| Walkthrough | Before | After |
|---|---|---|
| **ConstructionPermit** | FAIL (Action 6 stuck, register wedged for the test run) | **PASS** all 3 scenarios (27.9s / 54.2s / 17s) |
| **SelfBuildHouse** | PASS | **PASS** all 3 scenarios |
| **ForestryCertification** | PASS | **PASS** both scenarios |

ConstructionPermit Action 6 now reports \`Wait[AfterSubmit] tx=... -> Active in 0.1s (1 polls)\` — the docket usually has already sealed by the time we check, but the wait makes that explicit instead of racing past.

## Test plan

- [x] Module imports cleanly with new \`Wait-SorchaActorReady\` cmdlet
- [x] ConstructionPermit all 3 scenarios pass against n1 (the originally-failing walkthrough)
- [x] SelfBuildHouse all 3 scenarios pass against n1 (regression check — was passing before)
- [x] ForestryCertification both scenarios pass against n1
- [ ] CI green
- [ ] PR #787 follow-up: validator service-side fix for the underlying race

## Related

- Issue #787 — P0 validator wedge (this PR is the walkthrough-side mitigation; service-side fix still required separately)
- PR #786 — earlier walkthrough fixes (Docker check skip + brittle exit-code check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)