### PR TITLE
feat(114 US5 PR1): citizen presentation activity log (client-side)

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IActiveContextStore, IndexedDbActiveContextStore>();
         services.AddSingleton<IPerContextPersonaCache, IndexedDbPerContextPersonaCache>();
         services.AddSingleton<IVerificationHistoryStore, IndexedDbVerificationHistoryStore>();
+        services.AddSingleton<IPresentationLog, IndexedDbPresentationLog>();
 
         // Feature 125 / PR-C — doorstep verification (US1). EphemeralVerifierIdentity
         // generates a fresh EC P-256 key per session via webcrypto-bridge.js;

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Activity.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Activity.razor
@@ -2,23 +2,28 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Activity page (Feature 125, T086). Renders the TransactionHistoryFeed
-    component from the shared library — v1 sources entries from the
-    per-device IVerificationHistoryStore so doorstep verifications the
-    user has performed (PR-C) appear here scoped to the active context.
+    Activity page (Feature 125, T086; extended Feature 114 US5). Renders the
+    TransactionHistoryFeed component from the shared library, merging two
+    per-device sources chronologically:
+      - IVerificationHistoryStore — verifications the user PERFORMED (F125),
+        scoped to the active context.
+      - IPresentationLog — presentations the user MADE (F114 US5).
 
-    Future PRs feed in real issuance / presentation / submission /
-    revocation events via IUserHistoryClient against a server-side
-    history endpoint.
+    Presentation entries are tappable to delete (local-only; platform records
+    are unaffected). Future PRs feed in real issuance / submission / revocation
+    events via a server-side history endpoint.
 *@
 @page "/activity"
 @layout MainLayout
+@using MudBlazor
 @using Sorcha.UI.Components.User.Components.History
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Context
 @implements IAsyncDisposable
 @inject IVerificationHistoryStore VerificationHistory
+@inject IPresentationLog PresentationLog
 @inject IUserContext UserContext
+@inject IDialogService DialogService
 @inject NavigationManager Nav
 
 <PageTitle>Activity · Sorcha Wallet</PageTitle>
@@ -36,6 +41,8 @@
 </MudContainer>
 
 @code {
+    private const string PresentationIdPrefix = "pres:";
+
     private IReadOnlyList<TransactionHistoryFeed.HistoryFeedEntry>? _entries;
     private bool _loading = true;
 
@@ -50,20 +57,42 @@
         _loading = true;
         try
         {
-            var records = await VerificationHistory.ListByContextAsync(UserContext.ActiveContextOrgId);
-            _entries = records
-                .Select(r => new TransactionHistoryFeed.HistoryFeedEntry(
+            var verifications = await VerificationHistory.ListByContextAsync(UserContext.ActiveContextOrgId);
+            var presentations = await PresentationLog.ListAsync();
+
+            var verificationEntries = verifications.Select(r =>
+                new TransactionHistoryFeed.HistoryFeedEntry(
                     Id: r.Id.ToString("N"),
                     Kind: TransactionHistoryFeed.HistoryFeedKind.Verification,
                     Title: $"Verified {r.HolderDisplayName}",
                     Subtitle: $"{r.IssuerOrgName} · {r.CredentialType} · {r.Outcome}",
-                    At: r.VerifiedAt))
+                    At: r.VerifiedAt));
+
+            var presentationEntries = presentations.Select(p =>
+                new TransactionHistoryFeed.HistoryFeedEntry(
+                    Id: PresentationIdPrefix + p.Id.ToString("N"),
+                    Kind: TransactionHistoryFeed.HistoryFeedKind.Presentation,
+                    Title: $"Presented {p.CredentialLabel ?? p.CredentialType}",
+                    Subtitle: BuildPresentationSubtitle(p),
+                    At: p.PresentedAt));
+
+            _entries = verificationEntries
+                .Concat(presentationEntries)
+                .OrderByDescending(e => e.At)
                 .ToList();
         }
         finally
         {
             _loading = false;
         }
+    }
+
+    private static string BuildPresentationSubtitle(PresentationLogEntry p)
+    {
+        var claimCount = p.DisclosedClaims.Count;
+        var claimText = claimCount == 1 ? "1 claim" : $"{claimCount} claims";
+        var outcomeText = p.Outcome == PresentationLogOutcome.Sent ? "Sent" : "Rejected";
+        return $"{p.VerifierLabel} · {claimText} · {outcomeText}";
     }
 
     private async Task HandleContextChangedAsync(UserContextChangedEventArgs args)
@@ -75,11 +104,26 @@
         });
     }
 
-    private Task HandleEntryAsync(string entryId)
+    private async Task HandleEntryAsync(string entryId)
     {
-        // Future: navigate to a per-entry detail drawer / page that
-        // re-renders the trust panel from VerificationRecord.TrustPanelJson.
-        return Task.CompletedTask;
+        // Only presentation entries are deletable here — they're the citizen's
+        // own local log. Verification entries (F125) tap into their own detail
+        // surface in a future PR.
+        if (!entryId.StartsWith(PresentationIdPrefix, StringComparison.Ordinal)) return;
+        if (!Guid.TryParseExact(entryId[PresentationIdPrefix.Length..], "N", out var id)) return;
+
+        var confirmed = await DialogService.ShowMessageBoxAsync(
+            "Remove from activity?",
+            "This only removes the entry from this device. It does not affect any "
+                + "official record of the presentation, or the credential itself.",
+            yesText: "Remove", cancelText: "Cancel");
+
+        if (confirmed == true)
+        {
+            await PresentationLog.DeleteAsync(id);
+            await LoadAsync();
+            StateHasChanged();
+        }
     }
 
     /// <inheritdoc />

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
@@ -25,6 +25,7 @@
 @inject IStatusListService StatusList
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject IPresentationLog PresentationLog
 
 <PageTitle>Present a credential</PageTitle>
 
@@ -187,10 +188,38 @@
                 _responseStatus = "fail";
                 _responseMessage = $"Verifier returned {(int)resp.StatusCode} {resp.StatusCode}.";
             }
+
+            // US5 — record the presentation in the local activity log. Best-effort:
+            // a logging failure must not change the presentation outcome the user sees.
+            await TryLogPresentationAsync(approved, resp.IsSuccessStatusCode);
+
             _phase = Phase.Done;
         }
         catch (Exception ex) { _error = ex.Message; }
         finally { _busy = false; }
+    }
+
+    private async Task TryLogPresentationAsync(IReadOnlyList<string> disclosedClaims, bool accepted)
+    {
+        if (_selected is null || _request is null) return;
+        try
+        {
+            var entry = new PresentationLogEntry(
+                Id: Guid.NewGuid(),
+                PresentedAt: DateTimeOffset.UtcNow,
+                CredentialType: _selected.Credential.Vct,
+                CredentialLabel: _selected.Credential.DisplayLabel,
+                VerifierLabel: string.IsNullOrWhiteSpace(_request.Purpose)
+                    ? _request.ClientId
+                    : _request.Purpose!,
+                DisclosedClaims: disclosedClaims,
+                Outcome: accepted ? PresentationLogOutcome.Sent : PresentationLogOutcome.Rejected);
+            await PresentationLog.AppendAsync(entry);
+        }
+        catch
+        {
+            // Activity log is a convenience surface; never let it break the flow.
+        }
     }
 
     private void Reset()

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IPresentationLog.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IPresentationLog.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Per-device log of presentations the citizen has made — credentials they
+/// showed to a verifier (Feature 114 US5). The inverse of
+/// <see cref="IVerificationHistoryStore"/> (which records verifications the
+/// citizen <i>performed</i> as a verifier). Surfaced chronologically on the
+/// Activity page.
+/// </summary>
+/// <remarks>
+/// Client-side only in this PR — a private notebook on the device. Entries
+/// carry disclosed claim <i>names</i> only (never values) plus the verifier
+/// label and timestamp. Server-side forwarding (so the platform writes the
+/// F111 lifecycle record) lands in a follow-up PR; <see cref="PresentationLogEntry.SyncedToServer"/>
+/// is the seam for it. Clearing site data wipes the log — matching the
+/// verification-history precedent.
+/// </remarks>
+public interface IPresentationLog
+{
+    /// <summary>Append a presentation entry.</summary>
+    Task AppendAsync(PresentationLogEntry entry, CancellationToken ct = default);
+
+    /// <summary>List entries, newest first.</summary>
+    Task<IReadOnlyList<PresentationLogEntry>> ListAsync(CancellationToken ct = default);
+
+    /// <summary>Delete a single entry by id. Idempotent.</summary>
+    Task DeleteAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>Wipe the log (e.g. on sign-out).</summary>
+    Task ClearAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// One presentation the citizen made, persisted in IndexedDB store
+/// <c>presentationLog</c> (keyPath <c>id</c>).
+/// </summary>
+/// <param name="Id">Client-generated GUID — primary key.</param>
+/// <param name="PresentedAt">UTC time the presentation was sent.</param>
+/// <param name="CredentialType">Credential VCT presented (e.g. <c>AssuredIdentityCredential/v1</c>).</param>
+/// <param name="CredentialLabel">Issuer-supplied display label, if any.</param>
+/// <param name="VerifierLabel">Human-readable verifier identity — the request purpose, falling back to the OID4VP client_id.</param>
+/// <param name="DisclosedClaims">Names of the claims disclosed (never values).</param>
+/// <param name="Outcome">Wallet-observed outcome of the presentation.</param>
+/// <param name="SyncedToServer">True once forwarded to the platform lifecycle record (follow-up PR). Always false in this PR.</param>
+public sealed record PresentationLogEntry(
+    Guid Id,
+    DateTimeOffset PresentedAt,
+    string CredentialType,
+    string? CredentialLabel,
+    string VerifierLabel,
+    IReadOnlyList<string> DisclosedClaims,
+    PresentationLogOutcome Outcome,
+    bool SyncedToServer = false);
+
+/// <summary>Wallet-observed outcome of a presentation.</summary>
+public enum PresentationLogOutcome
+{
+    /// <summary>Verifier accepted the posted presentation (2xx from response_uri).</summary>
+    Sent = 0,
+
+    /// <summary>Verifier rejected or returned a non-success status.</summary>
+    Rejected = 1,
+}
+
+/// <summary>In-memory <see cref="IPresentationLog"/> for tests.</summary>
+public sealed class InMemoryPresentationLog : IPresentationLog
+{
+    private readonly List<PresentationLogEntry> _entries = new();
+
+    /// <inheritdoc />
+    public Task AppendAsync(PresentationLogEntry entry, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        _entries.Add(entry);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<PresentationLogEntry>> ListAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<PresentationLogEntry>>(
+            _entries.OrderByDescending(e => e.PresentedAt).ToList());
+
+    /// <inheritdoc />
+    public Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        _entries.RemoveAll(e => e.Id == id);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task ClearAsync(CancellationToken ct = default)
+    {
+        _entries.Clear();
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>IndexedDB-backed <see cref="IPresentationLog"/>.</summary>
+public sealed class IndexedDbPresentationLog : IPresentationLog
+{
+    private const string StoreName = "presentationLog";
+
+    private readonly IJSRuntime _js;
+
+    /// <summary>Initialise a new instance.</summary>
+    public IndexedDbPresentationLog(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public async Task AppendAsync(PresentationLogEntry entry, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        // Store uses keyPath "id"; pass the record alone — IndexedDB extracts the key.
+        await _js.InvokeVoidAsync("SorchaIndexedDb.put", ct, StoreName, entry);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<PresentationLogEntry>> ListAsync(CancellationToken ct = default)
+    {
+        var all = await _js.InvokeAsync<PresentationLogEntry[]?>("SorchaIndexedDb.getAll", ct, StoreName);
+        if (all is null || all.Length == 0) return Array.Empty<PresentationLogEntry>();
+        return all.OrderByDescending(e => e.PresentedAt).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+        => await _js.InvokeVoidAsync("SorchaIndexedDb.del", ct, StoreName, id.ToString());
+
+    /// <inheritdoc />
+    public async Task ClearAsync(CancellationToken ct = default)
+        => await _js.InvokeVoidAsync("SorchaIndexedDb.clear", ct, StoreName);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
@@ -13,6 +13,8 @@
 //     context       — singleton, key='active'    — active org context (per-device)
 //     verifications — keyed by id (GUID)         — verification history records
 //     personas      — keyed by contextKey string — per-context persona cache
+//   v3 additions (Feature 114 US5 — activity log):
+//     presentationLog — keyed by id (GUID)       — presentations the citizen has made
 //
 // Content-key strategy (Feature 114 T056): a 32-byte XChaCha20-Poly1305 content
 // key is generated on first run and stored as raw bytes in the `device` store.
@@ -34,7 +36,7 @@
   }
 
   const DB_NAME = "sorcha-wallet";
-  const DB_VERSION = 2;
+  const DB_VERSION = 3;
   const CONTENT_KEY_ID = "content-key/v1";
 
   let dbPromise = null;
@@ -54,6 +56,8 @@
         if (!db.objectStoreNames.contains("context")) db.createObjectStore("context");
         if (!db.objectStoreNames.contains("verifications")) db.createObjectStore("verifications", { keyPath: "id" });
         if (!db.objectStoreNames.contains("personas")) db.createObjectStore("personas");
+        // v3 (Feature 114 US5) — citizen's own presentation activity log.
+        if (!db.objectStoreNames.contains("presentationLog")) db.createObjectStore("presentationLog", { keyPath: "id" });
       };
       req.onsuccess = () => resolve(req.result);
       req.onerror = () => reject(req.error);

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/PresentationLogTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/PresentationLogTests.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Tests for the citizen presentation activity log (Feature 114 US5).
+/// Exercises the in-memory store's append / newest-first ordering / delete
+/// semantics — the same contract the IndexedDB-backed store fulfils.
+/// </summary>
+public sealed class PresentationLogTests
+{
+    private static PresentationLogEntry Entry(string vct, DateTimeOffset at, params string[] claims) =>
+        new(
+            Id: Guid.NewGuid(),
+            PresentedAt: at,
+            CredentialType: vct,
+            CredentialLabel: null,
+            VerifierLabel: "Strathcarron Council",
+            DisclosedClaims: claims,
+            Outcome: PresentationLogOutcome.Sent);
+
+    [Fact]
+    public async Task Append_Then_List_ReturnsNewestFirst()
+    {
+        var log = new InMemoryPresentationLog();
+        var older = Entry("AssuredIdentityCredential/v1", DateTimeOffset.UtcNow.AddMinutes(-10), "givenName");
+        var newer = Entry("BlueBadgeCredential/v1", DateTimeOffset.UtcNow, "familyName", "dateOfBirth");
+
+        await log.AppendAsync(older);
+        await log.AppendAsync(newer);
+
+        var list = await log.ListAsync();
+
+        list.Should().HaveCount(2);
+        list[0].Id.Should().Be(newer.Id, "entries list newest-first");
+        list[1].Id.Should().Be(older.Id);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesOnlyTheTargetEntry()
+    {
+        var log = new InMemoryPresentationLog();
+        var keep = Entry("A/v1", DateTimeOffset.UtcNow.AddMinutes(-5), "x");
+        var drop = Entry("B/v1", DateTimeOffset.UtcNow, "y");
+        await log.AppendAsync(keep);
+        await log.AppendAsync(drop);
+
+        await log.DeleteAsync(drop.Id);
+
+        var list = await log.ListAsync();
+        list.Should().ContainSingle().Which.Id.Should().Be(keep.Id);
+    }
+
+    [Fact]
+    public async Task Delete_UnknownId_IsNoOp()
+    {
+        var log = new InMemoryPresentationLog();
+        await log.AppendAsync(Entry("A/v1", DateTimeOffset.UtcNow, "x"));
+
+        await log.DeleteAsync(Guid.NewGuid());
+
+        (await log.ListAsync()).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Clear_EmptiesTheLog()
+    {
+        var log = new InMemoryPresentationLog();
+        await log.AppendAsync(Entry("A/v1", DateTimeOffset.UtcNow, "x"));
+        await log.AppendAsync(Entry("B/v1", DateTimeOffset.UtcNow, "y"));
+
+        await log.ClearAsync();
+
+        (await log.ListAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Entry_DefaultsToNotSyncedToServer()
+    {
+        var log = new InMemoryPresentationLog();
+        var entry = Entry("A/v1", DateTimeOffset.UtcNow, "x");
+        await log.AppendAsync(entry);
+
+        var stored = (await log.ListAsync())[0];
+
+        stored.SyncedToServer.Should().BeFalse("server forwarding is a follow-up PR");
+    }
+}


### PR DESCRIPTION
## Summary
First slice of US5 (activity log). Records presentations the citizen **made** — the inverse of F125's verification history (verifications they *performed*) — and surfaces both, merged chronologically, on the existing Activity page via F125's `TransactionHistoryFeed` (the `Presentation` kind already existed). **Client-only; no server changes.**

## Changes
- New IndexedDB store `presentationLog` (keyPath `id`, DB v2→v3 bump; not live, so no migration). Entries are a private per-device notebook like F125's verifications — they carry disclosed claim **names only** (never values) + verifier label + timestamp.
- `IPresentationLog` + `IndexedDbPresentationLog` + `InMemoryPresentationLog` + `PresentationLogEntry` (with a `SyncedToServer` seam for the forwarding PR).
- `Present.razor` appends an entry after each presentation — best-effort, so a logging failure never changes the outcome the user sees.
- `Activity.razor` merges presentation + verification entries newest-first; presentation rows are tappable to delete with explicit "this only removes it from this device; no official record is affected" messaging (FR-031 / US5 acceptance scenario 3).

## Follow-ups (separate PRs)
- **PR 2** — Wallet Service `POST /api/v1/wallet/presentations/log` + reporter + Redis dedupe + `ISyncService` drain.
- **PR 3** — Blueprint offline lifecycle consumer. **Needs a design pass first** to reconcile the 2026-04-26 offline contract with the shipped F127 model (consumers no longer write the register; the offline path has no server-side `InitiateAsync`).

## Tests
- 5 new in-memory-store tests (append/newest-first, delete-target-only, delete-unknown-noop, clear, not-synced-default).
- **127/127 PWA tests pass.**

## Test plan
- [ ] Build green: `dotnet build src/Apps/Sorcha.Wallet.Pwa` (0 errors)
- [ ] Present a credential to a verifier → entry appears on Activity (`Presented {credential}` · `{verifier} · N claims · Sent`)
- [ ] Activity merges with any F125 verification entries, newest-first
- [ ] Tap a presentation row → confirm dialog → Remove → entry gone, others intact
- [ ] Verifier rejection (non-2xx) → entry logs with `Rejected` outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)