### PR TITLE
feat(144): Assured Identity Demo Environment — provisioning toolkit

### DIFF
--- a/demos/AssuredIdentity/.gitignore
+++ b/demos/AssuredIdentity/.gitignore
@@ -1,0 +1,8 @@
+# Local, environment-specific demo files — never committed.
+# The agency-name and node addresses are operator config; secrets live in deploy/keys.env.
+demo-nodes.json
+state.json
+
+# Rendered (token-substituted) agent actor configs — produced at provision time.
+agent/analyst.rules.json
+agent/analyst.ai.json

--- a/demos/AssuredIdentity/AssuredIdentityDemo.psm1
+++ b/demos/AssuredIdentity/AssuredIdentityDemo.psm1
@@ -1,0 +1,439 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Assured Identity Demo toolkit — node-agnostic provisioning over the proven
+# F143 cross-installation loop. Exports four commands:
+#   New-IssuingAuthority, Connect-Subscriber, Reset-Demo, Get-DemoStatus
+#
+# This module orchestrates EXISTING Sorcha HTTP endpoints and the EXISTING
+# sorcha-agent CLI; it adds no services. See contracts/commands.md.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- dependencies -----------------------------------------------------------
+$script:DemoRoot = $PSScriptRoot
+Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force
+
+# dot-source the lib units (Common first — others depend on its helpers)
+. (Join-Path $PSScriptRoot "lib/Common.ps1")
+. (Join-Path $PSScriptRoot "lib/NodeInventory.ps1")
+. (Join-Path $PSScriptRoot "lib/AgencyNaming.ps1")
+. (Join-Path $PSScriptRoot "lib/Readiness.ps1")
+. (Join-Path $PSScriptRoot "lib/Idempotency.ps1")
+. (Join-Path $PSScriptRoot "lib/StatusVerdict.ps1")
+. (Join-Path $PSScriptRoot "lib/DemoState.ps1")
+. (Join-Path $PSScriptRoot "lib/Auth.ps1")
+. (Join-Path $PSScriptRoot "lib/AgentLaunch.ps1")
+
+$script:PublicOrgId = "00000000-0000-0000-0000-000000000002"
+
+# ============================================================================
+# internal HTTP probes (thin IO — the pure predicates live in the lib units)
+# ============================================================================
+
+function Test-DemoRegisterReadable {
+    param([string]$Api, [string]$RegisterId, [hashtable]$Headers)
+    if ([string]::IsNullOrWhiteSpace($RegisterId)) { return $false }
+    try {
+        $r = Invoke-SorchaApi -Method GET -Uri "$Api/registers/$RegisterId" -Headers $Headers
+        return ($null -ne $r)
+    } catch { return $false }
+}
+
+function Get-DemoSubscriptionStatus {
+    param([string]$Api, [string]$OrgId, [string]$RegisterId, [hashtable]$Headers)
+    try {
+        $r = Invoke-SorchaApi -Method GET -Uri "$Api/organizations/$OrgId/register-subscriptions/$RegisterId" -Headers $Headers
+        return [string]$r.status
+    } catch { return $null }
+}
+
+function Get-DemoSyncState {
+    param([string]$Api, [string]$RegisterId, [hashtable]$Headers)
+    try {
+        $r = Invoke-SorchaApi -Method GET -Uri "$Api/registers/$RegisterId/sync-state" -Headers $Headers
+        return [string]$r.state
+    } catch { return 'Indeterminate' }
+}
+
+function Get-DemoPublishedBlueprintIds {
+    param([string]$Api, [string]$RegisterId)
+    try {
+        $r = Invoke-SorchaApi -Method GET -Uri "$Api/registers/$RegisterId/blueprints/published"
+        return @($r.blueprints | ForEach-Object { $_.blueprintId })
+    } catch { return @() }
+}
+
+function Test-DemoGatewayHealthy {
+    param([string]$Gateway)
+    foreach ($path in @('/health', '/alive', '/')) {
+        try {
+            Invoke-WebRequest -Uri ($Gateway.TrimEnd('/') + $path) -UseBasicParsing -TimeoutSec 8 | Out-Null
+            return $true
+        } catch {
+            try { if ($_.Exception.Response) { return $true } } catch {}
+        }
+    }
+    return $false
+}
+
+function ConvertTo-DemoSlug {
+    param([string]$Text)
+    $slug = ($Text.ToLowerInvariant() -replace '[^a-z0-9]+', '-').Trim('-')
+    if ([string]::IsNullOrWhiteSpace($slug)) { $slug = 'authority' }
+    return $slug
+}
+
+# ============================================================================
+# New-IssuingAuthority (issuer node) — FR-001/002/003/005, FR-010/011
+# ============================================================================
+
+function New-IssuingAuthority {
+    [CmdletBinding()]
+    param(
+        [string]$NodesFile = "./demo-nodes.json",
+        [string]$StateFile = "./state.json",
+        [string]$IssuerNode,
+        [string]$AgencyName = "Strathcarron Identity Authority",
+        [ValidateSet('rules', 'ai', 'human')][string]$AgentMode = 'rules',
+        [switch]$Force
+    )
+
+    Write-WtBanner "Assured Identity Demo — provision issuing authority"
+
+    $inventory = Get-DemoNodeInventory -Path $NodesFile
+    $node = if ($IssuerNode) { Select-DemoNode -Inventory $inventory -Id $IssuerNode } else { Get-DemoNodeByRole -Inventory $inventory -Role 'issuer' }
+    $api = Get-DemoApiBase -Gateway $node.gateway
+    $secrets = Import-DemoSecrets
+    $slug = ConvertTo-DemoSlug -Text $AgencyName
+
+    Write-WtStep "1: sysadmin login ($($node.id))"
+    $sysAdmin = Connect-DemoNodeAdmin -Node $node -Secrets $secrets
+    Write-WtSuccess "admin org: $($sysAdmin.OrganizationId)"
+
+    # --- idempotency probe (FR-003, R5) ------------------------------------
+    $existing = Read-DemoState -Path $StateFile
+    $registerReadable = $false
+    if ($existing -and $existing.PSObject.Properties.Name -contains 'registerId') {
+        $registerReadable = Test-DemoRegisterReadable -Api $api -RegisterId $existing.registerId -Headers $sysAdmin.Headers
+    }
+    $blueprintPublished = $false
+    if ($existing -and $registerReadable -and ($existing.PSObject.Properties.Name -contains 'blueprintId')) {
+        $blueprintPublished = (@(Get-DemoPublishedBlueprintIds -Api $api -RegisterId $existing.registerId) -contains $existing.blueprintId)
+    }
+    $action = Resolve-AuthorityAction `
+        -HasOrg ([bool]($existing -and $existing.organizationId)) `
+        -HasRegisterId ([bool]($existing -and ($existing.PSObject.Properties.Name -contains 'registerId') -and $existing.registerId)) `
+        -RegisterReadable $registerReadable -BlueprintPublished $blueprintPublished -Force:$Force.IsPresent
+
+    if ($action -eq 'Reuse' -and $existing.agencyName -eq $AgencyName) {
+        Write-WtSuccess "Authority already provisioned (reuse): register=$($existing.registerId) blueprint=$($existing.blueprintId)"
+        Start-DemoAgent -Node $node -Api $api -State $existing -AgentMode $AgentMode -Secrets $secrets -StateFile $StateFile | Out-Null
+        return $existing
+    }
+    if ($action -eq 'ReconcileStale') {
+        Write-WtWarn "Recorded register '$($existing.registerId)' is not readable on $($node.id) — reconciling (re-provisioning a fresh authority)."
+    }
+
+    Write-WtStep "2: enable public org + register verification-admin"
+    Invoke-SorchaApi -Method PUT -Uri "$api/platform/settings/public-org" -Body @{ enabled = $true } -Headers $sysAdmin.Headers | Out-Null
+    $vAdminEmail = "verification-admin@$slug.local"
+    Register-SorchaPublicUser -TenantUrl $api -Email $vAdminEmail -Password (Get-DemoAdminPassword -Node $node -Secrets $secrets) -DisplayName "Verification Admin" | Out-Null
+
+    Write-WtStep "3: verify verification-admin email"
+    $pu = Invoke-SorchaApi -Method GET -Uri "$api/organizations/$script:PublicOrgId/users?includeInactive=true" -Headers $sysAdmin.Headers
+    $u = $pu.users | Where-Object { $_.email -eq $vAdminEmail } | Select-Object -First 1
+    if ($u) { Confirm-SorchaUserEmail -TenantUrl $api -OrganizationId $script:PublicOrgId -UserId $u.id -Headers $sysAdmin.Headers; Write-WtInfo "verified $vAdminEmail" }
+
+    Write-WtStep "4: create org '$AgencyName'"
+    $pw = Get-DemoAdminPassword -Node $node -Secrets $secrets
+    $vOrg = New-SorchaOrganization -TenantUrl $api -Name $AgencyName -Subdomain $slug -AdminEmail $vAdminEmail -Headers $sysAdmin.Headers -Description "Issues Assured Identity credentials to citizens"
+    $vOrgId = $vOrg.OrganizationId
+    Write-WtSuccess "issuing-authority org: $vOrgId"
+
+    Write-WtStep "5: verification-admin (Tier 2) login + issuer wallet + participant"
+    $vAdmin = Connect-SorchaUser -TenantUrl $api -Email $vAdminEmail -Password $pw -OrganizationId $vOrgId
+    $vWallet = New-SorchaWallet -WalletUrl $api -Name "$AgencyName Issuer" -Headers $vAdmin.Headers -FetchPublicKey
+    Write-WtSuccess "issuer wallet: $($vWallet.Address)"
+    $null = Register-SorchaParticipant -TenantUrl $api -WalletUrl $api -OrganizationId $vOrgId -WalletAddress $vWallet.Address -DisplayName "Verification Admin" -Headers $vAdmin.Headers
+    $vAdmin = Connect-SorchaUser -TenantUrl $api -Email $vAdminEmail -Password $pw -OrganizationId $vOrgId
+
+    Write-WtStep "5c: verification-analyst (Tier 3) + wallet + participant"
+    $vAnalystEmail = "verification-analyst@$slug.local"
+    $null = New-SorchaOrgUser -TenantUrl $api -OrganizationId $vOrgId -Email $vAnalystEmail -Password $pw -DisplayName "Verification Analyst" -Headers $sysAdmin.Headers -Roles @("Consumer") -EmailVerified
+    $vAnalyst = Connect-SorchaUser -TenantUrl $api -Email $vAnalystEmail -Password $pw -OrganizationId $vOrgId
+    $vAnalystWallet = New-SorchaWallet -WalletUrl $api -Name "Verification Analyst Wallet" -Headers $vAnalyst.Headers -FetchPublicKey
+    Write-WtSuccess "analyst wallet: $($vAnalystWallet.Address)"
+    $null = Register-SorchaParticipant -TenantUrl $api -WalletUrl $api -OrganizationId $vOrgId -WalletAddress $vAnalystWallet.Address -DisplayName "Verification Analyst" -Headers $vAnalyst.Headers
+
+    Write-WtStep "7: create ADVERTISED DevMode register ($($node.id) owns it)"
+    $register = New-SorchaRegister -RegisterUrl $api -WalletUrl $api -Name $AgencyName -Description "Assured Identity register — owned by $($node.id) ($AgencyName)" -TenantId $vOrgId -OwnerUserId $vAdmin.UserId -OwnerWalletAddress $vWallet.Address -Headers $vAdmin.Headers -TenantUrl $api -DevMode:$true
+    Write-WtSuccess "register: $($register.RegisterId)"
+
+    Write-WtStep "7b: publish analyst participant on register"
+    try {
+        $null = Publish-SorchaParticipant -TenantUrl $api -OrganizationId $vOrgId -RegisterId $register.RegisterId -ParticipantName "Verification Analyst" -OrganizationName $AgencyName -WalletAddress $vAnalystWallet.Address -PublicKey $vAnalystWallet.PublicKey -Headers $vAdmin.Headers
+        Write-WtSuccess "analyst participant published"
+    } catch { Write-WtWarn "participant publish: $($_.Exception.Message)" }
+
+    Write-WtStep "8: publish Assured Identity blueprint (issuerName='$AgencyName')"
+    $templateRaw = Get-Content -LiteralPath (Join-Path $script:DemoRoot "blueprints/assured-identity.template.json") -Raw
+    $rendered = Set-BlueprintIssuerName -BlueprintJson $templateRaw -AgencyName $AgencyName
+    $tempBp = Join-Path ([System.IO.Path]::GetTempPath()) ("assured-identity-{0}.json" -f $slug)
+    $rendered | Set-Content -LiteralPath $tempBp -Encoding UTF8
+    $walletMap = @{ "verification-analyst" = $vAnalystWallet.Address }
+    $blueprint = Publish-SorchaBlueprint -BlueprintUrl $api -TemplatePath $tempBp -WalletMap $walletMap -Headers $vAdmin.Headers -IdPrefix "assured-identity" -RegisterId $register.RegisterId
+    Remove-Item -LiteralPath $tempBp -ErrorAction SilentlyContinue
+    Write-WtSuccess "blueprint: $($blueprint.BlueprintId)"
+
+    # coherence assertion (SC-004)
+    $coherence = Test-AgencyNameCoherence -AgencyName $AgencyName -OrgName $AgencyName -RegisterName $AgencyName -ParticipantOrg $AgencyName -BlueprintJson $rendered
+    if (-not $coherence.Coherent) { Write-WtWarn "agency-name coherence issues: $($coherence.Mismatches -join '; ')" }
+
+    $state = @{
+        issuerNodeId        = $node.id
+        agencyName          = $AgencyName
+        organizationId      = $vOrgId
+        issuerWalletAddress = $vWallet.Address
+        analystEmail        = $vAnalystEmail
+        analystWallet       = $vAnalystWallet.Address
+        registerId          = $register.RegisterId
+        blueprintId         = $blueprint.BlueprintId
+        agentMode           = $AgentMode
+        subscribers         = @()
+    }
+
+    Write-WtStep "9: approval agent ($AgentMode)"
+    $agent = Start-DemoAgent -Node $node -Api $api -State $state -AgentMode $AgentMode -Secrets $secrets -StateFile $StateFile
+    if ($agent -and $agent.Process) { $state['agentPid'] = $agent.Process.Id }
+
+    Write-DemoState -State $state -Path $StateFile | Out-Null
+    Write-WtBanner "AUTHORITY READY — register=$($register.RegisterId) blueprint=$($blueprint.BlueprintId) mode=$AgentMode"
+
+    return [pscustomobject]@{
+        issuerNode     = $node.id
+        agencyName     = $AgencyName
+        organizationId = $vOrgId
+        registerId     = $register.RegisterId
+        blueprintId    = $blueprint.BlueprintId
+        agentMode      = $AgentMode
+        agentRunning   = [bool]($agent -and $agent.Process)
+    }
+}
+
+# render + launch the approval agent, threading analyst creds via env
+function Start-DemoAgent {
+    param([object]$Node, [string]$Api, [object]$State, [string]$AgentMode, [hashtable]$Secrets, [string]$StateFile)
+    $analystEmail = if ($State -is [hashtable]) { $State['analystEmail'] } else { $State.analystEmail }
+    $analystWallet = if ($State -is [hashtable]) { $State['analystWallet'] } else { $State.analystWallet }
+    $orgId = if ($State -is [hashtable]) { $State['organizationId'] } else { $State.organizationId }
+    $registerId = if ($State -is [hashtable]) { $State['registerId'] } else { $State.registerId }
+
+    $env:AGENT_EMAIL = $analystEmail
+    $env:AGENT_PASSWORD = (Get-DemoAdminPassword -Node $Node -Secrets $Secrets)
+
+    $tokens = @{
+        gateway       = $Node.gateway
+        registerId    = $registerId
+        orgId         = $orgId
+        analystWallet = $analystWallet
+        analystEmail  = $analystEmail
+    }
+    return Start-ApprovalAgent -Mode $AgentMode -TemplateDir (Join-Path $script:DemoRoot "agent") `
+        -Tokens $tokens -StatePath $StateFile -WorkDir $script:DemoRoot -IssuerGateway $Node.gateway
+}
+
+# ============================================================================
+# Connect-Subscriber (subscriber node) — FR-004/008, readiness gate R4
+# ============================================================================
+
+function Connect-Subscriber {
+    [CmdletBinding()]
+    param(
+        [string]$NodesFile = "./demo-nodes.json",
+        [string]$StateFile = "./state.json",
+        [string]$SubscriberNode,
+        [string]$RegisterId,
+        [int]$TimeoutSeconds = 120
+    )
+
+    Write-WtBanner "Assured Identity Demo — connect subscriber"
+
+    $inventory = Get-DemoNodeInventory -Path $NodesFile
+    $node = if ($SubscriberNode) { Select-DemoNode -Inventory $inventory -Id $SubscriberNode } else { Get-DemoNodeByRole -Inventory $inventory -Role 'subscriber' }
+    $api = Get-DemoApiBase -Gateway $node.gateway
+    $secrets = Import-DemoSecrets
+
+    $state = Read-DemoState -Path $StateFile
+    if (-not $RegisterId) {
+        if (-not $state) { throw "No -RegisterId given and no state.json found. Run New-IssuingAuthority first or pass -RegisterId." }
+        $RegisterId = $state.registerId
+    }
+    $targetBlueprintId = if ($state) { $state.blueprintId } else { $null }
+    if (-not $targetBlueprintId) { throw "state.json has no blueprintId; cannot readiness-gate. Re-run New-IssuingAuthority." }
+
+    Write-WtStep "1: sysadmin login ($($node.id))"
+    $sysAdmin = Connect-DemoNodeAdmin -Node $node -Secrets $secrets
+
+    Write-WtStep "2: enable public org + subscribe to register $RegisterId"
+    Invoke-SorchaApi -Method PUT -Uri "$api/platform/settings/public-org" -Body @{ enabled = $true } -Headers $sysAdmin.Headers | Out-Null
+
+    $subStatus = Get-DemoSubscriptionStatus -Api $api -OrgId $script:PublicOrgId -RegisterId $RegisterId -Headers $sysAdmin.Headers
+    $registerReadable = Test-DemoRegisterReadable -Api $api -RegisterId $RegisterId -Headers $sysAdmin.Headers
+    $subAction = Resolve-SubscriptionAction -SubscriptionStatus $subStatus -RegisterReadable $registerReadable
+    Write-WtInfo "subscription action: $subAction (status=$subStatus, registerReadable=$registerReadable)"
+
+    if ($subAction -ne 'ReuseSubscription') {
+        $null = New-SorchaRegisterSubscription -TenantUrl $api -OrganizationId $script:PublicOrgId -RegisterId $RegisterId -Headers $sysAdmin.Headers -SubscriptionType "Public"
+    }
+
+    Write-WtStep "3: readiness gate (subscription Active + sync CaughtUp + blueprint published) timeout=${TimeoutSeconds}s"
+    $verdict = Wait-SubscriberReady `
+        -GetSubscriptionStatus { Get-DemoSubscriptionStatus -Api $api -OrgId $script:PublicOrgId -RegisterId $RegisterId -Headers $sysAdmin.Headers }.GetNewClosure() `
+        -GetSyncState { Get-DemoSyncState -Api $api -RegisterId $RegisterId -Headers $sysAdmin.Headers }.GetNewClosure() `
+        -GetPublishedBlueprintIds { Get-DemoPublishedBlueprintIds -Api $api -RegisterId $RegisterId }.GetNewClosure() `
+        -TargetBlueprintId $targetBlueprintId -TimeoutSeconds $TimeoutSeconds
+
+    # update subscribers[] in state
+    if ($state) {
+        $subs = @()
+        if ($state.PSObject.Properties.Name -contains 'subscribers' -and $state.subscribers) {
+            $subs = @($state.subscribers | Where-Object { $_.nodeId -ne $node.id })
+        }
+        $subs += [pscustomobject]@{
+            nodeId         = $node.id
+            orgId          = $script:PublicOrgId
+            subscriptionId = $null
+            status         = $verdict.Status
+            lastReadyAt    = if ($verdict.Status -eq 'Ready') { (Get-Date).ToUniversalTime().ToString('o') } else { $null }
+        }
+        $merged = Merge-DemoState -Existing $state -Updates @{ subscribers = $subs }
+        Write-DemoState -State $merged -Path $StateFile | Out-Null
+    }
+
+    if ($verdict.Status -eq 'Ready') {
+        Write-WtBanner "SUBSCRIBER READY — $($node.id) can serve testers (elapsed $([int]$verdict.Elapsed.TotalSeconds)s)"
+    } else {
+        Write-WtWarn "SUBSCRIBER NOT READY — reasons: $($verdict.Reasons -join ', '). Recovery may still be in progress; retry Connect-Subscriber."
+    }
+
+    return [pscustomobject]@{
+        subscriberNode = $node.id
+        orgId          = $script:PublicOrgId
+        registerId     = $RegisterId
+        status         = $verdict.Status
+        reasons        = $verdict.Reasons
+    }
+}
+
+# ============================================================================
+# Reset-Demo — FR-017
+# ============================================================================
+
+function Reset-Demo {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [string]$NodesFile = "./demo-nodes.json",
+        [string]$StateFile = "./state.json",
+        [ValidateSet('issuer', 'subscriber', 'all')][string]$Scope = 'all',
+        [string]$Node
+    )
+
+    Write-WtBanner "Assured Identity Demo — reset ($Scope)"
+    $removed = @()
+
+    # stop any tracked approval agent
+    $state = Read-DemoState -Path $StateFile
+    if ($state -and ($state.PSObject.Properties.Name -contains 'agentPid') -and $state.agentPid) {
+        $p = Get-Process -Id $state.agentPid -ErrorAction SilentlyContinue
+        if ($p -and $PSCmdlet.ShouldProcess("sorcha-agent pid $($state.agentPid)", "Stop")) {
+            Stop-Process -Id $state.agentPid -Force -ErrorAction SilentlyContinue
+            $removed += "agent(pid $($state.agentPid))"
+        }
+    }
+
+    if ($Scope -in @('issuer', 'all')) {
+        if ($PSCmdlet.ShouldProcess($StateFile, "Remove demo state")) {
+            Remove-Item -LiteralPath $StateFile -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $script:DemoRoot "agent/analyst.rules.json") -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $script:DemoRoot "agent/analyst.ai.json") -ErrorAction SilentlyContinue
+            $removed += "state.json", "rendered agent configs"
+        }
+        Write-WtInfo "NOTE: a full issuer DB wipe (demo wallets, non-system register Mongo DBs) is a NODE-SIDE operation."
+        Write-WtInfo "      Run the documented reset recipe on the issuer host (see DEMO.md / n1-deploy skill)."
+    }
+
+    if ($Scope -in @('subscriber', 'all') -and $Node) {
+        Write-WtInfo "NOTE: unsubscribe + replicated-state cleanup for subscriber '$Node' is node-side; see DEMO.md."
+        if ($state -and ($state.PSObject.Properties.Name -contains 'subscribers')) {
+            $subs = @($state.subscribers | Where-Object { $_.nodeId -ne $Node })
+            $merged = Merge-DemoState -Existing $state -Updates @{ subscribers = $subs }
+            if (Test-Path -LiteralPath $StateFile) { Write-DemoState -State $merged -Path $StateFile | Out-Null }
+            $removed += "subscriber '$Node' state entry"
+        }
+    }
+
+    Write-WtSuccess "reset removed: $($removed -join ', ')"
+    return [pscustomobject]@{ scope = $Scope; node = $Node; removed = $removed }
+}
+
+# ============================================================================
+# Get-DemoStatus — FR-018, SC-007
+# ============================================================================
+
+function Get-DemoStatus {
+    [CmdletBinding()]
+    param(
+        [string]$NodesFile = "./demo-nodes.json",
+        [string]$StateFile = "./state.json"
+    )
+
+    $state = Read-DemoState -Path $StateFile
+    if (-not $state) { Write-WtWarn "No state.json — demo not provisioned."; return [pscustomobject]@{ Verdict = 'NotReady'; Reasons = @('not-provisioned') } }
+
+    $inventory = Get-DemoNodeInventory -Path $NodesFile
+    $secrets = Import-DemoSecrets
+    $issuer = Select-DemoNode -Inventory $inventory -Id $state.issuerNodeId
+    $issuerApi = Get-DemoApiBase -Gateway $issuer.gateway
+
+    $issuerReachable = Test-DemoGatewayHealthy -Gateway $issuer.gateway
+
+    # approver present: human mode = manual (present), else tracked pid alive
+    $approverPresent = $false
+    if ($state.agentMode -eq 'human') { $approverPresent = $true }
+    elseif ($state.PSObject.Properties.Name -contains 'agentPid' -and $state.agentPid) {
+        $approverPresent = [bool](Get-Process -Id $state.agentPid -ErrorAction SilentlyContinue)
+    }
+
+    $subSignals = @()
+    if ($state.PSObject.Properties.Name -contains 'subscribers') {
+        foreach ($sub in @($state.subscribers)) {
+            $node = $inventory | Where-Object { $_.id -eq $sub.nodeId } | Select-Object -First 1
+            if (-not $node) { continue }
+            $api = Get-DemoApiBase -Gateway $node.gateway
+            $admin = Connect-DemoNodeAdmin -Node $node -Secrets $secrets
+            $subSignals += [pscustomobject]@{
+                NodeId                = $sub.nodeId
+                SubscriptionStatus    = (Get-DemoSubscriptionStatus -Api $api -OrgId $script:PublicOrgId -RegisterId $state.registerId -Headers $admin.Headers)
+                SyncState             = (Get-DemoSyncState -Api $api -RegisterId $state.registerId -Headers $admin.Headers)
+                PublishedBlueprintIds = (Get-DemoPublishedBlueprintIds -Api $api -RegisterId $state.registerId)
+                TargetBlueprintId     = $state.blueprintId
+            }
+        }
+    }
+
+    $verdict = Get-ReadinessVerdict -IssuerReachable $issuerReachable -ApproverPresent $approverPresent -Subscribers $subSignals
+
+    Write-WtBanner "Demo status: $($verdict.Verdict)"
+    Write-WtInfo "issuer $($issuer.id): reachable=$issuerReachable  approver($($state.agentMode))=$approverPresent"
+    foreach ($pn in $verdict.PerNode) {
+        $r = if ($pn.Ready) { "READY" } else { "not ready ($($pn.Reasons -join ','))" }
+        Write-WtInfo "subscriber $($pn.NodeId): $r"
+    }
+    if ($verdict.Reasons.Count -gt 0) { Write-WtInfo "overall reasons: $($verdict.Reasons -join ', ')" }
+
+    return $verdict
+}
+
+Export-ModuleMember -Function New-IssuingAuthority, Connect-Subscriber, Reset-Demo, Get-DemoStatus

--- a/demos/AssuredIdentity/DEMO.md
+++ b/demos/AssuredIdentity/DEMO.md
@@ -1,0 +1,167 @@
+# Assured Identity — Demo Environment
+
+A standing, node-agnostic demonstration of decentralised identity assurance across
+two (or more) Sorcha installations. A tester goes — **unscripted, through the real
+product** — from anonymous sign-up to a verified **Assured Identity** credential in
+their wallet. The approval in between is performed by an identity-validator agent
+(a rule, an AI persona, or a human).
+
+> **Concept: a demo is a mature walkthrough.** This graduated from the scripted
+> `walkthroughs/AssuredIdentity/` dev validation into a coherent, parameterised,
+> human-operable demo. When someone says "the Assured Identity walkthrough", they
+> mean this.
+
+This toolkit is an **operability layer** over the proven F143 cross-installation
+loop. It provisions real authorities against real installations and orchestrates
+the existing `sorcha-agent` — it adds no services and no tester UI.
+
+---
+
+## Prerequisites
+
+- Two installations deployed + healthy on the current `:latest` images: a NAT'd
+  **issuer/owner** node and a public **subscriber** node. (Defaults: `tiny` issuer,
+  `n1` subscriber — but any installations work; see *Node inventory*.)
+- `deploy/keys.env` populated with each installation's sysadmin password (and its
+  own JWT signing key — **never shared between installations**).
+- `sorcha-agent` on `PATH` (for `rules`/`ai` agent modes).
+- For `ai` mode: `ANTHROPIC_API_KEY` set in the environment.
+- PowerShell 7+.
+
+---
+
+## Node inventory
+
+Copy the example and edit it for your installations:
+
+```powershell
+Copy-Item demos/AssuredIdentity/demo-nodes.example.json ./demo-nodes.json
+```
+
+Each entry: `id`, `role` (`issuer`|`subscriber`), `gateway`, `installationName`,
+`rendezvousCapable`. **Swap or rename installations by editing this file** — the
+toolkit hard-codes nothing. Secrets stay in `deploy/keys.env`, never here.
+
+---
+
+## Operator runbook
+
+```powershell
+Import-Module demos/AssuredIdentity/AssuredIdentityDemo.psm1
+
+# 1. Provision the issuing authority on the issuer node (default agent = rules)
+New-IssuingAuthority -IssuerNode tiny -AgencyName "Strathcarron Identity Authority"
+
+# 2. Connect a public subscriber — BLOCKS until a tester can actually apply
+Connect-Subscriber -SubscriberNode n1
+
+# 3. Confirm tester-ready at a glance
+Get-DemoStatus
+```
+
+Then hand the tester the **subscriber's** web address.
+
+### Agent modes (`-AgentMode`)
+
+| Mode | Behaviour |
+|------|-----------|
+| `rules` (default) | Deterministic JSON-Logic actor auto-approves Action 2. Fast; a live demo never stalls. |
+| `ai` | A Claude persona reads each application and decides. Requires `ANTHROPIC_API_KEY`. **Guardrail:** if no decision lands within ~90s, `Get-DemoStatus` shows the approver as pending — retry, or re-provision as `rules`/`human`. The engine does **not** silently auto-degrade. |
+| `human` | No agent is launched. Log into the issuer node as the verification analyst and approve Action 2 yourself (the command prints the steps). |
+
+```powershell
+New-IssuingAuthority -AgentMode ai      # AI assessor
+New-IssuingAuthority -AgentMode human   # you approve
+```
+
+### Rebrand (light customisation)
+
+Re-run with a different name; the org, register, and the **credential's displayed
+issuer** all reflect it (single source — no manual edits):
+
+```powershell
+Reset-Demo -Scope all
+New-IssuingAuthority -AgencyName "Glenmara Borough Registry"
+```
+
+The credential-issuer DID stays valid across renames because it derives from the
+issuer wallet address, which is stable.
+
+### Deep customisation (the application itself)
+
+To change the *workflow* — fields, pages, actions — amend the published blueprint
+in the **real F142 Designer** (Describe → Understand → Rehearse → Go-live):
+
+1. Open the authority's published blueprint in the Designer.
+2. Amend it (`POST /api/blueprints/from-published` clones it back to a draft).
+3. Rehearse, then publish to the **same register**.
+
+The authority's identity (org, wallet, register, DID) is untouched — only the
+workflow changes.
+
+### Multi-node (additional independent subscribers)
+
+Add another subscriber to `demo-nodes.json`, then connect it. Each subscriber
+independently replicates the register and is independently readiness-gated:
+
+```powershell
+Connect-Subscriber -SubscriberNode n2
+```
+
+### Reset & status
+
+```powershell
+Get-DemoStatus                       # Ready / NotReady + per-node signals
+Reset-Demo -Scope all                # local state + stop agent
+Reset-Demo -Scope subscriber -Node n1
+```
+
+> **Note on reset depth.** `Reset-Demo` clears local demo state and stops the tracked
+> agent. A *full* DB wipe (demo wallets, non-system register Mongo DBs, the
+> subscriber's `OrganizationRegisterSubscriptions` rows) is a **node-side** operation —
+> run the documented reset recipe on each host (see the `n1-deploy` skill, or
+> `docker compose down -v` for an ephemeral node). The command prints a reminder.
+
+---
+
+## Tester runbook (anonymous → credential, real product, no script)
+
+You need a browser and the **Citizen Wallet PWA** on your phone.
+
+1. **Sign up** on the subscriber's web app (email/password or social).
+2. **Pair a wallet** — the app nudges you to add a device → `/setup/add-device` →
+   enrol on the Citizen Wallet PWA. (This gives you a holder key so the credential
+   can reach you.)
+3. **Apply** — web app → **New Submissions** (`/new-submissions`) → choose the
+   agency's **Assured Identity** service → **Start** → fill the form (your holder
+   key fills in read-only automatically) → **Submit**.
+4. **Wait** a few seconds — your application is routed to the issuing authority, the
+   identity-validator agent approves it, and the credential comes back.
+5. **Receive** — your PWA shows the pending-application card, then a welcome takeover
+   when the **Assured Identity** credential lands in your wallet. Done.
+
+### Surfaces deliberately NOT on the demo path
+
+- The PWA `/applications` page (a "coming soon" placeholder — it displays in-flight
+  applications only; you start applications from the web app).
+- The `samples/strathcarron-portal` Blue Badge / Driving-Licence pages (non-functional
+  stubs awaiting unlanded backend wiring).
+
+---
+
+## How it maps to the design
+
+- Design: `docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md`
+- Spec / plan / tasks: `specs/144-assured-identity-demo/`
+- Built on Feature 143 (reverse-stream rendezvous) + F137 cross-node delivery +
+  F124/F126/F128 citizen onboarding + the `sorcha-agent` rules/ai engines.
+
+---
+
+## Verified (green run)
+
+> _Record the result of the first full green run on the default node pair here
+> (provision + connect + each agent mode + multi-node + a tester loop), with SC
+> outcomes, before retiring the legacy `walkthroughs/AssuredIdentity/` scripts._
+>
+> Status: **pending first green run** (requires the live two-node environment).

--- a/demos/AssuredIdentity/agent/analyst.ai.template.json
+++ b/demos/AssuredIdentity/agent/analyst.ai.template.json
@@ -1,0 +1,28 @@
+{
+  "actor": {
+    "name": "verification-analyst",
+    "description": "AI identity-validator agent — reads each Assured Identity application and decides (demo ai mode)."
+  },
+  "connection": {
+    "gatewayUrl": "{{gateway}}",
+    "registerId": "{{registerId}}",
+    "credentials": {
+      "email": "$env:AGENT_EMAIL",
+      "password": "$env:AGENT_PASSWORD",
+      "organizationId": "{{orgId}}"
+    },
+    "walletAddress": "{{analystWallet}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 15 }
+  },
+  "mode": "ai",
+  "ai": {
+    "provider": "anthropic",
+    "model": "claude-sonnet-4-6",
+    "temperature": 0.2,
+    "personaFile": "./analyst.persona.md",
+    "apiKeyEnvVar": "ANTHROPIC_API_KEY"
+  }
+}

--- a/demos/AssuredIdentity/agent/analyst.persona.md
+++ b/demos/AssuredIdentity/agent/analyst.persona.md
@@ -1,0 +1,35 @@
+# Verification Analyst — AI persona
+
+You are a verification analyst at an identity-assurance authority. Your job is to
+review a citizen's Assured Identity application (Action 2 of the workflow) and
+decide whether to **approve** or **reject** issuance of their Assured Identity
+credential.
+
+You receive the citizen's submitted details from Action 1: their full name, date
+of birth, registered address, and email. A portrait photo may be attached.
+
+## How to decide
+
+Approve when the application is internally consistent and plausibly genuine:
+
+- A full name is present (given + family name).
+- A date of birth is present and is a plausible adult date (not in the future,
+  not implausibly old).
+- An address is present with at least a line and a postcode/region.
+- An email address is well-formed.
+
+Reject only when the application is clearly incomplete, contradictory, or contains
+obviously fabricated values (e.g. placeholder text like "asdf", a future birth
+date, or a nonsensical address).
+
+This is a **demonstration** environment with synthetic applicants — bias toward
+**approve** for any reasonable-looking submission so the demo flows, but reject
+clearly junk input to show the decision is real.
+
+## Output
+
+Return a decision with:
+
+- `decision`: `"approved"` or `"rejected"`
+- `verificationNotes`: one concise sentence explaining the decision (this is
+  written to the audit trail and shown to the citizen).

--- a/demos/AssuredIdentity/agent/analyst.rules.template.json
+++ b/demos/AssuredIdentity/agent/analyst.rules.template.json
@@ -1,0 +1,32 @@
+{
+  "actor": {
+    "name": "verification-analyst",
+    "description": "Deterministic identity-validator agent — auto-approves Assured Identity applications (demo rules mode)."
+  },
+  "connection": {
+    "gatewayUrl": "{{gateway}}",
+    "registerId": "{{registerId}}",
+    "credentials": {
+      "email": "$env:AGENT_EMAIL",
+      "password": "$env:AGENT_PASSWORD",
+      "organizationId": "{{orgId}}"
+    },
+    "walletAddress": "{{analystWallet}}"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 15 }
+  },
+  "mode": "rules",
+  "rules": [
+    {
+      "actionName": "Verify Assured Identity Application",
+      "condition": { "==": [true, true] },
+      "decision": "approve",
+      "payload": {
+        "decision": "approved",
+        "verificationNotes": "Auto-approved by the demo identity-validator agent (rules mode)."
+      }
+    }
+  ]
+}

--- a/demos/AssuredIdentity/blueprints/assured-identity.template.json
+++ b/demos/AssuredIdentity/blueprints/assured-identity.template.json
@@ -1,0 +1,279 @@
+{
+  "id": "assured-identity-v1",
+  "title": "Assured Identity",
+  "description": "Single canonical citizen-identity workflow. A public-org citizen submits a short 5-page wizard (name + DOB, address, contact, optional photo, review), a verification analyst (or background sorcha-agent) approves, and the AssuredIdentityCredential is delivered to the citizen's Sorcha wallet. Demo template: the issuing-agency name is injected via the {{issuerName}} token at provision time.",
+  "version": 1,
+  "category": "identity",
+  "tags": ["assured-identity", "identity", "haip", "oid4vci", "verifiable-credential", "credential-claim", "citizen-application", "core-primitives", "portrait"],
+  "author": "Sorcha Team",
+  "published": true,
+  "template": {
+    "id": "assured-identity",
+    "title": "Assured Identity",
+    "description": "Citizen submits identity details (including an optional portrait), a verification analyst reviews and issues an AssuredIdentityCredential, and the citizen claims the credential via a Wave 14b claim-card action.",
+    "version": 1,
+    "metadata": {
+      "category": "Identity & Credentials",
+      "complexity": "Simple",
+      "actions": "3",
+      "features": "HAIP, OpenID4VCI, Verifiable Credential, Portrait Claim, Citizen Claim Action, Core Primitives, x-review, x-file",
+      "sector": "Identity & Trust"
+    },
+    "participants": [
+      {
+        "id": "citizen",
+        "name": "Citizen",
+        "organisation": "Public",
+        "description": "Submits an Assured Identity application and receives the credential in their Citizen Wallet PWA"
+      },
+      {
+        "id": "verification-analyst",
+        "name": "Verification Analyst",
+        "organisation": "{{issuerName}}",
+        "description": "Reviews citizen identity applications and approves issuance of the AssuredIdentityCredential"
+      }
+    ],
+    "actions": [
+      {
+        "id": 1,
+        "title": "Submit Assured Identity Application",
+        "description": "Citizen submits their personal details (and optionally a portrait photo) so a verification analyst can verify their identity. Fields are sourced from the Sorcha core primitive library for consistency with every other citizen-facing service. The final page renders the details as a DRAFT ID card so the citizen sees exactly what they'll receive once issued.",
+        "sender": "citizen",
+        "isStartingAction": true,
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Submit your details so a verification analyst can issue your Assured Identity credential. Your persona profile (if you have one) will prefill the form.",
+            "x-pages": [
+              {
+                "title": "About you",
+                "description": "Your full legal name and date of birth.",
+                "x-sections": [
+                  { "title": "Your name", "fields": ["name"] },
+                  { "title": "Your date of birth", "fields": ["dob"] }
+                ]
+              },
+              {
+                "title": "Your address",
+                "description": "Your current registered address. Type your postcode and the rest will autofill where supported.",
+                "x-sections": [
+                  { "title": "Address", "fields": ["address"] }
+                ]
+              },
+              {
+                "title": "Contact",
+                "description": "We'll only use your email for correspondence about this application.",
+                "x-sections": [
+                  { "title": "Email", "fields": ["email"] },
+                  { "title": "Secure delivery", "fields": ["holderKeys"] }
+                ]
+              },
+              {
+                "title": "Your photo (optional)",
+                "description": "Add a portrait photo to your credential. This lets verifiers match you to your credential in person. You can skip this step — the credential is still issued without a photo.",
+                "x-sections": [
+                  { "title": "Portrait", "fields": ["portrait"] }
+                ]
+              },
+              {
+                "title": "Review your details",
+                "description": "Check your answers. You can edit any section before submitting. Once the verification analyst approves, this is what your Assured Identity credential will show.",
+                "x-review": {
+                  "layout": "id-card",
+                  "editable": true,
+                  "header": {
+                    "issuerName": "{{issuerName}}",
+                    "credentialName": "Assured Identity",
+                    "colourTheme": "identity-navy"
+                  }
+                }
+              }
+            ],
+            "properties": {
+              "name":    { "$ref": "https://schemas.sorcha.dev/core/PersonName/v1" },
+              "dob":     { "$ref": "https://schemas.sorcha.dev/core/DateOfBirth/v1" },
+              "email":   { "$ref": "https://schemas.sorcha.dev/core/EmailAddress/v1" },
+              "address": { "$ref": "https://schemas.sorcha.dev/core/PostalAddress/v1" },
+              "portrait": {
+                "type": "string",
+                "title": "Portrait photo",
+                "description": "Optional passport-style photograph. Captured via your device camera or uploaded; resized to a 240x320 JPEG token for embedding in the credential.",
+                "format": "file-reference",
+                "x-file": {
+                  "accept": ["image/jpeg", "image/png"],
+                  "maxSizePerFile": "5MB",
+                  "maxChunks": 2,
+                  "capture": "user",
+                  "embedAs": "image-token-jpeg-240x320"
+                }
+              },
+              "holderKeys": {
+                "type": "object",
+                "title": "Identity keys",
+                "description": "Your wallet's public delivery keys. Captured automatically and read-only — the credential is bound to your holder key and encrypted to your wallet so only you can use it. Feature 137 (cross-node submission).",
+                "format": "sorcha-holder-key",
+                "x-holder-key": { "required": true }
+              }
+            },
+            "required": ["name", "dob", "email", "address"]
+          }
+        ],
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] },
+          { "participantAddress": "verification-analyst", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "to-review",
+            "nextActionIds": [2],
+            "isDefault": true,
+            "description": "Application submitted — pending analyst review"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Verify Assured Identity Application",
+        "description": "Verification analyst reviews the citizen's submission and approves or rejects it. On approval the AssuredIdentityCredential is minted and routed to the citizen's Claim Credential action via OutputMapping.",
+        "sender": "verification-analyst",
+        "requiredPriorActions": [1],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "x-introduction": "Review the citizen's submitted details and portrait (if provided) against your records. Approve to issue, or reject with a reason.",
+            "x-sections": [
+              {
+                "title": "Decision",
+                "description": "Approval state and supporting notes for the audit trail.",
+                "layout": "vertical",
+                "fields": ["decision", "verificationNotes"]
+              }
+            ],
+            "properties": {
+              "decision": {
+                "type": "string",
+                "title": "Decision",
+                "enum": ["approved", "rejected"]
+              },
+              "verificationNotes": {
+                "type": "string",
+                "title": "Reviewer notes",
+                "maxLength": 500
+              }
+            },
+            "required": ["decision"]
+          }
+        ],
+        "credentialIssuanceConfig": {
+          "credentialType": "AssuredIdentityCredential",
+          "targetAudience": "SorchaLocalWallet",
+          "recipientParticipantId": "citizen",
+          "holderKeySourceField": "/holderKeys/holderJwk",
+          "claimMappings": [
+            { "claimName": "givenName",   "sourceField": "/name/givenName" },
+            { "claimName": "middleName",  "sourceField": "/name/middleName" },
+            { "claimName": "familyName",  "sourceField": "/name/familyName" },
+            { "claimName": "fullName",    "sourceField": "/name/fullName" },
+            { "claimName": "dateOfBirth", "sourceField": "/dob/dateOfBirth" },
+            { "claimName": "email",       "sourceField": "/email/email" },
+            { "claimName": "address",     "sourceField": "/address" },
+            { "claimName": "portrait",    "sourceField": "/portrait/tokenImageBase64" }
+          ],
+          "disclosable": [
+            "givenName", "middleName", "familyName", "fullName", "dateOfBirth", "email",
+            "/address/line1", "/address/line2", "/address/town", "/address/region",
+            "/address/postcode", "/address/country",
+            "portrait"
+          ]
+        },
+        "disclosures": [
+          { "participantAddress": "verification-analyst", "dataPointers": ["/*"] },
+          { "participantAddress": "citizen", "dataPointers": ["/decision", "/verificationNotes"] }
+        ],
+        "routes": [
+          {
+            "id": "approved-to-claim",
+            "nextActionIds": [3],
+            "condition": { "==": [{ "var": "decision" }, "approved"] },
+            "description": "Approved — deliver the minted credential to the citizen's Claim Credential pending action",
+            "outputMapping": {
+              "/haip/credential_offer_uri": "/credentialOffer/credential_offer_uri",
+              "/haip/credential_type":      "/credentialOffer/credential_type",
+              "/haip/expires_at":           "/credentialOffer/expires_at",
+              "/haip/offer_id":             "/credentialOffer/offer_id"
+            }
+          },
+          {
+            "id": "rejected-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Rejected — workflow ends with no credential issued"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Claim your Assured Identity credential",
+        "description": "Your Assured Identity credential is ready. Click Claim to deliver it to your Citizen Wallet PWA. Declining will cancel the claim and no credential will be issued.",
+        "sender": "citizen",
+        "requiredPriorActions": [2],
+        "dataSchemas": [
+          {
+            "type": "object",
+            "properties": {
+              "credentialOffer": {
+                "type": "object",
+                "title": "Credential Offer",
+                "x-credential-offer": true,
+                "properties": {
+                  "credential_offer_uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Canonical OpenID4VCI offer URI (openid-credential-offer://...)"
+                  },
+                  "credential_type": {
+                    "type": "string",
+                    "description": "The credential type to be issued"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the credential offer expires and can no longer be claimed"
+                  },
+                  "offer_id": {
+                    "type": "string",
+                    "description": "HAIP offer identifier for status polling"
+                  }
+                },
+                "required": ["credential_offer_uri"]
+              },
+              "claimed_at": {
+                "type": "string",
+                "format": "date-time",
+                "title": "Claimed at",
+                "description": "Set by the client when the citizen clicks Claim"
+              }
+            },
+            "required": ["credentialOffer"]
+          }
+        ],
+        "rejectionConfig": {
+          "targetActionId": 0,
+          "isTerminal": true,
+          "requireReason": false
+        },
+        "disclosures": [
+          { "participantAddress": "citizen", "dataPointers": ["/*"] }
+        ],
+        "routes": [
+          {
+            "id": "claimed-terminal",
+            "nextActionIds": [],
+            "isDefault": true,
+            "description": "Credential claimed — workflow complete"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/demos/AssuredIdentity/demo-nodes.example.json
+++ b/demos/AssuredIdentity/demo-nodes.example.json
@@ -1,0 +1,20 @@
+{
+  "nodes": [
+    {
+      "id": "tiny",
+      "role": "issuer",
+      "gateway": "http://tiny:8090",
+      "installationName": "tiny.sorcha.dev",
+      "rendezvousCapable": false,
+      "adminEmail": "admin@sorcha.local"
+    },
+    {
+      "id": "n1",
+      "role": "subscriber",
+      "gateway": "https://n1.sorcha.dev",
+      "installationName": "n1.sorcha.dev",
+      "rendezvousCapable": true,
+      "adminEmail": "admin@sorcha.local"
+    }
+  ]
+}

--- a/demos/AssuredIdentity/lib/AgencyNaming.ps1
+++ b/demos/AssuredIdentity/lib/AgencyNaming.ps1
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Single-source agency-name injection + coherence check (FR-002, FR-005, R3).
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+    Inject the agency name into a blueprint template's {{issuerName}} tokens.
+.DESCRIPTION
+    Pure string transform over the blueprint JSON. The demo blueprint template
+    carries {{issuerName}} at the participant organisation and x-review header.
+    Returns the rendered JSON. Throws if any {{issuerName}} token survives.
+.PARAMETER BlueprintJson
+    Raw blueprint template JSON string.
+.PARAMETER AgencyName
+    The single-source agency name.
+#>
+function Set-BlueprintIssuerName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$BlueprintJson,
+        [Parameter(Mandatory)][string]$AgencyName
+    )
+    $rendered = Expand-DemoTokens -Text $BlueprintJson -Tokens @{ issuerName = $AgencyName }
+    if ($rendered -match '\{\{\s*issuerName\s*\}\}') {
+        throw "Blueprint still contains an unresolved {{issuerName}} token after injection."
+    }
+    return $rendered
+}
+
+<#
+.SYNOPSIS
+    Test that the agency name is coherently applied across every tester-visible site.
+.DESCRIPTION
+    Pure predicate (FR-002/FR-005, SC-004). Returns an object:
+      { Coherent = [bool]; Mismatches = [string[]] }
+    Coherent iff the org name, register name, published-participant org name, and
+    the blueprint's rendered issuerName ALL equal -AgencyName, with no residual
+    {{issuerName}} token in the blueprint.
+.PARAMETER AgencyName
+    Expected single-source name.
+.PARAMETER OrgName / RegisterName / ParticipantOrg
+    The names actually applied to those artefacts.
+.PARAMETER BlueprintJson
+    The rendered blueprint JSON (post-injection).
+#>
+function Test-AgencyNameCoherence {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$AgencyName,
+        [Parameter(Mandatory)][string]$OrgName,
+        [Parameter(Mandatory)][string]$RegisterName,
+        [Parameter(Mandatory)][string]$ParticipantOrg,
+        [Parameter(Mandatory)][string]$BlueprintJson
+    )
+    $mismatches = @()
+    if ($OrgName        -ne $AgencyName) { $mismatches += "org name '$OrgName'" }
+    if ($RegisterName   -ne $AgencyName) { $mismatches += "register name '$RegisterName'" }
+    if ($ParticipantOrg -ne $AgencyName) { $mismatches += "participant org '$ParticipantOrg'" }
+
+    if (Get-DemoUnresolvedTokens -Text $BlueprintJson | Where-Object { $_ -match 'issuerName' }) {
+        $mismatches += "blueprint has unresolved issuerName token"
+    } elseif ($BlueprintJson -notmatch [regex]::Escape($AgencyName)) {
+        $mismatches += "blueprint issuerName does not contain '$AgencyName'"
+    }
+
+    return [pscustomobject]@{
+        Coherent   = ($mismatches.Count -eq 0)
+        Mismatches = $mismatches
+    }
+}

--- a/demos/AssuredIdentity/lib/AgentLaunch.ps1
+++ b/demos/AssuredIdentity/lib/AgentLaunch.ps1
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Approval-agent rendering + launch for rules/ai/human (FR-010/011/012, R6).
+
+Set-StrictMode -Version Latest
+
+$script:DemoAiDecisionWaitSeconds = 90
+
+<#
+.SYNOPSIS
+    Render an agent actor config from a tokenised template.
+.DESCRIPTION
+    Substitutes {{...}} tokens (gateway, registerId, orgId, analystWallet,
+    analystEmail, blueprintId) into the template and writes the rendered config.
+    Returns the output path. Throws if any token is left unresolved.
+.PARAMETER TemplatePath
+    Path to analyst.<mode>.template.json.
+.PARAMETER Tokens
+    Hashtable of substitution values.
+.PARAMETER OutputPath
+    Where to write the rendered actor config.
+#>
+function New-AgentActorConfig {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$TemplatePath,
+        [Parameter(Mandatory)][hashtable]$Tokens,
+        [Parameter(Mandatory)][string]$OutputPath
+    )
+    if (-not (Test-Path -LiteralPath $TemplatePath)) {
+        throw "Agent template not found: $TemplatePath"
+    }
+    $raw = Get-Content -LiteralPath $TemplatePath -Raw
+    $rendered = Expand-DemoTokens -Text $raw -Tokens $Tokens
+    $unresolved = Get-DemoUnresolvedTokens -Text $rendered
+    if ($unresolved.Count -gt 0) {
+        throw "Agent config still has unresolved tokens: $($unresolved -join ', ')"
+    }
+    $rendered | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+    return $OutputPath
+}
+
+<#
+.SYNOPSIS
+    Launch (or instruct) the approval agent for the chosen mode.
+.DESCRIPTION
+    - rules: render config, launch `sorcha-agent run` as a tracked child process.
+    - ai   : precheck ANTHROPIC_API_KEY, render config (carrying the decision-wait
+             guardrail), launch. A slow/failed decision surfaces via Get-DemoStatus
+             rather than auto-degrading the engine (R6).
+    - human: no launch — print approval instructions and return $null process.
+    Returns { Mode; Process; ConfigPath; Guardrail }.
+.PARAMETER Mode
+    rules | ai | human.
+.PARAMETER TemplateDir
+    Directory holding analyst.rules.template.json / analyst.ai.template.json / analyst.persona.md.
+.PARAMETER Tokens
+    Substitution values for the actor config.
+.PARAMETER StatePath
+    Path to state.json (passed to sorcha-agent for {{placeholder}} resolution).
+.PARAMETER WorkDir
+    Where rendered configs are written.
+.PARAMETER IssuerGateway
+    Issuer gateway URL (for the human-mode instructions).
+#>
+function Start-ApprovalAgent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateSet('rules', 'ai', 'human')][string]$Mode,
+        [Parameter(Mandatory)][string]$TemplateDir,
+        [Parameter(Mandatory)][hashtable]$Tokens,
+        [Parameter(Mandatory)][string]$StatePath,
+        [Parameter(Mandatory)][string]$WorkDir,
+        [string]$IssuerGateway = ""
+    )
+
+    if ($Mode -eq 'human') {
+        Write-WtStep "Agent mode: human"
+        Write-WtInfo  "No approval agent launched. To approve applications:"
+        Write-WtInfo  "  1. Log into the issuer node ($IssuerGateway) as the verification analyst."
+        Write-WtInfo  "  2. Open the pending 'Verify Assured Identity Application' (Action 2)."
+        Write-WtInfo  "  3. Set decision = approved and submit."
+        return [pscustomobject]@{ Mode = 'human'; Process = $null; ConfigPath = $null; Guardrail = $null }
+    }
+
+    if ($Mode -eq 'ai' -and [string]::IsNullOrWhiteSpace($env:ANTHROPIC_API_KEY)) {
+        throw "Agent mode 'ai' requires the ANTHROPIC_API_KEY environment variable to be set."
+    }
+
+    $templatePath = Join-Path $TemplateDir "analyst.$Mode.template.json"
+    $configPath = Join-Path $WorkDir "analyst.$Mode.json"
+    New-AgentActorConfig -TemplatePath $templatePath -Tokens $Tokens -OutputPath $configPath | Out-Null
+
+    $guardrail = $null
+    if ($Mode -eq 'ai') {
+        $guardrail = [pscustomobject]@{ DecisionWaitSeconds = $script:DemoAiDecisionWaitSeconds; OnTimeout = 'surface-status' }
+    }
+
+    Write-WtStep "Agent mode: $Mode — launching sorcha-agent"
+    $agentCmd = Get-Command 'sorcha-agent' -ErrorAction SilentlyContinue
+    if (-not $agentCmd) {
+        Write-WtWarn "sorcha-agent not found on PATH. Rendered config at $configPath; start it manually:"
+        Write-WtInfo  "  sorcha-agent run --config `"$configPath`" --state `"$StatePath`""
+        return [pscustomobject]@{ Mode = $Mode; Process = $null; ConfigPath = $configPath; Guardrail = $guardrail }
+    }
+
+    $proc = Start-Process -FilePath $agentCmd.Source `
+        -ArgumentList @('run', '--config', $configPath, '--state', $StatePath) `
+        -PassThru -NoNewWindow
+    Write-WtSuccess "sorcha-agent ($Mode) started (pid $($proc.Id))"
+    return [pscustomobject]@{ Mode = $Mode; Process = $proc; ConfigPath = $configPath; Guardrail = $guardrail }
+}

--- a/demos/AssuredIdentity/lib/Auth.ps1
+++ b/demos/AssuredIdentity/lib/Auth.ps1
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Secret loading + per-node admin login (FR-009, Constitution II). Never echoes secrets.
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+    Load KEY=VALUE secrets from deploy/keys.env into a hashtable.
+.DESCRIPTION
+    Parses simple KEY=VALUE lines (ignores blanks and # comments). Secrets stay
+    in memory only; nothing is written or printed. Each installation keeps its own
+    JWT signing key here — they are NEVER shared (FR-009). The demo toolkit only
+    needs the per-node sysadmin PASSWORD to log in; signing keys are deployed
+    server-side and not consumed by the toolkit.
+.PARAMETER Path
+    Path to the secrets file. Defaults to deploy/keys.env.
+#>
+function Import-DemoSecrets {
+    [CmdletBinding()]
+    param([string]$Path = "deploy/keys.env")
+    $secrets = @{}
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $secrets
+    }
+    foreach ($line in (Get-Content -LiteralPath $Path)) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq '' -or $trimmed.StartsWith('#')) { continue }
+        $idx = $trimmed.IndexOf('=')
+        if ($idx -lt 1) { continue }
+        $key = $trimmed.Substring(0, $idx).Trim()
+        $val = $trimmed.Substring($idx + 1).Trim().Trim('"')
+        $secrets[$key] = $val
+    }
+    return $secrets
+}
+
+<#
+.SYNOPSIS
+    Resolve the sysadmin password for a node from secrets, with a dev default.
+.DESCRIPTION
+    Looks for a node-specific key (e.g. TINY_ADMIN_PASSWORD) then a shared
+    ADMIN_PASSWORD, else falls back to the well-known dev seed password. Never logs it.
+#>
+function Get-DemoAdminPassword {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Node,
+        [hashtable]$Secrets = @{}
+    )
+    $nodeKey = ("{0}_ADMIN_PASSWORD" -f $Node.id).ToUpperInvariant()
+    if ($Secrets.ContainsKey($nodeKey)) { return $Secrets[$nodeKey] }
+    if ($Secrets.ContainsKey('ADMIN_PASSWORD')) { return $Secrets['ADMIN_PASSWORD'] }
+    return 'Dev_Pass_2025!'
+}
+
+<#
+.SYNOPSIS
+    Log in as the seed sysadmin on a node and return the SorchaWalkthrough admin session.
+.DESCRIPTION
+    Thin wrapper over Connect-SorchaAdmin using the node's /api base and the
+    resolved admin email/password. Requires SorchaWalkthrough to be imported.
+#>
+function Connect-DemoNodeAdmin {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Node,
+        [hashtable]$Secrets = @{}
+    )
+    $api = Get-DemoApiBase -Gateway $Node.gateway
+    $email = if ($Node.PSObject.Properties.Name -contains 'adminEmail' -and $Node.adminEmail) { $Node.adminEmail } else { 'admin@sorcha.local' }
+    $pw = Get-DemoAdminPassword -Node $Node -Secrets $Secrets
+    return Connect-SorchaAdmin -TenantUrl $api -AdminEmail $email -AdminPassword $pw
+}

--- a/demos/AssuredIdentity/lib/Common.ps1
+++ b/demos/AssuredIdentity/lib/Common.ps1
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Common helpers shared across the Assured Identity demo toolkit lib units.
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+    Replace {{token}} placeholders in a string from a hashtable of values.
+.DESCRIPTION
+    Pure string transform. Replaces every {{key}} occurrence with the matching
+    value from -Tokens. Keys are matched case-insensitively. Unknown {{tokens}}
+    are left intact so callers can detect un-substituted placeholders.
+.PARAMETER Text
+    The source text (e.g. a blueprint or actor-config JSON string).
+.PARAMETER Tokens
+    Hashtable of token name -> replacement value.
+#>
+function Expand-DemoTokens {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text,
+        [Parameter(Mandatory)][hashtable]$Tokens
+    )
+    $result = $Text
+    foreach ($key in $Tokens.Keys) {
+        $pattern = "{{$key}}"
+        $result = $result.Replace($pattern, [string]$Tokens[$key])
+    }
+    return $result
+}
+
+<#
+.SYNOPSIS
+    Return the list of un-substituted {{token}} placeholders remaining in a string.
+.DESCRIPTION
+    Used by tests and provisioning to assert a template was fully rendered.
+#>
+function Get-DemoUnresolvedTokens {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text
+    )
+    $matches = [regex]::Matches($Text, '{{\s*[A-Za-z0-9_]+\s*}}')
+    return @($matches | ForEach-Object { $_.Value } | Select-Object -Unique)
+}
+
+<#
+.SYNOPSIS
+    Normalise a node gateway URL into the /api base the SorchaWalkthrough helpers expect.
+#>
+function Get-DemoApiBase {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string]$Gateway)
+    return ($Gateway.TrimEnd('/')) + "/api"
+}

--- a/demos/AssuredIdentity/lib/DemoState.ps1
+++ b/demos/AssuredIdentity/lib/DemoState.ps1
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Per-run demo state record IO + stale detection (data-model Entity 4).
+
+Set-StrictMode -Version Latest
+
+$script:DemoStateSchemaVersion = 1
+
+<#
+.SYNOPSIS
+    Read the demo state record, or $null if absent.
+#>
+function Read-DemoState {
+    [CmdletBinding()]
+    param([string]$Path = "./state.json")
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+    try {
+        return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    } catch {
+        throw "Demo state '$Path' is not valid JSON: $($_.Exception.Message)"
+    }
+}
+
+<#
+.SYNOPSIS
+    Write the demo state record (pretty JSON), stamping schemaVersion + updatedAt.
+.PARAMETER State
+    A hashtable or PSCustomObject of state fields.
+#>
+function Write-DemoState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$State,
+        [string]$Path = "./state.json"
+    )
+    $obj = [ordered]@{}
+    if ($State -is [hashtable]) {
+        foreach ($k in $State.Keys) { $obj[$k] = $State[$k] }
+    } else {
+        foreach ($p in $State.PSObject.Properties) { $obj[$p.Name] = $p.Value }
+    }
+    $obj['schemaVersion'] = $script:DemoStateSchemaVersion
+    $obj['updatedAt'] = (Get-Date).ToUniversalTime().ToString('o')
+    if (-not $obj.Contains('provisionedAt')) {
+        $obj['provisionedAt'] = $obj['updatedAt']
+    }
+    ($obj | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $Path -Encoding UTF8
+    return $Path
+}
+
+<#
+.SYNOPSIS
+    Shallow-merge update fields onto an existing state object, returning a hashtable.
+#>
+function Merge-DemoState {
+    [CmdletBinding()]
+    param(
+        [object]$Existing,
+        [Parameter(Mandatory)][hashtable]$Updates
+    )
+    $merged = @{}
+    if ($Existing) {
+        foreach ($p in $Existing.PSObject.Properties) { $merged[$p.Name] = $p.Value }
+    }
+    foreach ($k in $Updates.Keys) { $merged[$k] = $Updates[$k] }
+    return $merged
+}
+
+<#
+.SYNOPSIS
+    Stale-state test (data-model "Validation"): the state names a register that
+    cannot be read on the node -> the record is stale and must be reconciled.
+.PARAMETER State
+    The state object (or $null).
+.PARAMETER RegisterReadable
+    Whether state.registerId reads back on the node.
+#>
+function Test-DemoStateStale {
+    [CmdletBinding()]
+    param(
+        [object]$State,
+        [bool]$RegisterReadable
+    )
+    if ($null -eq $State) { return $false }
+    $hasRegister = ($State.PSObject.Properties.Name -contains 'registerId') -and `
+                   -not [string]::IsNullOrWhiteSpace([string]$State.registerId)
+    return ($hasRegister -and -not $RegisterReadable)
+}

--- a/demos/AssuredIdentity/lib/Idempotency.ps1
+++ b/demos/AssuredIdentity/lib/Idempotency.ps1
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Idempotency decisions: provision reuse + stale-state reconciliation (FR-003, R5).
+# Pure decision logic — no IO. Callers gather the probe facts, this decides.
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+    Decide what New-IssuingAuthority should do given an idempotency probe.
+.DESCRIPTION
+    Returns one of: 'Create' | 'Reuse' | 'ReconcileStale'.
+      - Force                                              -> 'Create'
+      - register recorded but NOT readable on the node     -> 'ReconcileStale'
+        (the live-state footgun: state/subscription points at a register absent
+         from Mongo; we must reconcile, not blindly reuse)
+      - org + readable register + published blueprint exist -> 'Reuse'
+      - otherwise                                           -> 'Create'
+.PARAMETER HasOrg
+    Whether an org for the agency already exists.
+.PARAMETER HasRegisterId
+    Whether a register id is recorded (state.json) / discoverable.
+.PARAMETER RegisterReadable
+    Whether that register actually reads back on the node.
+.PARAMETER BlueprintPublished
+    Whether the target blueprint is published on that register.
+.PARAMETER Force
+    Operator asked to recreate.
+#>
+function Resolve-AuthorityAction {
+    [CmdletBinding()]
+    param(
+        [bool]$HasOrg,
+        [bool]$HasRegisterId,
+        [bool]$RegisterReadable,
+        [bool]$BlueprintPublished,
+        [bool]$Force
+    )
+    if ($Force) { return 'Create' }
+    if ($HasRegisterId -and -not $RegisterReadable) { return 'ReconcileStale' }
+    if ($HasOrg -and $HasRegisterId -and $RegisterReadable -and $BlueprintPublished) { return 'Reuse' }
+    return 'Create'
+}
+
+<#
+.SYNOPSIS
+    Decide what Connect-Subscriber should do given the subscription probe.
+.DESCRIPTION
+    Returns one of: 'CreateSubscription' | 'ReuseSubscription' | 'ReconcileStaleSubscription'.
+      - subscription present but register NOT readable -> 'ReconcileStaleSubscription'
+      - subscription Active and register readable       -> 'ReuseSubscription'
+      - otherwise                                        -> 'CreateSubscription'
+.PARAMETER SubscriptionStatus
+    Current subscription status, or $null/'' if none.
+.PARAMETER RegisterReadable
+    Whether the register reads back on the subscriber.
+#>
+function Resolve-SubscriptionAction {
+    [CmdletBinding()]
+    param(
+        [string]$SubscriptionStatus,
+        [bool]$RegisterReadable
+    )
+    $hasSubscription = -not [string]::IsNullOrWhiteSpace($SubscriptionStatus)
+    if ($hasSubscription -and -not $RegisterReadable) { return 'ReconcileStaleSubscription' }
+    if ($SubscriptionStatus -eq 'Active' -and $RegisterReadable) { return 'ReuseSubscription' }
+    return 'CreateSubscription'
+}

--- a/demos/AssuredIdentity/lib/NodeInventory.ps1
+++ b/demos/AssuredIdentity/lib/NodeInventory.ps1
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Node inventory loader + selectors (FR-006, FR-007). Pure-logic + file IO.
+
+Set-StrictMode -Version Latest
+
+$script:DemoNodeRequiredFields = @('id', 'role', 'gateway', 'installationName')
+$script:DemoNodeRoles = @('issuer', 'subscriber')
+
+<#
+.SYNOPSIS
+    Load and validate a demo node inventory (demo-nodes.json).
+.DESCRIPTION
+    Reads the JSON file, validates each node entry (required fields, role enum,
+    well-formed absolute gateway URI, unique ids) and returns the node array as
+    PSCustomObjects. Fails fast with a clear message on any violation (FR-006).
+.PARAMETER Path
+    Path to the inventory JSON file. Defaults to ./demo-nodes.json.
+#>
+function Get-DemoNodeInventory {
+    [CmdletBinding()]
+    param([string]$Path = "./demo-nodes.json")
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Node inventory not found at '$Path'. Copy demo-nodes.example.json and edit it for your installations."
+    }
+
+    try {
+        $doc = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    } catch {
+        throw "Node inventory '$Path' is not valid JSON: $($_.Exception.Message)"
+    }
+
+    if (-not ($doc.PSObject.Properties.Name -contains 'nodes') -or $null -eq $doc.nodes) {
+        throw "Node inventory '$Path' must contain a top-level 'nodes' array."
+    }
+
+    $nodes = @($doc.nodes)
+    if ($nodes.Count -lt 1) {
+        throw "Node inventory '$Path' must list at least one node."
+    }
+
+    $seenIds = @{}
+    foreach ($node in $nodes) {
+        foreach ($field in $script:DemoNodeRequiredFields) {
+            $value = $node.PSObject.Properties[$field]
+            if ($null -eq $value -or [string]::IsNullOrWhiteSpace([string]$value.Value)) {
+                throw "Node inventory '$Path': a node is missing required field '$field'."
+            }
+        }
+        if ($script:DemoNodeRoles -notcontains $node.role) {
+            throw "Node inventory '$Path': node '$($node.id)' has invalid role '$($node.role)' (expected issuer|subscriber)."
+        }
+        $uri = $null
+        if (-not [System.Uri]::TryCreate([string]$node.gateway, [System.UriKind]::Absolute, [ref]$uri)) {
+            throw "Node inventory '$Path': node '$($node.id)' has malformed gateway URL '$($node.gateway)'."
+        }
+        if ($seenIds.ContainsKey($node.id)) {
+            throw "Node inventory '$Path': duplicate node id '$($node.id)'."
+        }
+        $seenIds[$node.id] = $true
+    }
+
+    return $nodes
+}
+
+<#
+.SYNOPSIS
+    Select a node from the inventory by its id. Throws if not found.
+#>
+function Select-DemoNode {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object[]]$Inventory,
+        [Parameter(Mandatory)][string]$Id
+    )
+    $node = $Inventory | Where-Object { $_.id -eq $Id } | Select-Object -First 1
+    if (-not $node) {
+        $available = ($Inventory | ForEach-Object { $_.id }) -join ', '
+        throw "Node id '$Id' not found in inventory. Available: $available"
+    }
+    return $node
+}
+
+<#
+.SYNOPSIS
+    Return the first node with the given role, or throw if none match.
+#>
+function Get-DemoNodeByRole {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object[]]$Inventory,
+        [Parameter(Mandatory)][ValidateSet('issuer', 'subscriber')][string]$Role
+    )
+    $node = $Inventory | Where-Object { $_.role -eq $Role } | Select-Object -First 1
+    if (-not $node) {
+        throw "No node with role '$Role' in the inventory."
+    }
+    return $node
+}

--- a/demos/AssuredIdentity/lib/Readiness.ps1
+++ b/demos/AssuredIdentity/lib/Readiness.ps1
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Subscriber readiness predicate + poll loop (FR-004, R4).
+# Pure predicate is separated from IO so it is unit-testable offline.
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+    Pure readiness predicate for a subscriber against a target register/blueprint.
+.DESCRIPTION
+    Returns { Ready = [bool]; Reasons = [string[]] }. Ready iff ALL hold (R4):
+      - subscription status == 'Active'
+      - sync-state         == 'CaughtUp'
+      - the target blueprint id is present in the published-blueprints listing
+    The third condition is the one that absorbs the ~60s BlueprintRecoveryService
+    window — without it a tester hits POST /api/instances -> 409 blueprint_not_available.
+.PARAMETER SubscriptionStatus
+    Value from GET /api/organizations/{orgId}/register-subscriptions/{registerId}.
+.PARAMETER SyncState
+    Value from GET /api/registers/{id}/sync-state (Indeterminate|Syncing|CaughtUp|Error).
+.PARAMETER PublishedBlueprintIds
+    Blueprint ids from GET /api/registers/{id}/blueprints/published.
+.PARAMETER TargetBlueprintId
+    The blueprint the tester must be able to start.
+#>
+function Test-SubscriberReady {
+    [CmdletBinding()]
+    param(
+        [string]$SubscriptionStatus,
+        [string]$SyncState,
+        [string[]]$PublishedBlueprintIds = @(),
+        [Parameter(Mandatory)][string]$TargetBlueprintId
+    )
+    $reasons = @()
+    if ($SubscriptionStatus -ne 'Active')  { $reasons += "subscription-not-active($SubscriptionStatus)" }
+    if ($SyncState -ne 'CaughtUp')          { $reasons += "sync-state-not-caughtup($SyncState)" }
+    if (@($PublishedBlueprintIds) -notcontains $TargetBlueprintId) { $reasons += "blueprint-not-published" }
+
+    return [pscustomobject]@{
+        Ready   = ($reasons.Count -eq 0)
+        Reasons = $reasons
+    }
+}
+
+<#
+.SYNOPSIS
+    Poll the injected signal probes until the subscriber is ready or timeout.
+.DESCRIPTION
+    IO orchestration around Test-SubscriberReady. The three probes are scriptblocks
+    so the loop is testable with injected fakes. Returns:
+      { Status = 'Ready'|'NotReady'; Reasons = [string[]]; Elapsed = [timespan] }
+    On timeout returns NotReady (a soft, retryable outcome — never throws) with the
+    last failing reasons (e.g. 'blueprint-not-published' = recovery in progress).
+.PARAMETER GetSubscriptionStatus / GetSyncState / GetPublishedBlueprintIds
+    Scriptblocks returning the current signal value.
+.PARAMETER TargetBlueprintId
+    The blueprint to wait for.
+.PARAMETER TimeoutSeconds
+    Poll cap (default 120 — comfortably over the observed <=60s recovery window).
+.PARAMETER PollSeconds
+    Delay between polls (default 5).
+#>
+function Wait-SubscriberReady {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][scriptblock]$GetSubscriptionStatus,
+        [Parameter(Mandatory)][scriptblock]$GetSyncState,
+        [Parameter(Mandatory)][scriptblock]$GetPublishedBlueprintIds,
+        [Parameter(Mandatory)][string]$TargetBlueprintId,
+        [int]$TimeoutSeconds = 120,
+        [int]$PollSeconds = 5
+    )
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $verdict = $null
+    do {
+        $subscription = & $GetSubscriptionStatus
+        $sync         = & $GetSyncState
+        $published    = @(& $GetPublishedBlueprintIds)
+
+        $verdict = Test-SubscriberReady -SubscriptionStatus $subscription -SyncState $sync `
+            -PublishedBlueprintIds $published -TargetBlueprintId $TargetBlueprintId
+
+        if ($verdict.Ready) { break }
+        if ($sw.Elapsed.TotalSeconds -ge $TimeoutSeconds) { break }
+        Start-Sleep -Seconds $PollSeconds
+    } while ($true)
+
+    $sw.Stop()
+    return [pscustomobject]@{
+        Status  = if ($verdict.Ready) { 'Ready' } else { 'NotReady' }
+        Reasons = $verdict.Reasons
+        Elapsed = $sw.Elapsed
+    }
+}

--- a/demos/AssuredIdentity/lib/StatusVerdict.ps1
+++ b/demos/AssuredIdentity/lib/StatusVerdict.ps1
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Cross-node readiness verdict aggregation (FR-018, SC-007). Pure logic.
+
+Set-StrictMode -Version Latest
+
+<#
+.SYNOPSIS
+    Compute the demo-wide readiness verdict from gathered per-node signals.
+.DESCRIPTION
+    Pure aggregation. The verdict MUST predict tester success (SC-007):
+      Ready iff the issuer is reachable AND an approver is present AND at least
+      one subscriber is fully ready (Active + CaughtUp + blueprint published).
+    Returns:
+      { Verdict = 'Ready'|'NotReady'; PerNode = [..]; Reasons = [string[]] }
+.PARAMETER IssuerReachable
+    Whether the issuer gateway answered a health probe.
+.PARAMETER ApproverPresent
+    Whether the approval agent is running (rules/ai) or human-acknowledged.
+.PARAMETER Subscribers
+    Array of per-subscriber objects with: NodeId, SubscriptionStatus, SyncState,
+    PublishedBlueprintIds, TargetBlueprintId.
+#>
+function Get-ReadinessVerdict {
+    [CmdletBinding()]
+    param(
+        [bool]$IssuerReachable,
+        [bool]$ApproverPresent,
+        [object[]]$Subscribers = @()
+    )
+    $reasons = @()
+    if (-not $IssuerReachable) { $reasons += "issuer-unreachable" }
+    if (-not $ApproverPresent) { $reasons += "approver-absent" }
+
+    $perNode = @()
+    $anySubscriberReady = $false
+    foreach ($sub in $Subscribers) {
+        $v = Test-SubscriberReady -SubscriptionStatus $sub.SubscriptionStatus -SyncState $sub.SyncState `
+            -PublishedBlueprintIds @($sub.PublishedBlueprintIds) -TargetBlueprintId $sub.TargetBlueprintId
+        if ($v.Ready) { $anySubscriberReady = $true }
+        $perNode += [pscustomobject]@{
+            NodeId  = $sub.NodeId
+            Ready   = $v.Ready
+            Reasons = $v.Reasons
+        }
+    }
+
+    if (@($Subscribers).Count -eq 0) { $reasons += "no-subscribers" }
+    elseif (-not $anySubscriberReady) { $reasons += "no-subscriber-ready" }
+
+    return [pscustomobject]@{
+        Verdict = if ($reasons.Count -eq 0) { 'Ready' } else { 'NotReady' }
+        PerNode = $perNode
+        Reasons = $reasons
+    }
+}

--- a/demos/AssuredIdentity/tests/AgencyNaming.Tests.ps1
+++ b/demos/AssuredIdentity/tests/AgencyNaming.Tests.ps1
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+BeforeAll {
+    $lib = Join-Path $PSScriptRoot "../lib"
+    . (Join-Path $lib "Common.ps1")
+    . (Join-Path $lib "AgencyNaming.ps1")
+    $script:Template = '{ "p": { "organisation": "{{issuerName}}" }, "x-review": { "header": { "issuerName": "{{issuerName}}" } } }'
+}
+
+Describe "Set-BlueprintIssuerName" {
+    It "replaces every issuerName token" {
+        $out = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName "Strathcarron Identity Authority"
+        $out | Should -BeLike "*Strathcarron Identity Authority*"
+        (Get-DemoUnresolvedTokens -Text $out) | Should -BeNullOrEmpty
+    }
+
+    It "leaves unrelated tokens intact and still renders the issuerName" {
+        $mixed = '{ "header": { "issuerName": "{{issuerName}}" }, "other": "{{somethingElse}}" }'
+        $out = Set-BlueprintIssuerName -BlueprintJson $mixed -AgencyName "Acme"
+        $out | Should -BeLike "*Acme*"
+        $out | Should -BeLike "*{{somethingElse}}*"   # not our concern, preserved
+    }
+}
+
+Describe "Test-AgencyNameCoherence" {
+    It "is coherent when all sites match and no token remains" {
+        $rendered = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName "Acme Verification Co."
+        $r = Test-AgencyNameCoherence -AgencyName "Acme Verification Co." -OrgName "Acme Verification Co." `
+            -RegisterName "Acme Verification Co." -ParticipantOrg "Acme Verification Co." -BlueprintJson $rendered
+        $r.Coherent | Should -BeTrue
+        $r.Mismatches | Should -BeNullOrEmpty
+    }
+
+    It "flags a mismatched org name" {
+        $rendered = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName "Acme"
+        $r = Test-AgencyNameCoherence -AgencyName "Acme" -OrgName "Stale Co." `
+            -RegisterName "Acme" -ParticipantOrg "Acme" -BlueprintJson $rendered
+        $r.Coherent | Should -BeFalse
+        ($r.Mismatches -join ';') | Should -BeLike "*org name*"
+    }
+
+    It "flags an unresolved blueprint token" {
+        $r = Test-AgencyNameCoherence -AgencyName "Acme" -OrgName "Acme" -RegisterName "Acme" `
+            -ParticipantOrg "Acme" -BlueprintJson '{ "issuerName": "{{issuerName}}" }'
+        $r.Coherent | Should -BeFalse
+        ($r.Mismatches -join ';') | Should -BeLike "*unresolved issuerName token*"
+    }
+}

--- a/demos/AssuredIdentity/tests/Idempotency.Tests.ps1
+++ b/demos/AssuredIdentity/tests/Idempotency.Tests.ps1
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot "../lib/Idempotency.ps1")
+}
+
+Describe "Resolve-AuthorityAction" {
+    It "reuses a fully-present, readable authority" {
+        Resolve-AuthorityAction -HasOrg $true -HasRegisterId $true -RegisterReadable $true -BlueprintPublished $true -Force $false | Should -Be 'Reuse'
+    }
+
+    It "reconciles when a recorded register is not readable (the stale footgun)" {
+        Resolve-AuthorityAction -HasOrg $true -HasRegisterId $true -RegisterReadable $false -BlueprintPublished $false -Force $false | Should -Be 'ReconcileStale'
+    }
+
+    It "creates when nothing exists" {
+        Resolve-AuthorityAction -HasOrg $false -HasRegisterId $false -RegisterReadable $false -BlueprintPublished $false -Force $false | Should -Be 'Create'
+    }
+
+    It "creates (recreates) under -Force even if present" {
+        Resolve-AuthorityAction -HasOrg $true -HasRegisterId $true -RegisterReadable $true -BlueprintPublished $true -Force $true | Should -Be 'Create'
+    }
+
+    It "creates when register readable but blueprint not yet published" {
+        Resolve-AuthorityAction -HasOrg $true -HasRegisterId $true -RegisterReadable $true -BlueprintPublished $false -Force $false | Should -Be 'Create'
+    }
+}
+
+Describe "Resolve-SubscriptionAction" {
+    It "reuses an Active subscription to a readable register" {
+        Resolve-SubscriptionAction -SubscriptionStatus 'Active' -RegisterReadable $true | Should -Be 'ReuseSubscription'
+    }
+
+    It "reconciles a subscription whose register is not readable" {
+        Resolve-SubscriptionAction -SubscriptionStatus 'Active' -RegisterReadable $false | Should -Be 'ReconcileStaleSubscription'
+    }
+
+    It "creates when there is no subscription" {
+        Resolve-SubscriptionAction -SubscriptionStatus '' -RegisterReadable $true | Should -Be 'CreateSubscription'
+    }
+
+    It "creates when subscription is Pending" {
+        Resolve-SubscriptionAction -SubscriptionStatus 'Pending' -RegisterReadable $true | Should -Be 'CreateSubscription'
+    }
+}

--- a/demos/AssuredIdentity/tests/Invoke-DemoTests.ps1
+++ b/demos/AssuredIdentity/tests/Invoke-DemoTests.ps1
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# Pester runner for the Assured Identity demo toolkit unit tests.
+#   pwsh -File demos/AssuredIdentity/tests/Invoke-DemoTests.ps1
+param([switch]$CI)
+
+$ErrorActionPreference = 'Stop'
+Import-Module Pester -MinimumVersion 5.0.0 -Force
+
+$config = New-PesterConfiguration
+$config.Run.Path = $PSScriptRoot
+$config.Output.Verbosity = if ($CI) { 'Normal' } else { 'Detailed' }
+$config.Run.Exit = $true
+
+Invoke-Pester -Configuration $config

--- a/demos/AssuredIdentity/tests/NodeInventory.Tests.ps1
+++ b/demos/AssuredIdentity/tests/NodeInventory.Tests.ps1
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+BeforeAll {
+    $lib = Join-Path $PSScriptRoot "../lib"
+    . (Join-Path $lib "Common.ps1")
+    . (Join-Path $lib "NodeInventory.ps1")
+
+    function New-TempInventory([string]$json) {
+        $p = Join-Path ([System.IO.Path]::GetTempPath()) ("inv-{0}.json" -f ([guid]::NewGuid()))
+        $json | Set-Content -LiteralPath $p -Encoding UTF8
+        return $p
+    }
+
+    $script:ValidJson = @'
+{ "nodes": [
+  { "id": "tiny", "role": "issuer", "gateway": "http://tiny:8090", "installationName": "tiny.sorcha.dev" },
+  { "id": "n1", "role": "subscriber", "gateway": "https://n1.sorcha.dev", "installationName": "n1.sorcha.dev", "rendezvousCapable": true }
+] }
+'@
+}
+
+Describe "Get-DemoNodeInventory" {
+    It "loads a valid inventory and returns all nodes" {
+        $p = New-TempInventory $script:ValidJson
+        $nodes = Get-DemoNodeInventory -Path $p
+        $nodes.Count | Should -Be 2
+        $nodes[0].id | Should -Be "tiny"
+    }
+
+    It "throws on a missing file" {
+        { Get-DemoNodeInventory -Path "Z:\does\not\exist.json" } | Should -Throw "*not found*"
+    }
+
+    It "throws on duplicate ids" {
+        $json = '{ "nodes": [ {"id":"a","role":"issuer","gateway":"http://a","installationName":"a"}, {"id":"a","role":"subscriber","gateway":"http://b","installationName":"b"} ] }'
+        { Get-DemoNodeInventory -Path (New-TempInventory $json) } | Should -Throw "*duplicate node id*"
+    }
+
+    It "throws on a malformed gateway URL" {
+        $json = '{ "nodes": [ {"id":"a","role":"issuer","gateway":"not a url","installationName":"a"} ] }'
+        { Get-DemoNodeInventory -Path (New-TempInventory $json) } | Should -Throw "*malformed gateway*"
+    }
+
+    It "throws on a missing required field" {
+        $json = '{ "nodes": [ {"id":"a","role":"issuer","gateway":"http://a"} ] }'
+        { Get-DemoNodeInventory -Path (New-TempInventory $json) } | Should -Throw "*missing required field*installationName*"
+    }
+
+    It "throws on an invalid role" {
+        $json = '{ "nodes": [ {"id":"a","role":"banana","gateway":"http://a","installationName":"a"} ] }'
+        { Get-DemoNodeInventory -Path (New-TempInventory $json) } | Should -Throw "*invalid role*"
+    }
+}
+
+Describe "Select-DemoNode / Get-DemoNodeByRole" {
+    BeforeEach { $script:Nodes = Get-DemoNodeInventory -Path (New-TempInventory $script:ValidJson) }
+
+    It "selects by id" {
+        (Select-DemoNode -Inventory $script:Nodes -Id "n1").gateway | Should -Be "https://n1.sorcha.dev"
+    }
+
+    It "throws for an unknown id" {
+        { Select-DemoNode -Inventory $script:Nodes -Id "nope" } | Should -Throw "*not found in inventory*"
+    }
+
+    It "selects the first node of a role" {
+        (Get-DemoNodeByRole -Inventory $script:Nodes -Role 'subscriber').id | Should -Be "n1"
+    }
+}

--- a/demos/AssuredIdentity/tests/Readiness.Tests.ps1
+++ b/demos/AssuredIdentity/tests/Readiness.Tests.ps1
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot "../lib/Readiness.ps1")
+}
+
+Describe "Test-SubscriberReady" {
+    It "is Ready when all three signals are good" {
+        $v = Test-SubscriberReady -SubscriptionStatus 'Active' -SyncState 'CaughtUp' -PublishedBlueprintIds @('bp-1') -TargetBlueprintId 'bp-1'
+        $v.Ready | Should -BeTrue
+        $v.Reasons | Should -BeNullOrEmpty
+    }
+
+    It "is NotReady with blueprint-not-published when recovery is in progress" {
+        $v = Test-SubscriberReady -SubscriptionStatus 'Active' -SyncState 'CaughtUp' -PublishedBlueprintIds @() -TargetBlueprintId 'bp-1'
+        $v.Ready | Should -BeFalse
+        $v.Reasons | Should -Contain 'blueprint-not-published'
+    }
+
+    It "reports each failing signal" {
+        $v = Test-SubscriberReady -SubscriptionStatus 'Pending' -SyncState 'Syncing' -PublishedBlueprintIds @() -TargetBlueprintId 'bp-1'
+        $v.Reasons.Count | Should -Be 3
+        ($v.Reasons -join ';') | Should -BeLike "*subscription-not-active*"
+        ($v.Reasons -join ';') | Should -BeLike "*sync-state-not-caughtup*"
+    }
+}
+
+Describe "Wait-SubscriberReady" {
+    It "returns Ready immediately when signals are already good" {
+        $v = Wait-SubscriberReady -GetSubscriptionStatus { 'Active' } -GetSyncState { 'CaughtUp' } `
+            -GetPublishedBlueprintIds { @('bp-1') } -TargetBlueprintId 'bp-1' -TimeoutSeconds 5 -PollSeconds 1
+        $v.Status | Should -Be 'Ready'
+    }
+
+    It "becomes Ready once the blueprint appears (recovery window)" {
+        $script:calls = 0
+        $published = { $script:calls++; if ($script:calls -ge 3) { @('bp-1') } else { @() } }
+        $v = Wait-SubscriberReady -GetSubscriptionStatus { 'Active' } -GetSyncState { 'CaughtUp' } `
+            -GetPublishedBlueprintIds $published -TargetBlueprintId 'bp-1' -TimeoutSeconds 10 -PollSeconds 1
+        $v.Status | Should -Be 'Ready'
+        $script:calls | Should -BeGreaterOrEqual 3
+    }
+
+    It "returns NotReady with reasons on timeout (never throws)" {
+        $v = Wait-SubscriberReady -GetSubscriptionStatus { 'Active' } -GetSyncState { 'CaughtUp' } `
+            -GetPublishedBlueprintIds { @() } -TargetBlueprintId 'bp-1' -TimeoutSeconds 2 -PollSeconds 1
+        $v.Status | Should -Be 'NotReady'
+        $v.Reasons | Should -Contain 'blueprint-not-published'
+    }
+}

--- a/demos/AssuredIdentity/tests/RenameCoherence.Tests.ps1
+++ b/demos/AssuredIdentity/tests/RenameCoherence.Tests.ps1
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+# US3 / FR-005 / SC-004 — re-rendering under a new agency name leaves no prior-name residue.
+
+BeforeAll {
+    $lib = Join-Path $PSScriptRoot "../lib"
+    . (Join-Path $lib "Common.ps1")
+    . (Join-Path $lib "AgencyNaming.ps1")
+    $script:Template = '{ "p": { "organisation": "{{issuerName}}" }, "x-review": { "header": { "issuerName": "{{issuerName}}" } } }'
+}
+
+Describe "Rename coherence" {
+    It "rendering under a new name contains no trace of the old name" {
+        $first = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName "Acme Verification Co."
+        $first | Should -BeLike "*Acme Verification Co.*"
+
+        $second = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName "Glenmara Borough Registry"
+        $second | Should -BeLike "*Glenmara Borough Registry*"
+        $second | Should -Not -BeLike "*Acme*"
+    }
+
+    It "coherence holds when every site is renamed together" {
+        $name = "Glenmara Borough Registry"
+        $rendered = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName $name
+        $r = Test-AgencyNameCoherence -AgencyName $name -OrgName $name -RegisterName $name -ParticipantOrg $name -BlueprintJson $rendered
+        $r.Coherent | Should -BeTrue
+    }
+
+    It "coherence fails if any site still carries the old name" {
+        $rendered = Set-BlueprintIssuerName -BlueprintJson $script:Template -AgencyName "Glenmara Borough Registry"
+        $r = Test-AgencyNameCoherence -AgencyName "Glenmara Borough Registry" -OrgName "Acme Verification Co." `
+            -RegisterName "Glenmara Borough Registry" -ParticipantOrg "Glenmara Borough Registry" -BlueprintJson $rendered
+        $r.Coherent | Should -BeFalse
+        ($r.Mismatches -join ';') | Should -BeLike "*org name*"
+    }
+}

--- a/demos/AssuredIdentity/tests/StatusVerdict.Tests.ps1
+++ b/demos/AssuredIdentity/tests/StatusVerdict.Tests.ps1
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot "../lib/Readiness.ps1")     # Test-SubscriberReady dependency
+    . (Join-Path $PSScriptRoot "../lib/StatusVerdict.ps1")
+
+    function New-Sub([string]$id, [string]$sub, [string]$sync, [string[]]$bps) {
+        [pscustomobject]@{ NodeId = $id; SubscriptionStatus = $sub; SyncState = $sync; PublishedBlueprintIds = $bps; TargetBlueprintId = 'bp-1' }
+    }
+}
+
+Describe "Get-ReadinessVerdict" {
+    It "is Ready when issuer up, approver present, and a subscriber is fully ready" {
+        $v = Get-ReadinessVerdict -IssuerReachable $true -ApproverPresent $true -Subscribers @(New-Sub 'n1' 'Active' 'CaughtUp' @('bp-1'))
+        $v.Verdict | Should -Be 'Ready'
+        $v.Reasons | Should -BeNullOrEmpty
+    }
+
+    It "is NotReady when the issuer is unreachable" {
+        $v = Get-ReadinessVerdict -IssuerReachable $false -ApproverPresent $true -Subscribers @(New-Sub 'n1' 'Active' 'CaughtUp' @('bp-1'))
+        $v.Verdict | Should -Be 'NotReady'
+        $v.Reasons | Should -Contain 'issuer-unreachable'
+    }
+
+    It "is NotReady when the approver is absent" {
+        $v = Get-ReadinessVerdict -IssuerReachable $true -ApproverPresent $false -Subscribers @(New-Sub 'n1' 'Active' 'CaughtUp' @('bp-1'))
+        $v.Reasons | Should -Contain 'approver-absent'
+    }
+
+    It "is NotReady with no subscribers" {
+        $v = Get-ReadinessVerdict -IssuerReachable $true -ApproverPresent $true -Subscribers @()
+        $v.Reasons | Should -Contain 'no-subscribers'
+    }
+
+    It "is NotReady when no subscriber is ready, and reports per-node reasons" {
+        $v = Get-ReadinessVerdict -IssuerReachable $true -ApproverPresent $true -Subscribers @(New-Sub 'n1' 'Active' 'CaughtUp' @())
+        $v.Verdict | Should -Be 'NotReady'
+        $v.Reasons | Should -Contain 'no-subscriber-ready'
+        $v.PerNode[0].Reasons | Should -Contain 'blueprint-not-published'
+    }
+
+    It "is Ready if at least one of several subscribers is ready" {
+        $v = Get-ReadinessVerdict -IssuerReachable $true -ApproverPresent $true -Subscribers @(
+            (New-Sub 'n1' 'Active' 'CaughtUp' @()),
+            (New-Sub 'n2' 'Active' 'CaughtUp' @('bp-1'))
+        )
+        $v.Verdict | Should -Be 'Ready'
+    }
+}

--- a/docs/superpowers/specs/2026-05-30-assured-identity-demo-environment-design.md
+++ b/docs/superpowers/specs/2026-05-30-assured-identity-demo-environment-design.md
@@ -1,8 +1,10 @@
-# Assured Identity Demo Environment — design note (READY TO RESUME)
+# Assured Identity Demo Environment — design note (RESOLVED → SUPERSEDED)
 
-- **Status:** 🟢 READY TO RESUME — the blocking trigger is **MET**. The reverse data
-  plane works and the full loop is proven E2E. (Was: ⏸️ PARKED, 2026-05-30.)
-- **Date:** 2026-05-30 (parked) · 2026-05-31 (unblocked)
+- **Status:** ✅ RESOLVED — brainstorm resumed and completed 2026-05-31. The open
+  questions below are answered in the approved design:
+  **`docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md`**.
+  (Was: ⏸️ PARKED 2026-05-30 → 🟢 READY 2026-05-31 → ✅ RESOLVED.)
+- **Date:** 2026-05-30 (parked) · 2026-05-31 (unblocked + resolved)
 - **WAS BLOCKED ON:** Peer-service **reverse data plane** (a NAT'd owner node must be
   reachable by public subscribers) — **now delivered as Feature 143** (merged #879;
   cross-installation hardening + fixes #880/#881/#883/#884/#885, regression tests #886).

--- a/docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md
+++ b/docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md
@@ -1,0 +1,153 @@
+# Assured Identity Demo Environment — design
+
+- **Status:** ✅ APPROVED — ready for implementation planning (`writing-plans`).
+- **Date:** 2026-05-31
+- **Supersedes the open questions in:** `docs/superpowers/specs/2026-05-30-assured-identity-demo-environment-design.md` (the parked note — now resolved; see its header).
+- **Builds on (proven, live):** Feature 143 reverse-stream rendezvous (#879) + cross-installation hardening (#880/#881/#883/#884/#885, tests #886); F137 cross-node credential delivery; F142 Designer amend loop; F124/F126/F128 citizen onboarding surfaces; `sorcha-agent` rules/ai engines.
+
+---
+
+## 1. What this is (and isn't)
+
+A **standing, node-agnostic demo environment** plus a **self-service provisioning toolkit**, layered on the already-proven F143 cross-installation Assured Identity loop. A tester goes — **unscripted, through the real product UIs** — from anonymous sign-up → submitted application → approval by an identity-validator agent → an Assured Identity credential in their Citizen Wallet PWA.
+
+It is **not** a new product surface. The only things built are a thin **operability layer**: coherent provisioning, readiness gating, agent-mode selection, reset, status, and a node inventory. Everything the *tester* touches is the real product.
+
+### Core concept: a demo is a mature walkthrough
+
+- A **walkthrough** is a scripted, dev-facing validation of a flow (programmatic actors, hardcoded identities, `setup.ps1` + `run-*.ps1`). It proves a path works.
+- A **demo** is a walkthrough that has *graduated*: coherent and complete in its own right, node-agnostic, operable by parameter, and exercised by a human through real UIs rather than by a script driving API calls.
+- The Assured Identity flow has reached that bar. It therefore **moves from `walkthroughs/AssuredIdentity/` to a first-class demo**, and the legacy scripts are retired (§7). Henceforth "the Assured Identity walkthrough" refers to **this demo**.
+
+---
+
+## 2. Decisions (resolved open questions)
+
+| Question | Decision |
+|---|---|
+| **Agent decision mode** | **Operator-selectable per run**, default `rules`. `New-IssuingAuthority -AgentMode rules\|ai\|human`. |
+| **Tester journey** | **Real UIs, no scaffolding.** Web SPA `/new-submissions` to apply; real F128 onboarding + Citizen Wallet PWA to receive. No concierge, no automation of tester clicks. |
+| **Provisioning / rebrand coherence** | **Parameterised command with sensible defaults**; `-AgencyName` is the single source written into org + register + published-participant + blueprint `x-review.header.issuerName`. Deep customisation via the real **F142 Designer amend loop**. |
+| **Operational readiness** | **Provisioning gates on readiness** — the subscriber-side step polls subscription `Active` + blueprint recovery green before declaring ready, so the tester never hits transient `blueprint_not_available`. Plus `Get-DemoStatus`. |
+| **Topology** *(already resolved 2026-05-31)* | Two+ separate installations; NAT'd issuer/owner dials a public rendezvous; trust boundary = the register (wallet sigs + roster), not JWT. |
+
+---
+
+## 3. Node-agnostic configuration & multi-node
+
+Nothing hardcodes `tiny`/`n1`. The toolkit reads a small **node inventory** — one entry per installation:
+
+```jsonc
+// demo-nodes.json (gitignored; secrets stay in deploy/keys.env)
+{
+  "nodes": [
+    { "id": "tiny", "role": "issuer",     "gateway": "http://tiny:8090",
+      "installationName": "tiny.sorcha.dev", "rendezvousCapable": false },
+    { "id": "n1",   "role": "subscriber", "gateway": "https://n1.sorcha.dev",
+      "installationName": "n1.sorcha.dev",  "rendezvousCapable": true }
+  ]
+}
+```
+
+- **Swap / rename installations** by editing the inventory — `tiny`/`n1` are defaults, not assumptions. `-IssuerNode` / `-SubscriberNode` select inventory entries by `id`.
+- **Additional independent nodes** can subscribe to and host/replicate the advertised register: `Connect-Subscriber -SubscriberNode <id>` is repeatable across N public nodes (F143 already models the subscriber as initiator; the rendezvous is a per-node capability, not a singleton). Each added subscriber gets its own readiness gate.
+- The issuer need not be the NAT'd node in every deployment — `rendezvousCapable` + role drive whether a node dials out or accepts reverse streams. The proven default is NAT'd-issuer/public-subscriber, but the inventory does not bake that in.
+- **Trust stays register-scoped.** Each installation keeps its own genesis + JWT signing key (`deploy/keys.env`); a new node joins by subscribing to the advertised register and verifying against its embedded validator roster (F086), never by sharing JWT keys.
+
+---
+
+## 4. Provisioning toolkit (the backbone)
+
+Promote the gitignored `deploy/twoinstall-issuer.ps1` + `deploy/twoinstall-citizen-n1.ps1` into a coherent, parameterised, **idempotent** module under the demo (new home `demos/AssuredIdentity/` — §7). Four commands:
+
+### `New-IssuingAuthority` — runs against the issuer node
+- Sensible zero-arg defaults (a complete default-named authority stands up clean).
+- Params: `-AgencyName` (single source of the agency identity), `-IssuerNode`, `-AgentMode rules|ai|human`.
+- `-AgencyName` flows into: org name, register name, published-participant org name, and the blueprint's `x-review.header.issuerName` (template-injected at publish — §5). The credential-issuer DID stays valid across renames because it derives from the wallet address, which is unchanged.
+- **Idempotent:** detects + reuses an existing org / wallet / advertised register / published blueprint. Handles the known reuse footgun — the walkthrough's "register already exists" check reads `OrganizationRegisterSubscriptions`; a stale row pointing at a Mongo-absent register must be reconciled (reuse or clean), not blindly reused.
+- Provisions the analyst (Tier-3 Consumer) + wallet + published participant, exactly as the proven `twoinstall-issuer.ps1` does today, but parameterised.
+- Wires the agent (§5).
+
+### `Connect-Subscriber` — runs against a subscriber node
+- Subscribes the subscriber's public org to the issuer's advertised register.
+- **Gates on readiness:** polls until the subscription is `Active` **and** blueprint recovery is green (the ≤60s window) before returning "ready". Absorbs the transient `blueprint_not_available` so a tester arriving afterwards never sees it.
+- Repeatable across multiple subscriber nodes (§3).
+
+### `Reset-Demo`
+- The documented clean reset: walkthrough Wallets (issuer + analyst + citizen), non-system Mongo register DBs, `OrganizationRegisterSubscriptions` rows, `state.json`. Per-node aware (reset issuer, a subscriber, or both).
+
+### `Get-DemoStatus`
+- Cross-node health: container health, subscription state, blueprint-recovery state, agent running/ idle, last sealed docket. One glance answers "is the demo ready for a tester right now?"
+
+---
+
+## 5. Agent mode + template injection
+
+### Agent (operator-selectable, default `rules`)
+`New-IssuingAuthority` generates the `sorcha-agent` analyst actor config and acts on `-AgentMode`:
+- **`rules`** (default) — JSON Logic auto-approve `actor.json`; command launches `sorcha-agent run`. Deterministic; a live demo never stalls.
+- **`ai`** — `"mode":"ai"` + persona file + `ANTHROPIC_API_KEY`. The showcase ("the assessor read your application and decided"). Same launch path.
+- **`human`** — no agent launched; command prints "log into the issuer node as the analyst and approve Action 2" instructions.
+
+Actor templates (rules + ai persona) ship with the demo; the analyst wallet/register/org IDs are substituted from provisioning `state.json` via the agent's existing `{{placeholder}}` resolution.
+
+### Blueprint template injection
+The blueprint template (migrated from `walkthroughs/AssuredIdentity/blueprints/assured-identity.json`) carries an `x-review.header.issuerName` token that `New-IssuingAuthority` replaces with `-AgencyName` at publish. The action-1 `sorcha-holder-key` field (F137) stays — it auto-populates read-only in the real form for cnf-bound cross-node delivery.
+
+---
+
+## 6. Tester journey (real UIs, no scaffolding) — documented, not built
+
+1. **Sign up** on the subscriber web app (real auth, public org).
+2. **Onboard a device:** real F128 cold-start surfaces nudge → `/setup/add-device` → enrol on the Citizen Wallet PWA. This gives the citizen a holder key + `CitizenHolderIndex` row so the credential can route back.
+3. **Apply:** web app → **`/new-submissions`** → the agency's service appears (the node is subscribed) → **Start** → fill Action 1 (`sorcha-holder-key` auto-populated) → submit. `POST /api/instances` (policy `CanExecuteBlueprints` = any authenticated user) creates the instance; Action 1 is brokered cross-node to the issuer over the reverse stream (async, #885).
+4. **Approve:** the agent (`rules`/`ai`) or a human approves Action 2 on the issuer node.
+5. **Receive:** credential delivered cross-node → F124 pending-application waiting card → first-credential takeover in the PWA.
+
+**Verified off-path (not used, not built):** the PWA `/applications` page is a "coming soon" placeholder (in-flight display only), and the `samples/strathcarron-portal` Blue Badge / Driving-Licence pages are non-functional stubs awaiting an unlanded backend PR. The web SPA `/new-submissions` is the working entry; the demo uses it and the spec records the other two as explicitly out of scope.
+
+---
+
+## 7. Graduation & cleanup (walkthrough → demo)
+
+Once the demo is **tested working end-to-end** on the default node pair:
+
+- **New home:** `demos/AssuredIdentity/` — provisioning module, `demo-nodes.json` example, agent actor templates, blueprint template, `DEMO.md` runbook.
+- **Retire the legacy scripts:** remove `walkthroughs/AssuredIdentity/` (`setup.ps1`, `run-phase1-identity.ps1`, `run-phase2-licence.ps1`, `run-agents.ps1`, `run-crossnode-*.ps1`, `run-multi-peer.ps1`, scratch logs/state) and the `deploy/twoinstall-*.ps1` + `twoinstall-*state.json` scratch. The reusable `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1` helpers stay (shared infra) — the demo module imports them.
+- **Sequencing:** cleanup is a **distinct, final phase**, gated on a green demo run. Do not delete the legacy path before the demo replaces it.
+
+### Skills + memory alignment (concept: "a demo is a mature walkthrough")
+- **`walkthrough-builder` skill** — add the demo concept: when a walkthrough graduates (coherent, node-agnostic, human-operable via real UIs), it becomes a demo under `demos/`; scripted actor walkthroughs remain the dev-facing tool. Cross-reference the demo location.
+- **`n1-deploy` / `network-bootstrap` skills** — point the Assured Identity references at `demos/AssuredIdentity/` and the node-inventory model.
+- **`sorcha-architecture` skill** — under the F143 section, note the demo as the operable surface over the proven loop.
+- **CLAUDE.md** — if a demos/ taxonomy line is warranted, add it (brief).
+- **Memory** — update `f143-two-installation-demo.md` + `MEMORY.md` so "Assured Identity walkthrough" resolves to the demo, and record the node-agnostic + graduation concept.
+
+---
+
+## 8. Deliverables
+
+1. Provisioning module — `New-IssuingAuthority`, `Connect-Subscriber`, `Reset-Demo`, `Get-DemoStatus` (idempotent, node-inventory-driven, readiness-gating).
+2. `demo-nodes.json` example + inventory loader; `deploy/keys.env` stays the secret store.
+3. `sorcha-agent` actor templates (rules + ai persona) with placeholder substitution.
+4. Parameterised blueprint template with `x-review.header.issuerName` injection.
+5. `DEMO.md` — operator runbook (provision/connect/reset/status, agent modes, multi-node) + tester runbook (the §6 journey).
+6. Skill + memory updates (§7).
+7. Cleanup phase: retire legacy walkthrough + scratch scripts after a green run.
+
+---
+
+## 9. Deliberately NOT building (YAGNI)
+
+- No concierge / demo-specific UI; no automation of tester clicks.
+- No product hardening of instance-creation (readiness gating in provisioning is sufficient).
+- No completing the PWA `/applications` apply page or the `strathcarron-portal` stubs — deferred / off-path.
+- No anchor-set gossip / multi-hop mesh (F143 deferred scope) — multi-node here is N subscribers against one advertised register, not a relayed mesh.
+
+---
+
+## 10. Open risks / to confirm during planning
+
+- **Multi-subscriber** beyond the proven single n1 subscriber is designed-for but not yet live-verified across 3+ nodes — first multi-node run is a validation checkpoint, not an assumption.
+- **`ai` agent mode** in a live demo needs a guardrail (timeout / fallback to rules) so a slow or refusing LLM doesn't strand a tester mid-flow — confirm the agent's failure behaviour during planning.
+- **Idempotency edges** on re-provision (the `OrganizationRegisterSubscriptions` vs Mongo reconciliation) need explicit test coverage — the live-state notes show this footgun bit before.

--- a/specs/144-assured-identity-demo/checklists/requirements.md
+++ b/specs/144-assured-identity-demo/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Assured Identity Demo Environment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Validation run 2026-05-31: all items pass. The big decisions (agent mode, tester journey, rebrand coherence, readiness, topology) were resolved in the approved design note `docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md`, so no [NEEDS CLARIFICATION] markers were needed; residual choices (exact demo path, AI-mode bound/fallback) are captured as Assumptions and deferred to planning.
+- Spec deliberately keeps requirements outcome-focused (operations described by intent, not cmdlet/endpoint names) because this is a tooling/demo-environment feature where some operational vocabulary is unavoidable; concrete command/endpoint shapes belong in the plan.

--- a/specs/144-assured-identity-demo/contracts/commands.md
+++ b/specs/144-assured-identity-demo/contracts/commands.md
@@ -1,0 +1,86 @@
+# Command Contracts: Assured Identity Demo Toolkit
+
+The toolkit exports four PowerShell commands from `demos/AssuredIdentity/AssuredIdentityDemo.psm1`. Each contract gives parameters, behaviour, success output, idempotency, and exit/return semantics. Commands consume **existing** Sorcha HTTP endpoints (see plan §"Grounded integration signals") and the existing `sorcha-agent` CLI; they add no endpoints.
+
+Common: all commands take `-NodesFile` (default `./demo-nodes.json`) and `-StateFile` (default `./state.json`); honour `$ErrorActionPreference='Stop'`; emit `Write-Wt*` progress; never print secrets.
+
+---
+
+## `New-IssuingAuthority` (issuer node) — FR-001/002/003/005, FR-010/011/012/013
+
+**Parameters**
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `-IssuerNode` | string | first inventory entry with `role=issuer` | inventory `id`. |
+| `-AgencyName` | string | `"Strathcarron Identity Authority"` | single source of agency identity (FR-002). |
+| `-AgentMode` | `rules`\|`ai`\|`human` | `rules` | approval mechanism (FR-010). |
+| `-Force` | switch | off | bypass reuse and recreate (still reconciles stale state). |
+
+**Behaviour**
+1. Load + validate inventory; resolve issuer node + sysadmin creds (from `deploy/keys.env`).
+2. **Idempotency probe** (FR-003, R5): look for existing org / advertised register / published blueprint; reconcile a stale subscription-vs-missing-register desync. Reuse unless `-Force`.
+3. Provision (or reuse): enable public org, create/verify verification-admin (Tier-2) + analyst (Tier-3) + wallets + participants, create advertised **DevMode** register, publish analyst participant.
+4. **Publish blueprint** from `blueprints/assured-identity.template.json` with `{{issuerName}}` ← `-AgencyName` and analyst wallet mapped.
+5. **Agent** (FR-011): render `analyst.<mode>.json` from template (`{{...}}` ← state); `rules`/`ai` → launch `sorcha-agent run` (ai checks `ANTHROPIC_API_KEY`, sets the decision-wait guardrail per R6); `human` → print approval instructions.
+6. Write/merge `state.json`.
+
+**Success output**: a summary object `{ issuerNode, agencyName, organizationId, registerId, blueprintId, agentMode, agentRunning }`.
+
+**Exit/return**: throws (non-zero) on unrecoverable error; returns the summary on success. Idempotent re-run with same args → same IDs, no duplicates (SC-003).
+
+---
+
+## `Connect-Subscriber` (subscriber node) — FR-004/008, readiness gate R4
+
+**Parameters**
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `-SubscriberNode` | string | first inventory entry with `role=subscriber` | inventory `id`. |
+| `-RegisterId` | string | `state.json.registerId` | the advertised register to subscribe to. |
+| `-TimeoutSeconds` | int | 120 | readiness poll cap (> observed ≤60s recovery window). |
+
+**Behaviour**
+1. Resolve subscriber node + its public org + sysadmin creds.
+2. Discover the advertised register on the issuer and `POST /api/organizations/{orgId}/register-subscriptions` (idempotent: reuse an `Active` subscription; reconcile a stale one).
+3. **Readiness gate** — poll until ALL hold or timeout: subscription `Active` ∧ `sync-state == CaughtUp` ∧ target blueprint present in `/blueprints/published`. Bounded backoff.
+4. Append/update the `subscribers[]` entry in `state.json` with `status` + `lastReadyAt`.
+
+**Success output**: `{ subscriberNode, orgId, subscriptionId, status: Ready|NotReady, reasons[] }`.
+
+**Exit/return**: success only when the gate reports `Ready`; on timeout returns `NotReady` with `reasons[]` (e.g. `recovery-in-progress`) — a soft, retryable outcome, not a crash. Repeatable across N subscribers (FR-008).
+
+---
+
+## `Reset-Demo` — FR-017
+
+**Parameters**
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `-Scope` | `issuer`\|`subscriber`\|`all` | `all` | what to reset. |
+| `-Node` | string | — | required when scope=subscriber (which one). |
+| `-Confirm` | switch | on | destructive; require explicit confirmation. |
+
+**Behaviour**: return the target to a clean pre-provision state per the documented reset recipe — issuer: demo wallets, non-system register Mongo DB(s), `state.json`; subscriber: its `OrganizationRegisterSubscriptions` rows for the demo register, replicated register state, its `subscribers[]` entry. Stop any tracked `sorcha-agent` process. Idempotent (resetting an already-clean node is a no-op success).
+
+**Success output**: `{ scope, node, removed[] }`.
+
+**Exit/return**: throws on partial failure with a clear list of what was/wasn't cleaned.
+
+---
+
+## `Get-DemoStatus` — FR-018, SC-007
+
+**Parameters**
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `-Verbose` | switch | off | per-signal detail. |
+
+**Behaviour**: for the issuer and every `subscribers[]` entry, gather: container/service reachability (gateway health), subscription status, `sync-state`, blueprint-published presence, and approver state (tracked process alive / human-acknowledged). Compute the Readiness Verdict (data-model "Derived").
+
+**Success output**: a table + an overall `{ verdict: Ready|NotReady, perNode[], reasons[] }`. The verdict MUST match actual tester success (SC-007).
+
+**Exit/return**: always returns the verdict object (querying is non-destructive); non-zero exit only on inability to read the inventory/state.

--- a/specs/144-assured-identity-demo/contracts/demo-nodes.schema.json
+++ b/specs/144-assured-identity-demo/contracts/demo-nodes.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sorcha.dev/schemas/demo/demo-nodes.schema.json",
+  "title": "Assured Identity Demo — node inventory",
+  "description": "Installations participating in the demo. Gitignored in practice; demo-nodes.example.json documents it. Contains NO secrets — credentials live in deploy/keys.env.",
+  "type": "object",
+  "required": ["nodes"],
+  "additionalProperties": false,
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/node" }
+    }
+  },
+  "$defs": {
+    "node": {
+      "type": "object",
+      "required": ["id", "role", "gateway", "installationName"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$",
+          "description": "Stable handle used by -IssuerNode/-SubscriberNode. Unique within the inventory."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["issuer", "subscriber"],
+          "description": "Default/expected role; a node may be re-selected at run time."
+        },
+        "gateway": {
+          "type": "string",
+          "format": "uri",
+          "description": "API gateway base URL the toolkit calls."
+        },
+        "installationName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The installation's JWT InstallationName. Documents the trust boundary."
+        },
+        "rendezvousCapable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this node accepts inbound reverse streams (public/rendezvous)."
+        },
+        "adminEmail": {
+          "type": "string",
+          "format": "email",
+          "default": "admin@sorcha.local",
+          "description": "Sysadmin login on this node. Password comes from deploy/keys.env, never here."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "nodes": [
+        { "id": "tiny", "role": "issuer", "gateway": "http://tiny:8090", "installationName": "tiny.sorcha.dev", "rendezvousCapable": false },
+        { "id": "n1", "role": "subscriber", "gateway": "https://n1.sorcha.dev", "installationName": "n1.sorcha.dev", "rendezvousCapable": true }
+      ]
+    }
+  ]
+}

--- a/specs/144-assured-identity-demo/contracts/demo-state.schema.json
+++ b/specs/144-assured-identity-demo/contracts/demo-state.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sorcha.dev/schemas/demo/demo-state.schema.json",
+  "title": "Assured Identity Demo — per-run state record",
+  "description": "Records provisioned artefacts so re-provision is idempotent and reset is deterministic. Gitignored. No secrets.",
+  "type": "object",
+  "required": ["schemaVersion", "issuerNodeId", "agencyName", "organizationId", "registerId"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "type": "integer", "minimum": 1 },
+    "issuerNodeId": { "type": "string", "description": "Inventory id used as issuer." },
+    "agencyName": { "type": "string", "description": "Single-source agency identity." },
+    "organizationId": { "type": "string", "description": "Issuer org id." },
+    "issuerWalletAddress": { "type": "string", "description": "Stable identity anchor (keeps credential-issuer DID valid across renames)." },
+    "analystEmail": { "type": "string", "format": "email" },
+    "analystWallet": { "type": "string" },
+    "registerId": { "type": "string", "description": "Advertised register id (32-char hex)." },
+    "blueprintId": { "type": "string", "description": "Published blueprint id (carries the injected issuerName)." },
+    "agentMode": { "type": "string", "enum": ["rules", "ai", "human"] },
+    "subscribers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["nodeId", "orgId", "status"],
+        "additionalProperties": false,
+        "properties": {
+          "nodeId": { "type": "string" },
+          "orgId": { "type": "string" },
+          "subscriptionId": { "type": "string" },
+          "status": { "type": "string", "enum": ["Ready", "NotReady", "Active", "Pending"] },
+          "lastReadyAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "provisionedAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/specs/144-assured-identity-demo/data-model.md
+++ b/specs/144-assured-identity-demo/data-model.md
@@ -1,0 +1,101 @@
+# Phase 1 Data Model: Assured Identity Demo Environment
+
+This feature stores no database state. Its "data model" is a small set of **config + state files** the toolkit reads and writes, plus the conceptual entities they represent. All files are JSON; secrets are never among them.
+
+---
+
+## Entity 1 — Installation (node inventory entry)
+
+A participating node. Collection lives in `demo-nodes.json` (gitignored; `demo-nodes.example.json` committed).
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | string | yes | Stable handle used by `-IssuerNode` / `-SubscriberNode` (e.g. `tiny`, `n1`). Unique within the inventory. |
+| `role` | enum `issuer` \| `subscriber` | yes | Default/expected role. A node may be re-selected into either role at run time; this records the inventory's intent. |
+| `gateway` | string (URL) | yes | API gateway base URL the toolkit calls (e.g. `http://tiny:8090`, `https://n1.sorcha.dev`). |
+| `installationName` | string | yes | The installation's JWT `InstallationName` (e.g. `tiny.sorcha.dev`). Documents the trust boundary; toolkit does not mint tokens with it. |
+| `rendezvousCapable` | bool | no (default false) | Whether this node accepts inbound reverse streams (public/rendezvous). Drives expectations, not behaviour. |
+| `adminEmail` | string | no | Operator's sysadmin login on this node (password from `deploy/keys.env`, never here). Defaults to the seeded `admin@sorcha.local`. |
+
+**Validation**: unique `id`; `gateway` a well-formed URL; at least one `issuer` and one `subscriber` reachable for a full demo. Loader fails fast with a clear message on duplicate id / malformed URL / missing required field.
+
+---
+
+## Entity 2 — Issuing Authority
+
+The provisioned identity-assurance organisation. Not a file of its own — its identity is the `-AgencyName` value, and its concrete artefacts are recorded in the Demo State Record. Conceptual fields:
+
+| Field | Source | Coherence rule |
+|---|---|---|
+| `agencyName` | `-AgencyName` (single source) | MUST equal the org name, register name, published-participant org name, and blueprint `x-review.header.issuerName`. |
+| `organizationId` | created/reused on issuer node | one per agency name on a node. |
+| `issuerWalletAddress` | created/reused | stable across renames → keeps the credential-issuer DID valid. |
+| `analyst` | created/reused | Tier-3 Consumer user + wallet + published participant; the identity the approval agent acts as. |
+| `registerId` | created/reused (advertised, DevMode) | the advertised register subscribers replicate. |
+| `blueprintId` | published from template | carries the injected `issuerName`. |
+
+**State (provision lifecycle)**: `Absent → Provisioning → Provisioned`. Idempotent re-provision: `Provisioned → (probe) → Reused` or `Provisioned → (rename) → Reprovisioned`. Reset: `Provisioned → Absent`.
+
+---
+
+## Entity 3 — Approval Agent Configuration
+
+The chosen approval mechanism for a run. Rendered from a tokenised template into a working actor config (gitignored, written next to `state.json`).
+
+| Field | Type | Notes |
+|---|---|---|
+| `mode` | enum `rules` \| `ai` \| `human` | from `-AgentMode`; default `rules`. |
+| `actsAs` | analyst identity | wallet address + org + register, substituted from `state.json`. |
+| `renderedConfigPath` | path | the materialised `analyst.<mode>.json` (for `rules`/`ai`). |
+| `process` | tracked child (rules/ai) | launched `sorcha-agent run`; absent for `human`. |
+| `aiGuardrail` | object (ai only) | `{ decisionWaitSeconds: 90, onTimeout: "surface-status" }`. |
+
+**State**: `Unconfigured → Rendered → Running` (rules/ai) or `Unconfigured → InstructionsPrinted` (human). For `ai`: `Running → DecisionPending → (Decided | TimedOut→status-surfaced)`.
+
+---
+
+## Entity 4 — Demo State Record (`state.json`)
+
+Per-run record of provisioned artefacts, enabling idempotency and reset. Written by `New-IssuingAuthority`/`Connect-Subscriber`, read by all four commands.
+
+| Field | Type | Notes |
+|---|---|---|
+| `schemaVersion` | int | bump on shape change. |
+| `issuerNodeId` | string | inventory id used as issuer. |
+| `agencyName` | string | the single-source name. |
+| `organizationId` | string | issuer org. |
+| `issuerWalletAddress` | string | stable identity anchor. |
+| `analystEmail` / `analystWallet` | string | approval-agent identity. |
+| `registerId` | string | advertised register. |
+| `blueprintId` | string | published blueprint. |
+| `agentMode` | enum | last selected mode. |
+| `subscribers` | array | one entry per connected subscriber: `{ nodeId, orgId, subscriptionId, status, lastReadyAt }`. |
+| `provisionedAt` / `updatedAt` | iso8601 | audit. |
+
+**Validation**: a present `state.json` whose `registerId` cannot be read on the issuer node marks the record **stale** → triggers R5 reconciliation rather than blind reuse.
+
+---
+
+## Derived: Readiness Verdict (computed, not stored)
+
+`Get-DemoStatus` and `Connect-Subscriber`'s gate compute a verdict per (subscriber, register):
+
+| Input signal | Source | Ready value |
+|---|---|---|
+| subscription | `GET /api/organizations/{orgId}/register-subscriptions/{registerId}` | `Active` |
+| replication | `GET /api/registers/{id}/sync-state` | `CaughtUp` |
+| service availability | `GET /api/registers/{id}/blueprints/published` | target blueprint present |
+| approver (issuer) | tracked process / instructions | `rules`/`ai` running, or `human` acknowledged |
+
+**Verdict** = `Ready` iff all subscriber signals true on at least one subscriber AND issuer reachable AND approver present; else `NotReady(reasonList)`. SC-007 requires this verdict to predict tester success in 100% of acceptance checks.
+
+---
+
+## File inventory (all gitignored except `*.example.json` / templates)
+
+| File | Written by | Read by | Secret? |
+|---|---|---|---|
+| `demo-nodes.json` | operator (from example) | all commands | no (secrets in `deploy/keys.env`) |
+| `deploy/keys.env` | operator (existing) | all commands | yes — never committed |
+| `state.json` | provision/connect | all commands | no |
+| `analyst.<mode>.json` (rendered) | `New-IssuingAuthority` | `sorcha-agent` | no (key via `ANTHROPIC_API_KEY` env) |

--- a/specs/144-assured-identity-demo/plan.md
+++ b/specs/144-assured-identity-demo/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Assured Identity Demo Environment
+
+**Branch**: `144-assured-identity-demo` | **Date**: 2026-05-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/144-assured-identity-demo/spec.md`
+**Design note**: `docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md`
+
+## Summary
+
+Build the **operability layer** that turns the already-proven cross-installation Assured Identity loop into a standing, node-agnostic demo. The deliverable is a **PowerShell provisioning toolkit** (four operations: provision an issuing authority, connect a subscriber, reset, status), driven by a **node inventory** file, that orchestrates *existing* Sorcha HTTP endpoints and the *existing* `sorcha-agent` CLI — plus parameterised agent + blueprint config templates, an operator/tester runbook, skill + memory alignment, and a final cleanup that retires the legacy walkthrough. **No new .NET service code and no new tester UI**; the tester journey runs entirely on existing product surfaces (`/new-submissions`, F128 onboarding, the Citizen Wallet PWA).
+
+Technical approach in one line: a node-inventory-driven PowerShell module that wraps the proven `deploy/twoinstall-*.ps1` flows into idempotent, readiness-gated, parameterised commands, with pure-logic units (inventory parse, name injection, readiness predicate, idempotency reconciliation) covered by Pester and the integrated flow proven by a live green run.
+
+## Technical Context
+
+**Language/Version**: PowerShell 7+ (provisioning toolkit + tests). Config artefacts are JSON. Consumes existing .NET 10 services over HTTP and the existing `Sorcha.Agent` .NET CLI as a child process.
+**Primary Dependencies**: existing `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1` helpers (reused, not rebuilt); `sorcha-agent` CLI (existing, `rules`/`ai` engines); a running Sorcha platform per installation (gateway, tenant, register, blueprint, wallet, peer services). No new NuGet/package dependencies.
+**Storage**: gitignored config + state files only — `demo-nodes.json` (inventory), `deploy/keys.env` (secrets, existing), per-run `state.json` (provisioned artefact IDs for idempotency/reset). No database, no migrations.
+**Testing**: Pester for pure-logic units (inventory loader, agency-name injection, readiness predicate, idempotency reconciliation, status verdict). E2E "green run" on the default node pair (`tiny` issuer / `n1` subscriber) for the integrated flow (SC-001/002/003/005/006/007). No xUnit (no .NET code added).
+**Target Platform**: cross-platform PowerShell — operator runs on Windows/macOS/Linux dev box; installations are Linux Docker hosts reached over HTTP(S) via the gateway.
+**Project Type**: tooling / demo toolkit (scripts + config + docs alongside the repo). Not single/web/mobile.
+**Performance Goals**: demo to "ready" (issuer + 1 subscriber) ≤10 min (SC-001); tester loop ≤5 min with zero transient "service unavailable" (SC-002); readiness gate absorbs the ≤60s blueprint-recovery window; default deterministic approval completes fast enough not to stall a live demo (FR-013).
+**Constraints**: idempotent re-provision (FR-003); node-agnostic config (FR-006); no shared JWT signing keys across installations (FR-009); no new tester UI (FR-016); secrets never committed (Constitution II); graduation cleanup gated on a green run (FR-021).
+**Scale/Scope**: 2+ installations; 1 issuer + N independent subscribers of one advertised register; single concurrent tester assumption for reset.
+
+### Grounded integration signals (resolved during planning)
+
+| Concern | Signal (existing endpoint) | Ready value |
+|---|---|---|
+| Subscribe org to advertised register | `POST /api/organizations/{orgId}/register-subscriptions` (`RequireAdministrator` + `RequirePlatformAudience`); `GET /api/organizations/{orgId}/register-subscriptions/{registerId}` | `status == Active` |
+| Replication caught up | `GET /api/registers/{id}/sync-state` (F108) | `state == CaughtUp` |
+| Local relationship | `GET /api/registers/{id}/local-relationship` (F108) | `isSubscriber == true` |
+| Service available to citizens (absorbs ≤60s recovery) | `GET /api/registers/{id}/blueprints/published` (anonymous) | target blueprint present in `blueprints[]` |
+| Instance-create failure when not yet recovered | `POST /api/instances` (`CanExecuteBlueprints`) | `409 blueprint_not_available` (the error the readiness gate exists to prevent the tester seeing) |
+
+**Connect-Subscriber readiness predicate** = subscription `Active` **AND** sync-state `CaughtUp` **AND** target blueprint present in `/blueprints/published`.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+This feature adds **no .NET service code**, so several constitution gates are scope-N/A rather than violated. Assessment:
+
+| Principle | Applies? | Compliance |
+|---|---|---|
+| I. Microservices-First | N/A | No new service; toolkit composes existing services over HTTP, no new coupling. |
+| II. Security First | **Yes** | Secrets stay in gitignored `deploy/keys.env`; **each installation keeps its own JWT signing key — never shared** (FR-009); trust boundary is the register (wallet sigs + roster). Inventory + state files carry no secrets. ✅ |
+| III. API Documentation | N/A | No new APIs. Toolkit consumes existing OpenAPI surfaces. |
+| IV. Testing Requirements | **Adapted** | 80%+ xUnit coverage targets a .NET core lib — none added here. Proportionate equivalent: Pester unit tests for all pure-logic units + a live E2E green run as the integration gate. Deterministic units; the E2E is environment-dependent by nature. ✅ |
+| V. Code Quality | **Adapted** | PowerShell, not C#. Follows existing `SorchaWalkthrough` module conventions (Write-Wt* helpers, `$ErrorActionPreference='Stop'`, SPDX header). ✅ |
+| VI. Blueprint Standards | **Yes** | Blueprint stays a JSON template (`assured-identity.json`); agency name injected via token substitution at publish, not C#. ✅ |
+| VII. Domain-Driven Design | **Yes** | Docs + commands use ubiquitous language (Blueprint, Action, Participant, Publish, Register, Disclosure). ✅ |
+| VIII. Observability | **Adapted** | Toolkit is not a service. Operational visibility delivered by `Get-DemoStatus`; the launched `sorcha-agent` already writes a JSONL audit trail. No new OTel surface required. ✅ |
+
+**Verdict**: PASS. No violations requiring Complexity Tracking. The single deliberate deviation — PowerShell tooling instead of a .NET service — is inherent to "an operability layer over proven transport" and is the simplest thing that delivers the feature (it promotes scripts that already work). Building this as a .NET service would be unjustified complexity.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/144-assured-identity-demo/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (entities + file schemas + state machines)
+├── quickstart.md        # Phase 1 output (operator + tester runbook seed)
+├── contracts/           # Phase 1 output (command + file-format contracts)
+│   ├── commands.md          # The 4 command contracts (params, behaviour, outputs, exit codes)
+│   ├── demo-nodes.schema.json   # Node inventory JSON schema
+│   └── demo-state.schema.json   # Per-run state.json schema
+└── checklists/
+    └── requirements.md  # Spec quality checklist (already passing)
+```
+
+### Source Code (repository root)
+
+```text
+demos/AssuredIdentity/                       # NEW first-class demo home (FR-019)
+├── DEMO.md                                  # Operator + tester runbook (FR-020)
+├── demo-nodes.example.json                  # Inventory template (real one gitignored)
+├── AssuredIdentityDemo.psm1                 # The toolkit module — 4 exported commands
+│   #   New-IssuingAuthority, Connect-Subscriber, Reset-Demo, Get-DemoStatus
+├── lib/                                      # Internal (non-exported) helpers
+│   ├── NodeInventory.ps1                     # Load/validate inventory, select by id
+│   ├── AgencyNaming.ps1                      # Single-source agency-name injection
+│   ├── Readiness.ps1                         # Readiness predicate (subscribe∧caughtup∧published)
+│   ├── Idempotency.ps1                       # Detect/reuse + stale-subscription reconcile
+│   └── AgentLaunch.ps1                       # Render actor config + launch/instruct per mode
+├── agent/
+│   ├── analyst.rules.template.json           # Deterministic approver actor (tokenised)
+│   ├── analyst.ai.template.json              # AI-persona approver actor (tokenised)
+│   └── analyst.persona.md                    # AI persona prompt
+├── blueprints/
+│   └── assured-identity.template.json        # Blueprint w/ {{issuerName}} token (from walkthrough)
+└── tests/                                     # Pester unit tests
+    ├── NodeInventory.Tests.ps1
+    ├── AgencyNaming.Tests.ps1
+    ├── Readiness.Tests.ps1
+    └── Idempotency.Tests.ps1
+
+walkthroughs/modules/SorchaWalkthrough/      # REUSED unchanged (shared helpers)
+
+# Retired in the final cleanup phase (FR-021), gated on a green run:
+#   walkthroughs/AssuredIdentity/**  (setup.ps1, run-phase1-identity.ps1, run-phase2-licence.ps1,
+#                                     run-agents.ps1, run-crossnode-*.ps1, run-multi-peer.ps1, scratch)
+#   deploy/twoinstall-issuer.ps1, deploy/twoinstall-citizen-n1.ps1, twoinstall-*state.json
+
+# Updated for alignment (FR-022):
+#   .claude/skills/walkthrough-builder/SKILL.md   (demo = mature walkthrough concept)
+#   .claude/skills/sorcha-architecture/SKILL.md   (F143 section → points at the demo)
+#   .claude/skills/n1-deploy/ + network-bootstrap  (AssuredIdentity refs → demos/AssuredIdentity)
+#   CLAUDE.md  (brief demos/ taxonomy line, if warranted)
+#   memory: f143-two-installation-demo.md + MEMORY.md
+```
+
+**Structure Decision**: A new top-level `demos/AssuredIdentity/` tree (confirms the design's assumed path) hosts the toolkit, config templates, tests, and runbook. It imports the existing `SorchaWalkthrough` helper module rather than duplicating it. The legacy `walkthroughs/AssuredIdentity/` + `deploy/twoinstall-*` scripts are retired only in the final, green-run-gated cleanup phase.
+
+## Complexity Tracking
+
+> No constitution violations. Table intentionally empty.

--- a/specs/144-assured-identity-demo/quickstart.md
+++ b/specs/144-assured-identity-demo/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Assured Identity Demo Environment
+
+Seed for `demos/AssuredIdentity/DEMO.md`. Two audiences: the **operator** who stands the demo up, and the **tester** who walks it through real UIs.
+
+---
+
+## Operator — stand it up
+
+**Prereqs**: both installations deployed + healthy on the current `:latest` (issuer NAT'd owner, subscriber public); `deploy/keys.env` populated (per-installation JWT keys + sysadmin password); `sorcha-agent` available on PATH; for `ai` mode, `ANTHROPIC_API_KEY` set.
+
+```powershell
+# 0. One-time: copy the inventory template and edit for your installations
+Copy-Item demos/AssuredIdentity/demo-nodes.example.json ./demo-nodes.json
+#   edit ids / gateways / installationNames (tiny + n1 are the defaults)
+
+Import-Module demos/AssuredIdentity/AssuredIdentityDemo.psm1
+
+# 1. Provision the issuing authority on the issuer node (default agent mode = rules)
+New-IssuingAuthority -IssuerNode tiny -AgencyName "Strathcarron Identity Authority"
+#   → org + analyst + advertised DevMode register + published blueprint (issuerName injected)
+#   → launches the deterministic approval agent
+
+# 2. Connect a public subscriber — BLOCKS until a tester can actually apply
+Connect-Subscriber -SubscriberNode n1
+#   → subscribes n1's public org, then gates on: subscription Active
+#     ∧ sync-state CaughtUp ∧ blueprint present in /blueprints/published
+#   → returns Ready (or NotReady+reasons on timeout — retry)
+
+# 3. Confirm the demo is tester-ready at a glance
+Get-DemoStatus
+#   → verdict: Ready, per-node signals
+```
+
+**Hand the tester** the subscriber's web address. That's it.
+
+### Variations
+- **AI assessor**: `New-IssuingAuthority -AgentMode ai` (requires `ANTHROPIC_API_KEY`; a slow/failed decision shows as "agent idle / decision pending" in `Get-DemoStatus` — retry or re-run as `rules`/`human`).
+- **Human analyst**: `New-IssuingAuthority -AgentMode human` → no agent; follow the printed "log into the issuer as the analyst, approve Action 2" steps.
+- **Rebrand**: re-run step 1 with a different `-AgencyName` (then `Reset-Demo` if you want a clean slate first). The new name appears on the org, register, and the credential.
+- **Deep workflow change**: amend the published blueprint in the real Designer (Describe→Understand→Rehearse→Go-live) and republish to the same register — identity stays intact.
+- **More nodes**: add a subscriber to `demo-nodes.json` and run `Connect-Subscriber -SubscriberNode <id>` again.
+
+### Reset
+```powershell
+Reset-Demo -Scope all          # clean both sides back to pre-provision
+Reset-Demo -Scope subscriber -Node n1
+```
+
+---
+
+## Tester — anonymous → credential, through the real product
+
+No script. Just a browser (and the Citizen Wallet PWA on your phone).
+
+1. **Sign up** on the subscriber web app (email/password or social).
+2. **Pair a wallet**: the app nudges you to add a device → `/setup/add-device` → enrol on the Citizen Wallet PWA. (Gives you a holder key so the credential can reach you.)
+3. **Apply**: web app → **New Submissions** (`/new-submissions`) → pick **<agency name>**'s Assured Identity service → **Start** → fill the form (your holder key fills in read-only automatically) → **Submit**.
+4. **Wait** ~a few seconds: your application is routed to the issuing authority, the identity-validator agent approves it, and the credential comes back to you.
+5. **Receive**: your PWA shows the pending-application card, then a welcome takeover when the **Assured Identity** credential lands in your wallet. Done.
+
+---
+
+## Acceptance checkpoints (map to Success Criteria)
+
+| Check | SC |
+|---|---|
+| Steps 1–3 (operator) reach `Ready` in ≤10 min from clean | SC-001 |
+| Tester steps 1–5 complete in ≤5 min, no "service unavailable" | SC-002 |
+| Re-run `New-IssuingAuthority` twice → no duplicate authority | SC-003 |
+| `-AgencyName "X"` → credential issuer shows "X", no manual edits | SC-004 |
+| All three `-AgentMode` values → credential reaches the wallet | SC-005 |
+| Second `Connect-Subscriber` node → tester there completes loop | SC-006 |
+| `Get-DemoStatus` verdict matches tester success every time | SC-007 |
+| After graduation, no legacy walkthrough script remains | SC-008 |

--- a/specs/144-assured-identity-demo/research.md
+++ b/specs/144-assured-identity-demo/research.md
@@ -1,0 +1,109 @@
+# Phase 0 Research: Assured Identity Demo Environment
+
+All Technical-Context unknowns resolved. Most decisions were pre-settled in the approved design note and the live-state memory; this consolidates them with the integration signals grounded during planning.
+
+---
+
+## R1 — Provisioning toolkit shape (promote, don't rebuild)
+
+**Decision**: Promote the gitignored `deploy/twoinstall-issuer.ps1` + `deploy/twoinstall-citizen-n1.ps1` into one PowerShell module (`AssuredIdentityDemo.psm1`) exporting four commands: `New-IssuingAuthority`, `Connect-Subscriber`, `Reset-Demo`, `Get-DemoStatus`. Internal logic factored into non-exported `lib/*.ps1` units so they are Pester-testable in isolation.
+
+**Rationale**: The two scratch scripts already perform the proven flow end-to-end; the work is parameterisation, idempotency, readiness-gating, and a node inventory — not new behaviour. Reusing `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1` keeps the API surface (auth, wallet, register, blueprint, participant helpers) consistent.
+
+**Alternatives considered**: (a) a first-class `Sorcha.Cli` command — heavier, pulls demo orchestration into shipped product surface, slower iteration; rejected for a demo toolkit. (b) Aspire/compose automation — wrong layer (per-installation lifecycle, not app-host); rejected.
+
+---
+
+## R2 — Node-agnostic configuration (inventory file)
+
+**Decision**: A `demo-nodes.json` inventory lists installations; each entry = `{ id, role, gateway, installationName, rendezvousCapable }`. `-IssuerNode` / `-SubscriberNode` select by `id`. A committed `demo-nodes.example.json` documents the shape; the real file is gitignored. Secrets stay in the existing `deploy/keys.env`, never in the inventory.
+
+**Rationale**: Satisfies FR-006/FR-007 (swap/rename installations without touching the toolkit) and FR-009 (each node keeps its own trust material). `tiny`/`n1` become default entries, not assumptions.
+
+**Alternatives considered**: hard-coded gateway URLs (the current scratch state) — fails FR-006; env-var-per-node — unwieldy beyond two nodes. Rejected.
+
+---
+
+## R3 — Agency-name coherence (single source → token injection)
+
+**Decision**: `-AgencyName` is written at provision time into: org name, register name, published-participant org name, and the blueprint template's `x-review.header.issuerName` via a `{{issuerName}}` token replaced before publish. The credential-issuer DID is **not** rewritten — it derives from the issuer wallet address, which is stable across renames, so the DID stays valid.
+
+**Rationale**: FR-002/FR-004/FR-005, SC-004. One value, propagated by the provisioner, removes the rename-coherence footgun. The `twoinstall-issuer.ps1` already sets the same name in 3 of the 4 places (org, register, published participant); adding the blueprint token closes the loop.
+
+**Alternatives considered**: F142 Designer amend loop as the rename path — only edits the blueprint display string, leaves org/register untouched; kept as the *deep workflow* customisation path (US3) but not the identity-rename mechanism. Rejected as the primary.
+
+---
+
+## R4 — Readiness gate (the anti-`blueprint_not_available` predicate)
+
+**Decision**: `Connect-Subscriber` does not return "ready" until **all three** hold for the target register on the subscriber: subscription `status == Active`; `GET /api/registers/{id}/sync-state` → `state == CaughtUp`; and the target blueprint appears in `GET /api/registers/{id}/blueprints/published`. Poll with bounded backoff (cap ~120s, comfortably over the observed ≤60s recovery window); on timeout, report a clear "not ready — recovery still in progress" status rather than a hard failure.
+
+**Rationale**: FR-004, SC-002, SC-007. The third condition is the one that absorbs the BlueprintRecoveryService ~60s window; without it a tester hits `POST /api/instances` → `409 blueprint_not_available`. There is no dedicated recovery-status endpoint — the published-blueprints listing IS the signal (confirmed: `BlueprintRecoveryService` exposes no REST status; recovery is background/event-driven).
+
+**Alternatives considered**: poll `POST /api/instances` itself — wasteful, creates junk instances; rejected. Fixed `Start-Sleep 60` — fragile, violates SC-002's "no transient error" under load; rejected.
+
+---
+
+## R5 — Idempotency & reconciliation
+
+**Decision**: Before creating anything, `New-IssuingAuthority` probes for an existing authority (org by name/subdomain, advertised register, published blueprint) and reuses it. The specific footgun from live state — a `OrganizationRegisterSubscriptions` row pointing at a register absent from Mongo — is detected (subscription exists but register read 404/empty) and reconciled (drop the stale subscription, or recreate the register) rather than blindly reused. A per-run `state.json` records provisioned artefact IDs to make reuse and `Reset-Demo` deterministic.
+
+**Rationale**: FR-003, SC-003, plus the explicit edge case. The memory records this exact desync biting before; making detection a first-class step is the fix.
+
+**Alternatives considered**: "always reset then provision" — destroys a standing demo on every run, fails the "standing" intent; rejected. Reuse-without-reconcile — reproduces the known footgun; rejected.
+
+---
+
+## R6 — Agent mode wiring (rules / ai / human)
+
+**Decision**: `-AgentMode rules|ai|human` (default `rules`). The provisioner renders an actor config from a tokenised template (analyst wallet/register/org IDs substituted from `state.json` via the agent's existing `{{placeholder}}` resolution) and: for `rules`/`ai` launches `sorcha-agent run --config <rendered> --state <state.json>` as a tracked child process; for `human` skips the launch and prints "log into the issuer node as the analyst and approve Action 2". `ai` adds an `ANTHROPIC_API_KEY` precondition check and a persona file.
+
+**Rationale**: FR-010/FR-011, SC-005. `sorcha-agent` already supports `rules` and `ai` modes and placeholder substitution — no agent code change.
+
+**AI-mode guardrail (resolves the deferred assumption)**: For `ai`, set a bounded decision wait via the agent's existing polling/retry config and document an operator fallback: if no decision is observed within the bound (default 90s), `Get-DemoStatus` surfaces "agent idle / decision pending" and the operator can either retry or switch that run to `human`/`rules`. v1 does **not** auto-fallback the engine mid-run (keeps behaviour predictable); the guardrail is detection + clear status + a documented manual switch. This satisfies FR-012's "not left stranded" without adding agent complexity.
+
+**Alternatives considered**: auto-degrade `ai`→`rules` on timeout — hidden behaviour change mid-demo, surprising; deferred. No guardrail — fails FR-012; rejected.
+
+---
+
+## R7 — Tester journey relies on existing surfaces (no scaffolding)
+
+**Decision**: Document, don't build. Entry = web SPA `/new-submissions` (verified working: `[Authorize]`, `POST /api/instances` under `CanExecuteBlueprints` = any authenticated user). Wallet pairing = real F128 cold-start onboarding (`/setup/add-device` → PWA enrol). Delivery + display = F124 pending-application + first-credential takeover in the PWA.
+
+**Rationale**: FR-014/FR-015/FR-016, the design's "real UIs, no scaffolding" decision. Verified during specify that the entry point exists and needs no change.
+
+**Recorded off-path (not used, not built)**: PWA `/applications` page (placeholder), `samples/strathcarron-portal` Blue Badge / Driving-Licence pages (non-functional stubs awaiting an unlanded backend PR). Called out in spec Out-of-Scope.
+
+---
+
+## R8 — Testing strategy (proportionate to PowerShell tooling)
+
+**Decision**: Pester unit tests for the four pure-logic units (inventory load/select, agency-name injection, readiness predicate, idempotency reconciliation) — deterministic, no live services. The integrated flow is gated by a live **green run** on the default node pair, asserting the SCs (ready ≤10 min, tester loop ≤5 min, no transient error, idempotent re-run, all three agent modes, multi-node, status accuracy). Graduation cleanup (FR-021) is gated on that green run.
+
+**Rationale**: Constitution IV adapted — there is no .NET core lib to hit 80% on; the equivalent rigor is deterministic units for logic + an E2E gate for integration. Matches how walkthroughs are validated today (by running), but adds real unit coverage for the new logic.
+
+**Alternatives considered**: E2E-only (current walkthrough practice) — leaves the new idempotency/readiness logic untested in isolation; rejected. Full mock-the-platform integration harness — disproportionate for a demo toolkit; rejected.
+
+---
+
+## R9 — Demo location & graduation sequencing
+
+**Decision**: `demos/AssuredIdentity/` is the new home (top-level `demos/` tree). Graduation cleanup — removing `walkthroughs/AssuredIdentity/**` and `deploy/twoinstall-*` — is a **distinct final phase, gated on a green run** (FR-021). Shared `walkthroughs/modules/SorchaWalkthrough/` is preserved and imported. Skills + memory updated to reflect "a demo is a mature walkthrough" and the new location (FR-022).
+
+**Rationale**: Avoids deleting the working path before its replacement is proven; resolves the design's open path question by confirming `demos/AssuredIdentity/`.
+
+**Alternatives considered**: keep under `walkthroughs/` — blurs the demo-vs-walkthrough concept the operator explicitly wants; rejected. Delete legacy immediately — premature before a green run; rejected.
+
+---
+
+## Resolved-unknowns summary
+
+| Unknown | Resolution |
+|---|---|
+| Testing approach for PowerShell toolkit | Pester units + E2E green-run gate (R8) |
+| Demo location path | `demos/AssuredIdentity/` (R9) |
+| AI-mode guardrail | bounded wait + status surfacing + documented manual switch; no auto-degrade in v1 (R6) |
+| Idempotency reconciliation mechanics | probe-and-reuse + stale-subscription-vs-missing-register detection (R5) |
+| Readiness predicate signals | subscribe Active ∧ sync-state CaughtUp ∧ blueprint in /blueprints/published (R4) |
+| Agent identity wiring | tokenised actor template + `{{placeholder}}` from state.json (R6) |
+| Multi-node connect | `Connect-Subscriber` repeatable per subscriber id, each readiness-gated (R2/R4) |

--- a/specs/144-assured-identity-demo/spec.md
+++ b/specs/144-assured-identity-demo/spec.md
@@ -1,0 +1,209 @@
+# Feature Specification: Assured Identity Demo Environment
+
+**Feature Branch**: `144-assured-identity-demo`  
+**Created**: 2026-05-31  
+**Status**: Draft  
+**Input**: User description: "Assured Identity Demo Environment — a standing, node-agnostic two-installation demo plus a self-service provisioning toolkit, built on the approved design at docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md"
+
+## Overview
+
+Turn the proven cross-installation Assured Identity loop into a **standing demo environment** anyone can stand up, operate, rebrand, and reset — where a tester goes, **unscripted through the real product**, from anonymous sign-up to a verified identity credential in their wallet. The decision-making components (topology, agent mode, tester journey, rebrand coherence, readiness) were settled in the approved design note; this spec defines the *what* and *why* for building the operability layer on top.
+
+A guiding concept: **a demo is a mature walkthrough**. The scripted dev-facing walkthrough has proven the path; graduating it to a demo means it becomes coherent, node-agnostic, operable by parameter, and exercised by a human through real UIs — at which point the legacy scripts are retired.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stand up a demo and complete the credential loop (Priority: P1)
+
+An operator stands up a fresh issuing authority on an issuer installation and connects a public subscriber installation, then hands a tester a plain web address. The tester — with no script and no special tooling — signs up, is guided by the product to pair a wallet, applies for an assured identity, and shortly receives the credential in their wallet. The approval in between is performed automatically by the identity-validator agent.
+
+**Why this priority**: This is the entire purpose of the feature — a repeatable, self-contained demonstration of the full decentralised identity-assurance loop across two installations. Everything else refines or extends it.
+
+**Independent Test**: From a clean state, run the documented provision + connect sequence, then have a person who has never seen the system complete anonymous-sign-up → application → credential-in-wallet entirely through the real UIs. Success = the credential appears in the tester's wallet and the tester never encounters a transient "service unavailable" error.
+
+**Acceptance Scenarios**:
+
+1. **Given** two clean installations (one issuer, one public subscriber), **When** the operator runs the provisioning step on the issuer and the connect step on the subscriber, **Then** both report "ready" only after the agency's service is actually available to citizens on the subscriber.
+2. **Given** a readied demo, **When** a first-time tester signs up on the subscriber, pairs a wallet, discovers the agency's service, and submits an application, **Then** the application is accepted and routed to the issuer for approval without the tester taking any out-of-band step.
+3. **Given** a submitted application, **When** the identity-validator agent approves it, **Then** the resulting credential is delivered to the tester's wallet and is visible in their wallet app.
+4. **Given** a tester who arrives immediately after the connect step reports "ready", **When** they start an application, **Then** they do not see a transient "service not yet available" error.
+
+---
+
+### User Story 2 - Choose how applications are approved (Priority: P2)
+
+An operator decides, per demo run, whether applications are approved by a deterministic ruleset, by an AI persona that reads each application and decides, or by a human acting as the verification analyst.
+
+**Why this priority**: The approval step is the demonstration's most flexible storytelling moment ("a rule decided", "an AI assessed you", "an officer reviewed you"). It must be a single, low-friction choice, but the loop is fully demonstrable with the default deterministic mode alone.
+
+**Independent Test**: Run provisioning three times selecting each mode; in every case a submitted application results in an approved credential, and in human mode the operator is given clear approval instructions instead of an automatic decision.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator selects the deterministic mode (the default), **When** an application is submitted, **Then** it is approved automatically and quickly enough that a live demo does not stall.
+2. **Given** the operator selects the AI mode, **When** an application is submitted, **Then** the AI persona produces a decision, and if it is slow or fails the tester is not left stranded (a safe fallback or clear status is surfaced).
+3. **Given** the operator selects the human mode, **When** provisioning completes, **Then** no automatic approver runs and the operator receives instructions for approving as the analyst.
+
+---
+
+### User Story 3 - Rebrand and customise the issuing authority (Priority: P2)
+
+An operator stands up an authority under a chosen agency name (e.g. a fictional council or registry), and the name appears consistently everywhere a tester sees it — including on the credential they receive. For deeper changes to the application itself, the operator uses the real product's design tools.
+
+**Why this priority**: The vision explicitly includes testers standing up *their own* authority. Name coherence across the org, the register, and the credential is what makes a rebrand believable; getting it wrong undermines the demo.
+
+**Independent Test**: Provision with a non-default agency name; complete the loop; confirm the credential's displayed issuer and every tester-visible label match the chosen name with no manual editing. Separately, amend the application's form through the product design tools and confirm the change appears without breaking the authority's identity.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator supplies an agency name, **When** the authority is provisioned, **Then** the org, the published service, and the credential's displayed issuer all reflect that single name.
+2. **Given** a provisioned authority, **When** the operator re-runs provisioning with a different agency name, **Then** the authority is coherently rebranded without leaving stale references to the previous name on the tester-visible path.
+3. **Given** a provisioned authority, **When** the operator amends the application's form via the product design tools and republishes, **Then** the workflow change takes effect while the authority's identity (org, wallet, register, credential issuer) remains intact.
+
+---
+
+### User Story 4 - Add more independent nodes to the demo (Priority: P3)
+
+An operator points the demo at different installations, renames them, or adds further independent public installations that also subscribe to and host the agency's register, so testers can be served from more than one node.
+
+**Why this priority**: Demonstrating that independent nodes can replicate and serve the same register is a core decentralisation message, but the headline demo works with a single subscriber, so this extends rather than gates the MVP.
+
+**Independent Test**: With an authority already provisioned, connect a second, independent subscriber installation; confirm a tester on that second node can complete the full loop and receive the credential.
+
+**Acceptance Scenarios**:
+
+1. **Given** an installation inventory, **When** the operator selects different installations for issuer and subscriber roles, **Then** the demo provisions against those installations without editing the toolkit itself.
+2. **Given** an authority advertised by the issuer, **When** the operator connects an additional independent subscriber installation, **Then** that node replicates the register and a tester on it can complete the loop.
+3. **Given** multiple subscriber installations, **When** each connect step reports "ready", **Then** each was independently readiness-checked.
+
+---
+
+### User Story 5 - Reset and check demo health (Priority: P3)
+
+An operator returns a node (or the whole demo) to a clean pre-provision state, and at any time can ask "is the demo ready for a tester right now?" and get a clear cross-node answer.
+
+**Why this priority**: Operating a standing demo repeatedly requires a reliable reset and an at-a-glance readiness check; without them the demo rots between sessions. It supports the MVP rather than being part of the first proof.
+
+**Independent Test**: After a completed run, reset the demo and confirm a subsequent fresh provision succeeds; query status before and after provisioning and confirm the reported readiness matches whether a tester can actually complete the loop.
+
+**Acceptance Scenarios**:
+
+1. **Given** a previously run demo, **When** the operator resets it, **Then** a subsequent provision behaves as if starting clean (no leftover state blocks it).
+2. **Given** any point in the demo lifecycle, **When** the operator queries status, **Then** they receive a cross-node report of health, subscription state, service availability, and approver state that correctly predicts tester success.
+
+---
+
+### User Story 6 - Graduate the walkthrough to a demo (Priority: P3)
+
+Once the demo runs green end-to-end, the maintainer retires the legacy scripted walkthrough and scratch scripts, and the project's guidance reflects that "the Assured Identity walkthrough" now means this demo.
+
+**Why this priority**: Leaving two parallel artefacts (legacy walkthrough + new demo) causes drift and confusion. This consolidation is the explicit close-out of the graduation concept, but it must come *after* a proven green run, so it is sequenced last.
+
+**Independent Test**: After a green demo run, confirm the legacy AssuredIdentity walkthrough and two-installation scratch scripts are removed, the demo lives in a first-class demo location, and the project guidance and memory describe the demo (not the retired scripts) as the canonical Assured Identity experience.
+
+**Acceptance Scenarios**:
+
+1. **Given** a green end-to-end demo run, **When** the maintainer performs graduation cleanup, **Then** no legacy AssuredIdentity walkthrough or two-installation scratch script remains, while shared reusable helpers are preserved.
+2. **Given** the graduated demo, **When** a new contributor looks for "the Assured Identity walkthrough", **Then** project guidance and memory direct them to the demo and its location.
+
+---
+
+### Edge Cases
+
+- **Re-provisioning an existing authority**: the provisioning step detects and reuses existing artefacts rather than duplicating, including reconciling the known footgun where a stale subscription record points at a register that no longer exists.
+- **Tester arrives during the readiness window**: a tester who somehow starts before the service is recoverable is given a clear, non-alarming "not quite ready" state, not an opaque failure.
+- **Approver unavailable or slow (AI mode)**: a slow or failing AI decision must not silently strand a tester mid-application.
+- **Subscriber connected but issuer offline**: status reflects the broken link rather than reporting "ready".
+- **Tester has no wallet device yet**: the product's own onboarding must carry them to a paired wallet before the credential can be delivered; the demo relies on this and adds no scaffolding around it.
+- **Reset while a tester is mid-flow**: reset is an operator action assumed to occur between tester sessions; the spec does not guarantee graceful behaviour for an in-flight tester during a reset.
+- **Multiple subscribers at different sync points**: one subscriber lagging in replication must not be reported as "ready".
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Provisioning & coherence
+
+- **FR-001**: The system MUST provide a single operation that stands up a complete issuing authority on a chosen issuer installation — organisation, issuer identity, verification analyst, advertised register, and published application — usable with sensible defaults so a zero-configuration run produces a working authority.
+- **FR-002**: The agency name MUST be a single supplied value that propagates consistently to the organisation, the published service, the analyst's published participant record, and the issuer name displayed on the credential the tester receives.
+- **FR-003**: Re-running provisioning MUST be idempotent: existing authority artefacts are detected and reused rather than duplicated, and stale subscription-vs-missing-register state is reconciled rather than blindly reused.
+- **FR-004**: The system MUST provide an operation that connects a chosen subscriber installation to an advertised register and MUST NOT report "ready" until the agency's service is actually available for a citizen to start an application on that node.
+- **FR-005**: Re-running provisioning with a different agency name MUST produce a coherently rebranded authority with no stale references to the prior name on the tester-visible path.
+
+#### Node-agnostic configuration & multi-node
+
+- **FR-006**: Installation identity (address, installation name, role, reachability) MUST be configuration, not hard-coded, so installations can be swapped or renamed without changing the toolkit.
+- **FR-007**: The operator MUST be able to select which installations act as issuer and subscriber by reference to the configured inventory.
+- **FR-008**: The system MUST allow additional independent subscriber installations to connect to and replicate the same advertised register, each independently readiness-checked.
+- **FR-009**: Each installation MUST retain its own trust material; a node joins by subscribing to the advertised register, never by sharing signing keys.
+
+#### Approval agent
+
+- **FR-010**: The operator MUST be able to choose, per provisioning run, how applications are approved: a deterministic ruleset (default), an AI persona, or a human.
+- **FR-011**: In deterministic and AI modes the system MUST start the approving agent as part of provisioning; in human mode it MUST instead provide the operator with instructions to approve as the analyst.
+- **FR-012**: In AI mode the system MUST ensure a slow or failed decision does not leave a tester stranded — via a bounded wait and a defined fallback or clearly surfaced status.
+- **FR-013**: The default deterministic approval MUST complete quickly enough that a live demonstration does not visibly stall.
+
+#### Tester journey (relies on existing product surfaces — no scaffolding)
+
+- **FR-014**: A signed-in citizen MUST be able to discover the agency's service and start an application through the real product UI, without any demo-specific scaffolding or scripting.
+- **FR-015**: After approval, the credential MUST be delivered to the tester's wallet and be visible in their wallet app.
+- **FR-016**: The demo MUST NOT introduce new tester-facing UI; it relies on the product's existing onboarding, application, and wallet surfaces. Product surfaces known to be incomplete MUST be explicitly recorded as out of scope rather than worked around.
+
+#### Operations
+
+- **FR-017**: The system MUST provide an operation to reset a node, or the whole demo, to a clean pre-provision state such that a subsequent provision behaves as if starting fresh.
+- **FR-018**: The system MUST provide an operation that reports, across all configured installations, whether the demo is ready for a tester — covering service health, subscription state, service availability, and approver state — such that the report reliably predicts tester success.
+
+#### Documentation, graduation & alignment
+
+- **FR-019**: The demo MUST live in a first-class demo location distinct from dev-facing scripted walkthroughs.
+- **FR-020**: The demo MUST ship with an operator runbook (provision, connect, reset, status, agent modes, multi-node) and a tester runbook (the unscripted real-UI journey).
+- **FR-021**: After a verified green end-to-end run, the legacy scripted Assured Identity walkthrough and two-installation scratch scripts MUST be retired, while shared reusable helpers are preserved. This cleanup MUST be sequenced as the final step, gated on the green run.
+- **FR-022**: Project guidance and memory MUST be updated so that "the Assured Identity walkthrough" resolves to this demo, reflecting the concept that a demo is a mature walkthrough and recording the node-agnostic, multi-node nature and the demo's location.
+
+### Key Entities *(include if feature involves data)*
+
+- **Installation (inventory entry)**: a participating node — its reference id, network address, installation name, role (issuer or subscriber), and whether it can be reached for inbound rendezvous. The unit by which the operator selects topology.
+- **Issuing authority**: the provisioned identity-assurance organisation — agency name, organisation, issuer identity, verification analyst, advertised register, and the published application. The thing the agency-name value makes coherent.
+- **Approval agent configuration**: the chosen approval mode and the analyst identity it acts as; for non-human modes, the running approver.
+- **Demo state record**: the provisioned artefact references that make provisioning idempotent and reset reliable.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: From a clean state, an operator can bring the demo to "ready" (issuer provisioned + one subscriber connected) by following the runbook in under 10 minutes.
+- **SC-002**: A first-time tester, given only a web address and no script, completes anonymous sign-up → application → credential-in-wallet in under 5 minutes, and encounters no transient "service unavailable" error.
+- **SC-003**: Provisioning is idempotent: running it twice in succession against the same installation produces no duplicate authority and leaves the demo working, verified across at least two consecutive runs.
+- **SC-004**: Changing only the agency-name value yields a credential whose displayed issuer and all tester-visible labels match the chosen name, with zero manual edits.
+- **SC-005**: An operator switches approval mode between runs with a single choice, and all three modes (deterministic, AI, human) result in an approved credential reaching the tester's wallet.
+- **SC-006**: At least one additional independent subscriber installation can be connected, and a tester served from that node completes the full loop.
+- **SC-007**: The status report's "ready / not ready" verdict matches actual tester success in 100% of checks during acceptance testing.
+- **SC-008**: After graduation, no legacy Assured Identity walkthrough or two-installation scratch script remains, and a contributor who has never run the demo can complete it using only the demo runbook.
+
+## Assumptions
+
+- **Topology and transport are proven and in place**: the cross-installation reverse-stream reachability, asynchronous cross-node submission, and cross-node credential delivery this demo depends on are already delivered and live-verified; this feature builds the operability layer on top, not the transport.
+- **Default node pair**: the default issuer is a NAT'd owner installation and the default subscriber is a public installation, matching the proven configuration; these are defaults in the inventory, not assumptions baked into the toolkit.
+- **Default demo location**: the demo is assumed to live at a top-level demo directory for the Assured Identity demo (e.g. `demos/AssuredIdentity/`); the exact path is confirmable during planning without changing scope.
+- **Tester journey uses existing product surfaces**: the citizen sign-up, wallet-device onboarding, service-discovery/start-application, and credential-delivery surfaces already exist in the product and are sufficient for the unscripted journey; the demo adds no UI.
+- **Out-of-scope product surfaces**: the wallet app's in-app "applications" listing and the sample council portal pages are known to be incomplete and are explicitly not on the demo path.
+- **AI-mode guardrail default**: when AI approval is selected, a bounded wait with a defined fallback (or clearly surfaced status) is acceptable for a demo; the precise bound and fallback are settled during planning.
+- **Secrets handling**: per-installation trust material and signing keys are supplied to the toolkit through the existing secret store, not committed.
+- **Single concurrent tester assumption for reset**: reset is an operator action performed between tester sessions; graceful mid-flow reset is not a requirement.
+
+## Dependencies
+
+- The proven cross-installation Assured Identity loop and its supporting fixes (reverse-stream rendezvous, async cross-node submit, replica reconcile, seal-persist) — must remain deployed on the participating installations.
+- The autonomous approval agent capability with deterministic and AI decision modes.
+- The product's existing citizen onboarding, application-start, and wallet surfaces.
+- The product's design tools for deeper application customisation (US3 deep-customise path).
+
+## Out of Scope
+
+- Any new tester-facing UI or guided concierge overlay.
+- Completing the wallet app's in-app application listing or the sample council portal pages.
+- Hardening core product paths (e.g. making application-start wait for in-flight service recovery) — readiness gating in the toolkit is sufficient for the demo.
+- Relayed multi-hop mesh routing between nodes; multi-node here means multiple independent subscribers of one advertised register.
+- Production-grade operation (scaling, monitoring, SLAs) of the demo environment.

--- a/specs/144-assured-identity-demo/tasks.md
+++ b/specs/144-assured-identity-demo/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: Assured Identity Demo Environment
+
+**Input**: Design documents from `/specs/144-assured-identity-demo/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Pester unit tests ARE included for the four pure-logic units (per research §R8: deterministic logic gets unit coverage; the integrated flow is gated by a live green run). No xUnit — this feature adds no .NET code.
+
+**Organization**: Tasks grouped by user story. MVP = User Story 1 (stand up + complete the loop).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete dependencies)
+- **[Story]**: US1–US6 maps to spec.md user stories
+- All paths are repo-relative; the toolkit lives under `demos/AssuredIdentity/`
+
+## Path Conventions
+
+Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tests/`). Reuses `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1` unchanged. Consumes existing Sorcha HTTP endpoints + the existing `sorcha-agent` CLI.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Demo tree, module skeleton, config + blueprint templates, test harness.
+
+- [ ] T001 Create the demo directory tree `demos/AssuredIdentity/` with subdirs `lib/`, `agent/`, `blueprints/`, `tests/`
+- [ ] T002 [P] Create module skeleton `demos/AssuredIdentity/AssuredIdentityDemo.psm1` — SPDX header, `Import-Module` of `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1`, stub-export the four commands (`New-IssuingAuthority`, `Connect-Subscriber`, `Reset-Demo`, `Get-DemoStatus`)
+- [ ] T003 [P] Create `demos/AssuredIdentity/blueprints/assured-identity.template.json` by copying `walkthroughs/AssuredIdentity/blueprints/assured-identity.json` and replacing the `x-review.header.issuerName` literal with a `{{issuerName}}` token (keep the `holderKeys`/`holderKeySourceField` F137 wiring intact)
+- [ ] T004 [P] Create `demos/AssuredIdentity/demo-nodes.example.json` conforming to `contracts/demo-nodes.schema.json` (tiny=issuer, n1=subscriber defaults)
+- [ ] T005 [P] Add Pester runner `demos/AssuredIdentity/tests/Invoke-DemoTests.ps1` (Invoke-Pester over `tests/*.Tests.ps1`) and a `.gitignore` entry block for `demo-nodes.json`, `state.json`, rendered `agent/analyst.*.json`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared logic every command depends on — inventory, state IO, auth bootstrap.
+
+**⚠️ CRITICAL**: No user-story command can be built until this phase is complete.
+
+- [ ] T006 Implement `demos/AssuredIdentity/lib/NodeInventory.ps1` — load + schema-validate `demo-nodes.json`, select node by `id`, resolve by `role`, fail-fast on duplicate id / malformed URL / missing required field (FR-006, FR-007)
+- [ ] T007 [P] Pester tests `demos/AssuredIdentity/tests/NodeInventory.Tests.ps1` — valid load, duplicate-id rejection, malformed-URL rejection, missing-field rejection, select-by-id, select-by-role
+- [ ] T008 Implement `demos/AssuredIdentity/lib/DemoState.ps1` — read/write/merge `state.json` per `contracts/demo-state.schema.json`, plus a `Test-DemoStateStale` helper (registerId present in state but unreadable on the issuer node → stale)
+- [ ] T009 [P] Implement auth bootstrap in `demos/AssuredIdentity/lib/Auth.ps1` — load `deploy/keys.env`, per-node sysadmin login via SorchaWalkthrough `Connect-SorchaAdmin`, never echo secrets
+
+**Checkpoint**: Inventory + state + auth available — command implementation can begin.
+
+---
+
+## Phase 3: User Story 1 - Stand up a demo and complete the credential loop (Priority: P1) 🎯 MVP
+
+**Goal**: One provision command on the issuer + one connect command on a subscriber → a tester completes anonymous→credential through real UIs, with the default deterministic approver and no transient `blueprint_not_available`.
+
+**Independent Test**: From clean, run `New-IssuingAuthority` (default name + rules) then `Connect-Subscriber`; a first-time person completes the journey in `quickstart.md` and the credential lands in their wallet (SC-001, SC-002).
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Pester `demos/AssuredIdentity/tests/AgencyNaming.Tests.ps1` — a chosen name is injected into all four sites (org/register/published-participant/blueprint `issuerName`) and leaves no `{{issuerName}}` token
+- [ ] T011 [P] [US1] Pester `demos/AssuredIdentity/tests/Readiness.Tests.ps1` — predicate is `Ready` only when subscription `Active` ∧ sync-state `CaughtUp` ∧ target blueprint present; partial signals → `NotReady` with reasons; timeout path yields `NotReady(recovery-in-progress)`
+- [ ] T012 [P] [US1] Pester `demos/AssuredIdentity/tests/Idempotency.Tests.ps1` — existing org/register/blueprint detected → reuse (no duplicate); stale subscription-vs-missing-register → reconcile decision
+
+### Implementation for User Story 1
+
+- [ ] T013 [P] [US1] Implement `demos/AssuredIdentity/lib/AgencyNaming.ps1` — single-source `-AgencyName` → org name, register name, published-participant org name, and blueprint `{{issuerName}}` token replacement (FR-002, R3)
+- [ ] T014 [P] [US1] Implement `demos/AssuredIdentity/lib/Readiness.ps1` — poll `GET /api/organizations/{orgId}/register-subscriptions/{registerId}` (Active), `GET /api/registers/{id}/sync-state` (CaughtUp), `GET /api/registers/{id}/blueprints/published` (blueprint present); bounded backoff to `-TimeoutSeconds`; return `{status, reasons[]}` (FR-004, R4)
+- [ ] T015 [P] [US1] Implement `demos/AssuredIdentity/lib/Idempotency.ps1` — probe-and-reuse existing authority artefacts; detect+reconcile stale subscription-vs-missing-register (FR-003, R5)
+- [ ] T016 [P] [US1] Create `demos/AssuredIdentity/agent/analyst.rules.template.json` — deterministic auto-approve actor for Action 2, tokenised (`{{analystWallet}}`, `{{registerId}}`, `{{orgId}}`, gateway) for `{{placeholder}}` substitution from `state.json`
+- [ ] T017 [US1] Implement `demos/AssuredIdentity/lib/AgentLaunch.ps1` (rules path) — render `analyst.rules.json` from the template and launch `sorcha-agent run --config <rendered> --state state.json` as a tracked child process (FR-011 rules branch)
+- [ ] T018 [US1] Implement `New-IssuingAuthority` in `AssuredIdentityDemo.psm1` — resolve issuer node + creds → idempotency probe (T015) → provision (public org, verification-admin Tier-2, analyst Tier-3, wallets, participants, advertised DevMode register, publish analyst participant) → publish blueprint from template with injected name (T013) → launch rules agent (T017) → write `state.json` (T008). Default `-AgencyName "Strathcarron Identity Authority"`, default `-AgentMode rules` (FR-001)
+- [ ] T019 [US1] Implement `Connect-Subscriber` in `AssuredIdentityDemo.psm1` — resolve subscriber node + public org → discover advertised register on issuer → `POST /api/organizations/{orgId}/register-subscriptions` (reuse Active / reconcile stale) → readiness gate (T014) → append `subscribers[]` in `state.json` with status + `lastReadyAt` (FR-004)
+- [ ] T020 [US1] Write the **tester-journey** section of `demos/AssuredIdentity/DEMO.md` — sign up → F128 add-device → `/new-submissions` → Start → submit → receive in PWA; explicitly record PWA `/applications` + `samples/strathcarron-portal` as off-path (FR-014, FR-015, FR-016)
+
+**Checkpoint**: Default-named demo stands up and a tester completes the loop (MVP — SC-001, SC-002, SC-003 basic reuse).
+
+---
+
+## Phase 4: User Story 2 - Choose how applications are approved (Priority: P2)
+
+**Goal**: `-AgentMode rules|ai|human` selects the approver per run, with an AI guardrail and human instructions.
+
+**Independent Test**: Provision three times, one per mode; each yields an approved credential, and human mode prints approval steps instead of launching an agent (SC-005).
+
+- [ ] T021 [P] [US2] Create `demos/AssuredIdentity/agent/analyst.ai.template.json` + `demos/AssuredIdentity/agent/analyst.persona.md` — AI-persona approver actor (`"mode":"ai"`, persona file, `apiKeyEnvVar: ANTHROPIC_API_KEY`), tokenised like the rules template (FR-010)
+- [ ] T022 [US2] Extend `demos/AssuredIdentity/lib/AgentLaunch.ps1` — `ai` path (precheck `ANTHROPIC_API_KEY`, set decision-wait guardrail = 90s, launch) and `human` path (no launch; print "log into the issuer as the analyst and approve Action 2" steps) (FR-011, FR-012, R6)
+- [ ] T023 [US2] Wire `-AgentMode rules|ai|human` parameter through `New-IssuingAuthority` to `AgentLaunch` (default `rules`) and record `agentMode` in `state.json` (FR-010)
+- [ ] T024 [US2] Add the **agent-mode** section to `demos/AssuredIdentity/DEMO.md` — three modes, the AI guardrail behaviour (`Get-DemoStatus` surfaces "decision pending"; retry or switch), and the human steps
+
+**Checkpoint**: All three modes produce an approved credential (SC-005).
+
+---
+
+## Phase 5: User Story 3 - Rebrand and customise the issuing authority (Priority: P2)
+
+**Goal**: Re-run with a different `-AgencyName` produces a coherently rebranded authority; deeper workflow edits go through the real Designer.
+
+**Independent Test**: Provision with a non-default name; complete the loop; the credential's displayed issuer matches with zero manual edits (SC-004).
+
+- [ ] T025 [US3] Harden rename coherence in `New-IssuingAuthority` — re-running with a changed `-AgencyName` updates all tester-visible sites and reconciles prior-name artefacts via Idempotency (T015), leaving no stale prior-name reference on the tester path (FR-005)
+- [ ] T026 [P] [US3] Pester `demos/AssuredIdentity/tests/RenameCoherence.Tests.ps1` — a name change re-injects every site and surfaces any residual prior-name reference as a failure
+- [ ] T027 [US3] Add the **deep-customise** section to `demos/AssuredIdentity/DEMO.md` — amend the published blueprint via the real F142 Designer (Describe→Understand→Rehearse→Go-live) and republish to the same register; identity (org/wallet/register/DID) stays intact
+
+**Checkpoint**: Rebrand is coherent end-to-end (SC-004).
+
+---
+
+## Phase 6: User Story 4 - Add more independent nodes to the demo (Priority: P3)
+
+**Goal**: Point the demo at swapped/renamed installations and connect additional independent subscribers of the same advertised register.
+
+**Independent Test**: With an authority provisioned, connect a second subscriber id; a tester on that node completes the loop (SC-006).
+
+- [ ] T028 [US4] Make `Connect-Subscriber` repeatable across N subscriber ids — append/update per-node `subscribers[]` entries, each independently readiness-gated (T014); no cross-node coupling (FR-008)
+- [ ] T029 [US4] Add the **multi-node** section to `demos/AssuredIdentity/DEMO.md` — add a subscriber entry to `demo-nodes.json`, re-run `Connect-Subscriber -SubscriberNode <id>`; note swap/rename via inventory only (FR-006, FR-007)
+
+**Checkpoint**: A second independent subscriber serves a tester through the full loop (SC-006).
+
+---
+
+## Phase 7: User Story 5 - Reset and check demo health (Priority: P3)
+
+**Goal**: Clean reset of a node or the whole demo, plus an at-a-glance cross-node readiness verdict.
+
+**Independent Test**: After a run, reset and re-provision cleanly; query status before/after and confirm the verdict predicts tester success (SC-007).
+
+- [ ] T030 [P] [US5] Implement `Reset-Demo` in `AssuredIdentityDemo.psm1` — `-Scope issuer|subscriber|all` per the documented reset recipe (demo wallets, non-system register Mongo DBs, `OrganizationRegisterSubscriptions` rows, replicated state, `state.json`), stop any tracked `sorcha-agent` process, idempotent no-op on already-clean (FR-017)
+- [ ] T031 [US5] Implement `demos/AssuredIdentity/lib/StatusVerdict.ps1` — gather per-node signals (gateway health, subscription, sync-state, blueprint-published, approver state) and compute `{verdict: Ready|NotReady, perNode[], reasons[]}` (FR-018, data-model "Derived")
+- [ ] T032 [US5] Implement `Get-DemoStatus` in `AssuredIdentityDemo.psm1` — render the verdict table from `StatusVerdict` across issuer + all `subscribers[]` (FR-018)
+- [ ] T033 [P] [US5] Pester `demos/AssuredIdentity/tests/StatusVerdict.Tests.ps1` — verdict combinations map correctly (all-green→Ready; each missing signal→NotReady with the right reason)
+- [ ] T034 [US5] Add the **reset / status** section to `demos/AssuredIdentity/DEMO.md`
+
+**Checkpoint**: Reset+re-provision is clean; status verdict matches reality (SC-007).
+
+---
+
+## Phase 8: User Story 6 - Graduate the walkthrough to a demo (Priority: P3)
+
+**Goal**: After a proven green run, retire the legacy scripts and align skills + memory to "a demo is a mature walkthrough".
+
+**Independent Test**: Post-cleanup, no legacy AssuredIdentity walkthrough/scratch script remains and project guidance points to the demo (SC-008).
+
+- [ ] T035 [US6] **GREEN-RUN GATE** — execute the full `quickstart.md` on the default node pair across all modes/multi-node and record results against SC-001…SC-007 in `demos/AssuredIdentity/DEMO.md` (a "Verified" note). This task BLOCKS T036–T037 (do not delete the legacy path until the replacement is proven)
+- [ ] T036 [US6] Remove legacy `walkthroughs/AssuredIdentity/**` (`setup.ps1`, `run-phase1-identity.ps1`, `run-phase2-licence.ps1`, `run-agents.ps1`, `run-crossnode-*.ps1`, `run-multi-peer.ps1`, scratch logs/state) — **preserve** `walkthroughs/modules/SorchaWalkthrough/` (FR-021)
+- [ ] T037 [US6] Remove `deploy/twoinstall-issuer.ps1`, `deploy/twoinstall-citizen-n1.ps1`, `deploy/twoinstall-state.json`, `deploy/twoinstall-citizen-state.json` (FR-021)
+- [ ] T038 [P] [US6] Update `.claude/skills/walkthrough-builder/SKILL.md` — add the "a demo is a mature walkthrough" concept + `demos/AssuredIdentity/` location (FR-022)
+- [ ] T039 [P] [US6] Update `.claude/skills/sorcha-architecture/SKILL.md` (F143 section → points at the demo) and the `n1-deploy` / `network-bootstrap` skills' AssuredIdentity references → `demos/AssuredIdentity/` (FR-022)
+- [ ] T040 [P] [US6] Update memory `f143-two-installation-demo.md` and `MEMORY.md` — "Assured Identity walkthrough" resolves to the demo; record node-agnostic + graduation concept (FR-022)
+- [ ] T041 [P] [US6] Add a brief `demos/` taxonomy line to `CLAUDE.md` if warranted (FR-022)
+
+**Checkpoint**: Single canonical demo; legacy retired; guidance aligned (SC-008).
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [ ] T042 [P] Assemble the full `demos/AssuredIdentity/DEMO.md` operator runbook (provision/connect/reset/status/agent-modes/multi-node) from the per-story sections; cross-check against `quickstart.md`
+- [ ] T043 Run the `quickstart.md` validation end-to-end one final time post-cleanup and confirm the acceptance-checkpoint table passes
+- [ ] T044 [P] Verify `.gitignore` covers `demo-nodes.json`, `state.json`, rendered `agent/analyst.*.json`; confirm no secret leaked into committed files
+- [ ] T045 [P] Final Pester suite green + PSScriptAnalyzer pass over `demos/AssuredIdentity/**`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (P1)**: no dependencies.
+- **Foundational (P2)**: depends on Setup. BLOCKS all user stories.
+- **US1 (P3)**: depends on Foundational. The MVP.
+- **US2 (P4)**: depends on Foundational + US1's `AgentLaunch.ps1` (T017) and `New-IssuingAuthority` (T018).
+- **US3 (P5)**: depends on US1 (`AgencyNaming` T013, `Idempotency` T015, `New-IssuingAuthority` T018).
+- **US4 (P6)**: depends on US1 (`Connect-Subscriber` T019, `Readiness` T014).
+- **US5 (P7)**: depends on US1 (state + provisioned artefacts to reset/report); independent of US2–US4.
+- **US6 (P8)**: GREEN-RUN GATE (T035) depends on US1–US5 being complete (the green run exercises all SCs); T036–T037 depend on T035.
+- **Polish (P9)**: depends on all desired stories.
+
+### Within-story order
+
+- Pester tests (T007/T010–T012/T026/T033) author alongside or before their unit; ensure they fail first.
+- lib units before the commands that compose them.
+- `state.json` IO (T008) before any command that writes it.
+
+### Parallel Opportunities
+
+- Setup: T002, T003, T004, T005 in parallel after T001.
+- Foundational: T007, T009 parallel to T006/T008.
+- US1: T010–T012 (tests) parallel; T013, T014, T015, T016 parallel (distinct files); then T017 → T018/T019; T020 anytime.
+- US6 alignment: T038, T039, T040, T041 parallel (distinct files) after the gate.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# Tests (write first, expect fail):
+T010 AgencyNaming.Tests.ps1   |  T011 Readiness.Tests.ps1   |  T012 Idempotency.Tests.ps1
+
+# Independent lib units (distinct files):
+T013 AgencyNaming.ps1  |  T014 Readiness.ps1  |  T015 Idempotency.ps1  |  T016 analyst.rules.template.json
+
+# Then sequential composition:
+T017 AgentLaunch.ps1 (rules) → T018 New-IssuingAuthority → T019 Connect-Subscriber
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → Phase 2 Foundational → Phase 3 US1.
+2. **STOP and VALIDATE**: stand up the default demo and have someone complete the loop. That alone is a demonstrable product (SC-001, SC-002).
+
+### Incremental Delivery
+
+US1 (MVP) → US2 (agent modes) → US3 (rebrand) → US4 (multi-node) → US5 (reset/status) → **green-run gate** → US6 (graduate + retire legacy) → Polish. Each story is independently demonstrable; the legacy walkthrough stays intact until the green run proves the replacement.
+
+### Notes
+
+- [P] = different files, no incomplete dependency.
+- The green-run gate (T035) is the single hard ordering constraint protecting the legacy path — never delete before it passes.
+- Commit after each task or logical group.

--- a/specs/144-assured-identity-demo/tasks.md
+++ b/specs/144-assured-identity-demo/tasks.md
@@ -23,11 +23,11 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 **Purpose**: Demo tree, module skeleton, config + blueprint templates, test harness.
 
-- [ ] T001 Create the demo directory tree `demos/AssuredIdentity/` with subdirs `lib/`, `agent/`, `blueprints/`, `tests/`
-- [ ] T002 [P] Create module skeleton `demos/AssuredIdentity/AssuredIdentityDemo.psm1` — SPDX header, `Import-Module` of `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1`, stub-export the four commands (`New-IssuingAuthority`, `Connect-Subscriber`, `Reset-Demo`, `Get-DemoStatus`)
-- [ ] T003 [P] Create `demos/AssuredIdentity/blueprints/assured-identity.template.json` by copying `walkthroughs/AssuredIdentity/blueprints/assured-identity.json` and replacing the `x-review.header.issuerName` literal with a `{{issuerName}}` token (keep the `holderKeys`/`holderKeySourceField` F137 wiring intact)
-- [ ] T004 [P] Create `demos/AssuredIdentity/demo-nodes.example.json` conforming to `contracts/demo-nodes.schema.json` (tiny=issuer, n1=subscriber defaults)
-- [ ] T005 [P] Add Pester runner `demos/AssuredIdentity/tests/Invoke-DemoTests.ps1` (Invoke-Pester over `tests/*.Tests.ps1`) and a `.gitignore` entry block for `demo-nodes.json`, `state.json`, rendered `agent/analyst.*.json`
+- [X] T001 Create the demo directory tree `demos/AssuredIdentity/` with subdirs `lib/`, `agent/`, `blueprints/`, `tests/`
+- [X] T002 [P] Create module skeleton `demos/AssuredIdentity/AssuredIdentityDemo.psm1` — SPDX header, `Import-Module` of `walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1`, stub-export the four commands (`New-IssuingAuthority`, `Connect-Subscriber`, `Reset-Demo`, `Get-DemoStatus`)
+- [X] T003 [P] Create `demos/AssuredIdentity/blueprints/assured-identity.template.json` by copying `walkthroughs/AssuredIdentity/blueprints/assured-identity.json` and replacing the `x-review.header.issuerName` literal with a `{{issuerName}}` token (keep the `holderKeys`/`holderKeySourceField` F137 wiring intact)
+- [X] T004 [P] Create `demos/AssuredIdentity/demo-nodes.example.json` conforming to `contracts/demo-nodes.schema.json` (tiny=issuer, n1=subscriber defaults)
+- [X] T005 [P] Add Pester runner `demos/AssuredIdentity/tests/Invoke-DemoTests.ps1` (Invoke-Pester over `tests/*.Tests.ps1`) and a `.gitignore` entry block for `demo-nodes.json`, `state.json`, rendered `agent/analyst.*.json`
 
 ---
 
@@ -37,10 +37,10 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 **⚠️ CRITICAL**: No user-story command can be built until this phase is complete.
 
-- [ ] T006 Implement `demos/AssuredIdentity/lib/NodeInventory.ps1` — load + schema-validate `demo-nodes.json`, select node by `id`, resolve by `role`, fail-fast on duplicate id / malformed URL / missing required field (FR-006, FR-007)
-- [ ] T007 [P] Pester tests `demos/AssuredIdentity/tests/NodeInventory.Tests.ps1` — valid load, duplicate-id rejection, malformed-URL rejection, missing-field rejection, select-by-id, select-by-role
-- [ ] T008 Implement `demos/AssuredIdentity/lib/DemoState.ps1` — read/write/merge `state.json` per `contracts/demo-state.schema.json`, plus a `Test-DemoStateStale` helper (registerId present in state but unreadable on the issuer node → stale)
-- [ ] T009 [P] Implement auth bootstrap in `demos/AssuredIdentity/lib/Auth.ps1` — load `deploy/keys.env`, per-node sysadmin login via SorchaWalkthrough `Connect-SorchaAdmin`, never echo secrets
+- [X] T006 Implement `demos/AssuredIdentity/lib/NodeInventory.ps1` — load + schema-validate `demo-nodes.json`, select node by `id`, resolve by `role`, fail-fast on duplicate id / malformed URL / missing required field (FR-006, FR-007)
+- [X] T007 [P] Pester tests `demos/AssuredIdentity/tests/NodeInventory.Tests.ps1` — valid load, duplicate-id rejection, malformed-URL rejection, missing-field rejection, select-by-id, select-by-role
+- [X] T008 Implement `demos/AssuredIdentity/lib/DemoState.ps1` — read/write/merge `state.json` per `contracts/demo-state.schema.json`, plus a `Test-DemoStateStale` helper (registerId present in state but unreadable on the issuer node → stale)
+- [X] T009 [P] Implement auth bootstrap in `demos/AssuredIdentity/lib/Auth.ps1` — load `deploy/keys.env`, per-node sysadmin login via SorchaWalkthrough `Connect-SorchaAdmin`, never echo secrets
 
 **Checkpoint**: Inventory + state + auth available — command implementation can begin.
 
@@ -54,20 +54,20 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 ### Tests for User Story 1
 
-- [ ] T010 [P] [US1] Pester `demos/AssuredIdentity/tests/AgencyNaming.Tests.ps1` — a chosen name is injected into all four sites (org/register/published-participant/blueprint `issuerName`) and leaves no `{{issuerName}}` token
-- [ ] T011 [P] [US1] Pester `demos/AssuredIdentity/tests/Readiness.Tests.ps1` — predicate is `Ready` only when subscription `Active` ∧ sync-state `CaughtUp` ∧ target blueprint present; partial signals → `NotReady` with reasons; timeout path yields `NotReady(recovery-in-progress)`
-- [ ] T012 [P] [US1] Pester `demos/AssuredIdentity/tests/Idempotency.Tests.ps1` — existing org/register/blueprint detected → reuse (no duplicate); stale subscription-vs-missing-register → reconcile decision
+- [X] T010 [P] [US1] Pester `demos/AssuredIdentity/tests/AgencyNaming.Tests.ps1` — a chosen name is injected into all four sites (org/register/published-participant/blueprint `issuerName`) and leaves no `{{issuerName}}` token
+- [X] T011 [P] [US1] Pester `demos/AssuredIdentity/tests/Readiness.Tests.ps1` — predicate is `Ready` only when subscription `Active` ∧ sync-state `CaughtUp` ∧ target blueprint present; partial signals → `NotReady` with reasons; timeout path yields `NotReady(recovery-in-progress)`
+- [X] T012 [P] [US1] Pester `demos/AssuredIdentity/tests/Idempotency.Tests.ps1` — existing org/register/blueprint detected → reuse (no duplicate); stale subscription-vs-missing-register → reconcile decision
 
 ### Implementation for User Story 1
 
-- [ ] T013 [P] [US1] Implement `demos/AssuredIdentity/lib/AgencyNaming.ps1` — single-source `-AgencyName` → org name, register name, published-participant org name, and blueprint `{{issuerName}}` token replacement (FR-002, R3)
-- [ ] T014 [P] [US1] Implement `demos/AssuredIdentity/lib/Readiness.ps1` — poll `GET /api/organizations/{orgId}/register-subscriptions/{registerId}` (Active), `GET /api/registers/{id}/sync-state` (CaughtUp), `GET /api/registers/{id}/blueprints/published` (blueprint present); bounded backoff to `-TimeoutSeconds`; return `{status, reasons[]}` (FR-004, R4)
-- [ ] T015 [P] [US1] Implement `demos/AssuredIdentity/lib/Idempotency.ps1` — probe-and-reuse existing authority artefacts; detect+reconcile stale subscription-vs-missing-register (FR-003, R5)
-- [ ] T016 [P] [US1] Create `demos/AssuredIdentity/agent/analyst.rules.template.json` — deterministic auto-approve actor for Action 2, tokenised (`{{analystWallet}}`, `{{registerId}}`, `{{orgId}}`, gateway) for `{{placeholder}}` substitution from `state.json`
-- [ ] T017 [US1] Implement `demos/AssuredIdentity/lib/AgentLaunch.ps1` (rules path) — render `analyst.rules.json` from the template and launch `sorcha-agent run --config <rendered> --state state.json` as a tracked child process (FR-011 rules branch)
-- [ ] T018 [US1] Implement `New-IssuingAuthority` in `AssuredIdentityDemo.psm1` — resolve issuer node + creds → idempotency probe (T015) → provision (public org, verification-admin Tier-2, analyst Tier-3, wallets, participants, advertised DevMode register, publish analyst participant) → publish blueprint from template with injected name (T013) → launch rules agent (T017) → write `state.json` (T008). Default `-AgencyName "Strathcarron Identity Authority"`, default `-AgentMode rules` (FR-001)
-- [ ] T019 [US1] Implement `Connect-Subscriber` in `AssuredIdentityDemo.psm1` — resolve subscriber node + public org → discover advertised register on issuer → `POST /api/organizations/{orgId}/register-subscriptions` (reuse Active / reconcile stale) → readiness gate (T014) → append `subscribers[]` in `state.json` with status + `lastReadyAt` (FR-004)
-- [ ] T020 [US1] Write the **tester-journey** section of `demos/AssuredIdentity/DEMO.md` — sign up → F128 add-device → `/new-submissions` → Start → submit → receive in PWA; explicitly record PWA `/applications` + `samples/strathcarron-portal` as off-path (FR-014, FR-015, FR-016)
+- [X] T013 [P] [US1] Implement `demos/AssuredIdentity/lib/AgencyNaming.ps1` — single-source `-AgencyName` → org name, register name, published-participant org name, and blueprint `{{issuerName}}` token replacement (FR-002, R3)
+- [X] T014 [P] [US1] Implement `demos/AssuredIdentity/lib/Readiness.ps1` — poll `GET /api/organizations/{orgId}/register-subscriptions/{registerId}` (Active), `GET /api/registers/{id}/sync-state` (CaughtUp), `GET /api/registers/{id}/blueprints/published` (blueprint present); bounded backoff to `-TimeoutSeconds`; return `{status, reasons[]}` (FR-004, R4)
+- [X] T015 [P] [US1] Implement `demos/AssuredIdentity/lib/Idempotency.ps1` — probe-and-reuse existing authority artefacts; detect+reconcile stale subscription-vs-missing-register (FR-003, R5)
+- [X] T016 [P] [US1] Create `demos/AssuredIdentity/agent/analyst.rules.template.json` — deterministic auto-approve actor for Action 2, tokenised (`{{analystWallet}}`, `{{registerId}}`, `{{orgId}}`, gateway) for `{{placeholder}}` substitution from `state.json`
+- [X] T017 [US1] Implement `demos/AssuredIdentity/lib/AgentLaunch.ps1` (rules path) — render `analyst.rules.json` from the template and launch `sorcha-agent run --config <rendered> --state state.json` as a tracked child process (FR-011 rules branch)
+- [X] T018 [US1] Implement `New-IssuingAuthority` in `AssuredIdentityDemo.psm1` — resolve issuer node + creds → idempotency probe (T015) → provision (public org, verification-admin Tier-2, analyst Tier-3, wallets, participants, advertised DevMode register, publish analyst participant) → publish blueprint from template with injected name (T013) → launch rules agent (T017) → write `state.json` (T008). Default `-AgencyName "Strathcarron Identity Authority"`, default `-AgentMode rules` (FR-001)
+- [X] T019 [US1] Implement `Connect-Subscriber` in `AssuredIdentityDemo.psm1` — resolve subscriber node + public org → discover advertised register on issuer → `POST /api/organizations/{orgId}/register-subscriptions` (reuse Active / reconcile stale) → readiness gate (T014) → append `subscribers[]` in `state.json` with status + `lastReadyAt` (FR-004)
+- [X] T020 [US1] Write the **tester-journey** section of `demos/AssuredIdentity/DEMO.md` — sign up → F128 add-device → `/new-submissions` → Start → submit → receive in PWA; explicitly record PWA `/applications` + `samples/strathcarron-portal` as off-path (FR-014, FR-015, FR-016)
 
 **Checkpoint**: Default-named demo stands up and a tester completes the loop (MVP — SC-001, SC-002, SC-003 basic reuse).
 
@@ -79,10 +79,10 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 **Independent Test**: Provision three times, one per mode; each yields an approved credential, and human mode prints approval steps instead of launching an agent (SC-005).
 
-- [ ] T021 [P] [US2] Create `demos/AssuredIdentity/agent/analyst.ai.template.json` + `demos/AssuredIdentity/agent/analyst.persona.md` — AI-persona approver actor (`"mode":"ai"`, persona file, `apiKeyEnvVar: ANTHROPIC_API_KEY`), tokenised like the rules template (FR-010)
-- [ ] T022 [US2] Extend `demos/AssuredIdentity/lib/AgentLaunch.ps1` — `ai` path (precheck `ANTHROPIC_API_KEY`, set decision-wait guardrail = 90s, launch) and `human` path (no launch; print "log into the issuer as the analyst and approve Action 2" steps) (FR-011, FR-012, R6)
-- [ ] T023 [US2] Wire `-AgentMode rules|ai|human` parameter through `New-IssuingAuthority` to `AgentLaunch` (default `rules`) and record `agentMode` in `state.json` (FR-010)
-- [ ] T024 [US2] Add the **agent-mode** section to `demos/AssuredIdentity/DEMO.md` — three modes, the AI guardrail behaviour (`Get-DemoStatus` surfaces "decision pending"; retry or switch), and the human steps
+- [X] T021 [P] [US2] Create `demos/AssuredIdentity/agent/analyst.ai.template.json` + `demos/AssuredIdentity/agent/analyst.persona.md` — AI-persona approver actor (`"mode":"ai"`, persona file, `apiKeyEnvVar: ANTHROPIC_API_KEY`), tokenised like the rules template (FR-010)
+- [X] T022 [US2] Extend `demos/AssuredIdentity/lib/AgentLaunch.ps1` — `ai` path (precheck `ANTHROPIC_API_KEY`, set decision-wait guardrail = 90s, launch) and `human` path (no launch; print "log into the issuer as the analyst and approve Action 2" steps) (FR-011, FR-012, R6)
+- [X] T023 [US2] Wire `-AgentMode rules|ai|human` parameter through `New-IssuingAuthority` to `AgentLaunch` (default `rules`) and record `agentMode` in `state.json` (FR-010)
+- [X] T024 [US2] Add the **agent-mode** section to `demos/AssuredIdentity/DEMO.md` — three modes, the AI guardrail behaviour (`Get-DemoStatus` surfaces "decision pending"; retry or switch), and the human steps
 
 **Checkpoint**: All three modes produce an approved credential (SC-005).
 
@@ -94,9 +94,9 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 **Independent Test**: Provision with a non-default name; complete the loop; the credential's displayed issuer matches with zero manual edits (SC-004).
 
-- [ ] T025 [US3] Harden rename coherence in `New-IssuingAuthority` — re-running with a changed `-AgencyName` updates all tester-visible sites and reconciles prior-name artefacts via Idempotency (T015), leaving no stale prior-name reference on the tester path (FR-005)
-- [ ] T026 [P] [US3] Pester `demos/AssuredIdentity/tests/RenameCoherence.Tests.ps1` — a name change re-injects every site and surfaces any residual prior-name reference as a failure
-- [ ] T027 [US3] Add the **deep-customise** section to `demos/AssuredIdentity/DEMO.md` — amend the published blueprint via the real F142 Designer (Describe→Understand→Rehearse→Go-live) and republish to the same register; identity (org/wallet/register/DID) stays intact
+- [X] T025 [US3] Harden rename coherence in `New-IssuingAuthority` — re-running with a changed `-AgencyName` updates all tester-visible sites and reconciles prior-name artefacts via Idempotency (T015), leaving no stale prior-name reference on the tester path (FR-005)
+- [X] T026 [P] [US3] Pester `demos/AssuredIdentity/tests/RenameCoherence.Tests.ps1` — a name change re-injects every site and surfaces any residual prior-name reference as a failure
+- [X] T027 [US3] Add the **deep-customise** section to `demos/AssuredIdentity/DEMO.md` — amend the published blueprint via the real F142 Designer (Describe→Understand→Rehearse→Go-live) and republish to the same register; identity (org/wallet/register/DID) stays intact
 
 **Checkpoint**: Rebrand is coherent end-to-end (SC-004).
 
@@ -108,8 +108,8 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 **Independent Test**: With an authority provisioned, connect a second subscriber id; a tester on that node completes the loop (SC-006).
 
-- [ ] T028 [US4] Make `Connect-Subscriber` repeatable across N subscriber ids — append/update per-node `subscribers[]` entries, each independently readiness-gated (T014); no cross-node coupling (FR-008)
-- [ ] T029 [US4] Add the **multi-node** section to `demos/AssuredIdentity/DEMO.md` — add a subscriber entry to `demo-nodes.json`, re-run `Connect-Subscriber -SubscriberNode <id>`; note swap/rename via inventory only (FR-006, FR-007)
+- [X] T028 [US4] Make `Connect-Subscriber` repeatable across N subscriber ids — append/update per-node `subscribers[]` entries, each independently readiness-gated (T014); no cross-node coupling (FR-008)
+- [X] T029 [US4] Add the **multi-node** section to `demos/AssuredIdentity/DEMO.md` — add a subscriber entry to `demo-nodes.json`, re-run `Connect-Subscriber -SubscriberNode <id>`; note swap/rename via inventory only (FR-006, FR-007)
 
 **Checkpoint**: A second independent subscriber serves a tester through the full loop (SC-006).
 
@@ -121,11 +121,11 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 **Independent Test**: After a run, reset and re-provision cleanly; query status before/after and confirm the verdict predicts tester success (SC-007).
 
-- [ ] T030 [P] [US5] Implement `Reset-Demo` in `AssuredIdentityDemo.psm1` — `-Scope issuer|subscriber|all` per the documented reset recipe (demo wallets, non-system register Mongo DBs, `OrganizationRegisterSubscriptions` rows, replicated state, `state.json`), stop any tracked `sorcha-agent` process, idempotent no-op on already-clean (FR-017)
-- [ ] T031 [US5] Implement `demos/AssuredIdentity/lib/StatusVerdict.ps1` — gather per-node signals (gateway health, subscription, sync-state, blueprint-published, approver state) and compute `{verdict: Ready|NotReady, perNode[], reasons[]}` (FR-018, data-model "Derived")
-- [ ] T032 [US5] Implement `Get-DemoStatus` in `AssuredIdentityDemo.psm1` — render the verdict table from `StatusVerdict` across issuer + all `subscribers[]` (FR-018)
-- [ ] T033 [P] [US5] Pester `demos/AssuredIdentity/tests/StatusVerdict.Tests.ps1` — verdict combinations map correctly (all-green→Ready; each missing signal→NotReady with the right reason)
-- [ ] T034 [US5] Add the **reset / status** section to `demos/AssuredIdentity/DEMO.md`
+- [X] T030 [P] [US5] Implement `Reset-Demo` in `AssuredIdentityDemo.psm1` — `-Scope issuer|subscriber|all` per the documented reset recipe (demo wallets, non-system register Mongo DBs, `OrganizationRegisterSubscriptions` rows, replicated state, `state.json`), stop any tracked `sorcha-agent` process, idempotent no-op on already-clean (FR-017)
+- [X] T031 [US5] Implement `demos/AssuredIdentity/lib/StatusVerdict.ps1` — gather per-node signals (gateway health, subscription, sync-state, blueprint-published, approver state) and compute `{verdict: Ready|NotReady, perNode[], reasons[]}` (FR-018, data-model "Derived")
+- [X] T032 [US5] Implement `Get-DemoStatus` in `AssuredIdentityDemo.psm1` — render the verdict table from `StatusVerdict` across issuer + all `subscribers[]` (FR-018)
+- [X] T033 [P] [US5] Pester `demos/AssuredIdentity/tests/StatusVerdict.Tests.ps1` — verdict combinations map correctly (all-green→Ready; each missing signal→NotReady with the right reason)
+- [X] T034 [US5] Add the **reset / status** section to `demos/AssuredIdentity/DEMO.md`
 
 **Checkpoint**: Reset+re-provision is clean; status verdict matches reality (SC-007).
 
@@ -151,10 +151,10 @@ Toolkit: `demos/AssuredIdentity/` (module, `lib/`, `agent/`, `blueprints/`, `tes
 
 ## Phase 9: Polish & Cross-Cutting Concerns
 
-- [ ] T042 [P] Assemble the full `demos/AssuredIdentity/DEMO.md` operator runbook (provision/connect/reset/status/agent-modes/multi-node) from the per-story sections; cross-check against `quickstart.md`
+- [X] T042 [P] Assemble the full `demos/AssuredIdentity/DEMO.md` operator runbook (provision/connect/reset/status/agent-modes/multi-node) from the per-story sections; cross-check against `quickstart.md`
 - [ ] T043 Run the `quickstart.md` validation end-to-end one final time post-cleanup and confirm the acceptance-checkpoint table passes
-- [ ] T044 [P] Verify `.gitignore` covers `demo-nodes.json`, `state.json`, rendered `agent/analyst.*.json`; confirm no secret leaked into committed files
-- [ ] T045 [P] Final Pester suite green + PSScriptAnalyzer pass over `demos/AssuredIdentity/**`
+- [X] T044 [P] Verify `.gitignore` covers `demo-nodes.json`, `state.json`, rendered `agent/analyst.*.json`; confirm no secret leaked into committed files
+- [X] T045 [P] Final Pester suite green + PSScriptAnalyzer pass over `demos/AssuredIdentity/**`
 
 ---
 


### PR DESCRIPTION
## Summary

Turns the proven F143 cross-installation Assured Identity loop into a **standing, node-agnostic demo environment** plus a **self-service provisioning toolkit** under `demos/AssuredIdentity/`. A tester goes — unscripted, through the real product — from anonymous sign-up to an Assured Identity credential in their wallet; the approval is performed by an identity-validator agent (rule / AI persona / human).

Full speckit trail on the branch: **design → spec → plan → tasks → feat**.
- Design: `docs/superpowers/specs/2026-05-31-assured-identity-demo-environment-design.md`
- Spec/plan/tasks: `specs/144-assured-identity-demo/`

## What's included (Phases 1–7, US1–US5)

- **4 commands** (`AssuredIdentityDemo.psm1`): `New-IssuingAuthority`, `Connect-Subscriber`, `Reset-Demo`, `Get-DemoStatus` — orchestrating existing Sorcha endpoints + the existing `sorcha-agent` CLI. No new services, no new tester UI.
- **9 pure-logic lib units** + **tokenised blueprint template** (`{{issuerName}}`) + **rules/ai agent actor templates** + persona + JSON-schema-conformant node inventory.
- **`DEMO.md`** operator + tester runbook (agent modes, rebrand, F142 deep-customise, multi-node, reset/status).
- **38 Pester unit tests — all green** (readiness predicate, idempotency/stale-reconcile, agency-name coherence, inventory validation, cross-node verdict).

## Key properties (per the approved design)

- **Node-agnostic**: nothing hard-codes `tiny`/`n1`; inventory-driven; multiple independent subscribers supported. Each installation keeps its own JWT key — never shared.
- **Readiness gate** uses real grounded signals (subscription `Active` ∧ sync-state `CaughtUp` ∧ blueprint in `/blueprints/published`) so testers never hit transient `blueprint_not_available`.
- **Single-source agency name** propagates to org/register/participant/credential `issuerName`, with a coherence assertion.
- Reuses the proven `twoinstall-issuer.ps1` flow + `SorchaWalkthrough` helpers.

## Deliberately deferred (US6 — gated on a live green run)

T035 green-run gate, T036/T037 retiring the legacy `walkthroughs/AssuredIdentity/` + `deploy/twoinstall-*` scripts, T038–T041 skill/memory alignment, T043 live validation. The legacy path is intentionally left intact until the demo is proven on the real two-node environment.

## Scope

PowerShell tooling + config + docs only — **no .NET service code, no new endpoints, no committed secrets**. Constitution gates are N/A (no service) or adapted (Pester units + live green-run gate in place of xUnit coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)