### PR TITLE
feat(spec5): resolve verifier (council org) DID for OID4VP client_id

### DIFF
--- a/docs/superpowers/specs/2026-05-20-spec-5-verifier-did-resolution-design.md
+++ b/docs/superpowers/specs/2026-05-20-spec-5-verifier-did-resolution-design.md
@@ -1,0 +1,112 @@
+# Spec 5 — Verifier-DID Resolution
+
+**Date:** 2026-05-20
+**Arc:** Strathcarron citizen arc (umbrella: `2026-05-13-strathcarron-citizen-arc.md`)
+**Builds on:** F127 (Spec 4, credential-gated second service), F120 (production issuer signature verification + DID resolver), F111 (timebound presentation lifecycle)
+**Status:** Scope A (this doc). Scope B (signed request objects) deferred — see §6.
+
+## Problem
+
+`SorchaWalletPresentationConsumer.BuildInitiationAsync` (F127) emits the OID4VP
+authorization request with a placeholder verifier identity:
+
+```
+openid4vp://?client_id=did:sorcha:org:UNKNOWN&response_type=vp_token&nonce=...&request_id=...
+```
+
+`client_id` is the verifier identity — the party requesting the presentation. For
+the F127 council-page credential gate that's the council operating the page. The
+hardcoded `UNKNOWN` means the citizen's wallet cannot display *who* is asking for
+their credential. F127 deferred the real resolution to "Spec 5".
+
+This mirrors the issuer side: F120 made the credential **issuer's** DID resolve;
+this makes the **verifier's** DID resolve. Both sides of the trust handshake then
+carry real, resolvable identities. (#795 wired F120's DID resolver into Blueprint
+Service, so the same resolver path the verifier engine uses can resolve the
+verifier DID too.)
+
+## Scope (this doc)
+
+Populate `client_id` with the council's real organisation DID
+(`did:sorcha:org:{walletAddress}`), resolved from the published blueprint's
+owning organisation. The OID4VP request stays **unsigned** — `client_id` is a
+**display identity** the wallet shows to the citizen ("Strathcarron Council is
+requesting your Assured Identity credential"), not yet a cryptographically
+verified claim.
+
+## Identity source — publishing org DID
+
+The verifier is the organisation that published the blueprint and operates the
+council page: `blueprint.OrganizationId` (a GUID). Tenant Service publishes that
+org's W3C DID document on the org's first credential issuance (F120 US2), reachable
+at `GET /orgs/{orgId}/did.json`; the document's top-level `id` is the canonical
+`did:sorcha:org:{walletAddress}`.
+
+**Why the org DID, not a participant wallet:** the org DID is the identifier that
+already resolves (via the F120 resolver) to the org's **published signing keys**.
+When Scope B adds signed request objects, the wallet verifies the request against
+exactly this DID with no rework. A blueprint-participant wallet (e.g.
+`licensing-officer`) is locally available on the instance but may have no published
+DID document with keys — choosing it would be a false economy that Scope B would
+rip out.
+
+## Mechanism
+
+```
+PresentationLifecycleService.InitiateAsync  (has the blueprint in hand)
+  └─ resolve blueprint.OrganizationId → did:sorcha:org:{addr}
+       via IOrgDidDocumentClient.ResolveCanonicalDidAsync (GET /orgs/{id}/did.json, read .id)
+  └─ pass result as PresentationInitiationContext.VerifierClientId
+       └─ SorchaWalletPresentationConsumer.BuildInitiationAsync
+            client_id = context.VerifierClientId ?? "did:sorcha:org:UNKNOWN"
+```
+
+The lifecycle service owns resolution (it has the blueprint); the consumer stays a
+pure adapter that consumes a thin context. This matches the existing
+`PresentationInitiationContext` contract ("only fields the consumer needs").
+
+## Graceful degradation
+
+Resolution is **best-effort** and never fails the gate:
+
+- `blueprint.OrganizationId` null (unpublished / legacy) → `VerifierClientId` null
+- org has never issued a credential, so no DID doc published → Tenant returns 404 → null
+- transport / parse failure → null
+
+In every null case the consumer falls back to the existing `did:sorcha:org:UNKNOWN`
+placeholder. The gate's actual job — verifying the citizen's presented credential —
+is unaffected; only the displayed verifier identity degrades. The Strathcarron
+council has issued the AssuredIdentity credential, so its DID doc exists and the
+happy path resolves.
+
+## Forward-compatibility with Scope B
+
+Scope B (deferred): sign the OID4VP request object as a JWT with the council's
+signing key, serve it via a `request_uri`, and have the wallet resolve `client_id`
++ verify the request signature (mutual auth). Scope A is a clean stepping stone —
+the `client_id` it populates becomes the DID the wallet resolves in Scope B, and
+that DID already resolves to the org's published signing keys via F120. Scope B is
+purely additive (signing step + request_uri endpoint + wallet-side verification);
+nothing in Scope A is rework.
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `Sorcha.ServiceClients.Http/OrgDidDocument/IOrgDidDocumentClient.cs` | `+ ResolveCanonicalDidAsync(Guid orgId, ct)` |
+| `Sorcha.ServiceClients.Http/OrgDidDocument/OrgDidDocumentClient.cs` | GET `/orgs/{id}/did.json`, parse `id`, null on 404/error |
+| `Sorcha.Blueprint.Service/Program.cs` | register `IOrgDidDocumentClient` against Tenant base address |
+| `Sorcha.PresentationLifecycle.Abstractions/PresentationInitiationContext.cs` | `+ string? VerifierClientId` |
+| `Sorcha.Blueprint.Service/.../PresentationLifecycleService.cs` | resolve org DID in non-HAIP branch, populate context |
+| `Sorcha.Blueprint.Service/.../SorchaWalletPresentationConsumer.cs` | `client_id = VerifierClientId ?? UNKNOWN`; drop `TODO(T032)` |
+
+## Testing
+
+- Consumer: `BuildInitiationAsync` puts `VerifierClientId` into `client_id`; falls back to `UNKNOWN` when null.
+- Client: `ResolveCanonicalDidAsync` → parsed `id` on 200; `null` on 404.
+
+## Non-goals
+
+- Scope B (signed request objects / mutual auth).
+- Verifier-DID resolution for the HAIP consumer (HAIP keeps its own external request flow).
+- Any blueprint schema or authoring change.

--- a/src/Common/Sorcha.PresentationLifecycle.Abstractions/PresentationInitiationContext.cs
+++ b/src/Common/Sorcha.PresentationLifecycle.Abstractions/PresentationInitiationContext.cs
@@ -19,6 +19,12 @@ namespace Sorcha.PresentationLifecycle.Abstractions;
 /// requirements at the time of submission. Consumers can use this to detect
 /// blueprint drift between submission and callback.</param>
 /// <param name="InitiatedAt">When the attempt was recorded on the register.</param>
+/// <param name="VerifierClientId">Canonical DID of the verifier (the org operating
+/// the presentation request, e.g. the council page) — <c>did:sorcha:org:{walletAddress}</c>.
+/// Resolved by the lifecycle service from the blueprint's owning organisation (Spec 5).
+/// Null when the org has no published DID document or resolution fails; consumers
+/// fall back to a placeholder. Used as the OID4VP <c>client_id</c> (display identity
+/// in the current unsigned-request flow).</param>
 public sealed record PresentationInitiationContext(
     Guid PresentationRequestId,
     Guid InstanceId,
@@ -27,4 +33,5 @@ public sealed record PresentationInitiationContext(
     string BlueprintId,
     string SubmitterWallet,
     byte[] RequirementsDigest,
-    DateTimeOffset InitiatedAt);
+    DateTimeOffset InitiatedAt,
+    string? VerifierClientId = null);

--- a/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/IOrgDidDocumentClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/IOrgDidDocumentClient.cs
@@ -16,4 +16,20 @@ public interface IOrgDidDocumentClient
     /// projection that can be lazily rebuilt later).
     /// </summary>
     Task RegenerateAsync(OrgDidRegenerateRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves an organisation's canonical DID by fetching its published W3C DID
+    /// document (<c>GET /orgs/{orgId}/did.json</c>) and reading the document's
+    /// <c>id</c> — the canonical <c>did:sorcha:org:{walletAddress}</c> identifier
+    /// (Spec 5, verifier-DID resolution).
+    /// </summary>
+    /// <param name="orgId">The organisation whose canonical DID to resolve.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// The canonical <c>did:sorcha:org:*</c> string, or <c>null</c> when the org has
+    /// no published document (404 — never issued a credential), or on transport /
+    /// parse failure. Best-effort: this method never throws, so callers can use the
+    /// result as a display identity with a safe fallback.
+    /// </returns>
+    Task<string?> ResolveCanonicalDidAsync(Guid orgId, CancellationToken ct = default);
 }

--- a/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/OrgDidDocumentClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/OrgDidDocument/OrgDidDocumentClient.cs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Sorcha.ServiceClients.OrgDidDocument;
@@ -45,6 +47,43 @@ public sealed class OrgDidDocumentClient : IOrgDidDocumentClient
             _logger.LogWarning(ex,
                 "OrgDidDocument regenerate failed for org {OrgId} reason {Reason}; lazy rebuild will recover",
                 request.OrganizationId, request.KeyEventReason);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> ResolveCanonicalDidAsync(Guid orgId, CancellationToken ct = default)
+    {
+        try
+        {
+            using var resp = await _http.GetAsync($"/orgs/{orgId}/did.json", ct).ConfigureAwait(false);
+            if (resp.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Org has no published DID document — never issued a credential.
+                return null;
+            }
+            if (!resp.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Org DID resolve returned {Status} for org {OrgId}", resp.StatusCode, orgId);
+                return null;
+            }
+
+            await using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+            if (doc.RootElement.TryGetProperty("id", out var idEl)
+                && idEl.ValueKind == JsonValueKind.String)
+            {
+                var did = idEl.GetString();
+                return string.IsNullOrWhiteSpace(did) ? null : did;
+            }
+
+            _logger.LogWarning("Org DID document for {OrgId} had no string 'id' field", orgId);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Org DID resolve failed for org {OrgId}", orgId);
+            return null;
         }
     }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -271,6 +271,19 @@ builder.Services.AddSingleton<Sorcha.Verifier.Engine.IVerifiablePresentationVali
 builder.Services.AddSingleton<Sorcha.PresentationLifecycle.Abstractions.IPresentationConsumer,
     Sorcha.Blueprint.Service.Services.Implementation.SorchaWalletPresentationConsumer>();
 
+// Spec 5 — verifier-DID resolution. The lifecycle service resolves the council
+// org's canonical DID (blueprint.OrganizationId → GET /orgs/{id}/did.json) so the
+// OID4VP client_id carries a real verifier identity instead of did:sorcha:org:UNKNOWN.
+// Same Tenant base-address pattern as Wallet Service's F120 registration.
+builder.Services.AddHttpClient<Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient,
+    Sorcha.ServiceClients.OrgDidDocument.OrgDidDocumentClient>(client =>
+    {
+        client.BaseAddress = new Uri(
+            builder.Configuration["ServiceClients:TenantService:Address"]
+            ?? builder.Configuration["ServiceClients:Tenant:BaseAddress"]
+            ?? "http://tenant-service:8080");
+    });
+
 // Feature 127 — single-use ClaimsFetchToken store. Minted by InitiateAsync
 // (for Sorcha-wallet only); consumed atomically by the disclosed-claims
 // endpoint. Backed by Redis via the existing IConnectionMultiplexer the

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs
@@ -62,6 +62,7 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
     private readonly PresentationLifecycleMetrics? _metrics;
     private readonly IClock _clock;
     private readonly IServiceProvider? _serviceProvider;
+    private readonly Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient? _orgDidClient;
     private readonly ILogger<PresentationLifecycleService> _logger;
 
     /// <summary>Constructor — DI-friendly.</summary>
@@ -81,7 +82,8 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
         IPresentationSealCoordinator? sealCoordinator = null,
         IClaimsFetchTokenStore? claimsFetchTokenStore = null,
         IDisclosedClaimsStore? disclosedClaimsStore = null,
-        IHubContext<BlueprintHub, IBlueprintHubClient>? hubContext = null)
+        IHubContext<BlueprintHub, IBlueprintHubClient>? hubContext = null,
+        Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient? orgDidClient = null)
     {
         _transactionBuilder = transactionBuilder ?? throw new ArgumentNullException(nameof(transactionBuilder));
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
@@ -99,6 +101,7 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
         _claimsFetchTokenStore = claimsFetchTokenStore;
         _disclosedClaimsStore = disclosedClaimsStore;
         _hubContext = hubContext;
+        _orgDidClient = orgDidClient;
     }
 
     public async Task<PresentationInitiationResult> InitiateAsync(
@@ -181,6 +184,26 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
                     $"No IPresentationConsumer registered with name '{consumerName}'.");
 
             var digestPreview = ComputeRequirementsDigest(credentialRequirement);
+
+            // Spec 5 — resolve the verifier (council org) DID so the consumer can
+            // emit a real client_id instead of did:sorcha:org:UNKNOWN. Best-effort:
+            // a null result (no org id, unpublished DID doc, or transport failure)
+            // leaves the consumer's placeholder fallback intact and never blocks the gate.
+            string? verifierClientId = null;
+            if (_orgDidClient is not null
+                && !string.IsNullOrWhiteSpace(blueprint.OrganizationId)
+                && Guid.TryParse(blueprint.OrganizationId, out var orgGuid))
+            {
+                verifierClientId = await _orgDidClient.ResolveCanonicalDidAsync(orgGuid, cancellationToken);
+                if (verifierClientId is null)
+                {
+                    _logger.LogDebug(
+                        "Verifier DID unresolved for org {OrgId} (blueprint {BlueprintId}); " +
+                        "consumer will use placeholder client_id.",
+                        blueprint.OrganizationId, blueprint.Id);
+                }
+            }
+
             var ctx = new PresentationInitiationContext(
                 PresentationRequestId: requestId,
                 InstanceId: Guid.Parse(instance.Id),
@@ -189,7 +212,8 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
                 BlueprintId: blueprint.Id,
                 SubmitterWallet: submitterWallet,
                 RequirementsDigest: digestPreview,
-                InitiatedAt: DateTimeOffset.UtcNow);
+                InitiatedAt: DateTimeOffset.UtcNow,
+                VerifierClientId: verifierClientId);
 
             var consumerDescriptor = await consumer.BuildInitiationAsync(ctx, cancellationToken);
             descriptor = new InitiationDescriptor(

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/SorchaWalletPresentationConsumer.cs
@@ -31,11 +31,11 @@ namespace Sorcha.Blueprint.Service.Services.Implementation;
 /// F111 "non-HAIP initiation contract" that was deferred until this feature).
 /// The descriptor carries an OID4VP <c>openid4vp://</c> request URI that the
 /// council page renders as the hybrid universal QR / tap-link affordance.</para>
-/// <para>Until the lifecycle service's dispatch path lands (F127 task T032),
-/// the verifier-session construction inside <see cref="BuildInitiationAsync"/>
-/// is deliberately scoped to context-only data; the verifier DID, presentation
-/// request URI base, and nonce derivation are finalised in T032 when
-/// <c>InitiateAsync</c> grows the per-consumer dispatch.</para>
+/// <para>The verifier <c>client_id</c> (the council org DID) is resolved by the
+/// lifecycle service from the blueprint's owning organisation and supplied via
+/// <see cref="PresentationInitiationContext.VerifierClientId"/> (Spec 5). The
+/// OID4VP request is unsigned in this flow, so <c>client_id</c> is a display
+/// identity; signed request objects (mutual auth) are a deferred follow-up.</para>
 /// </remarks>
 public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
 {
@@ -196,20 +196,20 @@ public sealed class SorchaWalletPresentationConsumer : IPresentationConsumer
         PresentationInitiationContext context,
         CancellationToken cancellationToken)
     {
-        // The lifecycle service (T032) will resolve the verifier DID + response
-        // URI base from blueprint / org metadata before dispatching here. Until
-        // that wiring lands, return a clearly-marked placeholder so the build
-        // succeeds and a contract-test can pin the call shape; the URI is not
-        // yet stable for wallet consumption.
         ArgumentNullException.ThrowIfNull(context);
         var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16))
             .TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
-        // TODO(T032): resolve client_id (council org DID), response_uri base,
-        // and presentation_definition (derived from CredentialRequirement)
-        // when the lifecycle service grows the per-consumer dispatch.
+        // Spec 5 — the lifecycle service resolves the verifier (council org) DID from
+        // the blueprint's owning organisation and supplies it as VerifierClientId.
+        // The placeholder is the explicit graceful-degradation fallback for orgs with
+        // no published DID document (never issued a credential) — it never blocks the
+        // gate. The request is unsigned in this flow, so client_id is a display
+        // identity; Scope B (signed request objects) makes it cryptographically
+        // load-bearing and resolves it against the same DID via the F120 resolver.
+        var clientId = context.VerifierClientId ?? "did:sorcha:org:UNKNOWN";
         var uri =
-            $"openid4vp://?client_id=did:sorcha:org:UNKNOWN" +
+            $"openid4vp://?client_id={Uri.EscapeDataString(clientId)}" +
             $"&response_type=vp_token" +
             $"&nonce={Uri.EscapeDataString(nonce)}" +
             $"&request_id={Uri.EscapeDataString(context.PresentationRequestId.ToString("N"))}";

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/SorchaWalletPresentationConsumerTests.cs
@@ -264,4 +264,29 @@ public sealed class SorchaWalletPresentationConsumerTests
 
         first.Nonce.Should().NotBe(second.Nonce);
     }
+
+    [Fact]
+    public async Task BuildInitiationAsync_EmitsResolvedVerifierDid_AsClientId()
+    {
+        // Spec 5 — the lifecycle service supplies the council org DID via VerifierClientId.
+        var ctx = NewContext() with { VerifierClientId = "did:sorcha:org:ws11qstrathcarron" };
+
+        var descriptor = await _sut.BuildInitiationAsync(ctx, CancellationToken.None);
+
+        descriptor.AuthorizationRequestUri.Should().Contain(
+            "client_id=" + Uri.EscapeDataString("did:sorcha:org:ws11qstrathcarron"));
+        descriptor.AuthorizationRequestUri.Should().NotContain("did:sorcha:org:UNKNOWN");
+    }
+
+    [Fact]
+    public async Task BuildInitiationAsync_FallsBackToPlaceholder_WhenVerifierDidNull()
+    {
+        // Graceful degradation — unresolved org DID never blocks the gate.
+        var ctx = NewContext() with { VerifierClientId = null };
+
+        var descriptor = await _sut.BuildInitiationAsync(ctx, CancellationToken.None);
+
+        descriptor.AuthorizationRequestUri.Should().Contain(
+            "client_id=" + Uri.EscapeDataString("did:sorcha:org:UNKNOWN"));
+    }
 }

--- a/tests/Sorcha.ServiceClients.Tests/OrgDidDocument/OrgDidDocumentClientTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/OrgDidDocument/OrgDidDocumentClientTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.ServiceClients.OrgDidDocument;
+
+namespace Sorcha.ServiceClients.Tests.OrgDidDocument;
+
+/// <summary>
+/// Tests for <see cref="OrgDidDocumentClient.ResolveCanonicalDidAsync"/> (Spec 5 —
+/// verifier-DID resolution). The client fetches the org's published W3C DID
+/// document and returns the canonical <c>id</c>, degrading to <c>null</c> on any
+/// failure so callers can use it as a best-effort display identity.
+/// </summary>
+public class OrgDidDocumentClientTests
+{
+    private static readonly Guid OrgId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    private static OrgDidDocumentClient CreateClient(StubHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("http://tenant-service:8080") },
+            NullLogger<OrgDidDocumentClient>.Instance);
+
+    [Fact]
+    public async Task ResolveCanonicalDidAsync_Returns_IdField_On200()
+    {
+        const string did = "did:sorcha:org:ws11qstrathcarron";
+        var handler = new StubHandler(HttpStatusCode.OK,
+            $$"""{"id":"{{did}}","verificationMethod":[]}""", "application/did+json");
+
+        var result = await CreateClient(handler).ResolveCanonicalDidAsync(OrgId);
+
+        result.Should().Be(did);
+        handler.LastRequestPath.Should().Be($"/orgs/{OrgId}/did.json");
+    }
+
+    [Fact]
+    public async Task ResolveCanonicalDidAsync_ReturnsNull_On404()
+    {
+        // Org has never issued a credential → no published DID document.
+        var handler = new StubHandler(HttpStatusCode.NotFound, "", "text/plain");
+
+        var result = await CreateClient(handler).ResolveCanonicalDidAsync(OrgId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveCanonicalDidAsync_ReturnsNull_WhenIdMissing()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK,
+            """{"verificationMethod":[]}""", "application/did+json");
+
+        var result = await CreateClient(handler).ResolveCanonicalDidAsync(OrgId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveCanonicalDidAsync_ReturnsNull_OnMalformedJson()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, "{not json", "application/did+json");
+
+        var result = await CreateClient(handler).ResolveCanonicalDidAsync(OrgId);
+
+        result.Should().BeNull();
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+        private readonly string _contentType;
+
+        public string? LastRequestPath { get; private set; }
+
+        public StubHandler(HttpStatusCode status, string body, string contentType)
+        {
+            _status = status;
+            _body = body;
+            _contentType = contentType;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestPath = request.RequestUri?.AbsolutePath;
+            return Task.FromResult(new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, _contentType)
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the `did:sorcha:org:UNKNOWN` placeholder in `SorchaWalletPresentationConsumer.BuildInitiationAsync` with the council's **real organisation DID**, resolved from the published blueprint's owning org. This is the mirror of F120's issuer-side resolution (#795) on the verifier side — both halves of the F127 credential-gate trust handshake now carry real, resolvable identities.

## Scope A (this PR)
Populate `client_id`. The OID4VP request stays **unsigned**, so `client_id` is a **display identity** ("Strathcarron Council is requesting your Assured Identity credential"). **Scope B** (signed request objects / mutual auth) is a deferred follow-up — this PR sets it up cleanly: the `client_id` already resolves to the org's published signing keys via the F120 resolver wired into Blueprint Service in #795, so Scope B is purely additive.

## Changes
- `IOrgDidDocumentClient.ResolveCanonicalDidAsync` — `GET /orgs/{orgId}/did.json`, read the document's canonical `id`. **Best-effort:** `null` on 404 (org never issued a credential → no published doc), parse failure, or transport error. Never throws.
- Registered the client in Blueprint Service (Tenant base address, same pattern as Wallet Service's F120 registration).
- `PresentationInitiationContext` gains optional `VerifierClientId`. The lifecycle service resolves it from `blueprint.OrganizationId` in the non-HAIP branch and passes it down; the consumer emits `context.VerifierClientId ?? "did:sorcha:org:UNKNOWN"`.

## Graceful degradation
An unresolved DID **never blocks the gate** — the gate's job (verifying the citizen's credential) is unaffected; only the displayed verifier identity falls back to the placeholder. The Strathcarron council has issued the AssuredIdentity credential, so its DID document exists and the happy path resolves.

## Tests
- 2 consumer tests: resolved DID appears in `client_id`; fallback to `UNKNOWN` when null.
- 4 client tests: 200→`id`, 404→null, missing-`id`→null, malformed→null.
- Local full Blueprint suite: 27 pre-existing WebApplicationFactory integration failures unchanged (infra-dependent, pass in CI); my 2 consumer tests add cleanly (+2 passed/total vs baseline). ServiceClients suite 212/212 green.

## Design doc
`docs/superpowers/specs/2026-05-20-spec-5-verifier-did-resolution-design.md`

## Follow-up doc note
The `sorcha-architecture` skill currently says "Verifier-DID resolution from blueprint metadata lands in Spec 5 alongside the production IIssuerKeyResolver" and that `BuildInitiationAsync` emits `did:sorcha:org:UNKNOWN`. Both are now resolved (issuer side in #795, verifier side here). Skill text should be updated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)