### PR TITLE
chore(walkthroughs): admin-owned registers, genesis-seal wait, central F145 cadence retry

### DIFF
--- a/.claude/skills/walkthrough-builder/SKILL.md
+++ b/.claude/skills/walkthrough-builder/SKILL.md
@@ -200,6 +200,22 @@ $ownerSession = Connect-SorchaUser `
 
 This is the same pattern AssuredIdentity uses for its issuer-admin publisher. The 403 is NOT the rehearsal soft-gate (that's a `409 REHEARSAL_REQUIRED`, handled by `Publish-SorchaBlueprint -OverrideRehearsal`, default true) — it's the governance HARD gate, and only a `wallet_address`-bearing token clears it. Symptom triaged 2026-06-02 across ConstructionPermit + TradeFinance (both pre-dated F142); fixed in ConstructionPermit by the re-login above.
 
+#### REQUIRED: the register OWNER must be an Administrator, never a Consumer participant
+
+Blueprint publishing requires `CanPublishBlueprints` = **Administrator role OR a `can_publish_blueprint` claim**, AND (F142) the caller's `wallet_address` must be the register's roster owner. So the **same identity** must (a) hold Administrator and (b) own the register wallet. Consumer-role workflow participants (auditors, sales managers, citizens) satisfy neither cleanly. **Make the org admin own + publish the register** (give the org admin a wallet + participant, re-login, use *its* wallet as `-OwnerWalletAddress` and *its* session to publish). Workflow participants stay separate (referenced in the blueprint, not as the register owner). ForestryCertification/TradeFinance originally owned registers with a Consumer participant's wallet → permanent 403; fixed 2026-06-02 by switching ownership to the org admin.
+
+#### REQUIRED: wait for the register-genesis roster to seal before publishing (publish races the seal)
+
+The register's genesis control tx — which records the owner governance roster the F142 gate reads — seals **asynchronously after `New-SorchaRegister` returns**. A blueprint publish issued immediately reads an **empty** roster and fail-closes with the *same* `403 "You do not hold a publish-governance role"`. ConstructionPermit/Forestry got away with it by having other steps between register-create and publish; TradeFinance didn't and 403'd every time. **Poll `GET /api/registers/{id}/governance/roster` until `members.Count > 0` before publishing** (the register-genesis analogue of the F145 action-seal cadence).
+
+#### Cadence is now auto-retried in `Invoke-SorchaAction` (F145)
+
+`Invoke-SorchaAction` wraps its submit POST in `Invoke-SorchaActionPostWithCadenceRetry`, which **retries only the transient `400 "Action N is not a current action"`** (the projector hasn't folded the previous seal yet) up to 15×1s. So you no longer strictly need an explicit `Wait-SorchaActorReady -Mode AwaitingInbox` before every actor switch — the retry self-heals the cadence everywhere. Explicit `AwaitingInbox` gates remain valid (belt-and-braces) and are still clearer in setup.ps1 publish-seal waits. Any non-cadence 400 (schema, auth) is rethrown immediately.
+
+#### Idempotency for cross-walkthrough shared orgs
+
+Some walkthroughs deliberately share an org/identity (Forestry + TradeFinance both use `highland-timber` so a credential issued in one is visible to the other). Re-running one after the other hits `400 "a platform user … already exists"` from `New-SorchaOrgUser`. Participant-user provisioning helpers (e.g. `New-ParticipantUserSession`) MUST catch the `400/409` duplicate and fall through to `Connect-SorchaUser` (the password is deterministic), reusing the existing org-scoped user.
+
 #### Foot-gun: do NOT include open participants in `$walletMap`
 
 If the blueprint has a participant that is the sender of an `isStartingAction: true` action (a citizen, applicant, public submitter, etc.), that participant is **late-bound** at runtime — its `walletAddress` MUST be null in the published blueprint, and your `$walletMap` MUST NOT contain an entry for it.

--- a/walkthroughs/ForestryCertification/run.ps1
+++ b/walkthroughs/ForestryCertification/run.ps1
@@ -89,6 +89,17 @@ Write-WtStep "Step 3: Auditor performs audit (Action 2 — $($data.expectedDecis
 
 $action2Payload = $data.actions['2']
 
+# Feature 145: submission is single-async — Action 1's /execute returned 202 and the instance
+# advances only when the InstanceProjector folds the sealed docket (a beat after the seal).
+# Gate the auditor on the projection surfacing Action 2 as current, else we race the projector
+# and get "Action 2 is not a current action for instance". See walkthrough-builder skill, Cadence.
+Wait-SorchaActorReady -Mode AwaitingInbox `
+    -InstanceId $instanceId `
+    -ActionId 2 `
+    -RegisterId $state.registerId `
+    -Headers $auditorSession.Headers `
+    -GatewayUrl $state.gatewayUrl
+
 $action2Response = Invoke-SorchaAction `
     -BlueprintUrl $state.blueprintUrl `
     -InstanceId $instanceId `

--- a/walkthroughs/ForestryCertification/setup.ps1
+++ b/walkthroughs/ForestryCertification/setup.ps1
@@ -77,16 +77,29 @@ function New-ParticipantUserSession {
 
     # Spec 136: provision the operator org-scoped + verified (single-org — no public account, no
     # multi-org clash). Org operators are never public users; only citizens are.
-    $provisioned = New-SorchaOrgUser `
-        -TenantUrl $sorchaEnv.TenantUrl `
-        -OrganizationId $OrganizationId `
-        -Email $email `
-        -Password $password `
-        -DisplayName $DisplayName `
-        -Headers $OrgAdminHeaders `
-        -Roles @("Consumer") `
-        -EmailVerified
-    $userId = $provisioned.UserId
+    # Idempotent: this org/user may already exist from a sibling walkthrough that shares the org
+    # (Forestry + TradeFinance both use highland-timber by design). On a duplicate, fall through
+    # to login as the existing org-scoped user — the password is deterministic.
+    $userId = $null
+    try {
+        $provisioned = New-SorchaOrgUser `
+            -TenantUrl $sorchaEnv.TenantUrl `
+            -OrganizationId $OrganizationId `
+            -Email $email `
+            -Password $password `
+            -DisplayName $DisplayName `
+            -Headers $OrgAdminHeaders `
+            -Roles @("Consumer") `
+            -EmailVerified
+        $userId = $provisioned.UserId
+    } catch {
+        $status = $null; try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+        if ($status -eq 400 -or $status -eq 409) {
+            Write-WtInfo "  $email already provisioned — reusing"
+        } else {
+            throw
+        }
+    }
 
     $session = Connect-SorchaUser `
         -TenantUrl $sorchaEnv.TenantUrl `
@@ -97,7 +110,7 @@ function New-ParticipantUserSession {
     return @{
         Email    = $email
         Password = $password
-        UserId   = $userId
+        UserId   = if ($userId) { $userId } else { $session.UserId }
         Headers  = $session.Headers
         Token    = $session.Token
     }
@@ -338,6 +351,30 @@ Write-WtInfo "Sales Manager participant registered"
 # ============================================================================
 Write-WtStep "Step 6: Create Forestry Certification Register"
 
+# The blueprint publisher must be BOTH an Administrator (CanPublishBlueprints policy) AND the
+# register's governance-roster owner (F142 PublishGate matches the caller's wallet_address against
+# the roster owner wallet-DID). The org admin (fc-admin) holds the Administrator role, so make it
+# the register owner too: give it a wallet + participant, then re-login so the JWT carries
+# wallet_address (minted from the first linked wallet at login). The auditor stays a workflow
+# participant. See walkthrough-builder skill, "re-login any session AFTER its wallet is created".
+$fcAdminWallet = New-SorchaWallet `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -Name "Forestry Certification Admin" `
+    -Headers $fcAdminSession.Headers `
+    -FetchPublicKey
+$null = Register-SorchaParticipant `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -WalletUrl $sorchaEnv.WalletUrl `
+    -OrganizationId $fcOrgId `
+    -WalletAddress $fcAdminWallet.Address `
+    -DisplayName "Forestry Certification Admin" `
+    -Headers $fcAdminSession.Headers
+$fcAdminSession = Connect-SorchaUser `
+    -TenantUrl $sorchaEnv.TenantUrl `
+    -Email $fcAdminEmail `
+    -Password $fcAdminPassword `
+    -OrganizationId $fcOrgId
+
 $register = New-SorchaRegister `
     -RegisterUrl $sorchaEnv.RegisterUrl `
     -WalletUrl $sorchaEnv.WalletUrl `
@@ -345,9 +382,9 @@ $register = New-SorchaRegister `
     -Description "Digital Product Passports for verifiably-sustainable timber batches" `
     -TenantId $fcOrgId `
     -OwnerUserId $fcAdminSession.UserId `
-    -OwnerWalletAddress $auditorWallet.Address `
+    -OwnerWalletAddress $fcAdminWallet.Address `
     -Headers $fcAdminSession.Headers `
-    -WalletSignerHeaders $auditorUser.Headers `
+    -WalletSignerHeaders $fcAdminSession.Headers `
     -TenantUrl $sorchaEnv.TenantUrl `
     -DevMode
 Write-WtSuccess "Register: $($register.RegisterId)"

--- a/walkthroughs/TradeFinance/run.ps1
+++ b/walkthroughs/TradeFinance/run.ps1
@@ -158,6 +158,16 @@ function Invoke-BlueprintScenario {
         $senderToken = $participantTokens[$sender]
         $actionDataObj = $ActionData."$actionId"
 
+        # Feature 145: submission is single-async — the previous action's /execute returned 202 and
+        # the instance advances only when the InstanceProjector folds the sealed docket. Gate each
+        # subsequent action on the projection surfacing it as current, else we race the projector and
+        # get a 400 ("Action N is not a current action"). See walkthrough-builder skill, Cadence.
+        if ($actionId -ne $ExpectedPath[0]) {
+            Wait-SorchaActorReady -Mode AwaitingInbox `
+                -InstanceId $instanceId -ActionId ([int]$actionId) -RegisterId $RegisterId `
+                -Headers @{ Authorization = "Bearer $senderToken" } -GatewayUrl $env.GatewayUrl
+        }
+
         # Convert PSObject to hashtable
         $payloadData = @{}
         if ($actionDataObj) {
@@ -263,6 +273,14 @@ function Invoke-DisputedProcurement {
         $senderWallet = $wallets[$sender]
         $senderToken = $participantTokens[$sender]
         $actionDataObj = $ActionData."$actionId"
+
+        # Feature 145: gate each subsequent action on the projector surfacing it as current (the
+        # async-submit cadence) — otherwise we race the projector and get a 400. See run loop above.
+        if ($actionId -ne 1) {
+            Wait-SorchaActorReady -Mode AwaitingInbox `
+                -InstanceId $instanceId -ActionId ([int]$actionId) -RegisterId $RegisterId `
+                -Headers @{ Authorization = "Bearer $senderToken" } -GatewayUrl $env.GatewayUrl
+        }
 
         $payloadData = @{}
         if ($actionDataObj) {

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -332,6 +332,47 @@ foreach ($org in $selectedOrgs) {
 }
 
 # ============================================================================
+# Step 3b: Org-admin wallets (register owners + blueprint publishers)
+# ============================================================================
+# A register must NOT be owned by a Consumer participant. The owner + publisher must be an
+# Administrator (CanPublishBlueprints policy) AND hold the register's governance-roster wallet
+# (F142 PublishGate matches the caller's wallet_address against the roster owner wallet-DID). The
+# org admin holds Administrator; give it a wallet + participant so it can own its register, then
+# re-login so the JWT carries wallet_address (minted from the first linked wallet at login).
+# See walkthrough-builder skill, "re-login any session AFTER its wallet is created".
+Write-WtStep "Step 3b: Org-admin wallets (register owners)"
+
+foreach ($org in $selectedOrgs) {
+    $subdomain = $org.subdomain
+    $ctx = $orgContexts[$subdomain]
+
+    $adminWallet = New-SorchaWallet `
+        -WalletUrl $env.WalletUrl `
+        -Name "$($org.name) Admin" `
+        -Headers $ctx.Headers `
+        -FetchPublicKey
+    try {
+        $null = Register-SorchaParticipant `
+            -TenantUrl $env.TenantUrl `
+            -WalletUrl $env.WalletUrl `
+            -OrganizationId $ctx.OrganizationId `
+            -WalletAddress $adminWallet.Address `
+            -DisplayName "$($org.name) Admin" `
+            -Headers $ctx.Headers
+    } catch { Write-WtInfo "  admin participant for $subdomain already registered" }
+
+    $adminRelogin = Connect-SorchaUser `
+        -TenantUrl $env.TenantUrl `
+        -Email "admin@$subdomain.sorcha.dev" `
+        -Password (Get-AdminPassword -OrgSubdomain $subdomain) `
+        -OrganizationId $ctx.OrganizationId
+    $ctx.Headers = $adminRelogin.Headers
+    $ctx.AdminToken = $adminRelogin.Token
+    $ctx.AdminWallet = $adminWallet.Address
+    Write-WtInfo "  $subdomain admin wallet (register owner): $($adminWallet.Address)"
+}
+
+# ============================================================================
 # Step 4: Create Registers
 # ============================================================================
 
@@ -355,15 +396,12 @@ foreach ($regDef in $config.registers) {
     }
 
     $ctx = $orgContexts[$ownerSubdomain]
-    $ownerOrg = $selectedOrgs | Where-Object { $_.subdomain -eq $ownerSubdomain } | Select-Object -First 1
-    $firstParticipant = $ownerOrg.participants[0]
-    $ownerWalletAddress = $state.wallets[$firstParticipant.id]
-    # Initiate/finalize run as the org admin (org-level operation), but the
-    # `/v1/wallets/{addr}/sign` call inside the function is delegated to the
-    # wallet-owner participant — pass their headers via WalletSignerHeaders.
-    $walletOwner = $state.roles[$firstParticipant.id]
+    # Register owner = the org ADMIN's wallet (Administrator + roster owner), NOT a Consumer
+    # participant. Both -Headers and -WalletSignerHeaders are the (re-logged) admin, who owns
+    # $ctx.AdminWallet, so the owner attestation is signed by the wallet it names.
+    $ownerWalletAddress = $ctx.AdminWallet
 
-    Write-WtInfo "  Creating register '$($regDef.name)' (owner: $ownerSubdomain/$($firstParticipant.id))..."
+    Write-WtInfo "  Creating register '$($regDef.name)' (owner: $ownerSubdomain admin)..."
 
     $register = New-SorchaRegister `
         -RegisterUrl $env.RegisterUrl `
@@ -374,7 +412,7 @@ foreach ($regDef in $config.registers) {
         -OwnerUserId $ctx.AdminUserId `
         -OwnerWalletAddress $ownerWalletAddress `
         -Headers $ctx.Headers `
-        -WalletSignerHeaders $walletOwner.participantHeaders `
+        -WalletSignerHeaders $ctx.Headers `
         -DevMode `
         -Metadata @{ createdBy = "TradeFinance/setup.ps1"; registerType = $regDef.ownerOrg }
 
@@ -441,6 +479,33 @@ foreach ($regDef in $config.registers) {
     $ctx = $orgContexts[$ownerSubdomain]
     $registerId = $state.registers[$regShortName].id
 
+    # Re-login the owner admin FRESH right here so the publish token definitely carries the
+    # wallet_address claim (F142 PublishGate matches it against the register's roster owner). The
+    # owner admin holds Administrator (CanPublishBlueprints) and owns the register wallet (Step 3b),
+    # so a fresh token clears both gates. Done inline rather than reusing a step-old session token.
+    $publisher = Connect-SorchaUser `
+        -TenantUrl $env.TenantUrl `
+        -Email "admin@$ownerSubdomain.sorcha.dev" `
+        -Password (Get-AdminPassword -OrgSubdomain $ownerSubdomain) `
+        -OrganizationId $ctx.OrganizationId
+    # The register's genesis control tx — which records the owner governance roster — seals
+    # asynchronously AFTER New-SorchaRegister returns. The F142 publish gate reads that roster and
+    # fail-closes with a 403 ("no publish-governance role") when it isn't recorded yet. Wait for the
+    # roster to populate before publishing (the register-genesis analogue of the F145 action-seal
+    # cadence). Unlike ConstructionPermit/Forestry there are no intervening on-register steps here,
+    # so the publish would otherwise race the seal.
+    $rosterReady = $false
+    for ($i = 0; $i -lt 30; $i++) {
+        try {
+            $roster = Invoke-SorchaApi -Method GET `
+                -Uri "$($env.RegisterUrl)/registers/$registerId/governance/roster" `
+                -Headers $publisher.Headers
+            if ($roster.members -and $roster.members.Count -gt 0) { $rosterReady = $true; break }
+        } catch { }
+        Start-Sleep -Seconds 1
+    }
+    if (-not $rosterReady) { Write-WtWarn "  register $registerId governance roster not populated after 30s" }
+
     # Build wallet map from all participants across all selected orgs.
     # Publish-SorchaBlueprint auto-skips any participant that is the sender
     # of an open starting action (isStartingAction: true), so we don't need
@@ -456,7 +521,7 @@ foreach ($regDef in $config.registers) {
         -BlueprintUrl $env.BlueprintUrl `
         -TemplatePath $templatePath `
         -WalletMap $walletMap `
-        -Headers $ctx.Headers `
+        -Headers $publisher.Headers `
         -IdPrefix "trade-$bpShortName" `
         -RegisterId $registerId
 

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -1517,6 +1517,41 @@ function Publish-SorchaBlueprint {
 # T016: Invoke-SorchaAction — Execute or Reject an Action
 # ============================================================================
 
+# Feature 145 cadence: action submission is single-async — the previous action's /execute returns
+# 202 and the instance only advances once the InstanceProjector folds the sealed docket (a beat
+# later). A script that submits the next action immediately races the projector and gets a transient
+# 400 "Action N is not a current action for instance". Rather than make every walkthrough gate each
+# actor switch on AwaitingInbox, this wraps the submit POST and retries ONLY that transient error
+# (bounded), so the cadence self-heals everywhere. Any other error (schema 400, auth, etc.) is
+# rethrown immediately.
+function Invoke-SorchaActionPostWithCadenceRetry {
+    param(
+        [string]$Method,
+        [string]$Uri,
+        [hashtable]$Body,
+        [hashtable]$Headers,
+        [string]$ActionId,
+        [int]$MaxAttempts = 15,
+        [int]$DelaySeconds = 1
+    )
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            return Invoke-SorchaApi -Method $Method -Uri $Uri -Body $Body -Headers $Headers
+        } catch {
+            $errBody = $null
+            try { $errBody = Get-SorchaErrorBody -Exception $_.Exception } catch {}
+            if ($attempt -lt $MaxAttempts -and $errBody -and ($errBody -match 'not a current action')) {
+                if ($attempt -eq 1) {
+                    Write-WtInfo "  Action $ActionId not yet current (projector folding) — waiting…"
+                }
+                Start-Sleep -Seconds $DelaySeconds
+                continue
+            }
+            throw
+        }
+    }
+}
+
 function Invoke-SorchaAction {
     <#
     .SYNOPSIS
@@ -1578,10 +1613,11 @@ function Invoke-SorchaAction {
             registerAddress = $RegisterId
         }
 
-        $response = Invoke-SorchaApi -Method POST `
+        $response = Invoke-SorchaActionPostWithCadenceRetry -Method POST `
             -Uri "$BlueprintUrl/instances/$InstanceId/actions/$ActionId/reject" `
             -Body $rejectBody `
-            -Headers $executeHeaders
+            -Headers $executeHeaders `
+            -ActionId $ActionId
 
         Write-WtSuccess "Action $ActionId REJECTED"
 
@@ -1610,10 +1646,11 @@ function Invoke-SorchaAction {
             $actionBody.credentialPresentations = @($CredentialPresentations)
         }
 
-        $response = Invoke-SorchaApi -Method POST `
+        $response = Invoke-SorchaActionPostWithCadenceRetry -Method POST `
             -Uri "$BlueprintUrl/instances/$InstanceId/actions/$ActionId/execute" `
             -Body $actionBody `
-            -Headers $executeHeaders
+            -Headers $executeHeaders `
+            -ActionId $ActionId
 
         $nextAction = if ($response.nextAction) { $response.nextAction } else { "complete" }
         Write-WtSuccess "Action $ActionId executed (next: $nextAction)"


### PR DESCRIPTION
Continues the walkthrough regression sweep (clean local docker). Four more **pre-existing** failure modes found + fixed — none caused by #908/#912/#919/#921.

## Fixes

1. **Register owner must be an Administrator, not a Consumer** (you flagged this). F142 publish requires the *same identity* to hold Administrator (`CanPublishBlueprints`) **and** own the register's roster wallet. ForestryCertification + TradeFinance owned registers with a Consumer participant's wallet → permanent 403. Ownership + publishing switched to the org admin (wallet + participant + re-login); workflow participants stay separate.

2. **Publish races the register-genesis seal.** The roster the F142 gate reads seals *asynchronously* after `New-SorchaRegister` returns; an immediate publish reads an empty roster and fail-closes 403. TradeFinance now polls `GET /api/registers/{id}/governance/roster` until populated before publishing.

3. **F145 cadence centralised.** `Invoke-SorchaAction` now retries *only* the transient `400 "Action N is not a current action"` (projector hasn't folded the prior seal) up to 15×1s, self-healing the async-submit cadence at every action site. Non-cadence 400s rethrow immediately. Explicit `AwaitingInbox` gates kept as belt-and-braces.

4. **Idempotency for cross-walkthrough shared orgs.** Forestry shares `highland-timber` with TradeFinance by design; `New-ParticipantUserSession` now reuses an existing org-scoped user on a 400/409 duplicate instead of throwing.

## Verified (clean local docker)

- **ConstructionPermit 3/3**, **FormCoverage 5/5**, **PayloadTests** actions, **ForestryCertification** golden-path — PASS.
- **TradeFinance**: setup publishes both blueprints + **Procurement phase APPROVED (6/6)** (was totally broken at publish).

## Remaining (documented in the skill, deeper/walkthrough-specific)

- TradeFinance **Finance phase** — cross-register credential *presentation/verification* 400 (F093/F135), separate from these patterns.
- SelfBuildHouse — multi-org public-user operator provisioning needs the org-scoped-operator rework.

No server-side changes. Skill updated with all four patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)