### PR TITLE
fix: [137] resolve citizen wallet by owner when consumer token omits wallet_address

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionResolverService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionResolverService.cs
@@ -18,6 +18,7 @@ namespace Sorcha.Blueprint.Service.Services.Implementation;
 public class ActionResolverService : IActionResolverService
 {
     private readonly IBlueprintStore _blueprintStore;
+    private readonly IPublishedBlueprintStore _publishedBlueprintStore;
     private readonly IDistributedCache _cache;
     private readonly ILogger<ActionResolverService> _logger;
     private const int CacheTtlMinutes = 10;
@@ -31,10 +32,12 @@ public class ActionResolverService : IActionResolverService
     /// <summary>Initialises a new instance of the <see cref="ActionResolverService"/> class.</summary>
     public ActionResolverService(
         IBlueprintStore blueprintStore,
+        IPublishedBlueprintStore publishedBlueprintStore,
         IDistributedCache cache,
         ILogger<ActionResolverService> logger)
     {
         _blueprintStore = blueprintStore ?? throw new ArgumentNullException(nameof(blueprintStore));
+        _publishedBlueprintStore = publishedBlueprintStore ?? throw new ArgumentNullException(nameof(publishedBlueprintStore));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -63,8 +66,19 @@ public class ActionResolverService : IActionResolverService
             return cached;
         }
 
-        // Get from store
+        // Get from the draft/editable store. The draft store only exists on the node that
+        // authored the blueprint; a replica (Feature 137 / C1) holds it solely in the
+        // replicated published store. Fall back to the latest published version so action
+        // execution works on a node that does not own the register — mirroring the published-
+        // store-aware CreateInstance path (Program.cs) so a replica-origin submission can be
+        // validated + signed + fanned out to the owner.
         var blueprint = await _blueprintStore.GetAsync(blueprintId);
+        if (blueprint == null)
+        {
+            var publishedVersions = await _publishedBlueprintStore.GetVersionsAsync(blueprintId);
+            blueprint = PublishedBlueprintSelector.SelectLatest(publishedVersions)?.Blueprint;
+        }
+
         if (blueprint == null)
         {
             _logger.LogWarning("Blueprint {BlueprintId} not found", blueprintId);

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -10,6 +10,8 @@ using Sorcha.CitizenWallet.Abstractions.Models;
 using Sorcha.ServiceClients.Auth;
 using Sorcha.ServiceClients.PlatformUserDevice;
 using Sorcha.ServiceDefaults;
+using Sorcha.Wallet.Core.Domain;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Service.Services.Interfaces;
 
 namespace Sorcha.Wallet.Service.Endpoints;
@@ -345,9 +347,10 @@ public static class CitizenWalletEndpoints
         [FromBody] DelegationRenewalRequest request,
         HttpContext context,
         IDelegationRenewalService renewal,
+        IWalletRepository walletRepository,
         CancellationToken ct)
     {
-        var (platformUserId, citizenWallet, organizationId) = ResolveCitizenContext(context.User);
+        var (platformUserId, citizenWallet, organizationId) = await ResolveCitizenContextAsync(context.User, walletRepository, ct);
         if (platformUserId is null || citizenWallet is null || organizationId is null)
         {
             return Results.Unauthorized();
@@ -373,9 +376,10 @@ public static class CitizenWalletEndpoints
         HttpContext context,
         ICitizenSyncService sync,
         IHolderKeyService holderKeys,
+        IWalletRepository walletRepository,
         CancellationToken ct)
     {
-        var (platformUserId, citizenWallet, _) = ResolveCitizenContext(context.User);
+        var (platformUserId, citizenWallet, _) = await ResolveCitizenContextAsync(context.User, walletRepository, ct);
         if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
 
         var holderKeyId = await holderKeys.GetHolderJwkThumbprintAsync(citizenWallet, ct);
@@ -386,10 +390,11 @@ public static class CitizenWalletEndpoints
     private static async Task<IResult> GetHolderKeys(
         HttpContext context,
         IHolderKeyService holderKeys,
+        IWalletRepository walletRepository,
         ILogger<Program> logger,
         CancellationToken ct)
     {
-        var (platformUserId, citizenWallet, _) = ResolveCitizenContext(context.User);
+        var (platformUserId, citizenWallet, _) = await ResolveCitizenContextAsync(context.User, walletRepository, ct);
         if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
 
         try
@@ -423,9 +428,10 @@ public static class CitizenWalletEndpoints
         [FromQuery] string? since,
         ICitizenSyncService sync,
         IHolderKeyService holderKeys,
+        IWalletRepository walletRepository,
         CancellationToken ct)
     {
-        var (platformUserId, citizenWallet, _) = ResolveCitizenContext(context.User);
+        var (platformUserId, citizenWallet, _) = await ResolveCitizenContextAsync(context.User, walletRepository, ct);
         if (platformUserId is null || citizenWallet is null) return Results.Unauthorized();
 
         var holderKeyId = await holderKeys.GetHolderJwkThumbprintAsync(citizenWallet, ct);
@@ -453,6 +459,7 @@ public static class CitizenWalletEndpoints
         IOrgStatusSigningWalletResolver orgWalletResolver,
         IPlatformUserDeviceClient deviceClient,
         IHolderAddressLookup holderAddressLookup,
+        IWalletRepository walletRepository,
         Microsoft.AspNetCore.SignalR.IHubContext<Sorcha.Wallet.Service.Hubs.WalletHub> hub,
         ILogger<Program> logger,
         CancellationToken ct)
@@ -463,7 +470,7 @@ public static class CitizenWalletEndpoints
             return Results.ValidationProblem(validation.ToDictionary());
         }
 
-        var (platformUserId, citizenWallet, organizationId) = ResolveCitizenContext(context.User);
+        var (platformUserId, citizenWallet, organizationId) = await ResolveCitizenContextAsync(context.User, walletRepository, ct);
         if (platformUserId is null || citizenWallet is null || organizationId is null)
         {
             return Results.Unauthorized();
@@ -565,6 +572,38 @@ public static class CitizenWalletEndpoints
         if (string.IsNullOrWhiteSpace(walletAddress)) walletAddress = null;
 
         Guid? organizationId = Guid.TryParse(user.FindFirstValue(TokenClaimConstants.OrgId), out var oid) ? oid : null;
+
+        return (platformUserId, walletAddress, organizationId);
+    }
+
+    /// <summary>
+    /// Resolves the citizen context, falling back to a wallet-by-owner lookup when the JWT carries
+    /// no <c>wallet_address</c> claim. Feature 136 strips <c>wallet_address</c> from consumer-tier
+    /// tokens (wallet binding is a platform-privilege marker), but every citizen-wallet surface here
+    /// is consumer-tier — so without this fallback the wallet address is never resolvable for a real
+    /// citizen. The citizen's wallet is owned by their identity (<see cref="ClaimTypes.NameIdentifier"/>
+    /// = the <c>sub</c> claim, the same owner <c>CreateWallet</c> stamps), scoped to the token's
+    /// tenant (<c>"default"</c> for public-org citizens). The active wallet (oldest first) is chosen.
+    /// </summary>
+    internal static async Task<(Guid? platformUserId, string? walletAddress, Guid? organizationId)> ResolveCitizenContextAsync(
+        ClaimsPrincipal user, IWalletRepository walletRepository, CancellationToken ct)
+    {
+        var (platformUserId, walletAddress, organizationId) = ResolveCitizenContext(user);
+
+        if (string.IsNullOrWhiteSpace(walletAddress))
+        {
+            var owner = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub");
+            if (!string.IsNullOrWhiteSpace(owner))
+            {
+                var tenant = user.FindFirstValue("tenant") ?? "default";
+                var owned = await walletRepository.GetByOwnerAsync(owner, tenant, ct);
+                var chosen = owned
+                    .OrderByDescending(w => w.Status == WalletStatus.Active)
+                    .ThenBy(w => w.CreatedAt)
+                    .FirstOrDefault();
+                walletAddress = chosen?.Address;
+            }
+        }
 
         return (platformUserId, walletAddress, organizationId);
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Integration/ServiceLayerIntegrationTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Integration/ServiceLayerIntegrationTests.cs
@@ -54,6 +54,7 @@ public class ServiceLayerIntegrationTests
         var actionResolverLogger = Mock.Of<ILogger<ActionResolverService>>();
         _actionResolver = new ActionResolverService(
             _mockBlueprintStore.Object,
+            Mock.Of<IPublishedBlueprintStore>(),
             _cache,
             actionResolverLogger);
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionResolverServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionResolverServiceTests.cs
@@ -16,6 +16,7 @@ namespace Sorcha.Blueprint.Service.Tests.Services;
 public class ActionResolverServiceTests
 {
     private readonly Mock<IBlueprintStore> _mockBlueprintStore;
+    private readonly Mock<IPublishedBlueprintStore> _mockPublishedStore;
     private readonly Mock<IDistributedCache> _mockCache;
     private readonly Mock<ILogger<ActionResolverService>> _mockLogger;
     private readonly ActionResolverService _service;
@@ -23,12 +24,51 @@ public class ActionResolverServiceTests
     public ActionResolverServiceTests()
     {
         _mockBlueprintStore = new Mock<IBlueprintStore>();
+        _mockPublishedStore = new Mock<IPublishedBlueprintStore>();
         _mockCache = new Mock<IDistributedCache>();
         _mockLogger = new Mock<ILogger<ActionResolverService>>();
         _service = new ActionResolverService(
             _mockBlueprintStore.Object,
+            _mockPublishedStore.Object,
             _mockCache.Object,
             _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetBlueprintAsync_DraftMiss_FallsBackToPublishedStore()
+    {
+        // Feature 137: on a replica the blueprint exists only in the replicated published
+        // store, so action execution must fall back to it when the draft store misses.
+        var blueprintId = "replicated-bp";
+        var blueprint = new BlueprintModel { Id = blueprintId, Title = "Replicated", Description = "" };
+
+        _mockCache.Setup(x => x.GetAsync($"blueprint:{blueprintId}", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+        _mockBlueprintStore.Setup(x => x.GetAsync(blueprintId))
+            .ReturnsAsync((BlueprintModel?)null);
+        _mockPublishedStore.Setup(x => x.GetVersionsAsync(blueprintId))
+            .ReturnsAsync(new[] { new PublishedBlueprint { Version = 2, Blueprint = blueprint } });
+
+        var result = await _service.GetBlueprintAsync(blueprintId);
+
+        result.Should().NotBeNull("a replica resolves the blueprint from the published store");
+        result!.Id.Should().Be(blueprintId);
+        _mockPublishedStore.Verify(x => x.GetVersionsAsync(blueprintId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetBlueprintAsync_NotInEitherStore_ReturnsNull()
+    {
+        var blueprintId = "ghost-bp";
+        _mockCache.Setup(x => x.GetAsync($"blueprint:{blueprintId}", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+        _mockBlueprintStore.Setup(x => x.GetAsync(blueprintId)).ReturnsAsync((BlueprintModel?)null);
+        _mockPublishedStore.Setup(x => x.GetVersionsAsync(blueprintId))
+            .ReturnsAsync(Array.Empty<PublishedBlueprint>());
+
+        var result = await _service.GetBlueprintAsync(blueprintId);
+
+        result.Should().BeNull();
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletContextResolutionTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletContextResolutionTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using FluentAssertions;
+using Moq;
+using Sorcha.Wallet.Core.Domain;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
+using Sorcha.Wallet.Service.Endpoints;
+using Xunit;
+using WalletEntity = Sorcha.Wallet.Core.Domain.Entities.Wallet;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Tests for <see cref="CitizenWalletEndpoints.ResolveCitizenContextAsync"/> — the consumer-token
+/// wallet resolution that repairs the Feature 136 / Feature 137 gap: consumer-tier tokens omit the
+/// <c>wallet_address</c> claim (wallet binding is platform-only), so the citizen-wallet endpoints
+/// must resolve the wallet from the owner (the <c>sub</c> / NameIdentifier) instead of the claim.
+/// </summary>
+public sealed class CitizenWalletContextResolutionTests
+{
+    private const string Owner = "97bb186d-e4f4-46ea-a878-4ada3f0130f8";
+    private const string CitizenWallet = "ws11qr977yn3citizenwalletaddress";
+
+    private static ClaimsPrincipal Principal(bool withWalletClaim)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, Owner),
+            new("platform_user_id", "e2b28602-03a4-4da9-96b3-1c43408f2640"),
+            new("org_id", "00000000-0000-0000-0000-000000000002")
+        };
+        if (withWalletClaim) claims.Add(new Claim("wallet_address", "ws11qPLATFORMtokenwallet"));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private static WalletEntity TestWallet(string address, WalletStatus status = WalletStatus.Active) => new()
+    {
+        Address = address,
+        EncryptedPrivateKey = "enc",
+        EncryptionKeyId = "k1",
+        Algorithm = "ED25519",
+        Owner = Owner,
+        Tenant = "default",
+        Name = "Citizen Wallet",
+        PublicKey = "pk",
+        Status = status,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    [Fact]
+    public async Task ConsumerToken_NoWalletClaim_ResolvesWalletByOwner()
+    {
+        var repo = new Mock<IWalletRepository>();
+        repo.Setup(r => r.GetByOwnerAsync(Owner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { TestWallet(CitizenWallet) });
+
+        var (pid, wallet, org) = await CitizenWalletEndpoints.ResolveCitizenContextAsync(
+            Principal(withWalletClaim: false), repo.Object, CancellationToken.None);
+
+        wallet.Should().Be(CitizenWallet, "a consumer token with no wallet_address resolves via owner lookup");
+        pid.Should().NotBeNull();
+        org.Should().Be(Guid.Parse("00000000-0000-0000-0000-000000000002"));
+    }
+
+    [Fact]
+    public async Task WalletClaimPresent_UsesClaim_AndDoesNotQueryRepo()
+    {
+        var repo = new Mock<IWalletRepository>(MockBehavior.Strict);
+
+        var (_, wallet, _) = await CitizenWalletEndpoints.ResolveCitizenContextAsync(
+            Principal(withWalletClaim: true), repo.Object, CancellationToken.None);
+
+        wallet.Should().Be("ws11qPLATFORMtokenwallet");
+        repo.Verify(r => r.GetByOwnerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task NoWalletForOwner_ReturnsNullWallet()
+    {
+        var repo = new Mock<IWalletRepository>();
+        repo.Setup(r => r.GetByOwnerAsync(Owner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WalletEntity>());
+
+        var (_, wallet, _) = await CitizenWalletEndpoints.ResolveCitizenContextAsync(
+            Principal(withWalletClaim: false), repo.Object, CancellationToken.None);
+
+        wallet.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PrefersActiveWallet_OverArchived()
+    {
+        var repo = new Mock<IWalletRepository>();
+        repo.Setup(r => r.GetByOwnerAsync(Owner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                TestWallet("ws11qARCHIVED", WalletStatus.Archived),
+                TestWallet(CitizenWallet, WalletStatus.Active)
+            });
+
+        var (_, wallet, _) = await CitizenWalletEndpoints.ResolveCitizenContextAsync(
+            Principal(withWalletClaim: false), repo.Object, CancellationToken.None);
+
+        wallet.Should().Be(CitizenWallet);
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletEnrolEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletEnrolEndpointTests.cs
@@ -42,6 +42,7 @@ public sealed class CitizenWalletEnrolEndpointTests
     private readonly Mock<IDeviceDelegationIssuer> _issuer = new();
     private readonly Mock<IOrgStatusSigningWalletResolver> _resolver = new();
     private readonly Mock<IPlatformUserDeviceClient> _deviceClient = new();
+    private readonly Mock<Sorcha.Wallet.Core.Repositories.Interfaces.IWalletRepository> _walletRepository = new();
     private readonly Mock<IHubContext<WalletHub>> _hub = new();
     private readonly Mock<IHubClients> _hubClients = new();
     private readonly Mock<IClientProxy> _hubGroup = new();
@@ -120,6 +121,7 @@ public sealed class CitizenWalletEnrolEndpointTests
             _resolver.Object,
             _deviceClient.Object,
             _holderAddressLookup.Object,
+            _walletRepository.Object,
             _hub.Object,
             NullLogger<Program>.Instance,
             CancellationToken.None


### PR DESCRIPTION
The consumer-tier citizen wallet endpoints (F114 /credentials, /sync, /enrol,
/devices/renew-delegation and the new F137 /holder-keys) read the wallet from the
`wallet_address` JWT claim via ResolveCitizenContext. But F136 adds `wallet_address`
only to Tier.Platform tokens ("wallet binding is platform-only"), so a real
consumer citizen token never carries it — every one of those endpoints 401s for a
genuine citizen. Unit tests passed only because they injected the claim directly;
the live Tier-2 cross-node run surfaced the gap.

Fix: add ResolveCitizenContextAsync, which falls back to a wallet-by-owner lookup
(IWalletRepository.GetByOwnerAsync on the token's NameIdentifier/sub + tenant —
the same owner CreateWallet stamps) when the wallet_address claim is absent,
preferring the active wallet. The five consumer citizen-wallet handlers now use it.

Tests: CitizenWalletContextResolutionTests (claim-present short-circuits the repo;
no-claim resolves by owner; no wallet → null; active preferred over archived).
Full Wallet.Service suite green (836).
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
