### PR TITLE
fix(pwa): wipe all per-device data on sign-out, not just the token

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -799,6 +799,10 @@ Detailed authoring guidance lives in `.claude/skills/blueprint-builder/SKILL.md`
 
 The seam shipped in PR #434; the DID-resolver-backed production impl shipped in **Feature 120** (`DidResolverBackedIssuerKeyResolver`, resolving `did:sorcha:org:...` via the F120 DID resolver registry → published verification methods). Both the reference verifier (`Sorcha.Verifier`) and Blueprint Service (PR #795, for `SorchaWalletPresentationConsumer`) now register a `CompositeIssuerKeyResolver` that tries the DID-backed resolver first and falls back to `JwkRegistryIssuerKeyResolver`. `RequireIssuerSignature` defaults to `true` (F120 FR-019). The demo flow still uses the JWK registry — `DemoMintEndpoint` registers each freshly-generated issuer JWK on every mint so demo presentations pass full signature verification without a published DID document.
 
+### Sign-out data purge (PWA)
+
+`IAuthService.SignOutAsync` clears the access token **and** wipes every per-device IndexedDB store via `ILocalDataPurge` → `SorchaIndexedDb.wipe()` (a single transaction that enumerates `db.objectStoreNames` and clears each — future-proof against new stores). Sign-out previously cleared only the access token, leaving the next citizen on a shared device with the prior user's `credentials`, `personas`, `delegation`, `verifications`, `presentationLog`, `context`, and the `flags` record (`WelcomedAt`/`TourDismissedAt`) — a cross-user leak that also suppressed the welcome takeover + guided tour for the new user. `Pages/Settings.razor` sign-out then `forceLoad`-navigates home (`NavigateTo("", forceLoad: true)`) so singleton in-memory state (hub connection, `IHasPairedDeviceProbe` cache, `ManagedUserContext`) re-initialises clean. **Do NOT add a new per-device store and wire its own per-store clear into sign-out** — `wipe()` already covers it; the per-store approach is what caused the original bug. Regression guard: `CitizenWalletSignOutWipeTests` (E2E) + `AuthAndBearerTests.AuthService_SignOut_PurgesAllLocalData` (unit).
+
 ---
 
 ## AssuredIdentity on the PWA (Feature 124) — pending-application notice + first-credential takeover

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -106,6 +106,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IServerClockObserver, ServerClockObserver>();
         services.AddTransient<ServerClockHandler>();
 
+        // Sign-out cascade: wipes every per-device IndexedDB store so a
+        // signed-out citizen leaves no credentials, personas, history, or
+        // welcome/tour flags behind for the next user on the device.
+        services.AddSingleton<ILocalDataPurge, IndexedDbLocalDataPurge>();
+
         // Auth surface: a separate HttpClient that does NOT inject the bearer
         // token (so sign-in requests don't carry stale tokens). Still observes
         // the server clock — sign-in is a great moment to capture initial drift.

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
@@ -331,8 +331,13 @@
 
     private async Task SignOutAsync()
     {
+        // Clears the token + wipes every per-device IndexedDB store.
         await Auth.SignOutAsync();
         _signedInEmail = null;
+        // Force-reload to home (base-relative — the PWA is mounted under /wallet/)
+        // so singleton state held in memory — the hub connection, the paired-device
+        // probe cache, the active-context — is re-initialised clean for the next user.
+        Nav.NavigateTo("", forceLoad: true);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -42,7 +42,12 @@ public interface IAuthService
     Task<SignInResult> VerifyTwoFactorAsync(
         string loginToken, string email, string code, bool isBackupCode = false, CancellationToken ct = default);
 
-    /// <summary>Clears the persisted token.</summary>
+    /// <summary>
+    /// Signs the citizen out: clears the persisted token AND wipes every
+    /// per-device wallet store (credentials, personas, delegation, history,
+    /// sync cursor, active-context, welcome/tour flags) so no trace of the
+    /// signed-out citizen survives for the next user on this device.
+    /// </summary>
     Task SignOutAsync(CancellationToken ct = default);
 }
 
@@ -77,12 +82,14 @@ public sealed class AuthService : IAuthService
 {
     private readonly HttpClient _http;
     private readonly IAccessTokenStore _store;
+    private readonly ILocalDataPurge _purge;
 
     /// <summary>Initialises a new instance.</summary>
-    public AuthService(HttpClient http, IAccessTokenStore store)
+    public AuthService(HttpClient http, IAccessTokenStore store, ILocalDataPurge purge)
     {
         _http = http ?? throw new ArgumentNullException(nameof(http));
         _store = store ?? throw new ArgumentNullException(nameof(store));
+        _purge = purge ?? throw new ArgumentNullException(nameof(purge));
     }
 
     /// <inheritdoc />
@@ -177,7 +184,13 @@ public sealed class AuthService : IAuthService
     }
 
     /// <inheritdoc />
-    public Task SignOutAsync(CancellationToken ct = default) => _store.ClearAsync(ct);
+    public async Task SignOutAsync(CancellationToken ct = default)
+    {
+        // Clear the token first so the UI flips to signed-out immediately even
+        // if the wider purge throws; then wipe every per-device store.
+        await _store.ClearAsync(ct);
+        await _purge.PurgeAsync(ct);
+    }
 
     private async Task PersistAsync(string accessToken, int expiresIn, string email, CancellationToken ct)
     {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ILocalDataPurge.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ILocalDataPurge.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.JSInterop;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Wipes every per-device wallet store on sign-out. Sign-out previously cleared
+/// only the access token (<see cref="IAccessTokenStore"/>), which left a signed-out
+/// citizen's credentials, personas, delegation, presentation/verification history,
+/// sync cursor, active-context, and the welcome/guided-tour flags in IndexedDB for
+/// whoever signed in next on the same device — a cross-user data leak and the cause
+/// of the "welcome wizard won't reappear for a new user" symptom.
+/// <para>
+/// The implementation clears the whole IndexedDB database by enumerating its object
+/// stores, so any store added in future is wiped automatically — no per-store
+/// maintenance, which is precisely the fragility that caused the original bug.
+/// </para>
+/// </summary>
+public interface ILocalDataPurge
+{
+    /// <summary>Clear every per-device wallet store. Idempotent; safe when already empty.</summary>
+    Task PurgeAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Production <see cref="ILocalDataPurge"/> — delegates to the
+/// <c>SorchaIndexedDb.wipe</c> bridge function which clears every object store in
+/// the <c>sorcha-wallet</c> database in a single transaction.
+/// </summary>
+public sealed class IndexedDbLocalDataPurge : ILocalDataPurge
+{
+    private readonly IJSRuntime _js;
+
+    /// <summary>Initialises a new instance.</summary>
+    public IndexedDbLocalDataPurge(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    /// <inheritdoc />
+    public async Task PurgeAsync(CancellationToken ct = default)
+        => await _js.InvokeVoidAsync("SorchaIndexedDb.wipe", ct);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/indexeddb-bridge.js
@@ -127,6 +127,25 @@
     });
   }
 
+  // Sign-out wipe: clears EVERY object store in one transaction by enumerating
+  // db.objectStoreNames, so a store added in a future spec is wiped without any
+  // per-store maintenance. Also resets the cached content key so the next
+  // session derives a fresh one. The caller (sign-out) force-reloads the app
+  // afterwards, which discards in-memory singleton state too.
+  async function wipe() {
+    const db = await openDb();
+    const names = Array.from(db.objectStoreNames);
+    contentKeyPromise = null;
+    if (names.length === 0) return;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(names, "readwrite");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+      for (const n of names) tx.objectStore(n).clear();
+    });
+  }
+
   // --- content-key + symmetric encryption -----------------------------------
 
   let contentKeyPromise = null;
@@ -204,7 +223,7 @@
 
   globalThis.SorchaIndexedDb = {
     // raw store ops
-    put, get, del, getAll, clear,
+    put, get, del, getAll, clear, wipe,
     // credentials (encrypted)
     putCredential, getCredential, listCredentials, deleteCredential,
   };

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignOutWipeTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignOutWipeTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+
+namespace Sorcha.UI.E2E.Tests.Docker.CitizenWallet;
+
+/// <summary>
+/// Regression guard for the sign-out data-purge fix. Sign-out used to clear ONLY
+/// the access token, leaving credentials, personas, history and the welcome/tour
+/// flags in IndexedDB for the next citizen on the same device — a cross-user data
+/// leak and the cause of the "welcome wizard won't reappear for a new user"
+/// symptom.
+/// </summary>
+/// <remarks>
+/// The real <c>Sign out</c> button on the Settings page only renders for a
+/// signed-in citizen, which needs a citizen JWT seeded into IndexedDB — the
+/// fixture gap tracked by Issue #700. So this test exercises the mechanism the
+/// sign-out path delegates to: <c>SorchaIndexedDb.wipe()</c>, which
+/// <c>IndexedDbLocalDataPurge</c> calls. It seeds a representative set of object
+/// stores (keyed and keyPath shapes), wipes, and asserts every store is empty.
+/// </remarks>
+[TestFixture]
+[Category("Docker")]
+[Category("CitizenWallet")]
+public class CitizenWalletSignOutWipeTests : AuthenticatedCitizenWalletTestBase
+{
+    [Test]
+    [Retry(2)]
+    public async Task IndexedDbWipe_ClearsEveryObjectStore()
+    {
+        var jsErrors = new List<string>();
+        Page.PageError += (_, error) => jsErrors.Add(error);
+
+        await NavigateToWalletAndWaitForBlazorAsync();
+
+        var bridgePresent = await Page.EvaluateAsync<bool>("() => !!window.SorchaIndexedDb");
+        if (!bridgePresent)
+        {
+            Assert.Inconclusive("SorchaIndexedDb bridge not present — PWA static assets may not be served.");
+            return;
+        }
+
+        var hasWipe = await Page.EvaluateAsync<bool>(
+            "() => typeof window.SorchaIndexedDb.wipe === 'function'");
+        Assert.That(hasWipe, Is.True,
+            "SorchaIndexedDb.wipe must be exported — the sign-out purge calls it.");
+
+        // Seed a representative spread of stores: the shared `device` store
+        // (flags + access-token), a keyPath store (`credentials`), a keyed
+        // store (`personas`), and two more keyPath stores (`verifications`,
+        // `presentationLog`). Then wipe and re-read.
+        var result = await Page.EvaluateAsync<JsonElement>(
+            @"async () => {
+                const db = window.SorchaIndexedDb;
+                await db.put('device', { welcomedAt: new Date().toISOString() }, 'flags');
+                await db.put('device', { accessToken: 'jwt-leak' }, 'access-token');
+                await db.put('credentials', { id: 'cred-leak', nonce: 'n', ciphertext: 'c' });
+                await db.put('personas', { value: 1 }, 'persona-leak');
+                await db.put('verifications', { id: 'verif-leak' });
+                await db.put('presentationLog', { id: 'plog-leak' });
+
+                const snapshot = async () => ({
+                    flags: !!(await db.get('device', 'flags')),
+                    token: !!(await db.get('device', 'access-token')),
+                    creds: (await db.getAll('credentials')).length,
+                    personas: !!(await db.get('personas', 'persona-leak')),
+                    verifs: (await db.getAll('verifications')).length,
+                    plog: (await db.getAll('presentationLog')).length,
+                });
+
+                const before = await snapshot();
+                await db.wipe();
+                const after = await snapshot();
+                return { before, after };
+            }");
+
+        var before = result.GetProperty("before");
+        var after = result.GetProperty("after");
+
+        // Sanity: the seed actually landed (otherwise the wipe assertion is vacuous).
+        Assert.Multiple(() =>
+        {
+            Assert.That(before.GetProperty("flags").GetBoolean(), Is.True, "seed: flags");
+            Assert.That(before.GetProperty("token").GetBoolean(), Is.True, "seed: access-token");
+            Assert.That(before.GetProperty("creds").GetInt32(), Is.GreaterThan(0), "seed: credentials");
+            Assert.That(before.GetProperty("personas").GetBoolean(), Is.True, "seed: personas");
+            Assert.That(before.GetProperty("verifs").GetInt32(), Is.GreaterThan(0), "seed: verifications");
+            Assert.That(before.GetProperty("plog").GetInt32(), Is.GreaterThan(0), "seed: presentationLog");
+        });
+
+        // The fix: every store is empty after wipe.
+        Assert.Multiple(() =>
+        {
+            Assert.That(after.GetProperty("flags").GetBoolean(), Is.False, "wipe must clear welcome/tour flags");
+            Assert.That(after.GetProperty("token").GetBoolean(), Is.False, "wipe must clear the access token");
+            Assert.That(after.GetProperty("creds").GetInt32(), Is.Zero, "wipe must clear credentials");
+            Assert.That(after.GetProperty("personas").GetBoolean(), Is.False, "wipe must clear personas");
+            Assert.That(after.GetProperty("verifs").GetInt32(), Is.Zero, "wipe must clear verification history");
+            Assert.That(after.GetProperty("plog").GetInt32(), Is.Zero, "wipe must clear the presentation log");
+        });
+
+        Assert.That(jsErrors, Is.Empty,
+            $"wipe must not raise uncaught JS errors. Got: {string.Join("\n", jsErrors)}");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -35,7 +35,7 @@ public sealed class AuthAndBearerTests
             };
         });
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") };
-        var auth = new AuthService(http, store);
+        var auth = NewAuth(http, store);
 
         var result = await auth.SignInAsync("citizen@example.com", "secret-pw");
 
@@ -52,7 +52,7 @@ public sealed class AuthAndBearerTests
     {
         var store = new InMemoryAccessTokenStore();
         var handler = new StubHttpHandler((_, _) => new HttpResponseMessage(HttpStatusCode.Unauthorized));
-        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+        var auth = NewAuth(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
 
         var result = await auth.SignInAsync("citizen@example.com", "wrong");
 
@@ -71,7 +71,7 @@ public sealed class AuthAndBearerTests
                 """{"requires_two_factor":true,"login_token":"lt-abc","available_methods":["totp"]}""",
                 Encoding.UTF8, "application/json"),
         });
-        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+        var auth = NewAuth(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
 
         var result = await auth.SignInAsync("citizen@example.com", "pw");
 
@@ -90,7 +90,7 @@ public sealed class AuthAndBearerTests
                 """{"requires_two_factor":true,"login_token":"lt-123","available_methods":["totp"]}""",
                 Encoding.UTF8, "application/json"),
         });
-        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+        var auth = NewAuth(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
 
         var result = await auth.SignInAsync("citizen@example.com", "pw");
 
@@ -115,7 +115,7 @@ public sealed class AuthAndBearerTests
                     Encoding.UTF8, "application/json"),
             };
         });
-        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+        var auth = NewAuth(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
 
         var result = await auth.VerifyTwoFactorAsync("lt-123", "citizen@example.com", "123456");
 
@@ -131,7 +131,7 @@ public sealed class AuthAndBearerTests
     {
         var store = new InMemoryAccessTokenStore();
         var handler = new StubHttpHandler((_, _) => new HttpResponseMessage(HttpStatusCode.Unauthorized));
-        var auth = new AuthService(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
+        var auth = NewAuth(new HttpClient(handler) { BaseAddress = new Uri("https://localhost/") }, store);
 
         var result = await auth.VerifyTwoFactorAsync("lt-123", "citizen@example.com", "000000");
 
@@ -145,12 +145,29 @@ public sealed class AuthAndBearerTests
     {
         var store = new InMemoryAccessTokenStore();
         await store.SetAsync(new AccessTokenRecord("jwt", DateTimeOffset.UtcNow.AddHours(1), "x@example.com"));
-        var auth = new AuthService(new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage())),
-            store);
+        var auth = NewAuth(new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage())), store);
 
         await auth.SignOutAsync();
 
         (await auth.IsSignedInAsync()).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AuthService_SignOut_PurgesAllLocalData()
+    {
+        // Regression: sign-out used to clear ONLY the access token, leaving
+        // credentials, personas, delegation, history and the welcome/tour
+        // flags in IndexedDB for the next citizen who signs in on the same
+        // device. Sign-out MUST wipe every per-device store.
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("jwt", DateTimeOffset.UtcNow.AddHours(1), "x@example.com"));
+        var purge = new SpyLocalDataPurge();
+        var auth = NewAuth(
+            new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage())), store, purge);
+
+        await auth.SignOutAsync();
+
+        purge.PurgeCount.Should().Be(1, "sign-out must wipe all per-device wallet data, not just the token");
     }
 
     [Fact]
@@ -189,6 +206,22 @@ public sealed class AuthAndBearerTests
         await http.GetAsync("api/v1/wallet/sync");
 
         observedAuth.Should().BeNull("requests must go out unauthenticated when no token is stored");
+    }
+
+    // Constructs an AuthService with a throwaway purge for the tests that
+    // don't assert on the sign-out cascade; AuthService_SignOut_PurgesAllLocalData
+    // passes its own spy to inspect the call.
+    private static AuthService NewAuth(HttpClient http, IAccessTokenStore store, ILocalDataPurge? purge = null)
+        => new(http, store, purge ?? new SpyLocalDataPurge());
+
+    private sealed class SpyLocalDataPurge : ILocalDataPurge
+    {
+        public int PurgeCount { get; private set; }
+        public Task PurgeAsync(CancellationToken ct = default)
+        {
+            PurgeCount++;
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class StubHttpHandler : HttpMessageHandler


### PR DESCRIPTION
## Problem

The Citizen Wallet PWA's `IAuthService.SignOutAsync` cleared **only** the access token. Every other per-device IndexedDB store survived sign-out:

- `credentials`, `personas` (sensitive PII), `delegation`
- `verifications`, `presentationLog`, `context` (active org)
- the `flags` record holding `WelcomedAt` / `TourDismissedAt`

On a shared device, the next citizen to sign in inherited the previous user's credentials and PII — a **cross-user data leak** — and the welcome takeover + guided tour stayed suppressed (the "welcome wizard won't reappear for a new user" symptom). The per-device store interfaces already documented "invoked on sign-out" in their XML docs — the cascade was intended but never wired.

## Fix

- **`SorchaIndexedDb.wipe()`** — clears every object store in one transaction by enumerating `db.objectStoreNames`. Future-proof: any store added later is wiped automatically. The fragile per-store approach is precisely what let the original bug ship.
- **`ILocalDataPurge`** seam + `IndexedDbLocalDataPurge`; `SignOutAsync` now clears the token **and** purges all local data.
- **`Settings.razor`** sign-out `forceLoad`-navigates home so in-memory singleton state (hub connection, `IHasPairedDeviceProbe` cache, `ManagedUserContext`) re-initialises clean for the next user.

## Tests

- **Unit (TDD):** `AuthAndBearerTests.AuthService_SignOut_PurgesAllLocalData` — written test-first (RED → GREEN). Full PWA unit suite green (142).
- **E2E:** `CitizenWalletSignOutWipeTests.IndexedDbWipe_ClearsEveryObjectStore` — seeds 6 stores, wipes, asserts all empty, no JS errors. Verified against a rebuilt `sorcha-wallet-pwa` container; full `CitizenWallet` E2E category green.

## Docs

- `sorcha-architecture` skill F114 — added a sign-out purge note (incl. the "don't wire per-store clears, `wipe()` covers it" guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)