### PR TITLE
fix(walkthrough/assured-identity): Step 6 performs the SorchaLocalWallet holder-accept PATCH

### DIFF
--- a/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
+++ b/walkthroughs/AssuredIdentity/run-phase1-identity.ps1
@@ -228,6 +228,25 @@ if (-not $delivered) {
 
 Write-WtSuccess "AssuredIdentityCredential delivered to PWA (credentialId=$credentialId)"
 
+# Holder-accept claim — mirror what a real citizen does when they tap "Claim" on
+# the pending-credential card in the PWA. For SorchaLocalWallet credentials the
+# acceptance contract is a PATCH on the citizen-scoped wallet credential resource
+# with `status: Active`. The credential lands at `PendingAcceptance` from
+# InboundCredentialDetector; without this PATCH it stays in that state until the
+# citizen acts in-app, so an automated walkthrough that wants to leave the wallet
+# in "credential held and usable for presentation" must drive the claim itself.
+# (Blueprint action-3 is HAIP-offer-shaped, not this path — see MEMORY 2026-05-25.)
+$claimUri = "$($state.walletUrl)/v1/wallets/$($state.citizenWalletAddress)/credentials/$credentialId"
+$claimResp = Invoke-SorchaApi -Method PATCH `
+    -Uri $claimUri `
+    -Body @{ status = "Active" } `
+    -Headers $citizenSession.Headers
+if ($claimResp.status -ne "Active") {
+    Write-WtFail "Holder-accept PATCH returned status='$($claimResp.status)' (expected 'Active') for credential $credentialId"
+    exit 1
+}
+Write-WtSuccess "Credential claimed (PATCH status=Active) — citizen wallet holding the AssuredIdentityCredential"
+
 Clear-SorchaCitizenPendingApplication `
     -WalletUrl $state.walletUrl `
     -Headers $citizenSession.Headers


### PR DESCRIPTION
Phase 1 Step 6 polled GET /api/v1/wallet/credentials and reported success the
moment the credential appeared. That left the credential at PendingAcceptance
— the citizen wallet "holding the credential" status — which is the wallet
state immediately after issuance, before any holder action. A real citizen
opens the pending-credential card in the PWA and taps "Claim", which fires
PATCH /api/v1/wallets/{addr}/credentials/{id} { "status": "Active" }; an
automated walkthrough that wants to leave the wallet in "credential held and
usable for presentation" must drive the same call itself.

After the credential is found in the polled snapshot, Step 6 now:
1. PATCHes the credential resource to Active (the SorchaLocalWallet "claim"
   contract — confirmed live on n1 the day after PR #871: HTTP 200 with
   status=Active in the response).
2. Asserts the response's status field is "Active" — anything else fails
   loudly so a future contract drift surfaces here instead of at presentation
   time.
3. Surfaces a separate "Credential claimed" success line so the run log
   distinguishes "credential delivered" from "credential claimed" — both
   states are meaningful for the citizen UX and both should be observable.

Blueprint action-3 (HAIP-shaped credential offer) is a different acceptance
path and is intentionally not used here — see MEMORY 2026-05-25 for the
HAIP-vs-SorchaLocalWallet distinction.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
