### PR TITLE
fix(143): replica pull uses held reverse stream for NAT'd owner with placeholder address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,4 @@ walkthroughs/*/state.gateway.json
 
 # Spec 117 — Phase 2 baseline OpenAPI capture (T006), local-only review artefact
 specs/117-ai-discoverability/baseline-openapi.json
+deploy/

--- a/src/Services/Sorcha.Peer.Service/Communication/RelayCommunicationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Communication/RelayCommunicationService.cs
@@ -92,6 +92,15 @@ public class RelayCommunicationService
     };
 
     /// <summary>
+    /// True when this node can reach <paramref name="peerId"/> over a held reverse stream — i.e. the
+    /// peer is a NAT'd node that dialled in and is registered in the <see cref="ReverseStreamManager"/>.
+    /// Replication source-peer selection uses this to engage the relay path for a NAT'd owner that
+    /// self-registered with a placeholder (non-empty, undialable) address (Feature 143).
+    /// </summary>
+    public bool CanReachViaReverseStream(string peerId) =>
+        _reverseStreams is not null && _reverseStreams.TryGetStream(peerId, out _);
+
+    /// <summary>
     /// Sends a message to a peer via relay (fire-and-forget). Order: (1) rendezvous — if this node
     /// holds the target's reverse stream, broker over it; (2) outbound anchors — if this node is NAT'd
     /// and dialled anchors, write over the best one (target-match → lowest-latency) with failover;

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterReplicationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterReplicationService.cs
@@ -146,8 +146,13 @@ public class RegisterReplicationService
 
             if (channel == null)
             {
-                // No direct channel — try relay batch sync for NAT'd peers
-                if (string.IsNullOrEmpty(sourcePeer.Address) && _relayCommunication != null)
+                // No direct channel — try relay batch sync for NAT'd peers. A NAT'd owner may have
+                // self-registered with a placeholder (non-empty, undialable) address, so the relay
+                // path must also engage when we hold its reverse stream — not only on empty Address
+                // (Feature 143: the submit/fan-out path keys off the held reverse stream the same way).
+                if (_relayCommunication != null &&
+                    (string.IsNullOrEmpty(sourcePeer.Address) ||
+                     _relayCommunication.CanReachViaReverseStream(sourcePeer.PeerId)))
                 {
                     var (relayResult, relayDockets, relayTransactions) = await TryRelayBatchSyncAsync(
                         sourcePeer, subscription, cacheEntry, replicationToken);

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -226,7 +226,10 @@ public class RegisterSyncBackgroundService : BackgroundService
         try
         {
             var peers = _peerListManager!.GetPeersForRegister(registerId);
-            var natdPeers = peers.Where(p => string.IsNullOrEmpty(p.Address)).ToList();
+            // A NAT'd owner is reachable via relay either when it has no dialable address OR when we
+            // hold its reverse stream (it may have self-registered a placeholder address) — Feature 143.
+            var natdPeers = peers.Where(p => string.IsNullOrEmpty(p.Address)
+                || (_relayCommunication?.CanReachViaReverseStream(p.PeerId) ?? false)).ToList();
 
             if (natdPeers.Count == 0) return;
 


### PR DESCRIPTION
A NAT'd owner self-registers via RegisterPeer with a placeholder (non-empty,
undialable) address (PeerConnectionPool:434 — ResolvedPeerId, since ExternalAddress
is empty), and the comment there notes the remote "never dials this back over NAT".
But the replication source-peer selection gated the reverse-stream relay path on an
EMPTY address (RegisterReplicationService:150, RegisterSyncBackgroundService:229), so
a public subscriber that holds the owner's reverse stream skipped the relay and
silently failed to replicate the owner's register — even though the submit/fan-out
path (TransactionDistributionService:83) and RelayCommunicationService:110 already
key off the held reverse stream (TryGetStream).

Add RelayCommunicationService.CanReachViaReverseStream(peerId) and use it in both
replication gates so a held reverse stream engages the relay regardless of the
peer's advertised address. Unblocks cross-installation full-replica pull + relay-poll
sync-back over the F143 reverse-stream rendezvous (tiny NAT'd owner -> n1 subscriber).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
