### PR TITLE
fix/137 mirror advance and resync cadence

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
@@ -464,10 +464,24 @@ public sealed class EncryptionBackgroundService : BackgroundService
             instance.CompletedAt = DateTimeOffset.UtcNow;
         }
 
-        await instanceStore.UpdateAsync(instance, ct);
+        // Feature 137 (C5): on the register-OWNING node a cross-node workflow surfaces as a
+        // read-only mirror row (the owner never ran CreateInstance), yet the owner MUST advance it
+        // when its own participant acts (e.g. the verification-analyst's credential issuance).
+        // IInstanceStore.UpdateAsync rejects mirror rows by design (Feature 106), so route the
+        // advance through the mirror-safe writer — mirroring the inline path's PersistInstanceAsync.
+        // Without this the async-encrypted issuance sealed the credential but threw here, leaving the
+        // owner's mirror stuck at the issuing action (the citizen's claim action never surfaced on n1).
+        if (instance.IsReadOnlyMirror)
+        {
+            await instanceStore.UpdateMirrorAsync(instance, ct);
+        }
+        else
+        {
+            await instanceStore.UpdateAsync(instance, ct);
+        }
         _logger.LogInformation(
-            "Instance {InstanceId} advanced after encrypted action {ActionId}. Next actions: [{NextActions}]",
-            workItem.InstanceId, workItem.ActionId,
+            "Instance {InstanceId} advanced after encrypted action {ActionId} (mirror={IsMirror}). Next actions: [{NextActions}]",
+            workItem.InstanceId, workItem.ActionId, instance.IsReadOnlyMirror,
             string.Join(", ", instance.CurrentActionIds));
 
         // B-15 — notify the next-action participants and emit workflow-complete

--- a/src/Services/Sorcha.Peer.Service/Core/RegisterSyncConfiguration.cs
+++ b/src/Services/Sorcha.Peer.Service/Core/RegisterSyncConfiguration.cs
@@ -11,10 +11,13 @@ namespace Sorcha.Peer.Service.Core;
 public class RegisterSyncConfiguration
 {
     /// <summary>
-    /// Periodic sync interval in minutes (default: 5 minutes)
+    /// Periodic sync interval in seconds (default: 90s). Drives the RegisterSyncBackgroundService
+    /// re-pull loop — the upper bound on how long a fully-replicated subscriber lags the owner
+    /// before its incremental re-pull catches a freshly-sealed docket (e.g. a cross-node credential
+    /// delivery). Tightened from the former 5-minute cadence so replication-back is timely.
     /// </summary>
-    [Range(1, 60)]
-    public int PeriodicSyncIntervalMinutes { get; set; } = 5;
+    [Range(20, 3600)]
+    public int PeriodicSyncIntervalSeconds { get; set; } = 90;
 
     /// <summary>
     /// Heartbeat interval in seconds (default: 30 seconds)
@@ -77,8 +80,10 @@ public class RegisterSyncConfiguration
     public int ReplicationTimeoutMinutes { get; set; } = 30;
 
     /// <summary>
-    /// Interval in seconds for periodic relay sync polling of NAT'd peers (default: 60 seconds)
+    /// Interval in seconds for periodic relay sync polling of NAT'd peers (default: 20 seconds).
+    /// Tightened from 60s so a NAT'd subscriber (e.g. the local replica behind Caddy) pulls
+    /// freshly-sealed dockets from the seed quickly rather than lagging up to a minute.
     /// </summary>
     [Range(10, 300)]
-    public int RelayPollIntervalSeconds { get; set; } = 60;
+    public int RelayPollIntervalSeconds { get; set; } = 20;
 }

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -76,7 +76,7 @@ public class RegisterSyncBackgroundService : BackgroundService
         // Load existing subscriptions from database
         await LoadSubscriptionsAsync(stoppingToken);
 
-        var periodicInterval = TimeSpan.FromMinutes(_syncConfig.PeriodicSyncIntervalMinutes);
+        var periodicInterval = TimeSpan.FromSeconds(_syncConfig.PeriodicSyncIntervalSeconds);
 
         // Establish reverse stream to seed node before processing subscriptions
         Task? reverseStreamTask = null;

--- a/src/Services/Sorcha.Peer.Service/appsettings.json
+++ b/src/Services/Sorcha.Peer.Service/appsettings.json
@@ -65,7 +65,8 @@
       "EnableCompression": true
     },
     "RegisterSync": {
-      "PeriodicSyncIntervalMinutes": 5,
+      "PeriodicSyncIntervalSeconds": 90,
+      "RelayPollIntervalSeconds": 20,
       "HeartbeatIntervalSeconds": 30,
       "HeartbeatTimeoutSeconds": 30,
       "MaxRetryAttempts": 10,

--- a/tests/Sorcha.Peer.Service.Tests/Core/RegisterSyncConfigurationTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Core/RegisterSyncConfigurationTests.cs
@@ -13,7 +13,8 @@ public class RegisterSyncConfigurationTests
     {
         var config = new RegisterSyncConfiguration();
 
-        config.PeriodicSyncIntervalMinutes.Should().Be(5);
+        config.PeriodicSyncIntervalSeconds.Should().Be(90);
+        config.RelayPollIntervalSeconds.Should().Be(20);
         config.HeartbeatIntervalSeconds.Should().Be(30);
         config.HeartbeatTimeoutSeconds.Should().Be(30);
         config.MaxRetryAttempts.Should().Be(10);
@@ -28,13 +29,13 @@ public class RegisterSyncConfigurationTests
     {
         var config = new RegisterSyncConfiguration
         {
-            PeriodicSyncIntervalMinutes = 10,
+            PeriodicSyncIntervalSeconds = 120,
             HeartbeatIntervalSeconds = 60,
             MaxConcurrentDocketPulls = 5,
             DocketPullBatchSize = 500
         };
 
-        config.PeriodicSyncIntervalMinutes.Should().Be(10);
+        config.PeriodicSyncIntervalSeconds.Should().Be(120);
         config.HeartbeatIntervalSeconds.Should().Be(60);
         config.MaxConcurrentDocketPulls.Should().Be(5);
         config.DocketPullBatchSize.Should().Be(500);

--- a/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSyncBackgroundServiceTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSyncBackgroundServiceTests.cs
@@ -29,7 +29,7 @@ public class RegisterSyncBackgroundServiceTests : IDisposable
             NodeId = "test-node",
             RegisterSync = new RegisterSyncConfiguration
             {
-                PeriodicSyncIntervalMinutes = 1,
+                PeriodicSyncIntervalSeconds = 60,
                 MaxRetryAttempts = 3
             },
             PeerDiscovery = new PeerDiscoveryConfiguration(),
@@ -270,7 +270,7 @@ public class RegisterSyncBackgroundServiceRelayTests : IAsyncDisposable
             NodeId = "test-node",
             RegisterSync = new RegisterSyncConfiguration
             {
-                PeriodicSyncIntervalMinutes = 1,
+                PeriodicSyncIntervalSeconds = 60,
                 MaxRetryAttempts = 3,
                 RelayPollIntervalSeconds = 10
             },
@@ -386,7 +386,7 @@ public class RegisterSyncBackgroundServiceWithDbTests : IDisposable
             NodeId = "test-node",
             RegisterSync = new RegisterSyncConfiguration
             {
-                PeriodicSyncIntervalMinutes = 1,
+                PeriodicSyncIntervalSeconds = 60,
                 MaxRetryAttempts = 3
             },
             PeerDiscovery = new PeerDiscoveryConfiguration(),


### PR DESCRIPTION
- **fix: [137] async encrypted path advances an owner-side read-only mirror**
- **perf: [137] tighten cross-node resync cadence (5min/60s -> 90s/20s)**
