### PR TITLE
fix(909): bind peer external address to NetworkAddress.ExternalAddress (dead PublicAddress key)

### DIFF
--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -112,7 +112,8 @@ services:
       ServiceClients__TenantService__Address: http://tenant-service-b:8080
       ServiceClients__RegisterService__Address: http://register-service-b:8080
       PeerService__NodeId: "peer-b.sorcha.local"
-      PeerService__PublicAddress: "peer-service-b:5000"
+      # ExternalAddress (not the dead PublicAddress key) is the node's dialable address. (#909)
+      PeerService__NetworkAddress__ExternalAddress: "peer-service-b:5000"
       PeerService__Port: "5000"
       PeerService__EnableTls: "false"
       # Seed peer-a so the two peers discover each other.

--- a/docker-compose.n1.yml
+++ b/docker-compose.n1.yml
@@ -96,7 +96,13 @@ services:
     environment:
       <<: *jwt-env
       PeerService__NodeId: n1.sorcha.dev
-      PeerService__PublicAddress: ${N1_PUBLIC_IP:-n1.sorcha.dev}
+      # n1 is the public rendezvous anchor for NAT'd federated nodes (F143). PublicAddress
+      # was a dead env var (no such config property) — rendezvous-capability is derived from
+      # NetworkAddress.ExternalAddress (or the explicit RelayRendezvousEnabled flag). Without
+      # this, n1 rejects NAT'd owners' reverse streams and cross-node app-register sync fails.
+      # See issue #909.
+      PeerService__NetworkAddress__ExternalAddress: ${N1_PUBLIC_IP:-n1.sorcha.dev}
+      PeerService__RelayRendezvousEnabled: "true"
 
   validator-service:
     image: sorchadev/validator-service:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,7 +525,10 @@ services:
       ServiceClients__ValidatorService__Address: http://validator-service:8080
       # Node identity and network configuration
       PeerService__NodeId: "${PEER_NODE_ID:-local-peer.sorcha.dev}"
-      PeerService__PublicAddress: "${PEER_PUBLIC_ADDRESS:-}"
+      # PEER_PUBLIC_ADDRESS sets the node's externally-dialable address. It must bind to
+      # NetworkAddress.ExternalAddress — PublicAddress was a dead config key (no such property),
+      # so the value was silently ignored and the node never became rendezvous-capable. (#909)
+      PeerService__NetworkAddress__ExternalAddress: "${PEER_PUBLIC_ADDRESS:-}"
       PeerService__Port: "5000"
       PeerService__EnableTls: "false"
       # Cross-machine seed node (configure via .env). The legacy n0.sorcha.dev


### PR DESCRIPTION
PeerService__PublicAddress binds to no config property — PeerServiceConfiguration
has no PublicAddress, and IsRendezvousCapable derives from
RelayRendezvousEnabled ?? NetworkAddress.ExternalAddress. So the public anchor (n1)
and any node setting PEER_PUBLIC_ADDRESS were silently never reachable nor
rendezvous-capable; n1 rejected NAT'd owners' reverse streams and cross-node
app-register sync failed.

- docker-compose.n1.yml: NetworkAddress.ExternalAddress + explicit RelayRendezvousEnabled (public anchor)
- docker-compose.yml: PEER_PUBLIC_ADDRESS now binds NetworkAddress.ExternalAddress
- docker-compose.federation.yml: same dead-key fix

Closes #909

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
