### PR TITLE
fix(register-models): centralise wrapped-vs-bare control-payload reading + flip CLI genesis writer to wrapper

### DIFF
--- a/src/Apps/Sorcha.Cli/Commands/SystemRegisterCommands.cs
+++ b/src/Apps/Sorcha.Cli/Commands/SystemRegisterCommands.cs
@@ -155,9 +155,24 @@ public class SystemRegisterCreateCommand : Command
         var controlPublicKeyBytes = controlKeySet.PublicKey.Key!;
         var controlPrivateKey = controlKeySet.PrivateKey.Key!;
 
-        // 2. Build the control record
+        // 2. Build the control record and wrap it in a ControlTransactionPayload envelope.
+        //    PR #868 made the orchestrator's genesis path emit the wrapper shape
+        //    ({ version, roster, operation }) so GovernanceRosterService and the non-genesis
+        //    governance-commit path can read it back via a single deserialise. The CLI mints
+        //    the SYSTEM register genesis JSON that is then embedded in the register-service
+        //    image, so it must produce the same shape — otherwise the system register's
+        //    /governance/roster surfaces members:[] (an issue observed live on n1 the day
+        //    after PR #868 deployed). All known readers accept either shape via
+        //    RegisterControlPayloadReader; new genesis bytes therefore go through the same
+        //    path the orchestrator uses.
         var controlRecord = BuildControlRecord(publicKeyBytes, algorithm);
-        var controlRecordJson = JsonSerializer.Serialize(controlRecord, CanonicalJsonOptions);
+        var controlPayload = new ControlTransactionPayload
+        {
+            Version = 1,
+            Roster = controlRecord,
+            Operation = null, // genesis carries no producing operation
+        };
+        var controlRecordJson = JsonSerializer.Serialize(controlPayload, CanonicalJsonOptions);
         var controlRecordBytes = Encoding.UTF8.GetBytes(controlRecordJson);
 
         // 3. Compute payload hash

--- a/src/Common/Sorcha.Register.Models/RegisterControlPayloadReader.cs
+++ b/src/Common/Sorcha.Register.Models/RegisterControlPayloadReader.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+
+namespace Sorcha.Register.Models;
+
+/// <summary>
+/// Shared reader for a serialised register control payload.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR #868 changed the writer side (<c>RegisterCreationOrchestrator.CreateGenesisTransaction</c>
+/// and the non-genesis governance-commit path) to wrap <see cref="RegisterControlRecord"/> in
+/// a <see cref="ControlTransactionPayload"/> envelope <c>{ version, roster, operation }</c>.
+/// PR #870 (relationship reader) and PR #871 (roster-projection reader) added dual-shape
+/// support on two consumers. This helper centralises the same rule for every remaining reader
+/// so future writer drift (or pre-#868 bytes still on disk after an upgrade-in-place) can't
+/// silently produce a default-empty record.
+/// </para>
+/// <para>
+/// The rule: probe the wrapper shape first (returning <c>wrapper.Roster</c> when the embedded
+/// record carries at least one attestation or a non-null validator roster). Fall back to the
+/// bare shape and return it under the same emptiness guard. A genuinely empty record — no
+/// attestations, no validator roster — is indistinguishable from a default-constructed
+/// deserialisation; treat it as "not a real control payload" and return null so the caller
+/// keeps scanning rather than acting on phantom roster data.
+/// </para>
+/// </remarks>
+public static class RegisterControlPayloadReader
+{
+    /// <summary>
+    /// Attempts to read a populated <see cref="RegisterControlRecord"/> from a serialised
+    /// payload that may be in either the wrapper or bare shape.
+    /// </summary>
+    /// <param name="payloadJson">The UTF-8 JSON bytes of the payload.</param>
+    /// <returns>
+    /// The decoded record when the payload carries at least one attestation or a non-null
+    /// validator roster; <c>null</c> when the payload is not a real control payload (either
+    /// JSON is malformed or the deserialised record is default-empty).
+    /// </returns>
+    public static RegisterControlRecord? TryRead(ReadOnlySpan<byte> payloadJson)
+    {
+        if (payloadJson.IsEmpty) return null;
+
+        try
+        {
+            // Wrapper shape ({ version, roster, operation }) first — the post-#868 default.
+            var wrapper = JsonSerializer.Deserialize<ControlTransactionPayload>(payloadJson);
+            if (IsPopulated(wrapper?.Roster)) return wrapper!.Roster;
+        }
+        catch (JsonException)
+        {
+            // fall through to bare-shape probe
+        }
+
+        try
+        {
+            var bare = JsonSerializer.Deserialize<RegisterControlRecord>(payloadJson);
+            if (IsPopulated(bare)) return bare;
+        }
+        catch (JsonException)
+        {
+            // fall through to null
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Convenience overload accepting the UTF-8 JSON as a string.
+    /// </summary>
+    public static RegisterControlRecord? TryRead(string payloadJson) =>
+        TryRead(System.Text.Encoding.UTF8.GetBytes(payloadJson));
+
+    private static bool IsPopulated(RegisterControlRecord? record)
+    {
+        if (record is null) return false;
+        // A real control record carries at least one of: an attestation, a validator roster
+        // entry, a CryptoPolicy, or a Name. The fourth (Name) catches genuine genesis records
+        // that pre-date the orchestrator wrapping but still carry meaningful content; the
+        // earlier three catch every wrapper-shape governance commit. A truly-default
+        // deserialisation (no name, no attestations, no validators, no policy) is treated as
+        // "not a real control payload" — that's the silent-failure mode this helper exists
+        // to prevent.
+        if (!string.IsNullOrWhiteSpace(record.Name)) return true;
+        if (record.Attestations is { Count: > 0 }) return true;
+        if (record.Validators?.Validators is { Count: > 0 }) return true;
+        if (record.CryptoPolicy is not null) return true;
+        return false;
+    }
+}

--- a/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
+++ b/src/Core/Sorcha.Register.Core/LocalRelationship/RegisterLocalRelationshipService.cs
@@ -168,44 +168,16 @@ public sealed class RegisterLocalRelationshipService : IRegisterLocalRelationshi
 
             try
             {
-                var bytes = DecodeBase64Auto(data);
-
-                // Two on-disk shapes are valid here:
-                //   (a) ControlTransactionPayload { Version, Roster: RegisterControlRecord, Operation }
-                //       — the post-PR-#868 shape that GovernanceRosterService and the non-genesis
-                //       governance-commit path both produce.
-                //   (b) Bare RegisterControlRecord — the pre-PR-#868 genesis shape, still on disk
-                //       for any pre-existing register that hasn't been re-created since.
-                // Probe the wrapper shape first (it carries an explicit "roster" property); fall
-                // back to the bare shape so legacy genesis dockets still derive correctly. Without
-                // this, the post-#868 wrapped payload silently deserialises into a default-empty
-                // RegisterControlRecord — no validators, no attestations — which causes
-                // /api/internal/my-validated-registers to drop this register from the validator's
-                // monitoring set and stops every subsequent docket from sealing.
-                var wrapper = JsonSerializer.Deserialize<ControlTransactionPayload>(bytes);
-                if (wrapper?.Roster is not null
-                    && (wrapper.Roster.Attestations is { Count: > 0 }
-                        || wrapper.Roster.Validators is not null))
-                {
-                    return wrapper.Roster;
-                }
-
-                var bare = JsonSerializer.Deserialize<RegisterControlRecord>(bytes);
-                if (bare is not null
-                    && (bare.Attestations is { Count: > 0 } || bare.Validators is not null))
-                {
-                    return bare;
-                }
+                // RegisterControlPayloadReader handles both on-disk shapes (pre-#868 bare and
+                // post-#868 wrapped) and returns null for an empty/non-populated payload, so
+                // a default-empty deserialisation doesn't poison the relationship lookup.
+                var record = RegisterControlPayloadReader.TryRead(DecodeBase64Auto(data));
+                if (record is not null) return record;
             }
             catch (FormatException ex)
             {
                 _logger?.LogDebug(ex,
                     "Control tx payload for register {RegisterId} is not valid Base64/Base64Url", registerId);
-            }
-            catch (JsonException ex)
-            {
-                _logger?.LogDebug(ex,
-                    "Control tx payload for register {RegisterId} is not a valid control payload", registerId);
             }
         }
         return null;

--- a/src/Services/Sorcha.Peer.Service/Replication/ValidatorKeyCache.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/ValidatorKeyCache.cs
@@ -51,25 +51,26 @@ public class ValidatorKeyCache
     /// </summary>
     public bool ExtractFromControlRecord(string registerId, byte[] controlRecordData)
     {
-        try
+        // Genesis control bytes carry either the bare RegisterControlRecord shape (pre-#868)
+        // or the ControlTransactionPayload wrapper shape (post-#868). Both paths are accepted.
+        var controlRecord = RegisterControlPayloadReader.TryRead(controlRecordData);
+        if (controlRecord is null)
         {
-            var controlRecord = JsonSerializer.Deserialize<RegisterControlRecord>(controlRecordData);
-            if (controlRecord?.Validators == null)
-            {
-                _logger.LogWarning(
-                    "Genesis control record for register {RegisterId} does not contain a validators field",
-                    registerId);
-                return false;
-            }
-
-            return ExtractFromControlRecord(registerId, controlRecord);
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogWarning(ex,
-                "Failed to deserialize control record for register {RegisterId}", registerId);
+            _logger.LogWarning(
+                "Failed to deserialise control record for register {RegisterId} (payload was neither a bare RegisterControlRecord nor a populated ControlTransactionPayload)",
+                registerId);
             return false;
         }
+
+        if (controlRecord.Validators is null)
+        {
+            _logger.LogWarning(
+                "Genesis control record for register {RegisterId} does not contain a validators field",
+                registerId);
+            return false;
+        }
+
+        return ExtractFromControlRecord(registerId, controlRecord);
     }
 
     /// <summary>

--- a/src/Services/Sorcha.Register.Service/Services/CryptoPolicyService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/CryptoPolicyService.cs
@@ -173,8 +173,9 @@ public class CryptoPolicyService
             if (policy != null && policy.Version > 0 && policy.AcceptedSignatureAlgorithms.Length > 0)
                 return policy;
 
-            // Try as RegisterControlRecord and extract CryptoPolicy
-            var controlRecord = JsonSerializer.Deserialize<RegisterControlRecord>(json);
+            // Try as RegisterControlRecord (either bare-shape pre-#868 or wrapped post-#868
+            // — RegisterControlPayloadReader handles both) and extract its CryptoPolicy.
+            var controlRecord = RegisterControlPayloadReader.TryRead(bytes);
             return controlRecord?.CryptoPolicy;
         }
         catch (JsonException)

--- a/src/Services/Sorcha.Register.Service/Services/GenesisControlRecordExtractor.cs
+++ b/src/Services/Sorcha.Register.Service/Services/GenesisControlRecordExtractor.cs
@@ -50,14 +50,16 @@ internal static class GenesisControlRecordExtractor
 
             try
             {
-                var json = Encoding.UTF8.GetString(ContentEncodings.DecodeBase64Auto(tx.Payloads[0].Data));
-                var record = JsonSerializer.Deserialize<RegisterControlRecord>(json);
+                var jsonBytes = ContentEncodings.DecodeBase64Auto(tx.Payloads[0].Data);
+                // Genesis bytes carry either the bare RegisterControlRecord shape (pre-#868)
+                // or the ControlTransactionPayload wrapper shape (post-#868).
+                var record = RegisterControlPayloadReader.TryRead(jsonBytes);
                 if (record is not null && !string.IsNullOrWhiteSpace(record.Name))
                 {
                     return record;
                 }
             }
-            catch (Exception ex) when (ex is FormatException or JsonException)
+            catch (FormatException)
             {
                 // Not a decodable control record — try the next transaction.
             }

--- a/src/Services/Sorcha.Register.Service/Services/GenesisIngestionService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/GenesisIngestionService.cs
@@ -204,12 +204,15 @@ public class GenesisIngestionService
         try
         {
             var payloadBytes = Convert.FromBase64String(genesis.GenesisTransaction.Payload);
-            controlRecord = JsonSerializer.Deserialize<RegisterControlRecord>(payloadBytes);
+            // Genesis bytes carry either the bare RegisterControlRecord shape (pre-PR #868
+            // / pre-CLI flip) or the ControlTransactionPayload wrapper shape (post-flip).
+            // RegisterControlPayloadReader handles both.
+            controlRecord = RegisterControlPayloadReader.TryRead(payloadBytes);
         }
-        catch (Exception ex) when (ex is FormatException or JsonException)
+        catch (FormatException ex)
         {
             _logger.LogWarning(ex,
-                "Failed to decode genesis payload into RegisterControlRecord — " +
+                "Failed to base64-decode genesis payload — " +
                 "skipping pre-create. Validator enrolment will rely on docket-0 seal.");
             return;
         }
@@ -217,7 +220,7 @@ public class GenesisIngestionService
         if (controlRecord is null)
         {
             _logger.LogWarning(
-                "Genesis payload decoded to null RegisterControlRecord — skipping pre-create");
+                "Genesis payload decoded to a null/empty RegisterControlRecord — skipping pre-create");
             return;
         }
 

--- a/tests/Sorcha.Register.Models.Tests/RegisterControlPayloadReaderTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/RegisterControlPayloadReaderTests.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Xunit;
+
+namespace Sorcha.Register.Models.Tests;
+
+public class RegisterControlPayloadReaderTests
+{
+    [Fact]
+    public void TryRead_WrapperShape_PopulatedRoster_ReturnsRoster()
+    {
+        var inner = MakeRecord(withAttestation: true, withValidator: false);
+        var wrapper = new ControlTransactionPayload
+        {
+            Version = 1,
+            Roster = inner,
+            Operation = null,
+        };
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(wrapper);
+
+        var result = RegisterControlPayloadReader.TryRead(bytes);
+
+        result.Should().NotBeNull();
+        result!.Attestations.Should().HaveCount(1);
+        result.Attestations[0].Subject.Should().Be("did:sorcha:w:owner1");
+    }
+
+    [Fact]
+    public void TryRead_WrapperShape_WithOnlyValidatorRoster_StillReturnsRoster()
+    {
+        // A valid governance snapshot may carry the validator set without any participant
+        // attestations — the reader should still surface it (not treat it as empty).
+        var inner = MakeRecord(withAttestation: false, withValidator: true);
+        var wrapper = new ControlTransactionPayload { Version = 1, Roster = inner, Operation = null };
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(wrapper);
+
+        var result = RegisterControlPayloadReader.TryRead(bytes);
+
+        result.Should().NotBeNull();
+        result!.Validators!.Validators.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void TryRead_BareShape_PopulatedRoster_ReturnsRoster()
+    {
+        // Pre-#868 genesis bytes — bare RegisterControlRecord on disk. The reader must keep
+        // accepting these so a long-lived register's docket-0 control tx still derives roles
+        // after the writer flip.
+        var record = MakeRecord(withAttestation: true, withValidator: false);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(record);
+
+        var result = RegisterControlPayloadReader.TryRead(bytes);
+
+        result.Should().NotBeNull();
+        result!.Attestations.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void TryRead_EmptyBytes_ReturnsNull()
+    {
+        RegisterControlPayloadReader.TryRead(ReadOnlySpan<byte>.Empty).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_NonControlJson_ReturnsNull()
+    {
+        // An action-submission JSON blob — neither shape carries attestations or validators,
+        // so a silent default-empty deserialisation must not poison downstream callers.
+        // This is the exact symptom that drove PR #871 on the projection side.
+        var bytes = Encoding.UTF8.GetBytes("{\"action\":1,\"applicantName\":\"Alex MacLeod\"}");
+
+        RegisterControlPayloadReader.TryRead(bytes).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_MalformedJson_ReturnsNull()
+    {
+        var bytes = Encoding.UTF8.GetBytes("not-json-at-all");
+
+        RegisterControlPayloadReader.TryRead(bytes).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryRead_StringOverload_RoundTrips()
+    {
+        var record = MakeRecord(withAttestation: true, withValidator: false);
+        var wrapper = new ControlTransactionPayload { Version = 1, Roster = record };
+        var json = JsonSerializer.Serialize(wrapper);
+
+        var result = RegisterControlPayloadReader.TryRead(json);
+
+        result.Should().NotBeNull();
+        result!.Attestations[0].Subject.Should().Be("did:sorcha:w:owner1");
+    }
+
+    private static RegisterControlRecord MakeRecord(bool withAttestation, bool withValidator)
+    {
+        var record = new RegisterControlRecord
+        {
+            RegisterId = "abc",
+            Name = "Test Register",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        if (withAttestation)
+        {
+            record.Attestations = new List<RegisterAttestation>
+            {
+                new()
+                {
+                    Role = RegisterRole.Owner,
+                    Subject = "did:sorcha:w:owner1",
+                    PublicKey = Convert.ToBase64String(new byte[32]),
+                    Signature = Convert.ToBase64String(new byte[64]),
+                    Algorithm = SignatureAlgorithm.ED25519,
+                    GrantedAt = DateTimeOffset.UtcNow,
+                },
+            };
+        }
+
+        if (withValidator)
+        {
+            record.Validators = new ValidatorRoster
+            {
+                Validators = new List<ValidatorRosterEntry>
+                {
+                    new()
+                    {
+                        ValidatorId = "v1",
+                        PublicKey = Convert.ToBase64String(new byte[32]),
+                        Algorithm = SignatureAlgorithm.ED25519,
+                    },
+                },
+            };
+        }
+
+        return record;
+    }
+}


### PR DESCRIPTION
Completes the symmetric fix story from PRs #868 / #870 / #871.

After #868 (orchestrator writes ControlTransactionPayload wrapper) and
#870 / #871 (relationship + projection readers now accept either shape),
three more reader sites still deserialised the genesis payload as a bare
RegisterControlRecord:

- GenesisIngestionService.EnsureSystemRegisterRowAsync (register-service
  startup pre-create — stashes InitialControlRecord on the row so the
  validator can derive its relationship pre-seal).
- GenesisControlRecordExtractor (WriteDocket auto-create-on-genesis path
  used by subscribers replicating someone else's register).
- ValidatorKeyCache.ExtractFromControlRecord (peer-service replication
  validator-roster cache).

And one writer site mirrored the bug:

- SystemRegisterCommands.cs `system-register create` (CLI) still wrote
  a bare RegisterControlRecord into the embedded genesis JSON. After
  PR #868 deployed on n1 the day before, the SYSTEM register's
  /governance/roster correctly surfaced members:[] (the API-created
  registers like assured-identity DID populate because they go through
  the fixed orchestrator). No production path consults the system
  register's roster today so it didn't bite, but it leaves a latent
  trap and the asymmetry made the fix story confusing — the same code
  base now ships two writer paths that emit different shapes.

This PR:

1. Adds Sorcha.Register.Models.RegisterControlPayloadReader — a shared
   `TryRead(bytes)` helper that probes the wrapper shape first and
   falls back to the bare shape. Returns null when neither shape
   yields a populated record (attestations, validator roster,
   crypto policy, or a non-empty Name) — so default-empty
   deserialisations from unrelated bytes (e.g. an action submission
   stored with TransactionType=Control — the exact failure mode that
   drove #871) can't poison downstream callers.
2. Flips the CLI genesis writer to emit ControlTransactionPayload —
   the SYSTEM register now ships the same shape as every other
   register from day one.
3. Updates all five reader sites to call the shared helper:
   GenesisIngestionService, GenesisControlRecordExtractor,
   ValidatorKeyCache, CryptoPolicyService (keeps its CryptoPolicy-
   first probe; falls through to the shared reader for the
   RegisterControlRecord case), and refactors
   RegisterLocalRelationshipService (PR #870's inline implementation)
   to call the helper for consistency.

Tests:
- 7 new unit tests on RegisterControlPayloadReader covering wrapper +
  bare populated, wrapper-with-only-validators, empty bytes, non-
  control JSON (action-submission payload — the exact failure mode
  from #871), malformed JSON, and the string overload.
- All existing test suites still green: Sorcha.Register.Models.Tests
  204, Sorcha.Register.Core.Tests 325, Sorcha.Register.Service.Tests
  303 (the previously-failing CryptoPolicyServiceTests
  GetActivePolicyAsync_GenesisHasPolicy_ReturnsGenesisPolicy was
  caught by an over-strict initial "populated" definition; the
  definition was broadened to accept Name/CryptoPolicy as populated
  signals so policy-only control records still derive).

Backward compatibility:
- All known readers accept BOTH shapes, so a pre-#868 genesis still
  on disk somewhere keeps deserialising.
- Validator hash verification is shape-agnostic (it hashes whatever
  bytes it receives) so the wire format change is transparent to
  SyncOnly replicas and peer-service replication.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
