### PR TITLE
fix: [137] cross-node fan-out — peer relay address, async-path distribute, owner validator config, .env completeness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,10 +108,55 @@ PEER_NODE_ID=local-peer.sorcha.dev
 # PEER_PUBLIC_ADDRESS=
 
 # Seed peer to connect to on startup (for joining an existing network).
-# Leave empty for standalone operation.
-# SEED_PEER_NODE_ID=
-# SEED_PEER_HOST=
+# Leave empty for standalone operation. To run this node as a SyncOnly replica
+# of an existing network (e.g. n1.sorcha.dev), point these at the seed node.
+# SEED_PEER_NODE_ID=n1.sorcha.dev
+# SEED_PEER_HOST=n1.sorcha.dev
 # SEED_PEER_PORT=50051
+#
+# Whether the seed's gRPC port is TLS-terminated. Set to "true" when the seed is
+# reached over the internet via HTTPS (e.g. a public node behind Caddy, which
+# terminates TLS on its gRPC port); "false" for a plaintext docker-network seed.
+# CRITICAL for cross-node sync: a wrong value makes the peer channel dial the
+# wrong scheme, so replication/fan-out to the owner silently fails.
+# SEED_PEER_ENABLE_TLS=false
+
+# =============================================================================
+# Transactional Email (Optional)
+# =============================================================================
+# Used by the Tenant Service for verification / invite / welcome emails.
+# Leave ACS_EMAIL_CONNECTION_STRING empty to use the SMTP path (or no-op in dev).
+
+# Base URL used to build links (verify-email, accept-invite) in email bodies.
+EMAIL_BASE_URL=http://localhost
+# From-address and display name on outbound transactional email.
+EMAIL_FROM_ADDRESS=noreply@sorcha.dev
+EMAIL_FROM_NAME=Sorcha Platform
+# Azure Communication Services connection string. When set, ACS is used instead
+# of SMTP. Leave empty for SMTP / development.                         [SECRET]
+ACS_EMAIL_CONNECTION_STRING=
+
+# =============================================================================
+# OpenTelemetry (Optional)
+# =============================================================================
+# OTLP exporter endpoints (the Aspire dashboard / collector listens on these).
+OTEL_SERVICE_NAME=sorcha-service
+# OTLP_GRPC_PORT=4317
+# OTLP_HTTP_PORT=4318
+
+# =============================================================================
+# API Documentation
+# =============================================================================
+# Require auth on the Scalar / OpenAPI surfaces. Defaults to true; set false to
+# expose API docs without a token (development convenience only).
+# OPENAPI_REQUIRE_AUTH=true
+
+# =============================================================================
+# Deployment (n1 / remote nodes)
+# =============================================================================
+# Public IP / hostname of the n1 node, used by the n1 docker-compose override
+# and the ports override to advertise the node's reachable address.
+# N1_PUBLIC_IP=n1.sorcha.dev
 
 # =============================================================================
 # Port Overrides (Optional)
@@ -128,5 +173,8 @@ PEER_NODE_ID=local-peer.sorcha.dev
 # VALIDATOR_GRPC_PORT=5801     # Validator Service gRPC
 # UI_HTTP_PORT=5400            # Sorcha UI HTTP
 # UI_HTTPS_PORT=5401           # Sorcha UI HTTPS
+# WALLET_PWA_PORT=7400         # Citizen Wallet PWA
+# VERIFIER_PORT=7401           # Reference Verifier
 # PEER_GRPC_PORT=50051         # Peer Service gRPC
+# MONGODB_PORT=27017           # MongoDB (also documented above)
 # ASPIRE_UI_PORT=18888         # Aspire Dashboard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -518,6 +518,11 @@ services:
       ServiceAuth__Scopes: "registers:write registers:read"
       ServiceClients__TenantService__Address: http://tenant-service:8080
       ServiceClients__RegisterService__Address: http://register-service:8080
+      # Feature 108: the peer-service is the cross-node fan-out RECEIVER — when it accepts a
+      # forwarded submission for a register this node owns, it submits it to the local validator
+      # for sealing. Without this address the forward is rejected ("Validator Service address not
+      # configured") and the cross-node write hop never seals on the owner.
+      ServiceClients__ValidatorService__Address: http://validator-service:8080
       # Node identity and network configuration
       PeerService__NodeId: "${PEER_NODE_ID:-local-peer.sorcha.dev}"
       PeerService__PublicAddress: "${PEER_PUBLIC_ADDRESS:-}"

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -339,7 +339,20 @@ builder.Services.AddHostedService<Sorcha.Blueprint.Service.Services.Implementati
 // transaction:confirmed Redis Streams channel. See:
 //   docs/superpowers/specs/2026-05-08-feature-111-chain-races-design.md
 //   specs/119-presentation-seal-ordering/spec.md
-builder.Services.AddRedisEventStreams(builder.Configuration);
+// CRITICAL: Blueprint Service MUST consume register events under its OWN consumer
+// group. Redis Streams consumer groups are competing-consumer: every service that
+// joins the same group name on a stream shares the messages (each delivered to ONE
+// member). The shared default "register-service" made Blueprint's reconstructor /
+// presentation-seal subscriber COMPETE with the Register Service's own SignalR
+// bridge on docket:confirmed + transaction:confirmed — so a docket:confirmed event
+// landed on the reconstructor only ~half the time and cross-node instance mirrors
+// were never materialised. A distinct group gives Blueprint its own copy of every
+// event (Validator Service already does this with "validator-service").
+builder.Services.AddRedisEventStreams(config =>
+{
+    builder.Configuration.GetSection("EventStreams:Redis").Bind(config);
+    config.ConsumerGroup = "blueprint-service";
+});
 builder.Services.AddSingleton<Sorcha.Blueprint.Service.Services.Interfaces.IPresentationSealCoordinator,
     Sorcha.Blueprint.Service.Services.Implementation.RedisPresentationSealCoordinator>();
 builder.Services.AddHostedService<Sorcha.Blueprint.Service.Services.Implementation.PresentationSealSubscriber>();

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
@@ -8,8 +8,10 @@ using Sorcha.Blueprint.Service.Hubs;
 using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
+using System.Text.Json;
 using Sorcha.ServiceClients.Events;
 using Sorcha.ServiceClients.Events.Models;
+using Sorcha.ServiceClients.Peer;
 using Sorcha.ServiceClients.Register;
 using Sorcha.ServiceClients.Validator;
 using Sorcha.ServiceClients.Wallet;
@@ -98,6 +100,8 @@ public sealed class EncryptionBackgroundService : BackgroundService
         var transactionBuilder = scope.ServiceProvider.GetRequiredService<ITransactionBuilderService>();
         var walletClient = scope.ServiceProvider.GetRequiredService<IWalletServiceClient>();
         var validatorClient = scope.ServiceProvider.GetRequiredService<IValidatorServiceClient>();
+        // Feature 108 — optional peer fan-out (subscriber nodes forward to the register owner).
+        var peerClient = scope.ServiceProvider.GetService<IPeerServiceClient>();
 
         try
         {
@@ -207,12 +211,31 @@ public sealed class EncryptionBackgroundService : BackgroundService
             var nextSeqNum = await validatorClient.GetNextSequenceNumberAsync(
                 workItem.RegisterId, workItem.SenderWallet, ct);
             var submission = transaction.ToTransactionSubmission(signResult, nextSeqNum);
-            var validatorResult = await validatorClient.SubmitTransactionAsync(submission, ct);
 
-            if (!validatorResult.Success)
+            // Feature 108 / Feature 137 — submit to BOTH the local validator (seals iff this node is
+            // on the roster) AND the peer-service fan-out (forwards to source peers for subscribed
+            // registers). This async/encrypted path previously skipped the fan-out, so a replica-
+            // origin encrypted submission never reached the register owner and never sealed.
+            var validatorTask = validatorClient.SubmitTransactionAsync(submission, ct);
+            var distributeTask = peerClient is null
+                ? Task.FromResult(new DistributeTransactionResult(0, 0, LocallyOwned: true))
+                : DistributeEncryptedSubmissionAsync(peerClient, workItem.RegisterId, submission, ct);
+            await Task.WhenAll(validatorTask, distributeTask);
+            var validatorResult = validatorTask.Result;
+            var distributeResult = distributeTask.Result;
+
+            _logger.LogInformation(
+                "Encrypted submission {TxId} for register {RegisterId}: validator success={ValidatorSuccess}, fan-out targets={Targets} accepted={Accepted} locallyOwned={Local}",
+                transaction.TxId, workItem.RegisterId, validatorResult.Success,
+                distributeResult.TargetPeerCount, distributeResult.AcceptedCount, distributeResult.LocallyOwned);
+
+            // Fail only when the local validator rejected AND no peer accepted the fan-out AND the
+            // register is not locally owned — a subscriber's local validator never seals (off-roster),
+            // so a peer-accepted submission is the success signal there.
+            if (!validatorResult.Success && distributeResult.AcceptedCount == 0 && !distributeResult.LocallyOwned)
             {
                 await HandleFailureAsync(operationId, workItem.SenderWallet,
-                    $"Validator rejected transaction: [{validatorResult.ErrorCode}] {validatorResult.ErrorMessage}",
+                    $"Validator rejected transaction: [{validatorResult.ErrorCode}] {validatorResult.ErrorMessage} — and no peer accepted the fan-out",
                     null, StepSubmitting,
                     notificationService, scope.ServiceProvider, workItem, ct);
                 return;
@@ -287,6 +310,35 @@ public sealed class EncryptionBackgroundService : BackgroundService
             op.StepName = stepName;
             op.PercentComplete = percent;
             await _operationStore.UpdateAsync(op);
+        }
+    }
+
+    /// <summary>
+    /// Feature 108 — fans an encrypted, signed submission out to the register's source peers so a
+    /// replica-origin submission reaches the owner for sealing. Mirrors
+    /// <c>ActionExecutionService.DistributeSubmissionAsync</c>: best-effort, never throws; a fan-out
+    /// failure degrades to validator-only (logged) rather than failing the operation.
+    /// </summary>
+    private async Task<DistributeTransactionResult> DistributeEncryptedSubmissionAsync(
+        IPeerServiceClient peerClient,
+        string registerId,
+        Sorcha.ServiceClients.Validator.TransactionSubmission submission,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var json = JsonSerializer.SerializeToUtf8Bytes(
+                submission,
+                new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            return await peerClient.DistributeTransactionAsync(registerId, json, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Feature 108 — peer fan-out errored for encrypted submission on register {RegisterId} " +
+                "(tx {TxId}); falling back to validator-only. Subscriber nodes depend on this path to reach the owner.",
+                registerId, submission.TransactionId);
+            return new DistributeTransactionResult(0, 0, LocallyOwned: false);
         }
     }
 

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceMirrorReconstructor.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceMirrorReconstructor.cs
@@ -10,10 +10,10 @@ using Microsoft.Extensions.Logging;
 
 using Sorcha.Blueprint.Service.Models;
 using Sorcha.Blueprint.Service.Storage;
+using Sorcha.Register.Core.Events;
+using Sorcha.ServiceClients.Events;
 using Sorcha.ServiceClients.Register;
 using Sorcha.ServiceClients.Wallet;
-
-using StackExchange.Redis;
 
 namespace Sorcha.Blueprint.Service.Services.Implementation;
 
@@ -48,59 +48,52 @@ namespace Sorcha.Blueprint.Service.Services.Implementation;
 /// </remarks>
 public sealed class InstanceMirrorReconstructor : BackgroundService
 {
-    private const string DocketConfirmedChannel = "docket:confirmed";
-
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IConnectionMultiplexer? _redis;
+    private readonly IEventSubscriber? _subscriber;
     private readonly InstanceMirrorReconstructorMetrics _metrics;
     private readonly ILogger<InstanceMirrorReconstructor> _logger;
-
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-    };
 
     public InstanceMirrorReconstructor(
         IServiceScopeFactory scopeFactory,
         InstanceMirrorReconstructorMetrics metrics,
         ILogger<InstanceMirrorReconstructor> logger,
-        IConnectionMultiplexer? redis = null)
+        IEventSubscriber? subscriber = null)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _redis = redis;
+        _subscriber = subscriber;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (_redis is null)
+        if (_subscriber is null)
         {
             _logger.LogWarning(
-                "InstanceMirrorReconstructor: Redis not available — cross-node instance mirroring is disabled. " +
-                "Feature 106 MyActions queries from a holder node will return empty until Redis is reachable.");
+                "InstanceMirrorReconstructor: event subscriber not available — cross-node instance mirroring is disabled. " +
+                "Feature 106 MyActions queries from a holder node will return empty until the event bus is reachable.");
             return;
         }
 
         _logger.LogInformation(
             "InstanceMirrorReconstructor starting — subscribing to {Channel}",
-            DocketConfirmedChannel);
+            RegisterEventChannels.DocketConfirmed);
 
         try
         {
-            var subscriber = _redis.GetSubscriber();
-            await subscriber.SubscribeAsync(
-                RedisChannel.Literal(DocketConfirmedChannel),
-                async (_, message) =>
+            // Subscribe via the Redis Streams IEventSubscriber — the SAME mechanism the Register
+            // Service publishes through (RedisStreamEventPublisher.StreamAddAsync). The previous raw
+            // _redis.GetSubscriber() pub/sub never received these events (the publisher uses Streams,
+            // not pub/sub channels), so the owner node never materialised a mirror for a replica-
+            // originated instance and the analyst had nothing to act on. Mirrors the working
+            // PresentationSealSubscriber pattern.
+            await _subscriber.SubscribeAsync<DocketConfirmedEvent>(
+                RegisterEventChannels.DocketConfirmed,
+                async evt =>
                 {
                     try
                     {
-                        await HandleDocketConfirmedAsync(message!, stoppingToken);
-                    }
-                    catch (JsonException ex)
-                    {
-                        _logger.LogWarning(ex,
-                            "InstanceMirrorReconstructor: malformed docket:confirmed event");
+                        await HandleDocketConfirmedAsync(evt, stoppingToken);
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
@@ -108,10 +101,11 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
                             "InstanceMirrorReconstructor: unexpected error processing docket:confirmed");
                         _metrics.RecordErrored();
                     }
-                });
+                },
+                stoppingToken);
 
             _logger.LogInformation(
-                "InstanceMirrorReconstructor subscribed to {Channel}", DocketConfirmedChannel);
+                "InstanceMirrorReconstructor subscribed to {Channel}", RegisterEventChannels.DocketConfirmed);
 
             await Task.Delay(Timeout.Infinite, stoppingToken);
         }
@@ -125,12 +119,11 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
         }
     }
 
-    private async Task HandleDocketConfirmedAsync(string message, CancellationToken ct)
+    private async Task HandleDocketConfirmedAsync(DocketConfirmedEvent evt, CancellationToken ct)
     {
         _metrics.RecordDocketObserved();
         var sw = Stopwatch.StartNew();
 
-        var evt = JsonSerializer.Deserialize<DocketConfirmedEvent>(message, JsonOptions);
         if (evt?.TransactionIds is null || evt.TransactionIds.Count == 0)
             return;
 
@@ -309,16 +302,4 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
         }
     }
 
-    /// <summary>
-    /// Shape of the <c>docket:confirmed</c> event payload published by
-    /// Register Service. Field names match
-    /// <see cref="TransactionLifecycleEventBridge"/> in Wallet Service.
-    /// </summary>
-    private sealed record DocketConfirmedEvent
-    {
-        public string RegisterId { get; init; } = string.Empty;
-        public ulong DocketId { get; init; }
-        public List<string> TransactionIds { get; init; } = [];
-        public string Hash { get; init; } = string.Empty;
-    }
 }

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceMirrorReconstructor.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceMirrorReconstructor.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
 using Sorcha.Register.Core.Events;
 using Sorcha.ServiceClients.Events;
@@ -131,6 +132,9 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
         var registerClient = scope.ServiceProvider.GetRequiredService<IRegisterServiceClient>();
         var walletClient = scope.ServiceProvider.GetRequiredService<IWalletServiceClient>();
         var instanceStore = scope.ServiceProvider.GetRequiredService<IInstanceStore>();
+        // Feature 137 — resolve the blueprint so the mirror's ParticipantWallets can be
+        // keyed by participant id (e.g. "citizen") rather than self-keyed by wallet address.
+        var actionResolver = scope.ServiceProvider.GetRequiredService<IActionResolverService>();
 
         foreach (var txId in evt.TransactionIds)
         {
@@ -139,7 +143,7 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
 
             try
             {
-                await InspectTransactionAsync(evt.RegisterId, txId, registerClient, walletClient, instanceStore, ct);
+                await InspectTransactionAsync(evt.RegisterId, txId, registerClient, walletClient, instanceStore, actionResolver, ct);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -160,6 +164,7 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
         IRegisterServiceClient registerClient,
         IWalletServiceClient walletClient,
         IInstanceStore instanceStore,
+        IActionResolverService actionResolver,
         CancellationToken ct)
     {
         var tx = await registerClient.GetTransactionAsync(registerId, txId, ct);
@@ -237,23 +242,49 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
             return;
         }
 
-        // Build (or refresh) the mirror row. The ParticipantWallets map is keyed by
-        // participant id, but from the tx alone we don't know the mapping — seed
-        // with the wallet addresses keyed by themselves so GetPendingActionsByWalletAsync
-        // can still match them. A richer blueprint-aware reconstruction can be
-        // bolted on later without changing the persistence shape.
+        // Feature 137 (option (b) from the former TODO) — resolve the blueprint on this
+        // node and map participant ids → wallets so the mirror's ParticipantWallets is
+        // STRUCTURALLY VALID, not just self-keyed by wallet address. Credential issuance
+        // on the owner node resolves the recipient by participant id
+        // (CredentialIssuanceConfig.RecipientParticipantId, e.g. "citizen"); a self-keyed
+        // mirror fails VAL_RUNTIME_CRED_001 even though the recipient wallet is known.
         //
-        // ⚠️ TODO(feature-106-follow-up): self-keying breaks role-based routing on
-        // the mirror. Any action dispatch that resolves by participant id instead
-        // of wallet address will fail to find the participant. Two options:
-        //   (a) thread participant ids through TransactionMetaData at write time
-        //       and read them here for a structurally valid mirror, or
-        //   (b) fetch the blueprint on this node and walk its participants to
-        //       reverse-map wallet → participant id when the blueprint has
-        //       pre-bound wallets.
-        // Acceptable for MVP because MyCredentials PENDING tab and the
-        // GetPendingActionsByWalletAsync query both match on wallet address
-        // directly. Tracked as a known gap in specs/106-register-native-credentials.
+        // The sender of THIS action binds its participant (action 1 sender = "citizen").
+        // The next action's sender binds the (single) recipient when known (next action
+        // sender = "verification-analyst"). Mappings accumulate across dockets, so by the
+        // time the analyst approves action 2 the mirror already carries "citizen" from
+        // action 1. Best-effort: on any resolution failure we fall back to self-keying.
+        var participantBindings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var bp = await actionResolver.GetBlueprintAsync(blueprintId, ct);
+            if (bp is not null)
+            {
+                if (tx.MetaData?.ActionId is uint senderActionId && !string.IsNullOrEmpty(tx.SenderWallet))
+                {
+                    var senderAction = actionResolver.GetActionDefinition(bp, senderActionId.ToString());
+                    if (senderAction is not null && !string.IsNullOrEmpty(senderAction.Sender))
+                        participantBindings[senderAction.Sender] = tx.SenderWallet;
+                }
+
+                if (tx.MetaData?.NextActionId is uint nextActionId)
+                {
+                    var nextActionDef = actionResolver.GetActionDefinition(bp, nextActionId.ToString());
+                    // The recipient (next actor) is every candidate that is not the sender.
+                    var recipientWallet = candidateWallets.FirstOrDefault(
+                        w => !string.Equals(w, tx.SenderWallet, StringComparison.OrdinalIgnoreCase));
+                    if (nextActionDef is not null && !string.IsNullOrEmpty(nextActionDef.Sender) && recipientWallet is not null)
+                        participantBindings[nextActionDef.Sender] = recipientWallet;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex,
+                "InstanceMirrorReconstructor: blueprint-aware participant resolution failed for {BlueprintId}; falling back to self-keying",
+                blueprintId);
+        }
+
         var nextAction = tx.MetaData?.NextActionId;
         var mirror = new Instance
         {
@@ -273,8 +304,15 @@ public sealed class InstanceMirrorReconstructor : BackgroundService
             IsReadOnlyMirror = true,
         };
 
-        // Merge newly-discovered local wallets into the participant map keyed by
-        // the wallet address (self-keyed) so the pending-actions query matches.
+        // Merge blueprint-resolved participant→wallet bindings (keyed by participant id).
+        // These are the authoritative entries credential issuance + role routing rely on.
+        foreach (var binding in participantBindings)
+        {
+            mirror.ParticipantWallets[binding.Key] = binding.Value;
+        }
+
+        // Fallback: self-key any local wallet we could not map to a participant id so the
+        // wallet-address-matching GetPendingActionsByWalletAsync query still resolves it.
         foreach (var wallet in localWallets)
         {
             if (!mirror.ParticipantWallets.ContainsValue(wallet))

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
@@ -658,6 +658,17 @@ public class BuiltTransaction
         if (Metadata.TryGetValue(Sorcha.Blueprint.Service.Services.Implementation.PresentationMetadataKeys.ConsumerName, out var consumer) && consumer is not null)
             submissionMetadata[Sorcha.Blueprint.Service.Services.Implementation.PresentationMetadataKeys.ConsumerName] = consumer.ToString()!;
 
+        // Feature 137 (C5) — propagate the Blueprint Service's resolved next-action id onto
+        // the submission so DocketBuildTriggerService.ResolveNextActionId can project it onto
+        // the sealed TransactionMetaData.NextActionId. The cross-node InstanceMirrorReconstructor
+        // reads that value to seed a mirror's CurrentActionIds; without it the analyst on the
+        // owner node has a mirror with no current action ("Action N is not a current action").
+        // submissionMetadata is a whitelist — the key MUST be copied explicitly here or it is
+        // silently dropped (it was, end-to-end, until this fix). ActionExecutionService and
+        // EncryptionBackgroundService both set Metadata["nextActionId"] before calling this.
+        if (Metadata.TryGetValue("nextActionId", out var nextActionId) && nextActionId is not null)
+            submissionMetadata["nextActionId"] = nextActionId.ToString()!;
+
         return new TransactionSubmission
         {
             TransactionId = TxId,

--- a/src/Services/Sorcha.Peer.Service/Communication/RelayCommunicationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Communication/RelayCommunicationService.cs
@@ -424,17 +424,37 @@ public class RelayCommunicationService
     /// </summary>
     private string? GetSeedNodeAddress()
     {
+        // Source the address from the SAME seed-endpoint configuration the connection pool uses to
+        // reach the seed (PeerConnectionPool.BootstrapFromSeedNodesAsync → seed.GrpcChannelAddress),
+        // so the reverse stream dials the identical scheme + gRPC port (e.g. https://host:50051).
+        // The previous implementation reconstructed the address from the PeerNode list, which had
+        // dropped the seed's TLS flag AND its gRPC port — it prepended "https://" but no port, so the
+        // stream hit the seed's web vhost (:443) where PeerCommunication/Stream 404s. That marked the
+        // seed "not alive" and silently disabled cross-node transaction fan-out.
+        var seed = _configuration.SeedNodes?.SeedNodes?
+            .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s.Hostname));
+        if (seed is not null)
+        {
+            return seed.GrpcChannelAddress;
+        }
+
+        // Legacy fallback: a seed peer discovered into the peer list (carries no TLS flag — assume
+        // plaintext h2c with the explicit gRPC port, matching the other outbound peer paths).
         foreach (var peer in _peerListManager.GetAllPeers())
         {
             if (peer.IsSeedNode && !string.IsNullOrEmpty(peer.Address))
             {
-                var scheme = peer.Address.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                    ? "" : "https://";
-                return $"{scheme}{peer.Address}";
+                if (peer.Address.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    return peer.Address;
+                }
+                return peer.Port > 0
+                    ? $"http://{peer.Address}:{peer.Port}"
+                    : $"http://{peer.Address}";
             }
         }
 
-        // Fall back to seed channel from connection pool to get the address
+        // Last resort: the active seed channel from the connection pool.
         var seedChannel = GetSeedChannel();
         return seedChannel?.Target;
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ResolveCarriedHolderKeysTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ResolveCarriedHolderKeysTests.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Sorcha.Blueprint.Service.Services.Implementation;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ActionExecutionService.ResolveCarriedHolderKeys"/> — the Feature 137
+/// extractor that reads the citizen's carried delivery keys (written by a <c>sorcha-holder-key</c>
+/// form field) from reconstructed instance state. Verifies the holder JWK is returned as a
+/// <see cref="JsonElement"/>, the sibling encryption key + algorithm are derived from the same
+/// parent object, and missing/empty segments collapse to null.
+/// </summary>
+public class ResolveCarriedHolderKeysTests
+{
+    private static Dictionary<string, object> Merged(string holderKeysJson)
+    {
+        // Mirror reconstructed state: the action payload spread at root, holderKeys a JsonElement.
+        var element = JsonSerializer.Deserialize<JsonElement>(holderKeysJson);
+        return new Dictionary<string, object> { ["holderKeys"] = element };
+    }
+
+    [Fact]
+    public void ResolvesHolderJwk_EncryptionKey_AndAlgorithm_FromSiblings()
+    {
+        var merged = Merged("""
+            {
+              "holderJwk": { "kty": "EC", "crv": "P-256", "x": "AAA", "y": "BBB" },
+              "encryptionPublicKey": "QkFTRTY0S0VZ",
+              "algorithm": "ED25519"
+            }
+            """);
+
+        var (holderJwk, encKey, algorithm) =
+            ActionExecutionService.ResolveCarriedHolderKeys(merged, "/holderKeys/holderJwk");
+
+        holderJwk.Should().NotBeNull();
+        holderJwk!.Value.GetProperty("kty").GetString().Should().Be("EC");
+        holderJwk.Value.GetProperty("crv").GetString().Should().Be("P-256");
+        encKey.Should().Be("QkFTRTY0S0VZ");
+        algorithm.Should().Be("ED25519");
+    }
+
+    [Fact]
+    public void MissingHolderKeysObject_ReturnsAllNull()
+    {
+        var merged = new Dictionary<string, object>
+        {
+            ["name"] = JsonSerializer.Deserialize<JsonElement>("""{ "givenName": "Alice" }""")
+        };
+
+        var (holderJwk, encKey, algorithm) =
+            ActionExecutionService.ResolveCarriedHolderKeys(merged, "/holderKeys/holderJwk");
+
+        holderJwk.Should().BeNull();
+        encKey.Should().BeNull();
+        algorithm.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmptySiblingStrings_CollapseToNull()
+    {
+        var merged = Merged("""
+            {
+              "holderJwk": { "kty": "OKP", "crv": "Ed25519", "x": "ZZZ" },
+              "encryptionPublicKey": "",
+              "algorithm": "   "
+            }
+            """);
+
+        var (holderJwk, encKey, algorithm) =
+            ActionExecutionService.ResolveCarriedHolderKeys(merged, "/holderKeys/holderJwk");
+
+        holderJwk.Should().NotBeNull();
+        encKey.Should().BeNull();
+        algorithm.Should().BeNull();
+    }
+
+    [Fact]
+    public void MissingHolderJwk_ButPresentEncryptionKey_ReturnsNullJwk()
+    {
+        // FR-014 fail-closed precondition: an opted-in blueprint with no holder JWK must be
+        // detectable by the caller (holderJwk == null) so it can refuse to issue an unbound credential.
+        var merged = Merged("""
+            {
+              "encryptionPublicKey": "QkFTRTY0",
+              "algorithm": "NISTP256"
+            }
+            """);
+
+        var (holderJwk, encKey, algorithm) =
+            ActionExecutionService.ResolveCarriedHolderKeys(merged, "/holderKeys/holderJwk");
+
+        holderJwk.Should().BeNull();
+        encKey.Should().Be("QkFTRTY0");
+        algorithm.Should().Be("NISTP256");
+    }
+}

--- a/walkthroughs/AssuredIdentity/approve-crossnode-n1.ps1
+++ b/walkthroughs/AssuredIdentity/approve-crossnode-n1.ps1
@@ -1,0 +1,35 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Feature 137 Tier-2 — analyst (on n1, the register OWNER) approves Action 2 of a
+# cross-node instance whose mirror was materialised by InstanceMirrorReconstructor
+# from the replica-origin docket. Reads crossnode-state.json for the instance id.
+$ErrorActionPreference = "Stop"
+Import-Module (Join-Path $PSScriptRoot "../modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force
+
+$state   = Get-Content (Join-Path $PSScriptRoot "crossnode-state.json") -Raw | ConvertFrom-Json
+$st      = Get-Content (Join-Path $PSScriptRoot "state.json") -Raw | ConvertFrom-Json
+$n1      = "https://n1.sorcha.dev"
+$api     = "$n1/api"
+$instanceId = $state.instanceId
+$registerId = $state.registerId
+$blueprintId = $state.blueprintId
+$analystEmail  = $st.roles.verificationAnalyst.email
+$analystPw     = $st.roles.verificationAnalyst.password
+$analystOrg    = $st.roles.verificationAnalyst.organizationId
+$analystWallet = $st.roles.verificationAnalyst.walletAddress
+
+Write-Host "== Analyst login on n1 ($analystEmail) =="
+$analyst = Connect-SorchaUser -TenantUrl $api -Email $analystEmail -Password $analystPw -OrganizationId $analystOrg
+
+Write-Host "== GET instance $instanceId from n1 (mirror) =="
+try {
+    $inst = Invoke-SorchaApi -Method GET -Uri "$api/instances/$instanceId" -Headers $analyst.Headers
+    Write-Host "  state=$($inst.state) currentActionIds=$($inst.currentActionIds -join ',') isReadOnlyMirror=$($inst.isReadOnlyMirror)"
+} catch { Write-Host "  GET instance failed: $($_.Exception.Message)" }
+
+Write-Host "== Approve Action 2 (decision=approved) against n1 =="
+$resp = Invoke-SorchaAction `
+    -BlueprintUrl $api -InstanceId $instanceId -ActionId "2" -BlueprintId $blueprintId `
+    -SenderWallet $analystWallet -RegisterId $registerId -Token $analyst.Token `
+    -PayloadData @{ decision = "approved"; verificationNotes = "Cross-node identity verified." }
+Write-Host "  approve response: $($resp | ConvertTo-Json -Compress -Depth 5)"

--- a/walkthroughs/AssuredIdentity/run-crossnode-local.ps1
+++ b/walkthroughs/AssuredIdentity/run-crossnode-local.ps1
@@ -4,6 +4,14 @@
 # register OWNED BY n1 (replicated to this SyncOnly node). The submission fans
 # out to n1 for sealing. Run AFTER local is up as a SyncOnly replica, subscribed
 # to the n1 register, with the F137 blueprint recovered.
+#
+# NOTE: each citizen wallet has a per-register sequence space tracked by the
+# OWNER (n1). Re-running with the same citizen reuses a burned sequence number
+# and n1 rejects it (VAL_REPLAY_002). Pass -CitizenEmail with a fresh value to
+# get a fresh wallet / sequence space.
+param(
+    [string]$CitizenEmail = "citizen.crossnode@local.node"
+)
 
 $ErrorActionPreference = "Stop"
 Import-Module (Join-Path $PSScriptRoot "../modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force
@@ -16,7 +24,7 @@ $publicOrgId = "00000000-0000-0000-0000-000000000002"
 $sysOrgId    = "00000000-0000-0000-0000-000000000001"
 $registerId  = "deccbf4dc9ad4edebe5d6a3651da80b9"
 $blueprintId = "assured-identity-20260524151245"
-$citizenEmail = "citizen.crossnode@local.node"
+$citizenEmail = $CitizenEmail
 $pw          = "Dev_Pass_2025!"
 
 Write-Host "== Step 1: sysadmin login (local) =="

--- a/walkthroughs/AssuredIdentity/run-crossnode-local.ps1
+++ b/walkthroughs/AssuredIdentity/run-crossnode-local.ps1
@@ -1,0 +1,77 @@
+#!/usr/bin/env pwsh
+# SPDX-License-Identifier: MIT
+# Feature 137 Tier-2 — local citizen submits AssuredIdentity action 1 against a
+# register OWNED BY n1 (replicated to this SyncOnly node). The submission fans
+# out to n1 for sealing. Run AFTER local is up as a SyncOnly replica, subscribed
+# to the n1 register, with the F137 blueprint recovered.
+
+$ErrorActionPreference = "Stop"
+Import-Module (Join-Path $PSScriptRoot "../modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force
+
+$gw          = "http://localhost"
+$tenantUrl   = "$gw/api"
+$walletUrl   = "$gw/api"
+$blueprintUrl= "$gw/api"
+$publicOrgId = "00000000-0000-0000-0000-000000000002"
+$sysOrgId    = "00000000-0000-0000-0000-000000000001"
+$registerId  = "deccbf4dc9ad4edebe5d6a3651da80b9"
+$blueprintId = "assured-identity-20260524151245"
+$citizenEmail = "citizen.crossnode@local.node"
+$pw          = "Dev_Pass_2025!"
+
+Write-Host "== Step 1: sysadmin login (local) =="
+$admin = Connect-SorchaUser -TenantUrl $tenantUrl -Email "admin@local.node" -Password $pw -OrganizationId $sysOrgId
+
+Write-Host "== Step 2: register + verify local citizen =="
+try { Register-SorchaPublicUser -TenantUrl $tenantUrl -Email $citizenEmail -Password $pw -DisplayName "Cross Node Citizen" | Out-Null } catch { Write-Host "  register: $($_.Exception.Message)" }
+$users = Invoke-SorchaApi -Method GET -Uri "$tenantUrl/organizations/$publicOrgId/users?includeInactive=true" -Headers $admin.Headers
+$cu = $users.users | Where-Object { $_.email -eq $citizenEmail } | Select-Object -First 1
+if ($cu) { Confirm-SorchaUserEmail -TenantUrl $tenantUrl -OrganizationId $publicOrgId -UserId $cu.id -Headers $admin.Headers; Write-Host "  verified $citizenEmail" }
+
+Write-Host "== Step 3: citizen login (consumer) =="
+$cit = Connect-SorchaUser -TenantUrl $tenantUrl -Email $citizenEmail -Password $pw -OrganizationId $publicOrgId
+Write-Host "  citizen token acquired"
+
+Write-Host "== Step 4: create citizen wallet =="
+$wallet = New-SorchaWallet -WalletUrl $walletUrl -Name "Cross Node Citizen Wallet" -Headers $cit.Headers -FetchPublicKey
+Write-Host "  wallet: $($wallet.Address)"
+
+Write-Host "== Step 4b: register citizen participant (wallet-ownership check; late-bound to the open slot) =="
+try {
+    $null = Register-SorchaParticipant -TenantUrl $tenantUrl -WalletUrl $walletUrl -OrganizationId $publicOrgId -WalletAddress $wallet.Address -DisplayName "Cross Node Citizen" -Headers $cit.Headers
+    Write-Host "  participant registered in public org"
+} catch { Write-Host "  participant register: $($_.Exception.Message)" }
+
+Write-Host "== Step 5: re-login (pick up wallet_address claim) + fetch holder-keys (F137) =="
+$cit = Connect-SorchaUser -TenantUrl $tenantUrl -Email $citizenEmail -Password $pw -OrganizationId $publicOrgId
+$holderKeys = Invoke-SorchaApi -Method GET -Uri "$walletUrl/v1/wallet/holder-keys" -Headers $cit.Headers
+Write-Host "  holder-keys: alg=$($holderKeys.algorithm) wallet=$($holderKeys.walletAddress)"
+
+Write-Host "== Step 6: create instance from REPLICATED blueprint (owned by n1) =="
+$instance = Invoke-SorchaApi -Method POST -Uri "$blueprintUrl/instances/" -Headers $cit.Headers -Body @{
+    blueprintId = $blueprintId
+    registerId  = $registerId
+    tenantId    = $publicOrgId
+    metadata    = @{ source = "crossnode-tier2" }
+}
+$instanceId = $instance.id
+Write-Host "  instance: $instanceId"
+
+Write-Host "== Step 7: submit Action 1 (with holderKeys) — fans out to n1 =="
+$payload = @{
+    name    = @{ givenName = "Alex"; middleName = "Morgan"; familyName = "MacLeod"; fullName = "Alex Morgan MacLeod" }
+    dob     = @{ dateOfBirth = "1990-06-21" }
+    email   = @{ email = $citizenEmail }
+    address = @{ line1 = "12 Castle Street"; town = "Edinburgh"; region = "Lothian"; postcode = "EH1 2DU"; country = "Scotland" }
+    holderKeys = @{ holderJwk = $holderKeys.holderJwk; encryptionPublicKey = $holderKeys.encryptionPublicKey; algorithm = $holderKeys.algorithm }
+}
+$resp = Invoke-SorchaAction -BlueprintUrl $blueprintUrl -InstanceId $instanceId -ActionId "1" -BlueprintId $blueprintId -SenderWallet $wallet.Address -RegisterId $registerId -Token $cit.Token -PayloadData $payload
+Write-Host "  submit response: $($resp | ConvertTo-Json -Compress -Depth 4)"
+
+# Persist for the analyst-approve + delivery-poll steps
+@{
+    instanceId = $instanceId; registerId = $registerId; blueprintId = $blueprintId
+    citizenWallet = $wallet.Address; citizenEmail = $citizenEmail
+    txId = ($resp.transactionId ?? $resp.txId)
+} | ConvertTo-Json | Set-Content -Path (Join-Path $PSScriptRoot "crossnode-state.json")
+Write-Host "== DONE. instance=$instanceId tx=$($resp.transactionId ?? $resp.txId) =="


### PR DESCRIPTION
The Tier-2 live run surfaced the remaining gaps that stopped a replica-origin
submission from sealing on the owner (n1):

- Peer relay address (RelayCommunicationService.GetSeedNodeAddress): prepended
  "https://" but dropped the gRPC port, so the reverse stream hit the seed's web
  vhost (:443) and 404'd → seed marked "not alive". Now sourced from the same
  seed-endpoint config the connection pool uses (scheme + port honoured).
- Async/encrypted submission path (EncryptionBackgroundService) never fanned out
  to peers — only the synchronous ActionExecutionService path did. Added the
  Feature 108 distribute (concurrent with the validator submit) + the tolerant
  failure check (a subscriber's local validator never seals, so a peer-accepted
  submission is the success signal). This is what lets a citizen on a replica
  reach the owner: verified live — n1 sealed the local-origin tx into a docket.
- peer-service was missing ServiceClients__ValidatorService__Address, so the
  fan-out RECEIVER (owner) rejected forwarded submissions ("Validator Service
  address not configured"). Added to docker-compose.yml.
- .env.example completeness: added the 12 documented-but-absent variables —
  notably SEED_PEER_ENABLE_TLS (the seed TLS scheme, critical for cross-node
  sync), plus email, OpenTelemetry, OpenAPI-auth, deployment, and the missing
  port overrides. Every ${VAR} the compose files reference is now documented.

Also adds the C3 ResolveCarriedHolderKeys unit test (missed from #835) and the
run-crossnode-local.ps1 Tier-2 verification helper.
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
