### PR TITLE
feat: [138] US3 model layer — Consent default + Ejected roster state

### DIFF
--- a/specs/138-federation-trust-hardening/tasks.md
+++ b/specs/138-federation-trust-hardening/tasks.md
@@ -124,8 +124,8 @@ description: "Task list for Federation Trust Hardening (Feature 138)"
 
 ### Implementation for User Story 3
 
-- [ ] T040 [P] [US3] Flip `CreateDefault()` `RegistrationMode` `Public → Consent`, in `src/Common/Sorcha.Register.Models/RegisterPolicy.cs`
-- [ ] T041 [P] [US3] Add `Ejected` status + `EjectionRef` to roster entries, in `src/Common/Sorcha.Register.Models/ValidatorRoster.cs`
+- [X] T040 [P] [US3] Flip `CreateDefault()` `RegistrationMode` `Public → Consent`, in `src/Common/Sorcha.Register.Models/RegisterPolicy.cs`
+- [X] T041 [P] [US3] Add `Ejected` status + `EjectionRef` to roster entries, in `src/Common/Sorcha.Register.Models/ValidatorRoster.cs`
 - [ ] T042 [US3] Implement roster reconstruction from `RegisterControlRecord.Validators` (sealed) and make the `ValidatorRegistry` cache a derived, non-authoritative view (seal wins on divergence), in `src/Services/Sorcha.Validator.Service/Services/ValidatorRegistry.cs`
 - [ ] T043 [US3] Derive vote authority from the sealed roster in `ValidateVotesAsync` (key ∈ sealed ActiveValidators ∧ signatureValid ∧ ¬doubleVote), in `src/Services/Sorcha.Validator.Service/Services/ConsensusEngine.cs`
 - [ ] T044 [P] [US3] Define the `control.validator.eject` and `control.validator.liveness-violation` action types per `contracts/validator-control-transactions.md`, in `src/Common/Sorcha.Register.Models/`

--- a/src/Common/Sorcha.Register.Models/RegisterPolicy.cs
+++ b/src/Common/Sorcha.Register.Models/RegisterPolicy.cs
@@ -75,7 +75,10 @@ public class RegisterPolicy
             },
             Validators = new PolicyValidatorConfig
             {
-                RegistrationMode = RegistrationMode.Public,
+                // Feature 138 US3 (FR-011) — new registers default to Consent: a validator must be
+                // explicitly approved into the sealed roster before any vote counts. Open
+                // self-registration (Public) remains selectable by the register owner.
+                RegistrationMode = RegistrationMode.Consent,
                 ApprovedValidators = [],
                 MinValidators = 1,
                 MaxValidators = 100,
@@ -145,11 +148,13 @@ public class PolicyGovernanceConfig
 public class PolicyValidatorConfig
 {
     /// <summary>
-    /// How validators are registered: Public (open) or Approved (permissioned).
+    /// How validators are registered: Public (open self-registration) or Consent (permissioned —
+    /// explicit roster approval required). Feature 138 US3 / FR-011 defaults this to Consent so a
+    /// register is not silently open to self-admitting validators.
     /// </summary>
     [JsonPropertyName("registrationMode")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public RegistrationMode RegistrationMode { get; set; } = RegistrationMode.Public;
+    public RegistrationMode RegistrationMode { get; set; } = RegistrationMode.Consent;
 
     /// <summary>
     /// List of pre-approved validators when <see cref="RegistrationMode"/> is Approved.

--- a/src/Common/Sorcha.Register.Models/ValidatorKeyStatus.cs
+++ b/src/Common/Sorcha.Register.Models/ValidatorKeyStatus.cs
@@ -25,5 +25,14 @@ public enum ValidatorKeyStatus
     /// <summary>
     /// Key permanently revoked. Rejected for all verification purposes.
     /// </summary>
-    Revoked
+    Revoked,
+
+    /// <summary>
+    /// Validator automatically ejected by a deterministic on-chain rule (Feature 138 US3) — proven
+    /// equivocation or a liveness-timeout. Distinct from operator-driven <see cref="Revoked"/>:
+    /// ejection is sealed by a <c>control.validator.eject</c> / <c>control.validator.liveness-violation</c>
+    /// transaction that every honest node produces and applies identically. Excluded from voting and
+    /// from verification, like Revoked.
+    /// </summary>
+    Ejected
 }

--- a/src/Common/Sorcha.Register.Models/ValidatorRosterEntry.cs
+++ b/src/Common/Sorcha.Register.Models/ValidatorRosterEntry.cs
@@ -63,4 +63,35 @@ public class ValidatorRosterEntry
     [JsonPropertyName("revokedAt")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTimeOffset? RevokedAt { get; set; }
+
+    /// <summary>
+    /// Feature 138 US3 — transaction id of the sealing <c>control.validator.eject</c> or
+    /// <c>control.validator.liveness-violation</c> that moved this entry to
+    /// <see cref="ValidatorKeyStatus.Ejected"/>. Null unless ejected. Lets any node trace the
+    /// ejection back to its on-chain evidence.
+    /// </summary>
+    [JsonPropertyName("ejectionRef")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? EjectionRef { get; set; }
+
+    /// <summary>
+    /// Feature 138 US3 — why this validator was ejected (<c>Equivocation</c> or
+    /// <c>LivenessTimeout</c>). Null unless ejected.
+    /// </summary>
+    [JsonPropertyName("ejectionReason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ValidatorEjectionReason? EjectionReason { get; set; }
+}
+
+/// <summary>
+/// Reason a validator was automatically ejected from the sealed roster (Feature 138 US3).
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ValidatorEjectionReason
+{
+    /// <summary>Signed two conflicting states for the same slot (double-vote / equivocation).</summary>
+    Equivocation,
+
+    /// <summary>Accepted work for sealing but did not seal within the liveness window.</summary>
+    LivenessTimeout
 }

--- a/tests/Sorcha.Register.Models.Tests/RegisterPolicyTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/RegisterPolicyTests.cs
@@ -54,11 +54,13 @@ public class RegisterPolicyTests
     // --- CreateDefault: Validators ---
 
     [Fact]
-    public void CreateDefault_Validators_RegistrationMode_IsPublic()
+    public void CreateDefault_Validators_RegistrationMode_IsConsent()
     {
+        // Feature 138 US3 / FR-011 — new registers default to Consent (explicit roster approval),
+        // not open self-registration.
         var policy = RegisterPolicy.CreateDefault();
 
-        policy.Validators.RegistrationMode.Should().Be(RegistrationMode.Public);
+        policy.Validators.RegistrationMode.Should().Be(RegistrationMode.Consent);
     }
 
     [Fact]
@@ -353,8 +355,10 @@ public class RegisterPolicyTests
 
         var json = JsonSerializer.Serialize(policy);
 
-        json.Should().Contain("\"Public\"");
-        json.Should().NotContain("\"registrationMode\":0");
+        // Default is Consent (FR-011); the point of this test is that the enum serializes as a
+        // string, not its numeric value.
+        json.Should().Contain("\"Consent\"");
+        json.Should().NotContain("\"registrationMode\":1");
     }
 
     [Fact]
@@ -387,7 +391,7 @@ public class RegisterPolicyTests
 
         var deserialized = JsonSerializer.Deserialize<RegisterPolicy>(json);
 
-        deserialized!.Validators.RegistrationMode.Should().Be(RegistrationMode.Public);
+        deserialized!.Validators.RegistrationMode.Should().Be(RegistrationMode.Consent);
     }
 
     [Fact]

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationPolicyTests.cs
@@ -208,7 +208,7 @@ public class RegisterCreationPolicyTests
         policy.Governance.QuorumFormula.Should().Be(QuorumFormula.StrictMajority);
         policy.Governance.ProposalTtlDays.Should().Be(7);
         policy.Governance.OwnerCanBypassQuorum.Should().BeTrue();
-        policy.Validators.RegistrationMode.Should().Be(RegistrationMode.Public);
+        policy.Validators.RegistrationMode.Should().Be(RegistrationMode.Consent); // F138 US3 / FR-011 default
         policy.Validators.MinValidators.Should().Be(1);
         policy.Validators.MaxValidators.Should().Be(100);
         policy.Validators.RequireStake.Should().BeFalse();

--- a/tests/Sorcha.Validator.Service.Tests/Services/PolicyUpdateProcessorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/PolicyUpdateProcessorTests.cs
@@ -339,6 +339,10 @@ public class PolicyUpdateProcessorTests
     {
         var policy = RegisterPolicy.CreateDefault();
         policy.Version = 2;
+        // The default flipped to Consent (F138 US3 / FR-011). This payload models a plain policy
+        // update against a Public-mode register, so keep the mode Public — otherwise it would encode
+        // a Public→Consent transition, which validly requires a TransitionMode (covered separately).
+        policy.Validators.RegistrationMode = RegistrationMode.Public;
         return new
         {
             policy,


### PR DESCRIPTION
## Feature 138 — US3 model foundation (stacked on #848)

Model-layer prerequisites for **sealed-roster vote authority** (US3). Stacked on the verifier-side PR #848; will auto-retarget to `master` when that merges.

### Changes (T040, T041)
- **`RegisterPolicy`** — `CreateDefault()` and the `PolicyValidatorConfig` default flip `RegistrationMode` **Public → Consent** (FR-011). A validator must be explicitly approved into the sealed roster before any vote counts; open self-registration remains selectable by the register owner.
- **`ValidatorKeyStatus`** gains **`Ejected`** — a deterministic, on-chain ejection state distinct from operator-driven `Revoked`. Auto-excluded from `ActiveValidators` and `VerifiableValidators`.
- **`ValidatorRosterEntry`** gains **`EjectionRef`** (the sealing transaction id) and **`EjectionReason`** (`Equivocation` | `LivenessTimeout`), so any node can trace an ejection back to its on-chain evidence.

### Deliberately NOT in this PR — the consensus core (T042–T048)
The safety-critical rewrite is held for a focused, **multi-node-validated** session:
- sealed-roster reconstruction + making the `ValidatorRegistry` cache non-authoritative (T042)
- `ConsensusEngine.ValidateVotesAsync` deriving authority from the sealed roster (T043, SC-004)
- deterministic `control.validator.eject` / `control.validator.liveness-violation` emission + processing + quorum guard (T044–T048, SC-005)

These decide which votes seal the chain and genuinely need multi-node validation; landing them unvalidated at the model layer would risk a consensus-integrity bug.

> Note: flipping the `Consent` default will cascade test updates across the validator/register suites — those land with the consensus-core PR where the approval + ejection path makes them coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)