### PR TITLE
fix(demo): Assured Identity toolkit live-run fixes

### DIFF
--- a/demos/AssuredIdentity/AssuredIdentityDemo.psm1
+++ b/demos/AssuredIdentity/AssuredIdentityDemo.psm1
@@ -13,7 +13,7 @@ $ErrorActionPreference = 'Stop'
 
 # --- dependencies -----------------------------------------------------------
 $script:DemoRoot = $PSScriptRoot
-Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force
+Import-Module (Join-Path $PSScriptRoot "../../walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1") -Force -DisableNameChecking
 
 # dot-source the lib units (Common first — others depend on its helpers)
 . (Join-Path $PSScriptRoot "lib/Common.ps1")
@@ -289,11 +289,26 @@ function Connect-Subscriber {
     }
 
     Write-WtStep "3: readiness gate (subscription Active + sync CaughtUp + blueprint published) timeout=${TimeoutSeconds}s"
-    $verdict = Wait-SubscriberReady `
-        -GetSubscriptionStatus { Get-DemoSubscriptionStatus -Api $api -OrgId $script:PublicOrgId -RegisterId $RegisterId -Headers $sysAdmin.Headers }.GetNewClosure() `
-        -GetSyncState { Get-DemoSyncState -Api $api -RegisterId $RegisterId -Headers $sysAdmin.Headers }.GetNewClosure() `
-        -GetPublishedBlueprintIds { Get-DemoPublishedBlueprintIds -Api $api -RegisterId $RegisterId }.GetNewClosure() `
-        -TargetBlueprintId $targetBlueprintId -TimeoutSeconds $TimeoutSeconds
+    # Inline poll using the module-internal probes (cross-scope scriptblocks can't see
+    # module-private functions; Wait-SubscriberReady stays lib-only for unit tests).
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $rv = $null
+    do {
+        $subS  = Get-DemoSubscriptionStatus -Api $api -OrgId $script:PublicOrgId -RegisterId $RegisterId -Headers $sysAdmin.Headers
+        $syncS = Get-DemoSyncState -Api $api -RegisterId $RegisterId -Headers $sysAdmin.Headers
+        $pubIds = @(Get-DemoPublishedBlueprintIds -Api $api -RegisterId $RegisterId)
+        $rv = Test-SubscriberReady -SubscriptionStatus $subS -SyncState $syncS -PublishedBlueprintIds $pubIds -TargetBlueprintId $targetBlueprintId
+        if ($rv.Ready) { break }
+        if ($sw.Elapsed.TotalSeconds -ge $TimeoutSeconds) { break }
+        Write-WtInfo ("  waiting - sub=$subS sync=$syncS bpPublished=" + ($pubIds -contains $targetBlueprintId) + " (" + [int]$sw.Elapsed.TotalSeconds + "s)")
+        Start-Sleep -Seconds 6
+    } while ($true)
+    $sw.Stop()
+    $verdict = [pscustomobject]@{
+        Status  = if ($rv.Ready) { 'Ready' } else { 'NotReady' }
+        Reasons = $rv.Reasons
+        Elapsed = $sw.Elapsed
+    }
 
     # update subscribers[] in state
     if ($state) {

--- a/demos/AssuredIdentity/lib/AgentLaunch.ps1
+++ b/demos/AssuredIdentity/lib/AgentLaunch.ps1
@@ -32,7 +32,7 @@ function New-AgentActorConfig {
     }
     $raw = Get-Content -LiteralPath $TemplatePath -Raw
     $rendered = Expand-DemoTokens -Text $raw -Tokens $Tokens
-    $unresolved = Get-DemoUnresolvedTokens -Text $rendered
+    $unresolved = @(Get-DemoUnresolvedTokens -Text $rendered)
     if ($unresolved.Count -gt 0) {
         throw "Agent config still has unresolved tokens: $($unresolved -join ', ')"
     }

--- a/demos/AssuredIdentity/lib/Common.ps1
+++ b/demos/AssuredIdentity/lib/Common.ps1
@@ -41,8 +41,8 @@ function Get-DemoUnresolvedTokens {
     param(
         [Parameter(Mandatory)][AllowEmptyString()][string]$Text
     )
-    $matches = [regex]::Matches($Text, '{{\s*[A-Za-z0-9_]+\s*}}')
-    return @($matches | ForEach-Object { $_.Value } | Select-Object -Unique)
+    $found = [regex]::Matches($Text, '{{\s*[A-Za-z0-9_]+\s*}}')
+    return @($found | ForEach-Object { $_.Value } | Select-Object -Unique)
 }
 
 <#


### PR DESCRIPTION
## Summary

Three fixes to the `demos/AssuredIdentity/` toolkit found during the live `tiny`↔`n1` cross-node green run (the demo loop completed end-to-end — credential delivered to the citizen on n1).

- **`Common.ps1` / `AgentLaunch.ps1`** — `@()`-wrap `Get-DemoUnresolvedTokens` so `.Count` works under `Set-StrictMode` (was crashing `New-AgentActorConfig` at the agent-launch step with "property 'Count' cannot be found").
- **`AssuredIdentityDemo.psm1`** — `Connect-Subscriber`'s readiness gate now polls **inline**: the previous `.GetNewClosure()` scriptblocks re-anchored to the global session, hiding the module-internal probe functions (`Get-DemoSubscriptionStatus` "not recognized"). Also imports `SorchaWalkthrough` with `-DisableNameChecking` to silence the unapproved-verb warning noise.

## Verified

38 Pester unit tests green; the full cross-node loop ran with these fixes in place (instance created, Action 1 brokered to tiny, sealed, credential delivered back to n1).

## Known follow-up (not in this PR)

`Get-DemoPublishedBlueprintIds` calls `/registers/{id}/blueprints/published` without auth → 401, so the readiness gate is cosmetically wrong (the blueprint IS recovered on the subscriber). Tracked as **task T042** in `specs/145-ledger-derived-instances/tasks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)