### PR TITLE
feat: admin-provisioned org-scoped password users (gated verified bypass)

### DIFF
--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -61,6 +61,10 @@ services:
       # so visitors know the environment may be reset without notice. Plain
       # informational notice; no consent gate, no friction.
       DemoEnvironment__Enabled: "true"
+      # Demo node: allow SystemAdmin-provisioned pre-verified org-scoped users so walkthrough
+      # setup scripts create single-org operators (no public-user / multi-org clash). Off in
+      # real production; explicit here for the demo. Spec 136 follow-up.
+      Platform__AllowAdminVerifiedUserCreation: "true"
       # Public organisation is enabled at first DB seed so a freshly-reset n1
       # supports social signup without an admin manually flipping the toggle.
       # After first seed the value persists in tenant.platform_settings; this

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -436,6 +436,10 @@ services:
       ASPNETCORE_URLS: http://+:8080
       # Tenant service is the JWT authority - it issues tokens using the installation name
       JwtSettings__SigningKeySource: Configuration
+      # Dev/demo: allow a SystemAdmin to provision pre-verified org-scoped users (bypasses the
+      # email-verification loop). OFF by default in code; enabled here for local dev + walkthroughs.
+      # MUST stay false/unset in production. See OrgProvisioningService (spec 136 follow-up).
+      Platform__AllowAdminVerifiedUserCreation: "true"
       # Service-to-service auth for Wallet Service calls during wallet link verification
       ServiceAuth__ClientId: tenant-service
       ServiceAuth__ClientSecret: tenant-service-secret

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PlatformOrgEndpoints.cs
@@ -77,7 +77,10 @@ public static class PlatformOrgEndpoints
             request.Description,
             request.AdminEmail,
             request.Role,
-            cancellationToken);
+            cancellationToken,
+            adminPassword: request.AdminPassword,
+            adminDisplayName: request.AdminDisplayName,
+            adminEmailVerified: request.AdminEmailVerified);
 
         if (!result.Success)
         {

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/OrganizationDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/OrganizationDtos.cs
@@ -159,6 +159,26 @@ public record AdminCreateOrganizationRequest
     /// Defaults to Administrator. SystemAdmin is not allowed.
     /// </summary>
     public UserRole Role { get; init; } = UserRole.Administrator;
+
+    /// <summary>
+    /// Optional. When set AND <see cref="AdminEmail"/> is NOT an existing PlatformUser, the admin
+    /// is created directly as an org-scoped password user (PlatformUser + UserIdentity + membership
+    /// in this org only — never a public-org account), instead of a pending invitation. Lets a
+    /// SystemAdmin provision a ready, single-org operator in one call (the bootstrap pattern, for
+    /// any org). Ignored when the email already exists (that user is added directly as before).
+    /// </summary>
+    public string? AdminPassword { get; init; }
+
+    /// <summary>Optional display name for a directly-provisioned admin. Defaults to the email local-part.</summary>
+    public string? AdminDisplayName { get; init; }
+
+    /// <summary>
+    /// When true (with <see cref="AdminPassword"/>), the provisioned admin's email is marked verified,
+    /// bypassing the verification loop. GATED: only honoured when the installation enables
+    /// <c>Platform:AllowAdminVerifiedUserCreation</c> (off by default in production) — otherwise the
+    /// request is rejected. Always role-gated (SystemAdmin) and audit-logged.
+    /// </summary>
+    public bool AdminEmailVerified { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Services/IOrgProvisioningService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IOrgProvisioningService.cs
@@ -84,9 +84,13 @@ public interface IOrgProvisioningService
     /// <param name="adminEmail">Email of the user to invite.</param>
     /// <param name="role">Role to assign (Administrator, Designer, Auditor, Member). SystemAdmin is rejected.</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <param name="adminPassword">Optional. When set and the email is new, provision the admin directly as an org-scoped password user (no public account) instead of an invitation.</param>
+    /// <param name="adminDisplayName">Optional display name for a directly-provisioned admin (defaults to email local-part).</param>
+    /// <param name="adminEmailVerified">Mark the provisioned admin verified (bypasses the verification loop). Gated by <c>Platform:AllowAdminVerifiedUserCreation</c>; rejected when disabled.</param>
     Task<AdminProvisionResult> AdminProvisionAsync(
         Guid adminPlatformUserId, string name, string subdomain,
-        string? description, string adminEmail, UserRole role, CancellationToken ct);
+        string? description, string adminEmail, UserRole role, CancellationToken ct,
+        string? adminPassword = null, string? adminDisplayName = null, bool adminEmailVerified = false);
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Services/OrgProvisioningService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrgProvisioningService.cs
@@ -21,6 +21,7 @@ public class OrgProvisioningService : IOrgProvisioningService
     private readonly IInvitationService _invitationService;
     private readonly ITenantMembershipInboxWriter _membershipInbox;
     private readonly ILogger<OrgProvisioningService> _logger;
+    private readonly bool _allowAdminVerifiedUserCreation;
 
     /// <summary>
     /// Creates a new instance of <see cref="OrgProvisioningService"/>.
@@ -31,7 +32,8 @@ public class OrgProvisioningService : IOrgProvisioningService
         IPlatformSettingsService settingsService,
         IInvitationService invitationService,
         ITenantMembershipInboxWriter membershipInbox,
-        ILogger<OrgProvisioningService> logger)
+        ILogger<OrgProvisioningService> logger,
+        Microsoft.Extensions.Configuration.IConfiguration configuration)
     {
         _db = db;
         _orgService = orgService;
@@ -39,6 +41,11 @@ public class OrgProvisioningService : IOrgProvisioningService
         _invitationService = invitationService;
         _membershipInbox = membershipInbox;
         _logger = logger;
+        // Deployment-level gate (off by default, incl. production): when false an
+        // adminEmailVerified=true provisioning request is refused. Set per environment
+        // (e.g. dev / n1) — see Platform:AllowAdminVerifiedUserCreation. Spec 136 follow-up.
+        _allowAdminVerifiedUserCreation =
+            configuration?.GetValue("Platform:AllowAdminVerifiedUserCreation", false) ?? false;
     }
 
     /// <inheritdoc />
@@ -237,7 +244,8 @@ public class OrgProvisioningService : IOrgProvisioningService
     /// <inheritdoc />
     public async Task<AdminProvisionResult> AdminProvisionAsync(
         Guid adminPlatformUserId, string name, string subdomain,
-        string? description, string adminEmail, UserRole role, CancellationToken ct)
+        string? description, string adminEmail, UserRole role, CancellationToken ct,
+        string? adminPassword = null, string? adminDisplayName = null, bool adminEmailVerified = false)
     {
         // Reject SystemAdmin role assignment (only valid in system admin org bootstrap)
         if (role == UserRole.SystemAdmin)
@@ -290,6 +298,18 @@ public class OrgProvisioningService : IOrgProvisioningService
                 Success = false,
                 Error = "A valid admin email address is required.",
                 ErrorCode = "InvalidAdminEmail"
+            };
+        }
+
+        // 2b. Verified-bypass gate (spec 136 follow-up): minting a pre-verified user is only
+        //     permitted when the installation explicitly enables it (off by default in prod).
+        if (adminEmailVerified && !_allowAdminVerifiedUserCreation)
+        {
+            return new AdminProvisionResult
+            {
+                Success = false,
+                Error = "Creating pre-verified users is not enabled on this installation (Platform:AllowAdminVerifiedUserCreation).",
+                ErrorCode = "verified_creation_disabled"
             };
         }
 
@@ -353,6 +373,56 @@ public class OrgProvisioningService : IOrgProvisioningService
                         "Admin org creation: existing user {UserId} directly added as admin to org {OrgId}",
                         existingUser.Id, org.Id);
                 }
+                else if (!string.IsNullOrEmpty(adminPassword))
+                {
+                    // New email + password → provision a NEW org-scoped password user directly
+                    // (PlatformUser + UserIdentity + membership in THIS org only — never a public
+                    // account), instead of a pending invitation. The bootstrap pattern, for any org.
+                    var roles = BuildRoleSet(role);
+                    var displayName = string.IsNullOrWhiteSpace(adminDisplayName)
+                        ? adminEmail.Split('@')[0]
+                        : adminDisplayName;
+
+                    var newPlatformUser = new PlatformUser
+                    {
+                        Email = adminEmail,
+                        DisplayName = displayName,
+                        PasswordHash = BCrypt.Net.BCrypt.HashPassword(adminPassword),
+                        EmailVerified = adminEmailVerified,
+                        EmailVerifiedAt = adminEmailVerified ? DateTimeOffset.UtcNow : null,
+                        Status = PlatformUserStatus.Active,
+                        CreatedAt = DateTimeOffset.UtcNow
+                    };
+                    _db.PlatformUsers.Add(newPlatformUser);
+
+                    var adminIdentity = new UserIdentity
+                    {
+                        OrganizationId = org.Id,
+                        PlatformUserId = newPlatformUser.Id,
+                        Email = adminEmail,
+                        DisplayName = displayName,
+                        Roles = roles,
+                        Status = IdentityStatus.Active,
+                        ProvisionedVia = ProvisioningMethod.AdminCreated,
+                        CreatedAt = DateTimeOffset.UtcNow
+                    };
+                    _db.UserIdentities.Add(adminIdentity);
+                    org.CreatorIdentityId = adminIdentity.Id;
+
+                    _db.PlatformUserOrgMemberships.Add(new PlatformUserOrgMembership
+                    {
+                        PlatformUserId = newPlatformUser.Id,
+                        OrganizationId = org.Id,
+                        Role = role.ToString(),
+                        JoinedAt = DateTimeOffset.UtcNow
+                    });
+
+                    adminDirectlyAdded = true;
+
+                    _logger.LogInformation(
+                        "Admin org creation: provisioned NEW org-scoped user {Email} as admin of org {OrgId} (verified={Verified})",
+                        adminEmail, org.Id, adminEmailVerified);
+                }
 
                 // 5. Audit log
                 _db.AuditLogEntries.Add(new AuditLogEntry
@@ -368,6 +438,8 @@ public class OrgProvisioningService : IOrgProvisioningService
                         ["adminEmail"] = adminEmail,
                         ["assignedRole"] = role.ToString(),
                         ["adminDirectlyAdded"] = adminDirectlyAdded,
+                        ["adminProvisionedWithPassword"] = !string.IsNullOrEmpty(adminPassword),
+                        ["adminEmailVerified"] = adminEmailVerified,
                         ["createdBySystemAdmin"] = true
                     }
                 });

--- a/tests/Sorcha.Tenant.Service.Tests/Helpers/InMemoryDbContextFactory.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Helpers/InMemoryDbContextFactory.cs
@@ -24,6 +24,10 @@ public static class InMemoryDbContextFactory
 
         var options = new DbContextOptionsBuilder<TenantDbContext>()
             .UseInMemoryDatabase(databaseName)
+            // The in-memory provider has no transaction support; services that wrap writes in an
+            // execution-strategy transaction (e.g. OrgProvisioningService) would otherwise throw.
+            // Treat transactions as no-ops here — assertions verify the committed end state.
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 
         var context = new TenantDbContext(options, schema);

--- a/tests/Sorcha.Tenant.Service.Tests/Services/OrgProvisioningServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/OrgProvisioningServiceTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sorcha.Tenant.Service.Data;
@@ -33,14 +34,18 @@ public sealed class OrgProvisioningServiceTests : IDisposable
         _settings.Setup(s => s.GetAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PlatformSettings { MaxOrgsPerUser = 10 });
 
-        _sut = new OrgProvisioningService(
-            _db,
-            _orgService.Object,
-            _settings.Object,
-            _invitations.Object,
-            _membershipInbox.Object,
-            NullLogger<OrgProvisioningService>.Instance);
+        _sut = CreateSut(allowVerified: false);
     }
+
+    private static IConfiguration Config(bool allowVerified) =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Platform:AllowAdminVerifiedUserCreation"] = allowVerified ? "true" : "false"
+        }).Build();
+
+    private OrgProvisioningService CreateSut(bool allowVerified = false) =>
+        new(_db, _orgService.Object, _settings.Object, _invitations.Object,
+            _membershipInbox.Object, NullLogger<OrgProvisioningService>.Instance, Config(allowVerified));
 
     public void Dispose() => _db.Dispose();
 
@@ -80,5 +85,64 @@ public sealed class OrgProvisioningServiceTests : IDisposable
                 UserRole.Administrator.ToString(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // --- AdminProvisionAsync: direct org-scoped password user (spec 136 follow-up) ---
+
+    [Fact]
+    public async Task AdminProvision_NewEmailWithPassword_FlagOn_CreatesVerifiedSingleOrgUser()
+    {
+        var sut = CreateSut(allowVerified: true);
+        var sysAdminId = Guid.NewGuid();
+
+        var result = await sut.AdminProvisionAsync(
+            sysAdminId, "Acme Verification", "acme-verif", null,
+            "ops@acme-verif.test", UserRole.Administrator, CancellationToken.None,
+            adminPassword: "Dev_Pass_2025!", adminDisplayName: "Acme Ops", adminEmailVerified: true);
+
+        result.Success.Should().BeTrue();
+        result.AdminDirectlyAdded.Should().BeTrue();
+        result.InvitationId.Should().BeNull("a directly-provisioned admin needs no invitation");
+
+        var pu = _db.PlatformUsers.Single(u => u.Email == "ops@acme-verif.test");
+        pu.EmailVerified.Should().BeTrue();
+        pu.PasswordHash.Should().NotBeNullOrEmpty();
+        pu.Status.Should().Be(PlatformUserStatus.Active);
+
+        // Org-scoped: a membership in the new org and nowhere else (never the public org).
+        var memberships = _db.PlatformUserOrgMemberships.Where(m => m.PlatformUserId == pu.Id).ToList();
+        memberships.Should().ContainSingle()
+            .Which.OrganizationId.Should().Be(result.OrganizationId!.Value);
+        _db.UserIdentities.Should().Contain(i => i.PlatformUserId == pu.Id && i.OrganizationId == result.OrganizationId!.Value);
+    }
+
+    [Fact]
+    public async Task AdminProvision_VerifiedRequested_FlagOff_Rejected_NoUserCreated()
+    {
+        var sut = CreateSut(allowVerified: false);
+
+        var result = await sut.AdminProvisionAsync(
+            Guid.NewGuid(), "Acme", "acme-off", null,
+            "ops@acme-off.test", UserRole.Administrator, CancellationToken.None,
+            adminPassword: "Dev_Pass_2025!", adminEmailVerified: true);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("verified_creation_disabled");
+        _db.PlatformUsers.Any(u => u.Email == "ops@acme-off.test").Should().BeFalse("the request must be refused before any write");
+    }
+
+    [Fact]
+    public async Task AdminProvision_NewEmailWithPassword_NotVerified_FlagIrrelevant_CreatesUnverifiedUser()
+    {
+        var sut = CreateSut(allowVerified: false);
+
+        var result = await sut.AdminProvisionAsync(
+            Guid.NewGuid(), "Acme Licensing", "acme-lic", null,
+            "ops@acme-lic.test", UserRole.Administrator, CancellationToken.None,
+            adminPassword: "Dev_Pass_2025!", adminEmailVerified: false);
+
+        result.Success.Should().BeTrue("creating an unverified password user does not need the flag");
+        result.AdminDirectlyAdded.Should().BeTrue();
+        _db.PlatformUsers.Single(u => u.Email == "ops@acme-lic.test").EmailVerified.Should().BeFalse();
     }
 }

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1662,7 +1662,14 @@ function New-SorchaOrganization {
         [Parameter(Mandatory)][string]$Subdomain,
         [Parameter(Mandatory)][string]$AdminEmail,
         [Parameter(Mandatory)][hashtable]$Headers,
-        [string]$Description = ""
+        [string]$Description = "",
+        # When set (with a NEW AdminEmail), the admin is provisioned directly as an org-scoped
+        # password user (single-org — no public account, no invitation). Spec 136 follow-up.
+        [string]$AdminPassword,
+        [string]$AdminDisplayName,
+        # Mark the provisioned admin verified (bypasses the email loop). Requires the installation
+        # to enable Platform:AllowAdminVerifiedUserCreation (dev/n1 do; production does not).
+        [switch]$AdminEmailVerified
     )
 
     $body = @{
@@ -1670,6 +1677,11 @@ function New-SorchaOrganization {
         subdomain   = $Subdomain
         adminEmail  = $AdminEmail
         description = $Description
+    }
+    if ($AdminPassword) {
+        $body.adminPassword = $AdminPassword
+        $body.adminEmailVerified = [bool]$AdminEmailVerified
+        if ($AdminDisplayName) { $body.adminDisplayName = $AdminDisplayName }
     }
 
     try {


### PR DESCRIPTION
## Why
Walkthroughs (and real deployments) registered org admins as **public** users, then added them to a created org → **multi-org** → the OAuth2 password grant 401s (no org-selection step). An org operator should be **single-org** (org staff aren't public citizens). This adds the missing capability so a SystemAdmin can provision a ready, single-org operator in one call — the bootstrap pattern, generalised to any org.

## What
`AdminCreateOrganizationRequest` gains optional `AdminPassword` + `AdminDisplayName` + `AdminEmailVerified`. When `AdminPassword` is set **and the email is new**, `OrgProvisioningService` creates the `PlatformUser` (password hash) + `UserIdentity` + membership in **that org only** (never a public account), instead of a pending invitation. Existing-email (direct add) and no-password (invitation) paths are unchanged.

## Security (option b)
`AdminEmailVerified=true` bypasses the email-verification loop, so it is **gated behind `Platform:AllowAdminVerifiedUserCreation`** — **off by default, including production** (requests are refused with `verified_creation_disabled` when disabled). Plus the existing SystemAdmin role gate and the org-creation audit-log entry (now records the verified flag). Enabled via docker-compose on local dev + the n1 demo node only.

## Tests
3 new `OrgProvisioningService` cases (verified single-org create when flag on; refused when flag off; unverified create needs no flag). Tenant **1186/1186**. In-memory test context now ignores `TransactionIgnoredWarning`.

## Follow-up (separate PR, after deploy)
Refactor walkthrough `setup.ps1` scripts to use `New-SorchaOrganization -AdminPassword … -AdminEmailVerified` (already added) instead of `Register-SorchaPublicUser` for org admins → single-org operators → OAuth grant works → fixes the ForestryCertification/TradeFinance compliance failures. Done after this deploys so each is validated against the live endpoint. Citizens stay public (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)