### PR TITLE
chore(walkthroughs): org-scoped operators (fixes Forestry/TradeFinance multi-org) + skill rule

### DIFF
--- a/.claude/skills/walkthrough-builder/SKILL.md
+++ b/.claude/skills/walkthrough-builder/SKILL.md
@@ -147,6 +147,29 @@ Publish-SorchaBlueprint -TemplatePath "./my-template.json" -WalletMap $walletMap
 $state | ConvertTo-Json -Depth 10 | Set-Content "state.json"
 ```
 
+#### REQUIRED: provision org operators as org-scoped users — never public (no multi-org)
+
+**Org admins / operators (analysts, officers, issuers) MUST be created single-org.** Do NOT register them as public users. A public user (`Register-SorchaPublicUser`) who is then added to an org via `New-SorchaOrganization -AdminEmail <that email>` becomes **multi-org**, which forces org-selection on login and makes the **OAuth2 password grant return 401** (the grant has no org-selection step) — the #1 cause of walkthrough auth flakiness.
+
+Use the **sysadmin → org → org-scoped operator** hierarchy. `New-SorchaOrganization` with a *fresh* email + password provisions the operator directly in that org only (no public account, no invitation, no email loop):
+
+```powershell
+$admin = Connect-SorchaAdmin -TenantUrl $env.TenantUrl -Secrets $secrets   # bootstrap SystemAdmin
+
+# Org + its operator in one call. Operator exists ONLY in this org → single-org → OAuth grant works.
+$org = New-SorchaOrganization -TenantUrl $env.TenantUrl -Headers $admin.Headers `
+    -Name "Acme Verification Co." -Subdomain "acme-verif" `
+    -AdminEmail "ops@acme-verif.test" -AdminPassword $secrets.DefaultPassword `
+    -AdminDisplayName "Acme Ops" -AdminEmailVerified
+
+# Log in AS that operator (single-org → direct token, no org-selection):
+$ops = Connect-SorchaUser -TenantUrl $env.TenantUrl -Email "ops@acme-verif.test" -Password $secrets.DefaultPassword
+```
+
+- `-AdminEmailVerified` requires the installation to enable `Platform:AllowAdminVerifiedUserCreation` (dev + n1 set it; **production does not**). Without it, omit the switch and verify via the admin email-verify endpoint.
+- **ANTI-PATTERN (do not do this):** `Register-SorchaPublicUser ops@… ; New-SorchaOrganization -AdminEmail ops@…` → multi-org operator → 401 on the password grant.
+- **Citizens / public submitters are the deliberate exception** — they ARE public users (`Register-SorchaPublicUser`): a citizen belongs to the public org and is late-bound into the workflow. Only *org operators* use the org-scoped path.
+
 #### Foot-gun: do NOT include open participants in `$walletMap`
 
 If the blueprint has a participant that is the sender of an `isStartingAction: true` action (a citizen, applicant, public submitter, etc.), that participant is **late-bound** at runtime — its `walletAddress` MUST be null in the published blueprint, and your `$walletMap` MUST NOT contain an entry for it.

--- a/walkthroughs/ForestryCertification/setup.ps1
+++ b/walkthroughs/ForestryCertification/setup.ps1
@@ -75,28 +75,18 @@ function New-ParticipantUserSession {
     $email = "$ParticipantId@$Subdomain.sorcha.dev"
     $password = Get-ParticipantPassword -Subdomain $Subdomain -ParticipantId $ParticipantId
 
-    try {
-        $null = Register-SorchaPublicUser `
-            -TenantUrl $sorchaEnv.TenantUrl `
-            -Email $email `
-            -Password $password `
-            -DisplayName $DisplayName
-    } catch { Write-WtInfo "  user $email may already exist" }
-
-    try {
-        $null = Invoke-SorchaApi -Method POST `
-            -Uri "$($sorchaEnv.TenantUrl)/platform/users/verify-email" `
-            -Body @{ email = $email } `
-            -Headers $sysAdmin.Headers
-    } catch { Write-WtWarn "  email verify failed for $email" }
-
-    $userId = Get-OrCreateUser `
+    # Spec 136: provision the operator org-scoped + verified (single-org — no public account, no
+    # multi-org clash). Org operators are never public users; only citizens are.
+    $provisioned = New-SorchaOrgUser `
         -TenantUrl $sorchaEnv.TenantUrl `
         -OrganizationId $OrganizationId `
         -Email $email `
+        -Password $password `
         -DisplayName $DisplayName `
         -Headers $OrgAdminHeaders `
-        -Roles @("Consumer")
+        -Roles @("Consumer") `
+        -EmailVerified
+    $userId = $provisioned.UserId
 
     $session = Connect-SorchaUser `
         -TenantUrl $sorchaEnv.TenantUrl `
@@ -140,27 +130,17 @@ $fcSubdomain = "forestry-certification"
 $fcAdminEmail = "admin@$fcSubdomain.sorcha.dev"
 $fcAdminPassword = Get-OrgAdminPassword -Subdomain $fcSubdomain
 
-try {
-    $null = Register-SorchaPublicUser `
-        -TenantUrl $sorchaEnv.TenantUrl `
-        -Email $fcAdminEmail `
-        -Password $fcAdminPassword `
-        -DisplayName "Forestry Certification Admin"
-} catch { Write-WtInfo "  user $fcAdminEmail may already exist" }
-
-try {
-    $null = Invoke-SorchaApi -Method POST `
-        -Uri "$($sorchaEnv.TenantUrl)/platform/users/verify-email" `
-        -Body @{ email = $fcAdminEmail } `
-        -Headers $sysAdmin.Headers
-} catch { Write-WtWarn "  email verify failed for $fcAdminEmail" }
-
+# Spec 136: provision the org admin org-scoped + verified in one call (single-org — no public
+# account, no multi-org clash, no SMTP invite).
 try {
     $fcOrg = New-SorchaOrganization `
         -TenantUrl $sorchaEnv.TenantUrl `
         -Name "Forestry Certification" `
         -Subdomain $fcSubdomain `
         -AdminEmail $fcAdminEmail `
+        -AdminPassword $fcAdminPassword `
+        -AdminDisplayName "Forestry Certification Admin" `
+        -AdminEmailVerified `
         -Headers $sysAdmin.Headers `
         -Description "Independent forestry auditor — issues Digital Product Passports for timber batches"
     $fcOrgId = $fcOrg.OrganizationId
@@ -185,27 +165,16 @@ $htSubdomain = "highland-timber"
 $htAdminEmail = "admin@$htSubdomain.sorcha.dev"
 $htAdminPassword = Get-OrgAdminPassword -Subdomain $htSubdomain
 
-try {
-    $null = Register-SorchaPublicUser `
-        -TenantUrl $sorchaEnv.TenantUrl `
-        -Email $htAdminEmail `
-        -Password $htAdminPassword `
-        -DisplayName "Highland Timber Admin"
-} catch { Write-WtInfo "  user $htAdminEmail may already exist" }
-
-try {
-    $null = Invoke-SorchaApi -Method POST `
-        -Uri "$($sorchaEnv.TenantUrl)/platform/users/verify-email" `
-        -Body @{ email = $htAdminEmail } `
-        -Headers $sysAdmin.Headers
-} catch { Write-WtWarn "  email verify failed for $htAdminEmail" }
-
+# Spec 136: provision the org admin org-scoped + verified in one call (single-org).
 try {
     $htOrg = New-SorchaOrganization `
         -TenantUrl $sorchaEnv.TenantUrl `
         -Name "Highland Timber Supplies" `
         -Subdomain $htSubdomain `
         -AdminEmail $htAdminEmail `
+        -AdminPassword $htAdminPassword `
+        -AdminDisplayName "Highland Timber Admin" `
+        -AdminEmailVerified `
         -Headers $sysAdmin.Headers `
         -Description "Timber supplier — applies for Digital Product Passport certification on harvested batches"
     $htOrgId = $htOrg.OrganizationId

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -225,41 +225,23 @@ foreach ($org in $selectedOrgs) {
         $password = Get-ParticipantPassword -OrgSubdomain $subdomain -ParticipantId $partId
 
         if (-not ($state.roles.ContainsKey($roleKey) -and $state.roles[$roleKey].email)) {
-            # Register platform user first (may already exist from previous run)
-            # Retry on 429 (rate limit) with 2s backoff
-            $registered = $false
-            for ($attempt = 1; $attempt -le 3; $attempt++) {
-                try {
-                    $null = Register-SorchaPublicUser `
-                        -TenantUrl $env.TenantUrl `
-                        -Email $email `
-                        -Password $password `
-                        -DisplayName $participant.displayName
-                    $registered = $true
-                    break
-                } catch {
-                    $statusCode = $null
-                    try { $statusCode = $_.Exception.Response.StatusCode.value__ } catch {}
-                    if ($statusCode -eq 429 -and $attempt -lt 3) {
-                        Write-WtWarn "  Rate limited — retrying in 2s (attempt $attempt/3)"
-                        Start-Sleep -Seconds 2
-                    } else {
-                        Write-WtInfo "  User $email may already exist — continuing"
-                        break
-                    }
-                }
+            # Spec 136: provision the participant org-scoped + verified in one call (single-org —
+            # no public account, no multi-org clash). Org operators are never public users.
+            try {
+                $provisioned = New-SorchaOrgUser `
+                    -TenantUrl $env.TenantUrl `
+                    -OrganizationId $ctx.OrganizationId `
+                    -Email $email `
+                    -Password $password `
+                    -DisplayName $participant.displayName `
+                    -Headers $ctx.Headers `
+                    -Roles @("Consumer") `
+                    -EmailVerified
+                $userId = $provisioned.UserId
+                Write-WtInfo "  User provisioned (org-scoped): $($participant.displayName) ($email)"
+            } catch {
+                Write-WtInfo "  User $email may already exist — continuing"
             }
-
-            # Add user to the org
-            $userId = Get-OrCreateUser `
-                -TenantUrl $env.TenantUrl `
-                -OrganizationId $ctx.OrganizationId `
-                -Email $email `
-                -DisplayName $participant.displayName `
-                -Headers $ctx.Headers `
-                -Roles @("Consumer")
-
-            Write-WtInfo "  User created: $($participant.displayName) ($email)"
         } else {
             Write-WtInfo "  User '$($participant.displayName)' already in state"
         }

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -146,38 +146,19 @@ foreach ($org in $selectedOrgs) {
     } else {
         $adminEmail = "admin@$subdomain.sorcha.dev"
 
-        # Register the admin user on the public org first so PlatformUser exists
-        try {
-            $null = Register-SorchaPublicUser `
-                -TenantUrl $env.TenantUrl `
-                -Email $adminEmail `
-                -Password (Get-AdminPassword -OrgSubdomain $subdomain) `
-                -DisplayName "$($org.name) Admin"
-        } catch {
-            # User may already exist from a previous run — continue
-            Write-WtInfo "  Admin user $adminEmail may already exist — continuing"
-        }
-
-        # Verify the admin's email via platform API so New-SorchaOrganization
-        # can add them directly without triggering an SMTP invite email.
-        # Nodes without SMTP (e.g. n1) fail hard otherwise.
-        try {
-            $null = Invoke-SorchaApi -Method POST `
-                -Uri "$($env.TenantUrl)/platform/users/verify-email" `
-                -Body @{ email = $adminEmail } `
-                -Headers $seedAdmin.Headers
-            Write-WtInfo "  Verified email for $adminEmail"
-        } catch {
-            Write-WtWarn "  Could not verify $adminEmail — org creation may fall back to SMTP invite"
-        }
-
-        # Create the private org via platform admin API
+        # Spec 136: provision the org admin directly as an org-scoped, verified password user
+        # in one call — single-org (no public account → no multi-org clash → the OAuth2 password
+        # grant works), and no SMTP invite. The verified bypass requires the installation to enable
+        # Platform:AllowAdminVerifiedUserCreation (dev + n1 do; production does not).
         try {
             $newOrg = New-SorchaOrganization `
                 -TenantUrl $env.TenantUrl `
                 -Name $org.name `
                 -Subdomain $subdomain `
                 -AdminEmail $adminEmail `
+                -AdminPassword (Get-AdminPassword -OrgSubdomain $subdomain) `
+                -AdminDisplayName "$($org.name) Admin" `
+                -AdminEmailVerified `
                 -Headers $seedAdmin.Headers `
                 -Description "TradeFinance walkthrough - $($org.role)"
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -661,6 +661,51 @@ function Get-OrCreateUser {
 }
 
 # ============================================================================
+# New-SorchaOrgUser — provision an org-scoped password user (spec 136)
+# ============================================================================
+
+function New-SorchaOrgUser {
+    <#
+    .SYNOPSIS
+        Provision a NEW org-scoped password user directly into an org via
+        POST /organizations/{orgId}/users/provision — single-org (no public account, no
+        invitation, no email loop). Use for org OPERATORS (analysts, officers, issuers) so they
+        are single-org and avoid the multi-org OAuth-grant 401. Citizens use Register-SorchaPublicUser.
+    .NOTES
+        -EmailVerified requires the installation to enable Platform:AllowAdminVerifiedUserCreation
+        (dev + n1 enable it; production does not).
+    .RETURNS
+        Hashtable with UserId, Email.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$TenantUrl,
+        [Parameter(Mandatory)][string]$OrganizationId,
+        [Parameter(Mandatory)][string]$Email,
+        [Parameter(Mandatory)][string]$Password,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [Parameter(Mandatory)][hashtable]$Headers,
+        [string[]]$Roles = @("Consumer"),
+        [switch]$EmailVerified
+    )
+
+    $body = @{
+        email         = $Email
+        displayName   = $DisplayName
+        password      = $Password
+        roles         = $Roles
+        emailVerified = [bool]$EmailVerified
+    }
+
+    $response = Invoke-SorchaApi -Method POST `
+        -Uri "$TenantUrl/organizations/$OrganizationId/users/provision" `
+        -Body $body `
+        -Headers $Headers
+
+    Write-WtSuccess "Org-scoped user provisioned: $DisplayName (ID: $($response.id))"
+    return @{ UserId = $response.id; Email = $Email }
+}
+
+# ============================================================================
 # Register-SorchaPublicUser — Self-register a user on the public org
 # ============================================================================
 

--- a/walkthroughs/run-compliance-suite.ps1
+++ b/walkthroughs/run-compliance-suite.ps1
@@ -93,9 +93,11 @@ foreach ($name in $suite.Keys) {
     }
 
     # --- setup.ps1 (if present) ---
+    # NOTE: do NOT name this $args — that is a PowerShell automatic variable and the
+    # assignment won't propagate to Invoke-Step (the bug that skipped -Force on re-runs).
     if (Test-Path $setup) {
-        $args = Get-Args (Get-Content $setup -Raw) $profile
-        $r = Invoke-Step $setup $args (Join-Path $logDir "$name.setup.log") (Join-Path $logDir "$name.setup.err.log") $TimeoutSeconds
+        $stepArgs = Get-Args (Get-Content $setup -Raw) $profile
+        $r = Invoke-Step $setup $stepArgs (Join-Path $logDir "$name.setup.log") (Join-Path $logDir "$name.setup.err.log") $TimeoutSeconds
         $durStr = "{0:mm\:ss}" -f $r.Dur
         if ($r.TimedOut) {
             $results += [pscustomobject]@{ Name=$name; Stage='setup'; Status='TIMEOUT'; Duration=$durStr; Exit='-'; Note="setup exceeded ${TimeoutSeconds}s" }
@@ -109,8 +111,8 @@ foreach ($name in $suite.Keys) {
     }
 
     # --- run.ps1 ---
-    $args = Get-Args (Get-Content $run -Raw) $profile
-    $r = Invoke-Step $run $args (Join-Path $logDir "$name.run.log") (Join-Path $logDir "$name.run.err.log") $TimeoutSeconds
+    $stepArgs = Get-Args (Get-Content $run -Raw) $profile
+    $r = Invoke-Step $run $stepArgs (Join-Path $logDir "$name.run.log") (Join-Path $logDir "$name.run.err.log") $TimeoutSeconds
     $durStr = "{0:mm\:ss}" -f $r.Dur
     if ($r.TimedOut) {
         $results += [pscustomobject]@{ Name=$name; Stage='run'; Status='TIMEOUT'; Duration=$durStr; Exit='-'; Note="run exceeded ${TimeoutSeconds}s" }


### PR DESCRIPTION
Converts walkthrough **org operators** to single-org provisioning (using the #822/#823 capabilities), fixing the multi-org OAuth-grant failures, and **enforces the pattern for future walkthroughs** in the walkthrough-builder skill.

## Changes
- **walkthrough-builder skill**: REQUIRED rule — org operators provisioned single-org via `New-SorchaOrganization -AdminPassword -AdminEmailVerified` (admin) / `New-SorchaOrgUser` (members); **citizens stay public** (explicit exception).
- **`New-SorchaOrgUser`** module helper → `POST /organizations/{id}/users/provision` (#823).
- **ForestryCertification**: 2 admins + the sales-manager/auditor member helper → org-scoped.
- **TradeFinance**: admins + the participant loop → org-scoped.
- **Runner fix**: `run-compliance-suite.ps1` used `$args` (a PowerShell automatic variable) so `-Force` never reached setup → stale-state skips. Renamed to `$stepArgs`.

## Validation (local, #822+#823 deployed)
- **ForestryCertification: PASS end-to-end** (Sales Manager submits, Auditor approves, DPP credential issued). Previously 401'd authenticating multi-org operators.
- **TradeFinance: procurement APPROVED 6/6 + 8/8** (previously 401'd at setup/auth). Residual **Invoice-Finance Action 1 → 400** is a chained-blueprint credential-presentation issue (same class as SelfBuildHouse) — **not** multi-org, pre-existing, separate follow-up.

## Follow-up (not in scope)
- The chained-blueprint 400 (TradeFinance Invoice-Finance / SelfBuildHouse warrant Action 1).
- Converting the remaining passing-but-multi-org walkthroughs (incremental; the skill enforces all new ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)