### PR TITLE
docs(skills): reflect fresh-genesis n1 rebuild learnings

### DIFF
--- a/.claude/skills/entity-framework/SKILL.md
+++ b/.claude/skills/entity-framework/SKILL.md
@@ -34,6 +34,20 @@ services.AddDbContext<WalletDbContext>((sp, options) =>
 dotnet ef migrations add InitialSchema --project src/Core/Sorcha.Wallet.Core --startup-project src/Services/Sorcha.Wallet.Service
 ```
 
+### Clean-start migration convention (pre-release, no data preservation)
+
+This repo is pre-release and does **not** preserve existing data across schema changes. The convention is to **squash all migrations into a single `InitialCreate` per service** rather than accumulate incremental migrations — fold the new schema into the existing `*_InitialCreate.cs` + `.Designer.cs` + `*ModelSnapshot.cs`, keeping the **same migration ID** (don't regenerate the timestamp). Every environment re-creates its DB (`down -v`) to pick up the change. (E.g. `Sorcha.Blueprint.Service` absorbed the F142 RehearsalPass migration and the F145 `+LastAppliedTxId` / `−IsReadOnlyMirror` change into one `…_InitialCreate`.)
+
+Implications:
+- A **plain image swap is NOT enough** for a schema change on a *standing* node — `MigrateAsync` sees the `InitialCreate` ID already applied and skips it, so the new column never lands (symptom: `column "X" of relation "Y" does not exist`). Recreate the DB (`down -v`, or drop+recreate the one database) on existing nodes. A fresh-volume node is fine — it applies the full `InitialCreate`.
+- **Verify the single migration is in sync with the model** before relying on it (no need to regenerate if clean):
+
+```bash
+dotnet ef migrations has-pending-model-changes \
+  --project src/Services/Sorcha.Blueprint.Service --startup-project src/Services/Sorcha.Blueprint.Service
+# "No changes have been made to the model since the last migration." = in sync, nothing to squash.
+```
+
 ### Apply Migrations Programmatically
 
 ```csharp

--- a/.claude/skills/network-bootstrap/SKILL.md
+++ b/.claude/skills/network-bootstrap/SKILL.md
@@ -125,26 +125,20 @@ docker compose $COMPOSE_FILES up -d
 
 Replica nodes and routine n1 restarts omit `-f docker-compose.seed.yml`.
 
-### Step 4: Bootstrap Platform
+### Step 4: Platform bootstrap is AUTOMATIC — there is no manual bootstrap step (verified 2026-06-02)
 
-Create the first organization, admin user, and service principal. This step runs BEFORE importing the validator key (auth chicken-and-egg).
+`DatabaseInitializer` in tenant-service **auto-seeds the platform on startup**. The moment the full stack is healthy (i.e. as part of Step 5's "bring up the rest of the stack") it has already created: the System Admin Org (`00000000-…-0001` "Sorcha Local" / subdomain `sorcha-local`), the Public Org (`00000000-…-0002` "Sorcha Public" / `public`), the admin `PlatformUser` + `UserIdentity` + org membership, `PlatformSettings`, and the system-register Owner subscription.
+
+The seeded admin is **`admin@sorcha.local` / `Dev_Pass_2025!`** (`DatabaseInitializer.DefaultAdminPassword`; override via the `Seed:AdminPassword` config key). Log signals: `DatabaseInitializer … Admin UserIdentity created`, `… PlatformSettings seeded`, `… Owner subscription to system register`.
+
+⚠ **Do NOT run the CLI `sorcha bootstrap` against a freshly-seeded node.** The admin already exists, so it 500s with `duplicate key value violates unique constraint "UQ_PlatformUser_Email"` — but only AFTER committing a **stray org** in an earlier SaveChanges. (Earlier revisions of this doc told you to bootstrap with `admin@sorcha.dev` / `Dev_Pass_2026!` and a "Sorcha Dev" org — that account never existed; the startup seed owns the credentials now. The old "auth chicken-and-egg, bootstrap before import" framing is also obsolete — there's no manual bootstrap, and Step 5's import is independent of it.)
+
+Tenant tables live in the **`public`** schema (NOT `tenant`). If a stray org got created by a mistaken `bootstrap`, delete it once you've confirmed nothing references it:
 
 ```bash
-# Create CLI profile for n1
-dotnet run --project src/Apps/Sorcha.Cli -- config init \
-  --profile n1 --service-url https://n1.sorcha.dev --verify-ssl true --set-active true
-
-# Bootstrap (non-interactive)
-dotnet run --project src/Apps/Sorcha.Cli -- bootstrap --non-interactive \
-  --org-name "Sorcha Dev" --subdomain "sorcha-dev" \
-  --admin-email "admin@sorcha.dev" --admin-name "Admin" \
-  --admin-password "Dev_Pass_2026!" \
-  --create-sp --sp-name "n1-automation"
+docker exec sorcha-postgres psql -U sorcha -d sorcha_tenant \
+  -c "DELETE FROM public.\"Organizations\" WHERE \"Subdomain\"='<subdomain-you-passed>';"
 ```
-
-Save the service principal client ID and secret from the output.
-
-**Note:** The subdomain `dev` is reserved. Use `sorcha-dev` or similar.
 
 ### Step 5: Import Validator Key — must use the SYSTEM wallet endpoint
 
@@ -219,6 +213,8 @@ ssh sorcha@<n1-ip> 'cd /opt/sorcha && docker compose \
   -f docker-compose.yml -f docker-compose.n1.yml -f docker-compose.ports.yml \
   up -d'
 ```
+
+**`HTTP 000` from the import almost always means it SUCCEEDED (verified 2026-06-02).** The one-shot curl can exit non-zero (lost response / blip) even though wallet-service processed the POST and logged `system/recover responded 201`. The automated `n1-setup-remote.sh` treats `000` as fatal (`set -euo pipefail`) and **aborts before bringing up the rest of the stack**. Do NOT `down -v` and retry — wallet-service-alone can't auto-generate a `validator:` wallet, so the recovered wallet is real. Verify with `docker exec sorcha-postgres psql -U sorcha -d sorcha_wallet -tc 'select "Owner" from wallet."Wallets" where "Owner" like '"'"'validator:%'"'"';'` (or grep the wallet-service log for `responded 201`), then just run Step 5e (`up -d`) to finish.
 
 **Note on wallet address:** the address returned by `/system/recover`
 will NOT match the `walletAddress` in `genesis-validator-key.json`.


### PR DESCRIPTION
- n1-deploy + network-bootstrap: platform bootstrap is now AUTOMATIC via
  DatabaseInitializer startup seeding (admin@sorcha.local / Dev_Pass_2025!);
  CLI 'sorcha bootstrap' is obsolete and 500s on duplicate admin.
- HTTP 000 from /system/recover usually means success-but-script-aborts;
  verify + 'up -d' rather than down -v + retry.
- n1-reset.ps1 #472 import note de-staled; az corp-proxy TLS block +
  SSH-driven reset fallback; transient Docker Publish job rerun --failed.
- tenant tables are in the 'public' schema, not 'tenant'.
- entity-framework: document the clean-start squash-into-InitialCreate
  convention + 'dotnet ef migrations has-pending-model-changes' sync check.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
