### PR TITLE
fix(validator): schema-validate the union of all disclosed payload views

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/ValidationEngine.cs
@@ -573,14 +573,41 @@ public class ValidationEngine : IValidationEngine
                 transaction.Payload.TryGetProperty("payloads", out var payloadsElement) &&
                 payloadsElement.ValueKind == JsonValueKind.Object)
             {
-                // Use the first disclosed payload (all should conform to the schema)
-                using var enumerator = payloadsElement.EnumerateObject();
-                if (enumerator.MoveNext())
+                // Merge ALL disclosed payload views into a single union before schema
+                // validation. Each entry in `payloads` is one recipient's disclosure-
+                // filtered view of the action data. With field-level disclosures (e.g. a
+                // required "evaluationNotes" field disclosed only to the sender via "/*",
+                // while other recipients see only "/advancePercentage" + "/feeRate"), no
+                // single recipient view is guaranteed to contain every required field. The
+                // union of all views is the complete payload the submitter provided, which
+                // is what the schema's `required` constraint applies to. Validating only the
+                // first view (the previous behaviour) spuriously failed VAL_SCHEMA_004 when
+                // the first-enumerated recipient had a narrower disclosure than the schema's
+                // required set. Overlapping fields carry identical values across views, so
+                // first-writer-wins is safe.
+                var merged = new JsonObject();
+                var viewCount = 0;
+                foreach (var recipient in payloadsElement.EnumerateObject())
                 {
-                    payloadToValidate = enumerator.Current.Value;
-                    _logger.LogDebug(
-                        "Extracted user payload from envelope for schema validation");
+                    if (recipient.Value.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    viewCount++;
+                    foreach (var field in recipient.Value.EnumerateObject())
+                    {
+                        if (!merged.ContainsKey(field.Name))
+                        {
+                            merged[field.Name] = JsonNode.Parse(field.Value.GetRawText());
+                        }
+                    }
                 }
+
+                payloadToValidate = JsonSerializer.SerializeToElement(merged);
+                _logger.LogDebug(
+                    "Merged {ViewCount} disclosed payload view(s) into a union for schema validation",
+                    viewCount);
             }
 
             // Evaluate payload against all schemas (payload must pass ALL schemas)

--- a/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/ValidationEngineTests.cs
@@ -823,6 +823,65 @@ public class ValidationEngineTests
     }
 
     [Fact]
+    public async Task ValidateSchemaAsync_FieldLevelDisclosures_MergesAllViews_Passes()
+    {
+        // Arrange — a plaintext envelope carrying one disclosure-filtered view per
+        // recipient. With field-level disclosures the FIRST-enumerated view is narrower
+        // than the schema's required set: "amount" is disclosed to everyone but the
+        // required "name" is disclosed only to the second recipient. The complete
+        // submitted payload is the union of all views and DOES satisfy the schema.
+        // Regression for VAL_SCHEMA_004 spuriously firing when the validator validated
+        // only the first disclosed view (TradeFinance "evaluationNotes" disclosed to the
+        // sender only).
+        var envelope = """
+        {
+            "payloads": {
+                "ws-narrow-recipient": { "amount": 100 },
+                "ws-full-recipient":   { "name": "Alice", "amount": 100 }
+            }
+        }
+        """;
+        var tx = CreateValidTransaction(payloadJson: envelope);
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+
+        // Act
+        var result = await _engine.ValidateSchemaAsync(tx);
+
+        // Assert
+        result.IsValid.Should().BeTrue(
+            "the union of all disclosed views contains every required field");
+    }
+
+    [Fact]
+    public async Task ValidateSchemaAsync_FieldLevelDisclosures_RequiredFieldInNoView_StillFails()
+    {
+        // Arrange — guard that merging views does not silently disable required checks:
+        // if a required field ("name") appears in NO disclosed view, the union is still
+        // missing it and schema validation must fail.
+        var envelope = """
+        {
+            "payloads": {
+                "ws-recipient-a": { "amount": 100 },
+                "ws-recipient-b": { "amount": 100 }
+            }
+        }
+        """;
+        var tx = CreateValidTransaction(payloadJson: envelope);
+        var blueprint = CreateTestBlueprintWithSchema(tx.BlueprintId!);
+        _blueprintCacheMock.Setup(c => c.GetBlueprintAsync(tx.BlueprintId!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(blueprint);
+
+        // Act
+        var result = await _engine.ValidateSchemaAsync(tx);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Code == "VAL_SCHEMA_004");
+    }
+
+    [Fact]
     public async Task ValidateSchemaAsync_WrongType_ReturnsSchemaError()
     {
         // Arrange - amount is string instead of number


### PR DESCRIPTION
## Problem

The validator's plaintext (DevMode) schema-validation path extracted only the **first** disclosed payload view from a transaction's `payloads` envelope and validated that single view against the action's data schema, on the assumption "all should conform to the schema".

That assumption breaks under **field-level selective disclosure**. When an action discloses a required field to a narrower audience than the schema's `required` set — e.g. a required `evaluationNotes` disclosed only to one participant (`/*`) while other recipients see a two-field subset (`/advancePercentage`, `/feeRate`) — the first-enumerated recipient view is missing required fields and validation fails `VAL_SCHEMA_004: Required properties [...] not present`, even though the **complete submitted payload** (the union of all per-recipient views) satisfies the schema.

This was hit live by the TradeFinance walkthrough's Invoice-Finance "Evaluate Application" action.

## Fix

Merge **all** disclosed views into a single union object before evaluating it against the schema. Overlapping fields carry identical values across views (same source payload), so first-writer-wins is safe.

- A required field present in **no** view still fails — required-field enforcement is not weakened (covered by a guard test).
- The **encrypted** path is unchanged: it already skips schema validation (the Blueprint Service validates payloads against schemas before encryption).
- Behaviour is identical for `/*`-to-all-recipients disclosures (union == any single view).

## Tests

- `ValidateSchemaAsync_FieldLevelDisclosures_MergesAllViews_Passes` — a required field present only in a later view now validates.
- `ValidateSchemaAsync_FieldLevelDisclosures_RequiredFieldInNoView_StillFails` — guards that the merge does not disable required checks.

Full `Sorcha.Validator.Service.Tests` suite green (986 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)