### PR TITLE
feat: [137] C3/US2 credential delivery — cnf binding + cross-node key precedence

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -68,7 +68,15 @@
       "PowerShell(pwsh -File walkthroughs/AssuredIdentity/run-agents.ps1 -TimeoutMinutes 30)",
       "PowerShell(.specify/scripts/powershell/create-new-feature.ps1 -Json -Number 134 -ShortName \"presentation-history\" \"F114 US5 PR3 cross-device citizen presentation history - Wallet Service durable per-citizen presentation store with read and delete endpoints and a PWA Activity cross-device merge so a freshly-paired device shows past presentations\")",
       "PowerShell(.specify/scripts/powershell/update-agent-context.ps1 -AgentType claude 2>&1 | Select-Object -Last 20)",
-      "PowerShell(.specify/scripts/powershell/create-new-feature.ps1 -Json -Number 137 -ShortName \"cross-node-submission\" \"Cross-node submission round-trip \\(Stage 5\\): citizen on a local SyncOnly replica submits an AssuredIdentity application that reaches the n1 owner/validator node, is validated/sealed there, approved by the verification-analyst on n1, and the resulting AssuredIdentityCredential is delivered back to the citizen's local wallet. Source of truth: docs/superpowers/specs/2026-05-23-cross-node-submission-design.md\")"
+      "PowerShell(.specify/scripts/powershell/create-new-feature.ps1 -Json -Number 137 -ShortName \"cross-node-submission\" \"Cross-node submission round-trip \\(Stage 5\\): citizen on a local SyncOnly replica submits an AssuredIdentity application that reaches the n1 owner/validator node, is validated/sealed there, approved by the verification-analyst on n1, and the resulting AssuredIdentityCredential is delivered back to the citizen's local wallet. Source of truth: docs/superpowers/specs/2026-05-23-cross-node-submission-design.md\")",
+      "PowerShell(.specify/scripts/powershell/create-new-feature.ps1 -Json -Number 136 -ShortName \"jwt-audience-tiers\" \"Tiered-audience JWT identity model and issuer hardening \\(Spec A\\): four installation-namespaced tier audiences \\(consumer/platform/service/enrol-session\\), tier-selection at issuance, per-tier claim sets, authenticate-broad/authorize-narrow validation, and issuer hardening.\")",
+      "PowerShell(.specify/scripts/powershell/update-agent-context.ps1 -AgentType claude 2>&1 | Select-Object -Last 15)",
+      "PowerShell(cd C:\\\\Projects\\\\Sorcha; pwsh -NoProfile -File walkthroughs/AssuredIdentity/run.ps1 -Profile n1 -Force 2>&1 | Tee-Object -FilePath walkthroughs/AssuredIdentity/last-n1-run.log | Select-Object -Last 60)",
+      "PowerShell(cd C:\\\\Projects\\\\Sorcha; pwsh -NoProfile -File walkthroughs/AssuredIdentity/setup.ps1 -Profile n1 -Force 2>&1 | Select-Object -Last 50)",
+      "PowerShell(cd C:\\\\Projects\\\\Sorcha; pwsh -NoProfile -File walkthroughs/AssuredIdentity/run-agents.ps1 -TimeoutMinutes 45 2>&1 | Tee-Object -FilePath walkthroughs/AssuredIdentity/assurance-officer-agent.log)",
+      "PowerShell(cd C:\\\\Projects\\\\Sorcha; pwsh -NoProfile -File walkthroughs/run-compliance-suite.ps1 -TimeoutSeconds 420 2>&1 | Tee-Object -FilePath walkthroughs/compliance-suite-console.log)",
+      "PowerShell(cd C:\\\\Projects\\\\Sorcha; pwsh -NoProfile -File walkthroughs/run-compliance-suite.ps1 -TimeoutSeconds 420 2>&1 | Tee-Object -FilePath walkthroughs/compliance-suite-validate.log)",
+      "PowerShell(docker exec sorcha-mongodb *)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -1325,3 +1325,35 @@ Platform-security rework of how Sorcha issues + validates JWT access tokens. **F
 - **Tier follows the person, not the UI host**: a citizen is `:consumer` on both `/app` (web) and `/wallet` (PWA); an admin is `:platform` in org context. Login derives the tier from `returnTo` (`/wallet`⇒consumer, `/app`⇒platform) as a *preference* that **downgrades to entitlement** (citizen on `/app`→consumer); an explicit `tier=platform` over-request by a non-entitled user is **refused (403, FR-008)**. `switch-org` re-mints at the new context's tier (FR-016). Endpoint classification: consumer surfaces (`/api/v1/wallet/*`)→`RequireConsumerAudience`; admin/org→`RequirePlatformAudience` composed on the role policy; `/api/internal/*`→extended `RequireService`; genuinely cross-tier `/me/*` stay plain `.RequireAuthorization()`.
 - **Status: ALL FIVE user stories DONE** (branch `136-jwt-audience-tiers`). US1 classification, US2 service-isolation (`RequireService` asserts `:service`), US3 issuer hardening + per-deploy `InstallationName`, US4 consumer-tier login, US5 tier-follows-person + over-request gate, `IdentityMetrics` wired. McpServer validation realigned to the installation issuer. Remaining: docs/regression polish + an edge case (2FA-on-`/wallet` tier carry).
 - **No migration** (pre-release): coordinated config rollout; existing tokens expire. Dependency contract for downstream Spec B (PWA auth/signup parity).
+
+---
+
+## Cross-node submission round-trip (Feature 137 — Stage 5)
+
+Closes the citizen→credential loop across a federated node split: a citizen on a local SyncOnly replica submits an application against a register owned by another node (n1); the owner validates/seals it, an analyst approves, and the resulting credential is **bound to the citizen's holder key and encrypted to the citizen's wallet**, then delivered back to the citizen's local wallet. Four of five components (C5 mirror submission, C1 published-store-aware instance creation, C4 fan-out config, C2 event-driven recovery) landed earlier; **C3 (credential delivery) is this surface.**
+
+### `cnf` binding + recipient-key precedence (server)
+
+- **`cnf` binding is no longer skipped.** `IssueCredentialRequest.HolderJwk` (`Wallet.Service/Endpoints/CredentialEndpoints.cs`) flows into `SdJwtService.CreateTokenAsync(holderJwk:)` so the SD-JWT carries `cnf`. Threaded through `IWalletServiceClient.IssueCredentialAsync(holderJwk:)`. Absent → unbound credential (pre-137 behaviour).
+- **`CredentialIssuanceConfig.HolderKeySourceField`** (JSON Pointer, default `/holderKeys/holderJwk`) opts a blueprint into bound cross-node delivery. Null → pre-137 behaviour (no `cnf`, register/derivation-only recipient key).
+- **FR-012 precedence in `ActionExecutionService` (step 8c, before minting → SC-004 fail-closed):** (1) published participant record (`IRegisterServiceClient.ResolvePublicKeyAsync`) wins; (2) carried `encryptionPublicKey` (from the submitted `holderKeys` field, resolved by `ResolveCarriedHolderKeys`) injected into a local `effectiveExternalKeys` passed to `ResolveRecipientKeysAsync` at step 9d **only when the register lookup misses**; (3) neither → throw `[VAL_RUNTIME_CRED_004]` (no credential issued). A configured `HolderKeySourceField` with no resolvable holder JWK → `[VAL_RUNTIME_CRED_005]` (FR-014). The carried `encryptionPublicKey` is the citizen wallet's **primary public key** (ED25519/NISTP256); the AEAD pipeline derives X25519 from it, so it is byte-identical to the register-resolved recipient key.
+
+### `GET /api/v1/wallet/holder-keys` (Wallet Service, consumer-tier)
+
+`RequireConsumerAudience`. Returns the citizen's public delivery keys for the `sorcha-holder-key` form field: `{ holderJwk (slot 108), encryptionPublicKey (base64 wallet public key), algorithm (ED25519|NISTP256), walletAddress }`. Backed by `IHolderKeyService.GetDeliveryKeysAsync` (combines slot-108 JWK + `Wallet.PublicKey`). 404 when no wallet resolves (indistinguishable). Contract: `specs/137-cross-node-submission/contracts/holder-keys-endpoint.openapi.yaml`. Public material only — never a private key.
+
+### `sorcha-holder-key` form field (client)
+
+`ControlTypes.HolderKey` (`Sorcha.Blueprint.Models/Control.cs`) — dispatched by `FormSchemaService.InferControlFromSchema` when an object field carries `format: "sorcha-holder-key"` (checked before the object-recursion branch). Rendered read-only by `HolderKeyRenderer.razor` (`Sorcha.UI.Components.User`), which calls `IHolderKeyClient.GetHolderKeysAsync` and writes `{Scope}/holderJwk`, `{Scope}/encryptionPublicKey`, `{Scope}/algorithm` via `FormContext.SetValue` (sibling fan-out, like `PostcodeLookupRenderer`). `IHolderKeyClient` is registered auth-wrapped in both the web SPA (`Sorcha.UI.Core` `ServiceCollectionExtensions`) and the PWA (`Sorcha.Wallet.Pwa` DI). Contract: `specs/137-cross-node-submission/contracts/sorcha-holder-key-field.md`.
+
+### Validation note (`x-*` strip on both paths)
+
+`SchemaValidator` (`Sorcha.Blueprint.Engine`) now strips `x-*` extension keywords before evaluation (mirroring the Validator Service's `ValidationEngine.StripCustomExtensionKeywords`), so `x-holder-key` (and any other `x-*` UI hint) is tolerated on the blueprint-service action-data path as well as the validator path. Unknown `format` values (`sorcha-holder-key`) validate as pass.
+
+### PWA submission
+
+`Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor` renders `SorchaFormRenderer` for the instance's current action (loaded via `IApplicationActionClient.LoadFormAsync` → `GET /api/instances/{id}` + blueprint) and submits via `FormPayloadBuilder.BuildNested` → `POST /api/instances/{id}/actions/{actionId}/execute` (server-signed via the bearer token; the citizen wallet is server-custodied). The F125 `StubApplicationSubmissionService` / `IUserSigner` seam is retained for its tests.
+
+### Worked example
+
+`walkthroughs/AssuredIdentity/blueprints/assured-identity.json` — action 1 carries a `holderKeys` (`format: sorcha-holder-key`) field; action 2's `credentialIssuanceConfig.holderKeySourceField` points at `/holderKeys/holderJwk`. `run-phase1-identity.ps1` fetches `/api/v1/wallet/holder-keys` and supplies `holderKeys` in the action-1 payload. The live n1↔local cross-node run is **Tier-2** (the genesis-key machine); the C3 server is unit + single-node-integration covered (SC-005 Tier-1). Spec: `specs/137-cross-node-submission/`. Design: `docs/superpowers/specs/2026-05-23-cross-node-submission-design.md`.

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -1316,6 +1316,25 @@ Clear the citizen's notice. Idempotent — returns `204 No Content` whether or n
 
 **Response:** `204 No Content`
 
+#### 10b. Holder Keys — cross-node delivery keys (Feature 137)
+
+Returns the signed-in citizen's **public** delivery keys so a blueprint `sorcha-holder-key` form field can auto-fill the cross-node submission. Consumer-tier (`RequireConsumerAudience`). Public material only — never a private key. Contract: [`specs/137-cross-node-submission/contracts/holder-keys-endpoint.openapi.yaml`](../../specs/137-cross-node-submission/contracts/holder-keys-endpoint.openapi.yaml).
+
+##### GET /api/v1/wallet/holder-keys
+
+Resolves the caller's slot-108 holder public JWK (for the SD-JWT `cnf` binding) and wallet encryption public key (for the on-register AEAD envelope) from the citizen JWT.
+
+**Response:** `200 OK`
+```json
+{
+  "holderJwk": { "kty": "EC", "crv": "P-256", "x": "…", "y": "…" },
+  "encryptionPublicKey": "<base64 wallet public key>",
+  "algorithm": "ED25519",
+  "walletAddress": "ws1q…"
+}
+```
+`401` — missing/invalid citizen token. `404` — no wallet resolvable for the caller (indistinguishable from non-existence).
+
 #### 11. Cross-Device Presentation History (Feature 114 US5)
 
 The citizen's durable, cross-device record of presentations they have made. Reported presentations (via `POST /api/v1/wallet/presentations/log`) are persisted to a per-citizen Wallet Service store so the same history appears on any device the citizen pairs. **There is no register/ledger write** — a free-standing offline presentation has no originating register; these are citizen-owned convenience records carrying disclosed claim **names only**, never values.

--- a/docs/superpowers/specs/2026-05-23-cross-node-submission-design.md
+++ b/docs/superpowers/specs/2026-05-23-cross-node-submission-design.md
@@ -274,3 +274,15 @@ split).
 | D5 | Trust-on-submission (no PoP) for v1 | F103 late-binding collapses submitter and recipient into one wallet, removing the attacker |
 | D6 | Approach B (targeted root-cause) over A (point-fixes) or C (register-native rewrite) | Fixes causes (blueprint resolution, recovery, replica semantics) without a speculative rewrite |
 | D7 | Code written here; cross-node round-trip verified on a separate machine, via a committed scripted procedure | The genesis key + n1 access + sync-split live on a different machine |
+
+---
+
+## C3 implementation reconciliation (Stage 5, 2026-05-24)
+
+Two research findings (`specs/137-cross-node-submission/research.md` § "Design corrections") expanded C3 beyond the original sketch; both are now implemented:
+
+1. **`cnf` binding was a pre-existing hole.** Credentials were issued *unbound*. C3 adds `IssueCredentialRequest.HolderJwk` → `SdJwtService.CreateTokenAsync(holderJwk:)`, threaded through `IWalletServiceClient.IssueCredentialAsync` and `CredentialIssuanceConfig.HolderKeySourceField`. Recipient-key precedence (published participant record → carried `holderKeys` field → fail-closed) is enforced in `ActionExecutionService` **before minting** (SC-004: zero credentials when neither resolves; error codes `VAL_RUNTIME_CRED_004`/`005`). The carried `encryptionPublicKey` is injected into the existing `ExternalRecipientKeys` path only when the register lookup misses ("published wins").
+
+2. **Client autofill is a server round-trip; the PWA submit surface was a stub.** C3 adds `GET /api/v1/wallet/holder-keys` (consumer-tier) backed by `IHolderKeyService.GetDeliveryKeysAsync`, a `ControlTypes.HolderKey` field + `HolderKeyRenderer` (autofills the three sibling pointers), and wires `SorchaFormRenderer` into `Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor` (submit → `FormPayloadBuilder.BuildNested` → `/execute`, server-signed). A defensive `x-*` strip was added to the engine `SchemaValidator` so `x-holder-key` is tolerated on both validation paths.
+
+No change to the agreed trust model, precedence, or v1 scope. The cross-node round-trip is unit + single-node-integration covered (SC-005 Tier-1); the live n1↔local run remains Tier-2 on the genesis-key machine.

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/ControlDispatcher.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/ControlDispatcher.razor
@@ -66,6 +66,10 @@
             <PostcodeLookupRenderer Control="Control" IsDisabled="_isDisabled" />
             break;
 
+        case ControlTypes.HolderKey:
+            <HolderKeyRenderer Control="Control" IsDisabled="_isDisabled" />
+            break;
+
         default:
             <UnsupportedControlRenderer Control="Control" />
             break;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/HolderKeyRenderer.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Forms/Controls/HolderKeyRenderer.razor
@@ -1,0 +1,127 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@using Microsoft.Extensions.Logging
+@using Sorcha.Blueprint.Models
+@using Sorcha.UI.Core.Models.Forms
+@using Sorcha.UI.Core.Services.HolderKeys
+
+@inject IHolderKeyClient HolderKeys
+@inject ILogger<HolderKeyRenderer> Logger
+
+@*
+    Feature 137 (cross-node submission, C3)
+
+    Dispatched by FormSchemaService when an object property carries
+    format: "sorcha-holder-key". The field captures the signed-in citizen's
+    PUBLIC delivery keys so a credential issued on the owner node can be bound
+    (SD-JWT cnf) and encrypted (on-register AEAD envelope) to the citizen, then
+    delivered to their local wallet — without any private key ever leaving the
+    Wallet Service.
+
+    On init the renderer fetches GET /api/v1/wallet/holder-keys and writes the
+    three sibling pointers via FormContext.SetValue (sibling fan-out, like
+    PostcodeLookupRenderer):
+        {Scope}/holderJwk             — slot-108 holder public JWK
+        {Scope}/encryptionPublicKey   — base64 wallet public key
+        {Scope}/algorithm             — ED25519 | NISTP256
+
+    The user cannot edit the key material — the control is display-only. If the
+    fetch fails the renderer shows a retry affordance rather than silently
+    submitting an unbindable application.
+*@
+
+<div class="holder-key-field" data-testid="holder-key-field">
+    @switch (_state)
+    {
+        case State.Loading:
+            <MudAlert Severity="Severity.Normal" Dense="true" Variant="Variant.Outlined" Class="my-1">
+                <div class="d-flex align-center gap-2">
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+                    <span>Securing your identity keys…</span>
+                </div>
+            </MudAlert>
+            break;
+
+        case State.Captured:
+            <MudAlert Severity="Severity.Success" Dense="true" Variant="Variant.Outlined"
+                      Icon="@Icons.Material.Filled.Key" Class="my-1" data-testid="holder-key-captured">
+                Identity keys captured — your credential will be delivered securely to this wallet.
+            </MudAlert>
+            break;
+
+        case State.Error:
+            <MudAlert Severity="Severity.Warning" Dense="true" Variant="Variant.Outlined" Class="my-1"
+                      data-testid="holder-key-error">
+                <div class="d-flex align-center justify-space-between gap-2">
+                    <span>We couldn't reach your wallet to secure your identity keys.</span>
+                    <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Refresh"
+                               OnClick="LoadAsync"
+                               data-testid="holder-key-retry">
+                        Retry
+                    </MudButton>
+                </div>
+            </MudAlert>
+            break;
+    }
+</div>
+
+@code {
+    [CascadingParameter] public FormContext? FormContext { get; set; }
+    [Parameter, EditorRequired] public Control Control { get; set; } = new();
+    [Parameter] public bool IsDisabled { get; set; }
+
+    private enum State { Loading, Captured, Error }
+
+    private State _state = State.Loading;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // If the keys are already present (re-render, review/read-only view, or a
+        // resumed draft) skip the fetch — the captured values stay authoritative.
+        if (FormContext is not null
+            && FormContext.GetValue<object>($"{Control.Scope}/encryptionPublicKey") is not null)
+        {
+            _state = State.Captured;
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        if (FormContext is null)
+        {
+            _state = State.Error;
+            return;
+        }
+
+        _state = State.Loading;
+        StateHasChanged();
+
+        try
+        {
+            var keys = await HolderKeys.GetHolderKeysAsync();
+            if (keys is null || string.IsNullOrEmpty(keys.EncryptionPublicKey) || string.IsNullOrEmpty(keys.Algorithm))
+            {
+                _state = State.Error;
+                return;
+            }
+
+            // Sibling fan-out — write the three nested pointers the issuer reads at
+            // credential-issuance time (ActionExecutionService.ResolveCarriedHolderKeys).
+            FormContext.SetValue($"{Control.Scope}/holderJwk", keys.HolderJwk);
+            FormContext.SetValue($"{Control.Scope}/encryptionPublicKey", keys.EncryptionPublicKey);
+            FormContext.SetValue($"{Control.Scope}/algorithm", keys.Algorithm);
+
+            _state = State.Captured;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Holder-key autofill failed for scope {Scope}", Control.Scope);
+            _state = State.Error;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/Forms/FormSchemaService.cs
@@ -334,6 +334,23 @@ public class FormSchemaService : IFormSchemaService
         var title = schema.TryGetProperty("title", out var titleEl) ? titleEl.GetString() : HumanizeName(propertyName);
         var scope = parentScope + "/" + propertyName;
 
+        // Feature 137 (cross-node submission, C3): an object field carrying
+        // `format: "sorcha-holder-key"` is captured read-only by HolderKeyRenderer, which
+        // fetches the citizen's public delivery keys and writes the sibling pointers
+        // (/holderJwk, /encryptionPublicKey, /algorithm). Checked before the object-recursion
+        // branch so a holder-key field is never recursed into as a primitive group.
+        if (schema.TryGetProperty("format", out var holderKeyFormatEl)
+            && holderKeyFormatEl.GetString() == "sorcha-holder-key")
+        {
+            return new Control
+            {
+                ControlType = ControlTypes.HolderKey,
+                Title = title ?? propertyName,
+                Scope = scope,
+                Rule = TryParseXRule(schema)
+            };
+        }
+
         // Object-typed properties recurse into their children. Feature 103
         // ships four core primitives as schema objects (PersonName,
         // DateOfBirth, EmailAddress, PostalAddress) — the form renderer

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/HolderKeys/HolderKeyHttpClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/HolderKeys/HolderKeyHttpClient.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.UI.Core.Services.HolderKeys;
+
+/// <summary>
+/// Default <see cref="IHolderKeyClient"/> — thin wrapper over the Wallet Service
+/// <c>GET /api/v1/wallet/holder-keys</c> endpoint. Registered with an auth-wrapped
+/// <see cref="HttpClient"/> so the citizen's consumer-tier JWT is attached automatically
+/// (the endpoint is gated by <c>RequireConsumerAudience</c>). Feature 137.
+/// </summary>
+public sealed class HolderKeyHttpClient : IHolderKeyClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<HolderKeyHttpClient> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public HolderKeyHttpClient(HttpClient httpClient, ILogger<HolderKeyHttpClient> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<HolderKeysView?> GetHolderKeysAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync("/api/v1/wallet/holder-keys", ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "GET /api/v1/wallet/holder-keys returned {Status}", (int)response.StatusCode);
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<HolderKeysView>(JsonOptions, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Holder-keys request failed");
+            return null;
+        }
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/HolderKeys/IHolderKeyClient.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/User/HolderKeys/IHolderKeyClient.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.UI.Core.Services.HolderKeys;
+
+/// <summary>
+/// Feature 137 (cross-node submission, C3) — HTTP transport contract for the Wallet Service
+/// <c>GET /api/v1/wallet/holder-keys</c> endpoint. Exists so <c>HolderKeyRenderer.razor</c> can
+/// resolve an auth-wrapped client via DI (consumer-tier citizen JWT) rather than injecting a bare
+/// <c>HttpClient</c> that would hit the gateway's auth policy with a 401. Mirrors the
+/// <c>IAddressLookupClient</c> typed-client boundary so the renderer is unit-testable without Razor.
+/// </summary>
+public interface IHolderKeyClient
+{
+    /// <summary>
+    /// Calls <c>GET /api/v1/wallet/holder-keys</c>. Returns the signed-in citizen's public delivery
+    /// keys (holder JWK for the SD-JWT <c>cnf</c> binding, wallet encryption public key + algorithm
+    /// for the on-register AEAD envelope). Returns <c>null</c> on any non-success — the renderer
+    /// surfaces a retry affordance rather than silently submitting an unbindable application.
+    /// </summary>
+    Task<HolderKeysView?> GetHolderKeysAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Feature 137 — the citizen's public delivery keys, as returned by
+/// <c>GET /api/v1/wallet/holder-keys</c>. Public material only. The property names match the
+/// wire contract (<c>holder-keys-endpoint.openapi.yaml</c>) so System.Text.Json camelCase
+/// round-trips with the server's <c>HolderKeysResponse</c>.
+/// </summary>
+public sealed class HolderKeysView
+{
+    /// <summary>Slot-108 holder public JWK for the SD-JWT <c>cnf</c> binding.</summary>
+    public JsonElement HolderJwk { get; set; }
+
+    /// <summary>Base64 wallet public key used to wrap the on-register AEAD envelope.</summary>
+    public string EncryptionPublicKey { get; set; } = string.Empty;
+
+    /// <summary>Delivery algorithm: <c>ED25519</c> or <c>NISTP256</c>.</summary>
+    public string Algorithm { get; set; } = string.Empty;
+
+    /// <summary>The citizen's resolved wallet address.</summary>
+    public string WalletAddress { get; set; } = string.Empty;
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -366,6 +366,18 @@ public static class ServiceCollectionExtensions
             return new Sorcha.UI.Core.Services.AddressLookup.AddressLookupHttpClient(httpClient, logger);
         });
 
+        // Holder-Key Client (Feature 137) — required by HolderKeyRenderer. Auth-wrapped so the
+        // citizen's consumer-tier JWT reaches the Wallet Service holder-keys endpoint (which is
+        // gated by RequireConsumerAudience); a bare HttpClient would 401 at the gateway.
+        services.AddScoped<Sorcha.UI.Core.Services.HolderKeys.IHolderKeyClient>(sp =>
+        {
+            var handler = sp.GetRequiredService<AuthenticatedHttpMessageHandler>();
+            handler.InnerHandler = new HttpClientHandler();
+            var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
+            var logger = sp.GetRequiredService<ILogger<Sorcha.UI.Core.Services.HolderKeys.HolderKeyHttpClient>>();
+            return new Sorcha.UI.Core.Services.HolderKeys.HolderKeyHttpClient(httpClient, logger);
+        });
+
         // Persona autofill resolver — pure function, singleton.
         services.AddSingleton<Sorcha.UI.Core.Services.Forms.PersonaAutofillResolver>();
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -141,6 +141,23 @@ public static class ServiceCollectionExtensions
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // Feature 137 — holder-keys client for HolderKeyRenderer (cross-node submission).
+        // Same auth chain so the consumer-tier JWT reaches GET /api/v1/wallet/holder-keys.
+        services.AddHttpClient<Sorcha.UI.Core.Services.HolderKeys.IHolderKeyClient,
+                               Sorcha.UI.Core.Services.HolderKeys.HolderKeyHttpClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
+        // Feature 137 — application action client (cross-node submission). Loads the instance's
+        // current action for SorchaFormRenderer and POSTs the completed form to the Blueprint
+        // Service /execute endpoint (server-signed via the bearer token). Same auth chain.
+        services.AddHttpClient<Sorcha.Wallet.Pwa.Services.Applications.IApplicationActionClient,
+                               Sorcha.Wallet.Pwa.Services.Applications.HttpApplicationActionClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 128 — shared has-any-device probe. Drives the wallet PWA
         // pairing-takeover trigger (sub-PR A3) and the Sorcha Web nag-banner
         // trigger (sub-PR B). Registered Singleton so the cached value +

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -2,23 +2,22 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Application-instance host page (Feature 125, T055). Renders a specific
-    blueprint instance's form via SorchaFormRenderer, drives persona
-    autofill from IPerContextPersonaCache (Feature 092 + Feature 125 PR-A),
-    and signs the submission through IUserSigner via
-    IApplicationSubmissionService.
-
-    v1 ships the page shell + submission plumbing. SorchaFormRenderer
-    integration with a live blueprint instance lands in a follow-up
-    alongside the application catalogue endpoint.
+    Application-instance host page (Feature 125 shell, Feature 137 wiring).
+    Loads a blueprint instance's current action, renders it via
+    SorchaFormRenderer (so the Feature 137 sorcha-holder-key field auto-captures
+    the citizen's delivery keys), and submits the completed form to the Blueprint
+    Service /execute endpoint via IApplicationActionClient. On success it posts a
+    Feature 124 pending-application notice so Home shows the in-progress state
+    while the owner node validates, seals, and (on analyst approval) delivers the
+    credential back to this wallet.
 *@
 @page "/applications/{InstanceId:guid}"
 @layout MainLayout
+@using Sorcha.UI.Core.Components.Forms
+@using Sorcha.UI.Core.Models.Forms
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Applications
-@using Sorcha.Wallet.Pwa.Services.Context
-@inject IApplicationSubmissionService Submissions
-@inject IUserContext UserContext
+@inject IApplicationActionClient ActionClient
 @inject IPendingApplicationClient PendingApplications
 @inject NavigationManager Nav
 @inject ILogger<ApplicationInstance> Logger
@@ -26,78 +25,96 @@
 <PageTitle>Application · Sorcha Wallet</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Class="mt-4">
-    <MudText Typo="Typo.h5" Class="mb-3">Application</MudText>
-    <MudPaper Class="pa-4" Elevation="1" data-testid="application-instance-placeholder">
-        <MudStack Spacing="2">
-            <MudText Typo="Typo.body1">
-                Form host for blueprint instance <strong>@InstanceId</strong>.
-            </MudText>
-            <MudText Typo="Typo.body2" Class="mud-text-secondary">
-                SorchaFormRenderer integration with the application catalogue
-                lands in a follow-up. Submit signs the wallet-side payload
-                via IUserSigner and posts a pending-application notice so
-                Home shows the in-progress state.
-            </MudText>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                       OnClick="@SubmitDemoAsync" Disabled="@_busy"
-                       data-testid="application-instance-submit">
-                @(_busy ? "Submitting…" : "Submit (demo)")
-            </MudButton>
+    @switch (_state)
+    {
+        case State.Loading:
+            <MudPaper Class="pa-6 d-flex flex-column align-center gap-3" Elevation="1"
+                      data-testid="application-instance-loading">
+                <MudProgressCircular Indeterminate="true" />
+                <MudText Typo="Typo.body2" Class="mud-text-secondary">Loading your application…</MudText>
+            </MudPaper>
+            break;
+
+        case State.Ready when _ctx is not null:
+            <MudText Typo="Typo.h5" Class="mb-3">@_ctx.Title</MudText>
+            <div data-testid="application-instance-form">
+                <SorchaFormRenderer Action="_ctx.Action"
+                                    ParticipantAddress="_ctx.SenderWallet"
+                                    SigningWalletAddress="_ctx.SenderWallet"
+                                    IsSenderAction="true"
+                                    OnSubmit="HandleSubmitAsync" />
+            </div>
             @if (!string.IsNullOrEmpty(_status))
             {
-                <MudAlert Severity="@_severity" Class="mt-2"
-                          data-testid="application-instance-status">@_status</MudAlert>
+                <MudAlert Severity="@_severity" Class="mt-3" data-testid="application-instance-status">@_status</MudAlert>
             }
-        </MudStack>
-    </MudPaper>
+            break;
+
+        case State.Submitted:
+            <MudPaper Class="pa-6 d-flex flex-column align-center gap-3" Elevation="1"
+                      data-testid="application-instance-submitted">
+                <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Large" />
+                <MudText Typo="Typo.h6">Application submitted</MudText>
+                <MudText Typo="Typo.body2" Align="Align.Center" Class="mud-text-secondary">
+                    You'll see the in-progress state on Home. Watch your wallet — your credential will
+                    arrive here once it's approved.
+                </MudText>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="GoHome">
+                    Back to wallet
+                </MudButton>
+            </MudPaper>
+            break;
+
+        default:
+            <MudAlert Severity="Severity.Error" data-testid="application-instance-error">
+                We couldn't load this application. It may not be ready yet — try again shortly.
+            </MudAlert>
+            break;
+    }
 </MudContainer>
 
 @code {
     /// <summary>The blueprint instance the form binds to.</summary>
     [Parameter] public Guid InstanceId { get; set; }
 
-    private bool _busy;
+    private enum State { Loading, Ready, Submitted, Error }
+
+    private State _state = State.Loading;
+    private ApplicationFormContext? _ctx;
     private string? _status;
     private Severity _severity = Severity.Info;
+    private bool _busy;
 
-    private async Task SubmitDemoAsync()
+    protected override async Task OnInitializedAsync()
     {
+        _ctx = await ActionClient.LoadFormAsync(InstanceId);
+        _state = _ctx is null ? State.Error : State.Ready;
+    }
+
+    private async Task HandleSubmitAsync(FormSubmission submission)
+    {
+        if (_ctx is null || _busy) return;
         _busy = true;
         _status = null;
         try
         {
-            // Demo payload — real flow uses the canonicalised form data from
-            // SorchaFormRenderer keyed by the action's schemaRef.
-            var payload = System.Text.Encoding.UTF8.GetBytes($"{{\"instanceId\":\"{InstanceId:N}\"}}");
-            var result = await Submissions.SubmitAsync(
-                new ApplicationSubmissionRequest(
-                    BlueprintId: Guid.Empty,
-                    ApplicationLabel: "Application",
-                    ActionId: 1,
-                    Payload: payload));
-
+            var result = await ActionClient.SubmitAsync(_ctx, submission.Data);
             switch (result.Status)
             {
                 case ApplicationSubmissionStatus.Success:
-                    _severity = Severity.Success;
-                    _status = "Submitted. You'll see the in-progress state on Home shortly.";
-                    // Wire F124's pending-application notice so Home picks up the in-progress state.
                     try
                     {
-                        await PendingApplications.SetAsync("Application in review");
+                        await PendingApplications.SetAsync(_ctx.Title);
                     }
                     catch (Exception ex)
                     {
                         Logger.LogWarning(ex, "Failed to set pending-application notice after submit.");
                     }
+                    _state = State.Submitted;
                     break;
                 case ApplicationSubmissionStatus.ValidationFailed:
                     _severity = Severity.Warning;
                     _status = result.ErrorDetail ?? "Please check the form and try again.";
-                    break;
-                case ApplicationSubmissionStatus.SigningFailed:
-                    _severity = Severity.Error;
-                    _status = result.ErrorDetail ?? "Couldn't sign on this device. Try again.";
                     break;
                 default:
                     _severity = Severity.Error;
@@ -110,4 +127,6 @@
             _busy = false;
         }
     }
+
+    private void GoHome() => Nav.NavigateTo("");
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Applications/IApplicationActionClient.cs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.UI.Core.Services.Forms;
+using Sorcha.UI.Core.Services.HolderKeys;
+
+namespace Sorcha.Wallet.Pwa.Services.Applications;
+
+/// <summary>
+/// Feature 137 (cross-node submission, C3) — loads a blueprint instance's current action so the PWA
+/// can render <c>SorchaFormRenderer</c>, and submits the citizen's completed form to the Blueprint
+/// Service action-execution endpoint. The citizen's Sorcha wallet is server-custodied (Feature 114),
+/// so the action is signed server-side from the bearer token — this client carries no private key.
+/// </summary>
+public interface IApplicationActionClient
+{
+    /// <summary>
+    /// Resolves the instance's current action + submission context (blueprint id, register id, and
+    /// the citizen's own wallet address as the open-participant sender). Returns <c>null</c> when the
+    /// instance, blueprint, current action, or the citizen's wallet cannot be resolved.
+    /// </summary>
+    Task<ApplicationFormContext?> LoadFormAsync(Guid instanceId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Nests the flat JSON-Pointer-keyed form data and POSTs it to
+    /// <c>/api/instances/{id}/actions/{actionId}/execute</c>.
+    /// </summary>
+    Task<ApplicationSubmissionResult> SubmitAsync(
+        ApplicationFormContext context,
+        IReadOnlyDictionary<string, object?> formData,
+        CancellationToken ct = default);
+}
+
+/// <summary>Context needed to render and submit a blueprint instance's current action.</summary>
+/// <param name="InstanceId">The blueprint instance id.</param>
+/// <param name="Action">The current action (schema + layout) to render.</param>
+/// <param name="BlueprintId">The instance's blueprint id.</param>
+/// <param name="RegisterId">The register the action transaction is submitted to.</param>
+/// <param name="SenderWallet">The citizen's own wallet address (open-participant sender).</param>
+/// <param name="ActionId">The current action id.</param>
+/// <param name="Title">A user-facing title for the application.</param>
+public sealed record ApplicationFormContext(
+    Guid InstanceId,
+    Sorcha.Blueprint.Models.Action Action,
+    string BlueprintId,
+    string RegisterId,
+    string SenderWallet,
+    int ActionId,
+    string Title);
+
+/// <summary>
+/// Default <see cref="IApplicationActionClient"/> — talks to the Blueprint Service through the
+/// gateway-routed, bearer-authed PWA HttpClient. Mirrors the walkthrough's
+/// <c>Invoke-SorchaAction</c> contract: <c>GET /api/instances/{id}</c>,
+/// <c>GET /api/blueprints/{id}</c>, and <c>POST /api/instances/{id}/actions/{actionId}/execute</c>.
+/// </summary>
+public sealed class HttpApplicationActionClient : IApplicationActionClient
+{
+    private readonly HttpClient _http;
+    private readonly IHolderKeyClient _holderKeys;
+    private readonly ILogger<HttpApplicationActionClient> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public HttpApplicationActionClient(
+        HttpClient http,
+        IHolderKeyClient holderKeys,
+        ILogger<HttpApplicationActionClient> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _holderKeys = holderKeys ?? throw new ArgumentNullException(nameof(holderKeys));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ApplicationFormContext?> LoadFormAsync(Guid instanceId, CancellationToken ct = default)
+    {
+        try
+        {
+            var instance = await _http.GetFromJsonAsync<InstanceDto>(
+                $"api/instances/{instanceId:N}", JsonOptions, ct);
+            if (instance is null || string.IsNullOrEmpty(instance.BlueprintId))
+            {
+                return null;
+            }
+
+            var actionId = instance.CurrentActionIds is { Count: > 0 } ? instance.CurrentActionIds[0] : 1;
+
+            var blueprintJson = await _http.GetStringAsync(
+                $"api/blueprints/{Uri.EscapeDataString(instance.BlueprintId)}", ct);
+            var action = ExtractAction(blueprintJson, actionId);
+            if (action is null)
+            {
+                _logger.LogWarning(
+                    "Blueprint {BlueprintId} has no action {ActionId} to render for instance {InstanceId}",
+                    instance.BlueprintId, actionId, instanceId);
+                return null;
+            }
+
+            // Open-participant sender: the citizen's own wallet address. Resolved from the
+            // holder-keys endpoint (the same call HolderKeyRenderer makes) so we never assume the
+            // wallet is client-side.
+            var keys = await _holderKeys.GetHolderKeysAsync(ct);
+            if (keys is null || string.IsNullOrEmpty(keys.WalletAddress))
+            {
+                _logger.LogWarning("Could not resolve the citizen's wallet address for submission.");
+                return null;
+            }
+
+            return new ApplicationFormContext(
+                InstanceId: instanceId,
+                Action: action,
+                BlueprintId: instance.BlueprintId,
+                RegisterId: instance.RegisterId ?? string.Empty,
+                SenderWallet: keys.WalletAddress,
+                ActionId: actionId,
+                Title: string.IsNullOrWhiteSpace(instance.Title) ? "Application" : instance.Title!);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load form context for instance {InstanceId}", instanceId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<ApplicationSubmissionResult> SubmitAsync(
+        ApplicationFormContext context,
+        IReadOnlyDictionary<string, object?> formData,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(formData);
+
+        var payloadData = FormPayloadBuilder.BuildNested(formData);
+        var execBody = new ActionExecuteBody(
+            BlueprintId: context.BlueprintId,
+            ActionId: context.ActionId.ToString(),
+            InstanceId: context.InstanceId.ToString("N"),
+            SenderWallet: context.SenderWallet,
+            RegisterAddress: context.RegisterId,
+            PayloadData: payloadData);
+
+        try
+        {
+            var response = await _http.PostAsJsonAsync(
+                $"api/instances/{context.InstanceId:N}/actions/{context.ActionId}/execute",
+                execBody, JsonOptions, ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return new ApplicationSubmissionResult(
+                    ApplicationSubmissionStatus.Success, context.InstanceId, ErrorCode: null, ErrorDetail: null);
+            }
+
+            var detail = await SafeReadAsync(response, ct);
+            var status = (int)response.StatusCode is >= 400 and < 500
+                ? ApplicationSubmissionStatus.ValidationFailed
+                : ApplicationSubmissionStatus.ServerError;
+            return new ApplicationSubmissionResult(
+                status, InstanceId: null, ErrorCode: $"HTTP_{(int)response.StatusCode}", ErrorDetail: detail);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Action submission failed for instance {InstanceId}", context.InstanceId);
+            return new ApplicationSubmissionResult(
+                ApplicationSubmissionStatus.ServerError, InstanceId: null, ErrorCode: "ERR_APPSUBMIT_NETWORK",
+                ErrorDetail: "Couldn't reach the server to submit your application. Try again.");
+        }
+    }
+
+    private static async Task<string?> SafeReadAsync(HttpResponseMessage r, CancellationToken ct)
+    {
+        try { return await r.Content.ReadAsStringAsync(ct); } catch { return null; }
+    }
+
+    private static Sorcha.Blueprint.Models.Action? ExtractAction(string blueprintJson, int actionId)
+    {
+        using var doc = JsonDocument.Parse(blueprintJson);
+        var root = doc.RootElement;
+
+        // Served blueprints may be the flat Blueprint model ({ actions: [...] }) or wrap the
+        // authored template ({ template: { actions: [...] } }). Tolerate both.
+        var found = root.TryGetProperty("actions", out var actionsEl)
+            || (root.TryGetProperty("template", out var tmpl) && tmpl.TryGetProperty("actions", out actionsEl));
+        if (!found || actionsEl.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        foreach (var el in actionsEl.EnumerateArray())
+        {
+            if (el.TryGetProperty("id", out var idEl) && idEl.TryGetInt32(out var id) && id == actionId)
+            {
+                return el.Deserialize<Sorcha.Blueprint.Models.Action>(JsonOptions);
+            }
+        }
+        return null;
+    }
+
+    private sealed class InstanceDto
+    {
+        public string? BlueprintId { get; set; }
+        public string? RegisterId { get; set; }
+        public List<int>? CurrentActionIds { get; set; }
+        public string? Title { get; set; }
+    }
+
+    private sealed record ActionExecuteBody(
+        string BlueprintId,
+        string ActionId,
+        string InstanceId,
+        string SenderWallet,
+        string RegisterAddress,
+        Dictionary<string, object> PayloadData);
+}

--- a/src/Common/Sorcha.Blueprint.Models/Control.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Control.cs
@@ -191,5 +191,18 @@ public enum ControlTypes
     /// is configured. Feature 103 US3.
     /// </summary>
     [DataAnnotations.Display(Name = "Postcode Lookup")]
-    PostcodeLookup
+    PostcodeLookup,
+
+    /// <summary>
+    /// Read-only holder-key capture. Dispatched when an object field carries
+    /// <c>format: "sorcha-holder-key"</c>. The renderer fetches the signed-in
+    /// citizen's public delivery keys from the Wallet Service
+    /// (<c>GET /api/v1/wallet/holder-keys</c>) and writes the sibling pointers
+    /// <c>/{field}/holderJwk</c>, <c>/{field}/encryptionPublicKey</c>, and
+    /// <c>/{field}/algorithm</c> into the form payload so a cross-node credential
+    /// can be bound and delivered to the citizen. Public material only — the user
+    /// cannot edit it. Feature 137 (cross-node submission, C3).
+    /// </summary>
+    [DataAnnotations.Display(Name = "Holder Key")]
+    HolderKey
 }

--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
@@ -106,6 +106,22 @@ public class CredentialIssuanceConfig
     [JsonPropertyName("trustAnchor")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public TrustAnchor TrustAnchor { get; set; } = TrustAnchor.Register;
+
+    /// <summary>
+    /// Feature 137 (cross-node submission). JSON Pointer into the reconstructed instance state
+    /// where the recipient's carried delivery keys live — written by a <c>sorcha-holder-key</c>
+    /// form field on a starting action (default <c>/holderKeys/holderJwk</c>; siblings
+    /// <c>/holderKeys/encryptionPublicKey</c> + <c>/holderKeys/algorithm</c> are derived from the
+    /// same parent object). When set, the issuer binds the credential to the carried holder JWK
+    /// (SD-JWT <c>cnf</c>) and, for an open-participant recipient with no published participant
+    /// record (cross-node late binding), wraps the on-register AEAD envelope to the carried
+    /// encryption key. Resolution precedence is published participant record → carried keys →
+    /// fail closed without issuing (FR-012). Null (the default) preserves the pre-137 behaviour:
+    /// no <c>cnf</c> binding and no carried-key fallback.
+    /// </summary>
+    [JsonPropertyName("holderKeySourceField")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? HolderKeySourceField { get; set; }
 }
 
 /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/IWalletServiceClient.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
+
 namespace Sorcha.ServiceClients.Wallet;
 
 /// <summary>
@@ -167,6 +169,9 @@ public interface IWalletServiceClient
     /// credentialStatus claim in the signed SD-JWT payload (Feature 093 US2).</param>
     /// <param name="statusListIndex">Optional pre-allocated status list index. See <paramref name="statusListUrl"/>.</param>
     /// <param name="statusListPurpose">Optional status purpose identifier. Defaults to "revocation" when the pair is provided.</param>
+    /// <param name="holderJwk">Feature 137 — recipient holder's public JWK (slot 108) for the SD-JWT
+    /// <c>cnf</c> key-confirmation binding. When supplied, the issued credential is bound to the holder
+    /// key so only the holder can present it. Null leaves the credential unbound (pre-137 behaviour).</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Issued credential information including the signed SD-JWT VC token</returns>
     Task<CredentialIssuanceResult> IssueCredentialAsync(
@@ -183,6 +188,7 @@ public interface IWalletServiceClient
         bool skipRecipientStore = false,
         string? issuerOrgName = null,
         string? tenantId = null,
+        JsonElement? holderJwk = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Wallet/WalletServiceClient.cs
@@ -336,6 +336,7 @@ public class WalletServiceClient : IWalletServiceClient
         bool skipRecipientStore = false,
         string? issuerOrgName = null,
         string? tenantId = null,
+        JsonElement? holderJwk = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -359,7 +360,8 @@ public class WalletServiceClient : IWalletServiceClient
                 statusListPurpose,
                 skipRecipientStore,
                 issuerOrgName,
-                tenantId
+                tenantId,
+                holderJwk
             };
 
             var response = await _httpClient.PostAsJsonAsync(

--- a/src/Core/Sorcha.Blueprint.Engine/Implementation/SchemaValidator.cs
+++ b/src/Core/Sorcha.Blueprint.Engine/Implementation/SchemaValidator.cs
@@ -49,8 +49,16 @@ public class SchemaValidator : ISchemaValidator
             // Convert data dictionary to JsonNode
             var dataJson = ConvertToJsonNode(data);
 
+            // Strip x-* custom keywords (x-pages, x-sections, x-file, x-review, x-persona,
+            // x-holder-key, …) before parsing. These are UI-renderer extensions consumed by
+            // Sorcha.Blueprint.Models.SchemaLayoutParser and friends, not JSON Schema vocabulary;
+            // Json.Schema is strict about unknown keywords and throws "Unknown keywords (x-…) are
+            // disallowed for this dialect". Mirrors ValidationEngine.StripCustomExtensionKeywords
+            // on the validator side so both validation paths tolerate the same blueprint schemas.
+            var strippedSchema = StripExtensionKeywords(schema);
+
             // Parse the JSON Schema (cached — avoids re-parsing same schema)
-            var jsonSchema = _schemaCache.GetOrAdd(schema, text => JsonSchema.FromText(text));
+            var jsonSchema = _schemaCache.GetOrAdd(strippedSchema, text => JsonSchema.FromText(text));
 
             // Convert JsonNode to JsonElement for evaluation
             var jsonString = dataJson.ToJsonString();
@@ -91,6 +99,47 @@ public class SchemaValidator : ISchemaValidator
                     }
                 )
             );
+        }
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="schema"/> with every property whose name starts with
+    /// <c>x-</c> recursively removed. The original node is not mutated (it is typically a shared
+    /// <c>Action.Form.Schema</c>). Mirrors <c>ValidationEngine.StripCustomExtensionKeywords</c>.
+    /// </summary>
+    private static JsonNode StripExtensionKeywords(JsonNode schema)
+    {
+        // Deep-clone via round-trip so the caller's schema node is never mutated.
+        var clone = JsonNode.Parse(schema.ToJsonString());
+        StripInPlace(clone);
+        return clone ?? new JsonObject();
+    }
+
+    private static void StripInPlace(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                var toRemove = obj
+                    .Where(kvp => kvp.Key.StartsWith("x-", StringComparison.Ordinal))
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+                foreach (var key in toRemove)
+                {
+                    obj.Remove(key);
+                }
+                foreach (var kvp in obj)
+                {
+                    StripInPlace(kvp.Value);
+                }
+                break;
+
+            case JsonArray arr:
+                foreach (var item in arr)
+                {
+                    StripInPlace(item);
+                }
+                break;
         }
     }
 

--- a/src/Core/Sorcha.Blueprint.Engine/Sorcha.Blueprint.Engine.xml
+++ b/src/Core/Sorcha.Blueprint.Engine/Sorcha.Blueprint.Engine.xml
@@ -1312,6 +1312,13 @@
             Validate data against a JSON Schema.
             </summary>
         </member>
+        <member name="M:Sorcha.Blueprint.Engine.Implementation.SchemaValidator.StripExtensionKeywords(System.Text.Json.Nodes.JsonNode)">
+            <summary>
+            Returns a copy of <paramref name="schema"/> with every property whose name starts with
+            <c>x-</c> recursively removed. The original node is not mutated (it is typically a shared
+            <c>Action.Form.Schema</c>). Mirrors <c>ValidationEngine.StripCustomExtensionKeywords</c>.
+            </summary>
+        </member>
         <member name="M:Sorcha.Blueprint.Engine.Implementation.SchemaValidator.ConvertToJsonNode(System.Collections.Generic.Dictionary{System.String,System.Object})">
             <summary>
             Converts a dictionary to JsonNode for validation.

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -581,6 +581,10 @@ public class ActionExecutionService : IActionExecutionService
         //     Contract: specs/106-register-native-credentials/contracts/credential-issuance-config.md
         CredentialIssuanceResult? localWalletCredential = null;
         string? localWalletRecipient = null;
+        // Feature 137 / C3 — carried encryption key injected into the encryption pipeline at
+        // step 9d when the recipient is an open-participant citizen with no published participant
+        // record (cross-node late binding). Null on the pre-137 (published/derivation) path.
+        ExternalKeyInfo? crossNodeDeliveryKey = null;
         // Reuse the caller's org context computed earlier (used by both the HAIP path
         // and SorchaLocalWallet path).
         var issuerOrgName = callerIssuerOrgName;
@@ -600,10 +604,65 @@ public class ActionExecutionService : IActionExecutionService
                     $"Ensure the recipient has submitted a prior action or is pre-bound in the published blueprint.");
             }
 
+            // Feature 137 / C3 — when the blueprint opts in via HolderKeySourceField, resolve the
+            // recipient's delivery keys with FR-012 precedence BEFORE minting so a credential that
+            // cannot be bound + delivered is never issued (SC-004 fail-closed). Blueprints that leave
+            // HolderKeySourceField null keep the pre-137 behaviour (no cnf binding; recipient key
+            // resolved from the register or derived from the Ed25519 signing key at step 9d).
+            JsonElement? holderJwk = null;
+            var holderKeySourceField = actionDef.CredentialIssuanceConfig.HolderKeySourceField;
+            if (!string.IsNullOrWhiteSpace(holderKeySourceField))
+            {
+                var carried = ResolveCarriedHolderKeys(mergedData, holderKeySourceField);
+                holderJwk = carried.HolderJwk;
+
+                // Delivery (encryption) key precedence: (1) published participant record wins;
+                // (2) carried key fallback; (3) fail closed. ResolvePublicKeyAsync returns null on
+                // not-found and throws on revoked (410) — a revoked recipient is a hard stop, which
+                // is the correct fail-closed outcome (no delivery to a revoked participant).
+                var publishedKey = await _registerClient.ResolvePublicKeyAsync(
+                    instance.RegisterId, localWalletRecipient, cancellationToken: cancellationToken);
+                if (publishedKey is not null)
+                {
+                    _logger.LogInformation(
+                        "[137] Recipient {Recipient} resolved from a published participant record on register {RegisterId} — published delivery key wins.",
+                        localWalletRecipient, instance.RegisterId);
+                }
+                else if (!string.IsNullOrEmpty(carried.EncryptionPublicKey)
+                         && !string.IsNullOrEmpty(carried.Algorithm))
+                {
+                    crossNodeDeliveryKey = new ExternalKeyInfo
+                    {
+                        PublicKey = carried.EncryptionPublicKey!,
+                        Algorithm = carried.Algorithm!
+                    };
+                    _logger.LogInformation(
+                        "[137] Recipient {Recipient} has no published participant record on register {RegisterId} — using the carried delivery key ({Algorithm}).",
+                        localWalletRecipient, instance.RegisterId, carried.Algorithm);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"[VAL_RUNTIME_CRED_004] SorchaLocalWallet issuance for action {actionDef.Id} could not resolve a delivery key for recipient " +
+                        $"'{localWalletRecipient}': no published participant record on register {instance.RegisterId} and no carried encryption key in the submission. " +
+                        $"Failing closed without issuing a credential (FR-012 / SC-004).");
+                }
+
+                // FR-014 — the credential MUST be bound to the recipient's holder key. A configured
+                // HolderKeySourceField that resolves no holder JWK is a fail-closed condition.
+                if (holderJwk is null)
+                {
+                    throw new InvalidOperationException(
+                        $"[VAL_RUNTIME_CRED_005] SorchaLocalWallet issuance for action {actionDef.Id} is configured with HolderKeySourceField " +
+                        $"'{holderKeySourceField}' but no holder JWK resolved from the submission. Failing closed — the credential cannot be " +
+                        $"bound to the recipient's holder key (FR-014).");
+                }
+            }
+
             try
             {
                 localWalletCredential = await IssueCredentialFromActionAsync(
-                    actionDef, mergedData, request.SenderWallet, instance, issuerOrgName, issuerTenantId, cancellationToken);
+                    actionDef, mergedData, request.SenderWallet, instance, issuerOrgName, issuerTenantId, holderJwk, cancellationToken);
             }
             catch (Exception ex) when (ex is not InvalidOperationException)
             {
@@ -708,9 +767,23 @@ public class ActionExecutionService : IActionExecutionService
         DisclosureGroup[]? disclosureGroups = null;
         if (!registerDevMode && _encryptionPipeline != null && disclosedPayloads.Count > 0)
         {
-            // US4: Automatic register resolution with external key override
+            // US4: Automatic register resolution with external key override.
+            // Feature 137 / C3 — merge any carried cross-node delivery key for the SorchaLocalWallet
+            // recipient into the external-key set so the pipeline can wrap the credential disclosure
+            // to an open participant who has no published participant record. Honours "published wins"
+            // because crossNodeDeliveryKey is only populated (at step 8c) when the register lookup
+            // missed, and TryAdd never overrides an explicitly-supplied external key.
+            var effectiveExternalKeys = request.ExternalRecipientKeys;
+            if (crossNodeDeliveryKey is not null && !string.IsNullOrEmpty(localWalletRecipient))
+            {
+                effectiveExternalKeys = effectiveExternalKeys is null
+                    ? new Dictionary<string, ExternalKeyInfo>(StringComparer.OrdinalIgnoreCase)
+                    : new Dictionary<string, ExternalKeyInfo>(effectiveExternalKeys, StringComparer.OrdinalIgnoreCase);
+                effectiveExternalKeys.TryAdd(localWalletRecipient, crossNodeDeliveryKey);
+            }
+
             var (recipients, resolveError) = await ResolveRecipientKeysAsync(
-                disclosedPayloads.Keys, request.ExternalRecipientKeys, instance.RegisterId, cancellationToken);
+                disclosedPayloads.Keys, effectiveExternalKeys, instance.RegisterId, cancellationToken);
             if (resolveError != null)
             {
                 throw new InvalidOperationException(resolveError);
@@ -1972,6 +2045,7 @@ public class ActionExecutionService : IActionExecutionService
         Instance instance,
         string? issuerOrgName,
         string? issuerTenantId,
+        JsonElement? holderJwk,
         CancellationToken cancellationToken)
     {
         var config = actionDef.CredentialIssuanceConfig!;
@@ -2082,6 +2156,7 @@ public class ActionExecutionService : IActionExecutionService
                 skipRecipientStore: config.TargetAudience is TargetAudience.SorchaLocalWallet or TargetAudience.SorchaInternal,
                 issuerOrgName: issuerOrgName,
                 tenantId: issuerTenantId,
+                holderJwk: holderJwk,
                 cancellationToken: cancellationToken);
 
             return result;
@@ -2095,6 +2170,57 @@ public class ActionExecutionService : IActionExecutionService
             return null;
         }
     }
+
+    /// <summary>
+    /// Feature 137 / C3 — resolves the recipient's carried delivery keys from reconstructed
+    /// instance state. <paramref name="holderJwkPointer"/> (e.g. <c>/holderKeys/holderJwk</c>)
+    /// locates the holder JWK for the SD-JWT <c>cnf</c> binding; the sibling
+    /// <c>encryptionPublicKey</c> + <c>algorithm</c> are read from the same parent object and feed
+    /// the on-register AEAD envelope wrap. All values are public material written by a
+    /// <c>sorcha-holder-key</c> form field on the starting action. Any segment that does not
+    /// resolve is returned as null.
+    /// </summary>
+    internal static (JsonElement? HolderJwk, string? EncryptionPublicKey, string? Algorithm) ResolveCarriedHolderKeys(
+        Dictionary<string, object> mergedData,
+        string holderJwkPointer)
+    {
+        JsonElement? holderJwk = null;
+        if (TryResolveJsonPointer(mergedData!, holderJwkPointer, out var jwkValue) && jwkValue is not null)
+        {
+            // Re-serialise to a JsonElement regardless of whether the reconstructed value is a
+            // JsonElement (register-sourced) or a Dictionary (instance-stored fallback).
+            holderJwk = JsonSerializer.SerializeToElement(jwkValue);
+        }
+
+        var lastSlash = holderJwkPointer.LastIndexOf('/');
+        var parentPointer = lastSlash > 0 ? holderJwkPointer[..lastSlash] : string.Empty;
+
+        var encryptionPublicKey = TryResolveJsonPointer(mergedData!, $"{parentPointer}/encryptionPublicKey", out var encValue)
+            ? CoercePointerValueToString(encValue)
+            : null;
+        var algorithm = TryResolveJsonPointer(mergedData!, $"{parentPointer}/algorithm", out var algValue)
+            ? CoercePointerValueToString(algValue)
+            : null;
+
+        return (
+            holderJwk,
+            string.IsNullOrWhiteSpace(encryptionPublicKey) ? null : encryptionPublicKey,
+            string.IsNullOrWhiteSpace(algorithm) ? null : algorithm);
+    }
+
+    /// <summary>
+    /// Coerces a JSON-Pointer-resolved value to its string form. Handles raw strings,
+    /// <see cref="JsonElement"/> string nodes, and null/undefined nodes (returned as null).
+    /// </summary>
+    private static string? CoercePointerValueToString(object? value) => value switch
+    {
+        null => null,
+        string s => s,
+        JsonElement je when je.ValueKind == JsonValueKind.String => je.GetString(),
+        JsonElement je when je.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined => null,
+        JsonElement je => je.ToString(),
+        _ => value.ToString()
+    };
 
     private async Task RecordCredentialOnRegisterAsync(
         CredentialIssuanceResult credential,

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -57,6 +57,19 @@ public static class CitizenWalletEndpoints
             .Produces<CredentialListResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized);
 
+        group.MapGet("/holder-keys", GetHolderKeys)
+            .WithName("GetCitizenHolderKeys")
+            .WithSummary("Get the citizen's holder + encryption public keys")
+            .WithDescription(
+                "Feature 137 (cross-node submission). Resolves the caller's slot-108 holder public " +
+                "JWK (for the SD-JWT cnf binding) and wallet encryption public key (for the on-register " +
+                "AEAD envelope) from the citizen JWT. Used by the HolderKeyRenderer to auto-fill the " +
+                "cross-node submission key field. Public material only — never a private key. " +
+                "404 when no wallet resolves for the caller (indistinguishable from non-existence).")
+            .Produces<HolderKeysResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+
         group.MapPost("/devices/renew-delegation", RenewDelegation)
             .WithName("RenewCitizenDeviceDelegation")
             .WithSummary("Renew the device delegation credential")
@@ -370,6 +383,41 @@ public static class CitizenWalletEndpoints
         return Results.Ok(snapshot);
     }
 
+    private static async Task<IResult> GetHolderKeys(
+        HttpContext context,
+        IHolderKeyService holderKeys,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (platformUserId, citizenWallet, _) = ResolveCitizenContext(context.User);
+        if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
+
+        try
+        {
+            var keys = await holderKeys.GetDeliveryKeysAsync(citizenWallet, ct);
+            return Results.Ok(new HolderKeysResponse
+            {
+                HolderJwk = keys.HolderJwk,
+                EncryptionPublicKey = keys.EncryptionPublicKey,
+                Algorithm = keys.Algorithm,
+                WalletAddress = keys.WalletAddress
+            });
+        }
+        catch (KeyNotFoundException)
+        {
+            // No wallet / public key resolvable for the caller — 404, indistinguishable
+            // from non-existence (matches the rest of the citizen surface).
+            return Results.NotFound();
+        }
+        catch (NotSupportedException ex)
+        {
+            logger.LogWarning(ex,
+                "Holder-keys request for wallet {Wallet} rejected — unsupported delivery algorithm.",
+                citizenWallet);
+            return Results.NotFound();
+        }
+    }
+
     private static async Task<IResult> SyncCredentials(
         HttpContext context,
         [FromQuery] string? since,
@@ -538,4 +586,24 @@ public static class CitizenWalletEndpoints
         var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(canonical));
         return System.Buffers.Text.Base64Url.EncodeToString(hash);
     }
+}
+
+/// <summary>
+/// Feature 137 — response of <c>GET /api/v1/wallet/holder-keys</c>. The citizen's public delivery
+/// keys for a cross-node credential round-trip. Public material only — never a private key.
+/// Contract: <c>specs/137-cross-node-submission/contracts/holder-keys-endpoint.openapi.yaml</c>.
+/// </summary>
+public sealed class HolderKeysResponse
+{
+    /// <summary>Slot-108 holder public JWK for the SD-JWT <c>cnf</c> binding.</summary>
+    public required System.Text.Json.JsonElement HolderJwk { get; init; }
+
+    /// <summary>Base64 wallet public key used to wrap the on-register AEAD envelope.</summary>
+    public required string EncryptionPublicKey { get; init; }
+
+    /// <summary>Delivery algorithm: <c>ED25519</c> or <c>NISTP256</c>.</summary>
+    public required string Algorithm { get; init; }
+
+    /// <summary>The citizen's resolved wallet address.</summary>
+    public required string WalletAddress { get; init; }
 }

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CredentialEndpoints.cs
@@ -681,17 +681,33 @@ public static class CredentialEndpoints
             logger,
             cancellationToken);
 
-        var token = await sdJwtService.CreateTokenAsync(
-            claims,
-            request.DisclosableClaims,
-            issuer: signingIssuer,
-            subject: request.RecipientWallet,
-            signingKey: privateKey,
-            algorithm: signingAlgorithm,
-            expiresAt: expiresAt,
-            cancellationToken: cancellationToken,
-            x5cChain: x5cChain,
-            kid: signingKid);
+        // Feature 137 — when the caller supplies the recipient's holder JWK, bind the
+        // credential to it via the SD-JWT cnf claim (key confirmation). Absent → unbound
+        // credential (pre-137 behaviour). cnf is always non-disclosable.
+        var token = request.HolderJwk.HasValue
+            ? await sdJwtService.CreateTokenAsync(
+                claims,
+                request.DisclosableClaims,
+                issuer: signingIssuer,
+                subject: request.RecipientWallet,
+                signingKey: privateKey,
+                algorithm: signingAlgorithm,
+                holderJwk: request.HolderJwk.Value,
+                expiresAt: expiresAt,
+                cancellationToken: cancellationToken,
+                x5cChain: x5cChain,
+                kid: signingKid)
+            : await sdJwtService.CreateTokenAsync(
+                claims,
+                request.DisclosableClaims,
+                issuer: signingIssuer,
+                subject: request.RecipientWallet,
+                signingKey: privateKey,
+                algorithm: signingAlgorithm,
+                expiresAt: expiresAt,
+                cancellationToken: cancellationToken,
+                x5cChain: x5cChain,
+                kid: signingKid);
 
         // 5. Generate credential ID
         var credentialId = $"urn:uuid:{Guid.NewGuid()}";
@@ -874,6 +890,15 @@ public class IssueCredentialRequest
     /// existing Sorcha-internal default).
     /// </summary>
     public string? TenantId { get; init; }
+
+    /// <summary>
+    /// Feature 137 — recipient holder's public JWK (slot 108) for the SD-JWT
+    /// <c>cnf</c> (key confirmation) binding. When supplied, the issued credential
+    /// is cryptographically bound to the holder key so only the holder can present
+    /// it. Null leaves the credential unbound (the pre-137 behaviour). Public
+    /// material only — never a private key.
+    /// </summary>
+    public JsonElement? HolderJwk { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/HolderKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/HolderKeyService.cs
@@ -130,6 +130,48 @@ public sealed class HolderKeyService : IHolderKeyService
         return thumbprint;
     }
 
+    /// <inheritdoc />
+    public async Task<CitizenHolderDeliveryKeys> GetDeliveryKeysAsync(string walletAddress, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(walletAddress);
+
+        var holderJwk = await GetHolderPublicJwkAsync(walletAddress, ct);
+
+        var wallet = await _repository.GetByAddressAsync(walletAddress, false, false, false, ct)
+            ?? throw new KeyNotFoundException($"Wallet {walletAddress} not found");
+
+        if (string.IsNullOrEmpty(wallet.PublicKey))
+        {
+            throw new KeyNotFoundException($"Wallet {walletAddress} has no public key for AEAD delivery");
+        }
+
+        var algorithm = NormaliseDeliveryAlgorithm(wallet.Algorithm);
+
+        _logger.LogInformation(
+            "Resolved citizen delivery keys for wallet {Address} (delivery algorithm: {Algorithm})",
+            walletAddress, algorithm);
+
+        return new CitizenHolderDeliveryKeys(holderJwk, wallet.PublicKey, algorithm, walletAddress);
+    }
+
+    /// <summary>
+    /// Maps a wallet's stored algorithm to the cross-node delivery algorithm vocabulary
+    /// (<c>ED25519</c> | <c>NISTP256</c>) consumed by <c>ExternalKeyInfo.Algorithm</c>. The
+    /// AEAD pipeline derives X25519 from the Ed25519 key, so the raw wallet public key is carried.
+    /// </summary>
+    private static string NormaliseDeliveryAlgorithm(string walletAlgorithm)
+    {
+        var alg = walletAlgorithm.ToUpperInvariant();
+        return alg switch
+        {
+            "ED25519" or "EDDSA" => "ED25519",
+            "NISTP256" or "P-256" or "P256" or "ES256" or "ECDSA-P256" or "SECP256R1" => "NISTP256",
+            _ => throw new NotSupportedException(
+                $"Wallet algorithm '{walletAlgorithm}' is not a supported cross-node delivery key type " +
+                "(only ED25519 and NISTP256 wallets can receive a SorchaLocalWallet credential cross-node).")
+        };
+    }
+
     private async Task<(byte[] PrivateKey, byte[] PublicKey, string Algorithm)> DeriveHolderKeyAsync(
         string walletAddress, CancellationToken ct)
     {

--- a/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IHolderKeyService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Interfaces/IHolderKeyService.cs
@@ -54,4 +54,32 @@ public interface IHolderKeyService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>43-character base64url SHA-256 thumbprint.</returns>
     Task<string> GetHolderJwkThumbprintAsync(string walletAddress, CancellationToken ct = default);
+
+    /// <summary>
+    /// Feature 137 (cross-node submission, C3) — returns the citizen's public delivery keys so a
+    /// blueprint <c>sorcha-holder-key</c> form field can carry them into the submission. Combines
+    /// the slot-108 holder JWK (for the SD-JWT <c>cnf</c> binding) with the wallet's primary public
+    /// key + algorithm (for the on-register AEAD envelope). The encryption key is the wallet's own
+    /// signing public key — the encryption pipeline derives X25519 from it, so it is byte-identical
+    /// to the register-resolved recipient key. Public material only.
+    /// </summary>
+    /// <param name="walletAddress">Citizen's primary Sorcha wallet address.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The citizen's holder JWK, base64 encryption public key, and delivery algorithm.</returns>
+    /// <exception cref="KeyNotFoundException">Wallet does not exist or has no public key.</exception>
+    /// <exception cref="NotSupportedException">Wallet algorithm is not a supported delivery key type.</exception>
+    Task<CitizenHolderDeliveryKeys> GetDeliveryKeysAsync(string walletAddress, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Feature 137 — the citizen's public delivery keys for a cross-node credential round-trip.
+/// </summary>
+/// <param name="HolderJwk">Slot-108 holder public JWK for the SD-JWT <c>cnf</c> binding.</param>
+/// <param name="EncryptionPublicKey">Base64 wallet public key used to wrap the on-register AEAD envelope.</param>
+/// <param name="Algorithm">Delivery algorithm: <c>ED25519</c> or <c>NISTP256</c>.</param>
+/// <param name="WalletAddress">The citizen's resolved wallet address.</param>
+public sealed record CitizenHolderDeliveryKeys(
+    JsonElement HolderJwk,
+    string EncryptionPublicKey,
+    string Algorithm,
+    string WalletAddress);

--- a/tests/Sorcha.Blueprint.Engine.Tests/SchemaValidatorTests.cs
+++ b/tests/Sorcha.Blueprint.Engine.Tests/SchemaValidatorTests.cs
@@ -49,6 +49,50 @@ public class SchemaValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_SorchaHolderKeyField_ValidatesAsPass()
+    {
+        // Feature 137 (T019 lock-in): the action-data validator must tolerate an object field
+        // declared with format "sorcha-holder-key" and an x-holder-key extension — unknown formats
+        // pass under RequireFormatValidation and x- keywords are ignored as annotations, exactly
+        // like the existing x-file / file-reference fields on the same blueprint.
+        var schema = JsonNode.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "holderKeys": {
+                    "type": "object",
+                    "format": "sorcha-holder-key",
+                    "x-holder-key": { "required": true }
+                }
+            },
+            "required": ["name", "holderKeys"]
+        }
+        """);
+
+        var data = new Dictionary<string, object>
+        {
+            ["name"] = "Alice",
+            ["holderKeys"] = new Dictionary<string, object>
+            {
+                ["holderJwk"] = new Dictionary<string, object>
+                {
+                    ["kty"] = "EC", ["crv"] = "P-256", ["x"] = "AAA", ["y"] = "BBB"
+                },
+                ["encryptionPublicKey"] = "QkFTRTY0",
+                ["algorithm"] = "ED25519"
+            }
+        };
+
+        var result = await _validator.ValidateAsync(data, schema!);
+
+        result.IsValid.Should().BeTrue(
+            "holder-key fields must validate as pass; errors: {0}",
+            string.Join(" | ", result.Errors.Select(e => $"{e.InstanceLocation}:{e.Message}")));
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ValidateAsync_MissingRequiredField_ReturnsInvalid()
     {
         // Arrange

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/PublicKeyResolutionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/PublicKeyResolutionTests.cs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Sorcha.ServiceClients.Participant;
 using Sorcha.ServiceClients.Wallet;
 using Sorcha.ServiceClients.Register;
@@ -532,6 +534,179 @@ public class PublicKeyResolutionTests
     #endregion
 
     #region Helper Methods
+
+    #region Feature 137 — cross-node credential delivery-key precedence (FR-012 / SC-004)
+
+    [Fact]
+    public async Task SorchaLocalWallet_NoPublishedRecord_NoCarriedKey_FailsClosed_IssuesNoCredential()
+    {
+        // SC-004: when neither a published participant record nor carried keys resolve, the system
+        // issues ZERO credentials. With HolderKeySourceField set and no holderKeys in the payload,
+        // ExecuteAsync must fail closed before the Wallet Service is ever asked to mint.
+        var service = CreateService();
+        const string instanceId = "xnode-instance";
+        const string registerId = "register-x";
+        const string citizenWallet = "ws1qcitizen";
+
+        var blueprint = CreateSorchaLocalWalletBlueprint(citizenWallet);
+        var action = blueprint.Actions!.First(a => a.Id == 1);
+        var instance = CreateTestInstance(instanceId, blueprint.Id, registerId,
+            new Dictionary<string, string> { ["citizen"] = citizenWallet });
+
+        SetupCommonMocks(instanceId, instance, blueprint, action);
+        SetupRoutingAndDisclosure(blueprint, action);
+        // Lets the starting-action prerequisite (blueprint-publish tx confirmation) pass so
+        // execution reaches the step-8c credential-issuance precedence check.
+        SetupFullTransactionFlow(instance);
+
+        // Register has no published key for the open-participant citizen.
+        _mockRegisterClient
+            .Setup(x => x.ResolvePublicKeyAsync(registerId, citizenWallet, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PublicKeyResolution?)null);
+
+        var request = new ActionSubmissionRequest
+        {
+            BlueprintId = blueprint.Id,
+            ActionId = "1",
+            SenderWallet = citizenWallet,
+            RegisterAddress = registerId,
+            PayloadData = new Dictionary<string, object> { ["field1"] = "value1" } // no holderKeys
+        };
+
+        var act = () => service.ExecuteAsync(instanceId, 1, request, "test-token");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("VAL_RUNTIME_CRED_004");
+
+        _mockWalletClient.Verify(x => x.IssueCredentialAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(),
+            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<List<string>?>(), It.IsAny<string?>(),
+            It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<JsonElement?>(), It.IsAny<CancellationToken>()),
+            Times.Never, "fail-closed must issue zero credentials (SC-004)");
+    }
+
+    [Fact]
+    public async Task SorchaLocalWallet_CarriedKeys_BindCnf_AndInjectDeliveryKey_WhenRegisterMisses()
+    {
+        // FR-012/FR-014: register misses → the carried holder JWK binds cnf and the carried
+        // encryption key is injected so the credential disclosure encrypts to the citizen.
+        var service = CreateService();
+        const string instanceId = "xnode-instance-2";
+        const string registerId = "register-x2";
+        const string citizenWallet = "ws1qcitizen2";
+
+        var encKeyBytes = new byte[32];
+        new Random(137).NextBytes(encKeyBytes);
+        var encKeyBase64 = Convert.ToBase64String(encKeyBytes);
+
+        var blueprint = CreateSorchaLocalWalletBlueprint(citizenWallet);
+        var action = blueprint.Actions!.First(a => a.Id == 1);
+        var instance = CreateTestInstance(instanceId, blueprint.Id, registerId,
+            new Dictionary<string, string> { ["citizen"] = citizenWallet });
+
+        SetupCommonMocks(instanceId, instance, blueprint, action);
+        SetupRoutingAndDisclosure(blueprint, action);
+        SetupFullTransactionFlow(instance);
+
+        _mockRegisterClient
+            .Setup(x => x.ResolvePublicKeyAsync(registerId, citizenWallet, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PublicKeyResolution?)null);
+
+        JsonElement? capturedHolderJwk = null;
+        _mockWalletClient
+            .Setup(x => x.IssueCredentialAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, object>>(),
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<List<string>?>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<JsonElement?>(), It.IsAny<CancellationToken>()))
+            .Callback(new InvocationAction(inv => capturedHolderJwk = (JsonElement?)inv.Arguments[13]))
+            .ReturnsAsync(new CredentialIssuanceResult
+            {
+                CredentialId = "urn:uuid:cred-1",
+                Type = "AssuredIdentityCredential",
+                IssuerDid = citizenWallet,
+                SubjectDid = citizenWallet,
+                Claims = new Dictionary<string, object>(),
+                RawToken = "eyJ.tok.en",
+                IssuedAt = DateTimeOffset.UtcNow
+            });
+
+        DisclosureGroup[]? capturedGroups = null;
+        _mockEncryptionPipeline
+            .Setup(x => x.EncryptDisclosedPayloadsAsync(It.IsAny<DisclosureGroup[]>(), It.IsAny<CancellationToken>()))
+            .Callback<DisclosureGroup[], CancellationToken>((groups, _) => capturedGroups = groups)
+            .ReturnsAsync(EncryptionResult.Succeeded(CreateTestEncryptedGroups(citizenWallet)));
+
+        var request = new ActionSubmissionRequest
+        {
+            BlueprintId = blueprint.Id,
+            ActionId = "1",
+            SenderWallet = citizenWallet,
+            RegisterAddress = registerId,
+            PayloadData = new Dictionary<string, object>
+            {
+                ["field1"] = "value1",
+                ["holderKeys"] = new Dictionary<string, object>
+                {
+                    ["holderJwk"] = new Dictionary<string, object>
+                    {
+                        ["kty"] = "EC", ["crv"] = "P-256", ["x"] = "AAA", ["y"] = "BBB"
+                    },
+                    ["encryptionPublicKey"] = encKeyBase64,
+                    ["algorithm"] = "ED25519"
+                }
+            }
+        };
+
+        await service.ExecuteAsync(instanceId, 1, request, "test-token");
+
+        // cnf binding: the holder JWK was threaded to the Wallet Service issuance call.
+        capturedHolderJwk.Should().NotBeNull("the carried holder JWK must bind the credential cnf (FR-014)");
+        capturedHolderJwk!.Value.GetProperty("kty").GetString().Should().Be("EC");
+
+        // delivery key: the carried encryption key was injected so the recipient resolves externally.
+        capturedGroups.Should().NotBeNull();
+        var recipient = capturedGroups!.SelectMany(g => g.Recipients).FirstOrDefault(r => r.WalletAddress == citizenWallet);
+        recipient.Should().NotBeNull();
+        recipient!.Source.Should().Be(KeySource.External);
+        recipient.PublicKey.Should().BeEquivalentTo(encKeyBytes);
+    }
+
+    private static BlueprintModel CreateSorchaLocalWalletBlueprint(string citizenWallet)
+    {
+        return new BlueprintModel
+        {
+            Id = "blueprint-xnode",
+            Title = "Cross-node Assured Identity",
+            Participants =
+            [
+                // Open participant: walletAddress null in the published blueprint, late-bound at runtime.
+                new ParticipantModel { Id = "citizen", Name = "Citizen", WalletAddress = null }
+            ],
+            Actions =
+            [
+                new ActionModel
+                {
+                    Id = 1,
+                    Title = "Issue Assured Identity",
+                    Sender = "citizen",
+                    IsStartingAction = true,
+                    CredentialIssuanceConfig = new Sorcha.Blueprint.Models.Credentials.CredentialIssuanceConfig
+                    {
+                        CredentialType = "AssuredIdentityCredential",
+                        TargetAudience = Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaLocalWallet,
+                        RecipientParticipantId = "citizen",
+                        HolderKeySourceField = "/holderKeys/holderJwk",
+                        ClaimMappings = [new Sorcha.Blueprint.Models.Credentials.ClaimMapping { ClaimName = "field1", SourceField = "/field1" }]
+                    },
+                    Routes = [new RouteModel { NextActionIds = [] }]
+                }
+            ]
+        };
+    }
+
+    #endregion
 
     private void SetupCommonMocks(string instanceId, Instance instance, BlueprintModel blueprint, ActionModel action)
     {

--- a/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Forms/FormSchemaServiceTests.cs
@@ -204,6 +204,30 @@ public class FormSchemaServiceTests
     }
 
     [Fact]
+    public void AutoGenerateForm_ObjectWithSorchaHolderKeyFormat_DispatchesToHolderKey()
+    {
+        // Feature 137: an object field with format "sorcha-holder-key" routes to the
+        // HolderKey control (captured read-only by HolderKeyRenderer) and is NOT recursed
+        // into as a primitive group, even though it is type:object.
+        var schema = JsonDocument.Parse("""
+        {
+            "type": "object",
+            "properties": {
+                "email":      { "type": "string", "format": "email", "title": "Email" },
+                "holderKeys": { "type": "object", "format": "sorcha-holder-key", "x-holder-key": { "required": true } }
+            }
+        }
+        """);
+
+        var form = _sut.AutoGenerateForm(new[] { schema });
+
+        var holderKeys = form.Elements.FirstOrDefault(e => e.Scope == "/holderKeys");
+        holderKeys.Should().NotBeNull();
+        holderKeys!.ControlType.Should().Be(Sorcha.Blueprint.Models.ControlTypes.HolderKey);
+        holderKeys.Elements.Should().BeEmpty(because: "a holder-key field is not recursed into");
+    }
+
+    [Fact]
     public void AutoGenerateForm_XAddressLookupFalse_RemainsTextLine()
     {
         // Explicit `x-address-lookup: false` should NOT dispatch to postcode lookup.

--- a/tests/Sorcha.Wallet.Service.Tests/Services/HolderKeyServiceTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Services/HolderKeyServiceTests.cs
@@ -182,6 +182,69 @@ public sealed class HolderKeyServiceTests
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
+    // ---- Feature 137: GetDeliveryKeysAsync ----
+
+    [Fact]
+    public async Task GetDeliveryKeysAsync_ReturnsHolderJwk_WalletPublicKey_AndMappedAlgorithm()
+    {
+        SetupHappyPath(out _);
+
+        var keys = await _service.GetDeliveryKeysAsync("ws1qcitizen1");
+
+        keys.WalletAddress.Should().Be("ws1qcitizen1");
+        keys.EncryptionPublicKey.Should().Be(Convert.ToBase64String(new byte[32]),
+            because: "the AEAD envelope wraps to the wallet's own primary public key");
+        keys.Algorithm.Should().Be("NISTP256", because: "an ES256 wallet maps to the NISTP256 delivery vocabulary");
+        keys.HolderJwk.GetProperty("kty").GetString().Should().Be("EC");
+    }
+
+    [Fact]
+    public async Task GetDeliveryKeysAsync_Ed25519Wallet_MapsAlgorithmToEd25519()
+    {
+        var wallet = CreateTestWallet(algorithm: "ED25519");
+        var masterKey = new byte[64];
+        _repoMock.Setup(r => r.GetByAddressAsync("ws1qcitizen1", false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(wallet);
+        _keyMgmtMock.Setup(k => k.DecryptPrivateKeyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(masterKey);
+        _keyMgmtMock.Setup(k => k.DeriveKeyAtPathAsync(masterKey, It.IsAny<DerivationPath>(), "ED25519"))
+            .ReturnsAsync((new byte[32], new byte[32]));
+
+        var keys = await _service.GetDeliveryKeysAsync("ws1qcitizen1");
+
+        keys.Algorithm.Should().Be("ED25519");
+        keys.HolderJwk.GetProperty("kty").GetString().Should().Be("OKP");
+    }
+
+    [Fact]
+    public async Task GetDeliveryKeysAsync_WalletNotFound_ThrowsKeyNotFound()
+    {
+        _repoMock.Setup(r => r.GetByAddressAsync("ghost", false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((WalletEntity?)null);
+
+        var act = () => _service.GetDeliveryKeysAsync("ghost");
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetDeliveryKeysAsync_WalletWithoutPublicKey_ThrowsKeyNotFound()
+    {
+        var wallet = CreateTestWallet();
+        wallet.PublicKey = null;
+        var masterKey = new byte[64];
+        _repoMock.Setup(r => r.GetByAddressAsync("ws1qcitizen1", false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(wallet);
+        _keyMgmtMock.Setup(k => k.DecryptPrivateKeyAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(masterKey);
+        _keyMgmtMock.Setup(k => k.DeriveKeyAtPathAsync(masterKey, It.IsAny<DerivationPath>(), "ES256"))
+            .ReturnsAsync((new byte[32], GenerateP256PublicKeyBytes()));
+
+        var act = () => _service.GetDeliveryKeysAsync("ws1qcitizen1");
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
     private void SetupHappyPath(out byte[] derivedPublic)
     {
         var wallet = CreateTestWallet();

--- a/walkthroughs/AssuredIdentity/README.md
+++ b/walkthroughs/AssuredIdentity/README.md
@@ -37,6 +37,22 @@ fires when the credential lands.
 | 1 | Citizen → verification analyst → `AssuredIdentityCredential` lands in the PWA → welcome takeover fires | `run-phase1-identity.ps1` |
 | 2 | DEFERRED to Spec 4 (citizen-arc credential-gated second service). The stub script explains the deferral and exits. | `run-phase2-licence.ps1` |
 
+## Cross-node round-trip (Feature 137 — Tier 2)
+
+Phase 1 now carries the citizen's **public delivery keys** in the action-1 payload: `run-phase1-identity.ps1`
+fetches `GET /api/v1/wallet/holder-keys` and supplies `holderKeys` so the issued `AssuredIdentityCredential`
+is **bound to the citizen's holder key (SD-JWT `cnf`) and encrypted to their wallet** — the blueprint's
+`credentialIssuanceConfig.holderKeySourceField` points the issuer at `/holderKeys/holderJwk`. This works
+single-node (published participant key wins for encryption; carried holder JWK adds the `cnf` binding) and
+is the enabler for the genuine cross-node run.
+
+The **Tier-2 cross-node verification** (citizen on a local SyncOnly replica → submission reaches the n1
+owner/validator → analyst approves on n1 → credential delivered back to the local wallet) runs on the
+machine holding `genesis-validator-key.json` with the `docker-compose.sync-from-n1.yml` split, per
+`specs/137-cross-node-submission/quickstart.md` § Tier-2. SC-004 (fail-closed: zero credentials when
+neither a published record nor carried keys resolve) and the `cnf`/precedence logic are covered locally by
+unit + single-node integration tests (SC-005 Tier-1).
+
 ## Unattended reviewer agents (PR 3 / US3)
 
 The reviewer roles (`verification-analyst`, `licensing-officer`) have rules-mode agent

--- a/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
+++ b/walkthroughs/AssuredIdentity/blueprints/assured-identity.json
@@ -64,7 +64,8 @@
                 "title": "Contact",
                 "description": "We'll only use your email for correspondence about this application.",
                 "x-sections": [
-                  { "title": "Email", "fields": ["email"] }
+                  { "title": "Email", "fields": ["email"] },
+                  { "title": "Secure delivery", "fields": ["holderKeys"] }
                 ]
               },
               {
@@ -105,6 +106,13 @@
                   "capture": "user",
                   "embedAs": "image-token-jpeg-240x320"
                 }
+              },
+              "holderKeys": {
+                "type": "object",
+                "title": "Identity keys",
+                "description": "Your wallet's public delivery keys. Captured automatically and read-only — the credential is bound to your holder key and encrypted to your wallet so only you can use it. Feature 137 (cross-node submission).",
+                "format": "sorcha-holder-key",
+                "x-holder-key": { "required": true }
               }
             },
             "required": ["name", "dob", "email", "address"]
@@ -160,6 +168,7 @@
           "credentialType": "AssuredIdentityCredential",
           "targetAudience": "SorchaLocalWallet",
           "recipientParticipantId": "citizen",
+          "holderKeySourceField": "/holderKeys/holderJwk",
           "claimMappings": [
             { "claimName": "givenName",   "sourceField": "/name/givenName" },
             { "claimName": "middleName",  "sourceField": "/name/middleName" },

--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -130,6 +130,22 @@ if ($IncludePortrait) {
     }
 }
 
+# Feature 137 (cross-node submission, C3): carry the citizen's public delivery
+# keys in the starting-action payload. The blueprint's holderKeys field
+# (format: sorcha-holder-key) is auto-filled by HolderKeyRenderer in the UI; the
+# scripted path fetches the same keys from the Wallet Service so the issuer can
+# bind the credential (SD-JWT cnf) and encrypt it to the citizen even when the
+# owner node holds no published participant record for them (Stage-5 round-trip).
+$holderKeys = Invoke-SorchaApi -Method GET `
+    -Uri "$($state.walletUrl)/v1/wallet/holder-keys" `
+    -Headers $citizenSession.Headers
+$payloadData.holderKeys = @{
+    holderJwk           = $holderKeys.holderJwk
+    encryptionPublicKey = $holderKeys.encryptionPublicKey
+    algorithm           = $holderKeys.algorithm
+}
+Write-WtInfo "Holder keys captured ($($holderKeys.algorithm)) — credential will be bound + delivered to wallet $($holderKeys.walletAddress)"
+
 $null = Invoke-SorchaAction `
     -BlueprintUrl $state.blueprintUrl `
     -InstanceId $instanceId `


### PR DESCRIPTION
Completes **Feature 137 (Stage 5)** — the final component **C3 / US2** (credential bound + delivered to the local citizen wallet). C5, C1, C4, C2 are already merged (#831/#832/#833); this is the credential round-trip.

A credential issued on the owner node is **bound to the citizen's holder key (SD-JWT `cnf`) and encrypted to their wallet**, so it can be delivered to a citizen who has no published participant record on the register (cross-node open-participant late binding).

## Server track (unit + single-node integration covered — SC-005 Tier-1)
- **`cnf` binding** (was a pre-existing hole): `IssueCredentialRequest.HolderJwk` → `SdJwtService.CreateTokenAsync(holderJwk:)`, threaded through `IWalletServiceClient.IssueCredentialAsync`.
- **`CredentialIssuanceConfig.HolderKeySourceField`** (default `/holderKeys/holderJwk`) opts a blueprint into bound cross-node delivery; null = pre-137 behaviour.
- **FR-012 precedence in `ActionExecutionService`, before minting (SC-004 fail-closed)**: published participant record → carried `holderKeys` field → `VAL_RUNTIME_CRED_004` (no credential); configured-but-missing holder JWK → `VAL_RUNTIME_CRED_005` (FR-014). Carried `encryptionPublicKey` injected into the existing `ExternalRecipientKeys` path **only when the register lookup misses** ("published wins").
- **`GET /api/v1/wallet/holder-keys`** (consumer-tier) via `IHolderKeyService.GetDeliveryKeysAsync`.
- **`SchemaValidator` now strips `x-*` keywords** (mirrors the Validator Service `ValidationEngine`) so `x-holder-key` is tolerated on both validation paths.

## Client track (build-verified; behaviour validated in Tier-2)
- `ControlTypes.HolderKey` + `FormSchemaService` mapping + `ControlDispatcher` dispatch.
- `HolderKeyRenderer.razor` + `IHolderKeyClient` (registered auth-wrapped in web SPA + PWA).
- PWA `ApplicationInstance.razor` renders `SorchaFormRenderer` and submits via `IApplicationActionClient` (`/execute`, server-signed; the citizen wallet is server-custodied). The F125 `StubApplicationSubmissionService` / `IUserSigner` seam is retained for its tests.
- AssuredIdentity blueprint carries the `holderKeys` field; `run-phase1-identity.ps1` supplies it.

## Tests (all green locally)
`ResolveCarriedHolderKeysTests`, `HolderKeyService.GetDeliveryKeysAsync` tests, `FormSchemaService` holder-key mapping, `SchemaValidator` `x-holder-key` tolerance, and two `ExecuteAsync` integration tests (**SC-004 fail-closed** + **carried-key cnf binding**). Local suites: Engine 510, Blueprint.Service 740, ServiceClients 215, Wallet.Service 832, UI.Core 1234, Blueprint.Models 426, Wallet.Pwa 142 — **0 failures**.

## Out of scope / follow-ups
- **Tier-2 cross-node live run** (citizen on local SyncOnly replica → n1 owner/validator → analyst approval → credential back to local wallet) runs on the genesis-key machine per `specs/137-cross-node-submission/quickstart.md` §Tier-2.
- OTel key-resolution counters deferred (the three outcomes are covered by structured `[137]` logs).
- Backlog (unchanged): participant-record promotion + proof-of-possession.

Docs updated: `sorcha-architecture` skill, `docs/reference/API-DOCUMENTATION.md`, design doc, AssuredIdentity walkthrough README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)