### PR TITLE
fix(143): async cross-node action submit + flush register cache on unsubscribe

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1049,6 +1049,31 @@ public class ActionExecutionService : IActionExecutionService
             transaction.TxId, validatorResult.Success,
             distributeResult.AcceptedCount, distributeResult.TargetPeerCount, distributeResult.LocallyOwned);
 
+        // 12b. Cross-node async path. When this node does NOT own the register (the submission was
+        // brokered to a remote owner — e.g. a NAT'd owner over the F143 reverse stream), the docket
+        // seals on the owner and syncs back asynchronously (seconds to tens of seconds over the peer
+        // link). Blocking the HTTP caller on a synchronous confirmation poll would time out even though
+        // the seal succeeds. Return 202 like the encryption-offload path; the instance advances when the
+        // sealed docket syncs back (StateReconstructionService reads the replicated register). Only the
+        // locally-owned path (fast local seal) waits synchronously below. This makes DevMode cross-node
+        // submissions — which skip the async encryption offload — non-blocking too.
+        if (!distributeResult.LocallyOwned && distributeResult.AcceptedCount > 0)
+        {
+            await _actionStore.StoreIdempotencyKeyAsync(idempotencyKey, transaction.TxId, TimeSpan.FromHours(24));
+            _logger.LogInformation(
+                "Transaction {TxId} for register {RegisterId} brokered to remote owner ({Accepted}/{Targets} peer(s)); " +
+                "returning async — instance advances on sealed-docket sync-back.",
+                transaction.TxId, instance.RegisterId, distributeResult.AcceptedCount, distributeResult.TargetPeerCount);
+            return new ActionSubmissionResponse
+            {
+                TransactionId = transaction.TxId,
+                InstanceId = instanceId,
+                IsAsync = true,
+                NextActions = [],
+                IsComplete = false
+            };
+        }
+
         _logger.LogInformation(
             "Transaction {TxId} submitted to Validator for register {RegisterId}. Waiting for docket confirmation...",
             transaction.TxId, instance.RegisterId);

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -338,6 +338,18 @@ public class RegisterSyncBackgroundService : BackgroundService
             }
 
             await DeleteSubscriptionAsync(registerId, cancellationToken);
+
+            // Flush the in-memory register cache (dockets + transactions). Without this, a later
+            // re-subscribe finds the cache still populated at the old high-water-mark and the
+            // replication state machine reports the register already fully replicated — even though
+            // the Register Service copy was deleted on unsubscribe — so it never re-finalises the
+            // dockets (a v5-cache vs empty-Register-Service desync). Evicting the cache here makes
+            // re-subscribe a true from-scratch full replica.
+            if (_registerCache?.Remove(registerId) == true)
+            {
+                _logger.LogDebug("Flushed register cache for unsubscribed register {RegisterId}", registerId);
+            }
+
             _logger.LogInformation("Unsubscribed from register {RegisterId}", registerId);
         }
     }


### PR DESCRIPTION
Two cross-node follow-ups surfaced while closing the two-installation AssuredIdentity loop:

1. Cross-node action submit blocked the HTTP caller. ActionExecutionService waited
   synchronously on WaitForTransactionConfirmationAsync after submitting. When the register
   is owned by a remote peer (distributeResult.LocallyOwned == false — e.g. a NAT'd owner
   reached over the F143 reverse stream), the docket seals on the owner and syncs back
   asynchronously (~tens of seconds), so the poll timed out (HTTP 400) even though the seal
   succeeded and the instance advanced on sync-back. The encryption-offload path was already
   async, which masked this for encrypted (non-DevMode) registers; DevMode submissions skip
   that offload and hit the synchronous wait. Now: when the submission is brokered to a remote
   owner and accepted, return 202 (IsAsync) immediately — the instance advances when the sealed
   docket syncs back (StateReconstructionService). The locally-owned path still waits (fast
   local seal).

2. Unsubscribe didn't flush the in-memory register cache. RegisterSyncBackgroundService
   .UnsubscribeFromRegisterAsync removed the subscription and deleted its persisted state but
   left the RegisterCache populated. A later re-subscribe then saw the cache at the old
   high-water-mark and reported the register already fully replicated — while the Register
   Service copy had been deleted on unsubscribe — so it never re-finalised the dockets (cache
   vs Register-Service desync). Evict the register cache on unsubscribe so re-subscribe is a
   true from-scratch full replica.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
