### PR TITLE
fix(910): gate register sync-state + local-relationship reads with read policy, not write

### DIFF
--- a/src/Services/Sorcha.Register.Service/Endpoints/RelationshipEndpoints.cs
+++ b/src/Services/Sorcha.Register.Service/Endpoints/RelationshipEndpoints.cs
@@ -39,7 +39,10 @@ public static class RelationshipEndpoints
         .WithTags("Registers — Feature 108")
         .WithSummary("Get this node's derived role set for a register (Feature 108)")
         .WithDescription("Returns the local-installation's role set on the register, derived from the latest control record and local identity. Cached; recomputed on control-transaction seal.")
-        .RequireAuthorization(AuthorizationPolicies.CanWriteDockets)
+        // Read-only endpoint: the standard transaction-read policy (any authenticated caller that
+        // can read the register), NOT the write policy CanWriteDockets — which 403'd legitimate
+        // readers such as admins, subscribers, and AI agents (#910).
+        .RequireAuthorization("CanReadTransactions")
         .Produces<RegisterLocalRelationship>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
         .Produces(StatusCodes.Status404NotFound);
@@ -70,7 +73,9 @@ public static class RelationshipEndpoints
         .WithTags("Registers — Feature 108")
         .WithSummary("Get typed sync state for a register with the inputs that derived it (Feature 108)")
         .WithDescription("Returns the resolved sync state for a register (synced, recovering, stalled) along with the inputs the resolver used: local docket height, recent peer-height observations within the staleness window, the latest validator sealing observation, and the persisted state. AI agents call this to decide whether a register is current enough to read from before consuming transactions or generating verification bundles.")
-        .RequireAuthorization(AuthorizationPolicies.CanWriteDockets)
+        // Read-only endpoint: the standard transaction-read policy, NOT the write policy
+        // CanWriteDockets — which 403'd legitimate readers (admins, subscribers, AI agents) (#910).
+        .RequireAuthorization("CanReadTransactions")
         .Produces<RegisterSyncStateView>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
         .Produces(StatusCodes.Status404NotFound);


### PR DESCRIPTION
GET /api/registers/{id}/sync-state and /local-relationship are read-only (the
sync-state doc says 'AI agents call this to decide whether a register is current';
the code comment says 'Public-ish read — requires standard transaction-read policy')
but were gated by AuthorizationPolicies.CanWriteDockets (a write policy), 403'ing
legitimate read callers — admins, subscribers, AI agents, and the AssuredIdentity
demo readiness gate. Switch both to the standard transaction-read policy
'CanReadTransactions' (RequireAuthenticatedUser), matching the sibling read endpoints
in VerificationEndpoints (transactions/status, inclusion-proof, verification-bundle).
The validator-internal /api/internal/my-validated-registers endpoint is unchanged.

Closes #910

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
