### PR TITLE
feat: [137] US1 — published-store-aware instance creation (C1) + fan-out config (C4)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,13 @@ services:
       ServiceClients__ValidatorService__Address: http://validator-service:8080
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__HaipService__Address: http://haip-service:8080
+      # Feature 137 (C4): Peer Service client config so F108 submission fan-out
+      # (ActionExecutionService -> IPeerServiceClient.DistributeTransactionAsync) reaches the
+      # peer service. The distribute REST call uses HttpAddress (HTTP/8080); Address is the
+      # gRPC port (5000). Without HttpAddress the HttpClient BaseAddress is unset and fan-out
+      # fails with "BaseAddress must be set".
+      ServiceClients__PeerService__Address: http://peer-service:5000
+      ServiceClients__PeerService__HttpAddress: http://peer-service:8080
       # Service-to-service auth for Wallet/Register Service calls during action execution
       ServiceAuth__ClientId: service-blueprint
       ServiceAuth__ClientSecret: blueprint-service-secret

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1865,52 +1865,104 @@ instancesGroup.MapPost("/", async (
     CreateInstanceRequest request,
     Sorcha.Blueprint.Service.Storage.IInstanceStore instanceStore,
     IBlueprintStore blueprintStore,
+    IPublishedBlueprintStore publishedBlueprintStore,
     Sorcha.ServiceClients.Register.IRegisterServiceClient registerClient) =>
 {
     try
     {
-        // Validate blueprint exists
+        // Resolve the blueprint. The draft/editable store only exists on the node that
+        // authored the blueprint; a replica (Feature 137 / C1) holds it solely in the
+        // published (replicated) store. Try the draft store first, then fall back to the
+        // latest published version so instance creation works on a node that does not own
+        // the register.
         var blueprint = await blueprintStore.GetAsync(request.BlueprintId);
+        var resolvedVersion = 1;
         if (blueprint == null)
         {
-            return Results.BadRequest(new { error = "Blueprint not found" });
+            var publishedVersions = await publishedBlueprintStore.GetVersionsAsync(request.BlueprintId);
+            var latest = PublishedBlueprintSelector.SelectLatest(publishedVersions);
+            if (latest != null)
+            {
+                blueprint = latest.Blueprint;
+                resolvedVersion = latest.Version;
+            }
         }
 
-        // Ensure the blueprint publish transaction exists on the register.
-        // Action 0 chains from this TX, so it must be created before any actions execute.
-        // The Register Service endpoint is idempotent — safe to call on every instance creation.
+        if (blueprint == null)
+        {
+            // Not in either store. On a replica this usually means the register's blueprints
+            // have not finished replicating yet (event-driven recovery is in flight), so
+            // surface a typed, retryable state rather than a bare 400 "not found".
+            return Results.Json(
+                new
+                {
+                    error = "blueprint_not_available",
+                    blueprintId = request.BlueprintId,
+                    registerId = request.RegisterId,
+                    message = "Blueprint is not available on this node yet. If the register was recently synced, retry shortly."
+                },
+                statusCode: StatusCodes.Status409Conflict);
+        }
+
+        // Ensure the blueprint publish transaction exists on the register. Action 0 chains
+        // from this TX, so it must exist before any actions execute. Feature 137 (C1): ONLY
+        // the register owner publishes — a replica must never (re)publish onto a register it
+        // does not own (the publish tx already arrived via replication). The Register Service
+        // endpoint is idempotent, so the owner can safely call it on every instance creation.
+        var isOwner = false;
         try
         {
-            var blueprintJson = System.Text.Json.JsonSerializer.Serialize(blueprint, new System.Text.Json.JsonSerializerOptions
-            {
-                PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
-                WriteIndented = false
-            });
-
-            var published = await registerClient.PublishBlueprintToRegisterAsync(
-                request.RegisterId,
-                request.BlueprintId,
-                blueprintJson,
-                request.TenantId ?? "system");
-
-            if (!published)
-            {
-                logger.LogWarning(
-                    "Failed to publish blueprint {BlueprintId} to register {RegisterId} during instance creation",
-                    request.BlueprintId, request.RegisterId);
-            }
-            else
-            {
-                logger.LogInformation(
-                    "Blueprint {BlueprintId} published to register {RegisterId} for instance creation",
-                    request.BlueprintId, request.RegisterId);
-            }
+            var relationship = await registerClient.GetLocalRelationshipAsync(request.RegisterId);
+            isOwner = relationship?.IsOwner == true;
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex,
-                "Non-fatal: Could not publish blueprint {BlueprintId} to register {RegisterId}",
-                request.BlueprintId, request.RegisterId);
+                "Could not resolve local relationship for register {RegisterId}; treating as non-owner (skipping publish)",
+                request.RegisterId);
+        }
+
+        if (isOwner)
+        {
+            try
+            {
+                var blueprintJson = System.Text.Json.JsonSerializer.Serialize(blueprint, new System.Text.Json.JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+                    WriteIndented = false
+                });
+
+                var published = await registerClient.PublishBlueprintToRegisterAsync(
+                    request.RegisterId,
+                    request.BlueprintId,
+                    blueprintJson,
+                    request.TenantId ?? "system");
+
+                if (!published)
+                {
+                    logger.LogWarning(
+                        "Failed to publish blueprint {BlueprintId} to register {RegisterId} during instance creation",
+                        request.BlueprintId, request.RegisterId);
+                }
+                else
+                {
+                    logger.LogInformation(
+                        "Blueprint {BlueprintId} published to register {RegisterId} for instance creation",
+                        request.BlueprintId, request.RegisterId);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Non-fatal: Could not publish blueprint {BlueprintId} to register {RegisterId}",
+                    request.BlueprintId, request.RegisterId);
+            }
+        }
+        else
+        {
+            logger.LogDebug(
+                "Skipping blueprint publish for register {RegisterId}: this node is not the owner (replica path)",
+                request.RegisterId);
         }
 
         // Find starting actions
@@ -1939,7 +1991,7 @@ instancesGroup.MapPost("/", async (
         {
             Id = Guid.NewGuid().ToString(),
             BlueprintId = request.BlueprintId,
-            BlueprintVersion = 1, // TODO: Get actual published version
+            BlueprintVersion = resolvedVersion,
             RegisterId = request.RegisterId,
             CurrentActionIds = startingActions,
             ParticipantWallets = participantWallets,

--- a/src/Services/Sorcha.Blueprint.Service/PublishedBlueprintSelector.cs
+++ b/src/Services/Sorcha.Blueprint.Service/PublishedBlueprintSelector.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+/// <summary>
+/// Feature 137 (C1): selects which published blueprint version a node should use for instance
+/// creation when the draft/editable store has no copy — the replica case, where the blueprint
+/// exists only in the replicated published store. Picks the highest <c>Version</c> (newest
+/// <c>PublishedAt</c> as a tiebreak) and ignores entries with no blueprint payload. Extracted as
+/// an internal static so the selection contract is unit-testable without the full endpoint.
+/// </summary>
+internal static class PublishedBlueprintSelector
+{
+    internal static PublishedBlueprint? SelectLatest(IEnumerable<PublishedBlueprint> versions)
+        => versions
+            .Where(p => p.Blueprint is not null)
+            .OrderByDescending(p => p.Version)
+            .ThenByDescending(p => p.PublishedAt)
+            .FirstOrDefault();
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/PublishedBlueprintSelectorTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/PublishedBlueprintSelectorTests.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Feature 137 (C1): instance creation on a replica resolves the blueprint from the published
+/// (replicated) store when the draft store has no copy. These tests pin the version-selection
+/// contract used by that fallback.
+/// </summary>
+public class PublishedBlueprintSelectorTests
+{
+    private static PublishedBlueprint Published(int version, DateTimeOffset publishedAt, BlueprintModel? blueprint = null)
+        => new()
+        {
+            BlueprintId = "bp-1",
+            Version = version,
+            PublishedAt = publishedAt,
+            Blueprint = blueprint ?? new BlueprintModel { Title = $"v{version}" }
+        };
+
+    [Fact]
+    public void SelectLatest_MultipleVersions_PicksHighestVersion()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var versions = new[]
+        {
+            Published(1, now.AddMinutes(-10)),
+            Published(3, now.AddMinutes(-30)), // older timestamp but highest version
+            Published(2, now.AddMinutes(-5)),
+        };
+
+        var result = PublishedBlueprintSelector.SelectLatest(versions);
+
+        result.Should().NotBeNull();
+        result!.Version.Should().Be(3);
+    }
+
+    [Fact]
+    public void SelectLatest_SameVersion_PicksNewestPublishedAt()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var older = Published(1, now.AddHours(-1));
+        var newer = Published(1, now);
+
+        var result = PublishedBlueprintSelector.SelectLatest(new[] { older, newer });
+
+        result.Should().BeSameAs(newer);
+    }
+
+    [Fact]
+    public void SelectLatest_IgnoresEntriesWithNoBlueprintPayload()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var withPayload = Published(1, now.AddMinutes(-10));
+        var noPayload = new PublishedBlueprint { BlueprintId = "bp-1", Version = 9, PublishedAt = now, Blueprint = null! };
+
+        var result = PublishedBlueprintSelector.SelectLatest(new[] { noPayload, withPayload });
+
+        result.Should().BeSameAs(withPayload);
+    }
+
+    [Fact]
+    public void SelectLatest_EmptyOrAllNull_ReturnsNull()
+    {
+        PublishedBlueprintSelector.SelectLatest(Array.Empty<PublishedBlueprint>()).Should().BeNull();
+
+        var allNull = new[] { new PublishedBlueprint { BlueprintId = "bp-1", Version = 1, Blueprint = null! } };
+        PublishedBlueprintSelector.SelectLatest(allNull).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Feature 137 **US1 — the cross-node write hop**: a citizen on a SyncOnly **replica** can create a workflow instance and have the starting action reach the **owning** node. Builds on the merged C5 (#831). Spec/plan: `specs/137-cross-node-submission/`.

### C1 — published-store-aware blueprint resolution
- `CreateInstance` now falls back to the **published (replicated)** blueprint store when the draft/editable store has no copy — so instance creation works on a node that only holds the replicated blueprint (the replica case). Latest version chosen by the new, unit-tested `PublishedBlueprintSelector`.
- Not-found in **either** store returns a typed retryable **409 `blueprint_not_available`** (the register may still be syncing) rather than a bare 400 — clients retry.
- `PublishBlueprintToRegisterAsync` is **gated on node ownership** (`GetLocalRelationshipAsync().IsOwner`): a replica never re-publishes onto a register it does not own. `BlueprintVersion` reflects the resolved published version.

### C4 — F108 fan-out config
- `docker-compose` blueprint-service gains `ServiceClients__PeerService__Address` (gRPC `:5000`) + `__HttpAddress` (REST `:8080`) so `IPeerServiceClient.DistributeTransactionAsync` reaches the peer service. It was previously unset → `"BaseAddress must be set"` → fan-out was a silent no-op. The n1 overlay inherits the base; the Aspire single-node path is a locally-owned no-op so left unchanged.

## Test plan
- [x] Blueprint.Service builds clean
- [x] 4 `PublishedBlueprintSelector` unit tests pass
- [x] Full Blueprint unit suite: 705 passed (was 701) — the 27 failures are **pre-existing** integration tests needing Redis (`IConnectionMultiplexer`), unrelated
- [ ] **Deferred to the cross-node machine** (genesis key + n1 SSH): the live replica→owner submission + the ownership-gate / fallback wiring (Tier-2, per `quickstart.md`)

## Notes
- Remaining: C2 (event-driven recovery, US3) and C3 (key field + `cnf` + endpoint, US2) follow in separate PRs per `tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)