### PR TITLE
fix(ci): make claude-review actually post its review on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write   # required to post the review comments
+      issues: write          # required to post issue/PR comments
       id-token: write
 
     steps:
@@ -38,7 +38,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment makes the review POST its findings as PR comments (without
+          # it, the review only writes to the Actions log and nothing surfaces).
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
**claude-review has never actually commented.** The check shows green, but that only means the workflow *ran* — across #935–#947 there are **0 comments and 0 reviews** from the bot.

Two causes in `.github/workflows/claude-code-review.yml`:
1. **Read-only token** — `pull-requests: read` / `issues: read`; posting needs **write**. (Run log: `GITHUB_TOKEN Permissions → PullRequests: read`.)
2. **No `--comment`** — the review ran but didn't post (run log ends `No buffered inline comments`); output went only to the Actions log.

Fix: `pull-requests: write` + `issues: write`, and `--comment` on the prompt.

**Verify after merge:** the next PR should receive a claude review comment; `gh api repos/.../pulls/<pr>/reviews` and `.../issues/<pr>/comments` should be non-zero for the bot actor. (This PR's own claude-review run may also post, depending on how GitHub applies the modified workflow's permissions to a same-repo PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)