### PR TITLE
docs: cross-node federation state + Stage-5 kickoff prompt

### DIFF
--- a/docs/superpowers/prompts/cross-node-submission-kickoff.md
+++ b/docs/superpowers/prompts/cross-node-submission-kickoff.md
@@ -1,0 +1,58 @@
+# Kickoff prompt — design the cross-node submission round-trip ("Stage 5")
+
+Paste the block below into a fresh session (from the repo root). It is **brainstorm-first**: settle
+the correct architecture before any code, so we specify and build once instead of applying point-fixes.
+
+Portable context lives in source control:
+- State & gap analysis: `docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md`
+- This prompt: `docs/superpowers/prompts/cross-node-submission-kickoff.md`
+
+> **Before you start on a new machine:** copy `genesis-validator-key.json` to the repo root
+> out-of-band (it is gitignored — holds the validator mnemonic), and update the n1 `AllowSSH` NSG
+> rule for this machine's public IP. The local node's installation name comes from `INSTALLATION_NAME`
+> (default `localhost`) — it will differ from the previous box; that's fine, the design question is
+> structural (local install ≠ n1 install), not the literal name.
+
+---
+
+````
+# Design the cross-node submission round-trip ("Stage 5") — brainstorm FIRST, then spec, then build
+
+## Step 0 — load skills before doing anything (Skill tool), in this order
+1. `superpowers:brainstorming` — **the point of this session. Do NOT write code or apply point-fixes. Brainstorm and fully discuss the correct design first.**
+2. `sorcha-architecture` (F108 ownership-agnostic submission, F099 genesis, register replication, F114 credential delivery), `jwt` (F136 tiered audiences — installation = trust boundary), `network-bootstrap`, `n1-deploy`, `blueprint-builder`, `walkthrough-builder`.
+3. Keep `superpowers:systematic-debugging` + `grpc`/`signalr`/`mongodb`/`redis` for later.
+For "properly specify and build" use spec-kit (`/speckit.specify` → `/speckit.plan` → `/speckit.tasks`, producing `specs/{id}-{slug}/`), and ONLY after the design is agreed.
+
+Then read `docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md` — the full state, the verified read-path, the precise Stage-5 gaps, IDs, creds, and operational notes.
+
+## What already works (verified live n1↔local — do NOT re-debug)
+- Topology: n1.sorcha.dev = Auto seed + register OWNER/validator; local Docker = SyncOnly REPLICA via `docker-compose.sync-from-n1.yml`. Installation names differ per node (trust boundary — see below).
+- PR #828 (merged): system-register genesis federates byte-for-byte. PR #829 (merged): create-on-sync for regular registers (assured-identity `deccbf4dc9ad4edebe5d6a3651da80b9` replicates n1→local, queryable). The READ/replication path is solid.
+
+## The goal (Stage 5, NOT working)
+Citizen submits on LOCAL → reaches n1 → n1 validates/seals → verification-analyst agent on n1 approves → AssuredIdentityCredential issued → returns to the citizen.
+
+## Precisely where it breaks (from the last probe — see the state doc for detail)
+1. blueprint-service recovery is one-shot at startup (`BlueprintRecoveryService.ExecuteAsync`) — a node subscribing after boot doesn't materialise the register's blueprints until restart.
+2. THE wall: `Sorcha.Blueprint.Service/Program.cs` CreateInstance (~1873) resolves the blueprint via `IBlueprintStore` (draft store); recovery only loads `IPublishedBlueprintStore`. Replicas have only the published store → `POST /instances` 400 "Blueprint not found". Citizen can't start the workflow on local.
+3. Untested behind the wall: F108 peer fan-out on submit (`ActionExecutionService` → `IPeerServiceClient.DistributeTransactionAsync`), n1 sealing a local-origin tx, cross-node participant late-binding/identity, credential delivery to a local citizen wallet.
+
+## The task: brainstorm the CORRECT design before building
+Stop applying point-fixes; establish the right architecture so we specify and build once. Challenge assumptions; resolve at least:
+- **Trust-domain model (foundational, decide first):** F136 made *installation* the JWT trust boundary, yet our two nodes are different installations. Is federation meant to be MULTIPLE NODES WITHIN ONE installation/trust domain (shared issuer, distinct node identities) or ACROSS separate installations (register-level trust via control-record attestations)? This reshapes everything below.
+- **Identity & participant resolution across nodes:** how does a citizen who authenticated on local become a valid late-bound participant on n1's register — whose keys/issuer, how does n1 verify the signature and bind?
+- **Blueprint availability on replicas:** unify blueprint resolution so instance/action creation is published-store-aware; make recovery event-driven on register replication rather than one-shot.
+- **Submission fan-out (F108):** confirm the intended path and what must hold for n1 to accept a local-origin tx.
+- **Credential issuance delivery back to a local citizen wallet** (SorchaLocalWallet/HAIP) across nodes.
+- **Minimal correct "network" definition:** which existing pieces (F099/F108/F086 validator roster/F136) already cover parts vs what's genuinely missing.
+
+Produce a design doc at `docs/superpowers/specs/<date>-cross-node-submission-design.md` (decisions, chosen trust model, component-by-component plan, open risks). After I confirm it, drive `/speckit.specify` → `/speckit.plan` → `/speckit.tasks`. Do NOT implement until the design is confirmed.
+
+## Guardrails
+- Do NOT change validator keys; reuse `genesis-validator-key.json` (gitignored — must be copied to this machine out-of-band). n1 = Auto owner, local = SyncOnly replica.
+- Branch + PR per change (never push master); merge on green (claude-review pass; the `BatchPublicKeyResolutionTests` CI red is a known env-flake — passes locally 308/0).
+- `az` CLI has a TLS issue from this shell — use the SSH manual path for n1 (see n1-deploy skill). n1 auto-shuts ~23:00 GMT; update its `AllowSSH` NSG rule for this machine's IP.
+- Dev creds + service-token + subscribe procedure are in the state doc. Local install name = `INSTALLATION_NAME` (derive the actual value from a local token).
+- Brainstorm-first. Resist "just fix instance creation" — that's the point-fix pattern we're stepping back from.
+````

--- a/docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md
+++ b/docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md
@@ -1,0 +1,116 @@
+# Cross-node federation — state & gap analysis (2026-05-23)
+
+Source-controlled record of the n1↔local register-federation work, so it survives across
+machines and fresh sessions (the equivalent notes previously lived only in machine-local
+Claude memory). Companion kickoff prompt: `docs/superpowers/prompts/cross-node-submission-kickoff.md`.
+
+## Topology
+
+- **n1.sorcha.dev** — Azure VM, `Auto` seed, holds the genesis, is the **owner + validator** of
+  registers created on it. Installation name `n1.sorcha.dev` → JWT issuer `urn:sorcha:n1.sorcha.dev`,
+  audiences `n1.sorcha.dev:{consumer|platform|service|enrol-session}`.
+- **local Docker** — `SyncOnly` **replica** brought up with
+  `docker compose -f docker-compose.yml -f docker-compose.sync-from-n1.yml up -d`. It runs its OWN
+  tenant bootstrap (own admin + orgs). Only the **register layer** replicates from n1.
+- **Installation names differ by node.** `docker-compose.yml` sets
+  `JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}` — the local node's install name is
+  whatever `INSTALLATION_NAME` resolves to on that host (it was `phaethon` on the original dev box;
+  it will be different on another machine). **This divergence is the crux of the Stage-5 design
+  question** — post-F136, *installation* is the JWT trust boundary, so the two nodes are currently
+  separate trust domains.
+
+## What works — verified live (do NOT re-debug)
+
+The **read / replication path is solid**:
+
+- **System register** federates n1→local, byte-for-byte (id `aebf26362e079087571ac0932d4db973`,
+  matching genesis-docket hash + height). Fixed in **PR #828**.
+- **Regular registers** (e.g. assured-identity `deccbf4dc9ad4edebe5d6a3651da80b9`) replicate n1→local,
+  queryable, matching dockets/height; the register row is created on the replica from the synced
+  genesis. Fixed in **PR #829**.
+
+### PR #828 — system-register genesis federation (merged)
+Two validator-side bugs broke the genesis trust anchor on a SyncOnly node (transport itself was
+fine):
+1. `VAL_TIME_002` (transaction-freshness, max age 1h) rejected the **pre-signed genesis transaction**
+   (a ceremony artifact with a fixed timestamp, ingested days later) → `GenesisManager` sealed the
+   genesis docket **empty** → the trust anchor lived only in the seed's local
+   `Register.InitialControlRecord` row field, which peer-sync does not transfer. Fix:
+   `TransactionTypeClassifier.IsGenesisTransaction` exempts the genesis tx from `VAL_TIME_002`.
+2. The genesis payload was `\u`-re-escaped in the Redis mempool (`RedisVerifiedTransactionQueue`,
+   `MemPoolManager` used the default JSON encoder; an em-dash in the control record became `—`),
+   so `SHA256(sealed payload) ≠ signed payloadHash` and the sync verifier rejected it. Fix: both use
+   `UnsafeRelaxedJsonEscaping` (matching `TransactionPoolPoller`, which already did).
+
+### PR #829 — create-on-sync for regular registers (merged)
+The WriteDocket handler (`Sorcha.Register.Service/Program.cs`) auto-create-on-genesis was hardcoded
+to the system-register id, so any regular register's genesis docket 404'd on a replica. Fix:
+generalised to any genesis docket; for non-system registers, derive name/description from the genesis
+Control transaction via `GenesisControlRecordExtractor` and create as full-replica + advertised.
+
+## The Stage-5 goal (NOT working — design target)
+
+Citizen submits on the **local** node → submission reaches n1 → n1 validates/seals → the
+verification-analyst agent on n1 approves → an AssuredIdentityCredential is issued → it gets back to
+the requesting citizen.
+
+## Precise gaps found by empirical probe (2026-05-23)
+
+The **write/issue round-trip is blocked at the first hop**. A local citizen (local identity + wallet)
+could not even create a workflow instance on the replica:
+
+1. **blueprint-service recovery is one-shot at startup.** `BlueprintRecoveryService.ExecuteAsync` runs
+   `RunRecoveryAsync` once. `DiscoverRegistersAsync` → `IRegisterServiceClient.GetInternalRegistersAsync`
+   does enumerate all local registers (so it WOULD find a replicated register), but a node that
+   subscribes *after* boot won't materialise the register's blueprints until blueprint-service
+   restarts. (Workaround used in the probe: restart blueprint-service → it logged
+   "Recovered 2 published blueprints from register deccbf4d… (Assured Identity Register)".)
+2. **Instance creation can't see replicated blueprints — THE wall.** `Program.cs` `CreateInstance`
+   (~line 1873) resolves the blueprint via `IBlueprintStore.GetAsync` (the **draft/editable** store).
+   Recovery loads replicated blueprints into `IPublishedBlueprintStore` (the **published** store). On
+   the owner (n1) the blueprint is in both; on a **replica only the published store** has it →
+   `POST /api/instances/` returns **400 "Blueprint not found"**. The citizen cannot start the
+   workflow on local. (Also `CreateInstance` ~line 1890 calls `PublishBlueprintToRegisterAsync` on the
+   register — questionable on a non-owned replicated register.)
+3. **Untested, blocked behind #2** — F108 peer fan-out on submit
+   (`ActionExecutionService` → `IPeerServiceClient.DistributeTransactionAsync`; a
+   `BaseAddress must be set` warning was seen single-node); n1 validating/sealing a **local-origin**
+   transaction; cross-node participant late-binding / identity resolution across installations;
+   credential issuance delivery back to a **local** citizen wallet.
+
+**Verdict:** these are fixable, not fundamental — but they are genuinely new cross-node plumbing, and
+the trust-domain model (one installation vs many) must be settled before building, or we will keep
+applying point-fixes. That is the purpose of the kickoff prompt.
+
+## Operational notes (for reproducing on a new machine)
+
+- **`genesis-validator-key.json` is gitignored (it holds the validator mnemonic).** It will NOT
+  transfer via git — copy it to the new machine out-of-band before any n1 reset. Reuse it; never
+  regenerate (it matches the committed embedded genesis roster:
+  `ws11qzamquj62vk5…` / pubkey `u7ByW…` / fingerprint `6e6ec9f0…`).
+- **n1 access:** SSH `sorcha@51.105.7.135` (NSG is IP-restricted — update `AllowSSH` source for the
+  new machine's public IP). The `az` CLI has a TLS-trust issue from these shells, so use the SSH
+  manual path for n1 resets (see the `n1-deploy` / `network-bootstrap` skills). n1 auto-shuts ~23:00 GMT.
+- **n1 genesis-clean reset (SSH path):** scp `genesis-validator-key.json`→`/tmp/gvk.json`; `down -v`;
+  `docker volume create sorcha_wallet-encryption-keys` + chown `1654:1654`; `up -d wallet-service`
+  alone; wait healthy; one-shot `curlimages/curl` POST the mnemonic to
+  `/api/v1/wallets/system/recover` (`validatorId: local-validator`, `algorithm: ED25519`); shred;
+  `up -d` the rest; then `bootstrap`.
+- **Credentials (dev):** n1 admin `admin@sorcha.local` / `Dev_Pass_2025!`; local admin
+  `admin@local.node` / `Dev_Pass_2025!`. Peer-service `RequireService` calls need a service token —
+  `client_credentials` grant at `/api/service-auth/token` with `register-service` /
+  `register-service-secret` (form-encoded: `grant_type`, `client_id`, `client_secret`, `scope`).
+- **Subscribe a replica to a register** (peer-service, `RequireService`):
+  `POST {peer}/api/registers/{id}/subscribe` `{"mode":"full-replica"}`; poll
+  `{peer}/api/registers/subscriptions` for `FullyReplicated`. A persisted subscription resumes
+  *live-only* after restart — to force a fresh full pull you must **unsubscribe + resubscribe**
+  (`DELETE` then `POST`), which resets `LastSyncedDocketVersion` to -1.
+- **CI:** `build-and-test` runs on PRs; the `Sorcha.Register.Service.Tests.BatchPublicKeyResolutionTests`
+  failures are a CI-env flake (`SystemWalletSigning:ValidatorId configuration is required`) — they
+  pass locally (308/0). claude-review + the per-service Build jobs are the real gates.
+
+## Deferred / backlog already captured
+
+- `.specify/tasks/deferred-tasks.md` → **MCP-101/102/103**: review MCP capabilities — the admin slice
+  is observational only (no register-control/sync tools), so an agent can watch federation but not
+  drive it.


### PR DESCRIPTION
Source-controls the n1↔local federation context so it survives across machines/sessions (it previously lived only in machine-local notes), and adds a brainstorm-first kickoff prompt for the cross-node submission round-trip ("Stage 5").

- **`docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md`** — verified read/replication path (PRs #828 system-register genesis, #829 create-on-sync), the precise write-path gaps (blueprint resolution `IBlueprintStore` vs `IPublishedBlueprintStore` on replicas; one-shot recovery; untested fan-out/identity/credential-delivery), and operational/repro notes (n1 SSH reset, service tokens, subscribe procedure, gitignored validator key).
- **`docs/superpowers/prompts/cross-node-submission-kickoff.md`** — pasteable prompt that loads the skills, reads the state doc, and drives a **brainstorm-first** discussion (settle the trust-domain model: one installation vs many) before spec-kit and any code.

Repo-path references only (no `~/.claude/` paths). Notes that `genesis-validator-key.json` is gitignored and must be copied to a new machine out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)