### PR TITLE
feat(116 US1): AuthChallengeDialog + SocialLinksSection wiring

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Authentication/AuthChallengeModels.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Authentication/AuthChallengeModels.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.UI.Core.Models;
+
+/// <summary>
+/// Proof method selected by the server's re-authentication ladder
+/// (Feature 116). Wire-compatible with the Tenant Service enum of the same name.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ChallengeMethod
+{
+    /// <summary>Time-based one-time code from the user's authenticator app.</summary>
+    Totp = 0,
+
+    /// <summary>Current account password.</summary>
+    Password = 1,
+
+    /// <summary>WebAuthn assertion against an existing active passkey.</summary>
+    Passkey = 2,
+
+    /// <summary>OAuth round-trip on a still-linked social provider.</summary>
+    ReOAuth = 3,
+}
+
+/// <summary>
+/// Operation that a re-authentication challenge token authorises (Feature 116).
+/// Tokens are scoped — a token issued for one operation cannot be replayed
+/// against another.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ScopedOperation
+{
+    /// <summary>Unlink a social provider or revoke an active passkey.</summary>
+    RemoveAuthMethod = 0,
+
+    /// <summary>Rotate the existing account password.</summary>
+    ChangePassword = 1,
+
+    /// <summary>Set an initial password (when one or more other methods exist).</summary>
+    SetPassword = 2,
+
+    /// <summary>Clear the account password.</summary>
+    RemovePassword = 3,
+
+    /// <summary>Disable the user's enrolled time-based two-factor authentication.</summary>
+    Disable2Fa = 4,
+}
+
+/// <summary>
+/// Successful response from <c>POST /api/auth/challenge/initiate</c>. The
+/// dialog renders the proof input matching <see cref="Method"/>.
+/// </summary>
+public sealed record ChallengeInitiateResult(ChallengeMethod Method, JsonElement? Payload);
+
+/// <summary>
+/// Outcome of <c>POST /api/auth/challenge/verify</c>. On <see cref="Succeeded"/>
+/// the caller receives the opaque <see cref="Token"/> for the subsequent
+/// mutation call (presented via the <c>X-Auth-Challenge</c> header).
+/// </summary>
+public sealed record ChallengeVerifyResult(bool Succeeded, string? Token, ChallengeVerifyError Error);
+
+/// <summary>Failure reasons surfaced to the dialog.</summary>
+public enum ChallengeVerifyError
+{
+    /// <summary>No failure — the call succeeded.</summary>
+    None = 0,
+
+    /// <summary>The proof was rejected (wrong TOTP code, wrong password, etc.).</summary>
+    ProofRejected = 1,
+
+    /// <summary>The challenge has already been verified or expired (5-minute lifetime).</summary>
+    Expired = 2,
+
+    /// <summary>Transport or unexpected status — caller should offer retry.</summary>
+    Failed = 3,
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/AuthMethodsClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/AuthMethodsClientService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.UI.Core.Models;
 
@@ -39,6 +40,29 @@ public interface IAuthMethodsClientService
     /// </summary>
     Task<UnlinkSocialOutcome> UnlinkSocialAsync(
         Guid linkId, string challengeToken, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Begin a re-authentication challenge for <paramref name="scopedOperation"/>.
+    /// The server picks the proof method per its ladder (TOTP → Password →
+    /// Passkey → ReOAuth) unless <paramref name="preferredMethod"/> is supplied.
+    /// Returns null on transport failure or when no method is enrolled (400).
+    /// </summary>
+    Task<ChallengeInitiateResult?> InitiateChallengeAsync(
+        ScopedOperation scopedOperation,
+        ChallengeMethod? preferredMethod = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Submit the user's proof and exchange it for a one-shot challenge token.
+    /// On success the token is bound to <paramref name="scopedOperation"/> for
+    /// five minutes; the caller presents it via the <c>X-Auth-Challenge</c>
+    /// header on the subsequent mutation call.
+    /// </summary>
+    Task<ChallengeVerifyResult> VerifyChallengeAsync(
+        ChallengeMethod method,
+        ScopedOperation scopedOperation,
+        JsonElement proof,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>Outcome of an unlink call surfaced to the UI.</summary>
@@ -147,9 +171,84 @@ public sealed class AuthMethodsClientService : IAuthMethodsClientService
         }
     }
 
+    /// <inheritdoc />
+    public async Task<ChallengeInitiateResult?> InitiateChallengeAsync(
+        ScopedOperation scopedOperation,
+        ChallengeMethod? preferredMethod = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                "/api/auth/challenge/initiate",
+                new ChallengeInitiateBody(scopedOperation, preferredMethod),
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Challenge initiate returned {StatusCode} for {Operation}",
+                    response.StatusCode, scopedOperation);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<ChallengeInitiateResult>(
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initiate challenge for {Operation}", scopedOperation);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ChallengeVerifyResult> VerifyChallengeAsync(
+        ChallengeMethod method,
+        ScopedOperation scopedOperation,
+        JsonElement proof,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                "/api/auth/challenge/verify",
+                new ChallengeVerifyBody(method, scopedOperation, proof),
+                cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadFromJsonAsync<ChallengeVerifyBodyResponse>(
+                    cancellationToken: cancellationToken);
+                return body is null || string.IsNullOrEmpty(body.Token)
+                    ? new ChallengeVerifyResult(false, null, ChallengeVerifyError.Failed)
+                    : new ChallengeVerifyResult(true, body.Token, ChallengeVerifyError.None);
+            }
+
+            var error = response.StatusCode switch
+            {
+                System.Net.HttpStatusCode.Unauthorized => ChallengeVerifyError.ProofRejected,
+                System.Net.HttpStatusCode.Gone => ChallengeVerifyError.Expired,
+                _ => ChallengeVerifyError.Failed,
+            };
+            return new ChallengeVerifyResult(false, null, error);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Challenge verify failed for {Method}/{Operation}", method, scopedOperation);
+            return new ChallengeVerifyResult(false, null, ChallengeVerifyError.Failed);
+        }
+    }
+
     private sealed record SocialLinkInitiateResponse
     {
         public string AuthorizationUrl { get; init; } = string.Empty;
         public string State { get; init; } = string.Empty;
     }
+
+    private sealed record ChallengeInitiateBody(ScopedOperation ScopedOperation, ChallengeMethod? PreferredMethod);
+
+    private sealed record ChallengeVerifyBody(ChallengeMethod Method, ScopedOperation ScopedOperation, JsonElement Proof);
+
+    private sealed record ChallengeVerifyBodyResponse(string Token, int ExpiresIn);
 }

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AccountsTab.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AccountsTab.razor
@@ -59,7 +59,7 @@ else
     </MudPaper>
 
     <PasswordSection Password="_methods.Password" />
-    <SocialLinksSection Socials="_methods.Socials" />
+    <SocialLinksSection Socials="_methods.Socials" OnChanged="LoadAsync" />
     <PasskeysSection Passkeys="_methods.Passkeys" />
 }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AuthMethods/AuthChallengeDialog.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AuthMethods/AuthChallengeDialog.razor
@@ -1,0 +1,209 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+@*
+    Re-authentication step-up dialog (Feature 116 T023).
+
+    Caller pattern:
+        var parameters = new DialogParameters
+        {
+            ["Scope"] = ScopedOperation.RemoveAuthMethod,
+        };
+        var dialog = await DialogService.ShowAsync<AuthChallengeDialog>(
+            "Confirm it's you", parameters);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: string token })
+        {
+            // attach token to the subsequent mutation call
+        }
+*@
+
+@using System.Text.Json
+@using MudBlazor
+@using Sorcha.UI.Core.Models
+@using Sorcha.UI.Core.Services
+@inject IAuthMethodsClientService AuthMethodsClient
+
+<MudDialog>
+    <TitleContent>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.Security" />
+            <MudText Typo="Typo.h6">Confirm it's you</MudText>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" Style="min-width: 320px;">
+            @if (_loadingInitiate)
+            {
+                <MudProgressLinear Indeterminate="true" />
+                <MudText Typo="Typo.body2" Color="Color.Secondary">Preparing step-up...</MudText>
+            }
+            else if (_initiateFailed)
+            {
+                <MudAlert Severity="Severity.Error" Dense="true">
+                    No re-authentication method is available for your account.
+                </MudAlert>
+            }
+            else if (_initiated is not null)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    For security, confirm this action with your @MethodLabel(_initiated.Method).
+                </MudText>
+
+                @if (!string.IsNullOrEmpty(_errorMessage))
+                {
+                    <MudAlert Severity="Severity.Error" Dense="true">@_errorMessage</MudAlert>
+                }
+
+                @switch (_initiated.Method)
+                {
+                    case ChallengeMethod.Totp:
+                        <MudTextField T="string" @bind-Value="_totpCode"
+                                      Label="Authenticator code"
+                                      Variant="Variant.Outlined"
+                                      Immediate="true"
+                                      MaxLength="6"
+                                      InputMode="InputMode.numeric"
+                                      Placeholder="123456"
+                                      Disabled="_submitting" />
+                        break;
+
+                    case ChallengeMethod.Password:
+                        <MudTextField T="string" @bind-Value="_password"
+                                      Label="Password"
+                                      Variant="Variant.Outlined"
+                                      InputType="InputType.Password"
+                                      Immediate="true"
+                                      Disabled="_submitting" />
+                        break;
+
+                    case ChallengeMethod.Passkey:
+                    case ChallengeMethod.ReOAuth:
+                        <MudAlert Severity="Severity.Info" Dense="true">
+                            @MethodLabel(_initiated.Method) step-up will land in a follow-up.
+                            For now, please ensure you have a TOTP or password method enrolled.
+                        </MudAlert>
+                        break;
+                }
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Disabled="_submitting">Cancel</MudButton>
+        <MudButton Color="Color.Primary"
+                   Variant="Variant.Filled"
+                   OnClick="SubmitAsync"
+                   Disabled="@(!CanSubmit)">
+            @if (_submitting)
+            {
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="me-2" />
+                <span>Verifying...</span>
+            }
+            else
+            {
+                <span>Confirm</span>
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter, EditorRequired] public ScopedOperation Scope { get; set; }
+
+    private ChallengeInitiateResult? _initiated;
+    private bool _loadingInitiate = true;
+    private bool _initiateFailed;
+    private bool _submitting;
+    private string? _errorMessage;
+
+    private string _totpCode = string.Empty;
+    private string _password = string.Empty;
+
+    private bool CanSubmit
+    {
+        get
+        {
+            if (_submitting || _initiated is null) return false;
+            return _initiated.Method switch
+            {
+                ChallengeMethod.Totp => _totpCode.Length == 6 && _totpCode.All(char.IsDigit),
+                ChallengeMethod.Password => !string.IsNullOrEmpty(_password),
+                _ => false,
+            };
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        _initiated = await AuthMethodsClient.InitiateChallengeAsync(Scope);
+        _loadingInitiate = false;
+        _initiateFailed = _initiated is null;
+        StateHasChanged();
+    }
+
+    private async Task SubmitAsync()
+    {
+        if (_initiated is null || _submitting) return;
+
+        _submitting = true;
+        _errorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var proof = BuildProof(_initiated.Method);
+            var result = await AuthMethodsClient.VerifyChallengeAsync(
+                _initiated.Method, Scope, proof);
+
+            if (result.Succeeded && !string.IsNullOrEmpty(result.Token))
+            {
+                MudDialog.Close(DialogResult.Ok(result.Token));
+                return;
+            }
+
+            _errorMessage = result.Error switch
+            {
+                ChallengeVerifyError.ProofRejected => _initiated.Method switch
+                {
+                    ChallengeMethod.Totp => "That code didn't match. Try again.",
+                    ChallengeMethod.Password => "Password didn't match. Try again.",
+                    _ => "Verification failed. Try again.",
+                },
+                ChallengeVerifyError.Expired => "Step-up timed out. Close this dialog and try again.",
+                _ => "Something went wrong. Try again.",
+            };
+
+            // Clear the secret on failure so the user re-enters.
+            if (_initiated.Method == ChallengeMethod.Password) _password = string.Empty;
+            if (_initiated.Method == ChallengeMethod.Totp) _totpCode = string.Empty;
+        }
+        finally
+        {
+            _submitting = false;
+            StateHasChanged();
+        }
+    }
+
+    private JsonElement BuildProof(ChallengeMethod method)
+    {
+        object proof = method switch
+        {
+            ChallengeMethod.Totp => new { code = _totpCode },
+            ChallengeMethod.Password => new { password = _password },
+            _ => new { },
+        };
+        return JsonSerializer.SerializeToElement(proof);
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static string MethodLabel(ChallengeMethod m) => m switch
+    {
+        ChallengeMethod.Totp => "authenticator app",
+        ChallengeMethod.Password => "password",
+        ChallengeMethod.Passkey => "passkey",
+        ChallengeMethod.ReOAuth => "social provider",
+        _ => "method",
+    };
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AuthMethods/SocialLinksSection.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Settings/AuthMethods/SocialLinksSection.razor
@@ -1,9 +1,17 @@
-@* Read-only linked-providers section for the Accounts tab (Feature 116 US4).
-   Add-pill / Unlink actions get wired in US1 (SocialLinkService). *@
+@* Linked-providers section for the Accounts tab (Feature 116).
+   US4 shipped the read-only render; US1 wires Add pills (kick OAuth via
+   /social/initiate?intent=link) and Unlink (step up via
+   AuthChallengeDialog, then DELETE /api/auth/social/{linkId}). *@
 
+@using MudBlazor
 @using Sorcha.UI.Core.Models
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Services.Feedback
 @inject ILocalizationService Loc
+@inject IAuthMethodsClientService AuthMethodsClient
+@inject IDialogService DialogService
+@inject IInlineFeedback Feedback
+@inject NavigationManager Navigation
 
 <MudPaper Class="pa-4 mb-4" Elevation="0" Outlined="true">
     <MudText Typo="Typo.h6" Class="mb-1">
@@ -42,7 +50,9 @@
                 </div>
                 @if (social.CanRemove)
                 {
-                    <MudButton Variant="Variant.Outlined" Color="Color.Error" Disabled="true" Size="Size.Small">
+                    <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small"
+                               Disabled="@(_busyLinkId == social.LinkId)"
+                               OnClick="@(() => UnlinkAsync(social))">
                         @Loc.T("settings.accounts.socials.unlink")
                     </MudButton>
                 }
@@ -67,9 +77,10 @@
         {
             var isLinked = Socials?.Any(s => string.Equals(s.Provider, provider, StringComparison.OrdinalIgnoreCase)) == true;
             <MudChip T="string" Color="@(isLinked ? Color.Default : Color.Primary)"
-                     Disabled="true"
+                     Disabled="@(isLinked || _addingProvider is not null)"
                      Variant="@(isLinked ? Variant.Outlined : Variant.Filled)"
-                     Style="@(isLinked ? "text-decoration:line-through;opacity:0.5;" : "")">
+                     Style="@(isLinked ? "text-decoration:line-through;opacity:0.5;" : "")"
+                     OnClick="@(() => AddAsync(provider))">
                 @FormatProvider(provider)
             </MudChip>
         }
@@ -79,7 +90,86 @@
 @code {
     [Parameter] public IReadOnlyList<AuthMethodsSocial>? Socials { get; set; }
 
+    /// <summary>Invoked after a successful link initiation or unlink so the parent
+    /// can reload the aggregate. Optional; null = parent doesn't refresh.</summary>
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private Guid? _busyLinkId;
+    private string? _addingProvider;
+
     private static readonly string[] AllProviders = new[] { "google", "github", "microsoft", "apple" };
+
+    private async Task AddAsync(string provider)
+    {
+        if (_addingProvider is not null) return;
+        _addingProvider = provider;
+        StateHasChanged();
+
+        try
+        {
+            var url = await AuthMethodsClient.InitiateSocialLinkAsync(provider);
+            if (string.IsNullOrEmpty(url))
+            {
+                Feedback.ShowError(Loc.T("settings.accounts.socials.addFailed"));
+                return;
+            }
+
+            // Full-page navigation — OAuth provider takes over.
+            Navigation.NavigateTo(url, forceLoad: true);
+        }
+        finally
+        {
+            _addingProvider = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task UnlinkAsync(AuthMethodsSocial social)
+    {
+        if (_busyLinkId is not null) return;
+
+        var parameters = new DialogParameters
+        {
+            ["Scope"] = ScopedOperation.RemoveAuthMethod,
+        };
+        var dialog = await DialogService.ShowAsync<AuthChallengeDialog>(
+            Loc.T("settings.accounts.unlink.confirmTitle"), parameters);
+        var result = await dialog.Result;
+        if (result is null || result.Canceled || result.Data is not string token) return;
+
+        _busyLinkId = social.LinkId;
+        StateHasChanged();
+
+        try
+        {
+            var outcome = await AuthMethodsClient.UnlinkSocialAsync(social.LinkId, token);
+            switch (outcome)
+            {
+                case UnlinkSocialOutcome.Unlinked:
+                    Feedback.ShowSuccess(Loc.T("settings.accounts.socials.unlinked"));
+                    if (OnChanged.HasDelegate) await OnChanged.InvokeAsync();
+                    break;
+                case UnlinkSocialOutcome.LastSignInMethodProtected:
+                    Feedback.ShowError(Loc.T("settings.accounts.lastMethodWarning"), autoDismissMs: 0);
+                    break;
+                case UnlinkSocialOutcome.Forbidden:
+                    Feedback.ShowError(Loc.T("settings.accounts.stepUpExpired"));
+                    break;
+                case UnlinkSocialOutcome.NotFound:
+                    Feedback.ShowError(Loc.T("settings.accounts.socials.notFound"));
+                    if (OnChanged.HasDelegate) await OnChanged.InvokeAsync();
+                    break;
+                default:
+                    Feedback.ShowError(Loc.T("settings.accounts.socials.unlinkFailed"));
+                    break;
+            }
+        }
+        finally
+        {
+            _busyLinkId = null;
+            StateHasChanged();
+        }
+    }
 
     private static string FormatProvider(string provider) => provider switch
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/i18n/en.json
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/i18n/en.json
@@ -133,6 +133,12 @@
   "settings.accounts.socials.add": "Add",
   "settings.accounts.socials.unlink": "Unlink",
   "settings.accounts.socials.noEmail": "(no email shared)",
+  "settings.accounts.socials.addFailed": "Couldn't start the link flow. Try again.",
+  "settings.accounts.socials.unlinked": "Provider unlinked.",
+  "settings.accounts.socials.unlinkFailed": "Couldn't unlink that provider. Try again.",
+  "settings.accounts.socials.notFound": "That provider is no longer linked.",
+  "settings.accounts.unlink.confirmTitle": "Confirm it's you",
+  "settings.accounts.stepUpExpired": "Step-up expired. Try again.",
 
   "settings.accounts.passkeys.title": "Passkeys",
   "settings.accounts.passkeys.description": "Sign in passwordlessly with a hardware key, Touch ID, Windows Hello, or another platform authenticator.",


### PR DESCRIPTION
## Summary
- Builds `AuthChallengeDialog.razor` — the re-authentication step-up dialog that gates every sensitive auth-method mutation in Settings (Feature 116). Supports TOTP and Password proof methods fully; Passkey and ReOAuth render a clear placeholder pending follow-up PRs.
- Extends `IAuthMethodsClientService` with `InitiateChallengeAsync` + `VerifyChallengeAsync` (typed outcome enums) plus `ChallengeMethod` / `ScopedOperation` enums wire-compatible with the Tenant Service.
- Wires `SocialLinksSection` — Add chips kick OAuth via `/api/auth/social/initiate?intent=link`; Unlink opens the dialog and calls `UnlinkSocialAsync` with the returned token. `AccountsTab` reloads the aggregate on success.

## Scope
- US1 backend (`SocialLinkService`, `DELETE /api/auth/social/{id}`) is already on master; this PR only wires the UI.
- US2 (passkey lifecycle UI) and US3 (password lifecycle UI) reuse the same dialog and follow as separate PRs (tasks T057-T062 and T072-T077 in `specs/116-account-linking/tasks.md`).
- Passkey and ReOAuth proof methods deferred — the dialog renders a placeholder that points users to a TOTP/password method. Full WebAuthn step-up and OAuth-redirect step-up land in follow-up PRs.

## Test plan
- [ ] Build green locally: `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` (0 errors)
- [ ] Sign in as a public user with email+password + linked Google account
- [ ] Settings → Accounts → click Unlink on Google
- [ ] Dialog opens, prompts for password, submit → row disappears, success feedback shown
- [ ] Re-sign-in with email+password still works
- [ ] Settings → Accounts → click an unlinked provider chip → full-page redirect to OAuth authoriser
- [ ] Cancel button on dialog closes without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)