### PR TITLE
fix(912): resolve pending-actions wallet by platform_user_id, not just sub

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Endpoints/ActionEndpoints.cs
@@ -163,7 +163,7 @@ public static class ActionEndpoints
     /// Returns an empty list when neither path yields a wallet — the caller
     /// should surface an empty result rather than a 401.
     /// </summary>
-    private static async Task<IReadOnlyList<string>> ResolveUserWalletAddressesAsync(
+    internal static async Task<IReadOnlyList<string>> ResolveUserWalletAddressesAsync(
         HttpContext httpContext,
         IWalletServiceClient walletClient,
         ILogger logger,
@@ -175,22 +175,49 @@ public static class ActionEndpoints
             return new[] { claim };
         }
 
+        // Wallet Service fallback (no wallet_address claim — e.g. consumer-tier tokens, which
+        // omit wallet binding by design under Feature 136). Wallets are keyed by their Owner,
+        // and per the Feature 136 / #878 alignment a wallet's Owner is the cross-org
+        // platform_user_id, NOT the per-org sub/UserIdentity.Id. For admin tokens the two are
+        // equal, but for an org-scoped Consumer (e.g. a verification analyst running the rules
+        // agent) they differ — so a sub-keyed lookup silently misses the wallet and the agent
+        // never discovers the action it must approve (#912). Prefer platform_user_id, then fall
+        // back to sub/NameIdentifier so pre-#878 wallets stay discoverable. Both eras coexist.
+        var ownerCandidates = new List<string>();
+        var platformUserId = httpContext.User.FindFirst("platform_user_id")?.Value;
+        if (!string.IsNullOrEmpty(platformUserId))
+        {
+            ownerCandidates.Add(platformUserId);
+        }
+
         var userId = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
             ?? httpContext.User.FindFirst("sub")?.Value;
-        if (string.IsNullOrEmpty(userId))
+        if (!string.IsNullOrEmpty(userId) && !ownerCandidates.Contains(userId, StringComparer.Ordinal))
+        {
+            ownerCandidates.Add(userId);
+        }
+
+        if (ownerCandidates.Count == 0)
         {
             return Array.Empty<string>();
         }
 
         try
         {
-            var wallets = await walletClient.GetWalletsByOwnerAsync(userId, cancellationToken);
-            if (wallets.Count == 0)
+            foreach (var owner in ownerCandidates)
             {
-                return Array.Empty<string>();
+                var wallets = await walletClient.GetWalletsByOwnerAsync(owner, cancellationToken);
+                var addresses = wallets
+                    .Select(w => w.Address)
+                    .Where(a => !string.IsNullOrEmpty(a))
+                    .ToArray();
+                if (addresses.Length > 0)
+                {
+                    return addresses;
+                }
             }
 
-            return wallets.Select(w => w.Address).Where(a => !string.IsNullOrEmpty(a)).ToArray();
+            return Array.Empty<string>();
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -203,8 +230,8 @@ public static class ActionEndpoints
             // must propagate cleanly so ASP.NET's request pipeline can short
             // circuit without a bogus 200 response.
             logger.LogWarning(ex,
-                "Failed to resolve wallet addresses for user {UserId} via Wallet Service fallback; returning empty list",
-                userId);
+                "Failed to resolve wallet addresses for user (platform_user_id={PlatformUserId}, sub={UserId}) via Wallet Service fallback; returning empty list",
+                platformUserId, userId);
             return Array.Empty<string>();
         }
     }

--- a/tests/Sorcha.Blueprint.Service.Tests/Endpoints/ActionEndpointsTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Endpoints/ActionEndpointsTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.Blueprint.Service.Endpoints;
+using Sorcha.ServiceClients.Wallet;
+
+namespace Sorcha.Blueprint.Service.Tests.Endpoints;
+
+/// <summary>
+/// Feature 145 / #912 — the pending-actions endpoint must resolve the caller's wallet by
+/// <c>platform_user_id</c> (the cross-org Owner key per #878), not just <c>sub</c>. A consumer-tier
+/// token (e.g. the verification analyst running the rules agent) carries no <c>wallet_address</c>
+/// claim and its wallet is owned by <c>platform_user_id</c>, which differs from <c>sub</c> for an
+/// org-scoped user — so a sub-only lookup silently misses the wallet and the agent never discovers
+/// the action it must approve.
+/// </summary>
+public class ActionEndpointsTests
+{
+    private static HttpContext ContextWith(params (string Type, string Value)[] claims)
+    {
+        var identity = new ClaimsIdentity(claims.Select(c => new Claim(c.Type, c.Value)), "test");
+        return new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+    }
+
+    private static WalletInfo Wallet(string address) =>
+        new()
+        {
+            Address = address, Name = "w", PublicKey = "pk", Algorithm = "ED25519",
+            Status = "Active", Owner = "owner", Tenant = "tenant",
+        };
+
+    private static Mock<IWalletServiceClient> WalletClientReturning(
+        params (string Owner, string[] Addresses)[] byOwner)
+    {
+        var mock = new Mock<IWalletServiceClient>();
+        mock.Setup(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string owner, CancellationToken _) =>
+            {
+                var match = byOwner.FirstOrDefault(b => b.Owner == owner);
+                return (match.Addresses ?? Array.Empty<string>()).Select(Wallet).ToList();
+            });
+        return mock;
+    }
+
+    [Fact]
+    public async Task Resolve_WalletAddressClaimPresent_UsesFastPath_NoWalletServiceCall()
+    {
+        var wallet = new Mock<IWalletServiceClient>(MockBehavior.Strict);
+
+        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+            ContextWith(("wallet_address", "ws1-fast"), ("sub", "sub-1")),
+            wallet.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().Equal("ws1-fast");
+        wallet.Verify(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Resolve_NoWalletAddressClaim_PrefersPlatformUserIdOwner()
+    {
+        // The wallet is owned by platform_user_id (the #878 alignment). A sub-keyed lookup would
+        // miss it; the platform_user_id-keyed lookup finds it — the #912 agent-discovery fix.
+        var wallet = WalletClientReturning(
+            ("platform-1", new[] { "ws1-analyst" }),
+            ("sub-1", Array.Empty<string>()));
+
+        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+            ContextWith(("platform_user_id", "platform-1"), (ClaimTypes.NameIdentifier, "sub-1")),
+            wallet.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().Equal("ws1-analyst");
+        wallet.Verify(c => c.GetWalletsByOwnerAsync("platform-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Resolve_PlatformUserIdHasNoWallet_FallsBackToSubOwner()
+    {
+        // Legacy / pre-#878 wallet owned by sub: platform_user_id misses, sub hits.
+        var wallet = WalletClientReturning(
+            ("platform-1", Array.Empty<string>()),
+            ("sub-1", new[] { "ws1-legacy" }));
+
+        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+            ContextWith(("platform_user_id", "platform-1"), (ClaimTypes.NameIdentifier, "sub-1")),
+            wallet.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().Equal("ws1-legacy");
+        wallet.Verify(c => c.GetWalletsByOwnerAsync("platform-1", It.IsAny<CancellationToken>()), Times.Once);
+        wallet.Verify(c => c.GetWalletsByOwnerAsync("sub-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Resolve_NoIdentifyingClaims_ReturnsEmpty()
+    {
+        var wallet = new Mock<IWalletServiceClient>(MockBehavior.Strict);
+
+        var result = await ActionEndpoints.ResolveUserWalletAddressesAsync(
+            ContextWith(("some-other-claim", "x")),
+            wallet.Object, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeEmpty();
+        wallet.Verify(c => c.GetWalletsByOwnerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Why (completes #912)

PR #919 fixed the F145 projection so a pre-baked participant's wallet is seeded into `instance.ParticipantWallets` before they act — **necessary**, and proven live (the instance now sits at Action 2 with the analyst wallet present). But live validation surfaced a **second blocker** on the agent's discovery path, so the agent still didn't auto-approve.

## Root cause

`GET /api/actions/pending` → `ResolveUserWalletAddressesAsync` resolves the caller's wallets from:
1. the `wallet_address` JWT claim (fast path), else
2. a Wallet Service lookup by `sub` / `NameIdentifier`.

A **consumer-tier** token (e.g. the verification analyst running the rules agent) carries **no `wallet_address` claim** by design (Feature 136), and a wallet's `Owner` is the cross-org **`platform_user_id`** (the Feature 136 / #878 alignment), **not** the per-org `sub`. For an org-scoped Consumer `sub ≠ platform_user_id`, so the sub-keyed lookup silently missed the wallet → empty pending list → the agent never discovered the action.

Proven live on tiny: analyst token `sub=b8e842d7…`, `platform_user_id=70401c12…`, `wallet_address=None`; analyst wallet `ws11qq9g4qyz…` `Owner=70401c12…`. Pre-fix `/api/actions/pending` returned `[]`.

## Fix

In the fallback, prefer `platform_user_id`, then fall back to `sub`/`NameIdentifier` (mirrors #878 on the read side). Admin tokens are unchanged (`sub == platform_user_id`); pre-#878 wallets owned by `sub` stay discoverable. The `wallet_address` fast path is untouched.

## Tests

4 new `ActionEndpointsTests` (the resolver is now `internal` for direct testing): fast-path claim wins (no Wallet Service call), `platform_user_id` preference, `sub` fallback for legacy wallets, no-claims → empty. Full `Sorcha.Blueprint.Service.Tests` suite green (862/862) locally.

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)