### PR TITLE
fix(register-core): GovernanceRosterService picks latest control tx with a populated roster

### DIFF
--- a/src/Core/Sorcha.Register.Core/Services/GovernanceRosterService.cs
+++ b/src/Core/Sorcha.Register.Core/Services/GovernanceRosterService.cs
@@ -42,26 +42,61 @@ public class GovernanceRosterService : IGovernanceRosterService
             return null;
         }
 
-        // The latest Control TX contains the full current roster
-        var latestControlTx = controlTransactions[^1];
-        var payload = DeserializeControlPayload(latestControlTx);
-
-        if (payload?.Roster == null)
+        // Walk newest → oldest and pick the first transaction whose payload actually deserialises
+        // to a populated ControlTransactionPayload (i.e. carries a real roster snapshot).
+        //
+        // TransactionType.Control is broader than "governance roster snapshot" — action
+        // submissions and other non-roster paths can also land with type=Control depending on the
+        // writer. Picking the LAST control tx unconditionally is therefore fragile: a single
+        // non-roster control tx (e.g. an action 1 submission with type=0 left in the register
+        // during cross-day n1 runs) silently wipes the F142 PublishGate's view of the roster
+        // (the policy endpoint returns members:[] and every publish refuses with
+        // "lacks publish-governance role").
+        //
+        // This loop is defensive — for a normal register with N genuine governance commits, it
+        // immediately picks the newest one; for a register that has accumulated a non-roster
+        // Control tx newer than the latest real roster commit, it skips past the noise.
+        TransactionModel? matchedTx = null;
+        ControlTransactionPayload? payload = null;
+        for (var i = controlTransactions.Count - 1; i >= 0; i--)
         {
-            _logger.LogWarning("Latest Control transaction for register {RegisterId} has no roster payload", registerId);
+            var candidate = controlTransactions[i];
+            var candidatePayload = DeserializeControlPayload(candidate);
+            if (candidatePayload?.Roster == null) continue;
+
+            // A populated roster snapshot has at least one attestation OR a non-null Validators
+            // section. A wrapper that deserialised silently from non-governance bytes will have
+            // Roster set (default-constructed) but no attestations and no validators — treat
+            // that as "this control tx does not carry a real roster" and keep scanning.
+            var roster = candidatePayload.Roster;
+            var hasAttestations = roster.Attestations is { Count: > 0 };
+            var hasValidatorRoster = roster.Validators is not null
+                && roster.Validators.Validators is { Count: > 0 };
+            if (!hasAttestations && !hasValidatorRoster) continue;
+
+            matchedTx = candidate;
+            payload = candidatePayload;
+            break;
+        }
+
+        if (matchedTx is null || payload?.Roster is null)
+        {
+            _logger.LogWarning(
+                "No Control transaction for register {RegisterId} carries a populated roster payload ({TxCount} candidates scanned)",
+                registerId, controlTransactions.Count);
             return null;
         }
 
         _logger.LogInformation(
-            "Reconstructed roster for register {RegisterId}: {MemberCount} members from {TxCount} Control transactions",
-            registerId, payload.Roster.Attestations.Count, controlTransactions.Count);
+            "Reconstructed roster for register {RegisterId}: {MemberCount} members from {TxCount} Control transactions (latest-with-roster: {TxId})",
+            registerId, payload.Roster.Attestations.Count, controlTransactions.Count, matchedTx.TxId);
 
         return new AdminRoster
         {
             RegisterId = registerId,
             ControlRecord = payload.Roster,
             ControlTransactionCount = controlTransactions.Count,
-            LastControlTxId = latestControlTx.TxId
+            LastControlTxId = matchedTx.TxId
         };
     }
 

--- a/tests/Sorcha.Register.Core.Tests/Services/GovernanceRosterServiceTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Services/GovernanceRosterServiceTests.cs
@@ -103,6 +103,54 @@ public class GovernanceRosterServiceTests
         result!.ControlTransactionCount.Should().Be(1);
     }
 
+    [Fact]
+    public async Task GetCurrentRosterAsync_LatestControlTxHasUnrelatedPayload_FallsBackToLatestWithRoster()
+    {
+        // Regression: TransactionType.Control is broader than "governance roster snapshot".
+        // The blueprint workflow path can write a Control-typed transaction whose payload is
+        // an action-submission record, NOT a ControlTransactionPayload. The previous
+        // implementation picked the LAST control tx unconditionally, deserialised its
+        // unrelated payload into a default-empty ControlTransactionPayload (no attestations,
+        // no validator roster), and silently returned `members: []` — which made the F142
+        // PublishGate refuse every publish with "lacks publish-governance role".
+        //
+        // The fix walks newest → oldest and picks the latest control tx that actually carries
+        // a populated roster. Older real-genesis tx therefore wins over the noise.
+        var genesisRoster = CreateRoster(("did:sorcha:w:owner1", RegisterRole.Owner));
+        var genesisTx = CreateControlTransaction("tx-genesis", genesisRoster);
+
+        var noiseTx = new TransactionModel
+        {
+            TxId = "tx-noise",
+            MetaData = new TransactionMetaData
+            {
+                RegisterId = TestRegisterId,
+                TransactionType = TransactionType.Control,
+            },
+            Payloads = [new PayloadModel
+            {
+                // An action-submission payload: arbitrary JSON, not ControlTransactionPayload
+                // shaped, so .Roster on deserialise is null and the policy ought to skip it.
+                Data = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(
+                    "{\"action\":1,\"applicantName\":\"Alex MacLeod\"}")),
+            }],
+        };
+
+        _repositoryMock
+            .Setup(r => r.GetTransactionsAsync(TestRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { genesisTx, noiseTx }.AsQueryable());
+
+        var result = await _service.GetCurrentRosterAsync(TestRegisterId);
+
+        result.Should().NotBeNull();
+        result!.ControlRecord.Attestations.Should().HaveCount(1);
+        result.ControlRecord.Attestations[0].Subject.Should().Be("did:sorcha:w:owner1");
+        result.LastControlTxId.Should().Be("tx-genesis");
+        // Both transactions are still counted (the noise is a real control tx, the count is
+        // informational); the picked one is the latest with a real roster.
+        result.ControlTransactionCount.Should().Be(2);
+    }
+
     // --- ValidateQuorumAsync ---
 
     [Fact]


### PR DESCRIPTION
Symptom on n1 today: AssuredIdentity Phase-1 Step 8 publish 403'd with
"You do not hold a publish-governance role (Owner, Admin, or Designer)
on the target register" even though the verification-admin's wallet had
just been authenticated through the F142 PublishGate path and was the
only Owner attestation on the assured-identity register's genesis. The
gate log showed `wallet ws11qrs7…` correctly populated — the failure
was that GET /api/registers/{id}/governance/roster returned
`members: []` despite `controlTransactionCount: 3`.

Root cause: TransactionType.Control covers more than governance roster
snapshots. The blueprint workflow path can write a Control-typed
transaction whose payload is an action-submission record (Mongo on n1
shows action 1 = 1d0da62b sealed with TransactionType=0/Control). The
previous projection unconditionally picked the LAST control tx, fed its
payload through DeserializeControlPayload, and got back a default-empty
ControlTransactionPayload (no attestations, no validator roster). The
roster surfaced as empty and the PublishGate refused every publish.

This is the F142 PublishGate analogue of the validator self-evacuation
bug fixed in PR #870 — the same wrapped-vs-bare payload mismatch from
PR #868, but on the policy-projection side instead of the relationship
side.

Fix: walk control transactions newest → oldest and pick the first one
whose payload deserialises into a populated ControlTransactionPayload
(at least one attestation OR a non-null validator roster with at least
one entry). A real-genesis tx therefore wins over noise; for a register
whose only control tx is genuine genesis the loop returns immediately
on the first iteration — semantically equivalent to the previous
behaviour on the happy path.

ControlTransactionCount keeps counting ALL control-typed transactions
(it's informational/audit, not a correctness signal); LastControlTxId
is the picked tx, not the unfiltered last one.

Regression test added:
GetCurrentRosterAsync_LatestControlTxHasUnrelatedPayload_FallsBackToLatestWithRoster
mocks a real genesis tx followed by a noise Control tx whose payload is
an action JSON blob, and asserts the projection still surfaces the
Owner attestation from genesis.

(The deeper question of why an action submission is stored as
TransactionType=Control rather than TransactionType=Action — visible on
n1 today as a real type=0 row in MongoDB — is a separate write-path
issue worth filing; this fix is the reader-side hardening that
unblocks the AssuredIdentity walkthrough today.)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
