### PR TITLE
feat(114 T056): seal credential cache with XChaCha20-Poly1305

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Services/InMemoryCredentialCache.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/InMemoryCredentialCache.cs
@@ -8,8 +8,8 @@ namespace Sorcha.Wallet.Pwa.Services;
 
 /// <summary>
 /// Demo-grade in-memory <see cref="ICredentialCache"/>. The production impl
-/// (T060) replaces this with an IndexedDB-backed store wrapped in
-/// XChaCha20-Poly1305 via the libsodium-js bridge.
+/// (<see cref="IndexedDbCredentialCache"/>) replaces this with an IndexedDB-backed
+/// store sealed with XChaCha20-Poly1305 via the xchacha-bridge (@noble/ciphers).
 /// </summary>
 public sealed class InMemoryCredentialCache : ICredentialCache
 {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IndexedDbCredentialCache.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IndexedDbCredentialCache.cs
@@ -10,10 +10,10 @@ namespace Sorcha.Wallet.Pwa.Services;
 /// <summary>
 /// Production <see cref="ICredentialCache"/> backed by IndexedDB store
 /// <c>credentials</c> via <c>indexeddb-bridge.js</c>. Each credential is
-/// serialised to JSON and encrypted under the wallet's content key
-/// (AES-GCM-256 in v1; XChaCha20-Poly1305 once the libsodium bridge lands).
-/// The content key is a non-extractable WebCrypto <c>CryptoKey</c> persisted
-/// in the IndexedDB <c>device</c> store via structured-clone.
+/// serialised to JSON and sealed with IETF XChaCha20-Poly1305 (24-byte nonce,
+/// 16-byte tag) via the xchacha-bridge (@noble/ciphers). The content key is a
+/// 32-byte value generated on first run and persisted as raw bytes in the
+/// IndexedDB <c>device</c> store via structured-clone.
 /// </summary>
 public sealed class IndexedDbCredentialCache : ICredentialCache
 {

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
@@ -22,6 +22,7 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="js/webcrypto-bridge.js"></script>
+    <script src="js/xchacha-bridge.js"></script>
     <script src="js/indexeddb-bridge.js"></script>
     <script src="js/qr-scanner-bridge.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
@@ -14,11 +14,12 @@
 //     verifications — keyed by id (GUID)         — verification history records
 //     personas      — keyed by contextKey string — per-context persona cache
 //
-// Content-key strategy (deviation from data-model §B1, documented in the wallet README):
-// v1 uses a non-extractable AES-GCM-256 CryptoKey generated on first run and stored
-// directly in IndexedDB (browsers structured-clone CryptoKey natively). XChaCha20-Poly1305
-// via libsodium-js is the production target and lands when the libsodium bridge is added;
-// the wire-format on disk is incompatible between the two so the schema will rev to v2.
+// Content-key strategy (Feature 114 T056): a 32-byte XChaCha20-Poly1305 content
+// key is generated on first run and stored as raw bytes in the `device` store.
+// Each credential is sealed with IETF XChaCha20-Poly1305 (24-byte nonce, 16-byte
+// tag) via xchacha-bridge.js (@noble/ciphers). Raw key bytes are required because
+// the AEAD operates on byte arrays — unlike the earlier non-extractable WebCrypto
+// AES-GCM CryptoKey, which couldn't expose its material.
 //
 // All exports attach to globalThis.SorchaIndexedDb.
 
@@ -130,12 +131,9 @@
     if (contentKeyPromise) return contentKeyPromise;
     contentKeyPromise = (async () => {
       const existing = await get("device", CONTENT_KEY_ID);
-      if (existing && existing.key) return existing.key;
-      const key = await crypto.subtle.generateKey(
-        { name: "AES-GCM", length: 256 },
-        false /* non-extractable — CryptoKey persists via structured clone */,
-        ["encrypt", "decrypt"]
-      );
+      // Stored as a raw 32-byte key (Uint8Array survives structured-clone).
+      if (existing && existing.key instanceof Uint8Array) return existing.key;
+      const key = globalThis.SorchaXChaCha.keygen();
       await put("device", { key }, CONTENT_KEY_ID);
       return key;
     })();
@@ -160,22 +158,16 @@
 
   async function encryptString(plaintext) {
     const key = await getOrCreateContentKey();
-    const nonce = crypto.getRandomValues(new Uint8Array(12));
-    const ciphertext = await crypto.subtle.encrypt(
-      { name: "AES-GCM", iv: nonce },
-      key,
-      new TextEncoder().encode(plaintext)
-    );
+    const nonce = globalThis.SorchaXChaCha.nonce();
+    const ciphertext = await globalThis.SorchaXChaCha.encrypt(
+      key, nonce, new TextEncoder().encode(plaintext));
     return { nonce: bytesToB64Url(nonce), ciphertext: bytesToB64Url(ciphertext) };
   }
 
   async function decryptString(nonceB64, ciphertextB64) {
     const key = await getOrCreateContentKey();
-    const plain = await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: b64UrlToBytes(nonceB64) },
-      key,
-      b64UrlToBytes(ciphertextB64)
-    );
+    const plain = await globalThis.SorchaXChaCha.decrypt(
+      key, b64UrlToBytes(nonceB64), b64UrlToBytes(ciphertextB64));
     return new TextDecoder().decode(plain);
   }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/qr-scanner-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/qr-scanner-bridge.js
@@ -38,11 +38,15 @@
 
   function loadQrScanner() {
     if (!_qrScannerCtorPromise) {
-      _qrScannerCtorPromise = import("./vendor/qr-scanner/qr-scanner.min.js").then((m) => {
+      // Resolve against document.baseURI (<base href="/wallet/">) so the dynamic
+      // import + worker path work regardless of how the browser bases a classic
+      // script's import(). Same-origin paths satisfy CSP `script-src 'self'` /
+      // `worker-src 'self' blob:`.
+      const moduleUrl = new URL("js/vendor/qr-scanner/qr-scanner.min.js", document.baseURI).href;
+      const workerUrl = new URL("js/vendor/qr-scanner/qr-scanner-worker.min.js", document.baseURI).href;
+      _qrScannerCtorPromise = import(moduleUrl).then((m) => {
         const Ctor = m.default;
-        // Tell qr-scanner where to load its decoding worker from — same-origin path
-        // satisfies CSP `script-src 'self'` / `worker-src 'self' blob:`.
-        Ctor.WORKER_PATH = "./js/vendor/qr-scanner/qr-scanner-worker.min.js";
+        Ctor.WORKER_PATH = workerUrl;
         return Ctor;
       });
     }

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/LICENSE.md
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/LICENSE.md
@@ -1,0 +1,27 @@
+# @noble/ciphers
+
+Pinned vendor copy of [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers)
+version **1.2.1** (ESM build), fetched from `https://unpkg.com/@noble/ciphers@1.2.1/esm/`.
+
+Files in this directory are unmodified library output and are licensed under
+the upstream MIT licence — see
+<https://github.com/paulmillr/noble-ciphers/blob/main/LICENSE>.
+
+Only the dependency closure needed for `xchacha20poly1305` is vendored:
+`chacha.js`, `_arx.js`, `_poly1305.js`, `utils.js`, `_assert.js`. The ESM
+relative imports between these files resolve natively in the browser — no
+build step.
+
+Used by `wwwroot/js/xchacha-bridge.js` (Feature 114 T056) to encrypt the
+IndexedDB credential cache at rest with IETF XChaCha20-Poly1305.
+
+We vendor a pinned copy rather than depending on a CDN at runtime so that:
+
+- Builds are deterministic and offline-installable.
+- The PWA's Content-Security-Policy stays on `script-src 'self'` with no
+  remote allowlist.
+- Service-worker pre-cache picks up the assets like every other PWA bundle.
+
+Upgrading: replace the files with a newer pinned version (keeping the same
+dependency closure), run the wallet's test suite, and update this file's
+version line.

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/_arx.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/_arx.js
@@ -1,0 +1,171 @@
+/**
+ * Basic utils for ARX (add-rotate-xor) salsa and chacha ciphers.
+
+RFC8439 requires multi-step cipher stream, where
+authKey starts with counter: 0, actual msg with counter: 1.
+
+For this, we need a way to re-use nonce / counter:
+
+    const counter = new Uint8Array(4);
+    chacha(..., counter, ...); // counter is now 1
+    chacha(..., counter, ...); // counter is now 2
+
+This is complicated:
+
+- 32-bit counters are enough, no need for 64-bit: max ArrayBuffer size in JS is 4GB
+- Original papers don't allow mutating counters
+- Counter overflow is undefined [^1]
+- Idea A: allow providing (nonce | counter) instead of just nonce, re-use it
+- Caveat: Cannot be re-used through all cases:
+- * chacha has (counter | nonce)
+- * xchacha has (nonce16 | counter | nonce16)
+- Idea B: separate nonce / counter and provide separate API for counter re-use
+- Caveat: there are different counter sizes depending on an algorithm.
+- salsa & chacha also differ in structures of key & sigma:
+  salsa20:      s[0] | k(4) | s[1] | nonce(2) | ctr(2) | s[2] | k(4) | s[3]
+  chacha:       s(4) | k(8) | ctr(1) | nonce(3)
+  chacha20orig: s(4) | k(8) | ctr(2) | nonce(2)
+- Idea C: helper method such as `setSalsaState(key, nonce, sigma, data)`
+- Caveat: we can't re-use counter array
+
+xchacha [^2] uses the subkey and remaining 8 byte nonce with ChaCha20 as normal
+(prefixed by 4 NUL bytes, since [RFC8439] specifies a 12-byte nonce).
+
+[^1]: https://mailarchive.ietf.org/arch/msg/cfrg/gsOnTJzcbgG6OqD8Sc0GO5aR_tU/
+[^2]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha#appendix-A.2
+
+ * @module
+ */
+import { abool, abytes, anumber } from './_assert.js';
+import { checkOpts, clean, copyBytes, u32 } from './utils.js';
+// We can't make top-level var depend on utils.utf8ToBytes
+// because it's not present in all envs. Creating a similar fn here
+const _utf8ToBytes = (str) => Uint8Array.from(str.split('').map((c) => c.charCodeAt(0)));
+const sigma16 = _utf8ToBytes('expand 16-byte k');
+const sigma32 = _utf8ToBytes('expand 32-byte k');
+const sigma16_32 = u32(sigma16);
+const sigma32_32 = u32(sigma32);
+export function rotl(a, b) {
+    return (a << b) | (a >>> (32 - b));
+}
+// Is byte array aligned to 4 byte offset (u32)?
+function isAligned32(b) {
+    return b.byteOffset % 4 === 0;
+}
+// Salsa and Chacha block length is always 512-bit
+const BLOCK_LEN = 64;
+const BLOCK_LEN32 = 16;
+// new Uint32Array([2**32])   // => Uint32Array(1) [ 0 ]
+// new Uint32Array([2**32-1]) // => Uint32Array(1) [ 4294967295 ]
+const MAX_COUNTER = 2 ** 32 - 1;
+const U32_EMPTY = new Uint32Array();
+function runCipher(core, sigma, key, nonce, data, output, counter, rounds) {
+    const len = data.length;
+    const block = new Uint8Array(BLOCK_LEN);
+    const b32 = u32(block);
+    // Make sure that buffers aligned to 4 bytes
+    const isAligned = isAligned32(data) && isAligned32(output);
+    const d32 = isAligned ? u32(data) : U32_EMPTY;
+    const o32 = isAligned ? u32(output) : U32_EMPTY;
+    for (let pos = 0; pos < len; counter++) {
+        core(sigma, key, nonce, b32, counter, rounds);
+        if (counter >= MAX_COUNTER)
+            throw new Error('arx: counter overflow');
+        const take = Math.min(BLOCK_LEN, len - pos);
+        // aligned to 4 bytes
+        if (isAligned && take === BLOCK_LEN) {
+            const pos32 = pos / 4;
+            if (pos % 4 !== 0)
+                throw new Error('arx: invalid block position');
+            for (let j = 0, posj; j < BLOCK_LEN32; j++) {
+                posj = pos32 + j;
+                o32[posj] = d32[posj] ^ b32[j];
+            }
+            pos += BLOCK_LEN;
+            continue;
+        }
+        for (let j = 0, posj; j < take; j++) {
+            posj = pos + j;
+            output[posj] = data[posj] ^ block[j];
+        }
+        pos += take;
+    }
+}
+/** Creates ARX-like (ChaCha, Salsa) cipher stream from core function. */
+export function createCipher(core, opts) {
+    const { allowShortKeys, extendNonceFn, counterLength, counterRight, rounds } = checkOpts({ allowShortKeys: false, counterLength: 8, counterRight: false, rounds: 20 }, opts);
+    if (typeof core !== 'function')
+        throw new Error('core must be a function');
+    anumber(counterLength);
+    anumber(rounds);
+    abool(counterRight);
+    abool(allowShortKeys);
+    return (key, nonce, data, output, counter = 0) => {
+        abytes(key);
+        abytes(nonce);
+        abytes(data);
+        const len = data.length;
+        if (output === undefined)
+            output = new Uint8Array(len);
+        abytes(output);
+        anumber(counter);
+        if (counter < 0 || counter >= MAX_COUNTER)
+            throw new Error('arx: counter overflow');
+        if (output.length < len)
+            throw new Error(`arx: output (${output.length}) is shorter than data (${len})`);
+        const toClean = [];
+        // Key & sigma
+        // key=16 -> sigma16, k=key|key
+        // key=32 -> sigma32, k=key
+        let l = key.length;
+        let k;
+        let sigma;
+        if (l === 32) {
+            toClean.push((k = copyBytes(key)));
+            sigma = sigma32_32;
+        }
+        else if (l === 16 && allowShortKeys) {
+            k = new Uint8Array(32);
+            k.set(key);
+            k.set(key, 16);
+            sigma = sigma16_32;
+            toClean.push(k);
+        }
+        else {
+            throw new Error(`arx: invalid 32-byte key, got length=${l}`);
+        }
+        // Nonce
+        // salsa20:      8   (8-byte counter)
+        // chacha20orig: 8   (8-byte counter)
+        // chacha20:     12  (4-byte counter)
+        // xsalsa20:     24  (16 -> hsalsa,  8 -> old nonce)
+        // xchacha20:    24  (16 -> hchacha, 8 -> old nonce)
+        // Align nonce to 4 bytes
+        if (!isAligned32(nonce))
+            toClean.push((nonce = copyBytes(nonce)));
+        const k32 = u32(k);
+        // hsalsa & hchacha: handle extended nonce
+        if (extendNonceFn) {
+            if (nonce.length !== 24)
+                throw new Error(`arx: extended nonce must be 24 bytes`);
+            extendNonceFn(sigma, k32, u32(nonce.subarray(0, 16)), k32);
+            nonce = nonce.subarray(16);
+        }
+        // Handle nonce counter
+        const nonceNcLen = 16 - counterLength;
+        if (nonceNcLen !== nonce.length)
+            throw new Error(`arx: nonce must be ${nonceNcLen} or 16 bytes`);
+        // Pad counter when nonce is 64 bit
+        if (nonceNcLen !== 12) {
+            const nc = new Uint8Array(12);
+            nc.set(nonce, counterRight ? 0 : 12 - nonce.length);
+            nonce = nc;
+            toClean.push(nonce);
+        }
+        const n32 = u32(nonce);
+        runCipher(core, sigma, k32, n32, data, output, counter, rounds);
+        clean(...toClean);
+        return output;
+    };
+}
+//# sourceMappingURL=_arx.js.map

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/_assert.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/_assert.js
@@ -1,0 +1,43 @@
+/**
+ * Internal assertion helpers.
+ * @module
+ */
+function anumber(n) {
+    if (!Number.isSafeInteger(n) || n < 0)
+        throw new Error('positive integer expected, got ' + n);
+}
+// copied from utils
+function isBytes(a) {
+    return a instanceof Uint8Array || (ArrayBuffer.isView(a) && a.constructor.name === 'Uint8Array');
+}
+function abytes(b, ...lengths) {
+    if (!isBytes(b))
+        throw new Error('Uint8Array expected');
+    if (lengths.length > 0 && !lengths.includes(b.length))
+        throw new Error('Uint8Array expected of length ' + lengths + ', got length=' + b.length);
+}
+function ahash(h) {
+    if (typeof h !== 'function' || typeof h.create !== 'function')
+        throw new Error('Hash should be wrapped by utils.wrapConstructor');
+    anumber(h.outputLen);
+    anumber(h.blockLen);
+}
+function aexists(instance, checkFinished = true) {
+    if (instance.destroyed)
+        throw new Error('Hash instance has been destroyed');
+    if (checkFinished && instance.finished)
+        throw new Error('Hash#digest() has already been called');
+}
+function aoutput(out, instance) {
+    abytes(out);
+    const min = instance.outputLen;
+    if (out.length < min) {
+        throw new Error('digestInto() expects output buffer of length at least ' + min);
+    }
+}
+function abool(b) {
+    if (typeof b !== 'boolean')
+        throw new Error(`boolean expected, not ${b}`);
+}
+export { abool, abytes, aexists, ahash, anumber, aoutput, isBytes };
+//# sourceMappingURL=_assert.js.map

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/_poly1305.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/_poly1305.js
@@ -1,0 +1,277 @@
+/**
+ * Poly1305 ([PDF](https://cr.yp.to/mac/poly1305-20050329.pdf),
+ * [wiki](https://en.wikipedia.org/wiki/Poly1305))
+ * is a fast and parallel secret-key message-authentication code suitable for
+ * a wide variety of applications. It was standardized in
+ * [RFC 8439](https://datatracker.ietf.org/doc/html/rfc8439) and is now used in TLS 1.3.
+ *
+ * Polynomial MACs are not perfect for every situation:
+ * they lack Random Key Robustness: the MAC can be forged, and can't be used in PAKE schemes.
+ * See [invisible salamanders attack](https://keymaterial.net/2020/09/07/invisible-salamanders-in-aes-gcm-siv/).
+ * To combat invisible salamanders, `hash(key)` can be included in ciphertext,
+ * however, this would violate ciphertext indistinguishability:
+ * an attacker would know which key was used - so `HKDF(key, i)`
+ * could be used instead.
+ *
+ * Check out [original website](https://cr.yp.to/mac.html).
+ * @module
+ */
+import { abytes, aexists, aoutput } from './_assert.js';
+import { Hash, clean, toBytes } from './utils.js';
+// Based on Public Domain poly1305-donna https://github.com/floodyberry/poly1305-donna
+const u8to16 = (a, i) => (a[i++] & 0xff) | ((a[i++] & 0xff) << 8);
+class Poly1305 {
+    constructor(key) {
+        this.blockLen = 16;
+        this.outputLen = 16;
+        this.buffer = new Uint8Array(16);
+        this.r = new Uint16Array(10);
+        this.h = new Uint16Array(10);
+        this.pad = new Uint16Array(8);
+        this.pos = 0;
+        this.finished = false;
+        key = toBytes(key);
+        abytes(key, 32);
+        const t0 = u8to16(key, 0);
+        const t1 = u8to16(key, 2);
+        const t2 = u8to16(key, 4);
+        const t3 = u8to16(key, 6);
+        const t4 = u8to16(key, 8);
+        const t5 = u8to16(key, 10);
+        const t6 = u8to16(key, 12);
+        const t7 = u8to16(key, 14);
+        // https://github.com/floodyberry/poly1305-donna/blob/e6ad6e091d30d7f4ec2d4f978be1fcfcbce72781/poly1305-donna-16.h#L47
+        this.r[0] = t0 & 0x1fff;
+        this.r[1] = ((t0 >>> 13) | (t1 << 3)) & 0x1fff;
+        this.r[2] = ((t1 >>> 10) | (t2 << 6)) & 0x1f03;
+        this.r[3] = ((t2 >>> 7) | (t3 << 9)) & 0x1fff;
+        this.r[4] = ((t3 >>> 4) | (t4 << 12)) & 0x00ff;
+        this.r[5] = (t4 >>> 1) & 0x1ffe;
+        this.r[6] = ((t4 >>> 14) | (t5 << 2)) & 0x1fff;
+        this.r[7] = ((t5 >>> 11) | (t6 << 5)) & 0x1f81;
+        this.r[8] = ((t6 >>> 8) | (t7 << 8)) & 0x1fff;
+        this.r[9] = (t7 >>> 5) & 0x007f;
+        for (let i = 0; i < 8; i++)
+            this.pad[i] = u8to16(key, 16 + 2 * i);
+    }
+    process(data, offset, isLast = false) {
+        const hibit = isLast ? 0 : 1 << 11;
+        const { h, r } = this;
+        const r0 = r[0];
+        const r1 = r[1];
+        const r2 = r[2];
+        const r3 = r[3];
+        const r4 = r[4];
+        const r5 = r[5];
+        const r6 = r[6];
+        const r7 = r[7];
+        const r8 = r[8];
+        const r9 = r[9];
+        const t0 = u8to16(data, offset + 0);
+        const t1 = u8to16(data, offset + 2);
+        const t2 = u8to16(data, offset + 4);
+        const t3 = u8to16(data, offset + 6);
+        const t4 = u8to16(data, offset + 8);
+        const t5 = u8to16(data, offset + 10);
+        const t6 = u8to16(data, offset + 12);
+        const t7 = u8to16(data, offset + 14);
+        let h0 = h[0] + (t0 & 0x1fff);
+        let h1 = h[1] + (((t0 >>> 13) | (t1 << 3)) & 0x1fff);
+        let h2 = h[2] + (((t1 >>> 10) | (t2 << 6)) & 0x1fff);
+        let h3 = h[3] + (((t2 >>> 7) | (t3 << 9)) & 0x1fff);
+        let h4 = h[4] + (((t3 >>> 4) | (t4 << 12)) & 0x1fff);
+        let h5 = h[5] + ((t4 >>> 1) & 0x1fff);
+        let h6 = h[6] + (((t4 >>> 14) | (t5 << 2)) & 0x1fff);
+        let h7 = h[7] + (((t5 >>> 11) | (t6 << 5)) & 0x1fff);
+        let h8 = h[8] + (((t6 >>> 8) | (t7 << 8)) & 0x1fff);
+        let h9 = h[9] + ((t7 >>> 5) | hibit);
+        let c = 0;
+        let d0 = c + h0 * r0 + h1 * (5 * r9) + h2 * (5 * r8) + h3 * (5 * r7) + h4 * (5 * r6);
+        c = d0 >>> 13;
+        d0 &= 0x1fff;
+        d0 += h5 * (5 * r5) + h6 * (5 * r4) + h7 * (5 * r3) + h8 * (5 * r2) + h9 * (5 * r1);
+        c += d0 >>> 13;
+        d0 &= 0x1fff;
+        let d1 = c + h0 * r1 + h1 * r0 + h2 * (5 * r9) + h3 * (5 * r8) + h4 * (5 * r7);
+        c = d1 >>> 13;
+        d1 &= 0x1fff;
+        d1 += h5 * (5 * r6) + h6 * (5 * r5) + h7 * (5 * r4) + h8 * (5 * r3) + h9 * (5 * r2);
+        c += d1 >>> 13;
+        d1 &= 0x1fff;
+        let d2 = c + h0 * r2 + h1 * r1 + h2 * r0 + h3 * (5 * r9) + h4 * (5 * r8);
+        c = d2 >>> 13;
+        d2 &= 0x1fff;
+        d2 += h5 * (5 * r7) + h6 * (5 * r6) + h7 * (5 * r5) + h8 * (5 * r4) + h9 * (5 * r3);
+        c += d2 >>> 13;
+        d2 &= 0x1fff;
+        let d3 = c + h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * (5 * r9);
+        c = d3 >>> 13;
+        d3 &= 0x1fff;
+        d3 += h5 * (5 * r8) + h6 * (5 * r7) + h7 * (5 * r6) + h8 * (5 * r5) + h9 * (5 * r4);
+        c += d3 >>> 13;
+        d3 &= 0x1fff;
+        let d4 = c + h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+        c = d4 >>> 13;
+        d4 &= 0x1fff;
+        d4 += h5 * (5 * r9) + h6 * (5 * r8) + h7 * (5 * r7) + h8 * (5 * r6) + h9 * (5 * r5);
+        c += d4 >>> 13;
+        d4 &= 0x1fff;
+        let d5 = c + h0 * r5 + h1 * r4 + h2 * r3 + h3 * r2 + h4 * r1;
+        c = d5 >>> 13;
+        d5 &= 0x1fff;
+        d5 += h5 * r0 + h6 * (5 * r9) + h7 * (5 * r8) + h8 * (5 * r7) + h9 * (5 * r6);
+        c += d5 >>> 13;
+        d5 &= 0x1fff;
+        let d6 = c + h0 * r6 + h1 * r5 + h2 * r4 + h3 * r3 + h4 * r2;
+        c = d6 >>> 13;
+        d6 &= 0x1fff;
+        d6 += h5 * r1 + h6 * r0 + h7 * (5 * r9) + h8 * (5 * r8) + h9 * (5 * r7);
+        c += d6 >>> 13;
+        d6 &= 0x1fff;
+        let d7 = c + h0 * r7 + h1 * r6 + h2 * r5 + h3 * r4 + h4 * r3;
+        c = d7 >>> 13;
+        d7 &= 0x1fff;
+        d7 += h5 * r2 + h6 * r1 + h7 * r0 + h8 * (5 * r9) + h9 * (5 * r8);
+        c += d7 >>> 13;
+        d7 &= 0x1fff;
+        let d8 = c + h0 * r8 + h1 * r7 + h2 * r6 + h3 * r5 + h4 * r4;
+        c = d8 >>> 13;
+        d8 &= 0x1fff;
+        d8 += h5 * r3 + h6 * r2 + h7 * r1 + h8 * r0 + h9 * (5 * r9);
+        c += d8 >>> 13;
+        d8 &= 0x1fff;
+        let d9 = c + h0 * r9 + h1 * r8 + h2 * r7 + h3 * r6 + h4 * r5;
+        c = d9 >>> 13;
+        d9 &= 0x1fff;
+        d9 += h5 * r4 + h6 * r3 + h7 * r2 + h8 * r1 + h9 * r0;
+        c += d9 >>> 13;
+        d9 &= 0x1fff;
+        c = ((c << 2) + c) | 0;
+        c = (c + d0) | 0;
+        d0 = c & 0x1fff;
+        c = c >>> 13;
+        d1 += c;
+        h[0] = d0;
+        h[1] = d1;
+        h[2] = d2;
+        h[3] = d3;
+        h[4] = d4;
+        h[5] = d5;
+        h[6] = d6;
+        h[7] = d7;
+        h[8] = d8;
+        h[9] = d9;
+    }
+    finalize() {
+        const { h, pad } = this;
+        const g = new Uint16Array(10);
+        let c = h[1] >>> 13;
+        h[1] &= 0x1fff;
+        for (let i = 2; i < 10; i++) {
+            h[i] += c;
+            c = h[i] >>> 13;
+            h[i] &= 0x1fff;
+        }
+        h[0] += c * 5;
+        c = h[0] >>> 13;
+        h[0] &= 0x1fff;
+        h[1] += c;
+        c = h[1] >>> 13;
+        h[1] &= 0x1fff;
+        h[2] += c;
+        g[0] = h[0] + 5;
+        c = g[0] >>> 13;
+        g[0] &= 0x1fff;
+        for (let i = 1; i < 10; i++) {
+            g[i] = h[i] + c;
+            c = g[i] >>> 13;
+            g[i] &= 0x1fff;
+        }
+        g[9] -= 1 << 13;
+        let mask = (c ^ 1) - 1;
+        for (let i = 0; i < 10; i++)
+            g[i] &= mask;
+        mask = ~mask;
+        for (let i = 0; i < 10; i++)
+            h[i] = (h[i] & mask) | g[i];
+        h[0] = (h[0] | (h[1] << 13)) & 0xffff;
+        h[1] = ((h[1] >>> 3) | (h[2] << 10)) & 0xffff;
+        h[2] = ((h[2] >>> 6) | (h[3] << 7)) & 0xffff;
+        h[3] = ((h[3] >>> 9) | (h[4] << 4)) & 0xffff;
+        h[4] = ((h[4] >>> 12) | (h[5] << 1) | (h[6] << 14)) & 0xffff;
+        h[5] = ((h[6] >>> 2) | (h[7] << 11)) & 0xffff;
+        h[6] = ((h[7] >>> 5) | (h[8] << 8)) & 0xffff;
+        h[7] = ((h[8] >>> 8) | (h[9] << 5)) & 0xffff;
+        let f = h[0] + pad[0];
+        h[0] = f & 0xffff;
+        for (let i = 1; i < 8; i++) {
+            f = (((h[i] + pad[i]) | 0) + (f >>> 16)) | 0;
+            h[i] = f & 0xffff;
+        }
+        clean(g);
+    }
+    update(data) {
+        aexists(this);
+        const { buffer, blockLen } = this;
+        data = toBytes(data);
+        const len = data.length;
+        for (let pos = 0; pos < len;) {
+            const take = Math.min(blockLen - this.pos, len - pos);
+            // Fast path: we have at least one block in input
+            if (take === blockLen) {
+                for (; blockLen <= len - pos; pos += blockLen)
+                    this.process(data, pos);
+                continue;
+            }
+            buffer.set(data.subarray(pos, pos + take), this.pos);
+            this.pos += take;
+            pos += take;
+            if (this.pos === blockLen) {
+                this.process(buffer, 0, false);
+                this.pos = 0;
+            }
+        }
+        return this;
+    }
+    destroy() {
+        clean(this.h, this.r, this.buffer, this.pad);
+    }
+    digestInto(out) {
+        aexists(this);
+        aoutput(out, this);
+        this.finished = true;
+        const { buffer, h } = this;
+        let { pos } = this;
+        if (pos) {
+            buffer[pos++] = 1;
+            for (; pos < 16; pos++)
+                buffer[pos] = 0;
+            this.process(buffer, 0, true);
+        }
+        this.finalize();
+        let opos = 0;
+        for (let i = 0; i < 8; i++) {
+            out[opos++] = h[i] >>> 0;
+            out[opos++] = h[i] >>> 8;
+        }
+        return out;
+    }
+    digest() {
+        const { buffer, outputLen } = this;
+        this.digestInto(buffer);
+        const res = buffer.slice(0, outputLen);
+        this.destroy();
+        return res;
+    }
+}
+export function wrapConstructorWithKey(hashCons) {
+    const hashC = (msg, key) => hashCons(key).update(toBytes(msg)).digest();
+    const tmp = hashCons(new Uint8Array(32));
+    hashC.outputLen = tmp.outputLen;
+    hashC.blockLen = tmp.blockLen;
+    hashC.create = (key) => hashCons(key);
+    return hashC;
+}
+/** Poly1305 MAC from RFC 8439. */
+export const poly1305 = wrapConstructorWithKey((key) => new Poly1305(key));
+//# sourceMappingURL=_poly1305.js.map

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/chacha.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/chacha.js
@@ -1,0 +1,318 @@
+/**
+ * [ChaCha20](https://cr.yp.to/chacha.html) stream cipher, released
+ * in 2008. Developed after Salsa20, ChaCha aims to increase diffusion per round.
+ * It was standardized in [RFC 8439](https://datatracker.ietf.org/doc/html/rfc8439) and
+ * is now used in TLS 1.3.
+ *
+ * [XChaCha20](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha)
+ * extended-nonce variant is also provided. Similar to XSalsa, it's safe to use with
+ * randomly-generated nonces.
+ *
+ * Check out [PDF](http://cr.yp.to/chacha/chacha-20080128.pdf) and
+ * [wiki](https://en.wikipedia.org/wiki/Salsa20).
+ * @module
+ */
+import { createCipher, rotl } from './_arx.js';
+import { poly1305 } from './_poly1305.js';
+import { clean, createView, equalBytes, getOutput, setBigUint64, wrapCipher, } from './utils.js';
+/**
+ * ChaCha core function.
+ */
+// prettier-ignore
+function chachaCore(s, k, n, out, cnt, rounds = 20) {
+    let y00 = s[0], y01 = s[1], y02 = s[2], y03 = s[3], // "expa"   "nd 3"  "2-by"  "te k"
+    y04 = k[0], y05 = k[1], y06 = k[2], y07 = k[3], // Key      Key     Key     Key
+    y08 = k[4], y09 = k[5], y10 = k[6], y11 = k[7], // Key      Key     Key     Key
+    y12 = cnt, y13 = n[0], y14 = n[1], y15 = n[2]; // Counter  Counter	Nonce   Nonce
+    // Save state to temporary variables
+    let x00 = y00, x01 = y01, x02 = y02, x03 = y03, x04 = y04, x05 = y05, x06 = y06, x07 = y07, x08 = y08, x09 = y09, x10 = y10, x11 = y11, x12 = y12, x13 = y13, x14 = y14, x15 = y15;
+    for (let r = 0; r < rounds; r += 2) {
+        x00 = (x00 + x04) | 0;
+        x12 = rotl(x12 ^ x00, 16);
+        x08 = (x08 + x12) | 0;
+        x04 = rotl(x04 ^ x08, 12);
+        x00 = (x00 + x04) | 0;
+        x12 = rotl(x12 ^ x00, 8);
+        x08 = (x08 + x12) | 0;
+        x04 = rotl(x04 ^ x08, 7);
+        x01 = (x01 + x05) | 0;
+        x13 = rotl(x13 ^ x01, 16);
+        x09 = (x09 + x13) | 0;
+        x05 = rotl(x05 ^ x09, 12);
+        x01 = (x01 + x05) | 0;
+        x13 = rotl(x13 ^ x01, 8);
+        x09 = (x09 + x13) | 0;
+        x05 = rotl(x05 ^ x09, 7);
+        x02 = (x02 + x06) | 0;
+        x14 = rotl(x14 ^ x02, 16);
+        x10 = (x10 + x14) | 0;
+        x06 = rotl(x06 ^ x10, 12);
+        x02 = (x02 + x06) | 0;
+        x14 = rotl(x14 ^ x02, 8);
+        x10 = (x10 + x14) | 0;
+        x06 = rotl(x06 ^ x10, 7);
+        x03 = (x03 + x07) | 0;
+        x15 = rotl(x15 ^ x03, 16);
+        x11 = (x11 + x15) | 0;
+        x07 = rotl(x07 ^ x11, 12);
+        x03 = (x03 + x07) | 0;
+        x15 = rotl(x15 ^ x03, 8);
+        x11 = (x11 + x15) | 0;
+        x07 = rotl(x07 ^ x11, 7);
+        x00 = (x00 + x05) | 0;
+        x15 = rotl(x15 ^ x00, 16);
+        x10 = (x10 + x15) | 0;
+        x05 = rotl(x05 ^ x10, 12);
+        x00 = (x00 + x05) | 0;
+        x15 = rotl(x15 ^ x00, 8);
+        x10 = (x10 + x15) | 0;
+        x05 = rotl(x05 ^ x10, 7);
+        x01 = (x01 + x06) | 0;
+        x12 = rotl(x12 ^ x01, 16);
+        x11 = (x11 + x12) | 0;
+        x06 = rotl(x06 ^ x11, 12);
+        x01 = (x01 + x06) | 0;
+        x12 = rotl(x12 ^ x01, 8);
+        x11 = (x11 + x12) | 0;
+        x06 = rotl(x06 ^ x11, 7);
+        x02 = (x02 + x07) | 0;
+        x13 = rotl(x13 ^ x02, 16);
+        x08 = (x08 + x13) | 0;
+        x07 = rotl(x07 ^ x08, 12);
+        x02 = (x02 + x07) | 0;
+        x13 = rotl(x13 ^ x02, 8);
+        x08 = (x08 + x13) | 0;
+        x07 = rotl(x07 ^ x08, 7);
+        x03 = (x03 + x04) | 0;
+        x14 = rotl(x14 ^ x03, 16);
+        x09 = (x09 + x14) | 0;
+        x04 = rotl(x04 ^ x09, 12);
+        x03 = (x03 + x04) | 0;
+        x14 = rotl(x14 ^ x03, 8);
+        x09 = (x09 + x14) | 0;
+        x04 = rotl(x04 ^ x09, 7);
+    }
+    // Write output
+    let oi = 0;
+    out[oi++] = (y00 + x00) | 0;
+    out[oi++] = (y01 + x01) | 0;
+    out[oi++] = (y02 + x02) | 0;
+    out[oi++] = (y03 + x03) | 0;
+    out[oi++] = (y04 + x04) | 0;
+    out[oi++] = (y05 + x05) | 0;
+    out[oi++] = (y06 + x06) | 0;
+    out[oi++] = (y07 + x07) | 0;
+    out[oi++] = (y08 + x08) | 0;
+    out[oi++] = (y09 + x09) | 0;
+    out[oi++] = (y10 + x10) | 0;
+    out[oi++] = (y11 + x11) | 0;
+    out[oi++] = (y12 + x12) | 0;
+    out[oi++] = (y13 + x13) | 0;
+    out[oi++] = (y14 + x14) | 0;
+    out[oi++] = (y15 + x15) | 0;
+}
+/**
+ * hchacha helper method, used primarily in xchacha, to hash
+ * key and nonce into key' and nonce'.
+ * Same as chachaCore, but there doesn't seem to be a way to move the block
+ * out without 25% performance hit.
+ */
+// prettier-ignore
+export function hchacha(s, k, i, o32) {
+    let x00 = s[0], x01 = s[1], x02 = s[2], x03 = s[3], x04 = k[0], x05 = k[1], x06 = k[2], x07 = k[3], x08 = k[4], x09 = k[5], x10 = k[6], x11 = k[7], x12 = i[0], x13 = i[1], x14 = i[2], x15 = i[3];
+    for (let r = 0; r < 20; r += 2) {
+        x00 = (x00 + x04) | 0;
+        x12 = rotl(x12 ^ x00, 16);
+        x08 = (x08 + x12) | 0;
+        x04 = rotl(x04 ^ x08, 12);
+        x00 = (x00 + x04) | 0;
+        x12 = rotl(x12 ^ x00, 8);
+        x08 = (x08 + x12) | 0;
+        x04 = rotl(x04 ^ x08, 7);
+        x01 = (x01 + x05) | 0;
+        x13 = rotl(x13 ^ x01, 16);
+        x09 = (x09 + x13) | 0;
+        x05 = rotl(x05 ^ x09, 12);
+        x01 = (x01 + x05) | 0;
+        x13 = rotl(x13 ^ x01, 8);
+        x09 = (x09 + x13) | 0;
+        x05 = rotl(x05 ^ x09, 7);
+        x02 = (x02 + x06) | 0;
+        x14 = rotl(x14 ^ x02, 16);
+        x10 = (x10 + x14) | 0;
+        x06 = rotl(x06 ^ x10, 12);
+        x02 = (x02 + x06) | 0;
+        x14 = rotl(x14 ^ x02, 8);
+        x10 = (x10 + x14) | 0;
+        x06 = rotl(x06 ^ x10, 7);
+        x03 = (x03 + x07) | 0;
+        x15 = rotl(x15 ^ x03, 16);
+        x11 = (x11 + x15) | 0;
+        x07 = rotl(x07 ^ x11, 12);
+        x03 = (x03 + x07) | 0;
+        x15 = rotl(x15 ^ x03, 8);
+        x11 = (x11 + x15) | 0;
+        x07 = rotl(x07 ^ x11, 7);
+        x00 = (x00 + x05) | 0;
+        x15 = rotl(x15 ^ x00, 16);
+        x10 = (x10 + x15) | 0;
+        x05 = rotl(x05 ^ x10, 12);
+        x00 = (x00 + x05) | 0;
+        x15 = rotl(x15 ^ x00, 8);
+        x10 = (x10 + x15) | 0;
+        x05 = rotl(x05 ^ x10, 7);
+        x01 = (x01 + x06) | 0;
+        x12 = rotl(x12 ^ x01, 16);
+        x11 = (x11 + x12) | 0;
+        x06 = rotl(x06 ^ x11, 12);
+        x01 = (x01 + x06) | 0;
+        x12 = rotl(x12 ^ x01, 8);
+        x11 = (x11 + x12) | 0;
+        x06 = rotl(x06 ^ x11, 7);
+        x02 = (x02 + x07) | 0;
+        x13 = rotl(x13 ^ x02, 16);
+        x08 = (x08 + x13) | 0;
+        x07 = rotl(x07 ^ x08, 12);
+        x02 = (x02 + x07) | 0;
+        x13 = rotl(x13 ^ x02, 8);
+        x08 = (x08 + x13) | 0;
+        x07 = rotl(x07 ^ x08, 7);
+        x03 = (x03 + x04) | 0;
+        x14 = rotl(x14 ^ x03, 16);
+        x09 = (x09 + x14) | 0;
+        x04 = rotl(x04 ^ x09, 12);
+        x03 = (x03 + x04) | 0;
+        x14 = rotl(x14 ^ x03, 8);
+        x09 = (x09 + x14) | 0;
+        x04 = rotl(x04 ^ x09, 7);
+    }
+    let oi = 0;
+    o32[oi++] = x00;
+    o32[oi++] = x01;
+    o32[oi++] = x02;
+    o32[oi++] = x03;
+    o32[oi++] = x12;
+    o32[oi++] = x13;
+    o32[oi++] = x14;
+    o32[oi++] = x15;
+}
+/**
+ * Original, non-RFC chacha20 from DJB. 8-byte nonce, 8-byte counter.
+ */
+export const chacha20orig = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 8,
+    allowShortKeys: true,
+});
+/**
+ * ChaCha stream cipher. Conforms to RFC 8439 (IETF, TLS). 12-byte nonce, 4-byte counter.
+ * With 12-byte nonce, it's not safe to use fill it with random (CSPRNG), due to collision chance.
+ */
+export const chacha20 = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 4,
+    allowShortKeys: false,
+});
+/**
+ * XChaCha eXtended-nonce ChaCha. 24-byte nonce.
+ * With 24-byte nonce, it's safe to use fill it with random (CSPRNG).
+ * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha
+ */
+export const xchacha20 = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 8,
+    extendNonceFn: hchacha,
+    allowShortKeys: false,
+});
+/**
+ * Reduced 8-round chacha, described in original paper.
+ */
+export const chacha8 = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 4,
+    rounds: 8,
+});
+/**
+ * Reduced 12-round chacha, described in original paper.
+ */
+export const chacha12 = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 4,
+    rounds: 12,
+});
+const ZEROS16 = /* @__PURE__ */ new Uint8Array(16);
+// Pad to digest size with zeros
+const updatePadded = (h, msg) => {
+    h.update(msg);
+    const left = msg.length % 16;
+    if (left)
+        h.update(ZEROS16.subarray(left));
+};
+const ZEROS32 = /* @__PURE__ */ new Uint8Array(32);
+function computeTag(fn, key, nonce, data, AAD) {
+    const authKey = fn(key, nonce, ZEROS32);
+    const h = poly1305.create(authKey);
+    if (AAD)
+        updatePadded(h, AAD);
+    updatePadded(h, data);
+    const num = new Uint8Array(16);
+    const view = createView(num);
+    setBigUint64(view, 0, BigInt(AAD ? AAD.length : 0), true);
+    setBigUint64(view, 8, BigInt(data.length), true);
+    h.update(num);
+    const res = h.digest();
+    clean(authKey, num);
+    return res;
+}
+/**
+ * AEAD algorithm from RFC 8439.
+ * Salsa20 and chacha (RFC 8439) use poly1305 differently.
+ * We could have composed them similar to:
+ * https://github.com/paulmillr/scure-base/blob/b266c73dde977b1dd7ef40ef7a23cc15aab526b3/index.ts#L250
+ * But it's hard because of authKey:
+ * In salsa20, authKey changes position in salsa stream.
+ * In chacha, authKey can't be computed inside computeTag, it modifies the counter.
+ */
+export const _poly1305_aead = (xorStream) => (key, nonce, AAD) => {
+    const tagLength = 16;
+    return {
+        encrypt(plaintext, output) {
+            const plength = plaintext.length;
+            output = getOutput(plength + tagLength, output, false);
+            output.set(plaintext);
+            const oPlain = output.subarray(0, -tagLength);
+            xorStream(key, nonce, oPlain, oPlain, 1);
+            const tag = computeTag(xorStream, key, nonce, oPlain, AAD);
+            output.set(tag, plength); // append tag
+            clean(tag);
+            return output;
+        },
+        decrypt(ciphertext, output) {
+            output = getOutput(ciphertext.length - tagLength, output, false);
+            const data = ciphertext.subarray(0, -tagLength);
+            const passedTag = ciphertext.subarray(-tagLength);
+            const tag = computeTag(xorStream, key, nonce, data, AAD);
+            if (!equalBytes(passedTag, tag))
+                throw new Error('invalid tag');
+            output.set(ciphertext.subarray(0, -tagLength));
+            xorStream(key, nonce, output, output, 1); // start stream with i=1
+            clean(tag);
+            return output;
+        },
+    };
+};
+/**
+ * ChaCha20-Poly1305 from RFC 8439.
+ *
+ * Unsafe to use random nonces under the same key, due to collision chance.
+ * Prefer XChaCha instead.
+ */
+export const chacha20poly1305 = /* @__PURE__ */ wrapCipher({ blockSize: 64, nonceLength: 12, tagLength: 16 }, _poly1305_aead(chacha20));
+/**
+ * XChaCha20-Poly1305 extended-nonce chacha.
+ *
+ * Can be safely used with random nonces (CSPRNG).
+ * See [IRTF draft](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha).
+ */
+export const xchacha20poly1305 = /* @__PURE__ */ wrapCipher({ blockSize: 64, nonceLength: 24, tagLength: 16 }, _poly1305_aead(xchacha20));
+//# sourceMappingURL=chacha.js.map

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/utils.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/vendor/noble-ciphers/utils.js
@@ -1,0 +1,259 @@
+/**
+ * Utilities for hex, bytes, CSPRNG.
+ * @module
+ */
+/*! noble-ciphers - MIT License (c) 2023 Paul Miller (paulmillr.com) */
+import { abytes, isBytes } from './_assert.js';
+// Cast array to different type
+export const u8 = (arr) => new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+export const u32 = (arr) => new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
+// Cast array to view
+export const createView = (arr) => new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+// big-endian hardware is rare. Just in case someone still decides to run ciphers:
+// early-throw an error because we don't support BE yet.
+export const isLE = new Uint8Array(new Uint32Array([0x11223344]).buffer)[0] === 0x44;
+if (!isLE)
+    throw new Error('Non little-endian hardware is not supported');
+// Array where index 0xf0 (240) is mapped to string 'f0'
+const hexes = /* @__PURE__ */ Array.from({ length: 256 }, (_, i) => i.toString(16).padStart(2, '0'));
+/**
+ * @example bytesToHex(Uint8Array.from([0xca, 0xfe, 0x01, 0x23])) // 'cafe0123'
+ */
+export function bytesToHex(bytes) {
+    abytes(bytes);
+    // pre-caching improves the speed 6x
+    let hex = '';
+    for (let i = 0; i < bytes.length; i++) {
+        hex += hexes[bytes[i]];
+    }
+    return hex;
+}
+// We use optimized technique to convert hex string to byte array
+const asciis = { _0: 48, _9: 57, A: 65, F: 70, a: 97, f: 102 };
+function asciiToBase16(ch) {
+    if (ch >= asciis._0 && ch <= asciis._9)
+        return ch - asciis._0; // '2' => 50-48
+    if (ch >= asciis.A && ch <= asciis.F)
+        return ch - (asciis.A - 10); // 'B' => 66-(65-10)
+    if (ch >= asciis.a && ch <= asciis.f)
+        return ch - (asciis.a - 10); // 'b' => 98-(97-10)
+    return;
+}
+/**
+ * @example hexToBytes('cafe0123') // Uint8Array.from([0xca, 0xfe, 0x01, 0x23])
+ */
+export function hexToBytes(hex) {
+    if (typeof hex !== 'string')
+        throw new Error('hex string expected, got ' + typeof hex);
+    const hl = hex.length;
+    const al = hl / 2;
+    if (hl % 2)
+        throw new Error('hex string expected, got unpadded hex of length ' + hl);
+    const array = new Uint8Array(al);
+    for (let ai = 0, hi = 0; ai < al; ai++, hi += 2) {
+        const n1 = asciiToBase16(hex.charCodeAt(hi));
+        const n2 = asciiToBase16(hex.charCodeAt(hi + 1));
+        if (n1 === undefined || n2 === undefined) {
+            const char = hex[hi] + hex[hi + 1];
+            throw new Error('hex string expected, got non-hex character "' + char + '" at index ' + hi);
+        }
+        array[ai] = n1 * 16 + n2; // multiply first octet, e.g. 'a3' => 10*16+3 => 160 + 3 => 163
+    }
+    return array;
+}
+export function hexToNumber(hex) {
+    if (typeof hex !== 'string')
+        throw new Error('hex string expected, got ' + typeof hex);
+    return BigInt(hex === '' ? '0' : '0x' + hex); // Big Endian
+}
+// BE: Big Endian, LE: Little Endian
+export function bytesToNumberBE(bytes) {
+    return hexToNumber(bytesToHex(bytes));
+}
+export function numberToBytesBE(n, len) {
+    return hexToBytes(n.toString(16).padStart(len * 2, '0'));
+}
+// There is no setImmediate in browser and setTimeout is slow.
+// call of async fn will return Promise, which will be fullfiled only on
+// next scheduler queue processing step and this is exactly what we need.
+export const nextTick = async () => { };
+/**
+ * @example utf8ToBytes('abc') // new Uint8Array([97, 98, 99])
+ */
+export function utf8ToBytes(str) {
+    if (typeof str !== 'string')
+        throw new Error('string expected');
+    return new Uint8Array(new TextEncoder().encode(str)); // https://bugzil.la/1681809
+}
+/**
+ * @example bytesToUtf8(new Uint8Array([97, 98, 99])) // 'abc'
+ */
+export function bytesToUtf8(bytes) {
+    return new TextDecoder().decode(bytes);
+}
+/**
+ * Normalizes (non-hex) string or Uint8Array to Uint8Array.
+ * Warning: when Uint8Array is passed, it would NOT get copied.
+ * Keep in mind for future mutable operations.
+ */
+export function toBytes(data) {
+    if (typeof data === 'string')
+        data = utf8ToBytes(data);
+    else if (isBytes(data))
+        data = copyBytes(data);
+    else
+        throw new Error('Uint8Array expected, got ' + typeof data);
+    return data;
+}
+/**
+ * Checks if two U8A use same underlying buffer and overlaps (will corrupt and break if input and output same)
+ */
+export function overlapBytes(a, b) {
+    return (a.buffer === b.buffer && // probably will fail with some obscure proxies, but this is best we can do
+        a.byteOffset < b.byteOffset + b.byteLength && // a starts before b end
+        b.byteOffset < a.byteOffset + a.byteLength // b starts before a end
+    );
+}
+/**
+ * If input and output overlap and input starts before output, we will overwrite end of input before
+ * we start processing it, so this is not supported for most ciphers (except chacha/salse, which designed with this)
+ */
+export function complexOverlapBytes(input, output) {
+    // This is very cursed. It works somehow, but I'm completely unsure,
+    // reasoning about overlapping aligned windows is very hard.
+    if (overlapBytes(input, output) && input.byteOffset < output.byteOffset)
+        throw new Error('complex overlap of input and output is not supported');
+}
+/**
+ * Copies several Uint8Arrays into one.
+ */
+export function concatBytes(...arrays) {
+    let sum = 0;
+    for (let i = 0; i < arrays.length; i++) {
+        const a = arrays[i];
+        abytes(a);
+        sum += a.length;
+    }
+    const res = new Uint8Array(sum);
+    for (let i = 0, pad = 0; i < arrays.length; i++) {
+        const a = arrays[i];
+        res.set(a, pad);
+        pad += a.length;
+    }
+    return res;
+}
+export function checkOpts(defaults, opts) {
+    if (opts == null || typeof opts !== 'object')
+        throw new Error('options must be defined');
+    const merged = Object.assign(defaults, opts);
+    return merged;
+}
+// Compares 2 u8a-s in kinda constant time
+export function equalBytes(a, b) {
+    if (a.length !== b.length)
+        return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++)
+        diff |= a[i] ^ b[i];
+    return diff === 0;
+}
+// For runtime check if class implements interface
+export class Hash {
+}
+/**
+ * @__NO_SIDE_EFFECTS__
+ */
+export const wrapCipher = (params, constructor) => {
+    function wrappedCipher(key, ...args) {
+        // Validate key
+        abytes(key);
+        // Validate nonce if nonceLength is present
+        if (params.nonceLength !== undefined) {
+            const nonce = args[0];
+            if (!nonce)
+                throw new Error('nonce / iv required');
+            if (params.varSizeNonce)
+                abytes(nonce);
+            else
+                abytes(nonce, params.nonceLength);
+        }
+        // Validate AAD if tagLength present
+        const tagl = params.tagLength;
+        if (tagl && args[1] !== undefined) {
+            abytes(args[1]);
+        }
+        const cipher = constructor(key, ...args);
+        const checkOutput = (fnLength, output) => {
+            if (output !== undefined) {
+                if (fnLength !== 2)
+                    throw new Error('cipher output not supported');
+                abytes(output);
+            }
+        };
+        // Create wrapped cipher with validation and single-use encryption
+        let called = false;
+        const wrCipher = {
+            encrypt(data, output) {
+                if (called)
+                    throw new Error('cannot encrypt() twice with same key + nonce');
+                called = true;
+                abytes(data);
+                checkOutput(cipher.encrypt.length, output);
+                return cipher.encrypt(data, output);
+            },
+            decrypt(data, output) {
+                abytes(data);
+                if (tagl && data.length < tagl)
+                    throw new Error('invalid ciphertext length: smaller than tagLength=' + tagl);
+                checkOutput(cipher.decrypt.length, output);
+                return cipher.decrypt(data, output);
+            },
+        };
+        return wrCipher;
+    }
+    Object.assign(wrappedCipher, params);
+    return wrappedCipher;
+};
+export function getOutput(expectedLength, out, onlyAligned = true) {
+    if (out === undefined)
+        return new Uint8Array(expectedLength);
+    if (out.length !== expectedLength)
+        throw new Error('invalid output length, expected ' + expectedLength + ', got: ' + out.length);
+    if (onlyAligned && !isAligned32(out))
+        throw new Error('invalid output, must be aligned');
+    return out;
+}
+// Polyfill for Safari 14
+export function setBigUint64(view, byteOffset, value, isLE) {
+    if (typeof view.setBigUint64 === 'function')
+        return view.setBigUint64(byteOffset, value, isLE);
+    const _32n = BigInt(32);
+    const _u32_max = BigInt(0xffffffff);
+    const wh = Number((value >> _32n) & _u32_max);
+    const wl = Number(value & _u32_max);
+    const h = isLE ? 4 : 0;
+    const l = isLE ? 0 : 4;
+    view.setUint32(byteOffset + h, wh, isLE);
+    view.setUint32(byteOffset + l, wl, isLE);
+}
+export function u64Lengths(ciphertext, AAD) {
+    const num = new Uint8Array(16);
+    const view = createView(num);
+    setBigUint64(view, 0, BigInt(AAD ? AAD.length : 0), true);
+    setBigUint64(view, 8, BigInt(ciphertext.length), true);
+    return num;
+}
+// Is byte array aligned to 4 byte offset (u32)?
+export function isAligned32(bytes) {
+    return bytes.byteOffset % 4 === 0;
+}
+// copy bytes to new u8a (aligned). Because Buffer.slice is broken.
+export function copyBytes(bytes) {
+    return Uint8Array.from(bytes);
+}
+export function clean(...arrays) {
+    for (let i = 0; i < arrays.length; i++) {
+        arrays[i].fill(0);
+    }
+}
+//# sourceMappingURL=utils.js.map

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/xchacha-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/xchacha-bridge.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+//
+// XChaCha20-Poly1305 AEAD bridge for the Sorcha Wallet PWA (Feature 114, T056).
+//
+// Fulfils the T056 "libsodium-bridge" slot using @noble/ciphers instead of
+// libsodium-wrappers: same IETF XChaCha20-Poly1305 wire format (24-byte nonce,
+// 16-byte tag) at ~20 KB of pure-JS vs ~800 KB of WASM, and no extra CSP
+// (no wasm-unsafe-eval / WASM precache needed).
+//
+// Exposes a small same-JS-context API on globalThis.SorchaXChaCha consumed by
+// indexeddb-bridge.js. All byte arguments/returns are Uint8Array; nothing
+// crosses the Blazor JSInterop boundary here (only the IndexedDB string-level
+// putCredential/getCredential do).
+//
+//   keygen(): Uint8Array(32)              — fresh content key
+//   nonce():  Uint8Array(24)              — fresh per-message nonce
+//   encrypt(key, nonce, data, aad?): Promise<Uint8Array>  — ciphertext+tag
+//   decrypt(key, nonce, ct,   aad?): Promise<Uint8Array>  — plaintext
+//
+// The noble library is lazy-loaded as an ES module on first use and memoised.
+
+(function () {
+  let _cipherPromise = null;
+
+  function loadCipher() {
+    if (!_cipherPromise) {
+      // Resolve against document.baseURI (<base href="/wallet/">) so the dynamic
+      // import works regardless of how the browser bases a classic script's import().
+      const url = new URL("js/vendor/noble-ciphers/chacha.js", document.baseURI).href;
+      _cipherPromise = import(url).then((m) => m.xchacha20poly1305);
+    }
+    return _cipherPromise;
+  }
+
+  function keygen() {
+    return crypto.getRandomValues(new Uint8Array(32));
+  }
+
+  function nonce() {
+    return crypto.getRandomValues(new Uint8Array(24));
+  }
+
+  async function encrypt(key, nonceBytes, data, aad) {
+    const xchacha = await loadCipher();
+    const aead = aad
+      ? xchacha(key, nonceBytes, aad)
+      : xchacha(key, nonceBytes);
+    return aead.encrypt(data);
+  }
+
+  async function decrypt(key, nonceBytes, ciphertext, aad) {
+    const xchacha = await loadCipher();
+    const aead = aad
+      ? xchacha(key, nonceBytes, aad)
+      : xchacha(key, nonceBytes);
+    return aead.decrypt(ciphertext);
+  }
+
+  globalThis.SorchaXChaCha = { keygen, nonce, encrypt, decrypt };
+})();


### PR DESCRIPTION
## Summary
Swaps the wallet PWA's at-rest credential encryption from AES-GCM-256 (WebCrypto) to IETF **XChaCha20-Poly1305**, the portable wire format used by the wider VC wallet ecosystem. Fulfils T056's "libsodium-bridge" slot with **@noble/ciphers** instead of libsodium-wrappers — same wire format (24-byte nonce, 16-byte tag) at ~20 KB pure JS vs ~800 KB of WASM, with no `wasm-unsafe-eval` / WASM precache complexity.

**Pre-release, so this is a clean replacement** — no migration, no `alg` discriminator, no AES-GCM read path. The credential cache is also non-authoritative (`/sync` is the source of truth), so a worst-case cache loss self-heals on next sync.

## What's in
- **Vendored `@noble/ciphers@1.2.1`** ESM dependency closure for `xchacha20poly1305` (`chacha` + `_arx` + `_poly1305` + `utils` + `_assert`, 5 files, ~40 KB) under `wwwroot/js/vendor/noble-ciphers/`. Pinned, MIT, no build step — relative ESM imports resolve natively in-browser. `LICENSE.md` documents attribution + upgrade path.
- **New `wwwroot/js/xchacha-bridge.js`** — `globalThis.SorchaXChaCha` with `keygen` / `nonce` / `encrypt` / `decrypt`. noble lazy-loaded on first use, so the bytes only download when the wallet first touches the cache.
- **`indexeddb-bridge.js`** — content key is now a 32-byte raw value (XChaCha20 needs raw key material; the old AES-GCM `CryptoKey` was non-extractable); `encrypt`/`decrypt` route through the bridge with a 24-byte nonce.
- C# doc-comment updates on `IndexedDbCredentialCache` / `InMemoryCredentialCache`.

## Drive-by fix
Fixes a **latent dynamic-`import()` base-resolution bug shared by the qr-scanner bridge (#796)**: a classic `<script>`'s `import()` base is browser-ambiguous, and with `<base href="/wallet/">` the `./vendor/...` specifier could resolve to `/wallet/vendor/...` instead of the served `/wallet/js/vendor/...`. Both bridges now resolve vendored module + worker paths explicitly against `document.baseURI`. **Without this, the QR scanner from #796 may 404 its library at runtime on the gateway-mounted path** — worth verifying together.

## What's out
- JS-level round-trip test — no JS test runner is wired for the PWA bridges yet; noble's `xchacha20poly1305` is itself audited + extensively tested upstream.

## Test plan
- [ ] Build green: `dotnet build src/Apps/Sorcha.Wallet.Pwa` (0 errors)
- [ ] Fresh wallet on the gateway-mounted `/wallet/` path: enrol → credentials sync → reload → credentials still readable (round-trips through XChaCha20)
- [ ] Confirm `/wallet/js/vendor/noble-ciphers/chacha.js` loads (200, not 404) in the network tab
- [ ] Confirm the QR scanner library (#796) also loads from `/wallet/js/vendor/qr-scanner/...` after the base-resolution fix
- [ ] Inspect IndexedDB: `credentials` rows carry base64url nonce (24-byte) + ciphertext; `device` store has a 32-byte `content-key/v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)