### PR TITLE
fix(bucket-b): mechanical security-hardening fixes (publish enforcement, M2/M4, dead code)

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -110,15 +110,13 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IVerifierEngine, RealVerifierEngine>();
 
         // Feature 125 / PR-D — application-from-phone (US2). PortraitCaptureControl
-        // routes through IWebCameraService; the file-upload fallback is the
-        // v1 path until webcamera-bridge.js + native camera land in a
-        // follow-up. IApplicationSubmissionService signs payloads through
-        // IUserSigner under the active context and surfaces the in-progress
-        // state via F124's pending-application notice; the real HTTP
-        // submission to the blueprint endpoints lands alongside the
-        // application catalogue API.
+        // routes through IWebCameraService; the file-upload fallback is the v1 path
+        // until webcamera-bridge.js + native camera land in a follow-up.
         services.AddSingleton<IWebCameraService, FileFallbackWebCameraService>();
-        services.AddSingleton<IApplicationSubmissionService, StubApplicationSubmissionService>();
+        // Bucket B (review §4): the F125 StubApplicationSubmissionService no-op is NOT registered
+        // for production — it faked submission success and is superseded by the F137
+        // IApplicationActionClient path (ApplicationInstance.razor). The class + its tests are
+        // retained as a test-only seam; it is no longer injectable into the running app.
 
         // Server-clock observer (T101) — populated by the ServerClockHandler on
         // every outbound HTTP call; read by Pages/Index.razor to surface a

--- a/src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Blueprint/BlueprintServiceClient.cs
@@ -573,8 +573,45 @@ public class BlueprintServiceClient : IBlueprintServiceClient
     }
 
     /// <inheritdoc />
-    public Task<PublishBlueprintOutcome?> PublishBlueprintAsync(string blueprintId, PublishBlueprintRequest request, CancellationToken cancellationToken = default) =>
-        throw new NotImplementedException("TODO(US2/US3): governance-hard / rehearsal-soft publish — Feature 142.");
+    public async Task<PublishBlueprintOutcome?> PublishBlueprintAsync(string blueprintId, PublishBlueprintRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(blueprintId);
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            await SetAuthHeaderAsync(cancellationToken);
+            var response = await _httpClient.PostAsJsonAsync(
+                $"/api/blueprints/{Uri.EscapeDataString(blueprintId)}/publish", request, JsonOptions, cancellationToken);
+
+            // 409 = rehearsal soft-gate (Feature 142): the executable-definition hash was not rehearsed.
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                var rehearsal = await response.Content
+                    .ReadFromJsonAsync<RehearsalRequiredError>(JsonOptions, cancellationToken);
+                return new PublishBlueprintOutcome { RehearsalRequired = rehearsal ?? new RehearsalRequiredError() };
+            }
+
+            // 403 = governance-hard gate (caller lacks Owner/Admin/Designer on the register) and any
+            // other non-success: surface as null (the outcome type models success vs rehearsal-required only).
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Blueprint publish failed: {StatusCode} (blueprint {BlueprintId}, register {RegisterId})",
+                    response.StatusCode, blueprintId, request.RegisterId);
+                return null;
+            }
+
+            var result = await response.Content
+                .ReadFromJsonAsync<PublishBlueprintResult>(JsonOptions, cancellationToken);
+            return result is null ? null : new PublishBlueprintOutcome { Result = result };
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Blueprint publish request failed for {BlueprintId}", blueprintId);
+            return null;
+        }
+    }
 
     /// <inheritdoc />
     public async Task<CloneFromPublishedResult?> CloneFromPublishedAsync(CloneFromPublishedRequest request, CancellationToken cancellationToken = default)

--- a/src/Common/Sorcha.TransactionHandler/Core/Transaction.cs
+++ b/src/Common/Sorcha.TransactionHandler/Core/Transaction.cs
@@ -129,6 +129,18 @@ public class Transaction : ITransaction
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Review M1 (DEFERRED — see the security-hardening backlog): this verify is a placeholder —
+    /// it computes the signing hash but never compares it against the signature (public-key
+    /// extraction is a "return success as placeholder" TODO), so it returns
+    /// <see cref="TransactionStatus.Success"/> for any signed transaction with valid payloads.
+    /// It is NOT on any live path (the V1 <c>TransactionFactory</c> is not DI-registered; the real
+    /// validator verifies via <c>ICryptoModule.VerifyAsync</c>) and has no non-test callers, so the
+    /// risk is purely latent. Making it fail loud is the right fix, but V1 is the module's only
+    /// implemented transaction version and an entire signing/verification test suite asserts this
+    /// behaviour — resolving it needs a decision (implement real V1 verification vs excise the V1
+    /// verify path + its no-op tests), which is out of scope for the mechanical Bucket-B pass.
+    /// </remarks>
     public async Task<TransactionStatus> VerifyAsync(
         CancellationToken cancellationToken = default)
     {

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -3177,6 +3177,20 @@ public class PublishService(
         var errors = new List<string>();
         var warnings = new List<string>();
 
+        // Rule 0: Title and description must meet the model's required minimum lengths
+        // (BlueprintModel declares [Required] + MinLength(3)/(5), but DataAnnotations are not
+        // evaluated on the publish path — only the AI-chat tool enforced this. Mirror it here so
+        // a directly-authored blueprint can't be published with a missing/too-short title/description.)
+        if (string.IsNullOrWhiteSpace(blueprint.Title) || blueprint.Title.Length < 3)
+        {
+            errors.Add("Blueprint title must be at least 3 characters");
+        }
+
+        if (string.IsNullOrWhiteSpace(blueprint.Description) || blueprint.Description.Length < 5)
+        {
+            errors.Add("Blueprint description must be at least 5 characters");
+        }
+
         // Rule 1: Must have at least 2 participants
         if (blueprint.Participants.Count < 2)
         {

--- a/src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs
+++ b/src/Services/Sorcha.Haip.Service/Services/PresentationRequestStore.cs
@@ -1,33 +1,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text.Json;
-using Microsoft.Extensions.Caching.Distributed;
+using Sorcha.AtomicCache;
 using Sorcha.Haip.Service.Models;
 
 namespace Sorcha.Haip.Service.Services;
 
 /// <summary>
-/// Redis-backed store for HAIP presentation requests. Requests have TTL-based
-/// expiry and transition through Pending → Submitted → Verified/Denied states.
+/// Store for HAIP presentation requests. Requests have TTL-based expiry and transition through
+/// Pending → Submitted → Verified/Denied states. Backed by <see cref="IAtomicDistributedCache"/>
+/// (Redis in production, in-memory in tests) so the completion transition can be a compare-and-set
+/// — closing the prior Get-then-Set TOCTOU (review M4) where two concurrent verifier callbacks
+/// raced and the last writer won.
 /// </summary>
 public class PresentationRequestStore
 {
-    private readonly IDistributedCache? _cache;
+    private readonly IAtomicDistributedCache _cache;
     private readonly ILogger<PresentationRequestStore> _logger;
     private readonly int _ttlSeconds;
-
-    private readonly ConcurrentDictionary<Guid, PresentationRequest> _memoryStore = new();
 
     public PresentationRequestStore(
         ILogger<PresentationRequestStore> logger,
         IConfiguration configuration,
-        IDistributedCache? cache = null)
+        IAtomicDistributedCache cache)
     {
         _logger = logger;
-        _cache = cache;
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
         _ttlSeconds = configuration.GetValue<int>("Haip:PresentationRequestTtlSeconds", 600);
     }
 
@@ -60,18 +60,8 @@ public class PresentationRequestStore
             StateToken = id.ToString()
         };
 
-        if (_cache != null)
-        {
-            var key = $"haip:vp-request:{request.Id}";
-            var json = JsonSerializer.Serialize(request);
-            await _cache.SetStringAsync(key, json,
-                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_ttlSeconds) },
-                ct);
-        }
-        else
-        {
-            _memoryStore[request.Id] = request;
-        }
+        var key = $"haip:vp-request:{request.Id}";
+        await _cache.SetAsync(key, JsonSerializer.Serialize(request), TimeSpan.FromSeconds(_ttlSeconds), ct);
 
         _logger.LogInformation(
             "Created presentation request {RequestId} for credential type {Type}",
@@ -85,60 +75,59 @@ public class PresentationRequestStore
     /// </summary>
     public async Task<PresentationRequest?> GetAsync(Guid requestId, CancellationToken ct = default)
     {
-        if (_cache != null)
-        {
-            var key = $"haip:vp-request:{requestId}";
-            var json = await _cache.GetStringAsync(key, ct);
-            return json != null ? JsonSerializer.Deserialize<PresentationRequest>(json) : null;
-        }
-
-        _memoryStore.TryGetValue(requestId, out var request);
-        if (request != null && request.ExpiresAt < DateTimeOffset.UtcNow)
-        {
-            _memoryStore.TryRemove(requestId, out _);
-            return null;
-        }
-        return request;
+        var key = $"haip:vp-request:{requestId}";
+        var json = await _cache.GetAsync(key, ct);
+        return json != null ? JsonSerializer.Deserialize<PresentationRequest>(json) : null;
     }
 
     /// <summary>
     /// Updates a request with the verification result and marks it as completed.
     /// </summary>
     /// <remarks>
-    /// TODO(113-followup): The Get-then-Set sequence here is not CAS-protected.
-    /// Two HandleDirectPost callbacks for the same request landing concurrently
-    /// will each read the pending state, transition it independently, and the
-    /// last writer wins. Today this is a low-probability race because verifier
-    /// callbacks for the same request are unusual. Migrating this to
-    /// IAtomicDistributedCache.TryUpdateIfMatchAsync would close the window
-    /// fully — but the migration is more invasive than the
-    /// NonceStore/PreAuthCodeStore changes (this store has read-many semantics
-    /// and serialised PresentationRequest objects, not opaque tokens).
-    /// Tracked as a feature 113 follow-up; not blocking US3 closure.
+    /// Review M4: the completion transition is a compare-and-set
+    /// (<see cref="IAtomicDistributedCache.TryUpdateIfMatchAsync"/>) so two concurrent
+    /// verifier callbacks for the same request cannot both transition it — the first writer
+    /// wins, and a callback that loses the race observes the already-terminal state and is an
+    /// idempotent no-op (rather than the prior last-writer-wins Get-then-Set).
     /// </remarks>
     public async Task MarkCompletedAsync(
         Guid requestId,
         VerificationResult result,
         CancellationToken ct = default)
     {
-        if (_cache != null)
+        var key = $"haip:vp-request:{requestId}";
+        var ttl = TimeSpan.FromSeconds(_ttlSeconds);
+        var newState = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Denied;
+
+        // Bounded CAS retry: re-read on a lost race so we re-evaluate against the latest state.
+        for (var attempt = 0; attempt < 3; attempt++)
         {
-            var key = $"haip:vp-request:{requestId}";
-            var json = await _cache.GetStringAsync(key, ct);
-            if (json != null)
+            var json = await _cache.GetAsync(key, ct);
+            if (json is null)
             {
-                var request = JsonSerializer.Deserialize<PresentationRequest>(json)!;
-                request.State = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Denied;
-                request.Result = result;
-                await _cache.SetStringAsync(key, JsonSerializer.Serialize(request),
-                    new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(_ttlSeconds) },
-                    ct);
+                return; // expired or never created — nothing to complete
             }
-        }
-        else if (_memoryStore.TryGetValue(requestId, out var request))
-        {
-            request.State = result.IsValid ? PresentationRequestState.Verified : PresentationRequestState.Denied;
+
+            var request = JsonSerializer.Deserialize<PresentationRequest>(json)!;
+            if (request.State is PresentationRequestState.Verified or PresentationRequestState.Denied)
+            {
+                // Already completed by a concurrent callback (first-writer-wins) — idempotent no-op.
+                return;
+            }
+
+            request.State = newState;
             request.Result = result;
+            var newJson = JsonSerializer.Serialize(request);
+
+            if (await _cache.TryUpdateIfMatchAsync(key, json, newJson, ttl, ct))
+            {
+                return; // CAS succeeded — this callback completed the request
+            }
+            // CAS lost the race (value changed since the read); loop to re-read and re-evaluate.
         }
+
+        _logger.LogWarning(
+            "MarkCompletedAsync for request {RequestId} could not complete the compare-and-set after retries",
+            requestId);
     }
 }

--- a/src/Services/Sorcha.Wallet.Service/Program.cs
+++ b/src/Services/Sorcha.Wallet.Service/Program.cs
@@ -174,6 +174,15 @@ builder.Services.AddHostedService<
 // Replaces the v1 EmptyCitizenCredentialEventStream placeholder.
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.ICitizenCredentialEventStream,
     Sorcha.Wallet.Service.Services.Implementation.EfCoreCitizenCredentialEventStream>();
+// M2 (review): ICitizenCredentialEventStream is on the F113 audited list
+// (AuditedStorageInterfaces) but was registered with a bare AddScoped, so the storage-
+// registration log, the `storage-providers` health check, and the OTel gauges never saw it —
+// its audited status was inert. It has only an EF-backed implementation, so record it as
+// persistent (visible to the audit; never trips the in-memory fail-fast).
+builder.Services.GetStorageRegistrationLog().RegisterPersistent(
+    typeof(Sorcha.Wallet.Service.Services.Interfaces.ICitizenCredentialEventStream).FullName!,
+    typeof(Sorcha.Wallet.Service.Services.Implementation.EfCoreCitizenCredentialEventStream).FullName!,
+    "postgres");
 // Scoped (was Singleton) because it now consumes the Scoped EfCoreCitizenCredentialEventStream.
 // CitizenSyncService is stateless apart from its signing key, so per-request creation is cheap.
 builder.Services.AddScoped<Sorcha.Wallet.Service.Services.Interfaces.ICitizenSyncService,

--- a/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenSyncService.cs
+++ b/src/Services/Sorcha.Wallet.Service/Services/Implementation/CitizenSyncService.cs
@@ -207,19 +207,3 @@ public sealed class CitizenSyncService : ICitizenSyncService
         return byId.Values;
     }
 }
-
-/// <summary>
-/// Empty credential event source used until the citizen-credential issuance pipeline
-/// lands (US4 / Feature 114 Phase 6). Returns no events so a freshly enrolled wallet
-/// gets an empty snapshot and the sync surface is still exercisable end-to-end.
-/// </summary>
-public sealed class EmptyCitizenCredentialEventStream : ICitizenCredentialEventStream
-{
-    /// <inheritdoc />
-    public Task<IReadOnlyList<CitizenCredentialEvent>> ReadAsync(Guid platformUserId, long afterSeq, CancellationToken ct = default)
-        => Task.FromResult<IReadOnlyList<CitizenCredentialEvent>>(Array.Empty<CitizenCredentialEvent>());
-
-    /// <inheritdoc />
-    public Task<long> GetHighestSeqAsync(Guid platformUserId, CancellationToken ct = default)
-        => Task.FromResult(0L);
-}

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/CycleDetectionTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/CycleDetectionTests.cs
@@ -391,6 +391,7 @@ public class CycleDetectionTests
         {
             Id = "test-blueprint",
             Title = "Test Blueprint",
+            Description = "Cycle-detection test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Participant 1" },

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/PublishServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/PublishServiceTests.cs
@@ -70,6 +70,7 @@ public class PublishServiceTests
         {
             Id = "bp-2",
             Title = "Incomplete",
+            Description = "Validation test blueprint.",
             Participants = [new ParticipantModel { Id = "p1", Name = "Alice" }],
             Actions = []
         };
@@ -81,6 +82,33 @@ public class PublishServiceTests
         result.IsValid.Should().BeFalse();
         result.ValidationResults.Should().Contain(i => i.Message.Contains("at least 2 participants"));
         result.ValidationResults.Should().Contain(i => i.Message.Contains("at least 1 action"));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ShortTitleAndMissingDescription_ReturnsErrors()
+    {
+        // Bucket B: the publish path must enforce the model's [Required] + MinLength(3)/(5) on
+        // title/description (previously only the AI-chat tool did).
+        var blueprint = new BlueprintModel
+        {
+            Id = "bp-short",
+            Title = "ab",            // < 3 chars
+            Description = "x",        // < 5 chars
+            Participants =
+            [
+                new ParticipantModel { Id = "p1", Name = "Alice" },
+                new ParticipantModel { Id = "p2", Name = "Bob" }
+            ],
+            Actions = [new ActionModel { Id = 1, Title = "Start", Sender = "p1", IsStartingAction = true }]
+        };
+        _mockBlueprintStore.Setup(s => s.GetAsync("bp-short")).ReturnsAsync(blueprint);
+        var service = CreateService();
+
+        var result = await service.ValidateAsync("bp-short");
+
+        result.IsValid.Should().BeFalse();
+        result.ValidationResults.Should().Contain(i => i.Message.Contains("title must be at least 3"));
+        result.ValidationResults.Should().Contain(i => i.Message.Contains("description must be at least 5"));
     }
 
     [Fact]
@@ -147,6 +175,7 @@ public class PublishServiceTests
         {
             Id = "bp-invalid",
             Title = "Invalid",
+            Description = "Validation test blueprint.",
             Participants = [],
             Actions = []
         };
@@ -173,6 +202,7 @@ public class PublishServiceTests
         {
             Id = "bp-nostart",
             Title = "No Starting Action",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -204,6 +234,7 @@ public class PublishServiceTests
         {
             Id = "bp-badroute",
             Title = "Bad Route Target",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -237,6 +268,7 @@ public class PublishServiceTests
         {
             Id = "bp-badreject",
             Title = "Bad Rejection Target",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -270,6 +302,7 @@ public class PublishServiceTests
         {
             Id = "bp-orphan",
             Title = "Orphan Action",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -301,6 +334,7 @@ public class PublishServiceTests
         {
             Id = "bp-badsender",
             Title = "Bad Sender",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -331,6 +365,7 @@ public class PublishServiceTests
         {
             Id = "bp-badpointer",
             Title = "Bad JSON Pointer",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -364,6 +399,7 @@ public class PublishServiceTests
         {
             Id = "bp-goodpointer",
             Title = "Good JSON Pointers",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -401,6 +437,7 @@ public class PublishServiceTests
         {
             Id = "bp-badlogic",
             Title = "Bad JSON Logic",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -436,6 +473,7 @@ public class PublishServiceTests
         {
             Id = "bp-goodlogic",
             Title = "Good JSON Logic",
+            Description = "Validation test blueprint.",
             Participants =
             [
                 new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -470,6 +508,7 @@ public class PublishServiceTests
     {
         Id = "bp-1",
         Title = "Test Blueprint",
+        Description = "A valid test blueprint for publish validation.",
         Participants =
         [
             new ParticipantModel { Id = "p1", Name = "Alice" },
@@ -491,6 +530,7 @@ public class PublishServiceTests
     {
         Id = "bp-cycle",
         Title = "Cyclic Blueprint",
+        Description = "Validation test blueprint.",
         Participants =
         [
             new ParticipantModel { Id = "p1", Name = "Alice" },

--- a/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
+++ b/tests/Sorcha.Haip.Service.Tests/Services/PresentationRequestStoreTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Sorcha.AtomicCache;
 using Sorcha.Haip.Service.Models;
 using Sorcha.Haip.Service.Services;
 using Xunit;
@@ -12,7 +13,7 @@ using Xunit;
 namespace Sorcha.Haip.Service.Tests.Services;
 
 /// <summary>
-/// Tests for PresentationRequestStore — in-memory fallback.
+/// Tests for PresentationRequestStore — backed by the in-memory IAtomicDistributedCache.
 /// </summary>
 public class PresentationRequestStoreTests
 {
@@ -29,7 +30,8 @@ public class PresentationRequestStoreTests
 
         _store = new PresentationRequestStore(
             Mock.Of<ILogger<PresentationRequestStore>>(),
-            config);
+            config,
+            new InMemoryAtomicDistributedCache());
     }
 
     [Fact]
@@ -114,5 +116,34 @@ public class PresentationRequestStoreTests
         var updated = await _store.GetAsync(created.Id);
         updated!.State.Should().Be(PresentationRequestState.Denied);
         updated.Result!.Errors.Should().Contain("KB-JWT signature invalid");
+    }
+
+    [Fact]
+    public async Task MarkCompletedAsync_SecondCallAfterTerminal_IsIdempotentNoOp()
+    {
+        // Review M4: the CAS completion is first-writer-wins. A second callback for an
+        // already-completed request must NOT overwrite the recorded outcome.
+        var created = await _store.CreateAsync(
+            "https://test.example/haip", "TestCredential",
+            null, null, "https://test.example/haip");
+
+        await _store.MarkCompletedAsync(created.Id, new VerificationResult
+        {
+            IsValid = true,
+            VerifiedClaims = new() { ["name"] = "Alice" },
+            HolderKeyVerified = true
+        });
+
+        // A racing/second callback arriving with a different (denied) outcome must be ignored.
+        await _store.MarkCompletedAsync(created.Id, new VerificationResult
+        {
+            IsValid = false,
+            Errors = { "late duplicate callback" }
+        });
+
+        var final = await _store.GetAsync(created.Id);
+        final!.State.Should().Be(PresentationRequestState.Verified, "the first writer's terminal state wins");
+        final.Result!.IsValid.Should().BeTrue();
+        final.Result.VerifiedClaims.Should().ContainKey("name");
     }
 }

--- a/tests/Sorcha.Haip.Service.Tests/Sorcha.Haip.Service.Tests.csproj
+++ b/tests/Sorcha.Haip.Service.Tests/Sorcha.Haip.Service.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Services\Sorcha.Haip.Service\Sorcha.Haip.Service.csproj" />
     <ProjectReference Include="..\..\src\Services\Sorcha.Tenant.Service\Sorcha.Tenant.Service.csproj" />
+    <ProjectReference Include="..\..\src\Common\Sorcha.AtomicCache\Sorcha.AtomicCache.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Sorcha.ServiceClients.Tests/Blueprint/BlueprintServiceClientRehearsalTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Blueprint/BlueprintServiceClientRehearsalTests.cs
@@ -250,4 +250,55 @@ public class BlueprintServiceClientRehearsalTests
 
         Assert.Null(result);
     }
+
+    // Bucket B: PublishBlueprintAsync was a NotImplementedException stub; now it calls the endpoint.
+
+    [Fact]
+    public async Task PublishBlueprintAsync_Ok_ReturnsResult()
+    {
+        var body = new
+        {
+            blueprintId = "bp-1",
+            version = 3,
+            registerId = "reg-1",
+            publishedAt = DateTimeOffset.UtcNow,
+            overridden = true
+        };
+        var handler = CreateMockHandler(HttpStatusCode.OK, body);
+        var client = CreateClient(handler);
+
+        var result = await client.PublishBlueprintAsync("bp-1", new PublishBlueprintRequest { RegisterId = "reg-1" });
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Result);
+        Assert.False(result.IsRehearsalRequired);
+        Assert.Equal(3, result.Result!.Version);
+        Assert.True(result.Result.Overridden);
+    }
+
+    [Fact]
+    public async Task PublishBlueprintAsync_Conflict_ReturnsRehearsalRequired()
+    {
+        var body = new { code = "REHEARSAL_REQUIRED", execDefHash = "abc123", message = "Rehearse first." };
+        var handler = CreateMockHandler(HttpStatusCode.Conflict, body);
+        var client = CreateClient(handler);
+
+        var result = await client.PublishBlueprintAsync("bp-1", new PublishBlueprintRequest { RegisterId = "reg-1" });
+
+        Assert.NotNull(result);
+        Assert.True(result.IsRehearsalRequired);
+        Assert.Equal("abc123", result.RehearsalRequired!.ExecDefHash);
+    }
+
+    [Fact]
+    public async Task PublishBlueprintAsync_Forbidden_ReturnsNull()
+    {
+        // 403 governance-hard gate — the outcome type models success vs rehearsal-required only.
+        var handler = CreateMockHandler(HttpStatusCode.Forbidden);
+        var client = CreateClient(handler);
+
+        var result = await client.PublishBlueprintAsync("bp-1", new PublishBlueprintRequest { RegisterId = "reg-1" });
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
## Summary

Bucket B of the security-hardening initiative — the mechanical findings from `docs/reviews/2026-06-02-architecture-review.md` (§2 M2/M4, §4 dead code, §7). Each is a small, independent fix with tests.

| # | Fix | Commit |
|---|---|---|
| Publish title/desc | `PublishService.ValidateBlueprint` didn't enforce the model's `[Required]` + `MinLength(3)/(5)` on Title/Description (only the AI-chat tool did) — a directly-authored blueprint could publish with a missing/short title or description. Added the rules. All 25 real walkthrough/sample blueprints already carry descriptions; only lazy test fixtures needed them. | `21ee6070` |
| **M2** | `ICitizenCredentialEventStream` is on the F113 audited list but was a bare `AddScoped` — invisible to the storage-registration log / health check / OTel. Recorded via `RegisterPersistent` (EF-only impl). | `dfbf1741` |
| Client trap | `BlueprintServiceClient.PublishBlueprintAsync` threw `NotImplementedException` on a public consolidated-client method. Implemented it: `POST /api/blueprints/{id}/publish`, mapping 200→`Result`, 409→`RehearsalRequired`, 403/other→null. +3 tests. | `dfbf1741` |
| Dead code | Deleted the unreferenced `EmptyCitizenCredentialEventStream`; de-registered the F125 `StubApplicationSubmissionService` no-op from production PWA DI (superseded by F137 `IApplicationActionClient`) — class + tests kept as a test-only seam. | `dfbf1741` |
| **M4** | `PresentationRequestStore.MarkCompletedAsync` TOCTOU (non-atomic Get-then-Set, last-writer-wins). Migrated the store to `IAtomicDistributedCache` and made completion a compare-and-set (`TryUpdateIfMatchAsync`) — first-writer-wins, racing callbacks are idempotent no-ops. +1 idempotency test. | `f34e0231` |
| **M1** (deferred) | The orphaned V1 `Transaction.VerifyAsync` no-op turned out NOT to be mechanical: V1 is the module's only version, backed by a ~15-assertion signing/verification suite that asserts the no-op succeeds, and the module is referenced by 5 live projects. Risk is purely latent (factory not DI-registered, no non-test callers, real validator uses `ICryptoModule`). Documented the trap in a `<remarks>` and deferred to the backlog rather than half-fixing. | `a8772491` |

## Tests

Per affected project (MTP whole-project runs): Blueprint **874**, Wallet **839**, Wallet.Pwa **162**, ServiceClients **231**, Haip **71**, TransactionHandler **250** — all green.

## Out of scope / backlog (named)

- **M1** (V1 `Transaction.VerifyAsync` no-op) — needs a decision: implement real V1 verification vs excise the V1 verify path + its no-op tests.
- **Repo hygiene** (`Sorcha.PeerRouter/obj`, stale `.claude/worktrees/agent-*`) — local-environment cleanup, not committable repo content (PeerRouter is untracked / not in the solution; the worktrees are local git infrastructure the harness may rely on). Left to the operator.

> Full-solution `build-and-test`/`test` stay red on the unrelated Refit-cert / Playwright infra issues — `claude-review` is the effective gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)