### PR TITLE
feat: [138] federation trust hardening — verifier-side (US1, US4, US5 + foundation)

### DIFF
--- a/.specify/tasks/deferred-tasks.md
+++ b/.specify/tasks/deferred-tasks.md
@@ -238,12 +238,35 @@
 |----|------|----------|--------|--------|-------|
 | F137-X1 | Owner-side state reconstruction must decrypt the disclosure-group payload format | P2 | 8h | 📋 | **GitHub #838.** `StateReconstructionService.DecryptTransactionPayloadAsync` uses a legacy `WalletAccess` + whole-`Data` path; the stored payload is disclosure-group format (`encryptedPayloads[]` + per-group `Challenges`) → recovers 0 actions cross-node → `mergedData` empty → issuance fails `VAL_RUNTIME_CRED_004` (and would have empty credential claims too — the claims come from the same decrypted action-1 payload). Fix: reuse the canonical recipient decryptor `InboundCredentialDetector.TryDecryptGroupForWalletAsync` (walk encryptedPayloads → unwrap the acting wallet's challenge → symmetric-decrypt). Analyst is disclosed `/*` on action 1 and `ReconstructAsync` already holds the analyst delegation token. General fix: repairs cross-node prior-action reconstruction for ANY multi-action flow. Matches FR-013. Do NOT carry the keys in public tx metadata (dead end — claims still missing). |
 | F137-X2 | Verify direction 2 (local-owned register, n1 citizen) end-to-end | P2 | 2h | 📋 | Gated on F137-X1. Same delivery path; once X1 lands, run the reverse direction to confirm symmetry. |
+## Permissionless Validation — Open-Membership Consensus (Backlog)
+
+> **Context:** Red-team threat-model (2026-05-24) of a hardened v1, framed around "anyone can run a node." The analysis split into two features. The **federation hardening** feature (`specs/138-*`) makes the *permissioned-federation* model safe: validation is gated by an on-chain roster you control, peer participation is open but signed/authenticated, and the trust anchors that are currently soft (revocation list signature, peer advertisement provenance, blueprint-recovery provenance) get fixed. This backlog item is the **second** feature — making validation safe when admission to the validator set is *itself* open to anyone, with no roster gatekeeper.
+>
+> **Why it's separate, not just "more of 138":** Federation hardening assumes a *known, bounded* validator set whose misbehaviour can be punished by ejection from a roster you administer. Permissionless validation removes that assumption — admission is free, so identity is cheap (Sybil), and ejection is meaningless (re-register for nothing). Safety must then come from *economic* cost (bonded stake, slashing of real collateral) and Sybil-resistant consensus, which is a fundamentally different and larger design than roster governance.
+>
+> **Decision (2026-05-24):** Do federation first (`138`); backlog permissionless. The federation feature deliberately builds the primitives this depends on — an **on-chain roster as the sole vote-authority anchor** and **automatic, deterministic equivocation detection** — so that "swap roster-admission for stake-admission, swap roster-ejection for collateral-slashing" becomes the shape of this feature rather than a rewrite. Related existing items: `ADV-2` (Advanced consensus), `TRUST-6` (Consensus Finality Guarantees).
+
+| ID | Area | Priority | Impact | Status | Description |
+|----|------|----------|--------|--------|-------------|
+| PERM-1 | Sybil-resistant validator admission | P3 | High | 🔬 Research | Replace federation's roster-allowlist admission with a permissionless mechanism that makes validator identity *costly*: bonded stake / collateral deposit, proof-of-authority-at-scale, or equivalent. Admission record sealed on-chain (extends 138's on-chain roster). The cost-to-create-an-identity is the whole Sybil defence. |
+| PERM-2 | Bonded collateral + economic slashing | P3 | High | 🔬 Research | Federation punishes detected equivocation/withholding by roster ejection (138). Permissionless needs *financial* consequence: bonded collateral that is slashed automatically on a sealed proof-of-misbehaviour. Requires a stake/escrow primitive and an on-chain slashing transaction type. Depends on 138's deterministic equivocation detection. |
+| PERM-3 | Majority-collusion resistance under free admission | P3 | High | 🔬 Research | When admission is free, an attacker can cheaply approach quorum. Model the honest-majority assumption explicitly, choose a BFT threshold (≥2/3) with finality depth (ties to `TRUST-6`), and analyse the cost of a 1/3 / 1/2 / 2/3 attack given the PERM-1 admission cost. Output: a stated, quantified security margin rather than "assume most validators are honest." |
+| PERM-4 | Eclipse resistance without trusted seeds | P3 | Medium | 🔬 Research | Federation leans on operator-controlled seed nodes as the eclipse anchor (acceptable when you run them). Permissionless can't trust seeds. Needs diverse/authenticated peer selection (signed node identities from 138 + DHT-style or stake-weighted neighbour selection) so a victim node can't be surrounded by attacker-controlled peers cheaply. |
+| PERM-5 | Validator key liveness & rotation under open membership | P3 | Medium | 🔬 Research | Open validators join/leave continuously. Needs on-chain key rotation, graceful exit (unbonding period before collateral release), and liveness proofs so a withholding validator's stake can be slashed after a sealed timeout proof. Ties to `WALLET-R4` (key rotation) and `TRUST-9` (timestamp authority for the timeout proof). |
+
+### Priority Rationale
+
+| Tier | IDs | Rationale |
+|------|-----|-----------|
+| **Tier 1 — Sybil + economic core** | PERM-1, PERM-2 | The two primitives that make open admission safe at all: costly identity and slashable collateral. Everything else assumes these exist. |
+| **Tier 2 — Consensus safety margin** | PERM-3, PERM-4 | Quantified attack-cost analysis and eclipse resistance once admission is open. Depends on the Tier 1 cost mechanisms. |
+| **Tier 3 — Operational lifecycle** | PERM-5 | Join/leave/rotate/unbond lifecycle under continuous open membership. Important for a live permissionless network, not for the initial design. |
 
 ---
 
 ## Summary
 
-**Total Deferred Tasks:** 69 (11 now completed/implemented)
+**Total Deferred Tasks:** 74 (11 now completed/implemented)
 **Total Deferred Effort:** 588+ hours (~15 weeks, excluding research items)
 
 These tasks represent features that enhance the platform but are not critical for the Minimum Viable Deliverable (MVD). They can be prioritized for post-MVD development based on user feedback and business requirements.

--- a/specs/138-federation-trust-hardening/EXECUTION.md
+++ b/specs/138-federation-trust-hardening/EXECUTION.md
@@ -1,0 +1,109 @@
+# Execution Guide: Feature 138 — Federation Trust Hardening
+
+**Purpose**: How to pick up and execute this feature on a **different machine**. Everything needed travels in this branch — the SpecKit artifacts are committed, so a fresh clone has the full context.
+
+---
+
+## 1. Prerequisites on the new machine
+
+- **.NET 10 SDK** and **Docker Desktop** (running).
+- **Claude Code** with the SpecKit skills available (the `/speckit.*` commands) and this repo's `.specify/` toolchain (already in the repo).
+- Git access to `github.com/Sorcha-Platform/Sorcha`.
+
+```bash
+git clone https://github.com/Sorcha-Platform/Sorcha.git
+cd Sorcha
+git fetch origin
+git checkout 138-federation-trust-hardening   # the branch carries spec + plan + tasks
+dotnet restore
+docker-compose up -d                            # full local stack (or: dotnet run --project src/Apps/Sorcha.AppHost)
+```
+
+> PowerShell 7+ (`pwsh`) on Windows; the `.specify` scripts are under `.specify/scripts/powershell/`.
+
+---
+
+## 2. What's already in this branch
+
+```
+specs/138-federation-trust-hardening/
+├── spec.md            # WHAT + WHY: 6 user stories (US1-3 P1, US4-5 P2, US6 P3), 22 FRs, 8 success criteria
+├── plan.md            # HOW (high level): tech context, constitution check, per-US source files, build sequence
+├── research.md        # Grounded decisions per story + current-code file:line integration seams
+├── data-model.md      # Entities + fail-closed state transitions
+├── contracts/         # Proto changes, control-tx action types, verifier contract, config keys + metrics
+├── quickstart.md      # Adversarial validation per story (the acceptance bar)
+├── tasks.md           # 72 ordered tasks, grouped by story  ← the execution checklist
+├── checklists/requirements.md
+└── EXECUTION.md       # this file
+```
+
+**Read order on arrival**: `spec.md` → `plan.md` → `tasks.md`. Pull `research.md` / `contracts/` on demand while implementing (they carry the exact file:line seams).
+
+---
+
+## 3. How to execute
+
+### Option A — guided by Claude Code (recommended)
+
+From the repo root on the new machine, in Claude Code:
+
+```
+/speckit.implement
+```
+
+This reads `tasks.md` and executes tasks in order, respecting the phase gates. Optionally run `/speckit.analyze` first for a cross-artifact consistency check (spec ↔ plan ↔ tasks) before implementing.
+
+### Option B — manual, task by task
+
+Work `tasks.md` top to bottom. The hard rules:
+
+1. **Phase 1 (Setup T001–T002)** then **Phase 2 (Foundational T003–T004)** must complete before the dependent stories.
+2. **Tests first**: each story lists its negative tests before implementation — write them, watch them **fail**, then implement until green. This is the FR-021 / SC-008 gate (prove the forged/unsigned/replayed variant is rejected).
+3. **Build order = priority**: **US1 is the MVP** (revocation-forgery, verifier-only, smallest blast radius). Then US2, US3 (the P1 wave), then US4, US5 (P2), US6 (P3).
+4. **Stop at each checkpoint** and run that story's `quickstart.md` section to validate it independently before moving on.
+
+### MVP-only path (if time-boxed)
+
+`Setup → T003 → US1 (T005–T016) → validate quickstart US1 → ship`. That alone closes the highest-value, lowest-effort gap.
+
+---
+
+## 4. Parallelization (multi-dev or multi-agent)
+
+After Phase 2, the six stories are independent and can run in parallel:
+
+| Owner | Story | Service surface | Tasks |
+|-------|-------|-----------------|-------|
+| Dev A | US1 + US5 | `Sorcha.Verifier.Engine` | T005–T016, T056–T061 |
+| Dev B | US2 | `Sorcha.Peer.Service` | T017–T034 |
+| Dev C | US3 | `Sorcha.Validator.Service` + `Register.Models` | T035–T049 |
+| Dev D | US4 + US6 | `Sorcha.Blueprint.Service` (+ `Tenant.Service`) | T050–T055, T062–T066 |
+
+US3 is the largest slice (15 tasks) — weight staffing there. `[P]`-marked tasks within a story (distinct files) also parallelize.
+
+---
+
+## 5. Project-specific gotchas (carry these)
+
+- **EF migrations (T026)**: set `$env:ConnectionStrings__Sorcha__Postgres` to any value; do **not** use `--no-build` (produces an empty migration); avoid `migrations remove` if the DB is unreachable.
+- **Fail-closed is the invariant**: every new trust decision rejects when it cannot verify. Tests assert *rejection*, never silent fallback.
+- **Docker rebuilds**: use `--no-cache` after code changes; `--force-recreate` sometimes doesn't actually swap the image — verify container age, and `stop + rm + up` when it matters.
+- **Branch + PR policy**: `master` is protected. Each story is a clean PR boundary — branch off `138-federation-trust-hardening` (or work on it directly), push, `gh pr create`, await review, merge. Don't commit directly to `master`.
+- **Demo-mint exclusion (T067)**: the demo/JWK-registry issuer resolver must be *structurally* excluded from production composition, not flag-gated — there's a dedicated test task for this.
+- **Docs sync (T068–T070)**: update the `sorcha-architecture` skill, API docs, and affected service READMEs as part of Polish — PRs without doc updates aren't approved (CLAUDE.md policy).
+
+---
+
+## 6. Definition of done
+
+- `dotnet test` green; >85% coverage on new code (constitution IV).
+- Every `quickstart.md` adversarial variant has a passing negative test (FR-021 / SC-008).
+- `quickstart.md` executed end-to-end against the Docker stack (T072).
+- All six stories validate independently at their checkpoints.
+
+---
+
+## 7. Backlog pointer
+
+The **permissionless / open-membership** validation work (Sybil-resistant stake admission, bonded collateral, slashing) is the deliberately-separate follow-up: `PERM-1..PERM-5` in `.specify/tasks/deferred-tasks.md`. US3 here builds the on-chain-roster + deterministic-ejection primitives that feature will extend. Do **not** pull permissionless scope into 138.

--- a/specs/138-federation-trust-hardening/checklists/requirements.md
+++ b/specs/138-federation-trust-hardening/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Federation Trust Hardening
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Resolved (2026-05-24):** The one open clarification — whether US6 (open-participant carried-key binding, P3) is in v1 scope — was decided **in scope**. No [NEEDS CLARIFICATION] markers remain. All items pass.
+- The spec intentionally describes the *current vulnerable behaviour* of each surface as context for the gap; this is behavioural (what the system does/fails to do), not implementation detail, so it does not violate the "no implementation details" criterion.
+- Configurable thresholds (skew, freshness, expiry, rate limit, liveness timeout) are documented as Assumptions with secure-default intent — values are planning-phase tuning, not scope.

--- a/specs/138-federation-trust-hardening/contracts/config-and-metrics.md
+++ b/specs/138-federation-trust-hardening/contracts/config-and-metrics.md
@@ -1,0 +1,33 @@
+# Contract: Configuration Keys & Observability Metrics
+
+All thresholds are configurable with secure defaults (spec Assumptions). All security rejections are observable (FR-022).
+
+## Configuration keys
+
+| Key | Default | Applies to | Meaning |
+|-----|---------|-----------|---------|
+| `Verifier:ClockSkewSeconds` | 60 | US5, US1, US2 | Wall-clock tolerance for KB-JWT exp, delegation exp, status-list freshness, heartbeat timestamp |
+| `Verifier:KbJwtMaxLifetimeSeconds` | 120 | US5 | Upper bound enforced on accepted KB-JWT `exp − iat` (reject over-long-lived proofs) |
+| `IssuerSignature:Required` (existing) | `true` in prod | US1 | Already defaults true (F120); status-list path now honors the same fail-closed posture |
+| `PeerService:EnableTls` | `true` outside Development | US2 | Production/Staging refuse cleartext; Development may run cleartext HTTP/2 |
+| `PeerService:ChallengeTtlSeconds` | 30 | US2 | Lifetime of a registration challenge nonce |
+| `RateLimiting:*` (existing `RateLimitSettings`) | relaxed pre-release | US2 | Drives the new gRPC `RateLimitInterceptor` |
+| `RegisterPolicy` default `RegistrationMode` | **`Consent`** (was `Public`) | US3 | New-register validator-admission default |
+| `Consensus:LivenessTimeoutSeconds` (from policy `DocketTimeoutSeconds`) | 30 | US3 | Accept-to-seal deadline before a liveness-violation proof |
+
+## OpenTelemetry metrics (new counters on existing `Sorcha.*` meters)
+
+| Metric | Meter | Tags | Increment when |
+|--------|-------|------|----------------|
+| `sorcha_statuslist_rejected_total` | `Sorcha.Verifier` | `reason{signature\|issuer\|unresolved\|expired\|fetch}` | US1 status-list rejected |
+| `sorcha_presentation_replay_rejected_total` | `Sorcha.Verifier` | `reason{kbjwt_expired\|kbjwt_missing_exp\|revoked_at_verify}` | US5 / US1 verify-time rejection |
+| `sorcha_peer_registration_rejected_total` | `Sorcha.Peer` | `reason{signature\|id_mismatch\|stale\|challenge\|rate_limited}` | US2 registration refused |
+| `sorcha_peer_message_rejected_total` | `Sorcha.Peer` | `reason{replay_seq\|stale_timestamp\|unsigned_ad\|bad_signature}` | US2 message rejected |
+| `sorcha_validator_vote_rejected_total` | `Sorcha.Validator` | `reason{not_in_sealed_roster\|bad_signature\|double_vote}` | US3 vote rejected |
+| `sorcha_validator_ejected_total` | `Sorcha.Validator` | `reason{equivocation\|liveness_timeout}` | US3 automatic ejection sealed |
+| `sorcha_blueprint_recovery_rejected_total` | `Sorcha.Blueprint` | `reason{hash_mismatch\|no_provenance}` | US4 recovery rejected |
+| `sorcha_carried_key_rejected_total` | `Sorcha.Blueprint` | `reason{unbound\|commitment_mismatch}` | US6 open-participant key rejected |
+
+## Health degradation signals
+
+A node that falls back to a weaker posture (e.g., status-list unverifiable so failing closed, or peer transport unable to establish mTLS) surfaces `Degraded` on the relevant health check, consistent with the Storage Registration Log pattern (CLAUDE.md §10/§11), so operators see the condition without it silently weakening security.

--- a/specs/138-federation-trust-hardening/contracts/peer-protocol.md
+++ b/specs/138-federation-trust-hardening/contracts/peer-protocol.md
@@ -1,0 +1,54 @@
+# Contract: Peer Protocol Changes (US2)
+
+**Service**: `Sorcha.Peer.Service` | **Transport**: gRPC (HTTP/2)
+
+## Proto changes
+
+### `peer_communication.proto`
+```protobuf
+message RegisterPeerRequest {
+  PeerInfo peer_info       = 1;
+  bytes    public_key      = 2;  // NEW: ED25519 public key (node identity)
+  int64    timestamp       = 3;  // NEW: unix seconds, freshness-checked
+  bytes    challenge_nonce = 4;  // NEW: server-issued nonce echoed back
+  bytes    signature       = 5;  // NEW: sign(public_key) over
+                                 //   peer_id ‖ address ‖ port ‖ timestamp ‖ challenge_nonce
+}
+
+// NEW pre-step so the server controls the nonce:
+rpc RequestChallenge(ChallengeRequest) returns (ChallengeResponse);
+message ChallengeRequest  { string claimed_peer_id = 1; }
+message ChallengeResponse { bytes challenge_nonce = 1; int64 expires_at = 2; }
+```
+
+### `peer_heartbeat.proto`
+```protobuf
+message RegisterAdvertisement {
+  // existing fields 1-7 ...
+  bytes signature = 8;  // NEW: sign over register_id ‖ latest_version ‖ latest_docket_version
+}
+
+message PeerHeartbeatRequest {
+  // existing: sequence_number (3), timestamp (4) — now VALIDATED
+  bytes signature = N;  // NEW: sign over heartbeat body (peer_id ‖ sequence_number ‖ timestamp)
+}
+```
+
+## Behavioral contract
+
+| RPC | Precondition | Postcondition / rejection |
+|-----|--------------|---------------------------|
+| `RequestChallenge` | claimed peer id non-empty | returns single-use nonce with short TTL |
+| `RegisterPeer` | valid signature over the challenge by `public_key`; `peer_id` == thumbprint(public_key); timestamp within skew | accepted ⇒ `PeerNode` stores `PublicKey`. Invalid signature / id mismatch / stale timestamp / unknown-or-expired challenge ⇒ **refused** (`Success=false`). Rate-limited per source. |
+| `SendHeartbeat` / `StreamHeartbeat` | `sequence_number > PeerNode.LastHeartbeatSequenceNumber`; timestamp advancing within skew; valid body signature by stored `PublicKey` | accepted ⇒ update last seq/timestamp. Non-advancing seq / stale timestamp / bad-or-missing signature ⇒ **rejected** (replay). |
+| Advertisement processing | advertisement signature valid by the originating node's stored `PublicKey` | unsigned / bad-signature ⇒ **dropped, not propagated**. |
+
+## Transport contract
+
+- **Development**: cleartext HTTP/2 permitted (current behavior).
+- **Production / Staging**: mTLS **required**; unauthenticated/unencrypted peer transport is **refused at startup/connection** (fail-closed). `PeerAuthInterceptor` MUST NOT silently treat missing auth as anonymous outside Development.
+
+## Node identity contract (`NodeIdentityService`)
+
+- On first startup, generate an ED25519 keypair via `CryptoModule`; persist private key encrypted (Key Protection Provider) in `PeerDbContext`; reuse across restarts.
+- `NodeId` = thumbprint(public key). Exported in registration and heartbeats.

--- a/specs/138-federation-trust-hardening/contracts/validator-control-transactions.md
+++ b/specs/138-federation-trust-hardening/contracts/validator-control-transactions.md
@@ -1,0 +1,59 @@
+# Contract: Validator Control Transactions & Vote Authority (US3)
+
+**Service**: `Sorcha.Validator.Service` | **Sealed via**: register control transactions (MongoDB chain)
+
+## Vote authority contract
+
+`ConsensusEngine.ValidateVotesAsync` (currently `:459-500`) MUST derive authority from the **sealed roster** reconstructed from `RegisterControlRecord.Validators`, not from the `ValidatorRegistry` cache.
+
+```
+counted(vote) ⇔
+    key(vote) ∈ sealedRoster.ActiveValidators        # FR-010
+  ∧ signatureValid(vote)
+  ∧ ¬doubleVote(vote, thisRound)
+```
+- A vote whose signing key is absent from the sealed roster contributes **zero** quorum weight on every honest node (SC-004), regardless of cache contents (FR-014).
+- The cache MAY accelerate lookups but is **derived**; on cache↔seal divergence, the seal is authoritative.
+
+## Admission contract
+
+`RegisterPolicy.CreateDefault()` default `RegistrationMode` = **`Consent`** (was `Public`). New validators enter `Pending` and require an approval recorded in the sealed roster before any vote counts (FR-011). Public mode remains selectable explicitly by the register owner.
+
+## New control-transaction action types
+
+### `control.validator.eject`
+Sealed, deterministic ejection. Any honest node observing the same evidence produces an identical transaction ⇒ convergent roster state.
+```json
+{
+  "action": "control.validator.eject",
+  "validatorId": "<did/address>",
+  "reason": "Equivocation",
+  "evidence": {
+    "slot": "<registerId:docketNumber>",
+    "conflictingVotes": [
+      { "docketHash": "<hashA>", "signature": "<sigA>" },
+      { "docketHash": "<hashB>", "signature": "<sigB>" }
+    ]
+  },
+  "observedAt": "<iso8601>"
+}
+```
+Effect on seal: roster entry `Active → Ejected`, `EjectionRef` = this tx id. Source: emitted by `BadActorDetector` on detected double-vote (replaces the in-memory-only log + manual `RevokeValidatorAsync`).
+
+### `control.validator.liveness-violation`
+```json
+{
+  "action": "control.validator.liveness-violation",
+  "validatorId": "<did/address>",
+  "acceptedTxRef": "<txId>",
+  "deadline": "<iso8601>",      // acceptTime + DocketTimeoutSeconds
+  "observedAt": "<iso8601>"     // > deadline + skew
+}
+```
+Effect on seal: `Active → Ejected` (`reason = LivenessTimeout`).
+
+## Invariants
+
+- **Determinism** (SC-005): ejection outcome is a pure function of sealed state + observed evidence — no operator action, identical across honest nodes.
+- **Quorum guard**: ejection that would drop `ActiveValidators` below workable quorum MUST surface the condition (ties to `GOV-5`), not silently brick the register.
+- **No manual path required**: `RevokeValidatorAsync` may remain for operator override, but automatic detection→ejection MUST require zero human action (SC-005).

--- a/specs/138-federation-trust-hardening/contracts/verifier-statuslist-and-kbjwt.md
+++ b/specs/138-federation-trust-hardening/contracts/verifier-statuslist-and-kbjwt.md
@@ -1,0 +1,41 @@
+# Contract: Verifier — Status-List Verification & KB-JWT Expiry (US1, US5)
+
+**Component**: `Sorcha.Verifier.Engine`
+
+## US1 — Status-list signature verification contract
+
+`StatusListCache` MUST verify a fetched status-list JWT before trusting any revocation bit.
+
+```
+trust(statusList) ⇔
+    signatureValid(statusList, key)                 # key from IIssuerKeyResolver, sealed-state anchored
+  ∧ statusList.iss == expectedOrgDid                 # FR-002 issuer pinning
+  ∧ now < statusList.exp (within skew)               # FR-004 freshness, no +24h default
+```
+
+| Condition | Outcome |
+|-----------|---------|
+| signature valid + issuer pinned + fresh | list trusted; result cached |
+| signature invalid | **reject**; credential treated as unverifiable (fail closed) |
+| `iss` ≠ expected org DID | **reject** (even if signature internally valid) |
+| issuer key unresolved | **reject** |
+| list expired | **reject** |
+| fetch failed | **reject** — MUST NOT serve stale cache (removes current fail-open at `StatusListCache.cs:88-96`) |
+
+- Resolver: reuse `IIssuerKeyResolver` (`ResolveAsync(issuer, kid, ct) → JWK?`), injected into `StatusListCache` (new dependency). Composite = DID-backed (production) then JWK-registry (demo, dev-only).
+- Publisher (`CitizenStatusListPublisher`) adds a `kid` header; verifier matches by `kid`, falling back to first published verification method matching `alg` when `kid` absent (pre-release back-compat).
+- Caller (`VerifiablePresentationValidator.IsRevokedAsync` path) treats "unverifiable" as **fail** (not "unknown ⇒ allowed").
+
+## US5 — KB-JWT expiry contract
+
+`VerifiablePresentationValidator` (currently checks nonce + aud at `:196-206`, no `exp`) MUST additionally:
+
+```
+accept(kbJwt) requires
+    kbJwt.exp present                                 # FR-017, missing ⇒ reject
+  ∧ now ≤ kbJwt.exp + ClockSkewSeconds                # FR-018 wall-clock check via injected TimeProvider
+  ∧ nonce == session.nonce ∧ aud == session.clientId  # existing
+```
+- Ordering: KB-JWT `exp` validated **before** delegation/status validation, so a replayed proof for a since-revoked credential cannot pass.
+- Revocation re-checked at verify time (already at `:400-413`); combined with US1 fail-closed this satisfies FR-019 (mid-session revocation fails verification).
+- Skew: shared `Verifier:ClockSkewSeconds` (default 60), applied consistently to KB-JWT `exp`, delegation `exp`, and US2 heartbeat freshness.

--- a/specs/138-federation-trust-hardening/data-model.md
+++ b/specs/138-federation-trust-hardening/data-model.md
@@ -1,0 +1,137 @@
+# Data Model: Federation Trust Hardening (Feature 138)
+
+**Date**: 2026-05-24
+
+Entities are grouped by user story. "New" = net-new type/field; "Change" = modification to an existing type. Implementation types named where known from research; treat as the authoritative target.
+
+---
+
+## US1 — Revocation authenticity
+
+### Status List Verification Context *(new — transient, not persisted)*
+Carries what the verifier needs to authenticate a fetched status list.
+| Field | Type | Notes |
+|-------|------|-------|
+| ExpectedIssuerDid | string | `did:sorcha:org:{orgId:N}` derived from the consuming credential; the `iss` claim MUST equal this |
+| Kid | string? | from JWT header when present; resolver falls back to first VM matching `alg` |
+| ResolvedKey | JWK (JsonElement) | from `IIssuerKeyResolver`; null ⇒ fail closed |
+| ExpiresAt | timestamp | from list `exp`; expired ⇒ reject (no +24h default) |
+| VerificationOutcome | enum | `Verified` \| `SignatureFailed` \| `IssuerMismatch` \| `Unresolved` \| `Expired` \| `FetchFailed` |
+
+**Change — `CachedList`** (`StatusListCache`): only a *verified* list may be cached. `VerificationOutcome != Verified` ⇒ never cached, caller told "unverifiable".
+
+**Change — status-list JWT header** (`CitizenStatusListPublisher`): add `kid` identifying the signing verification method.
+
+**State transition (fetch)**: `Requested → Fetched → SignatureVerified → IssuerPinned → FreshnessChecked → Trusted`. Any failure transitions to `Rejected(reason)` (fail closed). Previously: fetch failure → `ServedStale` (removed).
+
+---
+
+## US2 — Authenticated peers
+
+### Node Identity *(new — persisted in `PeerDbContext`)*
+| Field | Type | Notes |
+|-------|------|-------|
+| NodeId | string (PK) | public-key thumbprint; self-certifying |
+| PublicKey | bytes | ED25519 public key, exported in messages |
+| EncryptedPrivateKey | bytes | private key sealed via Key Protection Provider (AES-256-GCM) |
+| Algorithm | enum | `ED25519` (initial) |
+| CreatedAt | timestamp | generated on first startup |
+
+### Change — `PeerNode`
+| Field | Type | Notes |
+|-------|------|-------|
+| PeerId | string | now bound to / equal to the node public-key thumbprint (was arbitrary string) |
+| PublicKey | bytes | **new** — captured at authenticated registration; used to verify later messages |
+| LastHeartbeatSequenceNumber | long | **new** — monotonicity anchor for replay rejection |
+| LastHeartbeatTimestamp | timestamp | **new** — freshness anchor |
+
+### Change — proto messages (`peer_communication.proto`, `peer_heartbeat.proto`)
+| Message | Added fields | Notes |
+|---------|--------------|-------|
+| RegisterPeerRequest | `bytes public_key`, `bytes signature`, `int64 timestamp`, challenge nonce | signature over `(PeerId‖Address‖Port‖Timestamp‖challenge)` |
+| RegisterAdvertisement | `bytes signature` | signature over `(register_id‖latest_version‖latest_docket_version)` by node key |
+| Heartbeat | (validate existing `sequence_number`/`timestamp`) | + signature over heartbeat body |
+
+**Registration state transition**: `ChallengeIssued → SignedResponseReceived → SignatureVerified → Registered`. Failure ⇒ `Refused`. Re-registration under an existing `NodeId` with a valid signature ⇒ `Registered` (idempotent restart). Replay (stale seq/timestamp) ⇒ `Rejected`.
+
+### Rate-limit state *(new — interceptor)*
+Per-source counters keyed `{sourceNodeId|ip}:{method}` feeding `RESOURCE_EXHAUSTED`. Fed by existing `RateLimitSettings`.
+
+---
+
+## US3 — Sealed-roster vote authority
+
+### Change — effective roster source
+`ValidatorRoster` / `RegisterControlRecord.Validators` (already sealed) becomes the **authoritative** source for vote authority. The `ValidatorRegistry` (Redis/Mongo) becomes a **derived, non-authoritative cache**; on divergence the sealed record wins.
+
+### Change — `ValidatorRosterEntry`
+| Field | Type | Notes |
+|-------|------|-------|
+| Status | enum | `Active` \| `Pending` \| `Ejected` (ejection now a first-class sealed state, was cache-only `Revoked`) |
+| EjectionRef | string? | **new** — transaction id of the sealing ejection control-tx |
+
+### Change — `RegisterPolicy.PolicyValidatorConfig`
+| Field | Type | Change |
+|-------|------|--------|
+| RegistrationMode | enum | `CreateDefault()` default flips `Public → Consent` |
+
+### Validator Ejection Record *(new — sealed control transaction `control.validator.eject`)*
+| Field | Type | Notes |
+|-------|------|-------|
+| ValidatorId | string | subject |
+| Reason | enum | `Equivocation` \| `LivenessTimeout` |
+| Evidence | object | for equivocation: the two conflicting signed votes (slot, two docket hashes, two signatures) |
+| ObservedAt | timestamp | |
+| Deterministic | invariant | any honest node with the same evidence produces an identical record ⇒ convergent ejection |
+
+### Liveness-Timeout Proof *(new — sealed control transaction `control.validator.liveness-violation`)*
+| Field | Type | Notes |
+|-------|------|-------|
+| ValidatorId | string | subject |
+| AcceptedTxRef | string | the work it accepted but did not seal |
+| Deadline | timestamp | accept-time + `DocketTimeoutSeconds` |
+| ObservedAt | timestamp | > Deadline + skew |
+
+**Vote authority transition**: `VoteReceived → KeyInSealedRoster? → SignatureValid? → NotDoubleVote? → Counted`. Any "no" ⇒ `Rejected` (zero quorum weight), identically on every honest node. Detected equivocation ⇒ emit `control.validator.eject`; on seal, entry `Active → Ejected`.
+
+---
+
+## US4 — Blueprint provenance
+
+### Change — `PublishedBlueprintEntry` (`IRegisterServiceClient`)
+| Field | Type | Notes |
+|-------|------|-------|
+| ContentHash | string | **new** — SHA-256 over canonical blueprint JSON, sealed at `control.blueprint.publish` |
+
+**Recovery transition**: `Fetched → CanonicalHashRecomputed → MatchesSealedHash? → Stored`. Mismatch or missing sealed hash ⇒ `Rejected` (not stored).
+
+---
+
+## US5 — Presentation replay
+
+### Change — KB-JWT validation (no persisted entity)
+KB-JWT MUST carry `exp`. Verifier checks `exp` against `_clock.GetUtcNow()` within `ClockSkewSeconds`. Missing `exp` ⇒ reject (FR-017). Ordering: KB-JWT `exp` checked **before** delegation/status validation.
+
+### Change — `VerifierSession`
+No schema change; revocation continues to be checked fresh at verify time (not cached on session).
+
+---
+
+## US6 — Open-participant key binding
+
+### Carried-Key Binding *(new — validation rule, leverages existing invitation)*
+| Field | Type | Notes |
+|-------|------|-------|
+| CarriedKey | JWK / public key | from submission form field (existing) |
+| BindingArtifactRef | string | invitation id or sealed pre-registration id |
+| Commitment | string | derived from `RegisterInvitationRecord.Nonce` + carried key; must match |
+
+**Resolution transition (open + unpublished participant)**: `CarriedKeyPresent → BindingArtifactResolved? → CommitmentMatches? → Accepted`. Any "no" ⇒ `Rejected`. Published-participant path (`ResolvePublicKeyAsync` wins) unchanged.
+
+---
+
+## Cross-cutting invariants
+
+- **Fail-closed**: every transition above terminates in `Rejected` when verification cannot complete; no state leads to "trust anyway".
+- **Sealed-state anchoring**: every `Verified`/`Counted`/`Stored`/`Accepted` terminal state traces to a signature checked against a key or digest sealed in register state (FR-021).
+- **Determinism (US3)**: ejection and vote-authority outcomes are pure functions of sealed state + observed evidence, identical across honest nodes (SC-004, SC-005).

--- a/specs/138-federation-trust-hardening/plan.md
+++ b/specs/138-federation-trust-hardening/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Federation Trust Hardening
+
+**Branch**: `138-federation-trust-hardening` | **Date**: 2026-05-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/138-federation-trust-hardening/spec.md`
+
+## Summary
+
+Close the soft network-edge trust gaps found by the 2026-05-24 red-team review, so that **every input crossing a node boundary is verified against a signature anchored in sealed register state** rather than trusted by sender or transport. Six independently-shippable slices: status-list signature verification (US1), authenticated peers (US2), sealed-roster vote authority (US3), verified blueprint recovery (US4), presentation replay hardening (US5), and open-participant key binding (US6). The cryptographic core (DID resolution, issuer-signature verification, chain integrity, double-vote *detection*) already exists and is sound — this feature wires those existing anchors into the surfaces that currently bypass them.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10 (per constitution Technology Stack)
+**Primary Dependencies**: ASP.NET Core Minimal APIs, Grpc.Net 2.71, Microsoft.IdentityModel (JWT), `Sorcha.Cryptography` (ED25519 / P-256 / RSA / ML-DSA), JsonSchema.Net, OpenTelemetry 1.12, Scalar 2.10, `Sorcha.Verifier.Engine`
+**Storage**: PostgreSQL (EF Core — Peer node identity, validator audit), MongoDB (register transactions / dockets / sealed roster), Redis (operational caches, presently the roster cache that US3 demotes)
+**Testing**: xUnit + FluentAssertions + Moq; integration via WebApplicationFactory; adversarial negative tests mandatory per FR-021
+**Target Platform**: Linux containers orchestrated by .NET Aspire 13 / docker-compose
+**Project Type**: Microservices (multi-service) — touches Verifier engine, Peer, Validator, Blueprint, Wallet, Tenant services + shared Register.Models
+**Performance Goals**: Not a throughput feature. Verification additions (signature checks, exp checks, roster lookups) MUST add bounded, sub-perceptible latency and MUST NOT regress consensus liveness.
+**Constraints**: All new trust decisions fail **closed**. Configurable thresholds (clock skew, status-list freshness, KB-JWT expiry, peer-registration rate, validator liveness timeout) with secure defaults. No backward-compat migration burden (pre-release).
+**Scale/Scope**: Existing federation scale (bounded validator roster ≤ 25 per `GOV-8`; small peer mesh). No open-membership scale assumptions (that is the backlogged `PERM-*` feature).
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.1.0.*
+
+| Principle | Assessment | Verdict |
+|-----------|------------|---------|
+| I. Microservices-First | Each US is contained to one service (or one shared model + its consumers). No new upward dependencies; verification logic stays in the engine/service that owns the boundary. Core/Register.Models changes (roster, blueprint hash) are pure model additions consumed downward. | ✅ Pass |
+| II. Security First | This feature *is* the principle — zero-trust at every node boundary, fail-closed, input validation on external boundaries, no secrets committed. Node identity private keys encrypted at rest (AES-256-GCM via existing KPP). | ✅ Pass (core intent) |
+| III. API Documentation | New/changed control-transaction action types and any config-surfaced endpoints documented; gRPC proto changes documented in `contracts/`. XML docs on all new public members; Scalar summaries where HTTP endpoints change. | ✅ Pass (commitment) |
+| IV. Testing | >85% on new code. Every forged/unsigned/replayed/out-of-roster variant gets a deterministic negative test (FR-021). Integration tests per service boundary. | ✅ Pass (commitment) |
+| V. Code Quality | async/await, DI, nullable enabled, no Release warnings. Reuse existing `IIssuerKeyResolver`, `CryptoModule`, `AddRateLimiting`, storage-registration-log patterns. | ✅ Pass |
+| VI. Blueprint Standards | US4 adds a content-hash field to published-blueprint records; no blueprints authored in C#. | ✅ Pass |
+| VII. Domain-Driven Design | Use ubiquitous terms: Validator, Docket, Register, Participant, Publish, Disclosure, Control transaction. New terms (Node Identity, Sealed Roster, Liveness-Timeout proof, Ejection record) are additive and consistent. | ✅ Pass |
+| VIII. Observability | FR-022 mandates metrics for every security rejection on existing OTel meters (`sorcha_*`), plus health-degradation signals where a node falls back to a weaker mode. | ✅ Pass |
+
+**No violations.** Complexity Tracking section intentionally empty. The one item worth flagging — mTLS + per-node key material (US2) introduces new certificate/key lifecycle — is squarely inside Principle II and is justified, not a deviation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/138-federation-trust-hardening/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 — decisions per user story (grounded in current code)
+├── data-model.md        # Phase 1 — entities, fields, state transitions
+├── quickstart.md        # Phase 1 — adversarial validation walkthrough per US
+├── contracts/           # Phase 1 — proto changes, control-tx action types, config keys, metrics, verifier contract
+│   ├── peer-protocol.md
+│   ├── validator-control-transactions.md
+│   ├── verifier-statuslist-and-kbjwt.md
+│   └── config-and-metrics.md
+└── checklists/
+    └── requirements.md  # Spec quality checklist (passing)
+```
+
+### Source Code (repository root) — surfaces touched, by user story
+
+```text
+# US1 — Status-list signature verification (verifier side)
+src/Common/Sorcha.Verifier.Engine/
+├── StatusListCache.cs                    # verify JWT sig in ParseJwt; fail-closed on fetch/verify failure
+├── IIssuerKeyResolver.cs                 # reuse existing resolver contract (no change)
+└── VerifiablePresentationValidator.cs    # (also US5) status check already at verify time
+src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs  # inject resolver into StatusListCache; ClockSkew config
+src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs  # add kid to header (resolver hygiene)
+
+# US2 — Authenticated peers
+src/Services/Sorcha.Peer.Service/
+├── Program.cs                            # fail-closed transport outside Development; node-identity bootstrap
+├── Interceptors/PeerAuthInterceptor.cs   # stop silent-anonymous; enforce in Prod/Staging
+├── Interceptors/RateLimitInterceptor.cs  # NEW — gRPC RESOURCE_EXHAUSTED throttle
+├── GrpcServices/PeerDiscoveryServiceImpl.cs   # challenge-response on RegisterPeer
+├── GrpcServices/PeerHeartbeatGrpcService.cs   # validate sequence/timestamp; verify ad signatures
+├── Services/RegisterAdvertisementService.cs   # sign/verify advertisements
+├── Services/NodeIdentityService.cs       # NEW — per-node ED25519 key lifecycle
+├── Models/PeerNode.cs                    # +PublicKey, +LastHeartbeatSequenceNumber
+└── Protos/peer_communication.proto, peer_heartbeat.proto  # +signature/+public_key fields, challenge msgs
+
+# US3 — Sealed-roster vote authority
+src/Common/Sorcha.Register.Models/
+├── RegisterPolicy.cs                     # CreateDefault(): RegistrationMode.Public -> Consent (line ~78)
+├── ValidatorRoster.cs                    # ejection state on entries
+└── RegisterControlRecord.cs              # sealed roster (exists)
+src/Services/Sorcha.Validator.Service/Services/
+├── ConsensusEngine.cs                    # vote authority from sealed roster, not Redis cache (~459-500)
+├── ValidatorRegistry.cs                  # roster reconstruction from chain; cache becomes derived/non-authoritative
+├── ControlDocketProcessor.cs             # process new ejection + liveness-violation control actions
+└── BadActorDetector.cs                   # emit sealed ejection control-tx on detected equivocation
+
+# US4 — Verified blueprint recovery
+src/Common/Sorcha.ServiceClients/.../IRegisterServiceClient.cs   # PublishedBlueprintEntry +ContentHash
+src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs  # verify hash before store
+
+# US5 — Presentation replay hardening
+src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs  # mandatory KB-JWT exp + wall-clock+skew check
+
+# US6 — Open-participant carried-key binding
+src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs  # bind carried key to artifact
+src/Services/Sorcha.Tenant.Service/Services/RegisterInvitationService.cs  # invitation nonce/commitment lookup
+
+# Cross-cutting
+src/Common/Sorcha.ServiceDefaults/  # rate-limit + mTLS helpers, OTel meters for new rejection metrics
+```
+
+**Structure Decision**: Multi-service. Each user story is a self-contained slice owned by one service (or one shared model plus its direct consumers), preserving Principle I. Build order follows spec priority and the dependency that US3 establishes the on-chain-roster primitives the backlogged `PERM-*` feature reuses.
+
+## Build Sequence (independently shippable slices)
+
+1. **US1** (P1, smallest blast radius — verifier-only): status-list signature verification + fail-closed. Ship first; no cross-service coordination. Each subsequent story is independently testable and deployable.
+2. **US2** (P1): peer identity + signed advertisements + replay validation + mTLS-outside-dev + gRPC rate limiting.
+3. **US3** (P1): sealed-roster vote authority + Consent default + automatic deterministic ejection + liveness-timeout proof. Largest slice; establishes `PERM-*` primitives.
+4. **US4** (P2): published-blueprint content hash + recovery verification.
+5. **US5** (P2): mandatory KB-JWT expiry + wall-clock/skew check (revocation re-check already at verify time once US1 lands).
+6. **US6** (P3): bind open-participant carried delivery key to invitation/pre-registration artifact.
+
+Phase 2 (`/speckit.tasks`) expands each slice into ordered, testable tasks.
+
+## Complexity Tracking
+
+*No constitution violations — section intentionally empty.*

--- a/specs/138-federation-trust-hardening/quickstart.md
+++ b/specs/138-federation-trust-hardening/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Validating Federation Trust Hardening (Feature 138)
+
+**Date**: 2026-05-24
+
+Each user story is validated **adversarially**: stand up the attack, confirm it is rejected; then confirm the honest path still works. Every check maps to a Success Criterion. This is the red-team acceptance bar (FR-021 / SC-008): *show the forged/unsigned/replayed variant being rejected.*
+
+## Prerequisites
+```bash
+docker-compose up -d        # full stack
+# or: dotnet run --project src/Apps/Sorcha.AppHost   # Aspire (HTTPS 7xxx)
+dotnet test                 # all negative tests must pass
+```
+
+## US1 — Revocation cannot be forged  → SC-001, SC-002
+1. **Forged list**: Serve a status list with a revoked credential's bit cleared, signed with a key NOT in the issuer's sealed DID document (or unsigned). Attempt to verify the credential.
+   - ✅ Expect: **rejected**; `sorcha_statuslist_rejected_total{reason="signature"}` increments.
+2. **Issuer mismatch**: Serve a validly self-signed list whose `iss` ≠ the credential's org DID.
+   - ✅ Expect: **rejected** (`reason="issuer"`).
+3. **Fail-closed**: Block the status-list fetch entirely.
+   - ✅ Expect: verification **fails closed** (credential unverifiable), no stale-cache serve; `reason="fetch"`.
+4. **Honest path**: Genuine signed, fresh list marking the credential revoked.
+   - ✅ Expect: verification fails *because revoked* (not because unverifiable). A non-revoked credential with a genuine list verifies.
+
+## US2 — Peer identity & claims are provable  → SC-003
+1. **Identity forgery**: Call `RegisterPeer` claiming a `peer_id` without a valid signature over the issued challenge.
+   - ✅ Expect: **refused**; `sorcha_peer_registration_rejected_total{reason="signature"}`.
+2. **Register spoofing**: From a registered node, send an advertisement for a register it does not hold, unsigned (or signed by the wrong key).
+   - ✅ Expect: **dropped, not propagated** (`sorcha_peer_message_rejected_total{reason="unsigned_ad"|"bad_signature"}`).
+3. **Replay**: Capture a valid heartbeat; resend it (stale sequence/timestamp).
+   - ✅ Expect: **rejected** (`reason="replay_seq"`).
+4. **Transport**: In a Production/Staging profile, attempt a cleartext peer connection.
+   - ✅ Expect: **refused** (mTLS required). In Development, cleartext still works.
+5. **Honest path**: Legitimate node restarts and re-registers under its existing identity key → succeeds.
+
+## US3 — Sealed-roster vote authority  → SC-004, SC-005
+1. **Out-of-roster vote**: Submit a consensus vote signed by a key absent from the sealed `RegisterControlRecord.Validators`.
+   - ✅ Expect: **zero quorum weight on every node**, deterministically; `sorcha_validator_vote_rejected_total{reason="not_in_sealed_roster"}`.
+2. **Default admission**: Create a register with no admission policy.
+   - ✅ Expect: defaults to **Consent**; a self-registering validator is `Pending`, casts no counting vote until approved in the sealed roster.
+3. **Equivocation**: Make a validator sign two conflicting states for one slot.
+   - ✅ Expect: **automatic** `control.validator.eject` sealed; entry → `Ejected`; identical on every honest node; **zero operator actions**; `sorcha_validator_ejected_total{reason="equivocation"}`.
+4. **Withholding**: A validator accepts work but never seals it.
+   - ✅ Expect: after `LivenessTimeoutSeconds`, a sealed `control.validator.liveness-violation` ejects it automatically.
+
+## US4 — Verified blueprint recovery  → SC-006
+1. **Tampered blueprint**: Offer a recovery path a blueprint whose content ≠ the sealed `ContentHash`.
+   - ✅ Expect: **rejected, not stored**; `sorcha_blueprint_recovery_rejected_total{reason="hash_mismatch"}`.
+2. **No provenance**: Offer a blueprint with no sealed digest available.
+   - ✅ Expect: **not stored** (`reason="no_provenance"`).
+3. **Honest path**: Correctly-sealed blueprint matching its on-chain digest → accepted and stored.
+
+## US5 — Presentation replay hardening  → SC-007
+1. **Expired proof replay**: Capture a valid KB-JWT; replay it after its `exp` (but while the session is still open).
+   - ✅ Expect: **rejected** (`sorcha_presentation_replay_rejected_total{reason="kbjwt_expired"}`).
+2. **Missing exp**: Present a KB-JWT with no `exp`.
+   - ✅ Expect: **rejected** (`reason="kbjwt_missing_exp"`).
+3. **Mid-session revocation**: Revoke the device credential after session open; verify a still-fresh proof.
+   - ✅ Expect: **rejected** (`reason="revoked_at_verify"`) — revocation re-checked at verify time + US1 fail-closed.
+
+## US6 — Open-participant key binding  → (US6 acceptance)
+1. **Key hijack**: Submit into an open, unpublished participant slot with a carried delivery key not bound to any invitation/pre-registration.
+   - ✅ Expect: **rejected** (`sorcha_carried_key_rejected_total{reason="unbound"}`).
+2. **Honest path**: Carried key bound to a valid, unconsumed invitation (commitment matches the invitation nonce) → accepted. A *published* participant's key path is unaffected.
+
+## Whole-feature gate  → SC-008
+- `dotnet test` green, including one negative test per forged/unsigned/replayed/out-of-roster variant above.
+- A reviewer can trace each ✅ to a signature-verification step backed by a negative test; **zero "trust the sender/transport" paths remain** in the affected surfaces.

--- a/specs/138-federation-trust-hardening/research.md
+++ b/specs/138-federation-trust-hardening/research.md
@@ -1,0 +1,136 @@
+# Research: Federation Trust Hardening (Feature 138)
+
+**Date**: 2026-05-24
+**Method**: Three parallel read-only code-exploration agents over the verifier engine, peer service, and validator/blueprint services. All file:line references reflect current `master`/`138` state. No `NEEDS CLARIFICATION` remain (US6 scope resolved in-scope).
+
+The guiding decision across every story: **reuse the existing sealed-state trust anchors rather than inventing new ones.** The red-team review confirmed DID resolution, issuer-signature verification, chain integrity, and double-vote *detection* already exist and are sound; the gaps are that several surfaces don't *consult* them.
+
+---
+
+## US1 — Status-list signature verification
+
+**Decision**: Verify the status-list JWT signature inside `StatusListCache.ParseJwt()` using the existing `IIssuerKeyResolver`, pin the `iss` claim to the expected org DID, and make every failure path (fetch failure, signature failure, issuer mismatch, expiry) **fail closed** — the caller treats "cannot verify" as revoked/unverifiable.
+
+**Rationale**: The trustworthy resolver already exists and is wired in the verifier (`DidResolverBackedIssuerKeyResolver` → register-anchored keys). The publisher already signs the list (`CitizenStatusListPublisher` with the `citizen-status-signing` derivation, `iss = did:sorcha:org:{orgId:N}`). The only missing half is verification. Smallest possible blast radius — confined to the verifier engine.
+
+**Current shape**:
+- `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs:119-145` — `ParseJwt()` base64url-decodes the payload and reads `status_list.lst` + `exp` **without touching the signature**. On missing `exp` it defaults to +24h.
+- `StatusListCache.cs:88-96` — `GetOrFetchAsync()` returns **stale cache on any fetch exception** (fail-open). This must become fail-closed.
+- `IIssuerKeyResolver.cs:22-39` — `ResolveAsync(issuer, kid, ct) → Task<JsonElement?>` returns a public JWK. Composite tries DID-backed then JWK-registry.
+- `CitizenStatusListPublisher.cs:197,225,244` — signs with `EdDSA`/`ES256`, `iss = did:sorcha:org:{orgId:N}`, **no `kid` in header**.
+- Consumed at `VerifiablePresentationValidator.cs:400-413` via `IsRevokedAsync(uri, idx, ct)` — already at verify time.
+
+**Decisions / sub-choices**:
+- Add a `kid` to the publisher's JWT header (publisher-side hygiene) so the resolver can match a specific verification method; resolver must still fall back to "first published VM matching `alg`" when `kid` is absent (back-compat with already-issued lists during pre-release).
+- Inject `IIssuerKeyResolver` into `StatusListCache` (currently it has none). The verifier DI (`src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs:30-87`) already constructs the composite resolver — pass it in.
+- Expected-issuer pinning: the consuming credential's `status.status_list.uri` and the delegation/credential `iss` together determine the expected org DID; reject if the fetched list's `iss` ≠ expected.
+
+**Alternatives considered**: (a) Verify at the presentation validator instead of in the cache — rejected: the cache is the single fetch/parse choke point, verifying there covers all callers. (b) Trust transport (TLS to a known publisher host) — rejected: violates the unifying criterion; any node can serve the list.
+
+---
+
+## US2 — Authenticated peers
+
+**Decision**: Give every node a persistent **ED25519 node-identity key**; require a challenge-response signature on `RegisterPeer`; sign advertisements and heartbeats and reject unsigned ones; validate the already-transmitted `sequence_number` + `timestamp` for monotonicity/freshness; enforce mTLS + non-anonymous auth as **fail-closed outside Development**; add a gRPC rate-limit interceptor.
+
+**Rationale**: The transport is currently forgeable end-to-end (no identity, cleartext, silent-anonymous auth, unsigned ads, unvalidated replay counters). `Sorcha.Cryptography`'s `CryptoModule` already supports ED25519, so node keys are net-new material but not net-new crypto. The anti-replay fields already exist on the wire — they just need to be checked.
+
+**Current shape**:
+- `PeerDiscoveryServiceImpl.cs:71-128` — `RegisterPeer` validates only non-empty `PeerId`/`Address`. `PeerNode.PeerId` is an arbitrary `string` (`PeerNode.cs:16-18`).
+- `PeerAuthInterceptor.cs:40-108` — JWT validation is skipped entirely when `JwtSettings:SigningKey` is empty; unauthenticated peers pass through as anonymous.
+- `Program.cs:113` — `Http2UnencryptedSupport` switch enables cleartext HTTP/2; Kestrel endpoints (54-78) carry no TLS. `PeerConnectionPool.cs:535-546` builds channels with no client cert.
+- `peer_heartbeat.proto:115-137` — `RegisterAdvertisement` has no signature/ownership-proof field. Sent at `PeerHeartbeatService.cs:227`, received at `PeerHeartbeatGrpcService.cs:54-71`.
+- `peer_heartbeat.proto:48` — `sequence_number` received at `PeerHeartbeatGrpcService.cs:46,115` but never validated. No per-peer last-sequence state on `PeerNode`.
+- `Program.cs:42` — `AddRateLimiting()` is called but no policy is applied to the gRPC methods.
+
+**Decisions / sub-choices**:
+- **Node key source**: generate ED25519 on first startup via `CryptoModule`, persist the private key encrypted (existing Key Protection Provider) in `PeerDbContext`; export the public key in registration/heartbeat. Chosen over deriving from the shared JWT key (weaker isolation) — a new `NodeIdentityService` owns the lifecycle.
+- **`PeerId` becomes the node public-key thumbprint** (or is bound to it), so identity is self-certifying and a node cannot register under another's id.
+- **Replay**: add `LastHeartbeatSequenceNumber` to `PeerNode`; reject non-advancing sequence and stale timestamps (reuse a configured skew window, see US5).
+- **Transport**: read an `EnableTls`/environment gate; in Production/Staging refuse cleartext and require mTLS (client-cert validation server-side, client cert in `PeerConnectionPool`). Dev keeps cleartext.
+- **Rate limiting**: gRPC bypasses Minimal-API `.RequireRateLimiting`, so add a `RateLimitInterceptor` returning `RESOURCE_EXHAUSTED`, fed by the same `RateLimitSettings`.
+
+**Alternatives considered**: (a) IP allowlist for admission — rejected: not cryptographic, defeated by spoofing/NAT. (b) Proof-of-work on registration — rejected: that's Sybil-economics, explicitly the backlogged `PERM-*` feature; federation gates participation by signed identity + roster, not cost.
+
+---
+
+## US3 — Sealed on-chain roster as sole vote authority
+
+**Decision**: Derive consensus vote authority from the roster **sealed in `RegisterControlRecord.Validators`** (reconstructed from committed control transactions), not the Redis/Mongo `ValidatorRegistry` cache; flip the default admission mode to **Consent**; convert the existing in-memory double-vote detection into an **automatic, deterministic, sealed ejection** (a control transaction every honest node produces and applies identically); and produce a **sealed liveness-timeout proof** that ejects a withholding validator.
+
+**Rationale**: This is the structural heart of federation hardening, and it deliberately builds the two primitives (`authoritative on-chain roster`, `deterministic equivocation handling`) that the backlogged permissionless feature (`PERM-1..PERM-5`) will extend by swapping roster-admission for stake-admission and roster-ejection for collateral-slashing. The roster already lives on-chain; the gap is that the vote check reads the cache.
+
+**Current shape**:
+- Sealed roster: `RegisterControlRecord.cs:84` (`Validators`), `ValidatorRoster.cs:50-97` (`ActiveValidators`/`VerifiableValidators`, `Validate()`), updated via `control.policy.update` in `ControlDocketProcessor.cs:32,200-293`.
+- Vote authority **reads the cache**: `ConsensusEngine.cs:459-500` — double-vote detection (462), registered+Active check against `ValidatorRegistry.GetValidatorAsync` (477-487, Redis/Mongo), pubkey match (498-500).
+- **No chain-reconstruction path yet** — `ValidatorRegistry.cs:358` comment: "Chain-based validator discovery can be added when register transactions include validator registration metadata."
+- Admission default: `RegisterPolicy.CreateDefault():78` = `RegistrationMode.Public`. Consent logic exists at `ValidatorRegistry.cs:255-274`; new validators are `Active` immediately in Public, `Pending` in Consent (302-304).
+- Ejection is manual + cache-only: `RevokeValidatorAsync` (`ValidatorRegistry.cs:687-756`) mutates Redis/Mongo, writes an audit row, **no control transaction**. `BadActorDetector.cs:108-141` logs incidents in memory only (purged at 286-325).
+- Liveness: `DocketTimeoutSeconds` (`RegisterPolicy.cs:267-268`) drives local vote-collection deadlines only; no sealed proof.
+
+**Decisions / sub-choices**:
+- Reconstruct the effective roster from the latest sealed control record (and cache it as a *derived, non-authoritative* view — the cache may accelerate lookups but the sealed record is the source of truth; on divergence the seal wins, FR-014). Coordinate with `GOV-6` (roster reconstruction caching).
+- New control-transaction action types: `control.validator.eject` (carries the equivocation proof: the two conflicting signed votes) and `control.validator.liveness-violation` (carries the timeout proof). Both are deterministic — any node observing the same evidence produces the identical control tx, so honest nodes converge.
+- Flip `CreateDefault()` to `Consent`; accept the test-cascade cost (pre-release, no migration burden).
+- Guard against ejection dropping the roster below workable quorum (surface the condition; ties to `GOV-5` deadlock detection).
+
+**Alternatives considered**: (a) Keep the cache authoritative but sign it — rejected: the cache is per-node mutable state, not consensus-sealed; signing it doesn't make it agreed. (b) Operator-driven ejection with an alert — rejected: that's the current procedural control the spec explicitly replaces with a technical one (SC-005).
+
+---
+
+## US4 — Verified blueprint recovery
+
+**Decision**: Add a `ContentHash` (SHA-256 of canonical blueprint JSON) to the published-blueprint record, sealed at publish time; on recovery, recompute and compare before storing — reject on mismatch or missing provenance.
+
+**Rationale**: Closes the F137 US3 gap where recovery trusts the register's HTTP response over an unencrypted channel. The register already carries the canonical blueprint; it just doesn't expose a verifiable digest.
+
+**Current shape**:
+- `BlueprintRecoveryService.cs:262-323` — `RecoverFromRegisterAsync` fetches via `GetPublishedBlueprintsAsync` (268) and stores (294-310) with **no hash check**.
+- `IRegisterServiceClient.cs:758-770` — `PublishedBlueprintEntry` has `BlueprintJson` but **no `ContentHash`/`Digest`**.
+
+**Decisions / sub-choices**: compute the hash in the `control.blueprint.publish` path (sealed on-chain) so the digest itself is consensus-anchored; recovery verifies against it. Define a single canonical-JSON serialization so producer and consumer hash identically.
+
+**Alternatives considered**: signing each blueprint with the publisher key — heavier and redundant given the register already seals the publish transaction; a sealed digest is sufficient and cheaper.
+
+---
+
+## US5 — Presentation replay hardening
+
+**Decision**: Require an `exp` claim on the KB-JWT itself and validate it against wall-clock time within a configurable skew window, *before* delegation/status validation. Revocation is already re-checked at verify time, so US1's fail-closed change completes the mid-session-revocation requirement.
+
+**Rationale**: The session nonce/aud/TTL leaves a multi-minute replay window for a captured proof. An independently-enforced short `exp` closes it without changing the session model.
+
+**Current shape**:
+- `VerifiablePresentationValidator.cs:196-206` — nonce + aud checked on KB-JWT; **no `exp` check**. The delegation credential has `exp` (384-391) but the KB-JWT does not. `_clock` is an injected `TimeProvider` (37,50); **no skew tolerance configured** (delegation check uses strict `exp <= now`).
+- Status-list checked at verify time already (`:400-413`), so US1 fail-closed + verify-time check together satisfy FR-019.
+- `VerifierSession.cs:34-38` — `CreatedAt`/`ExpiresAt`; no revocation state on session (good — checked fresh).
+
+**Decisions / sub-choices**: add `Verifier:ClockSkewSeconds` (default 60) and apply the same tolerance to the KB-JWT `exp`, the delegation `exp`, and US2's heartbeat timestamp freshness for consistency. Reject KB-JWTs with no `exp` (FR-017).
+
+**Alternatives considered**: shortening session TTL instead — rejected: doesn't bind the proof itself and still allows replay within the shorter window.
+
+---
+
+## US6 — Open-participant carried-key binding
+
+**Decision**: For an **unpublished** open participant, bind the carried delivery key to a verifiable prior artifact — a `RegisterInvitationRecord` (which already carries a `Nonce`) or a sealed pre-registration — and reject unbound carried keys. Published participants are unaffected ("published wins" already protects them).
+
+**Rationale**: Today the carried key for an open slot is accepted from a submission form field with no commitment, so an attacker racing into the slot can substitute their own delivery key. The Register Invitations feature already provides a per-invitation nonce that can commit the key.
+
+**Current shape**:
+- `ActionExecutionService.cs:616,2183-2209` — `ResolveCarriedHolderKeys` reads `holderJwk`/`encryptionPublicKey`/`algorithm` from a JSON-pointer form field.
+- Precedence (619-648): published record wins (`ResolvePublicKeyAsync`), else carried key, else fail-closed `VAL_RUNTIME_CRED_004`. **No invitation binding today.**
+- `RegisterInvitationRecord` (Tenant Service) carries `Nonce` and `Status` usable for freshness/commitment.
+
+**Decisions / sub-choices**: when the participant is open + unpublished, require the carried key to match a commitment recorded against a valid, unconsumed invitation (or sealed pre-registration); otherwise reject. Keep the published-wins path untouched.
+
+**Alternatives considered**: encrypting the carried key in transit — rejected: it's already inside a signed submission; the gap is *authorization of the key*, not its confidentiality.
+
+---
+
+## Cross-cutting decisions
+
+- **Fail-closed everywhere**: every new verification returns reject on inability to verify; no silent fallback to a weaker mode.
+- **Observability** (FR-022): each rejection class emits a counter on an existing `Sorcha.*` OTel meter (names in `contracts/config-and-metrics.md`); nodes that fall back to a weaker posture surface a health degradation.
+- **Config defaults secure**: skew 60s, status-list freshness from list `exp`, KB-JWT exp short (e.g. 120s), peer-registration rate via `RateLimitSettings`, validator liveness timeout from policy `DocketTimeoutSeconds`. Values are tunable, documented in `contracts/config-and-metrics.md`.
+- **Demo/dev bridges stay dev-only**: the demo-mint JWK-registry resolver path must be structurally excluded from production composition (not flag-gated), consistent with the spec assumption.

--- a/specs/138-federation-trust-hardening/spec.md
+++ b/specs/138-federation-trust-hardening/spec.md
@@ -1,0 +1,225 @@
+# Feature Specification: Federation Trust Hardening
+
+**Feature Branch**: `138-federation-trust-hardening`
+**Created**: 2026-05-24
+**Status**: Draft
+**Input**: Red-team threat model (2026-05-24) of a hardened v1, framed around "anyone can run a node."
+
+## Context & Guiding Principle
+
+Sorcha is a decentralised register platform where **anyone can stand up a node**. That single fact inverts the trust model: a node operator may be hostile, may run modified software, and every message a node receives over the network is potentially attacker-controlled.
+
+This feature hardens the **permissioned-federation** model — the network is open to participation, but consensus validation is gated by a roster the operator controls, and the validator set is known and bounded. The deeper economic problems of *fully permissionless* validation (Sybil-resistant admission, bonded collateral, slashing) are explicitly a **separate, backlogged feature** (see `PERM-1..PERM-5` in `.specify/tasks/deferred-tasks.md`).
+
+**Unifying acceptance criterion for every story below:** *Every input that crosses a node boundary must be verifiable against a cryptographic signature anchored in sealed register state — never trusted because of who sent it or how it arrived.* A red-team reviewer should be able to point at any cross-node trust decision and find the signature that backs it.
+
+The red-team analysis found that Sorcha's cryptographic core is already strong (chain integrity, DID resolution, issuer-signature verification are all sealed-state-anchored and fail-closed). The weaknesses are concentrated at the network edges, where some trust decisions currently reduce to "a peer told me so." This feature closes those gaps.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Revocation cannot be forged by a hostile node (Priority: P1)
+
+A credential verifier must be able to trust that a credential's revocation status is authentic, even when the revocation status list is served by an untrusted node.
+
+Today, a verifier fetches the per-organisation revocation status list over the network and checks the revocation bit **without verifying that the list is authentic**, and when the fetch fails it silently trusts a previously cached copy (fail-open). An attacker who runs a node can serve a forged status list that flips a revoked credential back to "valid" — no authentication required — and a presented stolen or revoked credential then verifies successfully.
+
+**Why this priority**: Cheapest possible attack (unauthenticated, any node), highest impact (defeats revocation entirely — the cornerstone of any credential system), and the smallest blast radius to fix (the change is confined to the verification side). Best value-per-effort in the feature.
+
+**Independent Test**: Stand up a node that serves a tampered status list (revoked bit cleared) and a correctly-revoked credential. Attempt to verify the credential. It MUST be rejected. Separately, block the status-list fetch entirely and confirm verification fails closed (credential treated as revoked/unknown), not open.
+
+**Acceptance Scenarios**:
+
+1. **Given** a revocation status list whose signature does not match the issuing organisation's key resolved from sealed state, **When** a verifier checks a credential against it, **Then** the list is rejected and the credential is treated as having unknown/revoked status.
+2. **Given** a status list whose issuer claim does not match the expected organisation's identifier, **When** a verifier consumes it, **Then** the list is rejected even if the signature itself is internally valid.
+3. **Given** the status list cannot be fetched (network failure, node offline, malicious drop), **When** a verifier needs revocation status, **Then** the verifier fails closed (treats the credential as not-verifiable) rather than trusting stale cached data.
+4. **Given** a correctly signed, fresh status list from the genuine issuer marking a credential as revoked, **When** a verifier checks that credential, **Then** verification fails because the credential is revoked.
+
+---
+
+### User Story 2 - A node's identity and its claims are cryptographically provable (Priority: P1)
+
+A node joining or participating in the peer network must prove control of a cryptographic identity, and every claim it broadcasts (which registers it holds, that it is alive) must be signed so other nodes can reject forgeries and replays.
+
+Today, peer registration has no admission control, peer-to-peer traffic can run unencrypted, peer authentication is silently disabled when no signing key is configured, network advertisements carry no signature and no proof that the advertising node actually holds the register it claims, and the anti-replay sequence numbers that already travel on heartbeat messages are never validated. An attacker can register unlimited free identities, advertise ownership of any register, and replay captured messages indefinitely.
+
+**Why this priority**: This is the open front door to the network. Until peer identity and advertisements are authenticated, no higher-layer guarantee about cross-node data can be trusted, because the transport itself is forgeable.
+
+**Independent Test**: From a node that does not control a given identity key, attempt to (a) register under an arbitrary peer identifier, (b) advertise ownership of a register it does not hold, and (c) replay a previously captured valid heartbeat. All three MUST be rejected. Confirm that unencrypted peer transport is refused outside development environments.
+
+**Acceptance Scenarios**:
+
+1. **Given** a node attempting to join, **When** it cannot produce a valid signature proving control of the identity it claims, **Then** its registration is refused.
+2. **Given** a register-ownership advertisement, **When** it is not signed by the advertising node's proven identity, **Then** it is rejected and not propagated.
+3. **Given** a captured, previously-valid signed message, **When** it is replayed (stale sequence number or stale timestamp), **Then** the receiving node rejects it.
+4. **Given** a peer connection in a production or staging environment, **When** the transport is not mutually authenticated and encrypted, **Then** the connection is refused.
+5. **Given** a flood of registration attempts from one source, **When** they exceed a configured rate, **Then** excess attempts are throttled.
+
+---
+
+### User Story 3 - Validator voting authority derives only from sealed on-chain roster (Priority: P1)
+
+The right to cast a consensus vote must derive **solely** from a validator-roster record sealed in the register's on-chain governance state, and detected misbehaviour must be punished automatically and deterministically by every honest node — with no human operator in the loop.
+
+Today, validator admission defaults to a mode where any node can self-register and become an active validator immediately; the live roster is held in operational stores that lag the on-chain record; and although the system *detects* double-voting and chain violations, the *consequence* (removing a misbehaving validator) is a manual operator action. A withholding validator (one that accepts work but never seals it) has no automatic penalty at all.
+
+**Why this priority**: A self-admitting or unpunished validator set undermines every transaction the network seals. This story also deliberately builds the two primitives — an authoritative on-chain roster and automatic, deterministic equivocation handling — that the backlogged permissionless feature will later extend (swapping roster-admission for stake-admission, roster-ejection for collateral-slashing).
+
+**Independent Test**: Submit a consensus vote signed by a key that is not present in the sealed on-chain roster; every honest node MUST reject it deterministically. Cause a validator to equivocate (sign two conflicting states); confirm it is ejected automatically with no operator action. Cause a validator to go silent after accepting work; confirm automatic ejection after the liveness timeout.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consensus vote, **When** the signing key is not in the roster sealed in on-chain governance state, **Then** the vote is rejected by every honest node and contributes nothing to quorum.
+2. **Given** a new register, **When** it is created without an explicit admission policy, **Then** validator admission defaults to requiring explicit roster approval (not open self-registration).
+3. **Given** a validator that signs two conflicting states for the same slot, **When** the conflict is observed, **Then** that validator is ejected from the effective roster automatically and deterministically, identically on every honest node, without operator intervention.
+4. **Given** a validator that accepts a transaction for sealing but does not seal within the configured liveness window, **When** the timeout elapses, **Then** a sealed liveness-timeout record is produced and the validator is ejected automatically.
+5. **Given** the operational (cached) roster diverges from the on-chain sealed roster, **When** voting authority is evaluated, **Then** the sealed on-chain roster is authoritative and the cache is never trusted over it.
+
+---
+
+### User Story 4 - Recovered blueprints are verified before being trusted (Priority: P2)
+
+When a node reconstructs a blueprint from another node's data during recovery or synchronisation, it must verify the blueprint's provenance against sealed register state before storing or executing it.
+
+Today, event-driven blueprint recovery stores a blueprint fetched from another node's response with no signature or digest verification, carried over an untrusted messaging channel. A node that is tricked into recovering a malicious blueprint could store and act on attacker-supplied workflow logic.
+
+**Why this priority**: Closes a provenance gap introduced by recent cross-node recovery work. Lower urgency than US1–US3 because exploitation requires the victim node to be on a recovery/sync path and there is partial mitigation today (blueprints are keyed by identifier and the register carries the canonical version), but "partial mitigation" is exactly what a red team converts into a full compromise.
+
+**Independent Test**: Feed a recovery path a blueprint whose content does not match the digest sealed in the register. It MUST be rejected and not stored. Feed a correctly-sealed blueprint and confirm it is accepted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a blueprint offered to a recovery/sync path, **When** its content digest does not match the digest sealed in the register, **Then** it is rejected and not stored.
+2. **Given** a blueprint with no verifiable provenance (no sealed digest or signature available), **When** recovery runs, **Then** it is not silently stored on the strength of the transport alone.
+3. **Given** a correctly-sealed blueprint matching its on-chain digest, **When** recovery runs, **Then** it is accepted and stored.
+
+---
+
+### User Story 5 - Captured presentation proofs cannot be replayed within the session window (Priority: P2)
+
+A holder's key-binding proof presented during a credential verification must be bound to a short, independently-checked expiry and re-validated against current revocation status at the moment of verification — so a captured proof cannot be replayed even before the verification session closes.
+
+Today, a key-binding proof is checked against a session nonce, an audience, and the session lifetime, but the proof itself carries no independently-enforced expiry. Within the (several-minute) session window, a captured proof can be replayed — even if the holder's device credential was revoked mid-session.
+
+**Why this priority**: Tightens an existing presentation lifecycle. The exposure window is bounded (single session, requires capturing a live proof), so it ranks below the structural gaps in US1–US3, but it is a genuine replay vector against high-value presentations.
+
+**Independent Test**: Capture a valid key-binding proof, then replay it after its short expiry has elapsed but while the session is still open — it MUST be rejected. Separately, revoke the device credential mid-session and replay a still-fresh proof — verification MUST fail because revocation is re-checked at verify time.
+
+**Acceptance Scenarios**:
+
+1. **Given** a key-binding proof whose own expiry has passed, **When** it is presented within an otherwise-open session, **Then** it is rejected.
+2. **Given** a key-binding proof with no expiry, **When** it is presented, **Then** it is rejected for failing the mandatory freshness requirement.
+3. **Given** a device credential revoked after a session opened but before verification completes, **When** a presentation is verified, **Then** revocation status is re-checked at verify time and verification fails.
+
+---
+
+### User Story 6 - Open-participant credential delivery keys cannot be hijacked (Priority: P3)
+
+For a late-bound ("open") participant who has not yet published a participant record, the credential-delivery key carried in a submission must be bound to a verifiable prior artefact, so an attacker cannot claim an open participant slot with a key they control.
+
+Today, key precedence correctly protects *published* participants (a published key cannot be overridden). But for an *unpublished* open participant, the carried delivery key is accepted without verification and travels in plaintext inside the (signed) submission. An attacker who can submit into an open slot before the genuine participant binds could insert their own delivery key and intercept the credential.
+
+**Why this priority**: Lowest urgency — affects only the open-participant late-binding edge, and the surrounding submission is already signed. Ranked P3 but **confirmed in v1 scope (2026-05-24)**: it is closed alongside the other "verify against sealed state" stories while those surfaces are being touched, rather than left as a known cheap-ish interception on open slots.
+
+**Independent Test**: Submit into an open participant slot with a carried delivery key not bound to any prior invitation or pre-registration. It MUST be rejected. Submit with a key bound to a valid invitation/pre-registration and confirm acceptance.
+
+**Acceptance Scenarios**:
+
+1. **Given** a submission into an open participant slot, **When** the carried delivery key is not bound to a verifiable prior artefact (invitation token or sealed pre-registration), **Then** the key is rejected.
+2. **Given** a carried delivery key bound to a valid prior artefact, **When** the submission is processed, **Then** the key is accepted for credential delivery.
+
+---
+
+### Edge Cases
+
+- **Clock skew** (US1, US5): expiry and freshness checks must tolerate a bounded, configured clock-skew window so honest nodes with minor drift are not falsely rejected, while still closing the replay window.
+- **Status-list publisher key rotation** (US1): when the issuing organisation rotates its status-list signing key, verifiers must resolve the current key from sealed state, not a stale pin.
+- **Roster change mid-consensus** (US3): a vote cast just before a validator's sealed ejection must be evaluated against a deterministic, well-defined roster snapshot so all honest nodes reach the same conclusion about whether the vote counted.
+- **Quorum impossibility after ejections** (US3): automatic ejection must not be able to silently drop the roster below a workable quorum without surfacing the condition (ties to existing deadlock-detection concerns, `GOV-5`).
+- **Legitimate node re-registration** (US2): a genuine node restarting and re-registering under its existing identity key must succeed; only identity-forgery and replay are refused.
+- **Recovery of a blueprint not yet sealed** (US4): if the canonical digest is not yet available from the register, recovery must wait or refuse rather than trust the transport.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**US1 — Revocation authenticity**
+- **FR-001**: The system MUST verify the cryptographic signature of a revocation status list against the issuing organisation's key resolved from sealed register state before trusting any revocation bit it contains.
+- **FR-002**: The system MUST reject a status list whose issuer claim does not match the expected organisation identifier, even if the signature is internally valid.
+- **FR-003**: The system MUST fail closed when a status list cannot be fetched or verified — treating affected credentials as not-verifiable rather than serving stale cached status.
+- **FR-004**: The system MUST enforce a freshness bound on accepted status lists, rejecting expired lists.
+
+**US2 — Authenticated peers**
+- **FR-005**: A node MUST prove control of its claimed cryptographic identity (e.g., by signing a challenge) before its registration is accepted.
+- **FR-006**: The system MUST reject network advertisements and liveness messages that are not signed by the originating node's proven identity.
+- **FR-007**: The system MUST validate anti-replay data already carried on peer messages — rejecting messages with non-advancing sequence numbers or stale timestamps.
+- **FR-008**: The system MUST refuse unauthenticated or unencrypted peer transport outside development environments (fail-closed, not silently disabled when unconfigured).
+- **FR-009**: The system MUST rate-limit peer registration attempts per source.
+
+**US3 — Sealed-roster voting authority**
+- **FR-010**: The system MUST derive consensus voting authority solely from the validator roster sealed in on-chain governance state; votes from keys not in that roster MUST be rejected deterministically by every honest node.
+- **FR-011**: The system MUST default new registers to an admission policy requiring explicit roster approval, not open self-registration.
+- **FR-012**: The system MUST eject a validator that equivocates (signs conflicting states for the same slot) automatically and deterministically, identically on every honest node, with no operator action.
+- **FR-013**: The system MUST produce a sealed liveness-timeout record and eject a validator that accepts work but fails to seal within a configured liveness window.
+- **FR-014**: The system MUST treat the on-chain sealed roster as authoritative over any operational/cached copy when evaluating voting authority.
+
+**US4 — Verified recovery**
+- **FR-015**: The system MUST verify a recovered or synchronised blueprint's content against a provenance anchor (digest or signature) sealed in the register before storing or executing it.
+- **FR-016**: The system MUST refuse to store a blueprint that has no verifiable provenance, rather than trusting the delivery channel.
+
+**US5 — Replay-resistant presentations**
+- **FR-017**: The system MUST require an independently-enforced expiry on each holder key-binding proof and reject proofs lacking one.
+- **FR-018**: The system MUST validate the key-binding proof's expiry against wall-clock time (within the configured skew tolerance) at verification, independent of the overall session lifetime.
+- **FR-019**: The system MUST re-check credential revocation status at the moment of verification, not only at session open.
+
+**US6 — Bound open-participant keys**
+- **FR-020**: The system MUST bind a carried credential-delivery key for an unpublished open participant to a verifiable prior artefact (invitation token or sealed pre-registration), and reject unbound carried keys for open slots.
+
+**Cross-cutting**
+- **FR-021**: Every cross-node trust decision introduced or modified by this feature MUST be traceable to a signature anchored in sealed state; the verification path MUST be exercised by an automated test that proves the forged/unsigned variant is rejected.
+- **FR-022**: Security-relevant rejections (forged list, unsigned advertisement, out-of-roster vote, replayed proof, failed recovery verification) MUST be observable via metrics/telemetry for monitoring and alerting.
+
+### Key Entities
+
+- **Revocation Status List**: A signed, time-bounded statement by an organisation of which of its credentials are revoked. Authenticity is anchored in the organisation's sealed-state key; freshness is bounded by an expiry.
+- **Node Identity**: A cryptographic key pair that uniquely identifies a network node. A node's claims (registration, advertisements, liveness) are valid only when signed by the identity it proves control of.
+- **Register Advertisement**: A signed claim by a node that it holds a given register, used for discovery and sync routing.
+- **Sealed Validator Roster**: The authoritative, on-chain governance record of which validator keys may vote, including admission policy and ejection state. The single source of voting authority.
+- **Liveness-Timeout Record**: A sealed, deterministic artefact attesting that a validator failed to seal accepted work within the configured window — the trigger for automatic ejection.
+- **Key-Binding Proof**: A holder/device-signed proof presented during verification, now carrying an independently-enforced short expiry.
+- **Carried Delivery Key**: A credential-delivery key supplied in a submission for a recipient; for open participants it must be bound to a verifiable prior artefact.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A forged, unsigned, or wrong-issuer revocation status list is rejected 100% of the time; a genuinely revoked credential never verifies as valid regardless of which node serves the status list.
+- **SC-002**: When revocation status is unavailable, the verifier fails closed in 100% of cases (zero fail-open occurrences).
+- **SC-003**: A node cannot register under an identity it does not control, cannot advertise ownership of a register it does not hold, and cannot replay a captured message — all three rejected 100% of the time in adversarial testing.
+- **SC-004**: A consensus vote from a key absent from the sealed roster contributes zero weight to quorum on every honest node, with identical outcomes across nodes (deterministic).
+- **SC-005**: A detected equivocating or withholding validator is ejected automatically with zero required operator actions, and the ejection is reproduced identically on every honest node.
+- **SC-006**: A blueprint whose content does not match its sealed provenance anchor is never stored or executed.
+- **SC-007**: A captured key-binding proof replayed after its expiry, or after the underlying credential's mid-session revocation, fails verification 100% of the time.
+- **SC-008**: A red-team reviewer can trace every cross-node trust decision touched by this feature to a specific signature-verification step backed by an automated negative test; there are zero "trust the sender/transport" paths remaining in the affected surfaces.
+
+## Assumptions
+
+- **Pre-release, no backward-compatibility burden**: The platform is pre-release (production readiness ~30%). Changing the default validator-admission policy and tightening verification is acceptable without a migration path for existing deployments. Existing dev/test registers may be re-created.
+- **Sealed-state trust anchors already exist and are sound**: The red-team analysis confirmed DID resolution, issuer-signature verification, and chain integrity are already sealed-state-anchored and fail-closed. This feature reuses those anchors rather than rebuilding them.
+- **Known, bounded validator set**: Federation assumes the operator controls roster admission. Economic/Sybil defences for open admission are out of scope (backlogged).
+- **Configurable thresholds**: Clock-skew tolerance, status-list freshness window, key-binding-proof expiry, peer-registration rate limit, and validator liveness-timeout window are all configurable, with secure defaults; their exact values are tuning details for planning, not scope decisions.
+- **Demo/dev bridges remain dev-only**: Any demo-mint or unauthenticated-dev affordance must be structurally excluded from production builds/config, not merely flag-gated.
+
+## Dependencies
+
+- Builds on existing sealed-state trust anchors (DID resolver, issuer-signature verification, chain integrity, double-vote detection).
+- US3 establishes the on-chain roster + deterministic equivocation primitives that the backlogged **permissionless validation** feature (`PERM-1..PERM-5`) will extend.
+- US5 extends the existing timebound presentation lifecycle.
+- US4 closes a gap in the existing cross-node blueprint recovery path.
+- Related existing backlog/governance items to keep coherent: `GOV-5` (quorum deadlock detection), `GOV-6` (roster reconstruction caching), `TRUST-6` (consensus finality).
+
+## Out of Scope (explicitly)
+
+- **Permissionless / open-membership validation** — Sybil-resistant stake-based admission, bonded collateral, economic slashing. These are the separate backlogged feature (`PERM-1..PERM-5`). This feature assumes a roster-gated, operator-controlled validator set.
+- General consensus-finality redesign (`TRUST-6`) beyond what roster authority requires.
+- Re-encryption of historical payloads after key compromise (`TRUST-10`).
+- Cross-register reference verification (`TRUST-7`).

--- a/specs/138-federation-trust-hardening/tasks.md
+++ b/specs/138-federation-trust-hardening/tasks.md
@@ -28,8 +28,8 @@ description: "Task list for Federation Trust Hardening (Feature 138)"
 
 **Purpose**: Configuration and observability scaffolding consumed across stories
 
-- [ ] T001 [P] Add feature config keys with secure defaults per `contracts/config-and-metrics.md` to the relevant `appsettings.json` and bind via options classes: `Verifier:ClockSkewSeconds` (60), `Verifier:KbJwtMaxLifetimeSeconds` (120) in `src/Apps/Sorcha.Verifier/appsettings.json`; `PeerService:EnableTls`, `PeerService:ChallengeTtlSeconds` (30) in `src/Services/Sorcha.Peer.Service/appsettings.json`; `Consensus:LivenessTimeoutSeconds` (from policy `DocketTimeoutSeconds`) referenced in `src/Services/Sorcha.Validator.Service/appsettings.json`
-- [ ] T002 [P] Declare the 8 new OTel rejection counters on the existing `Sorcha.Verifier` / `Sorcha.Peer` / `Sorcha.Validator` / `Sorcha.Blueprint` meters per `contracts/config-and-metrics.md` (instrument definitions only; incremented within each story)
+- [X] T001 [P] Add feature config keys with secure defaults per `contracts/config-and-metrics.md` to the relevant `appsettings.json` and bind via options classes: `Verifier:ClockSkewSeconds` (60), `Verifier:KbJwtMaxLifetimeSeconds` (120) in `src/Apps/Sorcha.Verifier/appsettings.json`; `PeerService:EnableTls`, `PeerService:ChallengeTtlSeconds` (30) in `src/Services/Sorcha.Peer.Service/appsettings.json`; `Consensus:LivenessTimeoutSeconds` (from policy `DocketTimeoutSeconds`) referenced in `src/Services/Sorcha.Validator.Service/appsettings.json`
+- [X] T002 [P] Declare the 8 new OTel rejection counters on the existing `Sorcha.Verifier` / `Sorcha.Peer` / `Sorcha.Validator` / `Sorcha.Blueprint` meters per `contracts/config-and-metrics.md` (instrument definitions only; incremented within each story)
 
 ---
 
@@ -39,8 +39,8 @@ description: "Task list for Federation Trust Hardening (Feature 138)"
 
 **⚠️ CRITICAL**: Complete before starting the dependent user stories
 
-- [ ] T003 Add a shared clock-skew helper bound to `Verifier:ClockSkewSeconds` in `src/Common/Sorcha.ServiceDefaults/` (consumed by US1 status-list freshness, US2 heartbeat timestamp, US5 KB-JWT exp) using the injected `TimeProvider`
-- [ ] T004 [P] Add a reusable "security-posture degraded" health-check signal helper in `src/Common/Sorcha.ServiceDefaults/` following the Storage Registration Log pattern (CLAUDE.md §10/§11), used by US1 (status-list unverifiable) and US2 (mTLS unavailable)
+- [X] T003 Add a shared clock-skew helper bound to `Verifier:ClockSkewSeconds` in `src/Common/Sorcha.ServiceDefaults/` (consumed by US1 status-list freshness, US2 heartbeat timestamp, US5 KB-JWT exp) using the injected `TimeProvider`
+- [X] T004 [P] Add a reusable "security-posture degraded" health-check signal helper in `src/Common/Sorcha.ServiceDefaults/` following the Storage Registration Log pattern (CLAUDE.md §10/§11), used by US1 (status-list unverifiable) and US2 (mTLS unavailable)
 
 **Checkpoint**: Shared config, metrics, clock-skew, and health signals ready — user stories can begin (in parallel if staffed).
 

--- a/specs/138-federation-trust-hardening/tasks.md
+++ b/specs/138-federation-trust-hardening/tasks.md
@@ -147,15 +147,15 @@ description: "Task list for Federation Trust Hardening (Feature 138)"
 
 ### Tests for User Story 4 ⚠️ (write first, must fail)
 
-- [ ] T050 [P] [US4] Negative test: blueprint whose content ≠ sealed `ContentHash` rejected and not stored, in `tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryProvenanceTests.cs`
-- [ ] T051 [P] [US4] Negative test: blueprint with no sealed digest not stored; honest-path: matching digest accepted, in `tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryHonestPathTests.cs`
+- [X] T050 [P] [US4] Negative test: blueprint whose content ≠ sealed `ContentHash` rejected and not stored, in `tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryProvenanceTests.cs`
+- [X] T051 [P] [US4] Negative test: blueprint with no sealed digest not stored; honest-path: matching digest accepted, in `tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryHonestPathTests.cs`
 
 ### Implementation for User Story 4
 
-- [ ] T052 [P] [US4] Add `ContentHash` to `PublishedBlueprintEntry`, in `src/Common/Sorcha.ServiceClients/.../IRegisterServiceClient.cs`
-- [ ] T053 [US4] Compute SHA-256 over canonical blueprint JSON at publish time (sealed via `control.blueprint.publish`), with a shared canonical-JSON serializer in `src/Services/Sorcha.Blueprint.Service/`
-- [ ] T054 [US4] Verify the recomputed canonical hash against the sealed `ContentHash` before storing; reject on mismatch/missing, in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs`
-- [ ] T055 [US4] Increment `sorcha_blueprint_recovery_rejected_total{reason}`, in `BlueprintRecoveryService.cs`
+- [X] T052 [P] [US4] Add `ContentHash` to `PublishedBlueprintEntry`, in `src/Common/Sorcha.ServiceClients/.../IRegisterServiceClient.cs`
+- [X] T053 [US4] Compute SHA-256 over canonical blueprint JSON at publish time (sealed via `control.blueprint.publish`), with a shared canonical-JSON serializer in `src/Services/Sorcha.Blueprint.Service/`
+- [X] T054 [US4] Verify the recomputed canonical hash against the sealed `ContentHash` before storing; reject on mismatch/missing, in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs`
+- [X] T055 [US4] Increment `sorcha_blueprint_recovery_rejected_total{reason}`, in `BlueprintRecoveryService.cs`
 
 **Checkpoint**: US1–US4 independently functional.
 

--- a/specs/138-federation-trust-hardening/tasks.md
+++ b/specs/138-federation-trust-hardening/tasks.md
@@ -1,0 +1,291 @@
+---
+description: "Task list for Federation Trust Hardening (Feature 138)"
+---
+
+# Tasks: Federation Trust Hardening
+
+**Input**: Design documents from `/specs/138-federation-trust-hardening/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ (all present)
+
+**Tests**: REQUIRED. The spec's unifying criterion (FR-021 / SC-008) mandates an automated negative test proving the forged/unsigned/replayed variant is rejected for every hardened surface. Constitution Principle IV requires >85% coverage on new code. Tests are written test-first within each story.
+
+**Organization**: Tasks are grouped by user story. Each story is an independently shippable slice (US1 → US6 in priority order).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete tasks)
+- **[Story]**: US1–US6 maps to spec user stories
+- All paths are absolute-from-repo-root; types named per data-model.md / research.md
+
+## Path Conventions
+
+- Source: `src/Common/…`, `src/Services/…`, `src/Apps/…` (microservices layout from plan.md)
+- Tests: `tests/<Project>.Tests/…` (xUnit + FluentAssertions + Moq)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Configuration and observability scaffolding consumed across stories
+
+- [ ] T001 [P] Add feature config keys with secure defaults per `contracts/config-and-metrics.md` to the relevant `appsettings.json` and bind via options classes: `Verifier:ClockSkewSeconds` (60), `Verifier:KbJwtMaxLifetimeSeconds` (120) in `src/Apps/Sorcha.Verifier/appsettings.json`; `PeerService:EnableTls`, `PeerService:ChallengeTtlSeconds` (30) in `src/Services/Sorcha.Peer.Service/appsettings.json`; `Consensus:LivenessTimeoutSeconds` (from policy `DocketTimeoutSeconds`) referenced in `src/Services/Sorcha.Validator.Service/appsettings.json`
+- [ ] T002 [P] Declare the 8 new OTel rejection counters on the existing `Sorcha.Verifier` / `Sorcha.Peer` / `Sorcha.Validator` / `Sorcha.Blueprint` meters per `contracts/config-and-metrics.md` (instrument definitions only; incremented within each story)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared primitives that US1/US2/US5 (clock skew) and US1/US2 (health degradation) all depend on
+
+**⚠️ CRITICAL**: Complete before starting the dependent user stories
+
+- [ ] T003 Add a shared clock-skew helper bound to `Verifier:ClockSkewSeconds` in `src/Common/Sorcha.ServiceDefaults/` (consumed by US1 status-list freshness, US2 heartbeat timestamp, US5 KB-JWT exp) using the injected `TimeProvider`
+- [ ] T004 [P] Add a reusable "security-posture degraded" health-check signal helper in `src/Common/Sorcha.ServiceDefaults/` following the Storage Registration Log pattern (CLAUDE.md §10/§11), used by US1 (status-list unverifiable) and US2 (mTLS unavailable)
+
+**Checkpoint**: Shared config, metrics, clock-skew, and health signals ready — user stories can begin (in parallel if staffed).
+
+---
+
+## Phase 3: User Story 1 - Revocation cannot be forged (Priority: P1) 🎯 MVP
+
+**Goal**: The verifier authenticates the revocation status list against a sealed-state-anchored key and fails closed when it cannot.
+
+**Independent Test**: Serve a forged/unsigned/wrong-issuer status list and confirm the credential is rejected; block the fetch and confirm fail-closed; confirm a genuine list still correctly reports revoked/valid. (quickstart US1)
+
+### Tests for User Story 1 ⚠️ (write first, must fail)
+
+- [ ] T005 [P] [US1] Negative test: forged-signature status list rejected, in `tests/Sorcha.Verifier.Engine.Tests/StatusListSignatureTests.cs`
+- [ ] T006 [P] [US1] Negative test: `iss` mismatch rejected even when signature internally valid, in `tests/Sorcha.Verifier.Engine.Tests/StatusListIssuerPinningTests.cs`
+- [ ] T007 [P] [US1] Negative test: fetch failure fails closed (no stale-cache serve), in `tests/Sorcha.Verifier.Engine.Tests/StatusListFailClosedTests.cs`
+- [ ] T008 [P] [US1] Negative test: expired list rejected (no +24h default), and honest-path: genuine signed list reports revoked correctly, in `tests/Sorcha.Verifier.Engine.Tests/StatusListFreshnessTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Inject `IIssuerKeyResolver` into `StatusListCache` and verify the JWT signature inside `ParseJwt()` before trusting any bit, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [ ] T010 [US1] Pin `iss` to the expected org DID and reject on mismatch in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [ ] T011 [US1] Make `GetOrFetchAsync` fail closed: remove stale-cache fallback on fetch/verify failure; only cache `Verified` lists, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [ ] T012 [US1] Enforce freshness against list `exp` within clock skew (T003); remove the +24h default, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [ ] T013 [US1] Ensure the consuming path treats "unverifiable" as fail (not "unknown ⇒ allowed") at the `IsRevokedAsync` call site, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
+- [ ] T014 [P] [US1] Add a `kid` header identifying the signing verification method, in `src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs`
+- [ ] T015 [US1] Wire the `IIssuerKeyResolver` into `StatusListCache` registration (DID-backed → JWK-registry composite; JWK-registry path dev-only), in `src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs`
+- [ ] T016 [US1] Increment `sorcha_statuslist_rejected_total{reason}` on each rejection path, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+
+**Checkpoint**: US1 fully functional and independently testable — revocation forgery is closed.
+
+---
+
+## Phase 4: User Story 2 - Peer identity & claims are provable (Priority: P1)
+
+**Goal**: Nodes prove control of a cryptographic identity; advertisements/heartbeats are signed and replay-checked; transport is fail-closed outside dev; registration is rate-limited.
+
+**Independent Test**: Attempt identity forgery, register-ownership spoofing, and heartbeat replay — all rejected; cleartext peer connection refused in prod profile; legitimate node restart re-registers fine. (quickstart US2)
+
+### Tests for User Story 2 ⚠️ (write first, must fail)
+
+- [ ] T017 [P] [US2] Negative test: `RegisterPeer` without valid challenge signature refused, in `tests/Sorcha.Peer.Service.Tests/PeerRegistrationSignatureTests.cs`
+- [ ] T018 [P] [US2] Negative test: `peer_id` ≠ public-key thumbprint refused, in `tests/Sorcha.Peer.Service.Tests/PeerIdentityBindingTests.cs`
+- [ ] T019 [P] [US2] Negative test: replayed heartbeat (stale sequence/timestamp) rejected, in `tests/Sorcha.Peer.Service.Tests/HeartbeatReplayTests.cs`
+- [ ] T020 [P] [US2] Negative test: unsigned/wrong-key advertisement dropped and not propagated, in `tests/Sorcha.Peer.Service.Tests/AdvertisementSignatureTests.cs`
+- [ ] T021 [P] [US2] Negative test: cleartext transport refused outside Development; allowed in Development, in `tests/Sorcha.Peer.Service.Tests/TransportFailClosedTests.cs`
+- [ ] T022 [P] [US2] Negative test: registration rate limit returns `RESOURCE_EXHAUSTED`, in `tests/Sorcha.Peer.Service.Tests/PeerRateLimitTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T023 [P] [US2] Add proto changes (`RequestChallenge` RPC + `RegisterPeerRequest` public_key/timestamp/challenge_nonce/signature) in `src/Services/Sorcha.Peer.Service/Protos/peer_communication.proto`
+- [ ] T024 [P] [US2] Add `signature` to `RegisterAdvertisement` and a signature to the heartbeat body in `src/Services/Sorcha.Peer.Service/Protos/peer_heartbeat.proto`
+- [ ] T025 [P] [US2] Add `PublicKey`, `LastHeartbeatSequenceNumber`, `LastHeartbeatTimestamp` to `src/Services/Sorcha.Peer.Service/Models/PeerNode.cs`; bind `PeerId` to the public-key thumbprint
+- [ ] T026 [US2] EF migration for the new `PeerNode` fields and the `NodeIdentity` table, in `src/Services/Sorcha.Peer.Service/` (set `$env:ConnectionStrings__Sorcha__Postgres`; do not use `--no-build`)
+- [ ] T027 [US2] Create `NodeIdentityService` (ED25519 keygen via `CryptoModule`, private key encrypted via Key Protection Provider, public-key thumbprint as NodeId) in `src/Services/Sorcha.Peer.Service/Services/NodeIdentityService.cs`; bootstrap in `Program.cs`
+- [ ] T028 [US2] Implement `RequestChallenge` + signature verification on `RegisterPeer` (reject bad signature / id mismatch / stale timestamp / unknown-expired challenge), in `src/Services/Sorcha.Peer.Service/GrpcServices/PeerDiscoveryServiceImpl.cs`
+- [ ] T029 [US2] Validate `sequence_number` monotonicity + timestamp freshness (T003) and heartbeat body signature, in `src/Services/Sorcha.Peer.Service/GrpcServices/PeerHeartbeatGrpcService.cs`
+- [ ] T030 [US2] Sign outgoing advertisements and verify incoming ones against the originating node's stored `PublicKey`; drop unsigned/bad, in `src/Services/Sorcha.Peer.Service/Services/RegisterAdvertisementService.cs` and `src/Services/Sorcha.Peer.Service/Services/PeerHeartbeatService.cs`
+- [ ] T031 [US2] Make `PeerAuthInterceptor` fail closed outside Development (no silent anonymous; reject expired/missing auth), in `src/Services/Sorcha.Peer.Service/Interceptors/PeerAuthInterceptor.cs`
+- [ ] T032 [US2] Enforce mTLS outside Development: gate the cleartext HTTP/2 switch on `PeerService:EnableTls`; configure Kestrel client-cert validation and client cert in `src/Services/Sorcha.Peer.Service/Program.cs` and `src/Services/Sorcha.Peer.Service/Services/PeerConnectionPool.cs`
+- [ ] T033 [P] [US2] Create `RateLimitInterceptor` (gRPC `RESOURCE_EXHAUSTED`, fed by `RateLimitSettings`) and register it, in `src/Services/Sorcha.Peer.Service/Interceptors/RateLimitInterceptor.cs` + `Program.cs`
+- [ ] T034 [US2] Increment `sorcha_peer_registration_rejected_total{reason}` and `sorcha_peer_message_rejected_total{reason}`; surface degraded health when mTLS unavailable (T004), across the peer GrpcServices
+
+**Checkpoint**: US1 and US2 both independently functional.
+
+---
+
+## Phase 5: User Story 3 - Sealed-roster vote authority (Priority: P1)
+
+**Goal**: Vote authority derives solely from the sealed on-chain roster; admission defaults to Consent; equivocation and withholding trigger automatic, deterministic, sealed ejection. Establishes the `PERM-*` primitives.
+
+**Independent Test**: Out-of-roster vote gets zero quorum weight deterministically; new register defaults to Consent; equivocation auto-ejects with no operator action; withholding auto-ejects after timeout. (quickstart US3)
+
+### Tests for User Story 3 ⚠️ (write first, must fail)
+
+- [ ] T035 [P] [US3] Negative test: vote signed by key absent from sealed roster contributes zero quorum weight, deterministically across nodes, in `tests/Sorcha.Validator.Service.Tests/SealedRosterVoteAuthorityTests.cs`
+- [ ] T036 [P] [US3] Test: `RegisterPolicy.CreateDefault()` defaults to Consent; self-registered validator is `Pending` and casts no counting vote, in `tests/Sorcha.Register.Models.Tests/RegistrationModeDefaultTests.cs`
+- [ ] T037 [P] [US3] Test: equivocation produces a deterministic sealed `control.validator.eject` with zero operator actions; entry → `Ejected`, in `tests/Sorcha.Validator.Service.Tests/EquivocationEjectionTests.cs`
+- [ ] T038 [P] [US3] Test: withholding produces a sealed `control.validator.liveness-violation` after the timeout, in `tests/Sorcha.Validator.Service.Tests/LivenessTimeoutEjectionTests.cs`
+- [ ] T039 [P] [US3] Test: ejection that would break quorum surfaces the condition rather than silently bricking, in `tests/Sorcha.Validator.Service.Tests/QuorumGuardTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T040 [P] [US3] Flip `CreateDefault()` `RegistrationMode` `Public → Consent`, in `src/Common/Sorcha.Register.Models/RegisterPolicy.cs`
+- [ ] T041 [P] [US3] Add `Ejected` status + `EjectionRef` to roster entries, in `src/Common/Sorcha.Register.Models/ValidatorRoster.cs`
+- [ ] T042 [US3] Implement roster reconstruction from `RegisterControlRecord.Validators` (sealed) and make the `ValidatorRegistry` cache a derived, non-authoritative view (seal wins on divergence), in `src/Services/Sorcha.Validator.Service/Services/ValidatorRegistry.cs`
+- [ ] T043 [US3] Derive vote authority from the sealed roster in `ValidateVotesAsync` (key ∈ sealed ActiveValidators ∧ signatureValid ∧ ¬doubleVote), in `src/Services/Sorcha.Validator.Service/Services/ConsensusEngine.cs`
+- [ ] T044 [P] [US3] Define the `control.validator.eject` and `control.validator.liveness-violation` action types per `contracts/validator-control-transactions.md`, in `src/Common/Sorcha.Register.Models/`
+- [ ] T045 [US3] Process the two new control actions (apply ejection to sealed roster state) in `src/Services/Sorcha.Validator.Service/Services/ControlDocketProcessor.cs`
+- [ ] T046 [US3] Emit a deterministic `control.validator.eject` (carrying the two conflicting signed votes) on detected double-vote, replacing the in-memory-only log + manual revoke, in `src/Services/Sorcha.Validator.Service/Services/BadActorDetector.cs`
+- [ ] T047 [US3] Detect accept-without-seal past `LivenessTimeoutSeconds` and emit `control.validator.liveness-violation`, in `src/Services/Sorcha.Validator.Service/Services/ConsensusEngine.cs`
+- [ ] T048 [US3] Add the quorum guard (surface, don't silently drop below workable quorum; ties to GOV-5), in `src/Services/Sorcha.Validator.Service/Services/ConsensusEngine.cs`
+- [ ] T049 [US3] Increment `sorcha_validator_vote_rejected_total{reason}` and `sorcha_validator_ejected_total{reason}`, across the validator services
+
+**Checkpoint**: US1–US3 independently functional; on-chain-roster + deterministic-ejection primitives in place for `PERM-*`.
+
+---
+
+## Phase 6: User Story 4 - Verified blueprint recovery (Priority: P2)
+
+**Goal**: Recovered blueprints are verified against a sealed content digest before storage.
+
+**Independent Test**: Tampered blueprint (hash mismatch) and no-provenance blueprint both rejected; correctly-sealed blueprint accepted. (quickstart US4)
+
+### Tests for User Story 4 ⚠️ (write first, must fail)
+
+- [ ] T050 [P] [US4] Negative test: blueprint whose content ≠ sealed `ContentHash` rejected and not stored, in `tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryProvenanceTests.cs`
+- [ ] T051 [P] [US4] Negative test: blueprint with no sealed digest not stored; honest-path: matching digest accepted, in `tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryHonestPathTests.cs`
+
+### Implementation for User Story 4
+
+- [ ] T052 [P] [US4] Add `ContentHash` to `PublishedBlueprintEntry`, in `src/Common/Sorcha.ServiceClients/.../IRegisterServiceClient.cs`
+- [ ] T053 [US4] Compute SHA-256 over canonical blueprint JSON at publish time (sealed via `control.blueprint.publish`), with a shared canonical-JSON serializer in `src/Services/Sorcha.Blueprint.Service/`
+- [ ] T054 [US4] Verify the recomputed canonical hash against the sealed `ContentHash` before storing; reject on mismatch/missing, in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs`
+- [ ] T055 [US4] Increment `sorcha_blueprint_recovery_rejected_total{reason}`, in `BlueprintRecoveryService.cs`
+
+**Checkpoint**: US1–US4 independently functional.
+
+---
+
+## Phase 7: User Story 5 - Presentation replay hardening (Priority: P2)
+
+**Goal**: KB-JWT carries a mandatory, independently-checked short expiry; revocation re-checked at verify time.
+
+**Independent Test**: Expired KB-JWT replay rejected within an open session; missing-exp rejected; mid-session revocation fails verification. (quickstart US5)
+
+### Tests for User Story 5 ⚠️ (write first, must fail)
+
+- [ ] T056 [P] [US5] Negative test: KB-JWT replayed after its `exp` rejected within an open session, in `tests/Sorcha.Verifier.Engine.Tests/KbJwtExpiryTests.cs`
+- [ ] T057 [P] [US5] Negative test: KB-JWT with no `exp` rejected; over-long-lived KB-JWT (> `KbJwtMaxLifetimeSeconds`) rejected, in `tests/Sorcha.Verifier.Engine.Tests/KbJwtMissingExpTests.cs`
+- [ ] T058 [P] [US5] Negative test: device credential revoked mid-session fails verification (revocation re-checked at verify time), in `tests/Sorcha.Verifier.Engine.Tests/MidSessionRevocationTests.cs`
+
+### Implementation for User Story 5
+
+- [ ] T059 [US5] Require and validate KB-JWT `exp` against wall-clock within clock skew (T003), before delegation/status validation; reject missing `exp`, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
+- [ ] T060 [US5] Enforce `KbJwtMaxLifetimeSeconds` upper bound on `exp − iat`, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
+- [ ] T061 [US5] Increment `sorcha_presentation_replay_rejected_total{reason}`, in `VerifiablePresentationValidator.cs`
+
+**Checkpoint**: US1–US5 independently functional.
+
+---
+
+## Phase 8: User Story 6 - Open-participant key binding (Priority: P3)
+
+**Goal**: For open/unpublished participants, the carried delivery key must be bound to a verifiable prior artifact; published participants unaffected.
+
+**Independent Test**: Unbound carried key into an open slot rejected; key bound to a valid invitation accepted; published-participant path unchanged. (quickstart US6)
+
+### Tests for User Story 6 ⚠️ (write first, must fail)
+
+- [ ] T062 [P] [US6] Negative test: unbound carried key for open/unpublished participant rejected; commitment-mismatch rejected, in `tests/Sorcha.Blueprint.Service.Tests/CarriedKeyBindingTests.cs`
+- [ ] T063 [P] [US6] Test: carried key bound to a valid unconsumed invitation accepted; published-participant ("published wins") path unaffected, in `tests/Sorcha.Blueprint.Service.Tests/CarriedKeyHonestPathTests.cs`
+
+### Implementation for User Story 6
+
+- [ ] T064 [US6] Add an invitation commitment lookup (commitment derived from `RegisterInvitationRecord.Nonce` + carried key), in `src/Services/Sorcha.Tenant.Service/Services/RegisterInvitationService.cs`
+- [ ] T065 [US6] For open + unpublished participants, require the carried key to match the binding artifact; reject unbound/mismatch; leave the published-wins path untouched, in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs`
+- [ ] T066 [US6] Increment `sorcha_carried_key_rejected_total{reason}`, in `ActionExecutionService.cs`
+
+**Checkpoint**: All six stories independently functional.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, security hardening verification, and whole-feature validation
+
+- [ ] T067 Verify the demo-mint / JWK-registry issuer resolver is **structurally excluded** from production composition (not flag-gated), with a test asserting it, in `tests/Sorcha.Verifier.Engine.Tests/ProductionIssuerCompositionTests.cs`
+- [ ] T068 [P] Update `.claude/skills/sorcha-architecture/SKILL.md` with the Feature 138 trust-hardening surfaces (status-list verification, peer identity, sealed-roster authority, control.validator.* actions, blueprint content hash, KB-JWT expiry, carried-key binding)
+- [ ] T069 [P] Update `docs/reference/API-DOCUMENTATION.md` and affected service READMEs (Peer, Validator, Blueprint, Wallet, Tenant) for changed contracts/config
+- [ ] T070 [P] Add a CLAUDE.md Critical Patterns entry for the federation fail-closed/sealed-state trust rule (one concise section)
+- [ ] T071 Run `dotnet test` and confirm >85% coverage on new code (constitution IV); confirm every quickstart negative variant has a passing test (FR-021 / SC-008)
+- [ ] T072 Execute `specs/138-federation-trust-hardening/quickstart.md` end-to-end against the Docker stack and record results
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: depends on Setup; blocks US1/US2/US5 (clock skew T003) and US1/US2 (health T004). US3/US4/US6 do not depend on T003/T004.
+- **User Stories (Phases 3–8)**: depend on Foundational; otherwise mutually independent and parallelizable
+- **Polish (Phase 9)**: depends on the targeted stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: needs T003 (clock skew). Independent of other stories. **MVP.**
+- **US2 (P1)**: needs T003, T004. Independent.
+- **US3 (P1)**: independent (no T003/T004 dependency). Establishes `PERM-*` primitives.
+- **US4 (P2)**: independent.
+- **US5 (P2)**: needs T003. Mid-session-revocation behavior is *strengthened* by US1's fail-closed change but the exp checks are independently testable.
+- **US6 (P3)**: independent.
+
+### Within Each Story
+
+- Tests first (must fail) → models/proto → services → wiring/metrics
+- Same-file tasks are sequential; different-file tasks marked [P] parallelize
+
+### Parallel Opportunities
+
+- Setup T001/T002 parallel; Foundational T004 parallel with T003-dependent prep
+- Once Phase 2 done, all six stories can proceed in parallel by different developers
+- All `[P]` test tasks within a story run together; proto/model `[P]` tasks within a story run together
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (all parallel — distinct files):
+Task: "Forged-signature rejected — tests/Sorcha.Verifier.Engine.Tests/StatusListSignatureTests.cs"
+Task: "iss mismatch rejected — tests/Sorcha.Verifier.Engine.Tests/StatusListIssuerPinningTests.cs"
+Task: "Fail-closed on fetch failure — tests/Sorcha.Verifier.Engine.Tests/StatusListFailClosedTests.cs"
+Task: "Expired list rejected + honest path — tests/Sorcha.Verifier.Engine.Tests/StatusListFreshnessTests.cs"
+
+# Then implementation — T014 (publisher kid) parallel with the StatusListCache work;
+# T009–T013 are sequential (same file: StatusListCache.cs / VerifiablePresentationValidator.cs).
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup → Phase 2 Foundational (T003 at minimum)
+2. Phase 3 US1 (status-list signature verification + fail-closed)
+3. **STOP and VALIDATE**: run quickstart US1; revocation forgery closed with the smallest blast radius
+4. Ship
+
+### Incremental Delivery
+
+US1 → US2 → US3 (P1 wave: the structural gaps "someone will try first") → US4 → US5 (P2) → US6 (P3). Each story ships and validates independently.
+
+### Parallel Team Strategy
+
+After Phase 2: Dev A → US1+US5 (verifier engine), Dev B → US2 (peer), Dev C → US3 (validator), Dev D → US4+US6 (blueprint). US3 is the largest; weight staffing there.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete-task dependency
+- Every hardened surface has a negative test proving the forged/unsigned/replayed variant is rejected (FR-021)
+- All new trust decisions fail **closed**; verify tests assert rejection, not silent fallback
+- Commit after each task or logical group; each story is a clean PR boundary (branch + PR policy)
+- EF migrations (T026): set `$env:ConnectionStrings__Sorcha__Postgres`, avoid `--no-build`

--- a/specs/138-federation-trust-hardening/tasks.md
+++ b/specs/138-federation-trust-hardening/tasks.md
@@ -169,15 +169,15 @@ description: "Task list for Federation Trust Hardening (Feature 138)"
 
 ### Tests for User Story 5 ⚠️ (write first, must fail)
 
-- [ ] T056 [P] [US5] Negative test: KB-JWT replayed after its `exp` rejected within an open session, in `tests/Sorcha.Verifier.Engine.Tests/KbJwtExpiryTests.cs`
-- [ ] T057 [P] [US5] Negative test: KB-JWT with no `exp` rejected; over-long-lived KB-JWT (> `KbJwtMaxLifetimeSeconds`) rejected, in `tests/Sorcha.Verifier.Engine.Tests/KbJwtMissingExpTests.cs`
-- [ ] T058 [P] [US5] Negative test: device credential revoked mid-session fails verification (revocation re-checked at verify time), in `tests/Sorcha.Verifier.Engine.Tests/MidSessionRevocationTests.cs`
+- [X] T056 [P] [US5] Negative test: KB-JWT replayed after its `exp` rejected within an open session, in `tests/Sorcha.Verifier.Engine.Tests/KbJwtExpiryTests.cs`
+- [X] T057 [P] [US5] Negative test: KB-JWT with no `exp` rejected; over-long-lived KB-JWT (> `KbJwtMaxLifetimeSeconds`) rejected, in `tests/Sorcha.Verifier.Engine.Tests/KbJwtMissingExpTests.cs`
+- [X] T058 [P] [US5] Negative test: device credential revoked mid-session fails verification (revocation re-checked at verify time), in `tests/Sorcha.Verifier.Engine.Tests/MidSessionRevocationTests.cs`
 
 ### Implementation for User Story 5
 
-- [ ] T059 [US5] Require and validate KB-JWT `exp` against wall-clock within clock skew (T003), before delegation/status validation; reject missing `exp`, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
-- [ ] T060 [US5] Enforce `KbJwtMaxLifetimeSeconds` upper bound on `exp − iat`, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
-- [ ] T061 [US5] Increment `sorcha_presentation_replay_rejected_total{reason}`, in `VerifiablePresentationValidator.cs`
+- [X] T059 [US5] Require and validate KB-JWT `exp` against wall-clock within clock skew (T003), before delegation/status validation; reject missing `exp`, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
+- [X] T060 [US5] Enforce `KbJwtMaxLifetimeSeconds` upper bound on `exp − iat`, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
+- [X] T061 [US5] Increment `sorcha_presentation_replay_rejected_total{reason}`, in `VerifiablePresentationValidator.cs`
 
 **Checkpoint**: US1–US5 independently functional.
 

--- a/specs/138-federation-trust-hardening/tasks.md
+++ b/specs/138-federation-trust-hardening/tasks.md
@@ -54,21 +54,21 @@ description: "Task list for Federation Trust Hardening (Feature 138)"
 
 ### Tests for User Story 1 ⚠️ (write first, must fail)
 
-- [ ] T005 [P] [US1] Negative test: forged-signature status list rejected, in `tests/Sorcha.Verifier.Engine.Tests/StatusListSignatureTests.cs`
-- [ ] T006 [P] [US1] Negative test: `iss` mismatch rejected even when signature internally valid, in `tests/Sorcha.Verifier.Engine.Tests/StatusListIssuerPinningTests.cs`
-- [ ] T007 [P] [US1] Negative test: fetch failure fails closed (no stale-cache serve), in `tests/Sorcha.Verifier.Engine.Tests/StatusListFailClosedTests.cs`
-- [ ] T008 [P] [US1] Negative test: expired list rejected (no +24h default), and honest-path: genuine signed list reports revoked correctly, in `tests/Sorcha.Verifier.Engine.Tests/StatusListFreshnessTests.cs`
+- [X] T005 [P] [US1] Negative test: forged-signature status list rejected, in `tests/Sorcha.Verifier.Engine.Tests/StatusListSignatureTests.cs`
+- [X] T006 [P] [US1] Negative test: `iss` mismatch rejected even when signature internally valid, in `tests/Sorcha.Verifier.Engine.Tests/StatusListIssuerPinningTests.cs`
+- [X] T007 [P] [US1] Negative test: fetch failure fails closed (no stale-cache serve), in `tests/Sorcha.Verifier.Engine.Tests/StatusListFailClosedTests.cs`
+- [X] T008 [P] [US1] Negative test: expired list rejected (no +24h default), and honest-path: genuine signed list reports revoked correctly, in `tests/Sorcha.Verifier.Engine.Tests/StatusListFreshnessTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] Inject `IIssuerKeyResolver` into `StatusListCache` and verify the JWT signature inside `ParseJwt()` before trusting any bit, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
-- [ ] T010 [US1] Pin `iss` to the expected org DID and reject on mismatch in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
-- [ ] T011 [US1] Make `GetOrFetchAsync` fail closed: remove stale-cache fallback on fetch/verify failure; only cache `Verified` lists, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
-- [ ] T012 [US1] Enforce freshness against list `exp` within clock skew (T003); remove the +24h default, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
-- [ ] T013 [US1] Ensure the consuming path treats "unverifiable" as fail (not "unknown ⇒ allowed") at the `IsRevokedAsync` call site, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
-- [ ] T014 [P] [US1] Add a `kid` header identifying the signing verification method, in `src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs`
-- [ ] T015 [US1] Wire the `IIssuerKeyResolver` into `StatusListCache` registration (DID-backed → JWK-registry composite; JWK-registry path dev-only), in `src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs`
-- [ ] T016 [US1] Increment `sorcha_statuslist_rejected_total{reason}` on each rejection path, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [X] T009 [US1] Inject `IIssuerKeyResolver` into `StatusListCache` and verify the JWT signature inside `ParseJwt()` before trusting any bit, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [X] T010 [US1] Pin `iss` to the expected org DID and reject on mismatch in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [X] T011 [US1] Make `GetOrFetchAsync` fail closed: remove stale-cache fallback on fetch/verify failure; only cache `Verified` lists, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [X] T012 [US1] Enforce freshness against list `exp` within clock skew (T003); remove the +24h default, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
+- [X] T013 [US1] Ensure the consuming path treats "unverifiable" as fail (not "unknown ⇒ allowed") at the `IsRevokedAsync` call site, in `src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs`
+- [X] T014 [P] [US1] Add a `kid` header identifying the signing verification method, in `src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs`
+- [X] T015 [US1] Wire the `IIssuerKeyResolver` into `StatusListCache` registration (DID-backed → JWK-registry composite; JWK-registry path dev-only), in `src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs`
+- [X] T016 [US1] Increment `sorcha_statuslist_rejected_total{reason}` on each rejection path, in `src/Common/Sorcha.Verifier.Engine/StatusListCache.cs`
 
 **Checkpoint**: US1 fully functional and independently testable — revocation forgery is closed.
 

--- a/src/Apps/Sorcha.Agent/Haip/KbJwtBuilder.cs
+++ b/src/Apps/Sorcha.Agent/Haip/KbJwtBuilder.cs
@@ -33,11 +33,15 @@ public static class KbJwtBuilder
             ["typ"] = "kb+jwt"
         };
 
+        // Feature 138 US5 — carry a short, mandatory exp (120s) so the proof cannot be replayed
+        // beyond a tight window; verifiers reject KB-JWTs lacking exp or exceeding the lifetime bound.
+        var iat = DateTimeOffset.UtcNow;
         var payload = new Dictionary<string, object>
         {
             ["aud"] = audience,
             ["nonce"] = nonce,
-            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["iat"] = iat.ToUnixTimeSeconds(),
+            ["exp"] = iat.AddSeconds(120).ToUnixTimeSeconds(),
             ["sd_hash"] = sdHash
         };
 

--- a/src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Verifier/Extensions/ServiceCollectionExtensions.cs
@@ -5,7 +5,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Sorcha.Verifier.Services;
-using Sorcha.ServiceClients.Http.Extensions;using Sorcha.Verifier.Engine;
+using Sorcha.ServiceClients.Http.Extensions;
+using Sorcha.ServiceDefaults;
+using Sorcha.Verifier.Engine;
 
 
 namespace Sorcha.Verifier.Extensions;
@@ -27,10 +29,29 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration? configuration = null)
     {
-        services.AddHttpClient<IStatusListCache, StatusListCache>();
         services.TryAddSingleton(TimeProvider.System);
         services.AddSingleton<IVerifierSessionStore, InMemoryVerifierSessionStore>();
         services.AddSingleton<IPresentationRequestBuilder, PresentationRequestBuilder>();
+
+        // Feature 138 US1 — verifier trust-rejection metrics + clock-skew tolerance.
+        services.AddSingleton<FederationVerifierMetrics>();
+        services.AddSecurityPostureSignal();
+        var clockSkew = TimeSpan.FromSeconds(
+            configuration?.GetValue<int?>("Verifier:ClockSkewSeconds") ?? 60);
+        var kbJwtMaxLifetime = TimeSpan.FromSeconds(
+            configuration?.GetValue<int?>("Verifier:KbJwtMaxLifetimeSeconds") ?? 120);
+
+        // StatusListCache now verifies the list signature against the sealed-state issuer key, pins iss,
+        // and fails closed (Feature 138). Registered via a factory so the configured skew + metrics flow
+        // in; SCOPED so it can depend on the scoped IIssuerKeyResolver (the DID-backed tier is scoped).
+        services.AddHttpClient(nameof(StatusListCache));
+        services.AddScoped<IStatusListCache>(sp => new StatusListCache(
+            sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(StatusListCache)),
+            sp.GetRequiredService<IIssuerKeyResolver>(),
+            sp.GetRequiredService<TimeProvider>(),
+            sp.GetRequiredService<ILogger<StatusListCache>>(),
+            sp.GetService<FederationVerifierMetrics>(),
+            clockSkew));
 
         // Feature 120 US1 — issuer key resolution. The JWK registry tier always exists
         // (demo-mint populates it; empty in production). The DID-backed tier verifies
@@ -84,7 +105,10 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<IIssuerKeyResolver>(),
                 sp.GetRequiredService<TimeProvider>(),
                 sp.GetRequiredService<ILogger<VerifiablePresentationValidator>>(),
-                requireIssuerSignature));
+                requireIssuerSignature,
+                sp.GetService<FederationVerifierMetrics>(),
+                clockSkew,
+                kbJwtMaxLifetime));
 
         services.AddSingleton<QrRenderer>();
         return services;

--- a/src/Apps/Sorcha.Verifier/appsettings.json
+++ b/src/Apps/Sorcha.Verifier/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Verifier": {
+    "ClockSkewSeconds": 60,
+    "KbJwtMaxLifetimeSeconds": 120
+  }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Presentation/PresentationEngine.cs
@@ -159,9 +159,14 @@ public sealed class PresentationEngine : IPresentationEngine
         var hashable = credentialJwt + string.Concat(selected.Select(s => "~" + s)) + "~";
         var sdHash = Base64Url.EncodeToString(SHA256.HashData(Encoding.ASCII.GetBytes(hashable)));
 
+        // Feature 138 US5 — the KB-JWT carries its own short, mandatory exp so a captured proof
+        // cannot be replayed beyond a tight window even within an open verifier session. 120s
+        // matches the verifier's KbJwtMaxLifetimeSeconds upper bound.
+        var kbIssuedAt = _clock.GetUtcNow();
         var payload = new Dictionary<string, object>
         {
-            ["iat"] = _clock.GetUtcNow().ToUnixTimeSeconds(),
+            ["iat"] = kbIssuedAt.ToUnixTimeSeconds(),
+            ["exp"] = kbIssuedAt.AddSeconds(120).ToUnixTimeSeconds(),
             ["aud"] = request.ClientId,
             ["nonce"] = request.Nonce,
             ["sd_hash"] = sdHash,

--- a/src/Common/Sorcha.ServiceClients.Http/Register/BlueprintContentHash.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/BlueprintContentHash.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Sorcha.ServiceClients.Register;
+
+/// <summary>
+/// Canonical content hash of a blueprint JSON (Feature 138 US4). Producer (the register's
+/// blueprint-publish path) and consumer (the Blueprint Service recovery path) MUST hash the
+/// identical canonical form, so this single helper defines it: parse the JSON, re-serialize with
+/// no indentation and relaxed escaping (the same canonical options the publish path already uses to
+/// compute the sealed payload hash), then SHA-256 to lowercase hex.
+/// </summary>
+public static class BlueprintContentHash
+{
+    private static readonly JsonSerializerOptions CanonicalOptions = new()
+    {
+        WriteIndented = false,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    /// <summary>
+    /// Computes the canonical SHA-256 (lowercase hex) of <paramref name="blueprintJson"/>.
+    /// Throws <see cref="JsonException"/> if the input is not valid JSON.
+    /// </summary>
+    public static string Compute(string blueprintJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(blueprintJson);
+        using var doc = JsonDocument.Parse(blueprintJson);
+        var canonical = JsonSerializer.Serialize(doc.RootElement, CanonicalOptions);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}

--- a/src/Common/Sorcha.ServiceClients.Http/Register/IRegisterServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Register/IRegisterServiceClient.cs
@@ -767,4 +767,12 @@ public class PublishedBlueprintEntry
     public DateTimeOffset PublishedAt { get; set; }
     /// <summary>The blueprint json.</summary>
     public string BlueprintJson { get; set; } = string.Empty;
+    /// <summary>
+    /// Feature 138 US4 — the canonical SHA-256 (lowercase hex) of the blueprint JSON, sealed in the
+    /// publish control transaction. A recovering node recomputes the canonical hash of
+    /// <see cref="BlueprintJson"/> and rejects the entry if it does not match this digest (tampered)
+    /// or if this digest is absent (no verifiable provenance). Computed by
+    /// <see cref="BlueprintContentHash.Compute(string)"/>.
+    /// </summary>
+    public string ContentHash { get; set; } = string.Empty;
 }

--- a/src/Common/Sorcha.ServiceDefaults/ClockSkew.cs
+++ b/src/Common/Sorcha.ServiceDefaults/ClockSkew.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.ServiceDefaults;
+
+/// <summary>
+/// Options for the shared wall-clock skew tolerance used by Feature 138 freshness checks
+/// (KB-JWT <c>exp</c>, delegation <c>exp</c>, status-list freshness, peer heartbeat timestamp).
+/// Bound from the <c>Verifier</c> configuration section so a single value governs every
+/// boundary's tolerance for honest clock drift.
+/// </summary>
+public sealed class ClockSkewOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    public const string SectionName = "Verifier";
+
+    /// <summary>
+    /// Wall-clock tolerance, in seconds, applied to expiry and freshness checks. Secure
+    /// default 60s — wide enough to absorb honest NTP drift, narrow enough to keep replay
+    /// windows tight. (<c>Verifier:ClockSkewSeconds</c>.)
+    /// </summary>
+    public int ClockSkewSeconds { get; set; } = 60;
+
+    /// <summary>The configured skew as a <see cref="TimeSpan"/>.</summary>
+    public TimeSpan Skew => TimeSpan.FromSeconds(ClockSkewSeconds);
+}
+
+/// <summary>
+/// Pure, dependency-free wall-clock comparisons that apply a bounded <c>skew</c>
+/// tolerance. Fail-closed by construction: a value at or past its boundary (after adding skew)
+/// is treated as expired/stale. Callers supply <c>now</c> from an injected
+/// <see cref="TimeProvider"/> so the checks are deterministic under test.
+/// </summary>
+public static class ClockSkew
+{
+    /// <summary>
+    /// True when <paramref name="expiresAt"/> has passed relative to <paramref name="now"/>,
+    /// allowing <paramref name="skew"/> of tolerance. Use to reject expired tokens/lists.
+    /// </summary>
+    public static bool IsExpired(DateTimeOffset expiresAt, DateTimeOffset now, TimeSpan skew) =>
+        now > expiresAt + skew;
+
+    /// <summary>
+    /// True when <paramref name="timestamp"/> is within <paramref name="skew"/> of
+    /// <paramref name="now"/> in either direction — i.e. fresh enough to accept. A timestamp
+    /// too far in the past (stale/replayed) or implausibly far in the future is rejected.
+    /// </summary>
+    public static bool IsFresh(DateTimeOffset timestamp, DateTimeOffset now, TimeSpan skew)
+    {
+        var delta = now - timestamp;
+        return delta <= skew && delta >= -skew;
+    }
+}

--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -100,6 +100,13 @@ public static class Extensions
 
                 // Feature 136 — tiered-audience identity (tokens minted by tier; tier requests refused)
                 metrics.AddMeter(Sorcha.ServiceDefaults.Auth.IdentityMetrics.MeterName);
+
+                // Feature 138 — federation trust-hardening rejection counters (FR-022).
+                // One meter per boundary owner; counters defined in each service's *TrustMetrics class.
+                metrics.AddMeter("Sorcha.Verifier");
+                metrics.AddMeter("Sorcha.Peer");
+                metrics.AddMeter("Sorcha.Validator");
+                metrics.AddMeter("Sorcha.Blueprint");
             })
             .WithTracing(tracing =>
             {

--- a/src/Common/Sorcha.ServiceDefaults/SecurityPostureSignal.cs
+++ b/src/Common/Sorcha.ServiceDefaults/SecurityPostureSignal.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.ServiceDefaults;
+
+/// <summary>
+/// Records that a component has fallen back to a weaker security posture (Feature 138, FR-022).
+/// When a node cannot establish a trust guarantee it is designed to provide — e.g. it cannot
+/// verify status lists so it fails closed, or it cannot establish mTLS for peer transport — it
+/// reports the condition here so operators see it on the <c>security-posture</c> health check
+/// rather than have security silently weaken. Mirrors the Storage Registration Log pattern
+/// (CLAUDE.md §10/§11): a singleton observability surface, not an enforcement gate.
+/// </summary>
+public interface ISecurityPostureSignal
+{
+    /// <summary>
+    /// Mark <paramref name="component"/> as operating in a degraded security posture. Idempotent:
+    /// repeated reports for the same component overwrite the reason. Logs at Warning with the
+    /// <c>[SECURITY-POSTURE]</c> banner the first time a component degrades.
+    /// </summary>
+    /// <param name="component">Stable component key, e.g. <c>status-list-verification</c>, <c>peer-mtls</c>.</param>
+    /// <param name="reason">Operator-facing rationale, e.g. "issuer key unresolved; failing closed".</param>
+    void ReportDegraded(string component, string reason);
+
+    /// <summary>Clears a previously-reported degradation for <paramref name="component"/> once recovered.</summary>
+    void ClearDegraded(string component);
+
+    /// <summary>Returns an immutable snapshot of currently-degraded components and their reasons.</summary>
+    IReadOnlyDictionary<string, string> Snapshot();
+}
+
+/// <summary>Thread-safe singleton implementation of <see cref="ISecurityPostureSignal"/>.</summary>
+public sealed class SecurityPostureSignal : ISecurityPostureSignal
+{
+    private readonly ConcurrentDictionary<string, string> _degraded = new(StringComparer.Ordinal);
+    private readonly ILogger<SecurityPostureSignal> _logger;
+
+    /// <summary>Creates the signal registry.</summary>
+    public SecurityPostureSignal(ILogger<SecurityPostureSignal> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void ReportDegraded(string component, string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(component);
+        var isNew = !_degraded.ContainsKey(component);
+        _degraded[component] = reason ?? string.Empty;
+        if (isNew)
+        {
+            _logger.LogWarning(
+                "[SECURITY-POSTURE] {Component} degraded: {Reason}", component, reason);
+        }
+    }
+
+    /// <inheritdoc />
+    public void ClearDegraded(string component)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(component);
+        if (_degraded.TryRemove(component, out _))
+        {
+            _logger.LogInformation("[SECURITY-POSTURE] {Component} recovered", component);
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string> Snapshot() =>
+        new Dictionary<string, string>(_degraded, StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Health check that reports <see cref="HealthStatus.Degraded"/> while any component has an
+/// active security-posture degradation, and <see cref="HealthStatus.Healthy"/> otherwise.
+/// Degraded (not Unhealthy) because the node is still functioning correctly and fail-closed —
+/// it has simply lost a trust guarantee operators should be alerted to.
+/// </summary>
+public sealed class SecurityPostureHealthCheck : IHealthCheck
+{
+    /// <summary>The well-known name used to register this health check.</summary>
+    public const string Name = "security-posture";
+
+    private readonly ISecurityPostureSignal _signal;
+
+    /// <summary>Creates the health check bound to the given signal registry.</summary>
+    public SecurityPostureHealthCheck(ISecurityPostureSignal signal)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        _signal = signal;
+    }
+
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var snapshot = _signal.Snapshot();
+        if (snapshot.Count == 0)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy("No security-posture degradations."));
+        }
+
+        var description = "Security posture degraded: " +
+            string.Join(", ", snapshot.Select(kv => $"{kv.Key} ({kv.Value})"));
+        var data = snapshot.ToDictionary<KeyValuePair<string, string>, string, object>(
+            kv => kv.Key, kv => kv.Value);
+
+        return Task.FromResult(HealthCheckResult.Degraded(description, exception: null, data: data));
+    }
+}
+
+/// <summary>Registration helpers for the security-posture signal and its health check.</summary>
+public static class SecurityPostureSignalExtensions
+{
+    /// <summary>
+    /// Registers <see cref="ISecurityPostureSignal"/> as a singleton and adds the
+    /// <see cref="SecurityPostureHealthCheck"/> under the name <c>security-posture</c>.
+    /// Idempotent — safe to call from multiple services' wiring.
+    /// </summary>
+    public static IServiceCollection AddSecurityPostureSignal(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<ISecurityPostureSignal, SecurityPostureSignal>();
+        services.AddHealthChecks()
+            .AddCheck<SecurityPostureHealthCheck>(
+                SecurityPostureHealthCheck.Name,
+                tags: new[] { "security" });
+        return services;
+    }
+}

--- a/src/Common/Sorcha.Verifier.Engine/FederationVerifierMetrics.cs
+++ b/src/Common/Sorcha.Verifier.Engine/FederationVerifierMetrics.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+namespace Sorcha.Verifier.Engine;
+
+/// <summary>
+/// OpenTelemetry instruments for the verifier-side federation trust-hardening rejections
+/// (Feature 138, FR-022). Status-list authenticity (US1) and presentation-replay (US5)
+/// rejections are counted with a coarse reason only — no subject or credential data.
+/// Register as a singleton; the meter source <see cref="MeterName"/> is added to the OTel
+/// meter provider in <c>Sorcha.ServiceDefaults</c>.
+/// </summary>
+public sealed class FederationVerifierMetrics
+{
+    /// <summary>The OpenTelemetry meter name. Added via <c>metrics.AddMeter("Sorcha.Verifier")</c>.</summary>
+    public const string MeterName = "Sorcha.Verifier";
+
+    private static readonly Meter _meter = new(MeterName, "1.0.0");
+
+    private static readonly Counter<long> _statusListRejected = _meter.CreateCounter<long>(
+        "sorcha_statuslist_rejected_total",
+        unit: "{rejection}",
+        description: "Revocation status lists rejected during verification (US1), by reason.");
+
+    private static readonly Counter<long> _presentationReplayRejected = _meter.CreateCounter<long>(
+        "sorcha_presentation_replay_rejected_total",
+        unit: "{rejection}",
+        description: "Presentation key-binding proofs rejected at verify time (US5 / US1), by reason.");
+
+    /// <summary>
+    /// Record a rejected status list. <paramref name="reason"/> is one of
+    /// <c>signature</c>, <c>issuer</c>, <c>unresolved</c>, <c>expired</c>, <c>fetch</c>.
+    /// </summary>
+    public void StatusListRejected(string reason) =>
+        _statusListRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    /// <summary>
+    /// Record a rejected presentation proof. <paramref name="reason"/> is one of
+    /// <c>kbjwt_expired</c>, <c>kbjwt_missing_exp</c>, <c>revoked_at_verify</c>.
+    /// </summary>
+    public void PresentationReplayRejected(string reason) =>
+        _presentationReplayRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+}

--- a/src/Common/Sorcha.Verifier.Engine/IStatusListCache.cs
+++ b/src/Common/Sorcha.Verifier.Engine/IStatusListCache.cs
@@ -4,32 +4,63 @@
 namespace Sorcha.Verifier.Engine;
 
 /// <summary>
-/// Verifier-side cache of signed Token Status List 2024 JWTs (Feature 114, T072).
-/// Used by the VP validator to check whether a delegation credential — or any
-/// other status-list-tracked artefact — has been revoked.
+/// The verdict of a status-list revocation check (Feature 138 US1). A tri-state so the caller
+/// can <b>fail closed</b>: anything other than <see cref="Active"/> must block verification.
+/// </summary>
+public enum StatusListVerdict
+{
+    /// <summary>The list was authenticated and fresh, and the credential's bit is clear (not revoked).</summary>
+    Active = 0,
+
+    /// <summary>The list was authenticated and fresh, and the credential's bit is set (revoked).</summary>
+    Revoked = 1,
+
+    /// <summary>
+    /// The list could not be authenticated against sealed-state-anchored trust — bad/absent signature,
+    /// issuer mismatch, unresolved key, expired list, or fetch failure. The caller MUST treat this as a
+    /// verification failure (fail closed), never as "active".
+    /// </summary>
+    Unverifiable = 2,
+}
+
+/// <summary>
+/// Verifier-side cache of signed Token Status List 2024 JWTs (Feature 114; hardened in Feature 138 US1).
+/// Used by the VP validator to check whether a delegation credential — or any other status-list-tracked
+/// artefact — has been revoked.
 /// </summary>
 /// <remarks>
-/// Verifiers MUST tolerate a stale cache up to the list's <c>exp</c> per the spec
-/// — that's the point of the publisher's signed <c>exp</c> claim. Beyond <c>exp</c>
-/// the cached entry is considered authoritative-but-expired and a fresh fetch is
-/// attempted; on a network failure during a fresh fetch the verifier falls back
-/// to the stale entry with a logged warning rather than rejecting the
-/// presentation outright (offline verifier scenario).
+/// <para>
+/// Feature 138 closes the revocation-forgery gap: the cache now verifies the status-list JWT signature
+/// against the issuing organisation's key resolved from sealed register state
+/// (<see cref="IIssuerKeyResolver"/>), pins the list's <c>iss</c> claim to the expected org DID, enforces
+/// freshness against the list's own <c>exp</c> (within a bounded clock skew), and <b>fails closed</b> on
+/// any inability to verify. A fetch failure no longer serves a stale cached copy; only a fully-verified
+/// list is ever cached.
+/// </para>
 /// </remarks>
 public interface IStatusListCache
 {
     /// <summary>
-    /// Returns true if the bit at <paramref name="index"/> in the status list at
-    /// <paramref name="statusListUri"/> is set (revoked).
+    /// Authenticates the status list at <paramref name="statusListUri"/> against
+    /// <paramref name="expectedIssuer"/> and returns the verdict for the bit at <paramref name="index"/>.
     /// </summary>
     /// <param name="statusListUri">Public URI of the Token Status List JWT.</param>
     /// <param name="index">Bit position to evaluate.</param>
+    /// <param name="expectedIssuer">
+    /// The org DID the list MUST be issued by (the consuming credential's <c>iss</c>, e.g.
+    /// <c>did:sorcha:org:{orgId:N}</c>). A list whose <c>iss</c> differs is <see cref="StatusListVerdict.Unverifiable"/>.
+    /// </param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>True if revoked, false if active or unable to determine.</returns>
-    Task<bool> IsRevokedAsync(string statusListUri, int index, CancellationToken ct = default);
+    /// <returns>
+    /// <see cref="StatusListVerdict.Active"/>, <see cref="StatusListVerdict.Revoked"/>, or
+    /// <see cref="StatusListVerdict.Unverifiable"/> (fail closed).
+    /// </returns>
+    Task<StatusListVerdict> CheckAsync(
+        string statusListUri, int index, string expectedIssuer, CancellationToken ct = default);
 
     /// <summary>
-    /// Forces a fresh fetch of the given status list, replacing any cached entry.
+    /// Forces a fresh, verified fetch of the given status list, replacing any cached entry. The entry is
+    /// replaced only if the fetched list authenticates against <paramref name="expectedIssuer"/>.
     /// </summary>
-    Task RefreshAsync(string statusListUri, CancellationToken ct = default);
+    Task RefreshAsync(string statusListUri, string expectedIssuer, CancellationToken ct = default);
 }

--- a/src/Common/Sorcha.Verifier.Engine/StatusListCache.cs
+++ b/src/Common/Sorcha.Verifier.Engine/StatusListCache.cs
@@ -4,119 +4,260 @@
 using System.Buffers.Text;
 using System.Collections.Concurrent;
 using System.IO.Compression;
-using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Sorcha.Verifier.Engine;
 
 /// <summary>
-/// Default <see cref="IStatusListCache"/>. In-memory cache keyed by status list
-/// URI; entries hold the decoded bitstring and the JWT's <c>exp</c> for
-/// freshness checks. Concurrent — multiple presentations against the same list
-/// share a single decode.
+/// Default <see cref="IStatusListCache"/>. In-memory cache keyed by status list URI; entries hold the
+/// decoded bitstring and the JWT's <c>exp</c>. Concurrent — multiple presentations against the same
+/// list share a single decode.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Feature 138 US1 hardening — the cache no longer trusts a fetched list on the strength of the
+/// transport. Before any revocation bit is read it:
+/// </para>
+/// <list type="number">
+///   <item>resolves the issuing org's public key from sealed register state via <see cref="IIssuerKeyResolver"/>;</item>
+///   <item>verifies the list JWT's signature against that key;</item>
+///   <item>pins the list's <c>iss</c> to the credential's expected org DID;</item>
+///   <item>enforces freshness against the list's own <c>exp</c> within a bounded clock skew.</item>
+/// </list>
+/// <para>
+/// Every failure path returns <see cref="StatusListVerdict.Unverifiable"/> (fail closed) and increments
+/// <c>sorcha_statuslist_rejected_total</c>. Only a fully-verified list is cached; a fetch failure never
+/// serves a stale copy. The host owns any health-posture surface
+/// (<c>ISecurityPostureSignal</c> in <c>Sorcha.ServiceDefaults</c>) — the engine stays dependency-light
+/// and signals through the metric and logs.
+/// </para>
+/// <para>
+/// Only ES256 (P-256) list signatures are verifiable in-engine, matching the rest of the engine's
+/// ES256-only JWS posture (the citizen wallet's default classical algorithm). A list signed with any
+/// other algorithm is treated as <see cref="StatusListVerdict.Unverifiable"/> — fail closed, never open.
+/// </para>
+/// </remarks>
 public sealed class StatusListCache : IStatusListCache
 {
+    private static readonly TimeSpan DefaultClockSkew = TimeSpan.FromSeconds(60);
+
     private readonly HttpClient _httpClient;
+    private readonly IIssuerKeyResolver _issuerKeys;
+    private readonly TimeProvider _clock;
+    private readonly TimeSpan _clockSkew;
     private readonly ILogger<StatusListCache> _logger;
+    private readonly FederationVerifierMetrics? _metrics;
 
     private readonly ConcurrentDictionary<string, CachedList> _entries = new();
 
     /// <summary>Initialises a new instance of the <see cref="StatusListCache"/> class.</summary>
-    public StatusListCache(HttpClient httpClient, ILogger<StatusListCache> logger)
+    public StatusListCache(
+        HttpClient httpClient,
+        IIssuerKeyResolver issuerKeys,
+        TimeProvider clock,
+        ILogger<StatusListCache> logger,
+        FederationVerifierMetrics? metrics = null,
+        TimeSpan? clockSkew = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _issuerKeys = issuerKeys ?? throw new ArgumentNullException(nameof(issuerKeys));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _metrics = metrics;
+        _clockSkew = clockSkew ?? DefaultClockSkew;
     }
 
     /// <inheritdoc />
-    public async Task<bool> IsRevokedAsync(string statusListUri, int index, CancellationToken ct = default)
+    public async Task<StatusListVerdict> CheckAsync(
+        string statusListUri, int index, string expectedIssuer, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(statusListUri);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedIssuer);
         if (index < 0) throw new ArgumentOutOfRangeException(nameof(index));
 
-        var entry = await GetOrFetchAsync(statusListUri, ct);
+        var entry = await GetOrFetchVerifiedAsync(statusListUri, expectedIssuer, ct);
         if (entry is null)
         {
-            // Could not fetch and nothing in cache — fail closed (treat as revoked)
-            // would be too aggressive (offline verifier). Caller decides; we
-            // surface "false (no info)" and log so the caller can correlate.
-            _logger.LogWarning(
-                "StatusListCache: no entry available for {Uri} — IsRevoked returning false (no info)",
-                statusListUri);
-            return false;
+            // Could not fetch or could not verify — fail closed. The specific reason was already
+            // logged + counted inside the fetch/verify path.
+            return StatusListVerdict.Unverifiable;
         }
 
         var byteIndex = index / 8;
         var bitOffset = index % 8;
         if (byteIndex >= entry.Bitstring.Length)
         {
+            // Index outside the list. The list is authentic but says nothing about this credential —
+            // an out-of-range index is itself suspicious. Fail closed.
             _logger.LogWarning(
-                "StatusListCache: index {Index} outside list length {Length} for {Uri}",
+                "StatusListCache: index {Index} outside list length {Length} for {Uri} — failing closed",
                 index, entry.Bitstring.Length * 8, statusListUri);
-            return false;
+            return StatusListVerdict.Unverifiable;
         }
 
-        return (entry.Bitstring[byteIndex] & (1 << bitOffset)) != 0;
+        var revoked = (entry.Bitstring[byteIndex] & (1 << bitOffset)) != 0;
+        return revoked ? StatusListVerdict.Revoked : StatusListVerdict.Active;
     }
 
     /// <inheritdoc />
-    public async Task RefreshAsync(string statusListUri, CancellationToken ct = default)
+    public async Task RefreshAsync(string statusListUri, string expectedIssuer, CancellationToken ct = default)
     {
-        var fresh = await FetchAsync(statusListUri, ct);
+        var fresh = await FetchAndVerifyAsync(statusListUri, expectedIssuer, ct);
         if (fresh is not null)
         {
             _entries[statusListUri] = fresh;
         }
     }
 
-    private async Task<CachedList?> GetOrFetchAsync(string uri, CancellationToken ct)
+    private async Task<CachedList?> GetOrFetchVerifiedAsync(string uri, string expectedIssuer, CancellationToken ct)
     {
-        var now = DateTimeOffset.UtcNow;
-        if (_entries.TryGetValue(uri, out var cached) && cached.ExpiresAt > now)
+        var now = _clock.GetUtcNow();
+        if (_entries.TryGetValue(uri, out var cached)
+            && !ClockSkewExpired(cached.ExpiresAt, now)
+            && string.Equals(cached.Issuer, expectedIssuer, StringComparison.Ordinal))
         {
             return cached;
         }
 
-        var fresh = await FetchAsync(uri, ct);
+        // Fail closed: a fresh fetch/verify failure does NOT fall back to a stale cached entry.
+        var fresh = await FetchAndVerifyAsync(uri, expectedIssuer, ct);
         if (fresh is not null)
         {
             _entries[uri] = fresh;
             return fresh;
         }
 
-        // Fresh fetch failed — fall back to stale cached entry if any, with a warning.
-        if (cached is not null)
-        {
-            _logger.LogWarning(
-                "StatusListCache: fresh fetch failed for {Uri} — serving stale entry (exp {Exp:O})",
-                uri, cached.ExpiresAt);
-            return cached;
-        }
-
         return null;
     }
 
-    private async Task<CachedList?> FetchAsync(string uri, CancellationToken ct)
+    private async Task<CachedList?> FetchAndVerifyAsync(string uri, string expectedIssuer, CancellationToken ct)
     {
+        string jwt;
         try
         {
-            var jwt = await _httpClient.GetStringAsync(uri, ct);
-            return ParseJwt(jwt);
+            jwt = await _httpClient.GetStringAsync(uri, ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogError(ex, "StatusListCache: failed to fetch {Uri}", uri);
+            _logger.LogWarning(ex, "StatusListCache: fetch failed for {Uri} — failing closed", uri);
+            _metrics?.StatusListRejected("fetch");
             return null;
+        }
+
+        return await VerifyAsync(jwt, uri, expectedIssuer, ct);
+    }
+
+    private async Task<CachedList?> VerifyAsync(string compactJwt, string uri, string expectedIssuer, CancellationToken ct)
+    {
+        ParsedList parsed;
+        try
+        {
+            parsed = ParseJwt(compactJwt);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "StatusListCache: malformed status list for {Uri} — failing closed", uri);
+            _metrics?.StatusListRejected("signature");
+            return null;
+        }
+
+        // ── Issuer pinning (FR-002) ───────────────────────────────────────────────
+        if (string.IsNullOrEmpty(parsed.Issuer)
+            || !string.Equals(parsed.Issuer, expectedIssuer, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "StatusListCache: issuer mismatch for {Uri} — list iss '{Actual}' ≠ expected '{Expected}'",
+                uri, parsed.Issuer, expectedIssuer);
+            _metrics?.StatusListRejected("issuer");
+            return null;
+        }
+
+        // ── Resolve the issuing org's key from sealed state (FR-001) ──────────────
+        var jwk = await _issuerKeys.ResolveAsync(expectedIssuer, parsed.Kid, ct);
+        if (jwk is null)
+        {
+            _logger.LogWarning(
+                "StatusListCache: no key resolved for issuer '{Issuer}' (kid '{Kid}') for {Uri} — failing closed",
+                expectedIssuer, parsed.Kid, uri);
+            _metrics?.StatusListRejected("unresolved");
+            return null;
+        }
+
+        // ── Signature verification (FR-001) ───────────────────────────────────────
+        if (!VerifyListSignature(parsed, jwk.Value))
+        {
+            _logger.LogWarning(
+                "StatusListCache: signature verification failed for {Uri} against issuer '{Issuer}' key",
+                uri, expectedIssuer);
+            _metrics?.StatusListRejected("signature");
+            return null;
+        }
+
+        // ── Freshness (FR-004) — list MUST carry exp and MUST be fresh within skew ─
+        if (parsed.ExpiresAt is null)
+        {
+            _logger.LogWarning("StatusListCache: status list for {Uri} has no exp — failing closed", uri);
+            _metrics?.StatusListRejected("expired");
+            return null;
+        }
+        if (ClockSkewExpired(parsed.ExpiresAt.Value, _clock.GetUtcNow()))
+        {
+            _logger.LogWarning(
+                "StatusListCache: status list for {Uri} expired at {Exp:O} — failing closed",
+                uri, parsed.ExpiresAt.Value);
+            _metrics?.StatusListRejected("expired");
+            return null;
+        }
+
+        return new CachedList(parsed.Bitstring, parsed.ExpiresAt.Value, expectedIssuer);
+    }
+
+    private bool ClockSkewExpired(DateTimeOffset expiresAt, DateTimeOffset now) => now > expiresAt + _clockSkew;
+
+    /// <summary>
+    /// Verifies a status-list JWS signature against a public JWK. ES256 (P-256) only — any other
+    /// algorithm fails closed, consistent with the engine's ES256-only JWS posture.
+    /// </summary>
+    private static bool VerifyListSignature(ParsedList parsed, JsonElement jwk)
+    {
+        try
+        {
+            if (!string.Equals(parsed.Alg, "ES256", StringComparison.Ordinal)) return false;
+            if (!jwk.TryGetProperty("x", out var xEl) || !jwk.TryGetProperty("y", out var yEl)) return false;
+            var x = xEl.GetString();
+            var y = yEl.GetString();
+            if (x is null || y is null) return false;
+
+            using var ecdsa = ECDsa.Create(new ECParameters
+            {
+                Curve = ECCurve.NamedCurves.nistP256,
+                Q = new ECPoint
+                {
+                    X = Base64Url.DecodeFromChars(x),
+                    Y = Base64Url.DecodeFromChars(y),
+                },
+            });
+
+            // Citizen wallet signs with raw ECDSA → IEEE P1363 fixed-field concatenation; accept DER too.
+            return ecdsa.VerifyData(parsed.SigningInput, parsed.Signature, HashAlgorithmName.SHA256,
+                       DSASignatureFormat.IeeeP1363FixedFieldConcatenation)
+                || ecdsa.VerifyData(parsed.SigningInput, parsed.Signature, HashAlgorithmName.SHA256);
+        }
+        catch
+        {
+            return false;
         }
     }
 
     /// <summary>
-    /// Parses a Token Status List 2024 JWT into a <see cref="CachedList"/>. Public
-    /// for unit testing — production code goes through <see cref="GetOrFetchAsync"/>.
+    /// Parses a Token Status List 2024 JWT into a <see cref="ParsedList"/> — bitstring, claims, and the
+    /// signing input + signature needed to authenticate it. Public for unit testing — production code
+    /// goes through <see cref="CheckAsync"/>. Does NOT verify the signature (the cache does that).
     /// </summary>
-    internal static CachedList ParseJwt(string compactJwt)
+    internal static ParsedList ParseJwt(string compactJwt)
     {
         var parts = compactJwt.Split('.');
         if (parts.Length != 3)
@@ -124,8 +265,15 @@ public sealed class StatusListCache : IStatusListCache
             throw new FormatException("Status list JWT must have three parts.");
         }
 
-        var payloadJson = JsonSerializer.Deserialize<JsonElement>(
-            Base64Url.DecodeFromChars(parts[1]));
+        var headerJson = JsonSerializer.Deserialize<JsonElement>(Base64Url.DecodeFromChars(parts[0]));
+        var alg = headerJson.TryGetProperty("alg", out var algEl) && algEl.ValueKind == JsonValueKind.String
+            ? algEl.GetString() ?? string.Empty
+            : string.Empty;
+        var kid = headerJson.TryGetProperty("kid", out var kidEl) && kidEl.ValueKind == JsonValueKind.String
+            ? kidEl.GetString()
+            : null;
+
+        var payloadJson = JsonSerializer.Deserialize<JsonElement>(Base64Url.DecodeFromChars(parts[1]));
 
         var statusList = payloadJson.GetProperty("status_list");
         var lstB64 = statusList.GetProperty("lst").GetString()
@@ -137,13 +285,31 @@ public sealed class StatusListCache : IStatusListCache
         using var output = new MemoryStream();
         inflater.CopyTo(output);
 
-        var exp = payloadJson.TryGetProperty("exp", out var expEl)
+        // No +24h default — a list with no exp is rejected by the freshness gate (FR-004).
+        DateTimeOffset? exp = payloadJson.TryGetProperty("exp", out var expEl) && expEl.ValueKind == JsonValueKind.Number
             ? DateTimeOffset.FromUnixTimeSeconds(expEl.GetInt64())
-            : DateTimeOffset.UtcNow.AddHours(24);
+            : null;
 
-        return new CachedList(output.ToArray(), exp);
+        var issuer = payloadJson.TryGetProperty("iss", out var issEl) && issEl.ValueKind == JsonValueKind.String
+            ? issEl.GetString()
+            : null;
+
+        var signingInput = Encoding.ASCII.GetBytes($"{parts[0]}.{parts[1]}");
+        var signature = Base64Url.DecodeFromChars(parts[2]);
+
+        return new ParsedList(output.ToArray(), exp, issuer, alg, kid, signingInput, signature);
     }
 
-    /// <summary>Internal cache entry — bitstring + freshness window.</summary>
-    internal sealed record CachedList(byte[] Bitstring, DateTimeOffset ExpiresAt);
+    /// <summary>Parsed-but-unverified status list: bitstring, claims, and the material to authenticate it.</summary>
+    internal sealed record ParsedList(
+        byte[] Bitstring,
+        DateTimeOffset? ExpiresAt,
+        string? Issuer,
+        string Alg,
+        string? Kid,
+        byte[] SigningInput,
+        byte[] Signature);
+
+    /// <summary>Internal cache entry — only ever holds a verified list. Issuer recorded for pinning re-check.</summary>
+    internal sealed record CachedList(byte[] Bitstring, DateTimeOffset ExpiresAt, string Issuer);
 }

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -208,6 +208,42 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
                 return Failure(errors);
             }
 
+            // ── 5b. Enforce KB-JWT freshness (Feature 138 US5) ────────────────────
+            //   The key-binding proof carries its own short, independently-enforced exp. Checked here —
+            //   the earliest point the payload is signature-verified and therefore trustworthy — so a
+            //   captured proof replayed after its exp is rejected even while the session is still open
+            //   (the session nonce/aud/TTL alone left a multi-minute replay window). exp is mandatory
+            //   (FR-017); freshness is wall-clock within the configured skew (FR-018). Mid-session
+            //   revocation is independently re-checked at verify time by the delegation status-list
+            //   check above (US1 fail-closed), together satisfying FR-019.
+            if (!kbPayload.TryGetProperty("exp", out var kbExpEl) || kbExpEl.ValueKind != JsonValueKind.Number)
+            {
+                errors.Add("KB-JWT is missing the mandatory exp claim.");
+                _metrics?.PresentationReplayRejected("kbjwt_missing_exp");
+                return Failure(errors);
+            }
+            var kbExp = DateTimeOffset.FromUnixTimeSeconds(kbExpEl.GetInt64());
+            var nowUtc = _clock.GetUtcNow();
+            if (nowUtc > kbExp + _clockSkew)
+            {
+                errors.Add("KB-JWT has expired; the key-binding proof is no longer fresh.");
+                _metrics?.PresentationReplayRejected("kbjwt_expired");
+                return Failure(errors);
+            }
+            // Cap the proof lifetime so an over-long-lived KB-JWT cannot widen the replay window.
+            if (kbPayload.TryGetProperty("iat", out var kbIatEl) && kbIatEl.ValueKind == JsonValueKind.Number)
+            {
+                var kbIat = DateTimeOffset.FromUnixTimeSeconds(kbIatEl.GetInt64());
+                if (kbExp - kbIat > _kbJwtMaxLifetime)
+                {
+                    errors.Add(
+                        $"KB-JWT lifetime ({(kbExp - kbIat).TotalSeconds:0}s) exceeds the maximum " +
+                        $"permitted ({_kbJwtMaxLifetime.TotalSeconds:0}s).");
+                    _metrics?.PresentationReplayRejected("kbjwt_expired");
+                    return Failure(errors);
+                }
+            }
+
             // ── 6. Verify KB-JWT nonce + aud match the session ────────────────────
             var kbNonce = TryGetString(kbPayload, "nonce");
             var kbAudience = TryGetString(kbPayload, "aud");

--- a/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
+++ b/src/Common/Sorcha.Verifier.Engine/VerifiablePresentationValidator.cs
@@ -32,30 +32,45 @@ namespace Sorcha.Verifier.Engine;
 /// </summary>
 public sealed class VerifiablePresentationValidator : IVerifiablePresentationValidator
 {
+    private static readonly TimeSpan DefaultClockSkew = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DefaultKbJwtMaxLifetime = TimeSpan.FromSeconds(120);
+
     private readonly IStatusListCache _statusListCache;
     private readonly IIssuerKeyResolver _issuerKeys;
     private readonly TimeProvider _clock;
     private readonly ILogger<VerifiablePresentationValidator> _logger;
     private readonly bool _requireIssuerSignature;
+    private readonly FederationVerifierMetrics? _metrics;
+    private readonly TimeSpan _clockSkew;
+    private readonly TimeSpan _kbJwtMaxLifetime;
 
     /// <summary>
     /// Initialises a new instance. <paramref name="issuerKeys"/> defaults to
     /// the opt-out resolver via DI registration; <paramref name="requireIssuerSignature"/>
     /// is read from configuration <c>Verifier:RequireIssuerSignature</c>
     /// (default false in v1, true expected in production hardening pass).
+    /// Feature 138: <paramref name="metrics"/> records trust rejections, <paramref name="clockSkew"/>
+    /// (<c>Verifier:ClockSkewSeconds</c>) bounds wall-clock tolerance, and
+    /// <paramref name="kbJwtMaxLifetime"/> (<c>Verifier:KbJwtMaxLifetimeSeconds</c>) caps KB-JWT lifetime.
     /// </summary>
     public VerifiablePresentationValidator(
         IStatusListCache statusListCache,
         IIssuerKeyResolver issuerKeys,
         TimeProvider clock,
         ILogger<VerifiablePresentationValidator> logger,
-        bool requireIssuerSignature = false)
+        bool requireIssuerSignature = false,
+        FederationVerifierMetrics? metrics = null,
+        TimeSpan? clockSkew = null,
+        TimeSpan? kbJwtMaxLifetime = null)
     {
         _statusListCache = statusListCache ?? throw new ArgumentNullException(nameof(statusListCache));
         _issuerKeys = issuerKeys ?? throw new ArgumentNullException(nameof(issuerKeys));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _requireIssuerSignature = requireIssuerSignature;
+        _metrics = metrics;
+        _clockSkew = clockSkew ?? DefaultClockSkew;
+        _kbJwtMaxLifetime = kbJwtMaxLifetime ?? DefaultKbJwtMaxLifetime;
     }
 
     /// <summary>
@@ -397,7 +412,9 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
             return errors;
         }
 
-        // Check status list bit if present
+        // Check status list bit if present. Feature 138 US1 — the status list MUST authenticate against
+        // the issuing org's sealed-state key, pinned to the credential's own iss, and freshness-checked;
+        // anything other than a verified "Active" fails closed (Revoked OR Unverifiable both reject).
         if (payload.Value.TryGetProperty("status", out var status)
             && status.ValueKind == JsonValueKind.Object
             && status.TryGetProperty("status_list", out var sl)
@@ -405,10 +422,30 @@ public sealed class VerifiablePresentationValidator : IVerifiablePresentationVal
             && sl.TryGetProperty("uri", out var uriEl) && uriEl.ValueKind == JsonValueKind.String
             && sl.TryGetProperty("idx", out var idxEl) && idxEl.ValueKind == JsonValueKind.Number)
         {
-            var revoked = await _statusListCache.IsRevokedAsync(uriEl.GetString()!, idxEl.GetInt32(), ct);
-            if (revoked)
+            var expectedIssuer = TryGetString(payload.Value, "iss");
+            if (string.IsNullOrEmpty(expectedIssuer))
             {
-                errors.Add("Delegation credential has been revoked via status list.");
+                // No issuer to pin the status list to — cannot authenticate revocation. Fail closed.
+                errors.Add("Delegation credential is missing iss; cannot authenticate its status list.");
+                _metrics?.PresentationReplayRejected("revoked_at_verify");
+                return errors;
+            }
+
+            var verdict = await _statusListCache.CheckAsync(
+                uriEl.GetString()!, idxEl.GetInt32(), expectedIssuer, ct);
+            switch (verdict)
+            {
+                case StatusListVerdict.Revoked:
+                    errors.Add("Delegation credential has been revoked via status list.");
+                    _metrics?.PresentationReplayRejected("revoked_at_verify");
+                    break;
+                case StatusListVerdict.Unverifiable:
+                    errors.Add("Delegation credential status list could not be authenticated; failing closed.");
+                    _metrics?.PresentationReplayRejected("revoked_at_verify");
+                    break;
+                case StatusListVerdict.Active:
+                default:
+                    break;
             }
         }
 

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -273,6 +273,7 @@ builder.Services.TryAddSingleton(TimeProvider.System);
 // sealed-state key and fails closed. Metrics record rejections (FR-022); the configured clock skew
 // bounds freshness tolerance. The StatusListCache auto-injects the metrics via ActivatorUtilities.
 builder.Services.AddSingleton<Sorcha.Verifier.Engine.FederationVerifierMetrics>();
+builder.Services.AddSingleton<Sorcha.Blueprint.Service.Services.Implementation.FederationBlueprintMetrics>();
 var f138ClockSkew = TimeSpan.FromSeconds(
     builder.Configuration.GetValue<int?>("Verifier:ClockSkewSeconds") ?? 60);
 var f138KbJwtMaxLifetime = TimeSpan.FromSeconds(

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -269,6 +269,15 @@ builder.Services.AddHttpClient<Sorcha.Verifier.Engine.IStatusListCache,
     Sorcha.Verifier.Engine.StatusListCache>();
 builder.Services.TryAddSingleton(TimeProvider.System);
 
+// Feature 138 US1 — the council-gate verifier authenticates status lists against the issuer's
+// sealed-state key and fails closed. Metrics record rejections (FR-022); the configured clock skew
+// bounds freshness tolerance. The StatusListCache auto-injects the metrics via ActivatorUtilities.
+builder.Services.AddSingleton<Sorcha.Verifier.Engine.FederationVerifierMetrics>();
+var f138ClockSkew = TimeSpan.FromSeconds(
+    builder.Configuration.GetValue<int?>("Verifier:ClockSkewSeconds") ?? 60);
+var f138KbJwtMaxLifetime = TimeSpan.FromSeconds(
+    builder.Configuration.GetValue<int?>("Verifier:KbJwtMaxLifetimeSeconds") ?? 120);
+
 // Feature 120 — DID resolver infrastructure (cache, OTel meters, registry, did:sorcha
 // + did:web + did:key built-ins). Idempotent; safe even if a transitive dependency
 // has already registered the same components.
@@ -294,7 +303,10 @@ builder.Services.AddScoped<Sorcha.Verifier.Engine.IVerifiablePresentationValidat
         sp.GetRequiredService<Sorcha.Verifier.Engine.IIssuerKeyResolver>(),
         sp.GetRequiredService<TimeProvider>(),
         sp.GetRequiredService<ILogger<Sorcha.Verifier.Engine.VerifiablePresentationValidator>>(),
-        requireIssuerSignature: builder.Configuration.GetValue<bool?>("IssuerSignature:Required") ?? true));
+        requireIssuerSignature: builder.Configuration.GetValue<bool?>("IssuerSignature:Required") ?? true,
+        metrics: sp.GetService<Sorcha.Verifier.Engine.FederationVerifierMetrics>(),
+        clockSkew: f138ClockSkew,
+        kbJwtMaxLifetime: f138KbJwtMaxLifetime));
 
 // Feature 127 — Sorcha-wallet consumer. Verifies SD-JWT presentations posted
 // by the citizen's Sorcha wallet via Sorcha.Verifier.Engine. The first

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/BlueprintRecoveryService.cs
@@ -21,6 +21,7 @@ public class BlueprintRecoveryService : BackgroundService
     private readonly RecoveryOptions _options;
     private readonly ILogger<BlueprintRecoveryService> _logger;
     private readonly IConnectionMultiplexer? _redis;
+    private readonly FederationBlueprintMetrics? _metrics;
 
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
@@ -30,13 +31,15 @@ public class BlueprintRecoveryService : BackgroundService
         RecoveryState recoveryState,
         IOptions<RecoveryOptions> options,
         ILogger<BlueprintRecoveryService> logger,
-        IConnectionMultiplexer? redis = null)
+        IConnectionMultiplexer? redis = null,
+        FederationBlueprintMetrics? metrics = null)
     {
         _scopeFactory = scopeFactory;
         _recoveryState = recoveryState;
         _options = options.Value;
         _logger = logger;
         _redis = redis;
+        _metrics = metrics;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -259,6 +262,40 @@ public class BlueprintRecoveryService : BackgroundService
         }
     }
 
+    /// <summary>
+    /// Feature 138 US4 — decides whether a recovered blueprint's content matches the digest sealed at
+    /// publish time. Returns <c>false</c> (fail closed) with <paramref name="rejectReason"/> set to
+    /// <c>no_provenance</c> (no sealed hash) or <c>hash_mismatch</c> (content tampered / malformed).
+    /// </summary>
+    internal static bool TryVerifyProvenance(string blueprintJson, string contentHash, out string? rejectReason)
+    {
+        if (string.IsNullOrEmpty(contentHash))
+        {
+            rejectReason = "no_provenance";
+            return false;
+        }
+
+        string recomputed;
+        try
+        {
+            recomputed = BlueprintContentHash.Compute(blueprintJson);
+        }
+        catch (JsonException)
+        {
+            rejectReason = "hash_mismatch";
+            return false;
+        }
+
+        if (!string.Equals(recomputed, contentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            rejectReason = "hash_mismatch";
+            return false;
+        }
+
+        rejectReason = null;
+        return true;
+    }
+
     private async Task<(long Height, int BlueprintCount)> RecoverFromRegisterAsync(
         IRegisterServiceClient registerClient,
         IPublishedBlueprintStore publishedStore,
@@ -293,6 +330,18 @@ public class BlueprintRecoveryService : BackgroundService
             {
                 var blueprint = JsonSerializer.Deserialize<Sorcha.Blueprint.Models.Blueprint>(bp.BlueprintJson);
                 if (blueprint is null) continue;
+
+                // Feature 138 US4 — verify provenance against the sealed content hash BEFORE storing.
+                // A blueprint arrives over an untrusted channel; we trust it only if its canonical hash
+                // matches the digest sealed in the publish control transaction. Fail closed.
+                if (!TryVerifyProvenance(bp.BlueprintJson, bp.ContentHash, out var rejectReason))
+                {
+                    _logger.LogWarning(
+                        "Rejecting blueprint {BlueprintId} from register {RegisterId}: provenance check failed ({Reason})",
+                        bp.BlueprintId, registerId, rejectReason);
+                    _metrics?.RecoveryRejected(rejectReason!);
+                    continue;
+                }
 
                 // Check if already in store (idempotent)
                 var existing = await publishedStore.GetVersionsAsync(bp.BlueprintId);

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/FederationBlueprintMetrics.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/FederationBlueprintMetrics.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+namespace Sorcha.Blueprint.Service.Services.Implementation;
+
+/// <summary>
+/// OpenTelemetry instruments for blueprint-boundary federation trust-hardening rejections
+/// (Feature 138 US4/US6, FR-022). Recovery provenance failures and open-participant
+/// carried-key rejections are counted with a coarse reason only — no blueprint or key data.
+/// Register as a singleton; the meter source <see cref="MeterName"/> is added to the OTel
+/// meter provider in <c>Sorcha.ServiceDefaults</c>.
+/// </summary>
+public sealed class FederationBlueprintMetrics
+{
+    /// <summary>The OpenTelemetry meter name. Added via <c>metrics.AddMeter("Sorcha.Blueprint")</c>.</summary>
+    public const string MeterName = "Sorcha.Blueprint";
+
+    private static readonly Meter _meter = new(MeterName, "1.0.0");
+
+    private static readonly Counter<long> _recoveryRejected = _meter.CreateCounter<long>(
+        "sorcha_blueprint_recovery_rejected_total",
+        unit: "{rejection}",
+        description: "Recovered/synced blueprints rejected for failing sealed-provenance verification (US4), by reason.");
+
+    private static readonly Counter<long> _carriedKeyRejected = _meter.CreateCounter<long>(
+        "sorcha_carried_key_rejected_total",
+        unit: "{rejection}",
+        description: "Open-participant carried delivery keys rejected for failing binding verification (US6), by reason.");
+
+    /// <summary>
+    /// Record a rejected recovery. <paramref name="reason"/> is one of
+    /// <c>hash_mismatch</c>, <c>no_provenance</c>.
+    /// </summary>
+    public void RecoveryRejected(string reason) =>
+        _recoveryRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    /// <summary>
+    /// Record a rejected carried key. <paramref name="reason"/> is one of
+    /// <c>unbound</c>, <c>commitment_mismatch</c>.
+    /// </summary>
+    public void CarriedKeyRejected(string reason) =>
+        _carriedKeyRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+}

--- a/src/Services/Sorcha.Peer.Service/Core/PeerServiceConfiguration.cs
+++ b/src/Services/Sorcha.Peer.Service/Core/PeerServiceConfiguration.cs
@@ -74,11 +74,25 @@ public class PeerServiceConfiguration
     public DataCleanupConfiguration DataCleanup { get; set; } = new();
 
     /// <summary>
-    /// Whether to enable mutual TLS (mTLS) for peer-to-peer gRPC connections (FR-016).
+    /// Whether to require TLS for peer-to-peer gRPC transport (Feature 138 US2, FR-008).
+    /// Outside the Development environment this MUST be honoured fail-closed: a node refuses
+    /// cleartext HTTP/2 when TLS is required. Development may run cleartext. The effective
+    /// requirement is resolved per-environment in <c>Program.cs</c>; this is the operator override.
+    /// </summary>
+    public bool EnableTls { get; set; } = false;
+
+    /// <summary>
+    /// Whether to enable mutual TLS (mTLS) for peer-to-peer gRPC connections (FR-008).
     /// When enabled, peers must present a valid client certificate to establish connections.
-    /// Implementation deferred — this config option is scaffolding only.
     /// </summary>
     public bool EnableMtls { get; set; } = false;
+
+    /// <summary>
+    /// Lifetime, in seconds, of a peer-registration challenge nonce (Feature 138 US2).
+    /// A node must echo back the server-issued nonce in a signed <c>RegisterPeer</c> within
+    /// this window; expired or unknown nonces are refused. Default 30s.
+    /// </summary>
+    public int ChallengeTtlSeconds { get; set; } = 30;
 }
 
 public class NetworkAddressConfiguration

--- a/src/Services/Sorcha.Peer.Service/Observability/FederationPeerMetrics.cs
+++ b/src/Services/Sorcha.Peer.Service/Observability/FederationPeerMetrics.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+namespace Sorcha.Peer.Service.Observability;
+
+/// <summary>
+/// OpenTelemetry instruments for peer-boundary federation trust-hardening rejections
+/// (Feature 138 US2, FR-022). Registration refusals and per-message rejections are counted
+/// with a coarse reason only — no peer address or payload data. Register as a singleton;
+/// the meter source <see cref="MeterName"/> is added to the OTel meter provider in
+/// <c>Sorcha.ServiceDefaults</c>.
+/// </summary>
+public sealed class FederationPeerMetrics
+{
+    /// <summary>The OpenTelemetry meter name. Added via <c>metrics.AddMeter("Sorcha.Peer")</c>.</summary>
+    public const string MeterName = "Sorcha.Peer";
+
+    private static readonly Meter _meter = new(MeterName, "1.0.0");
+
+    private static readonly Counter<long> _registrationRejected = _meter.CreateCounter<long>(
+        "sorcha_peer_registration_rejected_total",
+        unit: "{rejection}",
+        description: "Peer registrations refused (US2), by reason.");
+
+    private static readonly Counter<long> _messageRejected = _meter.CreateCounter<long>(
+        "sorcha_peer_message_rejected_total",
+        unit: "{rejection}",
+        description: "Peer messages (heartbeats/advertisements) rejected (US2), by reason.");
+
+    /// <summary>
+    /// Record a refused registration. <paramref name="reason"/> is one of
+    /// <c>signature</c>, <c>id_mismatch</c>, <c>stale</c>, <c>challenge</c>, <c>rate_limited</c>.
+    /// </summary>
+    public void RegistrationRejected(string reason) =>
+        _registrationRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    /// <summary>
+    /// Record a rejected message. <paramref name="reason"/> is one of
+    /// <c>replay_seq</c>, <c>stale_timestamp</c>, <c>unsigned_ad</c>, <c>bad_signature</c>.
+    /// </summary>
+    public void MessageRejected(string reason) =>
+        _messageRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+}

--- a/src/Services/Sorcha.Peer.Service/appsettings.json
+++ b/src/Services/Sorcha.Peer.Service/appsettings.json
@@ -26,6 +26,7 @@
     "ListenPort": 5000,
     "EnableTls": false,
     "EnableMtls": false,
+    "ChallengeTtlSeconds": 30,
     "NetworkAddress": {
       "ExternalAddress": "",
       "StunServers": [

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1860,7 +1860,11 @@ app.MapPost("/api/registers/{registerId}/blueprints/publish", async (
             ["Type"] = "Control",
             ["transactionType"] = "BlueprintPublish",
             ["publishedBy"] = request.PublishedBy,
-            ["SystemWalletAddress"] = signResult.WalletAddress
+            ["SystemWalletAddress"] = signResult.WalletAddress,
+            // Feature 138 US4 — seal the canonical content hash so recovering nodes can verify the
+            // blueprint they receive against a sealed digest rather than trusting the transport.
+            // payloadHashHex is already SHA-256 over the canonical blueprint JSON (see above).
+            ["contentHash"] = payloadHashHex
         }
     };
 
@@ -1935,13 +1939,19 @@ app.MapGet("/api/registers/{registerId}/blueprints/published", async (
             blueprintJson = rawPayload;
         }
 
+        // Feature 138 US4 — the canonical content hash sealed at publish time. Sourced from the
+        // sealed transaction metadata (NOT recomputed from blueprintJson here), so a recovering node
+        // comparing its own recomputed hash against this value detects tampering in transit.
+        var contentHash = tx.MetaData?.TrackingData?.GetValueOrDefault("contentHash", "") ?? "";
+
         return new
         {
             blueprintId,
             transactionId = tx.TxId,
             publishedBy,
             publishedAt = tx.TimeStamp,
-            blueprintJson
+            blueprintJson,
+            contentHash
         };
     }).ToList();
 

--- a/src/Services/Sorcha.Validator.Service/Configuration/ConsensusConfiguration.cs
+++ b/src/Services/Sorcha.Validator.Service/Configuration/ConsensusConfiguration.cs
@@ -35,4 +35,12 @@ public class ConsensusConfiguration
     /// require multi-validator consensus — this flag is ignored unless ASPNETCORE_ENVIRONMENT=Development.
     /// </summary>
     public bool SingleValidatorAutoApprove { get; set; } = true;
+
+    /// <summary>
+    /// Accept-to-seal deadline, in seconds, before a validator that accepted work but did not
+    /// seal it is treated as withholding and ejected via a sealed
+    /// <c>control.validator.liveness-violation</c> (Feature 138 US3, FR-013). Mirrors the
+    /// register policy's <c>DocketTimeoutSeconds</c>; default 30s.
+    /// </summary>
+    public int LivenessTimeoutSeconds { get; set; } = 30;
 }

--- a/src/Services/Sorcha.Validator.Service/Services/FederationValidatorMetrics.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/FederationValidatorMetrics.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Diagnostics.Metrics;
+
+namespace Sorcha.Validator.Service.Services;
+
+/// <summary>
+/// OpenTelemetry instruments for validator-boundary federation trust-hardening events
+/// (Feature 138 US3, FR-022). Out-of-roster vote rejections and automatic ejections are
+/// counted with a coarse reason only — no vote payload data. Register as a singleton; the
+/// meter source <see cref="MeterName"/> is added to the OTel meter provider in
+/// <c>Sorcha.ServiceDefaults</c>.
+/// </summary>
+public sealed class FederationValidatorMetrics
+{
+    /// <summary>The OpenTelemetry meter name. Added via <c>metrics.AddMeter("Sorcha.Validator")</c>.</summary>
+    public const string MeterName = "Sorcha.Validator";
+
+    private static readonly Meter _meter = new(MeterName, "1.0.0");
+
+    private static readonly Counter<long> _voteRejected = _meter.CreateCounter<long>(
+        "sorcha_validator_vote_rejected_total",
+        unit: "{rejection}",
+        description: "Consensus votes rejected because authority did not derive from the sealed roster (US3), by reason.");
+
+    private static readonly Counter<long> _ejected = _meter.CreateCounter<long>(
+        "sorcha_validator_ejected_total",
+        unit: "{ejection}",
+        description: "Validators automatically ejected via a sealed control transaction (US3), by reason.");
+
+    /// <summary>
+    /// Record a rejected vote. <paramref name="reason"/> is one of
+    /// <c>not_in_sealed_roster</c>, <c>bad_signature</c>, <c>double_vote</c>.
+    /// </summary>
+    public void VoteRejected(string reason) =>
+        _voteRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    /// <summary>
+    /// Record an automatic ejection. <paramref name="reason"/> is one of
+    /// <c>equivocation</c>, <c>liveness_timeout</c>.
+    /// </summary>
+    public void Ejected(string reason) =>
+        _ejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+}

--- a/src/Services/Sorcha.Validator.Service/appsettings.json
+++ b/src/Services/Sorcha.Validator.Service/appsettings.json
@@ -28,7 +28,8 @@
     "ApprovalThreshold": 0.51,
     "VoteTimeout": "00:00:30",
     "MaxRetries": 3,
-    "RequireQuorum": true
+    "RequireQuorum": true,
+    "LivenessTimeoutSeconds": 30
   },
 
   "MemPool": {

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenStatusListPublisher.cs
@@ -192,9 +192,10 @@ public sealed class CitizenStatusListPublisher : ICitizenStatusListPublisher
         list.ExpiresAt = now.Add(ListLifetime);
 
         var compressed = ZlibDeflate(list.Bitstring);
+        var issuer = $"did:sorcha:org:{list.OrganizationId:N}";
         var payload = new
         {
-            iss = $"did:sorcha:org:{list.OrganizationId:N}",
+            iss = issuer,
             iat = now.ToUnixTimeSeconds(),
             exp = list.ExpiresAt.ToUnixTimeSeconds(),
             sub = BuildStatusListUri(list.OrganizationId, list.ListId),
@@ -205,7 +206,11 @@ public sealed class CitizenStatusListPublisher : ICitizenStatusListPublisher
             }
         };
 
-        list.SignedJwt = await SignJwtAsync(payload, signingWalletAddress, ct);
+        // Feature 138 US1 — identify the signing verification method so the verifier's
+        // IIssuerKeyResolver can match the correct key (it falls back to the first VM matching
+        // the alg when the kid does not resolve, preserving back-compat with already-issued lists).
+        var kid = $"{issuer}#citizen-status-signing";
+        list.SignedJwt = await SignJwtAsync(payload, signingWalletAddress, kid, ct);
 
         await _db.SaveChangesAsync(ct);
 
@@ -214,7 +219,7 @@ public sealed class CitizenStatusListPublisher : ICitizenStatusListPublisher
             list.OrganizationId, list.ListId, list.RevokedCount, list.Capacity, list.SignedJwt.Length);
     }
 
-    private async Task<string> SignJwtAsync(object payload, string signingWalletAddress, CancellationToken ct)
+    private async Task<string> SignJwtAsync(object payload, string signingWalletAddress, string kid, CancellationToken ct)
     {
         var wallet = await _walletRepository.GetByAddressAsync(signingWalletAddress, false, false, false, ct)
             ?? throw new KeyNotFoundException($"Signing wallet {signingWalletAddress} not found");
@@ -241,7 +246,7 @@ public sealed class CitizenStatusListPublisher : ICitizenStatusListPublisher
                 _ => throw new NotSupportedException($"Unsupported status-list signing algorithm: {derivationAlg}")
             };
 
-            var header = new { alg = joseAlg, typ = StatusListMediaType };
+            var header = new { alg = joseAlg, kid, typ = StatusListMediaType };
             var headerJson = JsonSerializer.SerializeToUtf8Bytes(header);
             var payloadJson = JsonSerializer.SerializeToUtf8Bytes(payload);
 

--- a/tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryHonestPathTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryHonestPathTests.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.ServiceClients.Register;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests;
+
+/// <summary>
+/// Feature 138 US4 (T051) — a blueprint with no sealed digest is not stored (no provenance), while a
+/// blueprint whose canonical hash matches the sealed digest is accepted.
+/// </summary>
+public sealed class BlueprintRecoveryHonestPathTests
+{
+    private const string Blueprint = """{"title":"Permit","participants":[{"id":"applicant"}],"actions":[]}""";
+
+    [Fact]
+    public void TryVerifyProvenance_NoSealedHash_Rejected_NoProvenance()
+    {
+        var ok = BlueprintRecoveryService.TryVerifyProvenance(Blueprint, contentHash: "", out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Be("no_provenance");
+    }
+
+    [Fact]
+    public void TryVerifyProvenance_MatchingSealedHash_Accepted()
+    {
+        // This is the producer→consumer contract: the digest the publish path sealed is exactly what
+        // BlueprintContentHash.Compute yields for the same JSON.
+        var sealedHash = BlueprintContentHash.Compute(Blueprint);
+
+        var ok = BlueprintRecoveryService.TryVerifyProvenance(Blueprint, sealedHash, out var reason);
+
+        ok.Should().BeTrue();
+        reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void Compute_IsStableAcrossWhitespaceVariants()
+    {
+        // Canonicalisation means producer and consumer agree regardless of incidental formatting.
+        const string pretty = """
+            {
+                "title": "Permit",
+                "participants": [ { "id": "applicant" } ],
+                "actions": []
+            }
+            """;
+
+        BlueprintContentHash.Compute(pretty).Should().Be(BlueprintContentHash.Compute(Blueprint));
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryProvenanceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/BlueprintRecoveryProvenanceTests.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.ServiceClients.Register;
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests;
+
+/// <summary>
+/// Feature 138 US4 (T050) — a recovered blueprint whose content does not match the sealed
+/// <c>ContentHash</c> is rejected and not stored.
+/// </summary>
+public sealed class BlueprintRecoveryProvenanceTests
+{
+    private const string GenuineBlueprint = """{"title":"Permit","participants":[],"actions":[]}""";
+
+    [Fact]
+    public void TryVerifyProvenance_TamperedContent_Rejected()
+    {
+        // The sealed hash is over the genuine blueprint…
+        var sealedHash = BlueprintContentHash.Compute(GenuineBlueprint);
+        // …but the content served has been tampered (an extra action injected).
+        const string tampered = """{"title":"Permit","participants":[],"actions":[{"id":"evil"}]}""";
+
+        var ok = BlueprintRecoveryService.TryVerifyProvenance(tampered, sealedHash, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Be("hash_mismatch");
+    }
+
+    [Fact]
+    public void TryVerifyProvenance_MalformedContent_Rejected()
+    {
+        var sealedHash = BlueprintContentHash.Compute(GenuineBlueprint);
+
+        var ok = BlueprintRecoveryService.TryVerifyProvenance("not-json{", sealedHash, out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Be("hash_mismatch");
+    }
+
+    [Fact]
+    public void TryVerifyProvenance_WrongHashForGenuineContent_Rejected()
+    {
+        // Genuine content, but the claimed sealed hash is for something else.
+        var ok = BlueprintRecoveryService.TryVerifyProvenance(
+            GenuineBlueprint,
+            contentHash: new string('a', 64),
+            out var reason);
+
+        ok.Should().BeFalse();
+        reason.Should().Be("hash_mismatch");
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintRecoveryServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/BlueprintRecoveryServiceTests.cs
@@ -90,7 +90,8 @@ public class BlueprintRecoveryServiceTests
                         TransactionId = "tx-1",
                         PublishedBy = "user-1",
                         PublishedAt = DateTimeOffset.UtcNow,
-                        BlueprintJson = blueprintJson
+                        BlueprintJson = blueprintJson,
+                        ContentHash = BlueprintContentHash.Compute(blueprintJson)
                     }
                 ]
             });
@@ -174,7 +175,8 @@ public class BlueprintRecoveryServiceTests
                         BlueprintId = "bp-1",
                         TransactionId = "tx-1",
                         PublishedAt = DateTimeOffset.UtcNow,
-                        BlueprintJson = blueprintJson
+                        BlueprintJson = blueprintJson,
+                        ContentHash = BlueprintContentHash.Compute(blueprintJson)
                     }
                 ]
             });
@@ -207,6 +209,10 @@ public class BlueprintRecoveryServiceTests
     {
         var older = DateTimeOffset.UtcNow.AddHours(-2);
         var newer = DateTimeOffset.UtcNow;
+        // Serialize once — the blueprint model has per-instance default fields, so a fresh
+        // serialization would not match the sealed ContentHash computed from a different instance.
+        var dupJson = JsonSerializer.Serialize(CreateMinimalBlueprint("bp-dup"));
+        var dupHash = BlueprintContentHash.Compute(dupJson);
 
         _mockRegisterClient
             .Setup(c => c.GetInternalRegistersAsync(It.IsAny<CancellationToken>()))
@@ -225,14 +231,16 @@ public class BlueprintRecoveryServiceTests
                         BlueprintId = "bp-dup",
                         TransactionId = "tx-old",
                         PublishedAt = older,
-                        BlueprintJson = JsonSerializer.Serialize(CreateMinimalBlueprint("bp-dup"))
+                        BlueprintJson = dupJson,
+                        ContentHash = dupHash
                     },
                     new PublishedBlueprintEntry
                     {
                         BlueprintId = "bp-dup",
                         TransactionId = "tx-new",
                         PublishedAt = newer,
-                        BlueprintJson = JsonSerializer.Serialize(CreateMinimalBlueprint("bp-dup"))
+                        BlueprintJson = dupJson,
+                        ContentHash = dupHash
                     }
                 ]
             });
@@ -303,6 +311,9 @@ public class BlueprintRecoveryServiceTests
     [Fact]
     public async Task RunRecoveryAsync_InvalidBlueprintJson_SkipsAndContinues()
     {
+        var goodJson = JsonSerializer.Serialize(CreateMinimalBlueprint("bp-good"));
+        var goodHash = BlueprintContentHash.Compute(goodJson);
+
         _mockRegisterClient
             .Setup(c => c.GetInternalRegistersAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([new InternalRegisterInfo { Id = "reg-1", Name = "R1", Height = 2 }]);
@@ -327,7 +338,8 @@ public class BlueprintRecoveryServiceTests
                         BlueprintId = "bp-good",
                         TransactionId = "tx-2",
                         PublishedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
-                        BlueprintJson = JsonSerializer.Serialize(CreateMinimalBlueprint("bp-good"))
+                        BlueprintJson = goodJson,
+                        ContentHash = goodHash
                     }
                 ]
             });
@@ -510,7 +522,8 @@ public class BlueprintRecoveryServiceTests
                         BlueprintId = "bp-1",
                         TransactionId = "tx-1",
                         PublishedAt = DateTimeOffset.UtcNow,
-                        BlueprintJson = blueprintJson
+                        BlueprintJson = blueprintJson,
+                        ContentHash = BlueprintContentHash.Compute(blueprintJson)
                     }
                 ]
             });

--- a/tests/Sorcha.Verifier.Tests/Services/KbJwtExpiryTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/KbJwtExpiryTests.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US5 (T056) — a captured KB-JWT replayed after its own <c>exp</c> is rejected even
+/// while the verifier session is still open, closing the multi-minute session-TTL replay window.
+/// </summary>
+public sealed class KbJwtExpiryTests
+{
+    [Fact]
+    public async Task ValidateAsync_KbJwtExpiredBeyondSkew_Rejected()
+    {
+        var validator = VpValidatorTestHarness.BuildValidator();
+        // KB-JWT expired 120s ago — well beyond the 60s default skew. Session is still open.
+        var bundle = TestVpFactory.Mint(
+            VpValidatorTestHarness.Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId,
+            VpValidatorTestHarness.Nonce,
+            kbJwtIssuedAt: DateTimeOffset.UtcNow.AddSeconds(-180),
+            kbJwtExpiresAt: DateTimeOffset.UtcNow.AddSeconds(-120));
+
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("KB-JWT has expired", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_KbJwtFreshWithinSkew_Accepted()
+    {
+        var validator = VpValidatorTestHarness.BuildValidator();
+        // Expired 30s ago but within the 60s skew → still fresh.
+        var bundle = TestVpFactory.Mint(
+            VpValidatorTestHarness.Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId,
+            VpValidatorTestHarness.Nonce,
+            kbJwtIssuedAt: DateTimeOffset.UtcNow.AddSeconds(-40),
+            kbJwtExpiresAt: DateTimeOffset.UtcNow.AddSeconds(-30));
+
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeTrue(string.Join(", ", outcome.Errors));
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/KbJwtMissingExpTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/KbJwtMissingExpTests.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US5 (T057) — a KB-JWT MUST carry an <c>exp</c> (FR-017) and MUST NOT exceed the
+/// configured maximum lifetime (so an over-long-lived proof cannot widen the replay window).
+/// </summary>
+public sealed class KbJwtMissingExpTests
+{
+    [Fact]
+    public async Task ValidateAsync_KbJwtMissingExp_Rejected()
+    {
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var bundle = TestVpFactory.Mint(
+            VpValidatorTestHarness.Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId,
+            VpValidatorTestHarness.Nonce,
+            omitKbJwtExp: true);
+
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("missing the mandatory exp", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_KbJwtOverLongLifetime_Rejected()
+    {
+        // Default max lifetime is 120s. Fresh (exp in the future) but minted with a 600s lifetime.
+        var validator = VpValidatorTestHarness.BuildValidator();
+        var bundle = TestVpFactory.Mint(
+            VpValidatorTestHarness.Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId,
+            VpValidatorTestHarness.Nonce,
+            kbJwtIssuedAt: DateTimeOffset.UtcNow.AddSeconds(-300),
+            kbJwtExpiresAt: DateTimeOffset.UtcNow.AddSeconds(300));
+
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("exceeds the maximum", StringComparison.Ordinal));
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/MidSessionRevocationTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/MidSessionRevocationTests.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Verifier.Engine;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US5 (T058) — revocation is re-checked at verify time, so a credential revoked after
+/// the session opened fails verification even when a still-fresh KB-JWT is presented (FR-019).
+/// Combined with US1's fail-closed status check, a presentation for a since-revoked credential cannot
+/// pass mid-session.
+/// </summary>
+public sealed class MidSessionRevocationTests
+{
+    [Fact]
+    public async Task ValidateAsync_DeviceCredentialRevokedMidSession_FreshProof_Rejected()
+    {
+        // Status list now reports the delegation credential as revoked (revoked after session open).
+        var validator = VpValidatorTestHarness.BuildValidator(statusVerdict: StatusListVerdict.Revoked);
+
+        // A perfectly fresh KB-JWT (default exp now+120s) — only revocation should fail it.
+        var bundle = TestVpFactory.Mint(
+            VpValidatorTestHarness.Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId,
+            VpValidatorTestHarness.Nonce);
+
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("revoked", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_StatusListUnverifiableMidSession_FreshProof_Rejected()
+    {
+        // US1 fail-closed: if the status list cannot be authenticated, verification fails closed.
+        var validator = VpValidatorTestHarness.BuildValidator(statusVerdict: StatusListVerdict.Unverifiable);
+
+        var bundle = TestVpFactory.Mint(
+            VpValidatorTestHarness.Vct,
+            VpValidatorTestHarness.Claims(("givenName", "Stuart")),
+            VpValidatorTestHarness.ClientId,
+            VpValidatorTestHarness.Nonce);
+
+        var outcome = await validator.ValidateAsync(
+            VpValidatorTestHarness.Session(), bundle.VpToken, bundle.Delegation);
+
+        outcome.Accepted.Should().BeFalse();
+        outcome.Errors.Should().Contain(e => e.Contains("could not be authenticated", StringComparison.Ordinal));
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListCacheTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListCacheTests.cs
@@ -2,180 +2,89 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System;
-using System.Buffers.Text;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
-using Moq.Protected;
-using Sorcha.Verifier.Services;
-using Xunit;using Sorcha.Verifier.Engine;
-
+using Sorcha.Verifier.Engine;
+using Xunit;
 
 namespace Sorcha.Verifier.Tests.Services;
 
 /// <summary>
-/// Tests for <see cref="StatusListCache"/> (Feature 114, T072). Verifies the
-/// JWT parse path, bit lookup, freshness reuse, stale-fallback on fetch
-/// failure, and out-of-range index handling.
+/// Tests for <see cref="StatusListCache"/> (Feature 114; hardened in Feature 138 US1). Covers the
+/// JWT parse path, verified bit lookup, fail-closed out-of-range handling, and verified-entry caching.
+/// The forged/issuer-mismatch/fail-closed/freshness rejection paths live in the dedicated
+/// StatusList*Tests classes alongside.
 /// </summary>
 public sealed class StatusListCacheTests
 {
-    private const string ListUri = "https://verify.test/api/v1/wallet/status/abc/citizen-devices/0.statuslist+jwt";
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-25T12:00:00Z");
 
     [Fact]
-    public void ParseJwt_ValidPayload_DecodesBitstring()
+    public void ParseJwt_ValidPayload_DecodesBitstringAndClaims()
     {
+        var key = StatusListTestHelpers.NewKey();
         var bits = new byte[32];
         bits[5] = 0b0000_0010; // index 41 set (5*8 + 1)
-        var jwt = BuildStatusListJwt(bits, expiresAt: DateTimeOffset.UtcNow.AddHours(24));
+        var jwt = StatusListTestHelpers.BuildSignedList(bits, Now.AddHours(24), key);
 
-        var entry = StatusListCache.ParseJwt(jwt);
+        var parsed = StatusListCache.ParseJwt(jwt);
 
-        entry.Bitstring.Length.Should().Be(32);
-        entry.Bitstring[5].Should().Be(0b0000_0010);
-        entry.ExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow.AddHours(23));
+        parsed.Bitstring.Length.Should().Be(32);
+        parsed.Bitstring[5].Should().Be(0b0000_0010);
+        parsed.Issuer.Should().Be(StatusListTestHelpers.Issuer);
+        parsed.Alg.Should().Be("ES256");
+        parsed.Kid.Should().Be("did:sorcha:org:abc#citizen-status-signing");
+        parsed.ExpiresAt.Should().NotBeNull();
     }
 
     [Fact]
-    public async Task IsRevokedAsync_BitSet_ReturnsTrue()
+    public async Task CheckAsync_BitSet_ReturnsRevoked_BitClear_ReturnsActive()
     {
+        var key = StatusListTestHelpers.NewKey();
         var bits = new byte[32];
         bits[1] = 0b0000_1000; // index 11 set
-        var cache = BuildCache(BuildStatusListJwt(bits, DateTimeOffset.UtcNow.AddHours(24)));
+        var cache = StatusListTestHelpers.BuildCache(
+            StatusListTestHelpers.BuildSignedList(bits, Now.AddHours(24), key),
+            StatusListTestHelpers.ResolverFor(key.PublicJwk),
+            new FixedTimeProvider(Now));
 
-        (await cache.IsRevokedAsync(ListUri, 11)).Should().BeTrue();
-        (await cache.IsRevokedAsync(ListUri, 10)).Should().BeFalse();
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Revoked);
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 10, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Active);
     }
 
     [Fact]
-    public async Task IsRevokedAsync_OutOfRange_ReturnsFalseAndLogs()
+    public async Task CheckAsync_OutOfRange_FailsClosed()
     {
-        var cache = BuildCache(BuildStatusListJwt(new byte[32], DateTimeOffset.UtcNow.AddHours(24)));
+        var key = StatusListTestHelpers.NewKey();
+        var cache = StatusListTestHelpers.BuildCache(
+            StatusListTestHelpers.BuildSignedList(new byte[32], Now.AddHours(24), key),
+            StatusListTestHelpers.ResolverFor(key.PublicJwk),
+            new FixedTimeProvider(Now));
 
-        (await cache.IsRevokedAsync(ListUri, 32 * 8)).Should().BeFalse();
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 32 * 8, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Unverifiable);
     }
 
     [Fact]
-    public async Task IsRevokedAsync_FetchFailure_NoCachedEntry_ReturnsFalse()
+    public async Task CheckAsync_SecondCallReusesVerifiedCache_NoSecondHttpHit()
     {
-        var cache = BuildCache(httpStatus: HttpStatusCode.InternalServerError);
-
-        (await cache.IsRevokedAsync(ListUri, 0)).Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task IsRevokedAsync_SecondCallReusesCache_NoSecondHttpHit()
-    {
+        var key = StatusListTestHelpers.NewKey();
         var bits = new byte[32];
         bits[0] = 0b0000_0001;
         var fetchCount = 0;
-        var cache = BuildCache(
-            BuildStatusListJwt(bits, DateTimeOffset.UtcNow.AddHours(24)),
+        var cache = StatusListTestHelpers.BuildCache(
+            StatusListTestHelpers.BuildSignedList(bits, Now.AddHours(24), key),
+            StatusListTestHelpers.ResolverFor(key.PublicJwk),
+            new FixedTimeProvider(Now),
             onRequest: _ => Interlocked.Increment(ref fetchCount));
 
-        await cache.IsRevokedAsync(ListUri, 0);
-        await cache.IsRevokedAsync(ListUri, 0);
-        await cache.IsRevokedAsync(ListUri, 0);
+        await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
+        await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
+        await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
 
         fetchCount.Should().Be(1);
-    }
-
-    [Fact]
-    public async Task IsRevokedAsync_StaleEntryServedWhenFreshFetchFails()
-    {
-        var bits = new byte[32];
-        bits[0] = 0b0000_0010; // bit 1 set
-        var responses = new Queue<HttpResponseMessage>();
-        responses.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StringContent(BuildStatusListJwt(bits, DateTimeOffset.UtcNow.AddSeconds(-1)))
-        });
-        responses.Enqueue(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
-
-        var cache = BuildCacheFromResponses(responses);
-
-        // First call seeds the cache (with already-stale entry — exp in the past).
-        (await cache.IsRevokedAsync(ListUri, 1)).Should().BeTrue();
-        // Second call: cache is stale → fresh fetch attempted → fails → falls back to stale.
-        (await cache.IsRevokedAsync(ListUri, 1)).Should().BeTrue();
-    }
-
-    private static string BuildStatusListJwt(byte[] bits, DateTimeOffset expiresAt)
-    {
-        using var ms = new MemoryStream();
-        using (var compressor = new ZLibStream(ms, CompressionLevel.Optimal, leaveOpen: true))
-        {
-            compressor.Write(bits, 0, bits.Length);
-        }
-        var compressed = ms.ToArray();
-
-        var header = new { alg = "ES256", typ = "statuslist+jwt" };
-        var payload = new
-        {
-            iss = "did:sorcha:org:test",
-            iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            exp = expiresAt.ToUnixTimeSeconds(),
-            sub = ListUri,
-            status_list = new { bits = 1, lst = Base64Url.EncodeToString(compressed) }
-        };
-
-        var headerB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
-        var payloadB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
-        // Signature ignored by ParseJwt — we don't verify here, only structurally parse.
-        return $"{headerB64}.{payloadB64}.fakesig";
-    }
-
-    private static StatusListCache BuildCache(
-        string body,
-        Action<HttpRequestMessage>? onRequest = null)
-    {
-        return BuildCacheFromHandler(HttpStatusCode.OK, body, onRequest);
-    }
-
-    private static StatusListCache BuildCache(HttpStatusCode httpStatus)
-    {
-        return BuildCacheFromHandler(httpStatus, body: "", onRequest: null);
-    }
-
-    private static StatusListCache BuildCacheFromHandler(
-        HttpStatusCode status,
-        string body,
-        Action<HttpRequestMessage>? onRequest)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
-            {
-                onRequest?.Invoke(req);
-                return Task.FromResult(new HttpResponseMessage(status)
-                {
-                    Content = new StringContent(body, Encoding.UTF8, "application/jwt")
-                });
-            });
-
-        var http = new HttpClient(handler.Object);
-        return new StatusListCache(http, NullLogger<StatusListCache>.Instance);
-    }
-
-    private static StatusListCache BuildCacheFromResponses(Queue<HttpResponseMessage> responses)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
-                Task.FromResult(responses.Count > 0 ? responses.Dequeue() : new HttpResponseMessage(HttpStatusCode.NotFound)));
-
-        var http = new HttpClient(handler.Object);
-        return new StatusListCache(http, NullLogger<StatusListCache>.Instance);
     }
 }

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListFailClosedTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListFailClosedTests.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Verifier.Engine;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US1 (T007) — when the status list cannot be fetched (or its key cannot be resolved)
+/// the verifier fails closed (<see cref="StatusListVerdict.Unverifiable"/>) and never serves a stale
+/// cached copy. This is the removal of the old fail-open path.
+/// </summary>
+public sealed class StatusListFailClosedTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-25T12:00:00Z");
+
+    [Fact]
+    public async Task CheckAsync_FetchFails_NoCache_ReturnsUnverifiable()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var cache = StatusListTestHelpers.BuildCache(
+            HttpStatusCode.InternalServerError,
+            StatusListTestHelpers.ResolverFor(key.PublicJwk),
+            new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_KeyUnresolved_ReturnsUnverifiable()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var jwt = StatusListTestHelpers.BuildSignedList(new byte[32], Now.AddHours(1), key);
+
+        // Genuine list, but the resolver has no key for the issuer (e.g. DID not published).
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.NullResolver(), new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_FreshFetchFails_DoesNotServeStaleCache()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var bits = new byte[32];
+        bits[1] = 0b0000_1000; // index 11 = revoked
+        var clock = new FixedTimeProvider(Now);
+
+        var responses = new Queue<HttpResponseMessage>();
+        // First response seeds a VERIFIED entry that is about to expire.
+        responses.Enqueue(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                StatusListTestHelpers.BuildSignedList(bits, Now.AddSeconds(1), key),
+                Encoding.UTF8, "application/statuslist+jwt"),
+        });
+        // Second fetch fails.
+        responses.Enqueue(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        var cache = StatusListTestHelpers.BuildCacheFromResponses(
+            responses, StatusListTestHelpers.ResolverFor(key.PublicJwk), clock, skew: TimeSpan.Zero);
+
+        // First call: seeds the cache, reports revoked.
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Revoked);
+
+        // Advance past the entry's exp so a fresh fetch is forced; that fetch fails.
+        clock.Advance(TimeSpan.FromSeconds(5));
+
+        // MUST fail closed — NOT serve the stale (now-expired) cached copy.
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Unverifiable);
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListFreshnessTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListFreshnessTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Verifier.Engine;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US1 (T008) — freshness is enforced against the list's own <c>exp</c> within the
+/// configured clock skew (no +24h default for a list missing <c>exp</c>), and the honest path still
+/// reports revoked/active correctly for a genuine, signed, fresh list.
+/// </summary>
+public sealed class StatusListFreshnessTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-25T12:00:00Z");
+
+    [Fact]
+    public async Task CheckAsync_ExpiredList_ReturnsUnverifiable()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var jwt = StatusListTestHelpers.BuildSignedList(new byte[32], Now.AddHours(-2), key);
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(key.PublicJwk), new FixedTimeProvider(Now),
+            skew: TimeSpan.FromSeconds(60));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_NoExpClaim_ReturnsUnverifiable_NoTwentyFourHourDefault()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var jwt = StatusListTestHelpers.BuildSignedList(new byte[32], Now, key, omitExp: true);
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(key.PublicJwk), new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 0, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_GenuineFreshList_ReportsRevokedAndActiveCorrectly()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var bits = new byte[32];
+        bits[1] = 0b0000_1000; // index 11 = revoked
+        var jwt = StatusListTestHelpers.BuildSignedList(bits, Now.AddHours(1), key);
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(key.PublicJwk), new FixedTimeProvider(Now));
+
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Revoked);
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 10, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Active);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ExpiredButWithinSkew_StillTrusted()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var bits = new byte[32];
+        bits[1] = 0b0000_1000;
+        // Expired 30s ago, but skew is 60s → still fresh.
+        var jwt = StatusListTestHelpers.BuildSignedList(bits, Now.AddSeconds(-30), key);
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(key.PublicJwk), new FixedTimeProvider(Now),
+            skew: TimeSpan.FromSeconds(60));
+
+        (await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer))
+            .Should().Be(StatusListVerdict.Revoked);
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListIssuerPinningTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListIssuerPinningTests.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Verifier.Engine;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US1 (T006) — a status list whose <c>iss</c> claim does not match the expected
+/// organisation DID is rejected, even when its own signature is internally valid (an attacker's
+/// genuinely-self-signed list must not satisfy a different org's revocation check).
+/// </summary>
+public sealed class StatusListIssuerPinningTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-25T12:00:00Z");
+
+    [Fact]
+    public async Task CheckAsync_IssuerMismatch_ReturnsUnverifiable_EvenWithValidSelfSignature()
+    {
+        var attackerKey = StatusListTestHelpers.NewKey();
+        // A perfectly valid, self-signed list — but issued by the attacker's own org DID.
+        const string attackerIssuer = "did:sorcha:org:evil";
+        var jwt = StatusListTestHelpers.BuildSignedList(
+            new byte[32], Now.AddHours(1), attackerKey, issuer: attackerIssuer);
+
+        // The resolver would even hand back the attacker's key for the attacker's DID — but the
+        // verifier pins to the EXPECTED issuer (the credential's org), so the mismatch is caught first.
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(attackerKey.PublicJwk, attackerIssuer), new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(
+            StatusListTestHelpers.ListUri, 11, expectedIssuer: StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListSignatureTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListSignatureTests.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Verifier.Engine;
+using Xunit;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Feature 138 US1 (T005) — a status list whose signature does not verify against the issuing
+/// organisation's resolved key is rejected (fail closed), even though it is structurally valid.
+/// </summary>
+public sealed class StatusListSignatureTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-05-25T12:00:00Z");
+
+    [Fact]
+    public async Task CheckAsync_ForgedSignature_ReturnsUnverifiable()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        var bits = new byte[32]; // index 11 NOT set — the attacker wants it to read "active"
+        // Forge: the bytes say "active" but the signature is corrupt.
+        var jwt = StatusListTestHelpers.BuildSignedList(
+            bits, Now.AddHours(1), key, corruptSignature: true);
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(key.PublicJwk), new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_SignedByWrongKey_ReturnsUnverifiable()
+    {
+        var realKey = StatusListTestHelpers.NewKey();
+        var attackerKey = StatusListTestHelpers.NewKey();
+        // List signed by the attacker's key, but the resolver only trusts the real issuer key.
+        var jwt = StatusListTestHelpers.BuildSignedList(new byte[32], Now.AddHours(1), attackerKey);
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(realKey.PublicJwk), new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+
+    [Fact]
+    public async Task CheckAsync_UnsupportedAlgorithm_ReturnsUnverifiable()
+    {
+        var key = StatusListTestHelpers.NewKey();
+        // EdDSA is not verifiable in-engine → fail closed (never fail open).
+        var jwt = StatusListTestHelpers.BuildSignedList(new byte[32], Now.AddHours(1), key, alg: "EdDSA");
+
+        var cache = StatusListTestHelpers.BuildCache(
+            jwt, StatusListTestHelpers.ResolverFor(key.PublicJwk), new FixedTimeProvider(Now));
+
+        var verdict = await cache.CheckAsync(StatusListTestHelpers.ListUri, 11, StatusListTestHelpers.Issuer);
+
+        verdict.Should().Be(StatusListVerdict.Unverifiable);
+    }
+}

--- a/tests/Sorcha.Verifier.Tests/Services/StatusListTestHelpers.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/StatusListTestHelpers.cs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using Sorcha.Verifier.Engine;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Shared harness for the Feature 138 US1 status-list verification tests. Builds genuinely
+/// ES256-signed Token Status List JWTs (matching <c>CitizenStatusListPublisher</c>'s
+/// <c>ecdsa.SignData</c> IEEE-P1363 output), the matching public JWK, and a configurable
+/// <see cref="IIssuerKeyResolver"/> + <see cref="StatusListCache"/> wired to a mock transport.
+/// </summary>
+internal static class StatusListTestHelpers
+{
+    public const string Issuer = "did:sorcha:org:abc";
+    public const string ListUri = "https://verify.test/api/v1/wallet/status/abc/citizen-devices/0.statuslist+jwt";
+
+    /// <summary>A signing key plus the matching public JWK extracted from it.</summary>
+    public sealed record SigningKey(ECDsa Ecdsa, JsonElement PublicJwk);
+
+    /// <summary>Creates a fresh ES256 (P-256) key and its public JWK.</summary>
+    public static SigningKey NewKey()
+    {
+        var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var p = ecdsa.ExportParameters(includePrivateParameters: false);
+        var jwk = JsonSerializer.SerializeToElement(new
+        {
+            kty = "EC",
+            crv = "P-256",
+            x = Base64Url.EncodeToString(p.Q.X!),
+            y = Base64Url.EncodeToString(p.Q.Y!),
+        });
+        return new SigningKey(ecdsa, jwk);
+    }
+
+    /// <summary>
+    /// Builds a status-list JWT. When <paramref name="signingKey"/> is null a fresh key is used.
+    /// <paramref name="corruptSignature"/> flips the signature bytes (forged list); <paramref name="alg"/>
+    /// overrides the header alg (e.g. to test an unsupported algorithm).
+    /// </summary>
+    public static string BuildSignedList(
+        byte[] bits,
+        DateTimeOffset exp,
+        SigningKey signingKey,
+        string issuer = Issuer,
+        string? kid = "did:sorcha:org:abc#citizen-status-signing",
+        bool corruptSignature = false,
+        bool omitExp = false,
+        string alg = "ES256")
+    {
+        using var ms = new MemoryStream();
+        using (var compressor = new ZLibStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            compressor.Write(bits, 0, bits.Length);
+        }
+        var compressed = ms.ToArray();
+
+        object header = kid is null
+            ? new { alg, typ = "statuslist+jwt" }
+            : new { alg, kid, typ = "statuslist+jwt" };
+
+        var payload = omitExp
+            ? (object)new
+            {
+                iss = issuer,
+                iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                sub = ListUri,
+                status_list = new { bits = 1, lst = Base64Url.EncodeToString(compressed) },
+            }
+            : new
+            {
+                iss = issuer,
+                iat = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                exp = exp.ToUnixTimeSeconds(),
+                sub = ListUri,
+                status_list = new { bits = 1, lst = Base64Url.EncodeToString(compressed) },
+            };
+
+        var headerB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(header));
+        var payloadB64 = Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload));
+        var signingInput = Encoding.ASCII.GetBytes($"{headerB64}.{payloadB64}");
+
+        // Matches the publisher: raw ECDsa.SignData → IEEE P1363 concatenated (r‖s).
+        var signature = signingKey.Ecdsa.SignData(signingInput, HashAlgorithmName.SHA256);
+        if (corruptSignature)
+        {
+            signature[0] ^= 0xFF;
+            signature[^1] ^= 0xFF;
+        }
+
+        return $"{headerB64}.{payloadB64}.{Base64Url.EncodeToString(signature)}";
+    }
+
+    /// <summary>A stub resolver that returns <paramref name="jwk"/> for <paramref name="issuer"/>, else null.</summary>
+    public static IIssuerKeyResolver ResolverFor(JsonElement jwk, string issuer = Issuer)
+        => new StubResolver(jwk, issuer);
+
+    /// <summary>A resolver that always returns null (no key available).</summary>
+    public static IIssuerKeyResolver NullResolver() => new StubResolver(null, Issuer);
+
+    /// <summary>Builds a <see cref="StatusListCache"/> serving <paramref name="body"/> over a mock transport.</summary>
+    public static StatusListCache BuildCache(
+        string body,
+        IIssuerKeyResolver resolver,
+        TimeProvider clock,
+        TimeSpan? skew = null,
+        Action<HttpRequestMessage>? onRequest = null)
+        => BuildCacheFromHandler(HttpStatusCode.OK, body, resolver, clock, skew, onRequest);
+
+    /// <summary>Builds a <see cref="StatusListCache"/> whose transport returns <paramref name="status"/>.</summary>
+    public static StatusListCache BuildCache(
+        HttpStatusCode status,
+        IIssuerKeyResolver resolver,
+        TimeProvider clock,
+        TimeSpan? skew = null)
+        => BuildCacheFromHandler(status, body: string.Empty, resolver, clock, skew, onRequest: null);
+
+    private static StatusListCache BuildCacheFromHandler(
+        HttpStatusCode status,
+        string body,
+        IIssuerKeyResolver resolver,
+        TimeProvider clock,
+        TimeSpan? skew,
+        Action<HttpRequestMessage>? onRequest)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                onRequest?.Invoke(req);
+                return Task.FromResult(new HttpResponseMessage(status)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/statuslist+jwt"),
+                });
+            });
+
+        var http = new HttpClient(handler.Object);
+        return new StatusListCache(http, resolver, clock, NullLogger<StatusListCache>.Instance, metrics: null, skew);
+    }
+
+    /// <summary>Builds a cache that serves a queue of responses (for stale/fail-closed sequencing).</summary>
+    public static StatusListCache BuildCacheFromResponses(
+        Queue<HttpResponseMessage> responses,
+        IIssuerKeyResolver resolver,
+        TimeProvider clock,
+        TimeSpan? skew = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((_, _) =>
+                Task.FromResult(responses.Count > 0 ? responses.Dequeue() : new HttpResponseMessage(HttpStatusCode.NotFound)));
+
+        var http = new HttpClient(handler.Object);
+        return new StatusListCache(http, resolver, clock, NullLogger<StatusListCache>.Instance, metrics: null, skew);
+    }
+
+    private sealed class StubResolver : IIssuerKeyResolver
+    {
+        private readonly JsonElement? _jwk;
+        private readonly string _issuer;
+
+        public StubResolver(JsonElement? jwk, string issuer)
+        {
+            _jwk = jwk;
+            _issuer = issuer;
+        }
+
+        public Task<JsonElement?> ResolveAsync(string issuer, CancellationToken ct = default)
+            => Task.FromResult(string.Equals(issuer, _issuer, StringComparison.Ordinal) ? _jwk : null);
+
+        public Task<JsonElement?> ResolveAsync(string issuer, string? kid, CancellationToken ct = default)
+            => ResolveAsync(issuer, ct);
+    }
+}
+
+/// <summary>Minimal deterministic <see cref="TimeProvider"/> for freshness tests (no package dependency).</summary>
+internal sealed class FixedTimeProvider : TimeProvider
+{
+    private DateTimeOffset _now;
+
+    public FixedTimeProvider(DateTimeOffset now) => _now = now;
+
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    public void Advance(TimeSpan delta) => _now += delta;
+}

--- a/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/TestVpFactory.cs
@@ -36,7 +36,10 @@ internal static class TestVpFactory
         string verifierNonce,
         DateTimeOffset? delegationExpiresAt = null,
         string statusListUri = "https://verify.test/status/00000000000000000000000000000000/citizen-devices/0.statuslist+jwt",
-        int statusListIndex = 7)
+        int statusListIndex = 7,
+        DateTimeOffset? kbJwtIssuedAt = null,
+        DateTimeOffset? kbJwtExpiresAt = null,
+        bool omitKbJwtExp = false)
     {
         var issuer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var holder = ECDsa.Create(ECCurve.NamedCurves.nistP256);
@@ -103,13 +106,20 @@ internal static class TestVpFactory
             ["typ"] = "kb+jwt",
             ["kid"] = deviceThumbprint,
         };
+        // Feature 138 US5 — the KB-JWT carries its own short exp (default now+120s, within the
+        // 120s max-lifetime bound). Negative tests override iat/exp or omit exp entirely.
+        var kbIat = (kbJwtIssuedAt ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds();
         var kbPayload = new Dictionary<string, object>
         {
-            ["iat"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            ["iat"] = kbIat,
             ["aud"] = verifierClientId,
             ["nonce"] = verifierNonce,
             ["sd_hash"] = "placeholder",
         };
+        if (!omitKbJwtExp)
+        {
+            kbPayload["exp"] = (kbJwtExpiresAt ?? DateTimeOffset.UtcNow.AddSeconds(120)).ToUnixTimeSeconds();
+        }
         var kbJwt = SignEs256(kbHeader, kbPayload, device);
 
         var disclosureSegments = string.Concat(disclosures.Select(d => "~" + d));

--- a/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/VerifiablePresentationValidatorTests.cs
@@ -33,8 +33,8 @@ public sealed class VerifiablePresentationValidatorTests
     public VerifiablePresentationValidatorTests()
     {
         _statusList
-            .Setup(s => s.IsRevokedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+            .Setup(s => s.CheckAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StatusListVerdict.Active);
         _validator = new VerifiablePresentationValidator(
             _statusList.Object, TimeProvider.System,
             NullLogger<VerifiablePresentationValidator>.Instance);
@@ -140,8 +140,8 @@ public sealed class VerifiablePresentationValidatorTests
     public async Task ValidateAsync_RevokedDelegation_Rejected()
     {
         _statusList
-            .Setup(s => s.IsRevokedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
+            .Setup(s => s.CheckAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StatusListVerdict.Revoked);
         var bundle = TestVpFactory.Mint(Vct, Claims(("givenName", "Stuart")), ClientId, Nonce);
 
         var outcome = await _validator.ValidateAsync(Session(), bundle.VpToken, bundle.Delegation);

--- a/tests/Sorcha.Verifier.Tests/Services/VpValidatorTestHarness.cs
+++ b/tests/Sorcha.Verifier.Tests/Services/VpValidatorTestHarness.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Verifier.Engine;
+using Sorcha.Verifier.Engine.Models;
+
+namespace Sorcha.Verifier.Tests.Services;
+
+/// <summary>
+/// Shared builder for Feature 138 US5 presentation-replay tests. Wires a
+/// <see cref="VerifiablePresentationValidator"/> with a stub status-list cache (so the test can
+/// isolate KB-JWT freshness from revocation) and the standard verifier session.
+/// </summary>
+internal static class VpValidatorTestHarness
+{
+    public const string Vct = "https://sorcha.dev/vc/test/v1";
+    public const string Nonce = "verifier-nonce-us5";
+    public const string ClientId = "did:sorcha:verifier:00000000000000000000000000000001";
+
+    public static VerifiablePresentationValidator BuildValidator(
+        StatusListVerdict statusVerdict = StatusListVerdict.Active,
+        TimeProvider? clock = null,
+        TimeSpan? clockSkew = null,
+        TimeSpan? kbJwtMaxLifetime = null)
+    {
+        var statusList = new Mock<IStatusListCache>();
+        statusList
+            .Setup(s => s.CheckAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(statusVerdict);
+
+        return new VerifiablePresentationValidator(
+            statusList.Object,
+            new OptOutIssuerKeyResolver(),
+            clock ?? TimeProvider.System,
+            NullLogger<VerifiablePresentationValidator>.Instance,
+            requireIssuerSignature: false,
+            metrics: null,
+            clockSkew: clockSkew,
+            kbJwtMaxLifetime: kbJwtMaxLifetime);
+    }
+
+    public static VerifierSession Session() => new()
+    {
+        SessionId = "sess-us5",
+        ClientId = ClientId,
+        Nonce = Nonce,
+        RequiredVct = Vct,
+        RequiredClaims = ["givenName"],
+        OptionalClaims = [],
+        Purpose = "test",
+        CreatedAt = DateTimeOffset.UtcNow,
+        ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+    };
+
+    public static Dictionary<string, JsonElement> Claims(params (string Name, string Value)[] pairs)
+    {
+        var d = new Dictionary<string, JsonElement>();
+        foreach (var (n, v) in pairs)
+            d[n] = JsonSerializer.SerializeToElement(v);
+        return d;
+    }
+}


### PR DESCRIPTION
## Feature 138 — Federation Trust Hardening (part 1 of 3)

Red-team-driven hardening so **every cross-node input is verified against a signature anchored in sealed register state, fail-closed** — never trusted by sender or transport. This PR delivers the **verifier-side** stories (the cheapest/highest-impact attacks); the two infra-heavy P1 stories land in follow-up PRs.

### What's in this PR (29 / 72 tasks)

**Phase 1 — Setup**
- Config keys with secure defaults: `Verifier:ClockSkewSeconds` (60), `Verifier:KbJwtMaxLifetimeSeconds` (120), `PeerService:ChallengeTtlSeconds` (30) + `EnableTls` binding, `Consensus:LivenessTimeoutSeconds` (30)
- 8 FR-022 rejection counters on new `Sorcha.Verifier/Peer/Validator/Blueprint` meters

**Phase 2 — Foundational**
- `ClockSkew` helper + `ClockSkewOptions` (fail-closed, `TimeProvider`-driven)
- `ISecurityPostureSignal` + `SecurityPostureHealthCheck` (Degraded on fail-closed fallback), mirroring the Storage Registration Log pattern

**US1 — Revocation cannot be forged (P1 🎯 MVP)** — SC-001/SC-002
- `IStatusListCache` → tri-state `CheckAsync(uri, index, expectedIssuer)` so callers fail closed
- Verify the status-list ES256 signature against the issuing org's sealed-state key (`IIssuerKeyResolver`), pin `iss`, enforce freshness against the list's own `exp` ± skew (no +24h default), cache only verified lists, never serve stale on fetch failure
- Validator treats `Revoked` **or** `Unverifiable` as rejection; publisher adds a `kid` header
- 11 new tests; existing cache/validator tests migrated to the fail-closed contract

**US5 — Presentation replay hardening (P2)** — SC-007
- Mandatory KB-JWT `exp` + `exp − iat ≤ KbJwtMaxLifetimeSeconds`, checked after signature verification; mid-session revocation re-checked at verify time (completed by US1's fail-closed)
- Producers mint `exp`: PWA `PresentationEngine` + Agent `KbJwtBuilder`
- 6 new tests

**US4 — Verified blueprint recovery (P2)** — SC-006
- `PublishedBlueprintEntry.ContentHash` + `BlueprintContentHash.Compute` (single canonical SHA-256 for producer + consumer)
- Register seals the canonical hash in the publish control-tx metadata and returns it from sealed state; recovery recomputes and rejects on mismatch / no-provenance before storing
- 6 new tests + 4 pre-existing recovery tests updated to supply sealed provenance

### Tests
47 verifier + 142 PWA + 20 blueprint-recovery tests green. Every hardened surface has a negative test proving the forged/unverifiable/replayed variant is rejected (FR-021).

### Follow-ups (separate PRs)
- **US2** — authenticated peers (proto regen + EF migration + mTLS; multi-node validation)
- **US3** — sealed-roster vote authority + deterministic ejection (consensus core)
- **US6** — open-participant carried-key binding (needs a commitment-scheme design decision + EF migration)

### Notes
- EdDSA status lists are treated as `Unverifiable` (fail closed), consistent with the engine's existing ES256-only JWS posture (default citizen signing algorithm is ES256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)