### PR TITLE
fix(143): reconcile replica DevMode from synced genesis when register row pre-exists

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1539,6 +1539,26 @@ docketsGroup.MapPost("/", async (
             return Results.NotFound(new { error = "Register not found" });
         }
     }
+    else if (request.DocketNumber == 0 && !register.DevMode)
+    {
+        // Reconcile DevMode from the synced genesis control record even when the register row
+        // already existed — e.g. a subscribe-flow stub was created (DevMode defaulting to false)
+        // before the genesis docket arrived, so the create-on-sync DevMode extraction above was
+        // skipped. The owner's DevMode posture is authoritative; a replica that misses it refuses
+        // to read the owner's plaintext payloads, so register-native credential delivery (a
+        // DevMode credential carried in an action payload) is silently dropped by the wallet
+        // service's InboundCredentialDetector. Only ever turns DevMode ON from genesis — turning
+        // it off is the governed one-way crypto-policy-update path, never a replication side effect.
+        var genesisControl = Sorcha.Register.Service.Services.GenesisControlRecordExtractor.TryExtract(request.Transactions);
+        if (genesisControl?.CryptoPolicy?.DevMode == true)
+        {
+            register.DevMode = true;
+            await registerManager.UpdateRegisterAsync(register);
+            logger.LogInformation(
+                "Reconciled DevMode=true on replicated register {RegisterId} from synced genesis control record",
+                registerId);
+        }
+    }
 
     // Create docket from request
     var docket = new Docket


### PR DESCRIPTION
The create-on-sync path sets a replicated register's DevMode from the genesis crypto
policy, but only when the register row doesn't yet exist. A subscribe-flow stub is
created (DevMode defaulting false) before the genesis docket syncs, so the extraction
was skipped and the replica kept DevMode=false while the owner had DevMode=true. The
wallet service's InboundCredentialDetector then refused to parse the owner's plaintext
register-native credential (a security guard: plaintext on a non-DevMode register is
dropped), so a cross-installation citizen never received their issued credential.

Reconcile DevMode=true from the synced genesis control record on docket-0 finalisation
even when the register row already exists. One-way (only turns DevMode on from genesis;
turning it off stays the governed crypto-policy-update path).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
