### PR TITLE
fix: [141] PWA crash — register IThemeService in DI + manifest icon 404

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -57,6 +57,23 @@ public static class ServiceCollectionExtensions
         // plus Feature 125 guided-tour dismissal).
         services.AddSingleton<IWalletFlagsStore, IndexedDbWalletFlagsStore>();
 
+        // Feature 141 — theme service so the shell (MainLayout) can drive dark
+        // mode from the citizen's resolved preference. IThemeService lives in
+        // Sorcha.UI.Core but its registration was web-host-only; the PWA must
+        // register it too or MainLayout's @inject fails at startup.
+        // UserPreferencesService swallows transport errors and returns defaults,
+        // so an unauthenticated citizen (no per-user prefs endpoint) still gets
+        // OS-driven light/dark via ThemeService's matchMedia detection.
+        services.AddSingleton<IUserPreferencesService>(sp =>
+            new UserPreferencesService(
+                sp.GetRequiredService<HttpClient>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<UserPreferencesService>>()));
+        services.AddSingleton<IThemeService>(sp =>
+            new ThemeService(
+                sp.GetRequiredService<IUserPreferencesService>(),
+                sp.GetRequiredService<Microsoft.JSInterop.IJSRuntime>(),
+                sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<ThemeService>>()));
+
         // Feature 125 — PR-A foundation. The signing seam (IUserSigner) and
         // its v1 managed-mode implementation; per-device stores for active
         // org context, per-context persona cache, verification history. The

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/icons/icon.svg
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/icons/icon.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <!-- Clip to iOS-style rounded square -->
+    <clipPath id="iconShape">
+      <rect x="0" y="0" width="512" height="512" rx="112" ry="112"/>
+    </clipPath>
+
+    <!-- Deep dark purple-black background gradient -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%"   style="stop-color:#090A14"/>
+      <stop offset="100%" style="stop-color:#0F1020"/>
+    </linearGradient>
+
+    <!-- Subtle radial bloom behind the S (violet) -->
+    <radialGradient id="bloom" cx="50%" cy="50%" r="42%">
+      <stop offset="0%"   style="stop-color:#6366F1;stop-opacity:0.14"/>
+      <stop offset="100%" style="stop-color:#6366F1;stop-opacity:0"/>
+    </radialGradient>
+
+    <!-- Glow for drifting squares -->
+    <filter id="squareGlow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- S glow: white text + violet bloom -->
+    <filter id="sGlow" x="-18%" y="-18%" width="136%" height="136%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="12" result="blur"/>
+      <feColorMatrix in="blur" type="matrix"
+        values="0.24 0    0    0 0
+                0    0.25 0    0 0
+                0    0    0.95 0 0
+                0    0    0    0.55 0" result="violetBloom"/>
+      <feMerge>
+        <feMergeNode in="violetBloom"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <g clip-path="url(#iconShape)">
+
+    <!-- ── BACKGROUND ── -->
+    <rect x="0" y="0" width="512" height="512" fill="url(#bgGrad)"/>
+    <rect x="0" y="0" width="512" height="512" fill="url(#bloom)"/>
+
+    <!-- ── GRID (56px spacing, 9 divisions) ── -->
+    <!-- These are intentionally very faint — just like the site -->
+    <g stroke="#6366F1" stroke-width="0.7" opacity="0.10">
+      <!-- Horizontal -->
+      <line x1="0" y1="56"  x2="512" y2="56"/>
+      <line x1="0" y1="112" x2="512" y2="112"/>
+      <line x1="0" y1="168" x2="512" y2="168"/>
+      <line x1="0" y1="224" x2="512" y2="224"/>
+      <line x1="0" y1="280" x2="512" y2="280"/>
+      <line x1="0" y1="336" x2="512" y2="336"/>
+      <line x1="0" y1="392" x2="512" y2="392"/>
+      <line x1="0" y1="448" x2="512" y2="448"/>
+      <!-- Vertical -->
+      <line x1="56"  y1="0" x2="56"  y2="512"/>
+      <line x1="112" y1="0" x2="112" y2="512"/>
+      <line x1="168" y1="0" x2="168" y2="512"/>
+      <line x1="224" y1="0" x2="224" y2="512"/>
+      <line x1="280" y1="0" x2="280" y2="512"/>
+      <line x1="336" y1="0" x2="336" y2="512"/>
+      <line x1="392" y1="0" x2="392" y2="512"/>
+      <line x1="448" y1="0" x2="448" y2="512"/>
+    </g>
+
+    <!-- ── DRIFTING SQUARES (the animated particles from the site) ── -->
+    <!-- Varied sizes, opacities, and positions for an organic scatter feel -->
+    <!-- Each is a small square aligned loosely to the grid -->
+
+    <!-- Top area -->
+    <rect x="52"  y="49"  width="8" height="8" rx="1.5" fill="#6366F1" opacity="0.45" filter="url(#squareGlow)"/>
+    <rect x="358" y="94"  width="6" height="6" rx="1"   fill="#818CF8" opacity="0.35"/>
+    <rect x="446" y="47"  width="9" height="9" rx="1.5" fill="#6366F1" opacity="0.40" filter="url(#squareGlow)"/>
+    <rect x="108" y="108" width="7" height="7" rx="1.5" fill="#6366F1" opacity="0.30"/>
+
+    <!-- Right side -->
+    <rect x="450" y="168" width="8" height="8" rx="1.5" fill="#818CF8" opacity="0.38" filter="url(#squareGlow)"/>
+    <rect x="392" y="280" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.28"/>
+    <rect x="460" y="335" width="9" height="9" rx="1.5" fill="#6366F1" opacity="0.42" filter="url(#squareGlow)"/>
+    <rect x="390" y="450" width="7" height="7" rx="1.5" fill="#818CF8" opacity="0.32"/>
+
+    <!-- Bottom area -->
+    <rect x="275" y="454" width="8" height="8" rx="1.5" fill="#6366F1" opacity="0.38" filter="url(#squareGlow)"/>
+    <rect x="108" y="446" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.30"/>
+    <rect x="52"  y="396" width="9" height="9" rx="1.5" fill="#818CF8" opacity="0.40" filter="url(#squareGlow)"/>
+
+    <!-- Left side -->
+    <rect x="48"  y="168" width="7" height="7" rx="1.5" fill="#6366F1" opacity="0.35"/>
+    <rect x="56"  y="280" width="8" height="8" rx="1.5" fill="#818CF8" opacity="0.40" filter="url(#squareGlow)"/>
+    <rect x="110" y="335" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.28"/>
+
+    <!-- A few mid-field, smaller/dimmer so they don't compete with S -->
+    <rect x="168" y="112" width="5" height="5" rx="1"   fill="#6366F1" opacity="0.22"/>
+    <rect x="340" y="168" width="5" height="5" rx="1"   fill="#6366F1" opacity="0.20"/>
+    <rect x="168" y="400" width="5" height="5" rx="1"   fill="#818CF8" opacity="0.22"/>
+    <rect x="340" y="390" width="6" height="6" rx="1"   fill="#6366F1" opacity="0.20"/>
+
+    <!-- ── S LETTER ── -->
+    <!-- Shadow/depth layer -->
+    <text x="258" y="338"
+          font-family="'Helvetica Neue', 'Arial Black', Arial, sans-serif"
+          font-size="282"
+          font-weight="900"
+          text-anchor="middle"
+          fill="#4F46E5"
+          opacity="0.35"
+          transform="translate(3,5)">S</text>
+    <!-- Main S with violet glow -->
+    <text x="256" y="336"
+          font-family="'Helvetica Neue', 'Arial Black', Arial, sans-serif"
+          font-size="282"
+          font-weight="900"
+          text-anchor="middle"
+          fill="#FFFFFF"
+          filter="url(#sGlow)">S</text>
+
+  </g>
+</svg>

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/index.html
@@ -9,6 +9,10 @@
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="css/welcome-takeover.css" rel="stylesheet" />
+    <!-- Blazor CSS-isolation bundle — without this, every component .razor.css
+         (incl. the Feature 141 wallet chrome + shared Sorcha.UI.Components.User
+         scoped styles) is never loaded and components render unstyled. -->
+    <link href="Sorcha.Wallet.Pwa.styles.css" rel="stylesheet" />
 </head>
 <body>
     <div id="app">

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/manifest.webmanifest
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/manifest.webmanifest
@@ -10,20 +10,10 @@
   "description": "Sorcha Wallet — your credentials, applications, evidence, identity in one place.",
   "icons": [
     {
-      "src": "icons/icon-192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "icons/icon-512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    },
-    {
-      "src": "icons/icon-192-maskable.png",
-      "type": "image/png",
-      "sizes": "192x192",
-      "purpose": "maskable"
+      "src": "icons/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/CitizenWalletServiceRegistrationTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/CitizenWalletServiceRegistrationTests.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using Moq;
+using Sorcha.UI.Core.Services;
+using Sorcha.Wallet.Pwa.Extensions;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Guards the PWA's DI composition root (<see cref="ServiceCollectionExtensions.AddCitizenWalletServices"/>).
+/// Feature 141 shipped a regression: <c>MainLayout</c> began injecting
+/// <c>IThemeService</c> to drive dark mode, but that service was only
+/// registered in <c>Sorcha.UI.Core</c>'s web-host extension — so the citizen
+/// wallet crashed on first load with "no registered service of type
+/// 'Sorcha.UI.Core.Services.IThemeService'". These tests resolve the shell's
+/// theme dependencies from the real registration to keep that from recurring.
+/// </summary>
+public class CitizenWalletServiceRegistrationTests
+{
+    // Mirrors Program.cs: the framework provides IJSRuntime + logging and an
+    // HttpClient is registered before AddCitizenWalletServices runs.
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped(_ => new HttpClient { BaseAddress = new Uri("http://localhost/") });
+        services.AddSingleton(new Mock<IJSRuntime>().Object);
+        services.AddCitizenWalletServices("http://localhost/");
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AddCitizenWalletServices_ResolvesThemeService()
+    {
+        using var sp = BuildProvider();
+
+        sp.GetService<IThemeService>()
+            .Should().NotBeNull("MainLayout @injects IThemeService; a missing "
+                + "registration crashed the PWA shell on load (Feature 141 regression).");
+    }
+
+    [Fact]
+    public void AddCitizenWalletServices_ResolvesUserPreferencesService()
+    {
+        using var sp = BuildProvider();
+
+        sp.GetService<IUserPreferencesService>()
+            .Should().NotBeNull("ThemeService depends on IUserPreferencesService.");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/CitizenWalletServiceRegistrationTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/CitizenWalletServiceRegistrationTests.cs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System;
+using System.Net.Http;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;


### PR DESCRIPTION
## Problem

Loading the Citizen Wallet PWA (`/wallet`) crashed on first render:

```
Cannot provide a value for property 'ThemeService' on type 'Sorcha.Wallet.Pwa.MainLayout'.
There is no registered service of type 'Sorcha.UI.Core.Services.IThemeService'.
```

Feature 141 (#857) wired `MainLayout`'s `MudThemeProvider` dark mode to `IThemeService`, but that service is registered only in `Sorcha.UI.Core`'s **web-host** DI extension — the PWA composes its own services via `AddCitizenWalletServices` and never registered it. Every PWA page crashed because the shell layout couldn't instantiate.

The console also showed three pre-existing icon 404s (`/wallet/icons/icon-192.png` etc.).

## Fix

1. **Register `IThemeService` + `IUserPreferencesService`** in `AddCitizenWalletServices`. `UserPreferencesService` swallows transport errors and returns defaults, so an unauthenticated citizen (no per-user prefs endpoint) still gets OS-driven light/dark via `ThemeService`'s `matchMedia` detection.
2. **Manifest icon 404 (pre-existing, Feature 125)**: `manifest.webmanifest` referenced an `icons/` directory that never existed. Ship one SVG icon (`icons/icon.svg`, the Sorcha brand mark) and repoint the manifest at it (`image/svg+xml`, `any maskable`).

## Verification

- **Deterministic DI regression test** (`CitizenWalletServiceRegistrationTests`): builds the PWA DI composition and asserts `IThemeService` + `IUserPreferencesService` resolve. Reproduces the crash without Docker. **PWA test suite: 159 passed, 0 failed.**
- Builds clean.

### Honest note on the original feature's verification
The Feature 141 E2E (`WalletHomeRedesignTests`/`WalletHomeResponsiveTests`) did **not** catch this: the E2E project runs under Microsoft.Testing.Platform, which **ignores the VSTest `--filter` syntax** I used, so those runs reported "Tests succeeded" vacuously (≈zero tests executed). The deterministic DI test above is the reliable guard going forward. Full in-browser re-verification against the rebuilt container is pending — Docker Desktop's engine started returning 500s on this machine mid-session (`/_ping` API-version errors), unrelated to this change.

## Test plan
- [x] PWA DI test resolves `IThemeService` (159/0)
- [x] `dotnet build` clean
- [ ] Reviewer: load `/wallet` once Docker is back — confirm home renders (no `IThemeService` crash) and no icon 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)