### PR TITLE
fix(validator): IsGenesisOrControlTransaction recognises Type="BlueprintPublish" — fixes VAL_SCHEMA_002 + VAL_REPLAY_001 regression from PR #876

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/TransactionTypeClassifier.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/TransactionTypeClassifier.cs
@@ -16,6 +16,13 @@ namespace Sorcha.Validator.Service.Services;
 /// </summary>
 internal static class TransactionTypeClassifier
 {
+    /// <summary>
+    /// True for transactions that bypass action-schema validation and per-sender replay
+    /// protection: genesis, governance Control, and (post-#876) BlueprintPublish. All three
+    /// are administrative — signed by the system wallet (or in genesis's case the offline
+    /// ceremony key) and have no per-sender sequence; they carry a free-form ActionId
+    /// (<c>"blueprint-publish"</c>, etc.) that can't and shouldn't parse as an int.
+    /// </summary>
     public static bool IsGenesisOrControlTransaction(Transaction transaction)
     {
         if (string.Equals(transaction.BlueprintId, GenesisConstants.BlueprintId, StringComparison.OrdinalIgnoreCase))
@@ -23,7 +30,8 @@ internal static class TransactionTypeClassifier
 
         if (transaction.Metadata.TryGetValue("Type", out var typeStr) &&
             (string.Equals(typeStr, "Genesis", StringComparison.OrdinalIgnoreCase) ||
-             string.Equals(typeStr, "Control", StringComparison.OrdinalIgnoreCase)))
+             string.Equals(typeStr, "Control", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(typeStr, "BlueprintPublish", StringComparison.OrdinalIgnoreCase)))
             return true;
 
         return false;

--- a/tests/Sorcha.Validator.Service.Tests/Services/TransactionTypeClassifierTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/TransactionTypeClassifierTests.cs
@@ -54,8 +54,14 @@ public class TransactionTypeClassifierTests
     [InlineData("genesis")]
     [InlineData("Control")]
     [InlineData("CONTROL")]
+    [InlineData("BlueprintPublish")]
+    [InlineData("blueprintpublish")]
     public void IsGenesisOrControlTransaction_TypeMetadataMatches_ReturnsTrue(string type)
     {
+        // BlueprintPublish (post-#876) joins Genesis+Control in bypassing action-schema
+        // validation and per-sender replay protection: the publish is signed by the
+        // system wallet with an ActionId of "blueprint-publish" (not an int) and no
+        // per-sender sequence number — both checks would reject otherwise.
         var tx = TxWithMetadata(("Type", type));
 
         TransactionTypeClassifier.IsGenesisOrControlTransaction(tx).Should().BeTrue();


### PR DESCRIPTION
Direct follow-up to #876 — caught during the live re-verification on n1.

Symptom: after #876 deployed (register-service writing Metadata["Type"]
= "BlueprintPublish" + validator-service shipping the new enum), every
blueprint publish was REJECTED by the validator with:

  VAL_SCHEMA_002: Invalid action ID format: 'blueprint-publish';
  VAL_SCHEMA_002: Invalid action ID format: 'blueprint-publish';
  VAL_REPLAY_001: Non-genesis transactions must have a sequence number > 0

Action 1 then timed out at 60s polling for a blueprint that was never
sealed; walkthrough Phase 1 regressed from a 12-second pass back to a
60-second timeout.

Root cause: ValidationEngine routes around action-schema validation
(int.TryParse on ActionId) and per-sender replay protection (sequence
> 0) for "administrative" txs via the IsGenesisOrControlTransaction
predicate. Pre-#876 publishes carried Metadata["Type"]="Control" so
they qualified for the bypass. Post-#876 publishes carry "BlueprintPublish"
and were therefore treated as regular action submissions — but a publish
has ActionId="blueprint-publish" (deliberately not an int — it's an
admin-flavoured marker) and is signed by the system wallet with no
per-sender sequence. Both checks fired and the publish was rejected.

Fix: extend IsGenesisOrControlTransaction to recognise Type="BlueprintPublish"
alongside Genesis/Control. The bypass is correct here for the same reason
it was correct for legacy Control-typed publishes — signature is still
validated, only the action-shaped checks (schema + replay) are skipped.

Renamed nothing for backward compat (callers can keep using the existing
predicate); added a docstring explaining the three-way membership.

Tests: extended the existing InlineData theory to assert
"BlueprintPublish" + "blueprintpublish" both classify as control.
Sorcha.Validator.Service.Tests 972 passing (+2 from this PR).

The downstream chain-fork bypass at ValidationEngine.cs:862 + DocketSerializer's
string→enum map + BlueprintVersionResolver.IsBlueprintPublicationTransaction
were already updated in #876; this PR fills the third validator carve-out
needed to make the new type round-trip end-to-end.

Live n1 verification after deploy will confirm the walkthrough returns
to the 12-second pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
