### PR TITLE
docs: deferred doc corrections (project-structure re-enum, IRepository<T>/Storage.EFCore fiction)

### DIFF
--- a/.claude/skills/entity-framework/SKILL.md
+++ b/.claude/skills/entity-framework/SKILL.md
@@ -8,14 +8,14 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Bash, mcp__context7__resolve-libra
 
 # Entity Framework Core Skill
 
-Sorcha uses EF Core 9+ with PostgreSQL (Npgsql) as the primary relational data store. The codebase implements a layered repository pattern with generic and specialized repositories, soft delete via query filters, and automatic migrations on startup.
+Sorcha uses EF Core 9+ with PostgreSQL (Npgsql) as the primary relational data store. The codebase uses **service-specific** repositories (each a focused interface + a concrete EF Core implementation — there is no generic `IRepository<T>` base), soft delete via query filters, and automatic migrations on startup.
 
 ## Quick Start
 
 ### Register DbContext with PostgreSQL
 
 ```csharp
-// src/Common/Sorcha.Storage.EFCore/Extensions/EFCoreServiceExtensions.cs
+// src/Services/Sorcha.Wallet.Service/Extensions/WalletServiceExtensions.cs (AddWalletDatabase)
 services.AddDbContext<WalletDbContext>((sp, options) =>
 {
     var dataSource = sp.GetRequiredService<NpgsqlDataSource>();

--- a/.claude/skills/entity-framework/references/patterns.md
+++ b/.claude/skills/entity-framework/references/patterns.md
@@ -116,25 +116,20 @@ entity.HasIndex(e => e.ExternalIdpUserId)
 
 ## Repository Patterns
 
-### Generic Repository Base
+### Concrete repository (no generic base)
+
+There is **no** generic `IRepository<T>` / `EFCoreRepository<T>` base in Sorcha. Each service defines a
+focused repository interface and a concrete EF Core implementation over its own `DbContext`. The audited
+storage interfaces (`IWalletRepository`, `IRegisterRepository`, …) are registered via
+`IStorageRegistrationLog` (Feature 113), so the backend choice (EF Core / Mongo / Redis / in-memory) is
+visible at startup and fails closed in Production/Staging on an in-memory fallback.
 
 ```csharp
-// src/Common/Sorcha.Storage.EFCore/EFCoreRepository.cs
-public class EFCoreRepository<TEntity, TId, TContext> : IRepository<TEntity, TId>
-    where TEntity : class
-    where TContext : DbContext
+// src/Core/Sorcha.Wallet.Core/Repositories/EfCoreWalletRepository.cs
+public sealed class EfCoreWalletRepository(WalletDbContext context) : IWalletRepository
 {
-    protected readonly TContext _context;
-
-    public async Task<IEnumerable<TEntity>> GetAllAsync()
-    {
-        return await _context.Set<TEntity>().AsNoTracking().ToListAsync();
-    }
-
-    public async Task<TEntity?> GetByIdAsync(TId id)
-    {
-        return await _context.Set<TEntity>().FindAsync(id);
-    }
+    // Focused, domain-specific query methods over WalletDbContext — not a generic CRUD surface.
+    // (See "Specialized Repository with Eager Loading" below for the include/AsNoTracking idiom.)
 }
 ```
 

--- a/.claude/skills/mongodb/references/modules.md
+++ b/.claude/skills/mongodb/references/modules.md
@@ -237,7 +237,7 @@ See the **redis** skill for caching patterns and **entity-framework** skill for 
 public class WorkflowService
 {
     private readonly IDocumentStore<Blueprint, string> _blueprintStore;  // MongoDB
-    private readonly IRepository<Wallet> _walletRepo;                    // PostgreSQL via EF
+    private readonly IWalletRepository _walletRepo;                       // PostgreSQL via EF (service-specific repo; no generic IRepository<T>)
     private readonly IDistributedCache _cache;                           // Redis
 }
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,14 +172,14 @@ var result = schema.Evaluate(element);
 ```
 
 ### 5. Storage Abstraction Pattern
+Depend on a **service-specific repository interface** (e.g. `IWalletRepository`, `IRegisterRepository`, `IInstanceStore`, `IActionStore`) — there is **no** generic `IRepository<T>`. The concrete backend (EF Core / MongoDB / Redis / in-memory) is chosen at registration time and recorded via `IStorageRegistrationLog` (Pattern #10/#13).
 ```csharp
-// Use IRepository<T> from Sorcha.Storage.Abstractions
-public class WalletService
+public class WalletService(IWalletRepository repository)
 {
-    private readonly IRepository<Wallet> _repository;
-    public WalletService(IRepository<Wallet> repository) => _repository = repository;
+    // domain logic delegates persistence to the injected repository
 }
 ```
+For tiered / cache storage the seams live in `Sorcha.Storage.Abstractions`: `ICacheStore`, `IDocumentStore`, `IWormStore`, `IVerifiedCache`.
 
 ### 6. Instance Reference Configuration
 Blueprints should define an `instanceReference` to generate human-readable identifiers for workflow instances (e.g., "CP-RIV-14-A7K3"). The reference is auto-generated from first-action payload fields and stored as public metadata on the instance.

--- a/docs/reference/data-persistence-architecture.md
+++ b/docs/reference/data-persistence-architecture.md
@@ -156,6 +156,15 @@ public interface ICacheStore
 
 ### 2. Repository Interface (Warm Tier - Relational)
 
+> **Implementation note (2026-06-03):** the generic `IRepository<TEntity, TId>` below is an
+> **illustrative model of the warm-tier role — it is NOT a type in the codebase.** Sorcha does not use
+> a generic repository; each service defines a **focused repository interface** (`IWalletRepository`,
+> `IRegisterRepository`, `IInstanceStore`, `IActionStore`, …) with a concrete EF Core implementation
+> over its own `DbContext`, registered via `IStorageRegistrationLog` (Feature 113) so the backend
+> choice is visible at startup and fails closed on an in-memory fallback in Production/Staging. The
+> `IRepository<…>` rows in the tables below denote "a warm-tier relational repository for this entity",
+> not a literal shared interface. (See the `entity-framework` skill → "Concrete repository".)
+
 ```csharp
 namespace Sorcha.Storage.Abstractions;
 

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-Sorcha is organised around a four-tier layering (Apps / Services / Core / Common) with a dedicated `tests/` root and top-level support directories for docs, specs, blueprints, walkthroughs, infra, and tooling.
+Sorcha is organised around layered tiers (Apps / Services / Core / Common, plus a small `Providers/` tier for pluggable infrastructure) with a dedicated `tests/` root and top-level support directories for docs, specs, blueprints, walkthroughs, infra, and tooling.
 
-**Last Updated:** 2026-04-21
-**Version:** 3.0.0
+**Last Updated:** 2026-06-03
+**Version:** 3.1.0
 
 ## Directory Structure
 
@@ -30,25 +30,27 @@ Sorcha/
 │   │           └── Sorcha.UI.Integration.Tests/
 │   ├── Common/                                 # Cross-cutting libraries (no business logic)
 │   │   ├── Sorcha.AddressLookup/               # Postal-address lookup abstractions
+│   │   ├── Sorcha.AtomicCache/                 # IAtomicDistributedCache (GETDEL + Lua CAS primitive)
 │   │   ├── Sorcha.Blueprint.Models/            # Blueprint domain models + JSON-LD
 │   │   ├── Sorcha.Blueprint.Schemas/           # Schema definitions (shared)
-│   │   ├── Sorcha.Cryptography/                # Multi-algorithm crypto (ED25519, P-256, RSA-4096)
+│   │   ├── Sorcha.CitizenWallet.Abstractions/  # Citizen-wallet DTOs, derivation contexts, VCT URIs (F114)
+│   │   ├── Sorcha.Cryptography/                # Multi-algorithm crypto (ED25519, P-256, RSA-4096) + SD-JWT + mdoc
+│   │   ├── Sorcha.PresentationLifecycle.Abstractions/ # Cross-consumer presentation-lifecycle contract (F111)
 │   │   ├── Sorcha.Register.Models/             # Register domain models + genesis resources
 │   │   ├── Sorcha.ServiceClients/              # Consolidated HTTP/gRPC clients
 │   │   ├── Sorcha.ServiceClients.Http/         # HTTP REST clients + SignalR (NuGet, mobile-friendly)
-│   │   ├── Sorcha.ServiceDefaults/             # Aspire shared configuration + rate limiting
-│   │   ├── Sorcha.Storage.Abstractions/        # IRepository<T>, IUnitOfWork
+│   │   ├── Sorcha.ServiceDefaults/             # Aspire shared config, rate limiting, tiered-audience auth, storage audit
+│   │   ├── Sorcha.Storage.Abstractions/        # Storage seams: ICacheStore, IDocumentStore, IWormStore, IVerifiedCache
 │   │   ├── Sorcha.Storage.InMemory/            # In-memory implementation (testing)
 │   │   ├── Sorcha.Storage.MongoDB/             # MongoDB implementation
 │   │   ├── Sorcha.Storage.Redis/               # Redis caching implementation
 │   │   ├── Sorcha.Tenant.Models/               # Tenant domain models
 │   │   ├── Sorcha.TransactionHandler/          # Transaction building/serialization
 │   │   ├── Sorcha.Validator.Core/              # Enclave-safe validation library
-│   │   └── Sorcha.Wallet.Core/                 # Wallet domain logic
+│   │   └── Sorcha.Verifier.Engine/             # WASM-friendly OID4VP presentation validator + issuer-key resolvers
 │   ├── Core/                                   # Business logic
-│   │   ├── Sorcha.Blueprint.Engine/            # Portable execution (WASM-compatible)
+│   │   ├── Sorcha.Blueprint.Engine/            # Portable execution (WASM-compatible) + credential trust/format handlers
 │   │   ├── Sorcha.Blueprint.Fluent/            # Fluent API for blueprint construction
-│   │   ├── Sorcha.Blueprint.Schemas/           # Schema management with caching
 │   │   ├── Sorcha.Blueprint.Schemas.Client/    # Client-side schema facade
 │   │   ├── Sorcha.Register.Core/               # Ledger business logic + LocalRelationship + SyncState
 │   │   ├── Sorcha.Register.Storage/            # Register-specific storage abstractions
@@ -57,6 +59,8 @@ Sorcha/
 │   │   ├── Sorcha.Register.Storage.Redis/
 │   │   ├── Sorcha.Wallet.Core/                 # Wallet business logic
 │   │   └── Sorcha.Wallet.Portable/             # Portable wallet: entities, enums, derivation (NuGet)
+│   ├── Providers/                              # Pluggable infrastructure providers
+│   │   └── Sorcha.Wallet.Providers.Azure/      # Azure Key Vault / KMS-resident wallet key protection
 │   └── Services/                               # REST / gRPC / background services
 │       ├── Sorcha.ApiGateway/                  # YARP reverse proxy
 │       ├── Sorcha.Blueprint.Service/           # Workflow management + SignalR
@@ -66,7 +70,7 @@ Sorcha/
 │       ├── Sorcha.Tenant.Service/              # Multi-tenant auth, JWT, Participant/Platform Identity
 │       ├── Sorcha.Validator.Service/           # Consensus + chain integrity
 │       └── Sorcha.Wallet.Service/              # Crypto wallet management
-├── tests/                                      # ~47 top-level test projects (plus UI-scoped tests under src/Apps/Sorcha.UI/tests)
+├── tests/                                      # ~52 top-level test projects (plus 2 UI-scoped tests under src/Apps/Sorcha.UI/tests)
 │   ├── Sorcha.Testing/                         # Shared test factory / fixtures
 │   ├── {Project}.Tests/                        # Unit tests
 │   ├── {Project}.IntegrationTests/             # Integration tests (real DB/services)
@@ -89,7 +93,7 @@ Sorcha/
 └── Sorcha.sln                                  # Solution file
 ```
 
-**Counts (2026-04-21):** 7 App projects, 17 Common libraries, 11 Core libraries, 8 Services, ~47 top-level test projects + 2 UI-scoped test projects.
+**Counts (2026-06-03):** 7 standalone App projects + 4 UI projects (under `Sorcha.UI/`), 19 Common libraries, 10 Core libraries, 1 Providers project, 8 Services. Tests: ~52 top-level test projects (under `tests/`) + 2 UI-scoped test projects (under `src/Apps/Sorcha.UI/tests/`).
 
 ## Layer Purposes
 
@@ -104,6 +108,10 @@ Cross-cutting libraries. Contents: domain models, cryptography, storage abstract
 ### src/Core/
 
 Domain business logic — execution engines, ledger core, schema management, fluent builders, portable wallet. Depends on Common only.
+
+### src/Providers/
+
+Pluggable infrastructure providers selected by configuration — e.g. `Sorcha.Wallet.Providers.Azure` supplies Azure Key Vault / KMS-resident wallet key protection behind the Wallet Service's key-protection seam. Kept separate so a deployment pulls in only the cloud providers it uses.
 
 ### src/Services/
 


### PR DESCRIPTION
## Summary

The **deferred docs** from the 2026-06-02 review (D7 + the `IRepository<T>` gap) — code-is-truth corrections, no behaviour change.

- **`project-structure.md`** re-enumerated against the actual tree: added the 4 missing Common libs (`AtomicCache`, `CitizenWallet.Abstractions`, `PresentationLifecycle.Abstractions`, `Verifier.Engine`), removed the mis-placed `Wallet.Core` (it's Core) and the phantom `Core/Blueprint.Schemas`, **added the `src/Providers/` tier** (`Sorcha.Wallet.Providers.Azure`), corrected the `Storage.Abstractions` annotation (`IRepository<T>, IUnitOfWork` → the real seams `ICacheStore`/`IDocumentStore`/`IWormStore`/`IVerifiedCache`), refreshed counts + Last Updated.
- **CLAUDE.md Pattern #5** corrected: there is **no** generic `IRepository<T>`; services depend on focused repository interfaces (`IWalletRepository`, …) registered via `IStorageRegistrationLog`.
- **entity-framework skill**: fixed the phantom `src/Common/Sorcha.Storage.EFCore/...` paths (SKILL.md + patterns.md) → real `WalletServiceExtensions` / `EfCoreWalletRepository`; replaced the fictional "Generic Repository Base" (`IRepository<T,TId>`) with the real concrete-repository pattern.
- **mongodb skill + `data-persistence-architecture.md`**: same `IRepository<T>` fiction — fixed the mongodb example to `IWalletRepository`; added an implementation-note banner to the persistence doc clarifying `IRepository<…>` denotes a warm-tier *role*, not a codebase type.

## Notes

- `development-status.md` (PeerRouter) was already corrected by #928.
- Left untouched: `docs/archive/plans/*` (historical records) and the generic `entity-framework-core` skill's "Generic Repository Anti-Pattern" (correct general .NET guidance — and consistent with Sorcha's no-generic-repo choice).

Doc-only; no code or tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)