### PR TITLE
fix(908): reconcile cross-node sync floor against actual local register height

### DIFF
--- a/src/Services/Sorcha.Peer.Service/Communication/RelayMessageHandler.cs
+++ b/src/Services/Sorcha.Peer.Service/Communication/RelayMessageHandler.cs
@@ -548,12 +548,17 @@ public class RelayMessageHandler
         {
             _logger.LogDebug("Relayed transaction notification triggering sync for register {RegisterId}", registerId);
 
+            // Issue #908: reconcile against the actual local register height, not the possibly-stale
+            // LastSyncedDocketVersion cursor — an empty subscription requests from -1 so the owner
+            // serves from docket 0 instead of serving nothing.
+            var fromDocketVersion = await _syncBackgroundService.ResolveSyncFromVersionAsync(
+                subscription, cancellationToken);
             var correlationId = Guid.NewGuid().ToString();
             var syncRequest = new RelayModels.RegisterSyncRequest
             {
                 CorrelationId = correlationId,
                 RegisterId = registerId,
-                FromDocketVersion = subscription.LastSyncedDocketVersion
+                FromDocketVersion = fromDocketVersion
             };
 
             var syncResponse = await _relayCommunication.SendAndWaitAsync<RelayModels.RegisterSyncResponse>(

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterReplicationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterReplicationService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Grpc.Core;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Sorcha.Peer.Service.Communication;
@@ -9,6 +10,7 @@ using Sorcha.Peer.Service.Connection;
 using Sorcha.Peer.Service.Core;
 using Sorcha.Peer.Service.Discovery;
 using Sorcha.Peer.Service.Protos;
+using Sorcha.ServiceClients.Register;
 using RelayModels = Sorcha.Peer.Service.Communication.Models;
 
 namespace Sorcha.Peer.Service.Replication;
@@ -33,6 +35,7 @@ public class RegisterReplicationService
     private readonly RegisterCache _registerCache;
     private readonly RelayCommunicationService? _relayCommunication;
     private readonly DocketFinalizationService? _docketFinalizationService;
+    private readonly IServiceScopeFactory? _scopeFactory;
     private readonly RegisterSyncConfiguration _syncConfig;
     private readonly string _localPeerId;
 
@@ -44,7 +47,8 @@ public class RegisterReplicationService
         RegisterCache registerCache,
         IOptions<PeerServiceConfiguration>? configuration = null,
         RelayCommunicationService? relayCommunication = null,
-        DocketFinalizationService? docketFinalizationService = null)
+        DocketFinalizationService? docketFinalizationService = null,
+        IServiceScopeFactory? scopeFactory = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _connectionPool = connectionPool ?? throw new ArgumentNullException(nameof(connectionPool));
@@ -53,8 +57,59 @@ public class RegisterReplicationService
         _registerCache = registerCache ?? throw new ArgumentNullException(nameof(registerCache));
         _relayCommunication = relayCommunication;
         _docketFinalizationService = docketFinalizationService;
+        _scopeFactory = scopeFactory;
         _syncConfig = configuration?.Value?.RegisterSync ?? new RegisterSyncConfiguration();
         _localPeerId = configuration?.Value?.ResolvedPeerId ?? Environment.MachineName;
+    }
+
+    /// <summary>
+    /// Resolves the docket version to request a sync FROM, reconciled against the subscriber's
+    /// <b>actual</b> local register height rather than a possibly-stale
+    /// <see cref="RegisterSubscription.LastSyncedDocketVersion"/> cursor (issue #908).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both serve loops (direct gRPC <c>PullDocketChainFromRegisterServiceAsync</c> and relay
+    /// <c>RelayMessageHandler.PopulateResponseFromRegisterServiceAsync</c>) serve dockets in the
+    /// half-open range <c>(fromVersion, height)</c> — i.e. <c>docketNum = fromVersion + 1 .. height-1</c>,
+    /// where <c>height</c> is a COUNT. So <c>fromVersion</c> MUST be the highest docket index the
+    /// subscriber already holds. An empty/absent local register holds nothing, so it requests from
+    /// <see cref="AllDocketVersions"/> (-1) → the owner serves from docket 0. The previous code sent
+    /// the raw <c>LastSyncedDocketVersion</c>, which for an empty subscription could be a non-(-1)
+    /// value (e.g. 1) that made the owner serve 0 dockets despite a non-zero height — the register
+    /// then looked stuck until the owner's peer-service was restarted.
+    /// </para>
+    /// <para>
+    /// <see cref="IRegisterServiceClient.GetRegisterHeightAsync"/> returns the local docket COUNT,
+    /// or -1 when the register is absent locally. We map that to the highest held index
+    /// (<c>count - 1</c>), or -1 (full sync from genesis) when nothing is held. Falls back to the
+    /// subscription cursor only when the co-located Register Service cannot be consulted (e.g. the
+    /// scope factory is absent in unit tests).
+    /// </para>
+    /// </remarks>
+    internal async Task<long> ResolveFromVersionAsync(
+        RegisterSubscription subscription, CancellationToken cancellationToken)
+    {
+        if (_scopeFactory is not null)
+        {
+            try
+            {
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var registerClient = scope.ServiceProvider.GetRequiredService<IRegisterServiceClient>();
+                var localHeight = await registerClient.GetRegisterHeightAsync(
+                    subscription.RegisterId, cancellationToken);
+
+                return localHeight > 0 ? localHeight - 1 : AllDocketVersions;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogDebug(ex,
+                    "Could not resolve local register height for {RegisterId} — falling back to subscription cursor {Cursor}",
+                    subscription.RegisterId, subscription.LastSyncedDocketVersion);
+            }
+        }
+
+        return subscription.LastSyncedDocketVersion;
     }
 
     /// <summary>
@@ -66,9 +121,13 @@ public class RegisterReplicationService
         CancellationToken cancellationToken = default)
     {
         var registerId = subscription.RegisterId;
+        // Issue #908: reconcile the request floor against the actual local register height once,
+        // up front, so this diagnostic line (and every source-peer attempt below) reflects what we
+        // truly hold — not a possibly-stale LastSyncedDocketVersion cursor.
+        var resolvedFromVersion = await ResolveFromVersionAsync(subscription, cancellationToken);
         _logger.LogInformation(
             "Starting full replica sync for register {RegisterId} from docket version {FromVersion}",
-            registerId, subscription.LastSyncedDocketVersion);
+            registerId, resolvedFromVersion);
 
         // Find peers that can serve full replica
         var sourcePeers = _peerListManager.GetFullReplicaPeersForRegister(registerId);
@@ -155,7 +214,7 @@ public class RegisterReplicationService
                      _relayCommunication.CanReachViaReverseStream(sourcePeer.PeerId)))
                 {
                     var (relayResult, relayDockets, relayTransactions) = await TryRelayBatchSyncAsync(
-                        sourcePeer, subscription, cacheEntry, replicationToken);
+                        sourcePeer, subscription, cacheEntry, resolvedFromVersion, replicationToken);
 
                     totalDockets += relayDockets;
                     totalTransactions += relayTransactions;
@@ -170,7 +229,7 @@ public class RegisterReplicationService
             try
             {
                 var client = new RegisterSync.RegisterSyncClient(channel);
-                var fromVersion = subscription.LastSyncedDocketVersion;
+                var fromVersion = resolvedFromVersion;
                 var batchSize = _syncConfig.DocketPullBatchSize;
                 var batchDocketCount = 0;
 
@@ -330,6 +389,7 @@ public class RegisterReplicationService
         PeerNode sourcePeer,
         RegisterSubscription subscription,
         RegisterCacheEntry cacheEntry,
+        long resolvedFromVersion,
         CancellationToken cancellationToken)
     {
         var registerId = subscription.RegisterId;
@@ -342,7 +402,10 @@ public class RegisterReplicationService
 
         try
         {
-            var fromVersion = subscription.LastSyncedDocketVersion;
+            // Issue #908: request from the reconciled local height (resolved by the caller), not the
+            // possibly-stale LastSyncedDocketVersion — an empty subscription requests from -1 so the
+            // owner serves from docket 0 instead of serving nothing.
+            var fromVersion = resolvedFromVersion;
             var maxDockets = _syncConfig.DocketPullBatchSize;
             var hasMore = true;
             var consecutiveNullRetries = 0;

--- a/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/RegisterSyncBackgroundService.cs
@@ -237,12 +237,18 @@ public class RegisterSyncBackgroundService : BackgroundService
 
             foreach (var peer in natdPeers)
             {
+                // Issue #908: reconcile against the actual local register height rather than the
+                // possibly-stale LastSyncedDocketVersion cursor (shared with PullFullReplica /
+                // TryRelayBatchSync) so an empty subscription polls from -1 and backfills, instead
+                // of requesting a stale floor that makes the owner serve 0 dockets.
+                var fromDocketVersion = await _replicationService.ResolveFromVersionAsync(
+                    subscription, cancellationToken);
                 var correlationId = Guid.NewGuid().ToString();
                 var syncRequest = new RelayModels.RegisterSyncRequest
                 {
                     CorrelationId = correlationId,
                     RegisterId = registerId,
-                    FromDocketVersion = subscription.LastSyncedDocketVersion
+                    FromDocketVersion = fromDocketVersion
                 };
 
                 var response = await _relayCommunication!.SendAndWaitAsync<RelayModels.RegisterSyncResponse>(
@@ -370,6 +376,17 @@ public class RegisterSyncBackgroundService : BackgroundService
         _subscriptions.TryGetValue(registerId, out var sub);
         return sub;
     }
+
+    /// <summary>
+    /// Resolves the docket version to request a sync FROM, reconciled against the actual local
+    /// register height rather than the possibly-stale <see cref="RegisterSubscription.LastSyncedDocketVersion"/>
+    /// cursor (issue #908). Delegates to the single implementation on
+    /// <see cref="RegisterReplicationService.ResolveFromVersionAsync"/> so every sync-request site
+    /// (full pull, relay batch, relay poll, notification-triggered pull) shares one floor semantics.
+    /// </summary>
+    internal Task<long> ResolveSyncFromVersionAsync(
+        RegisterSubscription subscription, CancellationToken cancellationToken)
+        => _replicationService.ResolveFromVersionAsync(subscription, cancellationToken);
 
     internal async Task ProcessSubscriptionsAsync(CancellationToken cancellationToken)
     {

--- a/tests/Sorcha.Peer.Service.Tests/Replication/RegisterReplicationServiceTests.cs
+++ b/tests/Sorcha.Peer.Service.Tests/Replication/RegisterReplicationServiceTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -11,6 +12,7 @@ using Sorcha.Peer.Service.Core;
 using Sorcha.Peer.Service.Discovery;
 using Sorcha.Peer.Service.Observability;
 using Sorcha.Peer.Service.Replication;
+using Sorcha.ServiceClients.Register;
 
 namespace Sorcha.Peer.Service.Tests.Replication;
 
@@ -402,6 +404,88 @@ public class RegisterReplicationServiceTests : IAsyncDisposable
 
         // Should complete without throwing
         await _service.SubscribeToLiveTransactionsAsync(subscription);
+    }
+
+    // ---- Issue #908: incremental sync floor reconciled against the actual local register height ----
+
+    /// <summary>
+    /// Builds a service whose co-located Register Service reports <paramref name="localHeight"/> as
+    /// the local docket count for any register (a real DI scope chain, so CreateAsyncScope works).
+    /// </summary>
+    private RegisterReplicationService ServiceWithLocalHeight(long localHeight)
+    {
+        var registerClient = new Mock<IRegisterServiceClient>();
+        registerClient
+            .Setup(c => c.GetRegisterHeightAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(localHeight);
+
+        var services = new ServiceCollection();
+        services.AddScoped(_ => registerClient.Object);
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        return new RegisterReplicationService(
+            new Mock<ILogger<RegisterReplicationService>>().Object,
+            _connectionPool,
+            _peerListManager,
+            _advertisementService,
+            _registerCache,
+            _config,
+            _relayCommunication,
+            docketFinalizationService: null,
+            scopeFactory: scopeFactory);
+    }
+
+    [Fact]
+    public async Task ResolveFromVersion_EmptyLocalRegister_RequestsFromMinusOne()
+    {
+        // height=-1 (register absent locally) ⇒ request from -1 so the owner serves from docket 0.
+        var svc = ServiceWithLocalHeight(-1);
+        var subscription = new RegisterSubscription { RegisterId = "reg-1", LastSyncedDocketVersion = 1 };
+
+        var fromVersion = await svc.ResolveFromVersionAsync(subscription, CancellationToken.None);
+
+        fromVersion.Should().Be(-1,
+            "an empty subscription must request from -1 even when a stale cursor says otherwise (the #908 bug)");
+    }
+
+    [Fact]
+    public async Task ResolveFromVersion_LocalHeightZero_RequestsFromMinusOne()
+    {
+        // A 0-count register holds nothing ⇒ still request from -1 (full backfill from genesis).
+        var svc = ServiceWithLocalHeight(0);
+        var subscription = new RegisterSubscription { RegisterId = "reg-1", LastSyncedDocketVersion = 1 };
+
+        var fromVersion = await svc.ResolveFromVersionAsync(subscription, CancellationToken.None);
+
+        fromVersion.Should().Be(-1);
+    }
+
+    [Theory]
+    [InlineData(1, 0)]  // holds docket 0 ⇒ request the tail after index 0
+    [InlineData(2, 1)]  // holds dockets 0,1 ⇒ request after index 1
+    [InlineData(5, 4)]  // holds 0..4 ⇒ request after index 4
+    public async Task ResolveFromVersion_NonEmptyLocalRegister_RequestsIncrementalTail(long localHeight, long expectedFromVersion)
+    {
+        var svc = ServiceWithLocalHeight(localHeight);
+        var subscription = new RegisterSubscription { RegisterId = "reg-1", LastSyncedDocketVersion = 0 };
+
+        var fromVersion = await svc.ResolveFromVersionAsync(subscription, CancellationToken.None);
+
+        fromVersion.Should().Be(expectedFromVersion,
+            "the floor is the highest docket index already held (height-1), so the owner serves only the missing tail");
+    }
+
+    [Fact]
+    public async Task ResolveFromVersion_NoScopeFactory_FallsBackToSubscriptionCursor()
+    {
+        // Unit-test path (and any context without a co-located Register Service): preserve the prior
+        // behaviour of trusting the persisted cursor rather than failing.
+        var subscription = new RegisterSubscription { RegisterId = "reg-1", LastSyncedDocketVersion = 7 };
+
+        var fromVersion = await _service.ResolveFromVersionAsync(subscription, CancellationToken.None);
+
+        fromVersion.Should().Be(7);
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
## Problem

When a subscriber node syncs a register from a (NAT'd) owner over the relay path, it sent `subscription.LastSyncedDocketVersion` as the sync floor (`fromVersion`). For an **empty / 0-docket** subscription whose cursor had drifted to a non-`-1` value (e.g. `1`), the owner's serve loop — which serves the half-open range `(fromVersion, height)`, i.e. `docketNum = fromVersion+1 .. height-1` where `height` is a **count** — computed `2 < height(2)` = false and served **0 dockets** despite `height>0`.

Observed live (register `4148…`, tiny owner / n1 subscriber): n1 had 0 dockets, tiny had height=2, every poll transferred 0. The register looked stuck and only an **owner peer-service restart** (which re-advertised + reset state) recovered it.

## Fix

Resolve the sync floor against the subscriber's **actual local register height** via the co-located Register Service (`IRegisterServiceClient.GetRegisterHeightAsync`), not the possibly-stale cursor:

- empty / absent local register (`height <= 0`) → request from `-1` (`AllDocketVersions`) so the owner serves from docket 0;
- otherwise → request the incremental tail after the highest docket already held (`height - 1`).

One shared `RegisterReplicationService.ResolveFromVersionAsync` feeds **every** subscriber-side sync-request site so the floor semantics are consistent:
- direct gRPC full pull (`PullFullReplicaAsync`),
- relay batch sync (`TryRelayBatchSyncAsync`),
- relay poll (`RegisterSyncBackgroundService.TryRelayPollForRegisterAsync`),
- notification-triggered relay pull (`RelayMessageHandler.HandleRelayedTransactionNotificationAsync`).

It falls back to the persisted cursor only when the co-located Register Service can't be consulted (e.g. unit tests without a scope factory).

### Direct gRPC path is not regressed

Both serve loops (direct `PullDocketChainFromRegisterServiceAsync` and relay `PopulateResponseFromRegisterServiceAsync`) already use identical `fromVersion+1 … height-1` semantics, and the cache's `GetDocketsFromVersion` is exclusive of `fromVersion`. So the computed floor is correct for both transports; the working SSR direct-sync path is unaffected.

### Scope note

This closes the **incremental / "looks stuck"** half of #908. The **stale-advert** half (a subscriber stranded at a stale owner height because a one-shot advert was missed while the reverse stream was down) is addressed by the now-merged #909 (reverse-stream rendezvous) — with the stream up, adverts flow, and this change removes the dependency on a fresh advert / owner restart for sync **correctness**.

## Tests

6 new `RegisterReplicationServiceTests` (built on a real DI scope chain):
- empty local register (`height = -1` and `0`) → floor `-1`;
- incremental tail (`height = 1/2/5` → floor `0/1/4`);
- no scope factory → falls back to the subscription cursor.

Full `Sorcha.Peer.Service.Tests` suite green (710/710) locally.

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)