### PR TITLE
chore(build): XML-doc warning policy + mechanical warning fixes (PR 3/4)

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -78,8 +78,7 @@
                            Color="Color.Inherit"
                            OnClick="@ToggleInboxPanel"
                            data-testid="topbar-inbox-button"
-                           aria-label="Inbox"
-                           Title="Inbox">
+                           aria-label="Inbox">
                 @if (_inboxUnreadCount > 0)
                 {
                     <MudBadge Content="@_inboxUnreadCount"

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Enrol.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Enrol.razor
@@ -50,7 +50,7 @@
     {
     <MudText Typo="Typo.h5" Class="mb-3">Enrol this device</MudText>
 
-    <MudStepper @ref="_stepper" Linear="true" NonLinear="false">
+    <MudStepper @ref="_stepper" NonLinear="false">
         <MudStep Title="Welcome">
             <MudText Typo="Typo.body2" Class="mb-3">
                 Enrolling registers this browser as a wallet device under your

--- a/src/Common/Directory.Build.props
+++ b/src/Common/Directory.Build.props
@@ -16,7 +16,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- CS1591 (missing doc) and CS1573 (missing <param>) are doc-completeness nags. Since the
+         project does not require complete XML docs (CS1591 is suppressed), enforcing CS1573 is
+         inconsistent. Cref-correctness warnings (CS1574 etc.) are NOT suppressed in libraries —
+         a broken <see cref> in a shipped package degrades IntelliSense — but there are none. -->
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
 
     <!-- NuGet Packaging -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/Common/Sorcha.AtomicCache/RedisAtomicDistributedCache.cs
+++ b/src/Common/Sorcha.AtomicCache/RedisAtomicDistributedCache.cs
@@ -7,7 +7,7 @@ namespace Sorcha.AtomicCache;
 
 /// <summary>
 /// Redis-backed <see cref="IAtomicDistributedCache"/> using
-/// <see cref="IDatabase.StringGetDeleteAsync"/> (GETDEL) for atomic
+/// <c>IDatabase.StringGetDeleteAsync</c> (GETDEL) for atomic
 /// get-and-remove and a Lua script for compare-and-set with TTL refresh.
 /// </summary>
 /// <remarks>

--- a/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
+++ b/src/Common/Sorcha.Cryptography/SdJwt/ISdJwtService.cs
@@ -76,8 +76,8 @@ public interface ISdJwtService
     /// <summary>
     /// External-signer overload for sign-on-behalf flows (Feature 120 HAIP kid-swap).
     /// The caller supplies an <paramref name="externalSigner"/> that produces the
-    /// signature for the unsigned JWS bytes; <paramref name="signingKey"/> may be
-    /// null/empty when the external signer is supplied. Used by HAIP service to
+    /// signature for the unsigned JWS bytes; this overload carries no signing key
+    /// (unlike the key-based overload) — the external signer holds it. Used by HAIP service to
     /// delegate signing to wallet without holding private key material.
     /// </summary>
     Task<SdJwtToken> CreateTokenAsync(

--- a/src/Common/Sorcha.ServiceClients.Http/Did/KidThumbprintHelper.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Did/KidThumbprintHelper.cs
@@ -116,7 +116,7 @@ public static class KidThumbprintHelper
     /// <summary>
     /// RFC 7638 SHA-256 JWK thumbprint, base64url, no padding. Inlined here to keep
     /// <c>Sorcha.ServiceClients.Http</c> free of a project reference to
-    /// <c>Sorcha.Cryptography</c> (Sodium/BouncyCastle) — see <see cref="Utilities.Multicodec"/>
+    /// <c>Sorcha.Cryptography</c> (Sodium/BouncyCastle) — see the <c>Multicodec</c> helper
     /// for the same architectural rationale.
     /// </summary>
     internal static bool TryComputeThumbprint(JsonElement jwk, [NotNullWhen(true)] out string? thumbprint)

--- a/src/Common/Sorcha.ServiceClients.Http/Did/VerificationKeyMaterialComparer.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Did/VerificationKeyMaterialComparer.cs
@@ -61,7 +61,7 @@ public static class VerificationKeyMaterialComparer
 
         try
         {
-            var decoded = Base58.Bitcoin.Decode(multibase[1..]);
+            var decoded = Base58.Bitcoin.Decode(multibase.AsSpan(1));
             // Strip the multicodec varint prefix — the first byte's high bit indicates
             // continuation. For the codecs we care about (ed25519=0xed varint, p256=0x1200,
             // rsa=0x1205) the varint is 1-2 bytes; we strip until we find a byte without

--- a/src/Common/Sorcha.ServiceClients.Http/Participant/IParticipantServiceClient.cs
+++ b/src/Common/Sorcha.ServiceClients.Http/Participant/IParticipantServiceClient.cs
@@ -70,7 +70,7 @@ public interface IParticipantServiceClient
     /// <param name="walletAddress">Newly created wallet address</param>
     /// <param name="userId">Authenticated user ID</param>
     /// <param name="organizationId">User's current organisation</param>
-    /// <param name="publicKey">Wallet public key bytes (Base64)</param>
+    /// <param name="publicKeyBase64">Wallet public key bytes (Base64)</param>
     /// <param name="algorithm">Wallet signing algorithm</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Auto-link result</returns>

--- a/src/Core/Directory.Build.props
+++ b/src/Core/Directory.Build.props
@@ -16,7 +16,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- CS1591 (missing doc) + CS1573 (missing <param>) are doc-completeness nags; suppressing
+         CS1573 while CS1591 is already off keeps the policy consistent. Cref-correctness warnings
+         stay enabled for shipped libraries. -->
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
 
     <!-- NuGet Packaging -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/Core/Sorcha.Wallet.Core/Encryption/Providers/WindowsDpapiEncryptionProvider.cs
+++ b/src/Core/Sorcha.Wallet.Core/Encryption/Providers/WindowsDpapiEncryptionProvider.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System.IO;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,7 @@ namespace Sorcha.Wallet.Core.Encryption.Providers;
 /// - Machine-specific (encrypted DEKs tied to Windows machine identity)
 /// - No built-in key rotation (manual via CreateKeyAsync)
 /// </summary>
+[SupportedOSPlatform("windows")] // DPAPI ProtectedData is Windows-only; availability is gated at runtime via IsAvailable.
 public sealed class WindowsDpapiEncryptionProvider : EncryptionProviderBase
 {
     private readonly string _keyStorePath;

--- a/src/Services/Directory.Build.props
+++ b/src/Services/Directory.Build.props
@@ -16,6 +16,19 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Deterministic>true</Deterministic>
+    <!--
+      Doc-file generation stays on (parity with src/Common and src/Core, and so any future
+      OpenAPI XML-comment integration has the file available), but the XML-doc warning family is
+      suppressed for service projects. Service projects are applications, not published NuGet
+      libraries — their external contract is the OpenAPI surface, which CLAUDE.md mandates
+      separately via .WithSummary()/.WithDescription() on every endpoint. Enforcing per-member
+      C# XML docs on an app assembly with no doc consumer is noise (~1,250 warnings), not signal.
+        CS1591 missing doc on a public member        CS1573 missing <param>
+        CS1572 unmatched <param>                      CS1574/CS1734/CS0419 unresolved/ambiguous cref
+        CS1587 XML comment on a non-doc element
+      (CS1591 is already suppressed in Common/Core/tests/bench; this is the same intent.)
+    -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS1572;CS1574;CS1734;CS0419;CS1587</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Services/Sorcha.ApiGateway/Program.cs
+++ b/src/Services/Sorcha.ApiGateway/Program.cs
@@ -93,7 +93,7 @@ builder.Services.Configure<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>
     options.ForwardedHeaders =
         Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor |
         Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto;
-    options.KnownNetworks.Clear();
+    options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });
 

--- a/tests/Sorcha.Blueprint.Models.Tests/BlueprintVersionTests.cs
+++ b/tests/Sorcha.Blueprint.Models.Tests/BlueprintVersionTests.cs
@@ -60,7 +60,7 @@ public class BlueprintVersionTests
     public void MajorBump_ResetsMinor()
     {
         // v3.5 → structural change → v4.0
-        int prevMajor = 3, prevMinor = 5;
+        int prevMajor = 3;
         var newMajor = prevMajor + 1;
         var newMinor = 0; // reset on major bump
 

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ChatOrchestrationServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ChatOrchestrationServiceTests.cs
@@ -10,7 +10,6 @@ using Sorcha.Blueprint.Fluent;
 using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Models.Chat;
 using Sorcha.Blueprint.Service.Services;
-using Sorcha.Blueprint.Service.Services.Interfaces;
 using Sorcha.Blueprint.Service.Templates;
 using BlueprintModel = Sorcha.Blueprint.Models.Blueprint;
 

--- a/tests/Sorcha.ServiceClients.Tests/Did/SorchaDidResolverTests.cs
+++ b/tests/Sorcha.ServiceClients.Tests/Did/SorchaDidResolverTests.cs
@@ -81,7 +81,7 @@ public class SorchaDidResolverTests
         multibase.Should().NotBeNull();
         multibase!.Should().StartWith("z", because: "W3C base58btc multibase prefix");
 
-        var decoded = Base58.Bitcoin.Decode(multibase[1..]);
+        var decoded = Base58.Bitcoin.Decode(multibase.AsSpan(1));
         decoded[0].Should().Be(0xed, because: "Ed25519 multicodec varint first byte");
         decoded[1].Should().Be(0x01, because: "Ed25519 multicodec varint second byte");
         decoded.Skip(2).Should().Equal(Ed25519KeyBytes);
@@ -189,7 +189,7 @@ public class SorchaDidResolverTests
         multibase.Should().NotBeNull();
         multibase!.Should().StartWith("z");
 
-        var decoded = Base58.Bitcoin.Decode(multibase[1..]);
+        var decoded = Base58.Bitcoin.Decode(multibase.AsSpan(1));
         decoded[0].Should().Be(0xed);
         decoded[1].Should().Be(0x01);
         decoded.Skip(2).Should().Equal(Ed25519KeyBytes);
@@ -260,7 +260,7 @@ public class SorchaDidResolverTests
         multibase.Should().NotBeNull();
         multibase!.Should().StartWith("z");
 
-        var decoded = Base58.Bitcoin.Decode(multibase[1..]);
+        var decoded = Base58.Bitcoin.Decode(multibase.AsSpan(1));
         decoded[0].Should().Be(0x80);
         decoded[1].Should().Be(0x24);
         decoded.Skip(2).Should().Equal(P256KeyBytes);

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/Presentation/PresentationEngineTests.cs
@@ -236,9 +236,9 @@ public sealed class PresentationEngineTests
         var credentialJwt = $"{headerSeg}.{payloadSeg}.{sig}";
 
         var allDisclosures = new List<string>();
+        Span<byte> salt = stackalloc byte[16]; // reused per iteration (refilled below) — avoids stackalloc-in-loop (CA2014)
         foreach (var (name, value) in claims)
         {
-            Span<byte> salt = stackalloc byte[16];
             RandomNumberGenerator.Fill(salt);
             var disc = JsonSerializer.SerializeToUtf8Bytes(new object[]
             {


### PR DESCRIPTION
## Summary
**PR 3 of 4** in the build/CI cleanup. Takes the solution from **~1,300 build warnings → 41**, fixing properly (not blanket-suppressing).

### The big structural decision — XML-doc warning policy (~1,244 warnings)
CS1591 (missing XML doc) was **1,174 of all warnings**, all from the 8 service projects, which had `GenerateDocumentationFile=true` but — unlike Common/Core/tests/bench — no `NoWarn`. Service projects are **applications**: their external contract is the OpenAPI surface (CLAUDE.md mandates `.WithSummary()`/`.WithDescription()` per endpoint), not a consumed XML doc file.
- **Services** suppress the full XML-doc family (CS1591/CS1573/CS1572/CS1574/CS1734/CS0419/CS1587) — doc generation stays on for future OpenAPI integration.
- **Common/Core** (shipped libraries) add only CS1573 to the existing CS1591 suppression (don't half-enforce doc *completeness*); **cref-correctness stays enabled**, and the 4 genuine broken crefs/params in those libraries are **fixed**.

### Mechanical / analyzer fixes (done properly)
- **CA1416**: `[SupportedOSPlatform("windows")]` on `WindowsDpapiEncryptionProvider` (call site already OS-guarded).
- **CA1831 ×4**: `AsSpan` instead of string Range-indexer.
- **CA2014**: hoisted `stackalloc` out of a loop.
- **ASPDEPR005**: `KnownNetworks` → `KnownIPNetworks`.
- **MUD0002 ×2**: removed redundant `Title` (aria-label present) / non-existent `Linear` param.
- **CS0105 / CS0219**: duplicate using / unused local.

### Residual (41) → PR 3b
Needs careful per-site work, deliberately **not** rushed: **CS0618** obsolete-API dispositioning (25 — mostly intentional backward-compat suppressions for the deprecated `TargetAudience.SorchaInternal` handling + `IEncryptionProvider` contract tests), **nullability** CS86xx (11), **CS0649** (3), **NU1608** libsodium transitive constraint (2).

### Verification
`dotnet build Sorcha.sln -c Release` → **0 errors**, **41 warnings** (was ~1,300). No behavioural code changes — props policy + doc-comment text + mechanical analyzer fixes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)