### PR TITLE
docs(wave3): blueprint model corrections + new Blueprint Designer guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -115,6 +115,7 @@ gtag('config', 'G-B2MKVEP45T', { anonymize_ip: true });`],
                   { text: 'JSON Logic Guide', link: '/guides/blueprints/json-logic-guide' },
                 ],
               },
+              { text: 'Blueprint Designer', link: '/guides/designer' },
               {
                 text: 'Integration',
                 collapsed: true,

--- a/docs/ai-prompts/blueprint-examples.md
+++ b/docs/ai-prompts/blueprint-examples.md
@@ -2,6 +2,12 @@
 
 These examples show how an LLM should interact with users when helping them build Sorcha blueprints.
 
+> **Model corrections** (these conversational examples predate the current schema). When generating a
+> blueprint: use **`dataSchemas`** (an array) not `dataSchema`; route via **`routes[]`**
+> (`nextActionIds` → action ids, JSON-Logic `condition`, `isDefault`) not a `routing`/`condition`
+> block returning a participant; participants have **no `type`** field. The authoritative model is the
+> `blueprint-builder` skill and [Blueprint Format](../guides/blueprints/blueprint-format.md).
+
 ---
 
 ### Example 1: Simple Purchase Order

--- a/docs/getting-started/blueprint-quick-start.md
+++ b/docs/getting-started/blueprint-quick-start.md
@@ -1,5 +1,14 @@
 # Blueprint Quick Start Guide
 
+> **Current model (read this first).** Flow uses **`routes[]`** (`nextActionIds` → target **action
+> ids**, optional JSON-Logic `condition`, `isDefault`; `[]` ends the workflow) — not the legacy
+> participant-condition routing shown in places below. Action payloads use **`dataSchemas`** (an
+> array). One action has **`isStartingAction: true`** with an **open** sender (`walletAddress` null,
+> late-bound on first submit). Forms use schema **`x-` extensions** (`x-pages`/`x-sections`/`x-persona`),
+> not a `form` control tree. See the [Blueprint Designer](../guides/designer.md),
+> [Blueprint Format](../guides/blueprints/blueprint-format.md), and the `blueprint-builder` skill for
+> the authoritative model.
+
 ## Table of Contents
 
 1. [What Are Blueprints?](#what-are-blueprints)

--- a/docs/guides/blueprints/blueprint-architecture.md
+++ b/docs/guides/blueprints/blueprint-architecture.md
@@ -1,5 +1,14 @@
 # Sorcha Blueprint Architecture: Integration with JSON-LD, JSON-e, and JSON Logic
 
+> **Execution model has moved on (Feature 145).** Sections below describe an imperative
+> instance/advancement model with transaction-chaining and routing off `Action.Participants`. The
+> current engine is: routing via **`routes[]`** (which take precedence over the legacy participant
+> conditions, `RoutingEngine.DetermineNextWithMappingAsync`), and workflow **instances are
+> ledger-derived projections** — an `InstanceProjector` advances an instance from a signed
+> `RoutingDecision` sealed on the register, rather than imperatively mutating instance state. Treat
+> the code line-number citations below as illustrative; grep the methods if they miss. See the
+> [Blueprint Designer](../designer.md) and the `blueprint-builder` skill for the current model.
+
 ## Table of Contents
 
 1. [Overview](#overview)

--- a/docs/guides/blueprints/blueprint-format.md
+++ b/docs/guides/blueprints/blueprint-format.md
@@ -4,6 +4,16 @@
 
 Blueprints are the core workflow definitions in Sorcha. They define multi-party, data-driven workflows with conditional routing, selective data disclosure, and JSON Logic-based business rules.
 
+> **Current model (read this first).** Sorcha blueprints use:
+> - **`routes[]`** for flow — each route has `nextActionIds` (target **action ids**), an optional JSON-Logic `condition`, and `isDefault`; `nextActionIds: []` ends the workflow. Routes **supersede** the legacy participant-condition routing some sections below still show.
+> - **`dataSchemas`** — an **array** of JSON Schemas per action (not a singular `dataSchema`).
+> - **`isStartingAction: true`** on exactly one action; its sender participant is **open** — leave `walletAddress` null so the first submitter is late-bound (gate it with `credentialRequirements`). A baked-in wallet there fails publish (`VAL_BP_010`).
+> - **`disclosures`** on every action (the sender always needs `/*` on their own data).
+> - **Form layout** via schema `x-` extensions (`x-pages`, `x-sections`, `x-persona`, `x-file`, `x-review`) — not a separate `form` control tree.
+> - Workflow **instances are ledger-derived projections** (Feature 145), not imperatively advanced.
+>
+> The authoritative worked reference is the **`blueprint-builder` skill**; build visually with the [Blueprint Designer](../designer.md).
+
 ## Primary Blueprint Format: JSON/YAML
 
 **IMPORTANT**: Blueprints should **always** be created as JSON or YAML documents. This is the primary and recommended format for:

--- a/docs/guides/blueprints/json-ld-implementation-summary.md
+++ b/docs/guides/blueprints/json-ld-implementation-summary.md
@@ -187,7 +187,7 @@ Actions automatically get appropriate ActivityStreams types based on title.
 
 ### 5. API Content Negotiation
 
-#### JSON-LD Middleware ([JsonLdMiddleware.cs](../src/Apps/Services/Sorcha.Blueprint.Api/JsonLd/JsonLdMiddleware.cs))
+#### JSON-LD Middleware ([JsonLdMiddleware.cs](../src/Services/Sorcha.Blueprint.Service/JsonLd/JsonLdMiddleware.cs))
 
 Implemented content negotiation for `application/ld+json`:
 
@@ -202,7 +202,7 @@ JsonLdHelper.EnsureJsonLdContext(blueprint) // Add context if missing
 JsonLdResults.Ok(context, blueprint)        // Smart response helper
 ```
 
-#### API Updates ([Program.cs](../src/Apps/Services/Sorcha.Blueprint.Api/Program.cs))
+#### API Updates ([Program.cs](../src/Services/Sorcha.Blueprint.Service/Program.cs))
 
 Updated endpoints to support JSON-LD:
 - `GET /api/blueprints` - List with JSON-LD support
@@ -445,7 +445,7 @@ Currently contexts are embedded in code. For production:
 ### New Files
 - `src/Common/Sorcha.Blueprint.Models/JsonLd/JsonLdContext.cs`
 - `src/Common/Sorcha.Blueprint.Models/JsonLd/JsonLdType.cs`
-- `src/Apps/Services/Sorcha.Blueprint.Api/JsonLd/JsonLdMiddleware.cs`
+- `src/Services/Sorcha.Blueprint.Service/JsonLd/JsonLdMiddleware.cs`
 - `tests/Sorcha.Blueprint.Models.Tests/JsonLd/JsonLdContextTests.cs`
 - `tests/Sorcha.Blueprint.Models.Tests/JsonLd/JsonLdTypeHelperTests.cs`
 - `tests/Sorcha.Blueprint.Fluent.Tests/JsonLd/BlueprintBuilderJsonLdTests.cs`
@@ -459,7 +459,7 @@ Currently contexts are embedded in code. For production:
 - `src/Core/Sorcha.Blueprint.Fluent/BlueprintBuilder.cs` - Added JSON-LD methods
 - `src/Core/Sorcha.Blueprint.Fluent/ParticipantBuilder.cs` - Added type methods
 - `src/Core/Sorcha.Blueprint.Fluent/ActionBuilder.cs` - Added ActivityStreams methods
-- `src/Apps/Services/Sorcha.Blueprint.Api/Program.cs` - Added content negotiation
+- `src/Services/Sorcha.Blueprint.Service/Program.cs` - Added content negotiation
 
 ---
 

--- a/docs/guides/designer.md
+++ b/docs/guides/designer.md
@@ -1,0 +1,68 @@
+# Blueprint Designer
+
+The **Blueprint Designer** is the visual, AI-assisted way to build and publish a Sorcha workflow.
+The canonical route is **`/designer/blueprint`** (the legacy `/designer` and `/designer/chat` routes
+redirect here). It produces the same blueprint JSON you could author by hand — see
+[Blueprint Format](blueprints/blueprint-format.md) and the `blueprint-builder` skill — so anything
+the designer creates can also be written, versioned, and reviewed as a file.
+
+## The rail: Describe → Understand → Rehearse → Go live
+
+The designer is a four-stage shell (Feature 142). You move along the rail; you cannot **Go live**
+until a **Rehearse** has passed for the exact definition you're publishing.
+
+### 1. Describe
+
+Build the workflow. You can converse with the **AI designer** (a streaming assistant over the
+`/hubs/chat` ChatHub) to add participants, actions, data fields, routes, disclosures, and credential
+requirements/issuance in plain language, and/or edit the structure directly. The AI uses the
+standardised schema library — prefer `$ref`-ing the core identity components (`PersonName`,
+`DateOfBirth`, `EmailAddress`, `PostalAddress`) over re-inlining them.
+
+Key authoring rules the designer applies (and you should know):
+- **One starting action** carries `isStartingAction: true`. Its sender participant is **open** —
+  leave its `walletAddress` null so any submitter can be late-bound to the role. Gate it with
+  `credentialRequirements` if it should be restricted.
+- **Routing uses `routes[]`** (`nextActionIds`, JSON-Logic `condition`, `isDefault`); `nextActionIds: []`
+  ends the workflow. (The legacy participant-condition routing is superseded.)
+- **Every action declares at least one `disclosure`**; the sender always needs `/*` on their own data.
+- **Form layout** is driven by schema `x-` extensions (`x-pages`, `x-sections`, `x-introduction`,
+  `x-persona`, `x-file`, `x-review`).
+
+### 2. Understand
+
+Review the **executable definition** — the resolved, `$ref`-flattened blueprint that will actually
+run. This is your chance to confirm participants, the action graph, routing, and disclosures before
+testing.
+
+### 3. Rehearse
+
+**Dry-run the workflow without publishing.** The designer steps through the actions with sample
+input, showing schema validation, computed `calculations`, the chosen `routes`, and per-participant
+disclosures at each step — so you can see exactly how the workflow will behave. A successful rehearsal
+records a **`RehearsalPass`** bound to a hash of the executable definition.
+
+### 4. Go live
+
+Publishing is **gated server-side by a `RehearsalPass` on the executable-definition hash**: you can
+only publish a definition that has passed a rehearsal *of that exact definition*. Change the blueprint
+after rehearsing and you must rehearse again — the hash no longer matches. On publish, the Blueprint
+Service runs `PublishService.ValidateBlueprint` (structural + credential validation, see the validation
+codes in [Blueprint Format](blueprints/blueprint-format.md)) and seals the published blueprint to the
+register.
+
+## After Go live
+
+A published blueprint is immutable and versioned. Workflow **instances** are **ledger-derived
+projections** (Feature 145): as participants submit actions, the validator seals them and an
+`InstanceProjector` advances the instance from a signed `RoutingDecision` on the ledger — the instance
+state is reconstructed from the register, not held imperatively. Create an instance via
+`POST /api/instances` (mapping any pre-bound participants to wallets; open participants bind on first
+submission), then participants act through their *My Actions* queue.
+
+## Authoring as files instead
+
+The designer is optional. Per the platform's blueprint-creation policy, blueprints can be authored
+**primarily as JSON or YAML files** (Fluent API for programmatic generation). The format, validation
+codes, routing, credentials, disclosures, and form extensions are all documented in
+[Blueprint Format](blueprints/blueprint-format.md) and the `blueprint-builder` skill.


### PR DESCRIPTION
**Wave 3 of the pre-production docs remediation** — designer + blueprint authoring (you specifically asked for designer + blueprint creation/execution coverage).

- **NEW `docs/guides/designer.md`** (+ nav) — documents the **Feature 142 Designer** (previously undocumented anywhere): the canonical `/designer/blueprint` route, the **Describe → Understand → Rehearse → Go-live** rail, and the server-side **`RehearsalPass`** gate (publish only after rehearsing the exact executable-definition hash).
- **blueprint-format.md + blueprint-quick-start.md** — authoritative "current model" callout: `routes[]` (`nextActionIds` → action ids, JSON-Logic `condition`, `isDefault`) **supersede** legacy participant-condition routing; `dataSchemas` is an **array**; `isStartingAction` + open participants (`walletAddress` null, late-bound, `VAL_BP_010`); disclosures required; `x-` form extensions; F145 ledger-derived instances.
- **blueprint-architecture.md** — flags the imperative-execution sections as superseded by F145 (`InstanceProjector` + signed `RoutingDecision`) + routes precedence.
- **ai-prompts/blueprint-examples.md** — model-corrections callout (`dataSchemas` not `dataSchema`; `routes[]` not `routing`; no participant `type`).
- **json-ld-implementation-summary.md** — fixed dead paths (`src/Apps/Services/Sorcha.Blueprint.Api/` → `src/Services/Sorcha.Blueprint.Service/`; the middleware really lives there).

Full rewrites of the legacy routing *sections* in format/quick-start are a noted follow-up; the callouts correct the reader's mental model and point to the `blueprint-builder` skill + Designer as authoritative.

Next: Wave 4 — architecture.md overhaul, retire/rebuild status pages, add missing-surface coverage (credentials, citizen wallet/PWA, notifications, tiered-JWT concept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)