### PR TITLE
ci(playwright): time-box browser install (120s × 3 retries) — it wedges for an hour

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,8 +25,30 @@ jobs:
         node-version: lts/*
     - name: Install dependencies
       run: npm ci
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+    # OS deps are reliable (apt) — install them once, separately from the browser binaries.
+    - name: Install Playwright system deps
+      run: npx playwright install-deps
+    # The browser DOWNLOAD is what wedges: `playwright install` can hang indefinitely after a
+    # binary reaches 100% (the CDN connection stalls and the downloader has no internal timeout),
+    # blocking the job until the 60-min job timeout. Time-box each attempt to 120s and retry with a
+    # fresh connection so a stalled download is killed and recovered in seconds, not an hour.
+    - name: Install Playwright Browsers (time-boxed + retry)
+      shell: bash
+      run: |
+        set -uo pipefail
+        for attempt in 1 2 3; do
+          echo "::group::Playwright browser install attempt $attempt (120s budget)"
+          if timeout --signal=KILL 120 npx playwright install; then
+            echo "::endgroup::"
+            echo "Playwright browsers installed (attempt $attempt)"
+            exit 0
+          fi
+          rc=$?
+          echo "::endgroup::"
+          echo "::warning::Browser install attempt $attempt did not finish within 120s (exit $rc) — retrying"
+        done
+        echo "::error::Playwright browser install failed after 3 attempts of 120s each"
+        exit 1
     - name: Run Playwright tests
       run: npx playwright test
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why is it wedged?

From the live logs of a stuck run:

```
13:49:27  Downloading Chrome for Testing 145.0.7632.6 ... from cdn.playwright.dev ... 167.3 MiB
13:49:27  |■■■...■■| 100% of 167.3 MiB          ← download completes
14:49:02  Terminate orphan process: pid (2334) (npm exec playwright install --with-deps)
```

`npx playwright install` hangs **after** the Chromium binary reaches 100% — the CDN connection stalls (no proper close) and Playwright's downloader/extractor has **no internal timeout**, so the process blocks. The only safety net is the job's `timeout-minutes: 60`, which fires **exactly one hour later** (13:49 → 14:49). That's the "takes ages to fail," and it keeps the branch's checks pending the whole time. It's a runner/CDN network stall, not a code problem.

## Fix

- **Split OS deps from browser binaries.** `playwright install-deps` (apt) is reliable and runs once on its own, so a timeout-kill of the download can never interrupt `dpkg`.
- **Time-box + retry the browser download** (the part that stalls): each attempt gets a 120s budget via `timeout --signal=KILL 120`, retried up to 3×. A stalled CDN connection is now killed and retried with a fresh connection in seconds. Worst case the step fails in ~6 min instead of hanging for an hour; a healthy install finishes in ~20s.

No change to which browsers/tests run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)