### PR TITLE
fix(117): gateway honours X-Forwarded-Proto (https in generated URLs)

### DIFF
--- a/src/Services/Sorcha.ApiGateway/Program.cs
+++ b/src/Services/Sorcha.ApiGateway/Program.cs
@@ -84,10 +84,26 @@ builder.Services.AddSingleton<Sorcha.ApiGateway.Discoverability.ToolCataloguePro
 // Add CORS for frontend - production restriction handled at infrastructure level
 builder.AddSorchaCors();
 
+// Honour X-Forwarded-Proto / -For from the edge proxy (Caddy terminates TLS on n1 and forwards
+// HTTP, so without this Request.Scheme is "http" — making generated absolute URLs in robots.txt,
+// sitemap.xml and the OpenAPI/MCP manifests use http://). The gateway is only reachable via the
+// trusted edge proxy in every deployment, so the immediate hop's headers are trusted.
+builder.Services.Configure<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders =
+        Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor |
+        Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto;
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline
 app.MapDefaultEndpoints();
+
+// Must run before any middleware that reads Request.Scheme (HTTPS enforcement, URL generation).
+app.UseForwardedHeaders();
 
 // Add Serilog HTTP request logging (OPS-001)
 app.UseSerilogLogging();


### PR DESCRIPTION
Behind Caddy (TLS termination → HTTP to the gateway), `Request.Scheme` was `http`, so the new root `robots.txt` `Sitemap:` line, `sitemap.xml` `<loc>`s, and the OpenAPI/MCP absolute URLs read `http://n1.sorcha.dev/...`. Adds `UseForwardedHeaders` (X-Forwarded-Proto/-For) early in the gateway pipeline. Verified locally: `X-Forwarded-Proto: https` → `Sitemap: https://.../sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)