### PR TITLE
fix: filter pending actions by sender so participants only see their own

### DIFF
--- a/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Storage/EfCoreInstanceStore.cs
@@ -289,7 +289,12 @@ public class EfCoreInstanceStore : IInstanceStore
             {
                 blueprintCache.TryGetValue(instance.BlueprintId, out var blueprint);
 
-                return instance.CurrentActionIds.Select(actionId =>
+                // Only surface actions this wallet is actually the sender of — not every current
+                // action of an instance the wallet merely participates in (the citizen-sees-the-
+                // analyst's-action bug). See IsActionForWallet.
+                return instance.CurrentActionIds
+                    .Where(actionId => IsActionForWallet(blueprint, actionResolver, instance, actionId, walletAddress))
+                    .Select(actionId =>
                 {
                     var actionTitle = $"Action {actionId}";
                     JsonElement? dataSchema = null;
@@ -373,13 +378,35 @@ public class EfCoreInstanceStore : IInstanceStore
             .Where(i => i.State == activeState)
             .ToListAsync(cancellationToken);
 
-        return entities
+        var matchingInstances = entities
             .Where(e => ContainsWalletAddress(e.ParticipantWallets, walletAddress))
-            .Sum(e =>
+            .Select(ToModel)
+            .Where(i => i is not null)
+            .Cast<Instance>()
+            .ToList();
+
+        // Resolve blueprints to apply the same sender-filter as GetPendingActionsByWalletAsync, so
+        // the badge count matches the list (count only actions this wallet is the sender of).
+        var blueprintCache = new Dictionary<string, Sorcha.Blueprint.Models.Blueprint?>();
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var actionResolver = scope.ServiceProvider.GetService<IActionResolverService>();
+        if (actionResolver != null)
+        {
+            foreach (var bpId in matchingInstances.Select(i => i.BlueprintId).Distinct())
             {
-                var actionIds = DeserializeJson<List<int>>(e.CurrentActionIds);
-                return actionIds?.Count ?? 0;
-            });
+                if (!blueprintCache.ContainsKey(bpId))
+                {
+                    blueprintCache[bpId] = await actionResolver.GetBlueprintAsync(bpId, cancellationToken);
+                }
+            }
+        }
+
+        return matchingInstances.Sum(instance =>
+        {
+            blueprintCache.TryGetValue(instance.BlueprintId, out var blueprint);
+            return instance.CurrentActionIds.Count(actionId =>
+                IsActionForWallet(blueprint, actionResolver, instance, actionId, walletAddress));
+        });
     }
 
     /// <inheritdoc/>
@@ -616,5 +643,44 @@ public class EfCoreInstanceStore : IInstanceStore
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Whether a current action is actionable by <paramref name="walletAddress"/> — i.e. the
+    /// action's <c>Sender</c> participant either binds to that wallet in the instance, or is not
+    /// yet bound to any wallet (open / late-bound, ambiguous). It excludes ONLY actions whose
+    /// sender is bound to a <b>different</b> wallet, so a participant who merely shares an instance
+    /// (e.g. the citizen applicant whose wallet is in <see cref="Instance.ParticipantWallets"/>
+    /// alongside the analyst's) is no longer shown the analyst's action as if it were their own.
+    /// Falls back to inclusive whenever the blueprint / action / sender can't be resolved, so a
+    /// resolution failure never hides a legitimate pending action from the actor who must perform it.
+    /// </summary>
+    internal static bool IsActionForWallet(
+        Sorcha.Blueprint.Models.Blueprint? blueprint,
+        IActionResolverService? actionResolver,
+        Instance instance,
+        int actionId,
+        string walletAddress)
+    {
+        if (blueprint is null || actionResolver is null)
+        {
+            return true;
+        }
+
+        var sender = actionResolver.GetActionDefinition(blueprint, actionId.ToString())?.Sender;
+        if (string.IsNullOrEmpty(sender))
+        {
+            return true;
+        }
+
+        if (instance.ParticipantWallets.TryGetValue(sender, out var senderWallet)
+            && !string.IsNullOrEmpty(senderWallet))
+        {
+            // Sender is bound to a wallet — the action belongs to that wallet only.
+            return string.Equals(senderWallet, walletAddress, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Sender not yet bound (open / late-bound participant) — ambiguous, don't hide it.
+        return true;
     }
 }

--- a/tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreInstanceStorePendingFilterTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Storage/EfCoreInstanceStorePendingFilterTests.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Moq;
+using Sorcha.Blueprint.Service.Models;
+using Sorcha.Blueprint.Service.Services.Interfaces;
+using Sorcha.Blueprint.Service.Storage;
+
+namespace Sorcha.Blueprint.Service.Tests.Storage;
+
+/// <summary>
+/// The pending-actions sender-filter (<see cref="EfCoreInstanceStore.IsActionForWallet"/>): a wallet
+/// that merely participates in an instance must NOT be shown an action whose Sender is bound to a
+/// DIFFERENT participant's wallet (the "citizen sees the analyst's Action 2" bug). It must still see
+/// its own actions, must not hide ambiguous open/late-bound actions, and must fail open when the
+/// blueprint can't be resolved.
+/// </summary>
+public class EfCoreInstanceStorePendingFilterTests
+{
+    private const string AnalystWallet = "ws-analyst";
+    private const string CitizenWallet = "ws-citizen";
+
+    /// <summary>AssuredIdentity-shaped blueprint: action 1 sender=applicant, action 2 sender=analyst.</summary>
+    private static IActionResolverService Resolver()
+    {
+        var blueprint = new Sorcha.Blueprint.Models.Blueprint
+        {
+            Id = "bp-1",
+            Actions =
+            [
+                new Sorcha.Blueprint.Models.Action { Id = 1, Sender = "applicant", IsStartingAction = true },
+                new Sorcha.Blueprint.Models.Action { Id = 2, Sender = "analyst" },
+                new Sorcha.Blueprint.Models.Action { Id = 3, Sender = "" }, // no sender declared
+            ],
+        };
+        var mock = new Mock<IActionResolverService>();
+        mock.Setup(r => r.GetActionDefinition(It.IsAny<Sorcha.Blueprint.Models.Blueprint>(), It.IsAny<string>()))
+            .Returns((Sorcha.Blueprint.Models.Blueprint bp, string id) =>
+                bp.Actions.FirstOrDefault(a => a.Id.ToString() == id));
+        return mock.Object;
+    }
+
+    private static Sorcha.Blueprint.Models.Blueprint Blueprint() => new()
+    {
+        Id = "bp-1",
+        Actions =
+        [
+            new Sorcha.Blueprint.Models.Action { Id = 1, Sender = "applicant", IsStartingAction = true },
+            new Sorcha.Blueprint.Models.Action { Id = 2, Sender = "analyst" },
+            new Sorcha.Blueprint.Models.Action { Id = 3, Sender = "" },
+        ],
+    };
+
+    /// <summary>Instance at action 2 with both the applicant and the (pre-baked) analyst bound.</summary>
+    private static Instance InstanceAtAction2() => new()
+    {
+        Id = "inst-1",
+        BlueprintId = "bp-1",
+        BlueprintVersion = 1,
+        RegisterId = "reg-1",
+        TenantId = "tenant-1",
+        CurrentActionIds = [2],
+        ParticipantWallets = { ["applicant"] = CitizenWallet, ["analyst"] = AnalystWallet },
+    };
+
+    [Fact]
+    public void AnalystSeesOwnAction()
+    {
+        EfCoreInstanceStore.IsActionForWallet(Blueprint(), Resolver(), InstanceAtAction2(), 2, AnalystWallet)
+            .Should().BeTrue("the analyst is the Sender of action 2");
+    }
+
+    [Fact]
+    public void CitizenDoesNotSeeAnalystAction()
+    {
+        // The bug: the citizen participates in the instance, so the unfiltered query surfaced the
+        // analyst's action to them. The filter must exclude it.
+        EfCoreInstanceStore.IsActionForWallet(Blueprint(), Resolver(), InstanceAtAction2(), 2, CitizenWallet)
+            .Should().BeFalse("action 2's Sender (analyst) is bound to a different wallet");
+    }
+
+    [Fact]
+    public void UnboundSenderIsNotHidden()
+    {
+        // Action 2's sender 'analyst' is not bound to any wallet yet (open / late-bound) — ambiguous,
+        // so it must not be hidden from a participant who might be the one to act.
+        var instance = new Instance
+        {
+            Id = "inst-2", BlueprintId = "bp-1", BlueprintVersion = 1, RegisterId = "reg-1",
+            TenantId = "tenant-1", CurrentActionIds = [2],
+            ParticipantWallets = { ["applicant"] = CitizenWallet }, // analyst not bound
+        };
+        EfCoreInstanceStore.IsActionForWallet(Blueprint(), Resolver(), instance, 2, CitizenWallet)
+            .Should().BeTrue("an unbound sender is ambiguous and must not be hidden");
+    }
+
+    [Fact]
+    public void ActionWithNoDeclaredSenderIsInclusive()
+    {
+        EfCoreInstanceStore.IsActionForWallet(Blueprint(), Resolver(), InstanceAtAction2(), 3, CitizenWallet)
+            .Should().BeTrue("action 3 declares no Sender — fail open");
+    }
+
+    [Fact]
+    public void NullBlueprintFailsOpen()
+    {
+        EfCoreInstanceStore.IsActionForWallet(null, Resolver(), InstanceAtAction2(), 2, CitizenWallet)
+            .Should().BeTrue("a resolution failure must never hide a legitimate action");
+    }
+}


### PR DESCRIPTION
## Problem (the n1 "came straight to me for approval")

`GET /api/actions/pending` → `EfCoreInstanceStore.GetPendingActionsByWalletAsync` returned **every** current action of any instance the caller's wallet participates in — it never checked whether the action's `Sender` is that wallet. So a citizen applicant, whose wallet sits in the instance's `ParticipantWallets` alongside the analyst's, was shown the **analyst's** review action as if it were their own.

The bug was latent until #921 made consumer-tier wallets resolve on this endpoint (before that the citizen's list was silently empty, so nobody noticed).

## Fix

A sender-aware filter (`IsActionForWallet`) shared by the list and the count methods. An action is surfaced to a wallet only when:
- its `Sender` participant binds to **that** wallet in the instance, **or**
- the sender isn't bound to any wallet yet (open / late-bound — ambiguous, never hidden).

It excludes **only** actions whose sender is bound to a **different** wallet (the bug). It **fails open** (inclusive) when the blueprint / action / sender can't be resolved, so a resolution failure never hides a legitimate pending action from the actor who must perform it. `GetPendingActionCountByWalletAsync` applies the same filter so the badge count matches the list.

## Tests

5 new `EfCoreInstanceStorePendingFilterTests`:
- analyst sees their own action ✓
- **citizen does NOT see the analyst's action** (the bug) ✓
- unbound (open) sender is not hidden ✓
- action with no declared sender → inclusive ✓
- null blueprint → fails open ✓

Full `Sorcha.Blueprint.Service.Tests` suite green (867/867) locally.

This is the server-side companion to #919/#921 (which made the analyst correctly discover their action); together the AssuredIdentity agent loop is hands-off **and** the citizen no longer sees the approver's step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)