### PR TITLE
feat(147): Authorization-gap closure (security hardening sub-project 2)

### DIFF
--- a/.claude/skills/jwt/SKILL.md
+++ b/.claude/skills/jwt/SKILL.md
@@ -81,14 +81,31 @@ group.MapPost("/", CreateBlueprint)
 
 ```csharp
 // AuthenticationExtensions.cs
-options.AddPolicy("CanManageBlueprints", policy =>
+options.AddPolicy("CanPublishBlueprints", policy =>
     policy.RequireAssertion(context =>
-    {
-        var hasOrgId = context.User.Claims.Any(c => c.Type == "org_id" && !string.IsNullOrEmpty(c.Value));
-        var isService = context.User.Claims.Any(c => c.Type == "token_type" && c.Value == "service");
-        return hasOrgId || isService;
-    }));
+        context.User.Claims.Any(c => c.Type == "can_publish_blueprint" && c.Value == "true")
+        || context.User.IsInRole("Administrator")));
 ```
+
+### Tier-aware policy (fold the audience in — Feature 147)
+
+**When:** A gate must admit a service-tier caller OR a specific human-tier caller. Because a
+**consumer**-tier token also carries `org_id` (Feature 136), a bare `hasOrgId || isService` check
+lets a citizen through — the tier **audience** must be part of the gate. Resolve the expected
+audience from the DI singleton `SorchaAudiences` (never hard-code the string), so the check lives in
+a requirement + handler rather than an inline assertion. `CanManageBlueprints` is the canonical example:
+
+```csharp
+// Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs
+//   succeed iff (token_type==service AND HasTierAudience(user, audiences, Tier.Service))
+//            || (org_id present       AND HasTierAudience(user, audiences, Tier.Platform))
+services.AddSingleton<IAuthorizationHandler, BlueprintManagementAuthorizationHandler>();
+options.AddPolicy("CanManageBlueprints", policy =>
+    policy.AddRequirements(new BlueprintManagementRequirement()));
+```
+
+The Wallet Service's `CanRecoverSystemWallet` (system-wallet BIP39 import) follows the same shape:
+service-tier **OR** (`Administrator`/`SystemAdmin` role AND `:platform` audience).
 
 ### Extract Claims in Handler
 

--- a/.claude/skills/jwt/references/patterns.md
+++ b/.claude/skills/jwt/references/patterns.md
@@ -170,8 +170,8 @@ options.AddPolicy("RequireService", policy =>
 ### Composite Policy (OR logic)
 
 ```csharp
-// Either org member OR service token
-options.AddPolicy("CanManageBlueprints", policy =>
+// Either org member OR service token (benign example — no tier sensitivity)
+options.AddPolicy("CanReadReports", policy =>
     policy.RequireAssertion(context =>
     {
         var hasOrgId = context.User.Claims.Any(c => c.Type == "org_id" && !string.IsNullOrEmpty(c.Value));
@@ -179,6 +179,13 @@ options.AddPolicy("CanManageBlueprints", policy =>
         return hasOrgId || isService;
     }));
 ```
+
+> **⚠️ Tier sensitivity (Feature 136/147).** A **consumer**-tier (citizen) token also carries
+> `org_id`, so `hasOrgId || isService` admits citizens. For an authoring/admin gate, the tier
+> **audience** must be part of the check. Do NOT hard-code the audience string — resolve
+> `SorchaAudiences` from DI in a requirement + handler. `CanManageBlueprints` is implemented this
+> way: `(token_type==service AND :service aud) || (org_id AND :platform aud)` — see
+> `Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs`.
 
 ### Multiple Conditions (AND logic)
 

--- a/.claude/skills/jwt/references/workflows.md
+++ b/.claude/skills/jwt/references/workflows.md
@@ -58,6 +58,10 @@ public static class AuthenticationExtensions
     {
         services.AddAuthorization(options =>
         {
+            // NOTE: a consumer-tier (citizen) token also carries org_id (Feature 136), so this
+            // bare org_id/service check admits citizens. For a tier-sensitive (authoring/admin)
+            // resource, fold the tier audience in via a requirement + handler — see the jwt skill
+            // "Tier-aware policy (Feature 147)".
             options.AddPolicy("CanManageResources", policy =>
                 policy.RequireAssertion(context =>
                 {

--- a/docs/guides/AUTHENTICATION-SETUP.md
+++ b/docs/guides/AUTHENTICATION-SETUP.md
@@ -336,7 +336,7 @@ curl https://localhost:7083/api/registers \
 
 | Policy | Description | Required Claims |
 |--------|-------------|-----------------|
-| `CanManageBlueprints` | Create, update, delete blueprints | `org_id` OR `token_type=service` |
+| `CanManageBlueprints` | Create, update, delete blueprints | (`token_type=service` AND `:service` aud) OR (`org_id` AND `:platform` aud) — Feature 147 |
 | `CanExecuteBlueprints` | Execute actions | Authenticated user |
 | `CanPublishBlueprints` | Publish blueprints | `can_publish_blueprint=true` OR `role=Administrator` |
 | `RequireService` | Service operations | `token_type=service` |
@@ -974,7 +974,8 @@ The following table consolidates all authorization policies used across the plat
 | `RequireOrganizationMember` | `org_id` claim present | User must belong to an organization |
 | `RequireAdministrator` | `role=Administrator` | User must have the Administrator role |
 | `CanManageWallets` | `org_id` OR `token_type=service` | Create, list, and configure wallets (org members or services) |
-| `CanManageBlueprints` | `org_id` OR `token_type=service` | Create, update, and delete blueprints (org members or services) |
+| `CanManageBlueprints` | (`token_type=service` AND `:service` aud) OR (`org_id` AND `:platform` aud) | Authoring; consumer-tier tokens (which carry `org_id` under F136) are refused — Feature 147 |
+| `CanRecoverSystemWallet` | (`token_type=service` AND `:service` aud) OR (`role=Administrator`/`SystemAdmin` AND `:platform` aud) | Wallet Service system-wallet BIP39 import (genesis ceremony / service automation) — Feature 147 |
 | `CanManageRegisters` | `org_id` + (`role=Administrator` OR `role=SystemAdmin`) | Create and manage registers (tightened from org_id-only) |
 | `CanCreateSystemRegisters` | `org_id=00000000-0000-0000-0000-000000000001` + `role=SystemAdmin` | Set register purpose to System (SystemAdmin org only) |
 | `RequireDelegatedAuthority` | `token_type=service` AND `delegated_user_id` present | Service acting on behalf of a user; both identities must be present |

--- a/docs/superpowers/specs/2026-06-03-authorization-gap-closure-design.md
+++ b/docs/superpowers/specs/2026-06-03-authorization-gap-closure-design.md
@@ -1,0 +1,114 @@
+# Authorization-gap closure — design
+
+**Date:** 2026-06-03
+**Initiative:** Security hardening (from the 2026-06-02 architecture review)
+**Sub-project:** 2 of N — Authorization-gap closure
+**Branch:** `147-authorization-gap-closure`
+**Source findings:** `docs/reviews/2026-06-02-architecture-review.md` §2 (H1, H2, LOW), §7, §8
+
+---
+
+## 1. Problem
+
+Four sensitive endpoints (or policies) accept callers they should refuse. The unifying defect: **the authorization decision is not enforced in code at the endpoint** — it relies on a comment, on the gateway (which is only `RequireAuthenticated`), or on a policy that a per-endpoint omission silently weakens.
+
+| # | Finding | Today | Who gets in that shouldn't |
+|---|---------|-------|-----------------------------|
+| H1 | System-wallet create/recover are `AllowAnonymous` | `POST /api/v1/wallets/system` and `/system/recover` carry `.AllowAnonymous()` with comments asserting an enforcement that isn't in code | Any authenticated token via the gateway; **fully unauthenticated on the internal network**. `recover` imports a BIP39 mnemonic → an attacker can seat an attacker-controlled validator docket-signing wallet. |
+| H2 | `CanManageBlueprints` passes on `hasOrgId OR isService` | Consumer/citizen tokens carry `org_id` (F136), so a citizen satisfies it on the bare-policy endpoints (`/api/blueprints` CRUD, `SchemaEndpoints`, `CredentialEndpoints`, `StatusListEndpoints`) | Consumer/citizen tokens reach blueprint & schema **authoring**. |
+| F124 (LOW) | Pending-applications uses plain `.RequireAuthorization()` | `/api/v1/wallet/pending-applications` group lacks `RequireConsumerAudience` unlike every sibling citizen surface | A platform token can read/set a citizen's notice. |
+| LOW | Tenant re-registers `RequireSystemAdmin` role-only | `AddTenantAuthorization` calls `AddSorchaAuthorizationPolicies()` (org-scoped `RequireSystemAdmin`) then **re-adds** it role-only; last-write-wins | A `SystemAdmin` in *any* org clears `platform-*` gateway routes — the system-admin-org constraint is dropped. |
+
+### Guiding principle
+
+A sensitive endpoint must enforce its own tier/role authorization **in code**, never relying on the gateway and never on a comment. Where a rule can be forgotten per-endpoint, push it **into the policy definition** so omission is impossible.
+
+---
+
+## 2. Design
+
+### 2.1 H1 — system-wallet endpoints (`Sorcha.Wallet.Service`)
+
+Both endpoints live under `walletGroup` (`/api/v1/wallets`, group policy `CanManageWallets`) but each overrides the group with `.AllowAnonymous()` — that override is the entire hole. **Remove `.AllowAnonymous()` from both** (which restores in-code authz independent of the gateway), and attach the right policy:
+
+- **`POST /system` (create)** → `.RequireAuthorization(AuthorizationPolicies.RequireService)`.
+  Sole caller: Validator Service via the consolidated `WalletServiceClient`, which already attaches a `:service` token (`ServiceClientAuthHelper`). No caller change.
+
+- **`POST /system/recover` (BIP39 import)** → new policy **`CanRecoverSystemWallet`**:
+
+  > *(`token_type == service` **AND** carries `:service` audience)* **OR** *(`Administrator`/`SystemAdmin` role **AND** carries `:platform` audience)*
+
+  - The admin CLI's `sorcha system-register import-validator-key` logs in (`sorcha auth login`) and sends a platform-tier admin token → **passes** the second branch.
+  - A future service automation → **passes** the first branch.
+  - A consumer/citizen token → **refused** (no `:service`, not admin, and consumer-tier audience).
+  - Anonymous → refused (no `AllowAnonymous`).
+  - The existing **409-on-exists** guard in the handler (`WalletEndpoints.cs:1768-1784`, "Refusing to recover … one already exists") is **kept** as belt-and-braces. It only stops *overwriting* an existing wallet; the auth gate is what closes the **fresh-install empty-window race** and the unauthenticated-internal-network reach.
+
+  Because the OR spans tiers and a `RequireAssertion` lambda has no DI access, `CanRecoverSystemWallet` is implemented as a small custom `IAuthorizationRequirement` + `AuthorizationHandler<T>` that injects the DI singleton `SorchaAudiences` and tests audiences via `AuthorizationPolicyExtensions.HasTierAudience`. This mirrors the F136 `TierAudienceAuthorizationHandler` pattern exactly — the expected audience string is resolved at request time from the configured `InstallationName`, never baked in.
+
+  Note on the group policy: after removing `AllowAnonymous`, these two endpoints are also subject to the group's `CanManageWallets` (= `org_id OR service`). Both valid callers satisfy it (service token, or admin with `org_id`), so the layered check is defense-in-depth with no false-deny.
+
+### 2.2 H2 — `CanManageBlueprints` (`Sorcha.Blueprint.Service`)
+
+Fix **in the policy definition**, not per-endpoint, so the gate can't be omitted on a future endpoint. Redefine `CanManageBlueprints` (in `AddBlueprintAuthorization`) via a custom `BlueprintManagementRequirement` + handler (injects `SorchaAudiences`):
+
+> *(`token_type == service` **AND** carries `:service` audience)* **OR** *(`org_id` present **AND** carries `:platform` audience)*
+
+- Auto-fixes every bare site at once with **zero endpoint edits**: `Program.cs:702` (`/api/blueprints` CRUD), `SchemaEndpoints.cs:93/105/117/128/138`, `CredentialEndpoints.cs:33`, `StatusListEndpoints.cs:51`.
+- The two siblings that already compose `+RequirePlatformAudience` (`RehearsalEndpoints.cs:39`, `BlueprintFromPublishedEndpoint.cs:69`) are **left untouched**. They keep a strict platform-only gate (the standalone `RequirePlatformAudience` still rejects service tokens there) — no behaviour change, the redundancy is harmless and documents intent.
+- The service branch is **preserved** so legitimate service-to-service blueprint management still works; only the consumer-tier walk-in is closed.
+
+### 2.3 F124 — pending-applications (`Sorcha.Wallet.Service`)
+
+`PendingApplicationEndpoints.cs:24-26` group: replace plain `.RequireAuthorization()` with `.RequireAuthorization(AuthorizationPolicies.RequireConsumerAudience)`, matching every sibling citizen surface. Closes the platform-token-reads-citizen-notice gap. One-line change.
+
+### 2.4 LOW — Tenant `RequireSystemAdmin` (`Sorcha.Tenant.Service`)
+
+In `AddTenantAuthorization` (`AuthenticationExtensions.cs:151-152`), **delete** the duplicate role-only `options.AddPolicy("RequireSystemAdmin", …)` so the shared, org-scoped definition from `AddSorchaAuthorizationPolicies` (system-admin-org `00000000-0000-0000-0000-000000000001` **AND** `SystemAdmin` role) stands.
+
+**Pre-condition to verify before deleting:** confirm every Tenant `RequireSystemAdmin` usage is a platform-management endpoint genuinely meant to be system-admin-org-scoped (the architecture's "Platform Management Endpoints — SystemAdmin only"). If any usage legitimately needs role-only-any-org behaviour, it gets its own named policy instead. Expectation: all usages are platform-management, so the delete is correct.
+
+---
+
+## 3. Testing (TDD)
+
+Tests are written before the production change for each component.
+
+- **Handler unit tests** (primary; fast; no host):
+  - `BlueprintManagementAuthorizationHandler`: consumer (`org_id` + `:consumer`) → **deny**; platform admin (`org_id` + `:platform`) → allow; service (`token_type=service` + `:service`) → allow; `org_id` + no/`:consumer` audience → deny; no `org_id`, non-service → deny.
+  - `CanRecoverSystemWallet` handler: service (+`:service`) → allow; admin role + `:platform` → allow; consumer → deny; admin role but `:consumer`/no `:platform` → deny; authenticated non-admin → deny.
+- **Endpoint-metadata regression test**: assert `/api/v1/wallets/system` and `/system/recover` carry **no** `AllowAnonymousAttribute` and require their expected policy; assert the pending-applications group requires consumer audience. Guards against `AllowAnonymous` re-introduction. (Mechanism finalized in planning — minimal host enumerating `EndpointDataSource`, or handler-level assertion if the host route is heavier than the codebase norm.)
+- **Tenant test**: a `SystemAdmin` in a **non-system** org is **denied** `RequireSystemAdmin` — the exact regression the duplicate caused; a system-admin-org `SystemAdmin` is allowed.
+
+**Test-runner note (MTP):** Microsoft.Testing.Platform ignores `dotnet test --filter` (MTP0001). Build + test are scoped to each **affected service's test project** (`Sorcha.Wallet.Service.Tests`, `Sorcha.Blueprint.Service.Tests`, `Sorcha.Tenant.Service.Tests`), each running its whole suite.
+
+---
+
+## 4. Increments & delivery
+
+One focused PR for the sub-project, four separable commits (built + tested against the affected test project before each commit):
+
+1. **H1** — Wallet system-wallet create/recover gating (`RequireService` + new `CanRecoverSystemWallet`) + handler/metadata tests.
+2. **H2** — Blueprint `CanManageBlueprints` folded into a tier-aware policy + handler tests.
+3. **F124** — Wallet pending-applications `RequireConsumerAudience` + metadata test.
+4. **LOW** — Tenant `RequireSystemAdmin` duplicate removal + denial test.
+
+Push → open PR → merge on green **claude-review**. The full-solution `build-and-test` workflow is currently red across all PRs due to an unrelated revoked Refit 10.1.6 NuGet signing cert (NU3012 at restore); PRs stay UNSTABLE/mergeable and claude-review is the effective gate.
+
+Documentation sync on merge: the `jwt` skill (policy catalogue), `sorcha-architecture` skill if any documented endpoint surface changes, and `docs/guides/AUTHENTICATION-SETUP.md` if policy semantics are documented there.
+
+---
+
+## 5. Out of scope (named, not silently dropped)
+
+- **H3** (PWA-local verifier `requireIssuerSignature:false`) → sub-project 3 (verification-correctness).
+- **M3** (OidcExchangeService issuer trust, PasskeyRecoveryService WebAuthn) → sub-project 3.
+- Other §2 LOW items — token-revocation fail-open on Redis error (deliberate availability tradeoff / risk acceptance), stale `sorcha:citizen-wallet` dev config (dead config cleanup), default service-principal secrets in base appsettings (config/ops), anonymous-but-guarded bootstrap (already guarded). None are authorization-gating in code; they belong to Bucket B / deferred-docs, not this sub-project.
+
+---
+
+## 6. Key decisions (settled during brainstorming)
+
+1. **Recover gate** = `RequireService` OR (`Administrator` + `:platform`), keeping the existing 409 guard — chosen over a deploy-time secret / one-shot disable because it reuses the platform's existing authz vocabulary and removing `AllowAnonymous` is what actually shuts both doors. (The 409-on-exists guard the operator might reach for already exists and does **not** close the empty-window race — the auth gate does.)
+2. **F124 included** in this sub-project — same consumer⊥platform isolation theme as H2, one-line fix.
+3. **H2 fixed in the policy**, not per-endpoint, so it can't be omitted again — the reviewer's explicit recommendation.

--- a/specs/147-authorization-gap-closure/checklists/requirements.md
+++ b/specs/147-authorization-gap-closure/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Authorization-gap closure
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec uses the platform's trust-tier vocabulary (consumer / platform / service) and role names (Administrator / SystemAdmin). These are domain security-model concepts, not implementation/tech-stack details, so they are retained deliberately for testability and unambiguity.
+- No [NEEDS CLARIFICATION] markers: the two genuine gray-area decisions (recover gate, F124 scope) were settled during brainstorming and are recorded in the design doc + the Assumptions section.
+- All items pass on the first iteration; spec is ready for `/speckit.plan`.

--- a/specs/147-authorization-gap-closure/contracts/authorization-matrix.md
+++ b/specs/147-authorization-gap-closure/contracts/authorization-matrix.md
@@ -1,0 +1,61 @@
+# Contract: Authorization matrix (per operation)
+
+No new HTTP endpoints. This is the behavioural contract — the allow/deny decision each in-scope operation MUST enforce after this feature. "Allow" means authorization passes (the request proceeds to the handler); "Deny" means an authorization failure (401 if unauthenticated, 403 if authenticated-but-unauthorized).
+
+Caller classes: **Anon** (no token), **Consumer** (`:consumer`, carries `org_id`, no roles), **Platform** (`:platform`, carries `org_id`), **Platform-Admin** (`:platform` + `Administrator`/`SystemAdmin` role), **Service** (`token_type==service` + `:service`).
+
+## H1 — `POST /api/v1/wallets/system` (create)  — policy `RequireService`
+
+| Caller | Result |
+|--------|--------|
+| Anon | **Deny** (401) |
+| Consumer | **Deny** (403) |
+| Platform | **Deny** (403) |
+| Platform-Admin | **Deny** (403) |
+| Service | **Allow** |
+
+## H1 — `POST /api/v1/wallets/system/recover` (recover) — policy `CanRecoverSystemWallet`
+
+| Caller | Result |
+|--------|--------|
+| Anon | **Deny** (401) |
+| Consumer | **Deny** (403) |
+| Platform (no admin role) | **Deny** (403) |
+| Platform-Admin | **Allow** |
+| Service | **Allow** |
+| Admin role but `:consumer` audience | **Deny** (403) |
+| any caller, when an active system wallet already exists | **Deny** (409 — existing guard, after authz passes) |
+
+## H2 — Blueprint authoring (CRUD `/api/blueprints`, `SchemaEndpoints`, `CredentialEndpoints`, `StatusListEndpoints`) — policy `CanManageBlueprints`
+
+| Caller | Result |
+|--------|--------|
+| Anon | **Deny** (401) |
+| Consumer (carries `org_id`) | **Deny** (403) — the gap being closed |
+| Platform (carries `org_id`) | **Allow** |
+| Platform (no `org_id`) | **Deny** (403) |
+| Service | **Allow** |
+
+Sibling endpoints already composing `+RequirePlatformAudience` (`RehearsalEndpoints`, `BlueprintFromPublishedEndpoint`): unchanged — Platform allowed, Service denied there (platform-only), Consumer denied.
+
+## F124 — `/api/v1/wallet/pending-applications` (GET/PUT/DELETE) — policy `RequireConsumerAudience`
+
+| Caller | Result |
+|--------|--------|
+| Anon | **Deny** (401) |
+| Consumer | **Allow** (scoped to own PlatformUser) |
+| Platform | **Deny** (403) — the gap being closed |
+| Service | **Deny** (403) |
+
+## LOW — Tenant platform-administration (`PlatformManagementEndpoints`, `PlatformOrgEndpoints`, `PlatformSettingsEndpoints`) — policy `RequireSystemAdmin` (+ `RequirePlatformAudience`, already composed)
+
+| Caller | Result |
+|--------|--------|
+| SystemAdmin in system-admin-org (`…0001`) + `:platform` | **Allow** |
+| SystemAdmin in a **non-system** org | **Deny** (403) — the gap being closed |
+| Non-SystemAdmin in system-admin-org | **Deny** (403) |
+
+## Cross-cutting
+
+- Every "Deny" above holds whether the request arrives via the gateway **or** directly on the internal network (authorization is enforced at the operation, not the perimeter — FR-011 / SC-005).
+- All audience comparisons resolve through `SorchaAudiences` for the configured installation (FR-012); a token from another installation's namespace is denied.

--- a/specs/147-authorization-gap-closure/data-model.md
+++ b/specs/147-authorization-gap-closure/data-model.md
@@ -1,0 +1,68 @@
+# Phase 1 Data Model: Authorization-gap closure
+
+No persistent data, schema, or DTO changes. The "model" here is the authorization configuration: policies, the custom requirements/handlers, and the claim shapes they evaluate.
+
+## Claim shapes evaluated (existing — not changed)
+
+| Concept | Claim | Source |
+|---------|-------|--------|
+| Token type | `token_type` ∈ {`user`,`service`} | `TokenClaimConstants.TokenType` / `TokenTypeService` |
+| Tier audience | `aud` = `{installation}:{consumer\|platform\|service\|enrol-session}` | `SorchaAudiences.For(tier)` |
+| Org membership | `org_id` (non-empty) | `TokenClaimConstants.OrgId` |
+| Role | `ClaimTypes.Role` ∈ {`SystemAdmin`,`Administrator`,…} | token role claims |
+
+## Policies (after this feature)
+
+| Policy | Service | Definition | Change |
+|--------|---------|-----------|--------|
+| `RequireService` | shared | `token_type==service` AND `aud`==`:service` | unchanged (reused for create) |
+| `CanRecoverSystemWallet` | Wallet | *(`token_type==service` AND `:service`)* **OR** *(`IsInRole(Administrator\|SystemAdmin)` AND `:platform`)* | **NEW** |
+| `CanManageWallets` | Wallet | `org_id` OR `service` | unchanged (group policy; still applies) |
+| `CanManageBlueprints` | Blueprint | *(`token_type==service` AND `:service`)* **OR** *(`org_id` non-empty AND `:platform`)* | **REDEFINED** (was `org_id OR service`) |
+| `RequireConsumerAudience` | shared | authenticated AND `:consumer` | unchanged (reused for pending-apps) |
+| `RequireSystemAdmin` | shared (Tenant override removed) | `org_id`==system-admin-org AND `IsInRole(SystemAdmin)` | **Tenant duplicate deleted** so shared definition stands |
+
+## New types
+
+### `BlueprintManagementRequirement : IAuthorizationRequirement`
+Marker requirement. No state.
+
+### `BlueprintManagementAuthorizationHandler : AuthorizationHandler<BlueprintManagementRequirement>`
+- Injects `SorchaAudiences`.
+- Succeeds iff:
+  - `token_type==service` AND `HasTierAudience(user, audiences, Tier.Service)`; **or**
+  - user has a non-empty `org_id` claim AND `HasTierAudience(user, audiences, Tier.Platform)`.
+- Never calls `Fail()`.
+
+### `SystemWalletRecoveryRequirement : IAuthorizationRequirement`
+Marker requirement. No state.
+
+### `SystemWalletRecoveryAuthorizationHandler : AuthorizationHandler<SystemWalletRecoveryRequirement>`
+- Injects `SorchaAudiences`.
+- Succeeds iff:
+  - `token_type==service` AND `HasTierAudience(user, audiences, Tier.Service)`; **or**
+  - (`user.IsInRole("Administrator")` OR `user.IsInRole("SystemAdmin")`) AND `HasTierAudience(user, audiences, Tier.Platform)`.
+- Never calls `Fail()`.
+
+## Registration (DI)
+
+Inside `AddBlueprintAuthorization` / `AddWalletAuthorization` (each already calls `AddSorchaAuthorizationPolicies()` first, which registers the `SorchaAudiences` singleton):
+
+```csharp
+services.AddSingleton<IAuthorizationHandler, BlueprintManagementAuthorizationHandler>();
+// AddAuthorization options:
+options.AddPolicy("CanManageBlueprints", p => p.AddRequirements(new BlueprintManagementRequirement()));
+```
+
+```csharp
+services.AddSingleton<IAuthorizationHandler, SystemWalletRecoveryAuthorizationHandler>();
+options.AddPolicy("CanRecoverSystemWallet", p =>
+    p.RequireAuthenticatedUser().AddRequirements(new SystemWalletRecoveryRequirement()));
+```
+
+## Invariants
+
+- INV-1: A consumer-tier token never satisfies `CanManageBlueprints` or `CanRecoverSystemWallet` (no `:platform`/`:service` audience, no role).
+- INV-2: Existing service-to-service create and admin-CLI recover flows are unchanged (FR-004).
+- INV-3: Audience comparison always goes through `SorchaAudiences` resolved from DI (FR-012) — no literal audience strings in handler code.
+- INV-4: Handlers never `Fail()` — only `Succeed()` — so they compose with any other requirement on the same policy.

--- a/specs/147-authorization-gap-closure/plan.md
+++ b/specs/147-authorization-gap-closure/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Authorization-gap closure
+
+**Branch**: `147-authorization-gap-closure` | **Date**: 2026-06-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/147-authorization-gap-closure/spec.md`
+**Design source**: `docs/superpowers/specs/2026-06-03-authorization-gap-closure-design.md`
+
+## Summary
+
+Close four authorization gaps by enforcing the correct trust tier / role at each operation rather than at the perimeter or via a comment, and by moving an omittable rule into its shared definition:
+
+1. **H1** — `Sorcha.Wallet.Service` system-wallet `create`/`recover`: drop `.AllowAnonymous()`; gate `create` → `RequireService`; gate `recover` → new `CanRecoverSystemWallet` (`:service` OR `Administrator`+`:platform`); keep the existing 409-on-exists guard.
+2. **H2** — `Sorcha.Blueprint.Service` `CanManageBlueprints`: redefine via a tier-aware requirement+handler so it admits *(service+`:service`)* OR *(org_id+`:platform`)* — fixing all bare sites with no per-endpoint edits.
+3. **F124** — `Sorcha.Wallet.Service` pending-applications group: plain `.RequireAuthorization()` → `RequireConsumerAudience`.
+4. **LOW** — `Sorcha.Tenant.Service` `AddTenantAuthorization`: delete the duplicate role-only `RequireSystemAdmin` so the shared org-scoped definition stands.
+
+Technical approach is grounded in the existing F136 authorization primitives (`SorchaAudiences`, `TierAudienceRequirement`/`TierAudienceAuthorizationHandler`, `AuthorizationPolicies`) and the existing test pattern (`AuthorizationPolicyExtensionsTests` policy-evaluation harness).
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10
+**Primary Dependencies**: ASP.NET Core authorization (`Microsoft.AspNetCore.Authorization`), `Sorcha.ServiceDefaults.Auth` (F136 `SorchaAudiences`, tier requirement/handler), `Sorcha.ServiceClients.Auth` (`TokenClaimConstants`)
+**Storage**: N/A (authorization configuration only; no schema/data changes)
+**Testing**: xUnit + FluentAssertions; policy-evaluation via `IAuthorizationService.AuthorizeAsync`; runner is Microsoft.Testing.Platform (`--filter` ignored — whole-project runs)
+**Target Platform**: Linux server containers (3 services: Wallet, Blueprint, Tenant)
+**Project Type**: web (multi-service)
+**Performance Goals**: No measurable change — authorization handlers are claim inspections on the request path
+**Constraints**: No behaviour change for legitimate callers (FR-004, FR-007); no new public endpoints; audience strings resolved from the single source of truth at request time (FR-012)
+**Scale/Scope**: 3 services, 1 shared pattern reused, ~2 new requirement+handler pairs, 1 policy redefinition, 2 endpoint-group edits, 1 deletion
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| II. Security First (zero trust, authz) | **Directly advances** — closes four authz gaps; enforces tier/role in-code at every boundary. No violation. |
+| IV. Testing (>85% new code, xUnit, deterministic, AAA) | Met — TDD: policy-evaluation tests (full `IAuthorizationService` pipeline) + endpoint-metadata regression tests, deterministic, no external deps. |
+| V. Code Quality (nullable, no warnings, DI) | Met — new requirement/handler types are nullable-clean, DI-registered, XML-documented. |
+| III. API Documentation | Met — no endpoint summaries/descriptions removed; new handler types carry XML docs. |
+| I. Microservices-First (no upward deps) | Met — all changes service-local (Wallet/Blueprint/Tenant); new types live in their own service; reuse the existing downward `ServiceDefaults.Auth` primitives. |
+| VIII. Observability | No new telemetry required; authz failures surface as standard 401/403 and the existing F136 `IdentityMetrics` tier-rejection counters already cover audience mismatches. No violation. |
+
+**Result: PASS — no violations, no Complexity Tracking entries required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/147-authorization-gap-closure/
+├── plan.md              # This file
+├── spec.md              # Feature spec
+├── research.md          # Phase 0 — decisions & rationale
+├── data-model.md        # Phase 1 — authorization model (policies, requirements, handlers)
+├── quickstart.md        # Phase 1 — how to verify the allow/deny matrix
+├── contracts/
+│   └── authorization-matrix.md   # Phase 1 — per-operation allow/deny contract (no new HTTP endpoints)
+└── checklists/
+    └── requirements.md  # Spec quality checklist (done)
+```
+
+### Source Code (repository root)
+
+```text
+src/Services/Sorcha.Wallet.Service/
+├── Authorization/                         # NEW folder
+│   ├── SystemWalletRecoveryRequirement.cs # NEW — IAuthorizationRequirement
+│   └── SystemWalletRecoveryAuthorizationHandler.cs  # NEW — injects SorchaAudiences
+├── Extensions/AuthenticationExtensions.cs # EDIT — register CanRecoverSystemWallet + handler
+└── Endpoints/
+    ├── WalletEndpoints.cs                  # EDIT — drop AllowAnonymous; RequireService + CanRecoverSystemWallet
+    └── PendingApplicationEndpoints.cs      # EDIT — RequireConsumerAudience
+
+src/Services/Sorcha.Blueprint.Service/
+├── Authorization/                          # NEW folder
+│   ├── BlueprintManagementRequirement.cs   # NEW — IAuthorizationRequirement
+│   └── BlueprintManagementAuthorizationHandler.cs   # NEW — injects SorchaAudiences
+└── Extensions/AuthenticationExtensions.cs  # EDIT — redefine CanManageBlueprints via requirement + register handler
+
+src/Services/Sorcha.Tenant.Service/
+└── Extensions/AuthenticationExtensions.cs  # EDIT — delete duplicate role-only RequireSystemAdmin
+
+tests/
+├── Sorcha.Wallet.Service.Tests/
+│   ├── Authorization/WalletAuthorizationPolicyTests.cs   # NEW — CanRecoverSystemWallet matrix
+│   └── Endpoints/SystemWalletEndpointAuthorizationTests.cs # NEW — metadata: no AllowAnonymous + required policy; pending-apps consumer
+├── Sorcha.Blueprint.Service.Tests/
+│   └── Authorization/BlueprintManagementPolicyTests.cs   # NEW — CanManageBlueprints matrix
+└── Sorcha.Tenant.Service.Tests/
+    └── Authorization/TenantSystemAdminPolicyTests.cs     # NEW — RequireSystemAdmin org-scoping
+```
+
+**Structure Decision**: Multi-service. Each service gets a small `Authorization/` folder for its custom requirement+handler (separation from `Extensions/` config wiring), registered in the existing `Add{Service}Authorization` method. Tests mirror the proven `AuthorizationPolicyExtensionsTests` policy-evaluation harness, placed in an `Authorization/` test folder per service; endpoint-metadata regression tests live under `Endpoints/`.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/147-authorization-gap-closure/quickstart.md
+++ b/specs/147-authorization-gap-closure/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: verifying Authorization-gap closure
+
+This feature changes authorization configuration only. Verification is by automated tests (no manual service run required), plus an optional manual probe.
+
+## Run the tests (per affected service — MTP ignores `--filter`, runs the whole project)
+
+```powershell
+dotnet test tests/Sorcha.Wallet.Service.Tests/Sorcha.Wallet.Service.Tests.csproj
+dotnet test tests/Sorcha.Blueprint.Service.Tests/Sorcha.Blueprint.Service.Tests.csproj
+dotnet test tests/Sorcha.Tenant.Service.Tests/Sorcha.Tenant.Service.Tests.csproj
+```
+
+Expected: the new authorization tests pass, asserting the [authorization matrix](./contracts/authorization-matrix.md):
+
+- **Wallet** — `CanRecoverSystemWallet` allows Service and Platform-Admin, denies Anon/Consumer/Platform-without-admin/admin-with-consumer-audience; system-wallet create requires Service; system-wallet create+recover endpoints carry no `AllowAnonymous`; pending-applications requires consumer audience.
+- **Blueprint** — `CanManageBlueprints` denies Consumer (even with `org_id`), allows Platform-with-org and Service, denies Platform-without-org.
+- **Tenant** — `RequireSystemAdmin` denies a SystemAdmin in a non-system org, allows a system-admin-org SystemAdmin.
+
+## What "done" looks like (maps to Success Criteria)
+
+- **SC-001 / SC-002**: the matrix tests above are green (unauthorized denied, legitimate allowed).
+- **SC-003**: the `CanManageBlueprints` matrix test exercises the policy directly, so it covers every bare authoring endpoint through the single central change.
+- **SC-004**: the Tenant org-scoping test is green.
+- **SC-005**: the endpoint-metadata test asserts the system-wallet endpoints have no `AllowAnonymous` and require their policy.
+- **SC-006**: the three project suites pass.
+
+## Optional manual probe (against a running stack)
+
+With a citizen (consumer-tier) token `$CT` and an admin (platform-tier) token `$PT`:
+
+```bash
+# H2: consumer must be refused at blueprint authoring (was allowed)
+curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $CT" http://localhost/api/blueprints      # expect 403
+
+# F124: platform token must be refused at a citizen surface
+curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $PT" http://localhost/api/v1/wallet/pending-applications  # expect 403
+
+# H1: anonymous must be refused at system-wallet create (was 2xx/anonymous)
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost/api/v1/wallets/system -d '{}'   # expect 401
+```
+
+## Caller flows that MUST keep working (no regression)
+
+- Validator Service seating its system wallet on startup (`SystemWalletInitializer` → service token → create).
+- `sorcha system-register import-validator-key` during the genesis ceremony (admin platform token → recover).
+- Platform-tier admins/designers authoring blueprints and schemas.
+- Citizens reading/setting their own pending-application notice.

--- a/specs/147-authorization-gap-closure/research.md
+++ b/specs/147-authorization-gap-closure/research.md
@@ -1,0 +1,54 @@
+# Phase 0 Research: Authorization-gap closure
+
+All decisions below are grounded in the existing codebase (F136 auth primitives and the existing test harness). No NEEDS CLARIFICATION remained from the spec.
+
+## R1 — How to express an "OR across tiers" gate without breaking service tokens
+
+**Context**: Both `CanManageBlueprints` (H2) and `CanRecoverSystemWallet` (H1-recover) must admit *either* a service-tier caller *or* a specific human-tier caller. Listing multiple ASP.NET policies on an endpoint **AND**s them; a single `RequireAssertion` lambda has no DI access to resolve `SorchaAudiences`.
+
+**Decision**: Implement each as a custom `IAuthorizationRequirement` + `AuthorizationHandler<T>` that injects the DI singleton `SorchaAudiences` and tests audiences via `AuthorizationPolicyExtensions.HasTierAudience(user, audiences, tier)`. The handler `context.Succeed(requirement)` on either branch; it never calls `Fail()` (so it composes cleanly). This mirrors `TierAudienceAuthorizationHandler` (`src/Common/Sorcha.ServiceDefaults/Auth/TierAudienceAuthorizationHandler.cs`) exactly.
+
+**Rationale**: Resolves the expected audience string from the configured `InstallationName` at request time (FR-012) — never baked in. Single requirement = the policy can't be split/forgotten. Matches the established F136 pattern, so it's idiomatic and reviewable.
+
+**Alternatives considered**:
+- *Compose two policies on the endpoint* — ASP.NET ANDs them; cannot express OR. Rejected.
+- *`RequireAssertion` reading `aud` claims directly* — would have to hard-code `"sorcha:platform"`/`":service"`, breaking per-installation namespaces (FR-012). Rejected.
+- *A shared `ServiceOrPlatformRequirement` in ServiceDefaults* — the two gates differ (Blueprint keys on `org_id`; recover keys on the `Administrator` role), so a shared abstraction would be parameter-heavy for two call sites. YAGNI — keep service-local; revisit if a third caller appears.
+
+## R2 — Placement & registration of the new requirement/handler types
+
+**Decision**: Service-local. Blueprint → `src/Services/Sorcha.Blueprint.Service/Authorization/`; Wallet → `src/Services/Sorcha.Wallet.Service/Authorization/`. Register the handler in the service's existing `Add{Service}Authorization` via `services.AddSingleton<IAuthorizationHandler, THandler>()` (handlers are stateless; `SorchaAudiences` is an immutable singleton) and define the named policy with `policy.AddRequirements(new TRequirement())`.
+
+**Rationale**: Keeps the authz logic next to the service it guards (Principle I — no upward deps; the types depend only on the downward `ServiceDefaults.Auth`). `SorchaAudiences` is already registered as a singleton by `AddSorchaAuthorizationPolicies()` (called first inside each `Add{Service}Authorization`), so the handler's dependency is satisfied.
+
+**Alternatives considered**: Putting the requirement/handler in `Extensions/AuthenticationExtensions.cs` — works, but conflates config wiring with the requirement type; a dedicated `Authorization/` folder is clearer.
+
+## R3 — Test strategy
+
+**Decision**: Two layers.
+
+1. **Policy-evaluation tests (primary)** — mirror `tests/Sorcha.ServiceDefaults.Tests/AuthorizationPolicyExtensionsTests.cs`: build a `ServiceProvider` with `services.AddLogging(); services.Add{Service}Authorization();`, resolve `IAuthorizationService`, and `AuthorizeAsync(principal, policyName)` against the full caller matrix. Default installation is `"sorcha"` (no `IConfiguration` → `SorchaAudiences(null)` → `"sorcha"`), so audience claims are `"sorcha:consumer|platform|service"`. This exercises the **real** authorization pipeline including the registered tier handler.
+2. **Endpoint-metadata regression tests** — for the Wallet system-wallet + pending-applications endpoints (no `WebApplicationFactory` exists in `Sorcha.Wallet.Service.Tests`): build a minimal host, call the `Map*Endpoints` extension, enumerate `EndpointDataSource.Endpoints`, locate the routes by pattern, and assert (a) **no** `IAllowAnonymous` metadata and (b) an `IAuthorizeData` carrying the expected policy name. This is the direct SC-005 guard against `AllowAnonymous` reintroduction. If mapping the full endpoint set proves to need unavailable services at map-time, fall back to asserting the policy via the route group in isolation.
+
+**Rationale**: Policy-eval tests prove the security *logic* fast and deterministically (matches the codebase's existing approach). Metadata tests prove the *wiring* (the actual H1 defect was wiring — `AllowAnonymous`). Blueprint H2 is fully proven by the policy-eval test because the fix is the policy definition, not endpoint wiring (the endpoints already reference `CanManageBlueprints`).
+
+**Alternatives considered**: Full `WebApplicationFactory` 401/403/2xx tests for Wallet — heavy (WalletManager + DB deps) for what is an authz-pipeline concern that short-circuits before the handler; not worth standing up a new factory. Blueprint already has factories but the policy-eval test is sufficient and cheaper.
+
+## R4 — FR-010 verification (Tenant `RequireSystemAdmin` usages)
+
+**Finding (verified)**: All four usages — `PlatformManagementEndpoints.cs:32,39`, `PlatformOrgEndpoints.cs:33,39,45`, `PlatformSettingsEndpoints.cs:27` — are platform-administration endpoints and **all already compose `("RequireSystemAdmin", "RequirePlatformAudience")`**. None need role-only-any-org semantics. **Conclusion**: deleting the duplicate role-only registration is safe; the shared org-scoped definition (system-admin-org `00000000-0000-0000-0000-000000000001` AND `SystemAdmin` role) is the intended behaviour for every site.
+
+## R5 — Role-claim mechanics for the recover handler
+
+**Finding (verified via `AuthorizationPolicyExtensionsTests.RequireAdministrator_*`)**: role checks use `ClaimTypes.Role` and `RequireRole("SystemAdmin","Administrator")` / `context.User.IsInRole(...)` work in policy-evaluation tests when the principal is built with `new Claim(ClaimTypes.Role, "Administrator")`. The recover handler's human branch will test `context.User.IsInRole("Administrator") || context.User.IsInRole("SystemAdmin")` AND `HasTierAudience(Platform)`. (The shared `RequireAdministrator` policy accepts both `SystemAdmin` and `Administrator`; the recover handler mirrors that role set.)
+
+## R6 — Caller-flow confirmation (no legitimate regression)
+
+**Findings (verified)**:
+- `create` (`POST /api/v1/wallets/system`) sole caller: Validator Service `SystemWalletInitializer` → consolidated `WalletServiceClient.CreateOrRetrieveSystemWalletAsync`, which sets a `:service` token via `ServiceClientAuthHelper`. `RequireService` passes unchanged.
+- `recover` (`POST /api/v1/wallets/system/recover`) sole caller: CLI `sorcha system-register import-validator-key`, which logs in (`authService.GetAccessTokenAsync`) and sends a platform-tier admin token. The consolidated `RecoverSystemWalletAsync` has **no** server-side caller. `CanRecoverSystemWallet`'s admin+platform branch passes; the `:service` branch is forward-looking.
+- The group policy `CanManageWallets` (= `org_id OR service`) still applies after `AllowAnonymous` is removed; both legitimate callers satisfy it (service token / admin with org_id), so the layered check is defense-in-depth with no false-deny.
+
+## R7 — Test-runner constraint
+
+Microsoft.Testing.Platform ignores `dotnet test --filter` (MTP0001). Build + test are scoped to each affected service's **whole** test project: `Sorcha.Wallet.Service.Tests`, `Sorcha.Blueprint.Service.Tests`, `Sorcha.Tenant.Service.Tests`.

--- a/specs/147-authorization-gap-closure/spec.md
+++ b/specs/147-authorization-gap-closure/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Authorization-gap closure
+
+**Feature Branch**: `147-authorization-gap-closure`
+**Created**: 2026-06-03
+**Status**: Draft
+**Input**: Sub-project 2 of the security-hardening initiative. Authoritative source: `docs/superpowers/specs/2026-06-03-authorization-gap-closure-design.md` and `docs/reviews/2026-06-02-architecture-review.md` §2 (H1, H2, LOW), §7, §8.
+
+## Overview
+
+Four sensitive operations currently accept callers they should refuse, because the authorization decision is not enforced at the operation itself — it relies on a comment, on the perimeter (which only checks "is authenticated"), or on a shared rule that a later override silently weakened. This feature makes each operation enforce the correct trust tier and/or role in its own right, and — where a rule could be omitted per-operation — moves the rule into the shared definition so it cannot be forgotten.
+
+The trust tiers referenced throughout are the platform's existing identity tiers: **consumer** (citizen / wallet holder), **platform** (org admin / designer / operator), and **service** (service-to-service / infrastructure). "Administrator" / "SystemAdmin" are roles carried by platform-tier human tokens.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Validator signing keys cannot be seated by unauthorized callers (Priority: P1)
+
+The system-wallet create and recover operations exist so the platform's own infrastructure (and a one-time genesis ceremony operator) can seat the validator key that signs the distributed ledger's dockets. The recover operation imports a supplied seed phrase. Today these operations are reachable by any authenticated token through the perimeter, and by *anyone* on the internal network. An attacker who reaches them can install an attacker-controlled validator signing key and forge ledger entries.
+
+**Why this priority**: A seated attacker key compromises the integrity guarantee at the heart of the platform (the ledger). It is the single highest-impact gap in the set.
+
+**Independent Test**: Attempt create and recover with (a) no credentials, (b) a consumer-tier citizen token, (c) a service-tier token, (d) a platform admin token. Confirm only the legitimate callers succeed and everyone else is refused — without changing any legitimate caller's existing flow (infrastructure for create, admin genesis CLI for recover).
+
+**Acceptance Scenarios**:
+
+1. **Given** no credentials, **When** create or recover is called, **Then** the request is refused as unauthenticated.
+2. **Given** a consumer-tier citizen token, **When** create or recover is called, **Then** the request is refused as unauthorized.
+3. **Given** a service-tier token, **When** create is called, **Then** it succeeds (the infrastructure caller is unchanged).
+4. **Given** a platform-tier token holding an administrator role, **When** recover is called, **Then** it succeeds (the genesis-ceremony operator is unchanged).
+5. **Given** a service-tier token, **When** recover is called, **Then** it succeeds (future automation is supported).
+6. **Given** a system wallet already exists for the validator, **When** recover is called with a different seed, **Then** it is refused with a conflict (the existing protective guard is preserved).
+
+---
+
+### User Story 2 - Blueprint and schema authoring is closed to non-platform callers (Priority: P1)
+
+Blueprint, schema, credential-definition, and status-list authoring operations are an organization-administration activity. Today the gate they share admits any token carrying an organization identifier — and citizen/consumer tokens carry one — so a citizen can reach authoring. Authoring must require a platform-tier caller (or a legitimate service-tier caller); it must exclude consumer-tier callers.
+
+**Why this priority**: Authoring surfaces let a caller change what workflows validate and what credentials are issued. Consumer access to them is a privilege-escalation gap across multiple endpoints at once.
+
+**Independent Test**: Call each authoring operation with a consumer-tier token (expect refusal), a platform-tier org member (expect success), and a service-tier token (expect success). Confirm the fix is applied centrally, so every current and future authoring operation sharing the gate is covered without per-operation edits.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer-tier token that carries an organization identifier, **When** any blueprint/schema/credential/status-list authoring operation is called, **Then** it is refused as unauthorized.
+2. **Given** a platform-tier token carrying an organization identifier, **When** the same operation is called, **Then** authorization succeeds.
+3. **Given** a service-tier token, **When** the same operation is called, **Then** authorization succeeds.
+4. **Given** the authoring operations already composing a platform-tier requirement, **When** the central gate is changed, **Then** their behavior is unchanged (no regression, no new access).
+
+---
+
+### User Story 3 - A citizen's pending-application notice is reachable only by that citizen (Priority: P3)
+
+The pending-application notice is a citizen-facing wallet surface. Today its gate accepts any authenticated token, so a platform-tier token could read or set a citizen's notice. It must require a consumer-tier caller, matching every sibling citizen surface.
+
+**Why this priority**: Lower blast radius than US1/US2 (a notice label, scoped per-user), but it is a clear consumer⊥platform isolation gap and a one-line correction in the same theme.
+
+**Independent Test**: Call the pending-application read/set/clear operations with a platform-tier token (expect refusal) and a consumer-tier token (expect success).
+
+**Acceptance Scenarios**:
+
+1. **Given** a platform-tier token, **When** the pending-application notice is read or set, **Then** the request is refused as unauthorized.
+2. **Given** a consumer-tier token, **When** the citizen reads or sets their own notice, **Then** it succeeds and remains scoped to that citizen.
+
+---
+
+### User Story 4 - Platform-administration operations require system-admin-org membership (Priority: P3)
+
+The platform-administration operations (managing all organizations, platform settings) are intended for members of the system administration organization holding the SystemAdmin role. Today, in the tenant service, the shared system-admin rule is re-declared as role-only, dropping the organization constraint — so a SystemAdmin in *any* organization clears these operations. The organization constraint must be restored.
+
+**Why this priority**: Lower likelihood (requires an existing SystemAdmin role in another org) but a real privilege-scope gap on platform-wide operations.
+
+**Independent Test**: Evaluate the system-admin gate for a SystemAdmin in a non-system organization (expect refusal) and a SystemAdmin in the system administration organization (expect success).
+
+**Acceptance Scenarios**:
+
+1. **Given** a token with the SystemAdmin role but whose organization is not the system administration organization, **When** a platform-administration operation is called, **Then** it is refused as unauthorized.
+2. **Given** a token with the SystemAdmin role in the system administration organization, **When** the same operation is called, **Then** it succeeds.
+
+---
+
+### Edge Cases
+
+- A platform-tier token holding an org id but **no** administrator role calling recover → refused (recover's human branch requires the administrator role, not merely platform tier).
+- A token presenting an administrator role but a non-platform (e.g. consumer) audience calling recover → refused (both role and platform audience are required on the human branch).
+- A token from a *different installation* (different audience namespace) → already refused at the perimeter; the per-operation gates do not weaken that.
+- The internal-network direct-reach path (bypassing the perimeter) → closed for all four, because authorization is now enforced at the operation rather than at the perimeter.
+- The genesis ceremony run before any administrator exists → not a supported path today; the recover caller already authenticates as an administrator (the platform bootstrap creates that administrator first). Documented as an assumption.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**System-wallet operations (US1)**
+
+- **FR-001**: The system-wallet create operation MUST refuse any caller that is not a service-tier caller, including unauthenticated callers and all human-tier (consumer or platform) tokens.
+- **FR-002**: The system-wallet recover operation MUST refuse any caller that is neither (a) a service-tier caller nor (b) a platform-tier caller holding an administrator role; unauthenticated and consumer-tier callers MUST be refused.
+- **FR-003**: The system-wallet recover operation MUST continue to refuse, with a conflict result, an attempt to recover when an active system wallet already exists for that validator (the existing protective guard is retained, not removed).
+- **FR-004**: The legitimate existing callers MUST keep working unchanged: infrastructure creates via a service-tier token; the genesis-ceremony administrator recovers via a platform-tier administrator token.
+
+**Blueprint/schema authoring (US2)**
+
+- **FR-005**: The shared blueprint-management gate MUST admit a caller only if the caller is a service-tier caller, OR is a platform-tier caller carrying an organization identifier. Consumer-tier callers MUST be refused even when they carry an organization identifier.
+- **FR-006**: The correction MUST be applied in the shared gate definition so that every operation using it — current and future — is covered without per-operation changes.
+- **FR-007**: Authoring operations that already additionally require a platform-tier audience MUST retain their stricter behavior (no new access granted to them by this change).
+
+**Pending-application notice (US3)**
+
+- **FR-008**: The pending-application notice operations MUST require a consumer-tier caller; platform-tier and other non-consumer callers MUST be refused. Per-citizen scoping of the notice is unchanged.
+
+**Platform-administration (US4)**
+
+- **FR-009**: The platform-administration system-admin gate MUST require both the SystemAdmin role and membership of the system administration organization. The tenant service MUST NOT weaken this to role-only.
+- **FR-010**: Before removing the weakening, every use of the system-admin gate MUST be confirmed to be a platform-administration operation intended to be system-admin-org-scoped; any use that legitimately needs different semantics MUST be given its own distinct rule rather than relying on the weakened shared one.
+
+**Cross-cutting**
+
+- **FR-011**: No operation in scope may depend on the perimeter for its tier/role decision; each MUST enforce its own authorization so a direct internal-network call is refused identically.
+- **FR-012**: Each gate MUST derive the expected trust-tier audience from the platform's single source of truth at evaluation time (so per-installation audience namespaces are honored), rather than hard-coding an audience string.
+
+### Key Entities *(include if feature involves data)*
+
+- **Trust tier**: The tier a token belongs to (consumer / platform / service / enrol-session), carried in the token's audience. The unit of cross-tier isolation.
+- **Role**: An authorization role carried by a platform-tier human token (e.g. Administrator, SystemAdmin).
+- **System administration organization**: The well-known organization whose membership (plus SystemAdmin role) authorizes platform-wide administration.
+- **System wallet**: The validator's docket-signing wallet; created by infrastructure or recovered (imported from a seed phrase) during the genesis ceremony.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of unauthorized caller classes are refused on every in-scope operation: unauthenticated and consumer-tier callers receive an authorization failure on system-wallet create/recover, blueprint/schema/credential/status-list authoring, and the pending-application notice.
+- **SC-002**: 100% of legitimate caller classes continue to succeed: service-tier create, service-tier or platform-administrator recover, platform-tier or service-tier authoring, consumer-tier pending-application access — verified to be unchanged from before this feature.
+- **SC-003**: The blueprint-management correction is verified to cover **all** operations sharing the gate (the full set of currently-bare authoring operations) through a single central change, demonstrated by tests that exercise the gate rather than each endpoint individually.
+- **SC-004**: A SystemAdmin in a non-system organization is refused platform-administration operations, while a system-admin-org SystemAdmin is allowed.
+- **SC-005**: Each in-scope operation enforces authorization independently of the perimeter — demonstrated by a check that the operations carry no "allow anonymous" exemption and require their expected rule.
+- **SC-006**: Automated tests covering every acceptance scenario above pass in the affected services' test suites.
+
+## Assumptions
+
+- The genesis-ceremony operator authenticates as a platform-tier administrator before running recover (the platform bootstrap creates the first administrator, then the operator logs in as that administrator). Recover is therefore not required to run before any administrator exists.
+- The system-wallet create operation's only caller is the infrastructure service-to-service path, which already presents a service-tier token.
+- The consolidated recover client method has no current service-to-service caller; recover is exercised today only by the administrator CLI. The service-tier branch on recover is forward-looking for future automation and does not change any current flow.
+- All current uses of the tenant system-admin gate are platform-administration operations intended to be system-admin-org-scoped (to be confirmed during implementation per FR-010).
+
+## Out of Scope
+
+- The PWA-local presentation verifier accepting unverified issuer signatures (review H3) — handled in sub-project 3 (verification-correctness).
+- Issuer-trust shortcuts in the OIDC exchange and passkey-recovery paths (review M3) — sub-project 3.
+- Other review LOW items not concerning in-code authorization gating: token-revocation fail-open on cache error (risk acceptance), stale dev audience config (cleanup), default service-principal secrets in base configuration (operations), the already-guarded anonymous bootstrap.

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -123,7 +123,7 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 ## Phase 7: Polish & Cross-Cutting
 
 - [x] T020 [P] Doc sync: update the `jwt` skill policy catalogue (`.claude/skills/jwt/`) — add `CanRecoverSystemWallet`, note `CanManageBlueprints` is now tier-aware (service OR platform+org), and that Tenant `RequireSystemAdmin` is org-scoped (duplicate removed). Update `docs/guides/AUTHENTICATION-SETUP.md` if it enumerates these policies.
-- [ ] T021 Push branch `147-authorization-gap-closure`; open PR (`gh pr create`) referencing the design + spec; confirm `claude-review` is green (full-solution `build-and-test` stays red on the unrelated Refit cert infra issue — claude-review is the gate); merge on green.
+- [x] T021 Push branch `147-authorization-gap-closure`; open PR (`gh pr create`) referencing the design + spec; confirm `claude-review` is green (full-solution `build-and-test` stays red on the unrelated Refit cert infra issue — claude-review is the gate); merge on green.
 
 ---
 

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -109,12 +109,12 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 
 ### Tests for User Story 4 (write first, must FAIL) ⚠️
 
-- [ ] T017 [P] [US4] Policy-evaluation tests in `tests/Sorcha.Tenant.Service.Tests/Authorization/TenantSystemAdminPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddTenantAuthorization();` and assert: SystemAdmin in `00000000-0000-0000-0000-000000000001`→allow; SystemAdmin in a different org→deny; non-SystemAdmin in the system-admin org→deny. (Fails: Tenant override is role-only, so non-system-org SystemAdmin currently allowed.)
+- [x] T017 [P] [US4] Policy-evaluation tests in `tests/Sorcha.Tenant.Service.Tests/Authorization/TenantSystemAdminPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddTenantAuthorization();` and assert: SystemAdmin in `00000000-0000-0000-0000-000000000001`→allow; SystemAdmin in a different org→deny; non-SystemAdmin in the system-admin org→deny. (Fails: Tenant override is role-only, so non-system-org SystemAdmin currently allowed.)
 
 ### Implementation for User Story 4
 
-- [ ] T018 [US4] In `src/Services/Sorcha.Tenant.Service/Extensions/AuthenticationExtensions.cs`: delete the duplicate `options.AddPolicy("RequireSystemAdmin", policy => policy.RequireRole("SystemAdmin"))` so the shared org-scoped definition from `AddSorchaAuthorizationPolicies` wins. (FR-010 verified: all four Tenant usages already compose `RequirePlatformAudience` and are platform-management endpoints.)
-- [ ] T019 [US4] Build + run `tests/Sorcha.Tenant.Service.Tests` to green; commit `fix(147): LOW restore org-scope on Tenant RequireSystemAdmin`.
+- [x] T018 [US4] In `src/Services/Sorcha.Tenant.Service/Extensions/AuthenticationExtensions.cs`: delete the duplicate `options.AddPolicy("RequireSystemAdmin", policy => policy.RequireRole("SystemAdmin"))` so the shared org-scoped definition from `AddSorchaAuthorizationPolicies` wins. (FR-010 verified: all four Tenant usages already compose `RequirePlatformAudience` and are platform-management endpoints.)
+- [x] T019 [US4] Build + run `tests/Sorcha.Tenant.Service.Tests` to green; commit `fix(147): LOW restore org-scope on Tenant RequireSystemAdmin`.
 
 **Checkpoint**: All four findings closed.
 

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -1,0 +1,173 @@
+---
+description: "Task list for Authorization-gap closure"
+---
+
+# Tasks: Authorization-gap closure
+
+**Input**: Design documents from `/specs/147-authorization-gap-closure/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/authorization-matrix.md, quickstart.md
+
+**Tests**: TDD is REQUIRED for this feature (per spec + design). Each story writes failing tests first.
+
+**Organization**: Grouped by user story. Stories are independent and map 1:1 to the four findings (US1=H1, US2=H2, US3=F124, US4=LOW). Delivery is one PR with one commit per story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 / US4
+
+## Path Conventions
+
+Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint,Tenant}.Service/`; tests under `tests/Sorcha.{...}.Service.Tests/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish a green TDD baseline so the new failing tests are meaningfully red. No project initialization needed (existing solution).
+
+- [ ] T001 Establish baseline: build `tests/Sorcha.Wallet.Service.Tests`, `tests/Sorcha.Blueprint.Service.Tests`, and `tests/Sorcha.Tenant.Service.Tests` to confirm they compile and pass before changes (MTP runs whole projects; `--filter` is ignored).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared prerequisites for all stories.
+
+**None.** There is no shared new infrastructure — each story introduces only service-local types and reuses the existing `Sorcha.ServiceDefaults.Auth` primitives (`SorchaAudiences`, `HasTierAudience`) and the `AuthorizationPolicies` constants already registered by `AddSorchaAuthorizationPolicies`. User stories may begin immediately after Setup.
+
+---
+
+## Phase 3: User Story 1 - Validator signing keys cannot be seated by unauthorized callers (Priority: P1) 🎯 MVP
+
+**Goal**: H1 — drop `.AllowAnonymous()` on the system-wallet endpoints; `create` requires a service token; `recover` requires `:service` OR `Administrator`+`:platform`; keep the 409-on-exists guard.
+
+**Independent Test**: Evaluate `CanRecoverSystemWallet` against the caller matrix and assert the two endpoints carry no `AllowAnonymous` and require their policies — see `contracts/authorization-matrix.md` (H1 rows).
+
+### Tests for User Story 1 (write first, must FAIL) ⚠️
+
+- [ ] T002 [P] [US1] Policy-evaluation tests for `CanRecoverSystemWallet` in `tests/Sorcha.Wallet.Service.Tests/Authorization/WalletAuthorizationPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddWalletAuthorization();` (mirror `AuthorizationPolicyExtensionsTests`) and assert: service(`token_type=service`+`sorcha:service`)→allow; admin role+`sorcha:platform`→allow; consumer(`sorcha:consumer`)→deny; admin role+`sorcha:consumer`→deny; authenticated non-admin no-audience→deny; unauthenticated→deny. (Fails: policy does not exist yet.)
+- [ ] T003 [P] [US1] Endpoint-metadata regression tests in `tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs` — map the wallet endpoints onto a minimal host, enumerate `EndpointDataSource`, and assert `POST /api/v1/wallets/system` and `/system/recover` carry **no** `IAllowAnonymous` metadata and an `IAuthorizeData` with policy `RequireService` and `CanRecoverSystemWallet` respectively. (Fails: endpoints currently `AllowAnonymous`.)
+
+### Implementation for User Story 1
+
+- [ ] T004 [P] [US1] Create `SystemWalletRecoveryRequirement : IAuthorizationRequirement` (marker, XML-documented) in `src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryRequirement.cs`.
+- [ ] T005 [US1] Create `SystemWalletRecoveryAuthorizationHandler : AuthorizationHandler<SystemWalletRecoveryRequirement>` in `src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryAuthorizationHandler.cs` — inject `SorchaAudiences`; succeed iff (`token_type==service` AND `HasTierAudience(Service)`) OR ((`IsInRole("Administrator")`||`IsInRole("SystemAdmin")`) AND `HasTierAudience(Platform)`); never `Fail()`. (Depends on T004.)
+- [ ] T006 [US1] Register the handler (`AddSingleton<IAuthorizationHandler, SystemWalletRecoveryAuthorizationHandler>`) and define policy `CanRecoverSystemWallet` (`RequireAuthenticatedUser().AddRequirements(new SystemWalletRecoveryRequirement())`) in `src/Services/Sorcha.Wallet.Service/Extensions/AuthenticationExtensions.cs`. (Depends on T004, T005.)
+- [ ] T007 [US1] In `src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs`: remove `.AllowAnonymous()` from `/system` and `/system/recover`; add `.RequireAuthorization(AuthorizationPolicies.RequireService)` to create and `.RequireAuthorization("CanRecoverSystemWallet")` to recover; update the misleading inline comments; leave the 409-on-exists guard untouched. (Depends on T006.)
+- [ ] T008 [US1] Build + run `tests/Sorcha.Wallet.Service.Tests` to green; commit `feat(147): H1 gate system-wallet create/recover (close AllowAnonymous)`.
+
+**Checkpoint**: System-wallet create/recover are gated; tests green.
+
+---
+
+## Phase 4: User Story 2 - Blueprint and schema authoring is closed to non-platform callers (Priority: P1)
+
+**Goal**: H2 — redefine `CanManageBlueprints` as (service+`:service`) OR (org_id+`:platform`) in the policy definition, fixing all bare authoring endpoints with no per-endpoint edits.
+
+**Independent Test**: Evaluate `CanManageBlueprints` against the caller matrix — see `contracts/authorization-matrix.md` (H2 rows). Consumer-with-org denied; platform-with-org and service allowed.
+
+### Tests for User Story 2 (write first, must FAIL) ⚠️
+
+- [ ] T009 [P] [US2] Policy-evaluation tests for `CanManageBlueprints` in `tests/Sorcha.Blueprint.Service.Tests/Authorization/BlueprintManagementPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddBlueprintAuthorization();` and assert: consumer(`org_id`+`sorcha:consumer`)→deny; platform(`org_id`+`sorcha:platform`)→allow; service(`token_type=service`+`sorcha:service`)→allow; platform no-`org_id`→deny; `org_id` but no tier audience→deny. (Fails: current policy allows consumer-with-org.)
+
+### Implementation for User Story 2
+
+- [ ] T010 [P] [US2] Create `BlueprintManagementRequirement : IAuthorizationRequirement` (marker, XML-documented) in `src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementRequirement.cs`.
+- [ ] T011 [US2] Create `BlueprintManagementAuthorizationHandler : AuthorizationHandler<BlueprintManagementRequirement>` in `src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs` — inject `SorchaAudiences`; succeed iff (`token_type==service` AND `HasTierAudience(Service)`) OR (non-empty `org_id` AND `HasTierAudience(Platform)`); never `Fail()`. (Depends on T010.)
+- [ ] T012 [US2] In `src/Services/Sorcha.Blueprint.Service/Extensions/AuthenticationExtensions.cs`: register the handler and redefine `CanManageBlueprints` to `policy.AddRequirements(new BlueprintManagementRequirement())` (replacing the `hasOrgId OR isService` assertion). Leave `RehearsalEndpoints`/`BlueprintFromPublishedEndpoint` (which also compose `RequirePlatformAudience`) untouched. (Depends on T010, T011.)
+- [ ] T013 [US2] Build + run `tests/Sorcha.Blueprint.Service.Tests` to green; commit `feat(147): H2 fold platform-audience gate into CanManageBlueprints`.
+
+**Checkpoint**: Consumer tokens cannot reach blueprint/schema/credential/status-list authoring; service + platform-admin unchanged.
+
+---
+
+## Phase 5: User Story 3 - A citizen's pending-application notice is reachable only by that citizen (Priority: P3)
+
+**Goal**: F124 — pending-applications group requires consumer-tier.
+
+**Independent Test**: Assert the pending-applications group requires `RequireConsumerAudience` (platform token denied) — `contracts/authorization-matrix.md` (F124 rows).
+
+### Tests for User Story 3 (write first, must FAIL) ⚠️
+
+- [ ] T014 [P] [US3] Endpoint-metadata test in `tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationAuthorizationTests.cs` — assert the `/api/v1/wallet/pending-applications` group endpoints carry an `IAuthorizeData` with policy `RequireConsumerAudience`. (Fails: currently plain `RequireAuthorization()`.)
+
+### Implementation for User Story 3
+
+- [ ] T015 [US3] In `src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs`: change the group `.RequireAuthorization()` to `.RequireAuthorization(AuthorizationPolicies.RequireConsumerAudience)`.
+- [ ] T016 [US3] Build + run `tests/Sorcha.Wallet.Service.Tests` to green; commit `fix(147): F124 require consumer audience on pending-applications`.
+
+**Checkpoint**: Pending-application notice is consumer-only.
+
+---
+
+## Phase 6: User Story 4 - Platform-administration requires system-admin-org membership (Priority: P3)
+
+**Goal**: LOW — delete Tenant's duplicate role-only `RequireSystemAdmin` so the shared org-scoped definition stands.
+
+**Independent Test**: Evaluate `RequireSystemAdmin` (via `AddTenantAuthorization`) — `contracts/authorization-matrix.md` (LOW rows). Non-system-org SystemAdmin denied; system-admin-org SystemAdmin allowed.
+
+### Tests for User Story 4 (write first, must FAIL) ⚠️
+
+- [ ] T017 [P] [US4] Policy-evaluation tests in `tests/Sorcha.Tenant.Service.Tests/Authorization/TenantSystemAdminPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddTenantAuthorization();` and assert: SystemAdmin in `00000000-0000-0000-0000-000000000001`→allow; SystemAdmin in a different org→deny; non-SystemAdmin in the system-admin org→deny. (Fails: Tenant override is role-only, so non-system-org SystemAdmin currently allowed.)
+
+### Implementation for User Story 4
+
+- [ ] T018 [US4] In `src/Services/Sorcha.Tenant.Service/Extensions/AuthenticationExtensions.cs`: delete the duplicate `options.AddPolicy("RequireSystemAdmin", policy => policy.RequireRole("SystemAdmin"))` so the shared org-scoped definition from `AddSorchaAuthorizationPolicies` wins. (FR-010 verified: all four Tenant usages already compose `RequirePlatformAudience` and are platform-management endpoints.)
+- [ ] T019 [US4] Build + run `tests/Sorcha.Tenant.Service.Tests` to green; commit `fix(147): LOW restore org-scope on Tenant RequireSystemAdmin`.
+
+**Checkpoint**: All four findings closed.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T020 [P] Doc sync: update the `jwt` skill policy catalogue (`.claude/skills/jwt/`) — add `CanRecoverSystemWallet`, note `CanManageBlueprints` is now tier-aware (service OR platform+org), and that Tenant `RequireSystemAdmin` is org-scoped (duplicate removed). Update `docs/guides/AUTHENTICATION-SETUP.md` if it enumerates these policies.
+- [ ] T021 Push branch `147-authorization-gap-closure`; open PR (`gh pr create`) referencing the design + spec; confirm `claude-review` is green (full-solution `build-and-test` stays red on the unrelated Refit cert infra issue — claude-review is the gate); merge on green.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately.
+- **Foundational (Phase 2)**: none.
+- **User Stories (Phases 3-6)**: each depends only on Setup. US1 and US2 touch different services and are fully parallelizable. US3 shares the Wallet test project with US1 (different files) but has no logic dependency. US4 is independent (Tenant).
+- **Polish (Phase 7)**: after all stories complete.
+
+### Within Each User Story
+
+- Tests first, confirmed failing, before implementation.
+- Requirement type before handler before policy registration before endpoint wiring.
+- Build + green + commit closes the story.
+
+### Parallel Opportunities
+
+- US1 (Wallet) and US2 (Blueprint) can be implemented fully in parallel.
+- Within a story, the marked `[P]` test/requirement tasks (e.g. T002+T003, T004) can run together.
+
+---
+
+## Implementation Strategy
+
+### MVP (highest-impact first)
+
+1. Phase 1 Setup (baseline green).
+2. Phase 3 US1 (H1) — the highest-impact gap (validator signing key). STOP and validate.
+3. Phase 4 US2 (H2) — close consumer access to authoring.
+4. Phases 5-6 US3 + US4 — the two LOW-severity same-theme gaps.
+5. Phase 7 — doc sync + PR.
+
+### Delivery
+
+One PR (`147-authorization-gap-closure`), one commit per story (T008, T013, T016, T019), each built + tested against its service's whole test project before committing. Merge on green `claude-review`.
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependency on an incomplete task.
+- MTP runs whole test projects; do not rely on `--filter`.
+- The handlers never call `Fail()` (compose-safe). Audience checks always go through `SorchaAudiences`/`HasTierAudience` (no literal audience strings) — FR-012.
+- No behaviour change for legitimate callers (service create, admin-CLI recover, platform authoring, consumer pending-apps) — FR-004 / FR-007.

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -69,14 +69,14 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 
 ### Tests for User Story 2 (write first, must FAIL) ⚠️
 
-- [ ] T009 [P] [US2] Policy-evaluation tests for `CanManageBlueprints` in `tests/Sorcha.Blueprint.Service.Tests/Authorization/BlueprintManagementPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddBlueprintAuthorization();` and assert: consumer(`org_id`+`sorcha:consumer`)→deny; platform(`org_id`+`sorcha:platform`)→allow; service(`token_type=service`+`sorcha:service`)→allow; platform no-`org_id`→deny; `org_id` but no tier audience→deny. (Fails: current policy allows consumer-with-org.)
+- [x] T009 [P] [US2] Policy-evaluation tests for `CanManageBlueprints` in `tests/Sorcha.Blueprint.Service.Tests/Authorization/BlueprintManagementPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddBlueprintAuthorization();` and assert: consumer(`org_id`+`sorcha:consumer`)→deny; platform(`org_id`+`sorcha:platform`)→allow; service(`token_type=service`+`sorcha:service`)→allow; platform no-`org_id`→deny; `org_id` but no tier audience→deny. (Fails: current policy allows consumer-with-org.)
 
 ### Implementation for User Story 2
 
-- [ ] T010 [P] [US2] Create `BlueprintManagementRequirement : IAuthorizationRequirement` (marker, XML-documented) in `src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementRequirement.cs`.
-- [ ] T011 [US2] Create `BlueprintManagementAuthorizationHandler : AuthorizationHandler<BlueprintManagementRequirement>` in `src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs` — inject `SorchaAudiences`; succeed iff (`token_type==service` AND `HasTierAudience(Service)`) OR (non-empty `org_id` AND `HasTierAudience(Platform)`); never `Fail()`. (Depends on T010.)
-- [ ] T012 [US2] In `src/Services/Sorcha.Blueprint.Service/Extensions/AuthenticationExtensions.cs`: register the handler and redefine `CanManageBlueprints` to `policy.AddRequirements(new BlueprintManagementRequirement())` (replacing the `hasOrgId OR isService` assertion). Leave `RehearsalEndpoints`/`BlueprintFromPublishedEndpoint` (which also compose `RequirePlatformAudience`) untouched. (Depends on T010, T011.)
-- [ ] T013 [US2] Build + run `tests/Sorcha.Blueprint.Service.Tests` to green; commit `feat(147): H2 fold platform-audience gate into CanManageBlueprints`.
+- [x] T010 [P] [US2] Create `BlueprintManagementRequirement : IAuthorizationRequirement` (marker, XML-documented) in `src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementRequirement.cs`.
+- [x] T011 [US2] Create `BlueprintManagementAuthorizationHandler : AuthorizationHandler<BlueprintManagementRequirement>` in `src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs` — inject `SorchaAudiences`; succeed iff (`token_type==service` AND `HasTierAudience(Service)`) OR (non-empty `org_id` AND `HasTierAudience(Platform)`); never `Fail()`. (Depends on T010.)
+- [x] T012 [US2] In `src/Services/Sorcha.Blueprint.Service/Extensions/AuthenticationExtensions.cs`: register the handler and redefine `CanManageBlueprints` to `policy.AddRequirements(new BlueprintManagementRequirement())` (replacing the `hasOrgId OR isService` assertion). Leave `RehearsalEndpoints`/`BlueprintFromPublishedEndpoint` (which also compose `RequirePlatformAudience`) untouched. (Depends on T010, T011.)
+- [x] T013 [US2] Build + run `tests/Sorcha.Blueprint.Service.Tests` to green; commit `feat(147): H2 fold platform-audience gate into CanManageBlueprints`.
 
 **Checkpoint**: Consumer tokens cannot reach blueprint/schema/credential/status-list authoring; service + platform-admin unchanged.
 

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -90,12 +90,12 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 
 ### Tests for User Story 3 (write first, must FAIL) ⚠️
 
-- [ ] T014 [P] [US3] Endpoint-metadata test in `tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationAuthorizationTests.cs` — assert the `/api/v1/wallet/pending-applications` group endpoints carry an `IAuthorizeData` with policy `RequireConsumerAudience`. (Fails: currently plain `RequireAuthorization()`.)
+- [x] T014 [P] [US3] Endpoint-metadata test in `tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationAuthorizationTests.cs` — assert the `/api/v1/wallet/pending-applications` group endpoints carry an `IAuthorizeData` with policy `RequireConsumerAudience`. (Fails: currently plain `RequireAuthorization()`.)
 
 ### Implementation for User Story 3
 
-- [ ] T015 [US3] In `src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs`: change the group `.RequireAuthorization()` to `.RequireAuthorization(AuthorizationPolicies.RequireConsumerAudience)`.
-- [ ] T016 [US3] Build + run `tests/Sorcha.Wallet.Service.Tests` to green; commit `fix(147): F124 require consumer audience on pending-applications`.
+- [x] T015 [US3] In `src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs`: change the group `.RequireAuthorization()` to `.RequireAuthorization(AuthorizationPolicies.RequireConsumerAudience)`.
+- [x] T016 [US3] Build + run `tests/Sorcha.Wallet.Service.Tests` to green; commit `fix(147): F124 require consumer audience on pending-applications`.
 
 **Checkpoint**: Pending-application notice is consumer-only.
 

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -26,7 +26,7 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 
 **Purpose**: Establish a green TDD baseline so the new failing tests are meaningfully red. No project initialization needed (existing solution).
 
-- [ ] T001 Establish baseline: build `tests/Sorcha.Wallet.Service.Tests`, `tests/Sorcha.Blueprint.Service.Tests`, and `tests/Sorcha.Tenant.Service.Tests` to confirm they compile and pass before changes (MTP runs whole projects; `--filter` is ignored).
+- [x] T001 Establish baseline: build `tests/Sorcha.Wallet.Service.Tests`, `tests/Sorcha.Blueprint.Service.Tests`, and `tests/Sorcha.Tenant.Service.Tests` to confirm they compile and pass before changes (MTP runs whole projects; `--filter` is ignored).
 
 ---
 
@@ -46,16 +46,16 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 
 ### Tests for User Story 1 (write first, must FAIL) ⚠️
 
-- [ ] T002 [P] [US1] Policy-evaluation tests for `CanRecoverSystemWallet` in `tests/Sorcha.Wallet.Service.Tests/Authorization/WalletAuthorizationPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddWalletAuthorization();` (mirror `AuthorizationPolicyExtensionsTests`) and assert: service(`token_type=service`+`sorcha:service`)→allow; admin role+`sorcha:platform`→allow; consumer(`sorcha:consumer`)→deny; admin role+`sorcha:consumer`→deny; authenticated non-admin no-audience→deny; unauthenticated→deny. (Fails: policy does not exist yet.)
-- [ ] T003 [P] [US1] Endpoint-metadata regression tests in `tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs` — map the wallet endpoints onto a minimal host, enumerate `EndpointDataSource`, and assert `POST /api/v1/wallets/system` and `/system/recover` carry **no** `IAllowAnonymous` metadata and an `IAuthorizeData` with policy `RequireService` and `CanRecoverSystemWallet` respectively. (Fails: endpoints currently `AllowAnonymous`.)
+- [x] T002 [P] [US1] Policy-evaluation tests for `CanRecoverSystemWallet` in `tests/Sorcha.Wallet.Service.Tests/Authorization/WalletAuthorizationPolicyTests.cs` — build a provider via `services.AddLogging(); services.AddWalletAuthorization();` (mirror `AuthorizationPolicyExtensionsTests`) and assert: service(`token_type=service`+`sorcha:service`)→allow; admin role+`sorcha:platform`→allow; consumer(`sorcha:consumer`)→deny; admin role+`sorcha:consumer`→deny; authenticated non-admin no-audience→deny; unauthenticated→deny. (Fails: policy does not exist yet.)
+- [x] T003 [P] [US1] Endpoint-metadata regression tests in `tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs` — map the wallet endpoints onto a minimal host, enumerate `EndpointDataSource`, and assert `POST /api/v1/wallets/system` and `/system/recover` carry **no** `IAllowAnonymous` metadata and an `IAuthorizeData` with policy `RequireService` and `CanRecoverSystemWallet` respectively. (Fails: endpoints currently `AllowAnonymous`.)
 
 ### Implementation for User Story 1
 
-- [ ] T004 [P] [US1] Create `SystemWalletRecoveryRequirement : IAuthorizationRequirement` (marker, XML-documented) in `src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryRequirement.cs`.
-- [ ] T005 [US1] Create `SystemWalletRecoveryAuthorizationHandler : AuthorizationHandler<SystemWalletRecoveryRequirement>` in `src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryAuthorizationHandler.cs` — inject `SorchaAudiences`; succeed iff (`token_type==service` AND `HasTierAudience(Service)`) OR ((`IsInRole("Administrator")`||`IsInRole("SystemAdmin")`) AND `HasTierAudience(Platform)`); never `Fail()`. (Depends on T004.)
-- [ ] T006 [US1] Register the handler (`AddSingleton<IAuthorizationHandler, SystemWalletRecoveryAuthorizationHandler>`) and define policy `CanRecoverSystemWallet` (`RequireAuthenticatedUser().AddRequirements(new SystemWalletRecoveryRequirement())`) in `src/Services/Sorcha.Wallet.Service/Extensions/AuthenticationExtensions.cs`. (Depends on T004, T005.)
-- [ ] T007 [US1] In `src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs`: remove `.AllowAnonymous()` from `/system` and `/system/recover`; add `.RequireAuthorization(AuthorizationPolicies.RequireService)` to create and `.RequireAuthorization("CanRecoverSystemWallet")` to recover; update the misleading inline comments; leave the 409-on-exists guard untouched. (Depends on T006.)
-- [ ] T008 [US1] Build + run `tests/Sorcha.Wallet.Service.Tests` to green; commit `feat(147): H1 gate system-wallet create/recover (close AllowAnonymous)`.
+- [x] T004 [P] [US1] Create `SystemWalletRecoveryRequirement : IAuthorizationRequirement` (marker, XML-documented) in `src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryRequirement.cs`.
+- [x] T005 [US1] Create `SystemWalletRecoveryAuthorizationHandler : AuthorizationHandler<SystemWalletRecoveryRequirement>` in `src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryAuthorizationHandler.cs` — inject `SorchaAudiences`; succeed iff (`token_type==service` AND `HasTierAudience(Service)`) OR ((`IsInRole("Administrator")`||`IsInRole("SystemAdmin")`) AND `HasTierAudience(Platform)`); never `Fail()`. (Depends on T004.)
+- [x] T006 [US1] Register the handler (`AddSingleton<IAuthorizationHandler, SystemWalletRecoveryAuthorizationHandler>`) and define policy `CanRecoverSystemWallet` (`RequireAuthenticatedUser().AddRequirements(new SystemWalletRecoveryRequirement())`) in `src/Services/Sorcha.Wallet.Service/Extensions/AuthenticationExtensions.cs`. (Depends on T004, T005.)
+- [x] T007 [US1] In `src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs`: remove `.AllowAnonymous()` from `/system` and `/system/recover`; add `.RequireAuthorization(AuthorizationPolicies.RequireService)` to create and `.RequireAuthorization("CanRecoverSystemWallet")` to recover; update the misleading inline comments; leave the 409-on-exists guard untouched. (Depends on T006.)
+- [x] T008 [US1] Build + run `tests/Sorcha.Wallet.Service.Tests` to green; commit `feat(147): H1 gate system-wallet create/recover (close AllowAnonymous)`.
 
 **Checkpoint**: System-wallet create/recover are gated; tests green.
 

--- a/specs/147-authorization-gap-closure/tasks.md
+++ b/specs/147-authorization-gap-closure/tasks.md
@@ -122,7 +122,7 @@ Multi-service repo. Production code under `src/Services/Sorcha.{Wallet,Blueprint
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T020 [P] Doc sync: update the `jwt` skill policy catalogue (`.claude/skills/jwt/`) — add `CanRecoverSystemWallet`, note `CanManageBlueprints` is now tier-aware (service OR platform+org), and that Tenant `RequireSystemAdmin` is org-scoped (duplicate removed). Update `docs/guides/AUTHENTICATION-SETUP.md` if it enumerates these policies.
+- [x] T020 [P] Doc sync: update the `jwt` skill policy catalogue (`.claude/skills/jwt/`) — add `CanRecoverSystemWallet`, note `CanManageBlueprints` is now tier-aware (service OR platform+org), and that Tenant `RequireSystemAdmin` is org-scoped (duplicate removed). Update `docs/guides/AUTHENTICATION-SETUP.md` if it enumerates these policies.
 - [ ] T021 Push branch `147-authorization-gap-closure`; open PR (`gh pr create`) referencing the design + spec; confirm `claude-review` is green (full-solution `build-and-test` stays red on the unrelated Refit cert infra issue — claude-review is the gate); merge on green.
 
 ---

--- a/src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementAuthorizationHandler.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Hosting; // AuthorizationPolicyExtensions.HasTierAudience
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceDefaults.Auth;
+
+namespace Sorcha.Blueprint.Service.Authorization;
+
+/// <summary>
+/// Succeeds a <see cref="BlueprintManagementRequirement"/> when the caller may author blueprints,
+/// schemas, credential definitions, or status lists (spec 147 / review H2). Two accepted callers:
+/// <list type="bullet">
+///   <item>a service-tier caller (<c>token_type==service</c> carrying this installation's <c>:service</c> audience); and</item>
+///   <item>a platform-tier organization member (a non-empty <c>org_id</c> claim carrying this installation's <c>:platform</c> audience).</item>
+/// </list>
+/// Consumer-tier tokens are refused <em>even though they carry an <c>org_id</c></em> (Feature 136): the
+/// previous <c>org_id OR service</c> gate let a citizen reach authoring. The expected audience is resolved
+/// from <see cref="SorchaAudiences"/> at evaluation time so per-installation namespaces are honored.
+/// Never calls <see cref="AuthorizationHandlerContext.Fail()"/> — a non-match simply leaves the
+/// requirement unmet, so it composes with other requirements on the same policy (e.g. an endpoint that
+/// also requires <c>RequirePlatformAudience</c>).
+/// </summary>
+public sealed class BlueprintManagementAuthorizationHandler
+    : AuthorizationHandler<BlueprintManagementRequirement>
+{
+    private readonly SorchaAudiences _audiences;
+
+    /// <summary>Creates the handler with the installation's audience set (from DI).</summary>
+    public BlueprintManagementAuthorizationHandler(SorchaAudiences audiences)
+    {
+        _audiences = audiences ?? throw new ArgumentNullException(nameof(audiences));
+    }
+
+    /// <inheritdoc />
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, BlueprintManagementRequirement requirement)
+    {
+        var user = context.User;
+
+        var isService =
+            user.Claims.Any(c =>
+                c.Type == TokenClaimConstants.TokenType &&
+                c.Value == TokenClaimConstants.TokenTypeService) &&
+            AuthorizationPolicyExtensions.HasTierAudience(user, _audiences, Tier.Service);
+
+        var isPlatformOrgMember =
+            user.Claims.Any(c => c.Type == TokenClaimConstants.OrgId && !string.IsNullOrEmpty(c.Value)) &&
+            AuthorizationPolicyExtensions.HasTierAudience(user, _audiences, Tier.Platform);
+
+        if (isService || isPlatformOrgMember)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementRequirement.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Authorization/BlueprintManagementRequirement.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Sorcha.Blueprint.Service.Authorization;
+
+/// <summary>
+/// Authorization requirement for blueprint / schema / credential / status-list authoring
+/// (the <c>CanManageBlueprints</c> policy). Satisfied by <see cref="BlueprintManagementAuthorizationHandler"/>
+/// for either a service-tier caller or a platform-tier organization member. Marker type — carries no state.
+/// </summary>
+public sealed class BlueprintManagementRequirement : IAuthorizationRequirement
+{
+}

--- a/src/Services/Sorcha.Blueprint.Service/Extensions/AuthenticationExtensions.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Extensions/AuthenticationExtensions.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.AspNetCore.Authorization;
+
+using Sorcha.Blueprint.Service.Authorization;
 using Sorcha.ServiceClients.Auth;
 
 namespace Sorcha.Blueprint.Service.Extensions;
@@ -21,16 +24,19 @@ public static class AuthenticationExtensions
         // RequireOrganizationMember, RequireDelegatedAuthority, RequireAdministrator, CanWriteDockets)
         services.AddSorchaAuthorizationPolicies();
 
+        // Feature 147 / review H2: blueprint authoring must exclude consumer-tier tokens (which carry
+        // an org_id under Feature 136). The tier gate lives in the policy itself (via the handler) so it
+        // cannot be omitted per-endpoint.
+        services.AddSingleton<IAuthorizationHandler, BlueprintManagementAuthorizationHandler>();
+
         services.AddAuthorization(options =>
         {
-            // Blueprint management (create, update, delete) - requires org member or service token
+            // Blueprint management (create, update, delete) — service-tier caller OR platform-tier
+            // org member. The previous `org_id OR service` assertion admitted consumer/citizen tokens
+            // (which carry org_id); the requirement folds in the platform-audience check so the gap
+            // is closed for every endpoint using this policy, current and future (review H2).
             options.AddPolicy("CanManageBlueprints", policy =>
-                policy.RequireAssertion(context =>
-                {
-                    var hasOrgId = context.User.Claims.Any(c => c.Type == TokenClaimConstants.OrgId && !string.IsNullOrEmpty(c.Value));
-                    var isService = context.User.Claims.Any(c => c.Type == TokenClaimConstants.TokenType && c.Value == TokenClaimConstants.TokenTypeService);
-                    return hasOrgId || isService;
-                }));
+                policy.AddRequirements(new BlueprintManagementRequirement()));
 
             // Blueprint execution - any authenticated user
             options.AddPolicy("CanExecuteBlueprints", policy =>

--- a/src/Services/Sorcha.Tenant.Service/Extensions/AuthenticationExtensions.cs
+++ b/src/Services/Sorcha.Tenant.Service/Extensions/AuthenticationExtensions.cs
@@ -147,9 +147,11 @@ public static class AuthenticationExtensions
             options.AddPolicy("CanPublishBlueprint", policy =>
                 policy.RequireClaim("can_publish_blueprint", "true"));
 
-            // Policy for system administrators only (platform-level operations)
-            options.AddPolicy("RequireSystemAdmin", policy =>
-                policy.RequireRole("SystemAdmin"));
+            // NOTE (Feature 147 / review LOW): RequireSystemAdmin is intentionally NOT re-registered
+            // here. The shared, org-scoped definition from AddSorchaAuthorizationPolicies
+            // (system-admin org membership AND SystemAdmin role) is authoritative. A previous
+            // role-only override here dropped the org-scope (last-write-wins), letting a SystemAdmin
+            // in any org clear platform-administration routes.
         });
 
         return services;

--- a/src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryAuthorizationHandler.cs
+++ b/src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryAuthorizationHandler.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Hosting; // AuthorizationPolicyExtensions.HasTierAudience
+using Sorcha.ServiceClients.Auth;
+using Sorcha.ServiceDefaults.Auth;
+
+namespace Sorcha.Wallet.Service.Authorization;
+
+/// <summary>
+/// Succeeds a <see cref="SystemWalletRecoveryRequirement"/> when the caller is authorized to recover
+/// (import) a validator's system docket-signing wallet from a BIP39 mnemonic. Two accepted callers
+/// (spec 147 / review H1):
+/// <list type="bullet">
+///   <item>a service-tier caller (<c>token_type==service</c> carrying this installation's <c>:service</c> audience) — forward-looking automation; and</item>
+///   <item>a platform-tier administrator (an <c>Administrator</c>/<c>SystemAdmin</c> role carrying this installation's <c>:platform</c> audience) — the genesis-ceremony operator running <c>sorcha system-register import-validator-key</c>.</item>
+/// </list>
+/// Consumer-tier and unauthenticated callers are refused. The expected audience is resolved from
+/// <see cref="SorchaAudiences"/> at evaluation time so per-installation namespaces are honored.
+/// Never calls <see cref="AuthorizationHandlerContext.Fail()"/> — a non-match simply leaves the
+/// requirement unmet, so it composes with any other requirement on the same policy.
+/// </summary>
+public sealed class SystemWalletRecoveryAuthorizationHandler
+    : AuthorizationHandler<SystemWalletRecoveryRequirement>
+{
+    private readonly SorchaAudiences _audiences;
+
+    /// <summary>Creates the handler with the installation's audience set (from DI).</summary>
+    public SystemWalletRecoveryAuthorizationHandler(SorchaAudiences audiences)
+    {
+        _audiences = audiences ?? throw new ArgumentNullException(nameof(audiences));
+    }
+
+    /// <inheritdoc />
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, SystemWalletRecoveryRequirement requirement)
+    {
+        var user = context.User;
+
+        var isService =
+            user.Claims.Any(c =>
+                c.Type == TokenClaimConstants.TokenType &&
+                c.Value == TokenClaimConstants.TokenTypeService) &&
+            AuthorizationPolicyExtensions.HasTierAudience(user, _audiences, Tier.Service);
+
+        var isPlatformAdmin =
+            (user.IsInRole("Administrator") || user.IsInRole("SystemAdmin")) &&
+            AuthorizationPolicyExtensions.HasTierAudience(user, _audiences, Tier.Platform);
+
+        if (isService || isPlatformAdmin)
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryRequirement.cs
+++ b/src/Services/Sorcha.Wallet.Service/Authorization/SystemWalletRecoveryRequirement.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Authorization;
+
+namespace Sorcha.Wallet.Service.Authorization;
+
+/// <summary>
+/// Authorization requirement for the system-wallet <c>recover</c> operation (BIP39 import that seats
+/// a validator docket-signing wallet). Satisfied by <see cref="SystemWalletRecoveryAuthorizationHandler"/>
+/// for either a service-tier caller or a platform-tier administrator. Marker type — carries no state.
+/// </summary>
+public sealed class SystemWalletRecoveryRequirement : IAuthorizationRequirement
+{
+}

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/PendingApplicationEndpoints.cs
@@ -23,7 +23,9 @@ public static class PendingApplicationEndpoints
     {
         var group = app.MapGroup("/api/v1/wallet/pending-applications")
             .WithTags("Citizen Wallet")
-            .RequireAuthorization()
+            // Feature 147 / review F124: consumer-tier only, matching every sibling citizen surface.
+            // Plain .RequireAuthorization() let a platform token read/set a citizen's notice.
+            .RequireAuthorization(Microsoft.Extensions.Hosting.AuthorizationPolicies.RequireConsumerAudience)
             .RequireRateLimiting(RateLimitPolicies.Strict);
 
         group.MapGet("", GetPendingApplication)

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/WalletEndpoints.cs
@@ -45,7 +45,9 @@ public static class WalletEndpoints
             .WithName("CreateOrRetrieveSystemWallet")
             .WithSummary("Create or retrieve system wallet")
             .WithDescription("Creates or retrieves a system wallet for a validator. Used by Validator Service for signing operations.")
-            .AllowAnonymous() // System wallets are service-to-service, use service auth
+            // Feature 147 / review H1: service-to-service only. Enforced in-code (not just at the
+            // gateway, which is RequireAuthenticated) so a direct internal-network call is also gated.
+            .RequireAuthorization(Microsoft.Extensions.Hosting.AuthorizationPolicies.RequireService)
             .Produces<SystemWalletResponse>(StatusCodes.Status200OK)
             .Produces<SystemWalletResponse>(StatusCodes.Status201Created)
             .ProducesValidationProblem();
@@ -58,7 +60,10 @@ public static class WalletEndpoints
                 "Used by 'sorcha system-register import-validator-key' to seat the genesis-ceremony validator wallet so " +
                 "the Validator Service can sign system register dockets. Idempotent only when the existing wallet's seed " +
                 "already matches the supplied mnemonic — otherwise returns 409 Conflict.")
-            .AllowAnonymous() // Service-to-service via the CLI's authenticated session; admin-only at the CLI layer
+            // Feature 147 / review H1: service-tier caller OR platform-tier administrator (the genesis
+            // ceremony operator). Enforced in-code so a direct internal-network call is gated too.
+            // The 409-on-exists guard in the handler remains as belt-and-braces.
+            .RequireAuthorization("CanRecoverSystemWallet")
             .Produces<SystemWalletResponse>(StatusCodes.Status200OK)
             .Produces<SystemWalletResponse>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status409Conflict)

--- a/src/Services/Sorcha.Wallet.Service/Extensions/AuthenticationExtensions.cs
+++ b/src/Services/Sorcha.Wallet.Service/Extensions/AuthenticationExtensions.cs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using Microsoft.AspNetCore.Authorization;
+
 using Sorcha.ServiceClients.Auth;
+using Sorcha.Wallet.Service.Authorization;
 
 namespace Sorcha.Wallet.Service.Extensions;
 
@@ -21,6 +24,10 @@ public static class AuthenticationExtensions
         // RequireOrganizationMember, RequireDelegatedAuthority, RequireAdministrator, CanWriteDockets)
         services.AddSorchaAuthorizationPolicies();
 
+        // Feature 147 / review H1: the system-wallet recover operation accepts either a service-tier
+        // caller or a platform-tier administrator (resolved against this installation's audiences).
+        services.AddSingleton<IAuthorizationHandler, SystemWalletRecoveryAuthorizationHandler>();
+
         services.AddAuthorization(options =>
         {
             // Wallet management (create, read wallet list)
@@ -31,6 +38,14 @@ public static class AuthenticationExtensions
                     var isService = context.User.Claims.Any(c => c.Type == TokenClaimConstants.TokenType && c.Value == TokenClaimConstants.TokenTypeService);
                     return hasOrgId || isService;
                 }));
+
+            // System-wallet recovery (BIP39 import that seats a validator docket-signing wallet).
+            // Feature 147 / review H1: service-tier caller OR platform-tier administrator.
+            // Logic lives in SystemWalletRecoveryAuthorizationHandler so the audience tier is
+            // resolved from the single source of truth at request time.
+            options.AddPolicy("CanRecoverSystemWallet", policy =>
+                policy.RequireAuthenticatedUser()
+                      .AddRequirements(new SystemWalletRecoveryRequirement()));
 
             // Wallet operations (sign, encrypt, decrypt) - requires wallet ownership
             options.AddPolicy("CanUseWallet", policy =>

--- a/tests/Sorcha.Blueprint.Service.Tests/Authorization/BlueprintManagementPolicyTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Authorization/BlueprintManagementPolicyTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+using Sorcha.Blueprint.Service.Extensions;
+using Sorcha.ServiceClients.Auth;
+
+using Xunit;
+
+namespace Sorcha.Blueprint.Service.Tests.Authorization;
+
+/// <summary>
+/// Policy-evaluation tests for the Blueprint Service <c>CanManageBlueprints</c> policy (Feature 147 / review H2).
+/// Mirrors the shared <c>AuthorizationPolicyExtensionsTests</c> harness: build a provider via
+/// <see cref="AuthenticationExtensions.AddBlueprintAuthorization"/> and evaluate through the real
+/// <see cref="IAuthorizationService"/> pipeline. Default installation is "sorcha", so tier audiences are
+/// <c>sorcha:{consumer|platform|service}</c>. The key regression: a consumer token carrying an
+/// <c>org_id</c> (Feature 136) must be refused.
+/// </summary>
+public class BlueprintManagementPolicyTests
+{
+    private const string PolicyName = "CanManageBlueprints";
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddBlueprintAuthorization();
+        return services.BuildServiceProvider();
+    }
+
+    private static ClaimsPrincipal AuthenticatedUser(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "TestScheme"));
+
+    private static async Task<bool> SucceedsAsync(ServiceProvider provider, ClaimsPrincipal user)
+    {
+        var authz = provider.GetRequiredService<IAuthorizationService>();
+        return (await authz.AuthorizeAsync(user, PolicyName)).Succeeded;
+    }
+
+    [Fact]
+    public async Task ConsumerWithOrgId_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, "org-1"),
+            new Claim("aud", "sorcha:consumer"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "a consumer/citizen token carrying org_id must not reach blueprint authoring (review H2)");
+    }
+
+    [Fact]
+    public async Task PlatformWithOrgId_Succeeds()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, "org-1"),
+            new Claim("aud", "sorcha:platform"));
+
+        (await SucceedsAsync(provider, user)).Should().BeTrue(
+            "a platform-tier org member may author blueprints");
+    }
+
+    [Fact]
+    public async Task ServiceToken_Succeeds()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.TokenType, TokenClaimConstants.TokenTypeService),
+            new Claim("aud", "sorcha:service"));
+
+        (await SucceedsAsync(provider, user)).Should().BeTrue(
+            "a service-tier caller may author blueprints (service-to-service)");
+    }
+
+    [Fact]
+    public async Task PlatformWithoutOrgId_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(new Claim("aud", "sorcha:platform"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "a platform-tier token without an org_id is not an org member for authoring purposes");
+    }
+
+    [Fact]
+    public async Task OrgIdWithoutTierAudience_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(new Claim(TokenClaimConstants.OrgId, "org-1"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "an org_id without the :platform audience must not satisfy the platform branch");
+    }
+
+    [Fact]
+    public async Task ServiceTokenWithoutServiceAudience_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.TokenType, TokenClaimConstants.TokenTypeService));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "token_type alone is insufficient; the :service audience is required");
+    }
+}

--- a/tests/Sorcha.Tenant.Service.Tests/Authorization/TenantSystemAdminPolicyTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Authorization/TenantSystemAdminPolicyTests.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+using Sorcha.ServiceClients.Auth;
+using Sorcha.Tenant.Service.Extensions;
+
+using Xunit;
+
+namespace Sorcha.Tenant.Service.Tests.Authorization;
+
+/// <summary>
+/// Policy-evaluation tests for the Tenant Service <c>RequireSystemAdmin</c> policy (Feature 147 / review LOW).
+/// <see cref="AuthenticationExtensions.AddTenantAuthorization"/> previously re-registered
+/// <c>RequireSystemAdmin</c> as role-only, dropping the org-scope from the shared definition (last-write-wins),
+/// so a SystemAdmin in <em>any</em> org cleared platform-administration routes. With the duplicate removed,
+/// the shared definition (system-admin org membership AND SystemAdmin role) stands.
+/// </summary>
+public class TenantSystemAdminPolicyTests
+{
+    private const string PolicyName = "RequireSystemAdmin";
+    private const string SystemAdminOrgId = "00000000-0000-0000-0000-000000000001";
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTenantAuthorization();
+        return services.BuildServiceProvider();
+    }
+
+    private static ClaimsPrincipal AuthenticatedUser(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "TestScheme"));
+
+    private static async Task<bool> SucceedsAsync(ServiceProvider provider, ClaimsPrincipal user)
+    {
+        var authz = provider.GetRequiredService<IAuthorizationService>();
+        return (await authz.AuthorizeAsync(user, PolicyName)).Succeeded;
+    }
+
+    [Fact]
+    public async Task SystemAdminInSystemAdminOrg_Succeeds()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, SystemAdminOrgId),
+            new Claim(ClaimTypes.Role, "SystemAdmin"));
+
+        (await SucceedsAsync(provider, user)).Should().BeTrue(
+            "a SystemAdmin in the system administration org may perform platform administration");
+    }
+
+    [Fact]
+    public async Task SystemAdminInNonSystemOrg_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, "11111111-1111-1111-1111-111111111111"),
+            new Claim(ClaimTypes.Role, "SystemAdmin"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "the SystemAdmin role outside the system administration org must NOT clear platform administration (review LOW)");
+    }
+
+    [Fact]
+    public async Task NonSystemAdminInSystemAdminOrg_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, SystemAdminOrgId),
+            new Claim(ClaimTypes.Role, "Administrator"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "membership of the system administration org without the SystemAdmin role is insufficient");
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Authorization/WalletAuthorizationPolicyTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Authorization/WalletAuthorizationPolicyTests.cs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+using Sorcha.ServiceClients.Auth;
+using Sorcha.Wallet.Service.Extensions;
+
+namespace Sorcha.Wallet.Service.Tests.Authorization;
+
+/// <summary>
+/// Policy-evaluation tests for the Wallet Service <c>CanRecoverSystemWallet</c> policy (Feature 147 / review H1).
+/// Mirrors the shared <c>AuthorizationPolicyExtensionsTests</c> harness: build a provider with
+/// <see cref="WalletServiceExtensions"/>-registered policies and evaluate through the real
+/// <see cref="IAuthorizationService"/> pipeline. Default installation is "sorcha" (no configuration),
+/// so tier audiences are <c>sorcha:{consumer|platform|service}</c>.
+/// </summary>
+public class WalletAuthorizationPolicyTests
+{
+    private const string PolicyName = "CanRecoverSystemWallet";
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddWalletAuthorization();
+        return services.BuildServiceProvider();
+    }
+
+    private static ClaimsPrincipal AuthenticatedUser(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "TestScheme"));
+
+    private static ClaimsPrincipal UnauthenticatedUser() => new(new ClaimsIdentity());
+
+    private static async Task<bool> SucceedsAsync(ServiceProvider provider, ClaimsPrincipal user)
+    {
+        var authz = provider.GetRequiredService<IAuthorizationService>();
+        return (await authz.AuthorizeAsync(user, PolicyName)).Succeeded;
+    }
+
+    [Fact]
+    public async Task ServiceTokenWithServiceAudience_Succeeds()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.TokenType, TokenClaimConstants.TokenTypeService),
+            new Claim("aud", "sorcha:service"));
+
+        (await SucceedsAsync(provider, user)).Should().BeTrue(
+            "a service-tier caller (forward-looking automation) may recover a system wallet");
+    }
+
+    [Fact]
+    public async Task AdministratorWithPlatformAudience_Succeeds()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(ClaimTypes.Role, "Administrator"),
+            new Claim("aud", "sorcha:platform"));
+
+        (await SucceedsAsync(provider, user)).Should().BeTrue(
+            "the genesis-ceremony administrator (platform tier) may recover a system wallet");
+    }
+
+    [Fact]
+    public async Task SystemAdminWithPlatformAudience_Succeeds()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(ClaimTypes.Role, "SystemAdmin"),
+            new Claim("aud", "sorcha:platform"));
+
+        (await SucceedsAsync(provider, user)).Should().BeTrue(
+            "a SystemAdmin platform-tier caller may recover a system wallet");
+    }
+
+    [Fact]
+    public async Task ConsumerToken_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, "org-1"),
+            new Claim("aud", "sorcha:consumer"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "a consumer/citizen token must never seat a validator signing wallet");
+    }
+
+    [Fact]
+    public async Task AdministratorWithConsumerAudience_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(ClaimTypes.Role, "Administrator"),
+            new Claim("aud", "sorcha:consumer"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "the administrator branch requires the :platform audience, not merely the role");
+    }
+
+    [Fact]
+    public async Task PlatformAudienceWithoutAdminRole_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.OrgId, "org-1"),
+            new Claim("aud", "sorcha:platform"));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "a platform-tier non-administrator must not recover a system wallet");
+    }
+
+    [Fact]
+    public async Task ServiceTokenWithoutServiceAudience_Fails()
+    {
+        using var provider = BuildProvider();
+        var user = AuthenticatedUser(
+            new Claim(TokenClaimConstants.TokenType, TokenClaimConstants.TokenTypeService));
+
+        (await SucceedsAsync(provider, user)).Should().BeFalse(
+            "token_type alone is insufficient; the :service audience is required");
+    }
+
+    [Fact]
+    public async Task UnauthenticatedUser_Fails()
+    {
+        using var provider = BuildProvider();
+
+        (await SucceedsAsync(provider, UnauthenticatedUser())).Should().BeFalse(
+            "an unauthenticated caller must be refused");
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/EndpointAuthorizationMetadata.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/EndpointAuthorizationMetadata.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Sorcha.Wallet.Service.Extensions;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Test harness for inspecting endpoint authorization metadata without issuing a request and without
+/// standing up the full wallet service graph. Maps the real <c>Map*Endpoints</c> extension onto a
+/// builder whose service provider returns a permissive <see cref="IServiceProviderIsService"/>, so
+/// RequestDelegateFactory treats every complex handler parameter as a DI service at delegate-build time
+/// (the services are only <em>resolved</em> when an endpoint is invoked — never here).
+/// </summary>
+internal static class EndpointAuthorizationMetadata
+{
+    /// <summary>Maps endpoints via <paramref name="map"/> and returns the resulting route endpoints.</summary>
+    public static IReadOnlyList<RouteEndpoint> Collect(Action<IEndpointRouteBuilder> map)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddWalletAuthorization();
+        var app = builder.Build();
+
+        var routeBuilder = new TestEndpointRouteBuilder(new PermissiveServiceProvider(app.Services));
+        map(routeBuilder);
+
+        return routeBuilder.DataSources
+            .SelectMany(ds => ds.Endpoints)
+            .OfType<RouteEndpoint>()
+            .ToList();
+    }
+
+    /// <summary>Finds the single route endpoint at <paramref name="rawPath"/> (leading slash optional).</summary>
+    public static RouteEndpoint FindByPath(IReadOnlyList<RouteEndpoint> endpoints, string rawPath) =>
+        endpoints.SingleOrDefault(e =>
+            string.Equals(e.RoutePattern.RawText?.TrimStart('/'), rawPath.TrimStart('/'),
+                StringComparison.OrdinalIgnoreCase))
+        ?? throw new Xunit.Sdk.XunitException($"No endpoint mapped at '{rawPath}'.");
+
+    /// <summary>Minimal <see cref="IEndpointRouteBuilder"/> whose service provider we control.</summary>
+    private sealed class TestEndpointRouteBuilder : IEndpointRouteBuilder
+    {
+        public TestEndpointRouteBuilder(IServiceProvider serviceProvider) => ServiceProvider = serviceProvider;
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
+
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
+    }
+
+    /// <summary>
+    /// Wraps a real provider but answers <see cref="IServiceProviderIsService"/> /
+    /// <see cref="IServiceProviderIsKeyedService"/> with "yes" for every type, so RequestDelegateFactory
+    /// treats all complex handler parameters as services at delegate-build time.
+    /// </summary>
+    private sealed class PermissiveServiceProvider
+        : IServiceProvider, IServiceProviderIsService, IServiceProviderIsKeyedService
+    {
+        private readonly IServiceProvider _inner;
+
+        public PermissiveServiceProvider(IServiceProvider inner) => _inner = inner;
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IServiceProviderIsService) ||
+                serviceType == typeof(IServiceProviderIsKeyedService))
+            {
+                return this;
+            }
+
+            return _inner.GetService(serviceType);
+        }
+
+        public bool IsService(Type serviceType) => true;
+
+        public bool IsKeyedService(Type serviceType, object? serviceKey) => true;
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationAuthorizationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/PendingApplicationAuthorizationTests.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Hosting;
+
+using Sorcha.Wallet.Service.Endpoints;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Endpoint-metadata regression test for the pending-application notice endpoints (Feature 147 / review F124).
+/// Confirms the group requires the consumer-tier audience so a platform token cannot read/set a
+/// citizen's notice. Only the pending-applications group is mapped, so every collected endpoint
+/// belongs to it. Inspects route metadata via <see cref="EndpointAuthorizationMetadata"/>.
+/// </summary>
+public class PendingApplicationAuthorizationTests
+{
+    [Fact]
+    public void PendingApplicationEndpoints_RequireConsumerAudience()
+    {
+        var endpoints = EndpointAuthorizationMetadata.Collect(rb => rb.MapPendingApplicationEndpoints());
+
+        endpoints.Should().NotBeEmpty("the pending-applications endpoints must be mapped");
+
+        foreach (var endpoint in endpoints)
+        {
+            endpoint.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull(
+                "a citizen notice surface must not be anonymous");
+            endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()
+                .Any(a => a.Policy == AuthorizationPolicies.RequireConsumerAudience).Should().BeTrue(
+                $"endpoint '{endpoint.RoutePattern.RawText}' must require the consumer-tier audience (review F124)");
+        }
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Sorcha.Wallet.Service.Endpoints;
+using Sorcha.Wallet.Service.Extensions;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Endpoint-metadata regression tests for the system-wallet endpoints (Feature 147 / review H1).
+/// Guards against re-introducing <c>AllowAnonymous</c> and confirms each endpoint requires its
+/// intended policy. Maps the real <see cref="WalletEndpoints.MapWalletEndpoints"/> and inspects
+/// the resulting <see cref="RouteEndpoint"/> metadata — no request is issued.
+/// <para>
+/// Reading <see cref="EndpointDataSource.Endpoints"/> forces <c>RequestDelegateFactory</c> to build
+/// each endpoint's delegate, which consults <see cref="IServiceProviderIsService"/> to decide whether
+/// a complex handler parameter (e.g. <c>WalletManager</c>) is a DI service. We route mapping through a
+/// builder whose service provider returns a permissive <see cref="IServiceProviderIsService"/> so every
+/// complex parameter is treated as a service — letting all delegates build without standing up the full
+/// wallet service graph. The services are only ever <em>resolved</em> when an endpoint is invoked
+/// (never here), so this stays a pure metadata inspection and is decoupled from the handlers' deps.
+/// </para>
+/// </summary>
+public class SystemWalletEndpointAuthorizationTests
+{
+    private static IReadOnlyList<RouteEndpoint> MapAndCollect()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddWalletAuthorization();
+        var app = builder.Build();
+
+        var routeBuilder = new TestEndpointRouteBuilder(new PermissiveServiceProvider(app.Services));
+        routeBuilder.MapWalletEndpoints();
+
+        return routeBuilder.DataSources
+            .SelectMany(ds => ds.Endpoints)
+            .OfType<RouteEndpoint>()
+            .ToList();
+    }
+
+    private static RouteEndpoint FindByPath(IReadOnlyList<RouteEndpoint> endpoints, string rawPath) =>
+        endpoints.SingleOrDefault(e =>
+            string.Equals(e.RoutePattern.RawText?.TrimStart('/'), rawPath.TrimStart('/'),
+                StringComparison.OrdinalIgnoreCase))
+        ?? throw new Xunit.Sdk.XunitException($"No endpoint mapped at '{rawPath}'.");
+
+    [Fact]
+    public void SystemWalletCreate_HasNoAllowAnonymous_AndRequiresService()
+    {
+        var endpoints = MapAndCollect();
+        var create = FindByPath(endpoints, "api/v1/wallets/system");
+
+        create.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull(
+            "the system-wallet create endpoint must not be anonymous (review H1)");
+        create.Metadata.GetOrderedMetadata<IAuthorizeData>()
+            .Any(a => a.Policy == AuthorizationPolicies.RequireService).Should().BeTrue(
+            "system-wallet create must require the RequireService policy");
+    }
+
+    [Fact]
+    public void SystemWalletRecover_HasNoAllowAnonymous_AndRequiresRecoveryPolicy()
+    {
+        var endpoints = MapAndCollect();
+        var recover = FindByPath(endpoints, "api/v1/wallets/system/recover");
+
+        recover.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull(
+            "the system-wallet recover endpoint must not be anonymous (review H1)");
+        recover.Metadata.GetOrderedMetadata<IAuthorizeData>()
+            .Any(a => a.Policy == "CanRecoverSystemWallet").Should().BeTrue(
+            "system-wallet recover must require the CanRecoverSystemWallet policy");
+    }
+
+    /// <summary>Minimal <see cref="IEndpointRouteBuilder"/> whose service provider we control.</summary>
+    private sealed class TestEndpointRouteBuilder : IEndpointRouteBuilder
+    {
+        public TestEndpointRouteBuilder(IServiceProvider serviceProvider) => ServiceProvider = serviceProvider;
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
+
+        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
+    }
+
+    /// <summary>
+    /// Wraps a real provider but answers <see cref="IServiceProviderIsService"/> /
+    /// <see cref="IServiceProviderIsKeyedService"/> queries with "yes" for every type, so
+    /// RequestDelegateFactory treats all complex handler parameters as services at delegate-build time.
+    /// </summary>
+    private sealed class PermissiveServiceProvider
+        : IServiceProvider, IServiceProviderIsService, IServiceProviderIsKeyedService
+    {
+        private readonly IServiceProvider _inner;
+
+        public PermissiveServiceProvider(IServiceProvider inner) => _inner = inner;
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IServiceProviderIsService) ||
+                serviceType == typeof(IServiceProviderIsKeyedService))
+            {
+                return this;
+            }
+
+            return _inner.GetService(serviceType);
+        }
+
+        public bool IsService(Type serviceType) => true;
+
+        public bool IsKeyedService(Type serviceType, object? serviceKey) => true;
+    }
+}

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/SystemWalletEndpointAuthorizationTests.cs
@@ -2,59 +2,27 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 using Sorcha.Wallet.Service.Endpoints;
-using Sorcha.Wallet.Service.Extensions;
 
 namespace Sorcha.Wallet.Service.Tests.Endpoints;
 
 /// <summary>
 /// Endpoint-metadata regression tests for the system-wallet endpoints (Feature 147 / review H1).
 /// Guards against re-introducing <c>AllowAnonymous</c> and confirms each endpoint requires its
-/// intended policy. Maps the real <see cref="WalletEndpoints.MapWalletEndpoints"/> and inspects
-/// the resulting <see cref="RouteEndpoint"/> metadata — no request is issued.
-/// <para>
-/// Reading <see cref="EndpointDataSource.Endpoints"/> forces <c>RequestDelegateFactory</c> to build
-/// each endpoint's delegate, which consults <see cref="IServiceProviderIsService"/> to decide whether
-/// a complex handler parameter (e.g. <c>WalletManager</c>) is a DI service. We route mapping through a
-/// builder whose service provider returns a permissive <see cref="IServiceProviderIsService"/> so every
-/// complex parameter is treated as a service — letting all delegates build without standing up the full
-/// wallet service graph. The services are only ever <em>resolved</em> when an endpoint is invoked
-/// (never here), so this stays a pure metadata inspection and is decoupled from the handlers' deps.
-/// </para>
+/// intended policy. Uses <see cref="EndpointAuthorizationMetadata"/> to map the real
+/// <see cref="WalletEndpoints.MapWalletEndpoints"/> and inspect route metadata — no request is issued.
 /// </summary>
 public class SystemWalletEndpointAuthorizationTests
 {
-    private static IReadOnlyList<RouteEndpoint> MapAndCollect()
-    {
-        var builder = WebApplication.CreateBuilder();
-        builder.Services.AddWalletAuthorization();
-        var app = builder.Build();
-
-        var routeBuilder = new TestEndpointRouteBuilder(new PermissiveServiceProvider(app.Services));
-        routeBuilder.MapWalletEndpoints();
-
-        return routeBuilder.DataSources
-            .SelectMany(ds => ds.Endpoints)
-            .OfType<RouteEndpoint>()
-            .ToList();
-    }
-
-    private static RouteEndpoint FindByPath(IReadOnlyList<RouteEndpoint> endpoints, string rawPath) =>
-        endpoints.SingleOrDefault(e =>
-            string.Equals(e.RoutePattern.RawText?.TrimStart('/'), rawPath.TrimStart('/'),
-                StringComparison.OrdinalIgnoreCase))
-        ?? throw new Xunit.Sdk.XunitException($"No endpoint mapped at '{rawPath}'.");
+    private static IReadOnlyList<Microsoft.AspNetCore.Routing.RouteEndpoint> Endpoints() =>
+        EndpointAuthorizationMetadata.Collect(rb => rb.MapWalletEndpoints());
 
     [Fact]
     public void SystemWalletCreate_HasNoAllowAnonymous_AndRequiresService()
     {
-        var endpoints = MapAndCollect();
-        var create = FindByPath(endpoints, "api/v1/wallets/system");
+        var create = EndpointAuthorizationMetadata.FindByPath(Endpoints(), "api/v1/wallets/system");
 
         create.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull(
             "the system-wallet create endpoint must not be anonymous (review H1)");
@@ -66,53 +34,12 @@ public class SystemWalletEndpointAuthorizationTests
     [Fact]
     public void SystemWalletRecover_HasNoAllowAnonymous_AndRequiresRecoveryPolicy()
     {
-        var endpoints = MapAndCollect();
-        var recover = FindByPath(endpoints, "api/v1/wallets/system/recover");
+        var recover = EndpointAuthorizationMetadata.FindByPath(Endpoints(), "api/v1/wallets/system/recover");
 
         recover.Metadata.GetMetadata<IAllowAnonymous>().Should().BeNull(
             "the system-wallet recover endpoint must not be anonymous (review H1)");
         recover.Metadata.GetOrderedMetadata<IAuthorizeData>()
             .Any(a => a.Policy == "CanRecoverSystemWallet").Should().BeTrue(
             "system-wallet recover must require the CanRecoverSystemWallet policy");
-    }
-
-    /// <summary>Minimal <see cref="IEndpointRouteBuilder"/> whose service provider we control.</summary>
-    private sealed class TestEndpointRouteBuilder : IEndpointRouteBuilder
-    {
-        public TestEndpointRouteBuilder(IServiceProvider serviceProvider) => ServiceProvider = serviceProvider;
-
-        public IServiceProvider ServiceProvider { get; }
-
-        public ICollection<EndpointDataSource> DataSources { get; } = new List<EndpointDataSource>();
-
-        public IApplicationBuilder CreateApplicationBuilder() => new ApplicationBuilder(ServiceProvider);
-    }
-
-    /// <summary>
-    /// Wraps a real provider but answers <see cref="IServiceProviderIsService"/> /
-    /// <see cref="IServiceProviderIsKeyedService"/> queries with "yes" for every type, so
-    /// RequestDelegateFactory treats all complex handler parameters as services at delegate-build time.
-    /// </summary>
-    private sealed class PermissiveServiceProvider
-        : IServiceProvider, IServiceProviderIsService, IServiceProviderIsKeyedService
-    {
-        private readonly IServiceProvider _inner;
-
-        public PermissiveServiceProvider(IServiceProvider inner) => _inner = inner;
-
-        public object? GetService(Type serviceType)
-        {
-            if (serviceType == typeof(IServiceProviderIsService) ||
-                serviceType == typeof(IServiceProviderIsKeyedService))
-            {
-                return this;
-            }
-
-            return _inner.GetService(serviceType);
-        }
-
-        public bool IsService(Type serviceType) => true;
-
-        public bool IsKeyedService(Type serviceType, object? serviceKey) => true;
     }
 }


### PR DESCRIPTION
## Summary

Sub-project 2 of the security-hardening initiative (from `docs/reviews/2026-06-02-architecture-review.md`). Closes four authorization gaps — each was relying on a comment, on the gateway (only `RequireAuthenticated`), or on a shared rule a later override weakened. Every fix now enforces the correct trust tier / role **in-code at the operation**, so a direct internal-network call is gated identically.

| Finding | Fix | Commit |
|---|---|---|
| **H1** — `POST /api/v1/wallets/system` + `/system/recover` are `AllowAnonymous` (recover imports a BIP39 mnemonic → an attacker could seat a validator signing key) | Drop `AllowAnonymous`; `create` → `RequireService`; `recover` → new `CanRecoverSystemWallet` (`:service` **OR** `Administrator`/`SystemAdmin` + `:platform`). 409-on-exists guard retained. | `d235a113` |
| **H2** — `CanManageBlueprints` = `hasOrgId OR isService`; consumer tokens carry `org_id` (F136) → citizens reached authoring | Redefine via a tier-aware requirement+handler: `(service + :service) OR (org_id + :platform)`. Fixed **in the policy** → all bare authoring endpoints covered with no per-endpoint edits. | `eeaaa5aa` |
| **F124** (LOW) — pending-applications used plain `.RequireAuthorization()` → a platform token could read/set a citizen's notice | Add `RequireConsumerAudience`. | `de3bb3d4` |
| **LOW** — Tenant re-registered `RequireSystemAdmin` role-only, dropping the org-scope (last-write-wins) | Delete the duplicate so the shared org-scoped definition stands. | `96b6fd5c` |

The two new gates are implemented as `IAuthorizationRequirement` + handler pairs injecting `SorchaAudiences` (mirroring F136's `TierAudienceAuthorizationHandler`), so the expected audience is resolved from the configured installation at request time — never hard-coded — and the rule can't be omitted per-endpoint.

## Decisions (settled in brainstorming)

- **Recover gate** = `Service` OR `Admin+:platform` (covers the genesis-ceremony admin CLI today and future service automation; excludes consumer). Chosen over a bespoke deploy-time secret — removing `AllowAnonymous` is what actually shuts both doors. The existing 409-on-exists guard is kept (belt-and-braces; it does **not** close the empty-window race — the auth gate does).
- **F124 folded in** as same-theme consumer⊥platform isolation.
- **H2 fixed in the policy**, not per-endpoint (reviewer's explicit recommendation).

## Tests (TDD)

- Policy-evaluation tests through the real `IAuthorizationService` pipeline (mirroring `AuthorizationPolicyExtensionsTests`) for `CanRecoverSystemWallet`, `CanManageBlueprints`, and Tenant `RequireSystemAdmin` org-scoping.
- Endpoint-metadata regression tests (shared `EndpointAuthorizationMetadata` harness) asserting the system-wallet + pending-applications endpoints carry **no** `AllowAnonymous` and require the intended policy.
- Suites green: **Wallet 852**, **Blueprint 873**, **Tenant 1237** (8 pre-existing skips). Scoped per affected service project (MTP ignores `--filter`).

## Docs

`jwt` skill (3 sites that documented the old vulnerable `CanManageBlueprints` pattern — corrected + added a "Tier-aware policy (Feature 147)" note) and `docs/guides/AUTHENTICATION-SETUP.md` policy tables.

## Spec

`specs/147-authorization-gap-closure/` (spec, plan, research, data-model, authorization-matrix contract, tasks) + design at `docs/superpowers/specs/2026-06-03-authorization-gap-closure-design.md`.

> Note: full-solution `build-and-test` is red across all PRs on an unrelated revoked Refit 10.1.6 NuGet signing cert (NU3012 at restore) — claude-review is the effective gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)