### PR TITLE
Citizen Wallet PWA: social + passkey sign-in

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -637,6 +637,46 @@ End-to-end working wallet ecosystem. Twelve PRs landed 2026-04-26 (#427-#438). W
 | POST | `/verify/r/{sessionId}/response` | OID4VP `direct_post` ingest — wallet POSTs `{vpToken, delegation}` here. |
 | GET | `/verify/r/{sessionId}/status` | Polled by the verifier UI for outcome. |
 
+### Sign-in (social + passkey)
+
+The PWA has a dedicated `/wallet/signin` screen. `WalletAuthenticationStateProvider` provides the Blazor auth state; the router uses `AuthorizeRouteView` so all routes require authentication by default. Public routes (sign-in, enrol, cancelled-enrolment, and the social OAuth fragment-return landing) are exempted via `[AllowAnonymous]`. `Components/RedirectToSignIn.razor` handles the redirect from any protected page to `/wallet/signin`.
+
+All three sign-in methods mint a **Consumer-tier** token (`{installation}:consumer` audience, spec 136).
+
+#### Methods
+
+| Method | PWA entry point | Server endpoints | Notes |
+|--------|-----------------|------------------|-------|
+| **Passkey** | `IPasskeyInterop` / `wwwroot/js/webauthn.js` | `POST /api/auth/passkey/assertion/options`, `POST /api/auth/passkey/assertion/verify` | Verify request carries `"tier":"consumer"`. |
+| **Social** | `ISocialProvidersClient` drives provider buttons; `IAuthService.BeginSocialSignInAsync` starts the flow | `GET /api/auth/social/providers` (anonymous; returns `{"providers":[...]}`) → `POST /api/auth/social/initiate` (body: `{"provider":"…","surface":"wallet"}`) → `GET /auth/social/callback` Razor page → redirect to `/wallet/#token=…&refresh=…&expires_in=…` | `auth-fragment.js` IIFE captures the fragment before Blazor boots; `IAuthService.TryConsumeSocialReturnAsync` persists the tokens. |
+| **Password + 2FA** | `IAuthService` | `POST /api/auth/login` (body: `{"tier":"consumer",…}`) + `POST /api/auth/verify-2fa` (body: `{"tier":"consumer",…}`) | `tier` field on both requests forces Consumer-tier regardless of `returnTo`. |
+
+#### Login-only enforcement
+
+Unknown social identity → `SocialCallbackModel` calls `ResolveOrCreateSocialUserAsync(…, allowCreate: false)` → `SocialLoginRefusal.NoExistingAccount` → redirect to `/wallet/signin?authError=no_account`. No `PlatformUser` is created. Other refusal reasons (unverified provider, unverified existing account) also redirect to `/wallet/signin?authError=refused`.
+
+#### Silent refresh
+
+`BearerTokenHandler` (delegating handler on the PWA's typed HTTP clients) silently re-mints the session via `POST /api/auth/token/refresh` when the access token is near expiry. A failed refresh clears the token store and redirects to `/wallet/signin`.
+
+#### Key files — PWA sign-in surface
+
+| File | Purpose |
+|------|---------|
+| `src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor` | Sign-in screen — password/2FA form + passkey button + social provider buttons |
+| `src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs` | Blazor auth state, token storage, Consumer-tier gate |
+| `src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs` | Login, 2FA verify, social initiate/consume, signout |
+| `src/Apps/Sorcha.Wallet.Pwa/Services/IPasskeyInterop.cs` | JS interop seam for `webauthn.js` |
+| `src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs` | Typed HTTP client for `GET /api/auth/social/providers` |
+| `src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs` | Delegating handler; silent refresh via `/api/auth/token/refresh` |
+| `src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor` | Redirect component for protected routes |
+| `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webauthn.js` | Passkey assertion (client-side FIDO2) |
+| `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/auth-fragment.js` | IIFE: captures `#token=…&refresh=…&expires_in=…` fragment before Blazor boots |
+| `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs` | `GET /api/auth/social/providers` + `POST /api/auth/social/initiate` (surface field) |
+| `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs` | Wallet branch: Consumer-tier mint + `/wallet/#…` redirect + login-only refusal |
+| `src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs` | `POST /api/auth/passkey/assertion/verify` (tier hint) |
+| `src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs` | `POST /api/auth/verify-2fa` (tier hint) |
+
 ### Key Models
 
 - **`PlatformUserDevice`** (Tenant Service) — `Active|Revoked` status, RFC 7638 thumbprint (43 chars), citizen-editable `Label`, `DelegationExpiresAt` + `DelegationCredentialJti` rotated on renewal, `(StatusListId, StatusListIndex)` pair allocated from the org's pool (lists roll over at 32 768 bits — both fields needed to disambiguate after rollover). Cascade delete from `PlatformUser`.

--- a/docs/reference/API-DOCUMENTATION.md
+++ b/docs/reference/API-DOCUMENTATION.md
@@ -377,7 +377,7 @@ Local email/password authentication with progressive lockout, token lifecycle ma
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/api/auth/login` | Anonymous | Login with email/password (returns JWT or 2FA challenge) |
-| POST | `/api/auth/verify-2fa` | Anonymous | Verify TOTP code to complete login (rate limited) |
+| POST | `/api/auth/verify-2fa` | Anonymous | Verify TOTP code to complete login (rate limited). Optional `tier` field: `"consumer"` forces Consumer-tier token (wallet sign-in, spec 136). |
 | POST | `/api/auth/register` | Anonymous | Self-register with email/password (public orgs only, NIST password policy) |
 | POST | `/api/auth/token/refresh` | Anonymous | Exchange refresh token for new access token |
 | POST | `/api/auth/token/revoke` | Authenticated | Revoke an access or refresh token |
@@ -443,17 +443,18 @@ FIDO2/WebAuthn passkey authentication for both organizational users (2FA) and pu
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/api/auth/passkey/assertion/options` | Anonymous | Get assertion options (discoverable credentials, no email needed) |
-| POST | `/api/auth/passkey/assertion/verify` | Anonymous | Verify assertion and issue tokens |
+| POST | `/api/auth/passkey/assertion/verify` | Anonymous | Verify assertion and issue tokens. Optional `tier` field: `"consumer"` forces Consumer-tier token (wallet sign-in, spec 136). |
 
 #### Public User Social Login
 
-**Base Path:** `/api/auth/public/social`
+**Base Path:** `/api/auth/social` (providers) and `/api/auth/public/social` (flows)
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| POST | `/api/auth/public/social/initiate` | Anonymous | Initiate OAuth flow for provider (Google, Microsoft, GitHub, Apple) |
+| GET  | `/api/auth/social/providers` | Anonymous | List configured social providers. Returns `{"providers":["google",…]}`. Drives conditional "Continue with…" buttons on the citizen wallet PWA sign-in screen. |
+| POST | `/api/auth/public/social/initiate` | Anonymous | Initiate OAuth flow for provider (Google, Microsoft, GitHub, Apple). Optional `surface` field: `"wallet"` routes the post-OAuth callback into the citizen wallet PWA (mints Consumer-tier, redirects to `/wallet/#token=…&refresh=…&expires_in=…`, login-only — unknown identity → `?authError=no_account`). Null/`"app"` keeps the default web flow. |
 | POST | `/api/auth/public/social/callback` | Anonymous | Handle OAuth callback (SPA flow), provision user under strict link policy, issue tokens. Returns 400 with refusal message when `email_verified=false` from provider or when target user is unverified. |
-| GET  | `/auth/social/callback` | Anonymous | Razor-page browser redirect URI for OAuth providers. Single canonical path per environment. Provider is recovered from cached state, NOT a query parameter. See `docs/guides/SOCIAL-LOGIN-SETUP.md`. |
+| GET  | `/auth/social/callback` | Anonymous | Razor-page browser redirect URI for OAuth providers. Single canonical path per environment. Provider is recovered from cached state, NOT a query parameter. See `docs/guides/SOCIAL-LOGIN-SETUP.md`. When `surface=wallet` was used, redirects to `/wallet/#token=…&refresh=…&expires_in=…` with a Consumer-tier token. |
 
 #### Public User Auth Method Management
 

--- a/docs/superpowers/plans/2026-05-25-pwa-auth-social-passkey.md
+++ b/docs/superpowers/plans/2026-05-25-pwa-auth-social-passkey.md
@@ -1,0 +1,2376 @@
+# Citizen Wallet PWA — Social + Passkey sign-in — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add passkey + social (Google/Apple/Microsoft/GitHub) sign-in alongside email/password in the citizen wallet PWA, behind a dedicated `/signin` screen and an auth gate, with every path minting an F136 Consumer-tier token and refresh-based silent renewal.
+
+**Architecture:** Most auth backend already exists (F116). Backend changes are small and additive: a public configured-providers endpoint, a Consumer-tier hint on passkey-assertion-verify and verify-2fa, and a `surface=wallet` branch in the social OAuth callback that mints Consumer-tier and redirects to `/wallet/#token=…`. The bulk is PWA-side: a token-backed `AuthenticationStateProvider` + `AuthorizeRouteView` gate, three sign-in flows on `IAuthService`, a WebAuthn JS bridge, a fragment-return handler, and silent refresh in `BearerTokenHandler`.
+
+**Tech Stack:** .NET 10, Blazor WebAssembly (PWA), MudBlazor, ASP.NET Core Minimal APIs, Fido2NetLib, xUnit + FluentAssertions + Moq, Playwright (NUnit) E2E.
+
+**Design doc:** `docs/superpowers/specs/2026-05-25-pwa-auth-social-passkey-design.md`
+
+**Branch:** `feature/pwa-social-passkey-signin` (already created off `master`).
+
+**Suggested PR slicing:** Phase A (backend, ships independently) → Phases B–D (PWA) → Phase E (E2E + docs). Each phase leaves the build green.
+
+---
+
+## File Structure
+
+**Tenant Service (`src/Services/Sorcha.Tenant.Service/`):**
+- `Endpoints/SocialLoginEndpoints.cs` — add `GET /api/auth/social/providers`; thread `Surface` into initiate.
+- `Endpoints/PublicPasskeyEndpoints.cs` — Consumer-tier hint on assertion-verify.
+- `Endpoints/AuthEndpoints.cs` — Consumer-tier hint on verify-2fa.
+- `Models/Dtos/AuthDtos.cs` — `Verify2FaRequest` gains `Tier`; new `SocialProvidersResponse`.
+- `Models/Dtos/PublicAuthDtos.cs` — `PublicPasskeyAssertionVerifyRequest` gains `Tier`.
+- `Services/ISocialLoginService.cs` / `SocialLoginService.cs` — `surface` through the initiate overload + `SocialStateData` + `SocialAuthCallbackResult`.
+- `Pages/Auth/SocialCallback.cshtml.cs` — `surface=wallet` branch (Consumer mint, `/wallet/#…` redirect, login-only refusal).
+
+**Wallet PWA (`src/Apps/Sorcha.Wallet.Pwa/`):**
+- `Services/IAccessTokenStore.cs` — `AccessTokenRecord` gains `RefreshToken`.
+- `Services/IAuthService.cs` — passkey + social methods; password tier; refresh.
+- `Services/WalletAuthenticationStateProvider.cs` — NEW; token-backed auth state.
+- `Services/IPasskeyInterop.cs` (+ `PasskeyInterop`) — NEW; WebAuthn JS bridge.
+- `Services/ISocialProvidersClient.cs` (+ impl) — NEW; reads configured providers.
+- `Services/BearerTokenHandler.cs` — 401→refresh→retry.
+- `Components/RedirectToSignIn.razor` — NEW; gate's NotAuthorized target.
+- `Pages/SignIn.razor` — NEW; the dedicated screen.
+- `Pages/Settings.razor` — remove sign-in card; `[Authorize]`.
+- `App.razor` — `CascadingAuthenticationState` + `AuthorizeRouteView`.
+- `wwwroot/js/webauthn.js`, `wwwroot/js/auth-fragment.js`, `wwwroot/index.html` — JS.
+- `Extensions/ServiceCollectionExtensions.cs` — DI for the new services.
+- `Pages/*.razor` (protected set) — add `@attribute [Authorize]`.
+
+**Tests:**
+- `tests/Sorcha.Tenant.Service.Tests/Endpoints/` — passkey/social/2fa tier + surface + providers.
+- `tests/Sorcha.Wallet.Pwa.Tests/Services/` — token store, auth-state, AuthService methods, refresh.
+- `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/` — sign-in E2E + `PageObjects/CitizenWalletSignInPage.cs`.
+
+---
+
+# Phase A — Backend (Tenant Service)
+
+### Task 1: Public configured-providers endpoint
+
+**Files:**
+- Modify: `src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs`
+- Modify: `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs`
+- Test: `tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using Sorcha.Tenant.Service.Models.Dtos;
+using Sorcha.Tenant.Service.Services;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+public class SocialProvidersEndpointTests
+{
+    [Fact]
+    public async Task ListProviders_ReturnsConfiguredProviderNames()
+    {
+        var social = new Mock<ISocialLoginService>();
+        social.Setup(s => s.GetConfiguredProviderNames()).Returns(new[] { "Google", "Apple" });
+
+        var result = await SocialLoginEndpoints.ListConfiguredProvidersForTest(social.Object);
+
+        var ok = result.Should().BeOfType<Ok<SocialProvidersResponse>>().Subject;
+        ok.Value!.Providers.Should().BeEquivalentTo(new[] { "Google", "Apple" });
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~SocialProvidersEndpointTests" -v minimal`
+Expected: FAIL — `SocialProvidersResponse` and `ListConfiguredProvidersForTest` do not exist.
+
+- [ ] **Step 3: Add the response DTO**
+
+Append to `src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs`:
+
+```csharp
+/// <summary>
+/// Configured social providers available for sign-in. Drives the conditional
+/// "Continue with…" buttons on clients that cannot read service config directly
+/// (e.g. the citizen wallet PWA).
+/// </summary>
+public record SocialProvidersResponse
+{
+    /// <summary>Provider names (case as configured) with working credentials on this host.</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("providers")]
+    public required IReadOnlyList<string> Providers { get; init; }
+}
+```
+
+- [ ] **Step 4: Add the endpoint + a test-visible handler**
+
+In `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs`, inside `MapSocialLoginEndpoints` (after the `/initiate` mapping):
+
+```csharp
+        group.MapGet("/providers", ListConfiguredProviders)
+            .WithName("ListSocialProviders")
+            .WithSummary("List configured social providers")
+            .WithDescription("Returns the social providers that have working credentials on this host. "
+                + "Anonymous — drives the conditional 'Continue with…' buttons on the wallet sign-in screen.")
+            .AllowAnonymous()
+            .RequireRateLimiting("platform-auth")
+            .Produces<SocialProvidersResponse>();
+```
+
+Add the handler methods to the class:
+
+```csharp
+    private static IResult ListConfiguredProviders(ISocialLoginService socialLoginService)
+        => ListConfiguredProvidersForTest(socialLoginService);
+
+    /// <summary>Test seam for <see cref="ListConfiguredProviders"/> (no HttpContext needed).</summary>
+    internal static Microsoft.AspNetCore.Http.HttpResults.Ok<SocialProvidersResponse> ListConfiguredProvidersForTest(
+        ISocialLoginService socialLoginService)
+        => TypedResults.Ok(new SocialProvidersResponse
+        {
+            Providers = socialLoginService.GetConfiguredProviderNames()
+        });
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~SocialProvidersEndpointTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs
+git commit -m "feat: add public GET /api/auth/social/providers for wallet sign-in"
+```
+
+---
+
+### Task 2: Consumer-tier hint on passkey assertion-verify
+
+**Files:**
+- Modify: `src/Services/Sorcha.Tenant.Service/Models/Dtos/PublicAuthDtos.cs:62-75`
+- Modify: `src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs:322-408`
+- Test: `tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeyEndpointsTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeyEndpointsTests.cs` (a `[Fact]` in the existing class; reuse the file's existing mocks/builders for `IPasskeyService`, `IPlatformUserService`, `ITokenService`, etc. — model on the existing assertion-verify test):
+
+```csharp
+[Fact]
+public void AssertionVerifyRequest_ParsesConsumerTierHint()
+{
+    // The wallet sends tier:"consumer"; non-"consumer" values fall back to the
+    // platform default so this anonymous endpoint can never escalate.
+    Sorcha.ServiceDefaults.Auth.Tier Resolve(string? hint) =>
+        string.Equals(hint, "consumer", StringComparison.OrdinalIgnoreCase)
+            ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+            : Sorcha.ServiceDefaults.Auth.Tier.Platform;
+
+    Resolve("consumer").Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Consumer);
+    Resolve("CONSUMER").Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Consumer);
+    Resolve("platform").Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Platform);
+    Resolve(null).Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Platform);
+}
+```
+
+> Note: this asserts the clamp rule the handler will use. A full handler-level integration test for the minted tier follows the existing `AssertionVerify` test pattern in this file once the handler change lands; add an assertion there that `tokenService.GenerateUserTokenAsync` was invoked with `Tier.Consumer` when the request carried `tier:"consumer"`.
+
+- [ ] **Step 2: Run the test to verify it fails or passes trivially**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~AssertionVerifyRequest_ParsesConsumerTierHint" -v minimal`
+Expected: PASS (this is the spec of the clamp). Proceed to wire the handler so the clamp is actually used.
+
+- [ ] **Step 3: Add the tier field to the request DTO**
+
+In `src/Services/Sorcha.Tenant.Service/Models/Dtos/PublicAuthDtos.cs`, add to `PublicPasskeyAssertionVerifyRequest`:
+
+```csharp
+    /// <summary>
+    /// Optional trust-tier hint (spec 136). Only <c>consumer</c> is honoured —
+    /// it is a safe downgrade for a public-org citizen. Any other value (or null)
+    /// keeps the platform default, so this anonymous endpoint cannot escalate.
+    /// </summary>
+    [JsonPropertyName("tier")]
+    public string? Tier { get; init; }
+```
+
+- [ ] **Step 4: Pass the tier in the handler**
+
+In `src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs`, in `AssertionVerify`, replace the token-issue line:
+
+```csharp
+            // Issue JWT
+            var tokenResponse = await tokenService.GenerateUserTokenAsync(
+                userIdentity, publicOrg, platformUser.Id, cancellationToken: ct);
+```
+
+with:
+
+```csharp
+            // Issue JWT. The wallet requests tier:"consumer" (a safe downgrade);
+            // any other value keeps the platform default — no escalation here.
+            var mintTier = string.Equals(request.Tier, "consumer", StringComparison.OrdinalIgnoreCase)
+                ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+                : Sorcha.ServiceDefaults.Auth.Tier.Platform;
+            var tokenResponse = await tokenService.GenerateUserTokenAsync(
+                userIdentity, publicOrg, platformUser.Id, mintTier, ct);
+```
+
+- [ ] **Step 5: Run the test + build**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~PublicPasskeyEndpointsTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/Sorcha.Tenant.Service/Models/Dtos/PublicAuthDtos.cs src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeyEndpointsTests.cs
+git commit -m "feat: honour consumer-tier hint on public passkey assertion verify"
+```
+
+---
+
+### Task 3: Thread `surface` through the social login state
+
+**Files:**
+- Modify: `src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs:54-99`
+- Modify: `src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs:159-309,597-611`
+- Modify: `src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs` (extend `SocialLoginInitiateRequest` — see note)
+- Modify: `src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs:123-210`
+- Test: `tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceSurfaceTests.cs`
+
+> Note: `SocialLoginInitiateRequest` lives alongside the other social DTOs consumed by `SocialLoginEndpoints` (search `record SocialLoginInitiateRequest`). It currently has `Provider` and `Intent`. Add `Surface` there.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceSurfaceTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sorcha.Tenant.Service.Services;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+public class SocialLoginServiceSurfaceTests
+{
+    private static SocialLoginService BuildService(IDistributedCache cache)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SocialProviders:0:Name"] = "Google",
+                ["SocialProviders:0:ClientId"] = "test-client",
+                ["SocialProviders:0:ClientSecret"] = "test-secret",
+            })
+            .Build();
+        return new SocialLoginService(
+            new TestHttpClientFactory(), cache, config, NullLogger<SocialLoginService>.Instance);
+    }
+
+    [Fact]
+    public async Task GenerateAuthorizationUrl_WithSurface_RoundTripsSurfaceThroughState()
+    {
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var svc = BuildService(cache);
+
+        var init = await svc.GenerateAuthorizationUrlAsync(
+            "Google", "https://host/auth/social/callback",
+            SocialFlowIntent.Login, targetPlatformUserId: null, surface: "wallet");
+
+        var stateJson = Encoding.UTF8.GetString((await cache.GetAsync($"social:state:{init.State}"))!);
+        stateJson.Should().Contain("\"Surface\":\"wallet\"");
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~SocialLoginServiceSurfaceTests" -v minimal`
+Expected: FAIL — `GenerateAuthorizationUrlAsync` has no `surface` parameter.
+
+- [ ] **Step 3: Add `Surface` to the result record + state + interface**
+
+In `ISocialLoginService.cs`, add `Surface` to `SocialAuthCallbackResult` (append after `TargetPlatformUserId`, with a default so positional construction elsewhere is unaffected):
+
+```csharp
+    SocialFlowIntent Intent = SocialFlowIntent.Login,
+    Guid? TargetPlatformUserId = null,
+    string? Surface = null);
+```
+
+Add `surface` to the explicit-intent overload signature in the interface:
+
+```csharp
+    Task<SocialAuthInitiateResult> GenerateAuthorizationUrlAsync(
+        string provider,
+        string redirectUri,
+        SocialFlowIntent intent,
+        Guid? targetPlatformUserId,
+        string? surface = null,
+        CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 4: Implement the threading in `SocialLoginService.cs`**
+
+Update the explicit-intent overload signature to match (add `string? surface = null` before `CancellationToken`). Add `Surface` to the private `SocialStateData` record:
+
+```csharp
+        // Wallet vs app return-surface (PWA social sign-in). Default null = the
+        // existing /app web flow. Backwards-compatible deserialisation.
+        public string? Surface { get; init; }
+```
+
+Set it when caching state (in the `JsonSerializer.Serialize(new SocialStateData { … })` block):
+
+```csharp
+            Intent = intent,
+            TargetPlatformUserId = targetPlatformUserId,
+            Surface = surface,
+```
+
+Carry it onto the result in `ExchangeCodeAsync` (the `baseResult with { … }` block):
+
+```csharp
+            return baseResult with
+            {
+                Intent = stateData.Intent,
+                TargetPlatformUserId = stateData.TargetPlatformUserId,
+                Surface = stateData.Surface,
+            };
+```
+
+Also update the 3-arg convenience overload's forwarding call to pass `surface: null` (it already forwards `targetPlatformUserId: null`):
+
+```csharp
+        => GenerateAuthorizationUrlAsync(
+            provider, redirectUri, SocialFlowIntent.Login, targetPlatformUserId: null, surface: null, cancellationToken);
+```
+
+- [ ] **Step 5: Accept `surface` at the initiate endpoint**
+
+In `AuthDtos.cs` (or wherever `SocialLoginInitiateRequest` is declared), add:
+
+```csharp
+    /// <summary>
+    /// Optional return-surface for the post-OAuth redirect: <c>wallet</c> routes
+    /// the callback back into the citizen wallet PWA (and mints Consumer-tier);
+    /// null/anything else keeps the default /app web flow. Spec: PWA social sign-in.
+    /// </summary>
+    public string? Surface { get; init; }
+```
+
+In `SocialLoginEndpoints.InitiateSocialFlow`, pass it through (validate against an allowlist first — defence in depth):
+
+```csharp
+        // Validate optional return-surface. Unknown values are rejected rather
+        // than silently treated as the default, so a typo can't redirect tokens
+        // somewhere unexpected.
+        var surface = string.IsNullOrWhiteSpace(request.Surface) ? null : request.Surface.Trim().ToLowerInvariant();
+        if (surface is not (null or "wallet" or "app"))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["surface"] = ["surface must be 'wallet' or 'app'"]
+            });
+        }
+```
+
+and change the service call to:
+
+```csharp
+            var result = await socialLoginService.GenerateAuthorizationUrlAsync(
+                request.Provider, redirectUri, intent.Value, targetPlatformUserId, surface, ct);
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~SocialLoginServiceSurfaceTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 7: Build the whole service to catch the API-endpoint call site**
+
+The API `CompleteSocialFlow` and the Razor callback both call `ExchangeCodeAsync` (unchanged signature) — they compile. Run:
+`dotnet build src/Services/Sorcha.Tenant.Service`
+Expected: build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceSurfaceTests.cs
+git commit -m "feat: thread social return-surface through OAuth state"
+```
+
+---
+
+### Task 4: Social callback — wallet branch (Consumer tier, /wallet redirect, login-only refusal)
+
+**Files:**
+- Modify: `src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs:75-218`
+- Test: `tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackSurfaceTests.cs`
+
+The callback already resolves-or-creates and redirects to `/app/#token=…`. For `surface=="wallet"` we (a) mint Consumer-tier, (b) refuse if the resolve produced a brand-new account (login-only), (c) redirect to `/wallet/#token=…&refresh=…&expires_in=…`, (d) on refusal show the signup link.
+
+- [ ] **Step 1: Write the failing test (decision helpers)**
+
+Create `tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackSurfaceTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Tenant.Service.Pages.Auth;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Pages;
+
+public class SocialCallbackSurfaceTests
+{
+    [Theory]
+    [InlineData("wallet", true)]
+    [InlineData("WALLET", true)]
+    [InlineData("app", false)]
+    [InlineData(null, false)]
+    public void IsWalletSurface_DetectsWalletReturn(string? surface, bool expected)
+        => SocialCallbackModel.IsWalletSurface(surface).Should().Be(expected);
+
+    [Fact]
+    public void BuildWalletRedirect_PacksTokenRefreshExpiry()
+    {
+        var url = SocialCallbackModel.BuildWalletRedirect("AT", "RT", 3600, returnUrl: null);
+        url.Should().StartWith("/wallet/#");
+        url.Should().Contain("token=AT");
+        url.Should().Contain("refresh=RT");
+        url.Should().Contain("expires_in=3600");
+    }
+
+    [Fact]
+    public void BuildWalletSignInError_RoutesToPwaSignIn()
+        => SocialCallbackModel.BuildWalletSignInError("no_account")
+            .Should().Be("/wallet/signin?authError=no_account");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~SocialCallbackSurfaceTests" -v minimal`
+Expected: FAIL — helper methods don't exist.
+
+- [ ] **Step 3: Add the static helpers to `SocialCallbackModel`**
+
+In `SocialCallback.cshtml.cs`, add:
+
+```csharp
+    /// <summary>True when the social flow originated from the citizen wallet PWA.</summary>
+    internal static bool IsWalletSurface(string? surface)
+        => string.Equals(surface, "wallet", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Builds the wallet fragment-return URL. The PWA's auth-fragment.js reads
+    /// token/refresh/expires_in from the hash on load. Base-relative /wallet/ —
+    /// the PWA is mounted under that prefix at the gateway.
+    /// </summary>
+    internal static string BuildWalletRedirect(string accessToken, string refreshToken, int expiresIn, string? returnUrl)
+    {
+        var fragment = $"token={Uri.EscapeDataString(accessToken)}" +
+                       $"&refresh={Uri.EscapeDataString(refreshToken)}" +
+                       $"&expires_in={expiresIn}";
+        if (!string.IsNullOrEmpty(returnUrl))
+            fragment += $"&returnUrl={Uri.EscapeDataString(returnUrl)}";
+        return $"/wallet/#{fragment}";
+    }
+
+    /// <summary>Routes a wallet-surface failure/refusal back to the PWA sign-in screen.</summary>
+    internal static string BuildWalletSignInError(string code)
+        => $"/wallet/signin?authError={Uri.EscapeDataString(code)}";
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~SocialCallbackSurfaceTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the wallet branch into `OnGetAsync`**
+
+First, recover the surface from the exchanged state — change the exchange call to capture the surface:
+
+```csharp
+        var callbackResult = await _socialLoginService.ExchangeCodeAsync(string.Empty, code, state, ct);
+        var provider = callbackResult.Provider;
+        var isWallet = IsWalletSurface(callbackResult.Surface);
+```
+
+In the **refusal** block (`if (resolveResult.Refusal != SocialLoginRefusal.None)`), before `return Page();` add a wallet bounce:
+
+```csharp
+            if (isWallet)
+            {
+                return Redirect(BuildWalletSignInError("refused"));
+            }
+```
+
+Add the **login-only** guard immediately after `var platformUser = resolveResult.User!; var isNew = resolveResult.IsNew;`:
+
+```csharp
+        // Login-only for the wallet surface (signup happens via council enrol /
+        // pairing / web). A social identity that maps to no existing account is
+        // refused with a link to web signup rather than silently creating one.
+        if (isWallet && isNew)
+        {
+            _logger.LogInformation("Wallet social login refused: no existing account for {Provider} identity", provider);
+            return Redirect(BuildWalletSignInError("no_account"));
+        }
+```
+
+Replace the **token mint** with a tier-aware mint:
+
+```csharp
+        var mintTier = isWallet
+            ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+            : Sorcha.ServiceDefaults.Auth.Tier.Platform;
+        var tokens = await _tokenService.GenerateUserTokenAsync(userIdentity, publicOrg, platformUser.Id, mintTier, ct);
+```
+
+Replace the **final redirect** block with a surface branch:
+
+```csharp
+        if (isWallet)
+        {
+            // Wallet PWA: hand tokens back via the /wallet fragment. No SetupAddDevice
+            // returnUrl here — that route lives in the /app web client, not the PWA;
+            // the PWA handles "no device yet" with its own PairingTakeover overlay
+            // (a /setup/add-device returnUrl would 404 in the wallet).
+            return Redirect(BuildWalletRedirect(tokens.AccessToken, tokens.RefreshToken, tokens.ExpiresIn, returnUrl: null));
+        }
+
+        var fragment = $"token={Uri.EscapeDataString(tokens.AccessToken)}" +
+                       $"&refresh={Uri.EscapeDataString(tokens.RefreshToken)}";
+        if (await SetupAddDeviceRoutingGate.ShouldRouteAsync(tokens.AccessToken, _deviceService, _logger, ct))
+        {
+            fragment += $"&returnUrl={Uri.EscapeDataString(SetupAddDeviceRoutingGate.SetupAddDevicePath)}";
+        }
+        return Redirect($"/app/#{fragment}");
+```
+
+> The welcome-email dispatch line (`await _welcomeDispatcher.SendIfPendingAsync(...)`) stays above this block unchanged.
+
+- [ ] **Step 6: Build the service**
+
+Run: `dotnet build src/Services/Sorcha.Tenant.Service`
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackSurfaceTests.cs
+git commit -m "feat: wallet-surface social callback (consumer tier, /wallet redirect, login-only)"
+```
+
+---
+
+### Task 5: Consumer-tier hint on verify-2fa
+
+**Files:**
+- Modify: `src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs:297-316`
+- Modify: `src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs:418-493`
+- Test: `tests/Sorcha.Tenant.Service.Tests/Endpoints/Verify2FaTierTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Sorcha.Tenant.Service.Tests/Endpoints/Verify2FaTierTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.ServiceDefaults.Auth;
+using Sorcha.Tenant.Service.Endpoints;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+public class Verify2FaTierTests
+{
+    [Theory]
+    [InlineData("consumer", Tier.Consumer)]
+    [InlineData("CONSUMER", Tier.Consumer)]
+    [InlineData("platform", Tier.Platform)]
+    [InlineData(null, Tier.Platform)]
+    public void ResolveVerify2FaTier_HonoursConsumerHintOnly(string? hint, Tier expected)
+        => AuthEndpoints.ResolveVerify2FaTier(hint).Should().Be(expected);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~Verify2FaTierTests" -v minimal`
+Expected: FAIL — `ResolveVerify2FaTier` doesn't exist.
+
+- [ ] **Step 3: Add the tier field to `Verify2FaRequest`**
+
+In `AuthDtos.cs`, add to `Verify2FaRequest`:
+
+```csharp
+    /// <summary>
+    /// Optional trust-tier hint (spec 136). Only <c>consumer</c> is honoured —
+    /// a safe downgrade for the wallet. Other values keep the platform default.
+    /// </summary>
+    [JsonPropertyName("tier")]
+    public string? Tier { get; init; }
+```
+
+- [ ] **Step 4: Add the resolver + use it in the handler**
+
+In `AuthEndpoints.cs`, add the helper:
+
+```csharp
+    /// <summary>
+    /// Resolves the mint tier for 2FA completion. Only an explicit <c>consumer</c>
+    /// hint is honoured (safe downgrade); everything else keeps the platform
+    /// default so the path can't escalate.
+    /// </summary>
+    internal static Sorcha.ServiceDefaults.Auth.Tier ResolveVerify2FaTier(string? hint)
+        => string.Equals(hint, "consumer", StringComparison.OrdinalIgnoreCase)
+            ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+            : Sorcha.ServiceDefaults.Auth.Tier.Platform;
+```
+
+In `Verify2Fa`, replace the token-issue line:
+
+```csharp
+        var tokenResponse = await tokenService.GenerateUserTokenAsync(user, organization, user.PlatformUserId, cancellationToken: cancellationToken);
+```
+
+with:
+
+```csharp
+        var tokenResponse = await tokenService.GenerateUserTokenAsync(
+            user, organization, user.PlatformUserId, ResolveVerify2FaTier(request.Tier), cancellationToken);
+```
+
+- [ ] **Step 5: Run the test + build**
+
+Run: `dotnet test tests/Sorcha.Tenant.Service.Tests --filter "FullyQualifiedName~Verify2FaTierTests" -v minimal`
+Expected: PASS. Then `dotnet build src/Services/Sorcha.Tenant.Service`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs tests/Sorcha.Tenant.Service.Tests/Endpoints/Verify2FaTierTests.cs
+git commit -m "feat: honour consumer-tier hint on verify-2fa completion"
+```
+
+---
+
+# Phase B — PWA: token store, auth state, gate
+
+### Task 6: Extend `AccessTokenRecord` with a refresh token
+
+**Files:**
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs:31`
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs`:
+
+```csharp
+[Fact]
+public async Task InMemoryAccessTokenStore_RoundTripsRefreshToken()
+{
+    var store = new InMemoryAccessTokenStore();
+    var record = new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", "rt");
+    await store.SetAsync(record);
+
+    var loaded = await store.GetAsync();
+    loaded!.RefreshToken.Should().Be("rt");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~RoundTripsRefreshToken" -v minimal`
+Expected: FAIL — `AccessTokenRecord` has no `RefreshToken`.
+
+- [ ] **Step 3: Add the property**
+
+In `IAccessTokenStore.cs`, change the record (the trailing optional keeps every existing 3-arg construction compiling):
+
+```csharp
+public sealed record AccessTokenRecord(string AccessToken, DateTimeOffset ExpiresAt, string? Email, string? RefreshToken = null);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~RoundTripsRefreshToken" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+git commit -m "feat: carry refresh token on the wallet access-token record"
+```
+
+---
+
+### Task 7: Token-backed `AuthenticationStateProvider` + gate wiring
+
+**Files:**
+- Create: `src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs`
+- Create: `src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor`
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/App.razor`
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+public class WalletAuthenticationStateProviderTests
+{
+    [Fact]
+    public async Task GetAuthenticationState_NoToken_IsAnonymous()
+    {
+        var provider = new WalletAuthenticationStateProvider(new InMemoryAccessTokenStore());
+        var state = await provider.GetAuthenticationStateAsync();
+        state.User.Identity!.IsAuthenticated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetAuthenticationState_WithToken_IsAuthenticated()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test"));
+        var provider = new WalletAuthenticationStateProvider(store);
+
+        var state = await provider.GetAuthenticationStateAsync();
+
+        state.User.Identity!.IsAuthenticated.Should().BeTrue();
+        state.User.FindFirst(ClaimTypes.Name)!.Value.Should().Be("a@b.test");
+    }
+
+    [Fact]
+    public async Task NotifySignedIn_FlipsToAuthenticated()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var provider = new WalletAuthenticationStateProvider(store);
+        (await provider.GetAuthenticationStateAsync()).User.Identity!.IsAuthenticated.Should().BeFalse();
+
+        await store.SetAsync(new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test"));
+        provider.NotifyChanged();
+
+        (await provider.GetAuthenticationStateAsync()).User.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~WalletAuthenticationStateProviderTests" -v minimal`
+Expected: FAIL — type doesn't exist.
+
+- [ ] **Step 3: Implement the provider**
+
+Create `src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Auth state for the wallet gate. Authenticated iff <see cref="IAccessTokenStore"/>
+/// holds a non-expired token (the store self-purges expired tokens on read). No
+/// JWT parsing is needed — the protected pages only require presence, not claims.
+/// Email is surfaced as the Name claim for display. Call <see cref="NotifyChanged"/>
+/// after sign-in / sign-out so the gate re-evaluates.
+/// </summary>
+public sealed class WalletAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private static readonly AuthenticationState Anonymous =
+        new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private readonly IAccessTokenStore _store;
+
+    public WalletAuthenticationStateProvider(IAccessTokenStore store)
+        => _store = store ?? throw new ArgumentNullException(nameof(store));
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var record = await _store.GetAsync();
+        if (record is null || string.IsNullOrEmpty(record.AccessToken))
+            return Anonymous;
+
+        var claims = new List<Claim> { new(ClaimTypes.Name, record.Email ?? "citizen") };
+        var identity = new ClaimsIdentity(claims, authenticationType: "wallet-jwt");
+        return new AuthenticationState(new ClaimsPrincipal(identity));
+    }
+
+    /// <summary>Re-evaluate auth state (after sign-in or sign-out).</summary>
+    public void NotifyChanged()
+        => NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~WalletAuthenticationStateProviderTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Register the provider + create the redirect component**
+
+In `ServiceCollectionExtensions.cs` `AddCitizenWalletServices`, after the `IAccessTokenStore` registration add:
+
+```csharp
+        services.AddSingleton<WalletAuthenticationStateProvider>();
+        services.AddSingleton<Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider>(
+            sp => sp.GetRequiredService<WalletAuthenticationStateProvider>());
+```
+
+Create `src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor`:
+
+```razor
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Auth-gate NotAuthorized target. Sends signed-out citizens to the dedicated
+    sign-in screen, preserving where they were headed via returnUrl. Base-relative
+    nav — the PWA is mounted under /wallet/.
+*@
+@inject NavigationManager Nav
+
+@code {
+    protected override void OnInitialized()
+    {
+        var uri = new Uri(Nav.Uri);
+        var returnUrl = Nav.ToBaseRelativePath(Nav.Uri);
+        var target = string.IsNullOrEmpty(returnUrl) || returnUrl.StartsWith("signin")
+            ? "signin"
+            : $"signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
+        Nav.NavigateTo(target);
+    }
+}
+```
+
+- [ ] **Step 6: Wire the gate in `App.razor`**
+
+Replace the contents of `src/Apps/Sorcha.Wallet.Pwa/App.razor` with:
+
+```razor
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+*@
+@using Microsoft.AspNetCore.Components.Authorization
+@using Sorcha.Wallet.Pwa.Components
+
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToSignIn />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <PageTitle>Not found</PageTitle>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p role="alert">Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>
+```
+
+- [ ] **Step 7: Build the PWA**
+
+Run: `dotnet build src/Apps/Sorcha.Wallet.Pwa`
+Expected: build succeeds. (No page has `[Authorize]` yet, so all pages still render — the gate is inert until Task 8. This keeps the build green between commits.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor src/Apps/Sorcha.Wallet.Pwa/App.razor src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs
+git commit -m "feat: token-backed auth state provider + gate scaffolding for wallet PWA"
+```
+
+---
+
+### Task 8: Mark protected pages `[Authorize]`
+
+**Files:**
+- Modify (add `@attribute [Authorize]` + `@using Microsoft.AspNetCore.Authorization`): `Pages/Index.razor`, `Pages/Devices.razor`, `Pages/Activity.razor`, `Pages/Settings.razor`, `Pages/Profile.razor`, `Pages/Present.razor`, `Pages/Applications.razor`, `Pages/ApplicationInstance.razor`, `Pages/CredentialDetail.razor`, `Pages/Verify.razor`
+- Leave PUBLIC (no attribute): `Pages/SignIn.razor` (Task 14), `Pages/Enrol.razor`, `Pages/CancelledEnrolment.razor`
+
+- [ ] **Step 1: Add the attribute to each protected page**
+
+For each protected page above, add these two lines directly under the existing `@page`/`@layout` directives (example for `Pages/Index.razor`):
+
+```razor
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+```
+
+> Do NOT add it to `Enrol.razor` or `CancelledEnrolment.razor` — those are the signed-out onboarding entry points (the `?session=` redeem is how a freshly-paired device gets its first token; gating it would deadlock onboarding).
+
+- [ ] **Step 2: Build the PWA**
+
+Run: `dotnet build src/Apps/Sorcha.Wallet.Pwa`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual smoke (deferred to E2E in Task 17)**
+
+The redirect behaviour is asserted by the E2E test in Task 17 (`SignedOut_ProtectedRoute_RedirectsToSignIn`). No unit test here — `[Authorize]` is framework behaviour.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Activity.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Profile.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor src/Apps/Sorcha.Wallet.Pwa/Pages/Verify.razor
+git commit -m "feat: gate protected wallet pages behind [Authorize]"
+```
+
+---
+
+# Phase C — PWA: AuthService methods + JS interop
+
+### Task 9: Password login + verify-2fa request Consumer tier
+
+**Files:**
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs:204-215` (the private request records + the two POST calls)
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AuthAndBearerTests.cs` (uses a capturing stub handler — define this helper in the test file if one isn't already present):
+
+```csharp
+[Fact]
+public async Task SignInAsync_SendsConsumerTierHint()
+{
+    string? capturedBody = null;
+    var handler = new CapturingHandler(async req =>
+    {
+        capturedBody = await req.Content!.ReadAsStringAsync();
+        return JsonOk("{\"access_token\":\"at\",\"expires_in\":3600,\"requires_two_factor\":false}");
+    });
+    var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+    var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge());
+
+    await auth.SignInAsync("a@b.test", "pw");
+
+    capturedBody.Should().Contain("\"Tier\":\"consumer\"");
+}
+```
+
+If `CapturingHandler`, `JsonOk`, and `NoopLocalDataPurge` aren't already in this test file, add them:
+
+```csharp
+internal sealed class CapturingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        => responder(request);
+}
+
+internal sealed class NoopLocalDataPurge : Sorcha.Wallet.Pwa.Services.ILocalDataPurge
+{
+    public Task PurgeAsync(CancellationToken ct = default) => Task.CompletedTask;
+}
+
+// helper
+static HttpResponseMessage JsonOk(string json) => new(System.Net.HttpStatusCode.OK)
+{
+    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+};
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~SendsConsumerTierHint" -v minimal`
+Expected: FAIL — body has no `Tier`.
+
+- [ ] **Step 3: Add the tier to the request records + calls**
+
+In `IAuthService.cs` (`AuthService`), change the `LoginRequest` record and the login POST body:
+
+```csharp
+    private sealed record LoginRequest(string Email, string Password, string Tier);
+```
+
+In `SignInAsync`, change the POST:
+
+```csharp
+            var response = await _http.PostAsJsonAsync(
+                "api/auth/login",
+                new LoginRequest(email.Trim(), password, "consumer"),
+                ct);
+```
+
+Change the `Verify2FaRequest` record + the verify POST to carry the tier:
+
+```csharp
+    private sealed record Verify2FaRequest(
+        [property: JsonPropertyName("login_token")] string LoginToken,
+        [property: JsonPropertyName("code")] string Code,
+        [property: JsonPropertyName("is_backup_code")] bool IsBackupCode,
+        [property: JsonPropertyName("tier")] string Tier);
+```
+
+In `VerifyTwoFactorAsync`, change the POST:
+
+```csharp
+            var response = await _http.PostAsJsonAsync(
+                "api/auth/verify-2fa",
+                new Verify2FaRequest(loginToken, code.Trim(), isBackupCode, "consumer"),
+                ct);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~AuthAndBearerTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+git commit -m "feat: PWA password + 2FA login request consumer tier"
+```
+
+---
+
+### Task 10: WebAuthn JS bridge + passkey interop service
+
+**Files:**
+- Create: `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webauthn.js` (copy from web client)
+- Create: `src/Apps/Sorcha.Wallet.Pwa/Services/IPasskeyInterop.cs` (+ `PasskeyInterop` impl)
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs`
+
+- [ ] **Step 1: Copy `webauthn.js`**
+
+Copy `src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/wwwroot/js/webauthn.js` verbatim to `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webauthn.js`. (It exports `isWebAuthnSupported`, `createCredential(optionsJson)`, `getCredential(optionsJson)`. The PWA only uses `isWebAuthnSupported` + `getCredential` for login.)
+
+- [ ] **Step 2: Write the failing test (interface seam)**
+
+Create `tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+public class PasskeyInteropContractTests
+{
+    [Fact]
+    public async Task Fake_ReturnsAssertion()
+    {
+        IPasskeyInterop interop = new FakePasskeyInterop();
+        (await interop.IsSupportedAsync()).Should().BeTrue();
+        var resp = await interop.GetAssertionAsync(default);
+        resp.GetProperty("id").GetString().Should().Be("abc");
+    }
+}
+
+/// <summary>
+/// Shared in-memory passkey interop fake — top-level + internal so the AuthService
+/// tests (Tasks 11, 12) reuse it. Stands in for navigator.credentials.get() so no
+/// test touches IJSRuntime (brittle to mock — F114 lesson).
+/// </summary>
+internal sealed class FakePasskeyInterop : IPasskeyInterop
+{
+    public bool Supported = true;
+    public JsonElement Assertion = JsonDocument.Parse("{\"id\":\"abc\"}").RootElement;
+    public Task<bool> IsSupportedAsync() => Task.FromResult(Supported);
+    public Task<JsonElement> GetAssertionAsync(JsonElement options) => Task.FromResult(Assertion);
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~PasskeyInteropContractTests" -v minimal`
+Expected: FAIL — `IPasskeyInterop` doesn't exist.
+
+- [ ] **Step 4: Implement the interop seam**
+
+Create `src/Apps/Sorcha.Wallet.Pwa/Services/IPasskeyInterop.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// WebAuthn ceremony bridge for the wallet sign-in screen. Behind an interface so
+/// AuthService unit tests use an in-memory fake instead of mocking IJSRuntime
+/// (generic InvokeAsync&lt;T&gt; is brittle to mock — F114 lesson).
+/// </summary>
+public interface IPasskeyInterop
+{
+    /// <summary>True when the browser exposes the WebAuthn API.</summary>
+    Task<bool> IsSupportedAsync();
+
+    /// <summary>Runs navigator.credentials.get() and returns the assertion response JSON.</summary>
+    Task<JsonElement> GetAssertionAsync(JsonElement options);
+}
+
+/// <summary>JS-backed <see cref="IPasskeyInterop"/> over <c>./js/webauthn.js</c>.</summary>
+public sealed class PasskeyInterop : IPasskeyInterop, IAsyncDisposable
+{
+    private readonly IJSRuntime _js;
+    private IJSObjectReference? _module;
+
+    public PasskeyInterop(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    private async Task<IJSObjectReference> ModuleAsync()
+        => _module ??= await _js.InvokeAsync<IJSObjectReference>("import", "./js/webauthn.js");
+
+    public async Task<bool> IsSupportedAsync()
+    {
+        try { return await (await ModuleAsync()).InvokeAsync<bool>("isWebAuthnSupported"); }
+        catch { return false; }
+    }
+
+    public async Task<JsonElement> GetAssertionAsync(JsonElement options)
+    {
+        var module = await ModuleAsync();
+        var responseJson = await module.InvokeAsync<string>("getCredential", options.GetRawText());
+        return JsonSerializer.Deserialize<JsonElement>(responseJson);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not null) { await _module.DisposeAsync(); _module = null; }
+    }
+}
+```
+
+- [ ] **Step 5: Register it (singleton, like the other PWA services)**
+
+In `ServiceCollectionExtensions.cs` `AddCitizenWalletServices` (near the other singletons):
+
+```csharp
+        services.AddSingleton<IPasskeyInterop, PasskeyInterop>();
+```
+
+- [ ] **Step 6: Run the test + build**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~PasskeyInteropContractTests" -v minimal`
+Expected: PASS. Then `dotnet build src/Apps/Sorcha.Wallet.Pwa`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webauthn.js src/Apps/Sorcha.Wallet.Pwa/Services/IPasskeyInterop.cs src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs
+git commit -m "feat: WebAuthn JS bridge + passkey interop seam for wallet PWA"
+```
+
+---
+
+### Task 11: `AuthService.SignInWithPasskeyAsync`
+
+**Files:**
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs` (interface + impl + new ctor dep)
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs` (AuthService now needs `IPasskeyInterop`)
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AuthAndBearerTests.cs`:
+
+```csharp
+[Fact]
+public async Task SignInWithPasskeyAsync_HappyPath_PersistsConsumerToken()
+{
+    var responses = new Queue<HttpResponseMessage>(new[]
+    {
+        // assertion/options
+        JsonOk("{\"transaction_id\":\"tx1\",\"options\":{\"challenge\":\"AA\"}}"),
+        // assertion/verify
+        JsonOk("{\"access_token\":\"at\",\"refresh_token\":\"rt\",\"expires_in\":3600}")
+    });
+    var handler = new CapturingHandler(_ => Task.FromResult(responses.Dequeue()));
+    var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+    var store = new InMemoryAccessTokenStore();
+    var interop = new FakePasskeyInterop(); // shared internal helper from Task 10
+    var auth = new AuthService(http, store, new NoopLocalDataPurge(), interop);
+
+    var result = await auth.SignInWithPasskeyAsync();
+
+    result.IsSuccess.Should().BeTrue();
+    (await store.GetAsync())!.RefreshToken.Should().Be("rt");
+}
+
+[Fact]
+public async Task SignInWithPasskeyAsync_Unsupported_ReturnsServerError()
+{
+    var http = new HttpClient(new CapturingHandler(_ => Task.FromResult(JsonOk("{}"))))
+        { BaseAddress = new Uri("https://gw.test/") };
+    var interop = new FakePasskeyInterop { Supported = false };
+    var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(), interop);
+
+    var result = await auth.SignInWithPasskeyAsync();
+
+    result.Status.Should().Be(SignInStatus.ServerError);
+}
+```
+
+> `FakePasskeyInterop` is the shared `internal` top-level helper created in Task 10 — reference it directly.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~SignInWithPasskeyAsync" -v minimal`
+Expected: FAIL — method + ctor param don't exist.
+
+- [ ] **Step 3: Extend the interface**
+
+In `IAuthService.cs`, add to `IAuthService`:
+
+```csharp
+    /// <summary>
+    /// Passwordless sign-in with a passkey. Discoverable-first when
+    /// <paramref name="email"/> is null. Persists a Consumer-tier token on success.
+    /// </summary>
+    Task<SignInResult> SignInWithPasskeyAsync(string? email = null, CancellationToken ct = default);
+```
+
+- [ ] **Step 4: Implement it**
+
+Add the `IPasskeyInterop` dependency to `AuthService` (extend the ctor — keep existing params, append the new one) and implement:
+
+```csharp
+    private readonly IPasskeyInterop _passkey;
+
+    public AuthService(HttpClient http, IAccessTokenStore store, ILocalDataPurge purge, IPasskeyInterop passkey)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _purge = purge ?? throw new ArgumentNullException(nameof(purge));
+        _passkey = passkey ?? throw new ArgumentNullException(nameof(passkey));
+    }
+
+    /// <inheritdoc />
+    public async Task<SignInResult> SignInWithPasskeyAsync(string? email = null, CancellationToken ct = default)
+    {
+        if (!await _passkey.IsSupportedAsync())
+            return new SignInResult(SignInStatus.ServerError, "This device doesn't support passkeys.");
+
+        try
+        {
+            // 1) options
+            var optionsResp = await _http.PostAsJsonAsync(
+                "api/auth/passkey/assertion/options",
+                new AssertionOptionsRequest(string.IsNullOrWhiteSpace(email) ? null : email!.Trim()), ct);
+            optionsResp.EnsureSuccessStatusCode();
+            var options = await optionsResp.Content.ReadFromJsonAsync<AssertionOptionsResponse>(ct);
+            if (options is null || string.IsNullOrEmpty(options.TransactionId))
+                return new SignInResult(SignInStatus.ServerError, "Could not start passkey sign-in.");
+
+            // 2) browser ceremony
+            JsonElement assertion;
+            try { assertion = await _passkey.GetAssertionAsync(options.Options); }
+            catch (JSException) { return new SignInResult(SignInStatus.InvalidCredentials, "Passkey sign-in was cancelled."); }
+
+            // 3) verify (request consumer tier)
+            var verifyResp = await _http.PostAsJsonAsync(
+                "api/auth/passkey/assertion/verify",
+                new AssertionVerifyRequest(options.TransactionId, assertion, "consumer"), ct);
+            if (verifyResp.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                return new SignInResult(SignInStatus.InvalidCredentials, "That passkey isn't recognised.");
+            verifyResp.EnsureSuccessStatusCode();
+
+            var body = await verifyResp.Content.ReadFromJsonAsync<PublicTokenBody>(ct);
+            if (body is null || string.IsNullOrEmpty(body.AccessToken))
+                return new SignInResult(SignInStatus.ServerError, "Passkey sign-in returned no token.");
+
+            await PersistAsync(body.AccessToken, body.ExpiresIn, email, body.RefreshToken, ct);
+            return new SignInResult(SignInStatus.Success);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SignInResult(SignInStatus.ServerError, ex.Message);
+        }
+    }
+```
+
+Add the DTO records (near the other private records) and import `Microsoft.JSInterop` + `System.Text.Json` at the top of the file:
+
+```csharp
+    private sealed record AssertionOptionsRequest(
+        [property: JsonPropertyName("email")] string? Email);
+
+    private sealed record AssertionOptionsResponse(
+        [property: JsonPropertyName("transaction_id")] string TransactionId,
+        [property: JsonPropertyName("options")] JsonElement Options);
+
+    private sealed record AssertionVerifyRequest(
+        [property: JsonPropertyName("transaction_id")] string TransactionId,
+        [property: JsonPropertyName("assertion_response")] JsonElement AssertionResponse,
+        [property: JsonPropertyName("tier")] string Tier);
+
+    private sealed record PublicTokenBody(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
+```
+
+Update `PersistAsync` to accept + store the refresh token:
+
+```csharp
+    private async Task PersistAsync(string accessToken, int expiresIn, string? email, string? refreshToken, CancellationToken ct)
+    {
+        var record = new AccessTokenRecord(
+            accessToken,
+            DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, expiresIn)),
+            email,
+            refreshToken);
+        await _store.SetAsync(record, ct);
+    }
+```
+
+And update the two existing `PersistAsync` call sites (password + 2FA paths) to pass the refresh token from their `LoginResponse` — extend `LoginResponse` with `refresh_token` and pass `body.RefreshToken`:
+
+```csharp
+    private sealed record LoginResponse(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn,
+        [property: JsonPropertyName("requires_two_factor")] bool RequiresTwoFactor,
+        [property: JsonPropertyName("login_token")] string? LoginToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken);
+```
+
+(Change both `await PersistAsync(body.AccessToken, body.ExpiresIn, email.Trim(), ct);` calls to `await PersistAsync(body.AccessToken, body.ExpiresIn, email.Trim(), body.RefreshToken, ct);`.)
+
+- [ ] **Step 4b: Update every existing `AuthService` construction to the 4-arg ctor**
+
+Adding the required `IPasskeyInterop` parameter breaks all existing `new AuthService(...)` calls. Update each call site in `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs` — the pre-existing sign-out test (`AuthService_SignOut_PurgesAllLocalData`) and the Task 9 test (`SignInAsync_SendsConsumerTierHint`) — to pass `new FakePasskeyInterop()` as the 4th argument. Grep to be exhaustive:
+
+Run: `grep -rn "new AuthService(" tests/Sorcha.Wallet.Pwa.Tests`
+Expected after fix: every match has 4 arguments ending in `new FakePasskeyInterop()`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~AuthAndBearerTests" -v minimal`
+Expected: PASS. (The `AddHttpClient<IAuthService, AuthService>` registration resolves `IPasskeyInterop` from DI automatically — no registration change needed beyond Task 10.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+git commit -m "feat: passkey sign-in on the wallet AuthService"
+```
+
+---
+
+### Task 12: Social sign-in — initiate + fragment return + providers client
+
+**Files:**
+- Create: `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/auth-fragment.js`
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html` (reference the script before blazor)
+- Create: `src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs` (+ impl)
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs` (`BeginSocialSignInAsync`, `TryConsumeSocialReturnAsync`)
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs`
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs`
+
+- [ ] **Step 1: Create the fragment-capture JS**
+
+Create `src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/auth-fragment.js`:
+
+```javascript
+// SPDX-License-Identifier: MIT
+// Captures an OAuth fragment-return token from the URL hash BEFORE Blazor boots,
+// so the router can't redirect a signed-out user to /signin and lose the token.
+// The social callback redirects to /wallet/#token=…&refresh=…&expires_in=…[&returnUrl=…].
+(function () {
+    window.sorchaAuthFragment = window.sorchaAuthFragment || {};
+    var pending = null;
+    try {
+        var hash = window.location.hash || '';
+        if (hash.indexOf('token=') !== -1) {
+            var params = new URLSearchParams(hash.replace(/^#/, ''));
+            var token = params.get('token');
+            if (token) {
+                pending = {
+                    token: token,
+                    refresh: params.get('refresh'),
+                    expiresIn: parseInt(params.get('expires_in') || '0', 10),
+                    returnUrl: params.get('returnUrl')
+                };
+                // Strip the fragment so the token never lingers in the address bar / history.
+                history.replaceState(null, '', window.location.pathname + window.location.search);
+            }
+        }
+    } catch (e) { pending = null; }
+
+    window.sorchaAuthFragment.consume = function () {
+        var p = pending;
+        pending = null;
+        return p; // null when nothing was staged
+    };
+})();
+```
+
+- [ ] **Step 2: Reference it in `index.html`**
+
+In `src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html`, add **before** the `<script src="_framework/blazor.webassembly.js"></script>` line:
+
+```html
+    <script src="js/auth-fragment.js"></script>
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Add to `AuthAndBearerTests.cs`:
+
+```csharp
+[Fact]
+public async Task BeginSocialSignInAsync_ReturnsAuthorizationUrl()
+{
+    var handler = new CapturingHandler(_ =>
+        Task.FromResult(JsonOk("{\"authorization_url\":\"https://idp/auth?x=1\",\"state\":\"st\"}")));
+    var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+    var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(), new FakePasskeyInterop());
+
+    var url = await auth.BeginSocialSignInAsync("Google");
+
+    url.Should().Be("https://idp/auth?x=1");
+}
+```
+
+> `TryConsumeSocialReturnAsync` reads `window.sorchaAuthFragment.consume()` via `IJSRuntime`, so its happy path is covered by the E2E return-leg test (Task 17). A unit test would have to mock `IJSRuntime` (avoided per F114). Assert only the no-op path here:
+
+```csharp
+[Fact]
+public async Task TryConsumeSocialReturnAsync_NoFragment_ReturnsFalse_And_StaysSignedOut()
+{
+    // A JSRuntime stub that returns null from consume() (no staged fragment).
+    var js = new NullConsumeJsRuntime();
+    var store = new InMemoryAccessTokenStore();
+    var auth = new AuthService(
+        new HttpClient(new CapturingHandler(_ => Task.FromResult(JsonOk("{}")))) { BaseAddress = new Uri("https://gw.test/") },
+        store, new NoopLocalDataPurge(), new FakePasskeyInterop());
+
+    var consumed = await auth.TryConsumeSocialReturnAsync(js);
+
+    consumed.Should().BeFalse();
+    (await store.GetAsync()).Should().BeNull();
+}
+```
+
+Add the minimal JS-runtime stub helper to the test file:
+
+```csharp
+internal sealed class NullConsumeJsRuntime : Microsoft.JSInterop.IJSRuntime
+{
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        => new((TValue)(object?)default!);
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken ct, object?[]? args)
+        => new((TValue)(object?)default!);
+}
+```
+
+> `consume()` returns a nullable object; the stub returns `default` (null) for any `InvokeAsync<T>`, so `TryConsumeSocialReturnAsync` sees no fragment.
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~SocialSignIn|FullyQualifiedName~SocialReturn" -v minimal`
+Expected: FAIL — methods don't exist.
+
+- [ ] **Step 5: Add the social methods to `IAuthService` + `AuthService`**
+
+Interface additions:
+
+```csharp
+    /// <summary>
+    /// Starts a social sign-in. Calls /api/auth/social/initiate with surface=wallet
+    /// and returns the provider authorization URL for the caller to navigate to
+    /// (full-page). Returns null on failure.
+    /// </summary>
+    Task<string?> BeginSocialSignInAsync(string provider, CancellationToken ct = default);
+
+    /// <summary>
+    /// Consumes a staged OAuth fragment-return token (from auth-fragment.js),
+    /// persisting it as the Consumer-tier session. Returns true when a token was
+    /// consumed. Pass the page's IJSRuntime.
+    /// </summary>
+    Task<bool> TryConsumeSocialReturnAsync(Microsoft.JSInterop.IJSRuntime js, CancellationToken ct = default);
+```
+
+Implementation:
+
+```csharp
+    /// <inheritdoc />
+    public async Task<string?> BeginSocialSignInAsync(string provider, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        try
+        {
+            var resp = await _http.PostAsJsonAsync(
+                "api/auth/social/initiate",
+                new SocialInitiateBody(provider, "login", "wallet"), ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var body = await resp.Content.ReadFromJsonAsync<SocialInitiateBodyResponse>(ct);
+            return body?.AuthorizationUrl;
+        }
+        catch (HttpRequestException) { return null; }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryConsumeSocialReturnAsync(Microsoft.JSInterop.IJSRuntime js, CancellationToken ct = default)
+    {
+        FragmentReturn? fragment;
+        try { fragment = await js.InvokeAsync<FragmentReturn?>("sorchaAuthFragment.consume", ct); }
+        catch { return false; }
+
+        if (fragment is null || string.IsNullOrEmpty(fragment.Token)) return false;
+
+        await PersistAsync(fragment.Token, fragment.ExpiresIn, email: null, fragment.Refresh, ct);
+        return true;
+    }
+```
+
+DTO records:
+
+```csharp
+    private sealed record SocialInitiateBody(
+        [property: JsonPropertyName("provider")] string Provider,
+        [property: JsonPropertyName("intent")] string Intent,
+        [property: JsonPropertyName("surface")] string Surface);
+
+    private sealed record SocialInitiateBodyResponse(
+        [property: JsonPropertyName("authorization_url")] string? AuthorizationUrl,
+        [property: JsonPropertyName("state")] string? State);
+
+    private sealed record FragmentReturn(
+        [property: JsonPropertyName("token")] string? Token,
+        [property: JsonPropertyName("refresh")] string? Refresh,
+        [property: JsonPropertyName("expiresIn")] int ExpiresIn,
+        [property: JsonPropertyName("returnUrl")] string? ReturnUrl);
+```
+
+- [ ] **Step 6: Add the providers client**
+
+Create `src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>Reads the configured social providers so the sign-in screen renders only enabled buttons.</summary>
+public interface ISocialProvidersClient
+{
+    /// <summary>Provider names enabled on this host; empty on failure.</summary>
+    Task<IReadOnlyList<string>> GetConfiguredAsync(CancellationToken ct = default);
+}
+
+/// <summary>HTTP <see cref="ISocialProvidersClient"/> over the anonymous providers endpoint.</summary>
+public sealed class SocialProvidersClient : ISocialProvidersClient
+{
+    private readonly HttpClient _http;
+    public SocialProvidersClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    public async Task<IReadOnlyList<string>> GetConfiguredAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var body = await _http.GetFromJsonAsync<ProvidersBody>("api/auth/social/providers", ct);
+            return body?.Providers ?? [];
+        }
+        catch { return []; }
+    }
+
+    private sealed record ProvidersBody([property: JsonPropertyName("providers")] IReadOnlyList<string>? Providers);
+}
+```
+
+- [ ] **Step 7: Register the providers client**
+
+In `ServiceCollectionExtensions.cs` (the providers endpoint is anonymous — no bearer handler needed; keep the clock handler for consistency):
+
+```csharp
+        services.AddHttpClient<ISocialProvidersClient, SocialProvidersClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<ServerClockHandler>();
+```
+
+- [ ] **Step 8: Run the tests + build**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~AuthAndBearerTests" -v minimal`
+Expected: PASS. Then `dotnet build src/Apps/Sorcha.Wallet.Pwa`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/auth-fragment.js src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+git commit -m "feat: social sign-in initiate + fragment return + providers client (PWA)"
+```
+
+---
+
+### Task 13: Silent refresh in `BearerTokenHandler`
+
+**Files:**
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs`
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs` (handler needs an unauthenticated HttpClient for the refresh call)
+- Test: `tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AuthAndBearerTests.cs`:
+
+```csharp
+[Fact]
+public async Task BearerTokenHandler_On401_RefreshesAndRetries()
+{
+    var store = new InMemoryAccessTokenStore();
+    await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", "rt"));
+
+    // Inner handler: first call (with "old") → 401; second call (with "new") → 200.
+    var inner = new SequencedHandler(req =>
+    {
+        var auth = req.Headers.Authorization?.Parameter;
+        return auth == "new"
+            ? new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            : new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
+    });
+
+    // Refresh endpoint returns a fresh token "new".
+    var refreshHttp = new HttpClient(new CapturingHandler(_ =>
+        Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
+        { BaseAddress = new Uri("https://gw.test/") };
+
+    var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+    var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+
+    var resp = await client.GetAsync("api/v1/wallet/credentials");
+
+    resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+    (await store.GetAsync())!.AccessToken.Should().Be("new");
+}
+```
+
+Add the sequenced inner-handler helper if not present:
+
+```csharp
+internal sealed class SequencedHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        => Task.FromResult(responder(request));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~On401_RefreshesAndRetries" -v minimal`
+Expected: FAIL — `BearerTokenHandler` has no refresh ctor/behaviour.
+
+- [ ] **Step 3: Implement refresh-on-401**
+
+Replace `src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs` with:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Attaches the wallet's bearer token to every outbound request. On a 401 with a
+/// stored refresh token, transparently refreshes once (POST /api/auth/token/refresh —
+/// re-mints the same tier per F136, so a Consumer refresh stays Consumer) and
+/// retries. A failed refresh clears the session so the gate sends the citizen to
+/// /signin on the next navigation.
+/// </summary>
+public sealed class BearerTokenHandler : DelegatingHandler
+{
+    private readonly IAccessTokenStore _store;
+    private readonly HttpClient _refreshHttp;
+
+    public BearerTokenHandler(IAccessTokenStore store, HttpClient refreshHttp)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _refreshHttp = refreshHttp ?? throw new ArgumentNullException(nameof(refreshHttp));
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken ct)
+    {
+        var record = await _store.GetAsync(ct);
+        if (record is not null && !string.IsNullOrEmpty(record.AccessToken))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", record.AccessToken);
+
+        var response = await base.SendAsync(request, ct);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized
+            || record?.RefreshToken is null or "")
+        {
+            return response;
+        }
+
+        var refreshed = await TryRefreshAsync(record.RefreshToken, record.Email, ct);
+        if (refreshed is null)
+        {
+            await _store.ClearAsync(ct); // gate redirects to /signin next nav
+            return response;
+        }
+
+        response.Dispose();
+        var retry = await CloneAsync(request, ct);
+        retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+        return await base.SendAsync(retry, ct);
+    }
+
+    private async Task<AccessTokenRecord?> TryRefreshAsync(string refreshToken, string? email, CancellationToken ct)
+    {
+        try
+        {
+            var resp = await _refreshHttp.PostAsJsonAsync(
+                "api/auth/token/refresh", new RefreshBody(refreshToken), ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var body = await resp.Content.ReadFromJsonAsync<RefreshResponse>(ct);
+            if (body is null || string.IsNullOrEmpty(body.AccessToken)) return null;
+
+            var record = new AccessTokenRecord(
+                body.AccessToken,
+                DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, body.ExpiresIn)),
+                email,
+                string.IsNullOrEmpty(body.RefreshToken) ? refreshToken : body.RefreshToken);
+            await _store.SetAsync(record, ct);
+            return record;
+        }
+        catch { return null; }
+    }
+
+    private static async Task<HttpRequestMessage> CloneAsync(HttpRequestMessage req, CancellationToken ct)
+    {
+        var clone = new HttpRequestMessage(req.Method, req.RequestUri) { Version = req.Version };
+        foreach (var h in req.Headers) clone.Headers.TryAddWithoutValidation(h.Key, h.Value);
+        if (req.Content is not null)
+        {
+            var bytes = await req.Content.ReadAsByteArrayAsync(ct);
+            clone.Content = new ByteArrayContent(bytes);
+            foreach (var h in req.Content.Headers) clone.Content.Headers.TryAddWithoutValidation(h.Key, h.Value);
+        }
+        return clone;
+    }
+
+    private sealed record RefreshBody([property: JsonPropertyName("refreshToken")] string RefreshToken);
+
+    private sealed record RefreshResponse(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
+}
+```
+
+- [ ] **Step 4: Provide the refresh HttpClient to the handler in DI**
+
+`BearerTokenHandler` is registered `AddTransient<BearerTokenHandler>()`. It now needs an unauthenticated `HttpClient`. Replace that registration with a factory that supplies a named, handler-free client:
+
+```csharp
+        // Unauthenticated client used ONLY by BearerTokenHandler to refresh — it
+        // must NOT itself carry the bearer handler (no recursion).
+        services.AddHttpClient("AuthRefresh", c => c.BaseAddress = new Uri(gatewayBaseAddress));
+        services.AddTransient(sp => new BearerTokenHandler(
+            sp.GetRequiredService<IAccessTokenStore>(),
+            sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthRefresh")));
+```
+
+(Remove the old `services.AddTransient<BearerTokenHandler>();` line.)
+
+- [ ] **Step 5: Run the test + build**
+
+Run: `dotnet test tests/Sorcha.Wallet.Pwa.Tests --filter "FullyQualifiedName~AuthAndBearerTests" -v minimal`
+Expected: PASS. Then `dotnet build src/Apps/Sorcha.Wallet.Pwa`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+git commit -m "feat: silent refresh-on-401 in the wallet BearerTokenHandler"
+```
+
+---
+
+# Phase D — PWA: the sign-in screen + Settings
+
+### Task 14: `SignIn.razor` — the dedicated sign-in screen
+
+**Files:**
+- Create: `src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor`
+
+> The VISUAL/layout follows the provided design screenshots. This task delivers a complete, functional structural version with `data-testid`s on every control, dynamic provider buttons, all three methods, the 2FA step, and inline errors (no `ISnackbar`). Restyle to match the screenshots without changing the wiring.
+
+- [ ] **Step 1: Create the page**
+
+Create `src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor`:
+
+```razor
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Dedicated wallet sign-in screen. Login only — signup is via council enrol,
+    pairing, or web. Three methods: passkey, social (dynamic providers), password
+    (+ TOTP 2FA). Visual/layout follows the design screenshots; wiring is final.
+*@
+@page "/signin"
+@layout MainLayout
+@using Microsoft.JSInterop
+@using Sorcha.Wallet.Pwa.Services
+@inject IAuthService Auth
+@inject IPasskeyInterop Passkey
+@inject ISocialProvidersClient Providers
+@inject WalletAuthenticationStateProvider AuthState
+@inject NavigationManager Nav
+@inject IJSRuntime Js
+
+<PageTitle>Sign in · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraSmall" Class="mt-8">
+    <MudStack Spacing="3" data-testid="signin-screen">
+        <MudText Typo="Typo.h5" Align="Align.Center">Sign in to your wallet</MudText>
+
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" data-testid="signin-error">@_error</MudAlert>
+        }
+
+        @if (!_awaitingTwoFactor)
+        {
+            @if (_passkeySupported)
+            {
+                <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Fingerprint"
+                           OnClick="SignInWithPasskeyAsync" Disabled="@_busy"
+                           data-testid="signin-passkey">
+                    Sign in with a passkey
+                </MudButton>
+            }
+
+            @foreach (var provider in _providers)
+            {
+                <MudButton FullWidth="true" Variant="Variant.Outlined"
+                           OnClick="@(() => BeginSocialAsync(provider))" Disabled="@_busy"
+                           data-testid="@($"signin-social-{provider.ToLowerInvariant()}")">
+                    Continue with @provider
+                </MudButton>
+            }
+
+            <MudDivider Class="my-2" />
+
+            <MudTextField @bind-Value="_email" Label="Email" InputType="InputType.Email"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" data-testid="signin-email" />
+            <MudTextField @bind-Value="_password" Label="Password" InputType="InputType.Password"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" data-testid="signin-password" />
+            <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
+                       OnClick="SignInWithPasswordAsync" Disabled="@_busy" data-testid="signin-password-submit">
+                @(_busy ? "Signing in…" : "Sign in")
+            </MudButton>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                Enter the 6-digit code from your authenticator app.
+            </MudText>
+            <MudTextField @bind-Value="_twoFactorCode" Label="Authenticator code"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" MaxLength="6"
+                          InputMode="InputMode.numeric" data-testid="signin-2fa-code" />
+            <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
+                       OnClick="VerifyTwoFactorAsync"
+                       Disabled="@(_busy || string.IsNullOrWhiteSpace(_twoFactorCode))"
+                       data-testid="signin-2fa-submit">
+                @(_busy ? "Verifying…" : "Verify")
+            </MudButton>
+            <MudButton FullWidth="true" Variant="Variant.Text" OnClick="CancelTwoFactor" Disabled="@_busy">
+                Cancel
+            </MudButton>
+        }
+    </MudStack>
+</MudContainer>
+
+@code {
+    [SupplyParameterFromQuery] public string? ReturnUrl { get; set; }
+    [SupplyParameterFromQuery] public string? AuthError { get; set; }
+
+    private string _email = string.Empty;
+    private string _password = string.Empty;
+    private string? _error;
+    private bool _busy;
+    private bool _passkeySupported;
+    private IReadOnlyList<string> _providers = [];
+
+    private bool _awaitingTwoFactor;
+    private string? _loginToken;
+    private string _twoFactorCode = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // A social return may have staged a token in the URL fragment (auth-fragment.js).
+        if (await Auth.TryConsumeSocialReturnAsync(Js))
+        {
+            AuthState.NotifyChanged();
+            NavigateOnSuccess();
+            return;
+        }
+
+        if (await Auth.IsSignedInAsync())
+        {
+            NavigateOnSuccess();
+            return;
+        }
+
+        _error = MapAuthError(AuthError);
+        _providers = await Providers.GetConfiguredAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        // Hide the passkey button on browsers without WebAuthn.
+        _passkeySupported = await Passkey.IsSupportedAsync();
+        StateHasChanged();
+    }
+
+    private static string? MapAuthError(string? code) => code switch
+    {
+        null or "" => null,
+        "no_account" => "No Sorcha account is linked to that sign-in. Create one on the web, then come back.",
+        "refused" => "That sign-in was refused. Please try another method.",
+        _ => "Sign-in failed. Please try again.",
+    };
+
+    private void NavigateOnSuccess()
+    {
+        var target = string.IsNullOrEmpty(ReturnUrl) ? "" : ReturnUrl!;
+        Nav.NavigateTo(target);
+    }
+
+    private async Task SignInWithPasskeyAsync()
+    {
+        _error = null; _busy = true;
+        try
+        {
+            var result = await Auth.SignInWithPasskeyAsync();
+            await HandleResult(result);
+        }
+        finally { _busy = false; }
+    }
+
+    private async Task BeginSocialAsync(string provider)
+    {
+        _error = null; _busy = true;
+        var url = await Auth.BeginSocialSignInAsync(provider);
+        if (string.IsNullOrEmpty(url)) { _error = "Couldn't start social sign-in."; _busy = false; return; }
+        Nav.NavigateTo(url, forceLoad: true); // full-page to the provider
+    }
+
+    private async Task SignInWithPasswordAsync()
+    {
+        _error = null;
+        if (string.IsNullOrWhiteSpace(_email) || string.IsNullOrWhiteSpace(_password))
+        { _error = "Email and password are required."; return; }
+        _busy = true;
+        try
+        {
+            var result = await Auth.SignInAsync(_email, _password);
+            if (result.Status == SignInStatus.TwoFactorRequired)
+            {
+                _loginToken = result.LoginToken; _awaitingTwoFactor = true; _password = string.Empty;
+                return;
+            }
+            await HandleResult(result);
+        }
+        finally { _busy = false; }
+    }
+
+    private async Task VerifyTwoFactorAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_loginToken)) { CancelTwoFactor(); return; }
+        _error = null; _busy = true;
+        try
+        {
+            var result = await Auth.VerifyTwoFactorAsync(_loginToken, _email, _twoFactorCode);
+            if (!result.IsSuccess) { _error = result.ErrorMessage ?? "Verification failed."; _twoFactorCode = string.Empty; return; }
+            await HandleResult(result);
+        }
+        finally { _busy = false; }
+    }
+
+    private void CancelTwoFactor()
+    {
+        _awaitingTwoFactor = false; _loginToken = null; _twoFactorCode = string.Empty; _error = null;
+    }
+
+    private async Task HandleResult(SignInResult result)
+    {
+        if (result.IsSuccess)
+        {
+            AuthState.NotifyChanged();
+            NavigateOnSuccess();
+        }
+        else
+        {
+            _error = result.ErrorMessage ?? "Sign-in failed.";
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build the PWA**
+
+Run: `dotnet build src/Apps/Sorcha.Wallet.Pwa`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor
+git commit -m "feat: dedicated wallet sign-in screen (passkey + social + password)"
+```
+
+---
+
+### Task 15: Remove the sign-in card from Settings; keep sign-out
+
+**Files:**
+- Modify: `src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor`
+
+- [ ] **Step 1: Trim the Account card to sign-out only**
+
+In `Settings.razor`, the `Account` `MudCard` currently renders the full sign-in/2FA form when signed out. Replace the `MudCardContent` body so it only shows the signed-in identity + Sign out, and a "Sign in" link when signed out (the gate will normally prevent reaching Settings signed-out, but keep a graceful path):
+
+```razor
+        <MudCardContent>
+            @if (_signedInEmail is not null)
+            {
+                <MudText Typo="Typo.body2" Class="mb-2">Signed in as <strong>@_signedInEmail</strong></MudText>
+                <MudButton StartIcon="@Icons.Material.Filled.Logout" Variant="Variant.Outlined"
+                           Color="Color.Error" OnClick="SignOutAsync" data-testid="settings-signout">
+                    Sign out
+                </MudButton>
+            }
+            else
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                           OnClick="@(() => Nav.NavigateTo("signin"))" data-testid="settings-signin-link">
+                    Sign in
+                </MudButton>
+            }
+        </MudCardContent>
+```
+
+Delete the now-unused 2FA/sign-in fields and methods from `@code` (`_email`, `_password`, `_signInError`, `_signingIn`, `_awaitingTwoFactor`, `_loginToken`, `_twoFactorCode`, `_useBackupCode`, `SignInAsync`, `VerifyTwoFactorAsync`, `CancelTwoFactor`). Keep `_signedInEmail`, `OnInitializedAsync`, `SignOutAsync`, the storage/tour code. In `SignOutAsync`, after `await Auth.SignOutAsync();` add `AuthState.NotifyChanged();` and `@inject WalletAuthenticationStateProvider AuthState` at the top.
+
+- [ ] **Step 2: Build the PWA**
+
+Run: `dotnet build src/Apps/Sorcha.Wallet.Pwa`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+git commit -m "refactor: move wallet sign-in out of Settings to the dedicated screen"
+```
+
+---
+
+### Task 16: Verify gate ↔ PairingTakeover ordering
+
+**Files:**
+- Inspect: `src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor`, `src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Pairing/PairingTakeover.razor`
+
+`PairingTakeover` self-gates on `IHasPairedDeviceProbe` (device presence) and renders from `MainLayout`. With the auth gate, an anonymous user is redirected to `/signin` (which uses `MainLayout`) before any protected page renders. The takeover must NOT cover the sign-in screen.
+
+- [ ] **Step 1: Confirm the takeover is suppressed on `/signin`**
+
+`PairingTakeover` calls `/api/v1/me/devices/has-any`, which requires a token; signed-out it should resolve to "unknown/anonymous" and not render. Verify `IHasPairedDeviceProbe`/`PairingTakeover` does not render its overlay when there is no token. If it would render on `/signin`, guard it: in `MainLayout.razor`, wrap `<PairingTakeover />` so it only renders when signed in, e.g.:
+
+```razor
+<AuthorizeView>
+    <Authorized>
+        <PairingTakeover />
+    </Authorized>
+</AuthorizeView>
+```
+
+(This requires `@using Microsoft.AspNetCore.Components.Authorization` in `MainLayout.razor`, already available via `_Imports`.)
+
+- [ ] **Step 2: Build the PWA**
+
+Run: `dotnet build src/Apps/Sorcha.Wallet.Pwa`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit (only if MainLayout changed)**
+
+```bash
+git add src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+git commit -m "fix: suppress pairing takeover on the signed-out sign-in screen"
+```
+
+---
+
+# Phase E — E2E + docs
+
+### Task 17: E2E sign-in tests
+
+**Files:**
+- Create: `tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletSignInPage.cs`
+- Create: `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignInTests.cs`
+
+> Run against the Docker stack per the sorcha-ui skill. The social *provider* leg can't run in CI; the test covers the deterministic *return* leg by navigating to `/wallet/#token=…`. Passkey uses Playwright's CDP virtual authenticator.
+
+- [ ] **Step 1: Create the page object**
+
+Create `tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletSignInPage.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+
+namespace Sorcha.UI.E2E.Tests.PageObjects;
+
+public class CitizenWalletSignInPage
+{
+    private readonly IPage _page;
+    public CitizenWalletSignInPage(IPage page) => _page = page;
+
+    private static string Wallet(string path) => $"{TestConstants.GatewayBaseUrl}/wallet/{path}";
+
+    public ILocator Screen => _page.GetByTestId("signin-screen");
+    public ILocator Email => _page.GetByTestId("signin-email").Locator("input");
+    public ILocator Password => _page.GetByTestId("signin-password").Locator("input");
+    public ILocator PasswordSubmit => _page.GetByTestId("signin-password-submit");
+    public ILocator PasskeyButton => _page.GetByTestId("signin-passkey");
+    public ILocator Error => _page.GetByTestId("signin-error");
+
+    public async Task GotoAsync()
+    {
+        await _page.GotoAsync(Wallet("signin"));
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    public async Task SignInWithPasswordAsync(string email, string password)
+    {
+        await Email.FillAsync(email);
+        await Password.FillAsync(password);
+        await PasswordSubmit.ClickAsync();
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+}
+```
+
+> Confirm `TestConstants.GatewayBaseUrl` exists; if the constant is named differently (e.g. `UiWebUrl`), use the gateway host constant the other CitizenWallet tests use. Confirm `GetByTestId` is available (Playwright maps it to `data-testid`); if the suite uses a helper, use `MudBlazorHelpers.TestId(_page, "…")` instead.
+
+- [ ] **Step 2: Write the tests**
+
+Create `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignInTests.cs`:
+
+```csharp
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using NUnit.Framework;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+using Sorcha.UI.E2E.Tests.PageObjects;
+
+namespace Sorcha.UI.E2E.Tests.Docker.CitizenWallet;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+[Category("Docker")]
+[Category("CitizenWallet")]
+[Category("Auth")]
+public class CitizenWalletSignInTests : DockerTestBase
+{
+    [Test]
+    public async Task SignedOut_ProtectedRoute_RedirectsToSignIn()
+    {
+        await Page.GotoAsync($"{TestConstants.GatewayBaseUrl}/wallet/devices");
+        await Page.WaitForURLAsync("**/wallet/signin**");
+        await Expect(Page.GetByTestId("signin-screen")).ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task Password_HappyPath_SignsInAndLeavesSignInScreen()
+    {
+        var signIn = new CitizenWalletSignInPage(Page);
+        await signIn.GotoAsync();
+        await signIn.SignInWithPasswordAsync(
+            TestConstants.CitizenTestEmail, TestConstants.CitizenTestPassword);
+        // Lands on home (no longer on /signin).
+        await Page.WaitForURLAsync(url => !url.Contains("/wallet/signin"));
+    }
+
+    [Test]
+    public async Task SocialReturnLeg_StoresTokenAndLeavesSignIn()
+    {
+        // Mint a consumer-tier token out-of-band (helper hits /api/auth/login with
+        // tier=consumer for the seeded citizen) and simulate the social fragment return.
+        var token = await TestTokens.MintConsumerAsync(
+            TestConstants.CitizenTestEmail, TestConstants.CitizenTestPassword);
+        await Page.GotoAsync(
+            $"{TestConstants.GatewayBaseUrl}/wallet/#token={token.AccessToken}&refresh={token.RefreshToken}&expires_in={token.ExpiresIn}");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+        // The fragment is consumed and stripped; we end up authenticated on home.
+        await Expect(Page).Not.ToHaveURLAsync("**/wallet/signin**");
+    }
+
+    [Test]
+    public async Task Passkey_VirtualAuthenticator_SignsIn()
+    {
+        // Register a CDP virtual authenticator with a resident key, then drive the
+        // passkey button. Requires the citizen to have a passkey enrolled server-side
+        // (seed in fixture). See Playwright .NET CDP: "WebAuthn.addVirtualAuthenticator".
+        var client = await Page.Context.NewCDPSessionAsync(Page);
+        await client.SendAsync("WebAuthn.enable");
+        await client.SendAsync("WebAuthn.addVirtualAuthenticator", new()
+        {
+            ["options"] = new Dictionary<string, object>
+            {
+                ["protocol"] = "ctap2",
+                ["transport"] = "internal",
+                ["hasResidentKey"] = true,
+                ["hasUserVerification"] = true,
+                ["isUserVerified"] = true,
+            }
+        });
+
+        var signIn = new CitizenWalletSignInPage(Page);
+        await signIn.GotoAsync();
+        // Passkey button only shows when WebAuthn is supported (virtual authenticator satisfies this).
+        Assert.That(await signIn.PasskeyButton.IsVisibleAsync(), Is.True);
+        // Full assertion requires a server-seeded credential for the virtual authenticator;
+        // if the fixture seeds one, click and assert sign-in; otherwise assert the options
+        // round-trip returns 200 (no server error surfaced).
+    }
+}
+```
+
+> Implementer notes:
+> - `TestTokens.MintConsumerAsync` and `TestConstants.CitizenTestEmail/Password` may need adding to the E2E infrastructure (mirror the existing authenticated-citizen helpers; see the F134 `dev-citizen-test-account` memory for seeding a usable citizen). If an authenticated-citizen base/fixture already exists, reuse it.
+> - The passkey test's full happy path depends on a server-seeded credential bound to the virtual authenticator; if seeding isn't available, keep the support-detection + options-round-trip assertions and mark the full ceremony `[Explicit]`.
+
+- [ ] **Step 3: Run the E2E suite (Docker up)**
+
+```bash
+docker-compose up -d
+dotnet test tests/Sorcha.UI.E2E.Tests --filter "Category=CitizenWallet&Category=Auth" -v minimal
+```
+Expected: redirect + password + social-return tests PASS; passkey test PASS or `[Explicit]`-skipped per seeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletSignInPage.cs tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignInTests.cs
+git commit -m "test: E2E coverage for wallet sign-in (gate, password, social return, passkey)"
+```
+
+---
+
+### Task 18: Documentation sync
+
+**Files:**
+- Modify: `.claude/skills/sorcha-architecture/SKILL.md` (Citizen Wallet PWA section — add the sign-in surface)
+- Modify: `src/Services/Sorcha.Tenant.Service/README.md` (new endpoints: `GET /api/auth/social/providers`, surface param, tier hints)
+- Modify: `docs/reference/API-DOCUMENTATION.md` (the new/changed endpoints)
+
+- [ ] **Step 1: Update the sorcha-architecture skill**
+
+In the Citizen Wallet PWA section, add a short "Sign-in (social + passkey)" subsection documenting: dedicated `/wallet/signin` screen + auth gate; three methods; `surface=wallet` social callback minting Consumer-tier and redirecting to `/wallet/#token=…`; `GET /api/auth/social/providers`; the `tier` hint on `passkey/assertion/verify` and `verify-2fa`; refresh via `POST /api/auth/token/refresh`; login-only refusal (`?authError=no_account`).
+
+- [ ] **Step 2: Update the Tenant Service README + API docs**
+
+Add the new endpoint rows and the `surface`/`tier` request fields.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/sorcha-architecture/SKILL.md src/Services/Sorcha.Tenant.Service/README.md docs/reference/API-DOCUMENTATION.md
+git commit -m "docs: document wallet social + passkey sign-in surface"
+```
+
+---
+
+## Final verification
+
+- [ ] `dotnet build` (solution) succeeds.
+- [ ] `dotnet test tests/Sorcha.Tenant.Service.Tests` green.
+- [ ] `dotnet test tests/Sorcha.Wallet.Pwa.Tests` green.
+- [ ] `docker-compose up -d` then `dotnet test tests/Sorcha.UI.E2E.Tests --filter "Category=CitizenWallet&Category=Auth"` green.
+- [ ] `pwsh scripts/check-no-snackbar.ps1` passes (sign-in screen uses `MudAlert`/`IInlineFeedback`, no `ISnackbar`).
+- [ ] Manual browser pass on the Docker stack: signed-out → `/signin`; password+2FA; passkey; social return; unknown-social → `no_account` message + web-signup link; token expiry → silent refresh.
+```

--- a/docs/superpowers/specs/2026-05-25-pwa-auth-social-passkey-design.md
+++ b/docs/superpowers/specs/2026-05-25-pwa-auth-social-passkey-design.md
@@ -1,0 +1,109 @@
+# Citizen Wallet PWA — Social + Passkey sign-in
+
+- **Date:** 2026-05-25
+- **Status:** Design approved; ready for implementation plan
+- **Surface:** `Sorcha.Wallet.Pwa` (citizen wallet PWA, mounted at `/wallet/`) + small changes in `Sorcha.Tenant.Service`
+- **Related:** F114 (citizen wallet PWA), F116 (account linking / auth-method management), F126/F128 (council enrol gate + cold-start pairing), F136 (tiered-audience JWT identity model)
+
+## Problem
+
+The PWA can only sign a citizen in with **email + password (+ TOTP 2FA)**, and that surface is buried in a card inside `Settings.razor`. There is no signed-out front door at all: `App.razor` uses a plain `<Router>`/`RouteView` (no `AuthorizeRouteView`, no `CascadingAuthenticationState`), so every page is open and unauthenticated callers just hit failing API calls.
+
+We want **passkey** and **social** sign-in alongside password, presented on a dedicated sign-in screen, with the PWA properly gated behind authentication.
+
+Most of the backend already exists (F116): anonymous passkey assertion and social-login endpoints that issue tokens. The bulk of this work is **PWA client-side** plus **two small backend changes** (Consumer-tier minting and a surface-aware social callback).
+
+## Scope
+
+**In scope (v1):**
+- Dedicated sign-in screen at `/signin` with three methods: passkey, social, password (+2FA).
+- An auth gate: signed-out access to a protected route redirects to `/signin?returnUrl=…`.
+- Social providers: Google, Apple, Microsoft, GitHub — rendered **dynamically** from whichever are enabled per deployment.
+- Refresh tokens stored + silent renewal.
+
+**Out of scope:**
+- **Sign-up / new-account creation** in the PWA. Login only — accounts are created via the council enrol gate (F126), pairing (F128), or web signup. An unknown social identity is **refused** (with a link to web signup), never auto-created.
+- Auth-method *management* in the PWA (the `AuthMethods.razor` stub stays a stub for now; F116's management surface migration is a separate effort).
+- Popup/`postMessage` social flow (full-page redirect only in v1).
+
+## Locked decisions
+
+1. **Login only.** No PWA signup; unknown social identity → "Sorry, no account" + link to the Tenant `/auth/signup` page. No silent account creation.
+2. **Dedicated sign-in screen + auth gate** (not an enhanced Settings card).
+3. **Social return = surface-aware callback redirect** (Approach A). The single fixed OAuth `redirect_uri` (`/auth/social/callback`) is preserved; the PWA's `initiate` carries `surface=wallet`, threaded through OAuth `state`, and the existing Razor callback mints a Consumer-tier token and redirects to `/wallet/#token=…&refresh=…`.
+4. **Every PWA sign-in path requests Consumer tier.** Requesting `consumer` is a safe downgrade (never an escalation), so the server honors it without an entitlement fight (F136). This also fixes a latent bug: the PWA password login currently sends no tier hint and therefore mints a **Platform**-tier token, which F136 refuses on `/api/v1/wallet/*`.
+5. **Refresh tokens + silent renewal** are in v1.
+6. **Ordering with F128:** auth gate first (must be signed in) → `PairingTakeover` (device-presence gate) fires after sign-in for citizens with no device.
+
+## Architecture & components
+
+### `Sorcha.Wallet.Pwa`
+
+- **`Pages/SignIn.razor`** (`@page "/signin"`) — the dedicated screen. Passkey button (hidden when WebAuthn unsupported), dynamic social row (only enabled providers), email + password with the existing 2FA step, and an inline error region. **Visual/layout follows provided screenshots**; this doc fixes the structure underneath.
+- **Auth gate** — introduce the idiomatic Blazor path the PWA currently lacks:
+  - A token-backed `AuthenticationStateProvider` (modeled on `CustomAuthenticationStateProvider` in `Sorcha.UI.Components.User`) that reads `IAccessTokenStore`.
+  - `<CascadingAuthenticationState>` in `App.razor`; switch `RouteView` → `AuthorizeRouteView`.
+  - `[Authorize]` on protected pages; `NotAuthorized` redirects to `/signin?returnUrl=…` (base-relative nav — PWA path-prefix rule).
+- **`IAuthService` / `AuthService`** gains:
+  - `SignInWithPasskeyAsync(string? email = null)` — discoverable-first.
+  - `BeginSocialSignInAsync(string provider)` — calls `initiate {surface:"wallet"}`, full-page nav to the returned authorization URL.
+  - `CompleteSocialReturnAsync()` — the fragment handler (parse `#token`/`#refresh`, persist, strip fragment).
+  - Password path adds `tier:"consumer"` to the request.
+- **`PasskeyInteropService`** + **`wwwroot/js/webauthn.js`** — ported from `Sorcha.UI.Web.Client` (copy for v1; candidate to move into the shared lib later). Wrapped behind an interface so unit tests use an in-memory fake.
+- **Fragment-before-gate bootstrap.** App startup parses and stores any `#token`/`#refresh` fragment **before** the auth gate evaluates, so a returning social user is not bounced to `/signin` with the token still in the URL fragment. (Mirrors the existing `/app` web-client behaviour.)
+- **Refresh / silent renewal.** Store the refresh token (IndexedDB, alongside the access token record). `BearerTokenHandler` gains a 401 → refresh (`POST /api/auth/token/refresh`, body `{refreshToken}`; re-mints the same tier per F136, so a Consumer refresh stays Consumer) → retry path; refresh failure → sign out + `/signin`. `AccessTokenRecord` / the login response DTOs are extended to capture the refresh token.
+
+### `Sorcha.Tenant.Service`
+
+- **Social initiate** (`SocialLoginInitiateRequest`): add optional `Surface` (allowlist: e.g. `wallet` | `app`; default app/none). `ISocialLoginService.GenerateAuthorizationUrlAsync` + the cached state persist `surface`. `SocialAuthCallbackResult` carries it back from `ExchangeCodeAsync`.
+- **Social callback** (`SocialCallbackModel.OnGetAsync`): when `surface=="wallet"` →
+  - mint **Consumer-tier** (`GenerateUserTokenAsync(..., tier: Tier.Consumer)`),
+  - **login-only:** resolve existing accounts only (including match-by-verified-email per the F115 strict-link policy); if the identity maps to no existing account, render a refusal page with a link to `/auth/signup` rather than creating one,
+  - redirect to `/wallet/#token=…&refresh=…` (the F128 SetupAddDevice routing gate still applies, but targeting `/wallet`),
+  - on failure/refusal, redirect to `/wallet/signin?authError=…` so errors render in the PWA's look.
+- **Passkey assertion verify** (`PublicPasskeyAssertionVerifyRequest` + handler): add an optional tier hint; pass `Tier.Consumer` when requested (today it hardcodes the Platform default).
+- **Tier through 2FA:** ensure the tier preference set at `/api/auth/login` time rides through the `loginToken` into `verify-2fa` so 2FA completion also mints Consumer.
+
+## Method flows
+
+**Password (+2FA):** unchanged except the PWA `LoginRequest` sends `tier:"consumer"`; tier preference carried through `loginToken` → `verify-2fa`.
+
+**Passkey:** `POST /api/auth/passkey/assertion/options` (no email → discoverable; email entry as fallback) → `PasskeyInteropService.GetCredentialAsync()` runs `navigator.credentials.get()` → `POST /api/auth/passkey/assertion/verify {transactionId, assertionResponse, tier:"consumer"}` → store Consumer token (+ refresh).
+
+**Social:** `POST /api/auth/social/initiate {provider, surface:"wallet"}` → full-page nav to provider → fixed `/auth/social/callback` Razor page (reads surface, mints Consumer, applies login-only refusal) → redirect `/wallet/#token=…&refresh=…` → PWA fragment handler stores the token and routes to `returnUrl`/home.
+
+## Auth-gate scope
+
+**Public (reachable signed-out):** `/signin`, `/enrol` (redeems the `?session=` token from F126/F128 — both an onboarding and a sign-in path; gating it would deadlock first-token acquisition), `CancelledEnrolment`, and the social-return landing (`/wallet/#token=…`).
+
+**Protected (redirect to `/signin?returnUrl=…`):** Home, Devices, Activity, Settings, Profile, Present, Applications, ApplicationInstance, CredentialDetail, Verify. Settings becomes protected — the sign-in card moves out to `/signin`; sign-out stays in Settings.
+
+## Error handling / edge cases
+
+- **Passkey:** `IsWebAuthnSupportedAsync()` → hide the button on unsupported browsers; user-cancel / no discoverable credential → inline message + email fallback.
+- **Social:** failures/refusals for `surface=wallet` → `/wallet/signin?authError=…`; the "no account" refusal carries the web-signup link.
+- **Token expiry:** silent refresh in `BearerTokenHandler`; refresh failure → sign out + `/signin`.
+- **Feedback surface:** `IInlineFeedback` / inline `MudAlert` only — no `ISnackbar` (platform rule, CI-gated).
+- **Sign-out:** existing per-device wipe is preserved; the new `AuthenticationStateProvider` must reflect sign-out so the gate re-engages.
+- F128 `PairingTakeover` ordering unchanged.
+
+## Testing
+
+**PWA unit / bUnit:** `SignIn.razor` shows the correct methods (passkey hidden when unsupported; only enabled providers); `AuthService` methods with a stubbed `HttpMessageHandler` and an in-memory passkey-interop fake (never mock `IJSRuntime.InvokeAsync<T>` directly — F114 lesson); assert password login sends `tier:"consumer"`; fragment handler parses and persists.
+
+**Backend unit (`Sorcha.Tenant.Service.Tests`, reflection-based static-handler pattern):** assertion-verify mints Consumer on tier hint; social `initiate` persists `surface`; `SocialCallbackModel` branches tier + redirect on `surface=="wallet"`; login-only refusal (`IsNew` + `surface=wallet`) renders the signup link; `surface` allowlist rejects unknown values.
+
+**E2E (`Sorcha.UI.E2E.Tests/Docker/CitizenWallet/`):** new `CitizenWalletSignInPage` page object, `data-testid` on every control. Cases: signed-out hit on a protected route → redirect to `/signin?returnUrl=…`; password happy path → authenticated + a wallet API call succeeds (proves Consumer tier); passkey via Playwright CDP **virtual authenticator**; social **return** leg deterministically (navigate to `/wallet/#token=<minted-consumer-token>&refresh=…`, assert store + land home) with the provider leg mocked/unit-covered; auto console-error / 5xx / CSS-health from the base classes; new routes use base-relative nav; sign-out wipe regression guard still passes.
+
+**Manual:** Docker stack, golden path + edges (cancel passkey, unknown social → refusal + link, expiry → silent refresh) in a browser.
+
+## Follow-ups / not-now
+
+- Popup/`postMessage` social flow (desktop polish).
+- Move `webauthn.js` + passkey interop into the shared `Sorcha.UI.Components.User` library if/when the web client and PWA converge.
+- Auth-method management surface migration into the PWA (`AuthMethods.razor`).
+
+## Implementation notes
+
+- Land on a dedicated branch off `master` (current working branch `138-federation-trust-hardening` is unrelated).
+- `SignIn.razor` visual/layout to be finalised against provided screenshots at build time.

--- a/src/Apps/Sorcha.Wallet.Pwa/App.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/App.razor
@@ -2,15 +2,24 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 *@
-<Router AppAssembly="@typeof(App).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-    <NotFound>
-        <PageTitle>Not found</PageTitle>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+@using Microsoft.AspNetCore.Components.Authorization
+@using Sorcha.Wallet.Pwa.Components
+
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToSignIn />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+        <NotFound>
+            <PageTitle>Not found</PageTitle>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p role="alert">Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor
@@ -1,0 +1,20 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Auth-gate NotAuthorized target. Sends signed-out citizens to the dedicated
+    sign-in screen, preserving where they were headed via returnUrl. Base-relative
+    nav — the PWA is mounted under /wallet/.
+*@
+@inject NavigationManager Nav
+
+@code {
+    protected override void OnInitialized()
+    {
+        var returnUrl = Nav.ToBaseRelativePath(Nav.Uri);
+        var target = string.IsNullOrEmpty(returnUrl) || returnUrl.StartsWith("signin")
+            ? "signin"
+            : $"signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
+        Nav.NavigateTo(target);
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Components/RedirectToSignIn.razor
@@ -12,7 +12,10 @@
     protected override void OnInitialized()
     {
         var returnUrl = Nav.ToBaseRelativePath(Nav.Uri);
-        var target = string.IsNullOrEmpty(returnUrl) || returnUrl.StartsWith("signin")
+        var alreadyOnSignIn = returnUrl.Equals("signin", StringComparison.OrdinalIgnoreCase)
+            || returnUrl.StartsWith("signin?", StringComparison.OrdinalIgnoreCase)
+            || returnUrl.StartsWith("signin/", StringComparison.OrdinalIgnoreCase);
+        var target = string.IsNullOrEmpty(returnUrl) || alreadyOnSignIn
             ? "signin"
             : $"signin?returnUrl={Uri.EscapeDataString(returnUrl)}";
         Nav.NavigateTo(target);

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -119,16 +119,16 @@ public static class ServiceCollectionExtensions
         // instead of mocking IJSRuntime (brittle — F114 lesson).
         services.AddSingleton<IPasskeyInterop, PasskeyInterop>();
 
-        // Auth surface: a separate HttpClient that does NOT inject the bearer
-        // token (so sign-in requests don't carry stale tokens). Still observes
-        // the server clock — sign-in is a great moment to capture initial drift.
-
-        // Unauthenticated client used ONLY by BearerTokenHandler to refresh — it
-        // MUST NOT itself carry BearerTokenHandler (that would recurse infinitely on 401).
+        // Unauthenticated client used ONLY by BearerTokenHandler to refresh — must NOT carry the
+        // bearer handler (no recursion).
         services.AddHttpClient("AuthRefresh", c => c.BaseAddress = new Uri(gatewayBaseAddress));
         services.AddTransient(sp => new BearerTokenHandler(
             sp.GetRequiredService<IAccessTokenStore>(),
             sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthRefresh")));
+
+        // Auth surface: a separate HttpClient that does NOT inject the bearer token
+        // (so sign-in requests don't carry stale tokens). Still observes the server
+        // clock — sign-in is a great moment to capture initial drift.
         services.AddHttpClient<IAuthService, AuthService>(c =>
             c.BaseAddress = new Uri(gatewayBaseAddress))
             .AddHttpMessageHandler<ServerClockHandler>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -122,7 +122,13 @@ public static class ServiceCollectionExtensions
         // Auth surface: a separate HttpClient that does NOT inject the bearer
         // token (so sign-in requests don't carry stale tokens). Still observes
         // the server clock — sign-in is a great moment to capture initial drift.
-        services.AddTransient<BearerTokenHandler>();
+
+        // Unauthenticated client used ONLY by BearerTokenHandler to refresh — it
+        // MUST NOT itself carry BearerTokenHandler (that would recurse infinitely on 401).
+        services.AddHttpClient("AuthRefresh", c => c.BaseAddress = new Uri(gatewayBaseAddress));
+        services.AddTransient(sp => new BearerTokenHandler(
+            sp.GetRequiredService<IAccessTokenStore>(),
+            sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthRefresh")));
         services.AddHttpClient<IAuthService, AuthService>(c =>
             c.BaseAddress = new Uri(gatewayBaseAddress))
             .AddHttpMessageHandler<ServerClockHandler>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IStatusListService, IndexedDbStatusListService>();
         services.AddSingleton<ISyncCursorStore, IndexedDbSyncCursorStore>();
         services.AddSingleton<IAccessTokenStore, IndexedDbAccessTokenStore>();
+        services.AddSingleton<WalletAuthenticationStateProvider>();
+        services.AddSingleton<Microsoft.AspNetCore.Components.Authorization.AuthenticationStateProvider>(
+            sp => sp.GetRequiredService<WalletAuthenticationStateProvider>());
         services.AddSingleton<ISyncService, SyncService>();
         services.AddSingleton<IDeviceMetaStore, IndexedDbDeviceMetaStore>();
         services.AddSingleton<IEnrolmentService, EnrolmentService>();

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -183,6 +183,12 @@ public static class ServiceCollectionExtensions
             c.BaseAddress = new Uri(gatewayBaseAddress))
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // Social sign-in provider list (anonymous endpoint — no bearer token).
+        // Still observes the server clock for consistency with other unauthenticated calls.
+        services.AddHttpClient<ISocialProvidersClient, SocialProvidersClient>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 125 / PR-B — user context (active org) + memberships client.
         // ManagedUserContext drives /api/auth/switch-org through the bearer-
         // and clock-handler chain so the new JWT is acquired with the

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -114,6 +114,11 @@ public static class ServiceCollectionExtensions
         // welcome/tour flags behind for the next user on the device.
         services.AddSingleton<ILocalDataPurge, IndexedDbLocalDataPurge>();
 
+        // WebAuthn ceremony bridge for the wallet sign-in screen (Feature 138).
+        // Behind IPasskeyInterop so AuthService unit tests use FakePasskeyInterop
+        // instead of mocking IJSRuntime (brittle — F114 lesson).
+        services.AddSingleton<IPasskeyInterop, PasskeyInterop>();
+
         // Auth surface: a separate HttpClient that does NOT inject the bearer
         // token (so sign-in requests don't carry stale tokens). Still observes
         // the server clock — sign-in is a great moment to capture initial drift.

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -11,6 +11,7 @@
     active organisational context is always visible. The chip is non-
     interactive when the user only holds the Personal context.
 *@
+@using Microsoft.AspNetCore.Components.Authorization
 @using Sorcha.UI.Components.User.Components.Context
 @using Sorcha.UI.Components.User.Components.Onboarding
 @using Sorcha.UI.Core.Components.Inbox
@@ -39,8 +40,14 @@
    full-screen overlay covers nav + content uniformly when an unpaired
    signed-in citizen lands in the wallet. The component self-gates on
    IHasPairedDeviceProbe and dismisses on local OR remote pair-success
-   via the CitizenWalletHub OnDeviceEnrolled event. *@
-<PairingTakeover />
+   via the CitizenWalletHub OnDeviceEnrolled event.
+   AuthorizeView ensures the takeover is suppressed entirely for signed-out
+   users (e.g. the /signin page) so the sign-in screen is never obscured. *@
+<AuthorizeView>
+    <Authorized>
+        <PairingTakeover />
+    </Authorized>
+</AuthorizeView>
 
 <MudLayout>
     <MudAppBar Elevation="1">

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Activity.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Activity.razor
@@ -24,6 +24,8 @@
 *@
 @page "/activity"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using MudBlazor
 @using Sorcha.UI.Components.User.Components.History
 @using Sorcha.Wallet.Pwa.Services

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/ApplicationInstance.razor
@@ -13,6 +13,8 @@
 *@
 @page "/applications/{InstanceId:guid}"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Sorcha.UI.Core.Components.Forms
 @using Sorcha.UI.Core.Models.Forms
 @using Sorcha.Wallet.Pwa.Services

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Applications.razor
@@ -11,6 +11,8 @@
 *@
 @page "/applications"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Sorcha.Wallet.Pwa.Services.Context
 @inject IUserContext UserContext
 @inject NavigationManager Nav

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
@@ -11,6 +11,8 @@
 *@
 @page "/credentials/{Id:guid}"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Presentation
 @inject ICredentialCache Credentials

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Devices.razor
@@ -15,6 +15,8 @@
 *@
 @page "/devices"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Sorcha.CitizenWallet.Abstractions.Models
 @using Sorcha.ServiceClients.CitizenWallet
 @using Sorcha.UI.Core.Services.Feedback

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
@@ -9,6 +9,8 @@
 *@
 @page "/"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using System.Net.Http
 @using System.Net.Http.Json
 @using System.Text.Json

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Present.razor
@@ -10,6 +10,8 @@
 *@
 @page "/present"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @implements IAsyncDisposable
 @using System.Net.Http
 @using System.Net.Http.Json

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Profile.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Profile.razor
@@ -10,6 +10,8 @@
 *@
 @page "/profile"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Sorcha.Wallet.Pwa.Services.Context
 @inject IUserContext UserContext
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
@@ -9,6 +9,8 @@
 *@
 @page "/settings"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Microsoft.JSInterop
 @using Sorcha.Wallet.Pwa.Services
 @inject IJSRuntime Js

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
@@ -18,6 +18,7 @@
 @inject NavigationManager Nav
 @inject IWalletFlagsStore WalletFlags
 @inject ILogger<Settings> Logger
+@inject WalletAuthenticationStateProvider AuthState
 
 <PageTitle>Settings</PageTitle>
 
@@ -95,74 +96,18 @@
         <MudCardContent>
             @if (_signedInEmail is not null)
             {
-                <MudText Typo="Typo.body2" Class="mb-2">
-                    Signed in as <strong>@_signedInEmail</strong>
-                </MudText>
-                <MudButton StartIcon="@Icons.Material.Filled.Logout"
-                           Variant="Variant.Outlined" Color="Color.Error"
-                           OnClick="SignOutAsync">
+                <MudText Typo="Typo.body2" Class="mb-2">Signed in as <strong>@_signedInEmail</strong></MudText>
+                <MudButton StartIcon="@Icons.Material.Filled.Logout" Variant="Variant.Outlined"
+                           Color="Color.Error" OnClick="SignOutAsync" data-testid="settings-signout">
                     Sign out
                 </MudButton>
             }
-            else if (_awaitingTwoFactor)
-            {
-                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-2">
-                    @(_useBackupCode
-                        ? "Enter one of your backup codes."
-                        : "Enter the 6-digit code from your authenticator app.")
-                </MudText>
-                <MudTextField @bind-Value="_twoFactorCode"
-                              Label="@(_useBackupCode ? "Backup code" : "Authenticator code")"
-                              Variant="Variant.Outlined" Margin="Margin.Dense"
-                              Class="mb-2" Immediate="true"
-                              MaxLength="@(_useBackupCode ? 12 : 6)"
-                              InputMode="@(_useBackupCode ? InputMode.text : InputMode.numeric)" />
-                <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                           OnClick="VerifyTwoFactorAsync"
-                           Disabled="@(_signingIn || string.IsNullOrWhiteSpace(_twoFactorCode))"
-                           FullWidth="true">
-                    @(_signingIn ? "Verifying…" : "Verify")
-                </MudButton>
-                <div class="d-flex justify-space-between mt-2">
-                    <MudButton Variant="Variant.Text" Size="Size.Small"
-                               OnClick="@(() => { _useBackupCode = !_useBackupCode; _twoFactorCode = string.Empty; })"
-                               Disabled="@_signingIn">
-                        @(_useBackupCode ? "Use authenticator code" : "Use a backup code")
-                    </MudButton>
-                    <MudButton Variant="Variant.Text" Size="Size.Small" OnClick="CancelTwoFactor"
-                               Disabled="@_signingIn">
-                        Cancel
-                    </MudButton>
-                </div>
-                @if (!string.IsNullOrEmpty(_signInError))
-                {
-                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">
-                        @_signInError
-                    </MudAlert>
-                }
-            }
             else
             {
-                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-2">
-                    Sign in to sync your credentials. Full enrolment wizard
-                    (device labelling, key gen, /devices/enrol) lands next.
-                </MudText>
-                <MudTextField @bind-Value="_email" Label="Email"
-                              Variant="Variant.Outlined" Margin="Margin.Dense"
-                              Class="mb-2" InputType="InputType.Email" />
-                <MudTextField @bind-Value="_password" Label="Password"
-                              Variant="Variant.Outlined" Margin="Margin.Dense"
-                              Class="mb-2" InputType="InputType.Password" />
                 <MudButton Variant="Variant.Filled" Color="Color.Primary"
-                           OnClick="SignInAsync" Disabled="@_signingIn" FullWidth="true">
-                    @(_signingIn ? "Signing in…" : "Sign in")
+                           OnClick="@(() => Nav.NavigateTo("signin"))" data-testid="settings-signin-link">
+                    Sign in
                 </MudButton>
-                @if (!string.IsNullOrEmpty(_signInError))
-                {
-                    <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">
-                        @_signInError
-                    </MudAlert>
-                }
             }
         </MudCardContent>
     </MudCard>
@@ -227,108 +172,10 @@
 
     private StorageInfo? _storage;
     private string? _signedInEmail;
-    private string _email = string.Empty;
-    private string _password = string.Empty;
-    private string? _signInError;
-    private bool _signingIn;
-
-    // 2FA step state.
-    private bool _awaitingTwoFactor;
-    private string? _loginToken;
-    private string _twoFactorCode = string.Empty;
-    private bool _useBackupCode;
 
     protected override async Task OnInitializedAsync()
     {
         _signedInEmail = await Auth.GetSignedInEmailAsync();
-    }
-
-    private async Task SignInAsync()
-    {
-        _signInError = null;
-        if (string.IsNullOrWhiteSpace(_email) || string.IsNullOrWhiteSpace(_password))
-        {
-            _signInError = "Email and password are required.";
-            return;
-        }
-        _signingIn = true;
-        try
-        {
-            var result = await Auth.SignInAsync(_email, _password);
-            if (result.IsSuccess)
-            {
-                _signedInEmail = await Auth.GetSignedInEmailAsync();
-                _password = string.Empty;
-            }
-            else if (result.Status == SignInStatus.TwoFactorRequired)
-            {
-                // Hold the password-derived login token and switch to the TOTP step.
-                _loginToken = result.LoginToken;
-                _awaitingTwoFactor = true;
-                _twoFactorCode = string.Empty;
-                _useBackupCode = false;
-                _password = string.Empty;
-            }
-            else
-            {
-                _signInError = result.ErrorMessage ?? "Sign-in failed.";
-            }
-        }
-        catch (Exception ex)
-        {
-            _signInError = ex.Message;
-            Logger.LogError(ex, "Sign-in threw");
-        }
-        finally
-        {
-            _signingIn = false;
-        }
-    }
-
-    private async Task VerifyTwoFactorAsync()
-    {
-        _signInError = null;
-        if (string.IsNullOrWhiteSpace(_loginToken))
-        {
-            // Login token lost (shouldn't happen) — restart sign-in.
-            CancelTwoFactor();
-            return;
-        }
-        _signingIn = true;
-        try
-        {
-            var result = await Auth.VerifyTwoFactorAsync(
-                _loginToken, _email, _twoFactorCode, _useBackupCode);
-            if (result.IsSuccess)
-            {
-                _signedInEmail = await Auth.GetSignedInEmailAsync();
-                CancelTwoFactor();
-            }
-            else
-            {
-                // 401 keeps us on the step with a retry message; other errors surface too.
-                _signInError = result.ErrorMessage ?? "Verification failed.";
-                _twoFactorCode = string.Empty;
-            }
-        }
-        catch (Exception ex)
-        {
-            _signInError = ex.Message;
-            Logger.LogError(ex, "2FA verify threw");
-        }
-        finally
-        {
-            _signingIn = false;
-        }
-    }
-
-    private void CancelTwoFactor()
-    {
-        _awaitingTwoFactor = false;
-        _loginToken = null;
-        _twoFactorCode = string.Empty;
-        _useBackupCode = false;
-        _signInError = null;
     }
 
     private async Task SignOutAsync()
@@ -336,6 +183,7 @@
         // Clears the token + wipes every per-device IndexedDB store.
         await Auth.SignOutAsync();
         _signedInEmail = null;
+        AuthState.NotifyChanged();
         // Force-reload to home (base-relative — the PWA is mounted under /wallet/)
         // so singleton state held in memory — the hub connection, the paired-device
         // probe cache, the active-context — is re-initialised clean for the next user.

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor
@@ -1,0 +1,210 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Dedicated wallet sign-in screen. Login only — signup is via council enrol,
+    pairing, or web. Three methods: passkey, social (dynamic providers), password
+    (+ TOTP 2FA). Visual/layout follows the design screenshots; wiring is final.
+    PUBLIC route (no [Authorize]) — this is the gate's redirect target.
+*@
+@page "/signin"
+@layout MainLayout
+@using Microsoft.JSInterop
+@using Sorcha.Wallet.Pwa.Services
+@inject IAuthService Auth
+@inject IPasskeyInterop Passkey
+@inject ISocialProvidersClient Providers
+@inject WalletAuthenticationStateProvider AuthState
+@inject NavigationManager Nav
+@inject IJSRuntime Js
+
+<PageTitle>Sign in · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraSmall" Class="mt-8">
+    <MudStack Spacing="3" data-testid="signin-screen">
+        <MudText Typo="Typo.h5" Align="Align.Center">Sign in to your wallet</MudText>
+
+        @if (!string.IsNullOrEmpty(_error))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" data-testid="signin-error">@_error</MudAlert>
+        }
+
+        @if (!_awaitingTwoFactor)
+        {
+            @if (_passkeySupported)
+            {
+                <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Fingerprint"
+                           OnClick="SignInWithPasskeyAsync" Disabled="@_busy"
+                           data-testid="signin-passkey">
+                    Sign in with a passkey
+                </MudButton>
+            }
+
+            @foreach (var provider in _providers)
+            {
+                <MudButton FullWidth="true" Variant="Variant.Outlined"
+                           OnClick="@(() => BeginSocialAsync(provider))" Disabled="@_busy"
+                           data-testid="@($"signin-social-{provider.ToLowerInvariant()}")">
+                    Continue with @provider
+                </MudButton>
+            }
+
+            <MudDivider Class="my-2" />
+
+            <MudTextField @bind-Value="_email" Label="Email" InputType="InputType.Email"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" data-testid="signin-email" />
+            <MudTextField @bind-Value="_password" Label="Password" InputType="InputType.Password"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" data-testid="signin-password" />
+            <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
+                       OnClick="SignInWithPasswordAsync" Disabled="@_busy" data-testid="signin-password-submit">
+                @(_busy ? "Signing in…" : "Sign in")
+            </MudButton>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                Enter the 6-digit code from your authenticator app.
+            </MudText>
+            <MudTextField @bind-Value="_twoFactorCode" Label="Authenticator code"
+                          Variant="Variant.Outlined" Margin="Margin.Dense" MaxLength="6"
+                          InputMode="InputMode.numeric" data-testid="signin-2fa-code" />
+            <MudButton FullWidth="true" Variant="Variant.Filled" Color="Color.Primary"
+                       OnClick="VerifyTwoFactorAsync"
+                       Disabled="@(_busy || string.IsNullOrWhiteSpace(_twoFactorCode))"
+                       data-testid="signin-2fa-submit">
+                @(_busy ? "Verifying…" : "Verify")
+            </MudButton>
+            <MudButton FullWidth="true" Variant="Variant.Text" OnClick="CancelTwoFactor" Disabled="@_busy">
+                Cancel
+            </MudButton>
+        }
+    </MudStack>
+</MudContainer>
+
+@code {
+    [SupplyParameterFromQuery] public string? ReturnUrl { get; set; }
+    [SupplyParameterFromQuery] public string? AuthError { get; set; }
+
+    private string _email = string.Empty;
+    private string _password = string.Empty;
+    private string? _error;
+    private bool _busy;
+    private bool _passkeySupported;
+    private IReadOnlyList<string> _providers = [];
+
+    private bool _awaitingTwoFactor;
+    private string? _loginToken;
+    private string _twoFactorCode = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // A social return may have staged a token in the URL fragment (auth-fragment.js).
+        if (await Auth.TryConsumeSocialReturnAsync(Js))
+        {
+            AuthState.NotifyChanged();
+            NavigateOnSuccess();
+            return;
+        }
+
+        if (await Auth.IsSignedInAsync())
+        {
+            NavigateOnSuccess();
+            return;
+        }
+
+        _error = MapAuthError(AuthError);
+        _providers = await Providers.GetConfiguredAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+        // Hide the passkey button on browsers without WebAuthn.
+        _passkeySupported = await Passkey.IsSupportedAsync();
+        StateHasChanged();
+    }
+
+    private static string? MapAuthError(string? code) => code switch
+    {
+        null or "" => null,
+        "no_account" => "No Sorcha account is linked to that sign-in. Create one on the web, then come back.",
+        "refused" => "That sign-in was refused. Please try another method.",
+        _ => "Sign-in failed. Please try again.",
+    };
+
+    private void NavigateOnSuccess()
+    {
+        var target = string.IsNullOrEmpty(ReturnUrl) ? "" : ReturnUrl!;
+        Nav.NavigateTo(target);
+    }
+
+    private async Task SignInWithPasskeyAsync()
+    {
+        _error = null; _busy = true;
+        try
+        {
+            var result = await Auth.SignInWithPasskeyAsync();
+            await HandleResult(result);
+        }
+        finally { _busy = false; }
+    }
+
+    private async Task BeginSocialAsync(string provider)
+    {
+        _error = null; _busy = true;
+        var url = await Auth.BeginSocialSignInAsync(provider);
+        if (string.IsNullOrEmpty(url)) { _error = "Couldn't start social sign-in."; _busy = false; return; }
+        Nav.NavigateTo(url, forceLoad: true); // full-page to the provider
+    }
+
+    private async Task SignInWithPasswordAsync()
+    {
+        _error = null;
+        if (string.IsNullOrWhiteSpace(_email) || string.IsNullOrWhiteSpace(_password))
+        { _error = "Email and password are required."; return; }
+        _busy = true;
+        try
+        {
+            var result = await Auth.SignInAsync(_email, _password);
+            if (result.Status == SignInStatus.TwoFactorRequired)
+            {
+                _loginToken = result.LoginToken; _awaitingTwoFactor = true; _password = string.Empty;
+                return;
+            }
+            await HandleResult(result);
+        }
+        finally { _busy = false; }
+    }
+
+    private async Task VerifyTwoFactorAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_loginToken)) { CancelTwoFactor(); return; }
+        _error = null; _busy = true;
+        try
+        {
+            var result = await Auth.VerifyTwoFactorAsync(_loginToken, _email, _twoFactorCode);
+            if (!result.IsSuccess) { _error = result.ErrorMessage ?? "Verification failed."; _twoFactorCode = string.Empty; return; }
+            await HandleResult(result);
+        }
+        finally { _busy = false; }
+    }
+
+    private void CancelTwoFactor()
+    {
+        _awaitingTwoFactor = false; _loginToken = null; _twoFactorCode = string.Empty; _error = null;
+    }
+
+    private async Task HandleResult(SignInResult result)
+    {
+        if (result.IsSuccess)
+        {
+            AuthState.NotifyChanged();
+            NavigateOnSuccess();
+        }
+        else
+        {
+            _error = result.ErrorMessage ?? "Sign-in failed.";
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Verify.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Verify.razor
@@ -9,6 +9,8 @@
 *@
 @page "/verify"
 @layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 @using Sorcha.UI.Components.User.Components.Verify
 @using Sorcha.UI.Components.User.Models.Verification
 @using Sorcha.Wallet.Pwa.Services

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
@@ -62,6 +62,9 @@ public sealed class BearerTokenHandler : DelegatingHandler
         return await base.SendAsync(retry, ct);
     }
 
+    // No refresh lock: WASM is single-threaded. Concurrent 401s can interleave across awaits and
+    // double-refresh, but rotating-token servers grant a grace window, so the worst case is one
+    // wasteful refresh call — not a stuck session. A SemaphoreSlim guard isn't worth the complexity here.
     private async Task<AccessTokenRecord?> TryRefreshAsync(
         string refreshToken, string? email, CancellationToken ct)
     {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
@@ -1,37 +1,109 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 
 namespace Sorcha.Wallet.Pwa.Services;
 
 /// <summary>
-/// HTTP message handler that attaches the wallet's stored bearer token to
-/// every outbound request. Sits at the head of the <see cref="HttpClient"/>
-/// pipeline used by <see cref="Sorcha.ServiceClients.CitizenWallet.ICitizenWalletClient"/>
-/// and the demo-mint helper. If the token store is empty, requests go out
-/// unauthenticated and the server returns 401 — that's the trigger for the
-/// UI to surface the sign-in prompt (Feature 114, T109 foundation).
+/// Attaches the wallet's bearer token to every outbound request. On a 401 with a
+/// stored refresh token, transparently refreshes once (POST /api/auth/token/refresh —
+/// re-mints the same tier per F136, so a Consumer refresh stays Consumer) and
+/// retries. A failed refresh clears the session so the gate sends the citizen to
+/// /signin on the next navigation.
 /// </summary>
 public sealed class BearerTokenHandler : DelegatingHandler
 {
     private readonly IAccessTokenStore _store;
+    private readonly HttpClient _refreshHttp;
 
     /// <summary>Initialises a new instance.</summary>
-    public BearerTokenHandler(IAccessTokenStore store)
+    /// <param name="store">The token store that holds the citizen's JWT and refresh token.</param>
+    /// <param name="refreshHttp">
+    /// An <see cref="HttpClient"/> pre-configured with the gateway base address used ONLY
+    /// for the refresh call. This client MUST NOT have <see cref="BearerTokenHandler"/>
+    /// in its pipeline — adding it would create infinite recursion on 401.
+    /// </param>
+    public BearerTokenHandler(IAccessTokenStore store, HttpClient refreshHttp)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
+        _refreshHttp = refreshHttp ?? throw new ArgumentNullException(nameof(refreshHttp));
     }
 
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request, CancellationToken cancellationToken)
+        HttpRequestMessage request, CancellationToken ct)
     {
-        var record = await _store.GetAsync(cancellationToken);
+        var record = await _store.GetAsync(ct);
         if (record is not null && !string.IsNullOrEmpty(record.AccessToken))
-        {
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", record.AccessToken);
+
+        var response = await base.SendAsync(request, ct);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized
+            || string.IsNullOrEmpty(record?.RefreshToken))
+        {
+            return response;
         }
-        return await base.SendAsync(request, cancellationToken);
+
+        var refreshed = await TryRefreshAsync(record.RefreshToken, record.Email, ct);
+        if (refreshed is null)
+        {
+            await _store.ClearAsync(ct); // gate redirects to /signin on next navigation
+            return response;
+        }
+
+        response.Dispose();
+        var retry = await CloneAsync(request, ct);
+        retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+        return await base.SendAsync(retry, ct);
     }
+
+    private async Task<AccessTokenRecord?> TryRefreshAsync(
+        string refreshToken, string? email, CancellationToken ct)
+    {
+        try
+        {
+            var resp = await _refreshHttp.PostAsJsonAsync(
+                "api/auth/token/refresh", new RefreshBody(refreshToken), ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var body = await resp.Content.ReadFromJsonAsync<RefreshResponse>(ct);
+            if (body is null || string.IsNullOrEmpty(body.AccessToken)) return null;
+
+            var record = new AccessTokenRecord(
+                body.AccessToken,
+                DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, body.ExpiresIn)),
+                email,
+                string.IsNullOrEmpty(body.RefreshToken) ? refreshToken : body.RefreshToken);
+            await _store.SetAsync(record, ct);
+            return record;
+        }
+        catch { return null; }
+    }
+
+    private static async Task<HttpRequestMessage> CloneAsync(
+        HttpRequestMessage req, CancellationToken ct)
+    {
+        var clone = new HttpRequestMessage(req.Method, req.RequestUri) { Version = req.Version };
+        foreach (var h in req.Headers) clone.Headers.TryAddWithoutValidation(h.Key, h.Value);
+        if (req.Content is not null)
+        {
+            var bytes = await req.Content.ReadAsByteArrayAsync(ct);
+            clone.Content = new ByteArrayContent(bytes);
+            foreach (var h in req.Content.Headers)
+                clone.Content.Headers.TryAddWithoutValidation(h.Key, h.Value);
+        }
+        return clone;
+    }
+
+    private sealed record RefreshBody(
+        [property: JsonPropertyName("refreshToken")] string RefreshToken);
+
+    private sealed record RefreshResponse(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAccessTokenStore.cs
@@ -28,7 +28,8 @@ public interface IAccessTokenStore
 /// <param name="AccessToken">JWT access token.</param>
 /// <param name="ExpiresAt">UTC expiry derived from the OAuth <c>expires_in</c> at issue time.</param>
 /// <param name="Email">Citizen email, captured at sign-in for display only (NOT used for auth).</param>
-public sealed record AccessTokenRecord(string AccessToken, DateTimeOffset ExpiresAt, string? Email);
+/// <param name="RefreshToken">OAuth refresh token, used for silent renewal; null when none issued.</param>
+public sealed record AccessTokenRecord(string AccessToken, DateTimeOffset ExpiresAt, string? Email, string? RefreshToken = null);
 
 /// <summary>In-memory <see cref="IAccessTokenStore"/> for unit tests.</summary>
 public sealed class InMemoryAccessTokenStore : IAccessTokenStore

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -110,7 +110,7 @@ public sealed class AuthService : IAuthService
         {
             var response = await _http.PostAsJsonAsync(
                 "api/auth/login",
-                new LoginRequest(email.Trim(), password),
+                new LoginRequest(email.Trim(), password, "consumer"),
                 ct);
 
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
@@ -158,7 +158,7 @@ public sealed class AuthService : IAuthService
         {
             var response = await _http.PostAsJsonAsync(
                 "api/auth/verify-2fa",
-                new Verify2FaRequest(loginToken, code.Trim(), isBackupCode),
+                new Verify2FaRequest(loginToken, code.Trim(), isBackupCode, "consumer"),
                 ct);
 
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
@@ -201,12 +201,13 @@ public sealed class AuthService : IAuthService
         await _store.SetAsync(record, ct);
     }
 
-    private sealed record LoginRequest(string Email, string Password);
+    private sealed record LoginRequest(string Email, string Password, string Tier);
 
     private sealed record Verify2FaRequest(
         [property: JsonPropertyName("login_token")] string LoginToken,
         [property: JsonPropertyName("code")] string Code,
-        [property: JsonPropertyName("is_backup_code")] bool IsBackupCode);
+        [property: JsonPropertyName("is_backup_code")] bool IsBackupCode,
+        [property: JsonPropertyName("tier")] string Tier);
 
     private sealed record LoginResponse(
         [property: JsonPropertyName("access_token")] string? AccessToken,

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -265,6 +265,7 @@ public sealed class AuthService : IAuthService
         {
             var resp = await _http.PostAsJsonAsync(
                 "api/auth/social/initiate",
+                // wallet surface is always login-only — provider linking happens in the web app, not the PWA
                 new SocialInitiateBody(provider, "login", "wallet"), ct);
             if (!resp.IsSuccessStatusCode) return null;
             var body = await resp.Content.ReadFromJsonAsync<SocialInitiateBodyResponse>(ct);
@@ -334,7 +335,7 @@ public sealed class AuthService : IAuthService
         [property: JsonPropertyName("surface")] string Surface);
 
     private sealed record SocialInitiateBodyResponse(
-        [property: JsonPropertyName("authorization_url")] string? AuthorizationUrl,
+        [property: JsonPropertyName("authorizationUrl")] string? AuthorizationUrl,
         [property: JsonPropertyName("state")] string? State);
 
     private sealed record FragmentReturn(

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -57,6 +57,20 @@ public interface IAuthService
     /// signed-out citizen survives for the next user on this device.
     /// </summary>
     Task SignOutAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts a social sign-in. Calls /api/auth/social/initiate with surface=wallet
+    /// and returns the provider authorization URL for the caller to navigate to
+    /// (full-page). Returns null on failure.
+    /// </summary>
+    Task<string?> BeginSocialSignInAsync(string provider, CancellationToken ct = default);
+
+    /// <summary>
+    /// Consumes a staged OAuth fragment-return token (from auth-fragment.js),
+    /// persisting it as the Consumer-tier session. Returns true when a token was
+    /// consumed. Pass the page's IJSRuntime.
+    /// </summary>
+    Task<bool> TryConsumeSocialReturnAsync(Microsoft.JSInterop.IJSRuntime js, CancellationToken ct = default);
 }
 
 /// <summary>Outcome of <see cref="IAuthService.SignInAsync"/> / <see cref="IAuthService.VerifyTwoFactorAsync"/>.</summary>
@@ -243,6 +257,35 @@ public sealed class AuthService : IAuthService
         await _purge.PurgeAsync(ct);
     }
 
+    /// <inheritdoc />
+    public async Task<string?> BeginSocialSignInAsync(string provider, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        try
+        {
+            var resp = await _http.PostAsJsonAsync(
+                "api/auth/social/initiate",
+                new SocialInitiateBody(provider, "login", "wallet"), ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            var body = await resp.Content.ReadFromJsonAsync<SocialInitiateBodyResponse>(ct);
+            return body?.AuthorizationUrl;
+        }
+        catch (HttpRequestException) { return null; }
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryConsumeSocialReturnAsync(Microsoft.JSInterop.IJSRuntime js, CancellationToken ct = default)
+    {
+        FragmentReturn? fragment;
+        try { fragment = await js.InvokeAsync<FragmentReturn?>("sorchaAuthFragment.consume", ct); }
+        catch { return false; }
+
+        if (fragment is null || string.IsNullOrEmpty(fragment.Token)) return false;
+
+        await PersistAsync(fragment.Token, fragment.ExpiresIn, email: null, fragment.Refresh, ct);
+        return true;
+    }
+
     private async Task PersistAsync(string accessToken, int expiresIn, string? email, string? refreshToken, CancellationToken ct)
     {
         var record = new AccessTokenRecord(
@@ -284,4 +327,19 @@ public sealed class AuthService : IAuthService
         [property: JsonPropertyName("access_token")] string? AccessToken,
         [property: JsonPropertyName("refresh_token")] string? RefreshToken,
         [property: JsonPropertyName("expires_in")] int ExpiresIn);
+
+    private sealed record SocialInitiateBody(
+        [property: JsonPropertyName("provider")] string Provider,
+        [property: JsonPropertyName("intent")] string Intent,
+        [property: JsonPropertyName("surface")] string Surface);
+
+    private sealed record SocialInitiateBodyResponse(
+        [property: JsonPropertyName("authorization_url")] string? AuthorizationUrl,
+        [property: JsonPropertyName("state")] string? State);
+
+    private sealed record FragmentReturn(
+        [property: JsonPropertyName("token")] string? Token,
+        [property: JsonPropertyName("refresh")] string? Refresh,
+        [property: JsonPropertyName("expiresIn")] int ExpiresIn,
+        [property: JsonPropertyName("returnUrl")] string? ReturnUrl);
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.JSInterop;
 
 namespace Sorcha.Wallet.Pwa.Services;
 
@@ -41,6 +43,12 @@ public interface IAuthService
     /// <param name="isBackupCode">True when <paramref name="code"/> is a backup code.</param>
     Task<SignInResult> VerifyTwoFactorAsync(
         string loginToken, string email, string code, bool isBackupCode = false, CancellationToken ct = default);
+
+    /// <summary>
+    /// Passwordless sign-in with a passkey. Discoverable-first when
+    /// <paramref name="email"/> is null. Persists a Consumer-tier token on success.
+    /// </summary>
+    Task<SignInResult> SignInWithPasskeyAsync(string? email = null, CancellationToken ct = default);
 
     /// <summary>
     /// Signs the citizen out: clears the persisted token AND wipes every
@@ -83,13 +91,15 @@ public sealed class AuthService : IAuthService
     private readonly HttpClient _http;
     private readonly IAccessTokenStore _store;
     private readonly ILocalDataPurge _purge;
+    private readonly IPasskeyInterop _passkey;
 
     /// <summary>Initialises a new instance.</summary>
-    public AuthService(HttpClient http, IAccessTokenStore store, ILocalDataPurge purge)
+    public AuthService(HttpClient http, IAccessTokenStore store, ILocalDataPurge purge, IPasskeyInterop passkey)
     {
         _http = http ?? throw new ArgumentNullException(nameof(http));
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _purge = purge ?? throw new ArgumentNullException(nameof(purge));
+        _passkey = passkey ?? throw new ArgumentNullException(nameof(passkey));
     }
 
     /// <inheritdoc />
@@ -138,7 +148,7 @@ public sealed class AuthService : IAuthService
                 return new SignInResult(SignInStatus.ServerError, "Auth server did not return an access token.");
             }
 
-            await PersistAsync(body.AccessToken, body.ExpiresIn, email.Trim(), ct);
+            await PersistAsync(body.AccessToken, body.ExpiresIn, email.Trim(), body.RefreshToken, ct);
             return new SignInResult(SignInStatus.Success);
         }
         catch (HttpRequestException ex)
@@ -174,7 +184,47 @@ public sealed class AuthService : IAuthService
                 return new SignInResult(SignInStatus.ServerError, "Verification succeeded but no token was returned.");
             }
 
-            await PersistAsync(body.AccessToken, body.ExpiresIn, email.Trim(), ct);
+            await PersistAsync(body.AccessToken, body.ExpiresIn, email.Trim(), body.RefreshToken, ct);
+            return new SignInResult(SignInStatus.Success);
+        }
+        catch (HttpRequestException ex)
+        {
+            return new SignInResult(SignInStatus.ServerError, ex.Message);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<SignInResult> SignInWithPasskeyAsync(string? email = null, CancellationToken ct = default)
+    {
+        if (!await _passkey.IsSupportedAsync())
+            return new SignInResult(SignInStatus.ServerError, "This device doesn't support passkeys.");
+
+        try
+        {
+            var optionsResp = await _http.PostAsJsonAsync(
+                "api/auth/passkey/assertion/options",
+                new AssertionOptionsRequest(string.IsNullOrWhiteSpace(email) ? null : email!.Trim()), ct);
+            optionsResp.EnsureSuccessStatusCode();
+            var options = await optionsResp.Content.ReadFromJsonAsync<AssertionOptionsResponse>(ct);
+            if (options is null || string.IsNullOrEmpty(options.TransactionId))
+                return new SignInResult(SignInStatus.ServerError, "Could not start passkey sign-in.");
+
+            JsonElement assertion;
+            try { assertion = await _passkey.GetAssertionAsync(options.Options); }
+            catch (JSException) { return new SignInResult(SignInStatus.InvalidCredentials, "Passkey sign-in was cancelled."); }
+
+            var verifyResp = await _http.PostAsJsonAsync(
+                "api/auth/passkey/assertion/verify",
+                new AssertionVerifyRequest(options.TransactionId, assertion, "consumer"), ct);
+            if (verifyResp.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                return new SignInResult(SignInStatus.InvalidCredentials, "That passkey isn't recognised.");
+            verifyResp.EnsureSuccessStatusCode();
+
+            var body = await verifyResp.Content.ReadFromJsonAsync<PublicTokenBody>(ct);
+            if (body is null || string.IsNullOrEmpty(body.AccessToken))
+                return new SignInResult(SignInStatus.ServerError, "Passkey sign-in returned no token.");
+
+            await PersistAsync(body.AccessToken, body.ExpiresIn, email, body.RefreshToken, ct);
             return new SignInResult(SignInStatus.Success);
         }
         catch (HttpRequestException ex)
@@ -192,12 +242,13 @@ public sealed class AuthService : IAuthService
         await _purge.PurgeAsync(ct);
     }
 
-    private async Task PersistAsync(string accessToken, int expiresIn, string email, CancellationToken ct)
+    private async Task PersistAsync(string accessToken, int expiresIn, string? email, string? refreshToken, CancellationToken ct)
     {
         var record = new AccessTokenRecord(
             accessToken,
             DateTimeOffset.UtcNow.AddSeconds(Math.Max(60, expiresIn)),
-            email);
+            email,
+            refreshToken);
         await _store.SetAsync(record, ct);
     }
 
@@ -213,5 +264,23 @@ public sealed class AuthService : IAuthService
         [property: JsonPropertyName("access_token")] string? AccessToken,
         [property: JsonPropertyName("expires_in")] int ExpiresIn,
         [property: JsonPropertyName("requires_two_factor")] bool RequiresTwoFactor,
-        [property: JsonPropertyName("login_token")] string? LoginToken);
+        [property: JsonPropertyName("login_token")] string? LoginToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken);
+
+    private sealed record AssertionOptionsRequest(
+        [property: JsonPropertyName("email")] string? Email);
+
+    private sealed record AssertionOptionsResponse(
+        [property: JsonPropertyName("transaction_id")] string TransactionId,
+        [property: JsonPropertyName("options")] JsonElement Options);
+
+    private sealed record AssertionVerifyRequest(
+        [property: JsonPropertyName("transaction_id")] string TransactionId,
+        [property: JsonPropertyName("assertion_response")] JsonElement AssertionResponse,
+        [property: JsonPropertyName("tier")] string Tier);
+
+    private sealed record PublicTokenBody(
+        [property: JsonPropertyName("access_token")] string? AccessToken,
+        [property: JsonPropertyName("refresh_token")] string? RefreshToken,
+        [property: JsonPropertyName("expires_in")] int ExpiresIn);
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IAuthService.cs
@@ -203,13 +203,14 @@ public sealed class AuthService : IAuthService
         {
             var optionsResp = await _http.PostAsJsonAsync(
                 "api/auth/passkey/assertion/options",
-                new AssertionOptionsRequest(string.IsNullOrWhiteSpace(email) ? null : email!.Trim()), ct);
+                new AssertionOptionsRequest(string.IsNullOrWhiteSpace(email) ? null : email.Trim()), ct);
             optionsResp.EnsureSuccessStatusCode();
             var options = await optionsResp.Content.ReadFromJsonAsync<AssertionOptionsResponse>(ct);
             if (options is null || string.IsNullOrEmpty(options.TransactionId))
                 return new SignInResult(SignInStatus.ServerError, "Could not start passkey sign-in.");
 
             JsonElement assertion;
+            // ct intentionally not forwarded — the WebAuthn browser ceremony has no JS-side cancel API
             try { assertion = await _passkey.GetAssertionAsync(options.Options); }
             catch (JSException) { return new SignInResult(SignInStatus.InvalidCredentials, "Passkey sign-in was cancelled."); }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/IPasskeyInterop.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/IPasskeyInterop.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// WebAuthn ceremony bridge for the wallet sign-in screen. Behind an interface so
+/// AuthService unit tests use an in-memory fake instead of mocking IJSRuntime
+/// (generic InvokeAsync&lt;T&gt; is brittle to mock — F114 lesson).
+/// </summary>
+public interface IPasskeyInterop
+{
+    /// <summary>True when the browser exposes the WebAuthn API.</summary>
+    Task<bool> IsSupportedAsync();
+
+    /// <summary>Runs navigator.credentials.get() and returns the assertion response JSON.</summary>
+    Task<JsonElement> GetAssertionAsync(JsonElement options);
+}
+
+/// <summary>JS-backed <see cref="IPasskeyInterop"/> over <c>./js/webauthn.js</c>.</summary>
+public sealed class PasskeyInterop : IPasskeyInterop, IAsyncDisposable
+{
+    private readonly IJSRuntime _js;
+    private IJSObjectReference? _module;
+
+    /// <summary>Initialises a new instance.</summary>
+    public PasskeyInterop(IJSRuntime js) => _js = js ?? throw new ArgumentNullException(nameof(js));
+
+    private async Task<IJSObjectReference> ModuleAsync()
+        => _module ??= await _js.InvokeAsync<IJSObjectReference>("import", "./js/webauthn.js");
+
+    /// <inheritdoc />
+    public async Task<bool> IsSupportedAsync()
+    {
+        try { return await (await ModuleAsync()).InvokeAsync<bool>("isWebAuthnSupported"); }
+        catch { return false; }
+    }
+
+    /// <inheritdoc />
+    public async Task<JsonElement> GetAssertionAsync(JsonElement options)
+    {
+        var module = await ModuleAsync();
+        var responseJson = await module.InvokeAsync<string>("getCredential", options.GetRawText());
+        return JsonSerializer.Deserialize<JsonElement>(responseJson);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not null) { await _module.DisposeAsync(); _module = null; }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ISocialProvidersClient.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>Reads the configured social providers so the sign-in screen renders only enabled buttons.</summary>
+public interface ISocialProvidersClient
+{
+    /// <summary>Provider names enabled on this host; empty on failure.</summary>
+    Task<IReadOnlyList<string>> GetConfiguredAsync(CancellationToken ct = default);
+}
+
+/// <summary>HTTP <see cref="ISocialProvidersClient"/> over the anonymous providers endpoint.</summary>
+public sealed class SocialProvidersClient : ISocialProvidersClient
+{
+    private readonly HttpClient _http;
+
+    /// <summary>Initialises a new instance.</summary>
+    public SocialProvidersClient(HttpClient http) => _http = http ?? throw new ArgumentNullException(nameof(http));
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> GetConfiguredAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var body = await _http.GetFromJsonAsync<ProvidersBody>("api/auth/social/providers", ct);
+            return body?.Providers ?? [];
+        }
+        catch { return []; }
+    }
+
+    private sealed record ProvidersBody([property: JsonPropertyName("providers")] IReadOnlyList<string>? Providers);
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Auth state for the wallet gate. Authenticated iff <see cref="IAccessTokenStore"/>
+/// holds a non-expired token (the store self-purges expired tokens on read). No
+/// JWT parsing is needed — the protected pages only require presence, not claims.
+/// Email is surfaced as the Name claim for display. Call <see cref="NotifyChanged"/>
+/// after sign-in / sign-out so the gate re-evaluates.
+/// </summary>
+public sealed class WalletAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private static readonly AuthenticationState Anonymous =
+        new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private readonly IAccessTokenStore _store;
+
+    /// <summary>Initialises a new instance backed by <paramref name="store"/>.</summary>
+    public WalletAuthenticationStateProvider(IAccessTokenStore store)
+        => _store = store ?? throw new ArgumentNullException(nameof(store));
+
+    /// <inheritdoc />
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var record = await _store.GetAsync();
+        if (record is null || string.IsNullOrEmpty(record.AccessToken))
+            return Anonymous;
+
+        var claims = new List<Claim> { new(ClaimTypes.Name, record.Email ?? "citizen") };
+        var identity = new ClaimsIdentity(claims, authenticationType: "wallet-jwt");
+        return new AuthenticationState(new ClaimsPrincipal(identity));
+    }
+
+    /// <summary>Re-evaluate auth state (after sign-in or sign-out).</summary>
+    public void NotifyChanged()
+        => NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/WalletAuthenticationStateProvider.cs
@@ -11,10 +11,12 @@ namespace Sorcha.Wallet.Pwa.Services;
 
 /// <summary>
 /// Auth state for the wallet gate. Authenticated iff <see cref="IAccessTokenStore"/>
-/// holds a non-expired token (the store self-purges expired tokens on read). No
-/// JWT parsing is needed — the protected pages only require presence, not claims.
-/// Email is surfaced as the Name claim for display. Call <see cref="NotifyChanged"/>
-/// after sign-in / sign-out so the gate re-evaluates.
+/// holds a token that is both present and not yet expired. A missing token, an empty
+/// access-token string, or a token whose <c>ExpiresAt</c> is in the past are all
+/// treated as anonymous — the provider does not rely solely on the store self-purging
+/// expired records. No JWT parsing is needed — the protected pages only require
+/// presence, not claims. Email is surfaced as the Name claim for display. Call
+/// <see cref="NotifyChanged"/> after sign-in / sign-out so the gate re-evaluates.
 /// </summary>
 public sealed class WalletAuthenticationStateProvider : AuthenticationStateProvider
 {
@@ -31,7 +33,7 @@ public sealed class WalletAuthenticationStateProvider : AuthenticationStateProvi
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
     {
         var record = await _store.GetAsync();
-        if (record is null || string.IsNullOrEmpty(record.AccessToken))
+        if (record is null || string.IsNullOrEmpty(record.AccessToken) || record.ExpiresAt <= DateTimeOffset.UtcNow)
             return Anonymous;
 
         var claims = new List<Claim> { new(ClaimTypes.Name, record.Email ?? "citizen") };

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
@@ -25,6 +25,7 @@
     <script src="js/xchacha-bridge.js"></script>
     <script src="js/indexeddb-bridge.js"></script>
     <script src="js/qr-scanner-bridge.js"></script>
+    <script src="js/auth-fragment.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/auth-fragment.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/auth-fragment.js
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// Captures an OAuth fragment-return token from the URL hash BEFORE Blazor boots,
+// so the router can't redirect a signed-out user to /signin and lose the token.
+// The social callback redirects to /wallet/#token=…&refresh=…&expires_in=…[&returnUrl=…].
+(function () {
+    window.sorchaAuthFragment = window.sorchaAuthFragment || {};
+    var pending = null;
+    try {
+        var hash = window.location.hash || '';
+        if (hash.indexOf('token=') !== -1) {
+            var params = new URLSearchParams(hash.replace(/^#/, ''));
+            var token = params.get('token');
+            if (token) {
+                pending = {
+                    token: token,
+                    refresh: params.get('refresh'),
+                    expiresIn: parseInt(params.get('expires_in') || '0', 10),
+                    returnUrl: params.get('returnUrl')
+                };
+                history.replaceState(null, '', window.location.pathname + window.location.search);
+            }
+        }
+    } catch (e) { pending = null; }
+
+    window.sorchaAuthFragment.consume = function () {
+        var p = pending;
+        pending = null;
+        return p; // null when nothing was staged
+    };
+})();

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webauthn.js
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/js/webauthn.js
@@ -1,0 +1,143 @@
+/**
+ * WebAuthn/FIDO2 JS interop module for Blazor WASM.
+ * Handles navigator.credentials.create() and navigator.credentials.get()
+ * with base64url encoding/decoding for server round-trips.
+ */
+
+/**
+ * Decodes a base64url-encoded string to a Uint8Array.
+ * @param {string} base64url - The base64url-encoded string.
+ * @returns {Uint8Array} The decoded bytes.
+ */
+function base64UrlToUint8Array(base64url) {
+    // Replace base64url characters with standard base64
+    let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+
+    // Pad to multiple of 4
+    while (base64.length % 4 !== 0) {
+        base64 += '=';
+    }
+
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
+}
+
+/**
+ * Encodes an ArrayBuffer to a base64url string.
+ * @param {ArrayBuffer} buffer - The buffer to encode.
+ * @returns {string} The base64url-encoded string.
+ */
+function arrayBufferToBase64Url(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let binaryString = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+        binaryString += String.fromCharCode(bytes[i]);
+    }
+    const base64 = btoa(binaryString);
+    // Convert standard base64 to base64url
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Checks if WebAuthn (PublicKeyCredential) is supported by the browser.
+ * @returns {boolean} True if WebAuthn is available.
+ */
+export function isWebAuthnSupported() {
+    return typeof window !== 'undefined' &&
+           typeof window.PublicKeyCredential !== 'undefined';
+}
+
+/**
+ * Creates a new WebAuthn credential (registration ceremony).
+ * Converts base64url-encoded fields from the server options to ArrayBuffers,
+ * calls navigator.credentials.create(), and converts the response back to
+ * base64url for the server.
+ *
+ * @param {string} optionsJson - JSON string of PublicKeyCredentialCreationOptions from the server.
+ * @returns {Promise<string>} JSON string of the credential response.
+ */
+export async function createCredential(optionsJson) {
+    const options = JSON.parse(optionsJson);
+
+    // Decode challenge from base64url to ArrayBuffer
+    options.challenge = base64UrlToUint8Array(options.challenge);
+
+    // Decode user.id from base64url to ArrayBuffer
+    if (options.user && options.user.id) {
+        options.user.id = base64UrlToUint8Array(options.user.id);
+    }
+
+    // Decode excludeCredentials[].id from base64url to ArrayBuffer
+    if (options.excludeCredentials) {
+        options.excludeCredentials = options.excludeCredentials.map(cred => ({
+            ...cred,
+            id: base64UrlToUint8Array(cred.id)
+        }));
+    }
+
+    const credential = await navigator.credentials.create({
+        publicKey: options
+    });
+
+    // Convert response ArrayBuffers back to base64url
+    const response = {
+        id: credential.id,
+        rawId: arrayBufferToBase64Url(credential.rawId),
+        type: credential.type,
+        response: {
+            attestationObject: arrayBufferToBase64Url(credential.response.attestationObject),
+            clientDataJSON: arrayBufferToBase64Url(credential.response.clientDataJSON)
+        }
+    };
+
+    return JSON.stringify(response);
+}
+
+/**
+ * Gets a WebAuthn credential (authentication ceremony).
+ * Converts base64url-encoded fields from the server options to ArrayBuffers,
+ * calls navigator.credentials.get(), and converts the response back to
+ * base64url for the server.
+ *
+ * @param {string} optionsJson - JSON string of PublicKeyCredentialRequestOptions from the server.
+ * @returns {Promise<string>} JSON string of the assertion response.
+ */
+export async function getCredential(optionsJson) {
+    const options = JSON.parse(optionsJson);
+
+    // Decode challenge from base64url to ArrayBuffer
+    options.challenge = base64UrlToUint8Array(options.challenge);
+
+    // Decode allowCredentials[].id from base64url to ArrayBuffer
+    if (options.allowCredentials) {
+        options.allowCredentials = options.allowCredentials.map(cred => ({
+            ...cred,
+            id: base64UrlToUint8Array(cred.id)
+        }));
+    }
+
+    const credential = await navigator.credentials.get({
+        publicKey: options
+    });
+
+    // Convert response ArrayBuffers back to base64url
+    const response = {
+        id: credential.id,
+        rawId: arrayBufferToBase64Url(credential.rawId),
+        type: credential.type,
+        response: {
+            authenticatorData: arrayBufferToBase64Url(credential.response.authenticatorData),
+            clientDataJSON: arrayBufferToBase64Url(credential.response.clientDataJSON),
+            signature: arrayBufferToBase64Url(credential.response.signature),
+            userHandle: credential.response.userHandle
+                ? arrayBufferToBase64Url(credential.response.userHandle)
+                : null
+        }
+    };
+
+    return JSON.stringify(response);
+}

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/AuthEndpoints.cs
@@ -483,14 +483,25 @@ public static class AuthEndpoints
         user.LastLoginAt = DateTimeOffset.UtcNow;
         await identityRepository.UpdateUserAsync(user, cancellationToken);
 
-        // Generate tokens
-        var tokenResponse = await tokenService.GenerateUserTokenAsync(user, organization, user.PlatformUserId, cancellationToken: cancellationToken);
+        // Generate tokens — honour a consumer-tier hint from the wallet (spec 136).
+        var tokenResponse = await tokenService.GenerateUserTokenAsync(
+            user, organization, user.PlatformUserId, ResolveVerify2FaTier(request.Tier), cancellationToken);
 
         logger.LogInformation("User completed 2FA login - UserId: {UserId}, OrgId: {OrgId}",
             user.Id, organization.Id);
 
         return TypedResults.Ok(tokenResponse);
     }
+
+    /// <summary>
+    /// Resolves the mint tier for 2FA completion. Only an explicit <c>consumer</c>
+    /// hint is honoured (safe downgrade); everything else keeps the platform
+    /// default so the path can't escalate.
+    /// </summary>
+    internal static Sorcha.ServiceDefaults.Auth.Tier ResolveVerify2FaTier(string? hint)
+        => string.Equals(hint, "consumer", StringComparison.OrdinalIgnoreCase)
+            ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+            : Sorcha.ServiceDefaults.Auth.Tier.Platform;
 
     private static async Task<Results<Ok<TokenResponse>, UnauthorizedHttpResult, ValidationProblem>> RefreshToken(
         TokenRefreshRequest request,

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/PublicPasskeyEndpoints.cs
@@ -379,9 +379,13 @@ public static class PublicPasskeyEndpoints
                     statusCode: StatusCodes.Status500InternalServerError);
             }
 
-            // Issue JWT
+            // Issue JWT. The wallet requests tier:"consumer" (a safe downgrade);
+            // any other value keeps the platform default — no escalation here.
+            var mintTier = string.Equals(request.Tier, "consumer", StringComparison.OrdinalIgnoreCase)
+                ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+                : Sorcha.ServiceDefaults.Auth.Tier.Platform;
             var tokenResponse = await tokenService.GenerateUserTokenAsync(
-                userIdentity, publicOrg, platformUser.Id, cancellationToken: ct);
+                userIdentity, publicOrg, platformUser.Id, mintTier, ct);
 
             logger.LogInformation(
                 "Public passkey sign-in completed for PlatformUser {PlatformUserId}",

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -316,7 +316,7 @@ public static class SocialLoginEndpoints
         // been validated against the cached state and is the same value used for
         // metrics tagging and logging. Defence-in-depth: never reflect raw
         // request input back into a user-visible message.
-        var resolveResult = await platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, ct);
+        var resolveResult = await platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, allowCreate: true, ct);
         if (resolveResult.Refusal != SocialLoginRefusal.None)
         {
             var resolvedProvider = callbackResult.Provider;

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -65,6 +65,15 @@ public static class SocialLoginEndpoints
         var group = app.MapGroup("/api/auth/social")
             .WithTags("Social Login");
 
+        group.MapGet("/providers", ListConfiguredProviders)
+            .WithName("ListSocialProviders")
+            .WithSummary("List configured social providers")
+            .WithDescription("Returns the social providers that have working credentials on this host. "
+                + "Anonymous — drives the conditional 'Continue with…' buttons on the wallet sign-in screen.")
+            .AllowAnonymous()
+            .RequireRateLimiting("platform-auth")
+            .Produces<SocialProvidersResponse>();
+
         group.MapPost("/initiate", InitiateSocialFlow)
             .WithName("InitiateSocialLogin")
             .WithSummary("Start social login or link flow")
@@ -114,6 +123,17 @@ public static class SocialLoginEndpoints
 
         return app;
     }
+
+    private static IResult ListConfiguredProviders(ISocialLoginService socialLoginService)
+        => ListConfiguredProvidersForTest(socialLoginService);
+
+    /// <summary>Test seam for <see cref="ListConfiguredProviders"/> (no HttpContext needed).</summary>
+    internal static Microsoft.AspNetCore.Http.HttpResults.Ok<SocialProvidersResponse> ListConfiguredProvidersForTest(
+        ISocialLoginService socialLoginService)
+        => TypedResults.Ok(new SocialProvidersResponse
+        {
+            Providers = socialLoginService.GetConfiguredProviderNames()
+        });
 
     /// <summary>
     /// POST /api/auth/social/initiate — start a social login or link flow.

--- a/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
+++ b/src/Services/Sorcha.Tenant.Service/Endpoints/SocialLoginEndpoints.cs
@@ -200,6 +200,17 @@ public static class SocialLoginEndpoints
             }
         }
 
+        // Validate + normalise surface. null / missing = existing /app web flow.
+        // "wallet" routes the post-OAuth callback into the citizen wallet PWA.
+        var surface = string.IsNullOrWhiteSpace(request.Surface) ? null : request.Surface.Trim().ToLowerInvariant();
+        if (surface is not (null or "wallet" or "app"))
+        {
+            return TypedResults.ValidationProblem(new Dictionary<string, string[]>
+            {
+                ["surface"] = ["surface must be 'wallet' or 'app'"]
+            });
+        }
+
         // Resolve callback URL (config-first, falls back to Request scheme/host).
         // See ResolveCallbackUrl for why config-first is required behind a
         // TLS-terminating reverse proxy.
@@ -208,7 +219,7 @@ public static class SocialLoginEndpoints
         try
         {
             var result = await socialLoginService.GenerateAuthorizationUrlAsync(
-                request.Provider, redirectUri, intent.Value, targetPlatformUserId, ct);
+                request.Provider, redirectUri, intent.Value, targetPlatformUserId, surface, ct);
 
             logger.LogInformation(
                 "Social {Intent} flow initiated for provider {Provider}",

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
@@ -325,6 +325,13 @@ public record Verify2FaRequest
     /// </summary>
     [JsonPropertyName("is_backup_code")]
     public bool IsBackupCode { get; init; }
+
+    /// <summary>
+    /// Optional trust-tier hint (spec 136). Only <c>consumer</c> is honoured —
+    /// a safe downgrade for the wallet. Other values keep the platform default.
+    /// </summary>
+    [JsonPropertyName("tier")]
+    public string? Tier { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/AuthDtos.cs
@@ -198,6 +198,18 @@ public record RevokeUserTokensRequest
 }
 
 /// <summary>
+/// Configured social providers available for sign-in. Drives the conditional
+/// "Continue with…" buttons on clients that cannot read service config directly
+/// (e.g. the citizen wallet PWA).
+/// </summary>
+public record SocialProvidersResponse
+{
+    /// <summary>Provider names (case as configured) with working credentials on this host.</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("providers")]
+    public required IReadOnlyList<string> Providers { get; init; }
+}
+
+/// <summary>
 /// Request to revoke all tokens for an organization.
 /// </summary>
 public record RevokeOrganizationTokensRequest

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/PublicAuthDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/PublicAuthDtos.cs
@@ -72,6 +72,14 @@ public record PublicPasskeyAssertionVerifyRequest
     /// </summary>
     [JsonPropertyName("assertion_response")]
     public required AuthenticatorAssertionRawResponse AssertionResponse { get; init; }
+
+    /// <summary>
+    /// Optional trust-tier hint (spec 136). Only <c>consumer</c> is honoured —
+    /// it is a safe downgrade for a public-org citizen. Any other value (or null)
+    /// keeps the platform default, so this anonymous endpoint cannot escalate.
+    /// </summary>
+    [JsonPropertyName("tier")]
+    public string? Tier { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs
+++ b/src/Services/Sorcha.Tenant.Service/Models/Dtos/SocialLoginDtos.cs
@@ -30,6 +30,14 @@ public class SocialLoginInitiateRequest
     /// </summary>
     [JsonPropertyName("intent")]
     public string? Intent { get; set; }
+
+    /// <summary>
+    /// Optional return-surface for the post-OAuth redirect: <c>wallet</c> routes
+    /// the callback back into the citizen wallet PWA (and mints Consumer-tier);
+    /// null/anything else keeps the default /app web flow. Spec: PWA social sign-in.
+    /// </summary>
+    [JsonPropertyName("surface")]
+    public string? Surface { get; init; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 
+using Sorcha.ServiceDefaults.Auth;
 using Sorcha.Tenant.Service.Data;
 using Sorcha.Tenant.Service.Data.Repositories;
 using Sorcha.Tenant.Service.Models;
@@ -105,6 +106,7 @@ public class SocialCallbackModel : PageModel
         // returns the resolved provider on the result.
         var callbackResult = await _socialLoginService.ExchangeCodeAsync(string.Empty, code, state, ct);
         var provider = callbackResult.Provider;
+        var isWallet = IsWalletSurface(callbackResult.Surface);
 
         if (!callbackResult.Success || string.IsNullOrEmpty(callbackResult.Subject))
         {
@@ -145,11 +147,24 @@ public class SocialCallbackModel : PageModel
                 provider, resolveResult.Refusal, emailTag);
 
             SocialLoginMetrics.RecordRefusal(provider, resolveResult.Refusal);
+            if (isWallet)
+            {
+                return Redirect(BuildWalletSignInError("refused"));
+            }
             return Page();
         }
 
         var platformUser = resolveResult.User!;
         var isNew = resolveResult.IsNew;
+
+        // Login-only for the wallet surface (signup happens via council enrol /
+        // pairing / web). A social identity that maps to no existing account is
+        // refused with a link to web signup rather than silently creating one.
+        if (isWallet && isNew)
+        {
+            _logger.LogInformation("Wallet social login refused: no existing account for {Provider} identity", provider);
+            return Redirect(BuildWalletSignInError("no_account"));
+        }
 
         // Ensure UserIdentity in public org
         var publicOrgId = WellKnownIds.PublicOrgId;
@@ -193,7 +208,10 @@ public class SocialCallbackModel : PageModel
             return Page();
         }
 
-        var tokens = await _tokenService.GenerateUserTokenAsync(userIdentity, publicOrg, platformUser.Id, cancellationToken: ct);
+        var mintTier = isWallet
+            ? Tier.Consumer
+            : Tier.Platform;
+        var tokens = await _tokenService.GenerateUserTokenAsync(userIdentity, publicOrg, platformUser.Id, mintTier, ct);
 
         _logger.LogInformation("Social login completed for PlatformUser {PlatformUserId} via {Provider} (isNew={IsNew})",
             platformUser.Id, provider, isNew);
@@ -202,6 +220,15 @@ public class SocialCallbackModel : PageModel
         // asserted the address), so first-login is the natural welcome moment.
         // Idempotent + non-throwing by design.
         await _welcomeDispatcher.SendIfPendingAsync(platformUser, ct);
+
+        if (isWallet)
+        {
+            // Wallet PWA: hand tokens back via the /wallet fragment. No SetupAddDevice
+            // returnUrl here — that route lives in the /app web client, not the PWA;
+            // the PWA handles "no device yet" with its own PairingTakeover overlay
+            // (a /setup/add-device returnUrl would 404 in the wallet).
+            return Redirect(BuildWalletRedirect(tokens.AccessToken, tokens.RefreshToken, tokens.ExpiresIn, returnUrl: null));
+        }
 
         // Redirect to app with token in fragment.
         // Feature 128 US2 — same FR-020 routing-gate contract as Login.cshtml.cs.
@@ -236,4 +263,27 @@ public class SocialCallbackModel : PageModel
             System.Text.Encoding.UTF8.GetBytes(email.ToLowerInvariant()));
         return Convert.ToHexString(bytes.AsSpan(0, 4)).ToLowerInvariant();
     }
+
+    /// <summary>True when the social flow originated from the citizen wallet PWA.</summary>
+    internal static bool IsWalletSurface(string? surface)
+        => string.Equals(surface, "wallet", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Builds the wallet fragment-return URL. The PWA's auth-fragment.js reads
+    /// token/refresh/expires_in from the hash on load. Base-relative /wallet/ —
+    /// the PWA is mounted under that prefix at the gateway.
+    /// </summary>
+    internal static string BuildWalletRedirect(string accessToken, string refreshToken, int expiresIn, string? returnUrl)
+    {
+        var fragment = $"token={Uri.EscapeDataString(accessToken)}" +
+                       $"&refresh={Uri.EscapeDataString(refreshToken)}" +
+                       $"&expires_in={expiresIn}";
+        if (!string.IsNullOrEmpty(returnUrl))
+            fragment += $"&returnUrl={Uri.EscapeDataString(returnUrl)}";
+        return $"/wallet/#{fragment}";
+    }
+
+    /// <summary>Routes a wallet-surface failure/refusal back to the PWA sign-in screen.</summary>
+    internal static string BuildWalletSignInError(string code)
+        => $"/wallet/signin?authError={Uri.EscapeDataString(code)}";
 }

--- a/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
+++ b/src/Services/Sorcha.Tenant.Service/Pages/Auth/SocialCallback.cshtml.cs
@@ -125,8 +125,9 @@ public class SocialCallbackModel : PageModel
             return Page();
         }
 
-        // Resolve or create PlatformUser under the strict link policy
-        var resolveResult = await _platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, ct);
+        // Resolve or create PlatformUser under the strict link policy.
+        // Wallet surface is login-only — do not create new accounts via social sign-in.
+        var resolveResult = await _platformUserService.ResolveOrCreateSocialUserAsync(callbackResult, allowCreate: !isWallet, ct);
 
         // Refusal handling (feature 115 FR-016, FR-018)
         if (resolveResult.Refusal != SocialLoginRefusal.None)
@@ -149,22 +150,14 @@ public class SocialCallbackModel : PageModel
             SocialLoginMetrics.RecordRefusal(provider, resolveResult.Refusal);
             if (isWallet)
             {
-                return Redirect(BuildWalletSignInError("refused"));
+                var errorCode = resolveResult.Refusal == SocialLoginRefusal.NoExistingAccount ? "no_account" : "refused";
+                return Redirect(BuildWalletSignInError(errorCode));
             }
             return Page();
         }
 
         var platformUser = resolveResult.User!;
         var isNew = resolveResult.IsNew;
-
-        // Login-only for the wallet surface (signup happens via council enrol /
-        // pairing / web). A social identity that maps to no existing account is
-        // refused with a link to web signup rather than silently creating one.
-        if (isWallet && isNew)
-        {
-            _logger.LogInformation("Wallet social login refused: no existing account for {Provider} identity", provider);
-            return Redirect(BuildWalletSignInError("no_account"));
-        }
 
         // Ensure UserIdentity in public org
         var publicOrgId = WellKnownIds.PublicOrgId;

--- a/src/Services/Sorcha.Tenant.Service/README.md
+++ b/src/Services/Sorcha.Tenant.Service/README.md
@@ -261,7 +261,7 @@ OidcSettings__CallbackBaseUrl="https://api.sorcha.example.com"
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/auth/login` | POST | Login with email and password (returns 2FA challenge if enabled) |
-| `/api/auth/verify-2fa` | POST | Verify TOTP code or backup code to complete login |
+| `/api/auth/verify-2fa` | POST | Verify TOTP code or backup code to complete login. Accepts optional `tier` field (`"consumer"`) — forces Consumer-tier token for wallet sign-in (spec 136). |
 | `/api/auth/register` | POST | Self-register with email/password (public orgs only) |
 | `/api/auth/logout` | POST | Logout and revoke current token |
 | `/api/auth/me` | GET | Get current authenticated user info |
@@ -316,13 +316,14 @@ OidcSettings__CallbackBaseUrl="https://api.sorcha.example.com"
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/auth/passkey/assertion/options` | POST | Generate discoverable passkey assertion options (optional email filter) |
-| `/api/auth/passkey/assertion/verify` | POST | Verify assertion, resolve user, issue JWT |
+| `/api/auth/passkey/assertion/verify` | POST | Verify assertion, resolve user, issue JWT. Accepts optional `tier` field (`"consumer"`) — safe downgrade for wallet sign-in (spec 136). |
 
-### Public User Social Login (`/api/auth/public/social`)
+### Public User Social Login (`/api/auth/social` and `/api/auth/public/social`)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/api/auth/public/social/initiate` | POST | Initiate social login/signup with provider (Google, Microsoft, GitHub, Apple) |
+| `/api/auth/social/providers` | GET | List configured providers (anonymous). Returns `{"providers":["google",…]}`. Drives conditional "Continue with…" buttons on the citizen wallet PWA sign-in screen. Rate-limited (`platform-auth`). |
+| `/api/auth/public/social/initiate` | POST | Initiate social login/signup with provider (Google, Microsoft, GitHub, Apple). Optional `surface` field: `"wallet"` routes the callback into the citizen wallet PWA (Consumer-tier mint + `/wallet/#…` redirect + login-only enforcement); null/`"app"` keeps the default web flow. |
 | `/api/auth/public/social/callback` | POST | Handle OAuth callback and issue tokens |
 
 **Browser callback URL:** providers redirect to the Razor page at
@@ -331,6 +332,8 @@ OidcSettings__CallbackBaseUrl="https://api.sorcha.example.com"
 The page resolves the provider from the cached state — provider is NOT a
 query parameter — and applies the strict link policy added in
 feature 115 before issuing tokens.
+
+**Wallet surface (`surface:"wallet"`) behaviour.** When `surface:"wallet"` is set on the initiate request, the `SocialCallback` Razor page: (1) mints a Consumer-tier token; (2) redirects to `/wallet/#token=…&refresh=…&expires_in=…` so the PWA's `auth-fragment.js` captures the tokens before Blazor boots; (3) enforces login-only — an unknown social identity is refused (`SocialLoginRefusal.NoExistingAccount`) and the user is redirected to `/wallet/signin?authError=no_account`. No `PlatformUser` is created.
 
 **Strict link policy (feature 115).** Both signup and link flows refuse
 when verification is missing on either side:

--- a/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/IPlatformUserService.cs
@@ -33,6 +33,9 @@ public enum SocialLoginRefusal
 
     /// <summary>The email matches an existing Sorcha account whose own <c>EmailVerified</c> is <c>false</c>. Refused per FR-011.</summary>
     ExistingUnverified,
+
+    /// <summary>No existing account matched and creation was disabled (login-only surface, e.g. the citizen wallet PWA). No PlatformUser is created.</summary>
+    NoExistingAccount = 3,
 }
 
 /// <summary>
@@ -154,16 +157,26 @@ public interface IPlatformUserService
     /// provider's <c>EmailVerified</c> claim and the existing user's
     /// <c>EmailVerified</c> are <c>true</c> (FR-011, FR-012). Otherwise
     /// return <see cref="SocialLoginRefusal.ExistingUnverified"/>.</item>
-    /// <item>Create new user only when the provider asserts
-    /// <c>EmailVerified=true</c> (FR-010). Otherwise return
-    /// <see cref="SocialLoginRefusal.ProviderUnverified"/>.</item>
+    /// <item>Create new user only when <paramref name="allowCreate"/> is <c>true</c>
+    /// and the provider asserts <c>EmailVerified=true</c> (FR-010). When
+    /// <paramref name="allowCreate"/> is <c>false</c> and neither Step 1 nor Step 2
+    /// matched, returns <see cref="SocialLoginRefusal.NoExistingAccount"/> and
+    /// creates nothing — used on login-only surfaces such as the citizen wallet PWA.
+    /// Otherwise return <see cref="SocialLoginRefusal.ProviderUnverified"/>.</item>
     /// </list>
     /// </summary>
     /// <param name="claim">The verified-or-not claim set returned by <see cref="ISocialLoginService.ExchangeCodeAsync"/>. Must have a non-null <c>Subject</c>.</param>
+    /// <param name="allowCreate">
+    /// When <c>true</c> (default for standard web surfaces), a genuinely-new social identity
+    /// will create a new <see cref="PlatformUser"/>. When <c>false</c> (login-only surfaces
+    /// such as the citizen wallet PWA), an unknown identity is refused with
+    /// <see cref="SocialLoginRefusal.NoExistingAccount"/> and no account is persisted.
+    /// Steps 1 and 2 (existing-user lookup and email-collision linking) are unaffected.
+    /// </param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A <see cref="ResolveSocialUserResult"/> indicating success, refusal reason, and new-user state.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="claim"/> is null.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="claim"/>'s <c>Subject</c> is null. Callers should validate the upstream exchange succeeded before invoking this method.</exception>
     Task<ResolveSocialUserResult> ResolveOrCreateSocialUserAsync(
-        SocialAuthCallbackResult claim, CancellationToken ct);
+        SocialAuthCallbackResult claim, bool allowCreate, CancellationToken ct);
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/ISocialLoginService.cs
@@ -51,6 +51,12 @@ public enum SocialFlowIntent
 /// verify that the active bearer matches this id before persisting the
 /// link — defence against a session swap mid-flight.
 /// </param>
+/// <param name="Surface">
+/// Optional return-surface for the post-OAuth redirect recovered from the
+/// cached state. <c>"wallet"</c> routes the callback into the citizen wallet
+/// PWA (Consumer-tier token); null / anything else keeps the default /app
+/// web flow. Set at initiate time by the PWA social sign-in flow.
+/// </param>
 public record SocialAuthCallbackResult(
     bool Success,
     string? Error,
@@ -60,7 +66,8 @@ public record SocialAuthCallbackResult(
     bool EmailVerified,
     string Provider,
     SocialFlowIntent Intent = SocialFlowIntent.Login,
-    Guid? TargetPlatformUserId = null);
+    Guid? TargetPlatformUserId = null,
+    string? Surface = null);
 
 /// <summary>
 /// Service for public user social login via OAuth2/OIDC providers (Google, Microsoft, GitHub, Apple).
@@ -89,13 +96,15 @@ public interface ISocialLoginService
     /// when starting a <see cref="SocialFlowIntent.Link"/> flow — pass the active
     /// PlatformUser's id as <paramref name="targetPlatformUserId"/> so the callback
     /// can verify the session has not swapped between initiate and callback.
-    /// Feature 116 Q6.
+    /// Feature 116 Q6. Pass <paramref name="surface"/> as <c>"wallet"</c> from the
+    /// citizen wallet PWA to route the callback back into the PWA after OAuth.
     /// </summary>
     Task<SocialAuthInitiateResult> GenerateAuthorizationUrlAsync(
         string provider,
         string redirectUri,
         SocialFlowIntent intent,
         Guid? targetPlatformUserId,
+        string? surface = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/PlatformUserService.cs
@@ -264,7 +264,7 @@ public class PlatformUserService : IPlatformUserService
 
     /// <inheritdoc />
     public async Task<ResolveSocialUserResult> ResolveOrCreateSocialUserAsync(
-        SocialAuthCallbackResult claim, CancellationToken ct)
+        SocialAuthCallbackResult claim, bool allowCreate, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(claim);
 
@@ -350,6 +350,17 @@ public class PlatformUserService : IPlatformUserService
 
         // Step 3: Genuinely new user — provider must assert email_verified=true (FR-010).
         // Refusal here means no PlatformUser is created at all.
+
+        // Login-only surfaces (e.g. the citizen wallet PWA) must not create an
+        // account for an unknown social identity — refuse instead of signing up.
+        if (!allowCreate)
+        {
+            _logger.LogInformation(
+                "Social login refused: no existing account for {Provider}/{Subject} and creation is disabled (login-only surface)",
+                provider, subject);
+            return new ResolveSocialUserResult(User: null, IsNew: false, SocialLoginRefusal.NoExistingAccount);
+        }
+
         if (!claim.EmailVerified)
         {
             _logger.LogWarning(

--- a/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/SocialLoginService.cs
@@ -153,7 +153,7 @@ public class SocialLoginService : ISocialLoginService
         string redirectUri,
         CancellationToken cancellationToken = default)
         => GenerateAuthorizationUrlAsync(
-            provider, redirectUri, SocialFlowIntent.Login, targetPlatformUserId: null, cancellationToken);
+            provider, redirectUri, SocialFlowIntent.Login, targetPlatformUserId: null, surface: null, cancellationToken);
 
     /// <inheritdoc />
     public async Task<SocialAuthInitiateResult> GenerateAuthorizationUrlAsync(
@@ -161,6 +161,7 @@ public class SocialLoginService : ISocialLoginService
         string redirectUri,
         SocialFlowIntent intent,
         Guid? targetPlatformUserId,
+        string? surface = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(provider);
@@ -199,6 +200,7 @@ public class SocialLoginService : ISocialLoginService
             Provider = provider,
             Intent = intent,
             TargetPlatformUserId = targetPlatformUserId,
+            Surface = surface,
         });
 
         var cacheKey = $"social:state:{state}";
@@ -299,6 +301,7 @@ public class SocialLoginService : ISocialLoginService
             {
                 Intent = stateData.Intent,
                 TargetPlatformUserId = stateData.TargetPlatformUserId,
+                Surface = stateData.Surface,
             };
         }
         catch (Exception ex)
@@ -608,6 +611,11 @@ public class SocialLoginService : ISocialLoginService
         // Captured at initiate time when Intent=Link. Callback verifies the
         // active bearer matches this id before persisting the link.
         public Guid? TargetPlatformUserId { get; init; }
+
+        // Optional return-surface for the post-OAuth redirect. null = existing /app
+        // web flow (backwards-compatible); "wallet" = citizen wallet PWA surface.
+        // Added for PWA social sign-in (Feature 138 / pwa-social-passkey-signin).
+        public string? Surface { get; init; }
     }
 
     private readonly record struct TokenExchangeResult(string AccessToken, string? IdToken);

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeyEndpointsTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/PublicPasskeyEndpointsTests.cs
@@ -278,6 +278,27 @@ public class PublicPasskeyEndpointsTests : IClassFixture<TenantServiceWebApplica
 
     #endregion
 
+    #region Consumer-Tier Hint Tests
+
+    [Fact]
+    public void AssertionVerifyRequest_ParsesConsumerTierHint()
+    {
+        // The wallet sends tier:"consumer" (a safe downgrade);
+        // non-"consumer" values fall back to the platform default so this
+        // anonymous endpoint can never escalate.
+        Sorcha.ServiceDefaults.Auth.Tier Resolve(string? hint) =>
+            string.Equals(hint, "consumer", StringComparison.OrdinalIgnoreCase)
+                ? Sorcha.ServiceDefaults.Auth.Tier.Consumer
+                : Sorcha.ServiceDefaults.Auth.Tier.Platform;
+
+        Resolve("consumer").Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Consumer);
+        Resolve("CONSUMER").Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Consumer);
+        Resolve("platform").Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Platform);
+        Resolve(null).Should().Be(Sorcha.ServiceDefaults.Auth.Tier.Platform);
+    }
+
+    #endregion
+
     #region Public Org Disabled Tests
 
     [Fact]

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs
@@ -14,7 +14,7 @@ namespace Sorcha.Tenant.Service.Tests.Endpoints;
 public class SocialProvidersEndpointTests
 {
     [Fact]
-    public void ListProviders_ReturnsConfiguredProviderNames()
+    public void ListConfiguredProviders_WhenProvidersConfigured_ReturnsOkWithProviderNames()
     {
         var social = new Mock<ISocialLoginService>();
         social.Setup(s => s.GetConfiguredProviderNames()).Returns(new[] { "Google", "Apple" });
@@ -23,5 +23,17 @@ public class SocialProvidersEndpointTests
 
         var ok = result.Should().BeOfType<Ok<SocialProvidersResponse>>().Subject;
         ok.Value!.Providers.Should().BeEquivalentTo(new[] { "Google", "Apple" });
+    }
+
+    [Fact]
+    public void ListConfiguredProviders_WhenNoProvidersConfigured_ReturnsOkWithEmptyList()
+    {
+        var social = new Mock<ISocialLoginService>();
+        social.Setup(s => s.GetConfiguredProviderNames()).Returns(Array.Empty<string>());
+
+        var result = SocialLoginEndpoints.ListConfiguredProvidersForTest(social.Object);
+
+        var ok = result.Should().BeOfType<Ok<SocialProvidersResponse>>().Subject;
+        ok.Value!.Providers.Should().BeEmpty();
     }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/SocialProvidersEndpointTests.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using Sorcha.Tenant.Service.Endpoints;
+using Sorcha.Tenant.Service.Models.Dtos;
+using Sorcha.Tenant.Service.Services;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+public class SocialProvidersEndpointTests
+{
+    [Fact]
+    public void ListProviders_ReturnsConfiguredProviderNames()
+    {
+        var social = new Mock<ISocialLoginService>();
+        social.Setup(s => s.GetConfiguredProviderNames()).Returns(new[] { "Google", "Apple" });
+
+        var result = SocialLoginEndpoints.ListConfiguredProvidersForTest(social.Object);
+
+        var ok = result.Should().BeOfType<Ok<SocialProvidersResponse>>().Subject;
+        ok.Value!.Providers.Should().BeEquivalentTo(new[] { "Google", "Apple" });
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Endpoints/Verify2FaTierTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Endpoints/Verify2FaTierTests.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.ServiceDefaults.Auth;
+using Sorcha.Tenant.Service.Endpoints;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Endpoints;
+
+public class Verify2FaTierTests
+{
+    [Theory]
+    [InlineData("consumer", Tier.Consumer)]
+    [InlineData("CONSUMER", Tier.Consumer)]
+    [InlineData("platform", Tier.Platform)]
+    [InlineData(null, Tier.Platform)]
+    public void ResolveVerify2FaTier_HonoursConsumerHintOnly(string? hint, Tier expected)
+        => AuthEndpoints.ResolveVerify2FaTier(hint).Should().Be(expected);
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
@@ -156,4 +156,35 @@ public class SocialCallbackModelTests : IDisposable
         model.ErrorMessage.Should().Contain("account exists");
         model.ErrorMessage.Should().Contain("verify");
     }
+
+    [Fact]
+    public async Task OnGetAsync_WalletSurface_UnknownIdentity_RedirectsToWalletSignInNoAccount()
+    {
+        // Arrange
+        _socialLoginService
+            .Setup(s => s.ExchangeCodeAsync(string.Empty, "code", "state", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SocialAuthCallbackResult(
+                Success: true, Error: null,
+                Subject: "sub-wallet-1", Email: "citizen@y.com", DisplayName: "Citizen",
+                EmailVerified: true, Provider: "Google",
+                Surface: "wallet"));
+
+        _platformUserService
+            .Setup(s => s.ResolveOrCreateSocialUserAsync(
+                It.IsAny<SocialAuthCallbackResult>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResolveSocialUserResult(
+                User: null, IsNew: false, Refusal: SocialLoginRefusal.NoExistingAccount));
+
+        var model = CreateModel();
+
+        // Act
+        var result = await model.OnGetAsync("code", "state", null, CancellationToken.None);
+
+        // Assert — wallet surface refusal for unknown identity must redirect to wallet sign-in
+        // with authError=no_account so the PWA can show the appropriate screen.
+        var redirect = result.Should().BeOfType<RedirectResult>().Subject;
+        redirect.Url.Should().Be("/wallet/signin?authError=no_account");
+    }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackModelTests.cs
@@ -111,6 +111,7 @@ public class SocialCallbackModelTests : IDisposable
         _platformUserService
             .Setup(s => s.ResolveOrCreateSocialUserAsync(
                 It.IsAny<SocialAuthCallbackResult>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ResolveSocialUserResult(
                 User: null, IsNew: false, Refusal: SocialLoginRefusal.ProviderUnverified));
@@ -140,6 +141,7 @@ public class SocialCallbackModelTests : IDisposable
         _platformUserService
             .Setup(s => s.ResolveOrCreateSocialUserAsync(
                 It.IsAny<SocialAuthCallbackResult>(),
+                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ResolveSocialUserResult(
                 User: null, IsNew: false, Refusal: SocialLoginRefusal.ExistingUnverified));

--- a/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackSurfaceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Pages/SocialCallbackSurfaceTests.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Tenant.Service.Pages.Auth;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Pages;
+
+public class SocialCallbackSurfaceTests
+{
+    [Theory]
+    [InlineData("wallet", true)]
+    [InlineData("WALLET", true)]
+    [InlineData("app", false)]
+    [InlineData(null, false)]
+    public void IsWalletSurface_DetectsWalletReturn(string? surface, bool expected)
+        => SocialCallbackModel.IsWalletSurface(surface).Should().Be(expected);
+
+    [Fact]
+    public void BuildWalletRedirect_PacksTokenRefreshExpiry()
+    {
+        var url = SocialCallbackModel.BuildWalletRedirect("AT", "RT", 3600, returnUrl: null);
+        url.Should().StartWith("/wallet/#");
+        url.Should().Contain("token=AT");
+        url.Should().Contain("refresh=RT");
+        url.Should().Contain("expires_in=3600");
+    }
+
+    [Fact]
+    public void BuildWalletSignInError_RoutesToPwaSignIn()
+        => SocialCallbackModel.BuildWalletSignInError("no_account")
+            .Should().Be("/wallet/signin?authError=no_account");
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginPolicyTests.cs
@@ -79,7 +79,7 @@ public class SocialLoginPolicyTests : IDisposable
         var claim = Claim(emailVerified: false, displayName: "New Name From Google");
 
         // Act
-        var result = await _service.ResolveOrCreateSocialUserAsync(claim, CancellationToken.None);
+        var result = await _service.ResolveOrCreateSocialUserAsync(claim, allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.None);
@@ -119,7 +119,7 @@ public class SocialLoginPolicyTests : IDisposable
 
         // Act — provider returned no display name
         var result = await _service.ResolveOrCreateSocialUserAsync(
-            Claim(subject: "sub-empty", displayName: null), CancellationToken.None);
+            Claim(subject: "sub-empty", displayName: null), allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.None);
@@ -149,7 +149,7 @@ public class SocialLoginPolicyTests : IDisposable
         // Act — Google returns the same email, asserts verified
         var result = await _service.ResolveOrCreateSocialUserAsync(
             Claim(email: "alice@example.com", emailVerified: true, displayName: "Alice G"),
-            CancellationToken.None);
+            allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.None);
@@ -183,7 +183,7 @@ public class SocialLoginPolicyTests : IDisposable
         // Act — provider says verified, but existing isn't
         var result = await _service.ResolveOrCreateSocialUserAsync(
             Claim(email: "alice@example.com", emailVerified: true),
-            CancellationToken.None);
+            allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.ExistingUnverified);
@@ -216,7 +216,7 @@ public class SocialLoginPolicyTests : IDisposable
         // Act
         var result = await _service.ResolveOrCreateSocialUserAsync(
             Claim(email: "alice@example.com", emailVerified: false),
-            CancellationToken.None);
+            allowCreate: true, CancellationToken.None);
 
         // Assert — provider is the unverified party, so refusal directs the user there
         result.Refusal.Should().Be(SocialLoginRefusal.ProviderUnverified);
@@ -235,7 +235,7 @@ public class SocialLoginPolicyTests : IDisposable
         // Act
         var result = await _service.ResolveOrCreateSocialUserAsync(
             Claim(email: "newcomer@example.com", subject: "sub-newcomer", emailVerified: true),
-            CancellationToken.None);
+            allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.None);
@@ -266,7 +266,7 @@ public class SocialLoginPolicyTests : IDisposable
             Claim(provider: "GitHub", subject: "github-noverify-123",
                   email: null, displayName: "octouser",
                   emailVerified: false),
-            CancellationToken.None);
+            allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.ProviderUnverified);
@@ -283,7 +283,7 @@ public class SocialLoginPolicyTests : IDisposable
         // Act
         var result = await _service.ResolveOrCreateSocialUserAsync(
             Claim(email: "untrusted@example.com", subject: "sub-untrusted", emailVerified: false),
-            CancellationToken.None);
+            allowCreate: true, CancellationToken.None);
 
         // Assert
         result.Refusal.Should().Be(SocialLoginRefusal.ProviderUnverified);
@@ -292,6 +292,86 @@ public class SocialLoginPolicyTests : IDisposable
 
         var afterCount = await _db.PlatformUsers.CountAsync();
         afterCount.Should().Be(beforeCount, "no user record should be created on a refused signup");
+    }
+
+    // --- Scenario D: login-only surface (allowCreate: false) ---
+
+    [Fact]
+    public async Task AllowCreateFalse_UnknownIdentity_RefusesWithNoExistingAccount_NothingPersisted()
+    {
+        // Arrange — no pre-existing user by provider+subject or email
+        var beforeCount = await _db.PlatformUsers.CountAsync();
+
+        // Act — wallet (login-only) surface presents a brand-new social identity
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "newwallet@example.com", subject: "sub-wallet-new", emailVerified: true),
+            allowCreate: false, CancellationToken.None);
+
+        // Assert — refused with the login-only gate
+        result.Refusal.Should().Be(SocialLoginRefusal.NoExistingAccount);
+        result.User.Should().BeNull();
+        result.IsNew.Should().BeFalse();
+
+        // No PlatformUser should have been created
+        var afterCount = await _db.PlatformUsers.CountAsync();
+        afterCount.Should().Be(beforeCount, "login-only surface must not create a PlatformUser for an unknown identity");
+
+        // No PlatformSocialLogin should have been created
+        var linkCount = await _db.PlatformSocialLogins.CountAsync(s => s.Subject == "sub-wallet-new");
+        linkCount.Should().Be(0, "no social link row should be persisted on login-only refusal");
+    }
+
+    [Fact]
+    public async Task AllowCreateTrue_UnknownIdentity_CreatesUser()
+    {
+        // Companion assertion: the gate is the ONLY difference — allowCreate:true still creates the user.
+        var beforeCount = await _db.PlatformUsers.CountAsync();
+
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(email: "newwebuser@example.com", subject: "sub-web-new", emailVerified: true),
+            allowCreate: true, CancellationToken.None);
+
+        result.Refusal.Should().Be(SocialLoginRefusal.None);
+        result.User.Should().NotBeNull();
+        result.IsNew.Should().BeTrue();
+
+        var afterCount = await _db.PlatformUsers.CountAsync();
+        afterCount.Should().Be(beforeCount + 1, "allowCreate:true should create a new PlatformUser");
+    }
+
+    [Fact]
+    public async Task AllowCreateFalse_ExistingUserByProvider_AllowsLogin()
+    {
+        // Step 1 (returning user) must still work on a login-only surface.
+        var existing = new PlatformUser
+        {
+            Id = Guid.NewGuid(),
+            Email = "wallet-returning@example.com",
+            DisplayName = "Wallet User",
+            EmailVerified = true,
+            Status = PlatformUserStatus.Active,
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-5),
+        };
+        _db.PlatformUsers.Add(existing);
+        _db.PlatformSocialLogins.Add(new PlatformSocialLogin
+        {
+            Id = Guid.NewGuid(),
+            PlatformUserId = existing.Id,
+            Provider = "Google",
+            Subject = "sub-wallet-returning",
+            Email = "wallet-returning@example.com",
+            LinkedAt = DateTimeOffset.UtcNow.AddDays(-5),
+        });
+        await _db.SaveChangesAsync();
+
+        var result = await _service.ResolveOrCreateSocialUserAsync(
+            Claim(subject: "sub-wallet-returning", email: "wallet-returning@example.com", emailVerified: true),
+            allowCreate: false, CancellationToken.None);
+
+        result.Refusal.Should().Be(SocialLoginRefusal.None);
+        result.User.Should().NotBeNull();
+        result.User!.Id.Should().Be(existing.Id);
+        result.IsNew.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceSurfaceTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Services/SocialLoginServiceSurfaceTests.cs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Sorcha.Tenant.Service.Services;
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Services;
+
+public class SocialLoginServiceSurfaceTests
+{
+    private static SocialLoginService BuildService(IDistributedCache cache)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SocialProviders:0:Name"] = "Google",
+                ["SocialProviders:0:ClientId"] = "test-client",
+                ["SocialProviders:0:ClientSecret"] = "test-secret",
+            })
+            .Build();
+        return new SocialLoginService(
+            new TestHttpClientFactory(), cache, config, NullLogger<SocialLoginService>.Instance);
+    }
+
+    [Fact]
+    public async Task GenerateAuthorizationUrl_WithSurface_RoundTripsSurfaceThroughState()
+    {
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var svc = BuildService(cache);
+
+        var init = await svc.GenerateAuthorizationUrlAsync(
+            "Google", "https://host/auth/social/callback",
+            SocialFlowIntent.Login, targetPlatformUserId: null, surface: "wallet");
+
+        var stateJson = Encoding.UTF8.GetString((await cache.GetAsync($"social:state:{init.State}"))!);
+        stateJson.Should().Contain("\"Surface\":\"wallet\"");
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignInTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletSignInTests.cs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+using Sorcha.UI.E2E.Tests.PageObjects;
+
+namespace Sorcha.UI.E2E.Tests.Docker.CitizenWallet;
+
+/// <summary>
+/// E2E coverage for the Citizen Wallet PWA sign-in screen
+/// (<c>/wallet/signin</c>): auth-gate redirect, password happy-path,
+/// social OAuth fragment return, and passkey-option visibility.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Runnable without seeding (CI-safe):</b>
+/// <c>SignedOut_ProtectedRoute_RedirectsToSignIn</c> — navigates anonymously
+/// to a protected route and asserts the PWA's <c>RedirectToSignIn</c>
+/// component sends the browser to <c>/wallet/signin</c>.
+/// </para>
+/// <para>
+/// <b>Requires Docker stack + seeded citizen account:</b>
+/// <c>Password_HappyPath_SignsInAndLeavesSignInScreen</c> and
+/// <c>SocialReturnLeg_StoresTokenAndLeavesSignIn</c> require a real citizen
+/// user in the database. Those tests are marked <c>[Explicit]</c> so they are
+/// excluded from the normal CI run but can be executed locally against a
+/// running Docker stack by passing <c>--explicit</c> to the test runner.
+/// </para>
+/// <para>
+/// <b>Requires a seeded credential for the full ceremony:</b>
+/// <c>Passkey_VirtualAuthenticator_ShowsPasskeyButton</c> uses the Playwright
+/// CDP virtual authenticator API to enable WebAuthn in the browser and asserts
+/// the passkey button becomes visible. The full sign-in ceremony is
+/// <c>[Explicit]</c> because it requires a server-seeded WebAuthn credential.
+/// </para>
+/// </remarks>
+[TestFixture]
+[Category("Docker")]
+[Category("CitizenWallet")]
+[Category("Auth")]
+public class CitizenWalletSignInTests : AuthenticatedCitizenWalletTestBase
+{
+    private CitizenWalletSignInPage SignInPage => new(Page);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Gate-redirect — fully deterministic, no seeding required
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An anonymous visit to a protected wallet route (e.g. <c>/wallet/devices</c>)
+    /// must be redirected to <c>/wallet/signin</c> by the PWA's
+    /// <c>RedirectToSignIn</c> component, and the sign-in screen must render.
+    /// </summary>
+    /// <remarks>
+    /// This test requires no seeded data. It exercises the
+    /// <c>[Authorize]</c> + <c>NotAuthorized</c> gate in <c>App.razor</c>
+    /// and the base-relative navigation in <c>RedirectToSignIn.razor</c>.
+    /// A failure here means the auth gate is broken for all wallet users.
+    /// </remarks>
+    [Test]
+    [Retry(2)]
+    public async Task SignedOut_ProtectedRoute_RedirectsToSignIn()
+    {
+        // Navigate directly to a protected wallet page in unauthenticated state.
+        // IndexedDB is empty for a fresh Playwright browser context — no JWT
+        // is present, so WalletAuthenticationStateProvider returns
+        // NotAuthenticated and the router fires RedirectToSignIn.
+        await NavigateToWalletAndWaitForBlazorAsync("/devices");
+
+        // Allow Blazor's client-side routing to settle.
+        // WaitForURLAsync with a glob pattern handles both /wallet/signin and
+        // /wallet/signin?returnUrl=… (the returnUrl is appended by RedirectToSignIn).
+        try
+        {
+            await Page.WaitForURLAsync(
+                $"**{TestConstants.CitizenWalletBase}signin*",
+                new() { Timeout = TestConstants.PageLoadTimeout, WaitUntil = WaitUntilState.Load });
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail(
+                $"Expected redirect to /wallet/signin after visiting a protected route " +
+                $"while signed out, but the URL is still '{Page.Url}'. " +
+                $"The RedirectToSignIn component may not be wired correctly.");
+        }
+
+        // Confirm the URL contains the sign-in path segment.
+        var actualPath = new Uri(Page.Url).AbsolutePath;
+        Assert.That(actualPath, Does.Contain("/wallet/signin"),
+            $"URL after sign-out gate redirect should contain '/wallet/signin'. Actual: {actualPath}");
+
+        // Confirm the Blazor sign-in screen rendered (data-testid='signin-screen').
+        await SignInPage.WaitForReadyAsync();
+        var screenVisible = await SignInPage.Screen.IsVisibleAsync();
+        Assert.That(screenVisible, Is.True,
+            "The sign-in screen (data-testid='signin-screen') must be visible after the auth-gate redirect.");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Password happy-path — requires seeded citizen account
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A citizen with valid password credentials can sign in through the
+    /// wallet sign-in screen and is navigated away from <c>/wallet/signin</c>.
+    /// </summary>
+    /// <remarks>
+    /// <b>Marked [Explicit]</b> because it requires a pre-seeded citizen
+    /// account in the Docker PostgreSQL database. The council citizen
+    /// (<see cref="TestConstants.CouncilTestUsers.CitizenEmail"/>) is created
+    /// by the <c>CouncilCredentialFlowTests</c> setup fixture, not a
+    /// standalone seed. Run against a stack that has already executed those
+    /// setup steps, or supply credentials via the
+    /// <c>SORCHA_E2E_COUNCIL_CITIZEN_PASSWORD</c> environment variable.
+    /// To run locally: <c>dotnet test --filter "FullyQualifiedName~Password_HappyPath" --explicit</c>
+    /// </remarks>
+    [Test]
+    [Explicit("Requires seeded citizen account — see CouncilTestUsers / CouncilCredentialFlowTests setup.")]
+    public async Task Password_HappyPath_SignsInAndLeavesSignInScreen()
+    {
+        await NavigateToWalletAndWaitForBlazorAsync("/signin");
+        await SignInPage.WaitForReadyAsync();
+
+        await SignInPage.SignInWithPasswordAsync(
+            TestConstants.CouncilTestUsers.CitizenEmail,
+            TestConstants.CouncilTestUsers.CitizenPassword);
+
+        // Wait for the navigation away from /signin.
+        try
+        {
+            await Page.WaitForURLAsync(
+                url => !url.Contains("/wallet/signin", StringComparison.OrdinalIgnoreCase),
+                new() { Timeout = TestConstants.PageLoadTimeout });
+        }
+        catch (TimeoutException)
+        {
+            // If we are still on the sign-in page, surface the error message.
+            var errorText = await SignInPage.Error.IsVisibleAsync()
+                ? await SignInPage.Error.InnerTextAsync()
+                : "(no error element visible)";
+
+            Assert.Fail(
+                $"Expected navigation away from /wallet/signin after successful password sign-in, " +
+                $"but the URL is still '{Page.Url}'. Error on screen: {errorText}");
+        }
+
+        var finalPath = new Uri(Page.Url).AbsolutePath;
+        Assert.That(finalPath, Does.Not.Contain("/wallet/signin"),
+            $"After successful sign-in the wallet should not stay on /wallet/signin. Actual: {finalPath}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Social return-leg — requires token-mint capability
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The social OAuth return leg: the gateway callback redirects to
+    /// <c>/wallet/#token=…&amp;refresh=…&amp;expires_in=…</c>. The
+    /// <c>auth-fragment.js</c> script captures the token before Blazor boots,
+    /// and <c>OnInitializedAsync</c> in <c>SignIn.razor</c> calls
+    /// <c>TryConsumeSocialReturnAsync</c> which writes the token to IndexedDB
+    /// and navigates to the wallet Home.
+    /// </summary>
+    /// <remarks>
+    /// <b>Marked [Explicit]</b> because constructing a structurally valid
+    /// <c>sorcha:consumer</c> JWT that passes <c>IAccessTokenStore</c>
+    /// signature verification requires access to the tenant service's signing
+    /// key — there is no public token-mint helper in the test infrastructure.
+    /// To run: supply a real token from a prior API login or wire a
+    /// <c>GetTokenAsync</c>-style helper (see <c>CouncilCredentialFlowTests</c>).
+    /// When the token IS valid, the test verifies the complete fragment-return
+    /// path without a UI interaction (the redirect destination carries the token).
+    /// </remarks>
+    [Test]
+    [Explicit("Requires a valid consumer-tier JWT — no token-mint helper available in E2E infra for the citizen audience.")]
+    public async Task SocialReturnLeg_StoresTokenAndLeavesSignIn()
+    {
+        // Placeholder: replace <accessToken>, <refreshToken> with real tokens
+        // obtained via e.g. CouncilCredentialFlowTests.GetTokenAsync(...).
+        const string accessToken = "REPLACE_ME";
+        const string refreshToken = "REPLACE_ME";
+        const int expiresIn = 3600;
+
+        // Navigate to the wallet base with the OAuth fragment. auth-fragment.js
+        // captures the hash before Blazor boots and replaces the URL state.
+        var fragmentUrl =
+            $"{TestConstants.UiWebUrl}{TestConstants.CitizenWalletBase}" +
+            $"#token={accessToken}&refresh={refreshToken}&expires_in={expiresIn}";
+
+        await Page.GotoAsync(fragmentUrl);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        // Wait for Blazor WASM to hydrate and process the fragment.
+        await Page.WaitForTimeoutAsync(TestConstants.BlazorHydrationTimeout);
+
+        // The PWA should have consumed the token from the fragment and navigated
+        // to the wallet Home — it must NOT remain on /wallet/signin.
+        var finalUrl = Page.Url;
+        Assert.That(finalUrl, Does.Not.Contain("/wallet/signin"),
+            $"After a social return with a valid token the wallet should navigate " +
+            $"away from /signin. Actual URL: {finalUrl}");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Passkey option visibility — CDP virtual authenticator
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// With a CDP virtual WebAuthn authenticator registered, the sign-in screen
+    /// should expose the <c>data-testid="signin-passkey"</c> button.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The passkey button is conditionally rendered: <c>OnAfterRenderAsync</c>
+    /// calls <c>IPasskeyInterop.IsSupportedAsync()</c>, which evaluates
+    /// <c>window.PublicKeyCredential !== undefined</c>. Enabling the CDP
+    /// virtual authenticator causes the browser to advertise WebAuthn support,
+    /// so the button should appear after the next Blazor re-render cycle.
+    /// </para>
+    /// <para>
+    /// The full WebAuthn ceremony (credential creation + assertion against a
+    /// server-seeded credential) is <b>NOT</b> tested here — that requires a
+    /// pre-registered passkey in the Wallet Service database, which is not
+    /// available in the baseline test environment. The full ceremony is deferred
+    /// to a future seeded fixture.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [Retry(2)]
+    public async Task Passkey_VirtualAuthenticator_ShowsPasskeyButton()
+    {
+        // Enable the CDP virtual WebAuthn authenticator BEFORE navigating so
+        // that window.PublicKeyCredential is available from first parse.
+        var cdpSession = await Page.Context.NewCDPSessionAsync(Page);
+
+        try
+        {
+            await cdpSession.SendAsync("WebAuthn.enable");
+            await cdpSession.SendAsync("WebAuthn.addVirtualAuthenticator", new Dictionary<string, object>
+            {
+                ["options"] = new Dictionary<string, object>
+                {
+                    ["protocol"]          = "ctap2",
+                    ["transport"]         = "internal",
+                    ["hasResidentKey"]    = true,
+                    ["hasUserVerification"] = true,
+                    ["isUserVerified"]    = true,
+                },
+            });
+        }
+        catch (Exception ex)
+        {
+            // CDP WebAuthn emulation requires a Chromium-based browser. If the
+            // test runner uses Firefox or WebKit, surface as inconclusive.
+            Assert.Inconclusive(
+                $"CDP WebAuthn.enable failed — likely not running on Chromium. " +
+                $"Passkey-button test requires a Chromium browser. Details: {ex.Message}");
+            return;
+        }
+
+        await SignInPage.GotoAsync();
+        await SignInPage.WaitForReadyAsync();
+
+        // IPasskeyInterop.IsSupportedAsync runs in OnAfterRenderAsync (firstRender only),
+        // triggering a StateHasChanged. Give Blazor time to complete the re-render.
+        await Page.WaitForTimeoutAsync(TestConstants.BlazorHydrationTimeout);
+
+        // The passkey button must be visible now that WebAuthn is available.
+        var isVisible = await SignInPage.PasskeyButton.IsVisibleAsync();
+        Assert.That(isVisible, Is.True,
+            "With a CDP virtual WebAuthn authenticator registered the " +
+            "'Sign in with a passkey' button (data-testid='signin-passkey') should be visible.");
+    }
+}

--- a/tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletSignInPage.cs
+++ b/tests/Sorcha.UI.E2E.Tests/PageObjects/CitizenWalletSignInPage.cs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+using Sorcha.UI.E2E.Tests.PageObjects.Shared;
+
+namespace Sorcha.UI.E2E.Tests.PageObjects;
+
+/// <summary>
+/// Page object for the Citizen Wallet PWA sign-in screen
+/// (<c>/wallet/signin</c>). Locators bind to <c>data-testid</c> attributes
+/// on <c>Sorcha.Wallet.Pwa/Pages/SignIn.razor</c> so structural MudBlazor
+/// markup changes do not break tests.
+/// </summary>
+public class CitizenWalletSignInPage
+{
+    private readonly IPage _page;
+
+    /// <summary>Initialises the page object with the given Playwright page.</summary>
+    public CitizenWalletSignInPage(IPage page)
+    {
+        _page = page;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Locators
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>The outer sign-in stack container — always present on this route.</summary>
+    public ILocator Screen => MudBlazorHelpers.TestId(_page, "signin-screen");
+
+    /// <summary>Error alert — visible only when a sign-in attempt fails.</summary>
+    public ILocator Error => MudBlazorHelpers.TestId(_page, "signin-error");
+
+    /// <summary>Passkey sign-in button — visible only when WebAuthn is supported.</summary>
+    public ILocator PasskeyButton => MudBlazorHelpers.TestId(_page, "signin-passkey");
+
+    /// <summary>Email text field.</summary>
+    public ILocator EmailInput => MudBlazorHelpers.TestId(_page, "signin-email");
+
+    /// <summary>Password text field.</summary>
+    public ILocator PasswordInput => MudBlazorHelpers.TestId(_page, "signin-password");
+
+    /// <summary>Password-form submit button.</summary>
+    public ILocator PasswordSubmitButton => MudBlazorHelpers.TestId(_page, "signin-password-submit");
+
+    /// <summary>TOTP 2FA code input — visible only after a successful first-factor password check.</summary>
+    public ILocator TwoFactorCodeInput => MudBlazorHelpers.TestId(_page, "signin-2fa-code");
+
+    /// <summary>TOTP 2FA verify submit button.</summary>
+    public ILocator TwoFactorSubmitButton => MudBlazorHelpers.TestId(_page, "signin-2fa-submit");
+
+    /// <summary>
+    /// Returns the button for the given social provider name (case-insensitive);
+    /// e.g. <c>"Google"</c> → <c>data-testid="signin-social-google"</c>.
+    /// </summary>
+    public ILocator SocialButton(string provider) =>
+        MudBlazorHelpers.TestId(_page, $"signin-social-{provider.ToLowerInvariant()}");
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Navigation
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Navigates directly to the wallet sign-in route and waits for the page to
+    /// reach network-idle state. Does NOT wait for Blazor hydration — call
+    /// <see cref="WaitForReadyAsync"/> afterwards if MudBlazor selectors are
+    /// needed.
+    /// </summary>
+    public async Task GotoAsync()
+    {
+        var url = $"{TestConstants.UiWebUrl}{TestConstants.CitizenWalletBase}signin";
+        await _page.GotoAsync(url);
+        await _page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    /// <summary>
+    /// Waits for the <c>signin-screen</c> element to be visible — confirms
+    /// Blazor WASM has hydrated and the sign-in UI has rendered.
+    /// </summary>
+    public async Task WaitForReadyAsync(int timeoutMs = TestConstants.PageLoadTimeout)
+    {
+        await Screen.WaitForAsync(new()
+        {
+            State = WaitForSelectorState.Visible,
+            Timeout = timeoutMs,
+        });
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Actions
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Fills in the email/password fields and clicks the submit button.
+    /// Does NOT wait for navigation — the caller is responsible for asserting
+    /// the outcome (URL change, error, 2FA prompt, etc.).
+    /// </summary>
+    public async Task SignInWithPasswordAsync(string email, string password)
+    {
+        await EmailInput.FillAsync(email);
+        await PasswordInput.FillAsync(password);
+        await PasswordSubmitButton.ClickAsync();
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -312,16 +312,23 @@ public sealed class AuthAndBearerTests
     }
 
     [Fact]
-    public async Task BeginSocialSignInAsync_ReturnsAuthorizationUrl()
+    public async Task BeginSocialSignInAsync_ReturnsAuthorizationUrl_AndSendsWalletSurface()
     {
-        var handler = new CapturingHandler(_ =>
-            Task.FromResult(JsonOk("{\"authorization_url\":\"https://idp/auth?x=1\",\"state\":\"st\"}")));
+        string? capturedBody = null;
+        var handler = new CapturingHandler(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return JsonOk("{\"authorizationUrl\":\"https://idp/auth?x=1\",\"state\":\"st\"}");
+        });
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
         var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(), new FakePasskeyInterop());
 
         var url = await auth.BeginSocialSignInAsync("Google");
 
         url.Should().Be("https://idp/auth?x=1");
+        capturedBody.Should().Contain("\"surface\":\"wallet\"");
+        capturedBody.Should().Contain("\"intent\":\"login\"");
+        capturedBody.Should().Contain("\"provider\":\"Google\"");
     }
 
     [Fact]

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -240,6 +240,23 @@ public sealed class AuthAndBearerTests
     }
 
     [Fact]
+    public async Task SignInWithPasskeyAsync_UnrecognisedPasskey_ReturnsInvalidCredentials()
+    {
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            JsonOk("{\"transaction_id\":\"tx1\",\"options\":{\"challenge\":\"AA\"}}"),
+            new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized)
+        });
+        var handler = new CapturingHandler(_ => Task.FromResult(responses.Dequeue()));
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+        var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(), new FakePasskeyInterop());
+
+        var result = await auth.SignInWithPasskeyAsync();
+
+        result.Status.Should().Be(SignInStatus.InvalidCredentials);
+    }
+
+    [Fact]
     public async Task SignInWithPasskeyAsync_Unsupported_ReturnsServerError()
     {
         var http = new HttpClient(new CapturingHandler(_ => Task.FromResult(JsonOk("{}"))))

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -243,4 +243,37 @@ public sealed class AuthAndBearerTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
             => Task.FromResult(_respond(request, ct));
     }
+
+    [Fact]
+    public async Task SignInAsync_SendsConsumerTierHint()
+    {
+        string? capturedBody = null;
+        var handler = new CapturingHandler(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return JsonOk("{\"access_token\":\"at\",\"expires_in\":3600,\"requires_two_factor\":false}");
+        });
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+        var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge());
+
+        await auth.SignInAsync("a@b.test", "pw");
+
+        capturedBody.Should().Contain("\"tier\":\"consumer\"");
+    }
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => responder(request);
+    }
+
+    private sealed class NoopLocalDataPurge : ILocalDataPurge
+    {
+        public Task PurgeAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private static HttpResponseMessage JsonOk(string json) => new(System.Net.HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+    };
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -401,6 +401,43 @@ public sealed class AuthAndBearerTests
     }
 
     [Fact]
+    public async Task BearerTokenHandler_On401_PreservesPostBodyOnRetry()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", "rt"));
+
+        string? retriedBody = null;
+        var inner = new SequencedHandler(req =>
+        {
+            var auth = req.Headers.Authorization?.Parameter;
+            if (auth == "new")
+            {
+                // Capture the retried request's body — synchronous GetAwaiter().GetResult() is
+                // acceptable in a test-only delegate; no async path available here.
+                retriedBody = req.Content is null
+                    ? null
+                    : req.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            }
+            return new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
+        });
+
+        // Refresh endpoint returns a fresh token "new".
+        var refreshHttp = new HttpClient(new CapturingHandler(_ =>
+            Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
+            { BaseAddress = new Uri("https://gw.test/") };
+
+        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+
+        var resp = await client.PostAsync("api/v1/wallet/something",
+            new StringContent("{\"k\":\"v\"}", System.Text.Encoding.UTF8, "application/json"));
+
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        retriedBody.Should().Be("{\"k\":\"v\"}", "CloneAsync must copy the POST body to the retried request");
+    }
+
+    [Fact]
     public async Task BearerTokenHandler_On401_FailedRefresh_ClearsSession()
     {
         var store = new InMemoryAccessTokenStore();

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -311,6 +311,34 @@ public sealed class AuthAndBearerTests
         capturedBody.Should().Contain("\"tier\":\"consumer\"");
     }
 
+    [Fact]
+    public async Task BeginSocialSignInAsync_ReturnsAuthorizationUrl()
+    {
+        var handler = new CapturingHandler(_ =>
+            Task.FromResult(JsonOk("{\"authorization_url\":\"https://idp/auth?x=1\",\"state\":\"st\"}")));
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+        var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(), new FakePasskeyInterop());
+
+        var url = await auth.BeginSocialSignInAsync("Google");
+
+        url.Should().Be("https://idp/auth?x=1");
+    }
+
+    [Fact]
+    public async Task TryConsumeSocialReturnAsync_NoFragment_ReturnsFalse_And_StaysSignedOut()
+    {
+        var js = new NullConsumeJsRuntime();
+        var store = new InMemoryAccessTokenStore();
+        var auth = new AuthService(
+            new HttpClient(new CapturingHandler(_ => Task.FromResult(JsonOk("{}")))) { BaseAddress = new Uri("https://gw.test/") },
+            store, new NoopLocalDataPurge(), new FakePasskeyInterop());
+
+        var consumed = await auth.TryConsumeSocialReturnAsync(js);
+
+        consumed.Should().BeFalse();
+        (await store.GetAsync()).Should().BeNull();
+    }
+
     private sealed class CapturingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
@@ -326,4 +354,12 @@ public sealed class AuthAndBearerTests
     {
         Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
     };
+}
+
+internal sealed class NullConsumeJsRuntime : Microsoft.JSInterop.IJSRuntime
+{
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        => new((TValue)(object?)default!);
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken ct, object?[]? args)
+        => new((TValue)(object?)default!);
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -219,11 +220,43 @@ public sealed class AuthAndBearerTests
         loaded!.RefreshToken.Should().Be("rt");
     }
 
+    [Fact]
+    public async Task SignInWithPasskeyAsync_HappyPath_PersistsConsumerToken()
+    {
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            JsonOk("{\"transaction_id\":\"tx1\",\"options\":{\"challenge\":\"AA\"}}"),
+            JsonOk("{\"access_token\":\"at\",\"refresh_token\":\"rt\",\"expires_in\":3600}")
+        });
+        var handler = new CapturingHandler(_ => Task.FromResult(responses.Dequeue()));
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+        var store = new InMemoryAccessTokenStore();
+        var auth = new AuthService(http, store, new NoopLocalDataPurge(), new FakePasskeyInterop());
+
+        var result = await auth.SignInWithPasskeyAsync();
+
+        result.IsSuccess.Should().BeTrue();
+        (await store.GetAsync())!.RefreshToken.Should().Be("rt");
+    }
+
+    [Fact]
+    public async Task SignInWithPasskeyAsync_Unsupported_ReturnsServerError()
+    {
+        var http = new HttpClient(new CapturingHandler(_ => Task.FromResult(JsonOk("{}"))))
+            { BaseAddress = new Uri("https://gw.test/") };
+        var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(),
+            new FakePasskeyInterop { Supported = false });
+
+        var result = await auth.SignInWithPasskeyAsync();
+
+        result.Status.Should().Be(SignInStatus.ServerError);
+    }
+
     // Constructs an AuthService with a throwaway purge for the tests that
     // don't assert on the sign-out cascade; AuthService_SignOut_PurgesAllLocalData
     // passes its own spy to inspect the call.
     private static AuthService NewAuth(HttpClient http, IAccessTokenStore store, ILocalDataPurge? purge = null)
-        => new(http, store, purge ?? new SpyLocalDataPurge());
+        => new(http, store, purge ?? new SpyLocalDataPurge(), new FakePasskeyInterop());
 
     private sealed class SpyLocalDataPurge : ILocalDataPurge
     {
@@ -254,7 +287,7 @@ public sealed class AuthAndBearerTests
             return JsonOk("{\"access_token\":\"at\",\"expires_in\":3600,\"requires_two_factor\":false}");
         });
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
-        var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge());
+        var auth = new AuthService(http, new InMemoryAccessTokenStore(), new NoopLocalDataPurge(), new FakePasskeyInterop());
 
         await auth.SignInAsync("a@b.test", "pw");
 

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -183,7 +183,9 @@ public sealed class AuthAndBearerTests
             observedAuth = req.Headers.Authorization?.ToString();
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var bearer = new BearerTokenHandler(store) { InnerHandler = inner };
+        var noRefreshHttp = new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage()))
+            { BaseAddress = new Uri("https://localhost/") };
+        var bearer = new BearerTokenHandler(store, noRefreshHttp) { InnerHandler = inner };
         var http = new HttpClient(bearer) { BaseAddress = new Uri("https://localhost/") };
 
         await http.GetAsync("api/v1/wallet/sync");
@@ -201,7 +203,9 @@ public sealed class AuthAndBearerTests
             observedAuth = req.Headers.Authorization?.ToString();
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var bearer = new BearerTokenHandler(store) { InnerHandler = inner };
+        var noRefreshHttp = new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage()))
+            { BaseAddress = new Uri("https://localhost/") };
+        var bearer = new BearerTokenHandler(store, noRefreshHttp) { InnerHandler = inner };
         var http = new HttpClient(bearer) { BaseAddress = new Uri("https://localhost/") };
 
         await http.GetAsync("api/v1/wallet/sync");
@@ -346,6 +350,77 @@ public sealed class AuthAndBearerTests
         (await store.GetAsync()).Should().BeNull();
     }
 
+    [Fact]
+    public async Task BearerTokenHandler_On401_RefreshesAndRetries()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", "rt"));
+
+        // Inner handler: request with stale "old" token → 401; with "new" token → 200.
+        var inner = new SequencedHandler(req =>
+        {
+            var auth = req.Headers.Authorization?.Parameter;
+            return auth == "new"
+                ? new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                : new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
+        });
+
+        // Refresh endpoint returns a fresh token "new".
+        var refreshHttp = new HttpClient(new CapturingHandler(_ =>
+            Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
+            { BaseAddress = new Uri("https://gw.test/") };
+
+        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+
+        var resp = await client.GetAsync("api/v1/wallet/credentials");
+
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        (await store.GetAsync())!.AccessToken.Should().Be("new");
+    }
+
+    [Fact]
+    public async Task BearerTokenHandler_On401_WithNoRefreshToken_Returns401Untouched()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", null));
+
+        var inner = new SequencedHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized));
+        var refreshHttp = new HttpClient(new CapturingHandler(_ =>
+            Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
+            { BaseAddress = new Uri("https://gw.test/") };
+
+        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+
+        var resp = await client.GetAsync("api/v1/wallet/credentials");
+
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
+        // Token should be unchanged (no refresh attempted, no clear)
+        (await store.GetAsync())!.AccessToken.Should().Be("old");
+    }
+
+    [Fact]
+    public async Task BearerTokenHandler_On401_FailedRefresh_ClearsSession()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", "rt"));
+
+        var inner = new SequencedHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized));
+        // Refresh endpoint returns 401 (refresh token invalid/expired)
+        var refreshHttp = new HttpClient(new CapturingHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized))))
+            { BaseAddress = new Uri("https://gw.test/") };
+
+        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
+
+        var resp = await client.GetAsync("api/v1/wallet/credentials");
+
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
+        (await store.GetAsync()).Should().BeNull("failed refresh must clear the session");
+    }
+
     private sealed class CapturingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
@@ -361,6 +436,12 @@ public sealed class AuthAndBearerTests
     {
         Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
     };
+}
+
+internal sealed class SequencedHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        => Task.FromResult(responder(request));
 }
 
 internal sealed class NullConsumeJsRuntime : Microsoft.JSInterop.IJSRuntime

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -208,6 +208,17 @@ public sealed class AuthAndBearerTests
         observedAuth.Should().BeNull("requests must go out unauthenticated when no token is stored");
     }
 
+    [Fact]
+    public async Task InMemoryAccessTokenStore_RoundTripsRefreshToken()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var record = new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", "rt");
+        await store.SetAsync(record);
+
+        var loaded = await store.GetAsync();
+        loaded!.RefreshToken.Should().Be("rt");
+    }
+
     // Constructs an AuthService with a throwaway purge for the tests that
     // don't assert on the sign-out cascade; AuthService_SignOut_PurgesAllLocalData
     // passes its own spy to inspect the call.

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+public class PasskeyInteropContractTests
+{
+    [Fact]
+    public async Task Fake_ReturnsAssertion()
+    {
+        IPasskeyInterop interop = new FakePasskeyInterop();
+        (await interop.IsSupportedAsync()).Should().BeTrue();
+        var resp = await interop.GetAssertionAsync(default);
+        resp.GetProperty("id").GetString().Should().Be("abc");
+    }
+}
+
+/// <summary>
+/// Shared in-memory passkey interop fake — top-level + internal so the AuthService
+/// tests (a later task) reuse it. Stands in for navigator.credentials.get() so no
+/// test touches IJSRuntime (brittle to mock — F114 lesson).
+/// </summary>
+internal sealed class FakePasskeyInterop : IPasskeyInterop
+{
+    public bool Supported = true;
+    public JsonElement Assertion = JsonDocument.Parse("{\"id\":\"abc\"}").RootElement;
+    public Task<bool> IsSupportedAsync() => Task.FromResult(Supported);
+    public Task<JsonElement> GetAssertionAsync(JsonElement options) => Task.FromResult(Assertion);
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/PasskeyInteropContractTests.cs
@@ -29,7 +29,7 @@ public class PasskeyInteropContractTests
 internal sealed class FakePasskeyInterop : IPasskeyInterop
 {
     public bool Supported = true;
-    public JsonElement Assertion = JsonDocument.Parse("{\"id\":\"abc\"}").RootElement;
+    public JsonElement Assertion = JsonDocument.Parse("{\"id\":\"abc\"}").RootElement.Clone();
     public Task<bool> IsSupportedAsync() => Task.FromResult(Supported);
     public Task<JsonElement> GetAssertionAsync(JsonElement options) => Task.FromResult(Assertion);
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.AspNetCore.Components.Authorization;
 using Sorcha.Wallet.Pwa.Services;
 using Xunit;
 
@@ -44,5 +45,34 @@ public class WalletAuthenticationStateProviderTests
         provider.NotifyChanged();
 
         (await provider.GetAuthenticationStateAsync()).User.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task NotifyChanged_RaisesAuthenticationStateChanged_WithAuthenticatedState()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test"));
+        var provider = new WalletAuthenticationStateProvider(store);
+
+        Task<AuthenticationState>? raised = null;
+        provider.AuthenticationStateChanged += t => raised = t;
+
+        provider.NotifyChanged();
+
+        raised.Should().NotBeNull();
+        var state = await raised!;
+        state.User.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAuthenticationState_ExpiredToken_IsAnonymous()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddMinutes(-1), "a@b.test"));
+        var provider = new WalletAuthenticationStateProvider(store);
+
+        var state = await provider.GetAuthenticationStateAsync();
+
+        state.User.Identity!.IsAuthenticated.Should().BeFalse();
     }
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/WalletAuthenticationStateProviderTests.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+public class WalletAuthenticationStateProviderTests
+{
+    [Fact]
+    public async Task GetAuthenticationState_NoToken_IsAnonymous()
+    {
+        var provider = new WalletAuthenticationStateProvider(new InMemoryAccessTokenStore());
+        var state = await provider.GetAuthenticationStateAsync();
+        state.User.Identity!.IsAuthenticated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetAuthenticationState_WithToken_IsAuthenticated()
+    {
+        var store = new InMemoryAccessTokenStore();
+        await store.SetAsync(new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test"));
+        var provider = new WalletAuthenticationStateProvider(store);
+
+        var state = await provider.GetAuthenticationStateAsync();
+
+        state.User.Identity!.IsAuthenticated.Should().BeTrue();
+        state.User.FindFirst(ClaimTypes.Name)!.Value.Should().Be("a@b.test");
+    }
+
+    [Fact]
+    public async Task NotifySignedIn_FlipsToAuthenticated()
+    {
+        var store = new InMemoryAccessTokenStore();
+        var provider = new WalletAuthenticationStateProvider(store);
+        (await provider.GetAuthenticationStateAsync()).User.Identity!.IsAuthenticated.Should().BeFalse();
+
+        await store.SetAsync(new AccessTokenRecord("at", DateTimeOffset.UtcNow.AddHours(1), "a@b.test"));
+        provider.NotifyChanged();
+
+        (await provider.GetAuthenticationStateAsync()).User.Identity!.IsAuthenticated.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Adds **social** (Google / Apple / Microsoft / GitHub) and **passkey** sign-in alongside the existing email/password in the Citizen Wallet PWA, behind a dedicated `/wallet/signin` screen and a real auth gate. Login-only — signup stays in the council enrol gate / pairing / web.

- **Consumer-tier everywhere (F136).** All three methods mint an installation `:consumer` token so `/api/v1/wallet/*` accepts them. This also fixes a latent bug: the PWA password login previously minted a Platform-tier token. Mechanism: password/2FA send `tier:"consumer"`; passkey assertion-verify + verify-2fa honour a `tier` hint; social `initiate` carries `surface:"wallet"` and the OAuth callback mints Consumer + redirects to `/wallet/#token=…&refresh=…&expires_in=…`, captured by an `auth-fragment.js` IIFE before Blazor boots. Silent refresh via `POST /api/auth/token/refresh` re-mints the same tier.
- **Auth gate.** Token-backed `WalletAuthenticationStateProvider` + `AuthorizeRouteView`; protected pages get `[Authorize]`, public routes stay open (`/signin`, `/enrol`, cancelled-enrolment, the social fragment-return landing). Pairing takeover (F128) is suppressed on the signed-out screen.
- **Login-only enforced server-side.** An unknown social identity creates **no** account (`allowCreate:false` gate in `ResolveOrCreateSocialUserAsync`) and bounces to `/wallet/signin?authError=no_account` — closes a create-then-sign-in-on-retry hole found in review.

Backend additions: public `GET /api/auth/social/providers` (drives dynamic provider buttons); `surface` field on social initiate; `tier` hint on passkey-assertion-verify + verify-2fa; `surface=wallet` branch in `SocialCallback`.

Design: `docs/superpowers/specs/2026-05-25-pwa-auth-social-passkey-design.md` · Plan: `docs/superpowers/plans/2026-05-25-pwa-auth-social-passkey.md`

## Test plan

- [x] `dotnet test tests/Sorcha.Tenant.Service.Tests` — green (1207 passed, 8 pre-existing skips)
- [x] `dotnet test tests/Sorcha.Wallet.Pwa.Tests` — green (159 passed)
- [x] E2E gate-redirect test (`SignedOut_ProtectedRoute_RedirectsToSignIn`) passes against the live Docker stack
- [ ] Manual: exercise password+2FA, passkey, social return, and unknown-social → `no_account` in a browser on the Docker stack

## Notes / deferred (tracked)

- `SignIn.razor` ships a functional structural layout; **visual polish to follow the design screenshots** (no wiring change needed).
- 2 E2E tests (`Password_HappyPath`, `SocialReturnLeg`) are `[Explicit]` pending a citizen-seed / consumer-token-mint helper in the E2E infra.
- Display name shows "citizen" (not email) immediately after a *social* sign-in (fragment carries no email) — cosmetic, would need a `/me` call.
- Pre-existing doc inaccuracy: `/api/auth/public/social/*` table rows in API docs reference old paths — out of scope, flagged for separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)