### PR TITLE
fix: federate the system register to SyncOnly nodes (genesis seal + payload byte-preservation)

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/MemPoolManager.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/MemPoolManager.cs
@@ -25,7 +25,13 @@ public class MemPoolManager : IMemPoolManager
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true
+        PropertyNameCaseInsensitive = true,
+        // Relaxed encoding so non-ASCII payload bytes round-trip literally through Redis
+        // rather than as \uXXXX. The validator seals payloads via Payload.GetRawText() and
+        // verifies the genesis trust anchor by hashing those exact bytes — an escaping
+        // difference at any serialization boundary breaks payload-hash verification.
+        // Matches TransactionPoolPoller / RedisVerifiedTransactionQueue.
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
     public MemPoolManager(

--- a/src/Services/Sorcha.Validator.Service/Services/RedisVerifiedTransactionQueue.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/RedisVerifiedTransactionQueue.cs
@@ -374,6 +374,19 @@ public class RedisVerifiedTransactionQueue : IVerifiedTransactionQueue
         return (-(double)priority * PriorityScale) + enqueuedAt.ToUnixTimeMilliseconds();
     }
 
+    // CRITICAL: relaxed encoding so non-ASCII characters in a transaction payload
+    // (e.g. an em-dash in the genesis control record) and '+' in DateTimeOffset/base64
+    // are stored literally, not as \uXXXX. The docket builder seals the payload via
+    // Transaction.Payload.GetRawText() and the genesis trust anchor is verified by
+    // hashing those exact bytes — an escaping difference at this serialization boundary
+    // changes the payload hash and breaks genesis signature verification on peer sync.
+    // Mirrors TransactionPoolPoller's unverified-pool serializer (the verified queue was
+    // the missed sibling).
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new()
+    {
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     private static string SerializePayload(VerifiedTransaction tx)
     {
         var doc = new
@@ -383,14 +396,14 @@ public class RedisVerifiedTransactionQueue : IVerifiedTransactionQueue
             tx.Priority,
             ExpiresAt = tx.ExpiresAt,
         };
-        return JsonSerializer.Serialize(doc);
+        return JsonSerializer.Serialize(doc, PayloadJsonOptions);
     }
 
     private static VerifiedTransaction? DeserializePayload(string json)
     {
         try
         {
-            var doc = JsonSerializer.Deserialize<JsonElement>(json);
+            var doc = JsonSerializer.Deserialize<JsonElement>(json, PayloadJsonOptions);
             if (!doc.TryGetProperty("Transaction", out var txElem)) return null;
             var transaction = txElem.Deserialize<Transaction>();
             if (transaction is null) return null;

--- a/src/Services/Sorcha.Validator.Service/Services/TransactionTypeClassifier.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/TransactionTypeClassifier.cs
@@ -29,6 +29,27 @@ internal static class TransactionTypeClassifier
         return false;
     }
 
+    /// <summary>
+    /// True only for the pre-signed genesis transaction (the network trust anchor),
+    /// NOT live control/governance transactions. The genesis transaction is signed
+    /// once during the offline ceremony with a fixed timestamp and embedded for the
+    /// life of the network — it is ingested whenever a node bootstraps, which may be
+    /// arbitrarily long after the ceremony. It must therefore be exempt from the
+    /// transaction-freshness window (VAL_TIME_002); live control transactions are
+    /// created at submission time and stay subject to it.
+    /// </summary>
+    public static bool IsGenesisTransaction(Transaction transaction)
+    {
+        if (string.Equals(transaction.BlueprintId, GenesisConstants.BlueprintId, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
+            string.Equals(typeStr, "Genesis", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
     public static bool IsParticipantTransaction(Transaction transaction)
     {
         return transaction.Metadata.TryGetValue("Type", out var typeStr) &&

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -1578,8 +1578,15 @@ public class ValidationEngine : IValidationEngine
                 ValidationErrorCategory.Timing, "CreatedAt"));
         }
 
-        // Check for expired transactions
-        if (transaction.CreatedAt < now.Subtract(_config.MaxTransactionAge))
+        // Check for expired transactions.
+        // The pre-signed genesis transaction is exempt: it is a ceremony artifact
+        // with a fixed timestamp, embedded and ingested whenever a node bootstraps
+        // (often days/years after the ceremony). Applying the live-transaction
+        // freshness window to it would reject the trust anchor, leaving the genesis
+        // docket sealed empty so federated SyncOnly nodes can never obtain or verify
+        // the system register. Live control/governance transactions stay subject to it.
+        if (transaction.CreatedAt < now.Subtract(_config.MaxTransactionAge)
+            && !TransactionTypeClassifier.IsGenesisTransaction(transaction))
         {
             errors.Add(CreateError("VAL_TIME_002",
                 $"Transaction is too old (max age: {_config.MaxTransactionAge})",

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
@@ -534,6 +534,26 @@ public class ValidationEngineTests
     }
 
     [Fact]
+    public async Task ValidateTransactionAsync_OldGenesisTransaction_IsExemptFromTooOldCheck()
+    {
+        // Arrange - a pre-signed genesis transaction far older than MaxTransactionAge.
+        // The genesis trust anchor is a ceremony artifact with a fixed timestamp; it is
+        // ingested whenever a node bootstraps (often long after the ceremony). Rejecting
+        // it as "too old" seals the genesis docket empty and prevents federated SyncOnly
+        // nodes from ever obtaining/verifying the system register.
+        var tx = CreateValidTransaction(
+            blueprintId: Sorcha.Register.Models.Constants.GenesisConstants.BlueprintId,
+            createdAt: DateTimeOffset.UtcNow.AddDays(-30));
+        SetupSuccessfulValidation(tx);
+
+        // Act
+        var result = await _engine.ValidateTransactionAsync(tx);
+
+        // Assert - the genesis transaction must NOT be rejected for being too old
+        result.Errors.Should().NotContain(e => e.Code == "VAL_TIME_002");
+    }
+
+    [Fact]
     public async Task ValidateTransactionAsync_WithNullTransaction_ThrowsArgumentNullException()
     {
         var act = async () => await _engine.ValidateTransactionAsync(null!);


### PR DESCRIPTION
## Problem

A second node brought up with `docker-compose.sync-from-n1.yml` (`SystemRegister:BootstrapMode=SyncOnly`) never obtained the **system register** from the seed node (n1). It sat in `System register not found — waiting for peer sync` indefinitely.

Diagnosis (full debug trail): the peer transport, register subscription, and full-replica pull **all worked** — local logged `Full replica sync completed: 2 dockets, 4 transactions from peer n1.sorcha.dev`. Two validator-side bugs broke the **genesis trust anchor** verification:

### Bug 1 — VAL_TIME_002 rejects the pre-signed genesis transaction
The embedded genesis is a ceremony artifact with a **fixed timestamp**, ingested whenever a node bootstraps (in this run, 10 days after the ceremony). The validator's 1-hour transaction-freshness window (`VAL_TIME_002`) rejected it:
```
VAL_TIME_002: Transaction is too old (max age: 01:00:00)
GenesisManager Creating genesis docket … with 0 transactions
```
So the genesis docket sealed **empty**. The trust anchor then lived only in the seed's local `Register.InitialControlRecord` row field, which the peer-sync protocol does not transfer — a SyncOnly node could never obtain or verify it.

**Fix:** `TransactionTypeClassifier.IsGenesisTransaction` exempts the genesis transaction from `VAL_TIME_002`. Live control/governance transactions stay subject to it.

### Bug 2 — genesis payload re-escaped in the Redis mempool
Even with the genesis sealed into docket 0, sync verification failed: `genesis signature does not match trusted public key`. `RedisVerifiedTransactionQueue` (the docket-build source) and `MemPoolManager` serialized the mempool transaction with the **default** JSON encoder, which escapes non-ASCII — an em-dash (`—`) in the genesis control record became `—`, growing the payload 1812→1837 bytes. The docket builder seals the payload via `Payload.GetRawText()`, and `SystemRegisterSyncVerifier` hashes those exact bytes against the signed `payloadHash`, so the escaping difference broke verification.

`TransactionPoolPoller` (the *unverified* pool) already used `UnsafeRelaxedJsonEscaping` for exactly this reason — the verified queue and mempool manager were the missed siblings. The **in-memory** queue keeps the object graph, which is why single-node local dev never reproduced this.

**Fix:** both now use `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`.

## Notes
- Neither fix requires regenerating the genesis or a protocol change — the existing embedded genesis now round-trips byte-for-byte.
- Verified end-to-end against n1 (lifting the freshness window sealed the genesis docket with the control tx) and by unit test (`ValidateTransactionAsync_OldGenesisTransaction_IsExemptFromTooOldCheck`).
- Full validator suite: **975 total, 0 failed, 958 passed, 17 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)