### PR TITLE
diag(143): temporary [TRACKDIAG] logging to localise TrackingData loss on seal/persist

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1566,12 +1566,17 @@ docketsGroup.MapPost("/", async (
         {
             // Set docket number for each transaction
             tx.DocketNumber = (ulong)request.DocketNumber;
+            logger.LogInformation(
+                "[TRACKDIAG register] docket {DocketNumber} tx {TxId}: type={Type} trackingDataCount={Count}",
+                request.DocketNumber, tx.TxId, tx.MetaData?.TransactionType,
+                tx.MetaData?.TrackingData?.Count ?? -1);
             try
             {
                 await repository.InsertTransactionAsync(tx);
             }
             catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Category == MongoDB.Driver.ServerErrorCategory.DuplicateKey)
             {
+                logger.LogWarning("[TRACKDIAG register] tx {TxId} ALREADY EXISTS — docket write-back skipped (pre-persisted version kept)", tx.TxId);
                 // Transaction already exists (e.g., genesis transactions stored during register creation).
                 // This is expected for docket write-back of transactions that were pre-persisted.
             }

--- a/src/Services/Sorcha.Validator.Service/Services/ValidatorOrchestrator.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidatorOrchestrator.cs
@@ -229,6 +229,13 @@ public class ValidatorOrchestrator : IValidatorOrchestrator
                 docket.DocketNumber);
 
             var docketModel = DocketSerializer.ToRegisterModel(docket);
+            foreach (var dtx in docketModel.Transactions)
+            {
+                _logger.LogInformation(
+                    "[TRACKDIAG validator] docket {DocketNumber} tx {TxId}: type={Type} trackingDataCount={Count}",
+                    docket.DocketNumber, dtx.TxId, dtx.MetaData?.TransactionType,
+                    dtx.MetaData?.TrackingData?.Count ?? -1);
+            }
             var written = await _registerClient.WriteDocketAsync(docketModel, cancellationToken);
 
             if (!written)


### PR DESCRIPTION
Logs per-tx TrackingData count at the validator (after DocketSerializer.ToRegisterModel)
and at the register-service docket-ingest handler, plus a warning when docket write-back
skips an already-existing tx. Diagnostic only — to be reverted once the drop point is
identified. TrackingData is universally null in stored transactions (genesis/participant/
blueprint, all registers), breaking F138 US4 blueprint-recovery provenance.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
