### PR TITLE
fix(walkthroughs): TradeFinance per-user tokens + setup seal-wait + wallet idempotency

### DIFF
--- a/walkthroughs/TradeFinance/run.ps1
+++ b/walkthroughs/TradeFinance/run.ps1
@@ -42,8 +42,12 @@ $financeRegisterId = $state.registers.'trade-finance-register'.id
 $wallets = @{}
 foreach ($prop in $state.wallets.PSObject.Properties) { $wallets[$prop.Name] = $prop.Value }
 
-# Authenticate org admins and use their tokens for all participants in that org
-# (multi-org walkthrough: admin acts on behalf of all participants via wallet delegation)
+# Authenticate per-participant — each action submission must run under the
+# participant's own user token so the participant-identity lookup in the
+# action-execution service finds a real record. The legacy shape used the
+# org-admin token for every participant, which 403s now because admins
+# aren't registered participants (ActionExecutionService.cs:2232 — "No
+# participant profile found for user ... in org ...").
 $orgAdminTokens = @{}
 $participantTokens = @{}
 
@@ -56,14 +60,22 @@ foreach ($orgProp in $state.organizations.PSObject.Properties) {
     $orgAdminTokens[$orgKey] = $adminCtx.Token
 }
 
-# Map each participant to their org's admin token
+# Login each participant user with their own credentials. state.json carries
+# email + password per role from setup.ps1.
 foreach ($role in $state.roles.PSObject.Properties) {
     $partId = $role.Name
-    $orgKey = $role.Value.orgKey
-    $participantTokens[$partId] = $orgAdminTokens[$orgKey]
+    $r = $role.Value
+    $session = Connect-SorchaUser `
+        -TenantUrl $env.TenantUrl `
+        -Email $r.email `
+        -Password $r.password `
+        -OrganizationId $r.organizationId
+    $participantTokens[$partId] = $session.Token
 }
 
-# Admin tokens per register owner (for instance creation)
+# Admin tokens per register owner (for instance creation — register-owning
+# org's admin is still the right token for creating a workflow instance on
+# their register).
 $cairngormOrgId = $state.organizations.cairngorm
 $scottradeOrgId = $state.organizations.scottrade
 $procurementAdminToken = $orgAdminTokens["cairngorm"]

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -296,9 +296,17 @@ foreach ($org in $selectedOrgs) {
         if ($state.wallets.ContainsKey($walletKey) -and $state.wallets[$walletKey]) {
             Write-WtInfo "  Wallet for '$partId' already exists: $($state.wallets[$walletKey])"
         } else {
+            # Wallet name = participant displayName (no " Wallet" suffix). The
+            # name is the idempotency key for New-SorchaWallet — keeping it
+            # aligned with other walkthroughs (ForestryCertification uses
+            # "Sales Manager" too) means the same user across walkthroughs
+            # gets ONE wallet, and credentials issued by one walkthrough are
+            # visible to another (e.g. ForestryCertification's
+            # ForestProductDPPCredential reaches TradeFinance's Invoice
+            # Finance phase).
             $wallet = New-SorchaWallet `
                 -WalletUrl $env.WalletUrl `
-                -Name "$($participant.displayName) Wallet" `
+                -Name $participant.displayName `
                 -Headers $participantSession.Headers `
                 -Algorithm $participant.algorithm `
                 -FetchPublicKey

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -987,6 +987,23 @@ function Publish-SorchaParticipant {
             -Headers $Headers
 
         Write-WtSuccess "Participant '$ParticipantName' published (TX: $($response.transactionId))"
+
+        # Wait for the publish tx to seal before returning. Setup scripts that
+        # immediately start run.ps1 will otherwise hit a 403 on Action 1 — the
+        # auth check looks up the participant record, gets a 404 because the
+        # publish tx hasn't sealed yet, and the auth layer wraps that as 403.
+        # Setup is single-threaded and not a hot path; the few-seconds wait
+        # for seal is harmless and prevents a real race-condition failure.
+        if ($response.transactionId) {
+            $gatewayUrl = $TenantUrl -replace '/api$', ''
+            Wait-SorchaActorReady -Mode ParticipantSealed `
+                -TxId $response.transactionId `
+                -RegisterId $RegisterId `
+                -Headers $Headers `
+                -GatewayUrl $gatewayUrl `
+                -TimeoutSeconds 90
+        }
+
         return $response
     } catch {
         $statusCode = $null
@@ -1327,10 +1344,27 @@ function Publish-SorchaBlueprint {
 
     Write-WtSuccess "Blueprint published: $blueprintId"
 
+    # Wait for the publish tx to seal before returning, when we know the
+    # register and have a transaction id on the response. Setup scripts that
+    # immediately start run.ps1 would otherwise race the validator — the
+    # action engine would look up the blueprint and find a not-yet-sealed
+    # record. Setup is single-threaded and not a hot path; a few-seconds
+    # wait per publish is harmless.
+    if ($RegisterId -and $publishResponse.transactionId) {
+        $gatewayUrl = $BlueprintUrl -replace '/api$', ''
+        Wait-SorchaActorReady -Mode BlueprintSealed `
+            -TxId $publishResponse.transactionId `
+            -RegisterId $RegisterId `
+            -Headers $Headers `
+            -GatewayUrl $gatewayUrl `
+            -TimeoutSeconds 90
+    }
+
     return @{
-        BlueprintId = $blueprintId
-        Title       = $createResponse.title
-        Warnings    = $warnings
+        BlueprintId   = $blueprintId
+        Title         = $createResponse.title
+        Warnings      = $warnings
+        TransactionId = $publishResponse.transactionId
     }
 }
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -761,9 +761,22 @@ function Confirm-SorchaUserEmail {
 function New-SorchaWallet {
     <#
     .SYNOPSIS
-        Create a new ED25519 wallet.
+        Get-or-create an ED25519 wallet for the calling user, idempotent by name.
+
+    .DESCRIPTION
+        Lists the caller's wallets and reuses any wallet whose Name matches
+        $Name. Creates a new wallet only if no match exists. This means
+        walkthroughs can compose — running ForestryCertification then
+        TradeFinance for the same sales-mgr@highland-timber user produces
+        ONE wallet across both walkthroughs, and the DPP credential issued
+        by Forestry is visible to TradeFinance's Invoice-Finance phase.
+
+        Mnemonic is returned only when the wallet is freshly created — on
+        reuse it's null (the seed was shown to the user at creation time;
+        the system does not store it).
+
     .RETURNS
-        Hashtable with Address, Mnemonic, PublicKey (PublicKey populated if -FetchPublicKey).
+        Hashtable with Address, Mnemonic, PublicKey, Reused.
     #>
     param(
         [Parameter(Mandatory)][string]$WalletUrl,
@@ -773,6 +786,49 @@ function New-SorchaWallet {
         [int]$WordCount = 12,
         [switch]$FetchPublicKey
     )
+
+    # Look for an existing wallet with this name owned by the caller.
+    try {
+        $existing = Invoke-SorchaApi -Method GET `
+            -Uri "$WalletUrl/v1/wallets/" `
+            -Headers $Headers
+
+        $match = $null
+        if ($existing) {
+            $match = @($existing) | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+        }
+
+        if ($match) {
+            Write-WtInfo "Wallet '$Name' already exists: $($match.address) — reusing"
+
+            $publicKey = $match.publicKey
+            # Older wallet records may not include publicKey on list — fall back
+            # to a probe sign so callers get a non-null value.
+            if (-not $publicKey -and $FetchPublicKey) {
+                $probeBody = @{
+                    transactionData = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("key-probe"))
+                    isPreHashed     = $false
+                }
+                $signResponse = Invoke-SorchaApi -Method POST `
+                    -Uri "$WalletUrl/v1/wallets/$($match.address)/sign" `
+                    -Body $probeBody `
+                    -Headers $Headers
+                $publicKey = $signResponse.publicKey
+            }
+
+            return @{
+                Address   = $match.address
+                Mnemonic  = $null
+                PublicKey = $publicKey
+                Reused    = $true
+            }
+        }
+    } catch {
+        # Lookup failed — fall through to create. Don't fail the whole call on
+        # a transient list error; New-SorchaWallet should always end with a
+        # usable wallet.
+        Write-WtWarn "Wallet lookup failed before create: $($_.Exception.Message) — proceeding to create"
+    }
 
     $walletBody = @{
         name      = $Name
@@ -795,6 +851,7 @@ function New-SorchaWallet {
         Address   = $address
         Mnemonic  = $mnemonic
         PublicKey = $null
+        Reused    = $false
     }
 
     # Optionally fetch public key by signing a probe message


### PR DESCRIPTION
## Summary

Three related fixes that together unblock TradeFinance end-to-end on a fresh n1.

### 1. TradeFinance — per-user tokens

TradeFinance \`run.ps1\` was using **org-admin tokens for every participant action** — a legacy pattern from before the action-execution service required the caller to be a registered participant. The org admin isn't a participant, so \`ActionExecutionService.ValidateWalletOwnership\` correctly 403'd:

\`\`\`
No participant profile found for user {admin-id} in org {org} — rejecting
request (fail-closed). Wallet: {participant-wallet}
\`\`\`

ConstructionPermit and SelfBuildHouse were retrofitted to per-user tokens earlier; TradeFinance was the last one on the legacy shape. Now each participant logs in with their own credentials and their session token is used for action submission.

### 2. Module: \`Publish-SorchaParticipant\` + \`Publish-SorchaBlueprint\` auto-wait

Both publish functions now call \`Wait-SorchaActorReady\` internally after their HTTP call to gate on docket-seal before returning. Setup scripts that immediately start \`run.ps1\` used to hit a 403/404 race because publish txs hadn't sealed yet.

### 3. \`New-SorchaWallet\` is now get-or-create (idempotent by name)

The function lists the caller's wallets and reuses any wallet whose \`Name\` matches. Same user across walkthroughs no longer ends up with siloed wallets per walkthrough. Aligned the TradeFinance wallet-naming convention (\`"$displayName Wallet"\` → \`"$displayName"\`) to match ForestryCertification so the same user reuses the same wallet.

## Verification on fresh n1 (post-#789 validator fix)

Full chain proving cross-walkthrough credential composition:

\`\`\`
1. ForestryCertification setup    →  creates "Sales Manager" wallet
2. ForestryCertification golden   →  issues ForestProductDPPCredential
                                     to that wallet
3. TradeFinance setup             →  log: "Wallet 'Sales Manager'
                                     already exists: ws11qp43rwe0k…
                                     - reusing"
4. TradeFinance all 3 scenarios   →  PASS end-to-end
\`\`\`

| Walkthrough | Result | Notes |
|---|---|---|
| AssuredIdentity | ✅ PASS | |
| HealthDeclaration | ✅ PASS | |
| ForestryCertification × 2 | ✅ PASS | |
| **ConstructionPermit × 3** | ✅ PASS | was the P0 wedge case (#787 / #789) |
| SelfBuildHouse × 3 | ✅ PASS | |
| **TradeFinance × 3** | ✅ **PASS** | Procurement 6/6 + 8/8 + 6/6, Finance 4/4 + 4/4 + 4/4 — first time end-to-end |

## Test plan

- [x] Each TradeFinance scenario completes both procurement and finance phases
- [x] ForestryCertification → TradeFinance chain proves DPP credential reuse
- [x] Full sweep regression: 7 walkthroughs all pass on fresh n1
- [ ] CI green

## Related

- #787 — P0 validator wedge (root cause issue)
- #789 — validator fix (merged)
- #788 — Wait-SorchaActorReady helper (this PR builds on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)