### PR TITLE
feat(145): US6 increment 1 — projector skips presentation-lifecycle txs without a decision (+ latent bug fix)

### DIFF
--- a/specs/145-ledger-derived-instances/US6-IMPLEMENTATION-PLAN.md
+++ b/specs/145-ledger-derived-instances/US6-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,85 @@
+# US6 — Presentation lifecycle onto the projection (implementation plan)
+
+**Status:** Increment 1 DONE + unit-tested (branch `feature/145-us6-presentation-projection`).
+Increments 2–3 designed below; they are **atomic + live-gated** (need the F111/F127 walkthroughs).
+
+This plan was written from a CURRENT-code recon (2026-06-01), correcting the stale-worktree recon
+the resume prompt warned about. Key correction below.
+
+## Critical finding (corrects the memory/skill)
+
+The skill said "presentation txs aren't projector-folded, so no double-write." **That is false on
+current master.** `BuildPresentationInitiatedAsync` / `BuildPresentationOutcomeAsync` /
+`BuildPresentationAbandonedAsync` (`ITransactionBuilderService.cs`) all stamp
+`blueprintId`+`actionId`+`instanceId` into metadata, and `DocketBuildTriggerService.cs:642` sets a
+numeric `TransactionMetaData.ActionId` (`uint.TryParse`). So `InstanceProjectionResolver.ResolveAsync`
+returns non-null for them and the `InstanceProjector` **folds them** — with no `RoutingDecision` they
+fold as an empty-terminal and retire the still-current presentation action.
+
+For a **non-terminal** presentation-gated action this is a latent bug: the projector prematurely
+completes the instance, then the imperative `CompleteAfterPresentationAsync` early-exits ("action no
+longer current") and the workflow never reaches the real successor. Masked today only because the
+tested presentation flows have the presentation as the **terminal** action.
+
+## Increment 1 (DONE)
+
+`InstanceProjectionResolver.ResolveAsync` skips a presentation-lifecycle tx
+(`IsPresentationLifecycle()` = Initiated/Outcome/Abandoned) that carries **no** `RoutingDecision`, so
+the gated action — current via the previous action's routing fold — stays current until a successful
+outcome routes onward. New `TransactionType.IsPresentationLifecycle()` /
+`IsIntraActionLifecycleTerminal()` predicates in `Sorcha.Register.Models`. 5 resolver tests; suite
+851/0. This restores the intended invariant AND fixes the non-terminal bug, independent of 2–3.
+
+## Increment 2 + 3 (atomic — must land together; live-gated)
+
+**Why atomic:** once a SUCCESS outcome carries a `RoutingDecision`, the projector folds it and
+advances. If the imperative `CompleteAfterPresentationAsync` advance is still wired, you get a
+double-advance race. So "attach decision" (2) and "retire imperative advance" (3) are one change.
+
+### 2 — Produce + sign a RoutingDecision for a successful outcome
+- Add `IActionExecutionService.BuildPresentationRoutingDecisionAsync(instanceId, completedActionId,
+  draftPayload, submitterWallet, ct)` → loads the real blueprint+instance+actionDef, runs the SAME
+  `EvaluateCalculationsAsync` + `BuildOutputMappingSource` + `EvaluateRoutingAsync` that
+  `CompleteAfterPresentationAsync` runs today, then builds + sender-signs a `RoutingDecision`
+  (mirror `ActionExecutionService` step 10d ~L1007–1029) and RETURNS it (does NOT advance). Returns
+  null if the action is no longer current (idempotency) so a replay attaches nothing.
+- `PresentationLifecycleService.HandleOutcomeAsync` (success branch, both the inline path ~L568+ and
+  the F119-deferred path ~L526+): call it and attach canonical JSON to `built.Metadata["routingDecision"]`
+  BEFORE `ToTransactionSubmission`. `ToTransactionSubmission` already whitelists `"routingDecision"`
+  (`ITransactionBuilderService.cs:669`), so it rides to the validator + seal. Attaching metadata
+  post-build does NOT change txId/signature (those are over `TransactionData`/`SigningData`, not
+  `Metadata`). **The `HandleOutcomeAsync` shims (blueprint/instance) stay for the BUILD** — the real
+  load happens inside `BuildPresentationRoutingDecisionAsync`.
+- Validator interaction: a success outcome now carries a decision, so `VAL_ROUTING_001/002` (which do
+  NOT skip intra-action-lifecycle terminals) will validate it — `nextActions` must be structural
+  successors of the presentation action. The `VAL_BP_003` carve-out
+  (`IsIntraActionLifecycleTerminal`) stays untouched. **This is the dormant-routing trap surface —
+  must verify in Mongo that the sealed success outcome shows `RoutingDecision=PRESENT` and the loop
+  advances.**
+
+### 3 — Retire the imperative advance (after 2 proves out live)
+- Remove the `EnqueueAdvancementAsync` calls (deferred ~L539 + inline ~L679) and the legacy
+  `Task.Run → CompleteAfterPresentationAsync` fallback (~L690–721) in `PresentationLifecycleService`.
+  Advancement now happens only on the outcome seal via the projector; the `ReactionDispatcher`
+  (post-fold) fires the action-available / workflow-completed notifications.
+- Keep `EnqueueSubmissionAsync` (the F119 outcome-tx **submission** deferral for chain ordering) — it
+  is still required so the outcome tx doesn't race its `PresentationInitiated` predecessor seal.
+- Delete the now-dead imperative methods: `CompleteAfterPresentationAsync`,
+  `UpdateInstanceAfterExecutionAsync`, `ApplyInstanceStateChanges`, `NotifyParticipantsAsync`
+  (`ActionExecutionService`), the `IActionExecutionService.CompleteAfterPresentationAsync` interface
+  member, and the `SealAwaitingAdvancement` / advancement branch of `DrainOnSealAsync` in
+  `RedisPresentationSealCoordinator` + `IPresentationSealCoordinator`. Keep the F119 idempotency
+  sentinels (`SetOutcomeSentinelAsync`) and the recovery sweep.
+- **Removal-follows-replacement:** delete only after the live walkthrough confirms the projector
+  advances on the carried decision. A clean rollback is "re-add the imperative advance call."
+
+### Tests to keep green
+`PresentationSealCoordinatorTests`, `PresentationLifecycle*`, `PresentationExecute*`,
+`SorchaWalletPresentationConsumerTests`. Many assert the imperative advance / `EnqueueAdvancementAsync`
+— they will need rework to assert "success outcome carries a signed RoutingDecision" +
+"projector folds it" instead.
+
+### Live validation (the gate — Stuart)
+Re-run the F111 + F127 presentation walkthroughs. Confirm: presentation success advances the
+instance on every node, no ordering race, and (Mongo) the sealed success outcome shows
+`RoutingDecision=PRESENT`. Then T040 can enforce the `ApplyInstanceStateChanges` clean-break pattern.

--- a/specs/145-ledger-derived-instances/tasks.md
+++ b/specs/145-ledger-derived-instances/tasks.md
@@ -152,7 +152,8 @@
 
 ### Implementation for US6
 
-- [ ] T037 [US6] `PresentationOutcome`/`PresentationAbandoned` carry a `RoutingDecision`; the projector advances on their seal (F111/F119 path)
+- [~] **US6 Increment 1 (DONE, unit-tested)** — `InstanceProjectionResolver` now skips a presentation-lifecycle tx (`TransactionType.IsPresentationLifecycle()` = Initiated/Outcome/Abandoned) that carries no `RoutingDecision`, so the gated action stays current until a successful outcome routes it onward. Also a **latent-bug fix**: today the projector folds these (numeric ActionId is stamped on the sealed tx), retiring a still-current non-terminal presentation action → premature completion + imperative early-exit. 5 resolver tests; suite 851/0. Full 2–3 design (the atomic, live-gated success-advances-via-projector cutover) in `US6-IMPLEMENTATION-PLAN.md`.
+- [ ] T037 [US6] `PresentationOutcome`(success) carries a `RoutingDecision`; the projector advances on its seal (F111/F119 path). **Increment 2** — see `US6-IMPLEMENTATION-PLAN.md`. (Decline/abandoned/Initiated carry no decision and are skipped per Increment 1.)
 - [ ] T038 [US6] Subsume the F119 `IPresentationSealCoordinator` ordering where the seal-ordered projection now guarantees it; retain the `VAL_BP_003` carve-out + remaining F119 idempotency sentinels
 - [ ] T039 [US6] Migrate presentation consumers off the bespoke advancement path onto the projection
 

--- a/src/Common/Sorcha.Register.Models/Enums/TransactionTypeExtensions.cs
+++ b/src/Common/Sorcha.Register.Models/Enums/TransactionTypeExtensions.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Register.Models.Enums;
+
+/// <summary>
+/// Typed predicates over <see cref="TransactionType"/>.
+/// </summary>
+public static class TransactionTypeExtensions
+{
+    /// <summary>
+    /// True when the transaction is an <b>intra-action-lifecycle terminal</b> —
+    /// <see cref="TransactionType.PresentationOutcome"/> or
+    /// <see cref="TransactionType.PresentationAbandoned"/> (Feature 111). These chain off the
+    /// same action's <see cref="TransactionType.PresentationInitiated"/> and carry the SAME
+    /// <c>ActionId</c>, so they describe how that single action's presentation attempt resolved —
+    /// they do not advance from one action to the next on their own. Excludes
+    /// <see cref="TransactionType.PresentationInitiated"/>, which genuinely advances from action
+    /// N-1 to action N and gets the full route-reachability check.
+    /// </summary>
+    /// <remarks>
+    /// Feature 145 (US6): the <c>InstanceProjector</c> folds one of these <b>only</b> when it
+    /// carries a signed <c>RoutingDecision</c> (a successful outcome that routes onward); a
+    /// decline / abandonment carries no decision and is skipped so the action stays current. The
+    /// validator's <c>TransactionTypeClassifier.IsIntraActionLifecycleTerminal</c> is the
+    /// submission-side (string-metadata) counterpart of this seal-side typed predicate.
+    /// </remarks>
+    public static bool IsIntraActionLifecycleTerminal(this TransactionType type)
+        => type is TransactionType.PresentationOutcome or TransactionType.PresentationAbandoned;
+
+    /// <summary>
+    /// True when the transaction is part of a Feature 111 presentation lifecycle —
+    /// <see cref="TransactionType.PresentationInitiated"/>,
+    /// <see cref="TransactionType.PresentationOutcome"/>, or
+    /// <see cref="TransactionType.PresentationAbandoned"/>. These all chain off (and carry the
+    /// ActionId of) a single presentation-gated action; none of them advances instance control
+    /// state on its own EXCEPT a successful outcome, which carries a signed <c>RoutingDecision</c>.
+    /// </summary>
+    /// <remarks>
+    /// Feature 145 (US6): the instance projection must NOT fold a presentation-lifecycle tx that
+    /// carries no decision — the action arrived as current via the <i>previous</i> action's routing
+    /// fold, and an empty next-action set would wrongly retire it (premature completion). The
+    /// presentation action stays current until a successful outcome (carrying a decision) routes
+    /// onward. Distinct from <see cref="IsIntraActionLifecycleTerminal(TransactionType)"/>, which
+    /// excludes <c>PresentationInitiated</c> for the validator's route-reachability carve-out.
+    /// </remarks>
+    public static bool IsPresentationLifecycle(this TransactionType type)
+        => type is TransactionType.PresentationInitiated
+                or TransactionType.PresentationOutcome
+                or TransactionType.PresentationAbandoned;
+}

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
 
 namespace Sorcha.Blueprint.Service.Services.Implementation;
 
@@ -43,6 +44,20 @@ public static class InstanceProjectionResolver
 
         var completedActionId = (int)tx.MetaData.ActionId.Value;
         var decision = ResolveRoutingDecision(tx.MetaData, logger);
+
+        // Feature 145 US6: a presentation-lifecycle tx (PresentationInitiated / PresentationOutcome /
+        // PresentationAbandoned) advances the instance ONLY when it carries a signed RoutingDecision —
+        // i.e. a successful outcome that routes onward. All three chain off (and carry the ActionId of)
+        // the same presentation-gated action, which became current via the PREVIOUS action's routing
+        // fold; folding one with an empty next-action set would wrongly retire that still-current
+        // action (premature completion) and then make the imperative advance early-exit. So skip a
+        // presentation-lifecycle tx that carries no decision — the action stays current until a
+        // successful outcome routes it onward. Genuine action terminals are unaffected: the producer
+        // always writes a RoutingDecision (with an empty NextActions set) for them, so they are not
+        // presentation-lifecycle txs and fold to completion correctly.
+        if (decision is null && tx.MetaData.TransactionType.IsPresentationLifecycle())
+            return null;
+
         // Feature 145: the carried RoutingDecision is the sole routing source — the legacy singular
         // NextActionId hint is fully removed. A tx with no decision contributes a terminal (empty)
         // next-action set (genuine terminals + legacy pre-145 txs that never carried one).

--- a/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionResolverTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Service.Services.Implementation;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Register.Models;
+using Sorcha.Register.Models.Enums;
+
+namespace Sorcha.Blueprint.Service.Tests.Projection;
+
+/// <summary>
+/// Feature 145 US6 — the shared <see cref="InstanceProjectionResolver"/> must treat presentation
+/// intra-action-lifecycle terminals correctly: fold a SUCCESS outcome (carries a signed
+/// RoutingDecision → advances) but SKIP a decline / abandonment (no decision → action stays
+/// current), while genuine action terminals (no decision, not intra-action-lifecycle) still fold.
+/// </summary>
+public class InstanceProjectionResolverTests
+{
+    private static readonly IActionResolverService NoActionResolver =
+        new Mock<IActionResolverService>().Object; // GetBlueprintAsync → null ⇒ best-effort empty bindings
+
+    private static TransactionModel Tx(
+        TransactionType type,
+        RoutingDecision? decision,
+        uint actionId = 2) => new()
+    {
+        TxId = "tx-outcome",
+        PrevTxId = "tx-initiated",
+        SenderWallet = "ws-submitter",
+        MetaData = new TransactionMetaData
+        {
+            BlueprintId = "bp-1",
+            InstanceId = "inst-1",
+            ActionId = actionId,
+            TransactionType = type,
+            RoutingDecision = decision,
+        },
+    };
+
+    private static RoutingDecision Decision(int completed, params int[] next) => new()
+    {
+        CompletedActionId = completed,
+        NextActions = next.Select(n => new ActionRef { ActionId = n }).ToList(),
+        Attestation = new Attestation { Kind = AttestationKind.SenderSigned },
+    };
+
+    [Fact]
+    public async Task ResolveAsync_PresentationOutcomeDecline_NoDecision_Skipped()
+    {
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            Tx(TransactionType.PresentationOutcome, decision: null),
+            NoActionResolver, NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().BeNull("a declined presentation carries no RoutingDecision and must not advance");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PresentationInitiated_NoDecision_Skipped()
+    {
+        // PresentationInitiated is a lifecycle marker — the gated action became current via the
+        // previous action's routing fold, so folding Initiated (empty next-action set) would wrongly
+        // retire the action before the outcome arrives. Must be skipped.
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            Tx(TransactionType.PresentationInitiated, decision: null),
+            NoActionResolver, NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().BeNull("PresentationInitiated carries no RoutingDecision and must not change instance state");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PresentationAbandoned_NoDecision_Skipped()
+    {
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            Tx(TransactionType.PresentationAbandoned, decision: null),
+            NoActionResolver, NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().BeNull("an abandoned presentation carries no RoutingDecision and must not advance");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PresentationOutcomeSuccess_WithDecision_FoldsAndAdvances()
+    {
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            Tx(TransactionType.PresentationOutcome, Decision(2, 3)),
+            NoActionResolver, NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().NotBeNull("a successful outcome carries a RoutingDecision and advances via the projector");
+        resolved!.Tx.CompletedActionId.Should().Be(2);
+        resolved.Tx.NextActionIds.Should().Equal(3);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ActionTerminal_NoDecision_FoldsAsTerminal()
+    {
+        // A plain Action tx with no decision is NOT an intra-action-lifecycle terminal, so it is NOT
+        // skipped — it folds with an empty next-action set (terminal). This guards against the skip
+        // over-reaching to ordinary action transactions.
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            Tx(TransactionType.Action, decision: null),
+            NoActionResolver, NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().NotBeNull();
+        resolved!.Tx.NextActionIds.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
First, foundational increment of **US6** (presentation lifecycle onto the projection) — and a **latent-bug fix** in its own right.

### The bug this fixes
`BuildPresentationInitiated/Outcome/AbandonedAsync` all stamp `blueprintId`+`actionId`+`instanceId` into metadata, and `DocketBuildTriggerService` sets a **numeric** `TransactionMetaData.ActionId`. So `InstanceProjectionResolver` returns non-null for presentation-lifecycle txs and the **`InstanceProjector` folds them** — and with no `RoutingDecision` they fold as an *empty-terminal*, retiring the still-current presentation-gated action.

For a **non-terminal** presentation action this prematurely completes the instance; the imperative `CompleteAfterPresentationAsync` then early-exits ("action no longer current") and the workflow never reaches its successor. Masked today only because the tested flows have the presentation as the terminal action. (This corrects the stale "presentation txs aren't projector-folded" assumption.)

### The fix
`InstanceProjectionResolver.ResolveAsync` now **skips** a presentation-lifecycle tx (`TransactionType.IsPresentationLifecycle()` = Initiated/Outcome/Abandoned) that carries **no** `RoutingDecision` — the gated action became current via the *previous* action's routing fold and stays current until a successful outcome (a later increment) routes it onward. Genuine action terminals are unaffected (the producer always writes a decision with an empty `NextActions` set).

New typed predicates in `Sorcha.Register.Models`: `IsPresentationLifecycle()` (the projector skip) and `IsIntraActionLifecycleTerminal()` (validator-aligned).

## What's NOT in this PR (designed, live-gated)
Increments 2–3 — making a SUCCESS outcome carry a signed `RoutingDecision` so the projector advances, and retiring the imperative advance — are **atomic** (once the outcome carries a decision the projector folds it, so the imperative path must be removed in the same change) and their correctness depends on the F111/F127 walkthroughs. Full design in `specs/145-ledger-derived-instances/US6-IMPLEMENTATION-PLAN.md`.

## Testing
- 5 new `InstanceProjectionResolverTests` (Initiated/decline/abandoned skipped; success-with-decision folds; plain action terminal still folds).
- Full `Sorcha.Blueprint.Service.Tests`: **851/0**. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)