### PR TITLE
test(ci): de-flake TransactionRow midnight test + InclusionProof env-var race (#904)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Registers/TransactionViewModel.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Models/User/Registers/TransactionViewModel.cs
@@ -109,7 +109,7 @@ public record TransactionViewModel
     /// <summary>
     /// Computed: Formatted timestamp (relative or absolute)
     /// </summary>
-    public string TimeStampFormatted => GetFormattedTime(TimeStamp);
+    public string TimeStampFormatted => GetFormattedTime(TimeStamp, DateTime.UtcNow);
 
     /// <summary>
     /// Computed: Whether this transaction is recent (within last 5 seconds)
@@ -149,9 +149,14 @@ public record TransactionViewModel
     /// </summary>
     public string DidUri => $"did:sorcha:register:{RegisterId}/tx/{TxId}";
 
-    private static string GetFormattedTime(DateTime dateTime)
+    // <c>now</c> is injected (rather than read from the clock inside) so the
+    // calendar-boundary branches below are deterministically unit-testable.
+    // Reading DateTime.UtcNow here made the "today" check flaky when a test ran
+    // in the first couple of hours of a UTC day (a "2 hours ago" timestamp fell
+    // on the previous calendar day). Callers pass DateTime.UtcNow.
+    internal static string GetFormattedTime(DateTime dateTime, DateTime now)
     {
-        var timeSpan = DateTime.UtcNow - dateTime;
+        var timeSpan = now - dateTime;
 
         // For recent transactions, show relative time
         if (timeSpan.TotalMinutes < 60)
@@ -162,7 +167,7 @@ public record TransactionViewModel
         }
 
         // For today's transactions, show time only
-        if (dateTime.Date == DateTime.UtcNow.Date)
+        if (dateTime.Date == now.Date)
         {
             return dateTime.ToString("HH:mm:ss");
         }

--- a/tests/Sorcha.Register.Service.Tests/Helpers/RegisterServiceWebApplicationFactory.cs
+++ b/tests/Sorcha.Register.Service.Tests/Helpers/RegisterServiceWebApplicationFactory.cs
@@ -44,14 +44,16 @@ namespace Sorcha.Register.Service.Tests.Helpers;
 /// </remarks>
 public class RegisterServiceWebApplicationFactory : WebApplicationFactory<Program>
 {
-    private static readonly string[] EnvironmentVariables =
-    [
-        "SystemWalletSigning__ValidatorId",
-        "ConnectionStrings__redis",
-        "RegisterStorage__Type"
-    ];
-
-    public RegisterServiceWebApplicationFactory()
+    // Required test config is set process-wide ONCE in the type initializer and
+    // never cleared. Previously each instance set these in its constructor and
+    // nulled them in Dispose; with xUnit running test classes in parallel, one
+    // instance's Dispose could clear SystemWalletSigning:ValidatorId while another
+    // instance's host was still starting, so AddSystemWalletSigning threw
+    // "SystemWalletSigning:ValidatorId configuration is required" intermittently
+    // (issue #904). These are test-only constants shared by every host in this
+    // assembly, so setting them once and leaving them set is both race-free and
+    // correct.
+    static RegisterServiceWebApplicationFactory()
     {
         Environment.SetEnvironmentVariable(
             "SystemWalletSigning__ValidatorId", "test-validator-001");
@@ -130,19 +132,6 @@ public class RegisterServiceWebApplicationFactory : WebApplicationFactory<Progra
             services.RemoveAll(typeof(HubLifetimeManager<RegisterHub>));
             services.AddSingleton<HubLifetimeManager<RegisterHub>, DefaultHubLifetimeManager<RegisterHub>>();
         });
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            foreach (var envVar in EnvironmentVariables)
-            {
-                Environment.SetEnvironmentVariable(envVar, null);
-            }
-        }
-
-        base.Dispose(disposing);
     }
 
     private static void ReplaceService<T>(IServiceCollection services, Func<IServiceProvider, T> factory)

--- a/tests/Sorcha.UI.Core.Tests/Components/Registers/TransactionRowTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Registers/TransactionRowTests.cs
@@ -181,11 +181,33 @@ public class TransactionRowTests
     [Fact]
     public void TransactionViewModel_TimeStampFormatted_ShowsTimeForToday()
     {
-        // Arrange - Transaction from 2 hours ago
-        var tx = CreateTestTransaction(timeStamp: DateTime.UtcNow.AddHours(-2));
+        // A transaction earlier the same day (>1h ago) shows HH:mm:ss.
+        // The clock is injected so this is deterministic — the previous version
+        // arranged DateTime.UtcNow.AddHours(-2) and was flaky in the first 2h of
+        // a UTC day, when "2 hours ago" fell on the previous calendar day and the
+        // formatter switched to the date format.
+        var now = new DateTime(2026, 1, 15, 14, 0, 0, DateTimeKind.Utc);
+        var earlierToday = new DateTime(2026, 1, 15, 9, 30, 15, DateTimeKind.Utc);
 
-        // Assert - Should show time in HH:mm:ss format
-        tx.TimeStampFormatted.Should().MatchRegex(@"\d{2}:\d{2}:\d{2}");
+        var result = TransactionViewModel.GetFormattedTime(earlierToday, now);
+
+        result.Should().Be("09:30:15");
+    }
+
+    [Fact]
+    public void TransactionViewModel_TimeStampFormatted_ShowsDateForPreviousDay()
+    {
+        // Regression for the midnight flake: a transaction >1h ago but on the
+        // previous calendar day shows the absolute date, not HH:mm:ss. This is
+        // exactly the state that intermittently broke the "today" test.
+        var now = new DateTime(2026, 1, 15, 1, 0, 0, DateTimeKind.Utc);          // 01:00 UTC
+        var lateYesterday = new DateTime(2026, 1, 14, 23, 0, 0, DateTimeKind.Utc); // 2h earlier, prev day
+
+        var result = TransactionViewModel.GetFormattedTime(lateYesterday, now);
+
+        // Date branch ("MMM dd, HH:mm") — culture-independent shape, and explicitly NOT the time-only format.
+        result.Should().MatchRegex(@"^\w{3} \d{2}, \d{2}:\d{2}$");
+        result.Should().NotMatchRegex(@"\d{2}:\d{2}:\d{2}");
     }
 
     [Theory]


### PR DESCRIPTION
Closes the two known CI flakes (both non-deterministic by construction, not product bugs).

## 1. `TransactionRowTests.TimeStampFormatted_ShowsTimeForToday` (UTC-midnight flake)
`GetFormattedTime` shows `HH:mm:ss` only when `dateTime.Date == DateTime.UtcNow.Date`. The test arranged `DateTime.UtcNow.AddHours(-2)` and asserted `HH:mm:ss` — but run in the first ~2h of a UTC day, "2 hours ago" is the **previous** calendar day, so the formatter returns `"MMM dd, HH:mm"` (no seconds) and the regex fails.

**Fix:** injected `now` into `GetFormattedTime` (made `internal` — the test project already has `InternalsVisibleTo`) so the calendar-boundary branches are deterministic. Rewrote the test with a fixed clock + same-day timestamp, and **added `ShowsDateForPreviousDay`** covering the exact `>1h-ago-but-yesterday` case that used to break.

## 2. `InclusionProofEndpointTests` — env-var race (issue #904)
`RegisterServiceWebApplicationFactory` set `SystemWalletSigning__ValidatorId` (+2 more) as **process-wide env vars** in its instance constructor and **nulled them in `Dispose`**. With xUnit running test classes in parallel, one instance's `Dispose` could clear the var while another instance's host was still building → `AddSystemWalletSigning` threw `"SystemWalletSigning:ValidatorId configuration is required"`, failing the whole class in its constructor.

**Fix:** moved the env-var set into the **type initializer** (set once, never cleared) and removed the `Dispose` nulling. The values are test-only constants shared by every host in the assembly, so this is race-free and correct. The race is eliminated by construction (nothing nulls the vars anymore).

## Verification
- `Sorcha.UI.Core.Tests`: **1337/1337** green (incl. new regression test).
- `Sorcha.Register.Service.Tests`: **303 passed / 9 skipped / 0 failed** (incl. `InclusionProofEndpointTests`).

Fixes #904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)