### PR TITLE
fix(907): SyncOnly system-register bootstrap must not seed governance blueprints

### DIFF
--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
@@ -359,8 +359,15 @@ public class SystemRegisterBootstrapper : BackgroundService
     {
         await WaitForGenesisDocketAsync(registerManager, cancellationToken);
 
-        var systemRegisterService = scope.ServiceProvider.GetRequiredService<SystemRegisterService>();
-        await SeedBlueprintsIfMissingAsync(systemRegisterService, cancellationToken);
+        // SyncOnly nodes are subscribers: the governance blueprints arrive via replication from
+        // the register owner, and a SyncOnly node is not on the system-register roster so it cannot
+        // seal a publish anyway. Seeding here is wasted work + log noise and briefly emits an
+        // unsealable publish tx. Owners (Auto / GenesisFile) seed; subscribers pull. (#907)
+        if (_options.BootstrapMode != BootstrapMode.SyncOnly)
+        {
+            var systemRegisterService = scope.ServiceProvider.GetRequiredService<SystemRegisterService>();
+            await SeedBlueprintsIfMissingAsync(systemRegisterService, cancellationToken);
+        }
 
         // Ensure peer-service knows to advertise the system register for sync.
         // Idempotent — SubscribeToRegisterAsync logs a warning and returns the


### PR DESCRIPTION
PostBootstrapAsync ran SeedBlueprintsIfMissingAsync for every mode, including
SyncOnly. A SyncOnly node is a subscriber: the governance blueprints arrive via
replication from the register owner, and it is not on the system-register roster
so it cannot seal a publish — the seed attempt is wasted work + log noise and
briefly emits an unsealable publish tx (observed on tiny). Gate the seed step on
BootstrapMode != SyncOnly; owners (Auto / GenesisFile) seed, subscribers pull.
Wait-for-genesis and the (idempotent) peer-subscription still run for all modes.

Closes #907

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
