### PR TITLE
docs(wave4): architecture/status currency + retire stale status pages + README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Sorcha
 
+[![NuGet CI](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/nuget-ci.yml/badge.svg)](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/nuget-ci.yml)
 [![Docker CI](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/docker-ci.yml/badge.svg)](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/docker-ci.yml)
 [![CodeQL](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/codeql.yml/badge.svg)](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/codeql.yml)
-[![Playwright Tests](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/playwright.yml/badge.svg)](https://github.com/Sorcha-Platform/Sorcha/actions/workflows/playwright.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A decentralised register platform for secure, multi-participant data flow orchestration.
@@ -20,7 +20,7 @@ Sorcha lets organizations define structured workflows — called **blueprints** 
 | **Multi-Tenant Identity** | JWT authentication with OAuth2 client credentials, participant identity registry, and wallet address linking |
 | **Peer Network** | gRPC-based P2P topology for register replication across nodes |
 | **Real-Time Notifications** | SignalR hubs for live action notifications, inbound transaction alerts, and workflow state changes |
-| **AI Integration** | MCP Server for AI assistant interaction + AI-assisted blueprint design with unified chat / diagram / preview shell |
+| **AI Integration** | MCP Server for AI assistant interaction + AI-assisted blueprint design in the rail-driven Describe → Understand → Rehearse → Go-live designer |
 
 ### The DAD Security Model
 
@@ -67,7 +67,7 @@ On success the script prints `[sorcha-setup] success — gateway reachable at ht
 | Service | URL | Description |
 |---------|-----|-------------|
 | **Sorcha UI** | http://localhost/app | Main application interface |
-| **Blueprint Designer** | http://localhost/app/designer/blueprint | Unified designer — AI / Diagram / Preview tabs |
+| **Blueprint Designer** | http://localhost/app/designer/blueprint | Rail-driven designer — Describe → Understand → Rehearse → Go live (Feature 142) |
 | **API Gateway** | http://localhost/ | REST API entry point |
 | **API Documentation** | http://localhost/scalar/ | Interactive Scalar API docs |
 | **Health Check** | http://localhost/api/health | Aggregated service health |
@@ -93,24 +93,40 @@ Blueprints are JSON documents that describe multi-party workflows:
 ```json
 {
   "title": "Invoice Approval",
+  "description": "Two-party invoice submission and approval",
   "participants": [
-    { "role": "submitter", "description": "Submits invoices" },
-    { "role": "approver", "description": "Reviews and approves" }
+    { "id": "submitter", "name": "Submitter" },
+    { "id": "approver", "name": "Approver" }
   ],
   "actions": [
     {
+      "id": 0,
       "title": "Submit Invoice",
-      "assignedTo": "submitter",
-      "schema": { "type": "object", "properties": { "amount": { "type": "number" } } }
+      "sender": "submitter",
+      "isStartingAction": true,
+      "dataSchemas": [
+        { "type": "object", "properties": { "amount": { "type": "number" } }, "required": ["amount"] }
+      ],
+      "routes": [{ "id": "to-review", "nextActionIds": [1], "isDefault": true }],
+      "disclosures": [{ "participantAddress": "submitter", "dataPointers": ["/*"] }]
     },
     {
+      "id": 1,
       "title": "Review Invoice",
-      "assignedTo": "approver",
-      "routing": { "conditions": [{ "if": { ">": [{ "var": "amount" }, 1000] }, "then": "escalate" }] }
+      "sender": "approver",
+      "dataSchemas": [
+        { "type": "object", "properties": { "decision": { "type": "string", "enum": ["approved", "rejected"] } }, "required": ["decision"] }
+      ],
+      "routes": [{ "id": "done", "nextActionIds": [], "isDefault": true }],
+      "disclosures": [{ "participantAddress": "approver", "dataPointers": ["/*"] }]
     }
   ]
 }
 ```
+
+> Flow uses `routes[]` (`nextActionIds` → action ids; `[]` ends the workflow); one action is the
+> open `isStartingAction`; every action declares `disclosures`. See the
+> [Blueprint Designer](docs/guides/designer.md) and `blueprint-builder` skill.
 
 See the [blueprints/](blueprints/) directory for ready-to-use templates across finance, healthcare, supply chain, and government domains.
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -35,6 +35,11 @@ gtag('config', 'G-B2MKVEP45T', { anonymize_ip: true });`],
       'archive/**',
       'plans/**',
       'superpowers/**',
+      // Retired: per-service "% MVD" status snapshots are inherently
+      // perpetually-stale. Files kept in-repo (so inbound links still resolve)
+      // but not built/navigated. Live status lives in development-status.md and
+      // the service READMEs.
+      'reference/status/**',
     ],
 
     // TODO: Remove after PR 2 fixes broken links
@@ -179,20 +184,6 @@ gtag('config', 'G-B2MKVEP45T', { anonymize_ip: true });`],
                 items: [
                   { text: 'Validator Design', link: '/reference/validator-service-design' },
                     { text: 'Architecture Decisions', link: '/reference/architecture/ADR-005-Validator-Service-Security-Boundary' },
-                ],
-              },
-              {
-                text: 'Service Status',
-                collapsed: true,
-                items: [
-                  { text: 'Authentication', link: '/reference/status/authentication' },
-                  { text: 'Blueprint Service', link: '/reference/status/blueprint-service' },
-                  { text: 'Core Libraries', link: '/reference/status/core-libraries' },
-                  { text: 'Peer Service', link: '/reference/status/peer-service' },
-                  { text: 'Register Service', link: '/reference/status/register-service' },
-                  { text: 'Tenant Service', link: '/reference/status/tenant-service' },
-                  { text: 'Validator Service', link: '/reference/status/validator-service' },
-                  { text: 'Wallet Service', link: '/reference/status/wallet-service' },
                 ],
               },
             ],

--- a/docs/reference/SECURITY-REQUIREMENTS.md
+++ b/docs/reference/SECURITY-REQUIREMENTS.md
@@ -1,10 +1,16 @@
 # Sorcha Security Requirements
 
 **Document Type:** Security Requirements Specification
-**Version:** 1.0
-**Date:** 2025-11-16
-**Status:** Active
-**Last Updated:** 2025-11-16
+**Status:** Partial / superseded in scope
+
+> **Superseded in scope.** This v1.0 (2025-11-16) document captures only the early DocketManager /
+> ChainValidator component-placement rules. It **predates** the platform's security model and does
+> not yet cover: JWT authentication + tiered audiences (Feature 136), at-rest secret protection
+> (Feature 146), authorization gates (Feature 147), verification correctness (Feature 148), encrypted
+> payloads, and post-quantum cryptography (Feature 040). For the current posture see the
+> [2026-03-19 Security Audit](../security/SECURITY-AUDIT-2026-03-19.md) (with its remediation-status
+> banner), [Authentication Setup](../guides/AUTHENTICATION-SETUP.md), [JWT Configuration](../guides/JWT-CONFIGURATION.md),
+> and the production gates in [Configuration Reference](../admin/configuration-reference.md).
 
 ## Overview
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -4,10 +4,18 @@
 
 Sorcha is a modern .NET 10 platform for defining, designing, and executing multi-participant data flow orchestration workflows (called "Blueprints"). Built on .NET Aspire for cloud-native orchestration, Sorcha provides a flexible and scalable solution for workflow automation with selective data disclosure and conditional routing.
 
-**Last Updated:** 2025-11-16
-**Version:** 2.3.0
-**Status:** Active Development
-**Recent Changes:** Added Validator.Service for secured docket validation and chain integrity
+**Status:** Active development
+
+> **Currency note (this document is mid-refresh).** Several capabilities marked "(planned)" below
+> have **shipped** and should be read as current: **JWT authentication** with tiered audiences
+> (Feature 136), **role-based access control**, **Entity Framework Core** persistence (service-specific
+> repositories, no generic `Sorcha.Storage.EFCore`), **encryption at rest** (wallet envelope
+> encryption + Azure KMS F082; Tenant AES-256-GCM F146), **centralised rate limiting** (SEC-002), and
+> **audit logging**. Current stack: **C# 14 / .NET 10**, **.NET Aspire 13.3.x**. The designer is the
+> rail-driven `/designer/blueprint` (Feature 142) in `Sorcha.UI` — there is no
+> `Sorcha.Blueprint.Designer.Client` project. The peer list is persisted in **PostgreSQL** (the SQLite
+> reference is historical). Authoritative service status: [development-status.md](development-status.md);
+> source tree: [project-structure.md](project-structure.md).
 
 ## High-Level Architecture
 
@@ -374,7 +382,7 @@ builder.AddProject<Projects.Sorcha_Blueprint_Designer_Client>("blueprint-designe
 ```
 
 **Technology:**
-- .NET Aspire 13.0.0
+- .NET Aspire 13.3.x
 - Service discovery
 - Health checks
 
@@ -821,7 +829,7 @@ Build Pipeline:
 
 ### Runtime
 - .NET 10 (10.0.100)
-- C# 13
+- C# 14
 - ASP.NET Core
 
 ### Frameworks

--- a/docs/reference/development-status.md
+++ b/docs/reference/development-status.md
@@ -1,14 +1,21 @@
 # Sorcha Platform - Development Status Report
 
-**Date:** 2026-04-22
-**Version:** 4.6 (Updated after Feature 109 AI Designer Unified Shell)
 **Overall Completion:** 100% MVD
+
+> **Currency note.** This snapshot was last comprehensively updated for ~Feature 109/145. Work has
+> continued since — notably tiered JWT audiences + issuer hardening (**Feature 136**), the
+> June 2026 security-hardening initiative (**Features 146/147/148** — Tenant at-rest secret
+> protection, authorization-gap closure, verification correctness), and the 2026-06-02 architecture
+> review. The current per-service completion figures live in the [CLAUDE.md](../../CLAUDE.md) service
+> table. The previous per-service `reference/status/*` "% MVD" pages have been **retired** (they were
+> perpetually-stale point-in-time snapshots) — this document plus the service READMEs are the live
+> status source.
 
 ---
 
 ## Executive Summary
 
-This document provides an accurate, evidence-based assessment of the Sorcha platform's development status. Updated after Feature 058 (Platform Organisation Topology, 10 phases, 81 tasks) on 2026-03-16.
+This document provides an accurate, evidence-based assessment of the Sorcha platform's development status.
 
 **Key Findings:**
 - Blueprint-Action Service is 100% complete with full orchestration and JWT authentication (123 tests)


### PR DESCRIPTION
**Wave 4 (final) of the pre-production docs remediation** — truth in the architecture/status surface, plus a root README pass.

- **Retired the `reference/status/*` per-service "% MVD" pages** — removed from the sidebar nav and added to VitePress `srcExclude`. They were perpetually-stale point-in-time snapshots (phantom files, months out of date). Files kept in-repo so inbound links still resolve; live status now lives in `development-status.md` + the service READMEs.
- **architecture.md**: currency callout — "(planned)" capabilities that actually **shipped** (JWT auth + F136 tiered audiences, RBAC, EF Core, encryption-at-rest / Azure KMS F082 / F146, rate limiting SEC-002, audit logging); fixed **C# 13 → 14**, **Aspire 13.0.0 → 13.3.x**; flagged the phantom `Sorcha.Blueprint.Designer.Client` (designer is `/designer/blueprint`, F142) and the historical Peer SQLite (now PostgreSQL).
- **development-status.md** + **SECURITY-REQUIREMENTS.md**: currency / superseded-in-scope banners with pointers to the current docs.
- **README.md**: replaced the **broken Playwright badge** (workflow deleted in Wave 0) with the NuGet CI badge; corrected the **blueprint example** to the real model (`participants` id/name, actions `sender`/`isStartingAction`/`dataSchemas[]`/`routes[]`/`disclosures` — was the fake `routing`/`assignedTo`/`schema` shape); updated the designer description to the Describe → Understand → Rehearse → Go-live rail.

This completes the 5-wave remediation. Deeper *net-new* feature pages (full credential / citizen-wallet-PWA / notifications guides) remain a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)