### PR TITLE
fix(116): wire 2FA-disable through AuthChallengeDialog (Disable2Fa)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TotpClientService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TotpClientService.cs
@@ -35,7 +35,18 @@ public interface ITotpClientService
     /// Disables TOTP two-factor authentication for the current user.
     /// </summary>
     /// <returns>True if TOTP was successfully disabled.</returns>
-    Task<bool> DisableTotpAsync();
+    /// <summary>
+    /// Disable TOTP 2FA for the signed-in user. The server-side endpoint
+    /// requires a fresh re-authentication challenge token (Feature 116 T068)
+    /// — callers must obtain one via <c>AuthChallengeDialog</c> with
+    /// <c>ScopedOperation.Disable2Fa</c> and pass it here.
+    /// </summary>
+    /// <param name="challengeToken">
+    /// Opaque challenge token from <c>/api/auth/challenge/verify</c>. Sent on
+    /// the request as <c>X-Auth-Challenge</c>. Optional only for transitional
+    /// reasons; production calls should always supply one.
+    /// </param>
+    Task<bool> DisableTotpAsync(string? challengeToken = null);
 
     /// <summary>
     /// Gets the current TOTP enrollment status for the user.
@@ -102,11 +113,16 @@ public class TotpClientService : ITotpClientService
         }
     }
 
-    public async Task<bool> DisableTotpAsync()
+    public async Task<bool> DisableTotpAsync(string? challengeToken = null)
     {
         try
         {
-            var response = await _httpClient.DeleteAsync("/api/totp");
+            using var request = new HttpRequestMessage(HttpMethod.Delete, "/api/totp");
+            if (!string.IsNullOrEmpty(challengeToken))
+            {
+                request.Headers.Add("X-Auth-Challenge", challengeToken);
+            }
+            using var response = await _httpClient.SendAsync(request);
             return response.IsSuccessStatusCode;
         }
         catch (Exception ex)

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Settings.razor
@@ -842,35 +842,38 @@
 
     private async Task DisableTwoFactor()
     {
-        var confirmed = await DialogService.ShowMessageBoxAsync(
-            Loc.T("settings.twoFactor.disableTitle"),
-            Loc.T("settings.twoFactor.disableConfirm"),
-            yesText: Loc.T("settings.twoFactor.disable"),
-            cancelText: Loc.T("common.cancel"));
-
-        if (confirmed == true)
+        // Feature 116 T068 — the /api/totp DELETE endpoint now requires a fresh
+        // re-authentication challenge with Scope=Disable2Fa. AuthChallengeDialog
+        // doubles as the confirmation surface (replaces the old ShowMessageBoxAsync).
+        var parameters = new MudBlazor.DialogParameters { ["Scope"] = ScopedOperation.Disable2Fa };
+        var dialog = await DialogService.ShowAsync<Sorcha.UI.Web.Client.Components.Settings.AuthMethods.AuthChallengeDialog>(
+            Loc.T("settings.twoFactor.disableTitle"), parameters);
+        var result = await dialog.Result;
+        if (result is not { Canceled: false, Data: string token })
         {
-            try
+            return;
+        }
+
+        try
+        {
+            var disabled = await TotpService.DisableTotpAsync(token);
+            if (disabled)
             {
-                var disabled = await TotpService.DisableTotpAsync();
-                if (disabled)
-                {
-                    _preferences.TwoFactorEnabled = false;
-                    _showTotpSetup = false;
-                    _totpSecret = string.Empty;
-                    _totpQrUri = string.Empty;
-                    _totpBackupCodes.Clear();
-                    Feedback.ShowInfo(Loc.T("settings.twoFactor.disabledSuccess"));
-                }
-                else
-                {
-                    Feedback.ShowError(Loc.T("settings.twoFactor.disableFailed"), autoDismissMs: 0);
-                }
+                _preferences.TwoFactorEnabled = false;
+                _showTotpSetup = false;
+                _totpSecret = string.Empty;
+                _totpQrUri = string.Empty;
+                _totpBackupCodes.Clear();
+                Feedback.ShowInfo(Loc.T("settings.twoFactor.disabledSuccess"));
             }
-            catch (Exception ex)
+            else
             {
-                Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
+                Feedback.ShowError(Loc.T("settings.twoFactor.disableFailed"), autoDismissMs: 0);
             }
+        }
+        catch (Exception ex)
+        {
+            Feedback.ShowError($"{Loc.T("common.error")}: {ex.Message}", autoDismissMs: 0);
         }
     }
 


### PR DESCRIPTION
## Summary
Closes the F116 UI gap surfaced in PR #793. T068 (already on master) made `DELETE /api/totp` require a `Disable2Fa` challenge token, but the Settings page's existing `DisableTwoFactor` handler still called `TotpService.DisableTotpAsync()` with no challenge — returning 401 to any real attempt.

- `ITotpClientService.DisableTotpAsync` gains an optional `challengeToken` parameter that, when supplied, rides as `X-Auth-Challenge` on the request.
- `Settings.razor`'s `DisableTwoFactor` now opens `AuthChallengeDialog` with `Scope=Disable2Fa` instead of the old yes/no `MudMessageBox`. The dialog doubles as the confirmation surface — fewer clicks, stronger guarantee.

Completes F116's UI surface across all four user stories (US1 social, US2 passkey, US3 password, plus this Disable2Fa adoption).

## Test plan
- [ ] Build green: `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.Web.Client` (0 errors)
- [ ] Sign in as a user with TOTP enrolled → Settings → Security → click **Disable 2FA**
- [ ] AuthChallengeDialog opens — prompts for password or TOTP code (whichever the user has)
- [ ] Submit valid proof → 2FA flips to disabled, success feedback shown
- [ ] Submit wrong proof → inline error in dialog, can retry without restart
- [ ] Cancel dialog → no state change

🤖 Generated with [Claude Code](https://claude.com/claude-code)