### PR TITLE
fix(wallet-service): Wallets.Owner mints from platform_user_id when present; citizen resolver tries new+legacy key

### DIFF
--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -592,17 +592,29 @@ public static class CitizenWalletEndpoints
 
         if (string.IsNullOrWhiteSpace(walletAddress))
         {
-            var owner = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub");
-            if (!string.IsNullOrWhiteSpace(owner))
+            // Wallet ownership keying alignment (cleanup of the Smell-1 architectural
+            // inconsistency): post-#878 WalletEndpoints.GetCurrentUser prefers
+            // platform_user_id when minting Wallets.Owner, so new citizen wallets land
+            // with Owner=PlatformUser.Id. Legacy wallets created pre-#878 still carry
+            // Owner=UserIdentity.Id (= sub). Try the new key first, then fall back to
+            // the legacy key — both eras coexist forever for any wallet that was on
+            // disk before the cutover.
+            var platformOwner = platformUserId?.ToString();
+            var legacyOwner = user.FindFirstValue(ClaimTypes.NameIdentifier) ?? user.FindFirstValue("sub");
+            var tenant = user.FindFirstValue("tenant") ?? "default";
+
+            Sorcha.Wallet.Core.Domain.Entities.Wallet? chosen = null;
+            foreach (var candidate in new[] { platformOwner, legacyOwner })
             {
-                var tenant = user.FindFirstValue("tenant") ?? "default";
-                var owned = await walletRepository.GetByOwnerAsync(owner, tenant, ct);
-                var chosen = owned
+                if (string.IsNullOrWhiteSpace(candidate)) continue;
+                var owned = await walletRepository.GetByOwnerAsync(candidate, tenant, ct);
+                chosen = owned
                     .OrderByDescending(w => w.Status == WalletStatus.Active)
                     .ThenBy(w => w.CreatedAt)
                     .FirstOrDefault();
-                walletAddress = chosen?.Address;
+                if (chosen is not null) break;
             }
+            walletAddress = chosen?.Address;
         }
 
         return (platformUserId, walletAddress, organizationId);

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -1897,9 +1897,28 @@ public static class WalletEndpoints
     }
 
     // Helper methods for authentication/authorization
+    //
+    // Identity model on a human JWT (Tenant Service TokenService.cs):
+    //   sub                = UserIdentity.Id — the user-IN-this-org row (per-org, can change
+    //                        if the user joins another org or their org-scoped record is
+    //                        regenerated).
+    //   platform_user_id   = PlatformUser.Id — the cross-org persistent identity.
+    //
+    // For admin tokens these two are equal by setup convention; for consumer-tier citizens
+    // they differ. The wallet is owned by the PERSON, not their org-scoped row, so prefer
+    // platform_user_id when it's present and fall back to NameIdentifier for service /
+    // recovery tokens that don't carry it. New citizen wallets therefore land with
+    // Owner=platform_user_id, aligning Wallets.Owner with CitizenHolderIndex.PlatformUserId
+    // and CitizenCredentialEventLog.PlatformUserId — the keying inconsistency that drove
+    // the manual SQL surgery on n1 the day after PR #875 deployed.
+    //
+    // Read paths that look up wallets by NameIdentifier need to be aware of both eras
+    // (legacy Owner=sub vs new Owner=platform_user_id) — see
+    // CitizenWalletEndpoints.ResolveCitizenContextAsync for the read-tolerant equivalent.
     private static string? GetCurrentUser(HttpContext context)
     {
-        return context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return context.User.FindFirstValue("platform_user_id")
+            ?? context.User.FindFirstValue(ClaimTypes.NameIdentifier);
     }
 
     private static async Task<IResult> EncapsulateKey(

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletContextResolutionTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletContextResolutionTests.cs
@@ -105,4 +105,54 @@ public sealed class CitizenWalletContextResolutionTests
 
         wallet.Should().Be(CitizenWallet);
     }
+
+    [Fact]
+    public async Task PrefersPlatformUserIdOwnerOverNameIdentifier()
+    {
+        // Cleanup of the Smell-1 architectural inconsistency: post-#878 WalletEndpoints.GetCurrentUser
+        // mints Wallets.Owner from the JWT platform_user_id claim (cross-org persistent identity)
+        // rather than NameIdentifier (per-org). The citizen-side resolver must therefore try the
+        // platform_user_id lookup FIRST so new-shape wallets are discoverable. Without this
+        // preference, a citizen would have to fall through to the legacy-sub branch — fine when no
+        // legacy wallet exists, but a wallet that happens to be co-owned by a wallet-under-sub
+        // would be mistakenly chosen on the first hit.
+        const string PlatformOwner = "e2b28602-03a4-4da9-96b3-1c43408f2640";
+        const string PlatformWallet = "ws11qPLATFORMERAcitizenwallet";
+
+        var repo = new Mock<IWalletRepository>();
+        repo.Setup(r => r.GetByOwnerAsync(PlatformOwner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { TestWallet(PlatformWallet) });
+        // Sub-keyed lookup is a fallback path and must NOT be reached when platform_user_id hits.
+        repo.Setup(r => r.GetByOwnerAsync(Owner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { TestWallet("ws11qLEGACYsubwallet") });
+
+        var (_, wallet, _) = await CitizenWalletEndpoints.ResolveCitizenContextAsync(
+            Principal(withWalletClaim: false), repo.Object, CancellationToken.None);
+
+        wallet.Should().Be(PlatformWallet, "platform_user_id-owned wallets are the new canonical shape");
+        repo.Verify(r => r.GetByOwnerAsync(Owner, "default", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task LegacyPath_FallsBackToNameIdentifierOwner()
+    {
+        // Legacy era support: any wallet that pre-dates #878 still carries Owner=sub (= NameIdentifier).
+        // The resolver tries the new platform_user_id key first, then falls back to the sub-keyed
+        // lookup so existing-on-disk citizen wallets stay discoverable forever.
+        const string PlatformOwner = "e2b28602-03a4-4da9-96b3-1c43408f2640";
+        const string LegacyWallet = "ws11qLEGACYsubwallet";
+
+        var repo = new Mock<IWalletRepository>();
+        // Platform_user_id-keyed lookup returns empty (no new-shape wallet exists for this user).
+        repo.Setup(r => r.GetByOwnerAsync(PlatformOwner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WalletEntity>());
+        // Sub-keyed lookup finds the legacy wallet.
+        repo.Setup(r => r.GetByOwnerAsync(Owner, "default", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { TestWallet(LegacyWallet) });
+
+        var (_, wallet, _) = await CitizenWalletEndpoints.ResolveCitizenContextAsync(
+            Principal(withWalletClaim: false), repo.Object, CancellationToken.None);
+
+        wallet.Should().Be(LegacyWallet);
+    }
 }


### PR DESCRIPTION
Cleanup of the architectural inconsistency that drove the manual SQL
surgery on n1 the day after PR #875 deployed.

Identity model on a human JWT (Tenant Service TokenService.cs):
- sub                = UserIdentity.Id — the user-IN-this-org row (per-org;
                       can change if the user joins another org or their
                       org-scoped record is regenerated)
- platform_user_id   = PlatformUser.Id — the cross-org persistent identity

For admin tokens these two are equal by setup convention; for consumer-tier
citizens they differ. Wallet ownership should follow the PERSON, not their
org-scoped row, but WalletEndpoints.GetCurrentUser was reading the JWT
NameIdentifier (= sub) — so Wallets.Owner landed as UserIdentity.Id for
citizens, while CitizenHolderIndex.PlatformUserId and
CitizenCredentialEventLog.PlatformUserId (the citizen-credential surfaces
fed by ResolveCitizenContext) keyed by platform_user_id. PR #873's
projector fallback then resolved the platform user from Wallets.Owner
and wrote events under the WRONG ID; the citizen's GET /v1/wallet/credentials
returned [] until #875 papered over it at wallet-create time by registering
the index with platform_user_id directly. The smell remained, ready to bite
any new citizen surface that resolved a wallet via Wallets.Owner.

This PR aligns the keying:

- WalletEndpoints.GetCurrentUser prefers platform_user_id, falls back to
  NameIdentifier. For admin tokens nothing changes (the two are equal).
  For consumer-tier citizens, Wallets.Owner now lands as PlatformUser.Id.
  For service / recovery tokens that don't carry platform_user_id, the
  fall-back preserves current behaviour.

- CitizenWalletEndpoints.ResolveCitizenContextAsync's owner-lookup path
  (used when the JWT carries no wallet_address — i.e. every consumer-tier
  citizen, since F136 strips that claim) tries the platform_user_id key
  first, then falls back to the legacy NameIdentifier key. New-era citizen
  wallets are discoverable; any wallet on disk from before the cutover
  remains discoverable too. Both eras coexist forever.

Consequence: PR #873's projector fallback (CitizenInboxProjector parses
Wallets.Owner as Guid and uses it as the platform user) is now CORRECT
by construction for new wallets — Owner == PlatformUser.Id, exactly the
identifier the citizen-credential tables key against. The fallback stays
in place as a backstop for legacy citizen wallets where Owner=sub still
mis-maps (those wallets predate #875, won't have a CitizenHolderIndex
row either, and rely on the same backfill semantics as before). For
production environments with throwaway citizen data (n1, dev) the
mismatch never bites.

Tests:
- Two new ResolveCitizenContextAsync tests: PrefersPlatformUserIdOwnerOverNameIdentifier
  (the new wallet shape is chosen first; sub-keyed lookup is NEVER reached)
  and LegacyPath_FallsBackToNameIdentifierOwner (legacy wallets keep working
  via the sub-keyed lookup).
- All existing tests still green: Sorcha.Wallet.Service.Tests 841 (+2).

Out of scope (notes for the future):
- No EF migration to backfill existing Wallets.Owner from sub to
  platform_user_id — would need a tenant-service roundtrip per row to
  resolve UserIdentity.Id → PlatformUser.Id. For pre-release / dev envs
  the legacy fallback is sufficient.
- Other Wallets.Owner read sites (PreserveDelegations, RecoverViaPasskey,
  RecoverViaOrg, dbContext.Wallets.Where(w => w.Owner == userId) inline
  query at ~L2158) are admin / recovery surfaces; for admin tokens
  sub == platform_user_id so behaviour is unchanged. Audit a follow-up
  if a new citizen-callable surface starts reading Owner directly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
