### PR TITLE
fix(register-core): read ControlTransactionPayload-wrapped genesis in RegisterLocalRelationshipService — fixes validator self-evacuation post-#868

### DIFF
--- a/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
+++ b/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
@@ -169,8 +169,33 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
             try
             {
                 var bytes = DecodeBase64Auto(data);
-                var record = JsonSerializer.Deserialize<RegisterControlRecord>(bytes);
-                if (record is not null) return record;
+
+                // Two on-disk shapes are valid here:
+                //   (a) ControlTransactionPayload { Version, Roster: RegisterControlRecord, Operation }
+                //       — the post-PR-#868 shape that GovernanceRosterService and the non-genesis
+                //       governance-commit path both produce.
+                //   (b) Bare RegisterControlRecord — the pre-PR-#868 genesis shape, still on disk
+                //       for any pre-existing register that hasn't been re-created since.
+                // Probe the wrapper shape first (it carries an explicit "roster" property); fall
+                // back to the bare shape so legacy genesis dockets still derive correctly. Without
+                // this, the post-#868 wrapped payload silently deserialises into a default-empty
+                // RegisterControlRecord — no validators, no attestations — which causes
+                // /api/internal/my-validated-registers to drop this register from the validator's
+                // monitoring set and stops every subsequent docket from sealing.
+                var wrapper = JsonSerializer.Deserialize<ControlTransactionPayload>(bytes);
+                if (wrapper?.Roster is not null
+                    && (wrapper.Roster.Attestations is { Count: > 0 }
+                        || wrapper.Roster.Validators is not null))
+                {
+                    return wrapper.Roster;
+                }
+
+                var bare = JsonSerializer.Deserialize<RegisterControlRecord>(bytes);
+                if (bare is not null
+                    && (bare.Attestations is { Count: > 0 } || bare.Validators is not null))
+                {
+                    return bare;
+                }
             }
             catch (FormatException ex)
             {
@@ -180,7 +205,7 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
             catch (JsonException ex)
             {
                 _logger?.LogDebug(ex,
-                    "Control tx payload for register {RegisterId} is not a valid RegisterControlRecord", registerId);
+                    "Control tx payload for register {RegisterId} is not a valid control payload", registerId);
             }
         }
         return null;

--- a/tests/Sorcha.Register.Core.Tests/LocalRelationship/RegisterLocalRelationshipServiceTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/LocalRelationship/RegisterLocalRelationshipServiceTests.cs
@@ -223,6 +223,64 @@ public class RegisterLocalRelationshipServiceTests
         rel.IsSubscriber.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task Derive_GenesisPayloadWrappedInControlTransactionPayload_StillDerivesOwnerAndValidator()
+    {
+        // Regression: PR #868 wraps the orchestrator's genesis payload in
+        // ControlTransactionPayload { Version, Roster, Operation }. Without the symmetric
+        // reader-side fix in TryExtractControlRecord, this wrapped shape silently
+        // deserialised into a default-empty RegisterControlRecord and the validator
+        // dropped its own register from monitoring after the first reconcile tick,
+        // wedging Action 1 sealing on a fresh n1 deploy.
+        var record = BuildControlRecord(
+            ownerAddress: LocalWalletAddress,
+            validatorKeys: new[] { LocalValidatorKey });
+
+        var wrapper = new ControlTransactionPayload
+        {
+            Version = 1,
+            Roster = record,
+            Operation = null,
+        };
+        var payloadJson = JsonSerializer.SerializeToUtf8Bytes(wrapper);
+
+        var repo = new Mock<IReadOnlyRegisterRepository>();
+        repo.Setup(r => r.GetDocketAsync(RegisterId, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Docket { Id = 0, RegisterId = RegisterId });
+        repo.Setup(r => r.GetTransactionsByDocketAsync(RegisterId, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new TransactionModel
+                {
+                    RegisterId = RegisterId,
+                    TxId = new string('0', 64),
+                    SenderWallet = "system",
+                    MetaData = new TransactionMetaData { TransactionType = TransactionType.Control },
+                    Payloads = new[]
+                    {
+                        new PayloadModel
+                        {
+                            Data = Convert.ToBase64String(payloadJson),
+                            Hash = string.Empty,
+                        },
+                    },
+                    Signature = string.Empty,
+                },
+            });
+
+        var svc = new RegisterLocalRelationshipService(
+            repo.Object,
+            new StaticIdentityProvider(
+                new LocalIdentitySnapshot(new[] { LocalWalletAddress }, LocalValidatorKey)),
+            NullLogger<RegisterLocalRelationshipService>.Instance);
+
+        var rel = await svc.DeriveAsync(RegisterId);
+
+        rel.Should().NotBeNull();
+        rel!.IsOwner.Should().BeTrue();
+        rel.IsValidator.Should().BeTrue();
+    }
+
     // -------- test helpers --------
 
     private static RegisterLocalRelationshipService BuildService(

--- a/walkthroughs/AssuredIdentity/setup.ps1
+++ b/walkthroughs/AssuredIdentity/setup.ps1
@@ -151,6 +151,29 @@ $verificationWallet = New-SorchaWallet `
     -FetchPublicKey
 Write-WtSuccess "Issuer wallet (Tier 2, org admin): $($verificationWallet.Address)"
 
+# Register verification-admin as a participant in her own org and link the issuer
+# wallet. This makes TokenService.AddWalletAddressClaimAsync find a (participant,
+# wallet) pair and emit `wallet_address` in her JWT — which F142 PublishGate
+# substring-matches against the register's roster Owner subject DID
+# (`did:sorcha:w:{walletAddress}`) to authorise blueprint publish (FR-027).
+# Without this link the token has no wallet_address claim and the publish 403s.
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $verificationOrgId `
+    -WalletAddress $verificationWallet.Address `
+    -DisplayName "Verification Admin" `
+    -Headers $verificationAdminSession.Headers
+Write-WtInfo "Verification admin participant registered (issuer wallet linked)"
+
+# Re-login so the refreshed access token carries the new wallet_address claim.
+$verificationAdminSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $verificationAdminEmail `
+    -Password $verificationAdminPassword `
+    -OrganizationId $verificationOrgId
+Write-WtInfo "Verification admin session refreshed (wallet_address claim now present)"
+
 # ============================================================================
 # Step 5b: Citizen — Login, Wallet, Participant (best-effort, late-bound)
 # ============================================================================
@@ -349,7 +372,22 @@ Write-WtSuccess "Blueprint: $($blueprint.BlueprintId)"
 
 # ============================================================================
 # Step 9: Acme Licensing Co. — Feature 107 PR 2 (US2)
+#
+# Phase 2 (driving licence) is currently a stub — Feature 124 deferred the
+# credential-gated second-service flow to Spec 4 of the citizen arc. Steps 9
+# and 10 also predate F142's PublishGate, which requires the publisher's
+# wallet to hold an Owner/Admin/Designer role on the target register —
+# licensing-admin's wallet is only a subscribed participant on the assured-
+# identity register, so the publish (Step 10) cannot satisfy the governance
+# hard gate today. Wrap both steps in a best-effort guard so Step 11+ and
+# Phase 1 still run; a real Phase 2 will need either a separate licensing
+# register (with licensing-admin as Owner) or an Admin/Designer attestation
+# on the assured-identity register at register-creation time.
 # ============================================================================
+$licensingWallet = $null
+$licenceBlueprint = $null
+$licensingOrgId = $null
+try {
 Write-WtStep "Step 9: Create Acme Licensing Co."
 
 $licensingAdminEmail    = "licensing-admin@assured-identity.local"
@@ -454,6 +492,9 @@ $licenceBlueprint = Publish-SorchaBlueprint `
     -RegisterId $register.RegisterId
 
 Write-WtSuccess "Driving Licence blueprint: $($licenceBlueprint.BlueprintId)"
+} catch {
+    Write-WtWarn "Phase 2 setup (Steps 9-10) skipped (F142 publish-gate blocks licensing-admin — no Owner role on assured-identity register): $($_.Exception.Message)"
+}
 
 # ============================================================================
 # Save State
@@ -482,10 +523,12 @@ $state = @{
     # Sorcha Wallet (PWA) (SorchaLocalWallet target audience), not in a
     # filesystem wallet on the operator host.
     # PR 2 additions — licensing org, licensing wallet, Driving Licence blueprint id.
+    # Phase 2 is best-effort (see Step 9 comment); these may be null when the
+    # F142 publish gate blocks licensing-admin on the assured-identity register.
     licensingOrgId            = $licensingOrgId
-    licensingWalletAddress    = $licensingWallet.Address
-    licensingWalletPublicKey  = $licensingWallet.PublicKey
-    licenceBlueprintId        = $licenceBlueprint.BlueprintId
+    licensingWalletAddress    = if ($licensingWallet) { $licensingWallet.Address } else { $null }
+    licensingWalletPublicKey  = if ($licensingWallet) { $licensingWallet.PublicKey } else { $null }
+    licenceBlueprintId        = if ($licenceBlueprint) { $licenceBlueprint.BlueprintId } else { $null }
     roles = @{
         # Tier 2: org admin — authoring only. The Phase-1 citizen flow MUST NOT
         # use this identity for action submission.

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1360,7 +1360,14 @@ function Publish-SorchaBlueprint {
         [Parameter(Mandatory)][hashtable]$WalletMap,
         [Parameter(Mandatory)][hashtable]$Headers,
         [string]$IdPrefix = "wt",
-        [string]$RegisterId
+        [string]$RegisterId,
+        # F142 publish-gate: walkthroughs don't run a UI rehearsal, so they
+        # default to publishing with the audited soft-gate override. The
+        # caller still has to pass the F142 governance HARD gate (their wallet
+        # must match an Owner/Admin/Designer on the register roster) — only
+        # the rehearsal soft gate is bypassed.
+        [switch]$OverrideRehearsal = $true,
+        [string]$OverrideReason = "Walkthrough automation: rehearsal not wired in scripted flow."
     )
 
     # Load template
@@ -1426,7 +1433,12 @@ function Publish-SorchaBlueprint {
     # Publish blueprint
     Write-WtInfo "Publishing blueprint..."
 
-    $publishBody = if ($RegisterId) { @{ registerId = $RegisterId } | ConvertTo-Json } else { $null }
+    $publishBodyHash = @{}
+    if ($RegisterId) { $publishBodyHash.registerId = $RegisterId }
+    if ($OverrideRehearsal) {
+        $publishBodyHash.override = @{ confirm = $true; reason = $OverrideReason }
+    }
+    $publishBody = if ($publishBodyHash.Count -gt 0) { $publishBodyHash | ConvertTo-Json -Depth 5 } else { $null }
 
     $publishRaw = Invoke-SorchaApi -Method POST `
         -Uri "$BlueprintUrl/blueprints/$blueprintId/publish" `


### PR DESCRIPTION
PR #868 changed RegisterCreationOrchestrator.CreateGenesisTransaction to wrap
the genesis Payloads[0].Data in ControlTransactionPayload { Version, Roster,
Operation } so GovernanceRosterService.DeserializeControlPayload (and the
/api/registers/{id}/governance/roster projection it serves) reads back a
populated roster. That fixed the F142 PublishGate 403 for the AssuredIdentity
walkthrough.

But RegisterLocalRelationshipService.TryExtractControlRecord (which serves
GET /api/internal/my-validated-registers — the endpoint
RegisterMonitoringBootstrap calls every safety-poll tick) was still
deserialising Payloads[0].Data as a bare RegisterControlRecord. Against a
post-#868 wrapped payload, JsonSerializer.Deserialize<RegisterControlRecord>
silently produces a default-empty record (no Attestations, no Validators) —
which means DeriveRoles emits None for the validator's own genesis-control
register, so the validator's safety reconcile decides the validator key is
"no longer on roster" and unregisters monitoring (visible in n1 logs as
"Monitoring released for register {id} — validator key no longer on roster"
~30s after the initial enrolment).

Net effect on a fresh n1 deploy with PR #868 + a freshly-minted genesis:
- Initial monitoring enrolment succeeds (it reads InitialControlRecord from
  the register row, not the docket-0 control tx) — looks fine for ~30s.
- First safety-reconcile tick re-derives via the docket path, finds an
  empty record, prunes the register from monitoring.
- DocketBuilder no longer seals new dockets for that register; every
  subsequent tx (Action 1 submission, participant publish, etc.) piles up
  in the unverified Redis pool indefinitely.
- Blueprint Service times out waiting 60s for Action 1 confirmation, then
  Action 2 reports "is not a current action for instance", credential is
  never delivered. This is the symptom diagnosed in the 2026-05-29
  AssuredIdentity n1 run.

Fix: TryExtractControlRecord now probes the wrapper shape first (returning
wrapper.Roster on success) and falls back to the bare RegisterControlRecord
shape — so the genesis written by current orchestrator code and any
legacy/pre-#868 genesis both derive correctly.

Test added: Derive_GenesisPayloadWrappedInControlTransactionPayload_StillDerivesOwnerAndValidator
locks the new path against future writer/reader drift. Existing bare-record
tests continue to exercise the fallback.

Also bundled (pre-existing AssuredIdentity follow-ups surfaced by the same
n1 run, kept together to avoid landing a half-fixed walkthrough):

- setup.ps1 Step 5: register verification-admin as a participant in her
  own org and link the issuer wallet, then re-login. The Tier-2/Tier-3
  split (PR #868) created her wallet but never linked it, so her JWT
  carried no wallet_address claim — F142 PublishGate substring-matched
  against the register's Owner subject DID and 403'd. This makes her
  token carry wallet_address so the gate's hard governance check passes.

- setup.ps1 Steps 9-10: wrap the Phase 2 (Acme Licensing Co. + Driving
  Licence blueprint) setup in a best-effort try/catch — the licensing
  admin is not on the assured-identity register's roster as
  Owner/Admin/Designer, so F142 PublishGate refuses the driving-licence
  publish. Phase 2 is already documented as deferred to Spec 4 of the
  citizen arc; this guard lets Phase 1 still run end-to-end.

- SorchaWalkthrough.psm1 Publish-SorchaBlueprint: add -OverrideRehearsal
  switch (default true) + -OverrideReason. F142's publish endpoint
  now blocks publishes whose blueprint version has no recorded
  rehearsal pass; walkthroughs don't drive the rehearsal UI, so they
  publish with an audited soft-gate override. The caller still has to
  pass the governance hard gate independently.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
