### PR TITLE
fix(912): seed pre-baked participant wallets into the F145 instance projection

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/InstanceProjectionResolver.cs
@@ -130,6 +130,23 @@ public static class InstanceProjectionResolver
             if (bp is null)
                 return bindings;
 
+            // Feature 145 (#912): seed pre-baked participant → wallet mappings straight from the
+            // published blueprint. A closed / pre-registered participant (e.g. a verification
+            // analyst) carries its WalletAddress baked into the blueprint at publish time. Without
+            // this, a participant only enters instance.ParticipantWallets once they ACT — so an
+            // instance sitting at a pre-baked participant's action is invisible to
+            // EfCoreInstanceStore.GetPendingActionsByWalletAsync(thatWallet) until they submit, the
+            // chicken-and-egg that stops a rules agent from auto-approving the action it was waiting
+            // on. Open participants (WalletAddress null, e.g. the late-bound applicant) are
+            // intentionally skipped — they bind from the tx sender below. Seeding here, in the
+            // shared resolver, keeps the online projector and the offline rebuild in lock-step
+            // (US4 parity); the per-tx bindings below take precedence via last-writer-wins.
+            foreach (var participant in bp.Participants)
+            {
+                if (!string.IsNullOrEmpty(participant.Id) && !string.IsNullOrEmpty(participant.WalletAddress))
+                    bindings[participant.Id] = participant.WalletAddress;
+            }
+
             var completedAction = actionResolver.GetActionDefinition(bp, completedActionId.ToString());
             if (completedAction is { Sender.Length: > 0 } && !string.IsNullOrEmpty(tx.SenderWallet))
                 bindings[completedAction.Sender] = tx.SenderWallet;

--- a/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionResolverTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Projection/InstanceProjectionResolverTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Sorcha.Blueprint.Models;
 using Sorcha.Blueprint.Service.Services.Implementation;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Register.Models;
@@ -104,5 +105,128 @@ public class InstanceProjectionResolverTests
 
         resolved.Should().NotBeNull();
         resolved!.Tx.NextActionIds.Should().BeEmpty();
+    }
+
+    // ---- Feature 145 (#912): pre-baked participant wallets are seeded into the projection so a
+    // closed participant (e.g. a verification analyst) is discoverable BEFORE they act. ----
+
+    /// <summary>
+    /// Builds an AssuredIdentity-shaped resolver: action 1 (open applicant, starting) → action 2
+    /// (pre-baked analyst). The analyst's wallet is baked into the published blueprint; the
+    /// applicant late-binds at runtime (WalletAddress null).
+    /// </summary>
+    private static IActionResolverService PreBakedAnalystResolver(string analystWallet)
+    {
+        var blueprint = new Sorcha.Blueprint.Models.Blueprint
+        {
+            Id = "bp-1",
+            Participants =
+            [
+                new Participant { Id = "applicant", Name = "Applicant", WalletAddress = null },
+                new Participant { Id = "analyst", Name = "Verification Analyst", WalletAddress = analystWallet },
+            ],
+            Actions =
+            [
+                new Sorcha.Blueprint.Models.Action { Id = 1, Sender = "applicant", IsStartingAction = true },
+                new Sorcha.Blueprint.Models.Action { Id = 2, Sender = "analyst" },
+            ],
+        };
+
+        var mock = new Mock<IActionResolverService>();
+        mock.Setup(r => r.GetBlueprintAsync("bp-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+        mock.Setup(r => r.GetActionDefinition(blueprint, It.IsAny<string>()))
+            .Returns((Sorcha.Blueprint.Models.Blueprint bp, string id) => bp.Actions.FirstOrDefault(a => a.Id.ToString() == id));
+        return mock.Object;
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SeedsPreBakedParticipantWallet_BeforeThatParticipantActs()
+    {
+        // Citizen submits the starting action (action 1). The analyst (action 2) has not acted, and
+        // the tx carries no recipient wallet — so the ONLY way the analyst's wallet enters the
+        // bindings is the pre-baked seed. This is the chicken-and-egg that issue #912 fixes.
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-citizen",
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 1,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(1, 2),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, PreBakedAnalystResolver("ws-analyst"), NullLogger.Instance, CancellationToken.None);
+
+        resolved.Should().NotBeNull();
+        // Open applicant late-bound from the tx sender.
+        resolved!.Tx.ParticipantBindings.Should().Contain("applicant", "ws-citizen");
+        // Pre-baked analyst seeded from the blueprint even though they have not yet acted.
+        resolved.Tx.ParticipantBindings.Should().Contain("analyst", "ws-analyst");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DoesNotSeedOpenParticipantWithNullWallet()
+    {
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-citizen",
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 1,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(1, 2),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, PreBakedAnalystResolver("ws-analyst"), NullLogger.Instance, CancellationToken.None);
+
+        // The open applicant's binding must come from the tx sender (late-bind), never from a
+        // pre-baked seed — there is exactly one applicant entry, the live wallet.
+        resolved!.Tx.ParticipantBindings["applicant"].Should().Be("ws-citizen");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_PreBakedSeed_FlowsIntoInstanceParticipantWallets_MakingItDiscoverable()
+    {
+        // End-to-end of the two pure pieces: resolve the starting tx, then fold it. The projected
+        // instance's ParticipantWallets must contain the analyst wallet so
+        // EfCoreInstanceStore.GetPendingActionsByWalletAsync(analystWallet) — which matches on
+        // ParticipantWallets — surfaces action 2 for the rules agent the moment action 1 seals.
+        var tx = new TransactionModel
+        {
+            TxId = "tx-action1",
+            PrevTxId = string.Empty,
+            SenderWallet = "ws-citizen",
+            MetaData = new TransactionMetaData
+            {
+                BlueprintId = "bp-1",
+                InstanceId = "inst-1",
+                ActionId = 1,
+                TransactionType = TransactionType.Action,
+                RoutingDecision = Decision(1, 2),
+            },
+        };
+
+        var resolved = await InstanceProjectionResolver.ResolveAsync(
+            tx, PreBakedAnalystResolver("ws-analyst"), NullLogger.Instance, CancellationToken.None);
+
+        var instance = InstanceProjection.Project(
+            "inst-1", "reg", "bp-1", 1, "tenant", [resolved!.Tx]);
+
+        instance.Should().NotBeNull();
+        instance!.CurrentActionIds.Should().Equal(2);
+        instance.ParticipantWallets.Should().Contain("analyst", "ws-analyst");
     }
 }


### PR DESCRIPTION
## Problem

In the AssuredIdentity cross-node demo (rules mode), after a citizen's Action 1 seals and the `InstanceProjector` materializes the instance at Action 2, the rules agent (verification analyst) does **not** auto-approve it — only a manual approval completes the loop. This is the load-bearing part B of #912.

## Root cause

The F145 projection seeded `instance.ParticipantWallets` **only** from each transaction's runtime `ParticipantBindings`. A **pre-baked** participant (the analyst, whose wallet is baked into the published blueprint at publish time) was therefore absent from `ParticipantWallets` until they *acted*. While the instance sat at the analyst's Action 2, `EfCoreInstanceStore.GetPendingActionsByWalletAsync(analystWallet)` — which matches active instances via `ContainsWalletAddress(e.ParticipantWallets, walletAddress)` — returned nothing, so the agent's polling never surfaced the action it had to approve. Chicken-and-egg.

## Fix

In the shared `InstanceProjectionResolver.ResolveParticipantBindingsAsync`, seed pre-baked participant→wallet mappings (participants with a non-empty `WalletAddress`) straight from the published blueprint, in addition to the runtime tx bindings.

- Open participants (`WalletAddress` null, e.g. the late-bound applicant) are intentionally skipped — they bind from the tx sender as before.
- Seeding in the **shared** resolver keeps the online projector and the offline rebuild in lock-step (US4 parity invariant).
- Per-tx bindings still take precedence via last-writer-wins.

## Tests

3 new `InstanceProjectionResolverTests`:
- pre-baked analyst wallet is seeded into the bindings **before** the analyst acts (with no recipient on the tx, so the seed is the only source);
- the open applicant is **not** pre-baked-seeded (binds from the tx sender);
- end-to-end resolve → `Project` → the projected instance's `ParticipantWallets` contains the analyst wallet (the `GetPendingActionsByWalletAsync` precondition).

Full `Sorcha.Blueprint.Service.Tests` suite green (858/858) locally.

Note: part A (agent `/hubs/blueprint` SignalR negotiate 404 on the gateway) is the secondary, lower-priority item from #912 — polling is the reliable auto-approve path once B is fixed, so it is out of scope for this PR.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)