### PR TITLE
chore(walkthroughs): TradeFinance + SelfBuildHouse green end-to-end (master keys, disclosure, F145 cadence)

### DIFF
--- a/demos/AssuredIdentity/analyst.rules.json
+++ b/demos/AssuredIdentity/analyst.rules.json
@@ -1,0 +1,33 @@
+{
+  "actor": {
+    "name": "verification-analyst",
+    "description": "Deterministic identity-validator agent — auto-approves Assured Identity applications (demo rules mode)."
+  },
+  "connection": {
+    "gatewayUrl": "http://tiny:8090",
+    "registerId": "4148b7d7573540c5af2d13fde5d2feb2",
+    "credentials": {
+      "email": "$env:AGENT_EMAIL",
+      "password": "$env:AGENT_PASSWORD",
+      "organizationId": "ed5f735a-cf12-4267-a305-9d8919a4c9bd"
+    },
+    "walletAddress": "ws11qq9g4qyz8m9uqla925h3xv6ks75tvw3m69j7sft33x494ycty83fw54dj3z"
+  },
+  "inbox": {
+    "signalR": { "enabled": true },
+    "polling": { "enabled": true, "intervalSeconds": 15 }
+  },
+  "mode": "rules",
+  "rules": [
+    {
+      "actionName": "Verify Assured Identity Application",
+      "condition": { "==": [true, true] },
+      "decision": "approve",
+      "payload": {
+        "decision": "approved",
+        "verificationNotes": "Auto-approved by the demo identity-validator agent (rules mode)."
+      }
+    }
+  ]
+}
+

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Sorcha Contributors
+#
+# LOCAL DEV ONLY — never deploy this override.
+#
+# Relaxes the validator's genesis freshness window so a clean local start can ingest the
+# embedded genesis even when it was minted more than the default 1h ago (avoids a full
+# re-mint + image rebuild just to stand up a local regression environment). The 1h
+# GenesisMaxAge is a replay guard for real networks; on an isolated localhost stack it only
+# blocks bootstrap. See network-bootstrap skill ("Genesis freshness window").
+services:
+  validator-service:
+    environment:
+      ValidationEngine__GenesisMaxAge: "30.00:00:00"

--- a/walkthroughs/ForestryCertification/setup.ps1
+++ b/walkthroughs/ForestryCertification/setup.ps1
@@ -218,6 +218,12 @@ $fcAdminSession = Connect-SorchaUser `
     -Password $fcAdminPassword `
     -OrganizationId $fcOrgId
 
+# Provision the FC org's Feature 083 master key so its Feature 120 VC-issuance key can derive —
+# the ForestProductDPPCredential it issues must be cross-register-verifiable (TradeFinance's
+# Finance phase presents it). Without it the credential signs with the bare wallet key and fails
+# the TrustEvaluator ("issuer signature not verified"). Idempotent. See walkthrough-builder skill.
+Set-SorchaOrgMasterKey -WalletUrl $sorchaEnv.WalletUrl -OrganizationId $fcOrgId -Headers $fcAdminSession.Headers
+
 $auditorUser = New-ParticipantUserSession `
     -ParticipantId "auditor" `
     -DisplayName "Forestry Auditor" `

--- a/walkthroughs/SelfBuildHouse/run.ps1
+++ b/walkthroughs/SelfBuildHouse/run.ps1
@@ -148,6 +148,17 @@ function Invoke-BlueprintScenario {
         # register.
         $senderToken = $roleTokenCache[$sender]
 
+        # Feature 145: submission is single-async — the previous action's /execute returned 202 and
+        # the instance advances only when the InstanceProjector folds the sealed docket. Gate each
+        # subsequent action on the projection surfacing it as current, else we race the projector and
+        # get a 400 ("Action N is not a current action"). See walkthrough-builder skill, Cadence.
+        if ($actionId -ne $ExpectedPath[0]) {
+            Wait-SorchaActorReady -Mode AwaitingInbox `
+                -InstanceId $instanceId -ActionId ([int]$actionId) -RegisterId $RegisterId `
+                -Headers @{ Authorization = "Bearer $senderToken" } `
+                -GatewayUrl ($state.blueprintUrl -replace '/api$', '')
+        }
+
         try {
             if ($isRejectionAction) {
                 $null = Invoke-SorchaAction `

--- a/walkthroughs/SelfBuildHouse/setup.ps1
+++ b/walkthroughs/SelfBuildHouse/setup.ps1
@@ -326,7 +326,36 @@ foreach ($orgKey in $privateOrgKeys) {
 # ============================================================================
 Write-WtStep "Step 10: Publish Blueprints (2)"
 
+# Both registers ISSUE credentials (planning permission, building warrant) that are later
+# presented across registers. Provision each issuing org's Feature 083 HD master key so the
+# F120 kid-swap signs with the org issuance key (iss=did:sorcha:org:..., kid=...#vc-issuance-N);
+# without it the credentials are signed with the bare wallet key and fail the engine
+# TrustEvaluator ("issuer signature not verified") on presentation. Idempotent (silent on 409).
+Set-SorchaOrgMasterKey -WalletUrl $env.WalletUrl `
+    -OrganizationId $users["planning-officer"].organizationId -Headers $planningSession.Headers
+Set-SorchaOrgMasterKey -WalletUrl $env.WalletUrl `
+    -OrganizationId $users["building-standards-officer"].organizationId -Headers $bsSession.Headers
+
+# The register's genesis control tx — which records the owner governance roster — seals
+# asynchronously AFTER New-SorchaRegister returns. The F142 publish gate reads that roster and
+# fail-closes with a 403 ("no publish-governance role") when it isn't recorded yet. Wait for each
+# register's roster to populate before publishing its blueprint (the register-genesis analogue of
+# the F145 action-seal cadence).
+function Wait-RegisterRosterReady($registerId, $headers) {
+    for ($i = 0; $i -lt 30; $i++) {
+        try {
+            $roster = Invoke-SorchaApi -Method GET `
+                -Uri "$($env.RegisterUrl)/registers/$registerId/governance/roster" -Headers $headers
+            if ($roster.members -and $roster.members.Count -gt 0) { return $true }
+        } catch { }
+        Start-Sleep -Seconds 1
+    }
+    Write-WtWarn "  register $registerId governance roster not populated after 30s"
+    return $false
+}
+
 Write-WtInfo "  Publishing Planning Permission blueprint..."
+$null = Wait-RegisterRosterReady $planningRegister.RegisterId $planningSession.Headers
 $planningBlueprint = Publish-SorchaBlueprint `
     -BlueprintUrl $env.BlueprintUrl `
     -TemplatePath (Join-Path $scriptDir "planning-permission-template.json") `
@@ -337,6 +366,7 @@ $planningBlueprint = Publish-SorchaBlueprint `
 Write-WtSuccess "  Planning Blueprint: $($planningBlueprint.BlueprintId)"
 
 Write-WtInfo "  Publishing Building Warrant blueprint..."
+$null = Wait-RegisterRosterReady $buildingRegister.RegisterId $bsSession.Headers
 $warrantBlueprint = Publish-SorchaBlueprint `
     -BlueprintUrl $env.BlueprintUrl `
     -TemplatePath (Join-Path $scriptDir "building-warrant-template.json") `

--- a/walkthroughs/TradeFinance/data/scenario-declined.json
+++ b/walkthroughs/TradeFinance/data/scenario-declined.json
@@ -1,12 +1,24 @@
 {
   "name": "Scenario C: Declined Finance",
-  "description": "Procurement-to-pay completes normally (approved invoice, VC issued). Finance flow initiated but buyer has low credit score (35/100) — financing declined by funder.",
-  "expectedProcurementPath": [1, 2, 3, 4, 5, 6],
-  "expectedFinancePath": [1, 2, 3, 4],
+  "description": "Procurement-to-pay completes normally (approved invoice, VC issued). Finance flow initiated but buyer has low credit score (35/100)  -  financing declined by funder.",
+  "expectedProcurementPath": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+  ],
+  "expectedFinancePath": [
+    1,
+    2,
+    3,
+    4
+  ],
   "expectedDispute": false,
   "expectedRejection": true,
-  "rejectionReason": "Buyer credit score 35/100 — below minimum threshold of 50. Financing declined.",
-  "expectedInvoiceTotal": 5916.00,
+  "rejectionReason": "Buyer credit score 35/100  -  below minimum threshold of 50. Financing declined.",
+  "expectedInvoiceTotal": 5916.0,
   "expectedDaysSinceDelivery": 2,
   "procurement": {
     "1": {
@@ -14,9 +26,24 @@
       "projectName": "Loch Ness View Cottages",
       "siteAddress": "Plot 3, Drumnadrochit Road, Drumnadrochit IV63 6TX",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x150mm", "quantity": 200, "unit": "linear metre", "unitPrice": 7.20 },
-        { "description": "Roofing Battens 25x50mm", "quantity": 150, "unit": "linear metre", "unitPrice": 3.80 },
-        { "description": "DPC Membrane 4m wide", "quantity": 50, "unit": "linear metre", "unitPrice": 12.50 }
+        {
+          "description": "Treated Structural Timber 47x150mm",
+          "quantity": 200,
+          "unit": "linear metre",
+          "unitPrice": 7.2
+        },
+        {
+          "description": "Roofing Battens 25x50mm",
+          "quantity": 150,
+          "unit": "linear metre",
+          "unitPrice": 3.8
+        },
+        {
+          "description": "DPC Membrane 4m wide",
+          "quantity": 50,
+          "unit": "linear metre",
+          "unitPrice": 12.5
+        }
       ],
       "deliveryAddress": "Site Entrance, Drumnadrochit Road, Drumnadrochit IV63 6TX",
       "paymentTerms": "Net 30",
@@ -32,11 +59,20 @@
       "deliveryNoteRef": "HTS-DN-2026-1206",
       "actualDeliveryDate": "2026-04-24",
       "deliveredItems": [
-        { "description": "Treated Structural Timber 47x150mm", "quantityDelivered": 200 },
-        { "description": "Roofing Battens 25x50mm", "quantityDelivered": 150 },
-        { "description": "DPC Membrane 4m wide", "quantityDelivered": 50 }
+        {
+          "description": "Treated Structural Timber 47x150mm",
+          "quantityDelivered": 200
+        },
+        {
+          "description": "Roofing Battens 25x50mm",
+          "quantityDelivered": 150
+        },
+        {
+          "description": "DPC Membrane 4m wide",
+          "quantityDelivered": 50
+        }
       ],
-      "deliveryCondition": "Good — all items as ordered"
+      "deliveryCondition": "Good  -  all items as ordered"
     },
     "4": {
       "grnReference": "LOCH-GRN-2026-00088",
@@ -48,40 +84,56 @@
       "invoiceNumber": "HTS-INV-2026-03849",
       "invoiceDate": "2026-04-26",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x150mm", "quantity": 200, "unitPrice": 7.20, "lineTotal": 1440.00 },
-        { "description": "Roofing Battens 25x50mm", "quantity": 150, "unitPrice": 3.80, "lineTotal": 570.00 },
-        { "description": "DPC Membrane 4m wide", "quantity": 50, "unitPrice": 12.50, "lineTotal": 625.00 }
+        {
+          "description": "Treated Structural Timber 47x150mm",
+          "quantity": 200,
+          "unitPrice": 7.2,
+          "lineTotal": 1440.0
+        },
+        {
+          "description": "Roofing Battens 25x50mm",
+          "quantity": 150,
+          "unitPrice": 3.8,
+          "lineTotal": 570.0
+        },
+        {
+          "description": "DPC Membrane 4m wide",
+          "quantity": 50,
+          "unitPrice": 12.5,
+          "lineTotal": 625.0
+        }
       ],
-      "subtotal": 2635.00,
-      "vatRate": 0.20,
-      "vatAmount": 527.00,
-      "invoiceTotal": 3162.00,
+      "subtotal": 2635.0,
+      "vatRate": 0.2,
+      "vatAmount": 527.0,
+      "invoiceTotal": 3162.0,
       "paymentTerms": "Net 30",
       "paymentDueDate": "2026-05-26",
       "supplierCostBreakdown": {
-        "materialCost": 1850.00,
-        "logistics": 320.00,
-        "margin": 465.00,
+        "materialCost": 1850.0,
+        "logistics": 320.0,
+        "margin": 465.0,
         "marginPercentage": 17.6
       }
     },
     "6": {
       "decision": "approve",
       "approvalNotes": "Invoice matches PO and GRN. Approved for payment.",
-      "approvedAmount": 3162.00
+      "approvedAmount": 3162.0,
+      "poReference": "PO-LOCH-2026-00087"
     }
   },
   "finance": {
     "1": {
       "invoiceReference": "HTS-INV-2026-03849",
-      "invoiceAmount": 3162.00,
+      "invoiceAmount": 3162.0,
       "buyerName": "Lochside Developments Ltd",
       "requestedAdvancePercentage": 85,
       "urgency": "express"
     },
     "2": {
       "buyerCreditScore": 35,
-      "creditLimit": 25000.00,
+      "creditLimit": 25000.0,
       "riskRating": "high",
       "assessmentDate": "2026-04-26",
       "paymentHistoryScore": 41,
@@ -89,13 +141,13 @@
       "assessmentNotes": "Recent CCJ. Multiple late payments. Limited trading history."
     },
     "3": {
-      "evaluationNotes": "Buyer credit score 35/100 — below minimum threshold of 50. High risk rating. Recommendation: DECLINE.",
+      "evaluationNotes": "Buyer credit score 35/100  -  below minimum threshold of 50. High risk rating. Recommendation: DECLINE.",
       "advancePercentage": 0,
       "feeRate": 0
     },
     "4": {
       "decision": "decline",
-      "declineReason": "Buyer credit score 35/100 — below minimum threshold of 50. Recent CCJ and limited trading history present unacceptable risk."
+      "declineReason": "Buyer credit score 35/100  -  below minimum threshold of 50. Recent CCJ and limited trading history present unacceptable risk."
     }
   }
 }

--- a/walkthroughs/TradeFinance/data/scenario-disputed.json
+++ b/walkthroughs/TradeFinance/data/scenario-disputed.json
@@ -1,13 +1,25 @@
 {
   "name": "Scenario B: Disputed Invoice",
   "description": "Procurement-to-pay with invoice dispute. Buyer disputes first invoice (incorrect quantities), supplier resubmits with corrections, second submission approved. Finance flow proceeds normally.",
-  "expectedProcurementPath": [1, 2, 3, 4, 5, 6],
-  "expectedFinancePath": [1, 2, 3, 4],
+  "expectedProcurementPath": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+  ],
+  "expectedFinancePath": [
+    1,
+    2,
+    3,
+    4
+  ],
   "expectedDispute": true,
   "expectedRejection": false,
-  "expectedInvoiceTotal": 9548.00,
+  "expectedInvoiceTotal": 9548.0,
   "expectedDaysSinceDelivery": 3,
-  "expectedAdvanceAmount": 8593.20,
+  "expectedAdvanceAmount": 8593.2,
   "expectedFeeAmount": 214.83,
   "expectedNetAdvance": 8378.37,
   "procurement": {
@@ -16,9 +28,24 @@
       "projectName": "Grantown Affordable Housing Phase 1",
       "siteAddress": "Plots 1-8, Spey Valley Business Park, Grantown-on-Spey PH26 3HG",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantity": 400, "unit": "linear metre", "unitPrice": 8.50 },
-        { "description": "Plywood Sheathing 12mm", "quantity": 80, "unit": "sheet", "unitPrice": 28.00 },
-        { "description": "Joist Hangers Assorted", "quantity": 15, "unit": "box", "unitPrice": 38.00 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantity": 400,
+          "unit": "linear metre",
+          "unitPrice": 8.5
+        },
+        {
+          "description": "Plywood Sheathing 12mm",
+          "quantity": 80,
+          "unit": "sheet",
+          "unitPrice": 28.0
+        },
+        {
+          "description": "Joist Hangers Assorted",
+          "quantity": 15,
+          "unit": "box",
+          "unitPrice": 38.0
+        }
       ],
       "deliveryAddress": "Site Office, Spey Valley Business Park, Grantown-on-Spey PH26 3HG",
       "paymentTerms": "Net 30",
@@ -34,36 +61,60 @@
       "deliveryNoteRef": "HTS-DN-2026-1205",
       "actualDeliveryDate": "2026-04-19",
       "deliveredItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantityDelivered": 400 },
-        { "description": "Plywood Sheathing 12mm", "quantityDelivered": 80 },
-        { "description": "Joist Hangers Assorted", "quantityDelivered": 15 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantityDelivered": 400
+        },
+        {
+          "description": "Plywood Sheathing 12mm",
+          "quantityDelivered": 80
+        },
+        {
+          "description": "Joist Hangers Assorted",
+          "quantityDelivered": 15
+        }
       ],
-      "deliveryCondition": "Good — minor surface marks on 3 sheets plywood, acceptable"
+      "deliveryCondition": "Good  -  minor surface marks on 3 sheets plywood, acceptable"
     },
     "4": {
       "grnReference": "CAIRN-GRN-2026-00419",
       "receivedDate": "2026-04-19",
-      "conditionNotes": "All items received. 3 sheets plywood with surface marks — within tolerance.",
+      "conditionNotes": "All items received. 3 sheets plywood with surface marks  -  within tolerance.",
       "discrepancyFlag": false
     },
     "5": {
       "invoiceNumber": "HTS-INV-2026-03848",
       "invoiceDate": "2026-04-22",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantity": 450, "unitPrice": 8.50, "lineTotal": 3825.00 },
-        { "description": "Plywood Sheathing 12mm", "quantity": 80, "unitPrice": 28.00, "lineTotal": 2240.00 },
-        { "description": "Joist Hangers Assorted", "quantity": 15, "unitPrice": 38.00, "lineTotal": 570.00 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantity": 450,
+          "unitPrice": 8.5,
+          "lineTotal": 3825.0
+        },
+        {
+          "description": "Plywood Sheathing 12mm",
+          "quantity": 80,
+          "unitPrice": 28.0,
+          "lineTotal": 2240.0
+        },
+        {
+          "description": "Joist Hangers Assorted",
+          "quantity": 15,
+          "unitPrice": 38.0,
+          "lineTotal": 570.0
+        }
       ],
-      "subtotal": 6635.00,
-      "vatRate": 0.20,
-      "vatAmount": 1327.00,
-      "invoiceTotal": 7962.00,
+      "subtotal": 6635.0,
+      "vatRate": 0.2,
+      "vatAmount": 1327.0,
+      "invoiceTotal": 7962.0,
       "paymentTerms": "Net 30",
       "paymentDueDate": "2026-05-22",
       "supplierCostBreakdown": {
-        "materialCost": 4800.00,
-        "logistics": 420.00,
-        "margin": 1415.00,
+        "materialCost": 4800.0,
+        "logistics": 420.0,
+        "margin": 1415.0,
         "marginPercentage": 21.3
       }
     },
@@ -75,40 +126,56 @@
       "invoiceNumber": "HTS-INV-2026-03848-R1",
       "invoiceDate": "2026-04-22",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantity": 400, "unitPrice": 8.50, "lineTotal": 3400.00 },
-        { "description": "Plywood Sheathing 12mm", "quantity": 80, "unitPrice": 28.00, "lineTotal": 2240.00 },
-        { "description": "Joist Hangers Assorted", "quantity": 15, "unitPrice": 38.00, "lineTotal": 570.00 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantity": 400,
+          "unitPrice": 8.5,
+          "lineTotal": 3400.0
+        },
+        {
+          "description": "Plywood Sheathing 12mm",
+          "quantity": 80,
+          "unitPrice": 28.0,
+          "lineTotal": 2240.0
+        },
+        {
+          "description": "Joist Hangers Assorted",
+          "quantity": 15,
+          "unitPrice": 38.0,
+          "lineTotal": 570.0
+        }
       ],
-      "subtotal": 6210.00,
-      "vatRate": 0.20,
-      "vatAmount": 1242.00,
-      "invoiceTotal": 7452.00,
+      "subtotal": 6210.0,
+      "vatRate": 0.2,
+      "vatAmount": 1242.0,
+      "invoiceTotal": 7452.0,
       "paymentTerms": "Net 30",
       "paymentDueDate": "2026-05-22",
       "supplierCostBreakdown": {
-        "materialCost": 4375.00,
-        "logistics": 420.00,
-        "margin": 1415.00,
+        "materialCost": 4375.0,
+        "logistics": 420.0,
+        "margin": 1415.0,
         "marginPercentage": 22.8
       }
     },
     "6": {
       "decision": "approve",
       "approvalNotes": "Corrected invoice matches PO quantities. Approved for payment.",
-      "approvedAmount": 7452.00
+      "approvedAmount": 7452.0,
+      "poReference": "PO-CAIRN-2026-00143"
     }
   },
   "finance": {
     "1": {
       "invoiceReference": "HTS-INV-2026-03848-R1",
-      "invoiceAmount": 7452.00,
+      "invoiceAmount": 7452.0,
       "buyerName": "Cairngorm Construction Ltd",
       "requestedAdvancePercentage": 90,
       "urgency": "standard"
     },
     "2": {
       "buyerCreditScore": 85,
-      "creditLimit": 250000.00,
+      "creditLimit": 250000.0,
       "riskRating": "low",
       "assessmentDate": "2026-04-22",
       "paymentHistoryScore": 92,
@@ -116,13 +183,13 @@
       "assessmentNotes": "Strong payment history. No defaults. Established Highland contractor."
     },
     "3": {
-      "evaluationNotes": "Verified invoice credential confirmed (resubmitted invoice). Buyer credit score 85/100 — well above threshold.",
+      "evaluationNotes": "Verified invoice credential confirmed (resubmitted invoice). Buyer credit score 85/100  -  well above threshold.",
       "advancePercentage": 90,
       "feeRate": 2.5
     },
     "4": {
       "decision": "approve",
-      "advanceAmount": 6706.80,
+      "advanceAmount": 6706.8,
       "feeAmount": 167.67,
       "netAdvance": 6539.13,
       "repaymentTerms": "Net 30 from original invoice due date",

--- a/walkthroughs/TradeFinance/data/scenario-golden-path.json
+++ b/walkthroughs/TradeFinance/data/scenario-golden-path.json
@@ -1,11 +1,23 @@
 {
   "name": "Scenario A: Golden Path",
   "description": "Full procurement-to-pay with approved invoice financing. Highland Timber additionally presents a ForestProductDPPCredential (sustainability score 87) which triggers a +10% advance-rate uplift at evaluation, raising the effective advance from 90% to 99%.",
-  "expectedProcurementPath": [1, 2, 3, 4, 5, 6],
-  "expectedFinancePath": [1, 2, 3, 4],
+  "expectedProcurementPath": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+  ],
+  "expectedFinancePath": [
+    1,
+    2,
+    3,
+    4
+  ],
   "expectedDispute": false,
   "expectedRejection": false,
-  "expectedInvoiceTotal": 10248.00,
+  "expectedInvoiceTotal": 10248.0,
   "expectedDaysSinceDelivery": 3,
   "expectedSustainabilityUpliftApplied": true,
   "expectedEffectiveAdvancePercentage": 99,
@@ -18,9 +30,24 @@
       "projectName": "Aviemore Heights Phase 2",
       "siteAddress": "Plot 14-18, Craig na Gower Road, Aviemore PH22 1RN",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantity": 500, "unit": "linear metre", "unitPrice": 8.50 },
-        { "description": "OSB Sheathing Board 18mm", "quantity": 120, "unit": "sheet", "unitPrice": 32.00 },
-        { "description": "Timber Connectors Assorted", "quantity": 10, "unit": "box", "unitPrice": 45.00 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantity": 500,
+          "unit": "linear metre",
+          "unitPrice": 8.5
+        },
+        {
+          "description": "OSB Sheathing Board 18mm",
+          "quantity": 120,
+          "unit": "sheet",
+          "unitPrice": 32.0
+        },
+        {
+          "description": "Timber Connectors Assorted",
+          "quantity": 10,
+          "unit": "box",
+          "unitPrice": 45.0
+        }
       ],
       "deliveryAddress": "Site Compound, Craig na Gower Road, Aviemore PH22 1RN",
       "paymentTerms": "Net 30",
@@ -36,11 +63,20 @@
       "deliveryNoteRef": "HTS-DN-2026-1204",
       "actualDeliveryDate": "2026-04-14",
       "deliveredItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantityDelivered": 500 },
-        { "description": "OSB Sheathing Board 18mm", "quantityDelivered": 120 },
-        { "description": "Timber Connectors Assorted", "quantityDelivered": 10 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantityDelivered": 500
+        },
+        {
+          "description": "OSB Sheathing Board 18mm",
+          "quantityDelivered": 120
+        },
+        {
+          "description": "Timber Connectors Assorted",
+          "quantityDelivered": 10
+        }
       ],
-      "deliveryCondition": "Good — no damage noted"
+      "deliveryCondition": "Good  -  no damage noted"
     },
     "4": {
       "grnReference": "CAIRN-GRN-2026-00418",
@@ -52,33 +88,49 @@
       "invoiceNumber": "HTS-INV-2026-03847",
       "invoiceDate": "2026-04-17",
       "lineItems": [
-        { "description": "Treated Structural Timber 47x200mm", "quantity": 500, "unitPrice": 8.50, "lineTotal": 4250.00 },
-        { "description": "OSB Sheathing Board 18mm", "quantity": 120, "unitPrice": 32.00, "lineTotal": 3840.00 },
-        { "description": "Timber Connectors Assorted", "quantity": 10, "unitPrice": 45.00, "lineTotal": 450.00 }
+        {
+          "description": "Treated Structural Timber 47x200mm",
+          "quantity": 500,
+          "unitPrice": 8.5,
+          "lineTotal": 4250.0
+        },
+        {
+          "description": "OSB Sheathing Board 18mm",
+          "quantity": 120,
+          "unitPrice": 32.0,
+          "lineTotal": 3840.0
+        },
+        {
+          "description": "Timber Connectors Assorted",
+          "quantity": 10,
+          "unitPrice": 45.0,
+          "lineTotal": 450.0
+        }
       ],
-      "subtotal": 8540.00,
-      "vatRate": 0.20,
-      "vatAmount": 1708.00,
-      "invoiceTotal": 10248.00,
+      "subtotal": 8540.0,
+      "vatRate": 0.2,
+      "vatAmount": 1708.0,
+      "invoiceTotal": 10248.0,
       "paymentTerms": "Net 30",
       "paymentDueDate": "2026-05-17",
       "supplierCostBreakdown": {
-        "materialCost": 6200.00,
-        "logistics": 480.00,
-        "margin": 1860.00,
+        "materialCost": 6200.0,
+        "logistics": 480.0,
+        "margin": 1860.0,
         "marginPercentage": 21.8
       }
     },
     "6": {
       "decision": "approve",
       "approvalNotes": "Invoice matches PO and GRN. Approved for payment.",
-      "approvedAmount": 10248.00
+      "approvedAmount": 10248.0,
+      "poReference": "PO-CAIRN-2026-00142"
     }
   },
   "finance": {
     "1": {
       "invoiceReference": "HTS-INV-2026-03847",
-      "invoiceAmount": 10248.00,
+      "invoiceAmount": 10248.0,
       "buyerName": "Cairngorm Construction Ltd",
       "requestedAdvancePercentage": 90,
       "urgency": "standard",
@@ -86,7 +138,7 @@
     },
     "2": {
       "buyerCreditScore": 85,
-      "creditLimit": 250000.00,
+      "creditLimit": 250000.0,
       "riskRating": "low",
       "assessmentDate": "2026-04-17",
       "paymentHistoryScore": 92,
@@ -94,7 +146,7 @@
       "assessmentNotes": "Strong payment history. No defaults. Established Highland contractor."
     },
     "3": {
-      "evaluationNotes": "Verified invoice credential confirmed. Buyer credit score 85/100 — well above threshold. Invoice amount within credit limit. ForestProductDPPCredential present with sustainability score 87/100 — preferential 10% advance-rate uplift applied (effective advance 99%).",
+      "evaluationNotes": "Verified invoice credential confirmed. Buyer credit score 85/100  -  well above threshold. Invoice amount within credit limit. ForestProductDPPCredential present with sustainability score 87/100  -  preferential 10% advance-rate uplift applied (effective advance 99%).",
       "advancePercentage": 90,
       "feeRate": 2.5
     },
@@ -103,7 +155,7 @@
       "advanceAmount": 10145.52,
       "feeAmount": 253.638,
       "netAdvance": 9891.882,
-      "repaymentTerms": "Net 30 from original invoice due date — preferential terms reflect verified sustainable sourcing.",
+      "repaymentTerms": "Net 30 from original invoice due date  -  preferential terms reflect verified sustainable sourcing.",
       "repaymentDate": "2026-05-17",
       "financingReference": "STF-FIN-2026-00291"
     }

--- a/walkthroughs/TradeFinance/invoice-finance-template.json
+++ b/walkthroughs/TradeFinance/invoice-finance-template.json
@@ -416,7 +416,7 @@
           },
           {
             "participantAddress": "finance-director",
-            "dataPointers": ["/advancePercentage", "/feeRate"]
+            "dataPointers": ["/evaluationNotes", "/advancePercentage", "/feeRate"]
           }
         ],
         "routes": [

--- a/walkthroughs/TradeFinance/procurement-to-pay-template.json
+++ b/walkthroughs/TradeFinance/procurement-to-pay-template.json
@@ -946,6 +946,12 @@
                 "type": "string",
                 "title": "Dispute Reason",
                 "maxLength": 1000
+              },
+              "poReference": {
+                "type": "string",
+                "title": "PO Reference",
+                "description": "The purchase-order reference being approved — confirmed by the approver and carried into the VerifiedInvoiceCredential (the issuing action's payload is the reliable claim-mapping source; cross-action state is not guaranteed to reach this action).",
+                "maxLength": 50
               }
             },
             "required": ["decision"]

--- a/walkthroughs/TradeFinance/run.ps1
+++ b/walkthroughs/TradeFinance/run.ps1
@@ -318,6 +318,14 @@ function Invoke-DisputedProcurement {
     $sender = $procurementSenderMap[6]
     $senderWallet = $wallets[$sender]
     $senderToken = $participantTokens[$sender]
+
+    # Feature 145: action 5 (last in the loop above) advances to action 6 only once the projector
+    # folds its sealed docket. Gate on AwaitingInbox before the dispute, else we race the projector
+    # and get a 400 ("Action 6 is not a current action").
+    Wait-SorchaActorReady -Mode AwaitingInbox `
+        -InstanceId $instanceId -ActionId 6 -RegisterId $RegisterId `
+        -Headers @{ Authorization = "Bearer $senderToken" } -GatewayUrl $env.GatewayUrl
+
     try {
         $disputeData = $ActionData."6_dispute"
         $payloadData = @{}
@@ -351,6 +359,14 @@ function Invoke-DisputedProcurement {
             $payloadData[$prop.Name] = $prop.Value
         }
     }
+
+    # Feature 145: the dispute (action 6) routes back to action 5. The instance only re-surfaces
+    # action 5 as current once the InstanceProjector folds the sealed dispute docket — a beat after
+    # the seal. Gate on AwaitingInbox before resubmitting, else we race the projector and get a 400
+    # ("Action 5 is not a current action"). See walkthrough-builder skill, Cadence.
+    Wait-SorchaActorReady -Mode AwaitingInbox `
+        -InstanceId $instanceId -ActionId 5 -RegisterId $RegisterId `
+        -Headers @{ Authorization = "Bearer $senderToken" } -GatewayUrl $env.GatewayUrl
 
     try {
         $response = Invoke-SorchaAction `
@@ -387,6 +403,12 @@ function Invoke-DisputedProcurement {
             $payloadData[$prop.Name] = $prop.Value
         }
     }
+
+    # Feature 145: gate on the resubmitted action 5 surfacing action 6 as current again before
+    # the final approval, same async-projection cadence as above.
+    Wait-SorchaActorReady -Mode AwaitingInbox `
+        -InstanceId $instanceId -ActionId 6 -RegisterId $RegisterId `
+        -Headers @{ Authorization = "Bearer $senderToken" } -GatewayUrl $env.GatewayUrl
 
     try {
         $response = Invoke-SorchaAction `

--- a/walkthroughs/TradeFinance/setup.ps1
+++ b/walkthroughs/TradeFinance/setup.ps1
@@ -370,6 +370,12 @@ foreach ($org in $selectedOrgs) {
     $ctx.AdminToken = $adminRelogin.Token
     $ctx.AdminWallet = $adminWallet.Address
     Write-WtInfo "  $subdomain admin wallet (register owner): $($adminWallet.Address)"
+
+    # Provision the org's Feature 083 master key so its Feature 120 VC-issuance key can derive —
+    # required for any credential this org issues to be cross-register-verifiable (otherwise the
+    # credential is signed with the bare wallet key and the Finance phase's TrustEvaluator rejects
+    # it: "issuer signature not verified"). Idempotent. See walkthrough-builder skill.
+    Set-SorchaOrgMasterKey -WalletUrl $env.WalletUrl -OrganizationId $ctx.OrganizationId -Headers $ctx.Headers
 }
 
 # ============================================================================

--- a/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
+++ b/walkthroughs/modules/SorchaWalkthrough/SorchaWalkthrough.psm1
@@ -933,6 +933,48 @@ function New-SorchaWallet {
 }
 
 # ============================================================================
+# Set-SorchaOrgMasterKey — provision the org's Feature 083 HD master key (idempotent)
+# ============================================================================
+
+function Set-SorchaOrgMasterKey {
+    <#
+    .SYNOPSIS
+        Provision the organisation's Feature 083 HD master key (idempotent).
+    .DESCRIPTION
+        POST /api/wallets/org/{orgId}/master-key. REQUIRED for any org that ISSUES credentials:
+        without a master key the org can't derive its Feature 120 VC-issuance key, so blueprint-
+        issued SorchaLocalWallet credentials are signed with the bare wallet key (iss = bare
+        address, no did:sorcha kid). Such credentials fail cross-register presentation — the
+        engine TrustEvaluator rejects them with "issuer signature not verified" (fail-closed),
+        breaking credential-chain walkthroughs (TradeFinance Finance, SelfBuildHouse warrant).
+        The server deliberately does NOT auto-provision master keys (they mint a recovery
+        mnemonic that must be backed up — an explicit org-setup step), so the walkthrough must.
+        Requires an Administrator + platform-audience token (the org admin, re-logged so it carries
+        wallet_address). Idempotent: returns silently on 409 (already provisioned). The one-time
+        recovery mnemonic in the response is intentionally discarded (walkthrough/dev only).
+    #>
+    param(
+        [Parameter(Mandatory)][string]$WalletUrl,
+        [Parameter(Mandatory)][string]$OrganizationId,
+        [Parameter(Mandatory)][hashtable]$Headers
+    )
+    try {
+        $null = Invoke-SorchaApi -Method POST `
+            -Uri "$WalletUrl/wallets/org/$OrganizationId/master-key" `
+            -Headers $Headers
+        Write-WtInfo "  Org master key provisioned for $OrganizationId (enables Feature 120 VC-issuance key)"
+    } catch {
+        $status = $null
+        try { $status = $_.Exception.Response.StatusCode.value__ } catch {}
+        if ($status -eq 409) {
+            Write-WtInfo "  Org master key already provisioned for $OrganizationId"
+        } else {
+            throw
+        }
+    }
+}
+
+# ============================================================================
 # T012: Register-SorchaParticipant — Participant Registration + Wallet Link
 # ============================================================================
 


### PR DESCRIPTION
Makes the two multi-register, credential-chain walkthroughs pass end-to-end against a clean local stack.

## TradeFinance (procurement-to-pay + invoice-finance, 2 registers)
All three scenarios green: golden-path, disputed (8/8 + 4/4), declined.

- **Org master keys** — provision each operating org's Feature 083 HD master key (new idempotent `Set-SorchaOrgMasterKey` in the shared module) so the F120 kid-swap signs issued credentials with the org issuance key (`iss=did:sorcha:org:…`, `kid=…#vc-issuance-N`). Without a master key the kid-swap is skipped and credentials fail downstream issuer-signature trust.
- **invoice-finance "Evaluate Application"** — disclose the required `evaluationNotes` to `finance-director` (the decision-maker in the next action) as well as `credit-analyst`. A required field disclosed *only to the sender* never reaches the transmitted disclosure envelope (the sender's own view is not sent), so the validator cannot verify it. Pairs with the validator union-merge fix (#926).
- **procurement-to-pay "Approve/Dispute"** — carry `poReference` on the issuing action's own payload + schema so it lands in the issued `VerifiedInvoiceCredential` claim mapping (F145 reconstructed state isn't guaranteed to reach the issuing action).
- **run.ps1 disputed flow** — add the F145 `AwaitingInbox` cadence gates before the dispute, the action-5 resubmit, and the final approval.
- scenario data cleaned of double-encoded em-dash mojibake → plain ASCII.

## SelfBuildHouse (planning-permission + building-warrant, 2 registers)
All three scenarios green: approved (6/6+7/7), approved (7/7+7/7), refused (5/5). The planning→warrant cross-register credential chain works.

- master keys for both credential-issuing orgs; roster-seal wait before each blueprint publish (F142 gate); `AwaitingInbox` cadence gate before each non-first action.

## Forestry
Org master key + org-admin-owned register (trust chain).

## Local-dev tooling
- `docker-compose.localdev.yml` relaxes the genesis freshness window for clean local regression stacks (local-dev only, never deployed).
- `demos/AssuredIdentity/analyst.rules.json` agent auto-approve rules.

> Depends conceptually on #926 (validator validates the union of disclosed payload views) for the TradeFinance Finance phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)