### PR TITLE
feat: [137] cross-node submission round-trip — C5 mirror submission + design/spec/plan

### DIFF
--- a/docs/superpowers/specs/2026-05-23-cross-node-submission-design.md
+++ b/docs/superpowers/specs/2026-05-23-cross-node-submission-design.md
@@ -1,0 +1,276 @@
+# Cross-node submission round-trip ("Stage 5") — design (2026-05-23)
+
+Design for the cross-node citizen-submission → credential round-trip. Companion to the
+state/gap analysis at `docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md`
+(read that first for the verified read-path and the empirical gap probe).
+
+**Status:** design agreed (brainstorm). Next: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks`.
+
+---
+
+## Goal
+
+A citizen submits on the **local** node → the submission reaches **n1** → n1 validates/seals →
+the verification-analyst agent on n1 approves → an `AssuredIdentityCredential` is issued → it is
+delivered back to the requesting citizen's **local** wallet.
+
+The read/replication path (system register + regular registers, n1→local) is already solid
+(PR #828, PR #829). This design closes the **write/issue round-trip**, which the empirical probe
+showed is blocked at the first hop.
+
+---
+
+## 1. Trust model & the two planes (foundation, decided first)
+
+Federation is **across separate installations, bridged at the ledger plane** — *not* one
+installation spanning many nodes. Sorcha already runs two independent trust planes, and we keep
+them independent:
+
+- **Identity plane (F136 JWT).** Per-installation. `n1.sorcha.dev` and `local` each keep their own
+  issuer / audiences / signing key. Tokens are **never** portable across nodes. This design does
+  not touch it.
+- **Ledger plane.** Cross-node. Trust is *cryptographic*: a docket is trusted because its signature
+  matches a key in the **genesis-anchored validator roster** (F086); a transaction is trusted
+  because its signature verifies and it obeys chain/route rules. The peer transport tolerates
+  anonymous peers (FR-014) precisely because it is **not** the trust boundary — the roster is.
+  (Verified: `PeerAuthInterceptor` validates with the shared signing key, `ValidateAudience=false`,
+  and falls back to a lower-trust "anonymous" flag rather than rejecting cross-installation calls.)
+
+### Minimal "network" definition
+
+A set of installations, each its own identity domain, that share one or more registers via peer
+subscription, with cross-node trust anchored **solely** by the genesis validator roster +
+transaction/docket signatures. No shared user directory, no cross-installation JWT, no online
+callback to the originating node.
+
+### Why this is the right model
+
+The ledger plane *already* federates across installations and works (read path verified). Trying to
+merge the nodes into one JWT trust domain would fight F136, couple the nodes' auth, and break the
+n1(`Auto` owner)/local(`SyncOnly` replica) divergence we rely on. Everything cross-node must reduce
+to ledger-native crypto facts (a signature verifies; a key is published on a replicated register).
+That constraint is healthy: it means n1 may resolve the local citizen's **keys** without ever
+resolving their **identity**.
+
+---
+
+## 2. What already exists (do NOT rebuild)
+
+The cross-node *workflow* and *trust* machinery is largely present. The remaining gaps are small and
+well-bounded, not a missing subsystem.
+
+- **Cross-node trust** — genesis validator roster (F086), anonymous-tolerant peer transport,
+  byte-faithful replication (PR #828/#829).
+- **Cross-node instance materialisation** — `InstanceMirrorReconstructor` (F106 Wave D) subscribes
+  to `docket:confirmed`, walks each sealed docket's transactions, and upserts a **read-only mirror**
+  Instance row whenever a participant wallet is local to that node. The register is the source of
+  truth; instances are derived per-node. The shared `instanceId` travels in the tx metadata, so both
+  nodes key the same instance.
+- **Register-as-source-of-truth execution** — `ActionExecutionService` loads a local Instance *row*
+  but reconstructs **accumulated state from the register** via
+  `StateReconstructionService.ReconstructAsync`. So n1 needs only the mirror row + replicated
+  transactions to let the analyst submit the next action.
+- **Ownership-agnostic submission (F108)** — `ActionExecutionService` already fans a submission out
+  to both the local validator mempool and `IPeerServiceClient.DistributeTransactionAsync`; the
+  receiving peer hands it to its local validator, which seals iff it is on the roster.
+- **Credential delivery to a local wallet (F114)** — `InboundCredentialDetector` decrypts the
+  AEAD envelope with the recipient wallet's X25519 key, `CitizenInboxProjector` pushes
+  `WalletHub.CredentialAvailable`, the PWA shows it.
+
+---
+
+## 3. The gaps (what this design closes)
+
+| # | Gap | Plane |
+|---|-----|-------|
+| 1 | Instance creation resolves the blueprint via the **draft** store (`IBlueprintStore`); replicas only have the **published** store → `400 "Blueprint not found"`. **The wall.** | local |
+| 2 | Blueprint recovery is **one-shot at boot** (`BlueprintRecoveryService.ExecuteAsync`); a register subscribed-to *after* boot never materialises its blueprints until restart. | local |
+| 3 | `CreateInstance` calls `PublishBlueprintToRegisterAsync` — wrong on a non-owned replicated register. | local |
+| 4 | n1 cannot resolve an **open/public-user** recipient's delivery keys (holder JWK + X25519) → cannot bind/wrap the credential. | ledger/identity |
+| 5 | F108 fan-out `IPeerServiceClient` had a `BaseAddress must be set` warning — config, not architecture. | transport |
+
+---
+
+## 4. Approach: targeted root-cause (Approach B)
+
+Fix the *causes*, not the symptoms, without a speculative rewrite. (Approach A — minimal point-fixes
+— was rejected as the very pattern we're stepping back from; Approach C — register-native execution
+refactor — was rejected as over-scoped/risky for proving Stage 5.)
+
+### Component-by-component plan
+
+| Component | Change | Source touch-points |
+|-----------|--------|---------------------|
+| **C1 — Unified blueprint resolution** | Instance/action creation resolves the blueprint **published-store-aware** (draft → published fallback), so replicas and owners share one path. Gate `PublishBlueprintToRegisterAsync` on **node-is-owner** (derived F108 relationship) so replicas never re-publish. | `Blueprint.Service/Program.cs` CreateInstance (~1873, ~1890); `IBlueprintStore` / `IPublishedBlueprintStore`; F108 `IRegisterLocalRelationshipService` |
+| **C2 — Event-driven recovery** | `BlueprintRecoveryService` subscribes to the register-replication/creation signal and recovers a newly-synced register's published blueprints **immediately**; periodic re-scan kept as a safety net. | `BlueprintRecoveryService`; the create-on-sync path from PR #829; Redis pub/sub channel (exact channel resolved in research) |
+| **C3 — Open-participant key delivery** | New **client-autofilled derived public-key field** (JSON-Schema extension, F085/F092 idiom) carrying holder JWK (slot 108) + wallet X25519 pubkey. n1 resolves recipient delivery keys by **precedence: published participant record → carried key → fail closed**. Wallet-Service issuance accepts a recipient by *supplied public key* (not requiring a local wallet row). | new schema field type + renderer/PWA autofill; `ActionExecutionService` (~1972 recipient resolution); `Wallet.Service/CredentialEndpoints` issuance path |
+| **C4 — Fan-out config** | Set `IPeerServiceClient` BaseAddress on the submitting node so F108 `DistributeTransactionAsync` reaches the peer → n1. | Blueprint.Service config / service-client wiring |
+| **C5 — Cross-node validation confirmation** | Confirm n1 seals a local-origin starting-action tx (F103 wallet-check skip + signature verifiability) and that the **n1 mirror instance** lets the analyst submit action 2. Add carve-outs only if integration testing exposes a real gap. | `Validator.Service/ValidationEngine`; `InstanceMirrorReconstructor`; `StateReconstructionService` |
+
+---
+
+## 5. The round-trip (data flow)
+
+1. **Citizen authenticates on LOCAL** — `local:consumer` JWT, local HD wallet.
+2. **Blueprint resolves on LOCAL** from the published store (replicated from n1), materialised by
+   event-driven recovery when the register synced — **C1/C2**.
+3. **Citizen submits the starting action on LOCAL.** The form carries the public-key field,
+   client-autofilled with derived holder JWK + X25519 — **C3**. The wallet signs (self-describing
+   signature). The citizen is late-bound as `applicant` (F103).
+4. **F108 fan-out** — local validator (not on the roster → no seal) **+**
+   `IPeerServiceClient.DistributeTransactionAsync` → n1 peer-service `SubmitTransaction` — **C4**.
+5. **n1 validates & seals** — on the roster; starting-action wallet-check skipped; signature
+   verifies cryptographically → docket sealed — **C5**.
+6. **Instances materialise both sides** — `docket:confirmed` on n1 → `InstanceMirrorReconstructor`
+   upserts the mirror (analyst wallet is n1-local); docket replicates → LOCAL mirrors too (citizen
+   wallet local). Shared `instanceId` rides the tx.
+7. **Analyst approves on n1** (action 2) — n1 reconstructs accumulated state from the register
+   (incl. the citizen payload + carried keys), routes, seals.
+8. **Credential issued on n1** (action 3) — recipient keys resolved by precedence (open citizen →
+   carried key). SD-JWT bound to the holder JWK (`cnf`); AEAD envelope encrypted to X25519;
+   `targetAudience: SorchaLocalWallet` tx sealed → replicates — **C3**.
+9. **Credential lands on LOCAL** — `docket:confirmed` → `InboundCredentialDetector` decrypts with
+   the citizen's local X25519 key → `CitizenInboxProjector` → `WalletHub.CredentialAvailable` →
+   the PWA shows it. **Round-trip complete.**
+
+---
+
+## 6. The one new wire contract — the public-key field
+
+Following the F085 `x-file` / F092 `x-persona` idiom: a blueprint-declared field the renderer
+recognises and the client autofills.
+
+```jsonc
+// In a starting action's schema
+"holderKeys": {
+  "type": "object",
+  "format": "sorcha-holder-key",        // renderer recognises → client autofills, read-only to the user
+  "x-holder-key": { "required": true }
+}
+```
+
+**Value shape** (client-autofilled; lands in the action payload → replicated register state):
+
+```jsonc
+{
+  "holderJwk": { "kty": "EC", "crv": "P-256", "x": "…", "y": "…" },  // slot 108, for the SD-JWT cnf binding
+  "encryptionPublicKey": "…"                                          // wallet X25519, for the AEAD envelope
+}
+```
+
+- **Client-autofilled, derived, public-only.** The PWA/renderer reads the *public* halves of keys
+  the wallet already derives (F114 derives the slot-108 holder key today). Private keys never leave
+  the device/local wallet.
+- **Trust-on-submission, not proof-of-possession (v1).** Because the open-participant submitter *is*
+  the recipient (late-bound applicant = starting-action sender), there is no adversarial incentive:
+  a wrong holder key → an unpresentable credential; a wrong X25519 key → a credential the submitter
+  cannot decrypt. Both are self-defeating. The identity collapse in F103's late-binding is what
+  removes the attacker. PoP (a key-binding proof) is a hardening backlog item, paired with the
+  participant-record promotion (which weakens that guarantee by letting a different actor vouch for
+  keys).
+- **Research note.** If Sorcha derives the wallet's X25519 key deterministically from its ED25519
+  signing key, n1 could derive `encryptionPublicKey` from the tx signature and the field could
+  shrink to `holderJwk` only. Confirm during research; this design assumes both are carried.
+
+---
+
+## 7. n1 recipient-key resolution precedence
+
+At credential issuance, `ActionExecutionService` resolves the recipient's delivery keys in order:
+
+1. **Published participant record** on the register (`/participants/by-address/{addr}/public-key`) —
+   replicated cross-node, **authoritative**. Covers org field agents (already published) with no
+   new plumbing.
+2. **Carried key field** from reconstructed instance state — the open/public-user fallback.
+3. **Neither** → **fail closed**: do not issue an unbindable/unencryptable credential; surface a
+   clear error.
+
+If both 1 and 2 are present, **published wins** (and on conflict, log + use published). This is the
+same precedence the backlogged promotion will use when a citizen later becomes published — the
+carried key is simply superseded.
+
+---
+
+## 8. Error handling & edge cases
+
+- **Blueprint not yet recovered when the citizen arrives** → C2 makes this rare; on miss, return a
+  typed "register still syncing" state (not a bare 400), and the client retries.
+- **Replica attempts to seal** → already prevented (F108: subscribers never seal); C1 also stops
+  replica re-publish.
+- **Fan-out to n1 fails / n1 unreachable** → the tx remains in the local mempool; submission UX
+  shows "submitted, awaiting validation"; define bounded retry + an operator-visible signal rather
+  than silent loss.
+- **Carried key missing/malformed** → issuance fails closed (§7.3).
+- **Late outcome / seal ordering** → F119 seal-aware ordering already governs the outcome/advance
+  chain; cross-node sealing latency is just a longer wait, handled by the same coordinator.
+
+---
+
+## 9. Verification strategy (two machines)
+
+The code is written **here**; the live n1↔local cross-node test runs on a **different machine** (the
+one holding `genesis-validator-key.json`, n1 SSH access, and the `docker-compose.sync-from-n1.yml`
+split).
+
+**Buildable & verifiable here (this machine):**
+
+- Unit: blueprint-resolver draft→published precedence; replica-creation gating; key-field autofill +
+  payload extraction; n1 recipient-key precedence (published → carried → fail-closed); event-driven
+  recovery firing on a simulated register-sync event.
+- Single-node integration: instance creation against a published-only blueprint; credential issuance
+  to a recipient supplied *by public key* (no local wallet row).
+
+**Deferred to the cross-node machine:**
+
+- The live n1↔local round-trip = the real success criterion (Tier 2 below).
+- **Deliverable from this work:** a *scripted, reproducible* verification procedure (extend the
+  AssuredIdentity walkthrough + a probe script) so the cross-node run is turn-key when we are on
+  that machine — not an ad-hoc manual probe.
+
+---
+
+## 10. Scope, success criteria, backlog, risks
+
+### Success criteria (two tiers)
+
+- **Tier 1 (gate, here):** code complete; all unit + single-node integration green; the scripted
+  cross-node verification procedure committed.
+- **Tier 2 (cross-node machine):** a citizen on LOCAL completes the AssuredIdentity application →
+  the analyst on n1 approves → the `AssuredIdentityCredential` appears in the citizen's LOCAL PWA
+  wallet — with **no manual blueprint-service restart** and **no manual key entry**.
+
+### Out of scope / backlog
+
+- **Participant-record promotion** (durable cross-node identity; field-agent use-or-supersede) —
+  **paired with PoP hardening** on the key field. *Motivation: org field agents are likely already
+  PublishedParticipants in real deployments, so those records must be used / superseded.*
+- Proof-of-possession on the key field (until promotion lands).
+- mdoc / non-SD-JWT formats cross-node; multi-register; >2 nodes (the design must not *preclude*
+  these, but will not test them).
+- MCP register-control/sync tools (the deferred MCP-101/102/103 backlog — the admin slice is
+  observational only today).
+
+### Risks (verify early in build)
+
+1. **Mirror-instance sufficiency** — does the analyst actually submit action 2 against the n1 mirror
+   + register reconstruction? Highest-value early integration check.
+2. **Recovery event channel** — pick the right signal (reuse PR #829's create-on-sync path vs. a
+   dedicated channel).
+3. **Wallet-Service issuance to a non-local recipient by supplied key** — may need a distinct
+   issuance code path (today it does `GetByAddressAsync`).
+4. **Holder-JWK format compatibility** — the carried JWK must match what `InboundCredentialDetector`
+   / the PWA expect for `cnf`.
+
+---
+
+## Decisions log
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Two-plane trust model; federation = separate installations bridged at the ledger plane | The ledger plane already federates cross-installation and works; merging into one JWT domain fights F136 and couples node auth |
+| D2 | Open-participant delivery keys carried in the submission via a client-autofilled, derived public-key field | Fits the F085/F092 schema-extension idiom; no participant record needed; HD-derived public keys, private keys never leave the device |
+| D3 | v1 = carry-in-submission only; participant-record promotion backlogged | Smallest path that proves Stage 5 end-to-end; promotion is designed-for via the reusable field type |
+| D4 | n1 recipient-key resolution precedence: published record → carried key → fail closed | Org field agents (published) work with no new plumbing; open users fall back to the carried key; never issue an unusable credential |
+| D5 | Trust-on-submission (no PoP) for v1 | F103 late-binding collapses submitter and recipient into one wallet, removing the attacker |
+| D6 | Approach B (targeted root-cause) over A (point-fixes) or C (register-native rewrite) | Fixes causes (blueprint resolution, recovery, replica semantics) without a speculative rewrite |
+| D7 | Code written here; cross-node round-trip verified on a separate machine, via a committed scripted procedure | The genesis key + n1 access + sync-split live on a different machine |

--- a/specs/137-cross-node-submission/checklists/requirements.md
+++ b/specs/137-cross-node-submission/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Cross-node submission round-trip (Stage 5)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- Validation result (2026-05-23): all items pass. The spec deliberately names domain concepts
+  (register, validator roster, wallet, holder/encryption keys, published vs draft store) because
+  they are the feature's subject matter, not implementation choices; concrete file paths and code
+  symbols are confined to the design doc, not this spec. No [NEEDS CLARIFICATION] markers — the
+  brainstorm resolved the foundational decisions (trust model, key-resolution precedence, v1 scope).

--- a/specs/137-cross-node-submission/contracts/holder-keys-endpoint.openapi.yaml
+++ b/specs/137-cross-node-submission/contracts/holder-keys-endpoint.openapi.yaml
@@ -1,0 +1,57 @@
+openapi: 3.1.0
+info:
+  title: Wallet Service — Citizen holder keys
+  version: "1.0.0"
+  description: >
+    Returns the signed-in citizen's public delivery keys so a blueprint form can auto-fill the
+    `sorcha-holder-key` field (Feature 137 / Stage 5). Public material only — no private keys.
+paths:
+  /api/v1/wallet/holder-keys:
+    get:
+      operationId: getCitizenHolderKeys
+      summary: Get the citizen's holder + encryption public keys
+      description: >
+        Resolves the caller's slot-108 holder public JWK (for SD-JWT `cnf` binding) and wallet
+        encryption public key (for the on-register AEAD envelope) from the citizen JWT. Used by the
+        HolderKeyRenderer to auto-fill the cross-node submission key field. Consumer-tier audience.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: The citizen's public delivery keys.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HolderKeysResponse"
+        "401":
+          description: Missing or invalid citizen token.
+        "404":
+          description: No wallet resolvable for the caller (indistinguishable from non-existence).
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    HolderKeysResponse:
+      type: object
+      required: [holderJwk, encryptionPublicKey, algorithm, walletAddress]
+      properties:
+        holderJwk:
+          type: object
+          description: Slot-108 holder public JWK for the SD-JWT cnf binding.
+          required: [kty]
+          properties:
+            kty: { type: string, enum: [EC, OKP] }
+            crv: { type: string, enum: [P-256, Ed25519] }
+            x: { type: string }
+            y: { type: string }
+        encryptionPublicKey:
+          type: string
+          description: Base64 wallet public key used to wrap the on-register AEAD envelope.
+        algorithm:
+          type: string
+          enum: [ED25519, NISTP256]
+        walletAddress:
+          type: string

--- a/specs/137-cross-node-submission/contracts/sorcha-holder-key-field.md
+++ b/specs/137-cross-node-submission/contracts/sorcha-holder-key-field.md
@@ -1,0 +1,44 @@
+# Contract: `sorcha-holder-key` blueprint field extension (C3)
+
+A blueprint-declared form field that the client auto-fills with the submitting citizen's public
+delivery keys and writes into the starting-action payload. Mirrors the F103 `x-address-lookup` →
+`PostcodeLookup` renderer-autofill idiom (NOT the form-block-driven `x-file` pattern).
+
+## Schema declaration (in a starting action's JSON Schema)
+
+```jsonc
+{
+  "holderKeys": {
+    "type": "object",
+    "format": "sorcha-holder-key",     // → ControlTypes.HolderKey via FormSchemaService.InferControlFromSchema
+    "x-holder-key": { "required": true } // optional config; tolerated by the generic x- strip
+  }
+}
+```
+
+## Payload value written (read-only to the user)
+
+```jsonc
+"holderKeys": {
+  "holderJwk": { "kty": "EC", "crv": "P-256", "x": "…", "y": "…" },
+  "encryptionPublicKey": "<base64>",
+  "algorithm": "ED25519"
+}
+```
+
+## Behavioural contract
+
+| Aspect | Requirement |
+|--------|-------------|
+| Recognition | `FormSchemaService.InferControlFromSchema` maps `format == "sorcha-holder-key"` → `ControlTypes.HolderKey`; `ControlDispatcher` renders `HolderKeyRenderer`. |
+| Autofill source | `HolderKeyRenderer.OnInitializedAsync` calls `GET /api/v1/wallet/holder-keys` (contract: `holder-keys-endpoint.openapi.yaml`) and writes `/holderKeys/holderJwk`, `/holderKeys/encryptionPublicKey`, `/holderKeys/algorithm` via `FormContext.SetValue` (sibling fan-out, like `PostcodeLookupRenderer`). |
+| User interaction | Field is display-only (shows "identity keys captured" affordance); the user cannot edit key material. |
+| Private keys | Never present in the field, payload, or wire — public material only. |
+| Submission | Values flow through `SorchaFormRenderer.HandleSubmit` → `FormSubmission.Data` → action payload → replicated register state. |
+| Server read | `ActionExecutionService.IssueCredentialFromActionAsync` reads `/holderKeys/holderJwk` + `/holderKeys/encryptionPublicKey` via the existing `TryResolveJsonPointer` walker (no new extraction code). |
+| Validation | `x-holder-key` auto-tolerated by `ValidationEngine` generic `x-` strip (`:1873`); unknown `format` validates as pass. **Build-time check**: confirm `SchemaValidator.cs` (no strip) is not on the action-data path; if it is, apply the same strip. Structural validation of the value shape is an optional opt-in validator (mirror `FileReferenceValidator`). |
+| Missing/malformed | Submission may still seal (field is data); the **credential-issuance** step fails closed if neither a published participant record nor a usable carried key resolves (FR-012). |
+
+## Out of scope (backlog)
+
+- Proof-of-possession (a key-binding challenge proving the citizen controls the carried keys). Safe to omit in v1 because the open-participant submitter is the recipient (self-defeating to lie). Pairs with participant-record promotion.

--- a/specs/137-cross-node-submission/data-model.md
+++ b/specs/137-cross-node-submission/data-model.md
@@ -1,0 +1,98 @@
+# Data Model: Cross-node submission round-trip (Stage 5)
+
+Phase 1 data shapes. These are additions/changes to existing models — no new persistent store
+beyond what's noted. Field names are indicative; exact casing follows the host model's convention.
+
+## 1. `HolderKeys` — the carried delivery-key field value (C3)
+
+The value written by the `sorcha-holder-key` form field into the starting-action payload, carried
+into replicated register state.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `holderJwk` | object (JWK) | yes | Slot-108 holder public key for the SD-JWT `cnf` binding. `{ kty, crv: "P-256"\|"Ed25519", x, y }`. Public only. |
+| `encryptionPublicKey` | string (base64) | yes (v1) | Wallet public key used to wrap the on-register AEAD envelope. For ED25519 wallets this is derivable by the owner from the tx signature; carried for algorithm-agnostic robustness. |
+| `algorithm` | string | yes | Wallet network/algorithm for `encryptionPublicKey` (`ED25519` \| `NISTP256`) — feeds `ExternalKeyInfo.Algorithm`. |
+
+- **Provenance**: client-autofilled, read-only to the user. Private keys never present.
+- **Validation**: `holderJwk` is a well-formed JWK of an allowed curve; `encryptionPublicKey` is valid base64 of the expected length for `algorithm`. Missing/malformed → the credential-issuance step fails closed (FR-012).
+- **Schema declaration** (blueprint action): `{ "type":"object", "format":"sorcha-holder-key", "x-holder-key": { "required": true } }`.
+
+## 2. `x-holder-key` schema extension (optional parser)
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `required` | bool | true | Whether the field must be present for submission. |
+
+Tolerated by the generic `x-` strip in `ValidationEngine`; no allowlist change. A
+`HolderKeySchemaExtension.TryParseFromSchema` mirroring `FileSchemaExtension` is optional (only if
+config grows beyond `required`).
+
+## 3. Wallet-Service public-key endpoint DTOs (C3)
+
+Response of the new `GET /api/v1/wallet/holder-keys` (citizen JWT, consumer-tier):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `holderJwk` | object (JWK) | From `HolderKeyService.GetHolderPublicJwkAsync(walletAddress)` (slot 108). |
+| `encryptionPublicKey` | string (base64) | Wallet X25519/Ed25519-derived public key. |
+| `algorithm` | string | `ED25519` \| `NISTP256`. |
+| `walletAddress` | string | The citizen's resolved wallet address. |
+
+No request body (identity from JWT). Idempotent, cacheable client-side for the form session.
+
+## 4. Issuance-request additions (C3 — the `cnf` binding)
+
+Net-new fields threaded through the issuance chain so a *bound* credential is produced:
+
+- `CredentialIssuanceConfig.HolderKeySourceField` (string, JSON Pointer, e.g. `/holderKeys/holderJwk`) — where the issuer reads the recipient holder JWK from reconstructed instance state. Optional; absent → no `cnf` (current behaviour).
+- `IssueCredentialRequest.HolderJwk` (object, JWK, nullable) — passed to `SdJwtService.CreateTokenAsync(holderJwk:)`.
+- `IWalletServiceClient.IssueCredentialAsync(...)` gains the `holderJwk` parameter.
+
+Resolution precedence at issuance (FR-012), in `ActionExecutionService.IssueCredentialFromActionAsync`:
+
+```
+1. published participant record (register, replicated)  → authoritative
+2. carried HolderKeys field (reconstructed instance state) → fallback
+3. neither → fail closed (no credential)
+```
+
+For the AEAD envelope, the resolved `encryptionPublicKey` (or derived) is injected into
+`request.ExternalRecipientKeys[recipientWallet] = { PublicKey, Algorithm }`; the existing
+`ResolveRecipientKeysAsync` pipeline consumes it. Honour "published wins" by injecting the carried
+key only when the register lookup misses (or reordering the existing external-first precedence).
+
+## 5. Transaction metadata addition (C5)
+
+`TransactionMetaData.NextActionId` (already exists on the type, `TransactionMetaData.cs:41`) MUST be
+populated by the authoritative projection in `DocketBuildTriggerService` (`:593-608`) so the mirror
+can seed `CurrentActionIds`. Value = the next action id implied by the sealed transaction's routing.
+
+## 6. Mirror Instance changes (C5)
+
+`InstanceMirrorReconstructor` upserts a read-only mirror `Instance` (`IsReadOnlyMirror=true`). **v1 decision (locked): Fix 1a + Fix 2a.**
+
+- **`CurrentActionIds` (Fix 1a)**: seed from the now-populated `NextActionId` written by the authoritative projection (§5). Today it falls back to `[]`, blocking the analyst's submission. **Out of v1**: deriving the next action from blueprint routing (Fix 1b) and retiring the reconstructor's `:253-263` self-keyed-`ParticipantWallets` TODO — deferred to backlog.
+- **Submission path (Fix 2a)**: `ActionExecutionService.ExecuteAsync` becomes mirror-aware — a submission against a mirror advances state via `UpdateMirrorAsync` (register-driven) instead of the guarded `UpdateAsync`, preserving the F106 invariant that mirrors are not locally authoritative while letting the owner act and re-derive on the sealed result. **Not** done by relaxing the write guard (Fix 2b, rejected).
+
+No schema migration: `IsReadOnlyMirror` and `NextActionId` already exist; this is population + branching logic.
+
+## 7. Event constant (C2)
+
+`RegisterEventChannels.RegisterCreated = "register:created"` — replaces the two inline literals
+(`RegisterManager.cs:85`, `RegisterEventBridgeService.cs:35`). Payload `RegisterCreatedEvent{RegisterId,…}`
+(unchanged) drives per-register blueprint recovery in `BlueprintRecoveryService`.
+
+## Entity relationships (round-trip view)
+
+```
+Citizen wallet (replica) ──signs──> Starting-action tx ──carries──> HolderKeys + instanceId
+        │                                   │
+        │ (X25519 priv)                     ▼ fan-out (F108)
+        │                          Owner validator ──seals──> Docket ──replicates──> both nodes
+        ▼                                   │
+   InboundCredentialDetector  <──AEAD──  Credential-issuance tx (owner)
+        │                                   ▲ binds cnf=holderJwk, wraps to encryptionPublicKey
+        ▼                                   │
+   CitizenInboxProjector → WalletHub → PWA  Analyst (owner) approves via mirror-aware submit
+```

--- a/specs/137-cross-node-submission/plan.md
+++ b/specs/137-cross-node-submission/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Cross-node submission round-trip (Stage 5)
+
+**Branch**: `137-cross-node-submission` | **Date**: 2026-05-23 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/137-cross-node-submission/spec.md`
+**Design**: `docs/superpowers/specs/2026-05-23-cross-node-submission-design.md` · **Research**: [research.md](./research.md)
+
+## Summary
+
+Enable the citizen→credential round-trip across two Sorcha installations: a citizen on a SyncOnly **replica** submits an AssuredIdentity application that the **owner** node validates, seals, approves (verification-analyst), and returns as an `AssuredIdentityCredential` to the citizen's local wallet. Trust stays two-plane — separate F136 installations bridged only at the ledger plane (genesis validator roster + tx/docket signatures). Five components: published-store-aware blueprint resolution (C1), event-driven blueprint recovery (C2), an open-participant derived-public-key field with published-record→carried-key→fail-closed resolution and the SD-JWT `cnf` binding (C3), F108 fan-out config (C4), and the mirror-instance submission fix that lets the analyst act on the owner node (C5 — confirmed by research to be a structural fix, not a check).
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10
+**Primary Dependencies**: ASP.NET Core Minimal APIs, .NET Aspire 13, YARP, Grpc.Net, StackExchange.Redis, JsonSchema.Net, Sorcha.Cryptography (libsodium/NSec), MudBlazor (Blazor WASM PWA + web)
+**Storage**: PostgreSQL (EF Core; Blueprint instances, Wallet), Redis (events/pub-sub, mempool, caches), MongoDB (Register ledger)
+**Testing**: xUnit + FluentAssertions + Moq; SQLite in-memory for EF service tests; Playwright for PWA E2E (Docker)
+**Target Platform**: Linux containers (Docker / Aspire); Blazor WASM PWA
+**Project Type**: Multi-service .NET solution (microservices) + Blazor front-ends
+**Performance Goals**: Round-trip completes within normal interactive latency; new register → usable blueprint within 30s (SC-003); no added per-request hot-path cost beyond one relationship lookup at instance creation
+**Constraints**: Two installations remain separate identity domains (no cross-installation JWT, FR-016); fail-closed credential issuance (FR-012); cross-node live test runs on a separate machine (genesis key + n1 SSH)
+**Scale/Scope**: 2 nodes, 1 register, 1 blueprint (AssuredIdentity) for v1; design must not preclude more
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 (passed) and re-checked after Phase 1 (passed).*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Microservices-First | PASS | Changes are within existing services (Blueprint, Wallet, Register, Validator) + shared libs; no new upward deps. Blueprint→Register relationship lookup uses the existing HTTP client. |
+| II. Security First | PASS | No secrets committed; reuses genesis key out-of-band. Carried keys are **public** only; private keys never leave the wallet. Fail-closed issuance (FR-012). Input validation via FluentValidation on the new endpoint + field. Two-plane trust preserved (FR-016). |
+| III. API Documentation | PASS | New Wallet-Service public-key endpoint gets OpenAPI `.WithSummary()/.WithDescription()` + XML docs; contract in `/contracts/`. |
+| IV. Testing | PASS | Unit + single-node integration on the build machine (SC-005); cross-node E2E scripted for the separate machine. Target >85% on new code. |
+| V. Code Quality | PASS | Nullable enabled, async I/O, DI, no new warnings. |
+| VI. Blueprint Standards | PASS | AssuredIdentity blueprint stays JSON; the new `sorcha-holder-key` field is a JSON-Schema extension (F085/F092/F103 idiom), not C#. |
+| VII. Domain-Driven Design | PASS | Uses Register/Blueprint/Action/Participant/Publish terms; "owner/replica/validator" are established F108 relationship terms. |
+| VIII. Observability | PASS | New OTel counters for recovery-on-event, key-resolution outcome (published/carried/fail-closed), and fan-out; structured logging, no interpolation. |
+
+**No constitution violations.** Complexity Tracking table omitted (nothing to justify).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/137-cross-node-submission/
+├── plan.md              # This file
+├── research.md          # Phase 0 — resolved unknowns
+├── data-model.md        # Phase 1 — entities & field shapes
+├── quickstart.md        # Phase 1 — single-node test plan + cross-node scripted procedure
+├── contracts/           # Phase 1 — new endpoint + schema-extension contracts
+└── tasks.md             # Phase 2 — /speckit.tasks (NOT created here)
+```
+
+### Source Code (touch-points by component)
+
+```text
+src/Services/Sorcha.Blueprint.Service/
+├── Program.cs                                   # C1: CreateInstance published-store fallback + owner-gated publish
+├── Services/Implementation/BlueprintRecoveryService.cs   # C2: subscribe register:created + per-register recovery
+├── Services/Implementation/ActionExecutionService.cs     # C3: cnf holder JWK + recipient-key precedence; C5: mirror-aware submit
+├── Services/Implementation/InstanceMirrorReconstructor.cs# C5: seed CurrentActionIds (blueprint-aware) 
+├── Storage/{EfCoreInstanceStore,InMemoryInstanceStore}.cs# C5: mirror-aware update path
+└── (config)                                     # C4: IPeerServiceClient BaseAddress
+
+src/Services/Sorcha.Validator.Service/
+└── Services/DocketBuildTriggerService.cs         # C5: emit NextActionId in authoritative tx metadata
+
+src/Services/Sorcha.Wallet.Service/
+├── Endpoints/CredentialEndpoints.cs              # C3: HolderJwk → SD-JWT cnf
+├── Endpoints/CitizenWalletEndpoints.cs (or new)  # C3: new public-key endpoint (holder JWK + X25519)
+└── Services/Implementation/HolderKeyService.cs    # C3: X25519 public-key accessor
+
+src/Common/
+├── Sorcha.Register.Core/Events/RegisterEventChannels.cs  # C2: RegisterCreated constant
+├── Sorcha.Blueprint.Models/Control.cs            # C3: ControlTypes.HolderKey
+├── Sorcha.Blueprint.Models/ (HolderKeySchemaExtension.cs)# C3: x-holder-key parser (optional)
+├── Sorcha.ServiceClients.Http/Wallet/            # C3: IWalletServiceClient.IssueCredentialAsync HolderJwk; public-key client
+└── Sorcha.Blueprint.Models/Credentials/          # C3: CredentialIssuanceConfig (no AcceptedIssuers churn)
+
+src/Apps/Sorcha.UI/Sorcha.UI.Components.User/
+├── Services/User/Forms/FormSchemaService.cs      # C3: format → ControlTypes.HolderKey
+├── Components/Forms/ControlDispatcher.razor       # C3: dispatch HolderKey
+└── Components/Forms/Controls/HolderKeyRenderer.razor  # C3: NEW — autofill from Wallet-Service endpoint
+
+src/Apps/Sorcha.Wallet.Pwa/
+├── Pages/ApplicationInstance.razor               # C3: wire real SorchaFormRenderer submit (replace stub)
+└── Services/Applications/IApplicationSubmissionService.cs # C3: real submission (replace StubApplicationSubmissionService)
+
+walkthroughs/AssuredIdentity/                      # SC-001: cross-node scripted verification procedure
+
+tests/ (per service)                               # unit + single-node integration (SC-005)
+```
+
+**Structure Decision**: Brownfield — extend existing services and shared libraries; one new Blazor renderer component, one new Wallet-Service endpoint, one new event constant. No new project.
+
+## Phase 1 outputs
+
+- `data-model.md` — the `holderKeys` field value, the public-key endpoint DTOs, the `cnf`/issuance-request additions, the `NextActionId` metadata addition, and mirror-instance field changes.
+- `contracts/` — OpenAPI for the new Wallet-Service public-key endpoint; the `sorcha-holder-key` / `x-holder-key` schema-extension contract.
+- `quickstart.md` — build-machine test plan (unit + single-node integration) and the cross-node scripted verification procedure (deferred machine).
+
+## Risks & sequencing
+
+- **C5 first** — highest risk/effort and a hard gate on the round-trip; validate the mirror-aware submit + `NextActionId` seeding with a single-node integration test before cross-node work.
+- **C1/C2** unblock instance creation on the replica — needed before any submission can be authored.
+- **C3** spans server (cnf, endpoint, precedence) + client (field, PWA wiring); the AEAD side reuses `ExternalRecipientKeys`, the `cnf` side is net-new.
+- **C4** is config; assert it via integration but it carries no design risk.

--- a/specs/137-cross-node-submission/quickstart.md
+++ b/specs/137-cross-node-submission/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart & verification: Cross-node submission round-trip (Stage 5)
+
+Two tiers, per the design's verification strategy. **Tier 1** runs on this (build) machine and gates
+the work. **Tier 2** is the live n1↔local round-trip, deferred to the machine holding
+`genesis-validator-key.json` + n1 SSH, but its procedure is authored and committed here so the run
+is turn-key.
+
+## Tier 1 — build-machine gate (unit + single-node integration)
+
+Run from repo root.
+
+```powershell
+dotnet build
+dotnet test
+```
+
+### Unit coverage to add (per component)
+
+- **C1**: `CreateInstance` resolves a published-only blueprint (draft store empty) → instance created, no 400. Replica relationship (`IsOwner=false`) → `PublishBlueprintToRegisterAsync` NOT called; owner (`IsOwner=true`) → called.
+- **C2**: `BlueprintRecoveryService` on a `register:created` event recovers exactly that register's published blueprints; Redis-unavailable path logs and degrades; periodic safety net still recovers a missed register.
+- **C3 (field)**: `FormSchemaService` maps `format:"sorcha-holder-key"` → `ControlTypes.HolderKey`; `HolderKeyRenderer` writes the three nested pointers from a stubbed holder-keys response; `x-holder-key` passes validation.
+- **C3 (issuance)**: recipient-key precedence — published record present → used; absent + carried key present → carried used; both absent → **fail closed** (no credential). `cnf` is set on the SD-JWT when `holderJwk` is supplied.
+- **C5**: with `NextActionId` populated, the mirror seeds `CurrentActionIds` with the next action; a submission against a mirror advances via `UpdateMirrorAsync` and does NOT throw the read-only guard; the authoritative projection emits `NextActionId` (regression test on `DocketBuildTriggerService`).
+
+### Single-node integration
+
+- Create an instance from a published-only blueprint and submit a starting action end-to-end on one node.
+- Issue a credential to a recipient supplied **by public key** (no local wallet row) and confirm the on-register envelope is wrapped to that key and decryptable; confirm `cnf` binds the holder JWK.
+
+**Gate (SC-005)**: all of the above green, and this `quickstart.md` + the AssuredIdentity scripted procedure committed.
+
+## Tier 2 — cross-node live round-trip (separate machine)
+
+Prerequisites (see the state doc `docs/superpowers/specs/2026-05-23-cross-node-federation-state-and-gaps.md`):
+`genesis-validator-key.json` copied out-of-band; n1 SSH reachable (update `AllowSSH` NSG for this
+machine's IP; n1 auto-shuts ~23:00 GMT); local stack via
+`docker compose -f docker-compose.yml -f docker-compose.sync-from-n1.yml up -d`.
+
+### Procedure (scripted via the AssuredIdentity walkthrough)
+
+1. **Bring up** n1 (owner/validator, Auto seed) and local (SyncOnly replica). Confirm the AssuredIdentity register replicates and is queryable on local.
+2. **C2 check** — subscribe the register *after* local's blueprint-service has booted; confirm its blueprint becomes usable within 30s with **no restart** (SC-003).
+3. **Citizen submit (US1)** — sign in as the dev citizen on local (per the state doc's dev account), open the AssuredIdentity application, submit the starting action. The `sorcha-holder-key` field auto-fills (no manual entry). Confirm a sealed docket containing the tx appears on n1 and replicates back (SC-002, FR-005/006/007).
+4. **Analyst approve (US2)** — as the verification-analyst on n1, submit the approval against the mirror instance (C5). Confirm it succeeds (no read-only-guard / not-current-action error).
+5. **Credential issuance + delivery** — confirm the `AssuredIdentityCredential` is issued bound to the citizen's holder key, encrypted to their key, and **appears in the citizen's local PWA wallet** automatically (FR-013/014/015).
+6. **Fail-closed check (FR-012)** — a variant where neither a published record nor carried keys resolve issues **no** credential.
+
+**Gate (SC-001)**: steps 3-5 complete in a single run with **zero** manual service restarts and **zero** manual key entry.
+
+### Notes
+
+- Do NOT change validator keys; reuse `genesis-validator-key.json` (n1 = Auto owner, local = SyncOnly replica).
+- The `BatchPublicKeyResolutionTests` CI red is a known env-flake (passes locally); claude-review + per-service Build jobs are the real gates.
+- Branch + PR per change; merge on green.

--- a/specs/137-cross-node-submission/research.md
+++ b/specs/137-cross-node-submission/research.md
@@ -1,0 +1,96 @@
+# Research: Cross-node submission round-trip (Stage 5)
+
+Phase 0 research for feature 137. Resolves the open questions flagged in the design doc
+(`docs/superpowers/specs/2026-05-23-cross-node-submission-design.md`) against the live codebase.
+All findings are read-only investigation; file:line references are to `master` as of 2026-05-23.
+
+Two design assumptions were **corrected** by this research — see "Design corrections" at the end.
+
+---
+
+## R1 — Blueprint resolution on replicas (C1)
+
+**Decision.** Make `CreateInstance` published-store-aware and gate the register publish on node-ownership.
+
+- `CreateInstance` is `instancesGroup.MapPost("/", …)` at `Sorcha.Blueprint.Service/Program.cs:1864-1969`. It resolves the blueprint via `IBlueprintStore.GetAsync(request.BlueprintId)` (**:1873**, the draft store) and 400s "Blueprint not found" on null — **the wall**.
+- It then uses only `blueprint.Actions` (starting-action ids → `CurrentActionIds`, :1917-1925), `blueprint.Participants` (pre-seed `ParticipantWallets`, :1932-1935), and `blueprint.Title` (:1954).
+- **No model gap.** `IPublishedBlueprintStore` (`Program.cs:2443-2449`) returns `PublishedBlueprint` (`:3639-3646`) whose `.Blueprint` is the **same** `Sorcha.Blueprint.Models.Blueprint` the draft store returns. Every field `CreateInstance` reads is present. The published store has no `GetAsync(id)` — use `GetVersionsAsync(blueprintId)` and pick latest by `PublishedAt` (the recovery service already does this, `BlueprintRecoveryService.cs:175-177`).
+- `PublishBlueprintToRegisterAsync` (`Program.cs:~1890`; `IRegisterServiceClient.cs:271-276`) POSTs a blueprint-publish transaction to the register. **Skip it when the node is not the owner.**
+
+**Rationale.** Resolution: try draft, then published-latest. Publish-gate: a replica must never re-publish onto a register it does not own.
+
+**Alternatives considered.** A dedicated `IBlueprintResolver` abstraction — deferred; a two-line draft→published fallback in `CreateInstance` is sufficient and lower-risk. Always-reconstruct-from-register (Approach C) — rejected in design.
+
+## R2 — Owner-vs-replica relationship API (C1)
+
+**Decision.** Use the already-injected `IRegisterServiceClient.GetLocalRelationshipAsync(registerId)`.
+
+- `IRegisterServiceClient` is already a `CreateInstance` dependency (`Program.cs:1868`) — **no new wiring**.
+- `GetLocalRelationshipAsync` (`IRegisterServiceClient.cs:496-498`; impl `RegisterServiceClient.cs:1684-1714`) → `GET /api/registers/{id}/local-relationship`, returns `RegisterLocalRelationship?` (null on 404). Booleans: `IsOwner`, `IsValidator`, `IsSubscriber`, etc. (`Sorcha.Register.Models/LocalRelationship/RegisterLocalRelationship.cs:18-46`).
+- Underlying derivation `IRegisterLocalRelationshipService` (Register.Core) runs in Register.Service — Blueprint.Service consumes only the HTTP shape.
+
+**Gate logic.** Skip publish unless `(await registerClient.GetLocalRelationshipAsync(id))?.IsOwner == true`. Treat null as "not owner → skip publish, do not hard-fail".
+
+## R3 — Event-driven recovery channel (C2)
+
+**Decision.** Subscribe `BlueprintRecoveryService` to the **`register:created`** Redis channel and recover that single register on the event; keep the periodic loop as the safety net.
+
+- Today `BlueprintRecoveryService.ExecuteAsync` (`…/BlueprintRecoveryService.cs:35-63`) runs `RunRecoveryAsync` once at boot + a periodic refresh. No event subscription.
+- `register:created` (payload `RegisterCreatedEvent{RegisterId,…}`, `Sorcha.Register.Core/Events/RegisterEvents.cs:12-18`) is published unconditionally inside `RegisterManager.CreateRegisterAsync` (`RegisterManager.cs:84-93`). **The PR #829 create-on-sync path goes through `CreateRegisterAsync`** (`Register.Service/Program.cs:1409-1448`), so a newly-replicated register emits it exactly once — the narrowest "a register just appeared locally" signal.
+- Candidates rejected: `docket:confirmed` (per-docket, coarser; already consumed by `InstanceMirrorReconstructor`), `register:height-updated` (noisy), `register:relationship-changed` (governance only), `register:sync-state-changed` (indirect).
+
+**Work.** (1) Add `RegisterEventChannels.RegisterCreated = "register:created"` and replace the two inline literals (`RegisterManager.cs:85`, `RegisterEventBridgeService.cs:35`). (2) Add an `IEventSubscriber`/`IConnectionMultiplexer` dependency to `BlueprintRecoveryService` (mirror `InstanceMirrorReconstructor.cs:91-111` or `PresentationSealSubscriber`; guard Redis-unavailable). (3) Expose a per-register recovery entrypoint (refactor the private `RecoverFromRegisterAsync` to open its own scope by `registerId`).
+
+## R4 — Mirror-instance sufficiency for analyst submission (C5) — **the structural gap**
+
+**Verdict.** As the code stands, the analyst **cannot** submit action 2 on n1 against the mirror. Two concrete blockers; both must be fixed.
+
+**Blocker A (fatal) — read-only-mirror write guard.** `ActionExecutionService.ExecuteAsync` has no mirror-aware branch; on a successful submission it calls `UpdateInstanceAfterExecutionAsync` → `_instanceStore.UpdateAsync(instance)` (`ActionExecutionService.cs:1016, 1626`). Both stores throw on a mirror row: `EfCoreInstanceStore.cs:112-118` and `InMemoryInstanceStore.cs:55-59` (`if (entity.IsReadOnlyMirror) throw …`). Mirrors are created `IsReadOnlyMirror=true` (`InstanceMirrorReconstructor.cs:280`), set-once.
+
+**Blocker B (conditional, hit first) — `CurrentActionIds` never seeded.** Submission validates `if (!instance.CurrentActionIds.Contains(actionId) && !actionDef.IsStartingAction) throw "not a current action"` (`ActionExecutionService.cs:208`). The mirror seeds `CurrentActionIds` from `tx.MetaData?.NextActionId` (`InstanceMirrorReconstructor.cs:264,273`), but the authoritative sealed-tx projection **never sets `NextActionId`** (`DocketBuildTriggerService.cs:593-608` writes only RegisterId/BlueprintId/ActionId/TransactionType/InstanceId). So `CurrentActionIds` falls back to `[]` and action 2 trips the check.
+
+**Decision (root-cause fix — v1 LOCKED to 1a + 2a).**
+1. **Fix 2a — make `ExecuteAsync` mirror-aware**: when the target instance is a mirror, advance it via `UpdateMirrorAsync` (register-driven) rather than the guarded `UpdateAsync` — the submission travels to the register normally; local mirror state is not authoritatively mutated by the submit path. (Touch `ActionExecutionService.cs:1016/1626`; the guard at `EfCoreInstanceStore.cs:112` / `InMemoryInstanceStore.cs:55`.) Rejected: 2b (relax the write guard) — erodes the F106 invariant.
+2. **Fix 1a — seed the next action**: emit `NextActionId` in the authoritative projection (`DocketBuildTriggerService.cs:593-608`) so the mirror seeds `CurrentActionIds`. **Deferred (not v1):** Fix 1b — make the reconstructor blueprint-aware and derive the next action from routing, retiring the `:253-263` self-keyed-`ParticipantWallets` TODO. Per user direction, 1b stays out of v1.
+
+**Confirmed-sound (design was right).** Register-sourced reconstruction works cross-node — `StateReconstructionService.ReconstructAsync` reads sealed txs via `GetTransactionsByInstanceIdAsync` (`StateReconstructionService.cs:73`). Shared `instanceId` travels in tx metadata end-to-end (`Program.cs:1940` → `TransactionBuilderService.cs:84` → `DocketBuildTriggerService.cs:604` → `InstanceMirrorReconstructor.cs:177`). "Local wallet" = `IWalletServiceClient.GetWalletAsync(addr)` non-null (`InstanceMirrorReconstructor.cs:214-215`).
+
+**Rationale.** This is deterministic and structural, not an edge case — so it is a first-class component, not a "confirm". Keeping submissions register-routed preserves the F106 invariant (mirrors are not locally authoritative) while letting the owner node act.
+
+## R5 — X25519 derivability + recipient-key resolution at issuance (C3)
+
+**Decision.** Carry `holderJwk` (mandatory, for `cnf`) and `encryptionPublicKey` (for the AEAD envelope) in the field. Feed `encryptionPublicKey` through the **existing** `ExternalRecipientKeys` path; build **net-new** `cnf` plumbing for `holderJwk`.
+
+- **X25519 is derivable from the Ed25519 public key alone.** `CryptoModule.EncryptED25519Async` (`Sorcha.Cryptography/Core/CryptoModule.cs:498-513`) converts the recipient's Ed25519 public key to Curve25519 via libsodium `ConvertEd25519PublicKeyToCurve25519PublicKey` and `SealedPublicKeyBox.Create` — **no private key**. So for ED25519 wallets n1 can derive the encryption key from the tx signature; carrying `encryptionPublicKey` is a robustness choice (algorithm-agnostic; P-256 wallets take a different path).
+- **AEAD "supply explicitly" path already exists.** `ActionExecutionService.ResolveRecipientKeysAsync` (`:2321-2414`) resolves recipient keys with precedence **external-supplied (`request.ExternalRecipientKeys`, `ExternalKeyInfo{PublicKey,Algorithm}`) → register batch lookup** (`ResolvePublicKeysBatchAsync`). The envelope wrap (`EncryptionPipelineService.EncryptGroupAsync:225-266`) needs only the public key. **No change to the encryption pipeline.** Note: today external is checked *first*; the design wants **published-record-first**, so inject the carried key only when the register lookup misses (or reorder).
+- **`cnf` binding is a pre-existing hole (net-new work).** `SdJwtService.CreateTokenAsync` only emits `cnf` when passed a `holderJwk` (`Sorcha.Cryptography/SdJwt/SdJwtService.cs:175-184`). The Wallet issuance handler calls it **without** one (`CredentialEndpoints.cs:684-694`); `IssueCredentialRequest` has no holder-JWK field (`:813-877`); `ActionExecutionService.IssueCredentialFromActionAsync` passes none (`:1943-2060`). So credentials are issued **unbound** today. Add `HolderJwk` to `IssueCredentialRequest` + `IWalletServiceClient.IssueCredentialAsync` + `CredentialIssuanceConfig`, thread from `IssueCredentialFromActionAsync`, pass into `CreateTokenAsync(holderJwk:)`.
+- **No local wallet row needed for SorchaLocalWallet.** The recipient-copy store (`CredentialEndpoints.cs:727-763`, `GetByAddressAsync`) is already bypassed via `SkipRecipientStore=true` (`ActionExecutionService.cs:2057`). Delivery is the on-register encrypted disclosure → `InboundCredentialDetector` on the recipient node.
+- **Caveat:** `InboundCredentialDetector` drops plaintext credentials on non-DevMode registers (`InboundCredentialDetector.cs:303-339`) — cross-node delivery MUST go through the encrypted path with a correctly-resolved recipient key (reinforces fail-closed, FR-012).
+
+**Key-type note.** `holderJwk` (slot 108, `cnf`) is P-256 or Ed25519 per `HolderKeyService` (`crv:"P-256"|"Ed25519"`); the AEAD wrap uses the wallet's Ed25519 signing-derived key. They are genuinely **two distinct keys** — the design's two-field shape is correct.
+
+## R6 — The `sorcha-holder-key` schema field type (C3 client)
+
+**Decision.** Add a `ControlTypes.HolderKey` field rendered by a new `HolderKeyRenderer` that autofills from a **new Wallet-Service public-key endpoint** (server round-trip), following the F103 `x-address-lookup → PostcodeLookup` renderer-autofill pattern (not the `x-file` pattern, which is form-block-driven).
+
+- Recognition: `FormSchemaService.InferControlFromSchema` (`Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs:331-408`, ladder at :376-399) → add `else if (format == "sorcha-holder-key") controlType = ControlTypes.HolderKey`.
+- Enum: add `ControlTypes.HolderKey` (`Sorcha.Blueprint.Models/Control.cs:123-195`, mirror `PostcodeLookup` :193-194).
+- Dispatch: `ControlDispatcher.razor:65-72` → `case ControlTypes.HolderKey: <HolderKeyRenderer/>`.
+- Renderer writes nested pointers `FormContext.SetValue("/holderKeys/holderJwk", …)` + `"/holderKeys/encryptionPublicKey"` (sibling fan-out like `PostcodeLookupRenderer.razor:275-298`), read-only to the user.
+- Server read: `ActionExecutionService.BuildClaimsFromMappings`/`TryResolveJsonPointer` (`:1782-1840, 1884-1941`) already walks nested objects — `"/holderKeys/holderJwk"` resolves with no new extraction code.
+- Validation: `x-holder-key` is auto-tolerated by the generic `x-` strip (`ValidationEngine.cs:1860-1892`, prefix match :1873); unknown `format` validates as pass (like `file-reference`). **Verify** `SchemaValidator.cs:53-65` (no strip) is not on the action-data path, else apply the same strip.
+
+**PWA reality (correction).** The PWA does **not** derive slot-108 on device — `WebCryptoDeviceKeyService` holds the F114 *device* key, not the holder key. The PWA submission surface is a **stub** (`Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor` placeholder + `StubApplicationSubmissionService`). So C3 also requires: (a) a **new Wallet-Service endpoint** returning the citizen's slot-108 holder JWK + X25519 public key (built on `HolderKeyService.GetHolderPublicJwkAsync`), and (b) **wiring `SorchaFormRenderer` into the real PWA submit path**.
+
+## R7 — F108 fan-out config (C4)
+
+**Decision.** Ensure `IPeerServiceClient` BaseAddress is configured on the submitting node so `DistributeTransactionAsync` reaches the peer service. This is a service-client configuration item (the `BaseAddress must be set` warning from the probe), not an architectural change. Confirm the service-client registration + the per-node config key during implementation; add an integration assertion that fan-out is attempted.
+
+---
+
+## Design corrections (fold back into the design doc)
+
+1. **§10 Risk 1 / C5 is a confirmed structural gap, not a tail risk.** The analyst-submits-on-mirror path has two deterministic blockers (read-only-mirror write guard + unseeded `CurrentActionIds`). C5 is a first-class component with real work in `ActionExecutionService`, the instance stores, `DocketBuildTriggerService`, and/or `InstanceMirrorReconstructor`.
+2. **§6 client autofill is a server round-trip, and the PWA submit surface is a stub.** The slot-108 holder key + X25519 key are Wallet-Service-managed; C3 needs a new Wallet-Service public-key endpoint and real PWA `SorchaFormRenderer` wiring. Also: the SD-JWT `cnf` binding is a pre-existing hole — issuing a *bound* credential is net-new plumbing, beneficial beyond cross-node.
+
+These do not change the agreed decisions (trust model, precedence, v1 scope); they expand the effort of C3 and C5 and are reflected in `plan.md` and `tasks.md`.

--- a/specs/137-cross-node-submission/spec.md
+++ b/specs/137-cross-node-submission/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Cross-node submission round-trip (Stage 5)
+
+**Feature Branch**: `137-cross-node-submission`
+**Created**: 2026-05-23
+**Status**: Draft
+**Input**: User description: "Cross-node submission round-trip (Stage 5): citizen on a local SyncOnly replica submits an AssuredIdentity application that reaches the n1 owner/validator node, is validated/sealed there, approved by the verification-analyst on n1, and the resulting AssuredIdentityCredential is delivered back to the citizen's local wallet."
+
+> Source of truth for the architecture and decisions: `docs/superpowers/specs/2026-05-23-cross-node-submission-design.md`. This spec restates that design as falsifiable requirements; where they differ, the design doc wins until this spec is updated.
+
+## User Scenarios & Testing *(mandatory)*
+
+A "node" is a Sorcha installation. The **owner node** holds a register's genesis and validator roster and seals its dockets; a **replica node** subscribes to that register read-only (SyncOnly). The two are separate identity domains — a person's account and wallet on the replica do not exist on the owner. Three actors appear below: the **citizen** (a public applicant on the replica), the **verification-analyst** (an operator on the owner node), and the **platform operator** (who runs and observes the nodes).
+
+### User Story 1 - Citizen submission reaches and seals on the owner node (Priority: P1)
+
+A citizen, signed in on a replica node, starts an AssuredIdentity application and submits it. Even though the replica cannot seal transactions for that register, the submission travels to the owner node, which validates and seals it. The citizen sees their application accepted.
+
+**Why this priority**: This is the foundational write hop. Until a replica-origin submission can be sealed by the owner, no cross-node workflow is possible. It is the minimum viable slice — it proves the write/ledger path crosses nodes — and everything else builds on it.
+
+**Independent Test**: On a replica with a register replicated from the owner, sign in as a citizen, create a workflow instance, and submit the starting action. Verify a sealed docket containing that transaction appears on the owner node and replicates back to the replica. No manual blueprint-service restart is required.
+
+**Acceptance Scenarios**:
+
+1. **Given** a register owned by the owner node and replicated to the replica, and the citizen is authenticated on the replica, **When** the citizen creates a workflow instance from the register's published blueprint, **Then** instance creation succeeds (no "Blueprint not found") without the blueprint existing in the replica's draft/editable store.
+2. **Given** the citizen has created an instance on the replica, **When** they submit the starting action, **Then** the submission is delivered to the owner node, validated (signature verified, open-participant late-binding applied), and sealed into a docket on the owner.
+3. **Given** the replica is not on the register's validator roster, **When** the starting action is submitted, **Then** the replica does not itself seal the transaction.
+4. **Given** instance creation on a replica, **When** the instance is created, **Then** the replica does not attempt to (re)publish the blueprint to the register it does not own.
+
+---
+
+### User Story 2 - Approved application returns a credential to the citizen's local wallet (Priority: P2)
+
+After the application is sealed on the owner node, the verification-analyst on the owner reviews and approves it. A credential is issued to the citizen and is delivered back to the citizen's wallet on the replica, where it appears automatically.
+
+**Why this priority**: This completes the round-trip and delivers the end-user value (the citizen receives their credential). It depends on US1's sealed submission but is independently testable given a sealed application.
+
+**Independent Test**: Given a sealed application on the owner node, drive the verification-analyst's approval action, then observe the `AssuredIdentityCredential` appear in the citizen's wallet on the replica — decryptable only by that citizen — with no manual key entry at any step.
+
+**Acceptance Scenarios**:
+
+1. **Given** a sealed starting-action transaction whose participants include the owner-node analyst, **When** the docket confirms on the owner, **Then** the owner materialises a workflow instance the analyst can act on, with prior state reconstructed from the register.
+2. **Given** the analyst approves, **When** the credential-issuance action runs, **Then** the owner resolves the citizen's delivery keys by precedence (published participant record → keys carried in the submission → fail closed) and issues the credential bound to the citizen's holder key and encrypted to the citizen's encryption key.
+3. **Given** the issued credential replicates to the replica, **When** the replica processes the docket, **Then** the credential is decrypted by the citizen's local wallet and surfaces to the citizen without manual intervention.
+4. **Given** neither a published participant record nor carried keys resolve for the recipient, **When** issuance is attempted, **Then** the system fails closed and does not issue an unusable credential.
+
+---
+
+### User Story 3 - Replicas pick up newly-synced registers without a restart (Priority: P3)
+
+A platform operator subscribes a running replica node to a new register. The register's blueprints become usable for instance creation immediately, without restarting the blueprint service.
+
+**Why this priority**: Operability hardening that removes the manual-restart workaround used in the probe. Valuable on its own (any post-boot subscription works), and it makes US1 robust to subscribe-after-boot ordering.
+
+**Independent Test**: On a running replica, subscribe to a register after the blueprint service has started, then immediately create an instance from that register's blueprint — succeeds with no restart.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running replica node, **When** a new register is replicated/subscribed after start-up, **Then** the register's published blueprints become available for instance creation without a service restart.
+2. **Given** a replication signal is missed, **When** the periodic safety reconciliation runs, **Then** the register's blueprints still eventually become available.
+
+---
+
+### Edge Cases
+
+- **Blueprint not yet recovered when the citizen arrives** → the system returns a typed "register still syncing" state (not a bare 400) and the client retries, rather than failing opaquely.
+- **Carried keys missing or malformed at issuance** → issuance fails closed; no credential is produced.
+- **Both a published participant record and carried keys are present** → the published record wins; any conflict is logged.
+- **Owner node unreachable at submission time** → the submission is accepted locally as "awaiting validation" and retried; it is never silently lost.
+- **Submitter supplies delivery keys they do not control** → self-defeating (the resulting credential is unusable to them); acceptable in v1 because the open-participant submitter is also the recipient (see Assumptions).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Blueprint availability on replicas**
+
+- **FR-001**: A citizen authenticated on a replica node MUST be able to create a workflow instance from a blueprint that exists only in the node's published (replicated) store, with no copy in the draft/editable store.
+- **FR-002**: A replica node MUST NOT attempt to publish or re-publish a blueprint to a register it does not own during instance creation.
+- **FR-003**: When a register is newly replicated to / subscribed by a node after that node has started, the node MUST make the register's published blueprints available for instance creation without a service restart.
+- **FR-004**: The system MUST retain a periodic safety reconciliation so a missed replication signal eventually yields blueprint availability.
+
+**Cross-node submission & sealing**
+
+- **FR-005**: When a citizen submits a starting action on a replica for a register owned by another node, the submission MUST be delivered to the owner node for validation.
+- **FR-006**: The owner node MUST validate and seal a starting-action transaction that originated on another node — verifying the submitter's signature cryptographically and applying open-participant late-binding (no pre-existing participant record required for the applicant).
+- **FR-007**: A node that is not on a register's validator roster MUST NOT seal transactions for that register.
+- **FR-008**: The same workflow instance MUST be identifiable on both nodes (a shared instance identifier travels with the transaction), so the owner can act on the instance the citizen started.
+
+**Open-participant delivery keys**
+
+- **FR-009**: A blueprint author MUST be able to declare a field that captures the submitting citizen's delivery public keys — a holder public key (for credential binding) and an encryption public key (for credential delivery).
+- **FR-010**: The client MUST auto-populate that field from the citizen's own derived public keys, with no manual entry and without exposing private keys.
+- **FR-011**: The captured public keys MUST be carried with the submission so they are present in replicated register state on the owner node.
+- **FR-012**: When issuing a credential to a recipient, the owner node MUST resolve the recipient's delivery keys by precedence: (1) a published participant record on the register, otherwise (2) the keys carried in the submission, otherwise (3) fail closed without issuing.
+
+**Approval & credential delivery**
+
+- **FR-013**: The verification-analyst on the owner node MUST be able to approve the application by submitting the next action against the owner-materialised instance, with prior state reconstructed from the register.
+- **FR-014**: The issued credential MUST be bound to the citizen's holder key and encrypted to the citizen's encryption key, such that only the citizen's local wallet can decrypt it.
+- **FR-015**: The delivered credential MUST arrive in the citizen's local wallet and surface to the citizen without manual intervention.
+
+**Trust model & scope boundaries**
+
+- **FR-016**: The cross-node round-trip MUST NOT require JWT access tokens to be portable across installations; the two nodes remain separate identity domains, and cross-node trust is anchored only by the register's validator roster and transaction/docket signatures.
+- **FR-017**: The submission key-capture path MUST support open/public-user participants who have no pre-existing participant record.
+- **FR-018**: v1 MUST NOT require the citizen to be promoted to a published participant record, and MUST NOT require a proof-of-possession challenge on the captured keys (both are explicitly deferred — see Out of Scope).
+
+### Key Entities *(include if feature involves data)*
+
+- **Owner node / Replica node**: roles of an installation relative to a given register; the owner seals, the replica subscribes read-only. Distinct identity domains.
+- **Register**: the shared ledger replicated across nodes; carries the validator roster and is the source of truth for workflow state.
+- **Published blueprint**: the replicated, read-only blueprint available on a replica (as opposed to the owner-only draft/editable blueprint).
+- **Workflow instance / mirror instance**: the per-node execution shell; the owner and replica each derive their own, keyed by a shared instance identifier, with accumulated state reconstructed from the register.
+- **Submission transaction**: the citizen's signed starting-action submission; carries the shared instance identifier, the signature, the action payload, and the delivery-key field.
+- **Delivery-key field value**: the citizen's holder public key (for credential binding) and encryption public key (for credential delivery), auto-captured at submission.
+- **AssuredIdentityCredential**: the credential issued by the owner, bound and encrypted to the citizen's keys, delivered to the citizen's local wallet.
+- **Citizen local wallet**: the wallet on the replica holding the citizen's private keys; the only party able to decrypt the delivered credential.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001** (full round-trip, cross-node machine): In a single end-to-end run, a citizen on the replica completes the AssuredIdentity application, the analyst on the owner approves, and the `AssuredIdentityCredential` appears in the citizen's local wallet — with **zero** manual service restarts and **zero** manual key entry.
+- **SC-002**: Instance creation on a replica from a published-only blueprint succeeds in 100% of attempts (no "Blueprint not found"), where previously it failed 100% of the time.
+- **SC-003**: A register subscribed after node start yields a usable blueprint for instance creation within 30 seconds, without a restart.
+- **SC-004**: 100% of credentials issued cross-node are decryptable by the intended citizen's local wallet; the system issues **zero** credentials when neither a published record nor carried keys resolve (fail-closed verified).
+- **SC-005** (build-machine gate): All unit and single-node integration tests pass on the build machine, and a scripted, reproducible cross-node verification procedure is committed and runnable on the machine that holds the genesis validator key.
+
+## Assumptions
+
+- **Trust-on-submission (no proof-of-possession) is safe in v1** because the open-participant submitter is late-bound as the applicant and is therefore also the credential recipient: a wrong holder key yields an unpresentable credential and a wrong encryption key yields one the submitter cannot decrypt — both self-defeating. PoP is deferred and paired with the backlogged participant-record promotion.
+- **Delivery keys are HD-derived** from the citizen's wallet, so the client can reproduce the public halves deterministically; only public material is ever carried.
+- **The owner may resolve the citizen's keys but never their identity** — all cross-node resolution reduces to ledger-native facts (a signature verifies; a key is in replicated register state).
+- **Cross-node integration testing runs on a separate machine** (holding `genesis-validator-key.json`, owner-node SSH access, and the sync split); the build machine delivers code plus the scripted procedure.
+- **Existing cross-node machinery is reused** (genesis validator roster, anonymous-tolerant peer transport, instance-mirror reconstruction, register-as-source-of-truth state reconstruction, ownership-agnostic submission fan-out, register-native credential delivery).
+
+## Out of Scope (backlog)
+
+- **Participant-record promotion** — promoting carried keys into a durable published participant record for reuse by later actions / repeat flows, including the "use-or-supersede" rule for org field agents who are already published. Paired with PoP hardening.
+- **Proof-of-possession** on the captured key field.
+- Non-SD-JWT credential formats cross-node, multiple registers per round-trip, and more than two nodes (the design must not preclude these but does not test them).
+- MCP register-control / sync tooling (the admin slice remains observational).

--- a/specs/137-cross-node-submission/tasks.md
+++ b/specs/137-cross-node-submission/tasks.md
@@ -1,0 +1,146 @@
+# Tasks: Cross-node submission round-trip (Stage 5)
+
+**Input**: Design documents from `/specs/137-cross-node-submission/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the spec's SC-005 makes unit + single-node integration tests a delivery gate (the cross-node E2E is Tier 2, deferred to the machine with the genesis key).
+
+**Organization**: By user story. US1 (P1) = submission seals on the owner; US2 (P2) = approved application returns a credential to the local wallet; US3 (P3) = restart-free register pickup.
+
+Component map (from plan.md): C1 blueprint resolution · C2 event-driven recovery · C3 open-participant key delivery · C4 fan-out config · C5 mirror-instance submission fix.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete dependency)
+- Paths are repo-relative.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm branch `137-cross-node-submission` and design artifacts are present; no new project — brownfield extension of existing services per `specs/137-cross-node-submission/plan.md`.
+- [ ] T002 [P] Add the `walkthroughs/AssuredIdentity/blueprints/assured-identity.json` worked-example blueprint scaffold (starting action + analyst decision + credential-issuance to `SorchaLocalWallet`), WITHOUT the `holderKeys` field yet (added in US2/T026).
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**⚠️ Complete before user-story phases.** Light for this brownfield feature — shared test harness + telemetry only.
+
+- [ ] T003 [P] Create the single-node integration test harness base for cross-node behaviours (published-only blueprint fixture, mirror-instance fixture) under `tests/Sorcha.Blueprint.Service.Tests/CrossNode/`.
+- [ ] T004 [P] Register the OTel instruments used by later phases on the appropriate meters (recovery-on-event, key-resolution outcome, fan-out attempt) — stubs in `Sorcha.Blueprint.Service`/`Sorcha.Wallet.Service` metrics types so phases can record without re-wiring.
+
+---
+
+## Phase 3: User Story 1 — Submission reaches and seals on the owner (P1) 🎯 MVP
+
+**Goal**: A citizen on a replica creates an instance from a replicated (published-only) blueprint and submits the starting action, which fans out to and seals on the owner node.
+
+**Independent test**: On a replica with the register replicated, create an instance and submit the starting action; verify a sealed docket appears on the owner and replicates back — no service restart.
+
+### Implementation (C1, C4)
+
+- [ ] T005 [US1] Make `CreateInstance` published-store-aware in `src/Services/Sorcha.Blueprint.Service/Program.cs` (~:1873): on `IBlueprintStore.GetAsync` miss, fall back to `IPublishedBlueprintStore.GetVersionsAsync(blueprintId)` latest-by-`PublishedAt`; return a typed "register syncing" result (not bare 400) when neither resolves.
+- [ ] T006 [US1] Gate `PublishBlueprintToRegisterAsync` (~:1890) on node-ownership via the already-injected `registerClient.GetLocalRelationshipAsync(registerId)` — skip the publish unless `IsOwner == true`; treat null relationship as not-owner (skip, do not hard-fail).
+- [ ] T007 [P] [US1] Configure `IPeerServiceClient` BaseAddress on the Blueprint Service so F108 `DistributeTransactionAsync` reaches the peer service (resolve the per-node config key; `src/Services/Sorcha.Blueprint.Service` service-client wiring + appsettings). Removes the `BaseAddress must be set` warning.
+
+### Tests (C1, C4, C5-seal)
+
+- [ ] T008 [P] [US1] Unit: `CreateInstance` resolves a published-only blueprint (draft store empty) → instance created, no 400; in `tests/Sorcha.Blueprint.Service.Tests/`.
+- [ ] T009 [P] [US1] Unit: publish-gate — `IsOwner=false` ⇒ `PublishBlueprintToRegisterAsync` NOT called; `IsOwner=true` ⇒ called; null relationship ⇒ skipped; in `tests/Sorcha.Blueprint.Service.Tests/`.
+- [ ] T010 [US1] Integration (single-node, in `tests/Sorcha.Blueprint.Service.Tests/CrossNode/`): create instance from published-only blueprint + submit starting action → fan-out attempted (peer client invoked) and the local-origin starting tx is accepted by the validator path (F103 starting-action wallet-check skip + signature verify). Asserts FR-005/006/007.
+
+**Checkpoint**: US1 independently testable — the write hop crosses nodes.
+
+---
+
+## Phase 4: User Story 2 — Approved application returns a credential to the local wallet (P2)
+
+**Goal**: The analyst on the owner approves the sealed application; a credential bound + encrypted to the citizen's keys is delivered to the citizen's local wallet automatically.
+
+**Independent test**: Given a sealed application carrying the citizen's holder keys, drive the analyst approval; the `AssuredIdentityCredential` appears in the citizen's local wallet, decryptable only by them, with no manual key entry.
+
+### C5 — mirror-instance submission fix (locked: Fix 1a + 2a)
+
+- [ ] T011 [US2] Emit `NextActionId` in the authoritative tx-metadata projection in `src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs` (~:593-608) — the next action id implied by the sealed tx's routing.
+- [ ] T012 [US2] Seed the mirror's `CurrentActionIds` from the now-populated `NextActionId` in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceMirrorReconstructor.cs` (~:264,273).
+- [ ] T013 [US2] Make `ActionExecutionService.ExecuteAsync` mirror-aware in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs` (~:1016/1626): when the instance `IsReadOnlyMirror`, advance via `UpdateMirrorAsync` (register-driven) instead of the guarded `UpdateAsync`. Do NOT relax the store guard (Fix 2b rejected).
+- [ ] T014 [P] [US2] Unit: with `NextActionId` populated, the mirror seeds `CurrentActionIds`; a mirror-targeted submission advances without throwing the read-only guard; `DocketBuildTriggerService` regression for `NextActionId`. In `tests/Sorcha.Blueprint.Service.Tests/` + `tests/Sorcha.Validator.Service.Tests/`.
+
+### C3 server — bound issuance + recipient-key precedence
+
+- [ ] T015 [US2] Add `HolderJwk` to `IssueCredentialRequest` in `src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs` (~:813-877) and pass it into `SdJwtService.CreateTokenAsync(holderJwk:)` (~:684-694) so the SD-JWT carries `cnf`.
+- [ ] T016 [US2] Thread `HolderJwk` through `IWalletServiceClient.IssueCredentialAsync` in `src/Common/Sorcha.ServiceClients.Http/Wallet/`.
+- [ ] T017 [US2] Add `CredentialIssuanceConfig.HolderKeySourceField` (JSON Pointer, default `/holderKeys/holderJwk`) in `src/Common/Sorcha.Blueprint.Models/Credentials/`.
+- [ ] T018 [US2] Implement recipient-key precedence in `ActionExecutionService.IssueCredentialFromActionAsync` (`…/ActionExecutionService.cs` ~:1943-2060): (1) published participant record → (2) carried `holderKeys` via `TryResolveJsonPointer` → (3) fail closed. Inject the carried `encryptionPublicKey` into `request.ExternalRecipientKeys` only when the register lookup misses (honour "published wins"); feed `holderJwk` to T015's path.
+- [ ] T019 [US2] Build-time validation check: confirm `src/Core/Sorcha.Blueprint.Engine/Implementation/SchemaValidator.cs` (no `x-` strip) is not on the action-data path for the `holderKeys` field; if it is, apply the same strip used at `ValidationEngine.cs:1860-1892`.
+- [ ] T020 [P] [US2] Unit: `cnf` is set when `holderJwk` supplied; recipient precedence (published→carried→fail-closed); fail-closed issues NO credential. In `tests/Sorcha.Wallet.Service.Tests/` + `tests/Sorcha.Blueprint.Service.Tests/`.
+
+### C3 client — derived-key field capture
+
+- [ ] T021 [US2] Add `ControlTypes.HolderKey` enum member in `src/Common/Sorcha.Blueprint.Models/Control.cs` (~:193, mirror `PostcodeLookup`).
+- [ ] T022 [US2] Map `format == "sorcha-holder-key"` → `ControlTypes.HolderKey` in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs` (~:376-399).
+- [ ] T023 [US2] Dispatch `ControlTypes.HolderKey` → `HolderKeyRenderer` in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/ControlDispatcher.razor` (~:65).
+- [ ] T024 [US2] New Wallet-Service endpoint `GET /api/v1/wallet/holder-keys` (consumer-tier) in `src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs` returning holder JWK + X25519 pubkey + algorithm, per `contracts/holder-keys-endpoint.openapi.yaml`; add the X25519 public-key accessor on `HolderKeyService` (`…/HolderKeyService.cs`). OpenAPI summary/description + XML docs.
+- [ ] T025 [US2] New `HolderKeyRenderer.razor` in `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/` — on init, call the new endpoint (via a thin client in `src/Common/Sorcha.ServiceClients.Http/`/PWA service) and write `/holderKeys/{holderJwk,encryptionPublicKey,algorithm}` via `FormContext.SetValue`; render read-only. Per `contracts/sorcha-holder-key-field.md`.
+- [ ] T026 [US2] Add the `holderKeys` (`format: sorcha-holder-key`) field to the starting action of `walkthroughs/AssuredIdentity/blueprints/assured-identity.json` and point `credentialIssuanceConfig.HolderKeySourceField` at it.
+- [ ] T027 [US2] Wire the real `SorchaFormRenderer` submit path into `src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor` (replace the placeholder) and implement the real submission in `src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationSubmissionService.cs` (replace `StubApplicationSubmissionService`).
+- [ ] T028 [P] [US2] Unit: `FormSchemaService` maps the format; `HolderKeyRenderer` writes the three nested pointers from a stubbed endpoint response; `x-holder-key` passes validation. In `tests/` for `Sorcha.UI.Components.User` + blueprint models.
+
+### Integration (US2)
+
+- [ ] T029 [US2] Integration (single-node, `tests/Sorcha.Blueprint.Service.Tests/CrossNode/`): issue a credential to a recipient supplied **by public key** (no local wallet row) → on-register envelope wrapped to that key and decryptable; `cnf` binds the holder JWK; analyst approval advances the mirror instance. Asserts FR-012/013/014 + the C5 path.
+
+**Checkpoint**: US1 + US2 = the full round-trip is implemented (single-node verified; cross-node deferred to Tier 2).
+
+---
+
+## Phase 5: User Story 3 — Restart-free register pickup (P3)
+
+**Goal**: A register subscribed after node start yields usable blueprints without a restart.
+
+**Independent test**: On a running replica, subscribe a register post-boot, then immediately create an instance from its blueprint — succeeds, no restart.
+
+### Implementation (C2)
+
+- [ ] T030 [US3] Add `RegisterEventChannels.RegisterCreated = "register:created"` in `src/Core/Sorcha.Register.Core/Events/RegisterEventChannels.cs` and replace the inline literals at `Sorcha.Register.Core/Managers/RegisterManager.cs:85` and `RegisterEventBridgeService.cs:35`.
+- [ ] T031 [US3] Expose a per-register recovery entrypoint in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs` (refactor the private `RecoverFromRegisterAsync` to open its own scope by `registerId`).
+- [ ] T032 [US3] Subscribe `BlueprintRecoveryService` to `register:created` (mirror `InstanceMirrorReconstructor` subscription pattern; guard Redis-unavailable with a degrade log) and call the per-register recovery on each event; keep the periodic safety-net loop.
+- [ ] T033 [P] [US3] Unit: a `register:created` event recovers exactly that register's published blueprints; Redis-unavailable degrades cleanly; the periodic safety net still recovers a missed register. In `tests/Sorcha.Blueprint.Service.Tests/`.
+
+**Checkpoint**: US3 independently testable — removes the manual-restart workaround.
+
+---
+
+## Phase 6: Polish & cross-cutting
+
+- [ ] T034 [P] Wire the OTel counters recorded in T004 at their call sites (recovery-on-event in C2, key-resolution outcome published/carried/fail-closed in C3, fan-out attempt in C4); structured logging, no interpolation.
+- [ ] T035 [P] Author the Tier-2 cross-node scripted verification procedure in `walkthroughs/AssuredIdentity/` (per `quickstart.md` §Tier 2) so the live n1↔local run is turn-key on the genesis-key machine.
+- [ ] T036 [P] Docs sync: add the Feature 137 surface (new endpoint, `sorcha-holder-key` field, C5 mirror-submit, recovery event) to `.claude/skills/sorcha-architecture/SKILL.md`, `docs/reference/API-DOCUMENTATION.md`, and the affected service READMEs.
+- [ ] T037 [P] Update `docs/superpowers/specs/2026-05-23-cross-node-submission-design.md` with the two research corrections (C5 structural; C3 server-side autofill + cnf) referencing `research.md`, and reconcile `specs/137-cross-node-submission/spec.md` if any requirement shifted.
+- [ ] T038 Full `dotnet test` green on the build machine (SC-005 Tier-1 gate); confirm no new build warnings.
+
+---
+
+## Dependencies & execution order
+
+- **Setup (P1-phase)**: T001 → T002.
+- **Foundational**: T003, T004 (after Setup; block user stories).
+- **US1 (P1)**: T005, T006 (same file `Program.cs` — sequential), T007 [P]; tests T008/T009 [P], T010 after T005-T007.
+- **US2 (P2)**: depends on US1 for a sealed application to approve. C5 (T011→T012, T013; T014) → enables analyst submit. C3 server (T015→T016, T017, T018; T019; T020) and C3 client (T021→T022→T023; T024; T025; T026; T027; T028) can proceed in parallel tracks. T029 after C5 + C3 land. Note: T013, T018 both edit `ActionExecutionService.cs` → sequential.
+- **US3 (P3)**: T030 → T031 → T032; T033. Fully independent of US1/US2 (can be built any time after Foundational).
+- **Polish**: T034-T038 after their source phases; T038 last.
+
+## Parallel opportunities
+
+- **Across stories**: US3 (T030-T033) is independent of US1/US2 — a second track can build it in parallel.
+- **Within US1**: T007, T008, T009 in parallel.
+- **Within US2**: the C3-server track (T015-T020) and C3-client track (T021-T028) run in parallel; C5 (T011-T014) is a third parallel track. Watch the two shared-file constraints (`ActionExecutionService.cs`: T013 & T018; `Program.cs`: T005 & T006).
+- **Polish**: T034-T037 in parallel.
+
+## Implementation strategy
+
+- **MVP = US1** (the write hop). Ship/verify it first: a replica-origin submission seals on the owner.
+- **US2** completes the user-visible value (credential returns). It is the largest phase (C3 + C5).
+- **US3** is operability hardening; independently shippable.
+- **Tier-1 gate (SC-005)**: T038 green + T035 committed. **Tier-2** (SC-001/002/003/004 live) runs on the separate cross-node machine.

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -908,6 +908,17 @@ public class ActionExecutionService : IActionExecutionService
             transaction.Metadata["credentialRecipient"] = issuedCredential.SubjectDid;
         }
 
+        // 10c. Feature 137 (C5): carry the resolved next action so that when this tx seals on
+        //      the owning node, a cross-node InstanceMirrorReconstructor can seed the mirror's
+        //      CurrentActionIds (DocketBuildTriggerService projects it onto TransactionMetaData).
+        //      Singular (first routed next action) — exact for linear flows; fan-out carries the
+        //      primary branch only.
+        var nextActionId = routingResult.NextActions.FirstOrDefault()?.ActionId;
+        if (nextActionId.HasValue)
+        {
+            transaction.Metadata["nextActionId"] = nextActionId.Value.ToString();
+        }
+
         // 11. Sign transaction using "{TxId}:{PayloadHash}" contract (matches Validator verification)
         var signResult = await _walletClient.SignTransactionAsync(
             request.SenderWallet,
@@ -1202,7 +1213,7 @@ public class ActionExecutionService : IActionExecutionService
             instance.CurrentActionIds = [actionDef.RejectionConfig.TargetActionId];
         }
         instance.LastTransactionId = transaction.TxId;
-        instance = await _instanceStore.UpdateAsync(instance, cancellationToken);
+        instance = await PersistInstanceAsync(instance, cancellationToken);
 
         // 10. Notify target participant via thin signal
         var targetParticipantId = actionDef.RejectionConfig.TargetParticipantId ?? targetAction.Sender;
@@ -1623,7 +1634,7 @@ public class ActionExecutionService : IActionExecutionService
 
             try
             {
-                return await _instanceStore.UpdateAsync(instance, cancellationToken);
+                return await PersistInstanceAsync(instance, cancellationToken);
             }
             catch (ConcurrencyException) when (attempt < MaxConcurrencyRetries)
             {
@@ -1635,6 +1646,20 @@ public class ActionExecutionService : IActionExecutionService
         throw new InvalidOperationException(
             $"Failed to update instance {instance.Id} after {MaxConcurrencyRetries} retries due to concurrent modifications");
     }
+
+    /// <summary>
+    /// Feature 137 (C5): persists instance state changes, choosing the mirror-safe writer when the
+    /// instance is a read-only mirror. On the register-owning node a cross-node workflow surfaces as
+    /// a mirror row (the node never ran CreateInstance), yet the owner MUST advance it when its own
+    /// participant acts (e.g. the verification-analyst approves). <see cref="IInstanceStore.UpdateAsync"/>
+    /// rejects mirror rows by design (Feature 106), so the advance is routed through
+    /// <see cref="IInstanceStore.UpdateMirrorAsync"/>. The register stays the source of truth — the
+    /// InstanceMirrorReconstructor re-derives the mirror when the resulting transaction seals.
+    /// </summary>
+    private Task<Instance> PersistInstanceAsync(Instance instance, CancellationToken cancellationToken)
+        => instance.IsReadOnlyMirror
+            ? _instanceStore.UpdateMirrorAsync(instance, cancellationToken)
+            : _instanceStore.UpdateAsync(instance, cancellationToken);
 
     private static void ApplyInstanceStateChanges(
         Instance instance,

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
@@ -179,6 +179,15 @@ public sealed class EncryptionBackgroundService : BackgroundService
                 workItem.PreviousTransactionId,
                 ct);
 
+            // Feature 137 (C5): carry the resolved next action so a cross-node mirror can seed
+            // CurrentActionIds when this tx seals. Mirrors the synchronous path in
+            // ActionExecutionService; DocketBuildTriggerService projects it onto TransactionMetaData.
+            var nextActionId = workItem.RoutingResult.NextActions.FirstOrDefault()?.ActionId;
+            if (nextActionId.HasValue)
+            {
+                transaction.Metadata["nextActionId"] = nextActionId.Value.ToString();
+            }
+
             // Step 4: Signing and Submitting
             await UpdateOperationStepAsync(operationId, EncryptionOpStatus.Submitting,
                 StepSubmitting, "Signing and submitting", 80);

--- a/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketBuildTriggerService.cs
@@ -506,6 +506,18 @@ public class DocketBuildTriggerService : BackgroundService
     }
 
     /// <summary>
+    /// Feature 137 (C5): resolves the next-action id carried in a transaction's submission
+    /// metadata (key <c>nextActionId</c>) for projection onto <see cref="TransactionMetaData.NextActionId"/>.
+    /// Returns null when absent or unparseable. The cross-node InstanceMirrorReconstructor reads the
+    /// projected value to seed a mirror's CurrentActionIds. Extracted as an internal static so the
+    /// parse/key contract can be unit-tested without the full docket-write flow.
+    /// </summary>
+    internal static uint? ResolveNextActionId(IReadOnlyDictionary<string, string> metadata)
+        => metadata.TryGetValue("nextActionId", out var raw) && uint.TryParse(raw, out var value)
+            ? value
+            : null;
+
+    /// <summary>
     /// Writes docket and transactions to Register Service after successful build
     /// </summary>
     private async Task WriteDocketAndTransactionsAsync(
@@ -605,6 +617,13 @@ public class DocketBuildTriggerService : BackgroundService
                                          && !string.IsNullOrWhiteSpace(iid)
                                 ? iid
                                 : null,
+                            // Feature 137 (C5): carry the Blueprint Service's resolved next
+                            // action through to the sealed tx so a cross-node InstanceMirror-
+                            // Reconstructor can seed CurrentActionIds without re-running routing.
+                            // The Blueprint Service evaluates conditional routes against the
+                            // payload (the validator only knows the static route graph), so the
+                            // authoritative next action must originate from the submission.
+                            NextActionId = ResolveNextActionId(t.Metadata),
                         }
                     };
                 }).ToList(),

--- a/tests/Sorcha.Blueprint.Service.Tests/Storage/InMemoryInstanceStoreTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Storage/InMemoryInstanceStoreTests.cs
@@ -209,4 +209,74 @@ public class InMemoryInstanceStoreTests
 
         result.Should().BeFalse();
     }
+
+    // Feature 137 (C5): the read-only-mirror write guard is the invariant the cross-node
+    // mirror-aware persist path (ActionExecutionService.PersistInstanceAsync) relies on.
+    // UpdateAsync must reject a mirror; UpdateMirrorAsync must advance it.
+
+    [Fact]
+    public async Task UpdateAsync_ReadOnlyMirror_ThrowsInvalidOperationException()
+    {
+        var mirror = CreateInstance("mirror-update");
+        await _store.CreateMirrorAsync(mirror);
+
+        mirror.CurrentActionIds = [2];
+        var act = () => _store.UpdateAsync(mirror);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*read-only mirror*");
+    }
+
+    [Fact]
+    public async Task UpdateMirrorAsync_OnMirror_AdvancesAndBumpsVersion()
+    {
+        var mirror = CreateInstance("mirror-advance");
+        await _store.CreateMirrorAsync(mirror);
+
+        mirror.CurrentActionIds = [2];
+        var result = await _store.UpdateMirrorAsync(mirror);
+
+        result.IsReadOnlyMirror.Should().BeTrue();
+        result.CurrentActionIds.Should().Equal(2);
+
+        var reread = await _store.GetAsync("mirror-advance");
+        reread!.CurrentActionIds.Should().Equal(2);
+        reread.IsReadOnlyMirror.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateMirrorAsync_OnAuthoritativeRow_ThrowsInvalidOperationException()
+    {
+        var authoritative = CreateInstance("auth-row");
+        await _store.CreateAsync(authoritative);
+
+        var act = () => _store.UpdateMirrorAsync(authoritative);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*locally authoritative*");
+    }
+
+    [Fact]
+    public async Task CreateMirrorAsync_ForcesReadOnlyMirrorFlag()
+    {
+        var instance = CreateInstance("mirror-flag");
+        instance.IsReadOnlyMirror = false;
+
+        var result = await _store.CreateMirrorAsync(instance);
+
+        result.IsReadOnlyMirror.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateMirrorAsync_ExistingAuthoritativeRow_DoesNotOverwrite()
+    {
+        var authoritative = CreateInstance("shared-id");
+        await _store.CreateAsync(authoritative);
+
+        var mirrorAttempt = CreateInstance("shared-id");
+        var result = await _store.CreateMirrorAsync(mirrorAttempt);
+
+        result.IsReadOnlyMirror.Should().BeFalse();
+        (await _store.GetAsync("shared-id"))!.IsReadOnlyMirror.Should().BeFalse();
+    }
 }

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketBuildTriggerNextActionIdTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketBuildTriggerNextActionIdTests.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Validator.Service.Services;
+
+namespace Sorcha.Validator.Service.Tests.Services;
+
+/// <summary>
+/// Feature 137 (C5): the authoritative metadata projection in DocketBuildTriggerService must carry
+/// the Blueprint Service's resolved next action (submission metadata key <c>nextActionId</c>) onto
+/// <c>TransactionMetaData.NextActionId</c>, so a cross-node InstanceMirrorReconstructor can seed a
+/// mirror's CurrentActionIds. These tests pin the parse/key contract.
+/// </summary>
+public class DocketBuildTriggerNextActionIdTests
+{
+    [Fact]
+    public void ResolveNextActionId_WithValidValue_ReturnsParsedId()
+    {
+        var metadata = new Dictionary<string, string> { ["nextActionId"] = "2" };
+
+        var result = DocketBuildTriggerService.ResolveNextActionId(metadata);
+
+        result.Should().Be(2u);
+    }
+
+    [Fact]
+    public void ResolveNextActionId_KeyAbsent_ReturnsNull()
+    {
+        var metadata = new Dictionary<string, string> { ["instanceId"] = "abc" };
+
+        var result = DocketBuildTriggerService.ResolveNextActionId(metadata);
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-number")]
+    [InlineData("-1")]
+    public void ResolveNextActionId_Unparseable_ReturnsNull(string raw)
+    {
+        var metadata = new Dictionary<string, string> { ["nextActionId"] = raw };
+
+        var result = DocketBuildTriggerService.ResolveNextActionId(metadata);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Stage 5 of cross-node federation: the citizen→credential round-trip across two installations. This PR delivers the **design → spec → plan → tasks** artifacts (spec-kit) plus the **first implementation chunk (C5)** — the hardest blocker.

Design source of truth: `docs/superpowers/specs/2026-05-23-cross-node-submission-design.md`. Spec/plan/tasks: `specs/137-cross-node-submission/`.

### Trust model (foundation)
Federation = **separate F136 installations bridged only at the ledger plane** (genesis validator roster + tx/docket signatures). No cross-installation JWT. The identity plane and ledger plane stay independent.

### C5 — cross-node mirror submission (this PR's code)
The verification-analyst acts on the register-**owning** node against an instance that exists there only as a **read-only mirror** (F106) — the node never ran `CreateInstance`. Two structural blockers fixed:

- **T011** — carry the Blueprint Service's *resolved* next action in submission metadata (sync + async encryption paths) and project it onto `TransactionMetaData.NextActionId` in the validator's authoritative docket-build. (Conditional routing is resolved by the Blueprint Service; the validator only knows the static graph — so the next action must originate from the submission. Extracted `ResolveNextActionId` for unit-testability.)
- **T012** — no change needed: `InstanceMirrorReconstructor` already seeds `CurrentActionIds` from `NextActionId` (which was always null until T011).
- **T013** — `ActionExecutionService.PersistInstanceAsync` routes the post-execution and rejection advances through `UpdateMirrorAsync` when the instance is a read-only mirror, instead of the guarded `UpdateAsync` (which rejects mirrors by design). The register stays source-of-truth; the reconstructor re-derives on seal.
- **T014** — unit tests for the mirror write-guard invariant + the `NextActionId` projection contract.

## Test plan
- [x] Blueprint.Service + Validator.Service build clean
- [x] New unit tests pass: 5 mirror-guard + 5 NextActionId-projection (10/10)
- [x] Full Validator suite: 963 passed / 0 failed / 17 skipped
- [x] Blueprint unit tests pass (701); the 27 failures are **pre-existing** integration tests needing Redis (`IConnectionMultiplexer`) — unrelated to this change
- [ ] **Deferred to the cross-node machine** (holds `genesis-validator-key.json` + n1 SSH): the live n1↔local round-trip (SC-001). Remaining components C1–C4 (blueprint resolution, recovery, key field, fan-out config) are planned in `tasks.md` and not in this PR.

## Notes
- Subsequent work (C1/C2/C3/C4) lands in follow-up PRs per `specs/137-cross-node-submission/tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)