### PR TITLE
fix: genesis roster projection + AssuredIdentity walkthrough Tier-2/Tier-3 split + fail-loud publish

### DIFF
--- a/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
+++ b/src/Services/Sorcha.Register.Service/Services/RegisterCreationOrchestrator.cs
@@ -713,10 +713,23 @@ public class RegisterCreationOrchestrator : IRegisterCreationOrchestrator
     /// </summary>
     private TransactionModel CreateGenesisTransaction(string registerId, RegisterControlRecord controlRecord, string ownerWalletAddress)
     {
+        // Wrap in ControlTransactionPayload so GovernanceRosterService can read the genesis
+        // payload via the same path as governance-proposal control transactions. The non-genesis
+        // commit at Program.cs:2204 already wraps in this shape; the genesis was the lone outlier
+        // — bare RegisterControlRecord deserialises silently into a default-empty
+        // ControlTransactionPayload, which surfaced as `members: []` on /governance/roster and
+        // led to a confusing 403 from the F142 PublishGate.
+        var payload = new ControlTransactionPayload
+        {
+            Version = 1,
+            Roster = controlRecord,
+            Operation = null   // genesis has no producing operation
+        };
+
         // Serialize to canonical form, then re-canonicalize through JsonElement round-trip.
         // This ensures the hash matches what the Validator computes when it receives the payload
         // and re-canonicalizes with the same options (compact, UnsafeRelaxedJsonEscaping).
-        var controlRecordJson = JsonSerializer.Serialize(controlRecord, _canonicalJsonOptions);
+        var controlRecordJson = JsonSerializer.Serialize(payload, _canonicalJsonOptions);
         using var doc = JsonDocument.Parse(controlRecordJson);
         var canonicalJson = JsonSerializer.Serialize(doc.RootElement, _canonicalJsonOptions);
         var controlRecordBytes = Encoding.UTF8.GetBytes(canonicalJson);

--- a/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/RegisterCreationOrchestratorTests.cs
@@ -874,4 +874,227 @@ public class RegisterCreationOrchestratorTests
     }
 
     #endregion
+
+    #region Genesis Roster Payload Projection
+
+    /// <summary>
+    /// Regression: the genesis transaction's payload MUST be wrapped in
+    /// <see cref="ControlTransactionPayload"/> so <c>GovernanceRosterService.GetCurrentRosterAsync</c>
+    /// can project it as the initial roster. Prior to this fix the orchestrator serialised a bare
+    /// <see cref="RegisterControlRecord"/>, which deserialised silently into a default-empty
+    /// payload (Roster.Attestations == 0) and surfaced as <c>members: []</c> on
+    /// <c>GET /api/registers/{id}/governance/roster</c> — the F142 PublishGate then 403'd the
+    /// Owner because the roster had no matching member.
+    /// </summary>
+    [Fact]
+    public async Task FinalizeAsync_GenesisPayloadIsControlTransactionPayloadShape()
+    {
+        // Arrange
+        var initiateRequest = new InitiateRegisterCreationRequest
+        {
+            Name = "Roster Projection Register",
+            Owners = new List<OwnerInfo>
+            {
+                new() { UserId = "user-001", WalletId = "wallet-001" }
+            }
+        };
+
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(new byte[32]);
+
+        var initiateResponse = await _orchestrator.InitiateAsync(initiateRequest);
+
+        var signedAttestations = initiateResponse.AttestationsToSign.Select(a => new SignedAttestation
+        {
+            AttestationData = a.AttestationData,
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            Signature = Convert.ToBase64String(new byte[64]),
+            Algorithm = SignatureAlgorithm.ED25519
+        }).ToList();
+
+        var finalizeRequest = new FinalizeRegisterCreationRequest
+        {
+            RegisterId = initiateResponse.RegisterId,
+            Nonce = initiateResponse.Nonce,
+            SignedAttestations = signedAttestations
+        };
+
+        _mockCryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CryptoStatus.Success);
+
+        _mockRegisterManager
+            .Setup(m => m.CreateRegisterAsync(
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = initiateResponse.RegisterId,
+                Name = "Roster Projection Register",
+                CreatedAt = DateTime.UtcNow
+            });
+
+        TransactionSubmission? capturedSubmission = null;
+        _mockValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(
+                It.IsAny<TransactionSubmission>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TransactionSubmission, CancellationToken>((s, _) => capturedSubmission = s)
+            .ReturnsAsync(new TransactionSubmissionResult
+            {
+                Success = true,
+                TransactionId = "tx-genesis",
+                RegisterId = initiateResponse.RegisterId,
+                AddedAt = DateTimeOffset.UtcNow
+            });
+
+        // Act
+        await _orchestrator.FinalizeAsync(finalizeRequest);
+
+        // Assert — the submitted genesis payload must be a ControlTransactionPayload, not a bare
+        // RegisterControlRecord. Deserialising as ControlTransactionPayload must yield a populated
+        // Roster (matching the Owner attestation we fed in) and Operation must be null (genesis
+        // has no producing governance operation).
+        capturedSubmission.Should().NotBeNull("FinalizeAsync should submit a genesis transaction");
+
+        var payloadJson = capturedSubmission!.Payload.GetRawText();
+        var payload = JsonSerializer.Deserialize<ControlTransactionPayload>(payloadJson, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        payload.Should().NotBeNull();
+        payload!.Version.Should().Be(1);
+        payload.Operation.Should().BeNull("genesis has no producing operation");
+        payload.Roster.Should().NotBeNull();
+        payload.Roster.Attestations.Should().HaveCount(1, "the initiate request had exactly one Owner");
+        payload.Roster.Attestations[0].Role.Should().Be(RegisterRole.Owner);
+        payload.Roster.Attestations[0].Subject.Should().Be("did:sorcha:w:wallet-001");
+    }
+
+    /// <summary>
+    /// Round-trip pin: feed the genesis transaction the orchestrator submitted into a real
+    /// <see cref="GovernanceRosterService"/> backed by an in-memory mock repository, and assert
+    /// <c>GetCurrentRosterAsync</c> projects a non-empty roster including the Owner. This is the
+    /// exact path <c>GET /api/registers/{id}/governance/roster</c> takes — the projection is what
+    /// the F142 PublishGate consumes.
+    /// </summary>
+    [Fact]
+    public async Task FinalizeAsync_GenesisPayload_RoundTripsThroughGovernanceRosterService()
+    {
+        // Arrange
+        var initiateRequest = new InitiateRegisterCreationRequest
+        {
+            Name = "Round-Trip Register",
+            Owners = new List<OwnerInfo>
+            {
+                new() { UserId = "user-001", WalletId = "wallet-001" }
+            }
+        };
+
+        _mockHashProvider
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), HashType.SHA256))
+            .Returns(new byte[32]);
+
+        var initiateResponse = await _orchestrator.InitiateAsync(initiateRequest);
+
+        var signedAttestations = initiateResponse.AttestationsToSign.Select(a => new SignedAttestation
+        {
+            AttestationData = a.AttestationData,
+            PublicKey = Convert.ToBase64String(new byte[32]),
+            Signature = Convert.ToBase64String(new byte[64]),
+            Algorithm = SignatureAlgorithm.ED25519
+        }).ToList();
+
+        var finalizeRequest = new FinalizeRegisterCreationRequest
+        {
+            RegisterId = initiateResponse.RegisterId,
+            Nonce = initiateResponse.Nonce,
+            SignedAttestations = signedAttestations
+        };
+
+        _mockCryptoModule
+            .Setup(c => c.VerifyAsync(
+                It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte>(),
+                It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CryptoStatus.Success);
+
+        _mockRegisterManager
+            .Setup(m => m.CreateRegisterAsync(
+                It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<RegisterPurpose>(), It.IsAny<RegisterSyncState?>(),
+                It.IsAny<RegisterControlRecord?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = initiateResponse.RegisterId,
+                Name = "Round-Trip Register",
+                CreatedAt = DateTime.UtcNow
+            });
+
+        TransactionSubmission? capturedSubmission = null;
+        _mockValidatorClient
+            .Setup(v => v.SubmitTransactionAsync(
+                It.IsAny<TransactionSubmission>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<TransactionSubmission, CancellationToken>((s, _) => capturedSubmission = s)
+            .ReturnsAsync(new TransactionSubmissionResult
+            {
+                Success = true,
+                TransactionId = "tx-genesis",
+                RegisterId = initiateResponse.RegisterId,
+                AddedAt = DateTimeOffset.UtcNow
+            });
+
+        // Act — finalize to drive the genesis-tx build
+        await _orchestrator.FinalizeAsync(finalizeRequest);
+
+        // Rebuild the on-the-wire TransactionModel from the captured submission, then drive it
+        // through GovernanceRosterService exactly as the real Register Service would.
+        capturedSubmission.Should().NotBeNull();
+        var canonicalPayloadJson = capturedSubmission!.Payload.GetRawText();
+        var payloadBytes = System.Text.Encoding.UTF8.GetBytes(canonicalPayloadJson);
+        var base64UrlPayload = System.Buffers.Text.Base64Url.EncodeToString(payloadBytes);
+
+        var genesisTxModel = new TransactionModel
+        {
+            TxId = capturedSubmission.TransactionId,
+            MetaData = new TransactionMetaData
+            {
+                RegisterId = initiateResponse.RegisterId,
+                TransactionType = TransactionType.Control
+            },
+            Payloads = [new PayloadModel { Data = base64UrlPayload }]
+        };
+
+        var repositoryMock = new Mock<Sorcha.Register.Core.Storage.IRegisterRepository>();
+        repositoryMock
+            .Setup(r => r.GetTransactionsAsync(initiateResponse.RegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { genesisTxModel }.AsQueryable());
+
+        var rosterLogger = new Mock<ILogger<Sorcha.Register.Core.Services.GovernanceRosterService>>();
+        var rosterService = new Sorcha.Register.Core.Services.GovernanceRosterService(
+            repositoryMock.Object, rosterLogger.Object);
+
+        // Act — drive the same projection the /governance/roster endpoint hits
+        var roster = await rosterService.GetCurrentRosterAsync(initiateResponse.RegisterId);
+
+        // Assert — roster is non-null AND non-empty (the bug pre-fix: members == 0 here)
+        roster.Should().NotBeNull("GovernanceRosterService must project the genesis payload");
+        roster!.ControlRecord.Attestations.Should().NotBeEmpty(
+            "the Owner attestation must round-trip from genesis-tx → ControlTransactionPayload → projected roster");
+        roster.ControlRecord.Attestations.Should().HaveCount(1);
+        roster.ControlRecord.Attestations[0].Role.Should().Be(RegisterRole.Owner);
+        roster.ControlRecord.Attestations[0].Subject.Should().Be("did:sorcha:w:wallet-001");
+        roster.LastControlTxId.Should().Be(capturedSubmission.TransactionId);
+    }
+
+    #endregion
 }

--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -179,7 +179,7 @@ $actionResponse = Invoke-SorchaAction `
     -InstanceId $instanceId `
     -ActionId "2" `
     -BlueprintId $state.blueprintId `
-    -SenderWallet $state.verificationWalletAddress `
+    -SenderWallet $state.roles.verificationAnalyst.walletAddress `
     -RegisterId $state.registerId `
     -Token $analystSession.Token `
     -PayloadData @{

--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -126,31 +126,30 @@ $verificationOrgId = $verificationOrg.OrganizationId
 Write-WtSuccess "Verification org: $verificationOrgId"
 
 # ============================================================================
-# Step 5: Verification Admin — Login, Wallet, Participant
+# Step 5: Verification Admin (Tier 2) — Login + issuer wallet
 # ============================================================================
-Write-WtStep "Step 5: Verification Admin — Login, Wallet, Participant"
+# Three-tier identity model:
+#   Tier 1: admin@sorcha.local           — system admin (creates orgs)
+#   Tier 2: verification-admin@...local  — org admin (issuer wallet, register, blueprint)
+#   Tier 3: verification-analyst@...local — consumer (executes Action 2 ONLY)
+#
+# Step 5 sets up Tier 2. Tier 3 is provisioned in Step 5c.
+Write-WtStep "Step 5: Verification Admin (Tier 2) — Login + Issuer Wallet"
 
-$verificationSession = Connect-SorchaUser `
+$verificationAdminSession = Connect-SorchaUser `
     -TenantUrl $sorchaEnv.TenantUrl `
     -Email $verificationAdminEmail `
     -Password $verificationAdminPassword `
     -OrganizationId $verificationOrgId
 
+# Issuer wallet — owned by the org-admin (the org's signing identity for register
+# creation + blueprint publishing). NOT used for action submission.
 $verificationWallet = New-SorchaWallet `
     -WalletUrl $sorchaEnv.WalletUrl `
     -Name "Acme Verification Co. Issuer" `
-    -Headers $verificationSession.Headers `
+    -Headers $verificationAdminSession.Headers `
     -FetchPublicKey
-Write-WtSuccess "Verification wallet: $($verificationWallet.Address)"
-
-$null = Register-SorchaParticipant `
-    -TenantUrl $sorchaEnv.TenantUrl `
-    -WalletUrl $sorchaEnv.WalletUrl `
-    -OrganizationId $verificationOrgId `
-    -WalletAddress $verificationWallet.Address `
-    -DisplayName "Verification Analyst" `
-    -Headers $verificationSession.Headers
-Write-WtInfo "Verification analyst participant registered"
+Write-WtSuccess "Issuer wallet (Tier 2, org admin): $($verificationWallet.Address)"
 
 # ============================================================================
 # Step 5b: Citizen — Login, Wallet, Participant (best-effort, late-bound)
@@ -189,6 +188,55 @@ try {
 } catch {
     Write-WtWarn "Scripted-citizen wallet provisioning skipped (spec 136: consumer token has no org_id; citizen is late-bound and provisions via the PWA enrol flow): $($_.Exception.Message)"
 }
+
+# ============================================================================
+# Step 5c: Verification Analyst (Tier 3) — provision, login, wallet, participant
+# ============================================================================
+# Three-tier identity model — Tier 3 = consumer user, EXECUTES actions only.
+# The analyst is org-scoped (Consumer role inside Acme Verification Co.) and is
+# the sender of Action 2 (verifies the citizen's application). Their wallet —
+# not the org-admin's — is what gets baked into the blueprint's walletMap for
+# the 'verification-analyst' participant.
+Write-WtStep "Step 5c: Verification Analyst (Tier 3) — Provision + Wallet + Participant"
+
+$verificationAnalystEmail    = "verification-analyst@assured-identity.local"
+$verificationAnalystPassword = $secrets.DefaultPassword
+
+# Tier 3 user provisioned single-org-direct so they avoid the multi-org
+# OAuth-grant flow. Consumer role = no authoring rights; only action execution.
+$verificationAnalystUser = New-SorchaOrgUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -OrganizationId $verificationOrgId `
+    -Email $verificationAnalystEmail `
+    -Password $verificationAnalystPassword `
+    -DisplayName "Verification Analyst" `
+    -Headers $sysAdmin.Headers `
+    -Roles @("Consumer") `
+    -EmailVerified
+
+$verificationAnalystSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $verificationAnalystEmail `
+    -Password $verificationAnalystPassword `
+    -OrganizationId $verificationOrgId
+
+# Analyst's own wallet — signs Action 2. The org's issuer wallet stays
+# separate (used by the Tier-2 admin path only).
+$verificationAnalystWallet = New-SorchaWallet `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Verification Analyst Wallet" `
+    -Headers $verificationAnalystSession.Headers `
+    -FetchPublicKey
+Write-WtSuccess "Analyst wallet (Tier 3, executes Action 2): $($verificationAnalystWallet.Address)"
+
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $verificationOrgId `
+    -WalletAddress $verificationAnalystWallet.Address `
+    -DisplayName "Verification Analyst" `
+    -Headers $verificationAnalystSession.Headers
+Write-WtInfo "Verification analyst participant registered (Tier 3 wallet)"
 
 # ============================================================================
 # Step 6: Provision Trust Anchor + Enrol as HAIP Issuer
@@ -236,23 +284,26 @@ $register = New-SorchaRegister `
     -Name $registerName `
     -Description "Register for Feature 107 Assured Identity workflows" `
     -TenantId $verificationOrgId `
-    -OwnerUserId $verificationSession.UserId `
+    -OwnerUserId $verificationAdminSession.UserId `
     -OwnerWalletAddress $verificationWallet.Address `
-    -Headers $verificationSession.Headers `
+    -Headers $verificationAdminSession.Headers `
     -TenantUrl $sorchaEnv.TenantUrl `
     -DevMode:$DevMode
 Write-WtSuccess "Register: $($register.RegisterId)"
 
 try {
+    # Publish the ANALYST (Tier 3) as the on-register participant — the analyst
+    # is the action sender, NOT the org-admin. Org-admin still authorises the
+    # publish via their session headers (publishing is a Tier-2 authoring act).
     $null = Publish-SorchaParticipant `
         -TenantUrl $sorchaEnv.TenantUrl `
         -OrganizationId $verificationOrgId `
         -RegisterId $register.RegisterId `
         -ParticipantName "Verification Analyst" `
         -OrganizationName "Acme Verification Co." `
-        -WalletAddress $verificationWallet.Address `
-        -PublicKey $verificationWallet.PublicKey `
-        -Headers $verificationSession.Headers
+        -WalletAddress $verificationAnalystWallet.Address `
+        -PublicKey $verificationAnalystWallet.PublicKey `
+        -Headers $verificationAdminSession.Headers
 } catch {
     Write-WtWarn "Verification analyst participant publish failed: $($_.Exception.Message)"
 }
@@ -280,7 +331,9 @@ Write-WtStep "Step 8: Publish Blueprint"
 # Action 1 as the bound citizen for that instance.
 # See: .claude/skills/blueprint-builder/SKILL.md — "Open Participants & Late Binding"
 $walletMap = @{
-    "verification-analyst" = $verificationWallet.Address
+    # Tier 3 analyst's wallet — the action SENDER. NOT the org-admin's issuer
+    # wallet (that one stays purely for org-level authoring acts).
+    "verification-analyst" = $verificationAnalystWallet.Address
     # "citizen" is intentionally absent — late-bound at runtime.
 }
 
@@ -288,7 +341,7 @@ $blueprint = Publish-SorchaBlueprint `
     -BlueprintUrl $sorchaEnv.BlueprintUrl `
     -TemplatePath (Join-Path $scriptDir "blueprints/assured-identity.json") `
     -WalletMap $walletMap `
-    -Headers $verificationSession.Headers `
+    -Headers $verificationAdminSession.Headers `
     -IdPrefix "assured-identity" `
     -RegisterId $register.RegisterId
 
@@ -413,8 +466,14 @@ $state = @{
     gatewayUrl                = $sorchaEnv.GatewayUrl
     tenantId                  = $tenantId
     verificationOrgId         = $verificationOrgId
+    # The Tier-2 org-admin's issuer wallet — used by org-level authoring acts
+    # (register creation, blueprint publish). NOT a runtime action sender.
     verificationWalletAddress = $verificationWallet.Address
     verificationWalletPublicKey = $verificationWallet.PublicKey
+    # The Tier-3 analyst's wallet — signs Action 2. This is the wallet bound
+    # to the verification-analyst participant on the published blueprint.
+    verificationAnalystWalletAddress = $verificationAnalystWallet.Address
+    verificationAnalystWalletPublicKey = $verificationAnalystWallet.PublicKey
     publicOrgId               = $publicOrgId
     citizenWalletAddress      = $citizenWallet.Address
     registerId                = $register.RegisterId
@@ -428,11 +487,22 @@ $state = @{
     licensingWalletPublicKey  = $licensingWallet.PublicKey
     licenceBlueprintId        = $licenceBlueprint.BlueprintId
     roles = @{
-        verificationAnalyst = @{
+        # Tier 2: org admin — authoring only. The Phase-1 citizen flow MUST NOT
+        # use this identity for action submission.
+        verificationAdmin = @{
             email          = $verificationAdminEmail
             password       = $verificationAdminPassword
             organizationId = $verificationOrgId
             walletAddress  = $verificationWallet.Address
+        }
+        # Tier 3: consumer (Consumer role inside Acme Verification Co.) — the
+        # sender of Action 2 (verifies the citizen's application). This is the
+        # identity Phase-1 step 5 logs in as.
+        verificationAnalyst = @{
+            email          = $verificationAnalystEmail
+            password       = $verificationAnalystPassword
+            organizationId = $verificationOrgId
+            walletAddress  = $verificationAnalystWallet.Address
         }
         citizen = @{
             email          = $citizenEmail

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1434,6 +1434,21 @@ function Publish-SorchaBlueprint {
         -Headers $Headers `
         -RawResponse
 
+    # Fail-loud guard: Invoke-WebRequest in PS 7+ throws on 4xx/5xx by default,
+    # but defense-in-depth — if a status ever slips through (proxy transform,
+    # custom 2xx-but-error JSON, future PS changes) make the script exit
+    # cleanly instead of silently proceeding to instance creation against a
+    # blueprint that was never actually published. This was the root cause of
+    # the AssuredIdentity "Action 1 not confirmed" 60s timeout: a 403 from the
+    # F142 PublishGate was swallowed and the citizen flow polled for a tx
+    # that never existed.
+    $publishStatus = [int]$publishRaw.StatusCode
+    if ($publishStatus -ne 200 -and $publishStatus -ne 201) {
+        $body = ""
+        try { $body = $publishRaw.Content } catch { }
+        throw "Blueprint publish failed for $blueprintId : HTTP $publishStatus, body=$body"
+    }
+
     $publishResponse = $publishRaw.Content | ConvertFrom-Json
 
     $warnings = @()


### PR DESCRIPTION
## Summary

Three related fixes for an AssuredIdentity walkthrough failure that surfaced as a confusing 60s "Action 1 not confirmed" timeout. RCA traced the symptom back to an empty-roster projection bug in the register service's genesis transaction; the walkthrough then layered two confounding factors on top of the underlying bug (a conflated org-admin/consumer identity, and a silent-swallow on a 403 from the F142 PublishGate). Each fix is in its own commit so they can be reverted independently.

### 1. `fix(register)` — wrap genesis payload in `ControlTransactionPayload` (`a1f2eb6d`)

`RegisterCreationOrchestrator.CreateGenesisTransaction` was serialising a bare `RegisterControlRecord` into the genesis transaction's `Payloads[0].Data`, but `GovernanceRosterService.DeserializeControlPayload` reads it back as a `ControlTransactionPayload` (wrapper carrying `{ Version, Roster, Operation }`). The shape mismatch deserialised silently into a default-empty payload — `GET /api/registers/{id}/governance/roster` returned `members: []` even when the stored `initialControlRecord` clearly held the Owner. The non-genesis governance-proposal commit at `Program.cs:2204` already wraps in this shape; the genesis was the lone outlier.

Two tests added in `RegisterCreationOrchestratorTests`:
- `FinalizeAsync_GenesisPayloadIsControlTransactionPayloadShape` — asserts the submitted genesis payload deserialises into a populated `ControlTransactionPayload`.
- `FinalizeAsync_GenesisPayload_RoundTripsThroughGovernanceRosterService` — feeds the captured payload into a real `GovernanceRosterService` and asserts a non-empty roster — the exact projection the `/governance/roster` endpoint and the F142 `PublishGate` consume.

### 2. `chore(walkthrough/assured-identity)` — split verification-analyst (Tier 3) from verification-admin (Tier 2) (`91428045`)

The setup had `verification-admin@assured-identity.local` doing both Tier-2 (org admin: issuer wallet, register, blueprint publish) AND Tier-3 (consumer: signing Action 2). Refactored to:
- Step 5 — admin keeps Tier-2 issuer wallet ONLY.
- Step 5c — new Tier-3 `verification-analyst@assured-identity.local` (Consumer role) provisioned single-org-direct via `New-SorchaOrgUser`, with their own wallet. This is the wallet baked into the blueprint walletMap and signing Action 2.
- `state.json` now carries `verificationAdmin` + `verificationAnalyst` as distinct roles.
- `run-phase1-identity.ps1` Step 5 reads the analyst's wallet from `state.roles.verificationAnalyst.walletAddress`.

The actor file already references `{{roles.verificationAnalyst.*}}` — no actor-side edit needed.

### 3. `fix(walkthrough/module)` — `Publish-SorchaBlueprint` fails loudly on non-2xx (`1615dd48`)

Defense-in-depth: explicit status guard after the publish call. `Invoke-WebRequest` in PS 7+ throws on 4xx/5xx by default, but the explicit check prevents any future status from slipping through and producing a `$publishResponse` that looks valid but isn't. The wrapper itself is left unchanged — broadening it would have non-trivial blast radius across other walkthroughs.

## Test plan

- [x] `dotnet build Sorcha.sln -c Debug` — 0 errors, 1515 warnings (pre-existing baseline).
- [x] `dotnet vstest Sorcha.Register.Service.Tests.dll` — 303 passed / 0 failed / 9 skipped (pre-existing).
- [x] `dotnet vstest --TestCaseFilter:"FullyQualifiedName~RegisterCreationOrchestrator"` — 17 passed / 0 failed (15 pre-existing + 2 new).
- [x] PowerShell parse-check `setup.ps1`, `run-phase1-identity.ps1`, `SorchaWalkthrough.psm1` — all OK.
- [ ] Live AssuredIdentity walkthrough run (post-merge, validates the full chain end-to-end).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>