### PR TITLE
fix: create register on cross-node genesis sync (regular registers)

### DIFF
--- a/.specify/tasks/deferred-tasks.md
+++ b/.specify/tasks/deferred-tasks.md
@@ -218,6 +218,18 @@
 
 ---
 
+## MCP Server Capability Review (2026-05-23)
+
+> **Context:** During cross-node federation work (PRs #828 system-register genesis sync, #829 create-on-sync for regular registers) the operator had to drive register subscription/sync via direct service-to-service peer-service calls (`POST /api/registers/{id}/subscribe`, `RequireService`). The MCP server's admin slice (35-tool catalogue) is **observational** — `sorcha_peer_status`, `sorcha_register_stats`, `sorcha_register_query`, `sorcha_validator_status` — plus tenant/user/token management. It has **no register-control / sync / replication / bootstrap tools**, so an AI agent can *observe* federation state but not *drive* it. Register control was expected to be useful here; review whether infra/register-control operations should be first-class MCP tools.
+
+| ID | Task | Priority | Effort | Status | Notes |
+|----|------|----------|--------|--------|-------|
+| MCP-101 | Audit MCP tool catalogue for register-control / infra gaps | P2 | 4h | 📋 | Review the 35-tool catalogue (Admin/Designer/Participant) against operator+agent needs surfaced by the federation work. Decide which infra actions (register subscribe/unsubscribe, sync-state, local-relationship, validator enrol/suspend) belong as MCP tools vs staying service-to-service only. |
+| MCP-102 | Add register-control admin tools (if MCP-101 approves) | P2 | 8h | 📋 | e.g. `sorcha_register_subscribe` / `sorcha_register_unsubscribe` / `sorcha_register_sync_status` wrapping peer-service `/api/registers/{id}/subscribe`+`/subscriptions` and register-service `/sync-state`+`/local-relationship`. Admin-role gated; the underlying `RequireService` s2s call handled server-side so the agent never holds a service secret. |
+| MCP-103 | Decide policy on node-lifecycle tools (bootstrap / validator-key import / reset) | P3 | 4h | 📋 | High-blast-radius; likely keep OUT of MCP (operator-only) but document the decision so it's deliberate, not an omission. |
+
+---
+
 ## Summary
 
 **Total Deferred Tasks:** 69 (11 now completed/implemented)

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1399,7 +1399,13 @@ docketsGroup.MapPost("/", async (
     string registerId,
     WriteDocketRequest request) =>
 {
-    // Validate register exists (auto-create for genesis docket 0 on system register)
+    // Validate register exists. A genesis docket (DocketNumber 0) for a register not
+    // yet known locally is the create-on-sync path: a peer is replicating a register's
+    // genesis to this node. By the time the docket reaches here the peer's
+    // DocketFinalizationService has already verified chain integrity, docket hash, and
+    // proposer signature (and the trust anchor, for the system register), so creating
+    // the register from the verified genesis is safe. The node only pulls genesis
+    // dockets for registers it has explicitly subscribed to.
     var register = await repository.GetRegisterAsync(registerId);
     if (register == null)
     {
@@ -1414,6 +1420,27 @@ docketsGroup.MapPost("/", async (
                 registerId: registerId,
                 description: "Sorcha platform system register — root of trust for blueprints and governance.",
                 purpose: Sorcha.Register.Models.Enums.RegisterPurpose.System);
+        }
+        else if (request.DocketNumber == 0)
+        {
+            // Regular register replicated from a peer: derive name/description from the
+            // genesis control record where available, else fall back to a synthetic name
+            // so the register row exists and subsequent dockets can be written.
+            var controlRecord = Sorcha.Register.Service.Services.GenesisControlRecordExtractor.TryExtract(request.Transactions);
+            var replicaName = controlRecord?.Name is { Length: > 0 } controlName
+                ? controlName
+                : $"replica-{registerId[..Math.Min(8, registerId.Length)]}";
+            logger.LogInformation(
+                "Auto-creating replicated register {RegisterId} ({Name}) from synced genesis docket",
+                registerId, replicaName);
+            register = await registerManager.CreateRegisterAsync(
+                replicaName,
+                advertise: true,
+                isFullReplica: true,
+                registerId: registerId,
+                description: controlRecord?.Description,
+                purpose: Sorcha.Register.Models.Enums.RegisterPurpose.General,
+                initialControlRecord: controlRecord);
         }
         else
         {

--- a/src/Services/Sorcha.Register.Service/Services/GenesisControlRecordExtractor.cs
+++ b/src/Services/Sorcha.Register.Service/Services/GenesisControlRecordExtractor.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using System.Text.Json;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Sorcha.TransactionHandler.Services;
+
+namespace Sorcha.Register.Service.Services;
+
+/// <summary>
+/// Extracts the <see cref="RegisterControlRecord"/> from a genesis docket's
+/// transactions. Used by the docket-write path to create a register row when a
+/// peer replicates a register's genesis (docket 0) that this node has not yet
+/// created locally — the "create-on-sync" path that lets a subscribed node hold
+/// a fully-replicated copy of a register it does not own.
+/// </summary>
+internal static class GenesisControlRecordExtractor
+{
+    /// <summary>
+    /// Returns the first Control transaction's <see cref="RegisterControlRecord"/>
+    /// from the supplied transactions, or null if none is present / decodable.
+    /// </summary>
+    /// <remarks>
+    /// Payload bytes are <c>base64url</c>/<c>base64</c>-encoded canonical JSON (the
+    /// same wire shape the participant index and crypto-policy paths decode). The
+    /// <c>[JsonPropertyName]</c> attributes on <see cref="RegisterControlRecord"/>
+    /// make deserialisation naming-policy independent, matching
+    /// <c>GenesisIngestionService</c> and <c>CryptoPolicyService</c>.
+    /// </remarks>
+    public static RegisterControlRecord? TryExtract(IReadOnlyList<TransactionModel>? transactions)
+    {
+        if (transactions is null)
+        {
+            return null;
+        }
+
+        foreach (var tx in transactions)
+        {
+            if (tx.MetaData?.TransactionType != TransactionType.Control)
+            {
+                continue;
+            }
+
+            if (tx.Payloads is null || tx.Payloads.Length == 0 || string.IsNullOrEmpty(tx.Payloads[0].Data))
+            {
+                continue;
+            }
+
+            try
+            {
+                var json = Encoding.UTF8.GetString(ContentEncodings.DecodeBase64Auto(tx.Payloads[0].Data));
+                var record = JsonSerializer.Deserialize<RegisterControlRecord>(json);
+                if (record is not null && !string.IsNullOrWhiteSpace(record.Name))
+                {
+                    return record;
+                }
+            }
+            catch (Exception ex) when (ex is FormatException or JsonException)
+            {
+                // Not a decodable control record — try the next transaction.
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Sorcha.Register.Service.Tests/Services/GenesisControlRecordExtractorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Services/GenesisControlRecordExtractorTests.cs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Sorcha.Register.Service.Services;
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests.Services;
+
+/// <summary>
+/// Tests for the create-on-sync genesis control-record extraction used when a peer
+/// replicates a regular register's genesis docket to a node that has not created it
+/// locally yet.
+/// </summary>
+public class GenesisControlRecordExtractorTests
+{
+    private static TransactionModel BuildControlTx(RegisterControlRecord record)
+    {
+        var json = JsonSerializer.Serialize(record);
+        var data = Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+        return new TransactionModel
+        {
+            TxId = "tx-control",
+            MetaData = new TransactionMetaData { TransactionType = TransactionType.Control },
+            Payloads = [new PayloadModel { Data = data }]
+        };
+    }
+
+    private static RegisterControlRecord SampleRecord(string name = "Assured Identity") => new()
+    {
+        RegisterId = "deccbf4dc9ad4edebe5d6a3651da80b9",
+        Name = name,
+        Description = "Citizen identity register",
+        CreatedAt = DateTimeOffset.UtcNow,
+        Attestations =
+        [
+            new RegisterAttestation
+            {
+                Role = RegisterRole.Owner,
+                Subject = "did:sorcha:org:ws1test",
+                PublicKey = "AAAA",
+                Signature = "BBBB",
+                Algorithm = SignatureAlgorithm.ED25519,
+                GrantedAt = DateTimeOffset.UtcNow
+            }
+        ]
+    };
+
+    [Fact]
+    public void TryExtract_ControlTransaction_ReturnsRecordWithName()
+    {
+        var txs = new List<TransactionModel> { BuildControlTx(SampleRecord()) };
+
+        var result = GenesisControlRecordExtractor.TryExtract(txs);
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Assured Identity");
+        result.Description.Should().Be("Citizen identity register");
+    }
+
+    [Fact]
+    public void TryExtract_NoControlTransaction_ReturnsNull()
+    {
+        var txs = new List<TransactionModel>
+        {
+            new()
+            {
+                TxId = "tx-action",
+                MetaData = new TransactionMetaData { TransactionType = TransactionType.Action },
+                Payloads = [new PayloadModel { Data = "e30=" }] // {}
+            }
+        };
+
+        GenesisControlRecordExtractor.TryExtract(txs).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryExtract_NullTransactions_ReturnsNull()
+    {
+        GenesisControlRecordExtractor.TryExtract(null).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryExtract_ControlTransactionWithGarbagePayload_ReturnsNullWithoutThrowing()
+    {
+        var txs = new List<TransactionModel>
+        {
+            new()
+            {
+                TxId = "tx-bad",
+                MetaData = new TransactionMetaData { TransactionType = TransactionType.Control },
+                Payloads = [new PayloadModel { Data = Convert.ToBase64String(Encoding.UTF8.GetBytes("not json")) }]
+            }
+        };
+
+        GenesisControlRecordExtractor.TryExtract(txs).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem (Stage 4 of cross-node federation)

A node that subscribes to a **peer-owned register** pulls the docket chain at the peer layer (`Full replica sync completed: 3 dockets, 5 transactions from peer n1`) but **register-service 404'd every `POST /api/registers/{id}/dockets`** and never created the register row — so transactions weren't queryable locally and sync status reported `NotFound`.

## Root cause

The `WriteDocket` handler's auto-create-on-genesis was **hardcoded to the system register id**:

```csharp
if (request.DocketNumber == 0 && registerId == SystemRegisterConstants.SystemRegisterId)
    register = await registerManager.CreateRegisterAsync(...);   // system only
else
    return Results.NotFound(...);   // every regular register lands here
```

The system register has a bespoke create-on-sync path; regular registers had none.

## Fix

Generalise auto-create to **any** genesis docket. For a non-system register, derive name/description from the genesis Control transaction's `RegisterControlRecord` (new `GenesisControlRecordExtractor`) and create it as a full-replica, advertised register; fall back to a synthetic `replica-{id8}` name if the control record is unavailable.

**Safety:** by the time a docket reaches `WriteDocket`, the peer's `DocketFinalizationService` has already verified chain integrity, docket hash, and proposer signature, and the node only pulls genesis dockets for registers it has **explicitly subscribed to** — so create-on-verified-genesis is consistent with the existing trust model.

## Tests
- `GenesisControlRecordExtractorTests` (4): control-record extraction, no-control, null, garbage payload.
- Full register-service suite: **308 total, 0 failed, 299 passed, 9 skipped**.

Verified end-to-end by replicating the assured-identity register `deccbf4d…` from n1 to a local SyncOnly node (was 404, now creates + reaches queryable FullyReplicated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)