### PR TITLE
test(143): regression tests for the cross-installation demo fixes

### DIFF
--- a/tests/Sorcha.Peer.Service.Tests/Communication/RelayCommunicationServiceTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Communication/RelayCommunicationServiceTests.cs
@@ -109,6 +109,48 @@ public class RelayCommunicationServiceTests : IAsyncDisposable
         ok.Should().BeFalse();
     }
 
+    // --- Feature 143 / PR #880: reverse-stream reachability predicate used by replication
+    //     source-peer selection. A NAT'd owner self-registers with a placeholder (non-empty)
+    //     address, so the replica-pull path must engage the relay when a reverse stream is HELD
+    //     — not only on an empty advertised address. Regression guard for that gap. ---
+
+    [Fact]
+    public void CanReachViaReverseStream_HeldStream_ReturnsTrue()
+    {
+        var reverseStreams = new ReverseStreamManager(NullLogger<ReverseStreamManager>.Instance);
+        reverseStreams.RegisterStream("natd-owner", new Mock<IServerStreamWriter<PeerMessage>>().Object);
+
+        var svc = new RelayCommunicationService(
+            new Mock<ILogger<RelayCommunicationService>>().Object,
+            _connectionPool, _peerListManager, Options.Create(_config),
+            new Lazy<RelayMessageHandler>(() => null!),
+            reverseStreams, new PeerServiceMetrics());
+
+        svc.CanReachViaReverseStream("natd-owner").Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanReachViaReverseStream_NoHeldStream_ReturnsFalse()
+    {
+        var reverseStreams = new ReverseStreamManager(NullLogger<ReverseStreamManager>.Instance);
+        reverseStreams.RegisterStream("other-peer", new Mock<IServerStreamWriter<PeerMessage>>().Object);
+
+        var svc = new RelayCommunicationService(
+            new Mock<ILogger<RelayCommunicationService>>().Object,
+            _connectionPool, _peerListManager, Options.Create(_config),
+            new Lazy<RelayMessageHandler>(() => null!),
+            reverseStreams, new PeerServiceMetrics());
+
+        svc.CanReachViaReverseStream("natd-owner").Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanReachViaReverseStream_NoReverseStreamManager_ReturnsFalse()
+    {
+        // Default ctor path (no ReverseStreamManager injected) — a non-rendezvous peer.
+        _service.CanReachViaReverseStream("any-peer").Should().BeFalse();
+    }
+
     [Fact]
     public void Constructor_NullLogger_ThrowsArgumentNullException()
     {

--- a/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSyncBackgroundServiceTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Replication/RegisterSyncBackgroundServiceTests.cs
@@ -126,6 +126,45 @@ public class RegisterSyncBackgroundServiceTests : IDisposable
         await _service.UnsubscribeFromRegisterAsync("nonexistent");
     }
 
+    // PR #885 regression: unsubscribe must FLUSH the in-memory register cache. Otherwise a later
+    // re-subscribe finds the cache still at the old high-water-mark and reports the register already
+    // fully replicated — while the Register Service copy was deleted on unsubscribe — so it never
+    // re-finalises the dockets (a cache-vs-Register-Service desync).
+    [Fact]
+    public async Task UnsubscribeFromRegisterAsync_FlushesRegisterCache()
+    {
+        var registerCache = new RegisterCache(new Mock<ILogger<RegisterCache>>().Object);
+
+        var peerListManager = new PeerListManager(
+            new Mock<ILogger<PeerListManager>>().Object, Options.Create(_config));
+        var loggerFactoryMock = new Mock<ILoggerFactory>();
+        loggerFactoryMock.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+        var connectionPool = new PeerConnectionPool(
+            new Mock<ILogger<PeerConnectionPool>>().Object, loggerFactoryMock.Object,
+            peerListManager, Options.Create(_config), new PeerServiceMetrics(), new PeerServiceActivitySource());
+        var advertisementService = new RegisterAdvertisementService(
+            new Mock<ILogger<RegisterAdvertisementService>>().Object, peerListManager);
+        var replicationService = new RegisterReplicationService(
+            new Mock<ILogger<RegisterReplicationService>>().Object,
+            connectionPool, peerListManager, advertisementService, registerCache);
+
+        using var service = new RegisterSyncBackgroundService(
+            new Mock<ILogger<RegisterSyncBackgroundService>>().Object,
+            replicationService, Options.Create(_config), Mock.Of<IServiceScopeFactory>(),
+            registerCache: registerCache);
+
+        // Subscribe + populate the cache (simulating a prior full-replica sync).
+        await service.SubscribeToRegisterAsync("reg-flush", ReplicationMode.FullReplica);
+        registerCache.GetOrCreate("reg-flush");
+        registerCache.Get("reg-flush").Should().NotBeNull("cache was populated by the prior sync");
+
+        // Act
+        await service.UnsubscribeFromRegisterAsync("reg-flush");
+
+        // Assert — cache evicted so a re-subscribe re-replicates from scratch.
+        registerCache.Get("reg-flush").Should().BeNull("unsubscribe must flush the register cache");
+    }
+
     [Fact]
     public async Task GetSubscriptions_ReturnsAllSubscriptions()
     {

--- a/tests/Sorcha.Register.Models.Tests/TransactionCanonicalSerializationTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/TransactionCanonicalSerializationTests.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+using Xunit;
+
+namespace Sorcha.Register.Models.Tests;
+
+/// <summary>
+/// PR #881 regression. Transactions relayed between peers MUST be serialised with
+/// <see cref="RegisterSerializationOptions.Canonical"/> (camelCase) because the receiver
+/// deserialises cached transactions with the same options (case-sensitive). Serialising with
+/// default options (PascalCase) made <see cref="TransactionMetaData"/> — which has no
+/// [JsonPropertyName] — silently deserialise to null, so the genesis Control transaction could
+/// not be identified, the validator roster could not be reconstructed, and post-genesis dockets
+/// were rejected ("validator key not available").
+/// </summary>
+public class TransactionCanonicalSerializationTests
+{
+    private static TransactionModel MakeTx() => new()
+    {
+        TxId = "tx-1",
+        RegisterId = "reg-1",
+        MetaData = new TransactionMetaData
+        {
+            RegisterId = "reg-1",
+            TransactionType = TransactionType.BlueprintPublish,
+            BlueprintId = "assured-identity-v1",
+            TrackingData = new Dictionary<string, string>
+            {
+                ["Type"] = "BlueprintPublish",
+                ["contentHash"] = "212b4f05497106dc11cc3db7366edad0110f0432afdb53a7d462da8060e95aea",
+            }
+        }
+    };
+
+    [Fact]
+    public void Canonical_RoundTrip_PreservesMetaDataAndTrackingData()
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(MakeTx(), RegisterSerializationOptions.Canonical);
+
+        var restored = JsonSerializer.Deserialize<TransactionModel>(bytes, RegisterSerializationOptions.Canonical);
+
+        restored.Should().NotBeNull();
+        restored!.MetaData.Should().NotBeNull();
+        restored.MetaData!.TransactionType.Should().Be(TransactionType.BlueprintPublish);
+        restored.MetaData.BlueprintId.Should().Be("assured-identity-v1");
+        restored.MetaData.TrackingData.Should().NotBeNull();
+        restored.MetaData.TrackingData!.Should().ContainKey("contentHash")
+            .WhoseValue.Should().Be("212b4f05497106dc11cc3db7366edad0110f0432afdb53a7d462da8060e95aea");
+    }
+
+    [Fact]
+    public void DefaultSerialize_CanonicalDeserialize_DropsMetaData_DocumentsTheBug()
+    {
+        // The #881 bug: serve side used default (PascalCase) options, receive side used Canonical
+        // (camelCase, case-sensitive). MetaData has no [JsonPropertyName], so the case mismatch
+        // wiped it on deserialise. This asserts that exact failure mode so the fix can't silently
+        // regress to default serialisation.
+        var defaultPascalBytes = JsonSerializer.SerializeToUtf8Bytes(MakeTx());
+
+        var restored = JsonSerializer.Deserialize<TransactionModel>(defaultPascalBytes, RegisterSerializationOptions.Canonical);
+
+        restored.Should().NotBeNull();
+        restored!.MetaData.Should().BeNull("PascalCase wire vs camelCase case-sensitive deserialise drops MetaData");
+    }
+}

--- a/tests/Sorcha.Validator.Service.Tests/Services/DocketSerializerTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/DocketSerializerTests.cs
@@ -214,6 +214,47 @@ public class DocketSerializerTests
         model.Transactions[1].RecipientsWallets.Should().BeEmpty();
     }
 
+    // PR #883 regression: the persisted-projection MUST carry the submission Metadata through to
+    // TransactionMetaData.TrackingData. Omitting it (as the parallel DocketBuildTriggerService
+    // authoritative path did) drops the F138 US4 blueprint contentHash, so a recovering subscriber
+    // rejects every blueprint with no_provenance. Both projections must satisfy this contract.
+    [Fact]
+    public void ToRegisterModel_PreservesSubmissionMetadataAsTrackingData()
+    {
+        // Arrange
+        var docket = CreateValidDocket();
+        var tx = CreateTransaction("tx-with-metadata");
+        tx.Metadata["Type"] = "BlueprintPublish";
+        tx.Metadata["contentHash"] = "212b4f05497106dc11cc3db7366edad0110f0432afdb53a7d462da8060e95aea";
+        tx.Metadata["publishedBy"] = "system";
+        docket.Transactions.Add(tx);
+
+        // Act
+        var model = DocketSerializer.ToRegisterModel(docket);
+
+        // Assert
+        var meta = model.Transactions[0].MetaData;
+        meta.Should().NotBeNull();
+        meta!.TrackingData.Should().NotBeNull();
+        meta.TrackingData!.Should().ContainKey("contentHash")
+            .WhoseValue.Should().Be("212b4f05497106dc11cc3db7366edad0110f0432afdb53a7d462da8060e95aea");
+        meta.TrackingData.Should().ContainKey("publishedBy");
+        meta.TransactionType.Should().Be(Sorcha.Register.Models.Enums.TransactionType.BlueprintPublish);
+    }
+
+    [Fact]
+    public void ToRegisterModel_EmptyMetadata_TrackingDataIsNull()
+    {
+        // Arrange — CreateTransaction starts with an empty Metadata dictionary.
+        var docket = CreateDocketWithTransactions();
+
+        // Act
+        var model = DocketSerializer.ToRegisterModel(docket);
+
+        // Assert — empty metadata maps to null TrackingData (not an empty dict).
+        model.Transactions[0].MetaData!.TrackingData.Should().BeNull();
+    }
+
     #endregion
 
     #region Round Trip Tests


### PR DESCRIPTION
Covers the bugs found + fixed while standing up the two-installation NAT-traversal demo:

- #880  RelayCommunicationService.CanReachViaReverseStream — held-stream true / no-stream
        false / no-manager false (replica-pull must engage the relay for a NAT'd owner that
        self-registered a placeholder address). +3 tests.
- #881  TransactionModel must round-trip MetaData/TrackingData through
        RegisterSerializationOptions.Canonical; default (PascalCase) serialise + Canonical
        (camelCase, case-sensitive) deserialise drops MetaData — the exact relay-sync data-loss
        the fix restored. +2 tests.
- #883  DocketSerializer.ToRegisterModel preserves submission Metadata as
        TransactionMetaData.TrackingData (the contentHash/publishedBy contract both persisted
        projections must satisfy; the authoritative DocketBuildTriggerService path was the one
        that had dropped it). +2 tests.
- #885  RegisterSyncBackgroundService.UnsubscribeFromRegisterAsync flushes the RegisterCache so
        a re-subscribe re-replicates from scratch (no cache-vs-Register-Service desync). +1 test.

All pass: Register.Models 207, Validator 974/+21 skipped, Peer 704 — 0 failures. Not unit-covered
here (verified live end-to-end + harder to unit-test as minimal-API/deep-service code): #884
(register-service docket-0 DevMode reconcile) and #885 async cross-node submit branch in
ActionExecutionService.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
