### PR TITLE
feat(145): US5 — complete routing-decision flow end-to-end + remove legacy nextActionId

### DIFF
--- a/src/Common/Sorcha.Register.Models/TransactionMetaData.cs
+++ b/src/Common/Sorcha.Register.Models/TransactionMetaData.cs
@@ -36,17 +36,6 @@ public class TransactionMetaData
     public uint? ActionId { get; set; }
 
     /// <summary>
-    /// Next action/step in blueprint.
-    /// </summary>
-    /// <remarks>
-    /// LEGACY (Feature 145): the singular next-action hint is superseded by
-    /// <see cref="RoutingDecision"/>, which carries the <b>full</b> next-action set plus a
-    /// pluggable attestation. Slated for removal once the validated decision is carried
-    /// through the seal (tasks T024/T040). Do not read or write this in new code.
-    /// </remarks>
-    public uint? NextActionId { get; set; }
-
-    /// <summary>
     /// Routing decision carried on this action transaction (Feature 145) — the complete
     /// next-action set plus its trust attestation, in the clear so every node can advance
     /// instance control state without decrypting the payload (FR-007/FR-010).

--- a/src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs
+++ b/src/Common/Sorcha.Register.Models/Transactions/RoutingDecision.cs
@@ -10,7 +10,7 @@ namespace Sorcha.Register.Models;
 /// A routing decision carried on an action transaction's clear metadata (Feature 145).
 /// Records the action this transaction completes and the <b>full</b> set of next actions
 /// (preserving parallel branches), trusted via a pluggable <see cref="Attestation"/>.
-/// Replaces the legacy singular <see cref="TransactionMetaData.NextActionId"/> hint.
+/// Replaces the legacy singular next-action hint (Feature 145 — fully removed).
 /// </summary>
 /// <remarks>
 /// The decision rides on the transaction in the clear so every node can advance instance

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -1004,19 +1004,6 @@ public class ActionExecutionService : IActionExecutionService
             transaction.Metadata["credentialRecipient"] = issuedCredential.SubjectDid;
         }
 
-        // 10c. Carry the singular resolved next action on the tx so a node that observes the sealed
-        //      docket can seed CurrentActionIds (DocketBuildTriggerService projects it onto
-        //      TransactionMetaData). Singular (first routed next action) — exact for linear flows.
-        //      LEGACY (Feature 145): superseded by the full RoutingDecision written below, which the
-        //      validator validates (VAL_ROUTING_*, T023) and carries onto the typed sealed metadata
-        //      (T024, both DONE). This singular string + the projector's NextActionId fallback are now
-        //      vestigial and are removed in the US5 dual-path sweep (T034).
-        var nextActionId = routingResult.NextActions.FirstOrDefault()?.ActionId;
-        if (nextActionId.HasValue)
-        {
-            transaction.Metadata["nextActionId"] = nextActionId.Value.ToString();
-        }
-
         // 10d. Feature 145: assemble + sender-sign the full RoutingDecision and carry it on the
         //      transaction's clear metadata. Every node folds decision.nextActions into the
         //      instance projection without decrypting the payload (FR-007/FR-010); the validator

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/EncryptionBackgroundService.cs
@@ -183,14 +183,29 @@ public sealed class EncryptionBackgroundService : BackgroundService
                 workItem.PreviousTransactionId,
                 ct);
 
-            // Feature 137 (C5): carry the resolved next action so a cross-node mirror can seed
-            // CurrentActionIds when this tx seals. Mirrors the synchronous path in
-            // ActionExecutionService; DocketBuildTriggerService projects it onto TransactionMetaData.
-            var nextActionId = workItem.RoutingResult.NextActions.FirstOrDefault()?.ActionId;
-            if (nextActionId.HasValue)
+            // Feature 145: assemble + sender-sign the full RoutingDecision (the encrypted path's
+            // analog of ActionExecutionService step 10d) and carry it on the tx's clear metadata.
+            // The validator validates it (VAL_ROUTING_*) and it rides to the seal as the typed
+            // RoutingDecision every node's InstanceProjector folds — replacing the legacy singular
+            // nextActionId hint. Without this, encrypted-register actions carried NO routing decision
+            // at all (only the now-removed nextActionId), so the decision never reached the seal.
+            var routingDecision = new Sorcha.Register.Models.RoutingDecision
             {
-                transaction.Metadata["nextActionId"] = nextActionId.Value.ToString();
-            }
+                CompletedActionId = workItem.ActionId,
+                NextActions = workItem.RoutingResult.NextActions
+                    .Select(n => new Sorcha.Register.Models.ActionRef { ActionId = n.ActionId, BranchKey = n.BranchId })
+                    .ToList(),
+                Attestation = new Sorcha.Register.Models.Attestation
+                {
+                    Kind = Sorcha.Register.Models.AttestationKind.SenderSigned,
+                },
+            };
+            var routingSignResult = await walletClient.SignTransactionAsync(
+                workItem.SenderWallet, routingDecision.ComputeSignableBytes(),
+                derivationPath: null, isPreHashed: false, ct);
+            routingDecision.Attestation.Signature = Convert.ToBase64String(routingSignResult.Signature);
+            transaction.Metadata["routingDecision"] = JsonSerializer.Serialize(
+                routingDecision, Sorcha.Register.Models.RegisterSerializationOptions.Canonical);
 
             // Step 4: Signing and Submitting
             await UpdateOperationStepAsync(operationId, EncryptionOpStatus.Submitting,

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
@@ -43,9 +43,12 @@ public static class InstanceProjectionResolver
 
         var completedActionId = (int)tx.MetaData.ActionId.Value;
         var decision = ResolveRoutingDecision(tx.MetaData, logger);
+        // Feature 145: the carried RoutingDecision is the sole routing source — the legacy singular
+        // NextActionId hint is fully removed. A tx with no decision contributes a terminal (empty)
+        // next-action set (genuine terminals + legacy pre-145 txs that never carried one).
         var nextActionIds = decision is not null
             ? decision.NextActions.Select(a => a.ActionId).ToList()
-            : tx.MetaData.NextActionId.HasValue ? [(int)tx.MetaData.NextActionId.Value] : [];
+            : new List<int>();
 
         var bindings = await ResolveParticipantBindingsAsync(
             blueprintId, completedActionId, nextActionIds, tx, actionResolver, logger, ct);
@@ -63,8 +66,8 @@ public static class InstanceProjectionResolver
     /// <summary>
     /// Reads the carried <see cref="RoutingDecision"/> — preferring the typed
     /// <see cref="TransactionMetaData.RoutingDecision"/> field, falling back to the canonical JSON
-    /// the producer wrote into the clear tracking metadata (key <c>routingDecision</c>), then to the
-    /// legacy singular <see cref="TransactionMetaData.NextActionId"/>. Returns null when none present.
+    /// the producer wrote into the clear tracking metadata (key <c>routingDecision</c>). Returns null
+    /// when none present.
     /// </summary>
     public static RoutingDecision? ResolveRoutingDecision(TransactionMetaData metadata, ILogger logger)
     {

--- a/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Interfaces/ITransactionBuilderService.cs
@@ -658,16 +658,16 @@ public class BuiltTransaction
         if (Metadata.TryGetValue(Sorcha.Blueprint.Service.Services.Implementation.PresentationMetadataKeys.ConsumerName, out var consumer) && consumer is not null)
             submissionMetadata[Sorcha.Blueprint.Service.Services.Implementation.PresentationMetadataKeys.ConsumerName] = consumer.ToString()!;
 
-        // Feature 137 (C5) — propagate the Blueprint Service's resolved next-action id onto
-        // the submission so DocketBuildTriggerService.ResolveNextActionId can project it onto
-        // the sealed TransactionMetaData.NextActionId. The cross-node InstanceMirrorReconstructor
-        // reads that value to seed a mirror's CurrentActionIds; without it the analyst on the
-        // owner node has a mirror with no current action ("Action N is not a current action").
-        // submissionMetadata is a whitelist — the key MUST be copied explicitly here or it is
-        // silently dropped (it was, end-to-end, until this fix). ActionExecutionService and
-        // EncryptionBackgroundService both set Metadata["nextActionId"] before calling this.
-        if (Metadata.TryGetValue("nextActionId", out var nextActionId) && nextActionId is not null)
-            submissionMetadata["nextActionId"] = nextActionId.ToString()!;
+        // Feature 145 — propagate the producer's signed RoutingDecision (canonical JSON) onto the
+        // submission so the validator can validate it (VAL_ROUTING_*) and DocketBuildTriggerService
+        // can carry it onto the sealed TransactionMetaData.RoutingDecision, which every node's
+        // InstanceProjector folds. submissionMetadata is a WHITELIST — the key MUST be copied
+        // explicitly here or it is silently dropped (the legacy singular `nextActionId` hint that
+        // this replaces was the only routing key copied before, so the RoutingDecision never reached
+        // the validator or the seal — the projector advanced on the nextActionId fallback). Both
+        // ActionExecutionService and EncryptionBackgroundService set Metadata["routingDecision"].
+        if (Metadata.TryGetValue("routingDecision", out var routingDecision) && routingDecision is not null)
+            submissionMetadata["routingDecision"] = routingDecision.ToString()!;
 
         return new TransactionSubmission
         {

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ToTransactionSubmissionMetadataTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ToTransactionSubmissionMetadataTests.cs
@@ -122,4 +122,31 @@ public class ToTransactionSubmissionMetadataTests
         // PresentationInitiated has no outcomeKind — ensure we don't leak anything stale.
         submission.Metadata!.ContainsKey("outcomeKind").Should().BeFalse();
     }
+
+    [Fact]
+    public async Task ToTransactionSubmission_CarriesRoutingDecision_AndNoLegacyNextActionId()
+    {
+        // Feature 145 US5: the submission whitelist must propagate `routingDecision` (the carried,
+        // signed decision the validator validates + the seal carries) — and must NOT carry the
+        // removed legacy `nextActionId` hint. This is the hop that was silently dropping the
+        // decision end-to-end before the fix.
+        var built = await _service.BuildPresentationInitiatedAsync(
+            MakeBp(), MakeInst(), MakeAct(),
+            presentationRequestId: Guid.NewGuid(),
+            consumerName: "haip",
+            requirementsDigest: new byte[] { 0x01 },
+            validityWindowSeconds: 600,
+            submitterWallet: "ws11qcitizen",
+            previousTransactionId: null);
+        built.SenderWallet = "ws11qcitizen";
+        const string canonicalDecision = "{\"completedActionId\":1,\"nextActions\":[{\"actionId\":2}],\"attestation\":{\"kind\":\"SenderSigned\",\"signature\":\"sig\"}}";
+        built.Metadata["routingDecision"] = canonicalDecision;
+        // A producer that still wrote the legacy key must NOT leak it through the whitelist.
+        built.Metadata["nextActionId"] = "2";
+
+        var submission = built.ToTransactionSubmission(MakeSig(), sequenceNumber: 1);
+
+        submission.Metadata!["routingDecision"].Should().Be(canonicalDecision);
+        submission.Metadata!.ContainsKey("nextActionId").Should().BeFalse();
+    }
 }

--- a/tests/Sorcha.Register.Core.Tests/Managers/TransactionManagerTests.cs
+++ b/tests/Sorcha.Register.Core.Tests/Managers/TransactionManagerTests.cs
@@ -263,7 +263,6 @@ public class TransactionManagerTests
             BlueprintId = "blueprint123",
             InstanceId = "instance456",
             ActionId = 1,
-            NextActionId = 2
         };
 
         // Act

--- a/tests/Sorcha.Register.Service.Tests/Unit/InboundTransactionRouterTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/InboundTransactionRouterTests.cs
@@ -403,7 +403,7 @@ public class InboundTransactionRouterTests
             BlueprintId = "bp-partial",
             InstanceId = null,
             ActionId = 5,
-            NextActionId = null
+            // No RoutingDecision → the derived gRPC NextActionId hint is 0 (asserted below).
         };
 
         SetupBloomMatch(address, isLocal: true);


### PR DESCRIPTION
Live finding (confirmed on n1/local Mongo): the US3 RoutingDecision was DORMANT
end-to-end — every sealed action tx carried nextActionId with RoutingDecision=null.
Two gaps closed:

- (A) ToTransactionSubmission is a metadata WHITELIST that copied only nextActionId,
  silently dropping routingDecision before the validator ever saw it. Now whitelists
  routingDecision (+ drops nextActionId). This activates VAL_ROUTING_* on real traffic
  and carries the typed decision to the seal.
- (B) EncryptionBackgroundService (encrypted-register path) never produced a
  RoutingDecision at all — only nextActionId. Now assembles + sender-signs the full
  RoutingDecision (the encrypted-path analog of ActionExecutionService step 10d).
- (C) Removed the legacy singular nextActionId everywhere: producer writes
  (ActionExecutionService 10c + EncryptionBackgroundService), the whitelist copy, the
  typed TransactionMetaData.NextActionId property, and the projector/resolver fallback.
  The carried RoutingDecision is now the sole routing source.

ToTransactionSubmission test locks routingDecision-carried + nextActionId-absent.
Blueprint 846, Register.Core 325, Register.Service 303; full solution build green.

NOTE: changes live routing/advancement — validated cross-node on rebuilt tiny+n1
(see PR description). T035 owner-vs-subscriber parity = the cross-node walkthrough.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
