### PR TITLE
fix(911): allow open-participant (F103) walk-in submission past SEC-006 missing-participant check

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -211,8 +211,18 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             throw new InvalidOperationException($"Action {actionId} is not a current action for instance {instanceId}");
         }
 
-        // 4b. Validate wallet ownership (SEC-006)
-        await ValidateWalletOwnershipAsync(request.SenderWallet, caller, cancellationToken);
+        // 4b. Validate wallet ownership (SEC-006). Feature 103: an OPEN starting action — one whose
+        // Sender participant carries no hardcoded wallet — accepts a walk-in submitter who has no
+        // participant profile yet (they are late-bound at 4d below). SEC-006's fail-closed
+        // missing-participant check must NOT block them (#911): F136 consumer tokens now carry org_id,
+        // which would otherwise trip the check the open-participant flow exists to bypass. Wallet
+        // ownership is still enforced by the Wallet Service at signing time, and participant binding
+        // by the validator (VAL_BP_002) + the late-bind below.
+        var senderParticipantDef = blueprint.Participants?
+            .FirstOrDefault(p => string.Equals(p.Id, actionDef.Sender, StringComparison.OrdinalIgnoreCase));
+        var isOpenStartingAction = actionDef.IsStartingAction
+            && string.IsNullOrWhiteSpace(senderParticipantDef?.WalletAddress);
+        await ValidateWalletOwnershipAsync(request.SenderWallet, caller, isOpenStartingAction, cancellationToken);
 
         // 4c. Validate sender matches action's designated participant role (SEC-AUDIT 3.1)
         // When a participant has a hardcoded wallet address in the blueprint, enforce strict matching.
@@ -1198,9 +1208,10 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
             throw new InvalidOperationException($"Rejection target action {actionDef.RejectionConfig.TargetActionId} not found");
         }
 
-        // 6b. Validate wallet ownership (SEC-006)
+        // 6b. Validate wallet ownership (SEC-006). A rejection is never an open-participant
+        // walk-in (the rejecter is an established participant), so the profile is required.
         var rejectWallet = request.SenderWallet ?? instance.ParticipantWallets.Values.FirstOrDefault() ?? "";
-        await ValidateWalletOwnershipAsync(rejectWallet, caller, cancellationToken);
+        await ValidateWalletOwnershipAsync(rejectWallet, caller, allowMissingParticipant: false, cancellationToken);
 
         // 7. Build rejection transaction
         var rejectionData = new Dictionary<string, object>
@@ -2372,6 +2383,7 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
     private async Task ValidateWalletOwnershipAsync(
         string senderWallet,
         ClaimsPrincipal? caller,
+        bool allowMissingParticipant,
         CancellationToken cancellationToken)
     {
         // Skip validation for null caller (backward compat / internal calls)
@@ -2434,6 +2446,18 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
 
         if (participant == null)
         {
+            // Feature 103: open-participant walk-in submission. The caller has no participant
+            // profile yet — they are late-bound to the action's Sender role immediately after this
+            // check. Wallet ownership is enforced at signing time by the Wallet Service, so a missing
+            // profile here is expected, not a failure (#911).
+            if (allowMissingParticipant)
+            {
+                _logger.LogInformation(
+                    "No participant profile for user {UserId} in org {OrgId} — allowing open-participant (Feature 103) walk-in submission. Wallet: {Wallet}",
+                    userId, orgId, senderWallet);
+                return;
+            }
+
             if (!_walletOwnershipSettings.AllowMissingParticipant
                 && _walletOwnershipSettings.EnforcementMode == Configuration.WalletOwnershipEnforcementMode.FailClosed)
             {

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionStartingActionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionStartingActionTests.cs
@@ -177,7 +177,65 @@ public class ActionExecutionStartingActionTests
         instance.ParticipantWallets.Should().NotContainKey("reviewer");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_OpenStartingAction_MissingParticipantProfile_IsAllowed_AndBinds()
+    {
+        // Feature 103 / #911: an OPEN starting action (Sender participant has no hardcoded wallet)
+        // accepts a walk-in submitter whose consumer token carries org_id (F136) but who has no
+        // participant profile yet. SEC-006 must NOT fail-closed on the missing profile — the wallet
+        // is late-bound right after the ownership check. The participant client returns null (default).
+        var instanceId = "inst-open-911";
+        var actionId = 0;
+        var senderWallet = "ws11q-citizen-walkin";
+        var instance = CreateInstance(instanceId, participantWallets: new());
+        var blueprint = CreateBlueprintWithStartingAction();
+        var action = blueprint.Actions!.First(a => a.Id == actionId);
+        var request = CreateRequest(senderWallet);
+        SetupMocks(instanceId, instance, blueprint, action);
+
+        var caller = CreateConsumerCaller(Guid.NewGuid(), Guid.NewGuid());
+
+        // Act — proceeds past the SEC-006 ownership check (no 403) and binds; later steps throw.
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() =>
+            _service.ExecuteAsync(instanceId, actionId, request, "token", caller));
+
+        // Assert — NOT the participant-profile rejection; the bind happened (proves it cleared 4b).
+        (ex is UnauthorizedAccessException && ex.Message.Contains("No participant profile"))
+            .Should().BeFalse("open-participant walk-in submission must not be rejected for a missing participant profile (#911)");
+        instance.ParticipantWallets.Should().ContainKey("citizen");
+        instance.ParticipantWallets["citizen"].Should().Be(senderWallet);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonOpenAction_MissingParticipantProfile_RejectsFailClosed()
+    {
+        // Regression guard: SEC-006 still fails closed on a missing participant for a NON-open action
+        // (a designated participant with a hardcoded wallet), so the #911 fix doesn't weaken the gate.
+        var instanceId = "inst-closed-911";
+        var actionId = 1; // reviewer (hardcoded wallet) — not an open starting action
+        var instance = CreateInstance(instanceId, participantWallets: new() { ["citizen"] = "ws11q-citizen" });
+        instance.CurrentActionIds = [1];
+        var blueprint = CreateBlueprintWithStartingAction();
+        var action = blueprint.Actions!.First(a => a.Id == 1);
+        var request = CreateRequest("ws11q-reviewer");
+        SetupMocks(instanceId, instance, blueprint, action);
+
+        var caller = CreateConsumerCaller(Guid.NewGuid(), Guid.NewGuid());
+
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            _service.ExecuteAsync(instanceId, actionId, request, "token", caller));
+        ex.Message.Should().Contain("No participant profile");
+    }
+
     #region Helpers
+
+    private static ClaimsPrincipal CreateConsumerCaller(Guid userId, Guid orgId) =>
+        new(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                new Claim("org_id", orgId.ToString())
+            ],
+            authenticationType: "test"));
 
     private void SetupMocks(string instanceId, Instance instance, BlueprintModel blueprint, ActionModel action)
     {


### PR DESCRIPTION
F136 made consumer tokens carry org_id, which trips SEC-006's fail-closed
participant-profile check in ValidateWalletOwnershipAsync — rejecting walk-in
citizens (Feature 103 open participants, no participant profile yet) with a 403
before the late-bind runs. ActionExecutionService now passes allowMissingParticipant
(true for open starting actions — Sender participant has no hardcoded wallet) so a
missing profile is allowed there; wallet ownership is still enforced at signing by
the Wallet Service and binding by the validator (VAL_BP_002). Fail-closed is
unchanged for non-open actions and the reject path.

Tests: open starting action with org_id + no participant is allowed and binds;
non-open action still rejects fail-closed.

Closes #911

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
