### PR TITLE
feat(120): wire DID-backed IIssuerKeyResolver in Blueprint Service

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -231,16 +231,31 @@ builder.Services.AddSingleton<Sorcha.PresentationLifecycle.Abstractions.IPresent
     Sorcha.Blueprint.Service.Services.Implementation.HaipPresentationConsumer>();
 
 // Feature 127 — Sorcha.Verifier.Engine dependencies the SorchaWalletPresentationConsumer
-// consumes. The full verifier-DID resolution stack lands in Spec 5 alongside
-// the production IIssuerKeyResolver; for now the JWK-registry resolver covers
-// the dev/demo path and the OptOut resolver is the fallback for tests that
-// don't populate the registry.
+// consumes. Production issuer-key resolution lands here (F120 → Blueprint Service):
+// the council-page credential gate verifies citizen-presented credentials against
+// the issuer's published DID document via DidResolverBackedIssuerKeyResolver, with
+// the JWK-registry resolver as a fallback for dev/demo flows that mint per-test
+// issuer keys without publishing a DID document. Verifier-DID resolution (the
+// client_id placeholder in SorchaWalletPresentationConsumer.BuildInitiationAsync)
+// is separate and still lands in Spec 5.
 builder.Services.AddHttpClient<Sorcha.Verifier.Engine.IStatusListCache,
     Sorcha.Verifier.Engine.StatusListCache>();
 builder.Services.TryAddSingleton(TimeProvider.System);
+
+// Feature 120 — DID resolver infrastructure (cache, OTel meters, registry, did:sorcha
+// + did:web + did:key built-ins). Idempotent; safe even if a transitive dependency
+// has already registered the same components.
+Sorcha.ServiceClients.Http.Extensions.HttpServiceCollectionExtensions
+    .AddDidResolvers(builder.Services, builder.Configuration);
+
 builder.Services.AddSingleton<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>();
+builder.Services.AddSingleton<Sorcha.Verifier.Engine.DidResolverBackedIssuerKeyResolver>();
 builder.Services.AddSingleton<Sorcha.Verifier.Engine.IIssuerKeyResolver>(sp =>
-    sp.GetRequiredService<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>());
+    new Sorcha.Verifier.Engine.CompositeIssuerKeyResolver(
+    [
+        sp.GetRequiredService<Sorcha.Verifier.Engine.DidResolverBackedIssuerKeyResolver>(),
+        sp.GetRequiredService<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>()
+    ]));
 builder.Services.AddSingleton<Sorcha.Verifier.Engine.IVerifiablePresentationValidator>(sp =>
     new Sorcha.Verifier.Engine.VerifiablePresentationValidator(
         sp.GetRequiredService<Sorcha.Verifier.Engine.IStatusListCache>(),


### PR DESCRIPTION
## Summary
F120 shipped the full DID resolver stack (`DidResolverBackedIssuerKeyResolver`, `SorchaDidResolver`, `WebDidResolver`, `KeyDidResolver`, `DidResolverCache`) and `Sorcha.Verifier` wired it correctly. **Blueprint Service** — which hosts the F127 `SorchaWalletPresentationConsumer` that verifies citizen credentials presented at council-page credential gates — was still on the JWK-registry-only path with an inline TODO deferring production wiring to Spec 5.

This PR closes that gap by replicating the Verifier app's cascade:

- `AddDidResolvers(configuration)` registers the DID resolver registry, `did:sorcha` / `did:web` / `did:key` resolvers, cross-resolution cache, and OTel meters.
- `IIssuerKeyResolver` becomes a `CompositeIssuerKeyResolver` that tries `DidResolverBackedIssuerKeyResolver` first then falls back to the `JwkRegistryIssuerKeyResolver` (kept for dev/demo flows that mint per-test issuer keys without publishing a DID document).
- `RequireIssuerSignature` default stays `true` per F120 FR-019 / D5.

## Scope
- Single file: `src/Services/Sorcha.Blueprint.Service/Program.cs` (DI wiring only).
- No new code files; no behavioural change to `Sorcha.Verifier` or other services.

## What this does NOT do
The verifier-DID resolution placeholder (`did:sorcha:org:UNKNOWN` in `SorchaWalletPresentationConsumer.BuildInitiationAsync`) is a separate concern — that's the **council-page's** identity, not the credential **issuer's** identity — and still lands in Spec 5 of the Strathcarron arc.

## Test plan
- [ ] Build green: `dotnet build src/Services/Sorcha.Blueprint.Service` (0 errors)
- [ ] Existing Blueprint Service tests pass unchanged
- [ ] Verify against a Strathcarron Blue Badge flow on a deployed environment: citizen presents a real-issued Assured Identity credential, server resolves the issuer DID, verifies the signature, accepts the presentation
- [ ] Verify dev/demo flow still works: per-mint issuer keys registered in `JwkRegistryIssuerKeyResolver` continue to satisfy the composite resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)