### PR TITLE
docs(wave1): security truth — F136 tiered auth, hardening config, audit remediation status

### DIFF
--- a/docs/admin/configuration-reference.md
+++ b/docs/admin/configuration-reference.md
@@ -147,6 +147,50 @@ Shared across all services via the `x-otel-env` YAML anchor:
 | `ASPNETCORE_ENVIRONMENT` | `Development` | Runtime environment (`Development`, `Docker`, `Production`) |
 | `ASPNETCORE_URLS` | `http://+:8080` | Listening URLs inside containers |
 
+## Production Hardening (fail-fast gates)
+
+Setting `ASPNETCORE_ENVIRONMENT=Production` (or `Staging`) turns on three **startup gates** — a host
+that isn't configured for them **refuses to start** (by design). Plan for these before your first
+production boot.
+
+### Storage provider audit (Feature 113)
+
+Six storage interfaces are **audited** and must be backed by a **persistent** provider in
+Production/Staging — `IWalletRepository`, `IRegisterRepository`, `IInstanceStore`, `IActionStore`,
+`IVerifiedTransactionQueue`, `IAtomicDistributedCache`. If any is left on an in-memory backend the
+host **fails fast at startup**. Provide the relevant connection strings (Postgres for wallet,
+MongoDB for register, Redis for the atomic cache).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `Storage__AllowInMemoryInProduction` | `false` | Escape hatch to bypass the fail-fast (CI smoke tests, ephemeral debugging). Logs at `LogCritical`. **Leave unset/false for real production.** |
+
+The `storage-providers` health check reports `Degraded` when any audited interface is in-memory; the
+`Sorcha.Storage` meter (`sorcha_storage_provider_info`, `sorcha_storage_fallback_active`) surfaces the
+same for dashboards.
+
+### SignalR Redis backplane (Feature 118)
+
+Every hub-hosting service (Tenant, Blueprint, Wallet, Register) **requires a Redis backplane** in
+Production/Staging — without it, multi-replica fan-out silently drops events, so the host **refuses
+to start**. Ensure the Redis connection string is set (`ConnectionStrings__Redis` /
+`ConnectionStrings__Sorcha__Redis`); the channel prefix is isolated per service automatically.
+
+### Rate limiting (SEC-002)
+
+Centralised rate limiting is bound from the `RateLimiting` section (`RateLimitSettings`). The
+shipped defaults are **deliberately relaxed (~100k/min)** for pre-release development — **tighten
+them in `appsettings.Production.json`** (policies: `Api`, `PlatformAuth`, `TotpValidation`,
+`Strict`). Do not ship the dev defaults to production.
+
+### Other production switches
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REDIS_PASSWORD` | (empty) | Set a Redis auth password for production (see Databases → Redis). |
+| `JWT_SIGNING_KEY` | dev key in `docker-compose.yml` | Replace with a real key from a secret store in any non-dev environment. |
+| `Platform__AllowAdminVerifiedUserCreation` | `false` | Must stay `false`/unset in production (admin-verified user creation is a dev convenience). |
+
 ## Feature Flags
 
 | Variable | Default | Description |
@@ -212,7 +256,7 @@ Additional seed nodes follow the same pattern with incrementing index (`__1__`, 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `Validator__ValidatorId` | `docker-validator-1` | Unique validator node identifier |
+| `Validator__ValidatorId` | `local-validator` | Unique validator node identifier. **MUST equal `SystemWalletSigning__ValidatorId` on the Register Service** — if they differ, docket sealing never starts. |
 | `Validator__SystemWalletAddress` | (empty) | System wallet address (auto-created if empty) |
 | `VALIDATOR_HTTP_PORT` | `5800` | Host port for HTTP REST API |
 | `VALIDATOR_GRPC_PORT` | `5801` | Host port for gRPC endpoint |

--- a/docs/guides/AUTHENTICATION-SETUP.md
+++ b/docs/guides/AUTHENTICATION-SETUP.md
@@ -149,20 +149,21 @@ Add to `appsettings.json` or `appsettings.Development.json`:
 ```json
 {
   "JwtSettings": {
-    "Issuer": "https://tenant.sorcha.io",
-    "Audience": "https://api.sorcha.io",
+    "InstallationName": "localhost",
     "SigningKey": "your-secret-key-min-32-characters-REPLACE-THIS-IN-PRODUCTION",
     "AccessTokenLifetimeMinutes": 60,
     "RefreshTokenLifetimeHours": 24,
     "ServiceTokenLifetimeHours": 8,
-    "ClockSkewMinutes": 5,
-    "ValidateIssuer": true,
-    "ValidateAudience": true,
-    "ValidateIssuerSigningKey": true,
-    "ValidateLifetime": true
+    "ClockSkewMinutes": 5
   }
 }
 ```
+
+> **Issuer and audiences are derived, not hand-set (Feature 136).** `InstallationName` drives both:
+> the issuer resolves to `urn:sorcha:{InstallationName}` (fail-closed in Production/Staging) and the
+> audiences are the four tier strings `{InstallationName}:consumer|platform|service|enrol-session`.
+> Do **not** set `JwtSettings:Issuer`/`Audience` here (the audience config is ignored). See
+> [JWT Configuration](JWT-CONFIGURATION.md) for the full tiered-audience model.
 
 ### Environment Variables (Recommended for Production)
 
@@ -237,34 +238,38 @@ Content-Type: application/json
 
 ## Token Claims
 
-### User Tokens
+The `aud` claim is the **trust tier** (`{installation}:consumer|platform|service|enrol-session`) and
+`iss` is `urn:sorcha:{installation}` — see [JWT Configuration](JWT-CONFIGURATION.md). Examples use the
+`localhost` installation.
+
+### User Tokens (Platform tier — admin / designer / org operator)
 ```json
 {
   "sub": "user-id-guid",
   "email": "user@organization.com",
-  "name": "User Name",
+  "platform_user_id": "platform-user-guid",
   "org_id": "organization-id-guid",
-  "role": "Administrator",
+  "org_name": "Example Org",
+  "roles": ["Administrator"],
   "token_type": "user",
-  "iss": "https://tenant.sorcha.io",
-  "aud": "https://api.sorcha.io",
-  "exp": 1735891200,
-  "iat": 1735887600
+  "iss": "urn:sorcha:localhost",
+  "aud": "localhost:platform"
 }
 ```
+
+> A **Consumer**-tier token (citizen / wallet holder) has the same shape **minus `roles` and
+> `wallet_address`**, with `aud": "localhost:consumer"`.
 
 ### Service Tokens
 ```json
 {
   "sub": "service-principal-id",
-  "client_id": "blueprint-service",
-  "org_id": "organization-id-guid",
+  "client_id": "service-blueprint",
+  "service_name": "Blueprint Service",
   "token_type": "service",
-  "scope": "blueprints:write registers:read",
-  "iss": "https://tenant.sorcha.io",
-  "aud": "https://api.sorcha.io",
-  "exp": 1735920000,
-  "iat": 1735887600
+  "scope": ["blueprints:write", "registers:read"],
+  "iss": "urn:sorcha:localhost",
+  "aud": "localhost:service"
 }
 ```
 
@@ -920,9 +925,9 @@ Authorization: Bearer <service-token>
   "delegated_user_id": "user-guid-here",
   "delegated_user_email": "user@organization.com",
   "org_id": "organization-id-guid",
-  "scope": "wallets:sign registers:write",
-  "iss": "https://tenant.sorcha.io",
-  "aud": "https://api.sorcha.io",
+  "scope": ["wallets:sign", "registers:write"],
+  "iss": "urn:sorcha:localhost",
+  "aud": "localhost:service",
   "exp": 1735891200,
   "iat": 1735887600
 }

--- a/docs/guides/JWT-CONFIGURATION.md
+++ b/docs/guides/JWT-CONFIGURATION.md
@@ -1,346 +1,152 @@
 # JWT Configuration Guide
 
-## Overview
+Sorcha uses **JWT Bearer authentication** with the **Tenant Service** as the sole token issuer.
+Every other service validates tokens using shared `JwtSettings` from `Sorcha.ServiceDefaults`. Since
+Feature 136 the configuration model is **tiered audiences + a hardened, installation-namespaced
+issuer** — the `aud` claim is the trust-tier boundary, not a single flat URL.
 
-Sorcha uses JSON Web Tokens (JWT) for authentication and authorization across all microservices. The JWT configuration ensures that tokens issued by the Tenant Service can be validated by all other services in the installation.
+## Installation name
 
-## Key Concepts
-
-### Installation Name
-
-The `InstallationName` is a unique identifier for your Sorcha deployment (e.g., `localhost`, `dev.sorcha.io`, `prod.sorcha.io`). It's used to automatically derive the JWT issuer and audience values.
-
-### Issuer (iss claim)
-
-The issuer identifies who created and signed the token. In Sorcha, the **Tenant Service is always the issuer**.
-
-### Audience (aud claim)
-
-The audience identifies who the token is intended for. All services in the same installation should accept tokens with the installation's audience.
-
-## Default Configuration
-
-### Docker Compose (Local Development)
-
-The default docker-compose setup uses:
-
-- **Installation Name:** `localhost`
-- **Issuer:** `http://localhost` (derived from InstallationName)
-- **Audience:** `http://localhost` (derived from InstallationName)
-- **Signing Key:** Shared base64-encoded key (auto-generated or from environment)
-
-### Configuration Hierarchy
-
-JWT settings are resolved in this priority order:
-
-1. **Explicit Configuration** - `JwtSettings:Issuer` and `JwtSettings:Audience` in appsettings or environment variables
-2. **Derived from InstallationName** - If not explicitly set, uses `http://{InstallationName}`
-3. **Fallback Defaults** - `https://tenant.sorcha.io` (issuer) and `https://api.sorcha.io` (audience)
-
-## Environment Variables
-
-### Required for Docker Compose
+`JwtSettings:InstallationName` is the unique identifier for a deployment (docker-compose defaults to
+`localhost`; when unset entirely it defaults to `sorcha`). It drives **both** the issuer and the
+audience namespace, so every service in one installation must use the **same** value.
 
 ```yaml
-environment:
-  # Installation identifier (required for automatic issuer/audience derivation)
-  JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}
-
-  # Shared signing key (required - must be same across all services)
-  JwtSettings__SigningKey: ${JWT_SIGNING_KEY:-<base64-key>}
+# Shared across all services (docker-compose x-jwt-env)
+JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}
+JwtSettings__SigningKey:       ${JWT_SIGNING_KEY:-<base64 dev key>}
 ```
 
-### Optional Overrides
+## Issuer (hardened — Feature 136)
+
+The issuer is resolved by `SorchaIssuer.Resolve`, in order:
+
+1. An explicit `JwtSettings:Issuer`, if set (wins — e.g. the AppHost sets `https://localhost:7110`).
+2. Otherwise **`urn:sorcha:{InstallationName}`** (e.g. `urn:sorcha:localhost`).
+3. In non-production (Development/Testing) only, the fallback **`urn:sorcha:dev-local`**.
+4. Otherwise it **throws at startup** — there is **no shared default**, so a misconfigured
+   Production/Staging host fails closed rather than minting unverifiable tokens.
+
+## Audiences = trust tiers (Feature 136)
+
+Audiences are **always derived** from `SorchaAudiences(InstallationName)` — `JwtSettings:Audience`
+config is **intentionally ignored**. Each token carries exactly one installation-namespaced,
+tier-scoped audience:
+
+| Tier | Audience (`localhost` install) | Who | Notable claims |
+|------|--------------------------------|-----|----------------|
+| **Consumer** | `localhost:consumer` | citizen / wallet holder (web + PWA) | `sub`, `email`, `platform_user_id`, `org_id`/`org_name`; **no `roles`, no `wallet_address`** |
+| **Platform** | `localhost:platform` | admin / designer / auditor / org operator | + `org_id`, `org_name`, `roles[]`, `wallet_address?` |
+| **Service** | `localhost:service` | service-to-service / internal | `client_id`, `service_name`, `scope[]`, `delegated_*?` |
+| **Enrol-session** | `localhost:enrol-session` | one-time device pairing | `scope:"enrol"`, single-use `jti` |
+
+**Authenticate broad, authorize narrow.** The bearer pipeline accepts **any** of the installation's
+four tier audiences (`ValidAudiences = SorchaAudiences.All`) and rejects tokens from other
+installations. The *specific* tier is then enforced **per endpoint** by policies (below). Mint and
+validate both resolve issuer + audiences through the same `SorchaIssuer`/`SorchaAudiences`, or
+tokens self-reject.
+
+### Authorization policies
+
+Registered by `AddSorchaAuthorizationPolicies` (every service calls it):
+
+| Policy | Admits |
+|--------|--------|
+| `RequireConsumerAudience` | consumer-tier tokens — citizen/wallet surfaces (`/api/v1/wallet`, application submission) |
+| `RequirePlatformAudience` | platform-tier tokens — **compose on top of a role policy**, e.g. `RequireAdministrator` + `RequirePlatformAudience` |
+| `RequireService` | `token_type==service` **and** `:service` audience — `/api/internal/*`, docket writes |
+
+Genuinely cross-tier endpoints (e.g. `/me/inbox`) stay plain `.RequireAuthorization()`. For gates
+that must admit a service caller **or** a specific human tier, fold the audience into the
+requirement (a consumer token also carries `org_id`, so `hasOrgId || isService` alone would leak) —
+`CanManageBlueprints` and `CanRecoverSystemWallet` are the canonical tier-folded examples.
+
+## Configuration reference
 
 ```yaml
 environment:
-  # Explicit issuer (overrides InstallationName derivation)
-  JwtSettings__Issuer: "https://auth.example.com"
+  JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}   # drives issuer + audiences
+  JwtSettings__SigningKey:       ${JWT_SIGNING_KEY}                # shared HMAC key (all services)
 
-  # Explicit audience (overrides InstallationName derivation)
-  JwtSettings__Audience__0: "https://api.example.com"
-  JwtSettings__Audience__1: "https://app.example.com"
-
-  # Token lifetimes
+  # Optional
+  JwtSettings__Issuer: "https://auth.example.com"   # explicit issuer override (audiences are NOT overridable)
   JwtSettings__AccessTokenLifetimeMinutes: 60
-  JwtSettings__RefreshTokenLifetimeHours: 24
-  JwtSettings__ServiceTokenLifetimeHours: 8
-
-  # Validation settings
-  JwtSettings__ValidateIssuer: true
-  JwtSettings__ValidateAudience: true
-  JwtSettings__ValidateIssuerSigningKey: true
-  JwtSettings__ValidateLifetime: true
+  JwtSettings__RefreshTokenLifetimeHours:  24
+  JwtSettings__ServiceTokenLifetimeHours:  8
   JwtSettings__ClockSkewMinutes: 5
 ```
 
-## Configuration by Environment
+> The pre-136 keys `JwtSettings__Audience__0/__1` no longer do anything — remove them. Audiences are
+> the four derived tier strings.
 
-### Local Development (Docker Compose)
+## Signing key management
 
-**File:** `docker-compose.yml`
+- **Development:** a shared key is auto-generated and persisted (`%LOCALAPPDATA%\Sorcha\dev-jwt-signing-key.txt`); docker-compose uses the `JWT_SIGNING_KEY` default. Never use these in production.
+- **Production:** supply `JwtSettings__SigningKey` from a secret store (Azure Key Vault recommended; the wallet/issuance crypto already integrates Azure KMS, Feature 082). HS256 (HMAC-SHA256). Rotate periodically; all services must share the same key.
 
-```yaml
-# Shared JWT configuration for all services
-x-jwt-env: &jwt-env
-  JwtSettings__InstallationName: ${INSTALLATION_NAME:-localhost}
-  JwtSettings__SigningKey: ${JWT_SIGNING_KEY:-<default-dev-key>}
-```
+## Token structure
 
-**Result:**
-- Issuer: `http://localhost`
-- Audience: `http://localhost`
-
-### .NET Aspire (Local Development)
-
-**File:** `src/Apps/Sorcha.AppHost/AppHost.cs`
-
-```csharp
-builder.AddProject<Projects.Sorcha_Tenant_Service>("tenant-service")
-    .WithEnvironment("JwtSettings__InstallationName", "localhost");
-```
-
-**Result:**
-- Issuer: `http://localhost`
-- Audience: `http://localhost`
-
-### Staging/Production
-
-**Option 1: Use Installation Name**
-
-```yaml
-environment:
-  JwtSettings__InstallationName: "staging.sorcha.io"
-  JwtSettings__SigningKey: ${JWT_SIGNING_KEY}  # From Azure Key Vault
-```
-
-**Result:**
-- Issuer: `http://staging.sorcha.io`
-- Audience: `http://staging.sorcha.io`
-
-**Option 2: Explicit Configuration**
-
-```yaml
-environment:
-  JwtSettings__Issuer: "https://auth.sorcha.io"
-  JwtSettings__Audience__0: "https://api.sorcha.io"
-  JwtSettings__SigningKey: ${JWT_SIGNING_KEY}  # From Azure Key Vault
-```
-
-**Result:**
-- Issuer: `https://auth.sorcha.io`
-- Audience: `https://api.sorcha.io`
-
-## Signing Key Management
-
-### Development
-
-**Auto-Generated Key:**
-- Services auto-generate a shared development key stored in `%LOCALAPPDATA%\Sorcha\dev-jwt-signing-key.txt`
-- Key is persisted across service restarts
-- **DO NOT use in production**
-
-**Docker Compose:**
-- Uses a default base64-encoded key specified in `docker-compose.yml`
-- Can be overridden via `.env` file:
-  ```
-  JWT_SIGNING_KEY=your-base64-key-here
-  ```
-
-### Production
-
-**REQUIRED:** Provide signing key via:
-
-1. **Environment Variable** (recommended):
-   ```bash
-   export JwtSettings__SigningKey="<base64-encoded-key>"
-   ```
-
-2. **Azure Key Vault** (best for production):
-   ```yaml
-   environment:
-     JwtSettings__SigningKeySource: "AzureKeyVault"
-     JwtSettings__KeyVaultUri: "https://your-vault.vault.azure.net/"
-     JwtSettings__SigningKeyName: "sorcha-jwt-signing-key"
-   ```
-
-3. **AWS Secrets Manager**:
-   ```yaml
-   environment:
-     JwtSettings__SigningKeySource: "AwsSecretsManager"
-     JwtSettings__SecretId: "sorcha/jwt-signing-key"
-   ```
-
-## Token Structure
-
-### User Token (Access Token)
+**Platform (admin/designer) token**
 
 ```json
 {
   "sub": "00000000-0000-0000-0001-000000000001",
   "email": "admin@sorcha.local",
-  "jti": "unique-token-id",
-  "name": "System Administrator",
+  "platform_user_id": "…",
   "org_id": "00000000-0000-0000-0000-000000000001",
   "org_name": "Sorcha Local",
+  "roles": ["Administrator", "SystemAdmin"],
   "token_type": "user",
-  "role": ["Administrator", "SystemAdmin"],
-  "iss": "http://localhost",
-  "aud": "http://localhost",
-  "exp": 1735858000,
-  "iat": 1735854400
+  "iss": "urn:sorcha:localhost",
+  "aud": "localhost:platform"
 }
 ```
 
-### Service Token
+**Consumer (citizen / wallet) token** — note: no `roles`, no `wallet_address`; carries home/public `org_id`:
 
 ```json
 {
-  "sub": "00000000-0000-0000-0002-000000000001",
-  "jti": "unique-token-id",
-  "client_id": "service-blueprint",
-  "service_name": "Blueprint Service",
-  "token_type": "service",
+  "sub": "…", "email": "citizen@example.com", "platform_user_id": "…",
+  "org_id": "…", "org_name": "…",
+  "token_type": "user",
+  "iss": "urn:sorcha:localhost", "aud": "localhost:consumer"
+}
+```
+
+**Service token**
+
+```json
+{
+  "client_id": "service-blueprint", "service_name": "Blueprint Service",
   "scope": ["blueprints:read", "blueprints:write"],
-  "iss": "http://localhost",
-  "aud": "http://localhost",
-  "exp": 1735883200,
-  "iat": 1735854400
+  "token_type": "service",
+  "iss": "urn:sorcha:localhost", "aud": "localhost:service"
 }
 ```
 
 ## Troubleshooting
 
-### Authentication Fails: "Invalid audience"
+| Symptom | Cause / fix |
+|---------|-------------|
+| `Invalid audience` | Token's `aud` isn't one of this installation's four tiers — usually a mismatched `InstallationName` across services, or a token from a different installation. Confirm `docker-compose config \| grep InstallationName` is identical everywhere. |
+| `403` on an endpoint despite a valid token | The token authenticated (right installation) but is the **wrong tier** for that endpoint (e.g. a consumer token on a `RequirePlatformAudience` admin route). Expected — use a platform-tier token. |
+| `Invalid signature` | Services have different `JwtSettings__SigningKey`. Make them identical and restart. |
+| Host **fails to start** in Production/Staging with an issuer error | Issuer could not be resolved (no explicit issuer and no `InstallationName`). Set `JwtSettings__InstallationName` (or an explicit `JwtSettings__Issuer`). This is the intended fail-closed behaviour. |
 
-**Cause:** Issuer or audience mismatch between token issuer (Tenant Service) and validator (other services).
-
-**Solution:**
-
-1. Check `InstallationName` is identical across all services:
-   ```bash
-   docker-compose config | grep InstallationName
-   ```
-
-2. Verify all services use the same configuration:
-   ```bash
-   docker logs sorcha-tenant-service 2>&1 | grep -i "jwt\|issuer"
-   docker logs sorcha-wallet-service 2>&1 | grep -i "jwt\|issuer"
-   ```
-
-3. Restart all services after configuration change:
-   ```bash
-   docker-compose down
-   docker-compose up -d
-   ```
-
-### Authentication Fails: "Invalid signature"
-
-**Cause:** Services are using different signing keys.
-
-**Solution:**
-
-1. Ensure all services use the same `JwtSettings__SigningKey`:
-   ```bash
-   docker-compose config | grep SigningKey
-   ```
-
-2. Rebuild services to pick up new key:
-   ```bash
-   docker-compose build
-   docker-compose up -d
-   ```
-
-### Tokens Expire Immediately
-
-**Cause:** Clock skew between services or token lifetime too short.
-
-**Solution:**
-
-1. Increase clock skew tolerance:
-   ```yaml
-   JwtSettings__ClockSkewMinutes: 10
-   ```
-
-2. Adjust token lifetimes:
-   ```yaml
-   JwtSettings__AccessTokenLifetimeMinutes: 120
-   JwtSettings__RefreshTokenLifetimeHours: 48
-   ```
-
-## Best Practices
-
-### Local Development
-
-✅ **DO:**
-- Use `InstallationName` approach for simplicity
-- Use the default development signing key
-- Set `ValidateAudience: true` to catch configuration issues early
-
-❌ **DON'T:**
-- Disable token validation
-- Use production keys in development
-
-### Production
-
-✅ **DO:**
-- Store signing key in Azure Key Vault or AWS Secrets Manager
-- Use HTTPS for issuer and audience URLs
-- Enable all validation options
-- Rotate signing keys periodically
-- Use separate installations for staging/production
-
-❌ **DON'T:**
-- Use auto-generated development keys
-- Commit signing keys to source control
-- Disable signature validation
-- Use HTTP in production
-
-## Default Credentials
-
-For local development, the Tenant Service creates a default admin user:
-
-- **Email:** `admin@sorcha.local`
-- **Password:** `Dev_Pass_2025!`
-- **Organization:** `Sorcha Local`
-
-⚠️ **Change these credentials immediately in production!**
-
-## Testing JWT Configuration
-
-### Using Sorcha CLI
+## Testing
 
 ```bash
-# Configure CLI for local Docker
-sorcha config list
-
-# Login with default credentials
-sorcha auth login
-# Email: admin@sorcha.local
-# Password: Dev_Pass_2025!
-
-# Check token
-sorcha auth status
-```
-
-### Manual Testing
-
-```bash
-# Get token
+# Service token (client credentials)
 curl -X POST http://localhost/api/service-auth/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=password&username=admin@sorcha.local&password=Dev_Pass_2025!&client_id=sorcha-cli"
+  -d "grant_type=client_credentials&client_id=service-blueprint&client_secret=blueprint-service-secret"
 
-# Decode token (using jwt.io or jwt-cli)
-echo "<access_token>" | jwt decode -
-
-# Verify issuer and audience match your configuration
+# Inspect the token at jwt.io — confirm iss=urn:sorcha:<install> and aud=<install>:<tier>
 ```
 
 ## References
 
-- [JWT Standard (RFC 7519)](https://tools.ietf.org/html/rfc7519)
-- [OAuth 2.0 (RFC 6749)](https://tools.ietf.org/html/rfc6749)
-- [.NET JWT Bearer Authentication](https://learn.microsoft.com/aspnet/core/security/authentication/)
-- [Sorcha Service Defaults](../../src/Common/Sorcha.ServiceDefaults/JwtAuthenticationExtensions.cs)
-- [Tenant Service Token Issuance](../../src/Services/Sorcha.Tenant.Service/Services/TokenService.cs)
+- `src/Common/Sorcha.ServiceDefaults/Auth/SorchaAudiences.cs` · `SorchaIssuer.cs`
+- `src/Common/Sorcha.ServiceDefaults/JwtAuthenticationExtensions.cs` · `AuthorizationPolicyExtensions.cs`
+- `src/Services/Sorcha.Tenant.Service/Services/TokenService.cs`
+- [Authentication Setup](AUTHENTICATION-SETUP.md) · [Bootstrap Credentials](../getting-started/BOOTSTRAP-CREDENTIALS.md)

--- a/docs/security/SECURITY-AUDIT-2026-03-19.md
+++ b/docs/security/SECURITY-AUDIT-2026-03-19.md
@@ -22,6 +22,32 @@ The Sorcha decentralised register platform demonstrates **strong foundational se
 
 ---
 
+## Remediation status (updated 2026-06-04)
+
+> This audit is a **point-in-time snapshot from 2026-03-19** and is **superseded** by the
+> 2026-06-02 architecture review and the June 2026 security-hardening initiative
+> (Features 146 / 147 / 148). The findings below are accurate as of the audit date; their
+> current status is:
+
+**✅ Remediated since this audit**
+
+- **§4.1 Consensus votes unsigned (CRITICAL)** — the Validator now verifies vote signatures during consensus (`ConsensusEngine` calls `VerifySignatureAsync`); votes with invalid/absent signatures are rejected.
+- **§4.2 Replay protection missing (CRITICAL)** — per-sender sequence enforcement shipped (`WalletSequence` / `WalletSequenceRepository`, error code `VAL_REPLAY`).
+- **Application-layer at-rest secrets** — TOTP secrets, OIDC client secrets, and login tokens are now encrypted with AES-256-GCM via `ISecretProtectionProvider` (Feature 146), replacing reversible/per-process storage.
+- **Authorization gaps (Feature 147)** — system-wallet endpoints gated, `CanManageBlueprints` tier-folded, consumer-audience added to citizen surfaces.
+- **Verification correctness (Feature 148)** — honest issuer-signature status in the PWA verifier, OIDC ID-token JWS verified against provider JWKS, recovery paths fail-loud.
+
+**⚠️ Still open — production blockers**
+
+- **§5.2 Redis has no `requirepass`** — set an auth password before production.
+- **§5.4 Default development JWT signing key** ships in `docker-compose.yml` — supply a real `JWT_SIGNING_KEY` (secret store) in any non-dev environment.
+- **§5.7 CORS `AllowAnyOrigin`** in `CorsExtensions.cs` — restrict to known origins for production.
+
+See also the production hardening gates in [Admin → Configuration Reference](../admin/configuration-reference.md)
+(storage fail-fast audit, rate limiting, SignalR Redis backplane).
+
+---
+
 ## Table of Contents
 
 1. [Authentication & Authorization](#1-authentication--authorization)


### PR DESCRIPTION
**Wave 1 of the pre-production docs remediation** — the security-facing docs, brought in line with the shipped model so operators/integrators don't misconfigure the trust boundary.

| Page | Fix |
|------|-----|
| `guides/JWT-CONFIGURATION.md` | **Full rewrite** to Feature 136. Out: pre-136 flat issuer/audience (`http://{InstallationName}`, fallback `tenant.sorcha.io`/`api.sorcha.io`). In: hardened issuer `urn:sorcha:{installation}` (fail-closed in Prod/Staging), the four trust tiers (`consumer`/`platform`/`service`/`enrol-session`) from `SorchaAudiences`, authenticate-broad/authorize-narrow with `RequireConsumerAudience`/`RequirePlatformAudience`/`RequireService`, corrected token examples (`roles[]`, `platform_user_id`, tier `aud`), and the note that `JwtSettings:Audience` is ignored. |
| `guides/AUTHENTICATION-SETUP.md` | Fixed the `JwtSettings` example (`InstallationName`, not hand-set issuer/audience) and the user/service/delegated token-claim examples (real `urn:sorcha` issuer + tier audiences; consumer-vs-platform shape). |
| `security/SECURITY-AUDIT-2026-03-19.md` | Added a **remediation-status banner**: §4.1 consensus-vote verification + §4.2 replay protection are **fixed** (were shown open); at-rest secrets/authz/verification closed by F146/147/148; §5.2 Redis auth, §5.4 default JWT key, §5.7 CORS remain **open** prod blockers. Marked superseded. |
| `admin/configuration-reference.md` | New **"Production Hardening (fail-fast gates)"** section — storage audit (F113, `Storage:AllowInMemoryInProduction`), SignalR Redis backplane (F118), rate limiting (SEC-002), `REDIS_PASSWORD`/`JWT_SIGNING_KEY`/`AllowAdminVerifiedUserCreation`. Fixed `Validator__ValidatorId` (`local-validator`) + must-match-Register constraint. |

Sources: `jwt` skill, `SorchaAudiences.cs`/`SorchaIssuer.cs`/`JwtAuthenticationExtensions.cs`, `docker-compose.yml`, CLAUDE.md Patterns #8/#10/#11/#13.

Next: Wave 2 — pattern sweep (`/actionshub`→`/hubs/blueprint`, "planned/in-memory" purge, integrator endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)