### PR TITLE
fix(808): unblock reference verifier present-flow (routing, vct, resolver, DI)

### DIFF
--- a/src/Apps/Sorcha.Verifier/Components/Pages/Index.razor
+++ b/src/Apps/Sorcha.Verifier/Components/Pages/Index.razor
@@ -47,9 +47,11 @@
 
 @code {
     private string _purpose = "Confirm identity";
-    private string _vct = "https://sorcha.dev/vc/test/v1";
-    private string _required = "givenName";
-    private string _optional = "familyName";
+    // Defaults match the "Load demo credential" mint (DemoMintEndpoint.DemoVct) so the
+    // out-of-the-box demo presents successfully without hand-editing these fields.
+    private string _vct = "https://sorcha.dev/vc/demo-id-card/v1";
+    private string _required = "givenName,familyName";
+    private string _optional = "dateOfBirth";
     private bool _starting;
     private string? _error;
 
@@ -84,13 +86,17 @@
 
     private string ResolveBaseUri()
     {
-        // Behind the gateway the verifier sees /verify/* as its mount prefix; build the
-        // response URI relative to whatever host scanned the QR.
+        // Return the ORIGIN ONLY (scheme://host). The request builder appends the
+        // /verify gateway mount prefix itself, so this must not include it.
+        // In interactive Blazor Server, HttpContext is null during the button-click
+        // handler — the fallback must derive the origin from Nav.BaseUri's authority,
+        // NOT Nav.BaseUri directly (which carries the /verify base-href and would
+        // double the prefix → …/verify/verify/r/{id}/response → 404).
         var ctx = HttpAccessor?.HttpContext;
         if (ctx is not null)
         {
             return $"{ctx.Request.Scheme}://{ctx.Request.Host.Value}";
         }
-        return Nav.BaseUri.TrimEnd('/');
+        return new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
     }
 }

--- a/src/Apps/Sorcha.Verifier/Components/Pages/VerifierSession.razor
+++ b/src/Apps/Sorcha.Verifier/Components/Pages/VerifierSession.razor
@@ -75,7 +75,10 @@
 
         // Re-derive the QR/deep-link payload by asking the builder for the cached link
         // shape — easier than persisting the link in the session record.
-        var responseBaseUri = $"{Nav.BaseUri.TrimEnd('/')}";
+        // ORIGIN ONLY — the /verify gateway mount prefix is appended by
+        // ReconstructDeepLink. Nav.BaseUri includes the /verify base-href, so using it
+        // directly would double the prefix (…/verify/verify/r/{id}/response → 404).
+        var responseBaseUri = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
         // Reconstruct deep-link fragments from the existing session — avoids creating a new one.
         _deepLink = ReconstructDeepLink(_session, responseBaseUri);
         _qrDataUrl = Qr.RenderDataUrl(_deepLink);
@@ -87,23 +90,17 @@
 
     private async Task PollAsync(CancellationToken ct)
     {
-        var http = HttpFactory.CreateClient();
-        http.BaseAddress = new Uri(Nav.BaseUri);
+        // Read the in-memory session store directly rather than HTTP-polling our own
+        // /status endpoint. The wallet's response POST updates the same singleton store,
+        // so this sees the outcome immediately — and it avoids a server-side fetch to the
+        // public gateway URL (https://localhost), which is unreachable from inside the
+        // verifier container (localhost:443 → connection refused). Issue #808.
         while (!ct.IsCancellationRequested)
         {
-            try
+            if (Store.Get(SessionId)?.Outcome is not null)
             {
-                var status = await http.GetFromJsonAsync<SessionStatusResponse>(
-                    $"r/{SessionId}/status", ct);
-                if (status is not null && status.Status != "pending")
-                {
-                    await InvokeAsync(() => Nav.NavigateTo($"s/{SessionId}/outcome"));
-                    return;
-                }
-            }
-            catch
-            {
-                // network blip — keep polling
+                await InvokeAsync(() => Nav.NavigateTo($"s/{SessionId}/outcome"));
+                return;
             }
             try { await Task.Delay(TimeSpan.FromSeconds(2), ct); }
             catch (TaskCanceledException) { return; }

--- a/src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs
@@ -32,28 +32,53 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IVerifierSessionStore, InMemoryVerifierSessionStore>();
         services.AddSingleton<IPresentationRequestBuilder, PresentationRequestBuilder>();
 
-        // Feature 120 — DID resolver infrastructure (cache, OTel meter, registry resolvers).
-        services.AddDidResolvers(configuration);
-
-        // Feature 120 US1 — production issuer key resolver. Composite tries DID-backed first
-        // then falls back to the JWK registry (empty in production; demo-mint populates it
-        // in dev). DID-resolver path enforces the FR-003 failure-mode classification; the
-        // registry tier exists only to keep dev/demo flows working without loosening
-        // production behaviour.
+        // Feature 120 US1 — issuer key resolution. The JWK registry tier always exists
+        // (demo-mint populates it; empty in production). The DID-backed tier verifies
+        // real did:sorcha:org credentials but its dependency graph
+        // (IDidResolverRegistry → SorchaDidResolver → IWalletServiceClient → ServiceAuthClient)
+        // needs an authenticated service principal. A standalone reference/demo verifier
+        // has no principal, so wiring the DID-backed tier unconditionally crashed the
+        // response callback at DI activation (issue #808): first "SorchaDidResolver has no
+        // constructable ctor" (IWalletServiceClient unregistered), then once the client
+        // graph was added, "ServiceAuth:ClientId not configured" from ServiceAuthClient.
+        //
+        // So the DID-backed tier is wired ONLY when a service principal is configured.
+        // Without one, issuer signatures verify via the JWK registry alone — which is all
+        // the demo (did:sorcha:org:demo, a non-resolvable fake) ever needed.
+        //
+        // SCOPED, not Singleton: the DID resolver registry + SorchaDidResolver +
+        // IWalletServiceClient are scoped, so a singleton resolver would be a captive
+        // dependency. The JWK registry stays a singleton — demo-mint writes to it and every
+        // request's composite reads the same instance.
         services.AddSingleton<JwkRegistryIssuerKeyResolver>();
-        services.AddSingleton<DidResolverBackedIssuerKeyResolver>();
-        services.AddSingleton<IIssuerKeyResolver>(sp => new CompositeIssuerKeyResolver(
-        [
-            sp.GetRequiredService<DidResolverBackedIssuerKeyResolver>(),
-            sp.GetRequiredService<JwkRegistryIssuerKeyResolver>()
-        ]));
+
+        var hasServicePrincipal = configuration is not null
+            && !string.IsNullOrWhiteSpace(configuration["ServiceAuth:ClientId"]);
+
+        if (hasServicePrincipal)
+        {
+            services.AddHttpServiceClients(configuration!);
+            services.AddScoped<DidResolverBackedIssuerKeyResolver>();
+            services.AddScoped<IIssuerKeyResolver>(sp => new CompositeIssuerKeyResolver(
+            [
+                sp.GetRequiredService<DidResolverBackedIssuerKeyResolver>(),
+                sp.GetRequiredService<JwkRegistryIssuerKeyResolver>()
+            ]));
+        }
+        else
+        {
+            services.AddScoped<IIssuerKeyResolver>(sp => new CompositeIssuerKeyResolver(
+            [
+                sp.GetRequiredService<JwkRegistryIssuerKeyResolver>()
+            ]));
+        }
 
         // Feature 120 T022 — production default is REQUIRED (FR-019 / D5).
         var requireIssuerSignature = configuration?
             .GetValue<bool?>("IssuerSignature:Required")
             ?? configuration?.GetValue<bool?>("Verifier:RequireIssuerSignature")
             ?? true;
-        services.AddSingleton<IVerifiablePresentationValidator>(sp =>
+        services.AddScoped<IVerifiablePresentationValidator>(sp =>
             new VerifiablePresentationValidator(
                 sp.GetRequiredService<IStatusListCache>(),
                 sp.GetRequiredService<IIssuerKeyResolver>(),

--- a/src/Common/Sorcha.Verifier.Engine/DidResolverBackedIssuerKeyResolver.cs
+++ b/src/Common/Sorcha.Verifier.Engine/DidResolverBackedIssuerKeyResolver.cs
@@ -68,7 +68,25 @@ public sealed class DidResolverBackedIssuerKeyResolver : IIssuerKeyResolver, IDi
         activity?.SetTag("verifier.issuer.iss", issuer);
         activity?.SetTag("verifier.issuer.kid", kid ?? "(null)");
 
-        var doc = await _registry.ResolveWithAlsoKnownAsAsync(issuer, ct).ConfigureAwait(false);
+        DidDocument? doc;
+        try
+        {
+            doc = await _registry.ResolveWithAlsoKnownAsAsync(issuer, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A resolution failure (network error, unreachable resolver, unresolvable
+            // demo issuer such as did:sorcha:org:demo) is a "cannot resolve" — classify
+            // it as did-unresolved and return null so a fallback resolver (e.g. the
+            // in-memory JWK registry used by demo-mint) gets its turn, rather than
+            // crashing the whole composite chain with a 500.
+            RecordOutcome(activity, "did-unresolved", "na");
+            _logger.LogWarning(ex,
+                "Issuer DID resolution threw; treating as unresolved so a fallback resolver can try: " +
+                "iss={Issuer} kid={Kid}", issuer, kid);
+            return null;
+        }
+
         if (doc is null)
         {
             RecordOutcome(activity, "did-unresolved", "na");

--- a/tests/Sorcha.Verifier.Tests/Services/DidResolverBackedIssuerKeyResolverTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/DidResolverBackedIssuerKeyResolverTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -171,6 +172,36 @@ public sealed class DidResolverBackedIssuerKeyResolverTests
         var result = await CreateResolver(registry.Object).ResolveAsync(Issuer, kid: null);
 
         result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_RegistryThrows_ReturnsNull_SoCompositeCanFallThrough()
+    {
+        // Issue #808 — a resolution failure (e.g. unreachable DID resolver / unresolvable
+        // demo issuer) must be treated as "unresolved" (null), NOT propagated as an
+        // exception. Otherwise CompositeIssuerKeyResolver crashes (500) instead of
+        // falling through to the in-memory JWK registry where demo-mint keys live.
+        var registry = new Mock<IDidResolverRegistry>();
+        registry.Setup(r => r.ResolveWithAlsoKnownAsAsync(Issuer, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Connection refused (localhost:443)"));
+
+        var result = await CreateResolver(registry.Object).ResolveAsync(Issuer, Kid);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_RegistryCancelled_PropagatesCancellation()
+    {
+        // A genuine cancellation must still surface — only non-cancellation failures
+        // are swallowed into a null return.
+        var registry = new Mock<IDidResolverRegistry>();
+        registry.Setup(r => r.ResolveWithAlsoKnownAsAsync(Issuer, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var act = async () => await CreateResolver(registry.Object).ResolveAsync(Issuer, Kid);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Four fixes to the reference verifier (`Sorcha.Verifier`) that take the citizen present-flow from an immediate **404 / 500** to **genuine VP validation**. Found while running the F114 US5 PR3 (feature 134) quickstart end-to-end against the local Docker stack. Refs #808.

| # | Bug | Fix |
|---|-----|-----|
| 1 | **404** — `response_uri` had a doubled `/verify` prefix (`…/verify/verify/r/{id}/response`): built from `Nav.BaseUri` (carries the `/verify` base-href) *and* a hardcoded `/verify`. | Both `VerifierSession.razor` and `Index.razor` now derive the **origin only** (`GetLeftPart(UriPartial.Authority)`); the single `/verify` mount is appended by the builder. |
| 2 | **vct default mismatch** — Index requested `…/vc/test/v1` but "Load demo credential" mints `…/vc/demo-id-card/v1` → "no matching credential". | Defaults now match the demo mint (vct + `givenName,familyName` / `dateOfBirth`). |
| 3 | **500** — DID-backed issuer resolver crashed at DI activation: `SorchaDidResolver` needs `IWalletServiceClient`→`ServiceAuthClient` (no service principal in a standalone verifier). | DID-backed tier wired **only when `ServiceAuth:ClientId` is configured**; otherwise issuer signatures verify via the JWK registry alone (all the demo needs). Resolver chain + validator made **Scoped** (was Singleton) to match the scoped DID registry. `DidResolverBackedIssuerKeyResolver` now treats a resolution failure as **unresolved (null)** instead of throwing, so a fallback resolver runs. |
| 4 | Verifier **self-poll** hit `https://localhost` (`:443`, unreachable in-container) so the session page never advanced to the outcome. | `PollAsync` reads `IVerifierSessionStore` directly instead of HTTP-polling its own `/status`. |

## F134 validation (the reason this surfaced)

With these fixes the genuine wallet PWA present→sync path records into the F134 store correctly — confirmed live: 6 real rows in `CitizenPresentationRecords` (claim names only, no register correlation), reported via the real `POST /presentations/log` drain. **T028 validated end-to-end through the actual UI.**

## Known remaining (next layer on #808 — not in this PR)

The demo still **declines** with *"Delegation credential signature verification failed against holder key."* This is a **demo-data consistency** issue: the demo credential is minted with the verifier's ephemeral holder key, but the wallet presents with its **enrolment** holder→device delegation (real slot-108 key) → different holder keys. Structural to the demo-mint vs enrol flows, independent of these fixes and of F134. Tracked as a follow-up on #808.

## Test plan

- [x] `tests/Sorcha.Verifier.Tests` — **32/32 green**, incl. 2 new `DidResolverBackedIssuerKeyResolver` cases (registry-throws→null fallback; cancellation still propagates).
- [x] Verifier builds clean (0 warnings, 0 errors).
- [x] Live: present-flow reaches real VP validation (no 404/500); F134 rows recorded via genuine drain.
- [ ] Full demo click-through to "accepted" — blocked on the remaining delegation/holder-key item above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)