### PR TITLE
fix(145): break circular scoped DI dependency that hung Action submit (504)

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/PresentationLifecycleService.cs
@@ -63,7 +63,6 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
     private readonly IClock _clock;
     private readonly IServiceProvider? _serviceProvider;
     private readonly Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient? _orgDidClient;
-    private readonly IPresentationRoutingDecisionBuilder? _routingDecisionBuilder;
     private readonly ILogger<PresentationLifecycleService> _logger;
 
     /// <summary>Constructor — DI-friendly.</summary>
@@ -84,8 +83,7 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
         IClaimsFetchTokenStore? claimsFetchTokenStore = null,
         IDisclosedClaimsStore? disclosedClaimsStore = null,
         IHubContext<BlueprintHub, IBlueprintHubClient>? hubContext = null,
-        Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient? orgDidClient = null,
-        IPresentationRoutingDecisionBuilder? routingDecisionBuilder = null)
+        Sorcha.ServiceClients.OrgDidDocument.IOrgDidDocumentClient? orgDidClient = null)
     {
         _transactionBuilder = transactionBuilder ?? throw new ArgumentNullException(nameof(transactionBuilder));
         _walletClient = walletClient ?? throw new ArgumentNullException(nameof(walletClient));
@@ -104,7 +102,6 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
         _disclosedClaimsStore = disclosedClaimsStore;
         _hubContext = hubContext;
         _orgDidClient = orgDidClient;
-        _routingDecisionBuilder = routingDecisionBuilder;
     }
 
     public async Task<PresentationInitiationResult> InitiateAsync(
@@ -510,9 +507,18 @@ public sealed class PresentationLifecycleService : IPresentationLifecycleService
         // decision rides through ToTransactionSubmission's whitelist (key "routingDecision") to the
         // validator (VAL_ROUTING_*) and the sealed docket. Attaching metadata here does NOT change
         // the txId/signature (those are over TransactionData/SigningData, not Metadata).
-        if (outcome.Kind == PresentationOutcomeKind.Success && _routingDecisionBuilder is not null)
+        // The routing-decision builder IS ActionExecutionService (it implements IPresentationRoutingDecisionBuilder,
+        // registered via a forwarding factory). Resolve it LAZILY here instead of via the constructor: a ctor-time
+        // dependency forms a circular scoped DI graph — ActionExecutionService → IPresentationLifecycleService →
+        // IPresentationRoutingDecisionBuilder → (factory) ActionExecutionService — which MEDI cannot detect through
+        // the factory lambda and which DEADLOCKS when the /execute endpoint resolves ActionExecutionService (the
+        // F145 504-hang root cause). By the time this method runs, this PresentationLifecycleService is already
+        // cached in the request scope, so resolving ActionExecutionService here returns without re-entering its
+        // construction — no cycle.
+        var routingDecisionBuilder = _serviceProvider?.GetService<IPresentationRoutingDecisionBuilder>();
+        if (outcome.Kind == PresentationOutcomeKind.Success && routingDecisionBuilder is not null)
         {
-            var routingDecision = await _routingDecisionBuilder.BuildForPresentationOutcomeAsync(
+            var routingDecision = await routingDecisionBuilder.BuildForPresentationOutcomeAsync(
                 pending.InstanceId.ToString(), pending.ActionId, draftPayload,
                 pending.SubmitterWallet, cancellationToken);
             if (routingDecision is not null)

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/PresentationLifecycleServiceOutcomeTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/PresentationLifecycleServiceOutcomeTests.cs
@@ -260,15 +260,22 @@ public class PresentationLifecycleServiceOutcomeTests
                 It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TransactionSubmissionResult { Success = true, TransactionId = "tx-ok" });
 
+        // F145 504-fix: the routing-decision builder (which IS ActionExecutionService) is now resolved
+        // lazily from IServiceProvider at the outcome site rather than injected via the constructor, to
+        // break the circular scoped DI dependency that deadlocked /execute. Surface it under test through
+        // a stub provider so the outcome path can still resolve it.
+        var sp = new Mock<IServiceProvider>();
+        sp.Setup(s => s.GetService(typeof(IPresentationRoutingDecisionBuilder)))
+            .Returns(routingDecisionBuilder!);
+
         return new PresentationLifecycleService(
             _builder, _wallet.Object, _validator.Object,
             _store.Object, [consumer], opts,
             new Mock<ILogger<PresentationLifecycleService>>().Object,
             haipClient: null, metrics: null, clock: null,
-            serviceProvider: null,
+            serviceProvider: sp.Object,
             registerClient: registerMock.Object,
-            sealCoordinator: coordMock.Object,
-            routingDecisionBuilder: routingDecisionBuilder);
+            sealCoordinator: coordMock.Object);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Action submission (`POST /api/instances/{id}/actions/{id}/execute`) hung and the gateway returned **504**. The instance stayed `State=0`, no Action transaction ever sealed. This blocked all live F145 validation and reproduced on every US6-based image (CI `:latest` and local builds) while US5 worked.

## Root cause — circular scoped DI dependency (regression from #900)

US6 (#900) registered the routing-decision builder as a forwarding factory:

```csharp
builder.Services.AddScoped<IPresentationRoutingDecisionBuilder>(
    sp => (IPresentationRoutingDecisionBuilder)sp.GetRequiredService<IActionExecutionService>());
```

`ActionExecutionService` implements `IPresentationRoutingDecisionBuilder` and depends on `IPresentationLifecycleService`; `PresentationLifecycleService` took `IPresentationRoutingDecisionBuilder` in its constructor. That closes a cycle:

```
IActionExecutionService → IPresentationLifecycleService
  → IPresentationRoutingDecisionBuilder → (factory) → IActionExecutionService
```

MEDI's call-site validation can't see through the factory lambda, so startup/build passes. But resolving `IActionExecutionService` for the `/execute` endpoint **deadlocks at DI resolution** — the request thread blocks *before* `ExecuteAsync` runs (no "Executing action" log, no outbound call, no crash, `RestartCount=0`) → gateway 504.

**Evidence:** ruled out the blueprint-publish wait (the publish tx is sealed and findable under the computed `ComputeBlueprintPublishTxId`); HttpClient + Debug logging showed the request dying immediately after `DelegationTokenMiddleware` with zero `ExecuteAsync` activity; an isolated repro of the exact MEDI pattern **hung** (not StackOverflow / not exception), confirming a factory-mediated scoped cycle deadlocks.

## Fix

`PresentationLifecycleService` resolves `IPresentationRoutingDecisionBuilder` **lazily from its injected `IServiceProvider`** at the outcome use-site instead of via the constructor. By the time `HandleOutcomeAsync` runs, the service is already cached in the request scope, so resolving `ActionExecutionService` returns without re-entering construction — the cycle is broken in both directions. The Program.cs forwarding registration is unchanged; the two US6 outcome tests now supply the builder through a stub `IServiceProvider`.

## Validation

Live on a single-node deployment: full AssuredIdentity Phase 1 — Action 1 sealed (0.6s) → projector advanced → Action 2 sealed → `AssuredIdentityCredential` delivered + claimed. Sealed action txs carry `RoutingDecision` and no `nextActionId` (intended F145 US3/US5/US6 state). Both `Sorcha.Blueprint.Service` and its test project build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)