### PR TITLE
feat: [137] US3 — event-driven blueprint recovery (C2)

### DIFF
--- a/src/Core/Sorcha.Register.Core/Events/RegisterEventChannels.cs
+++ b/src/Core/Sorcha.Register.Core/Events/RegisterEventChannels.cs
@@ -15,6 +15,14 @@ public static class RegisterEventChannels
     public const string TransactionConfirmed = "transaction:confirmed";
 
     /// <summary>
+    /// Published when a register row is created locally — including the create-on-sync path when a
+    /// register first replicates to this node (PR #829). Payload: <see cref="RegisterCreatedEvent"/>.
+    /// Feature 137 (C2): Blueprint.Service subscribes to recover the new register's published
+    /// blueprints immediately, rather than waiting for the next periodic recovery pass.
+    /// </summary>
+    public const string RegisterCreated = "register:created";
+
+    /// <summary>
     /// Published when a docket has been sealed and written. Payload: <see cref="DocketConfirmedEvent"/>.
     /// </summary>
     public const string DocketConfirmed = "docket:confirmed";

--- a/src/Core/Sorcha.Register.Core/Managers/RegisterManager.cs
+++ b/src/Core/Sorcha.Register.Core/Managers/RegisterManager.cs
@@ -82,7 +82,7 @@ public class RegisterManager
 
         // Publish register created event
         await _eventPublisher.PublishAsync(
-            "register:created",
+            RegisterEventChannels.RegisterCreated,
             new RegisterCreatedEvent
             {
                 RegisterId = createdRegister.Id,

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs
@@ -4,7 +4,9 @@
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Sorcha.Blueprint.Service.Models;
+using Sorcha.Register.Core.Events;
 using Sorcha.ServiceClients.Register;
+using StackExchange.Redis;
 
 namespace Sorcha.Blueprint.Service.Services.Implementation;
 
@@ -18,18 +20,23 @@ public class BlueprintRecoveryService : BackgroundService
     private readonly RecoveryState _recoveryState;
     private readonly RecoveryOptions _options;
     private readonly ILogger<BlueprintRecoveryService> _logger;
+    private readonly IConnectionMultiplexer? _redis;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     /// <summary>Initialises a new instance of the <see cref="BlueprintRecoveryService"/> class.</summary>
     public BlueprintRecoveryService(
         IServiceScopeFactory scopeFactory,
         RecoveryState recoveryState,
         IOptions<RecoveryOptions> options,
-        ILogger<BlueprintRecoveryService> logger)
+        ILogger<BlueprintRecoveryService> logger,
+        IConnectionMultiplexer? redis = null)
     {
         _scopeFactory = scopeFactory;
         _recoveryState = recoveryState;
         _options = options.Value;
         _logger = logger;
+        _redis = redis;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -50,6 +57,12 @@ public class BlueprintRecoveryService : BackgroundService
         _logger.LogInformation(
             "Blueprint recovery complete. Registers: {Online} online, {Offline} offline. Blueprints recovered: {Total}",
             onlineCount, offlineCount, totalBlueprints);
+
+        // Feature 137 (C2): subscribe to register:created so a register that replicates to this
+        // node AFTER boot (the create-on-sync path, PR #829) has its published blueprints recovered
+        // immediately, rather than only on the next periodic pass. The periodic loop below remains
+        // as the safety net for missed events / Redis-unavailable nodes.
+        await SubscribeToRegisterCreatedAsync(stoppingToken);
 
         // Periodic refresh loop
         var refreshInterval = TimeSpan.FromSeconds(_options.RefreshIntervalSeconds);
@@ -99,38 +112,135 @@ public class BlueprintRecoveryService : BackgroundService
                 continue;
             }
 
-            state.LastCheckedAt = DateTimeOffset.UtcNow;
+            await ApplyRecoveryAsync(registerClient, publishedStore, state, cancellationToken);
+        }
+    }
 
-            try
+    /// <summary>
+    /// Feature 137 (C2): event-driven recovery of a single register. Opens its own scope and
+    /// recovers the register's published blueprints immediately. Called when a
+    /// <see cref="RegisterEventChannels.RegisterCreated"/> event fires (a register replicated to
+    /// this node after boot). Idempotent: <see cref="RecoverFromRegisterAsync"/> skips blueprints
+    /// already present in the published store.
+    /// </summary>
+    internal async Task RecoverRegisterAsync(string registerId, string? registerName, CancellationToken cancellationToken)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var registerClient = scope.ServiceProvider.GetRequiredService<IRegisterServiceClient>();
+        var publishedStore = scope.ServiceProvider.GetRequiredService<IPublishedBlueprintStore>();
+
+        var state = _recoveryState.RegisterStates.GetOrAdd(registerId, _ => new RegisterRecoveryState
+        {
+            RegisterId = registerId,
+            RegisterName = registerName ?? registerId
+        });
+
+        await ApplyRecoveryAsync(registerClient, publishedStore, state, cancellationToken);
+    }
+
+    /// <summary>
+    /// Recovers one register's published blueprints and updates its <see cref="RegisterRecoveryState"/>.
+    /// Shared by the periodic recovery loop and the event-driven entrypoint.
+    /// </summary>
+    private async Task ApplyRecoveryAsync(
+        IRegisterServiceClient registerClient,
+        IPublishedBlueprintStore publishedStore,
+        RegisterRecoveryState state,
+        CancellationToken cancellationToken)
+    {
+        state.LastCheckedAt = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var result = await RecoverFromRegisterAsync(
+                registerClient, publishedStore, state.RegisterId, cancellationToken);
+
+            state.Status = RegisterHealthStatus.Online;
+            state.Height = (int)result.Height;
+            state.RecoveredBlueprintCount = result.BlueprintCount;
+            state.LastSuccessAt = DateTimeOffset.UtcNow;
+            state.ConsecutiveFailures = 0;
+            state.ErrorMessage = null;
+
+            if (result.BlueprintCount > 0)
             {
-                var result = await RecoverFromRegisterAsync(
-                    registerClient, publishedStore, registerId, cancellationToken);
-
-                state.Status = RegisterHealthStatus.Online;
-                state.Height = (int)result.Height;
-                state.RecoveredBlueprintCount = result.BlueprintCount;
-                state.LastSuccessAt = DateTimeOffset.UtcNow;
-                state.ConsecutiveFailures = 0;
-                state.ErrorMessage = null;
-
-                if (result.BlueprintCount > 0)
-                {
-                    _logger.LogInformation(
-                        "Recovered {Count} published blueprints from register {RegisterId} ({RegisterName})",
-                        result.BlueprintCount, registerId, registerName);
-                }
-            }
-            catch (Exception ex)
-            {
-                state.Status = RegisterHealthStatus.Offline;
-                state.ConsecutiveFailures++;
-                state.ErrorMessage = ex.Message;
-
-                _logger.LogWarning(ex,
-                    "Failed to recover from register {RegisterId} ({RegisterName}). Consecutive failures: {Failures}",
-                    registerId, registerName, state.ConsecutiveFailures);
+                _logger.LogInformation(
+                    "Recovered {Count} published blueprints from register {RegisterId} ({RegisterName})",
+                    result.BlueprintCount, state.RegisterId, state.RegisterName);
             }
         }
+        catch (Exception ex)
+        {
+            state.Status = RegisterHealthStatus.Offline;
+            state.ConsecutiveFailures++;
+            state.ErrorMessage = ex.Message;
+
+            _logger.LogWarning(ex,
+                "Failed to recover from register {RegisterId} ({RegisterName}). Consecutive failures: {Failures}",
+                state.RegisterId, state.RegisterName, state.ConsecutiveFailures);
+        }
+    }
+
+    /// <summary>
+    /// Feature 137 (C2): subscribes to <see cref="RegisterEventChannels.RegisterCreated"/> and
+    /// recovers the new register's published blueprints on each event. Degrades cleanly to
+    /// periodic-only recovery when Redis is unavailable (mirrors InstanceMirrorReconstructor).
+    /// </summary>
+    private async Task SubscribeToRegisterCreatedAsync(CancellationToken stoppingToken)
+    {
+        if (_redis is null)
+        {
+            _logger.LogWarning(
+                "BlueprintRecoveryService: Redis not available — event-driven recovery disabled. " +
+                "Newly-synced registers will be picked up on the next periodic refresh ({Interval}s).",
+                _options.RefreshIntervalSeconds);
+            return;
+        }
+
+        try
+        {
+            var subscriber = _redis.GetSubscriber();
+            await subscriber.SubscribeAsync(
+                RedisChannel.Literal(RegisterEventChannels.RegisterCreated),
+                async (_, message) =>
+                {
+                    try
+                    {
+                        if (message.IsNullOrEmpty) return;
+                        var evt = JsonSerializer.Deserialize<RegisterCreatedPayload>((string)message!, JsonOptions);
+                        if (evt is null || string.IsNullOrEmpty(evt.RegisterId)) return;
+
+                        _logger.LogInformation(
+                            "BlueprintRecoveryService: register:created for {RegisterId} — recovering its published blueprints",
+                            evt.RegisterId);
+                        await RecoverRegisterAsync(evt.RegisterId, evt.Name, stoppingToken);
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.LogWarning(ex, "BlueprintRecoveryService: malformed register:created event");
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        _logger.LogError(ex, "BlueprintRecoveryService: error handling register:created");
+                    }
+                });
+
+            _logger.LogInformation(
+                "BlueprintRecoveryService subscribed to {Channel}", RegisterEventChannels.RegisterCreated);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "BlueprintRecoveryService: failed to subscribe to {Channel}; falling back to periodic recovery only",
+                RegisterEventChannels.RegisterCreated);
+        }
+    }
+
+    /// <summary>Minimal projection of the register:created event payload (RegisterId + Name).</summary>
+    private sealed record RegisterCreatedPayload
+    {
+        public string RegisterId { get; init; } = string.Empty;
+        public string? Name { get; init; }
     }
 
     private async Task<List<(string Id, string Name)>> DiscoverRegistersAsync(

--- a/src/Services/Sorcha.Register.Service/Services/RegisterEventBridgeService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterEventBridgeService.cs
@@ -32,7 +32,7 @@ public class RegisterEventBridgeService : BackgroundService
         _logger.LogInformation("RegisterEventBridgeService registering event subscriptions");
 
         await _subscriber.SubscribeAsync<RegisterCreatedEvent>(
-            "register:created",
+            RegisterEventChannels.RegisterCreated,
             async e =>
             {
                 _logger.LogDebug("Bridging RegisterCreated for {RegisterId} to group register:{GroupRegisterId}", e.RegisterId, e.RegisterId);

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintRecoveryServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintRecoveryServiceTests.cs
@@ -488,6 +488,74 @@ public class BlueprintRecoveryServiceTests
 
     #endregion
 
+    #region RecoverRegisterAsync — event-driven (Feature 137 / C2)
+
+    [Fact]
+    public async Task RecoverRegisterAsync_RecoversBlueprintsAndMarksOnline()
+    {
+        var blueprintJson = JsonSerializer.Serialize(CreateMinimalBlueprint("bp-1"));
+
+        // Note: NO GetInternalRegistersAsync setup — the event-driven path targets one register
+        // directly (a register that replicated after boot, possibly not yet in discovery).
+        _mockRegisterClient
+            .Setup(c => c.GetPublishedBlueprintsAsync("reg-new", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PublishedBlueprintsResponse
+            {
+                RegisterId = "reg-new",
+                RegisterHeight = 9,
+                Blueprints =
+                [
+                    new PublishedBlueprintEntry
+                    {
+                        BlueprintId = "bp-1",
+                        TransactionId = "tx-1",
+                        PublishedAt = DateTimeOffset.UtcNow,
+                        BlueprintJson = blueprintJson
+                    }
+                ]
+            });
+
+        _mockPublishedStore
+            .Setup(s => s.GetVersionsAsync("bp-1"))
+            .ReturnsAsync(Enumerable.Empty<PublishedBlueprint>());
+        _mockPublishedStore
+            .Setup(s => s.AddAsync(It.IsAny<PublishedBlueprint>()))
+            .ReturnsAsync((PublishedBlueprint pb) => pb);
+
+        var service = CreateService();
+        await service.RecoverRegisterAsync("reg-new", "Newly Synced Register", CancellationToken.None);
+
+        _recoveryState.RegisterStates.Should().ContainKey("reg-new");
+        var state = _recoveryState.RegisterStates["reg-new"];
+        state.Status.Should().Be(RegisterHealthStatus.Online);
+        state.RegisterName.Should().Be("Newly Synced Register");
+        state.RecoveredBlueprintCount.Should().Be(1);
+
+        _mockPublishedStore.Verify(
+            s => s.AddAsync(It.Is<PublishedBlueprint>(pb => pb.BlueprintId == "bp-1" && pb.RegisterId == "reg-new")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RecoverRegisterAsync_ClientReturnsNull_MarksOffline()
+    {
+        _mockRegisterClient
+            .Setup(c => c.GetPublishedBlueprintsAsync("reg-down", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PublishedBlueprintsResponse?)null);
+
+        var service = CreateService();
+        await service.RecoverRegisterAsync("reg-down", registerName: null, CancellationToken.None);
+
+        var state = _recoveryState.RegisterStates["reg-down"];
+        state.Status.Should().Be(RegisterHealthStatus.Offline);
+        state.ConsecutiveFailures.Should().Be(1);
+        state.ErrorMessage.Should().NotBeNullOrEmpty();
+        // Falls back to registerId as the display name when none supplied.
+        state.RegisterName.Should().Be("reg-down");
+    }
+
+    #endregion
+
     #region Helpers
 
     private static BlueprintModel CreateMinimalBlueprint(string id) => new()


### PR DESCRIPTION
## Summary

Feature 137 **US3 — operability**: a register that replicates to a node **after** the blueprint service has started now has its published blueprints recovered **immediately**, removing the manual `blueprint-service` restart workaround used in the cross-node probe. Builds on C5 (#831) and US1 (#832). Spec/plan: `specs/137-cross-node-submission/`.

### C2 — event-driven recovery
- New `RegisterEventChannels.RegisterCreated` constant; the two inline `"register:created"` literals (`RegisterManager`, `RegisterEventBridgeService`) now reference it (no drift).
- `BlueprintRecoveryService` subscribes to `register:created` (optional `IConnectionMultiplexer`, mirroring `InstanceMirrorReconstructor`) and runs a **targeted per-register recovery** (new internal `RecoverRegisterAsync`) on each event — including the PR #829 create-on-sync path. The periodic loop remains the **safety net**, and the service **degrades cleanly to periodic-only** when Redis is unavailable.
- The per-register entrypoint and the periodic-loop body share a new `ApplyRecoveryAsync` (no duplicated state-update logic).

## Test plan
- [x] Blueprint.Service + Register.Service build clean
- [x] 2 new event-driven recovery tests; full recovery suite 14/14
- [x] Register.Service suite: 299 passed / 0 failed (constant-replacement safe)
- [ ] **Deferred to the cross-node machine**: subscribe a register post-boot → blueprint usable within 30s, no restart (SC-003, Tier-2 per `quickstart.md`)

## Notes
- Remaining: **C3** (the open-participant key field + SD-JWT `cnf` binding + Wallet-Service public-key endpoint + recipient-key precedence, US2) follows in its own PR per `tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)