### PR TITLE
fix(blueprint): scope DID-backed issuer-key resolver chain (startup captive dependency)

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -275,15 +275,20 @@ builder.Services.TryAddSingleton(TimeProvider.System);
 Sorcha.ServiceClients.Http.Extensions.HttpServiceCollectionExtensions
     .AddDidResolvers(builder.Services, builder.Configuration);
 
+// DidResolverBackedIssuerKeyResolver consumes the scoped IDidResolverRegistry, so it (and the
+// composite resolver + validator that depend on it) MUST be scoped — registering them as singletons
+// is a captive dependency that production DI validation (ValidateOnBuild) rejects at startup. Mirrors
+// the reference verifier's wiring (Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs, fixed in
+// #810). JwkRegistryIssuerKeyResolver holds no scoped dependency, so it stays a singleton.
 builder.Services.AddSingleton<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>();
-builder.Services.AddSingleton<Sorcha.Verifier.Engine.DidResolverBackedIssuerKeyResolver>();
-builder.Services.AddSingleton<Sorcha.Verifier.Engine.IIssuerKeyResolver>(sp =>
+builder.Services.AddScoped<Sorcha.Verifier.Engine.DidResolverBackedIssuerKeyResolver>();
+builder.Services.AddScoped<Sorcha.Verifier.Engine.IIssuerKeyResolver>(sp =>
     new Sorcha.Verifier.Engine.CompositeIssuerKeyResolver(
     [
         sp.GetRequiredService<Sorcha.Verifier.Engine.DidResolverBackedIssuerKeyResolver>(),
         sp.GetRequiredService<Sorcha.Verifier.Engine.JwkRegistryIssuerKeyResolver>()
     ]));
-builder.Services.AddSingleton<Sorcha.Verifier.Engine.IVerifiablePresentationValidator>(sp =>
+builder.Services.AddScoped<Sorcha.Verifier.Engine.IVerifiablePresentationValidator>(sp =>
     new Sorcha.Verifier.Engine.VerifiablePresentationValidator(
         sp.GetRequiredService<Sorcha.Verifier.Engine.IStatusListCache>(),
         sp.GetRequiredService<Sorcha.Verifier.Engine.IIssuerKeyResolver>(),
@@ -295,7 +300,10 @@ builder.Services.AddSingleton<Sorcha.Verifier.Engine.IVerifiablePresentationVali
 // by the citizen's Sorcha wallet via Sorcha.Verifier.Engine. The first
 // non-HAIP IPresentationConsumer, implementing the new BuildInitiationAsync
 // extension on the consumer contract.
-builder.Services.AddSingleton<Sorcha.PresentationLifecycle.Abstractions.IPresentationConsumer,
+// Scoped — it consumes the scoped IVerifiablePresentationValidator. The Scoped
+// PresentationLifecycleService resolves the IPresentationConsumer collection, so a scoped
+// consumer is valid alongside the singleton HaipPresentationConsumer above.
+builder.Services.AddScoped<Sorcha.PresentationLifecycle.Abstractions.IPresentationConsumer,
     Sorcha.Blueprint.Service.Services.Implementation.SorchaWalletPresentationConsumer>();
 
 // Spec 5 — verifier-DID resolution. The lifecycle service resolves the council


### PR DESCRIPTION
## Summary

`blueprint-service` crashes at startup with a DI captive-dependency error on a fresh production-mode boot:

> Cannot consume scoped service `Sorcha.ServiceClients.Did.IDidResolverRegistry` from singleton `Sorcha.Verifier.Engine.DidResolverBackedIssuerKeyResolver`.

`Program.cs` registered `DidResolverBackedIssuerKeyResolver`, the composite `IIssuerKeyResolver`, and `IVerifiablePresentationValidator` as **singletons**, but `DidResolverBackedIssuerKeyResolver` consumes the **scoped** `IDidResolverRegistry`. `ValidateOnBuild` (production) rejects it → the host never builds.

It was latent since #795/F120 wired this chain in; it only surfaces on a fresh production-mode start (caught by a clean n1 reset to current master). CI didn't catch it because the test host uses a different DI configuration.

## Fix

Mirror #810's reference-verifier fix (`Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs`): make the resolver chain + validator **scoped**, and `SorchaWalletPresentationConsumer` scoped (it consumes the validator). `JwkRegistryIssuerKeyResolver` stays singleton (no scoped dependency); the scoped `PresentationLifecycleService` resolves the `IPresentationConsumer` collection, so a scoped consumer is valid alongside the singleton `HaipPresentationConsumer`.

## Test Plan

- [x] `dotnet build` Blueprint.Service — 0 errors
- [x] Presentation integration tests (13) — build the real host and exercise the full consumer→validator→resolver→`IDidResolverRegistry` chain — green
- [ ] Confirmed by a clean n1 boot after redeploy (blueprint-service reaches healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)