### PR TITLE
fix(wallet-service): CreateWallet pre-populates CitizenHolderIndex with the JWT platform_user_id

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -375,6 +375,7 @@ public static class WalletEndpoints
         WalletManager walletManager,
         ICryptoModule cryptoModule,
         IWalletUtilities walletUtilities,
+        Sorcha.Wallet.Service.Services.Interfaces.IHolderAddressLookup holderAddressLookup,
         IServiceScopeFactory serviceScopeFactory,
         HttpContext context,
         ILogger<Program> logger,
@@ -407,6 +408,38 @@ public static class WalletEndpoints
                 request.Passphrase,
                 signingModeOverride,
                 cancellationToken);
+
+            // F114 PWA enrolment is the canonical population point for
+            // CitizenHolderIndex (wallet ↔ PlatformUser.Id mapping the citizen-side
+            // /v1/wallet/credentials endpoint reads against), but any flow that
+            // creates a citizen wallet through this endpoint without going through
+            // PWA enrol (walkthrough automation, scripted CI, future direct-create
+            // surfaces) needs the same mapping or the citizen's credential list
+            // surfaces empty. Wallets.Owner is the JWT NameIdentifier (UserIdentity.Id,
+            // org-scoped) — NOT the PlatformUser.Id the citizen-credential tables key
+            // against. The JWT has both — `sub` = UserIdentity.Id, `platform_user_id`
+            // = PlatformUser.Id — so we pull the latter here, where we still have the
+            // JWT, and pre-populate the index. RegisterAsync is idempotent on
+            // (WalletAddress) and tolerates concurrent first-write races.
+            // Skipped when the JWT doesn't carry a parseable platform_user_id (admin
+            // / service tokens where the citizen-credential pipeline isn't in play).
+            var platformUserIdClaim = context.User.FindFirstValue("platform_user_id");
+            if (Guid.TryParse(platformUserIdClaim, out var platformUserId))
+            {
+                try
+                {
+                    await holderAddressLookup.RegisterAsync(wallet.Address, platformUserId, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    // Non-critical: a transient index-write failure must NOT roll back
+                    // the wallet creation. The projector's fallback (PR #873) will
+                    // populate it lazily on the first inbound credential.
+                    logger.LogWarning(ex,
+                        "Failed to pre-populate CitizenHolderIndex for wallet {Address} platformUser {PlatformUserId} — projector fallback will retry",
+                        wallet.Address, platformUserId);
+                }
+            }
 
             var response = new CreateWalletResponse
             {


### PR DESCRIPTION
Closes the last gap from yesterday's SC-001 verification on n1.

Symptom after deploying PRs #870-#874 to n1: AssuredIdentity Phase 1 sealed
Action 1 + Action 2 in < 1s, blueprint-service issued the credential
(urn:uuid:9f4470b1-…) bound to the citizen wallet, InboundCredentialDetector
persisted it as PendingAcceptance, and PR #873's lazy projector populated
CitizenHolderIndex + appended an Added event. But the citizen-side
GET /api/v1/wallet/credentials still returned {credentials:[]} — Step 6
timed out and the walkthrough failed.

Root cause: PR #873's projector fallback resolves the platform user from
Wallets.Owner, which is set from the JWT NameIdentifier (= sub claim =
UserIdentity.Id, the citizen's org-scoped identity in the public org).
CitizenWalletEndpoints.ResolveCitizenContext prefers the platform_user_id
claim (= PlatformUser.Id, the citizen's cross-org persistent identity)
when keying the read of CitizenCredentialEventLog. For a citizen these
are two different GUIDs: sub = UserIdentity.Id, platform_user_id =
PlatformUser.Id. The projector wrote under sub; the endpoint read under
platform_user_id; the surfaces never agreed and the citizen's credentials
list was permanently empty.

(For admin tokens the two values are equal so admin paths were never
affected. The mismatch only bites consumer-tier tokens that distinguish
per-org UserIdentity from cross-org PlatformUser.)

F114 PWA EnrolDevice already populates the index correctly — it pulls
platform_user_id from the JWT at the moment a citizen enrols a device
and calls IHolderAddressLookup.RegisterAsync(citizenWallet, platformUserId).
Any flow that creates a citizen wallet WITHOUT going through PWA enrol
(walkthrough automation, scripted CI, future direct-create surfaces)
left the index unpopulated and depended on #873's projector fallback —
which gets the wrong ID.

Fix: at wallet creation time we still have the JWT and can pull the
correct platform_user_id directly. CreateWallet now reads the
platform_user_id claim, parses it as a Guid, and calls
IHolderAddressLookup.RegisterAsync(wallet.Address, platformUserId, ct)
immediately after walletManager.CreateWalletAsync. Idempotent on
(WalletAddress) per the existing lookup contract; tolerates concurrent
first-write races. Wrapped in try/catch + warn so a transient index-write
failure does NOT roll back the wallet creation (the projector's #873
fallback retries on the first inbound credential — even with the wrong
ID, the populated row stops the projector from re-writing).

Skipped silently when the JWT carries no parseable platform_user_id claim
(admin / service-principal tokens where the citizen-credential pipeline
isn't in play).

Verified live on n1 after manually correcting the pre-existing index row
to the right ID: walkthrough Phase 1 completed in 00:12, credential
surfaced via GET /v1/wallet/credentials, holder-accept PATCH to Active
returned 200, total run 00:20 — well under SC-001's 3-min budget.

Existing wallet-service tests still green (839 passing).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
