### PR TITLE
fix(wallet-service): CitizenInboxProjector lazily populates CitizenHolderIndex for credentials addressed to a wallet's own subject

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenInboxProjector.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenInboxProjector.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sorcha.Wallet.Core.Data;
 using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Service.Hubs;
 using Sorcha.Wallet.Service.Services.Interfaces;
 
@@ -40,6 +41,7 @@ public sealed class CitizenInboxProjector : ICitizenInboxProjector
 
     private readonly WalletDbContext _db;
     private readonly IHolderAddressLookup _holderLookup;
+    private readonly IWalletRepository _walletRepository;
     private readonly IHubContext<WalletHub, IWalletHubClient> _hub;
     private readonly ILogger<CitizenInboxProjector> _logger;
 
@@ -47,11 +49,13 @@ public sealed class CitizenInboxProjector : ICitizenInboxProjector
     public CitizenInboxProjector(
         WalletDbContext db,
         IHolderAddressLookup holderLookup,
+        IWalletRepository walletRepository,
         IHubContext<WalletHub, IWalletHubClient> hub,
         ILogger<CitizenInboxProjector> logger)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _holderLookup = holderLookup ?? throw new ArgumentNullException(nameof(holderLookup));
+        _walletRepository = walletRepository ?? throw new ArgumentNullException(nameof(walletRepository));
         _hub = hub ?? throw new ArgumentNullException(nameof(hub));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -64,8 +68,39 @@ public sealed class CitizenInboxProjector : ICitizenInboxProjector
         var platformUserId = await _holderLookup.ResolvePlatformUserIdAsync(credential.WalletAddress, ct);
         if (platformUserId is null)
         {
-            // Org wallet, not a citizen holder — pipeline unchanged.
-            return;
+            // Fast-path lookup missed. F114's PWA enrolment endpoint is the canonical
+            // population point for CitizenHolderIndex, but walkthrough automation and
+            // any flow that creates a citizen wallet without going through the device-
+            // enrolment ceremony will hit this branch — and silently dropping the event
+            // means GET /api/v1/wallet/credentials returns [] even though the credential
+            // is on disk (the symptom diagnosed live on n1 after PR #871).
+            //
+            // Discriminator for "this is a citizen-holder pattern, not an org wallet":
+            //   SubjectDid == WalletAddress — the credential's subject is the wallet's
+            //   own holder. The issuer-side ledger row stored on the analyst's wallet
+            //   has SubjectDid pointing at the recipient, so it does NOT match — that
+            //   row stays excluded, exactly as before. Only the recipient-side row
+            //   (Subject = Wallet) triggers the lazy population path.
+            if (!string.Equals(credential.SubjectDid, credential.WalletAddress, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var wallet = await _walletRepository.GetByAddressAsync(
+                credential.WalletAddress, cancellationToken: ct);
+            if (wallet is null || !Guid.TryParse(wallet.Owner, out var owner))
+            {
+                // Owner not a parseable platform-user GUID (or wallet not found) — bail.
+                return;
+            }
+
+            // Lazily populate the index so subsequent reads hit the fast path. RegisterAsync
+            // is idempotent on (WalletAddress) and tolerates concurrent first-write races.
+            await _holderLookup.RegisterAsync(credential.WalletAddress, owner, ct);
+            platformUserId = owner;
+            _logger.LogInformation(
+                "CitizenHolderIndex lazily populated for wallet {Wallet} → platformUserId {PlatformUserId} on first inbound credential",
+                credential.WalletAddress, owner);
         }
 
         await AppendEventAsync(platformUserId.Value, CitizenCredentialEventKindValues.Added, credential.Id, ct);

--- a/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/CitizenInboxProjectorTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/CitizenWallet/CitizenInboxProjectorTests.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sorcha.Wallet.Core.Domain.Entities;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Service.Hubs;
 using Sorcha.Wallet.Service.Services.Implementation;
 using Sorcha.Wallet.Service.Services.Interfaces;
@@ -26,6 +27,7 @@ public class CitizenInboxProjectorTests
         CitizenInboxProjector projector,
         TestCitizenWalletDbContext db,
         Mock<IHolderAddressLookup> lookup,
+        Mock<IWalletRepository> walletRepository,
         Mock<IHubContext<WalletHub, IWalletHubClient>> hub,
         Mock<IWalletHubClient> hubClient,
         List<(string group, string credentialId)> emissions
@@ -37,6 +39,7 @@ public class CitizenInboxProjectorTests
         var db = new TestCitizenWalletDbContext(options);
 
         var lookup = new Mock<IHolderAddressLookup>();
+        var walletRepository = new Mock<IWalletRepository>();
         var hub = new Mock<IHubContext<WalletHub, IWalletHubClient>>();
         var hubClients = new Mock<IHubClients<IWalletHubClient>>();
         var hubClient = new Mock<IWalletHubClient>();
@@ -54,9 +57,10 @@ public class CitizenInboxProjectorTests
             });
 
         var projector = new CitizenInboxProjector(
-            db, lookup.Object, hub.Object, NullLogger<CitizenInboxProjector>.Instance);
+            db, lookup.Object, walletRepository.Object, hub.Object,
+            NullLogger<CitizenInboxProjector>.Instance);
 
-        return (projector, db, lookup, hub, hubClient, emissions);
+        return (projector, db, lookup, walletRepository, hub, hubClient, emissions);
     }
 
     private static CredentialEntity NewCredential(string walletAddress, CredentialStatus status = CredentialStatus.PendingAcceptance) =>
@@ -77,7 +81,7 @@ public class CitizenInboxProjectorTests
     [Fact]
     public async Task OnCredentialAddedAsync_CitizenRecipient_AppendsEventAndEmits()
     {
-        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var (projector, db, lookup, _, _, _, emissions) = CreateSut();
         var pid = Guid.NewGuid();
         var credential = NewCredential("ws1qcitizen");
         lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
@@ -100,7 +104,7 @@ public class CitizenInboxProjectorTests
     [Fact]
     public async Task OnCredentialAddedAsync_OrgRecipient_NoOp()
     {
-        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var (projector, db, lookup, _, _, _, emissions) = CreateSut();
         var credential = NewCredential("ws1qorg");
         lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qorg", It.IsAny<CancellationToken>()))
             .ReturnsAsync((Guid?)null);
@@ -114,7 +118,7 @@ public class CitizenInboxProjectorTests
     [Fact]
     public async Task OnCredentialAddedAsync_SecondCredential_AdvancesSeq()
     {
-        var (projector, db, lookup, _, _, _) = CreateSut();
+        var (projector, db, lookup, _, _, _, _) = CreateSut();
         var pid = Guid.NewGuid();
         lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
             .ReturnsAsync(pid);
@@ -133,7 +137,7 @@ public class CitizenInboxProjectorTests
     [Fact]
     public async Task OnCredentialStatusChangedAsync_RevokedTransition_EmitsRevokedEvent()
     {
-        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var (projector, db, lookup, _, _, _, emissions) = CreateSut();
         var pid = Guid.NewGuid();
         var credential = NewCredential("ws1qcitizen", CredentialStatus.Revoked);
         lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
@@ -149,7 +153,7 @@ public class CitizenInboxProjectorTests
     [Fact]
     public async Task OnCredentialStatusChangedAsync_DeclinedTransition_EmitsRevokedEvent()
     {
-        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var (projector, db, lookup, _, _, _, emissions) = CreateSut();
         var pid = Guid.NewGuid();
         var credential = NewCredential("ws1qcitizen", CredentialStatus.Declined);
         lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
@@ -168,7 +172,7 @@ public class CitizenInboxProjectorTests
         // PendingAcceptance → Active is a successful holder accept. The wallet
         // already knows about the credential (we sent it as Added when it landed
         // in PendingAcceptance), so re-emitting on accept would be noise.
-        var (projector, db, lookup, _, _, emissions) = CreateSut();
+        var (projector, db, lookup, _, _, _, emissions) = CreateSut();
         var credential = NewCredential("ws1qcitizen", CredentialStatus.Active);
         lookup.Setup(l => l.ResolvePlatformUserIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Guid.NewGuid());
@@ -177,5 +181,103 @@ public class CitizenInboxProjectorTests
 
         (await db.CitizenCredentialEventLog.CountAsync()).Should().Be(0);
         emissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OnCredentialAddedAsync_LookupMisses_SubjectMatchesWallet_LazilyRegistersAndProjects()
+    {
+        // The walkthrough-automation path: the citizen wallet was created via the regular
+        // wallet API (not the F114 PWA enrol ceremony) so CitizenHolderIndex has no row.
+        // The credential's SubjectDid matches the WalletAddress (a SorchaLocalWallet
+        // recipient-side row), which is the discriminator for "this is a citizen-holder
+        // pattern". The projector resolves the platform user from Wallets.Owner, lazily
+        // registers the index for future fast-path reads, and appends the event so
+        // ListAllCredentialsAsync surfaces the credential.
+        var (projector, db, lookup, walletRepository, _, _, emissions) = CreateSut();
+        var pid = Guid.NewGuid();
+        var credential = NewCredential("ws1qcitizen");
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync("ws1qcitizen", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+        walletRepository
+            .Setup(r => r.GetByAddressAsync("ws1qcitizen", false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Wallet.Core.Domain.Entities.Wallet
+            {
+                Address = "ws1qcitizen",
+                Owner = pid.ToString(),
+                Tenant = "default",
+                Name = "Citizen Application Wallet",
+                Algorithm = "ED25519",
+                EncryptedPrivateKey = string.Empty,
+                EncryptionKeyId = string.Empty,
+            });
+
+        await projector.OnCredentialAddedAsync(credential);
+
+        var rows = await db.CitizenCredentialEventLog.ToListAsync();
+        rows.Should().HaveCount(1);
+        rows[0].PlatformUserId.Should().Be(pid);
+        rows[0].CredentialId.Should().Be(credential.Id);
+
+        emissions.Should().ContainSingle();
+        emissions[0].group.Should().Be(WalletHub.GroupNameFor(pid));
+
+        // The lazy registration call MUST have fired so the next inbound credential hits
+        // the fast path (lookup hit) without re-querying the wallets table.
+        lookup.Verify(l => l.RegisterAsync("ws1qcitizen", pid, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnCredentialAddedAsync_LookupMisses_SubjectDoesNotMatchWallet_StaysNoOp()
+    {
+        // The issuer-side ledger row stored on the issuer's wallet has SubjectDid pointing
+        // at the recipient — Subject ≠ Wallet. That's the org-issuer / cross-wallet pattern,
+        // not a citizen-holder pattern, so the fallback path must NOT trigger. This locks
+        // the existing org-credential pipeline shape.
+        var (projector, db, lookup, walletRepository, _, _, emissions) = CreateSut();
+        var credential = NewCredential("ws1qissuer");
+        credential.SubjectDid = "ws1qcitizen"; // recipient ≠ wallet
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+
+        await projector.OnCredentialAddedAsync(credential);
+
+        (await db.CitizenCredentialEventLog.CountAsync()).Should().Be(0);
+        emissions.Should().BeEmpty();
+        // Verify the wallet repository was NEVER queried — the cheap discriminator was
+        // enough to bail before incurring the lookup cost.
+        walletRepository.Verify(
+            r => r.GetByAddressAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(),
+                                     It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task OnCredentialAddedAsync_LookupMisses_WalletOwnerNotGuid_StaysNoOp()
+    {
+        // Some wallet owners are non-GUID strings (system identities, service principals
+        // in some configurations, legacy rows). The fallback path must refuse to register
+        // an index row in that case — there is no platform-user UUID to project against.
+        var (projector, db, lookup, walletRepository, _, _, emissions) = CreateSut();
+        var credential = NewCredential("ws1qweird");
+        lookup.Setup(l => l.ResolvePlatformUserIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
+        walletRepository
+            .Setup(r => r.GetByAddressAsync("ws1qweird", false, false, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Wallet.Core.Domain.Entities.Wallet
+            {
+                Address = "ws1qweird",
+                Owner = "system-identity-foo",
+                Tenant = "default",
+                Name = "Weird Wallet",
+                Algorithm = "ED25519",
+                EncryptedPrivateKey = string.Empty,
+                EncryptionKeyId = string.Empty,
+            });
+
+        await projector.OnCredentialAddedAsync(credential);
+
+        (await db.CitizenCredentialEventLog.CountAsync()).Should().Be(0);
+        emissions.Should().BeEmpty();
+        lookup.Verify(l => l.RegisterAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }


### PR DESCRIPTION
Closes the credential-delivery gap diagnosed live on n1 after PRs
#868 / #870 / #871: the AssuredIdentity walkthrough reached Phase 1
SC-001 in 01:21 with the credential sealed in docket 6 and stored
under the citizen's wallet at PendingAcceptance — but
GET /api/v1/wallet/credentials kept returning {credentials:[]} even
after a manual PATCH to Active. The credential row was on disk; the
CitizenCredentialEventLog row that ListAllCredentialsAsync reads was
missing.

Root cause: CitizenInboxProjector.OnCredentialAddedAsync resolves the
recipient via IHolderAddressLookup.ResolvePlatformUserIdAsync; if the
lookup returns null it bails. CitizenHolderIndex is only populated by
the F114 PWA device-enrolment endpoint (CitizenWalletEndpoints.EnrolDevice
line 483) — any flow that creates a citizen wallet through the regular
wallet API (walkthrough automation, scripted CI, any non-PWA citizen
provisioning path) leaves the index empty, the projector early-returns,
and the credential is permanently orphaned from the citizen's
/credentials view.

Fix: when the fast-path lookup misses, the projector checks the cheap
discriminator SubjectDid == WalletAddress (the SorchaLocalWallet
"credential addressed to the wallet's own subject" pattern). The
issuer-side ledger row stored on the issuer's wallet has SubjectDid
pointing at the recipient — Subject ≠ Wallet — and is excluded so the
existing org-credential pipeline shape is preserved. When the
discriminator passes, the projector resolves the platform user from
Wallets.Owner (parsed as Guid), lazily calls IHolderAddressLookup.RegisterAsync
to populate the index for future fast-path reads, and appends the event
so ListAllCredentialsAsync surfaces the credential.

Wallets.Owner is the platformUserId for citizen wallets (verified on
n1: citizen wallet ws11qzjp… has Owner = b6d41a6f-… which is Alex
MacLeod's platformUserId). The Guid.TryParse gate refuses to register
when the Owner is a non-GUID (system identities, service principals,
legacy rows).

Tests:
- 3 new unit tests on CitizenInboxProjector covering:
  - Lookup-misses-but-subject-matches-wallet: lazy RegisterAsync fires,
    event appended, hub emit captured.
  - Lookup-misses-but-Subject≠Wallet: cheap discriminator bails before
    the wallet-repo query, lookup.RegisterAsync NEVER called (locks
    the org-credential pipeline shape).
  - Lookup-misses-and-Owner-not-Guid: wallet repo returns a wallet with
    a non-GUID Owner, registration refused.
- Full Sorcha.Wallet.Service.Tests still green: 839 passing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
