### PR TITLE
feat: provision org-scoped password members (completes org-scoped user capability)

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/OrganizationEndpoints.cs
@@ -140,6 +140,17 @@ public static class OrganizationEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden);
 
+        group.MapPost("/{organizationId:guid}/users/provision", ProvisionOrgUser)
+            .WithName("ProvisionOrgUser")
+            .WithSummary("Provision an org-scoped password user")
+            .WithDescription("Creates a NEW single-org password user (no public account, no invitation) in the organization. The emailVerified bypass is gated by Platform:AllowAdminVerifiedUserCreation. Requires administrator role.")
+            .RequireAuthorization("RequireAdministrator", "RequirePlatformAudience")
+            .Produces<UserResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem()
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden);
+
         group.MapGet("/{organizationId:guid}/users", GetOrganizationUsers)
             .WithName("GetOrganizationUsers")
             .WithSummary("List organization users")
@@ -682,6 +693,39 @@ public static class OrganizationEndpoints
         try
         {
             var response = await organizationService.AddUserToOrganizationAsync(
+                organizationId, request, cancellationToken);
+            return TypedResults.Created(
+                $"/api/organizations/{organizationId}/users/{response.Id}", response);
+        }
+        catch (ArgumentException ex) when (ex.Message.Contains("not found"))
+        {
+            return TypedResults.NotFound();
+        }
+        catch (ArgumentException ex)
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                [ex.ParamName ?? "request"] = [ex.Message]
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["email"] = [ex.Message]
+            });
+        }
+    }
+
+    private static async Task<Results<Created<UserResponse>, NotFound, ValidationProblem>> ProvisionOrgUser(
+        Guid organizationId,
+        ProvisionOrgUserRequest request,
+        IOrganizationService organizationService,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await organizationService.ProvisionOrgUserAsync(
                 organizationId, request, cancellationToken);
             return TypedResults.Created(
                 $"/api/organizations/{organizationId}/users/{response.Id}", response);

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/UserDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/UserDtos.cs
@@ -30,6 +30,34 @@ public record AddUserToOrganizationRequest
 }
 
 /// <summary>
+/// Request to provision a NEW org-scoped password user directly into an organisation (spec 136
+/// follow-up). Unlike <see cref="AddUserToOrganizationRequest"/> (OIDC, links an existing user),
+/// this creates a single-org PlatformUser + identity + membership — no public account, no
+/// invitation. Used so org operators are single-org and avoid the multi-org OAuth-grant clash.
+/// </summary>
+public record ProvisionOrgUserRequest
+{
+    /// <summary>User email address (MUST be new platform-wide).</summary>
+    public required string Email { get; init; }
+
+    /// <summary>User display name.</summary>
+    public required string DisplayName { get; init; }
+
+    /// <summary>Initial password (the user authenticates with email + password).</summary>
+    public required string Password { get; init; }
+
+    /// <summary>Roles to assign in this organisation.</summary>
+    public UserRole[] Roles { get; init; } = [UserRole.Consumer];
+
+    /// <summary>
+    /// Mark the email verified (bypasses the verification loop). GATED by
+    /// <c>Platform:AllowAdminVerifiedUserCreation</c> (off by default incl. production) — the
+    /// request is rejected when disabled. Always org-admin gated + audit-logged.
+    /// </summary>
+    public bool EmailVerified { get; init; }
+}
+
+/// <summary>
 /// Request to update a user's details.
 /// </summary>
 public record UpdateUserRequest

--- a/src/Services/Sorcha.Tenant.Service/Services/IOrganizationService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IOrganizationService.cs
@@ -89,6 +89,20 @@ public interface IOrganizationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Provisions a NEW org-scoped password user directly into an organisation (single-org — no
+    /// public account, no invitation). The verified-email bypass is gated by
+    /// <c>Platform:AllowAdminVerifiedUserCreation</c>. Spec 136 follow-up.
+    /// </summary>
+    /// <param name="organizationId">Target organisation.</param>
+    /// <param name="request">Provision request (email, display name, password, roles, emailVerified).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The created user response.</returns>
+    Task<UserResponse> ProvisionOrgUserAsync(
+        Guid organizationId,
+        ProvisionOrgUserRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets users in an organization with optional filtering by verification and invitation status.
     /// </summary>
     /// <param name="organizationId">Organization ID.</param>

--- a/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/OrganizationService.cs
@@ -23,6 +23,7 @@ public partial class OrganizationService : IOrganizationService
     private readonly IWalletServiceClient _walletClient;
     private readonly ITenantMembershipInboxWriter _membershipInbox;
     private readonly ILogger<OrganizationService> _logger;
+    private readonly bool _allowAdminVerifiedUserCreation;
 
     // Reserved subdomains that cannot be used
     private static readonly HashSet<string> ReservedSubdomains = new(StringComparer.OrdinalIgnoreCase)
@@ -40,7 +41,8 @@ public partial class OrganizationService : IOrganizationService
         TenantDbContext dbContext,
         IWalletServiceClient walletClient,
         ITenantMembershipInboxWriter membershipInbox,
-        ILogger<OrganizationService> logger)
+        ILogger<OrganizationService> logger,
+        Microsoft.Extensions.Configuration.IConfiguration configuration)
     {
         _organizationRepository = organizationRepository ?? throw new ArgumentNullException(nameof(organizationRepository));
         _identityRepository = identityRepository ?? throw new ArgumentNullException(nameof(identityRepository));
@@ -48,6 +50,10 @@ public partial class OrganizationService : IOrganizationService
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
         _membershipInbox = membershipInbox ?? throw new ArgumentNullException(nameof(membershipInbox));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        // Same deployment-level gate as OrgProvisioningService: emailVerified bypass is off by
+        // default (incl. production). See Platform:AllowAdminVerifiedUserCreation (spec 136 follow-up).
+        _allowAdminVerifiedUserCreation =
+            configuration?.GetValue("Platform:AllowAdminVerifiedUserCreation", false) ?? false;
     }
 
     /// <inheritdoc />
@@ -293,6 +299,82 @@ public partial class OrganizationService : IOrganizationService
         _logger.LogInformation(
             "Added user {UserId} ({Email}) to organization {OrganizationId} (PlatformUser: {HasPlatformUser})",
             created.Id, created.Email, organizationId, platformUser != null);
+
+        return UserResponse.FromEntity(created, platformUser);
+    }
+
+    /// <inheritdoc />
+    public async Task<UserResponse> ProvisionOrgUserAsync(
+        Guid organizationId,
+        ProvisionOrgUserRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var organization = await _organizationRepository.GetByIdAsync(organizationId, cancellationToken)
+            ?? throw new ArgumentException($"Organization {organizationId} not found", nameof(organizationId));
+
+        // Verified bypass gate (off by default, incl. production) — spec 136 follow-up.
+        if (request.EmailVerified && !_allowAdminVerifiedUserCreation)
+        {
+            throw new InvalidOperationException(
+                "Creating pre-verified users is not enabled on this installation (Platform:AllowAdminVerifiedUserCreation).");
+        }
+
+        // This provisions a NEW org-scoped user. If a PlatformUser already exists for the email,
+        // refuse — adding an existing (possibly public) user here would create the very multi-org
+        // situation this endpoint exists to avoid. Use AddUserToOrganization for existing users.
+        var existingPlatform = await _dbContext.PlatformUsers
+            .FirstOrDefaultAsync(p => p.Email.ToLower() == request.Email.ToLower(), cancellationToken);
+        if (existingPlatform is not null)
+        {
+            throw new InvalidOperationException(
+                $"A platform user with email {request.Email} already exists; provision creates a NEW org-scoped user.");
+        }
+
+        var platformUser = new PlatformUser
+        {
+            Email = request.Email,
+            DisplayName = request.DisplayName,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password),
+            EmailVerified = request.EmailVerified,
+            EmailVerifiedAt = request.EmailVerified ? DateTimeOffset.UtcNow : null,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        _dbContext.PlatformUsers.Add(platformUser);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var user = new UserIdentity
+        {
+            OrganizationId = organizationId,
+            PlatformUserId = platformUser.Id,
+            Email = request.Email,
+            DisplayName = request.DisplayName,
+            Roles = request.Roles is { Length: > 0 } ? request.Roles : new[] { UserRole.Consumer },
+            Status = IdentityStatus.Active,
+            ProvisionedVia = ProvisioningMethod.AdminCreated,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+        var created = await _identityRepository.CreateUserAsync(user, cancellationToken);
+
+        var membershipRole = user.Roles.Any(r => r == UserRole.Administrator)
+            ? UserRole.Administrator.ToString() : UserRole.Consumer.ToString();
+        _dbContext.PlatformUserOrgMemberships.Add(new PlatformUserOrgMembership
+        {
+            PlatformUserId = platformUser.Id,
+            OrganizationId = organizationId,
+            Role = membershipRole,
+            JoinedAt = DateTimeOffset.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        await _membershipInbox.WriteOrgMembershipAddedAsync(
+            platformUser.Id, organizationId, membershipRole, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Provisioned org-scoped user {UserId} ({Email}) in organization {OrganizationId} (verified={Verified})",
+            created.Id, created.Email, organizationId, request.EmailVerified);
 
         return UserResponse.FromEntity(created, platformUser);
     }

--- a/tests/Sorcha.Tenant.Service.Tests/Services/DomainRestrictionTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/DomainRestrictionTests.cs
@@ -56,7 +56,8 @@ public class DomainRestrictionTests : IDisposable
             _dbContext,
             new Mock<IWalletServiceClient>().Object,
             Mock.Of<ITenantMembershipInboxWriter>(),
-            _loggerMock.Object);
+            _loggerMock.Object,
+            new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build());
     }
 
     // ── GetDomainRestrictionsAsync ────────────────────────────

--- a/tests/Sorcha.Tenant.Service.Tests/Services/OrganizationServiceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/OrganizationServiceTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Sorcha.ServiceClients.Wallet;
@@ -51,15 +52,21 @@ public class OrganizationServiceTests : IDisposable
         _dbContext.Dispose();
     }
 
-    private OrganizationService CreateService()
+    private OrganizationService CreateService(bool allowAdminVerifiedUserCreation = false)
     {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Platform:AllowAdminVerifiedUserCreation"] = allowAdminVerifiedUserCreation ? "true" : "false"
+            }).Build();
         return new OrganizationService(
             _orgRepoMock.Object,
             _identityRepoMock.Object,
             _dbContext,
             _walletClientMock.Object,
             _membershipInboxMock.Object,
-            _loggerMock.Object);
+            _loggerMock.Object,
+            config);
     }
 
     // ── Helper methods ─────────────────────────────────────────
@@ -686,5 +693,71 @@ public class OrganizationServiceTests : IDisposable
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // ProvisionOrgUserAsync — org-scoped password user (spec 136 follow-up)
+    // ══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ProvisionOrgUserAsync_NewEmail_FlagOn_Verified_CreatesSingleOrgUser()
+    {
+        _orgRepoMock.Setup(r => r.GetByIdAsync(_testOrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Organization { Id = _testOrgId, Name = "Acme", Subdomain = "acme" });
+        _identityRepoMock.Setup(r => r.CreateUserAsync(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserIdentity u, CancellationToken _) => u);
+
+        var service = CreateService(allowAdminVerifiedUserCreation: true);
+        var request = new Sorcha.Tenant.Service.Models.Dtos.ProvisionOrgUserRequest
+        {
+            Email = "analyst@acme.test", DisplayName = "Acme Analyst",
+            Password = "Dev_Pass_2025!", Roles = [UserRole.Auditor], EmailVerified = true
+        };
+
+        await service.ProvisionOrgUserAsync(_testOrgId, request);
+
+        var pu = _dbContext.PlatformUsers.Single(u => u.Email == "analyst@acme.test");
+        pu.EmailVerified.Should().BeTrue();
+        pu.PasswordHash.Should().NotBeNullOrEmpty();
+        var memberships = _dbContext.PlatformUserOrgMemberships.Where(m => m.PlatformUserId == pu.Id).ToList();
+        memberships.Should().ContainSingle().Which.OrganizationId.Should().Be(_testOrgId);
+    }
+
+    [Fact]
+    public async Task ProvisionOrgUserAsync_VerifiedRequested_FlagOff_Throws_NoUserCreated()
+    {
+        _orgRepoMock.Setup(r => r.GetByIdAsync(_testOrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Organization { Id = _testOrgId, Name = "Acme", Subdomain = "acme" });
+
+        var service = CreateService(allowAdminVerifiedUserCreation: false);
+        var request = new Sorcha.Tenant.Service.Models.Dtos.ProvisionOrgUserRequest
+        {
+            Email = "blocked@acme.test", DisplayName = "Blocked",
+            Password = "Dev_Pass_2025!", EmailVerified = true
+        };
+
+        var act = () => service.ProvisionOrgUserAsync(_testOrgId, request);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _dbContext.PlatformUsers.Any(u => u.Email == "blocked@acme.test").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ProvisionOrgUserAsync_ExistingPlatformUserEmail_Throws()
+    {
+        SeedPlatformUser(Guid.NewGuid(), "dupe@acme.test", emailVerified: true);
+        _orgRepoMock.Setup(r => r.GetByIdAsync(_testOrgId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Organization { Id = _testOrgId, Name = "Acme", Subdomain = "acme" });
+
+        var service = CreateService(allowAdminVerifiedUserCreation: true);
+        var request = new Sorcha.Tenant.Service.Models.Dtos.ProvisionOrgUserRequest
+        {
+            Email = "dupe@acme.test", DisplayName = "Dupe", Password = "Dev_Pass_2025!"
+        };
+
+        var act = () => service.ProvisionOrgUserAsync(_testOrgId, request);
+
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "provision creates a NEW org-scoped user; an existing platform user must use AddUserToOrganization");
     }
 }


### PR DESCRIPTION
Completes the org-scoped user capability started in #822.

#822 added the org **admin** path (via org-creation). This adds the same gated pattern for additional org **members** (analysts, officers): `POST /api/organizations/{id}/users/provision` creates a NEW single-org `PlatformUser` (password) + `UserIdentity` + membership in that org only — no public account, no invitation. Refuses if a `PlatformUser` already exists for the email (that would re-introduce the multi-org case).

**Why:** walkthroughs like ForestryCertification create org operators beyond the admin (sales-manager, auditor) as **public** login users → multi-org → OAuth2 password grant 401s. Provisioning them single-org fixes it.

**Security:** `emailVerified` gated behind `Platform:AllowAdminVerifiedUserCreation` (off by default incl. production); `RequireAdministrator` + `RequirePlatformAudience`; membership-inbox entry written.

**Tests:** 3 new `OrganizationService` cases. Tenant **1189/1189**.

After this merges + deploys (alongside #822), the walkthrough `setup.ps1` rollout uses `New-SorchaOrganization -AdminPassword …` for org admins and the new provision endpoint for members → single-org operators → fixes the Forestry/TradeFinance compliance failures. Citizens stay public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)