### PR TITLE
feat: [139] MCP Server Foundation — token forwarding + F136 tier-aware tools

### DIFF
--- a/docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md
+++ b/docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md
@@ -130,6 +130,15 @@ One coherent milestone in waves; **Phase 0 is load-bearing** — nothing else sh
 
 Each wave is independently shippable on top of Phase 0.
 
+### 5.1 Spec-kit decomposition
+
+This milestone is specified as **two consecutive spec-kit features**:
+
+1. **Feature 1 — Foundation** = Phase 0 above. Makes the existing 36-tool surface genuinely work, tiered by token, over both transports.
+2. **Feature 2 — Capability gap closure** = Waves 1–4 (register-control/federation, credential & presentation lifecycle, citizen self-service, platform-admin depth), built on top of Feature 1.
+
+The `wallet_sign` wave and the full MCP OAuth 2.1 AS remain **separate backlogged efforts**, each with its own design — they are not part of either feature.
+
 ---
 
 ## 6. Cross-cutting concerns

--- a/docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md
+++ b/docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md
@@ -1,0 +1,176 @@
+# MCP Server Remediation — Design
+
+**Date:** 2026-05-26
+**Status:** Approved (brainstorm) → ready for spec-kit
+**Author:** Stuart Fraser + Claude
+**Branch:** `feature/mcp-server-remediation`
+
+---
+
+## 1. Context & problem
+
+The Sorcha MCP server (`src/Apps/Sorcha.McpServer`) is structurally mature — 36 tools across admin/designer/participant slices, role gating, rate limiting, audit logging, graceful degradation, high-quality tool descriptions, an F117 discoverability manifest, and a registry-ready `server.json`. It has not been exercised against a live, secured backend in a long time, and a pass over it found **two foundational defects** plus a set of capability gaps.
+
+### Defect 1 — the caller's privileges never reach the backend
+
+Every tool performs a **local, in-process** authorization check (`McpAuthorizationService.CanInvokeTool`) and then calls the backend with a **bare `HttpClient`** that carries **no `Authorization` header**. `Program.cs` attaches no global auth handler. The supplied JWT is consumed only by `McpSessionService.InitializeFromToken()` for the local role gate, then discarded.
+
+Consequences:
+- Backend calls are anonymous → **401 against any auth-enforcing deployment** (real n1 / Production). The server only "works" against a dev stack with auth bypassed.
+- The "correct privileges" model is **client-side advisory theatre** — the backend never sees the caller's identity, tier, or org.
+- `AddServiceClients(...)` is registered but **unused** — tools bypass the typed clients (which *do* carry auth) for raw `HttpClient`.
+- **F136 consumer tier gets zero tools** — consumer tokens omit `roles`, and the RBAC map keys on roles, so a citizen token maps to an empty tool set.
+- The JWT is captured **once at process start** with no refresh — a long session dies on expiry.
+
+### Defect 2 — endpoint drift
+
+Tools were built against early/assumed endpoint shapes and never reconciled. Examples:
+- `sorcha_action_submit` POSTs `/api/actions/{id}/submit`; `ActionEndpoints.cs` exposes only `GET /api/actions/pending` + `/pending/count`. The real path is `POST /api/instances/{instanceId}/actions/{actionId}/execute`. **The tool 404s.**
+- `sorcha_tenant_create` POSTs `{name,adminEmail}` to `/api/organizations`; real org-with-admin provisioning is `POST /api/platform/organizations` (SystemAdmin, different body).
+
+Mocked unit tests hide both defects — the missing header and the wrong URL both pass CI green because nothing calls a live backend.
+
+### Capability gaps
+
+Mapping the 36 tools against the platform surface: no transaction-submission via the correct path, no register-control / federation tools (the federation work in PRs #828/#829 had the operator driving sync by hand — MCP-101/102), no credential/presentation lifecycle, no citizen/consumer self-service (wallet, devices, persona, invitations), and thin platform-admin (no org status/settings, no validator control). Transport is stdio-only. The gateway `/api/mcp/tools` catalogue is a hand-maintained list that can drift from the server.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+- Make tool invocation **execute with the caller's real privileges**, enforced by the backend, tiered by the F136 token (`consumer` / `platform`).
+- Eliminate the **endpoint-drift class of bug** permanently by routing all tool calls through the typed `Sorcha.ServiceClients`.
+- Support **both stdio (operators) and Streamable HTTP (external agents)**.
+- **Close the capability gaps** across register-control, credential/presentation lifecycle, citizen self-service, and platform-admin — phased.
+- Add a **live integration safety net** so this can't silently rot again.
+
+### Non-goals (this milestone)
+- **Full MCP OAuth 2.1 Authorization Server** — the Tenant Service is a capable token *issuer* and OAuth *client*, but not an authorization server (no first-party `/authorize`, no AS metadata RFC 8414, no protected-resource metadata RFC 9728, no DCR RFC 7591, no resource indicators RFC 8707, no consent UI). Standing that up is its own milestone. Seams are designed in so it slots in later.
+- **`wallet_sign`** as a usable tool — important, but raw signing-as-a-service for an agent needs a dedicated threat model and authz design. Parked to its own wave.
+- **`service`-tier MCP callers** — service tokens are for the internal mesh; rejected at the door.
+- **Node-lifecycle tools** (bootstrap / validator-key import / reset, MCP-103) — likely operator-only; the *decision* is documented, the tools are out.
+
+---
+
+## 3. Chosen approach
+
+**Approach 1 — Gateway-fronted, typed-client refactor** (selected over a minimal header-patch and a direct-to-service variant).
+
+Tools stop hand-rolling HTTP. They call the **API Gateway** (single base URL) through the existing typed `Sorcha.ServiceClients`. A per-request caller-token context feeds a `DelegatingHandler` that stamps `Authorization: Bearer` on every outbound call. The gateway enforces F136 tier/privilege for real; the MCP server keeps only an *advisory* tier/role filter on `ListTools`.
+
+Rationale: it is the only approach that makes "privileges tiered by token" *true* rather than advisory, kills drift structurally (routes live in the versioned clients), and makes the MCP server exercise the same front door an external agent uses — which keeps it honest. The service clients are core infrastructure intended for exactly this reuse.
+
+---
+
+## 4. Foundation architecture
+
+### 4.1 Caller context & token forwarding
+
+Replace the singleton `McpSessionService` (one token per process) with an ambient **`ICallerContext`** (one token per call context):
+- **stdio:** token from `--jwt-token` / `SORCHA_JWT_TOKEN` at startup (one caller per process).
+- **Streamable HTTP:** token per request from the inbound `Authorization` header via `IHttpContextAccessor`.
+
+`ICallerContext` exposes the raw bearer + parsed claims (tier from `aud` via `SorchaAudiences`, roles from the role claim, org_id, sub).
+
+A **`CallerTokenForwardingHandler : DelegatingHandler`** is registered on the `Sorcha.ServiceClients` HttpClients. It reads the raw bearer from `ICallerContext` and stamps `Authorization`. No tool touches a header. All service-client base addresses point at the **API Gateway**.
+
+### 4.2 Two enforcement layers
+
+1. **Advisory (local, UX):** validate the bearer locally (`JwtValidationHandler`, F136 issuer/audiences) to parse tier+roles → filter the advertised `ListTools` set and short-circuit obviously-unauthorised calls with a friendly message. **Invariant: the local gate can only ever narrow — never grant access the backend wouldn't.**
+2. **Authoritative (backend, security):** the gateway re-validates and enforces. `401/403/404/429` map to clean tool-result statuses (`Unauthorized`/`Forbidden`/`NotFound`/`RateLimited`).
+
+### 4.3 Tier → tool mapping (F136-aware)
+
+Tier-primary, role-secondary, with explicit cross-tier tools. Each tool is tagged with the tier(s) that may invoke it and (platform-only) a required role. The advisory `ListTools` filter shows the union the caller qualifies for.
+
+| Slice | Who (tier + role) | Tools |
+|---|---|---|
+| **Citizen / wallet self-service** *(new)* | `consumer` | my credentials, my devices, my persona, pending-applications, present-credential, my presentation history, holder-keys, my transaction history |
+| **Workflow participation** *(cross-tier)* | `consumer` **or** `platform` | inbox/pending actions, action details, action validate, **action submit**, workflow status, disclosed data |
+| **Designer** | `platform` + designer role | blueprint CRUD / validate / simulate / diff / export / schema / jsonlogic / workflow-instances / publish |
+| **Operator / Admin** | `platform` + admin role | health, logs, metrics, audit, tenant & org mgmt, user mgmt, peer/validator status, register stats, register-control, validator control, platform settings, token revoke |
+
+- Consumer tokens get a real surface (citizen + participation) — fixes the F136 shut-out.
+- Participation is cross-tier on purpose (citizen applicant *and* org analyst both submit actions); the tier routes the call to the right audience and the gateway enforces what each can touch.
+- `service`-tier tokens rejected at the door with a clear message.
+- `wallet_sign` removed from the participation slice pending its dedicated wave; `wallet_info` (read-only) stays.
+
+### 4.4 Endpoint reconciliation & service-client reuse
+
+**Rule: no hand-rolled URLs in the MCP server.** Every tool maps to a typed `Sorcha.ServiceClients` method. Where a method exists, use it; where it doesn't, **add it to the service client** (core infra — the whole platform benefits), never to the tool. Identified reconciliations:
+- `sorcha_action_submit` → `POST /api/instances/{instanceId}/actions/{actionId}/execute` via `IBlueprintServiceClient`.
+- `sorcha_tenant_create` → `POST /api/platform/organizations` via `ITenantServiceClient`.
+- Every other tool gets the same audit; nonexistent-route tools are corrected or removed.
+
+### 4.5 Transport & hosting
+
+`Program.cs` restructures from a console `Host` to a `WebApplication` selecting transport at startup (`--transport stdio|http`, default `stdio` for back-compat):
+- **stdio** — unchanged operator ergonomics.
+- **Streamable HTTP** — MCP SDK HTTP transport on ASP.NET Core. The endpoint is itself a **protected resource**: ServiceDefaults `AddJwtAuthentication` rejects anything without a valid F136 bearer before dispatch; the validated token flows per-request into `ICallerContext`.
+
+**Gateway-fronted, single origin:** the MCP HTTP endpoint is exposed via the API Gateway (a `/mcp` YARP route) alongside the existing `/.well-known/mcp.json`. The server's outbound calls also target the gateway (internal URL); the gateway→mcp→gateway loop is fine (distinct paths). docker-compose gains an HTTP-mode `mcp-server` with a port on `sorcha-network`; the stdio profile stays for local use.
+
+**Token lifecycle is the caller's job under pass-through** (deliberate): stdio operator sessions die on token expiry (documented); HTTP agents send a fresh bearer per request. This is the exact seam where the future OAuth AS slots in.
+
+---
+
+## 5. Phased milestone
+
+One coherent milestone in waves; **Phase 0 is load-bearing** — nothing else ships until the surface is genuinely wired.
+
+- **Phase 0 — Foundation:** `ICallerContext` + `CallerTokenForwardingHandler`; gateway-fronted typed-client refactor of existing tools; F136 tier→slice mapping (+ consumer slice, service-tier rejection); endpoint reconciliation (+ new `ServiceClients` methods); `WebApplication` restructure + Streamable HTTP + protected-resource auth; integration smoke harness; manifest/`server.json` reconciliation + CI gate. `wallet_sign` removed pending its wave. **Outcome: the existing surface works, tiered, over both transports.**
+- **Wave 1 — Register-control / federation** (MCP-101/102): subscribe/unsubscribe, sync-state, local-relationship, transaction submit/verify (F079 receipts, inclusion-proof, verification-bundle), revoke.
+- **Wave 2 — Credential & presentation lifecycle:** HAIP issue-offer, verifier request, presentation status/lifecycle (F111), credential revoke/suspend/reinstate/refresh.
+- **Wave 3 — Citizen/consumer self-service:** credentials, devices (F114/F128), persona (F125), pending-applications (F124), org + register invitations, present-credential.
+- **Wave 4 — Platform-admin depth:** org status (suspend/activate), platform settings, org user audit, validator start/stop/restart, platform user provisioning/password reset.
+- **Dedicated wave — `wallet_sign`:** strict authn/authz, threat model, consent + audit. Own design.
+- **Backlog milestone — full MCP OAuth 2.1 AS** (Tenant Service as authorization server). Seams designed in Phase 0.
+- **MCP-103 node-lifecycle:** explicit *documented* decision (likely operator-only, out of MCP).
+
+Each wave is independently shippable on top of Phase 0.
+
+---
+
+## 6. Cross-cutting concerns
+
+### 6.1 Testing
+- **Unit tests** stay for fast logic coverage (input validation, tier filtering, error mapping).
+- **Live integration smoke harness** (new, `Category=McpIntegration`): invokes tools in-process against a running gateway (Docker, ground-truth approach like the walkthroughs), authenticated with a **real minted token per tier** (consumer / platform-admin / platform-designer). Asserts a real success shape *or* the expected auth outcome (e.g. consumer token → 403 on an admin tool). Catches both defect classes — a missing header surfaces as 401, a drifted route as 404. CI runs it Docker-gated.
+
+### 6.2 Observability
+- Extend `ToolAuditService` to record caller tier + tool + outcome + backend status.
+- New `Sorcha.Mcp` OTel meter: `sorcha_mcp_tool_invoked_total{tool,tier,outcome}`, `sorcha_mcp_backend_call_total{service,status}`, + a latency histogram.
+- `RateLimitService` retained, keyed by caller.
+
+### 6.3 Manifest integrity
+- A CI gate reflects the MCP assembly's `[McpServerTool]` set and asserts the gateway `appsettings.json` catalogue **and** `server.json` match — build fails on drift. `server.json` version pinned per release.
+
+### 6.4 Security invariants
+- Advisory gate can only narrow, never grant.
+- Never log tokens.
+- `service`-tier rejected.
+- Local validation is defence-in-depth; the gateway is authoritative.
+
+### 6.5 Documentation
+Update `docs/mcp-server.md`, `docs/mcp-registry-publishing.md`, the `sorcha-architecture` skill (MCP surface), the MCP server README, and add a CLAUDE.md note for the token-forwarding rule.
+
+---
+
+## 7. Out of scope / backlog (explicit)
+
+| Item | Disposition |
+|---|---|
+| Full MCP OAuth 2.1 AS (Tenant Service as authorization server) | Backlog milestone; seams designed in Phase 0 |
+| `wallet_sign` usable tool | Dedicated security-reviewed wave |
+| Node-lifecycle tools (bootstrap / key import / reset, MCP-103) | Documented decision: operator-only, out of MCP |
+| `service`-tier MCP callers | Rejected at the door |
+
+---
+
+## 8. Risks & mitigations
+
+- **Big Phase 0 surface (touches MCP server + `Sorcha.ServiceClients.Http` + tests):** mitigated by the integration smoke harness gating "done," and by the fact that the typed-client refactor is mechanical once `ICallerContext` + handler exist.
+- **HTTP transport restructure (`Host` → `WebApplication`):** keep stdio as the default and verify operator parity before flipping any deployment to HTTP.
+- **Gateway loop (gateway→mcp→gateway):** distinct paths, no recursion; validated in the smoke harness.
+- **Per-request token context under the MCP SDK's HTTP transport:** confirm the SDK surfaces `HttpContext` to tool invocations; if not, capture the token in a scoped accessor at the transport boundary.

--- a/specs/139-mcp-foundation/checklists/requirements.md
+++ b/specs/139-mcp-foundation/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: MCP Server Foundation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated 2026-05-26, single pass — all items pass.
+- The spec deliberately keeps the HOW (class names, `ICallerContext`, `DelegatingHandler`, gateway `/mcp` route, OTel meter names, transport specifics) in the companion design doc `docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md`; the spec body uses neutral terms ("local mode" / "network mode", "tier", "advisory gate", "platform is authoritative") so requirements stay testable without prescribing implementation.
+- Domain terms that look technical (tier, token, transport) are first-class Sorcha concepts (F136), not implementation leakage.

--- a/specs/139-mcp-foundation/contracts/transport-and-tools.md
+++ b/specs/139-mcp-foundation/contracts/transport-and-tools.md
@@ -1,0 +1,98 @@
+# Phase 1 Contracts — MCP Server Foundation
+
+This feature adds no new platform REST endpoints. The "contracts" are: (1) the MCP transport surface, (2) the tier→tool entitlement matrix, and (3) the tool→service-client reconciliation table. The authoritative backend contracts are the existing platform endpoints reached via the typed `Sorcha.ServiceClients`.
+
+## 1. Transport surface
+
+| Transport | Entry | Auth | Notes |
+|---|---|---|---|
+| **stdio** | process started with `--transport stdio` (default) + `--jwt-token` / `SORCHA_JWT_TOKEN` | startup token validated once (`SorchaIssuer`/`SorchaAudiences`) | one caller per process |
+| **Streamable HTTP** | `app.MapMcp()` on the MCP server's `WebApplication`; exposed externally as gateway route `/mcp` | per-request `Authorization: Bearer`, validated by `AddJwtAuthentication` before dispatch; rejected if absent/invalid | stateless mode; `ConfigureSessionOptions` scopes the advertised tool set per request |
+
+Both transports resolve the same `ICallerContext` and reach the same tool surface, scoped by tier.
+
+## 2. Tier → tool entitlement matrix (foundation re-tagging — no new tools)
+
+Tier-primary, role-secondary. Participation/read tools are cross-tier. `wallet_sign` is **removed** from the advertised surface this feature.
+
+| Tool | Tier(s) | Role | Slice |
+|---|---|---|---|
+| `sorcha_health_check` | Platform | admin | Operator/Admin |
+| `sorcha_log_query` | Platform | admin | Operator/Admin |
+| `sorcha_metrics` | Platform | admin | Operator/Admin |
+| `sorcha_audit_query` | Platform | admin | Operator/Admin |
+| `sorcha_tenant_list` | Platform | admin | Operator/Admin |
+| `sorcha_tenant_create` | Platform | admin | Operator/Admin |
+| `sorcha_tenant_update` | Platform | admin | Operator/Admin |
+| `sorcha_user_list` | Platform | admin | Operator/Admin |
+| `sorcha_user_manage` | Platform | admin | Operator/Admin |
+| `sorcha_peer_status` | Platform | admin | Operator/Admin |
+| `sorcha_validator_status` | Platform | admin | Operator/Admin |
+| `sorcha_register_stats` | Platform | admin | Operator/Admin |
+| `sorcha_token_revoke` | Platform | admin | Operator/Admin |
+| `sorcha_blueprint_list` | Platform | designer | Designer |
+| `sorcha_blueprint_get` | Platform | designer | Designer |
+| `sorcha_blueprint_create` | Platform | designer | Designer |
+| `sorcha_blueprint_update` | Platform | designer | Designer |
+| `sorcha_blueprint_validate` | Platform | designer | Designer |
+| `sorcha_blueprint_simulate` | Platform | designer | Designer |
+| `sorcha_disclosure_analysis` | Platform | designer | Designer |
+| `sorcha_blueprint_diff` | Platform | designer | Designer |
+| `sorcha_blueprint_export` | Platform | designer | Designer |
+| `sorcha_schema_validate` | Platform | designer | Designer |
+| `sorcha_schema_generate` | Platform | designer | Designer |
+| `sorcha_jsonlogic_test` | Platform | designer | Designer |
+| `sorcha_workflow_instances` | Platform | designer | Designer |
+| `sorcha_inbox_list` | Consumer, Platform | — | Participation |
+| `sorcha_action_details` | Consumer, Platform | — | Participation |
+| `sorcha_action_validate` | Consumer, Platform | — | Participation |
+| `sorcha_action_submit` | Consumer, Platform | — | Participation |
+| `sorcha_workflow_status` | Consumer, Platform | — | Participation |
+| `sorcha_disclosed_data` | Consumer, Platform | — | Participation |
+| `sorcha_transaction_history` | Consumer, Platform | — | Participation / citizen read |
+| `sorcha_register_query` | Consumer, Platform | — | Participation / read |
+| `sorcha_wallet_info` | Consumer, Platform | — | Citizen read (read-only) |
+| `sorcha_wallet_sign` | — | — | **REMOVED** (deferred to dedicated wave) |
+
+Result: a consumer token sees the Participation + citizen-read tools (≥1 each) — fixing the F136 shut-out (FR-004). `service`-tier tokens see nothing and are rejected at connect.
+
+> Note: `schema_validate`, `schema_generate`, `jsonlogic_test` are pure-compute (no backend) and need no token forwarding, but keep the same entitlement tagging.
+
+## 3. Tool → service-client reconciliation
+
+Each backed tool maps to a typed `Sorcha.ServiceClients` method (add the method to the client when absent — never hand-roll a URL in the tool). Status legend: ✅ client method exists · ➕ add client method · 🔧 known route fix · 🖥 local compute (no backend).
+
+| Tool | Target client / operation | Status |
+|---|---|---|
+| `sorcha_action_submit` | `IBlueprintServiceClient` → `POST /api/instances/{instanceId}/actions/{actionId}/execute` | 🔧 (was `/api/actions/{id}/submit`) |
+| `sorcha_tenant_create` | `ITenantServiceClient` → `POST /api/platform/organizations` | 🔧 (was `/api/organizations`) |
+| `sorcha_inbox_list` | `IBlueprintServiceClient` → `GET /api/actions/pending` | ✅/verify |
+| `sorcha_action_details` | `IBlueprintServiceClient` action/instance read | verify/➕ |
+| `sorcha_action_validate` | `IBlueprintServiceClient` validate-against-schema | verify/➕ |
+| `sorcha_workflow_status` | `IBlueprintServiceClient` instance status | verify/➕ |
+| `sorcha_workflow_instances` | `IBlueprintServiceClient` instances-by-blueprint | verify/➕ |
+| `sorcha_blueprint_*` (list/get/create/update/validate/simulate/diff/export/disclosure) | `IBlueprintServiceClient` | verify/➕ per method |
+| `sorcha_register_query` | `IRegisterServiceClient` query | verify/➕ |
+| `sorcha_register_stats` | `IRegisterServiceClient` stats | verify/➕ |
+| `sorcha_transaction_history` | `IRegisterServiceClient` tx history | verify/➕ |
+| `sorcha_disclosed_data` | `IRegisterServiceClient` disclosed data | verify/➕ |
+| `sorcha_wallet_info` | `IWalletServiceClient` wallet metadata (read-only) | verify/➕ |
+| `sorcha_tenant_list` / `tenant_update` | `ITenantServiceClient` / `IPlatformOrg*` | verify/🔧 |
+| `sorcha_user_list` / `user_manage` | `ITenantServiceClient` platform user ops | verify/🔧 |
+| `sorcha_token_revoke` | `ITenantServiceClient` token revoke | verify/➕ |
+| `sorcha_audit_query` | `ITenantServiceClient` / event-audit | verify/➕ |
+| `sorcha_peer_status` | `IPeerServiceClient` (gRPC) | verify |
+| `sorcha_validator_status` | `IValidatorServiceClient` | verify |
+| `sorcha_health_check` | gateway `/health` aggregate | verify |
+| `sorcha_log_query` / `sorcha_metrics` | gateway / observability surface | verify |
+| `sorcha_schema_validate` / `sorcha_schema_generate` / `sorcha_jsonlogic_test` | local compute | 🖥 |
+
+**Implementation rule**: the audit confirms each row against the live service. Any "verify" that turns out drifted becomes a 🔧; any missing client method becomes a ➕ in `Sorcha.ServiceClients.Http`. The integration smoke harness (R-006) is the acceptance gate — every advertised tool must resolve to a live operation (SC-001).
+
+## 4. Integrity gate contract
+
+CI reflects the `[McpServerTool]`-attributed set from the MCP assembly and asserts:
+- the gateway `appsettings.json` MCP catalogue lists exactly that set, and
+- `server.json` is consistent and version-pinned.
+
+Mismatch → build fails (SC-005).

--- a/specs/139-mcp-foundation/data-model.md
+++ b/specs/139-mcp-foundation/data-model.md
@@ -1,0 +1,78 @@
+# Phase 1 Data Model — MCP Server Foundation
+
+This feature introduces no persisted entities. The "model" is the in-memory identity/authorization shape that flows through a tool invocation. All types live in `src/Apps/Sorcha.McpServer`.
+
+## ICallerContext
+
+The ambient identity behind the current invocation. One per process (stdio) or one per request (HTTP).
+
+| Member | Type | Notes |
+|---|---|---|
+| `RawToken` | `string` | The caller's bearer, forwarded verbatim to backends. Never logged. |
+| `Tier` | `Tier` | Parsed from the token `aud` via `SorchaAudiences`. |
+| `Roles` | `IReadOnlySet<string>` | From the role claim; empty for consumer tier. |
+| `OrganizationId` | `string?` | `org_id` claim (home/public org for consumer). |
+| `Subject` | `string?` | `sub` claim. |
+| `IsAuthenticated` | `bool` | True once a valid token is resolved. |
+
+**Implementations**:
+- `StdioCallerContext` — captures the startup `--jwt-token`/`SORCHA_JWT_TOKEN`, validates once, exposes it for the process lifetime.
+- `HttpCallerContext` — wraps `IHttpContextAccessor`; reads the validated `ClaimsPrincipal` + raw `Authorization` bearer per request.
+
+**Validation**: token validated against the installation issuer + tier audiences (`SorchaIssuer` / `SorchaAudiences`). Invalid / wrong-installation / missing-tier-audience → not authenticated → rejected before dispatch.
+
+## Tier
+
+The F136 trust boundary carried by the token audience.
+
+| Value | Audience | MCP meaning |
+|---|---|---|
+| `Consumer` | `{installation}:consumer` | Citizen / wallet holder. Gets citizen self-service + participation tools. |
+| `Platform` | `{installation}:platform` | Admin / operator / designer. Role sub-divides. |
+| `Service` | `{installation}:service` | Internal mesh. **Rejected** as an MCP caller. |
+
+(`enrol-session` audience is not a valid MCP caller and is treated like `Service`: rejected.)
+
+## ToolEntitlement
+
+Static metadata per tool driving the advisory `ListTools` filter and the per-invocation short-circuit.
+
+| Field | Type | Notes |
+|---|---|---|
+| `ToolName` | `string` | e.g. `sorcha_action_submit`. |
+| `Tiers` | `Tier[]` | Tier(s) permitted to see/invoke. Participation tools carry `[Consumer, Platform]`. |
+| `RequiredRole` | `string?` | Platform-only role gate (e.g. admin, designer). Null = any of the listed tiers. |
+
+**Slices** (from the tier mapping):
+- Citizen self-service → `[Consumer]`.
+- Workflow participation → `[Consumer, Platform]`, no required role.
+- Designer → `[Platform]` + designer role.
+- Operator/Admin → `[Platform]` + admin role.
+
+**Invariant**: the entitlement check may only ever *narrow* (hide/refuse). It can never grant access the gateway would refuse. The gateway is authoritative.
+
+## ToolResultStatus
+
+The caller-facing outcome, mapped from backend responses by `McpErrorHandler`.
+
+| Status | Source |
+|---|---|
+| `Success` | 2xx from the gateway. |
+| `Unauthorized` | 401 (invalid/expired token) or local not-authenticated. |
+| `Forbidden` | 403 (tier/role/ownership refused by the platform). |
+| `NotFound` | 404 (resource absent — must NOT be caused by route drift after reconciliation). |
+| `RateLimited` | 429 (carry Retry-After when present). |
+| `Unavailable` | service down / connection failure (`ServiceAvailabilityTracker`). |
+| `Error` | any other non-success. |
+
+## Relationships
+
+```
+ICallerContext ──(raw token)──▶ CallerTokenForwardingHandler ──▶ Sorcha.ServiceClients ──▶ API Gateway ──▶ services
+      │                                                                                         │
+      └──(tier, roles)──▶ McpAuthorizationService ◀──(ToolEntitlement table)                   └──(401/403/404/429)──▶ McpErrorHandler ──▶ ToolResultStatus
+                                  │
+                                  └──▶ advisory ListTools filter (HTTP: via stateless ConfigureSessionOptions)
+```
+
+`ToolAuditService` records `{ tier, toolName, outcome, backendStatus }` per invocation; `McpMetrics` (`Sorcha.Mcp` meter) emits `sorcha_mcp_tool_invoked_total{tool,tier,outcome}` + `sorcha_mcp_backend_call_total{service,status}` + a latency histogram. Neither records token material.

--- a/specs/139-mcp-foundation/plan.md
+++ b/specs/139-mcp-foundation/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: MCP Server Foundation
+
+**Branch**: `139-mcp-foundation` | **Date**: 2026-05-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/139-mcp-foundation/spec.md`
+**Milestone design**: `docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md`
+
+## Summary
+
+Make the existing 36-tool Sorcha MCP server genuinely work: forward the caller's token to backends (so the platform enforces F136-tiered privileges for real), reconcile every drifted tool onto the typed `Sorcha.ServiceClients`, map F136 tiers to tool slices (admitting consumer tokens, which are currently shut out), serve both stdio and Streamable HTTP, and add a live integration safety net plus a manifest-integrity gate so it cannot silently rot again. No new capability tools (those are Feature 140).
+
+Technical approach: replace the singleton `McpSessionService` with an ambient `ICallerContext` (startup token on stdio; per-request `HttpContext` Authorization header on HTTP via `IHttpContextAccessor`); register a `CallerTokenForwardingHandler : DelegatingHandler` on the `Sorcha.ServiceClients` HttpClients pointed at the API Gateway; restructure `Program.cs` to a `WebApplication` selecting transport at startup; keep the local authorization check as an advisory-narrowing `ListTools` filter while the gateway is authoritative.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10
+**Primary Dependencies**: `ModelContextProtocol` 1.1.0 (+ `ModelContextProtocol.AspNetCore` for Streamable HTTP — version aligned to the core pin), `Sorcha.ServiceClients` / `Sorcha.ServiceClients.Http`, `Sorcha.ServiceDefaults` (`AddJwtAuthentication`, `SorchaIssuer`, `SorchaAudiences`, OTel), `System.IdentityModel.Tokens.Jwt`, `Microsoft.AspNetCore` (HTTP host + `IHttpContextAccessor`)
+**Storage**: None new. Stateless server; existing `RateLimitService` keyed by caller; existing `ToolAuditService` extended (no persistence change)
+**Testing**: xUnit v3 unit tests (logic/tier-filtering/error-mapping) + new `Category=McpIntegration` Docker-gated in-process tool-invocation tests against a running gateway with real per-tier minted tokens
+**Target Platform**: Linux container (docker-compose `mcp-server`); stdio subprocess for local operators
+**Project Type**: Single .NET app (`src/Apps/Sorcha.McpServer`) + shared `Sorcha.ServiceClients` library + test project
+**Performance Goals**: Not latency-critical; tool round-trip dominated by backend calls. Stateless HTTP for horizontal scale
+**Constraints**: Pass-through auth only (no OAuth AS yet) — caller manages token lifecycle; advisory gate may only ever narrow; no secrets in logs; tokens validated against the installation's own issuer/audiences
+**Scale/Scope**: 36 existing tools reconciled; one new transport; ~1 new DI handler + 1 caller-context abstraction; no new platform endpoints except a gateway `/mcp` route
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|---|---|
+| I. Microservices-First | PASS — MCP server is an app depending downward on `ServiceClients`/`ServiceDefaults`; no upward or cross-service coupling introduced. New `ServiceClients` methods are additive, shared infra. |
+| II. Security First | PASS (improves) — closes an anonymous-backend-call defect; enforces F136 tiers at the authoritative boundary (gateway); fail-closed token validation; no secrets logged; service-tier rejected. |
+| III. API Documentation | PASS — no new REST surface beyond a YARP `/mcp` passthrough; tool descriptions retain the FR-017/Spec-117 quality bar; the MCP manifest is the discovery surface and stays in sync via the integrity gate. |
+| IV. Testing | PASS — unit coverage retained; **new** live integration smoke is the headline addition (the missing safety net). |
+| V. Code Quality | PASS — .NET 10 / C# 14, nullable enabled, async I/O, DI throughout. |
+| VI. Blueprint Standards | N/A |
+| VII. Domain-Driven Design | PASS — uses Participant/Blueprint/Register/Disclosure terms; "tier" is the F136 ubiquitous term. |
+| VIII. Observability | PASS (improves) — new `Sorcha.Mcp` OTel meter, structured logging, existing health surface retained. |
+
+**No violations.** Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/139-mcp-foundation/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions (MCP HTTP transport, caller-context, token forwarding, tier mapping, smoke harness, manifest gate)
+├── data-model.md        # Phase 1 — ICallerContext, Tier, ToolEntitlement, ToolResultStatus
+├── quickstart.md        # Phase 1 — run stdio + HTTP, mint per-tier tokens, run the smoke harness
+├── contracts/           # Phase 1 — transport endpoints + tier→tool matrix + tool→client-method reconciliation table
+└── tasks.md             # Phase 2 (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/Apps/Sorcha.McpServer/
+├── Program.cs                       # CHANGED: Host → WebApplication; --transport stdio|http; AddJwtAuthentication on HTTP; IHttpContextAccessor; register forwarding handler + ICallerContext
+├── Infrastructure/
+│   ├── ICallerContext.cs            # NEW: ambient caller identity (tier, roles, org, raw token)
+│   ├── StdioCallerContext.cs        # NEW: startup-token-backed
+│   ├── HttpCallerContext.cs         # NEW: IHttpContextAccessor-backed (per-request)
+│   ├── CallerTokenForwardingHandler.cs  # NEW: DelegatingHandler stamping Authorization from ICallerContext
+│   ├── McpErrorHandler.cs           # CHANGED: map gateway 401/403/404/429 → tool-result statuses
+│   └── ServiceAvailabilityTracker.cs# retained
+├── Services/
+│   ├── McpAuthorizationService.cs   # CHANGED: tier-primary, role-secondary entitlement; advisory ListTools filter; service-tier rejection
+│   ├── McpSessionService.cs         # REMOVED/REPLACED by ICallerContext
+│   ├── ToolAuditService.cs          # CHANGED: record tier + tool + outcome + backend status
+│   └── McpMetrics.cs                # NEW: Sorcha.Mcp meter
+└── Tools/{Admin,Designer,Participant,Citizen}/  # CHANGED: every tool → typed ServiceClients method; tier tags; wallet_sign removed; new Citizen slice surfaces existing consumer endpoints
+
+src/Common/Sorcha.ServiceClients.Http/
+└── (ADDITIVE methods where a tool needs an operation no client method exposes, e.g. action execute, platform org create)
+
+src/Services/Sorcha.ApiGateway/
+└── appsettings.json                 # CHANGED: add /mcp YARP route to mcp-server; catalogue stays manifest source
+
+tests/Sorcha.McpServer.Tests/
+├── (existing unit tests updated for ICallerContext + tier mapping)
+└── Integration/                     # NEW: Category=McpIntegration in-process tool invocation vs running gateway, per-tier tokens
+
+docker-compose.yml                   # CHANGED: HTTP-mode mcp-server service (port on sorcha-network) alongside stdio profile
+server.json                          # CHANGED: version pin; subject to integrity gate
+```
+
+**Structure Decision**: Single-app feature centred on `src/Apps/Sorcha.McpServer`, with additive shared-infra changes in `Sorcha.ServiceClients.Http`, a gateway route, a docker-compose service, and a new integration test area. No new service, no new persistence.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/139-mcp-foundation/quickstart.md
+++ b/specs/139-mcp-foundation/quickstart.md
@@ -1,0 +1,62 @@
+# Quickstart — MCP Server Foundation
+
+How to run and verify the MCP server in both transports, with tier-scoped tokens. Assumes the local Docker stack is up (`docker-compose up -d`) and the gateway is reachable.
+
+## Mint tier-scoped tokens
+
+```bash
+# Platform-admin (operator/admin + designer tools)
+scripts/get-jwt-token.sh   # admin@sorcha.local / Dev_Pass_2025!  → platform-tier token
+
+# Consumer (citizen) — obtain via a /wallet returnTo login or the enrol-redeem path
+# Platform-designer — a platform user holding the designer role
+```
+
+Tokens carry the F136 tier in `aud` (`{installation}:consumer|platform|service`) and, for platform, the role claim. The MCP server derives the caller's tool surface from these.
+
+## Run — stdio (local operator)
+
+```bash
+dotnet run --project src/Apps/Sorcha.McpServer -- --transport stdio --jwt-token <platform-admin-token>
+# or: SORCHA_JWT_TOKEN=<token> dotnet run --project src/Apps/Sorcha.McpServer
+```
+
+Tools call the API Gateway carrying your token; the gateway enforces what you may do.
+
+## Run — Streamable HTTP (remote agent)
+
+```bash
+dotnet run --project src/Apps/Sorcha.McpServer -- --transport http
+# served at the MCP HTTP endpoint; exposed via the gateway as /mcp
+```
+
+The HTTP endpoint requires a valid bearer per request (rejected before any tool runs). Point an MCP client at the gateway `/mcp` URL with `Authorization: Bearer <token>`.
+
+## Verify behaviour
+
+| Check | Expectation |
+|---|---|
+| `ListTools` with a **consumer** token | Participation + citizen-read tools appear; no admin/designer tools. (Was empty before this feature.) |
+| `ListTools` with a **platform-admin** token | Operator/admin + participation tools. |
+| `ListTools` with a **platform-designer** token | Designer + participation tools. |
+| Invoke an admin tool with a **consumer** token | `Forbidden` — refused by the **gateway**, not just locally. |
+| Invoke `sorcha_action_submit` as a participant | Workflow advances; a transaction id is returned (real `/execute`, not a 404). |
+| Connect with a **service**-tier token | Rejected at the door. |
+| HTTP request with no/invalid bearer | Rejected before dispatch. |
+
+## Run the integration safety net
+
+```bash
+# Docker stack must be running
+dotnet test tests/Sorcha.McpServer.Tests --filter "Category=McpIntegration"
+```
+
+Invokes every advertised tool in-process against the running gateway with real per-tier tokens, asserting real success shapes or expected refusals. INFRA-skips when no stack is present (consistent with the repo's other Docker-gated suites).
+
+## Manifest integrity
+
+```bash
+dotnet test tests/Sorcha.McpServer.Tests --filter "FullyQualifiedName~ManifestIntegrity"
+```
+
+Fails if the gateway `appsettings.json` catalogue or `server.json` drifts from the reflected `[McpServerTool]` set.

--- a/specs/139-mcp-foundation/research.md
+++ b/specs/139-mcp-foundation/research.md
@@ -1,0 +1,71 @@
+# Phase 0 Research — MCP Server Foundation
+
+All decisions below resolve the design's open questions. The spec carried zero `[NEEDS CLARIFICATION]` markers; this records the technical resolutions that back the plan.
+
+## R-001 — Streamable HTTP transport on the pinned SDK
+
+**Decision**: Add the `ModelContextProtocol.AspNetCore` package (version aligned to the core `ModelContextProtocol` 1.1.0 pin) and host via `WebApplication` → `builder.Services.AddMcpServer().WithHttpTransport(...)` + `app.MapMcp()`. Run in **stateless** mode.
+
+**Rationale**: The official C# SDK provides first-class Streamable HTTP through `ModelContextProtocol.AspNetCore`; stateless mode is the SDK's recommended posture for servers that don't need server-to-client requests (sampling/elicitation), and it scales horizontally. Confirmed against current SDK docs.
+
+**Alternatives considered**: SSE-only (legacy, being superseded by Streamable HTTP); custom HTTP shim (reinvents the SDK). Rejected.
+
+**Action**: Confirm the exact `ModelContextProtocol.AspNetCore` version that pairs with `1.1.0` at implementation time and add it to `Directory.Packages.props` (the AspNetCore package is versioned in lockstep with the core package).
+
+## R-002 — Per-request caller identity
+
+**Decision**: `ICallerContext` with two implementations. HTTP: inject `IHttpContextAccessor` and read the validated `ClaimsPrincipal` + raw bearer from the current request. stdio: a startup-token-backed implementation. Selected by transport at composition time.
+
+**Rationale**: The SDK explicitly supports injecting `IHttpContextAccessor` (or `ClaimsPrincipal`) into `[McpServerToolType]` classes for HTTP; stateless mode also exposes `ConfigureSessionOptions(httpContext, …)` per request. stdio has no `HttpContext`, so a separate startup-token source is needed. One abstraction keeps tools transport-agnostic.
+
+**Alternatives considered**: `AsyncLocal` token smuggling (works but fragile across await boundaries and duplicates what `IHttpContextAccessor` already gives); keeping the singleton session (the root defect). Rejected.
+
+## R-003 — Outbound token forwarding
+
+**Decision**: A `CallerTokenForwardingHandler : DelegatingHandler` registered on every `Sorcha.ServiceClients` HttpClient. It reads the raw bearer from `ICallerContext` and stamps `Authorization: Bearer`. Service-client base addresses point at the **API Gateway**.
+
+**Rationale**: Centralises auth in one place (vs 36 call sites), reuses the typed clients (core infra intended for reuse), and makes the MCP server a normal gateway client — the gateway enforces F136 tiers authoritatively and applies rate limiting/routing. Eliminates the endpoint-drift bug class because routes live in the versioned clients.
+
+**Alternatives considered**: Per-tool header stamping (brittle, 36 sites); direct-to-service typed clients (replicates gateway routing/auth knowledge, exposes internal endpoints). Rejected per the milestone design (Approach 1 chosen).
+
+## R-004 — F136 tier → tool entitlement
+
+**Decision**: Tier-primary, role-secondary entitlement. `ICallerContext.Tier` parsed from the token `aud` via `SorchaAudiences`; roles from the role claim (platform tier only). Each tool tagged with permitted tier(s) + optional platform role. `McpAuthorizationService` filters `ListTools` to the caller's union (advisory, narrowing-only). On HTTP, the stateless `ConfigureSessionOptions` hook is the natural place to scope the advertised tool collection per request; the same entitlement table drives the per-invocation short-circuit. Service-tier tokens rejected at the door.
+
+**Rationale**: Consumer tokens carry no roles, so the current role-only RBAC shuts citizens out entirely; keying on tier fixes that. Participation tools are cross-tier (consumer applicant + platform analyst both submit actions). The gateway remains authoritative — the local filter only improves UX.
+
+**Alternatives considered**: Keep role-only RBAC (leaves consumers with zero tools); backend-only with no local filter (agents see tools they can't use, wasted calls + poor UX). Rejected.
+
+## R-005 — Endpoint reconciliation
+
+**Decision**: Audit all 36 tools; map each to a typed `Sorcha.ServiceClients` method; add a method to the client where missing (never hand-roll in the tool). Confirmed corrections: `sorcha_action_submit` → `POST /api/instances/{instanceId}/actions/{actionId}/execute` (`IBlueprintServiceClient`); `sorcha_tenant_create` → `POST /api/platform/organizations` (`ITenantServiceClient`). The full per-tool table is in `contracts/`.
+
+**Rationale**: The clients hold correct, contract-compiled routes; routing through them prevents recurrence. Additive client methods benefit the whole platform.
+
+## R-006 — Live integration safety net
+
+**Decision**: New xUnit `Category=McpIntegration` tests invoking tools **in-process** against a running gateway (local Docker stack), authenticated with a **real minted token per tier** (consumer / platform-admin / platform-designer). Each test asserts a real success shape or the expected auth outcome (e.g. consumer → 403 on an admin tool). Docker-gated in CI; INFRA-skipped when no stack.
+
+**Rationale**: Mocked unit tests hid both defects (missing header → 401; drift → 404). Only a live call exercises the auth header and the real route. Mirrors the repo's existing ground-truth discipline (walkthroughs, UI E2E).
+
+**Alternatives considered**: WebApplicationFactory mock backend (wouldn't catch route drift against the real services); pure unit mocks (status quo, blind). Rejected.
+
+## R-007 — Manifest / catalogue integrity
+
+**Decision**: A CI gate reflects the `[McpServerTool]` set from the MCP assembly and asserts the gateway `appsettings.json` catalogue **and** `server.json` match it; build fails on drift. `server.json` version pinned per release.
+
+**Rationale**: The catalogue is currently a hand-maintained list that can drift from the server — the exact silent-rot failure mode. Reflection-as-source-of-truth removes the manual step.
+
+**Alternatives considered**: Gateway fetches the live catalogue at runtime (adds a runtime coupling + an MCP-server dependency on boot); manual review (status quo, drifts). Rejected.
+
+## R-008 — HTTP endpoint protection & gateway exposure
+
+**Decision**: The Streamable HTTP endpoint requires a valid bearer via ServiceDefaults `AddJwtAuthentication` (F136 issuer/audiences) before dispatch; the validated principal flows into `HttpCallerContext`. Exposed externally via a gateway `/mcp` YARP route (single origin alongside `/.well-known/mcp.json`). docker-compose gains an HTTP-mode `mcp-server`; the stdio profile stays.
+
+**Rationale**: The server is itself a protected resource — unauthenticated agents are rejected at the door, not at the first backend call. One origin matches what an external agent already discovers.
+
+## R-009 — OAuth seam (deferred, not built)
+
+**Decision**: Pass-through is the only auth mode in this feature. The caller manages token lifecycle (stdio session dies on expiry; HTTP agent sends a fresh bearer per request). The `ICallerContext` boundary is the exact seam where a future OAuth 2.1 resource-server flow plugs in without touching the tool layer.
+
+**Rationale**: Tenant Service is not an OAuth authorization server today (no first-party `/authorize`, AS metadata, DCR, resource indicators) — standing that up is its own milestone. Confirmed during brainstorm readiness check.

--- a/specs/139-mcp-foundation/spec.md
+++ b/specs/139-mcp-foundation/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: MCP Server Foundation
+
+**Feature Branch**: `139-mcp-foundation`
+**Created**: 2026-05-26
+**Status**: Draft
+**Input**: Phase 0 of the MCP remediation milestone. Full design and rationale: `docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md`.
+
+## Overview
+
+The Sorcha MCP server exposes 36 tools to AI agents, but a review found it does not work against a secured backend: tool calls reach backend services **without the caller's credentials** (so they are anonymous and rejected), several tools target **endpoints that no longer exist**, and **consumer-tier (citizen) tokens receive no tools at all**. It also runs only as a local subprocess, so remote agents cannot connect.
+
+This feature makes the **existing** tool surface genuinely usable: every tool executes with the caller's real privileges (enforced by the platform, tiered by the caller's token), every advertised tool reaches a working operation, citizens get a usable surface, and both local operators and remote agents can connect. No new capability tools are added here — that is the next feature.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tools execute with the caller's real privileges (Priority: P1)
+
+An AI agent or operator presents their Sorcha access token and invokes a tool. The tool performs the operation **as that identity**, and the platform — not the client — decides whether it is allowed. An admin token can run an admin operation; a citizen token attempting an admin operation is refused by the platform.
+
+**Why this priority**: This is the core defect. Until the caller's identity reaches the backend, every protected tool fails (or, worse, the local-only check creates a false impression of enforcement). Nothing else in the feature has value without this.
+
+**Independent Test**: Mint a platform-admin token, invoke an admin tool against a running backend, observe a real result. Mint a consumer token, invoke the same admin tool, observe a refusal that originates from the platform (not the local gate).
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid platform-admin token, **When** the caller invokes an admin tool, **Then** the operation is performed with that identity and returns a real backend result.
+2. **Given** a valid consumer token, **When** the caller invokes an admin tool, **Then** the call is refused with a clear "forbidden" result and no backend mutation occurs.
+3. **Given** an expired token, **When** the caller invokes any tool, **Then** the result is a clear "unauthorized" status rather than a crash or a misleading success.
+
+---
+
+### User Story 2 - Citizens get a usable, correctly-scoped tool surface (Priority: P1)
+
+A citizen (consumer-tier token) connects and sees the tools appropriate to them — their own wallet/credential self-service plus the workflow-participation tools needed to submit and track applications — and can use them. They do not see operator or designer tools.
+
+**Why this priority**: Consumer tokens currently receive zero tools, which silently excludes the entire citizen audience the platform is built around. Fixing the privilege path (US1) is meaningless for citizens unless the tier mapping also admits them.
+
+**Independent Test**: With a consumer token, list available tools and confirm the citizen and participation slices appear and the admin/designer slices do not; invoke a citizen self-service tool and a participation tool and confirm both succeed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer-tier token, **When** the caller lists tools, **Then** they see citizen self-service and workflow-participation tools and do **not** see operator or designer tools.
+2. **Given** a platform-tier token with the designer role, **When** the caller lists tools, **Then** they see designer and participation tools but not operator tools.
+3. **Given** a platform-tier token with neither admin nor designer role, **When** the caller lists tools, **Then** they see participation tools only.
+4. **Given** a service-tier token, **When** the caller connects, **Then** the connection is refused with a clear message that service tokens are not valid MCP callers.
+
+---
+
+### User Story 3 - Remote agents and local operators can both connect (Priority: P2)
+
+A remote AI agent connects to the MCP server over the network, authenticating with its own Sorcha token per request. A local operator continues to run the server as a subprocess with a token supplied at startup. Both reach the same tool surface, scoped to their token.
+
+**Why this priority**: The "external agent" audience requires a network transport; the existing operator workflow must keep working. This is gated behind US1/US2 because a transport with no working tools has no value.
+
+**Independent Test**: Start the server in network mode; send an authenticated request and confirm a tool dispatches; send an unauthenticated request and confirm it is rejected before any tool runs. Separately, start the server in local mode with a startup token and confirm a tool dispatches.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server running in network mode, **When** a request arrives with a valid token, **Then** the tool dispatches scoped to that token's tier.
+2. **Given** the server running in network mode, **When** a request arrives with no token or an invalid token, **Then** it is rejected before any tool executes.
+3. **Given** the server running in local mode with a startup token, **When** a tool is invoked, **Then** it behaves identically to the network path for the same identity.
+
+---
+
+### User Story 4 - Every advertised tool reaches a working operation (Priority: P2)
+
+A caller can trust that any tool the server advertises actually performs its stated operation against the current platform — no tool silently fails because it targets a route that no longer exists.
+
+**Why this priority**: Drifted tools erode agent trust and waste calls. This is verified by the safety net (US5) but is a user-facing guarantee in its own right.
+
+**Independent Test**: For each advertised tool, invoke it with an appropriately-scoped token against a running backend and confirm it returns either a real result or an expected, meaningful error — never a "route not found" caused by drift.
+
+**Acceptance Scenarios**:
+
+1. **Given** any advertised tool, **When** invoked with a correctly-scoped token, **Then** it resolves to a live platform operation (no drift-induced not-found).
+2. **Given** the previously-broken submit-action tool, **When** a participant submits action data, **Then** the workflow advances and a transaction identifier is returned.
+
+---
+
+### User Story 5 - Breakage is visible, and the advertised catalogue stays honest (Priority: P3)
+
+Operators can see which tools were invoked, by which tier, and with what outcome; and the publicly-advertised tool catalogue cannot drift away from what the server actually offers.
+
+**Why this priority**: Observability and catalogue integrity prevent silent regression — the exact failure mode that produced this whole remediation. Valuable, but only after the surface works.
+
+**Independent Test**: Invoke a mix of tools across tiers; confirm each invocation is recorded with caller tier, tool, and outcome, and counters reflect it. Separately, change the tool set without updating the advertised catalogue and confirm the integrity check fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** a series of tool invocations, **When** an operator inspects telemetry, **Then** each invocation is attributed by tool, caller tier, and outcome.
+2. **Given** a change to the set of tools, **When** the advertised catalogue is not updated to match, **Then** an automated integrity check fails and blocks release.
+
+---
+
+### Edge Cases
+
+- **Expired token mid-session** (local mode): tools return a clear "unauthorized" status; the session does not crash.
+- **Malformed / wrong-installation / no-tier-audience token**: rejected at the entry point with a clear message; no tool runs.
+- **Service-tier token**: rejected as a non-caller (service tokens are for the internal mesh).
+- **Backend rate-limit (429)**: surfaced to the caller as a clear "rate limited" status, not a raw error.
+- **Backend unavailable**: surfaced as "unavailable" with guidance to retry; not a crash.
+- **Local advisory gate disagrees with backend**: the advisory gate may only ever *narrow* visibility — it can never permit a call the backend would refuse. The backend is authoritative.
+- **Tool the caller is not entitled to**: hidden from the caller's tool list and refused if invoked directly.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every tool invocation MUST be performed against backend services carrying the **caller's own credentials**, so that the platform authorizes the operation as the calling identity.
+- **FR-002**: The platform (backend) MUST be the authoritative authorization decision for every tool; any check the MCP server performs locally is advisory and MUST only ever narrow access, never grant it.
+- **FR-003**: The set of tools a caller can see and invoke MUST be derived from their token's **tier** (and, for platform-tier callers, their role): consumer-tier callers receive citizen self-service and workflow-participation tools; platform-tier admins receive operator/admin tools; platform-tier designers receive designer tools; workflow-participation tools are available to both consumer and platform tiers.
+- **FR-004**: Consumer-tier tokens MUST receive a non-empty, usable tool surface (the prior behaviour of receiving zero tools is a defect to be removed).
+- **FR-005**: Service-tier tokens MUST be rejected as MCP callers with a clear, actionable message.
+- **FR-006**: Every advertised tool MUST resolve to a current, working platform operation; no advertised tool may target a non-existent route.
+- **FR-007**: The submit-action tool MUST advance a workflow via the platform's current action-execution operation and return the resulting transaction identifier.
+- **FR-008**: The server MUST support two connection modes — a local subprocess mode with a token supplied at startup, and a network mode where each request authenticates with its own token.
+- **FR-009**: In network mode, requests without a valid token MUST be rejected before any tool executes.
+- **FR-010**: Tool failures originating from the backend MUST be mapped to clear, distinct caller-facing statuses (at minimum: unauthorized, forbidden, not-found, rate-limited, unavailable, error).
+- **FR-011**: Each tool invocation MUST be recorded with the caller's tier, the tool name, and the outcome, and MUST be reflected in telemetry counters suitable for alerting on broken or unauthorized patterns.
+- **FR-012**: The publicly-advertised tool catalogue MUST match the set of tools the server actually offers, enforced by an automated check that fails the build on mismatch.
+- **FR-013**: The raw-signing tool MUST be removed from the advertised surface for this feature (it is deferred to a dedicated, security-reviewed effort); the read-only wallet-info tool remains.
+- **FR-014**: No new capability tools are introduced in this feature; the work is limited to making the existing surface correct, tiered, and reachable over both transports.
+- **FR-015**: The design MUST leave clean seams for a future full delegated-authorization (OAuth) model without requiring rework of the tool layer.
+- **FR-016**: Tokens MUST be validated against the installation's own issuer and tier audiences; tokens from another installation MUST be rejected.
+- **FR-017**: Credentials MUST never be written to logs or telemetry.
+
+### Key Entities *(include if feature involves data)*
+
+- **Caller context**: the identity behind the current invocation — tier (consumer / platform / service), roles (platform only), home organisation, and the raw token used for forwarding. Resolved per-process in local mode and per-request in network mode.
+- **Tier**: the trust boundary carried by the token's audience — consumer (citizen/wallet holder), platform (admin / operator / designer), service (internal mesh, not a valid caller).
+- **Tool entitlement**: the mapping from a tool to the tier(s) and, where applicable, the platform role that may invoke it.
+- **Tool result status**: the caller-facing outcome of an invocation (success, unauthorized, forbidden, not-found, rate-limited, unavailable, error).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of advertised tools resolve to a live platform operation when invoked with an appropriately-scoped token (zero drift-induced not-found results) — verified across all tiers by the integration safety net.
+- **SC-002**: Authorization is demonstrably enforced by the platform: a consumer token is refused at least one admin operation **by the backend**, and an admin token succeeds at the same operation, in an automated test.
+- **SC-003**: A consumer-tier token can invoke at least one citizen self-service tool and at least one workflow-participation tool — up from zero today.
+- **SC-004**: The server is reachable and functional over both transports: an authenticated tool invocation succeeds and an unauthenticated request is rejected, in each of local and network modes.
+- **SC-005**: An automated integrity check fails the build whenever the advertised catalogue diverges from the actual tool set.
+- **SC-006**: Every tool invocation in the safety-net run is attributed in telemetry by tool, caller tier, and outcome.
+- **SC-007**: The integration safety net exercises every advertised tool across the consumer, platform-admin, and platform-designer tiers and passes against a running platform.
+
+## Assumptions
+
+- Sorcha already issues tier-scoped, installation-namespaced access tokens (F136); this feature consumes them and does not change token issuance.
+- A running platform (the standard local Docker stack) is available for the integration safety net, consistent with how end-to-end verification is already done in this repo.
+- The full delegated-authorization (OAuth) model and the raw-signing tool are explicitly **out of scope** and tracked as separate efforts; this feature only ensures it can adopt them later without rework.
+- "Tiered by token" treats the token as the source of truth for authorization; the MCP server never elevates a caller beyond what their token permits.

--- a/specs/139-mcp-foundation/tasks.md
+++ b/specs/139-mcp-foundation/tasks.md
@@ -1,0 +1,200 @@
+# Tasks: MCP Server Foundation
+
+**Input**: Design documents from `/specs/139-mcp-foundation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/transport-and-tools.md, quickstart.md
+
+**Tests**: Integration ("safety net") and manifest-integrity tests are explicit feature requirements (FR-004, FR-012, SC-005, SC-007), so their tasks are included. Existing unit tests are updated, not expanded for their own sake.
+
+**Organization**: Tasks grouped by user story. MVP = Setup + Foundational + US1 + US2 (both P1).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1–US5 for story-phase tasks; none for Setup/Foundational/Polish
+
+## Path Conventions
+
+- MCP server: `src/Apps/Sorcha.McpServer/`
+- Service clients: `src/Common/Sorcha.ServiceClients.Http/`
+- Gateway: `src/Services/Sorcha.ApiGateway/`
+- Tests: `tests/Sorcha.McpServer.Tests/`
+- Repo root: `docker-compose.yml`, `server.json`, `Directory.Packages.props`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Bring in the HTTP-transport dependency and the test scaffolding everything else uses.
+
+- [ ] T001 Add `ModelContextProtocol.AspNetCore` (version aligned to the `ModelContextProtocol` 1.1.0 pin) to `Directory.Packages.props` and reference it from `src/Apps/Sorcha.McpServer/Sorcha.McpServer.csproj`
+- [ ] T002 [P] Add the ASP.NET Core framework reference (`<FrameworkReference Include="Microsoft.AspNetCore.App" />`) to `src/Apps/Sorcha.McpServer/Sorcha.McpServer.csproj` (HTTP host prerequisite)
+- [ ] T003 [P] Create the integration-test scaffolding in `tests/Sorcha.McpServer.Tests/Integration/`: `McpIntegrationTestBase` (Docker-gated `[Trait("Category","McpIntegration")]`, INFRA-skip when no gateway), plus a `TierTokenFixture` that mints real consumer / platform-admin / platform-designer tokens against the running Tenant Service
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The caller-identity + token-forwarding + error-mapping spine. Both P1 stories (US1, US2) require all of it. Delivers a fully wired **stdio** path; the HTTP path is added in US3.
+
+**⚠️ CRITICAL**: No user-story work begins until this phase is complete.
+
+- [ ] T004 Define `Tier` enum (`Consumer`/`Platform`/`Service`) + an `aud`→tier parser using `SorchaAudiences` in `src/Apps/Sorcha.McpServer/Infrastructure/Tier.cs`
+- [ ] T005 Define `ICallerContext` (`RawToken`, `Tier`, `Roles`, `OrganizationId`, `Subject`, `IsAuthenticated`) in `src/Apps/Sorcha.McpServer/Infrastructure/ICallerContext.cs`
+- [ ] T006 Implement `StdioCallerContext` (validate the startup `--jwt-token`/`SORCHA_JWT_TOKEN` once via the existing `JwtValidationHandler`; expose claims + raw token) in `src/Apps/Sorcha.McpServer/Infrastructure/StdioCallerContext.cs`
+- [ ] T007 Implement `CallerTokenForwardingHandler : DelegatingHandler` (stamp `Authorization: Bearer` from `ICallerContext`; no-op cleanly when unauthenticated) in `src/Apps/Sorcha.McpServer/Infrastructure/CallerTokenForwardingHandler.cs`
+- [ ] T008 Point all `Sorcha.ServiceClients` base addresses at the API Gateway and attach `CallerTokenForwardingHandler` to their HttpClients, in `src/Apps/Sorcha.McpServer/Program.cs` (gateway URL from config; one place)
+- [ ] T009 Rework `McpErrorHandler` to map gateway `401/403/404/429/5xx`/connection failures to `ToolResultStatus` (`Unauthorized`/`Forbidden`/`NotFound`/`RateLimited`/`Unavailable`/`Error`; carry Retry-After) in `src/Apps/Sorcha.McpServer/Infrastructure/McpErrorHandler.cs`
+- [ ] T010 Remove the singleton `McpSessionService`; rewire `Program.cs` DI to register `ICallerContext` (stdio impl for now), `IHttpContextAccessor`, the forwarding handler, and the existing infra services
+- [ ] T011 [P] Add `ToolEntitlement` model + the static entitlement table (tier(s) + optional role per tool, per `contracts/transport-and-tools.md` §2) in `src/Apps/Sorcha.McpServer/Services/ToolEntitlement.cs` (data only; application is US2)
+
+**Checkpoint**: A tool invoked over stdio now reaches the gateway carrying the caller's token; failures map to clean statuses. Tier model exists but is not yet applied.
+
+---
+
+## Phase 3: User Story 1 - Tools execute with the caller's real privileges (Priority: P1) 🎯 MVP
+
+**Goal**: Every tool call is authorized by the platform as the calling identity; the local check is advisory and narrowing-only.
+
+**Independent Test**: With an admin token a representative admin tool returns a real backend result; with a consumer token the same tool is refused **by the gateway**; an expired token yields a clean `Unauthorized`.
+
+- [ ] T012 [US1] Convert `McpAuthorizationService` to advisory/narrowing-only: it may hide/refuse but never grant; the per-invocation check returns `Unauthorized`/`Forbidden` cleanly and defers final authority to the backend. File: `src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs`
+- [ ] T013 [P] [US1] Reconcile a representative **admin** read tool (`sorcha_register_stats`) onto its typed `IRegisterServiceClient` method so it calls the gateway with the forwarded token — `src/Apps/Sorcha.McpServer/Tools/Admin/RegisterStatsTool.cs`
+- [ ] T014 [P] [US1] Reconcile a representative **participation** read tool (`sorcha_transaction_history`) onto its typed client — `src/Apps/Sorcha.McpServer/Tools/Participant/TransactionHistoryTool.cs`
+- [ ] T015 [US1] Integration test: admin token → `sorcha_register_stats` success; consumer token → same tool `Forbidden` (assert refusal originates from the gateway, not the local gate); expired token → `Unauthorized`. File: `tests/Sorcha.McpServer.Tests/Integration/PrivilegeEnforcementTests.cs`
+- [ ] T016 [US1] Update affected unit tests for the advisory-narrowing behaviour and `ICallerContext` (replace `McpSessionService` mocks) in `tests/Sorcha.McpServer.Tests/Services/McpAuthorizationServiceTests.cs`
+
+**Checkpoint**: Privilege enforcement is real and demonstrated end-to-end on representative tools. MVP backbone in place.
+
+---
+
+## Phase 4: User Story 2 - Citizens get a usable, correctly-scoped tool surface (Priority: P1)
+
+**Goal**: Tier→tool entitlement is applied; consumer tokens receive a non-empty surface; service tokens are rejected.
+
+**Independent Test**: A consumer token lists the participation + citizen-read tools (and no admin/designer tools) and can invoke one; a designer token sees designer+participation; a service token is refused at connect.
+
+- [ ] T017 [US2] Apply the entitlement table to `ListTools` so the advertised set is the caller's tier/role union (stdio path); ensure consumer-tier yields a non-empty set. File: `src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs`
+- [ ] T018 [P] [US2] Tag every tool with its `ToolEntitlement` per `contracts/transport-and-tools.md` §2 (participation/citizen-read = `[Consumer,Platform]`; designer/admin = `[Platform]`+role) across `src/Apps/Sorcha.McpServer/Tools/**`
+- [ ] T019 [US2] Reject `Service`-tier (and `enrol-session`) tokens at connect/first-invocation with a clear message, in `src/Apps/Sorcha.McpServer/Infrastructure/StdioCallerContext.cs` + `Program.cs`
+- [ ] T020 [P] [US2] Unit tests: `ListTools` per tier (consumer non-empty; consumer excludes admin/designer; designer excludes admin; service rejected) in `tests/Sorcha.McpServer.Tests/Services/ToolEntitlementTests.cs`
+- [ ] T021 [US2] Integration test: consumer token invokes a participation tool (`sorcha_inbox_list`) successfully and is refused an admin tool. File: `tests/Sorcha.McpServer.Tests/Integration/ConsumerSurfaceTests.cs`
+
+**Checkpoint**: US1 + US2 complete = MVP. The existing surface works, tiered, over stdio; citizens are no longer shut out.
+
+---
+
+## Phase 5: User Story 4 - Every advertised tool reaches a working operation (Priority: P2)
+
+> Sequenced ahead of US3 within P2: a remote surface is only worth exposing once the tools actually work. Independent of US3.
+
+**Goal**: All 36 tools resolve to a live platform operation via typed clients; no drift; `wallet_sign` removed.
+
+**Independent Test**: Every advertised tool, invoked with a permitted-tier token against a running backend, returns a real result or a meaningful error — never a drift-induced not-found.
+
+- [ ] T022 [US4] Audit all 36 tools against `contracts/transport-and-tools.md` §3; record per-tool target client method + status (✅/➕/🔧) as the working checklist for this phase
+- [ ] T023 [US4] Fix `sorcha_action_submit` → `IBlueprintServiceClient` `POST /api/instances/{instanceId}/actions/{actionId}/execute` in `src/Apps/Sorcha.McpServer/Tools/Participant/ActionSubmitTool.cs`
+- [ ] T024 [US4] Fix `sorcha_tenant_create` → `ITenantServiceClient` `POST /api/platform/organizations` in `src/Apps/Sorcha.McpServer/Tools/Admin/TenantCreateTool.cs`
+- [ ] T025 [P] [US4] Add any missing typed methods to `src/Common/Sorcha.ServiceClients.Http/` (e.g. Blueprint action/instance reads, Register query/stats/history/disclosed, Wallet info, Tenant user/token/audit ops) — one method per gap identified in T022
+- [ ] T026 [US4] Reconcile the remaining Designer tools onto `IBlueprintServiceClient` methods in `src/Apps/Sorcha.McpServer/Tools/Designer/**`
+- [ ] T027 [US4] Reconcile the remaining Admin tools onto their typed clients in `src/Apps/Sorcha.McpServer/Tools/Admin/**`
+- [ ] T028 [US4] Reconcile the remaining Participant/citizen-read tools onto their typed clients in `src/Apps/Sorcha.McpServer/Tools/Participant/**`
+- [ ] T029 [US4] Remove `sorcha_wallet_sign` from the advertised surface (delete the tool registration; leave a code comment pointing to the deferred dedicated wave) in `src/Apps/Sorcha.McpServer/Tools/Participant/WalletSignTool.cs`
+- [ ] T030 [US4] Integration test: invoke every advertised tool across its permitted tiers and assert no drift-induced `NotFound`; spot-check `sorcha_action_submit` advances a workflow and returns a transaction id. File: `tests/Sorcha.McpServer.Tests/Integration/ToolReachabilityTests.cs`
+
+**Checkpoint**: Every advertised tool is genuinely reachable (SC-001).
+
+---
+
+## Phase 6: User Story 3 - Remote agents and local operators can both connect (Priority: P2)
+
+**Goal**: stdio + Streamable HTTP both work; the HTTP endpoint is a protected resource; exposed via the gateway `/mcp`.
+
+**Independent Test**: In network mode, an authenticated request dispatches a tool and an unauthenticated one is rejected before dispatch; in local mode the same identity behaves identically.
+
+- [ ] T031 [US3] Restructure `Program.cs` from console `Host` to `WebApplication` with a `--transport stdio|http` switch (default `stdio`); preserve the stdio path verbatim. File: `src/Apps/Sorcha.McpServer/Program.cs`
+- [ ] T032 [US3] Implement `HttpCallerContext` (per-request, via `IHttpContextAccessor` — validated `ClaimsPrincipal` + raw bearer) in `src/Apps/Sorcha.McpServer/Infrastructure/HttpCallerContext.cs`; register it for the HTTP transport
+- [ ] T033 [US3] Wire `WithHttpTransport(stateless)` + `app.MapMcp()`; protect the endpoint with ServiceDefaults `AddJwtAuthentication` (F136 issuer/audiences) so invalid/absent bearers are rejected before dispatch. File: `src/Apps/Sorcha.McpServer/Program.cs`
+- [ ] T034 [US3] Use the stateless `ConfigureSessionOptions(httpContext,…)` hook to scope the advertised tool collection per request by caller tier (HTTP equivalent of the US2 `ListTools` filter). File: `src/Apps/Sorcha.McpServer/Program.cs`
+- [ ] T035 [P] [US3] Add a `/mcp` YARP route to the MCP server in `src/Services/Sorcha.ApiGateway/appsettings.json`
+- [ ] T036 [P] [US3] Add an HTTP-mode `mcp-server` service to `docker-compose.yml` (port on `sorcha-network`, `--transport http`, gateway base-URL env); keep the stdio `--profile tools` definition
+- [ ] T037 [US3] Integration test: HTTP request with a valid bearer dispatches a tool; no/invalid bearer is rejected pre-dispatch; stdio parity for the same identity. File: `tests/Sorcha.McpServer.Tests/Integration/TransportParityTests.cs`
+
+**Checkpoint**: Both transports functional; remote agents can connect through the gateway.
+
+---
+
+## Phase 7: User Story 5 - Breakage is visible & the catalogue stays honest (Priority: P3)
+
+**Goal**: Per-invocation telemetry by tier/tool/outcome; the advertised catalogue cannot drift from the server.
+
+**Independent Test**: A mixed run attributes each invocation in telemetry; changing the tool set without updating the catalogue fails an automated check.
+
+- [ ] T038 [US5] Extend `ToolAuditService` to record `{ tier, toolName, outcome, backendStatus }` per invocation (no token material) in `src/Apps/Sorcha.McpServer/Services/ToolAuditService.cs`
+- [ ] T039 [P] [US5] Add `McpMetrics` (`Sorcha.Mcp` meter): `sorcha_mcp_tool_invoked_total{tool,tier,outcome}`, `sorcha_mcp_backend_call_total{service,status}`, latency histogram; register on the meter provider. File: `src/Apps/Sorcha.McpServer/Services/McpMetrics.cs`
+- [ ] T040 [US5] Pin `server.json` to a real version and align its tool list to the server
+- [ ] T041 [US5] Manifest-integrity test: reflect the `[McpServerTool]` set from the MCP assembly and assert the gateway `appsettings.json` catalogue **and** `server.json` match; fail on drift. File: `tests/Sorcha.McpServer.Tests/ManifestIntegrityTests.cs`
+- [ ] T042 [P] [US5] Wire the manifest-integrity test into CI (the discoverability/build gate) so drift fails the build
+
+**Checkpoint**: Regression is observable and catalogue drift is build-blocking.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+- [ ] T043 [P] Update `docs/mcp-server.md` (tiered surface, both transports, token-forwarding, run/verify) and `docs/mcp-registry-publishing.md` (version pin)
+- [ ] T044 [P] Update the `sorcha-architecture` skill MCP surface section and `src/Apps/Sorcha.McpServer/README.md`
+- [ ] T045 [P] Add a CLAUDE.md Critical Pattern note: MCP tools forward the caller token via the typed clients; no hand-rolled HTTP/headers; gateway is authoritative
+- [ ] T046 Remove dead code / leftover `McpSessionService` references; ensure no compiler warnings (Release)
+- [ ] T047 Run `quickstart.md` end-to-end against the local Docker stack (all verify-matrix rows) and capture results
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (P1)** → no deps.
+- **Foundational (P2)** → after Setup. **BLOCKS all stories.**
+- **US1, US2 (both P1)** → after Foundational. US2 applies the entitlement table US1's gate consults; do US1 then US2 (or parallel with care — they touch `McpAuthorizationService` together, so sequential is safer).
+- **US4 (P2)** → after Foundational; independent of US3. Recommended before US3.
+- **US3 (P2)** → after Foundational; independent of US4. Adds `HttpCallerContext` + HTTP filter (mirrors US2's stdio filter).
+- **US5 (P3)** → after US4 (tool set stable) for the manifest gate; telemetry tasks (T038/T039) can start after Foundational.
+- **Polish** → after all desired stories.
+
+### Within stories
+
+- Reconcile-tool tasks marked [P] touch different files → parallelizable.
+- `McpAuthorizationService` is touched by T012/T017 → keep sequential.
+- Integration tests follow the implementation they assert.
+
+### Parallel opportunities
+
+- Setup: T002, T003 in parallel.
+- Foundational: T011 parallel with T004–T010 spine.
+- US4: T025 (client methods) parallel with T026/T027/T028 tool reconciliations once the gaps are known (T022 first).
+- US3: T035 (gateway route) + T036 (compose) parallel with the host work.
+- US5: T039 + T042 parallel with T038/T041.
+
+---
+
+## Implementation Strategy
+
+### MVP (Setup + Foundational + US1 + US2)
+
+Delivers the existing tool surface working over stdio, tiered by token, with privileges enforced by the platform and citizens admitted. Stop and validate here — this alone resolves both foundational defects for the local-operator path.
+
+### Incremental delivery
+
+1. Setup + Foundational → spine ready.
+2. + US1 → privileges real (demo on representative tools).
+3. + US2 → tiered surface, citizens admitted → **MVP**.
+4. + US4 → all 36 tools reachable (no drift).
+5. + US3 → remote agents over HTTP.
+6. + US5 → observability + manifest gate.
+7. Polish → docs, cleanup, quickstart validation.
+
+### Notes
+
+- [P] = different files, no incomplete-task dependency.
+- Each story is independently demonstrable at its checkpoint.
+- Commit after each task or logical group; keep `McpAuthorizationService`-touching tasks sequential.

--- a/specs/139-mcp-foundation/tasks.md
+++ b/specs/139-mcp-foundation/tasks.md
@@ -26,9 +26,9 @@
 
 **Purpose**: Bring in the HTTP-transport dependency and the test scaffolding everything else uses.
 
-- [ ] T001 Add `ModelContextProtocol.AspNetCore` (version aligned to the `ModelContextProtocol` 1.1.0 pin) to `Directory.Packages.props` and reference it from `src/Apps/Sorcha.McpServer/Sorcha.McpServer.csproj`
-- [ ] T002 [P] Add the ASP.NET Core framework reference (`<FrameworkReference Include="Microsoft.AspNetCore.App" />`) to `src/Apps/Sorcha.McpServer/Sorcha.McpServer.csproj` (HTTP host prerequisite)
-- [ ] T003 [P] Create the integration-test scaffolding in `tests/Sorcha.McpServer.Tests/Integration/`: `McpIntegrationTestBase` (Docker-gated `[Trait("Category","McpIntegration")]`, INFRA-skip when no gateway), plus a `TierTokenFixture` that mints real consumer / platform-admin / platform-designer tokens against the running Tenant Service
+- [ ] T001 ⏭️ DEFERRED to US3 — `ModelContextProtocol.AspNetCore` is an HTTP-transport dependency; not needed for the stdio MVP. Add when building US3.
+- [ ] T002 ⏭️ DEFERRED to US3 — ASP.NET Core framework reference is an HTTP-host prerequisite; add with US3.
+- [ ] T003 ⏭️ FOLDED into US1 (T015) — the integration scaffolding + `TierTokenFixture` lands with the first integration test (US1), so the fixture and base class are exercised immediately rather than sitting unused.
 
 ---
 
@@ -38,16 +38,16 @@
 
 **⚠️ CRITICAL**: No user-story work begins until this phase is complete.
 
-- [ ] T004 Define `Tier` enum (`Consumer`/`Platform`/`Service`) + an `aud`→tier parser using `SorchaAudiences` in `src/Apps/Sorcha.McpServer/Infrastructure/Tier.cs`
-- [ ] T005 Define `ICallerContext` (`RawToken`, `Tier`, `Roles`, `OrganizationId`, `Subject`, `IsAuthenticated`) in `src/Apps/Sorcha.McpServer/Infrastructure/ICallerContext.cs`
-- [ ] T006 Implement `StdioCallerContext` (validate the startup `--jwt-token`/`SORCHA_JWT_TOKEN` once via the existing `JwtValidationHandler`; expose claims + raw token) in `src/Apps/Sorcha.McpServer/Infrastructure/StdioCallerContext.cs`
-- [ ] T007 Implement `CallerTokenForwardingHandler : DelegatingHandler` (stamp `Authorization: Bearer` from `ICallerContext`; no-op cleanly when unauthenticated) in `src/Apps/Sorcha.McpServer/Infrastructure/CallerTokenForwardingHandler.cs`
-- [ ] T008 Point all `Sorcha.ServiceClients` base addresses at the API Gateway and attach `CallerTokenForwardingHandler` to their HttpClients, in `src/Apps/Sorcha.McpServer/Program.cs` (gateway URL from config; one place)
-- [ ] T009 Rework `McpErrorHandler` to map gateway `401/403/404/429/5xx`/connection failures to `ToolResultStatus` (`Unauthorized`/`Forbidden`/`NotFound`/`RateLimited`/`Unavailable`/`Error`; carry Retry-After) in `src/Apps/Sorcha.McpServer/Infrastructure/McpErrorHandler.cs`
-- [ ] T010 Remove the singleton `McpSessionService`; rewire `Program.cs` DI to register `ICallerContext` (stdio impl for now), `IHttpContextAccessor`, the forwarding handler, and the existing infra services
-- [ ] T011 [P] Add `ToolEntitlement` model + the static entitlement table (tier(s) + optional role per tool, per `contracts/transport-and-tools.md` §2) in `src/Apps/Sorcha.McpServer/Services/ToolEntitlement.cs` (data only; application is US2)
+- [X] T004 `aud`→`Tier` parser via audience suffix (`TierResolution.Resolve`, reusing the existing `Sorcha.ServiceDefaults.Auth.Tier` enum rather than duplicating it) — `src/Apps/Sorcha.McpServer/Infrastructure/ICallerContext.cs`
+- [X] T005 `ICallerContext` (`RawToken`, `Tier`, `Roles`, `OrganizationId`, `Subject`, `IsAuthenticated`) — `src/Apps/Sorcha.McpServer/Infrastructure/ICallerContext.cs`
+- [X] T006 Stdio caller context — `McpSessionService` now implements `ICallerContext` (computes `Tier` from `jwt.Audiences`; exposes raw token + claims). *Deviation: kept `McpSessionService` as the stdio impl instead of a separate `StdioCallerContext` class — minimal churn, no tool/test breakage; a dedicated `HttpCallerContext` arrives in US3 and the two unify there.*
+- [X] T007 `CallerTokenForwardingHandler : DelegatingHandler` (stamps `Authorization: Bearer` from `ICallerContext`; no-op when unauthenticated or header already present) — `src/Apps/Sorcha.McpServer/Infrastructure/CallerTokenForwardingHandler.cs`
+- [X] T008 Forwarding handler attached to the default `HttpClient` so all current tools forward the caller token immediately — `Program.cs`. *Carry-forward: pointing the typed `Sorcha.ServiceClients` at the gateway lands in US1 with the first reconciled typed client.*
+- [ ] T009 ⏭️ MOVED to US1 — gateway HTTP-status→`ToolResultStatus` mapping is exercised by the first reconciled tools; doing it there keeps it testable rather than speculative.
+- [X] T010 DI rewired in `Program.cs`: `ICallerContext` registered as the stdio session instance; forwarding handler registered. *Deviation: `McpSessionService` retained (see T006); `IHttpContextAccessor` registration deferred to US3 (HTTP only).*
+- [X] T011 [P] `ToolEntitlement` model + static tier→tool table (per `contracts/transport-and-tools.md` §2; `wallet_sign` excluded) — `src/Apps/Sorcha.McpServer/Services/ToolEntitlement.cs` (consumed by US2)
 
-**Checkpoint**: A tool invoked over stdio now reaches the gateway carrying the caller's token; failures map to clean statuses. Tier model exists but is not yet applied.
+**Checkpoint**: ✅ Reached. Token-forwarding spine live over stdio (all tools forward the caller's bearer); tier derived from the token; entitlement table modelled. Server + test projects build; **550/550 existing unit tests pass**. Deviations recorded inline + in the Implementation Log below.
 
 ---
 

--- a/specs/139-mcp-foundation/tasks.md
+++ b/specs/139-mcp-foundation/tasks.md
@@ -215,6 +215,11 @@ Delivers the existing tool surface working over stdio, tiered by token, with pri
 3. Entitlement tags centralised in `ToolEntitlements.All` rather than per-tool attributes (single source of truth; feeds the US5 manifest gate).
 4. T001/T002 (HTTP deps) deferred to US3; T009 (HTTP-status→ToolResultStatus mapping) and T013/T014 (typed-client reconciliation) folded into US4/Docker step since token forwarding already works via the default client.
 
+### 2026-05-26 — Live token-forwarding proof (Docker stack `phaethon`)
+
+- Integration harness landed: `McpIntegrationTestBase` (gateway reachability skip-gate + real admin-token login helper) and `TokenForwardingIntegrationTests` (`[Trait Category=McpIntegration]`). This is the deferred T003 scaffolding, exercised immediately.
+- **Ran live against the running gateway (`urn:sorcha:phaethon`, `aud phaethon:platform`): 537 tests, 0 skipped, 0 failed.** The forwarding handler stamps the caller bearer → authenticated gateway endpoint returns **200**; no token → **401**. Defect 1 (anonymous backend calls) is fixed and proven end-to-end on the stack.
+
 **Remaining to fully close the MVP (the "stop and validate" step the user asked for):**
 - **Protocol-level `tools/list` filtering** — wire `GetAuthorizedTools` into the MCP server's tool-list response so a consumer doesn't *see* admin/designer tools (needs an SDK list-handler seam). Security is already enforced at invocation (T012); this is the advertised-list cosmetic + UX.
 - **Two Docker integration tests** — T015 (privilege: admin success / consumer forbidden-by-gateway / expired unauthorized) and T021 (consumer invokes participation tool). Need a running stack + per-tier token minting (`TierTokenFixture`).

--- a/specs/139-mcp-foundation/tasks.md
+++ b/specs/139-mcp-foundation/tasks.md
@@ -57,13 +57,13 @@
 
 **Independent Test**: With an admin token a representative admin tool returns a real backend result; with a consumer token the same tool is refused **by the gateway**; an expired token yields a clean `Unauthorized`.
 
-- [ ] T012 [US1] Convert `McpAuthorizationService` to advisory/narrowing-only: it may hide/refuse but never grant; the per-invocation check returns `Unauthorized`/`Forbidden` cleanly and defers final authority to the backend. File: `src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs`
-- [ ] T013 [P] [US1] Reconcile a representative **admin** read tool (`sorcha_register_stats`) onto its typed `IRegisterServiceClient` method so it calls the gateway with the forwarded token — `src/Apps/Sorcha.McpServer/Tools/Admin/RegisterStatsTool.cs`
-- [ ] T014 [P] [US1] Reconcile a representative **participation** read tool (`sorcha_transaction_history`) onto its typed client — `src/Apps/Sorcha.McpServer/Tools/Participant/TransactionHistoryTool.cs`
-- [ ] T015 [US1] Integration test: admin token → `sorcha_register_stats` success; consumer token → same tool `Forbidden` (assert refusal originates from the gateway, not the local gate); expired token → `Unauthorized`. File: `tests/Sorcha.McpServer.Tests/Integration/PrivilegeEnforcementTests.cs`
-- [ ] T016 [US1] Update affected unit tests for the advisory-narrowing behaviour and `ICallerContext` (replace `McpSessionService` mocks) in `tests/Sorcha.McpServer.Tests/Services/McpAuthorizationServiceTests.cs`
+- [X] T012 [US1] `McpAuthorizationService` rewired onto `ICallerContext` + `ToolEntitlements` — advisory/narrowing-only (consults the entitlement table, never grants beyond it; backend authoritative). File: `src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs`
+- [ ] T013 [P] [US1] ⏭️ FOLDED into US4 — token already forwards via the default-client handler, so `sorcha_register_stats` forwards the caller bearer today; routing it through the typed `IRegisterServiceClient` + gateway base is part of the US4 reconciliation sweep (needs Docker to prove the success path).
+- [ ] T014 [P] [US1] ⏭️ FOLDED into US4 — same as T013 for `sorcha_transaction_history`.
+- [ ] T015 [US1] ⏳ PENDING DOCKER — integration test (admin success / consumer `Forbidden` from gateway / expired `Unauthorized`). Requires a running stack + per-tier token minting; lands in the Docker-validation step.
+- [X] T016 [US1] Authorization unit tests rewritten for the tier model + `ICallerContext` mocks — `tests/Sorcha.McpServer.Tests/Services/McpAuthorizationServiceTests.cs`
 
-**Checkpoint**: Privilege enforcement is real and demonstrated end-to-end on representative tools. MVP backbone in place.
+**Checkpoint**: ⚠️ Partial. Advisory gate enforces tier/role at invocation (unit-verified); the end-to-end privilege proof on a live tool is pending the Docker-validation step (T015).
 
 ---
 
@@ -73,13 +73,13 @@
 
 **Independent Test**: A consumer token lists the participation + citizen-read tools (and no admin/designer tools) and can invoke one; a designer token sees designer+participation; a service token is refused at connect.
 
-- [ ] T017 [US2] Apply the entitlement table to `ListTools` so the advertised set is the caller's tier/role union (stdio path); ensure consumer-tier yields a non-empty set. File: `src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs`
-- [ ] T018 [P] [US2] Tag every tool with its `ToolEntitlement` per `contracts/transport-and-tools.md` §2 (participation/citizen-read = `[Consumer,Platform]`; designer/admin = `[Platform]`+role) across `src/Apps/Sorcha.McpServer/Tools/**`
-- [ ] T019 [US2] Reject `Service`-tier (and `enrol-session`) tokens at connect/first-invocation with a clear message, in `src/Apps/Sorcha.McpServer/Infrastructure/StdioCallerContext.cs` + `Program.cs`
-- [ ] T020 [P] [US2] Unit tests: `ListTools` per tier (consumer non-empty; consumer excludes admin/designer; designer excludes admin; service rejected) in `tests/Sorcha.McpServer.Tests/Services/ToolEntitlementTests.cs`
-- [ ] T021 [US2] Integration test: consumer token invokes a participation tool (`sorcha_inbox_list`) successfully and is refused an admin tool. File: `tests/Sorcha.McpServer.Tests/Integration/ConsumerSurfaceTests.cs`
+- [X] T017 [US2] `GetAuthorizedTools` returns the caller's tier/role-filtered set via `ToolEntitlements.VisibleTools`; consumer tier yields a non-empty set. File: `src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs`. *Remaining: wiring this filtered set into the MCP `tools/list` protocol response (so a consumer doesn't even SEE admin tools) needs an SDK list-handler seam — see Implementation Log. Invocation-time enforcement (T012) already provides the security guarantee.*
+- [X] T018 [P] [US2] Tool→tier entitlement encoded in the central `ToolEntitlements.All` table per `contracts/transport-and-tools.md` §2. *Deviation: tags live in the one central table rather than per-tool attributes — single source of truth, equivalent effect, and it feeds the manifest-integrity gate (US5) directly.*
+- [X] T019 [US2] `Service`-tier (and `enrol-session` / unrecognised) tiers rejected by `McpAuthorizationService` (see/​invoke nothing). File: `McpAuthorizationService.cs`.
+- [X] T020 [P] [US2] Unit tests: tier-filtered visibility (consumer non-empty, excludes admin/designer; designer excludes admin; service empty) — `ToolEntitlementTests.cs` + `McpAuthorizationServiceTests.cs`.
+- [ ] T021 [US2] ⏳ PENDING DOCKER — integration test (consumer invokes a participation tool; refused an admin tool). Lands in the Docker-validation step.
 
-**Checkpoint**: US1 + US2 complete = MVP. The existing surface works, tiered, over stdio; citizens are no longer shut out.
+**Checkpoint**: ⚠️ Partial. Tier mapping + consumer surface + service rejection implemented and unit-verified (**535/535 green**). Remaining for full MVP: protocol-level `tools/list` filtering, the two Docker integration tests (T015, T021), and the typed-client/gateway reconciliation (folded into US4).
 
 ---
 
@@ -198,3 +198,24 @@ Delivers the existing tool surface working over stdio, tiered by token, with pri
 - [P] = different files, no incomplete-task dependency.
 - Each story is independently demonstrable at its checkpoint.
 - Commit after each task or logical group; keep `McpAuthorizationService`-touching tasks sequential.
+
+---
+
+## Implementation Log
+
+### 2026-05-26 — Foundational spine + US1/US2 authorization core (commits on `139-mcp-foundation`)
+
+**Done & verified (build green; 535/535 unit tests pass):**
+- Foundational token-forwarding spine: `ICallerContext` (+ `TierResolution`), `McpSessionService` implements it, `CallerTokenForwardingHandler` attached to the default `HttpClient` → every tool now forwards the caller's bearer (closes the anonymous-backend-call defect for the stdio path).
+- `ToolEntitlements` tier→tool table; `McpAuthorizationService` rewired onto `ICallerContext` + the table: tier-primary/role-secondary gate, service-tier rejection, **consumer surface non-empty** (F136 shut-out fixed), `wallet_sign` removed. Unit tests rewritten for the tier model + new `ToolEntitlementTests`.
+
+**Deviations from the original task text (all sound, recorded above inline):**
+1. Reused the existing `Sorcha.ServiceDefaults.Auth.Tier` enum instead of a new one; tier parsed from the audience suffix (gateway authoritative for the full namespaced check).
+2. `McpSessionService` retained as the stdio `ICallerContext` (no separate `StdioCallerContext`) — minimal churn, zero tool/test breakage. A dedicated `HttpCallerContext` arrives in US3 and the two unify there.
+3. Entitlement tags centralised in `ToolEntitlements.All` rather than per-tool attributes (single source of truth; feeds the US5 manifest gate).
+4. T001/T002 (HTTP deps) deferred to US3; T009 (HTTP-status→ToolResultStatus mapping) and T013/T014 (typed-client reconciliation) folded into US4/Docker step since token forwarding already works via the default client.
+
+**Remaining to fully close the MVP (the "stop and validate" step the user asked for):**
+- **Protocol-level `tools/list` filtering** — wire `GetAuthorizedTools` into the MCP server's tool-list response so a consumer doesn't *see* admin/designer tools (needs an SDK list-handler seam). Security is already enforced at invocation (T012); this is the advertised-list cosmetic + UX.
+- **Two Docker integration tests** — T015 (privilege: admin success / consumer forbidden-by-gateway / expired unauthorized) and T021 (consumer invokes participation tool). Need a running stack + per-tier token minting (`TierTokenFixture`).
+- **Typed-client / gateway-base reconciliation** for the representative tools (the success half of T015) — folded into the US4 sweep.

--- a/specs/139-mcp-foundation/tasks.md
+++ b/specs/139-mcp-foundation/tasks.md
@@ -220,7 +220,12 @@ Delivers the existing tool surface working over stdio, tiered by token, with pri
 - Integration harness landed: `McpIntegrationTestBase` (gateway reachability skip-gate + real admin-token login helper) and `TokenForwardingIntegrationTests` (`[Trait Category=McpIntegration]`). This is the deferred T003 scaffolding, exercised immediately.
 - **Ran live against the running gateway (`urn:sorcha:phaethon`, `aud phaethon:platform`): 537 tests, 0 skipped, 0 failed.** The forwarding handler stamps the caller bearer → authenticated gateway endpoint returns **200**; no token → **401**. Defect 1 (anonymous backend calls) is fixed and proven end-to-end on the stack.
 
-**Remaining to fully close the MVP (the "stop and validate" step the user asked for):**
-- **Protocol-level `tools/list` filtering** — wire `GetAuthorizedTools` into the MCP server's tool-list response so a consumer doesn't *see* admin/designer tools (needs an SDK list-handler seam). Security is already enforced at invocation (T012); this is the advertised-list cosmetic + UX.
-- **Two Docker integration tests** — T015 (privilege: admin success / consumer forbidden-by-gateway / expired unauthorized) and T021 (consumer invokes participation tool). Need a running stack + per-tier token minting (`TierTokenFixture`).
-- **Typed-client / gateway-base reconciliation** for the representative tools (the success half of T015) — folded into the US4 sweep.
+### 2026-05-26 — Protocol-level tools/list filtering (US2 complete)
+
+✅ `Program.cs` `WithRequestFilters` → `AddListToolsFilter` narrows the advertised `tools/list` to `GetAuthorizedTools()`, so a consumer never sees admin/designer tools. Transport-agnostic (also serves US3's HTTP path). Build + 537 tests green. US2's "consumer doesn't see admin tools" is now met at the protocol level, not just at invocation.
+
+**MVP status: CORE COMPLETE & VALIDATED.** Defect 1 (anonymous backend calls) fixed and live-proven; tier-aware authorization + consumer surface + service-tier rejection + tools/list filtering implemented and unit-tested (537/537 green).
+
+**Deferred to US4 / a follow-up with a provisioned citizen (not MVP-core blockers):**
+- **Per-tool invocation integration tests** — T015 success-path on a specific reconciled tool; T021 (consumer invokes a participation tool). T021 needs a real consumer-tier token, and the fresh `phaethon` stack has no citizen user (PWA enrol / minted consumer token required). The forwarding mechanism these exercise is already proven live by `TokenForwardingIntegrationTests`.
+- **Typed-client / gateway reconciliation** of the 36 tools (T013/T014 + the sweep) — the US4 deliverable; token forwarding already works via the default-client handler.

--- a/src/Apps/Sorcha.McpServer/Infrastructure/CallerTokenForwardingHandler.cs
+++ b/src/Apps/Sorcha.McpServer/Infrastructure/CallerTokenForwardingHandler.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+
+namespace Sorcha.McpServer.Infrastructure;
+
+/// <summary>
+/// Stamps the caller's bearer token onto every outbound backend request, so backend
+/// services (via the API Gateway) authorize the operation as the calling identity rather
+/// than anonymously. This is the centralised fix for the "tools call backends without
+/// credentials" defect — no tool sets an <c>Authorization</c> header itself.
+/// <para>
+/// If the request already carries an <c>Authorization</c> header it is left untouched; if
+/// the caller has no token the request proceeds unmodified (the backend will reject it).
+/// The token is never logged. See spec 139 (MCP Server Foundation).
+/// </para>
+/// </summary>
+public sealed class CallerTokenForwardingHandler : DelegatingHandler
+{
+    private readonly ICallerContext _caller;
+    private readonly ILogger<CallerTokenForwardingHandler> _logger;
+
+    public CallerTokenForwardingHandler(
+        ICallerContext caller,
+        ILogger<CallerTokenForwardingHandler> logger)
+    {
+        _caller = caller;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Headers.Authorization is null)
+        {
+            var token = _caller.RawToken;
+            if (!string.IsNullOrWhiteSpace(token))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Outbound request to {Uri} has no caller token to forward.",
+                    request.RequestUri);
+            }
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/Apps/Sorcha.McpServer/Infrastructure/ICallerContext.cs
+++ b/src/Apps/Sorcha.McpServer/Infrastructure/ICallerContext.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceDefaults.Auth;
+
+namespace Sorcha.McpServer.Infrastructure;
+
+/// <summary>
+/// The ambient identity behind the current MCP invocation. Resolved once per process on
+/// the stdio transport, and (in a later feature) once per request on the HTTP transport.
+/// <para>
+/// This is the single seam tools and authorization read for caller identity, and the
+/// <see cref="CallerTokenForwardingHandler"/> reads <see cref="RawToken"/> to forward the
+/// caller's credentials to backend services so the platform (API Gateway) enforces
+/// F136-tiered privileges authoritatively. See spec 139 (MCP Server Foundation).
+/// </para>
+/// </summary>
+public interface ICallerContext
+{
+    /// <summary>The caller's bearer token, forwarded verbatim to backends. Never logged.</summary>
+    string? RawToken { get; }
+
+    /// <summary>
+    /// The caller's trust tier, derived from the token audience. Null when no valid token
+    /// is present or the audience is not a recognised tier audience.
+    /// </summary>
+    Tier? Tier { get; }
+
+    /// <summary>The caller's roles in Sorcha MCP form (e.g. <c>sorcha:admin</c>). Empty for consumer tier.</summary>
+    IReadOnlyCollection<string> Roles { get; }
+
+    /// <summary>The caller's home/organisation identifier (<c>org_id</c>), if any.</summary>
+    string? OrganizationId { get; }
+
+    /// <summary>The caller's subject identifier (<c>sub</c>), if any.</summary>
+    string? Subject { get; }
+
+    /// <summary>True when a valid, unexpired token is resolved for this caller.</summary>
+    bool IsAuthenticated { get; }
+}
+
+/// <summary>
+/// Resolves a <see cref="Tier"/> from JWT audience values. The MCP server matches on the
+/// installation-namespaced tier <em>suffix</em> (<c>:consumer</c> / <c>:platform</c> /
+/// <c>:service</c> / <c>:enrol-session</c>) for transport-time tool gating; the API Gateway
+/// remains authoritative for the full installation-namespaced audience + signature checks.
+/// </summary>
+public static class TierResolution
+{
+    /// <summary>
+    /// Returns the first recognised tier among the supplied audiences, or null if none match.
+    /// </summary>
+    public static Tier? Resolve(IEnumerable<string>? audiences)
+    {
+        if (audiences is null)
+        {
+            return null;
+        }
+
+        foreach (var audience in audiences)
+        {
+            if (string.IsNullOrWhiteSpace(audience))
+            {
+                continue;
+            }
+
+            var suffix = audience.Contains(':')
+                ? audience[(audience.LastIndexOf(':') + 1)..]
+                : audience;
+
+            switch (suffix)
+            {
+                case "consumer": return ServiceDefaults.Auth.Tier.Consumer;
+                case "platform": return ServiceDefaults.Auth.Tier.Platform;
+                case "service": return ServiceDefaults.Auth.Tier.Service;
+                case "enrol-session": return ServiceDefaults.Auth.Tier.EnrolSession;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Apps/Sorcha.McpServer/Program.cs
+++ b/src/Apps/Sorcha.McpServer/Program.cs
@@ -74,6 +74,10 @@ builder.Services.AddSingleton<IMcpSessionService>(sp =>
     return session;
 });
 
+// Spec 139: the stdio session instance is also the ambient caller identity and the source
+// of the bearer token forwarded to backends (one caller per process on stdio).
+builder.Services.AddSingleton<ICallerContext>(sp => (ICallerContext)sp.GetRequiredService<IMcpSessionService>());
+
 // Register MCP infrastructure services
 builder.Services.AddSingleton<IMcpAuthorizationService, McpAuthorizationService>();
 builder.Services.AddSingleton<IRateLimitService, RateLimitService>();
@@ -83,6 +87,12 @@ builder.Services.AddSingleton<IServiceAvailabilityTracker, ServiceAvailabilityTr
 
 // Register Sorcha service clients for backend communication
 builder.Services.AddServiceClients(builder.Configuration);
+
+// Spec 139: forward the caller's bearer to every backend call. Attaching the handler to the
+// default HttpClient covers tools that resolve clients via IHttpClientFactory; the backend
+// (API Gateway) then authorizes the operation as the calling identity rather than anonymously.
+builder.Services.AddTransient<CallerTokenForwardingHandler>();
+builder.Services.AddHttpClient(string.Empty).AddHttpMessageHandler<CallerTokenForwardingHandler>();
 
 // Configure MCP server with stdio transport and auto-discovery
 builder.Services

--- a/src/Apps/Sorcha.McpServer/Program.cs
+++ b/src/Apps/Sorcha.McpServer/Program.cs
@@ -115,7 +115,26 @@ builder.Services
             """;
     })
     .WithStdioServerTransport()
-    .WithToolsFromAssembly();
+    .WithToolsFromAssembly()
+    // Spec 139: narrow the advertised tools/list to the caller's tier/role entitlement so a
+    // consumer never even sees admin/designer tools. Advisory only — invocation-time gating
+    // (McpAuthorizationService) and the gateway remain the authoritative enforcement.
+    .WithRequestFilters(filters =>
+    {
+        filters.AddListToolsFilter(next => async (context, cancellationToken) =>
+        {
+            var result = await next(context, cancellationToken);
+
+            var authz = context.Services?.GetService<IMcpAuthorizationService>();
+            if (authz is not null && result.Tools.Count > 0)
+            {
+                var allowed = authz.GetAuthorizedTools().ToHashSet(StringComparer.Ordinal);
+                result.Tools = [.. result.Tools.Where(tool => allowed.Contains(tool.Name))];
+            }
+
+            return result;
+        });
+    });
 
 var app = builder.Build();
 

--- a/src/Apps/Sorcha.McpServer/Services/IMcpSessionService.cs
+++ b/src/Apps/Sorcha.McpServer/Services/IMcpSessionService.cs
@@ -53,6 +53,12 @@ public sealed record McpSession
     public required IReadOnlyList<string> Roles { get; init; }
 
     /// <summary>
+    /// The caller's F136 trust tier, derived from the token audience (spec 139). Null when the
+    /// audience is not a recognised tier audience. Drives tier-based tool entitlement.
+    /// </summary>
+    public Sorcha.ServiceDefaults.Auth.Tier? Tier { get; init; }
+
+    /// <summary>
     /// The user's wallet address, if linked.
     /// </summary>
     public string? WalletAddress { get; init; }

--- a/src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs
+++ b/src/Apps/Sorcha.McpServer/Services/McpAuthorizationService.cs
@@ -2,124 +2,91 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.Extensions.Logging;
+using Sorcha.McpServer.Infrastructure;
+using Sorcha.ServiceDefaults.Auth;
 
 namespace Sorcha.McpServer.Services;
 
 /// <summary>
-/// Handles role-based access control for MCP tools.
+/// Advisory tier/role gate for MCP tools (spec 139). Decides, from the caller's F136 tier
+/// and roles, which tools the caller may see and attempt. This is a UX/efficiency narrowing
+/// only — the API Gateway is the authoritative authorization decision, and this gate can
+/// never grant access the gateway would refuse.
+/// <para>
+/// Tier-primary, role-secondary: consumer-tier callers get citizen + participation tools;
+/// platform-tier admins/designers get their slices; participation tools are cross-tier.
+/// Service-tier (and enrol-session) tokens are not valid MCP callers and see/​invoke nothing.
+/// </para>
 /// </summary>
 public sealed class McpAuthorizationService : IMcpAuthorizationService
 {
-    private readonly IMcpSessionService _sessionService;
+    private readonly ICallerContext _caller;
     private readonly ILogger<McpAuthorizationService> _logger;
 
-    // Role to tool mappings per spec
-    private static readonly Dictionary<string, HashSet<string>> RoleToToolsMap = new()
-    {
-        ["sorcha:admin"] =
-        [
-            "sorcha_health_check",
-            "sorcha_log_query",
-            "sorcha_metrics",
-            "sorcha_tenant_list",
-            "sorcha_tenant_create",
-            "sorcha_tenant_update",
-            "sorcha_user_list",
-            "sorcha_user_manage",
-            "sorcha_peer_status",
-            "sorcha_validator_status",
-            "sorcha_register_stats",
-            "sorcha_audit_query",
-            "sorcha_token_revoke"
-        ],
-        ["sorcha:designer"] =
-        [
-            "sorcha_blueprint_list",
-            "sorcha_blueprint_get",
-            "sorcha_blueprint_create",
-            "sorcha_blueprint_update",
-            "sorcha_blueprint_validate",
-            "sorcha_blueprint_simulate",
-            "sorcha_disclosure_analysis",
-            "sorcha_blueprint_diff",
-            "sorcha_blueprint_export",
-            "sorcha_schema_validate",
-            "sorcha_schema_generate",
-            "sorcha_jsonlogic_test",
-            "sorcha_workflow_instances"
-        ],
-        ["sorcha:participant"] =
-        [
-            "sorcha_inbox_list",
-            "sorcha_action_details",
-            "sorcha_action_submit",
-            "sorcha_action_validate",
-            "sorcha_transaction_history",
-            "sorcha_workflow_status",
-            "sorcha_disclosed_data",
-            "sorcha_wallet_info",
-            "sorcha_wallet_sign",
-            "sorcha_register_query"
-        ]
-    };
-
     public McpAuthorizationService(
-        IMcpSessionService sessionService,
+        ICallerContext caller,
         ILogger<McpAuthorizationService> logger)
     {
-        _sessionService = sessionService;
+        _caller = caller;
         _logger = logger;
     }
 
     /// <inheritdoc />
     public bool CanInvokeTool(string toolName)
     {
-        var session = _sessionService.CurrentSession;
-        if (session is null)
+        if (!_caller.IsAuthenticated)
         {
-            _logger.LogWarning("Authorization check failed: no active session");
+            _logger.LogWarning("Authorization check failed: no authenticated caller");
             return false;
         }
 
-        if (_sessionService.IsTokenExpired())
+        if (!IsCallerTier(out var tier))
         {
-            _logger.LogWarning("Authorization check failed: token expired for user {UserId}", session.UserId);
+            _logger.LogWarning(
+                "Authorization check failed: tier {Tier} is not a valid MCP caller for {ToolName}",
+                _caller.Tier, toolName);
             return false;
         }
 
-        foreach (var role in session.Roles)
+        var permitted = ToolEntitlements.IsPermitted(toolName, tier, _caller.Roles);
+        if (!permitted)
         {
-            if (RoleToToolsMap.TryGetValue(role, out var tools) && tools.Contains(toolName))
-            {
-                _logger.LogDebug("User {UserId} authorized for tool {ToolName} via role {Role}",
-                    session.UserId, toolName, role);
-                return true;
-            }
+            _logger.LogWarning(
+                "Caller {Subject} (tier {Tier}) denied tool {ToolName} — not entitled",
+                _caller.Subject, tier, toolName);
         }
 
-        _logger.LogWarning("User {UserId} denied access to tool {ToolName} - missing required role",
-            session.UserId, toolName);
-        return false;
+        return permitted;
     }
 
     /// <inheritdoc />
     public IReadOnlyList<string> GetAuthorizedTools()
     {
-        var session = _sessionService.CurrentSession;
-        if (session is null || _sessionService.IsTokenExpired())
+        if (!_caller.IsAuthenticated || !IsCallerTier(out var tier))
         {
             return [];
         }
 
-        var authorizedTools = new HashSet<string>();
-        foreach (var role in session.Roles)
-        {
-            if (RoleToToolsMap.TryGetValue(role, out var tools))
-            {
-                authorizedTools.UnionWith(tools);
-            }
-        }
+        return ToolEntitlements.VisibleTools(tier, _caller.Roles);
+    }
 
-        return authorizedTools.Order().ToList();
+    /// <summary>
+    /// True only for the human caller tiers (consumer / platform). Service and enrol-session
+    /// tokens are rejected as MCP callers; a null tier (unrecognised audience) is rejected too.
+    /// </summary>
+    private bool IsCallerTier(out Tier tier)
+    {
+        switch (_caller.Tier)
+        {
+            case Tier.Consumer:
+                tier = Tier.Consumer;
+                return true;
+            case Tier.Platform:
+                tier = Tier.Platform;
+                return true;
+            default:
+                tier = default;
+                return false;
+        }
     }
 }

--- a/src/Apps/Sorcha.McpServer/Services/McpSessionService.cs
+++ b/src/Apps/Sorcha.McpServer/Services/McpSessionService.cs
@@ -5,13 +5,15 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Microsoft.Extensions.Logging;
 using Sorcha.McpServer.Infrastructure;
+using Sorcha.ServiceDefaults.Auth;
 
 namespace Sorcha.McpServer.Services;
 
 /// <summary>
-/// Manages the current MCP session context derived from JWT authentication.
+/// Manages the current MCP session context derived from JWT authentication. Also serves as
+/// the stdio-transport <see cref="ICallerContext"/> — one caller per process (spec 139).
 /// </summary>
-public sealed class McpSessionService : IMcpSessionService
+public sealed class McpSessionService : IMcpSessionService, ICallerContext
 {
     private readonly IJwtValidationHandler _jwtHandler;
     private readonly ILogger<McpSessionService> _logger;
@@ -96,12 +98,16 @@ public sealed class McpSessionService : IMcpSessionService
             .Select(c => c.Value)
             .ToList();
 
+        // Spec 139: derive the F136 trust tier from the token audience(s).
+        var tier = TierResolution.Resolve(jwt.Audiences);
+
         _currentSession = new McpSession
         {
             UserId = userId,
             TenantId = tenantId,
             OrganizationName = organizationName,
             Roles = roles,
+            Tier = tier,
             WalletAddress = walletAddress,
             Email = email,
             DisplayName = displayName,
@@ -145,6 +151,26 @@ public sealed class McpSessionService : IMcpSessionService
     /// Gets the raw JWT token for forwarding to backend services.
     /// </summary>
     public string? GetRawToken() => _rawToken;
+
+    // --- ICallerContext (stdio transport: one caller per process) ---
+
+    /// <inheritdoc />
+    public string? RawToken => _rawToken;
+
+    /// <inheritdoc />
+    public Tier? Tier => _currentSession?.Tier;
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> Roles => _currentSession?.Roles ?? [];
+
+    /// <inheritdoc />
+    public string? OrganizationId => _currentSession?.TenantId;
+
+    /// <inheritdoc />
+    public string? Subject => _currentSession?.UserId;
+
+    /// <inheritdoc />
+    public bool IsAuthenticated => _currentSession is not null && !IsTokenExpired();
 
     private static string? GetClaimValue(ClaimsPrincipal principal, string claimType)
     {

--- a/src/Apps/Sorcha.McpServer/Services/ToolEntitlement.cs
+++ b/src/Apps/Sorcha.McpServer/Services/ToolEntitlement.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.ServiceDefaults.Auth;
+
+namespace Sorcha.McpServer.Services;
+
+/// <summary>
+/// Declares which trust tier(s) — and, for platform-tier tools, which role — may see and
+/// invoke a given MCP tool. This is the F136 tier-primary / role-secondary entitlement
+/// model that replaces the old role-only RBAC map (which left consumer-tier tokens, that
+/// carry no roles, with zero tools).
+/// <para>
+/// The check is advisory and may only ever <em>narrow</em> what a caller sees/attempts —
+/// the API Gateway remains the authoritative authorization decision. See spec 139.
+/// </para>
+/// </summary>
+public sealed record ToolEntitlement(string ToolName, Tier[] Tiers, string? RequiredRole);
+
+/// <summary>
+/// The static tier→tool entitlement table for the foundation tool surface. Mirrors
+/// <c>specs/139-mcp-foundation/contracts/transport-and-tools.md</c> §2.
+/// <c>sorcha_wallet_sign</c> is intentionally absent (deferred to a dedicated wave).
+/// </summary>
+public static class ToolEntitlements
+{
+    /// <summary>Sorcha MCP role constants.</summary>
+    public const string AdminRole = "sorcha:admin";
+
+    /// <summary>The designer role constant.</summary>
+    public const string DesignerRole = "sorcha:designer";
+
+    private static readonly Tier[] PlatformOnly = [Tier.Platform];
+    private static readonly Tier[] ConsumerAndPlatform = [Tier.Consumer, Tier.Platform];
+
+    /// <summary>The complete entitlement table for every advertised tool.</summary>
+    public static readonly IReadOnlyList<ToolEntitlement> All =
+    [
+        // Operator / Admin — platform tier + admin role
+        new("sorcha_health_check", PlatformOnly, AdminRole),
+        new("sorcha_log_query", PlatformOnly, AdminRole),
+        new("sorcha_metrics", PlatformOnly, AdminRole),
+        new("sorcha_audit_query", PlatformOnly, AdminRole),
+        new("sorcha_tenant_list", PlatformOnly, AdminRole),
+        new("sorcha_tenant_create", PlatformOnly, AdminRole),
+        new("sorcha_tenant_update", PlatformOnly, AdminRole),
+        new("sorcha_user_list", PlatformOnly, AdminRole),
+        new("sorcha_user_manage", PlatformOnly, AdminRole),
+        new("sorcha_peer_status", PlatformOnly, AdminRole),
+        new("sorcha_validator_status", PlatformOnly, AdminRole),
+        new("sorcha_register_stats", PlatformOnly, AdminRole),
+        new("sorcha_token_revoke", PlatformOnly, AdminRole),
+
+        // Designer — platform tier + designer role
+        new("sorcha_blueprint_list", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_get", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_create", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_update", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_validate", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_simulate", PlatformOnly, DesignerRole),
+        new("sorcha_disclosure_analysis", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_diff", PlatformOnly, DesignerRole),
+        new("sorcha_blueprint_export", PlatformOnly, DesignerRole),
+        new("sorcha_schema_validate", PlatformOnly, DesignerRole),
+        new("sorcha_schema_generate", PlatformOnly, DesignerRole),
+        new("sorcha_jsonlogic_test", PlatformOnly, DesignerRole),
+        new("sorcha_workflow_instances", PlatformOnly, DesignerRole),
+
+        // Workflow participation + citizen read — cross-tier (consumer OR platform), no role
+        new("sorcha_inbox_list", ConsumerAndPlatform, null),
+        new("sorcha_action_details", ConsumerAndPlatform, null),
+        new("sorcha_action_validate", ConsumerAndPlatform, null),
+        new("sorcha_action_submit", ConsumerAndPlatform, null),
+        new("sorcha_workflow_status", ConsumerAndPlatform, null),
+        new("sorcha_disclosed_data", ConsumerAndPlatform, null),
+        new("sorcha_transaction_history", ConsumerAndPlatform, null),
+        new("sorcha_register_query", ConsumerAndPlatform, null),
+        new("sorcha_wallet_info", ConsumerAndPlatform, null),
+        // sorcha_wallet_sign — REMOVED from the surface (deferred to a dedicated security-reviewed wave)
+    ];
+
+    private static readonly Dictionary<string, ToolEntitlement> ByName =
+        All.ToDictionary(e => e.ToolName, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Returns true if a caller of the given tier and roles may invoke the tool. Unknown
+    /// tools and unknown tiers return false (fail-closed). The gateway remains authoritative.
+    /// </summary>
+    public static bool IsPermitted(string toolName, Tier? tier, IReadOnlyCollection<string> roles)
+    {
+        if (tier is null || !ByName.TryGetValue(toolName, out var entitlement))
+        {
+            return false;
+        }
+
+        if (!entitlement.Tiers.Contains(tier.Value))
+        {
+            return false;
+        }
+
+        if (entitlement.RequiredRole is null)
+        {
+            return true;
+        }
+
+        return roles.Contains(entitlement.RequiredRole);
+    }
+
+    /// <summary>The tools a caller of the given tier and roles may see, sorted by name.</summary>
+    public static IReadOnlyList<string> VisibleTools(Tier? tier, IReadOnlyCollection<string> roles) =>
+        All.Where(e => IsPermitted(e.ToolName, tier, roles))
+           .Select(e => e.ToolName)
+           .Order(StringComparer.Ordinal)
+           .ToList();
+}

--- a/tests/Sorcha.McpServer.Tests/Integration/McpIntegrationTestBase.cs
+++ b/tests/Sorcha.McpServer.Tests/Integration/McpIntegrationTestBase.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Sorcha.McpServer.Tests.Integration;
+
+/// <summary>
+/// Base for live MCP integration tests (spec 139). These exercise the foundation against a
+/// running Sorcha stack reached through the API Gateway, so they catch the two defect classes
+/// mocked unit tests cannot — a missing forwarded token (401) and endpoint drift (404).
+/// <para>
+/// Docker-gated: when the gateway is not reachable the test is skipped, matching the repo's
+/// other infra-dependent suites. Run with the stack up via <c>docker-compose up -d</c>.
+/// </para>
+/// </summary>
+public abstract class McpIntegrationTestBase
+{
+    /// <summary>Gateway base URL — override with <c>SORCHA_GATEWAY_URL</c>; defaults to the local stack.</summary>
+    protected static string GatewayUrl =>
+        Environment.GetEnvironmentVariable("SORCHA_GATEWAY_URL")?.TrimEnd('/')
+        ?? "http://localhost:80";
+
+    private static readonly HttpClient ProbeClient = new() { Timeout = TimeSpan.FromSeconds(5) };
+
+    /// <summary>
+    /// Skips the calling test (xUnit dynamic skip) when the gateway is not reachable, so the
+    /// suite is a no-op on machines without the Docker stack rather than a failure.
+    /// </summary>
+    protected static async Task EnsureGatewayOrSkipAsync()
+    {
+        try
+        {
+            using var response = await ProbeClient.GetAsync($"{GatewayUrl}/health");
+            if (!response.IsSuccessStatusCode)
+            {
+                Assert.Skip($"Gateway at {GatewayUrl} returned {(int)response.StatusCode}; skipping live MCP integration test.");
+            }
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            Assert.Skip($"Gateway at {GatewayUrl} not reachable ({ex.GetType().Name}); skipping live MCP integration test.");
+        }
+    }
+
+    /// <summary>
+    /// Logs in via the gateway and returns a real, gateway-accepted platform-admin access token.
+    /// Credentials come from <c>SORCHA_ADMIN_EMAIL</c>/<c>SORCHA_ADMIN_PASSWORD</c> or the dev defaults.
+    /// </summary>
+    protected static async Task<string> GetPlatformAdminTokenAsync()
+    {
+        var email = Environment.GetEnvironmentVariable("SORCHA_ADMIN_EMAIL") ?? "admin@sorcha.local";
+        var password = Environment.GetEnvironmentVariable("SORCHA_ADMIN_PASSWORD") ?? "Dev_Pass_2025!";
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        using var response = await client.PostAsJsonAsync(
+            $"{GatewayUrl}/api/auth/login",
+            new { email, password });
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Assert.Skip($"Admin login returned {(int)response.StatusCode}; stack may not be bootstrapped. Skipping.");
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("access_token", out var tokenElement))
+        {
+            Assert.Skip("Login response carried no access_token (org-selection or 2FA path); skipping.");
+        }
+
+        return tokenElement.GetString()!;
+    }
+}

--- a/tests/Sorcha.McpServer.Tests/Integration/TokenForwardingIntegrationTests.cs
+++ b/tests/Sorcha.McpServer.Tests/Integration/TokenForwardingIntegrationTests.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.McpServer.Infrastructure;
+using Sorcha.ServiceDefaults.Auth;
+
+namespace Sorcha.McpServer.Tests.Integration;
+
+/// <summary>
+/// Live proof (spec 139) that the foundational token-forwarding spine works end-to-end
+/// against the running gateway: a tool's outbound call carries the caller's bearer (so the
+/// platform authorizes it), and an absent token is rejected by the platform — the exact
+/// behaviour the pre-139 anonymous-call defect lacked. Docker-gated.
+/// </summary>
+[Trait("Category", "McpIntegration")]
+public class TokenForwardingIntegrationTests : McpIntegrationTestBase
+{
+    // A representative authenticated, cross-tier gateway endpoint: 200 with a valid token, 401 anonymously.
+    private const string AuthedEndpoint = "/api/auth/me";
+
+    private static HttpClient BuildForwardingClient(string? token)
+    {
+        var caller = new StubCallerContext(token);
+        var handler = new CallerTokenForwardingHandler(caller, NullLogger<CallerTokenForwardingHandler>.Instance)
+        {
+            InnerHandler = new HttpClientHandler()
+        };
+        return new HttpClient(handler) { BaseAddress = new Uri(GatewayUrl), Timeout = TimeSpan.FromSeconds(10) };
+    }
+
+    [Fact]
+    public async Task ForwardingHandler_WithValidToken_ReachesAuthenticatedEndpoint()
+    {
+        await EnsureGatewayOrSkipAsync();
+        var token = await GetPlatformAdminTokenAsync();
+
+        using var client = BuildForwardingClient(token);
+        using var response = await client.GetAsync(AuthedEndpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "the forwarding handler must stamp the caller's bearer so the gateway authorizes the call");
+    }
+
+    [Fact]
+    public async Task ForwardingHandler_WithoutToken_IsRejectedByGateway()
+    {
+        await EnsureGatewayOrSkipAsync();
+
+        using var client = BuildForwardingClient(token: null);
+        using var response = await client.GetAsync(AuthedEndpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "an absent caller token must be rejected by the platform — proving the 200 above is real enforcement, not an open endpoint");
+    }
+
+    /// <summary>Minimal <see cref="ICallerContext"/> carrying a fixed raw token for the handler under test.</summary>
+    private sealed class StubCallerContext(string? token) : ICallerContext
+    {
+        public string? RawToken => token;
+        public Tier? Tier => ServiceDefaults.Auth.Tier.Platform;
+        public IReadOnlyCollection<string> Roles => [];
+        public string? OrganizationId => null;
+        public string? Subject => "integration-test";
+        public bool IsAuthenticated => token is not null;
+    }
+}

--- a/tests/Sorcha.McpServer.Tests/Services/McpAuthorizationServiceTests.cs
+++ b/tests/Sorcha.McpServer.Tests/Services/McpAuthorizationServiceTests.cs
@@ -2,222 +2,158 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.Extensions.Logging;
+using Sorcha.McpServer.Infrastructure;
 using Sorcha.McpServer.Services;
+using Sorcha.ServiceDefaults.Auth;
 
 namespace Sorcha.McpServer.Tests.Services;
 
+/// <summary>
+/// Tier-aware authorization (spec 139): tier-primary, role-secondary, with cross-tier
+/// participation tools, service-tier rejection, and a non-empty consumer surface.
+/// </summary>
 public class McpAuthorizationServiceTests
 {
-    private readonly Mock<IMcpSessionService> _sessionServiceMock;
-    private readonly Mock<ILogger<McpAuthorizationService>> _loggerMock;
+    private readonly Mock<ICallerContext> _callerMock;
     private readonly McpAuthorizationService _service;
 
     public McpAuthorizationServiceTests()
     {
-        _sessionServiceMock = new Mock<IMcpSessionService>();
-        _loggerMock = new Mock<ILogger<McpAuthorizationService>>();
-        _service = new McpAuthorizationService(_sessionServiceMock.Object, _loggerMock.Object);
+        _callerMock = new Mock<ICallerContext>();
+        _service = new McpAuthorizationService(_callerMock.Object, Mock.Of<ILogger<McpAuthorizationService>>());
     }
 
-    private void SetupSession(string[] roles, bool isExpired = false)
+    private void SetupCaller(Tier? tier, params string[] roles)
     {
-        var session = new McpSession
-        {
-            UserId = "test-user",
-            TenantId = "test-tenant",
-            Roles = roles,
-            ExpiresAt = DateTime.UtcNow.AddHours(1)
-        };
-
-        _sessionServiceMock.Setup(x => x.CurrentSession).Returns(session);
-        _sessionServiceMock.Setup(x => x.IsTokenExpired()).Returns(isExpired);
+        _callerMock.Setup(x => x.IsAuthenticated).Returns(true);
+        _callerMock.Setup(x => x.Tier).Returns(tier);
+        _callerMock.Setup(x => x.Roles).Returns(roles);
+        _callerMock.Setup(x => x.Subject).Returns("test-user");
     }
 
-    #region Admin Tools
+    #region Admin tools — platform tier + admin role
 
     [Theory]
     [InlineData("sorcha_health_check")]
-    [InlineData("sorcha_log_query")]
-    [InlineData("sorcha_metrics")]
-    [InlineData("sorcha_tenant_list")]
     [InlineData("sorcha_tenant_create")]
-    [InlineData("sorcha_tenant_update")]
-    [InlineData("sorcha_user_list")]
-    [InlineData("sorcha_user_manage")]
-    [InlineData("sorcha_peer_status")]
-    [InlineData("sorcha_validator_status")]
     [InlineData("sorcha_register_stats")]
-    [InlineData("sorcha_audit_query")]
     [InlineData("sorcha_token_revoke")]
-    public void CanInvokeTool_AdminTool_AdminRole_ReturnsTrue(string toolName)
+    public void CanInvokeTool_AdminTool_PlatformAdmin_ReturnsTrue(string toolName)
     {
-        // Arrange
-        SetupSession(["sorcha:admin"]);
-
-        // Act
-        var result = _service.CanInvokeTool(toolName);
-
-        // Assert
-        result.Should().BeTrue();
+        SetupCaller(Tier.Platform, "sorcha:admin");
+        _service.CanInvokeTool(toolName).Should().BeTrue();
     }
 
     [Theory]
     [InlineData("sorcha_health_check")]
-    [InlineData("sorcha_tenant_list")]
-    public void CanInvokeTool_AdminTool_DesignerRole_ReturnsFalse(string toolName)
+    [InlineData("sorcha_tenant_create")]
+    public void CanInvokeTool_AdminTool_PlatformDesigner_ReturnsFalse(string toolName)
     {
-        // Arrange
-        SetupSession(["sorcha:designer"]);
+        SetupCaller(Tier.Platform, "sorcha:designer");
+        _service.CanInvokeTool(toolName).Should().BeFalse();
+    }
 
-        // Act
-        var result = _service.CanInvokeTool(toolName);
-
-        // Assert
-        result.Should().BeFalse();
+    [Fact]
+    public void CanInvokeTool_AdminTool_Consumer_ReturnsFalse()
+    {
+        SetupCaller(Tier.Consumer);
+        _service.CanInvokeTool("sorcha_register_stats").Should().BeFalse();
     }
 
     #endregion
 
-    #region Designer Tools
+    #region Designer tools — platform tier + designer role
 
     [Theory]
-    [InlineData("sorcha_blueprint_list")]
-    [InlineData("sorcha_blueprint_get")]
     [InlineData("sorcha_blueprint_create")]
-    [InlineData("sorcha_blueprint_update")]
-    [InlineData("sorcha_blueprint_validate")]
-    [InlineData("sorcha_blueprint_simulate")]
-    [InlineData("sorcha_disclosure_analysis")]
-    [InlineData("sorcha_blueprint_diff")]
-    [InlineData("sorcha_blueprint_export")]
     [InlineData("sorcha_schema_validate")]
-    [InlineData("sorcha_schema_generate")]
-    [InlineData("sorcha_jsonlogic_test")]
     [InlineData("sorcha_workflow_instances")]
-    public void CanInvokeTool_DesignerTool_DesignerRole_ReturnsTrue(string toolName)
+    public void CanInvokeTool_DesignerTool_PlatformDesigner_ReturnsTrue(string toolName)
     {
-        // Arrange
-        SetupSession(["sorcha:designer"]);
-
-        // Act
-        var result = _service.CanInvokeTool(toolName);
-
-        // Assert
-        result.Should().BeTrue();
+        SetupCaller(Tier.Platform, "sorcha:designer");
+        _service.CanInvokeTool(toolName).Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData("sorcha_blueprint_create")]
-    [InlineData("sorcha_blueprint_validate")]
-    public void CanInvokeTool_DesignerTool_ParticipantRole_ReturnsFalse(string toolName)
+    [Fact]
+    public void CanInvokeTool_DesignerTool_PlatformAdminWithoutDesigner_ReturnsFalse()
     {
-        // Arrange
-        SetupSession(["sorcha:participant"]);
+        SetupCaller(Tier.Platform, "sorcha:admin");
+        _service.CanInvokeTool("sorcha_blueprint_create").Should().BeFalse();
+    }
 
-        // Act
-        var result = _service.CanInvokeTool(toolName);
-
-        // Assert
-        result.Should().BeFalse();
+    [Fact]
+    public void CanInvokeTool_DesignerTool_Consumer_ReturnsFalse()
+    {
+        SetupCaller(Tier.Consumer);
+        _service.CanInvokeTool("sorcha_blueprint_create").Should().BeFalse();
     }
 
     #endregion
 
-    #region Participant Tools
+    #region Participation tools — cross-tier (consumer OR platform), no role
 
     [Theory]
     [InlineData("sorcha_inbox_list")]
-    [InlineData("sorcha_action_details")]
     [InlineData("sorcha_action_submit")]
-    [InlineData("sorcha_action_validate")]
-    [InlineData("sorcha_transaction_history")]
     [InlineData("sorcha_workflow_status")]
-    [InlineData("sorcha_disclosed_data")]
+    [InlineData("sorcha_transaction_history")]
     [InlineData("sorcha_wallet_info")]
-    [InlineData("sorcha_wallet_sign")]
-    [InlineData("sorcha_register_query")]
-    public void CanInvokeTool_ParticipantTool_ParticipantRole_ReturnsTrue(string toolName)
+    public void CanInvokeTool_ParticipationTool_Consumer_ReturnsTrue(string toolName)
     {
-        // Arrange
-        SetupSession(["sorcha:participant"]);
+        SetupCaller(Tier.Consumer);
+        _service.CanInvokeTool(toolName).Should().BeTrue();
+    }
 
-        // Act
-        var result = _service.CanInvokeTool(toolName);
-
-        // Assert
-        result.Should().BeTrue();
+    [Theory]
+    [InlineData("sorcha_inbox_list")]
+    [InlineData("sorcha_action_submit")]
+    public void CanInvokeTool_ParticipationTool_PlatformNoRole_ReturnsTrue(string toolName)
+    {
+        SetupCaller(Tier.Platform);
+        _service.CanInvokeTool(toolName).Should().BeTrue();
     }
 
     #endregion
 
-    #region Multiple Roles
+    #region Removed / service tier / edge cases
 
     [Fact]
-    public void CanInvokeTool_MultipleRoles_CanAccessAllRoleTools()
+    public void CanInvokeTool_WalletSign_Removed_ReturnsFalseForAllTiers()
     {
-        // Arrange
-        SetupSession(["sorcha:admin", "sorcha:designer", "sorcha:participant"]);
+        SetupCaller(Tier.Consumer);
+        _service.CanInvokeTool("sorcha_wallet_sign").Should().BeFalse();
 
-        // Act & Assert
-        _service.CanInvokeTool("sorcha_health_check").Should().BeTrue(); // admin
-        _service.CanInvokeTool("sorcha_blueprint_create").Should().BeTrue(); // designer
-        _service.CanInvokeTool("sorcha_inbox_list").Should().BeTrue(); // participant
-    }
-
-    #endregion
-
-    #region Edge Cases
-
-    [Fact]
-    public void CanInvokeTool_NoSession_ReturnsFalse()
-    {
-        // Arrange
-        _sessionServiceMock.Setup(x => x.CurrentSession).Returns((McpSession?)null);
-
-        // Act
-        var result = _service.CanInvokeTool("sorcha_health_check");
-
-        // Assert
-        result.Should().BeFalse();
+        SetupCaller(Tier.Platform, "sorcha:admin");
+        _service.CanInvokeTool("sorcha_wallet_sign").Should().BeFalse();
     }
 
     [Fact]
-    public void CanInvokeTool_ExpiredToken_ReturnsFalse()
+    public void CanInvokeTool_ServiceTier_ReturnsFalse()
     {
-        // Arrange
-        SetupSession(["sorcha:admin"], isExpired: true);
+        SetupCaller(Tier.Service, "sorcha:admin");
+        _service.CanInvokeTool("sorcha_register_stats").Should().BeFalse();
+        _service.CanInvokeTool("sorcha_inbox_list").Should().BeFalse();
+    }
 
-        // Act
-        var result = _service.CanInvokeTool("sorcha_health_check");
+    [Fact]
+    public void CanInvokeTool_NotAuthenticated_ReturnsFalse()
+    {
+        _callerMock.Setup(x => x.IsAuthenticated).Returns(false);
+        _service.CanInvokeTool("sorcha_inbox_list").Should().BeFalse();
+    }
 
-        // Assert
-        result.Should().BeFalse();
+    [Fact]
+    public void CanInvokeTool_UnrecognisedTier_ReturnsFalse()
+    {
+        SetupCaller(tier: null);
+        _service.CanInvokeTool("sorcha_inbox_list").Should().BeFalse();
     }
 
     [Fact]
     public void CanInvokeTool_UnknownTool_ReturnsFalse()
     {
-        // Arrange
-        SetupSession(["sorcha:admin"]);
-
-        // Act
-        var result = _service.CanInvokeTool("sorcha_unknown_tool");
-
-        // Assert
-        result.Should().BeFalse();
-    }
-
-    [Fact]
-    public void CanInvokeTool_NoRoles_ReturnsFalse()
-    {
-        // Arrange
-        SetupSession([]);
-
-        // Act
-        var result = _service.CanInvokeTool("sorcha_health_check");
-
-        // Assert
-        result.Should().BeFalse();
+        SetupCaller(Tier.Platform, "sorcha:admin");
+        _service.CanInvokeTool("sorcha_unknown_tool").Should().BeFalse();
     }
 
     #endregion
@@ -225,60 +161,42 @@ public class McpAuthorizationServiceTests
     #region GetAuthorizedTools
 
     [Fact]
-    public void GetAuthorizedTools_AdminRole_ReturnsAdminTools()
+    public void GetAuthorizedTools_PlatformAdmin_ReturnsAdminAndParticipationNotDesigner()
     {
-        // Arrange
-        SetupSession(["sorcha:admin"]);
-
-        // Act
+        SetupCaller(Tier.Platform, "sorcha:admin");
         var tools = _service.GetAuthorizedTools();
 
-        // Assert
-        tools.Should().Contain("sorcha_health_check");
-        tools.Should().Contain("sorcha_tenant_list");
-        tools.Should().NotContain("sorcha_blueprint_create");
-        tools.Should().NotContain("sorcha_inbox_list");
+        tools.Should().Contain("sorcha_health_check");        // admin
+        tools.Should().Contain("sorcha_inbox_list");          // participation (cross-tier)
+        tools.Should().NotContain("sorcha_blueprint_create"); // designer only
+        tools.Should().NotContain("sorcha_wallet_sign");      // removed
     }
 
     [Fact]
-    public void GetAuthorizedTools_MultipleRoles_ReturnsCombinedTools()
+    public void GetAuthorizedTools_Consumer_IsNonEmptyAndExcludesAdminDesigner()
     {
-        // Arrange
-        SetupSession(["sorcha:admin", "sorcha:designer"]);
-
-        // Act
+        SetupCaller(Tier.Consumer);
         var tools = _service.GetAuthorizedTools();
 
-        // Assert
-        tools.Should().Contain("sorcha_health_check"); // admin
-        tools.Should().Contain("sorcha_blueprint_create"); // designer
-        tools.Should().NotContain("sorcha_inbox_list"); // participant only
+        tools.Should().NotBeEmpty(); // F136 shut-out fixed
+        tools.Should().Contain("sorcha_inbox_list");
+        tools.Should().Contain("sorcha_wallet_info");
+        tools.Should().NotContain("sorcha_health_check");     // admin
+        tools.Should().NotContain("sorcha_blueprint_create"); // designer
     }
 
     [Fact]
-    public void GetAuthorizedTools_NoSession_ReturnsEmpty()
+    public void GetAuthorizedTools_ServiceTier_ReturnsEmpty()
     {
-        // Arrange
-        _sessionServiceMock.Setup(x => x.CurrentSession).Returns((McpSession?)null);
-
-        // Act
-        var tools = _service.GetAuthorizedTools();
-
-        // Assert
-        tools.Should().BeEmpty();
+        SetupCaller(Tier.Service, "sorcha:admin");
+        _service.GetAuthorizedTools().Should().BeEmpty();
     }
 
     [Fact]
-    public void GetAuthorizedTools_ExpiredToken_ReturnsEmpty()
+    public void GetAuthorizedTools_NotAuthenticated_ReturnsEmpty()
     {
-        // Arrange
-        SetupSession(["sorcha:admin"], isExpired: true);
-
-        // Act
-        var tools = _service.GetAuthorizedTools();
-
-        // Assert
-        tools.Should().BeEmpty();
+        _callerMock.Setup(x => x.IsAuthenticated).Returns(false);
+        _service.GetAuthorizedTools().Should().BeEmpty();
     }
 
     #endregion

--- a/tests/Sorcha.McpServer.Tests/Services/ToolEntitlementTests.cs
+++ b/tests/Sorcha.McpServer.Tests/Services/ToolEntitlementTests.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.McpServer.Services;
+using Sorcha.ServiceDefaults.Auth;
+
+namespace Sorcha.McpServer.Tests.Services;
+
+/// <summary>Direct coverage of the tier→tool entitlement table (spec 139, contracts §2).</summary>
+public class ToolEntitlementTests
+{
+    [Fact]
+    public void All_DoesNotContainRemovedWalletSign()
+    {
+        ToolEntitlements.All.Select(e => e.ToolName).Should().NotContain("sorcha_wallet_sign");
+    }
+
+    [Fact]
+    public void IsPermitted_AdminTool_RequiresPlatformAndAdminRole()
+    {
+        ToolEntitlements.IsPermitted("sorcha_register_stats", Tier.Platform, ["sorcha:admin"]).Should().BeTrue();
+        ToolEntitlements.IsPermitted("sorcha_register_stats", Tier.Platform, ["sorcha:designer"]).Should().BeFalse();
+        ToolEntitlements.IsPermitted("sorcha_register_stats", Tier.Consumer, ["sorcha:admin"]).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPermitted_ParticipationTool_IsCrossTierWithoutRole()
+    {
+        ToolEntitlements.IsPermitted("sorcha_inbox_list", Tier.Consumer, []).Should().BeTrue();
+        ToolEntitlements.IsPermitted("sorcha_inbox_list", Tier.Platform, []).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPermitted_FailsClosed_OnNullTierUnknownToolAndServiceTier()
+    {
+        ToolEntitlements.IsPermitted("sorcha_inbox_list", null, []).Should().BeFalse();
+        ToolEntitlements.IsPermitted("sorcha_unknown", Tier.Platform, ["sorcha:admin"]).Should().BeFalse();
+        ToolEntitlements.IsPermitted("sorcha_inbox_list", Tier.Service, []).Should().BeFalse();
+    }
+
+    [Fact]
+    public void VisibleTools_Consumer_IsNonEmptyAndExcludesPrivilegedSlices()
+    {
+        var tools = ToolEntitlements.VisibleTools(Tier.Consumer, []);
+
+        tools.Should().NotBeEmpty();
+        tools.Should().Contain("sorcha_inbox_list");
+        tools.Should().Contain("sorcha_wallet_info");
+        tools.Should().NotContain("sorcha_health_check");
+        tools.Should().NotContain("sorcha_blueprint_create");
+    }
+
+    [Fact]
+    public void VisibleTools_PlatformDesigner_HasDesignerAndParticipationNotAdmin()
+    {
+        var tools = ToolEntitlements.VisibleTools(Tier.Platform, ["sorcha:designer"]);
+
+        tools.Should().Contain("sorcha_blueprint_create");
+        tools.Should().Contain("sorcha_inbox_list");
+        tools.Should().NotContain("sorcha_health_check");
+    }
+}


### PR DESCRIPTION
## MCP Server Foundation (Feature 139)

Phase 0 of the MCP remediation milestone. A pass over `Sorcha.McpServer` found the server **does not work against a secured backend**: tool calls reached backends with **no credentials** (anonymous → 401), several tools targeted **drifted endpoints**, and **consumer-tier (F136) tokens received zero tools**. This PR fixes the foundation so the existing surface genuinely works, tiered by token, with the platform enforcing privileges.

Design: `docs/superpowers/specs/2026-05-26-mcp-server-remediation-design.md` · Spec/plan/tasks: `specs/139-mcp-foundation/`

### What this delivers (all build-green; 537/537 unit+integration tests pass)

- **Token forwarding** — `ICallerContext` + `CallerTokenForwardingHandler` (on the default `HttpClient`) stamp the caller's bearer on every outbound backend call. **Closes the anonymous-call defect.**
- **F136 tier-aware authorization** — `ToolEntitlements` tier→tool table; `McpAuthorizationService` rewired to tier-primary/role-secondary: service-tier rejected, **consumer surface non-empty** (fixes the F136 shut-out), cross-tier participation tools, `wallet_sign` removed (deferred to its own security-reviewed wave).
- **Tier-filtered `tools/list`** — `WithRequestFilters`/`AddListToolsFilter` so a consumer never *sees* admin/designer tools.

### Verified live

`TokenForwardingIntegrationTests` ran against the running stack (`urn:sorcha:phaethon`): valid token → `/api/auth/me` **200** (bearer forwarded + gateway-authorized); no token → **401**. **Defect 1 proven fixed end-to-end.**

### Deferred (tracked in `specs/139-mcp-foundation/tasks.md` Implementation Log)

- Per-tool invocation integration tests (T015 success-path, T021 consumer) — T021 needs a consumer-tier token; the fresh stack has no citizen user.
- Typed-client / gateway reconciliation of the 36 tools → **US4** (Feature 140); forwarding already works via the default-client handler.
- HTTP transport → **US3** (needs `ModelContextProtocol.AspNetCore`).
- Full OAuth 2.1 AS and the `wallet_sign` wave → separate backlog efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
