### PR TITLE
feat(register-models): TransactionType.BlueprintPublish — split publishes out of Control for clean projections

### DIFF
--- a/src/Common/Sorcha.Register.Models/Enums/TransactionType.cs
+++ b/src/Common/Sorcha.Register.Models/Enums/TransactionType.cs
@@ -59,5 +59,18 @@ public enum TransactionType
     /// remains the authoritative cross-node check for verifiers — this tx exists
     /// to keep the holder's locally-cached row in sync.)
     /// </summary>
-    CredentialStatusChange = 8
+    CredentialStatusChange = 8,
+
+    /// <summary>
+    /// Blueprint-publish transaction — a register-owned record that announces
+    /// "blueprint {id} version {n} is now active on this register" so that all
+    /// participants can resolve the same canonical exec-def without trusting the
+    /// transport. Distinct from <see cref="Control"/> (which is governance/roster
+    /// state) so that roster projections, governance proposal feeds, and
+    /// crypto-policy reads don't have to discriminate via free-form
+    /// <c>TrackingData["transactionType"]</c>. Pre-#876 publishes were written
+    /// with <see cref="Control"/> + <c>TrackingData["transactionType"]="BlueprintPublish"</c>;
+    /// readers that need to surface both eras should filter on either type.
+    /// </summary>
+    BlueprintPublish = 9
 }

--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1843,7 +1843,7 @@ app.MapPost("/api/registers/{registerId}/blueprints/publish", async (
         txId: txId,
         payloadHash: payloadHashHex,
         derivationPath: "sorcha:register-control",
-        transactionType: "Control");
+        transactionType: "BlueprintPublish");
 
     var systemSignature = new Sorcha.ServiceClients.Validator.SignatureInfo
     {
@@ -1865,7 +1865,14 @@ app.MapPost("/api/registers/{registerId}/blueprints/publish", async (
         CreatedAt = DateTimeOffset.UtcNow,
         Metadata = new Dictionary<string, string>
         {
-            ["Type"] = "Control",
+            // Persisted TransactionType (the validator parses this via Enum.TryParse, ignoreCase=true).
+            // Pre-#876 publishes were "Control" + TrackingData; we now write a dedicated
+            // BlueprintPublish enum so roster, governance, and crypto-policy projections that
+            // filter on TransactionType.Control naturally exclude publishes without having to
+            // discriminate on free-form TrackingData strings. PR #871's reader-side defence stays
+            // as belt-and-braces for legacy registers; both eras coexist forever.
+            ["Type"] = "BlueprintPublish",
+            // Retained for legacy log/audit consumers that already scan TrackingData. Safe to keep.
             ["transactionType"] = "BlueprintPublish",
             ["publishedBy"] = request.PublishedBy,
             ["SystemWalletAddress"] = signResult.WalletAddress,
@@ -1918,12 +1925,15 @@ app.MapGet("/api/registers/{registerId}/blueprints/published", async (
         return Results.NotFound(new { error = $"Register '{registerId}' not found" });
     }
 
-    // Query all transactions then filter in-memory to blueprint-publish control transactions.
-    // Blueprint publishes are Control transactions (TransactionType == 0) with a non-genesis BlueprintId.
+    // Query all transactions then filter in-memory to blueprint-publish transactions.
+    // Post-#876 publishes are TransactionType.BlueprintPublish; pre-#876 publishes were
+    // TransactionType.Control + TrackingData["transactionType"]="BlueprintPublish".
+    // Both eras coexist forever, so this filter must accept either.
     var allTransactions = (await repository.GetTransactionsAsync(registerId)).ToList();
     var publishTransactions = allTransactions
         .Where(tx => tx.MetaData != null
-            && tx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control
+            && (tx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish
+                || tx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control)
             && !string.IsNullOrEmpty(tx.MetaData.BlueprintId)
             && tx.MetaData.BlueprintId != "genesis")
         .ToList();

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterService.cs
@@ -400,12 +400,13 @@ public class SystemRegisterService
         // null-propagating operators or out variables
         var materialized = allTransactions.ToList();
 
-        // Filter for blueprint transactions: Control type with a non-genesis BlueprintId.
-        // TrackingData is not reliably persisted through the validator pipeline,
-        // so we use BlueprintId from MetaData which IS stored.
+        // Filter for blueprint transactions: post-#876 BlueprintPublish OR pre-#876 Control
+        // with a non-genesis BlueprintId. TrackingData is not reliably persisted through the
+        // validator pipeline, so we use BlueprintId from MetaData which IS stored.
         return materialized
             .Where(t => t.MetaData is not null
-                && t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control
+                && (t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish
+                    || t.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control)
                 && !string.IsNullOrEmpty(t.MetaData.BlueprintId)
                 && t.MetaData.BlueprintId != "genesis")
             .ToList();

--- a/src/Services/Sorcha.Validator.Service/Services/BlueprintVersionResolver.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/BlueprintVersionResolver.cs
@@ -315,13 +315,9 @@ public class BlueprintVersionResolver : IBlueprintVersionResolver
 
         // A blueprint publication has:
         // - BlueprintId matching our target
-        // - No ActionId (or ActionId = 0 for initialization, but that's an action, not publication)
-        // - Could be TransactionType.Control or have specific markers
-
-        // For now, we identify blueprint publications as transactions with:
-        // - The correct BlueprintId
-        // - No ActionId set (null) - indicating it's a blueprint definition, not an action
-        // OR the ActionId indicates it's the blueprint registration action (typically -1 or a marker)
+        // - TransactionType.BlueprintPublish (post-#876) or TransactionType.Control (pre-#876)
+        // - No persisted ActionId (the validator's MetaData projection sets ActionId to null
+        //   when the submission's ActionId string ("blueprint-publish") does not parse as uint)
 
         if (tx.MetaData.BlueprintId != blueprintId)
             return false;
@@ -331,8 +327,10 @@ public class BlueprintVersionResolver : IBlueprintVersionResolver
         if (!tx.MetaData.ActionId.HasValue)
             return true;
 
-        // If it's the genesis transaction with this blueprint, it could be the initial publication
-        if (tx.MetaData.TransactionType == TransactionType.Control)
+        // Legacy edge case: a publish tx where ActionId somehow got set. Both the post-#876
+        // BlueprintPublish type and the pre-#876 Control type are valid here.
+        if (tx.MetaData.TransactionType == TransactionType.BlueprintPublish
+            || tx.MetaData.TransactionType == TransactionType.Control)
             return true;
 
         return false;

--- a/src/Services/Sorcha.Validator.Service/Services/DocketSerializer.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/DocketSerializer.cs
@@ -75,6 +75,7 @@ public static class DocketSerializer
                     {
                         "participant" => Sorcha.Register.Models.Enums.TransactionType.Participant,
                         "control" => Sorcha.Register.Models.Enums.TransactionType.Control,
+                        "blueprintpublish" => Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish,
                         _ => Sorcha.Register.Models.Enums.TransactionType.Action
                     };
                 }

--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -852,11 +852,15 @@ public class ValidationEngine : IValidationEngine
                 // children — each workflow instance forks from its blueprint publish TX by design.
                 if (previousTx != null)
                 {
-                    // Control transactions (genesis, blueprint-publish) may have multiple children by design.
-                    // When MetaData is null (e.g. legacy or genesis transactions), treat as control to avoid
-                    // false fork detection — non-control transactions always have MetaData populated.
+                    // Multi-child predecessors: genesis (Control) and blueprint-publish (post-#876
+                    // BlueprintPublish, pre-#876 Control). Every workflow instance forks from its
+                    // blueprint publish TX by design — without this bypass each new instance
+                    // triggers a spurious VAL_CHAIN_FORK. When MetaData is null (legacy / genesis
+                    // round-trip shape failures), treat as the multi-child case to avoid the same
+                    // false fork — non-control transactions always have MetaData populated.
                     var isControlTx = previousTx.MetaData == null
-                        || previousTx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control;
+                        || previousTx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.Control
+                        || previousTx.MetaData.TransactionType == Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish;
                     if (!isControlTx)
                     {
                         using var _forkScope = RuleTelemetry.TimeRule("VAL_CHAIN_FORK");

--- a/tests/Sorcha.Register.Models.Tests/GovernanceModelsTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/GovernanceModelsTests.cs
@@ -257,7 +257,17 @@ public class GovernanceModelsTests
     {
         // Control, Action, Docket, Participant, Revocation (Feature 079),
         // PresentationInitiated, PresentationOutcome, PresentationAbandoned (Feature 111),
-        // CredentialStatusChange (multi-node audit CRITICAL #2)
-        Enum.GetValues<Sorcha.Register.Models.Enums.TransactionType>().Should().HaveCount(9);
+        // CredentialStatusChange (multi-node audit CRITICAL #2),
+        // BlueprintPublish (PR #876 — split out of Control for clearer projections)
+        Enum.GetValues<Sorcha.Register.Models.Enums.TransactionType>().Should().HaveCount(10);
+    }
+
+    [Fact]
+    public void TransactionType_BlueprintPublish_HasValue9()
+    {
+        // The numeric value is part of the on-disk contract (MongoDB TransactionMetaData.
+        // TransactionType is persisted as int). Pin it so a reorder of the enum doesn't
+        // silently change what's already sealed in old dockets.
+        ((int)Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish).Should().Be(9);
     }
 }

--- a/tests/Sorcha.Register.Models.Tests/ParticipantRecordTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/ParticipantRecordTests.cs
@@ -271,12 +271,13 @@ public class ParticipantRecordTests
     }
 
     [Fact]
-    public void TransactionType_HasNineValues()
+    public void TransactionType_HasTenValues()
     {
         // Control, Action, Docket, Participant, Revocation (Feature 079),
         // PresentationInitiated, PresentationOutcome, PresentationAbandoned (Feature 111),
-        // CredentialStatusChange (multi-node audit CRITICAL #2)
-        Enum.GetValues<TransactionType>().Should().HaveCount(9);
+        // CredentialStatusChange (multi-node audit CRITICAL #2),
+        // BlueprintPublish (PR #876 — split out of Control for clearer projections)
+        Enum.GetValues<TransactionType>().Should().HaveCount(10);
     }
 
     #endregion


### PR DESCRIPTION
Cleanup of the architectural smell that drove PR #871's reader-side
defence: blueprint-publish transactions were intentionally submitted
with Metadata["Type"]="Control" + TrackingData["transactionType"]=
"BlueprintPublish", landing them in MongoDB with TransactionType=Control
even though they are not register-governance changes. Every consumer
that filters on TransactionType.Control then had to either accept the
noise (governance roster projection saw publishes as latest control tx
and silently mis-projected — the exact symptom PR #871 hardened
against) or discriminate via free-form TrackingData strings.

This PR gives publishes their own enum value:

- New TransactionType.BlueprintPublish = 9. Numeric value is part of the
  on-disk contract (MongoDB TransactionMetaData.TransactionType is
  persisted as int), so it's appended rather than reordered. A new test
  pins it against future reorders.
- Register Service Program.cs publish endpoint flips Metadata["Type"]
  from "Control" to "BlueprintPublish". TrackingData["transactionType"]
  is retained for legacy log/audit consumers; safe to keep alongside
  the typed field. signingService.SignAsync's transactionType argument
  is also updated for symmetric audit labelling.
- Three consumers updated to accept either era (post-#876 BlueprintPublish
  OR pre-#876 Control) since sealed legacy publishes stay on disk
  forever:
    * Register.Service Program.cs blueprint-publish history endpoint
      (~L2048) — surfaces ALL publishes, must include both.
    * Register.Service SystemRegisterService.cs blueprint history
      (~L408) — same.
    * Validator.Service BlueprintVersionResolver.cs IsBlueprintPublication
      Transaction (~L335) — must resolve both eras to a version.
- Two validator paths updated to recognise BlueprintPublish as a
  multi-child predecessor (every workflow instance forks from its
  publish tx by design):
    * Validator.Service ValidationEngine.cs VAL_CHAIN_FORK bypass
      (~L859) — without this, post-#876 publishes would trigger
      spurious fork detection on the first instance created from them.
    * Validator.Service DocketSerializer.cs string→enum mapper —
      added "blueprintpublish" so wire-shape submissions parse back to
      the enum value.
- Governance roster + crypto-policy + relationship-derivation consumers
  did NOT need updating. They filter on TransactionType.Control because
  they specifically want governance state — post-#876 publishes are
  now naturally OUT of the Control filter (no need to discriminate via
  TrackingData), and PR #871's "skip non-roster control tx" defence
  remains in place for pre-#876 sealed publishes that still surface as
  Control on disk.
- Governance proposals endpoint (Program.cs:2335) also unchanged: it
  filters Control AND requires TrackingData["transactionType"]=
  "GovernanceOperation", which publishes never set.

Tests:
- TransactionType_HasExpectedValues / TransactionType_HasNineValues
  → ...HasTenValues, with updated comment listing the new member.
- New TransactionType_BlueprintPublish_HasValue9 pinning the numeric
  value against accidental reorders.
- Existing test suites still green: Sorcha.Register.Models.Tests 205,
  Sorcha.Register.Core.Tests 325, Sorcha.Register.Service.Tests 303,
  Sorcha.Validator.Service.Tests 970.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
