### PR TITLE
feat(145): ledger-derived instances — routing decision + projection core

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -1516,3 +1516,40 @@ Accepts a reverse stream, registers it in `ReverseStreamManager` (keyed by the N
 v1 covers a NAT'd **owner** reached via its anchors (the demo: tiny=NAT'd owner dials n1=public subscriber; advert flows the proven `tiny→n1` heartbeat direction). **Deferred:** anchor-set *gossip* + multi-hop mesh routing (a subscriber relaying through a third-party anchor it doesn't hold — needs hub→hub forwarding); relay-payload re-encryption; rendezvous authz/quotas. **Trust boundary is the register** (wallet signatures + roster), not JWT — federated nodes are **separate installations** and MUST NOT share JWT signing keys.
 
 Spec: `specs/143-peer-nat-traversal/`. Design: `docs/superpowers/specs/2026-05-30-peer-nat-traversal-design.md`.
+
+---
+
+## Ledger-Derived Workflow Instances (Feature 145) — IN PROGRESS
+
+Makes a workflow instance a **deterministic projection of the sealed register** — one shared state machine on every node, no origin/mirror duplication, one async submission path, routing decisions carried on the transaction (in the clear) and validated at seal under a pluggable attestation. Replaces the imperative per-node instance mutation + the reconstructed cross-node mirror + the dual sync/async submission split. **Status: foundational layer landed (additive, non-breaking); the projector cutover + mirror removal (US1 T013-T020) is the next slice, gated on cross-node live validation.**
+
+### RoutingDecision — carried, attested routing fact (DONE)
+
+`RoutingDecision` rides on the action transaction's **clear** metadata (`TransactionMetaData.RoutingDecision`, `src/Common/Sorcha.Register.Models/Transactions/`), replacing the singular `TransactionMetaData.NextActionId` hint (now marked legacy, removed in T024). It carries the **full** next-action set (`ActionRef[]` — preserves parallel branches) plus a pluggable `Attestation`:
+
+```
+RoutingDecision { completedActionId:int, nextActions:ActionRef[], attestation:Attestation }
+ActionRef       { actionId:int, branchKey?:string }
+Attestation     { kind:AttestationKind, signature?:string }   // v1 = SenderSigned
+AttestationKind = SenderSigned | ValidatorReEvaluated | Proof  // v2/v3 reserved
+```
+
+- Serialized canonically via `RegisterSerializationOptions.Canonical` (camelCase, the #881 relay-stability lesson). `RoutingDecision.ComputeSignableBytes()` returns the attestation-free canonical bytes the sender signs (the signature can't sign over itself).
+- **Producer** (`ActionExecutionService.cs` step 10d): builds the decision from the routing result, signs `ComputeSignableBytes()` with the sender wallet via `IWalletServiceClient.SignTransactionAsync`, base64s into `Attestation.Signature`, writes canonical JSON to `transaction.Metadata["routingDecision"]`. That string-dict entry is copied wholesale into the sealed tx's `TrackingData` by the validator's authoritative projection (`DocketBuildTriggerService.cs:638-646`), so the carried decision reaches MongoDB with no validator change. The typed `TransactionMetaData.RoutingDecision` projection + `VAL_ROUTING_*` validation are US3 (T023/T024).
+- The projection consumes `nextActions` regardless of attestation kind; only validation branches on kind. v2/v3 throw "unsupported attestation strength" until implemented; required strength will be a register-governance field `routingAttestation` (default `sender-signed`, US3 T025).
+
+### Deterministic instance identity (DONE)
+
+`InstanceIdentity.Derive(registerId, blueprintId, startingActionTxHash)` (`src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceIdentity.cs`) = lowercase-hex SHA-256 over the three UTF-8 fields separated by `0x1F` unit-separator bytes (anti-collision on field boundaries). Node-independent: every node derives the same id for the same workflow. "Start application" becomes a local draft (no ledger write); the instance is born when its starting action seals. (Wiring `POST /instances` to a draft + returning the derived id on submit is US1 T018.)
+
+### The projection fold (DONE — pure core; BackgroundService wiring is T013)
+
+`InstanceProjection` (`src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjection.cs`) is the pure, deterministic heart:
+- `ProjectedTransaction` record = the facts a sealed action contributes (`TxId`, `PreviousTransactionId`, `CompletedActionId`, `NextActionIds`, `ParticipantBindings`, `IsRejection`).
+- `Project(...)` — batch rebuild from a transaction set, folded in **chain order** (predecessor links), **order-independent**, dedups by tx-id. This is also US4's `RebuildAsync` (FR-003 parity).
+- `Apply(instance, tx)` — online incremental fold, **idempotent** on the `Instance.LastAppliedTxId` watermark (re-observing a folded tx is a no-op, FR-004).
+- Advances `CurrentActionIds` from the full `nextActions` set (parallel branches preserved, sorted for canonical cross-node equality); merges participant-id-keyed bindings; derives terminal `Completed` (no current actions) / `Rejected` state. Needs only the validated decision — never decrypts payload (FR-010).
+
+The online `InstanceProjector : BackgroundService` (T013) will wrap `Apply`, subscribe `docket:confirmed` (`RegisterEventChannels.DocketConfirmed`) on **every** node (generalizing the owner-only `InstanceMirrorReconstructor`), and resolve `ProjectedTransaction`s from the register + carried decision. The cutover (T015 remove `ApplyInstanceStateChanges`, T016 single async submit, T017 roster sealer, T020 delete mirror) lands only after the projector is green and **cross-node-validated on the standing two-node demo** (SC-001/SC-002).
+
+Spec: `specs/145-ledger-derived-instances/`. Design: `docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md`. CI clean-break gate (skeleton, activated per-pattern in T040): `scripts/check-ledger-derived-clean-break.ps1`.

--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,8 @@ walkthroughs/*/state.gateway.json
 # Spec 117 — Phase 2 baseline OpenAPI capture (T006), local-only review artefact
 specs/117-ai-discoverability/baseline-openapi.json
 deploy/
+
+# Live demo runtime state (repo-root invocation of the Assured Identity demo)
+/demo-nodes.json
+/state.json
+/demo-citizen-state.json

--- a/docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md
+++ b/docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md
@@ -1,0 +1,195 @@
+# Ledger-Derived Workflow Instances — design
+
+- **Status:** ✅ APPROVED — ready for `/speckit.specify`.
+- **Date:** 2026-05-31
+- **Author:** architecture session (Stuart + Claude)
+- **Theme:** make a workflow instance a deterministic **projection of the sealed register**, identical on every node — eliminating the "origin vs mirror" duplication and the two-path submission model that have repeatedly caused cross-node friction.
+
+---
+
+## 1. Problem — why this exists
+
+Three investigations into the live code (Blueprint, Validator, Register, Peer services) established that a workflow **instance is not a projection of the ledger** today. It is independently-stored mutable state, mutated imperatively, with the cross-node case bolted on. Concretely, three deviations from an event-sourced model:
+
+1. **Instance control-state is authoritative mutable per-node store.** `CurrentActionIds`/`State` live in a Postgres row that `ActionExecutionService.ApplyInstanceStateChanges` edits in place right after a submit (`ActionExecutionService.cs:1762-1834`). The ledger does not drive it. (The *data* part, `AccumulatedData`, *is* a labelled cache of `StateReconstructionService`'s ledger projection — but control flow is not projected at all.)
+2. **Routing is computed off-ledger and is not replayable.** The next-action decision runs in the Blueprint Engine against the payload; the validator "only knows the static route graph" (`DocketBuildTriggerService.cs:636-642`) and the answer is carried as a **singular** `MetaData.NextActionId` *hint* (parallel branches collapse to one).
+3. **Instance creation is local-only with a node-local GUID.** `POST /instances` does `Id = Guid.NewGuid()` + a local store write, **no ledger transaction** (`Program.cs:2163-2185`). So "the same" workflow has a different id on every node, and a node that didn't run creation has no idea the instance exists until an action tx seals.
+
+**Consequences (the recurring symptoms):**
+- **Mirrors** (`InstanceMirrorReconstructor`, `IsReadOnlyMirror`) exist *only* to compensate for Deviation 3 — `ActionExecutionService` hard-requires a local instance row (`if (instance == null) throw "Instance not found"`, `:162-166`), which the owner lacks, so a synthetic mirror is reconstructed on `docket:confirmed`.
+- **Two submission paths** are one submission with an optimistic shortcut forced by Deviation 1: both downstream calls (validator submit + peer fan-out) always fire; the `!LocallyOwned && AcceptedCount>0` branch only decides *wait-synchronously-and-advance-now* (owner) vs *return-202-advance-on-sync-back* (subscriber). The owner advances its row imperatively *now*; the subscriber advances from the replicated seal *later* → **two independent projections that drift** (single-vs-multi next action, self-keyed vs participant-keyed wallets, missing `AccumulatedData`, count drift).
+- **Ownership is decided two ways**: the submit path uses a peer-topology heuristic (`TransactionDistributionService.ForwardSubmissionAsync` — "do I have seeds configured?"), bypassing the authoritative F108 `RegisterLocalRelationship` (roster-derived) which is computed but unused on this path.
+- Live demo symptoms all trace here: `nextActions:[]`/"next: complete" on cross-node submit; the autonomous agent blind to the mirror's Action 2 via `/api/actions/pending`; `sync-state Indeterminate`; two disagreeing published-blueprint reads; subscribe/re-subscribe desyncs.
+
+It is **one architectural choice expressed five ways**, not five bugs.
+
+---
+
+## 2. Target model
+
+The register's **sealed transactions are the only source of truth.** A workflow instance is a **deterministic projection** of the sealed action transactions for that instance, computed identically on every node holding the register. There is no origin and no mirror — there is *the instance*, the same everywhere. Submission appends an action transaction; whichever node is on the register's validator roster seals it; the sealed docket replicates; **every node re-projects and advances identically.**
+
+Two clean separations underpin it:
+- **Projection** (pure, deterministic, every node) advances *state*.
+- **Reactions** (at-least-once, idempotent, node-role-gated) perform *side effects*.
+
+---
+
+## 3. Routing as a carried, attested ledger fact
+
+The submitter computes the **full `NextActions` set** — the `RoutingDecision` — and writes it onto the action transaction. Trust in that decision comes from a **pluggable `Attestation`** whose strength is an upgrade path, while the ledger shape and the projection stay invariant:
+
+```
+RoutingDecision {
+  completedActionId : int
+  nextActions       : ActionRef[]          // FULL set — fixes parallel-branch collapse
+  attestation       : Attestation
+}
+Attestation =
+  | SenderSigned        { sig }                         // v1 — ships now
+  | ValidatorReEvaluated{ validatorSig, controlRef }    // v2 — control-plane disclosure
+  | Proof               { scheme, proof, commitments }  // v3 — ZK / universally verifiable
+```
+
+- **v1 — `SenderSigned`.** The decision is signed by the authorised sender. The **sealing validator validates**: the `nextActions` are real successors of the current action in the blueprint's **static route graph** (structural), the sender is authorised for the action, and the chain is intact. The validator does **not** decrypt payload or re-evaluate the condition — consistent with how the system already trusts submitters for action data on encrypted registers. Reject codes: `VAL_ROUTING_001` (decision not a structural successor), `VAL_ROUTING_002` (attestation/sig invalid).
+- **v2 — `ValidatorReEvaluated`.** A **control plane**: any field a route condition references is placed in a disclosure group wrapped to the validator roster (publish-time guard). The validator decrypts only those control fields and re-evaluates. Additive — same `Attestation` slot.
+- **v3 — `Proof`.** The submitter attaches a succinct proof that `nextActions = evaluate(routeGraph, committedInputs)`; verifiable **without** seeing inputs. Route conditions are JSON-Logic (comparisons / ==, ranges, booleans) — a ZK-friendly subset; the encrypted payload already commits the field values. A *universally-verifiable* ("shared") proof lets **every** subscriber confirm routing without decrypting or trusting the roster — a fully trustless projection, strictly stronger than v2.
+
+**Governance lever (ties to Register governance, F083/F086).** The required attestation strength is a **register governance policy**: the control record carries `routingAttestation: sender-signed | validator-reeval | proof` (default `sender-signed`). A register can *govern itself up* to stronger trust with no platform fork — the natural home for this decision.
+
+**The projection consumes `decision.nextActions` regardless of attestation type.** Ship v1; v2/v3 are drop-ins.
+
+---
+
+## 4. Deterministic, ledger-anchored instance identity
+
+"Start application" is a **local draft — no ledger write.** The instance is **born when its starting action seals**:
+
+```
+instanceId = H(registerId, blueprintId, startingActionTxHash)
+```
+
+derived identically on every node. The client submits the starting action with a local correlation id; the async response returns the canonical, ledger-derived `instanceId`. Every node, on observing the sealed starting action, derives the same id and creates the instance projection. Open-participant late-binding is unaffected — the id derives from the tx hash regardless of who is late-bound, and the binding is recorded by the projection from the sealed starting action.
+
+This removes Deviation 3 → removes the reason mirrors exist.
+
+---
+
+## 5. The Instance Projection (pure, deterministic, every node)
+
+A single **`InstanceProjector`** subscribes to `docket:confirmed` on **every** node. On each sealed **action** transaction for a register it holds, it folds the tx into the instance:
+
+- advance `CurrentActionIds` from the validated `RoutingDecision.nextActions` (full set → parallel branches preserved),
+- record the completed action + bump counts,
+- update participant→wallet bindings from the tx (participant-id keyed, from the blueprint + tx sender/recipients),
+- update the data view (disclosure-aware, what this node can decrypt).
+
+The stored instance row is a **materialized view** — a cache of the projection, **rebuildable from the ledger** at any time via `Rebuild(instanceId)` (replay the instance's sealed txs). A periodic/CI **parity self-check** asserts `materialized == fresh replay`.
+
+**Determinism invariants:** dockets folded in chain order (`PreviousHash`), transactions within a docket folded in a canonical order (by tx hash); re-folding an already-applied tx is a no-op (idempotent). Same sealed input → same state on every node, independent of arrival order or restarts.
+
+**Replaces:** `ApplyInstanceStateChanges` (imperative mutation), `InstanceMirrorReconstructor` (mirror), the origin/mirror split. `IsReadOnlyMirror`, `CreateMirrorAsync`, `UpdateMirrorAsync` are deleted.
+
+> This is what fixes the agent-discovery blocker: a node projects the next action as *current* from the same sealed docket every other node sees, so `/api/actions/pending` (fed by the projection, not a heuristic mirror) surfaces it naturally to the entitled participant.
+
+---
+
+## 6. Single async submission path
+
+`ExecuteAction` becomes one path:
+
+1. **Validate locally** — schema, sender authorisation, credential/presentation gates, then **compute the `RoutingDecision`** (full next-action set) and its `SenderSigned` attestation.
+2. **Build + sign** the action transaction carrying the `RoutingDecision`.
+3. **Submit to local mempool AND fan out to the roster's sealer** (both always — no ownership branch on the submit itself).
+4. **Return `202 {txId, instanceId, accepted}`.** The submitter does **not** mutate instance state. The projection advances it when the seal is observed — identically on every node.
+
+**Ownership is used only to route the fan-out to a sealer** — derived from the authoritative F108 `RegisterLocalRelationship` (validator roster), retiring the peer-topology heuristic. The `LocallyOwned` flow-branch is deleted.
+
+**Bounded-wait convenience (one path, not a branch):** the endpoint may optionally wait a short bound (~2–3s) for the projection to advance and return `200` with the advanced state; otherwise `202`. Clients always handle `202` (subscribe to instance-updated events / poll). This keeps the single-node case ergonomic without reintroducing an architectural fork.
+
+---
+
+## 7. Reactions (idempotent, role-gated side effects)
+
+A separate **`ReactionDispatcher`** subscribes to the same sealed-tx stream. On a sealed action that declares a side effect (`credentialIssuanceConfig`, notification, inbox write), it checks **"am I the entitled node?"** — i.e. *do I locally host the wallet responsible for this reaction* (issuer-wallet-host mints; recipient-wallet-host delivers/detects) — the same wallet-probe the current reconstructor uses. If entitled, it performs the side effect **once**, idempotent on `(sealedTxId, reactionKind)`.
+
+- **Credential mint + deliver** becomes a reaction keyed on the issuing-action txId — **cannot double-issue** across nodes, restarts, or replay.
+- **Inbound credential detection / wallet delivery** on the recipient node is a reaction on the same key.
+- **Notifications / inbox writes** likewise.
+
+Pure projection (state) and at-least-once side effects (reactions) are cleanly separated — credential issuance moves off the synchronous submit path entirely.
+
+---
+
+## 8. Presentation lifecycle reconciliation (F111 / F119)
+
+Presentation-driven advancement (`PresentationOutcome`, `PresentationAbandoned`) is the one genuinely fiddly area: today it has its own seal-aware ordering coordinator (F119, `IPresentationSealCoordinator`) to avoid chain races. In the new model these transitions also carry a `RoutingDecision`, and the projection — being inherently **seal-ordered** — **subsumes** the coordinator's job (advance only on observed seal, in chain order). This phase migrates the presentation lifecycle onto the projection and retires the bespoke seal-ordering where the projection now guarantees it, keeping the `VAL_BP_003` carve-out semantics intact. Scoped as its own phase + risk, not hand-waved.
+
+---
+
+## 9. Clean break + CI gate
+
+Pre-release, no migration. Delete outright and gate against reintroduction:
+
+- `InstanceMirrorReconstructor`, `IsReadOnlyMirror`, `CreateMirrorAsync`/`UpdateMirrorAsync`.
+- `ApplyInstanceStateChanges` imperative `CurrentActionIds` mutation.
+- The `LocallyOwned` synchronous-vs-async branch in `ActionExecutionService`.
+- The peer-topology ownership heuristic on the submit path (replaced by F108 roster).
+- The singular `MetaData.NextActionId` hint (replaced by the full validated `RoutingDecision`).
+
+`scripts/check-ledger-derived-clean-break.ps1` forbids their return (grep gate, like F135's clean-break gate).
+
+---
+
+## 10. Data flow — the AssuredIdentity loop in the new model
+
+1. Citizen (n1) submits the starting action → tx carries `RoutingDecision{next:[2], SenderSigned}` → fan-out to tiny (roster sealer).
+2. tiny's validator validates the decision (structural + sender-authz + chain) → seals. `instanceId = H(register, blueprint, startingTxHash)`.
+3. Docket replicates to n1 **and** tiny → **both project** the instance to `CurrentActionIds:[2]` identically. No mirror.
+4. Analyst (tiny) sees Action 2 as current — because tiny *projected* it (same projection n1 ran) — so `/api/actions/pending` surfaces it. Agent approves.
+5. Analyst's Action 2 → `RoutingDecision{next:[3], SenderSigned}` → sealed → projection advances to `[3]`.
+6. `ReactionDispatcher` on the **issuer-entitled** node mints the `AssuredIdentityCredential` (idempotent on the Action-2 txId) + the **recipient-entitled** node (n1) detects + delivers to the citizen wallet.
+7. Citizen holds the credential. The autonomous agent worked end-to-end with no mirror and no manual approval.
+
+---
+
+## 11. Testing
+
+- **Projection determinism** — same docket stream → identical instance state across nodes / arrival orders.
+- **Rebuild-from-ledger parity** — materialized view == fresh `Rebuild()` replay (CI self-check).
+- **Routing-decision validation** — validator rejects a structurally-invalid / mis-signed decision (`VAL_ROUTING_*`).
+- **Full-set routing** — parallel-branch fan-out preserved end-to-end (regression for the singular-hint collapse).
+- **Reaction idempotency** — duplicate / replayed seal → exactly one credential, one notification.
+- **Cross-node E2E** — the AssuredIdentity loop with autonomous agent discovery working, no mirror, no manual approval.
+- **Clean-break gate** — no references to mirror / `IsReadOnlyMirror` / `LocallyOwned` branch / singular hint.
+
+---
+
+## 12. Phasing (one feature, sequenced)
+
+- **P1 — Routing decision as a carried, attested fact.** `RoutingDecision` + `Attestation` (v1 `SenderSigned`) model; submitter emits the full set; validator structural+authz validation (`VAL_ROUTING_*`); `routingAttestation` governance field (default `sender-signed`). Replaces the singular `NextActionId` hint.
+- **P2 — Deterministic instance identity.** Born-at-first-action; `instanceId = H(...)`; creation = local draft; async response returns the ledger-derived id.
+- **P3 — Instance projection + rebuild.** `InstanceProjector` (pure, every node), materialized view, `Rebuild()`, determinism invariants + parity check. Removes imperative mutation + the mirror.
+- **P4 — Single async submission path.** One path, `202`, roster-based fan-out ownership (F108), bounded-wait convenience. Removes the `LocallyOwned` branch + the topology heuristic.
+- **P5 — Reactions.** `ReactionDispatcher`; credential mint/deliver + notifications as idempotent role-gated reactions keyed on sealed txId. Removes inline issuance from the submit path.
+- **P6 — Presentation-lifecycle migration.** Move F111/F119 advancement onto the projection; retire the bespoke seal-ordering where subsumed.
+- **P7 — Clean-break removal + CI gate + caller migration.** Delete the dead paths; add the gate; migrate demo / walkthrough / UI callers to the eventual model; cross-node E2E green run.
+
+---
+
+## 13. Risks / constraints
+
+- **Attestation evolution** is real work later (v2 control-plane disclosure, v3 ZK) but **out of scope for v1** — the seam + governance field are the only v1 obligations.
+- **Presentation lifecycle (P6)** is the highest-complexity reconciliation; keep the `VAL_BP_003` carve-out and F119 idempotency semantics intact while the projection takes over ordering.
+- **Determinism under encryption** — the projection's *state* needs only the validated decision (no payload); the projection's *data view* and *reactions* need disclosure access, so a node only materialises the data it can decrypt (consistent with today's disclosure model).
+- **Caller migration** — UI / walkthroughs / the demo read the synchronous `nextActions`/`issuedCredential`; they move to subscribe-or-poll on instance-updated + credential events. Bounded-wait softens the single-node case.
+- **Bounded-wait timeout tuning** — too long blocks HTTP; too short always 202s the owner case. ~2–3s default, configurable.
+
+---
+
+## 14. Out of scope (v1)
+
+- v2/v3 attestations (validator re-evaluation, ZK proofs) — seam + governance field only.
+- Register-governance UI for `routingAttestation` (the field exists; admin UX is later).
+- Outbox-grade reaction delivery (at-least-once + idempotent is sufficient for now; a durable outbox/worker is a later hardening).
+- Cross-installation anchor-set gossip / mesh routing (F143 deferred scope) — unchanged.

--- a/scripts/check-ledger-derived-clean-break.ps1
+++ b/scripts/check-ledger-derived-clean-break.ps1
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# Clean-break gate for Feature 145 (Ledger-Derived Workflow Instances).
+# Fails the build if the removed legacy constructs reappear.
+#
+# Usage: pwsh scripts/check-ledger-derived-clean-break.ps1
+#
+# SKELETON (T003): the patterns below are declared but NOT yet enforced — the
+# constructs they forbid are removed incrementally across US1-US6, so enforcing
+# now would fail against code that is still mid-migration. T040 activates each
+# pattern (flips $enforced = $true) once its replacement is green, and wires this
+# into CI. Until then this script exits 0 so it can live in the tree.
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$srcRoot = Join-Path $repoRoot 'src'
+$violations = @()
+
+# Each forbidden construct: the regex, a human message, and whether it is enforced yet.
+# T020 -> mirror; T015 -> imperative mutation; T016 -> dual-path branch;
+# T017 -> topology heuristic; T005/T024 -> singular NextActionId hint.
+$forbidden = @(
+    @{ Pattern = 'InstanceMirrorReconstructor';        Message = 'Mirror reconstructor reintroduced (use InstanceProjector)';           Enforced = $false }
+    @{ Pattern = 'IsReadOnlyMirror';                    Message = 'Mirror flag reintroduced (there is no mirror)';                       Enforced = $false }
+    @{ Pattern = 'Create(Mirror|MirrorAsync)|UpdateMirrorAsync'; Message = 'Mirror write method reintroduced';                          Enforced = $false }
+    @{ Pattern = 'ApplyInstanceStateChanges';           Message = 'Imperative instance-state mutation reintroduced (advance via projection)'; Enforced = $false }
+    @{ Pattern = '\bLocallyOwned\b';                    Message = 'Dual submit branch (LocallyOwned) reintroduced (single async path)';  Enforced = $false }
+    @{ Pattern = '\bNextActionId\b';                    Message = 'Singular NextActionId hint reintroduced (use RoutingDecision)';       Enforced = $false }
+)
+
+$searchFiles = Get-ChildItem -Path $srcRoot -Recurse -Include '*.cs' |
+    Where-Object { $_.FullName -notmatch '[\\/](bin|obj)[\\/]' }
+
+foreach ($rule in $forbidden) {
+    if (-not $rule.Enforced) { continue }
+    $matches = $searchFiles | Select-String -Pattern $rule.Pattern
+    if ($matches -and $matches.Count -gt 0) {
+        $violations += $rule
+        Write-Host "X VIOLATION: $($rule.Message)" -ForegroundColor Red
+        foreach ($m in $matches | Select-Object -First 10) {
+            Write-Host "   $($m.Path):$($m.LineNumber): $($m.Line.Trim())" -ForegroundColor DarkGray
+        }
+    }
+}
+
+if ($violations.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Clean-break check FAILED with $($violations.Count) violation type(s)." -ForegroundColor Red
+    Write-Host "These constructs were removed in feature 145 and must not return." -ForegroundColor Red
+    exit 1
+}
+
+$enforcedCount = ($forbidden | Where-Object { $_.Enforced }).Count
+Write-Host "OK Clean-break check passed ($enforcedCount/$($forbidden.Count) patterns enforced)." -ForegroundColor Green
+exit 0

--- a/specs/145-ledger-derived-instances/checklists/requirements.md
+++ b/specs/145-ledger-derived-instances/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Ledger-Derived Workflow Instances
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation run 2026-05-31: all items pass. The architectural decisions (projection-as-source-of-truth, born-at-first-action identity, carried+attested routing with a pluggable attestation seam, single async submission, idempotent role-gated reactions, clean break) were resolved in the approved design `docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md`, so no [NEEDS CLARIFICATION] markers were needed; residual choices (bounded-wait window, attestation-evolution path) are captured as Assumptions / Out of Scope.
+- The spec deliberately stays outcome-focused; the concrete component/contract shapes (RoutingDecision/Attestation records, the InstanceProjector, the ReactionDispatcher, the clean-break gate) belong in the plan.
+- US1 is intentionally the large coherent MVP — projection + identity + routing-fact + cross-node discovery land together because a half-migration would reintroduce the dual-model smell this feature exists to delete. The plan decomposes US1 into the design's P1–P4 sub-phases.

--- a/specs/145-ledger-derived-instances/contracts/instance-read.md
+++ b/specs/145-ledger-derived-instances/contracts/instance-read.md
@@ -1,0 +1,25 @@
+# Contract: Instance + pending-action reads (projection-backed)
+
+All reads are served from the materialized projection, which is identical on every node (modulo disclosure-scoped `dataView`).
+
+## Instance state
+`GET /api/instances/{instanceId}` →
+```jsonc
+{ "instanceId": "...", "registerId": "...", "blueprintId": "...",
+  "currentActionIds": [2], "completedActionCount": 1,
+  "state": "Active",                         // Active | Completed | Rejected
+  "participantBindings": { "verification-analyst": "ws1...", "citizen": "ws1..." },
+  "lastAppliedTxId": "..." }
+```
+- The same response on any node holding the register. `dataView` fields appear only for entitled callers.
+
+## Pending actions (discovery — fixes the cross-node blocker)
+`GET /api/actions/pending` (existing) is now fed by the projection:
+- A participant (incl. an autonomous agent) sees their current action on **any** node that holds the register, because that node *projected* the instance to the current action — no mirror, no origination requirement (FR-014, SC-002).
+- Bindings are participant-id keyed (never self-keyed), so the assignee's wallet matches.
+
+## Advancement signal (replaces the synchronous response)
+- A node emits an instance-advanced notification (existing hub/event surface) when the projection advances an instance. Callers that previously read the synchronous `nextActions` subscribe/poll this.
+
+## Rebuild / parity (operability)
+- `RebuildAsync(instanceId)` replays the instance's sealed txs to reconstruct state; used for recovery and the parity self-check (`materialized == rebuild`, FR-003 / SC-003). Exposed as an internal/operator operation, not a public mutation.

--- a/specs/145-ledger-derived-instances/contracts/reactions.md
+++ b/specs/145-ledger-derived-instances/contracts/reactions.md
@@ -1,0 +1,29 @@
+# Contract: Reactions (idempotent, role-gated side effects)
+
+A `ReactionDispatcher` subscribes to `docket:confirmed` on every node and performs side effects for sealed actions that declare them. Pure projection (state) and side effects (reactions) are separate.
+
+## Trigger
+A sealed action transaction whose blueprint action declares a side effect:
+- `credentialIssuanceConfig` → `CredentialMint` (issuer side) + `CredentialDeliver`/detect (recipient side)
+- notification / inbox config → `Notification` / `InboxWrite`
+
+## Entitlement
+A node performs a reaction only if it **locally hosts the responsible wallet**:
+- `CredentialMint`: the node hosting the **issuer** participant's wallet (the action sender's wallet).
+- `CredentialDeliver` / inbound detect: the node hosting the **recipient** wallet.
+- `Notification`/`InboxWrite`: the node hosting the target wallet/user.
+
+Entitlement is probed via `IWalletServiceClient.GetWalletAsync` (the existing pattern). Non-entitled nodes no-op (FR-017).
+
+## Idempotency
+- Keyed on `(sealedTxId, reactionKind)` via `Sorcha.AtomicCache` SET-NX (the F114/F128 single-use pattern).
+- First claim performs the effect; replays / restarts / duplicate seals find the claim and no-op (FR-016, SC-004).
+- At-least-once semantics with idempotent effect; durable-outbox delivery is out of scope.
+
+## Credential issuance specifics
+- Moves out of `ActionExecutionService`'s inline submit path entirely.
+- Mints using the existing issuance machinery (holder-key binding, encrypt-to-recipient), but triggered by the sealed Action tx, not by the submit call.
+- Cross-node delivery is unchanged in mechanism (encrypted credential tx → replicates → recipient node's inbound detection is itself a reaction on the same idempotency key).
+
+## Observability
+OTel on a `Sorcha.Blueprint.Reactions` meter: `reaction_dispatched_total{kind,outcome}`, `reaction_idempotent_skip_total{kind}`, `reaction_entitlement_skip_total{kind}`.

--- a/specs/145-ledger-derived-instances/contracts/routing-decision.md
+++ b/specs/145-ledger-derived-instances/contracts/routing-decision.md
@@ -1,0 +1,31 @@
+# Contract: RoutingDecision (transaction-carried, validated)
+
+## Shape (on `TransactionMetaData`, clear)
+
+```jsonc
+"routingDecision": {
+  "completedActionId": 1,
+  "nextActions": [ { "actionId": 2 } ],        // FULL set; [] = branch terminates
+  "attestation": {
+    "kind": "SenderSigned",                     // v1
+    "signature": "<sender-wallet sig over canonical(decision without attestation)>"
+  }
+}
+```
+
+## Producer (Blueprint Service / Engine)
+- The Engine routing evaluation produces the **complete** `nextActions` (no collapse to one).
+- `ActionExecutionService` assembles `RoutingDecision` and signs it with the sender wallet (the tx signer).
+- Serialized canonically (`RegisterSerializationOptions.Canonical`), `[JsonPropertyName]`-stable.
+
+## Validator (at seal — `ValidationEngine`)
+- **VAL_ROUTING_001** — reject unless every `nextActions[i].actionId` is a route-graph successor of `completedActionId` in the published blueprint (terminal `[]` valid only where allowed).
+- **VAL_ROUTING_002** — reject unless `attestation` verifies AND satisfies the register's `routingAttestation` policy. v1: verify the sender signature over the canonical decision. `validator-reeval` / `proof` ⇒ reject "unsupported attestation strength" (until v2/v3).
+- The validator does NOT decrypt payload or re-evaluate the condition in v1.
+- `DocketBuildTriggerService` carries the validated decision through the seal (replaces `ResolveNextActionId`).
+
+## Consumer (every node's `InstanceProjector`)
+- Reads `routingDecision.nextActions` to advance `currentActionIds`. No decryption needed.
+
+## Backwards-compat
+- None. `TransactionMetaData.NextActionId` is removed (pre-release clean break).

--- a/specs/145-ledger-derived-instances/contracts/submission-response.md
+++ b/specs/145-ledger-derived-instances/contracts/submission-response.md
@@ -1,0 +1,30 @@
+# Contract: Unified submission response (single async path)
+
+One path for `POST /api/instances/{id}/actions/{actionId}/execute` regardless of register ownership. The submitter never mutates instance state; state advances via the projection on seal.
+
+## Request
+Unchanged (action payload + sender). Starting-action submit additionally returns the canonical `instanceId`.
+
+## Response
+
+Always one of two shapes from the **same** path (the difference is timing, not branch):
+
+```jsonc
+// 202 Accepted — the default; projection will advance on seal
+{ "txId": "...", "instanceId": "...", "accepted": true, "pending": "awaiting-seal" }
+
+// 200 OK — bounded-wait convenience: the projection advanced within the wait window
+{ "txId": "...", "instanceId": "...", "accepted": true,
+  "currentActionIds": [2], "isComplete": false }
+```
+
+- The endpoint MAY wait up to `BoundedWaitSeconds` (default ~2–3s, configurable) for the projection to advance (signalled via `instance-advanced:{instanceId}`); on timeout it returns `202`.
+- **No field distinguishes "owner" from "subscriber"** and no behaviour selects on topology (SC-006).
+- `nextActions` and inline `issuedCredential` are **removed** from the submit response. Callers resolve outcomes by observing instance advancement (instance read / hub event) and credential availability (credential events) — see `instance-read.md`.
+
+## Sealer selection (fan-out)
+`TransactionDistributionService` selects the sealing target by `IRegisterLocalRelationshipService` roster membership (who is on the validator roster), not by seed/topology. F143 relay transport unchanged.
+
+## Removed
+- The `!LocallyOwned && AcceptedCount>0` branch and the synchronous confirmation-wait path.
+- Inline credential issuance on the submit path (moves to reactions).

--- a/specs/145-ledger-derived-instances/data-model.md
+++ b/specs/145-ledger-derived-instances/data-model.md
@@ -1,0 +1,104 @@
+# Phase 1 Data Model: Ledger-Derived Workflow Instances
+
+The canonical state lives in the **sealed register** (dockets + transactions, MongoDB). Everything below is either a **fact carried on a transaction** or a **derived projection** of those facts. The instance row is a materialized view, not a source of truth.
+
+---
+
+## Entity 1 — RoutingDecision (carried on the transaction, clear)
+
+Attached to every action transaction's clear metadata. Replaces the singular `TransactionMetaData.NextActionId`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `completedActionId` | int | the action this transaction completes |
+| `nextActions` | `ActionRef[]` | the **full** set of next actions (preserves parallel branches). Empty ⇒ this branch terminates. |
+| `attestation` | `Attestation` | the trust mechanism (Entity 2) |
+
+`ActionRef` = `{ actionId: int, branchKey?: string }` (branchKey distinguishes parallel branches where needed).
+
+**Validation (at seal, `ValidationEngine`):**
+- `VAL_ROUTING_001` — every `nextActions[i]` is a valid successor of `completedActionId` in the published blueprint's static route graph; a terminal (`[]`) is valid only where the route graph allows termination.
+- `VAL_ROUTING_002` — `attestation` verifies and satisfies the register's required `routingAttestation` strength.
+
+**Serialization:** canonical (`RegisterSerializationOptions.Canonical`), `[JsonPropertyName]`-stable (the #881 relay lesson). The decision is signed over its canonical bytes.
+
+---
+
+## Entity 2 — Attestation (pluggable trust)
+
+A discriminated union; v1 ships only the first.
+
+| Variant | Fields | Status |
+|---|---|---|
+| `SenderSigned` | `signature` (sender wallet sig over canonical `RoutingDecision` minus the attestation) | **v1 — implemented** |
+| `ValidatorReEvaluated` | `validatorSignature`, `controlDisclosureRef` | reserved (v2 — control-plane disclosure) |
+| `Proof` | `scheme`, `proof`, `commitments[]` | reserved (v3 — ZK / universally verifiable) |
+
+The projection reads `RoutingDecision.nextActions` regardless of variant. Only the **validation** step branches on variant; v2/v3 validation throws "unsupported attestation strength" until implemented.
+
+---
+
+## Entity 3 — Instance Projection (materialized view)
+
+The per-node cache of the deterministic fold. Reconstructable from the ledger.
+
+| Field | Type | Source |
+|---|---|---|
+| `instanceId` | string | `H(registerId, blueprintId, startingActionTxHash)` (Entity 4) |
+| `registerId`, `blueprintId`, `blueprintVersion` | — | from the starting action tx |
+| `currentActionIds` | int[] | folded from each `RoutingDecision.nextActions` (full set; multiple ⇒ parallel) |
+| `completedActionIds` / `completedActionCount` | — | folded |
+| `participantWallets` | map participant-id → wallet | folded from blueprint + tx sender/recipients (participant-id keyed, never self-keyed) |
+| `dataView` | map | disclosure-scoped: only fields this node is entitled to decrypt |
+| `state` | enum `Active` \| `Completed` \| `Rejected` | derived (no current actions + terminal route ⇒ Completed) |
+| `lastAppliedTxId` / `lastAppliedDocketHash` | — | idempotency watermark (fold is a no-op at/below it) |
+
+**Invariants:**
+- No `IsReadOnlyMirror` — there is no mirror.
+- Identical across nodes for the same sealed input (FR-001), modulo `dataView` (disclosure-scoped) which is the only legitimately node-varying field.
+- `materialized == RebuildAsync(instanceId)` (parity, FR-003).
+
+**State transitions (all via fold on a sealed action tx):**
+`(absent) → Active` on the sealed starting action; `Active → Active` advancing `currentActionIds` per decision; `Active → Completed` when a decision yields no next actions on the last branch; `Active → Rejected` on a sealed rejection. No transition is ever written by a submit path.
+
+---
+
+## Entity 4 — Instance identity derivation
+
+`instanceId = encode( SHA256( registerId || blueprintId || startingActionTxHash ) )`. Deterministic, node-independent, unique per application, stable under late-binding. A **local draft** correlation id exists only client-side until the starting action seals and the canonical id is returned.
+
+---
+
+## Entity 5 — Reaction (idempotent side effect)
+
+Not stored as domain data; an at-least-once handler keyed for idempotency.
+
+| Field | Type | Notes |
+|---|---|---|
+| `sealedTxId` | string | the action tx that triggers the effect |
+| `reactionKind` | enum | `CredentialMint` \| `CredentialDeliver` \| `Notification` \| `InboxWrite` |
+| idempotency key | `(sealedTxId, reactionKind)` | Redis SET-NX (`Sorcha.AtomicCache`); first claim wins |
+| entitlement | derived | node hosts the responsible wallet (issuer → mint; recipient → deliver/detect) |
+
+A reaction fires at-most-once-effectively (SET-NX claim) and is safe under replay/restart. Non-entitled nodes no-op.
+
+---
+
+## Entity 6 — Register routing-attestation policy (governance)
+
+On the register control record (sibling of crypto policy / validator roster).
+
+| Field | Type | Notes |
+|---|---|---|
+| `routingAttestation` | enum `sender-signed` \| `validator-reeval` \| `proof` | default `sender-signed`; enforced at seal by `VAL_ROUTING_002` |
+
+Changing it is a governance action; v1 supports only `sender-signed` (others reserved).
+
+---
+
+## Removed (clean break)
+
+- `Instance.IsReadOnlyMirror`; `InstanceMirrorReconstructor`; `CreateMirrorAsync`/`UpdateMirrorAsync`.
+- `TransactionMetaData.NextActionId` (singular hint) → replaced by `RoutingDecision`.
+- `ActionSubmissionResponse` synchronous `NextActions`/`IssuedCredential` semantics on the brokered path (unified — see contracts).
+- The imperative `AccumulatedData` write-on-submit as authoritative (becomes part of the disclosure-scoped projection `dataView`).

--- a/specs/145-ledger-derived-instances/plan.md
+++ b/specs/145-ledger-derived-instances/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Ledger-Derived Workflow Instances
+
+**Branch**: `145-ledger-derived-instances` | **Date**: 2026-05-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/145-ledger-derived-instances/spec.md`
+**Design**: `docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md`
+
+## Summary
+
+Make a workflow instance a **deterministic projection of the sealed register**: every node holding the register folds the same sealed action transactions into the same instance state. Replace the imperative per-node instance mutation + the reconstructed cross-node mirror + the dual synchronous/async submission split with: (1) routing decisions **carried on the transaction in the clear and validated at seal** under a pluggable attestation, (2) a **single `InstanceProjector`** that advances state on every node from `docket:confirmed`, (3) a **single async submission path** with roster-derived sealer selection, and (4) **idempotent role-gated reactions** for side effects (credential mint/deliver, notifications). Clean break, CI-gated. Anchored by three code investigations (file:line cited in Technical Context).
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (existing services).
+**Primary Dependencies**: Blueprint Engine (`Sorcha.Blueprint.Engine`); the Validator (`ValidationEngine`, `DocketBuildTriggerService`); Register Service (docket write + `docket:confirmed` Redis Streams event, `RegisterEventChannels.DocketConfirmed`); Peer Service (`TransactionDistributionService` fan-out, F143 relay); `IRegisterLocalRelationshipService` (F108 roster relationship); `IEventSubscriber`/`RedisStreamEventPublisher`; EF Core instance store; `Sorcha.AtomicCache` (idempotency).
+**Storage**: ledger = MongoDB dockets/transactions (canonical); instance materialized view = Postgres via `IInstanceStore`/`EfCoreInstanceStore`; Redis = event streams (`docket:confirmed`) + reaction idempotency (SET-NX) + bounded-wait signalling.
+**Testing**: xUnit + FluentAssertions + Moq (Constitution IV); plus deterministic projection tests, rebuild-parity tests, reaction-idempotency tests, and the cross-node E2E (the standing two-node Assured Identity demo, `demos/AssuredIdentity/`).
+**Target Platform**: Linux containers; federated installations (1 owner + N subscribers).
+**Project Type**: distributed microservices (existing) — changes span Register.Models, Blueprint Engine, Blueprint Service, Validator Service, Peer Service.
+**Performance Goals**: projection advances within ~1–2s of observing a sealed docket; bounded-wait convenience default ~2–3s; reaction dispatch idempotent under replay/restart.
+**Constraints**: deterministic, idempotent, order-independent fold; routing control state derivable **without** payload decryption; pre-release clean break (no instance migration); CI gate forbids the removed constructs.
+**Scale/Scope**: cross-installation; the projection + reactions run on every node holding the register.
+
+### Grounded current-state anchors (from the investigations)
+
+| Concern | Current code | Change |
+|---|---|---|
+| Imperative state mutation | `ActionExecutionService.ApplyInstanceStateChanges` (`:1762-1834`) | **Remove**; state advances only via projection |
+| Mirror reconstruction | `InstanceMirrorReconstructor` (subscribes `docket:confirmed`, `:50-67,288-322`); `IsReadOnlyMirror`; `Create/UpdateMirrorAsync` | **Replace** with the single `InstanceProjector` (runs on every node, not just owner) |
+| Singular routing hint | `MetaData.NextActionId` set at `ActionExecutionService.cs:984-993`, projected at `DocketBuildTriggerService.cs:636-642` | **Replace** with full `RoutingDecision` (carried + attested) |
+| Local GUID identity | `Program.cs:2163-2185` (`Guid.NewGuid()`, local store only) | Derive id from starting-action tx; creation = local draft |
+| Dual submit branch | `ActionExecutionService.cs:1060-1075` (`!LocallyOwned && AcceptedCount>0` → 202; else sync wait) | **One path**, always async-ack (+ bounded wait) |
+| Ownership heuristic | `TransactionDistributionService.ForwardSubmissionAsync` (seeds-configured topology, `:62-218`) | Use `IRegisterLocalRelationshipService` roster relationship |
+| Pending discovery | `EfCoreInstanceStore.GetPendingActionsByWalletAsync` (`:256-372`) reads the instance row | Works once the projection is the single writer + participant-id keyed bindings |
+| Inline issuance | credential mint inside the sync submit path (`ActionExecutionService.cs:~510-685`) | **Move** to `ReactionDispatcher` (role-gated, idempotent) |
+| Seal projection (validator) | `DocketBuildTriggerService.ResolveNextActionId` (`:531,636-642`) | Carry/validate the full `RoutingDecision`; validator adds `VAL_ROUTING_*` |
+| Presentation ordering | `IPresentationSealCoordinator` (F119) | Subsumed by the seal-ordered projection; keep `VAL_BP_003` carve-out |
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|---|---|
+| I. Microservices-First | **Honoured.** Each piece lands in its owning service: `RoutingDecision`/`Attestation` model in `Sorcha.Register.Models`; routing computation in `Sorcha.Blueprint.Engine`; validation in `Sorcha.Validator.Service`; `InstanceProjector` + `ReactionDispatcher` in `Sorcha.Blueprint.Service`; fan-out ownership in `Sorcha.Peer.Service`. No new upward dependencies; Core/Engine stay free of service refs (the Engine consumes seams, mirroring the existing `IRevocationChecker`/trust pattern). Cross-service span is inherent to the data model (a tx field validated by the validator, projected by Blueprint) — justified, not gratuitous. |
+| II. Security First | **Honoured.** Routing decision is sender-signed (authenticity) + validator-validated (structural). No new secrets. Disclosure model unchanged — control-state projection needs no decryption; reactions only act where entitled. Governance attestation policy is additive. |
+| III. API Documentation | **Required.** Changed/added endpoints (submission response contract, instance read, pending-actions) get `.WithSummary()/.WithDescription()` + XML + Scalar. No Swagger. |
+| IV. Testing | **Strong fit.** Determinism, idempotency, and parity are naturally unit-testable; ≥85% on new core (Engine routing-decision, projector fold, reaction idempotency). Cross-node E2E via the standing demo. |
+| V. Code Quality | **Honoured.** C# 14, nullable, async; no Release warnings. |
+| VI. Blueprint Standards | **Honoured.** Blueprints stay JSON; the route graph stays in the blueprint. The `RoutingDecision` is a **runtime transaction artifact**, not a blueprint-format change. |
+| VII. Domain-Driven Design | **Honoured.** Uses Register/Docket/Transaction/Action/Participant/Publish. New ubiquitous terms: **Instance Projection**, **Routing Decision**, **Attestation**, **Reaction** — defined in data-model.md. |
+| VIII. Observability | **Required.** New OTel: projection lag, fold idempotency hits, `VAL_ROUTING_*` rejects, reaction dispatch/idempotency, bounded-wait outcomes. Health: projection-up-to-head. |
+
+**Verdict**: PASS. The only notable item is the **cross-service breadth**, which is intrinsic to the architectural fix (one model change expressed in the tx contract + validator + projector + reactions). It is the *simplest* shape that delivers a single consistent state machine — the alternative (keeping per-node imperative state) is precisely the complexity being removed. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/145-ledger-derived-instances/
+├── plan.md              # This file
+├── research.md          # Phase 0 — resolved unknowns
+├── data-model.md        # Phase 1 — entities, tx-carried RoutingDecision, projection state machine
+├── quickstart.md        # Phase 1 — how to verify (determinism, parity, idempotency, cross-node E2E)
+├── contracts/           # Phase 1
+│   ├── routing-decision.md       # tx-carried RoutingDecision + Attestation shape + validation rules
+│   ├── submission-response.md    # the unified async submission contract (202 + bounded-wait 200)
+│   ├── instance-read.md          # instance state + pending-actions read contract
+│   └── reactions.md              # reaction entitlement + idempotency contract
+└── checklists/requirements.md    # spec quality checklist (passing)
+```
+
+### Source Code (repository root) — touched areas
+
+```text
+src/Common/Sorcha.Register.Models/
+└── Transactions/            # RoutingDecision + Attestation carried on TransactionMetaData (clear);
+                             #   retire NextActionId. Governance: RoutingAttestationPolicy on the control record.
+
+src/Core/Sorcha.Blueprint.Engine/
+└── Routing/                 # emit the FULL NextActions set + build the SenderSigned attestation
+                             #   (extends the existing routing evaluation; engine-local, WASM-safe)
+
+src/Services/Sorcha.Blueprint.Service/
+├── Services/Implementation/
+│   ├── InstanceProjector.cs        # NEW — subscribes docket:confirmed on EVERY node; pure fold → IInstanceStore
+│   │                               #   (replaces InstanceMirrorReconstructor)
+│   ├── ReactionDispatcher.cs       # NEW — role-gated idempotent side effects (credential mint/deliver, notify)
+│   ├── ActionExecutionService.cs   # single async path; remove ApplyInstanceStateChanges + LocallyOwned branch + inline issuance
+│   └── InstanceIdentity.cs         # NEW — deterministic id from starting-action tx
+├── Storage/
+│   └── EfCoreInstanceStore.cs      # materialized view + Rebuild(instanceId) + parity check; drop IsReadOnlyMirror/mirror writes
+└── Program.cs                      # POST /instances = local draft; submission response contract; instance/pending reads
+
+src/Services/Sorcha.Validator.Service/
+├── Services/ValidationEngine.cs    # VAL_ROUTING_001/002 (structural successor + attestation); enforce register attestation policy
+└── Services/DocketBuildTriggerService.cs # carry the validated RoutingDecision through the seal (replace ResolveNextActionId hint)
+
+src/Services/Sorcha.Peer.Service/
+└── Distribution/TransactionDistributionService.cs  # sealer selection via IRegisterLocalRelationshipService (retire topology heuristic)
+
+src/Core/Sorcha.Register.Core/
+└── Governance/                     # RoutingAttestationPolicy read/derive (sibling of the crypto policy, F083/F086)
+
+scripts/check-ledger-derived-clean-break.ps1   # NEW CI gate (forbids mirror/dual-path/imperative/heuristic/singular-hint)
+
+# Callers migrated (P7): demos/AssuredIdentity/ (toolkit + agent discovery), walkthroughs/*, Sorcha.UI / Wallet PWA submit surfaces.
+```
+
+**Structure Decision**: Existing distributed-microservices layout. The new behavioural core is two Blueprint-Service services (`InstanceProjector`, `ReactionDispatcher`) plus a carried+validated `RoutingDecision` on the transaction model and a roster-based sealer selection in Peer. Engine stays dependency-free (routing emission behind the existing seam pattern). The clean break deletes the mirror/dual-path/imperative constructs in the same change.
+
+## Complexity Tracking
+
+> No constitution violations. Cross-service breadth is intrinsic to the model change (justified inline above). Table intentionally empty.

--- a/specs/145-ledger-derived-instances/quickstart.md
+++ b/specs/145-ledger-derived-instances/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: verifying Ledger-Derived Workflow Instances
+
+How to confirm the model works, mapped to success criteria. Two layers: deterministic unit/integration checks (no live cluster) and the cross-node E2E (the standing two-node demo).
+
+## Unit / integration (deterministic, no cluster)
+
+```bash
+dotnet test --filter "FullyQualifiedName~LedgerDerivedInstances"
+```
+
+- **Projection determinism (SC-001)** — feed the same sealed docket stream to the projector in different orders / with a mid-stream restart → identical instance state every time.
+- **Full-set routing (SC-005)** — a multi-branch route seals with all branches in `RoutingDecision.nextActions`; the projector advances all of them.
+- **Routing validation (SC-007)** — a decision whose `nextActions` aren't route-graph successors, or with a bad signature, is rejected (`VAL_ROUTING_001/002`).
+- **Rebuild parity (SC-003)** — `RebuildAsync(instanceId)` equals the materialized view; deleting/corrupting the view and rebuilding restores it.
+- **Reaction idempotency (SC-004)** — replay a sealed credential-issuing tx N times + restart the dispatcher → exactly one credential; a non-entitled node performs none.
+- **Single submit contract (SC-006)** — owner-node and subscriber-node submits return the same response contract and reach the same projected state.
+
+## Cross-node E2E (the standing demo)
+
+```powershell
+Import-Module demos/AssuredIdentity/AssuredIdentityDemo.psm1
+New-IssuingAuthority -IssuerNode tiny      # owner
+Connect-Subscriber  -SubscriberNode n1     # subscriber
+# tester applies on n1; the autonomous agent on tiny approves
+```
+
+- **Autonomous cross-node loop (SC-002)** — the applicant submits on n1; **both** nodes project the instance to Action 2 identically; the autonomous agent on tiny **discovers** Action 2 via `/api/actions/pending` (no mirror, no manual approval) and approves; the credential is delivered to the citizen on n1. The whole loop runs with no manual step.
+- Verify instance state is byte-identical (modulo disclosure-scoped data) on tiny and n1 after each seal.
+
+## Clean break (SC-008)
+
+```powershell
+pwsh scripts/check-ledger-derived-clean-break.ps1
+```
+- Reports zero occurrences of `InstanceMirrorReconstructor`, `IsReadOnlyMirror`, `Create/UpdateMirrorAsync`, `ApplyInstanceStateChanges`, the `LocallyOwned` submit branch, `NextActionId` singular hint, and the topology ownership heuristic.
+
+## Acceptance checkpoints → SC map
+
+| Check | SC |
+|---|---|
+| same docket stream → identical state across nodes/orders | SC-001 |
+| autonomous two-node loop, agent discovers + approves, credential delivered | SC-002 |
+| rebuild == materialized; corrupt → restored | SC-003 |
+| replay/restart → exactly one credential | SC-004 |
+| multi-branch route preserves all branches | SC-005 |
+| owner vs subscriber submit identical | SC-006 |
+| forged/inconsistent decision rejected at seal | SC-007 |
+| clean-break gate green + demo green | SC-008 |

--- a/specs/145-ledger-derived-instances/research.md
+++ b/specs/145-ledger-derived-instances/research.md
@@ -1,0 +1,125 @@
+# Phase 0 Research: Ledger-Derived Workflow Instances
+
+The architectural decisions were resolved in the design session; the mechanics were established by three code investigations. This consolidates them as implementation decisions.
+
+---
+
+## R1 — Where the RoutingDecision rides on the transaction (clear, not encrypted)
+
+**Decision**: Carry the `RoutingDecision` (the full next-action set + attestation) on the transaction's **clear metadata** (`TransactionMetaData`), replacing the singular `NextActionId`. It is NOT inside the encrypted payload.
+
+**Rationale**: FR-010 requires every node to advance control state **without decrypting** payload. Metadata is already the clear, all-nodes-readable part of a tx (the current singular hint lives there). The validated decision must be projection-readable on subscribers that can't decrypt the payload. `TransactionMetaData` needs a `[JsonPropertyName]`-stable, canonical serialization (the #881 lesson: PascalCase silently dropped on relay) — use `RegisterSerializationOptions.Canonical`.
+
+**Alternatives**: in the encrypted payload (rejected — breaks subscriber projection); a separate sidecar tx (rejected — extra seal round-trip, ordering complexity).
+
+---
+
+## R2 — Routing decision computation + the SenderSigned attestation (v1)
+
+**Decision**: The Blueprint Engine's routing evaluation emits the **full** `NextActions` set (today `RoutingResult.NextActions` already computes it; the loss is downstream at `ActionExecutionService.cs:984-993` collapsing to a singular hint). `ActionExecutionService` builds a `RoutingDecision{completedActionId, nextActions[], attestation}` and signs it with the sender wallet (the same signer already used for the tx). v1 attestation = `SenderSigned{sig over canonical(decision)}`.
+
+**Rationale**: FR-007 (full set, parallel branches), FR-009 (sender-signed default). Reuses the existing routing engine + the sender's signing key; no new crypto.
+
+**Alternatives**: validator computes routing (rejected — validator "only knows the static route graph", `DocketBuildTriggerService.cs:636-642`, can't evaluate conditions).
+
+---
+
+## R3 — Validator validation of the decision (VAL_ROUTING_*)
+
+**Decision**: `ValidationEngine` adds, before seal: **VAL_ROUTING_001** — the decision's `nextActions` are valid successors of `completedActionId` in the published blueprint's static route graph (structural); **VAL_ROUTING_002** — the attestation verifies (sender signature over the canonical decision) and meets the register's required attestation strength. v1 does NOT decrypt payload or re-evaluate the condition. `DocketBuildTriggerService` carries the validated decision through the seal (replacing `ResolveNextActionId`).
+
+**Rationale**: FR-008. Consistent with the current trust model (validator does structure/signature/chain, submitter is trusted for data on encrypted registers). The route-graph is available to the validator (it already resolves the published blueprint for VAL_BP_002).
+
+**Alternatives**: full re-evaluation now (deferred to v2 control-disclosure — out of scope); no validation (rejected — the decision must be a trustworthy fact).
+
+---
+
+## R4 — Deterministic instance identity
+
+**Decision**: `instanceId = base32/hex( H( registerId || blueprintId || startingActionTxHash ) )`, computed by `InstanceIdentity` on both the submit side (returned in the ack once sealed) and the projector (on observing the sealed starting action). `POST /instances` becomes a **local draft** (no ledger write, no store row that other nodes need). The starting action is submitted against the draft; the canonical id is derived from its sealed tx.
+
+**Rationale**: FR-005/FR-006. Removes the node-local GUID (`Program.cs:2166`) that makes instances unshareable. Deterministic from on-chain data → identical on every node. Hash over the starting tx hash guarantees uniqueness per application and stability under late-binding.
+
+**Open detail for planning**: the client submits the starting action before it has the canonical id; the submit ack returns it. Draft-state correlation is a client/local concern (a local draft id mapped to the canonical id on ack).
+
+---
+
+## R5 — The InstanceProjector (pure fold, every node)
+
+**Decision**: One `InstanceProjector : BackgroundService` subscribes to `docket:confirmed` (Redis Streams, `RegisterEventChannels.DocketConfirmed`) on **every** node — generalizing `InstanceMirrorReconstructor` (which already subscribes to exactly this event and is owner-only). On each sealed **action** tx for a held register it folds: derive/confirm instanceId, advance `CurrentActionIds` from the validated `RoutingDecision.nextActions`, mark completed + counts, update participant→wallet bindings (participant-id keyed, from blueprint + tx), update the disclosure-scoped data view. Writes the materialized view via `IInstanceStore`. **Pure** (no side effects). **Idempotent** (re-folding an applied tx is a no-op, tracked by last-applied tx/docket per instance). **Order-independent** for the same sealed set (fold dockets in `PreviousHash` chain order; txns within a docket by canonical tx-hash order).
+
+**Rationale**: FR-001/002/004. The mechanism already exists for the owner case; making it run everywhere + reading the full validated decision (not the singular hint) + dropping the mirror flag yields the single shared state machine. `EfCoreInstanceStore.GetPendingActionsByWalletAsync` then surfaces the current action to the right participant on every node (fixes the discovery blocker).
+
+**Alternatives**: keep imperative mutation on the owner + projection on subscribers (rejected — that IS the origin/mirror drift).
+
+---
+
+## R6 — Materialized view + Rebuild + parity
+
+**Decision**: The instance row is a cache. `IInstanceStore` gains `RebuildAsync(instanceId)` (replay the instance's sealed txs via the register tx stream — the existing `StateReconstructionService` data path generalized to also fold control state) and a parity check `materialized == RebuildAsync`. A periodic/CI parity self-check + an operator-triggered rebuild for recovery. `IsReadOnlyMirror`, `CreateMirrorAsync`, `UpdateMirrorAsync` are deleted.
+
+**Rationale**: FR-003. The ledger is canonical; the view is reconstructable. Gives recovery + an integrity invariant (SC-003).
+
+---
+
+## R7 — Single async submission path + roster sealer selection
+
+**Decision**: `ActionExecutionService` collapses to one path: validate → compute `RoutingDecision` → build+sign tx (carrying the decision) → submit to local mempool AND fan out → return **`202 {txId, instanceId, accepted}`**. Remove `ApplyInstanceStateChanges` (no imperative mutation) and the `!LocallyOwned` branch. The projection advances state on seal. **Bounded-wait convenience**: optionally await the projection up to ~2–3s (signalled via a Redis key on `instance-advanced:{instanceId}`) and return `200` with advanced state if it lands, else `202`. **Sealer selection** for fan-out uses `IRegisterLocalRelationshipService` (F108 roster) — retiring the `TransactionDistributionService` seeds-topology heuristic; the F143 relay transport is unchanged.
+
+**Rationale**: FR-011/012/013, SC-006. One path = no owner/subscriber divergence. Bounded-wait keeps the single-node case ergonomic without a second architectural path.
+
+**Alternatives**: pure 202 always (viable; bounded-wait chosen for caller ergonomics during migration); keep the topology heuristic (rejected — two ownership mechanisms).
+
+---
+
+## R8 — Reactions (idempotent, role-gated)
+
+**Decision**: One `ReactionDispatcher : BackgroundService` subscribes to `docket:confirmed`. For a sealed action declaring a side effect (`credentialIssuanceConfig`, notification, inbox), it checks entitlement = **does this node locally host the responsible wallet** (issuer-wallet-host mints; recipient-wallet-host delivers/detects) — the same `IWalletServiceClient.GetWalletAsync` probe the reconstructor uses — and if entitled performs it **once**, idempotent on `(sealedTxId, reactionKind)` via `Sorcha.AtomicCache` SET-NX (the F114/F128 single-use pattern). Credential mint moves out of `ActionExecutionService`'s inline path into a reaction. Inbound credential detection/delivery on the recipient node is a reaction on the same key.
+
+**Rationale**: FR-015/016/017, SC-004. Pure projection (state) vs at-least-once idempotent side effects (reactions) — the textbook split, and it prevents double-issue across nodes/replay/restart.
+
+**Alternatives**: issuer-acts-inline (rejected — keeps a sliver of inline coupling + ties issuance to the submitter not the entitled node); durable outbox (deferred — at-least-once+idempotent suffices now).
+
+---
+
+## R9 — Register governance: routing-attestation policy
+
+**Decision**: Add `routingAttestation: sender-signed | validator-reeval | proof` to the register control record (default `sender-signed`), read via a `Sorcha.Register.Core/Governance` policy service (sibling of the F083 crypto policy / F086 roster). The validator enforces the declared strength at seal. v1 implements only `sender-signed`; the other values are reserved (the seam) and rejected-if-required until v2/v3 land.
+
+**Rationale**: FR-009. Makes the trust-level a per-register governance lever (where the user wants it), so v2/v3 attestations are additive, not a fork.
+
+---
+
+## R10 — Presentation lifecycle on the projection (the hard slice)
+
+**Decision**: `PresentationOutcome` / `PresentationAbandoned` transitions carry a `RoutingDecision` like any action; the `InstanceProjector` advances on their seal. The F119 `IPresentationSealCoordinator`'s job (don't advance until the predecessor seals) is **subsumed** by the seal-ordered projection (the projector only ever folds sealed txns, in chain order). Keep the `ValidationEngine` `VAL_BP_003` carve-out for these intra-action terminals and the F119 idempotency sentinels where they still apply. Migrate carefully as its own phase; verify no chain-ordering regression.
+
+**Rationale**: FR-018. The projection's seal-ordering naturally provides what F119 added bespoke machinery for. Highest-complexity reconciliation — isolated to its own phase.
+
+**Alternatives**: leave presentation on its own path (rejected — reintroduces a parallel advancement mechanism, the smell).
+
+---
+
+## R11 — Clean-break gate
+
+**Decision**: `scripts/check-ledger-derived-clean-break.ps1` (modeled on F135's `check-trust-clean-break.ps1`) greps for and fails on: `InstanceMirrorReconstructor`, `IsReadOnlyMirror`, `CreateMirrorAsync`/`UpdateMirrorAsync`, `ApplyInstanceStateChanges`, the `LocallyOwned` submit branch, the `NextActionId` singular hint, and the topology ownership heuristic. Wired into CI.
+
+**Rationale**: FR-019/020. Locks in the deletion.
+
+---
+
+## Resolved-unknowns summary
+
+| Unknown | Resolution |
+|---|---|
+| Where the decision rides | clear `TransactionMetaData`, canonical serialization (R1) |
+| Who computes / signs it | Blueprint Engine emits full set; sender signs (R2) |
+| Validator role | structural successor + attestation check, `VAL_ROUTING_*` (R3) |
+| Instance identity | `H(registerId,blueprintId,startingTxHash)`, draft-until-first-action (R4) |
+| Projection mechanism | generalize the `docket:confirmed` subscriber to every node, full-decision fold (R5) |
+| Recovery/integrity | Rebuild + parity; delete mirror writes (R6) |
+| Submission | one async path + bounded-wait; roster sealer selection (R7) |
+| Side effects | idempotent role-gated reactions, SET-NX on (txId,kind) (R8) |
+| Trust governance | register `routingAttestation` policy (R9) |
+| Presentation lifecycle | carry decisions; projection subsumes seal-ordering (R10) |
+| Cleanup enforcement | clean-break CI gate (R11) |

--- a/specs/145-ledger-derived-instances/spec.md
+++ b/specs/145-ledger-derived-instances/spec.md
@@ -1,0 +1,218 @@
+# Feature Specification: Ledger-Derived Workflow Instances
+
+**Feature Branch**: `145-ledger-derived-instances`  
+**Created**: 2026-05-31  
+**Status**: Draft  
+**Input**: User description: "Ledger-Derived Workflow Instances — make a workflow instance a deterministic projection of the sealed register (single shared state machine, no mirrors, one async submission path, carried+attested routing decisions, idempotent role-gated reactions). Based on the approved design at docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md"
+
+## Overview
+
+A workflow instance today is independently-stored, per-node mutable state that each node edits in place. Across federated nodes this produces two divergent copies of "the same" workflow (an "origin" on the submitting node and a reconstructed "mirror" on the owner), two different submission behaviours, and a decision (which action comes next) that no node can reproduce from the shared ledger. The result is recurring cross-node breakage: participants can't act on the right node, autonomous agents are blind to pending work, credentials risk double-issue, and "is this workflow done?" is ambiguous.
+
+This feature makes a workflow instance a **deterministic projection of the sealed register** — the register's sealed transactions are the only source of truth, and every node that holds the register computes the **same** instance state from them. There is one instance, the same on every node; one submission path; routing decisions that are carried on the ledger and trusted; and side effects that fire exactly once on the responsible node. The design and its rationale are in `docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md`.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A cross-node workflow advances as one consistent, autonomous state machine (Priority: P1)
+
+A workflow spans two installations: an applicant submits on one node; the register and its validator live on another; an approver (a person or an autonomous agent) acts on the owner node. Today this requires a reconstructed "mirror" and the approver's tooling can't even find the pending action. In the target, every node derives the **same** instance from the sealed ledger: the applicant submits, the owning node seals, and **both nodes project the workflow to the same next state**. The approver finds and acts on their action wherever they are, and the workflow runs to completion with no manual intervention and no node-specific workaround.
+
+**Why this priority**: This is the entire point — a single shared state machine across nodes. It is the MVP; everything else hardens or extends it. It also directly removes the class of cross-node failures observed repeatedly in the field.
+
+**Independent Test**: Run a two-node credential-issuance workflow (anonymous applicant on the subscriber, approver/agent on the owner). Verify the instance's control state (which action is current, which are complete) is identical on both nodes after each seal, the approver discovers and acts on its action autonomously, and the credential is delivered — with no mirror and no manual step.
+
+**Acceptance Scenarios**:
+
+1. **Given** an applicant submits the starting action on a subscriber node, **When** the owning node seals it, **Then** both nodes independently project the same instance (same identity, same current action) from the sealed transaction.
+2. **Given** the workflow has advanced to an action whose participant is on the owner node, **When** that participant (or their autonomous agent) lists their pending work on the owner node, **Then** the action appears and can be acted on, without the owner having originated the instance.
+3. **Given** any action seals, **When** each node observes the sealed docket, **Then** each node advances the instance identically (no divergence between nodes).
+4. **Given** a completed workflow, **When** instance state is read on any node, **Then** all nodes agree it is complete (no "complete vs still-running" ambiguity between nodes).
+
+---
+
+### User Story 2 - Side effects happen exactly once, on the responsible node (Priority: P2)
+
+When a workflow action triggers a side effect — issuing a credential, delivering it to a wallet, sending a notification — that effect must happen exactly once, performed by the node responsible for it, even though every node observes the same sealed transaction and nodes restart or re-observe transactions.
+
+**Why this priority**: Correctness of outcomes. Moving state to a shared projection means many nodes see the same seal; without disciplined side-effect handling that becomes duplicate credentials/notifications. High value, but it layers on the P1 projection.
+
+**Independent Test**: Trigger a credential-issuing action; confirm exactly one credential is minted and delivered. Replay the sealed transaction and restart the responsible node; confirm still exactly one credential (no duplicates), and that non-responsible nodes perform no side effect.
+
+**Acceptance Scenarios**:
+
+1. **Given** an action that issues a credential, **When** it seals and replicates to multiple nodes, **Then** only the entitled node mints + delivers it, exactly once.
+2. **Given** the responsible node restarts and re-observes the sealed transaction, **When** it re-processes, **Then** no duplicate side effect is produced.
+3. **Given** a node that does not host the responsible wallet, **When** it observes the same sealed transaction, **Then** it performs no side effect.
+
+---
+
+### User Story 3 - Routing decisions (including parallel branches) are trusted ledger facts (Priority: P2)
+
+The decision about which action(s) come next must be recorded on the ledger as a fact every node can read and trust, including workflows that fan out into multiple parallel branches — rather than being recomputed differently per node or collapsed to a single branch.
+
+**Why this priority**: It is the data foundation the projection reads, and it fixes the parallel-branch loss. Prioritised just below the headline because the P1 loop depends on it, but it is independently verifiable.
+
+**Independent Test**: Submit an action whose route fans out to multiple next actions; verify the sealed transaction carries the full next-action set and every node projects all branches. Attempt to submit a decision inconsistent with the workflow's route graph or improperly attested; verify it is rejected at seal.
+
+**Acceptance Scenarios**:
+
+1. **Given** an action with a multi-branch route, **When** it is submitted and sealed, **Then** the sealed transaction carries the complete set of next actions and all nodes advance all branches.
+2. **Given** a submitted decision that does not correspond to a valid successor in the blueprint's route graph, **When** it reaches the sealing node, **Then** it is rejected and not sealed.
+3. **Given** a register configured to require a stronger routing-trust level, **When** an action is submitted, **Then** the required attestation is enforced before seal.
+
+---
+
+### User Story 4 - Instance state is verifiable and rebuildable from the ledger (Priority: P3)
+
+Because the instance is a projection, its stored form is a cache that can always be reconstructed from the sealed ledger, and any divergence between the cache and a fresh reconstruction can be detected and corrected — giving operators a recovery path and an integrity check.
+
+**Why this priority**: Operability and trust hardening. Valuable for resilience and audit, but the core flows work without explicitly exercising rebuild.
+
+**Independent Test**: Reconstruct an instance from the ledger and confirm it equals the stored state. Corrupt or delete the stored cache and confirm reconstruction restores the correct state.
+
+**Acceptance Scenarios**:
+
+1. **Given** any instance, **When** it is reconstructed from the sealed ledger, **Then** the reconstruction equals the stored state.
+2. **Given** a corrupted or missing stored instance cache, **When** reconstruction runs, **Then** the correct state is restored from the ledger.
+3. **Given** routine operation, **When** a periodic integrity check runs, **Then** any cache-vs-ledger divergence is surfaced.
+
+---
+
+### User Story 5 - One submission path; legacy duplication removed (Priority: P3)
+
+Submitting an action behaves the same whether or not the submitting node owns the register — one path, one response contract — and the legacy constructs that created the duplication (mirror reconstruction, the dual synchronous/async branch, imperative state mutation, the topology-based ownership guess, the single-next-action shortcut) are removed and prevented from returning.
+
+**Why this priority**: This is the consolidation/cleanup that locks in the model and removes the smell, but the behavioural wins are delivered by P1–P3; this guarantees they can't regress.
+
+**Independent Test**: Submit the same action from an owner node and from a subscriber node; confirm identical response contract and identical resulting state (advanced via projection in both cases). Run the clean-break check and confirm no removed construct remains.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owner node and a subscriber node, **When** each submits an action, **Then** both follow the same submission path and the same response contract, and neither mutates instance state directly.
+2. **Given** the sealing node must be chosen, **When** a submission fans out, **Then** the choice is made by validator-roster membership, not by connection topology.
+3. **Given** the codebase after this work, **When** the clean-break check runs, **Then** it finds no mirror reconstruction, dual-path branch, imperative mutation, topology heuristic, or single-next-action hint.
+
+---
+
+### User Story 6 - Presentation-driven advancement runs on the projection (Priority: P3)
+
+Workflows that advance on a credential-presentation outcome (rather than a normal action submission) advance through the same projection, preserving the existing chain-integrity guarantees that prevent ordering races.
+
+**Why this priority**: The presentation lifecycle is the most intricate flow to fold into the new model; it is isolated as its own slice so it can be migrated carefully without destabilising the core.
+
+**Independent Test**: Drive a presentation-gated workflow to a terminal outcome; confirm the instance advances consistently across nodes via the projection and that no chain-ordering race occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a presentation-gated action, **When** its outcome seals, **Then** the instance advances via the projection identically on every node.
+2. **Given** the existing chain-ordering protections, **When** presentation outcomes advance the instance, **Then** ordering integrity is preserved (no out-of-order advancement).
+
+---
+
+### Edge Cases
+
+- **Same sealed input, different arrival order / node restart**: projection must reach identical state regardless of docket arrival order or restarts (idempotent fold).
+- **Abandoned draft**: starting an application but never submitting must leave no ledger footprint and no instance on any node.
+- **Two applications from the same applicant**: each starting action yields a distinct, deterministic instance identity.
+- **Open / late-bound applicant**: instance identity is stable regardless of who is late-bound; the binding is recorded from the sealed starting action.
+- **Node cannot decrypt some action data**: it still projects control state (current/next actions) from the validated decision, but materialises only the data it is entitled to see; it performs no side effect it isn't entitled to.
+- **Replayed or duplicate sealed transaction**: neither advances state twice nor fires a side effect twice.
+- **Forged or inconsistent routing decision**: rejected at seal, never projected.
+- **Stronger routing-trust requested by a register but unmet**: submission refused before seal.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Instance as a ledger projection
+
+- **FR-001**: An instance MUST be a deterministic projection of the sealed register transactions for that instance; given identical sealed transactions, every node holding the register MUST compute identical instance control state (current actions, completed actions, participant bindings).
+- **FR-002**: There MUST be exactly one representation of an instance's state per node — no separate "origin" and "mirror" copies.
+- **FR-003**: The stored instance MUST be a rebuildable materialized view; the system MUST be able to reconstruct an instance's state from the sealed ledger and MUST be able to detect divergence between the stored view and a fresh reconstruction.
+- **FR-004**: The projection MUST be idempotent: re-observing an already-applied sealed transaction MUST NOT change state; folding MUST be order-independent for the same set of sealed transactions.
+
+#### Instance identity
+
+- **FR-005**: An instance's identity MUST be deterministically derived from its starting action's sealed transaction, so every node derives the same identity for the same workflow.
+- **FR-006**: Starting an application MUST NOT write to the ledger; the instance is born on the ledger only when its starting action is submitted and sealed. The submitter MUST receive the canonical ledger-derived identity in the submission acknowledgement.
+
+#### Routing as a carried, attested fact
+
+- **FR-007**: Each action transaction MUST carry the complete set of next actions (the routing decision), preserving parallel/fan-out branches end-to-end.
+- **FR-008**: The routing decision MUST be validated at seal time against the blueprint's static route graph and the sender's authorisation; an inconsistent decision MUST be rejected and never sealed.
+- **FR-009**: The routing decision MUST carry a pluggable attestation. The default (v1) attestation is the authorised sender's signature. A register's governance policy MUST be able to declare a required attestation strength (default: sender-signed), enforced before seal.
+- **FR-010**: Projecting instance control state MUST require only the validated routing decision — no node needs to decrypt action payload to advance control state.
+
+#### Single submission path
+
+- **FR-011**: Action submission MUST follow a single path regardless of whether the submitting node owns the register; the submitter MUST NOT directly mutate instance state. State advances only when the seal is observed (via the projection).
+- **FR-012**: Submission MUST return a prompt acknowledgement containing the transaction reference and the instance identity. It MAY return the advanced state if the projection materialises within a short bounded wait; otherwise it returns an async acknowledgement that the caller resolves by observing instance advancement.
+- **FR-013**: The node that seals MUST be selected by validator-roster membership (the authoritative register relationship), not by connection/seed topology.
+
+#### Cross-node discovery
+
+- **FR-014**: A participant (human or autonomous agent) MUST be able to discover and act on their current action on any node that holds the register, even if that node did not originate the instance.
+
+#### Reactions (side effects)
+
+- **FR-015**: Side effects (credential issuance, delivery, notifications, inbox writes) MUST be performed exactly once, by the entitled node (the node hosting the wallet responsible for the effect), idempotent on the sealed transaction and the effect kind.
+- **FR-016**: A replayed or duplicated sealed transaction, or a node restart, MUST NOT produce a duplicate side effect.
+- **FR-017**: A node that is not entitled for a given side effect MUST NOT perform it.
+
+#### Presentation lifecycle
+
+- **FR-018**: Presentation-driven advancement (outcome/abandonment) MUST advance the instance through the same projection while preserving existing chain-ordering integrity guarantees.
+
+#### Clean break
+
+- **FR-019**: The legacy mirror reconstruction, the dual synchronous/async submission branch, imperative instance-state mutation, the topology-based ownership heuristic, and the single-next-action hint MUST be removed.
+- **FR-020**: An automated check MUST prevent reintroduction of the removed constructs.
+
+#### Caller migration
+
+- **FR-021**: Callers that depend on a synchronous next-action / issued-credential response (user interfaces, walkthroughs, the demo toolkit) MUST be migrated to resolve outcomes by observing instance advancement and credential availability.
+
+### Key Entities *(include if feature involves data)*
+
+- **Instance projection (materialized view)**: the per-node cache of the deterministic projection — ledger-derived identity, current actions, completed actions, participant→wallet bindings, and the disclosure-scoped data view. Reconstructable from the ledger.
+- **Routing decision**: a fact attached to an action transaction — the completed action and the **full** set of next actions — plus an attestation.
+- **Attestation**: the trust mechanism for a routing decision — sender-signed (v1); validator-re-evaluated and proof-based are future strengths sharing the same slot.
+- **Reaction**: a node-role-gated, idempotent side effect keyed on (sealed transaction, effect kind), performed only by the entitled node.
+- **Register routing-attestation policy**: a register-governance setting declaring the required attestation strength (default sender-signed).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Given identical sealed transactions, an instance's control state is identical on every node in 100% of checks (cross-node determinism).
+- **SC-002**: A two-node workflow (applicant on one node, approver/agent on another) completes **fully autonomously** — the approver discovers and acts on its action with no manual step and no node-specific workaround — in 100% of runs.
+- **SC-003**: Reconstructing any instance from the ledger matches its stored state in 100% of checks; a corrupted or deleted cache is restored by reconstruction.
+- **SC-004**: Replaying or duplicating a sealed credential-issuing transaction across restarts yields exactly one credential (zero double-issues) in 100% of trials.
+- **SC-005**: Parallel-branch workflows preserve every branch across all nodes (zero branch loss), versus the prior single-branch collapse.
+- **SC-006**: Action submission returns the same response contract and reaches the same resulting state whether submitted from an owner or a subscriber node; no behaviour selects on connection topology.
+- **SC-007**: A forged or route-graph-inconsistent routing decision is rejected before seal in 100% of attempts.
+- **SC-008**: After completion, the clean-break check reports zero occurrences of the removed constructs, and the standing two-node demo runs green end-to-end with the autonomous approver.
+
+## Assumptions
+
+- **Pre-release, no data migration.** A clean break is acceptable; existing in-flight instances need not be preserved.
+- **v1 attestation is sender-signed.** Stronger attestations (validator re-evaluation via a control-disclosure plane; zero-knowledge / universally-verifiable proofs) are out of scope here — only the pluggable attestation seam and the register governance policy field are delivered now, so they can be added later without re-architecting.
+- **The sealing validator validates routing structurally**, not by decrypting payload values, in v1 (consistent with how submitters are already trusted for action data on encrypted registers).
+- **Disclosure model unchanged.** A node materialises only the action data it is entitled to decrypt; control-state projection needs only the validated decision.
+- **Bounded-wait default ~2–3s, configurable.** Tuning the synchronous-convenience window is an operational setting, not a scope question.
+- **Existing platform primitives remain**: the validator roster, the authoritative register relationship, the cross-node replication transport, the cross-node credential-delivery binding, and the presentation-lifecycle chain-ordering protections.
+
+## Dependencies
+
+- The validator-roster model and the authoritative register relationship (who can seal / who owns).
+- The cross-node replication transport that delivers sealed dockets to subscribers.
+- The cross-node credential-delivery binding (holder-key-bound, encrypted-to-recipient delivery).
+- The presentation-lifecycle and its chain-ordering protections (for the presentation slice).
+
+## Out of Scope
+
+- Stronger routing attestations (validator re-evaluation, zero-knowledge proofs) — seam + governance field only.
+- A register-governance administration interface for the routing-attestation policy (the setting exists; its admin UX is later).
+- Durable outbox-grade delivery guarantees for reactions (at-least-once + idempotent is sufficient now).
+- Cross-installation peer gossip / multi-hop mesh routing (unchanged from current deferred scope).
+- Preserving or migrating any existing in-flight instances (pre-release clean break).

--- a/specs/145-ledger-derived-instances/tasks.md
+++ b/specs/145-ledger-derived-instances/tasks.md
@@ -1,0 +1,222 @@
+# Tasks: Ledger-Derived Workflow Instances
+
+**Input**: Design documents from `/specs/145-ledger-derived-instances/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED. Determinism, idempotency, parity, and routing-validation are the correctness heart of this feature (Constitution IV + quickstart.md); the deterministic core is built test-first.
+
+**Organization**: by user story. MVP = User Story 1 (the consistent cross-node state machine). Foundational carries the shared substrate (the carried `RoutingDecision` + instance identity) that the projection reads.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]** = parallelizable (different files, no incomplete dependency).
+- **[Story]** = US1–US6 from spec.md.
+- File paths are repo-relative and grounded in plan.md's "touched areas".
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Scaffold `RoutingDecision` + `Attestation` types in `src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs` + `Attestation.cs` — `[JsonPropertyName]`-stable, canonical-serialisable (per `contracts/routing-decision.md`, data-model Entity 1/2)
+- [ ] T002 [P] Register new OTel meters `Sorcha.Blueprint.Instances` (projection) and `Sorcha.Blueprint.Reactions` on the ServiceDefaults export allowlist
+- [ ] T003 [P] Create `scripts/check-ledger-derived-clean-break.ps1` skeleton (patterns stubbed, initially passing) modelled on `scripts/check-trust-clean-break.ps1`
+- [ ] T004 [P] Add test fixtures area for sealed-docket streams in `tests/Sorcha.Blueprint.Service.Tests/Fixtures/LedgerDerived/` (canonical fixtures the projection tests fold)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ Blocks all user stories** — the projection (US1) reads the carried decision; the validator (US3) validates it.
+
+- [ ] T005 Complete `RoutingDecision{completedActionId, nextActions[], attestation}` + `Attestation.SenderSigned` in `Sorcha.Register.Models`; carry it on `TransactionMetaData` (clear) with canonical serialization; mark the legacy `NextActionId` for removal (compile-guarded)
+- [ ] T006 [P] Engine: emit the **full** `NextActions` set from routing evaluation in `src/Core/Sorcha.Blueprint.Engine/Routing/` (stop collapsing to a singular next action)
+- [ ] T007 Producer: assemble + sender-sign the `RoutingDecision` onto the action tx in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs` (replace the `NextActionId` set at the former `:984-993`)
+- [ ] T008 [P] Implement deterministic identity `H(registerId, blueprintId, startingActionTxHash)` in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceIdentity.cs` (data-model Entity 4)
+- [ ] T009 [P] Foundational unit tests in `tests/Sorcha.Blueprint.Engine.Tests` + `tests/Sorcha.Blueprint.Service.Tests`: `RoutingDecision` canonical round-trip, full-set emission, identity determinism
+
+**Checkpoint**: a sealed action carries a full, signed `RoutingDecision`; instance ids are deterministic.
+
+---
+
+## Phase 3: User Story 1 - Consistent cross-node state machine (Priority: P1) 🎯 MVP
+
+**Goal**: Every node folds the same sealed transactions into the same instance; any participant acts on any node; the cross-node loop runs autonomously with no mirror.
+
+**Independent Test**: Two-node credential workflow — applicant on the subscriber, approver/agent on the owner; instance control state identical on both nodes after each seal; the approver discovers + acts via pending-actions with no manual step.
+
+### Tests for US1
+
+- [ ] T010 [P] [US1] Projection determinism test (same docket stream, varied order + mid-stream restart → identical state) in `tests/Sorcha.Blueprint.Service.Tests/Projection/`
+- [ ] T011 [P] [US1] Discovery + cross-node identical-state test (`GetPendingActionsByWalletAsync` surfaces the current action on a non-originating node) in `tests/Sorcha.Blueprint.Service.Tests/Projection/`
+- [ ] T012 [P] [US1] Single submission contract test (owner vs subscriber identical; `202` + bounded-wait `200`) in `tests/Sorcha.Blueprint.Service.Tests/Submission/`
+
+### Implementation for US1
+
+- [ ] T013 [US1] Implement `InstanceProjector.cs` (`BackgroundService`, subscribe `docket:confirmed`/`RegisterEventChannels.DocketConfirmed`, pure fold reading `RoutingDecision.nextActions`, idempotent via `lastAppliedTxId`, chain-ordered) in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/` — runs on **every** node
+- [ ] T014 [US1] Materialized-view writes from the projector in `EfCoreInstanceStore.cs`: add `lastAppliedTxId` watermark, participant-id-keyed bindings, disclosure-scoped `dataView`; remove mirror write methods
+- [ ] T015 [US1] Remove `ApplyInstanceStateChanges` imperative mutation from `ActionExecutionService.cs`; the submitter no longer advances instance state
+- [ ] T016 [US1] Single async submission path in `ActionExecutionService.cs`: always `202 {txId,instanceId,accepted}`; bounded-wait `200` via `instance-advanced:{instanceId}` signal; remove the `!LocallyOwned` branch (contracts/submission-response.md)
+- [ ] T017 [US1] Roster-based sealer selection in `src/Services/Sorcha.Peer.Service/Distribution/TransactionDistributionService.cs` via `IRegisterLocalRelationshipService` (retire the seeds/topology heuristic)
+- [ ] T018 [US1] `POST /api/instances` becomes a local draft (no GUID store row); the starting-action submit returns the canonical ledger-derived `instanceId` in `src/Services/Sorcha.Blueprint.Service/Program.cs`
+- [ ] T019 [US1] Instance + pending-action reads served from the projection (contracts/instance-read.md); emit instance-advanced notification on fold
+- [ ] T020 [US1] Delete `InstanceMirrorReconstructor`, `Instance.IsReadOnlyMirror`, `CreateMirrorAsync`/`UpdateMirrorAsync`
+
+**Checkpoint**: the AssuredIdentity cross-node loop runs with identical state on both nodes and autonomous discovery — no mirror (SC-001, SC-002).
+
+---
+
+## Phase 4: User Story 3 - Routing decisions are trusted ledger facts (Priority: P2)
+
+**Goal**: The carried decision is validated at seal and governed; parallel branches preserved.
+
+**Independent Test**: A multi-branch route seals with all branches and every node advances them; a forged/route-inconsistent decision is rejected; a register requiring stronger attestation refuses.
+
+### Tests for US3
+
+- [ ] T021 [P] [US3] `VAL_ROUTING_001/002` tests (forged sig rejected; non-successor rejected; valid passes; parallel branches preserved) in `tests/Sorcha.Validator.Service.Tests/`
+- [ ] T022 [P] [US3] Governance enforcement test (register `routingAttestation` requiring `validator-reeval`/`proof` → refused in v1) in `tests/Sorcha.Validator.Service.Tests/`
+
+### Implementation for US3
+
+- [ ] T023 [US3] Implement `VAL_ROUTING_001` (structural successor vs published route graph) + `VAL_ROUTING_002` (attestation verify + required strength) in `src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs`
+- [ ] T024 [US3] Carry the validated `RoutingDecision` through the seal in `DocketBuildTriggerService.cs` (replace `ResolveNextActionId`); remove the singular `NextActionId` persistence
+- [ ] T025 [US3] Add `routingAttestation` to the register control record + read/derive it in `src/Core/Sorcha.Register.Core/Governance/` (sibling of crypto policy); validator enforces strength (v1 `sender-signed`; reserved values rejected)
+
+**Checkpoint**: routing decisions are trustworthy, governed, branch-complete (SC-005, SC-007).
+
+---
+
+## Phase 5: User Story 2 - Exactly-once, role-gated side effects (Priority: P2)
+
+**Goal**: Credential mint/deliver + notifications fire once, on the entitled node, safe under replay/restart.
+
+**Independent Test**: Issue a credential; replay the sealed tx + restart the dispatcher → exactly one credential; non-entitled nodes do nothing.
+
+### Tests for US2
+
+- [ ] T026 [P] [US2] Reaction idempotency + entitlement test (replay/restart → one credential; non-entitled no-op; one notification) in `tests/Sorcha.Blueprint.Service.Tests/Reactions/`
+
+### Implementation for US2
+
+- [ ] T027 [US2] Implement `ReactionDispatcher.cs` (`BackgroundService`, subscribe `docket:confirmed`, entitlement via `IWalletServiceClient.GetWalletAsync` wallet-host probe, idempotent via `Sorcha.AtomicCache` SET-NX on `(sealedTxId, reactionKind)`) in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/`
+- [ ] T028 [US2] Move credential mint out of `ActionExecutionService` inline path into a `CredentialMint` reaction (reuse holder-key-bound, encrypt-to-recipient issuance)
+- [ ] T029 [US2] `CredentialDeliver`/inbound-detect + `Notification`/`InboxWrite` reactions keyed on the same idempotency contract (contracts/reactions.md)
+- [ ] T030 [US2] Wire reaction OTel instruments (`reaction_dispatched_total`, `reaction_idempotent_skip_total`, `reaction_entitlement_skip_total`)
+
+**Checkpoint**: no double-issue across nodes/replay/restart (SC-004).
+
+---
+
+## Phase 6: User Story 4 - Verifiable, rebuildable instance state (Priority: P3)
+
+**Goal**: The materialized view is reconstructable from the ledger; divergence is detectable.
+
+**Independent Test**: Rebuild equals the stored view; corrupt/delete the view → rebuild restores it.
+
+### Tests for US4
+
+- [ ] T031 [P] [US4] Rebuild-parity test (`RebuildAsync == materialized`; corrupt view → restored) in `tests/Sorcha.Blueprint.Service.Tests/Projection/`
+
+### Implementation for US4
+
+- [ ] T032 [US4] Implement `RebuildAsync(instanceId)` by generalising `StateReconstructionService` to fold control state (not just data) from the instance's sealed txs
+- [ ] T033 [US4] Periodic/CI parity self-check + an operator-triggered rebuild operation (internal, not a public mutation)
+
+**Checkpoint**: recovery + integrity invariant (SC-003).
+
+---
+
+## Phase 7: User Story 5 - One submission path; legacy duplication removed (Priority: P3)
+
+**Goal**: Lock in the single path + roster ownership and remove the last legacy residue.
+
+**Independent Test**: Owner-node and subscriber-node submits are identical; the clean-break check finds nothing.
+
+- [ ] T034 [US5] Sweep + delete residual references to the topology heuristic, the dual-path branch, and the `NextActionId` hint across Blueprint/Validator/Peer; remove now-dead code
+- [ ] T035 [US5] Owner-vs-subscriber parity integration test (same response contract + same projected state) in `tests/Sorcha.Blueprint.Service.Tests/Submission/`
+
+**Checkpoint**: the model is the only model (SC-006).
+
+---
+
+## Phase 8: User Story 6 - Presentation lifecycle on the projection (Priority: P3)
+
+**Goal**: Presentation-driven advancement runs through the projection, preserving chain-ordering integrity.
+
+**Independent Test**: A presentation-gated workflow reaches a terminal outcome; the instance advances consistently across nodes with no ordering race.
+
+### Tests for US6
+
+- [ ] T036 [P] [US6] Presentation-advance-on-projection test (consistent across nodes; no ordering regression; `VAL_BP_003` carve-out intact) in `tests/Sorcha.Blueprint.Service.Tests/Presentation/`
+
+### Implementation for US6
+
+- [ ] T037 [US6] `PresentationOutcome`/`PresentationAbandoned` carry a `RoutingDecision`; the projector advances on their seal (F111/F119 path)
+- [ ] T038 [US6] Subsume the F119 `IPresentationSealCoordinator` ordering where the seal-ordered projection now guarantees it; retain the `VAL_BP_003` carve-out + remaining F119 idempotency sentinels
+- [ ] T039 [US6] Migrate presentation consumers off the bespoke advancement path onto the projection
+
+**Checkpoint**: the intricate lifecycle is unified, races preserved-against (FR-018).
+
+---
+
+## Phase 9: Polish & Cross-Cutting
+
+- [ ] T040 Complete `scripts/check-ledger-derived-clean-break.ps1` (forbids `InstanceMirrorReconstructor`, `IsReadOnlyMirror`, `Create/UpdateMirrorAsync`, `ApplyInstanceStateChanges`, the `LocallyOwned` branch, `NextActionId` hint, topology heuristic) + wire into CI — runs after US6
+- [ ] T041 [P] Migrate callers off the synchronous `nextActions`/`issuedCredential` response: walkthroughs + `Sorcha.UI` / `Sorcha.Wallet.Pwa` submit surfaces → subscribe/poll on instance-advanced + credential events (FR-021)
+- [ ] T042 [P] Align the `demos/AssuredIdentity/` toolkit: fix the readiness-gate auth (`Get-DemoPublishedBlueprintIds` 401) and confirm autonomous agent discovery now works against the projection
+- [ ] T043 Cross-node E2E green run on the standing two-node demo (autonomous loop, no manual approval, identical state) — SC-002, SC-008
+- [ ] T044 [P] Docs sync: `docs/reference/API-DOCUMENTATION.md`, `.claude/skills/sorcha-architecture/SKILL.md`, Blueprint/Validator/Register service READMEs, `docs/reference/development-status.md`
+- [ ] T045 [P] OTel dashboards + `projection-up-to-head` health check; confirm ≥85% coverage on the new core (Engine routing, projector fold, reactions)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+- **Setup (P1)** → **Foundational (P2, blocks all)** → **US1 (P3, MVP)** → **US3 (P4)** → **US2 (P5)** → **US4 (P6)** → **US5 (P7)** → **US6 (P8)** → **Polish (P9)**.
+
+### Story dependencies
+- **US1** depends on Foundational (carried `RoutingDecision` + identity). It is the MVP and performs the core removals (mirror, imperative mutation, dual branch).
+- **US3** hardens US1's trust (validates the decision US1 already projects). Land right after US1.
+- **US2** depends on US1's projection (reactions subscribe to the same seal stream) but is otherwise independent.
+- **US4** depends on US1 (rebuild reconstructs the projection).
+- **US5** is the formal cleanup after US1's behavioural removals — sequence near the end.
+- **US6** depends on US1 (projection) + US3 (decisions on presentation txns); highest-complexity, isolated last.
+- **Polish** depends on all; the clean-break gate (T040) runs after US6 so it catches presentation-path residue too.
+
+### Within a story
+- Tests before implementation (the deterministic core is TDD).
+- Models/seams before services; services before endpoints; removals after their replacements are green.
+
+### Parallel opportunities
+- Setup: T001–T004 all [P].
+- Foundational: T006, T008, T009 parallel to T005/T007.
+- US1 tests T010–T012 parallel; then T013/T014 → T015/T016 → T017/T018/T019 → T020 (removal last).
+- Polish: T041, T042, T044, T045 parallel after T040/T043.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# Tests first (expect fail):
+T010 determinism  |  T011 discovery/identical-state  |  T012 single-contract
+
+# Then projection core, then submission unification, then removals:
+T013 InstanceProjector → T014 store view → T015 remove imperative → T016 single submit
+   → T017 roster sealer | T018 draft creation | T019 reads/notify → T020 delete mirror
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (US1)
+Setup → Foundational → US1. **STOP and validate**: the cross-node AssuredIdentity loop runs autonomously with identical state on both nodes and no mirror. That alone retires the architecture that caused the recurring friction (SC-001, SC-002).
+
+### Incremental delivery
+US1 (consistent state machine) → US3 (trusted decisions) → US2 (exactly-once effects) → US4 (verifiable/rebuildable) → US5 (cleanup + gate) → US6 (presentation) → Polish (gate + caller migration + E2E + docs). Each story is independently testable; the clean-break gate lands last so nothing regresses.
+
+### Notes
+- [P] = different files, no incomplete dependency.
+- Removals (T015, T020, T024, T034) follow their replacements being green — never delete a path before the projection replaces it.
+- The standing demo (`demos/AssuredIdentity/`) is the cross-node acceptance harness throughout.

--- a/specs/145-ledger-derived-instances/tasks.md
+++ b/specs/145-ledger-derived-instances/tasks.md
@@ -16,10 +16,10 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 [P] Scaffold `RoutingDecision` + `Attestation` types in `src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs` + `Attestation.cs` — `[JsonPropertyName]`-stable, canonical-serialisable (per `contracts/routing-decision.md`, data-model Entity 1/2)
-- [ ] T002 [P] Register new OTel meters `Sorcha.Blueprint.Instances` (projection) and `Sorcha.Blueprint.Reactions` on the ServiceDefaults export allowlist
-- [ ] T003 [P] Create `scripts/check-ledger-derived-clean-break.ps1` skeleton (patterns stubbed, initially passing) modelled on `scripts/check-trust-clean-break.ps1`
-- [ ] T004 [P] Add test fixtures area for sealed-docket streams in `tests/Sorcha.Blueprint.Service.Tests/Fixtures/LedgerDerived/` (canonical fixtures the projection tests fold)
+- [X] T001 [P] Scaffold `RoutingDecision` + `Attestation` types in `src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs` + `Attestation.cs` — `[JsonPropertyName]`-stable, canonical-serialisable (per `contracts/routing-decision.md`, data-model Entity 1/2)
+- [X] T002 [P] Register new OTel meters `Sorcha.Blueprint.Instances` (projection) and `Sorcha.Blueprint.Reactions` on the ServiceDefaults export allowlist
+- [X] T003 [P] Create `scripts/check-ledger-derived-clean-break.ps1` skeleton (patterns stubbed, initially passing) modelled on `scripts/check-trust-clean-break.ps1`
+- [X] T004 [P] Add test fixtures area for sealed-docket streams in `tests/Sorcha.Blueprint.Service.Tests/Fixtures/LedgerDerived/` (canonical fixtures the projection tests fold)
 
 ---
 
@@ -27,11 +27,11 @@
 
 **⚠️ Blocks all user stories** — the projection (US1) reads the carried decision; the validator (US3) validates it.
 
-- [ ] T005 Complete `RoutingDecision{completedActionId, nextActions[], attestation}` + `Attestation.SenderSigned` in `Sorcha.Register.Models`; carry it on `TransactionMetaData` (clear) with canonical serialization; mark the legacy `NextActionId` for removal (compile-guarded)
-- [ ] T006 [P] Engine: emit the **full** `NextActions` set from routing evaluation in `src/Core/Sorcha.Blueprint.Engine/Routing/` (stop collapsing to a singular next action)
-- [ ] T007 Producer: assemble + sender-sign the `RoutingDecision` onto the action tx in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs` (replace the `NextActionId` set at the former `:984-993`)
-- [ ] T008 [P] Implement deterministic identity `H(registerId, blueprintId, startingActionTxHash)` in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceIdentity.cs` (data-model Entity 4)
-- [ ] T009 [P] Foundational unit tests in `tests/Sorcha.Blueprint.Engine.Tests` + `tests/Sorcha.Blueprint.Service.Tests`: `RoutingDecision` canonical round-trip, full-set emission, identity determinism
+- [X] T005 Complete `RoutingDecision{completedActionId, nextActions[], attestation}` + `Attestation.SenderSigned` in `Sorcha.Register.Models`; carry it on `TransactionMetaData` (clear) with canonical serialization; mark the legacy `NextActionId` for removal (compile-guarded)
+- [X] T006 [P] Engine: emit the **full** `NextActions` set from routing evaluation in `src/Core/Sorcha.Blueprint.Engine/Routing/` (stop collapsing to a singular next action) — NO-OP: `RoutingEngine.BuildRoutingResult` already emits the full deduped `NextActionIds` set on `RoutingResult.NextActions`; the singular collapse is downstream in `ActionExecutionService` only (addressed by T007)
+- [X] T007 Producer: assemble + sender-sign the `RoutingDecision` onto the action tx in `ActionExecutionService.cs` step 10d (~:995). Builds `RoutingDecision{CompletedActionId, NextActions(full set, BranchKey), Attestation.SenderSigned}`, signs `ComputeSignableBytes()` via `SignTransactionAsync`, base64s into `Attestation.Signature`, writes canonical JSON to `transaction.Metadata["routingDecision"]` → rides to the sealed docket via `TrackingData` copy. Legacy `nextActionId` write retained until T024. Builds green.
+- [X] T008 [P] Implement deterministic identity `H(registerId, blueprintId, startingActionTxHash)` in `src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceIdentity.cs` (data-model Entity 4)
+- [X] T009 [P] Foundational unit tests: `tests/Sorcha.Register.Models.Tests/RoutingDecisionTests.cs` (6 tests — canonical round-trip, camelCase wire-stability, full-set/parallel preservation, attestation-free signable bytes, determinism, terminal empty set — all pass) + `tests/Sorcha.Blueprint.Service.Tests/Services/InstanceIdentityTests.cs` (identity determinism, distinctness, hex format, field-boundary anti-collision, arg validation — all pass). Full-set EMISSION (engine) was T006 no-op; carried-decision full-set is covered here.
 
 **Checkpoint**: a sealed action carries a full, signed `RoutingDecision`; instance ids are deterministic.
 
@@ -45,7 +45,7 @@
 
 ### Tests for US1
 
-- [ ] T010 [P] [US1] Projection determinism test (same docket stream, varied order + mid-stream restart → identical state) in `tests/Sorcha.Blueprint.Service.Tests/Projection/`
+- [X] T010 [P] [US1] Projection determinism test (same docket stream, varied order + mid-stream restart → identical state) in `tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionTests.cs` — 10 tests pass: order-independence across all permutations, duplicate-folds-once idempotency, incremental `Apply`==batch `Project` parity, parallel-branch preservation, rejection/completion terminals. Backed by the pure fold `InstanceProjection.cs` (`Project` batch rebuild + `Apply` online watermark fold) — the deterministic core reused by T013 (projector) and T032 (rebuild).
 - [ ] T011 [P] [US1] Discovery + cross-node identical-state test (`GetPendingActionsByWalletAsync` surfaces the current action on a non-originating node) in `tests/Sorcha.Blueprint.Service.Tests/Projection/`
 - [ ] T012 [P] [US1] Single submission contract test (owner vs subscriber identical; `202` + bounded-wait `200`) in `tests/Sorcha.Blueprint.Service.Tests/Submission/`
 

--- a/src/Common/Sorcha.Register.Models/TransactionMetaData.cs
+++ b/src/Common/Sorcha.Register.Models/TransactionMetaData.cs
@@ -36,9 +36,22 @@ public class TransactionMetaData
     public uint? ActionId { get; set; }
 
     /// <summary>
-    /// Next action/step in blueprint
+    /// Next action/step in blueprint.
     /// </summary>
+    /// <remarks>
+    /// LEGACY (Feature 145): the singular next-action hint is superseded by
+    /// <see cref="RoutingDecision"/>, which carries the <b>full</b> next-action set plus a
+    /// pluggable attestation. Slated for removal once the validated decision is carried
+    /// through the seal (tasks T024/T040). Do not read or write this in new code.
+    /// </remarks>
     public uint? NextActionId { get; set; }
+
+    /// <summary>
+    /// Routing decision carried on this action transaction (Feature 145) — the complete
+    /// next-action set plus its trust attestation, in the clear so every node can advance
+    /// instance control state without decrypting the payload (FR-007/FR-010).
+    /// </summary>
+    public RoutingDecision? RoutingDecision { get; set; }
 
     /// <summary>
     /// Custom tracking data (JSON serialized)

--- a/src/Common/Sorcha.Register.Models/Transactions/Attestation.cs
+++ b/src/Common/Sorcha.Register.Models/Transactions/Attestation.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Register.Models;
+
+/// <summary>
+/// The pluggable trust mechanism for a <see cref="RoutingDecision"/> (Feature 145, Entity 2).
+/// v1 ships only <see cref="AttestationKind.SenderSigned"/>; the other variants are the
+/// reserved upgrade seam. The instance projection reads
+/// <see cref="RoutingDecision.NextActions"/> regardless of variant — only validation branches
+/// on <see cref="Kind"/>.
+/// </summary>
+public class Attestation
+{
+    /// <summary>
+    /// Gets or sets the attestation variant. Defaults to <see cref="AttestationKind.SenderSigned"/>.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public AttestationKind Kind { get; set; } = AttestationKind.SenderSigned;
+
+    /// <summary>
+    /// Gets or sets the sender wallet signature over the canonical, attestation-free decision
+    /// (<see cref="RoutingDecision.ComputeSignableBytes"/>). Populated for
+    /// <see cref="AttestationKind.SenderSigned"/> (v1).
+    /// </summary>
+    [JsonPropertyName("signature")]
+    public string? Signature { get; set; }
+}
+
+/// <summary>
+/// Discriminates the attestation strength a routing decision carries. The required strength
+/// is a per-register governance policy (default <see cref="SenderSigned"/>); reserved values
+/// are rejected at seal until their implementation lands.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<AttestationKind>))]
+public enum AttestationKind
+{
+    /// <summary>v1 — signed by the authorised sender wallet. Validator checks the signature
+    /// plus structural successor; it does NOT decrypt payload or re-evaluate the condition.</summary>
+    SenderSigned,
+
+    /// <summary>v2 (reserved) — a control-plane disclosure lets the validator re-evaluate the
+    /// route condition over disclosed control fields.</summary>
+    ValidatorReEvaluated,
+
+    /// <summary>v3 (reserved) — a succinct, universally-verifiable proof that the next actions
+    /// follow from the route graph and committed inputs, with no disclosure.</summary>
+    Proof,
+}

--- a/src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs
+++ b/src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sorcha.Register.Models;
+
+/// <summary>
+/// A routing decision carried on an action transaction's clear metadata (Feature 145).
+/// Records the action this transaction completes and the <b>full</b> set of next actions
+/// (preserving parallel branches), trusted via a pluggable <see cref="Attestation"/>.
+/// Replaces the legacy singular <see cref="TransactionMetaData.NextActionId"/> hint.
+/// </summary>
+/// <remarks>
+/// The decision rides on the transaction in the clear so every node can advance instance
+/// control state without decrypting the payload (FR-010). It is signed over its canonical
+/// bytes (excluding the attestation) — see <see cref="ComputeSignableBytes"/>.
+/// </remarks>
+public class RoutingDecision
+{
+    /// <summary>
+    /// Gets or sets the identifier of the action this transaction completes.
+    /// </summary>
+    [JsonPropertyName("completedActionId")]
+    public int CompletedActionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the full set of next actions. Empty means this branch terminates.
+    /// Multiple entries express parallel/fan-out branches (preserved end-to-end, FR-007).
+    /// </summary>
+    [JsonPropertyName("nextActions")]
+    public List<ActionRef> NextActions { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the trust attestation for this decision (Entity 2 / FR-009).
+    /// </summary>
+    [JsonPropertyName("attestation")]
+    public Attestation? Attestation { get; set; }
+
+    /// <summary>
+    /// Computes the canonical bytes the attestation signs over — the decision with its
+    /// <see cref="Attestation"/> excluded (the signature cannot sign over itself).
+    /// Uses <see cref="RegisterSerializationOptions.Canonical"/> so producer and validator agree.
+    /// </summary>
+    /// <returns>UTF-8 canonical JSON of the attestation-free decision.</returns>
+    public byte[] ComputeSignableBytes()
+    {
+        var signable = new RoutingDecision
+        {
+            CompletedActionId = CompletedActionId,
+            NextActions = NextActions,
+            Attestation = null,
+        };
+        return JsonSerializer.SerializeToUtf8Bytes(signable, RegisterSerializationOptions.Canonical);
+    }
+}
+
+/// <summary>
+/// A reference to a next action within a routing decision. <see cref="BranchKey"/>
+/// distinguishes parallel branches where the route graph needs it.
+/// </summary>
+public class ActionRef
+{
+    /// <summary>
+    /// Gets or sets the next action identifier.
+    /// </summary>
+    [JsonPropertyName("actionId")]
+    public int ActionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional branch discriminator for parallel branches.
+    /// </summary>
+    [JsonPropertyName("branchKey")]
+    public string? BranchKey { get; set; }
+}

--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -111,6 +111,8 @@ public static class Extensions
                 // Feature 142 — Blueprint Design Lifecycle (rehearsal harness +
                 // governed Go-live). Exact-name allowlist entry; instruments in T058.
                 metrics.AddMeter("Sorcha.Blueprint.Designer");
+                metrics.AddMeter("Sorcha.Blueprint.Instances");
+                metrics.AddMeter("Sorcha.Blueprint.Reactions");
             })
             .WithTracing(tracing =>
             {

--- a/src/Services/Sorcha.Blueprint.Service/Models/Instance.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Models/Instance.cs
@@ -142,6 +142,15 @@ public class Instance
     /// set; mirror mutations go through the dedicated mirror-write path.
     /// </summary>
     public bool IsReadOnlyMirror { get; set; }
+
+    /// <summary>
+    /// Feature 145: idempotency watermark for the deterministic instance projection — the
+    /// id of the most recent sealed action transaction folded into this materialized view.
+    /// The <c>InstanceProjector</c> skips re-applying a transaction at or before this point,
+    /// so re-observing an already-folded sealed docket is a no-op (FR-004). Null until the
+    /// first sealed action is folded.
+    /// </summary>
+    public string? LastAppliedTxId { get; set; }
 }
 
 /// <summary>

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -26,6 +26,7 @@ using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Storage;
 using Sorcha.Blueprint.Service.Storage.Presentations;
 using Sorcha.Cryptography.Enums;
+using Sorcha.Register.Models;
 using Sorcha.TransactionHandler.Encryption;
 using Sorcha.TransactionHandler.Encryption.Models;
 using Microsoft.Extensions.Configuration;
@@ -986,11 +987,37 @@ public class ActionExecutionService : IActionExecutionService
         //      CurrentActionIds (DocketBuildTriggerService projects it onto TransactionMetaData).
         //      Singular (first routed next action) — exact for linear flows; fan-out carries the
         //      primary branch only.
+        //      LEGACY (Feature 145): superseded by the full RoutingDecision written below.
+        //      Retained until the validator carries the decision through the seal (T024).
         var nextActionId = routingResult.NextActions.FirstOrDefault()?.ActionId;
         if (nextActionId.HasValue)
         {
             transaction.Metadata["nextActionId"] = nextActionId.Value.ToString();
         }
+
+        // 10d. Feature 145: assemble + sender-sign the full RoutingDecision and carry it on the
+        //      transaction's clear metadata. Every node folds decision.nextActions into the
+        //      instance projection without decrypting the payload (FR-007/FR-010); the validator
+        //      validates it at seal (VAL_ROUTING_*, T023). The full set preserves parallel
+        //      branches that the singular nextActionId above collapses. TrackingData copies all
+        //      string metadata to the sealed tx, so "routingDecision" rides through to the docket.
+        var routingDecision = new RoutingDecision
+        {
+            CompletedActionId = actionId,
+            NextActions = routingResult.NextActions
+                .Select(n => new ActionRef { ActionId = n.ActionId, BranchKey = n.BranchId })
+                .ToList(),
+            Attestation = new Attestation { Kind = AttestationKind.SenderSigned },
+        };
+        var routingSignResult = await _walletClient.SignTransactionAsync(
+            request.SenderWallet,
+            routingDecision.ComputeSignableBytes(),
+            derivationPath: null,
+            isPreHashed: false,
+            cancellationToken);
+        routingDecision.Attestation.Signature = Convert.ToBase64String(routingSignResult.Signature);
+        transaction.Metadata["routingDecision"] =
+            JsonSerializer.Serialize(routingDecision, RegisterSerializationOptions.Canonical);
 
         // 11. Sign transaction using "{TxId}:{PayloadHash}" contract (matches Validator verification)
         var signResult = await _walletClient.SignTransactionAsync(

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceIdentity.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceIdentity.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Sorcha.Blueprint.Service.Services.Implementation;
+
+/// <summary>
+/// Deterministic, ledger-anchored workflow instance identity (Feature 145, data-model Entity 4).
+/// An instance is born when its starting action seals; its id is derived purely from on-ledger
+/// facts so every node computes the same id for the same workflow — with no node-local GUID and
+/// no mirror.
+/// </summary>
+/// <remarks>
+/// <c>instanceId = encode( SHA256( registerId || 0x1F || blueprintId || 0x1F || startingActionTxHash ) )</c>.
+/// The unit-separator (<c>0x1F</c>) byte between fields removes concatenation ambiguity (so that
+/// e.g. <c>("ab","c")</c> and <c>("a","bc")</c> cannot collide). The output is lowercase hex —
+/// stable, node-independent, and safe in URLs / store keys. Stability under open-participant
+/// late-binding is automatic: the id derives from the sealed starting-action tx hash, regardless
+/// of who is late-bound.
+/// </remarks>
+public static class InstanceIdentity
+{
+    private const byte FieldSeparator = 0x1F; // ASCII Unit Separator
+
+    /// <summary>
+    /// Derives the canonical instance id from the three on-ledger facts.
+    /// </summary>
+    /// <param name="registerId">The register the starting action sealed on.</param>
+    /// <param name="blueprintId">The blueprint the instance executes.</param>
+    /// <param name="startingActionTxHash">The hash of the sealed starting-action transaction.</param>
+    /// <returns>Lowercase-hex SHA-256 over the separated, UTF-8-encoded inputs.</returns>
+    /// <exception cref="ArgumentException">If any input is null or whitespace.</exception>
+    public static string Derive(string registerId, string blueprintId, string startingActionTxHash)
+    {
+        if (string.IsNullOrWhiteSpace(registerId))
+            throw new ArgumentException("registerId is required", nameof(registerId));
+        if (string.IsNullOrWhiteSpace(blueprintId))
+            throw new ArgumentException("blueprintId is required", nameof(blueprintId));
+        if (string.IsNullOrWhiteSpace(startingActionTxHash))
+            throw new ArgumentException("startingActionTxHash is required", nameof(startingActionTxHash));
+
+        using var buffer = new MemoryStream();
+        WriteUtf8(buffer, registerId);
+        buffer.WriteByte(FieldSeparator);
+        WriteUtf8(buffer, blueprintId);
+        buffer.WriteByte(FieldSeparator);
+        WriteUtf8(buffer, startingActionTxHash);
+
+        var hash = SHA256.HashData(buffer.ToArray());
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private static void WriteUtf8(Stream target, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        target.Write(bytes, 0, bytes.Length);
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjection.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjection.cs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Models;
+
+namespace Sorcha.Blueprint.Service.Services.Implementation;
+
+/// <summary>
+/// A single sealed action transaction reduced to the facts the deterministic instance
+/// projection needs (Feature 145). The impure <c>InstanceProjector</c> resolves these from
+/// the register (transaction + carried <c>RoutingDecision</c> + blueprint participant map)
+/// and hands the pure fold a value it can replay identically on any node.
+/// </summary>
+/// <param name="TxId">The sealed transaction id (idempotency key + chain node).</param>
+/// <param name="PreviousTransactionId">The predecessor in this instance's chain; null for the starting action.</param>
+/// <param name="CompletedActionId">The action this transaction completes.</param>
+/// <param name="NextActionIds">The full next-action set from the validated <c>RoutingDecision</c> (preserves parallel branches).</param>
+/// <param name="ParticipantBindings">Participant-id → wallet bindings this transaction contributes (already resolved against the blueprint; never self-keyed by the projector).</param>
+/// <param name="IsRejection">True when this transaction is a terminal rejection.</param>
+public sealed record ProjectedTransaction(
+    string TxId,
+    string? PreviousTransactionId,
+    int CompletedActionId,
+    IReadOnlyList<int> NextActionIds,
+    IReadOnlyDictionary<string, string> ParticipantBindings,
+    bool IsRejection = false);
+
+/// <summary>
+/// The pure, deterministic core of Feature 145: folds a set of sealed action transactions into
+/// an instance projection. Identical sealed input yields identical instance control state on
+/// every node, independent of arrival order (FR-001), and re-applying an already-folded
+/// transaction is a no-op (FR-004). This same fold backs both the online projector and the
+/// offline <c>RebuildAsync</c> (FR-003), so the materialized view and a fresh replay agree.
+/// </summary>
+/// <remarks>
+/// Determinism comes from folding in <b>chain order</b> (each transaction links to its
+/// predecessor via <see cref="ProjectedTransaction.PreviousTransactionId"/>), not arrival order.
+/// The fold needs only the validated <c>RoutingDecision</c> carried in the clear — never the
+/// encrypted payload (FR-010).
+/// </remarks>
+public static class InstanceProjection
+{
+    /// <summary>
+    /// Projects the complete set of an instance's sealed action transactions into an
+    /// <see cref="Instance"/> materialized view. Order-independent: any permutation of
+    /// <paramref name="sealedTransactions"/> yields the same result.
+    /// </summary>
+    /// <param name="instanceId">The ledger-derived instance id.</param>
+    /// <param name="registerId">The register the instance lives on.</param>
+    /// <param name="blueprintId">The blueprint the instance executes.</param>
+    /// <param name="blueprintVersion">The blueprint version at the starting action.</param>
+    /// <param name="tenantId">The owning tenant.</param>
+    /// <param name="sealedTransactions">Every sealed action transaction for this instance, in any order.</param>
+    /// <param name="createdAt">Creation timestamp to stamp on the rebuilt view (defaults to now).</param>
+    /// <returns>The folded instance, or null when no transactions are supplied.</returns>
+    public static Instance? Project(
+        string instanceId,
+        string registerId,
+        string blueprintId,
+        int blueprintVersion,
+        string tenantId,
+        IEnumerable<ProjectedTransaction> sealedTransactions,
+        DateTimeOffset? createdAt = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(instanceId);
+        var ordered = OrderByChain(sealedTransactions);
+        if (ordered.Count == 0)
+            return null;
+
+        var instance = new Instance
+        {
+            Id = instanceId,
+            RegisterId = registerId,
+            BlueprintId = blueprintId,
+            BlueprintVersion = blueprintVersion,
+            TenantId = tenantId,
+            State = InstanceState.Active,
+            CreatedAt = createdAt ?? DateTimeOffset.UtcNow,
+            FirstTransactionId = ordered[0].TxId,
+        };
+
+        foreach (var tx in ordered)
+            ApplyInPlace(instance, tx);
+
+        return instance;
+    }
+
+    /// <summary>
+    /// Idempotently folds a single sealed transaction into an existing instance view (the online
+    /// projector path). Returns the instance unchanged if <paramref name="tx"/> has already been
+    /// applied (its id equals the watermark, FR-004). The caller is responsible for delivering
+    /// transactions in chain order; out-of-order delivery is handled by a full
+    /// <see cref="Project"/> rebuild.
+    /// </summary>
+    /// <param name="instance">The current materialized view (mutated in place).</param>
+    /// <param name="tx">The sealed transaction to fold.</param>
+    /// <returns>True if the instance advanced; false if the transaction was already applied.</returns>
+    public static bool Apply(Instance instance, ProjectedTransaction tx)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentNullException.ThrowIfNull(tx);
+
+        if (string.Equals(instance.LastAppliedTxId, tx.TxId, StringComparison.Ordinal))
+            return false;
+
+        ApplyInPlace(instance, tx);
+        return true;
+    }
+
+    private static void ApplyInPlace(Instance instance, ProjectedTransaction tx)
+    {
+        // Advance control state: remove the completed action, add the full next-action set
+        // (parallel branches preserved). Dedup keeps CurrentActionIds a clean set.
+        instance.CurrentActionIds.RemoveAll(id => id == tx.CompletedActionId);
+        foreach (var next in tx.NextActionIds)
+        {
+            if (!instance.CurrentActionIds.Contains(next))
+                instance.CurrentActionIds.Add(next);
+        }
+        instance.CurrentActionIds.Sort(); // canonical order — identical on every node
+
+        // Merge participant→wallet bindings (participant-id keyed, last-writer-wins).
+        foreach (var binding in tx.ParticipantBindings)
+            instance.ParticipantWallets[binding.Key] = binding.Value;
+
+        instance.CompletedActionCount++;
+        instance.LastTransactionId = tx.TxId;
+        instance.LastAppliedTxId = tx.TxId;
+        instance.UpdatedAt = DateTimeOffset.UtcNow;
+
+        // Derive terminal state: a rejection is terminal; no remaining current actions means
+        // every branch has reached a route-graph terminal (Completed).
+        if (tx.IsRejection)
+        {
+            instance.State = InstanceState.Rejected;
+        }
+        else if (instance.CurrentActionIds.Count == 0)
+        {
+            instance.State = InstanceState.Completed;
+            instance.CompletedAt = DateTimeOffset.UtcNow;
+        }
+        else
+        {
+            instance.State = InstanceState.Active;
+        }
+    }
+
+    /// <summary>
+    /// Orders transactions by their instance chain (predecessor links), deterministically and
+    /// independent of input order. The root is the transaction whose predecessor is null or
+    /// outside the set (the starting action). Any transactions not reachable through the chain
+    /// (defensive: a gap or fork) are appended in stable tx-id order so the fold stays total.
+    /// </summary>
+    private static List<ProjectedTransaction> OrderByChain(IEnumerable<ProjectedTransaction> transactions)
+    {
+        // De-duplicate by TxId (idempotent input), keeping the first occurrence.
+        var byId = new Dictionary<string, ProjectedTransaction>(StringComparer.Ordinal);
+        foreach (var tx in transactions)
+            byId.TryAdd(tx.TxId, tx);
+
+        if (byId.Count == 0)
+            return [];
+
+        var byPrev = new Dictionary<string, ProjectedTransaction>(StringComparer.Ordinal);
+        var roots = new List<ProjectedTransaction>();
+        foreach (var tx in byId.Values)
+        {
+            if (tx.PreviousTransactionId is { Length: > 0 } prev && byId.ContainsKey(prev))
+                byPrev[prev] = tx;
+            else
+                roots.Add(tx);
+        }
+
+        // Deterministic root selection if more than one (defensive): lowest tx id.
+        roots.Sort((a, b) => string.CompareOrdinal(a.TxId, b.TxId));
+
+        var ordered = new List<ProjectedTransaction>(byId.Count);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var root in roots)
+        {
+            var cursor = root;
+            while (cursor is not null && seen.Add(cursor.TxId))
+            {
+                ordered.Add(cursor);
+                cursor = byPrev.TryGetValue(cursor.TxId, out var next) ? next : null;
+            }
+        }
+
+        // Append any stragglers not reached via the chain, in stable order.
+        if (ordered.Count != byId.Count)
+        {
+            foreach (var tx in byId.Values.OrderBy(t => t.TxId, StringComparer.Ordinal))
+                if (seen.Add(tx.TxId))
+                    ordered.Add(tx);
+        }
+
+        return ordered;
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Fixtures/LedgerDerived/README.md
+++ b/tests/Sorcha.Blueprint.Service.Tests/Fixtures/LedgerDerived/README.md
@@ -1,0 +1,14 @@
+# Ledger-Derived Instances — canonical fixtures (Feature 145)
+
+Canonical sealed-docket / sealed-transaction streams the projection tests fold to assert
+determinism, order-independence, idempotency, and rebuild parity (US1/US4, SC-001/SC-003).
+
+Each fixture is a deterministic stream of sealed action transactions (each carrying a
+`RoutingDecision` on its clear `TransactionMetaData`) that the `InstanceProjector` folds into
+an instance projection. Tests feed the same stream in varied order / with a mid-stream
+restart and assert identical resulting state.
+
+Conventions:
+- Fixtures are built in-code via the shared `LedgerDerivedFixtures` helper where possible;
+  JSON fixtures here are for cross-node parity goldens that must be byte-stable.
+- Keep fixtures small and intention-revealing (single-branch, parallel-branch, terminal).

--- a/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionTests.cs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Implementation;
+
+namespace Sorcha.Blueprint.Service.Tests.Projection;
+
+/// <summary>
+/// Feature 145 US1 — determinism, order-independence, and idempotency of the pure instance
+/// projection fold (the deterministic core; SC-001). The same sealed transaction set must
+/// project to identical control state regardless of arrival order or restart.
+/// </summary>
+public class InstanceProjectionTests
+{
+    private static readonly IReadOnlyDictionary<string, string> NoBindings =
+        new Dictionary<string, string>();
+
+    private static ProjectedTransaction Tx(
+        string id, string? prev, int completed, int[] next, bool rejection = false,
+        IReadOnlyDictionary<string, string>? bindings = null)
+        => new(id, prev, completed, next, bindings ?? NoBindings, rejection);
+
+    /// <summary>A linear 3-action chain: start(1)→2→3→complete.</summary>
+    private static List<ProjectedTransaction> LinearChain() =>
+    [
+        Tx("tx1", null, 1, [2], bindings: new Dictionary<string, string> { ["citizen"] = "ws-citizen" }),
+        Tx("tx2", "tx1", 2, [3], bindings: new Dictionary<string, string> { ["analyst"] = "ws-analyst" }),
+        Tx("tx3", "tx2", 3, []),
+    ];
+
+    [Fact]
+    public void Project_LinearChain_ReachesCompletedTerminalState()
+    {
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", LinearChain());
+
+        instance.Should().NotBeNull();
+        instance!.State.Should().Be(InstanceState.Completed);
+        instance.CurrentActionIds.Should().BeEmpty();
+        instance.CompletedActionCount.Should().Be(3);
+        instance.FirstTransactionId.Should().Be("tx1");
+        instance.LastTransactionId.Should().Be("tx3");
+        instance.LastAppliedTxId.Should().Be("tx3");
+        instance.ParticipantWallets.Should().Contain("citizen", "ws-citizen");
+        instance.ParticipantWallets.Should().Contain("analyst", "ws-analyst");
+    }
+
+    [Fact]
+    public void Project_IsOrderIndependent_AcrossAllPermutations()
+    {
+        var canonical = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", LinearChain())!;
+
+        var permutations = new[]
+        {
+            new[] { 0, 1, 2 }, new[] { 0, 2, 1 }, new[] { 1, 0, 2 },
+            new[] { 1, 2, 0 }, new[] { 2, 0, 1 }, new[] { 2, 1, 0 },
+        };
+
+        foreach (var perm in permutations)
+        {
+            var src = LinearChain();
+            var shuffled = perm.Select(i => src[i]).ToList();
+            var result = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", shuffled)!;
+
+            result.State.Should().Be(canonical.State);
+            result.CurrentActionIds.Should().Equal(canonical.CurrentActionIds);
+            result.CompletedActionCount.Should().Be(canonical.CompletedActionCount);
+            result.LastTransactionId.Should().Be(canonical.LastTransactionId);
+            result.FirstTransactionId.Should().Be(canonical.FirstTransactionId);
+            result.ParticipantWallets.Should().BeEquivalentTo(canonical.ParticipantWallets);
+        }
+    }
+
+    [Fact]
+    public void Project_DuplicateTransactions_FoldOnce()
+    {
+        var withDupes = LinearChain();
+        withDupes.Add(LinearChain()[0]); // duplicate tx1
+        withDupes.Add(LinearChain()[1]); // duplicate tx2
+
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", withDupes)!;
+
+        instance.CompletedActionCount.Should().Be(3, "duplicate sealed transactions must fold once");
+        instance.State.Should().Be(InstanceState.Completed);
+    }
+
+    [Fact]
+    public void Project_ParallelBranch_KeepsAllCurrentActions()
+    {
+        // start(1) fans out to 2 AND 3; only 2 completes → 3 still current.
+        var txs = new List<ProjectedTransaction>
+        {
+            Tx("tx1", null, 1, [2, 3]),
+            Tx("tx2", "tx1", 2, []),
+        };
+
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", txs)!;
+
+        instance.CurrentActionIds.Should().Equal(3);
+        instance.State.Should().Be(InstanceState.Active);
+        instance.CompletedActionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Apply_ReApplyingSameTransaction_IsNoOp()
+    {
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant",
+        [
+            Tx("tx1", null, 1, [2]),
+        ])!;
+        var countBefore = instance.CompletedActionCount;
+
+        var advanced = InstanceProjection.Apply(instance, Tx("tx1", null, 1, [2]));
+
+        advanced.Should().BeFalse();
+        instance.CompletedActionCount.Should().Be(countBefore);
+    }
+
+    [Fact]
+    public void Apply_NewTransaction_AdvancesAndReportsTrue()
+    {
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant",
+        [
+            Tx("tx1", null, 1, [2]),
+        ])!;
+
+        var advanced = InstanceProjection.Apply(instance, Tx("tx2", "tx1", 2, [3]));
+
+        advanced.Should().BeTrue();
+        instance.CurrentActionIds.Should().Equal(3);
+        instance.LastAppliedTxId.Should().Be("tx2");
+        instance.CompletedActionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Apply_IncrementalEqualsBatchProject_SameFinalState()
+    {
+        // Incremental online fold must equal an offline batch rebuild (the FR-003 parity invariant).
+        var batch = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", LinearChain())!;
+
+        var incremental = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant",
+        [
+            LinearChain()[0],
+        ])!;
+        InstanceProjection.Apply(incremental, LinearChain()[1]);
+        InstanceProjection.Apply(incremental, LinearChain()[2]);
+
+        incremental.State.Should().Be(batch.State);
+        incremental.CurrentActionIds.Should().Equal(batch.CurrentActionIds);
+        incremental.CompletedActionCount.Should().Be(batch.CompletedActionCount);
+        incremental.LastAppliedTxId.Should().Be(batch.LastAppliedTxId);
+        incremental.ParticipantWallets.Should().BeEquivalentTo(batch.ParticipantWallets);
+    }
+
+    [Fact]
+    public void Project_Rejection_ReachesRejectedTerminalState()
+    {
+        var txs = new List<ProjectedTransaction>
+        {
+            Tx("tx1", null, 1, [2]),
+            Tx("tx2", "tx1", 2, [], rejection: true),
+        };
+
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", txs)!;
+
+        instance.State.Should().Be(InstanceState.Rejected);
+    }
+
+    [Fact]
+    public void Project_EmptyInput_ReturnsNull()
+    {
+        var instance = InstanceProjection.Project("inst-1", "reg", "bp", 1, "tenant", []);
+        instance.Should().BeNull();
+    }
+}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/InstanceIdentityTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/InstanceIdentityTests.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Blueprint.Service.Services.Implementation;
+
+namespace Sorcha.Blueprint.Service.Tests.Services;
+
+/// <summary>
+/// Foundational tests for the Feature 145 deterministic, ledger-anchored instance identity
+/// (data-model Entity 4). The id must be reproducible on every node from on-ledger facts and
+/// must not be ambiguous under field-boundary collisions.
+/// </summary>
+public class InstanceIdentityTests
+{
+    [Fact]
+    public void Derive_SameInputs_ProducesSameId()
+    {
+        var a = InstanceIdentity.Derive("reg-1", "bp-1", "txhash-1");
+        var b = InstanceIdentity.Derive("reg-1", "bp-1", "txhash-1");
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Derive_DifferentStartingTx_ProducesDifferentId()
+    {
+        var first = InstanceIdentity.Derive("reg-1", "bp-1", "txhash-1");
+        var second = InstanceIdentity.Derive("reg-1", "bp-1", "txhash-2");
+
+        first.Should().NotBe(second);
+    }
+
+    [Fact]
+    public void Derive_OutputIsLowercaseHexSha256()
+    {
+        var id = InstanceIdentity.Derive("reg-1", "bp-1", "txhash-1");
+
+        id.Should().HaveLength(64);
+        id.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void Derive_FieldBoundaryShift_DoesNotCollide()
+    {
+        // Without a field separator, ("ab","c",...) and ("a","bc",...) would hash identical
+        // concatenations. The 0x1F separator must keep them distinct.
+        var x = InstanceIdentity.Derive("ab", "c", "tx");
+        var y = InstanceIdentity.Derive("a", "bc", "tx");
+
+        x.Should().NotBe(y);
+    }
+
+    [Theory]
+    [InlineData("", "bp", "tx")]
+    [InlineData("reg", "", "tx")]
+    [InlineData("reg", "bp", "")]
+    [InlineData("reg", "bp", "   ")]
+    public void Derive_MissingInput_Throws(string registerId, string blueprintId, string startingActionTxHash)
+    {
+        var act = () => InstanceIdentity.Derive(registerId, blueprintId, startingActionTxHash);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Sorcha.Register.Models.Tests/RoutingDecisionTests.cs
+++ b/tests/Sorcha.Register.Models.Tests/RoutingDecisionTests.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Text;
+using System.Text.Json;
+using Sorcha.Register.Models;
+
+namespace Sorcha.Register.Models.Tests;
+
+/// <summary>
+/// Foundational tests for the Feature 145 carried <see cref="RoutingDecision"/> — canonical
+/// serialization round-trip, full-set preservation (parallel branches), and the stable,
+/// attestation-free signable bytes the producer signs and the validator re-derives.
+/// </summary>
+public class RoutingDecisionTests
+{
+    [Fact]
+    public void RoutingDecision_CanonicalRoundTrip_PreservesAllFields()
+    {
+        var decision = new RoutingDecision
+        {
+            CompletedActionId = 1,
+            NextActions =
+            [
+                new ActionRef { ActionId = 2 },
+                new ActionRef { ActionId = 3, BranchKey = "approve" },
+            ],
+            Attestation = new Attestation { Kind = AttestationKind.SenderSigned, Signature = "c2ln" },
+        };
+
+        var json = JsonSerializer.Serialize(decision, RegisterSerializationOptions.Canonical);
+        var round = JsonSerializer.Deserialize<RoutingDecision>(json, RegisterSerializationOptions.Canonical)!;
+
+        Assert.Equal(1, round.CompletedActionId);
+        Assert.Equal(2, round.NextActions.Count);
+        Assert.Equal(2, round.NextActions[0].ActionId);
+        Assert.Null(round.NextActions[0].BranchKey);
+        Assert.Equal(3, round.NextActions[1].ActionId);
+        Assert.Equal("approve", round.NextActions[1].BranchKey);
+        Assert.Equal(AttestationKind.SenderSigned, round.Attestation!.Kind);
+        Assert.Equal("c2ln", round.Attestation.Signature);
+    }
+
+    [Fact]
+    public void RoutingDecision_CanonicalJson_UsesStableCamelCasePropertyNames()
+    {
+        var decision = new RoutingDecision
+        {
+            CompletedActionId = 5,
+            NextActions = [new ActionRef { ActionId = 6 }],
+            Attestation = new Attestation { Kind = AttestationKind.SenderSigned, Signature = "abc" },
+        };
+
+        var json = JsonSerializer.Serialize(decision, RegisterSerializationOptions.Canonical);
+
+        // The #881 relay lesson: property names must be wire-stable, not PascalCase.
+        Assert.Contains("\"completedActionId\":5", json);
+        Assert.Contains("\"nextActions\":", json);
+        Assert.Contains("\"actionId\":6", json);
+        Assert.Contains("\"attestation\":", json);
+        Assert.Contains("\"kind\":\"SenderSigned\"", json);
+        Assert.DoesNotContain("CompletedActionId", json);
+    }
+
+    [Fact]
+    public void RoutingDecision_FullSet_PreservesParallelBranchesEndToEnd()
+    {
+        // Regression for the singular-hint collapse: a multi-branch decision must round-trip
+        // every branch, in order.
+        var decision = new RoutingDecision
+        {
+            CompletedActionId = 1,
+            NextActions =
+            [
+                new ActionRef { ActionId = 10, BranchKey = "a" },
+                new ActionRef { ActionId = 20, BranchKey = "b" },
+                new ActionRef { ActionId = 30, BranchKey = "c" },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(decision, RegisterSerializationOptions.Canonical);
+        var round = JsonSerializer.Deserialize<RoutingDecision>(json, RegisterSerializationOptions.Canonical)!;
+
+        Assert.Equal(new[] { 10, 20, 30 }, round.NextActions.Select(a => a.ActionId).ToArray());
+        Assert.Equal(new[] { "a", "b", "c" }, round.NextActions.Select(a => a.BranchKey).ToArray());
+    }
+
+    [Fact]
+    public void ComputeSignableBytes_ExcludesAttestation_SoSignatureNeverSignsItself()
+    {
+        var withoutAttestation = new RoutingDecision
+        {
+            CompletedActionId = 7,
+            NextActions = [new ActionRef { ActionId = 8 }],
+        };
+        var withAttestation = new RoutingDecision
+        {
+            CompletedActionId = 7,
+            NextActions = [new ActionRef { ActionId = 8 }],
+            Attestation = new Attestation { Kind = AttestationKind.SenderSigned, Signature = "deadbeef" },
+        };
+
+        var bytesWithout = withoutAttestation.ComputeSignableBytes();
+        var bytesWith = withAttestation.ComputeSignableBytes();
+
+        // The signable bytes are identical regardless of the attestation: the signature is over
+        // the attestation-free decision, so a verifier can re-derive them from the carried decision.
+        Assert.Equal(bytesWithout, bytesWith);
+        var text = Encoding.UTF8.GetString(bytesWith);
+        Assert.DoesNotContain("deadbeef", text);
+        Assert.DoesNotContain("attestation", text);
+    }
+
+    [Fact]
+    public void ComputeSignableBytes_IsDeterministic_AcrossInstances()
+    {
+        var a = new RoutingDecision
+        {
+            CompletedActionId = 1,
+            NextActions = [new ActionRef { ActionId = 2 }, new ActionRef { ActionId = 3 }],
+        };
+        var b = new RoutingDecision
+        {
+            CompletedActionId = 1,
+            NextActions = [new ActionRef { ActionId = 2 }, new ActionRef { ActionId = 3 }],
+        };
+
+        Assert.Equal(a.ComputeSignableBytes(), b.ComputeSignableBytes());
+    }
+
+    [Fact]
+    public void RoutingDecision_EmptyNextActions_RepresentsTerminalBranch()
+    {
+        var decision = new RoutingDecision { CompletedActionId = 9, NextActions = [] };
+
+        var json = JsonSerializer.Serialize(decision, RegisterSerializationOptions.Canonical);
+        var round = JsonSerializer.Deserialize<RoutingDecision>(json, RegisterSerializationOptions.Canonical)!;
+
+        Assert.Empty(round.NextActions);
+    }
+}


### PR DESCRIPTION
## Feature 145 — Ledger-Derived Workflow Instances (foundational slice)

Makes a workflow instance a **deterministic projection of the sealed register**. This PR lands the **additive, non-breaking foundation**: routing as a carried + attested ledger fact, deterministic instance identity, and the pure projection fold — *without* removing the legacy mirror / imperative-mutation / dual-submit paths. That destructive cutover (US1 T013–T020) is the next PR, gated on the mandated cross-node live validation on the standing two-node demo (HARD RULE: no removal lands before its replacement is verified green).

Design: `docs/superpowers/specs/2026-05-31-ledger-derived-instances-design.md` · Spec: `specs/145-ledger-derived-instances/`

### What's in this PR

**Phase 1 — Setup**
- `RoutingDecision` + `ActionRef` + `Attestation` + `AttestationKind` (`Sorcha.Register.Models/Transactions/`) — clear-metadata, canonical, camelCase-stable
- OTel meters `Sorcha.Blueprint.Instances` / `.Reactions` on the ServiceDefaults export allowlist
- `scripts/check-ledger-derived-clean-break.ps1` (skeleton; patterns activated per-replacement in T040)

**Phase 2 — Foundational**
- `TransactionMetaData.RoutingDecision` carried in the clear; `NextActionId` marked legacy (removed in T024)
- Producer (`ActionExecutionService`) assembles the **full** next-action set, sender-signs the canonical attestation-free decision, and carries it on the action tx → rides to the sealed docket via `TrackingData`
- `InstanceIdentity.Derive` — deterministic, node-independent SHA-256 ledger-anchored id

**US1 — deterministic core (T010)**
- `Instance.LastAppliedTxId` idempotency watermark
- `InstanceProjection`: pure fold — `Project` (batch rebuild, chain-ordered, order-independent) + `Apply` (online, idempotent). Reused by the projector (T013) and rebuild (T032). Advances control state from the full `nextActions` set (parallel branches preserved), needs no payload decryption (FR-010).

### Verification
- `RoutingDecisionTests` (6), `InstanceIdentityTests` (5), `InstanceProjectionTests` (10) — determinism / order-independence / idempotency / parallel-branch / parity — **all green**
- Register.Models **213/213**, Blueprint.Engine **560/561** (1 pre-existing skip), Blueprint.Service **836/836**
- Full solution builds clean; clean-break gate passes

### Not in this PR (next slice, US1 cutover)
`InstanceProjector` BackgroundService on every node, single async submission path, roster-based sealer selection, `POST /instances` → local draft, projection-backed reads, and removal of `InstanceMirrorReconstructor` / `ApplyInstanceStateChanges` / the `LocallyOwned` branch — followed by the cross-node tiny+n1 validation gate (SC-001/SC-002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)