### PR TITLE
chore(build): clear residual code-quality warnings — build now 0 warnings (PR 3b/4)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Designer/Panes/AiDesignerPane.razor.cs
@@ -34,7 +34,11 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
     private bool _isDragging;
     private string? _sessionId;
     private bool _initialised;
+#if DEBUG || E2E_TEST_HOOKS
+    // Only assigned under the same directive (see InitializeAsync); scoped here so it isn't a
+    // never-assigned field (CS0649) in Release builds without the E2E test hooks.
     private DotNetObjectReference<AiDesignerPane>? _testHookRef;
+#endif
     private DotNetObjectReference<AiDesignerPane>? _dropZoneRef;
 
     private const string MessagesElementId = "ai-pane-messages";
@@ -740,7 +744,9 @@ public partial class AiDesignerPane : ComponentBase, IAsyncDisposable
             // Ignore cleanup errors.
         }
 
+#if DEBUG || E2E_TEST_HOOKS
         _testHookRef?.Dispose();
+#endif
         _dropZoneRef?.Dispose();
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
@@ -250,8 +250,12 @@
         Array.Empty<NeedsAttentionBand.NeedsAttentionItem>();
     private IReadOnlyList<RecentActivityFeed.RecentActivityEntry> _recentActivityEntries =
         Array.Empty<RecentActivityFeed.RecentActivityEntry>();
+    // Placeholders for the multi-context peek footer — not yet populated (the footer renders the
+    // default "no other contexts" state). Assigned once multi-context support lands.
+#pragma warning disable CS0649
     private int _otherContextCount;
     private string? _otherContextName;
+#pragma warning restore CS0649
 
     // Feature 124 (US3/US4/US5). The takeover fires exactly once per wallet
     // per device. _flagsLoaded gates eligibility until the IndexedDB flags

--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
@@ -89,7 +89,13 @@ public class CredentialIssuanceConfig
     /// </summary>
     [JsonPropertyName("targetAudience")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    // Default retained as SorchaInternal for backward compatibility with existing serialised
+    // configs. Flipping the default to SorchaLocalWallet is a deliberate behavioural change
+    // (alters credential delivery for configs that omit the field) tracked separately, not a
+    // warning-cleanup edit.
+#pragma warning disable CS0618
     public TargetAudience TargetAudience { get; set; } = TargetAudience.SorchaInternal;
+#pragma warning restore CS0618
 
     /// <summary>
     /// Credential format to mint (feature 135). Default <see cref="CredentialFormat.SdJwtVc"/>.

--- a/src/Common/Sorcha.Validator.Core/ReceiptValidator.cs
+++ b/src/Common/Sorcha.Validator.Core/ReceiptValidator.cs
@@ -81,7 +81,8 @@ public class ReceiptValidator
             try
             {
                 var receiptData = BuildReceiptSigningData(receipt);
-                signatureValid = _verifySignature(
+                // Reached only when signatureCheckApplicable (_verifySignature != null) — see guard above.
+                signatureValid = _verifySignature!(
                     Convert.FromBase64String(validatorPublicKey),
                     receiptData,
                     sig.SignatureValue,

--- a/src/Services/Sorcha.Blueprint.Service/Program.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Program.cs
@@ -1434,12 +1434,16 @@ actionsGroup.MapPost("/", async (
         var disclosureResults = new Dictionary<string, object>();
         var participantWalletMap = new Dictionary<string, string>();
 
+        // Disclosure processing and the sender's full-payload entry both require a non-null map;
+        // a null payload is treated as an empty payload.
+        var payloadData = request.PayloadData ?? new Dictionary<string, object>();
+
         var actionDisclosures = actionDef.Disclosures?.ToList();
         if (actionDisclosures != null && actionDisclosures.Count > 0)
         {
             // Apply disclosure rules: each participant gets only their authorized fields
             var engineDisclosures = disclosureProcessor.CreateDisclosures(
-                request.PayloadData,
+                payloadData,
                 actionDisclosures);
 
             foreach (var disclosure in engineDisclosures)
@@ -1456,7 +1460,7 @@ actionsGroup.MapPost("/", async (
         // Ensure sender always receives the full payload
         if (!disclosureResults.ContainsKey(request.SenderWallet))
         {
-            disclosureResults[request.SenderWallet] = request.PayloadData;
+            disclosureResults[request.SenderWallet] = payloadData;
             participantWalletMap[request.SenderWallet] = request.SenderWallet;
         }
 
@@ -3514,6 +3518,9 @@ public class PublishService(
             var issuance = action.CredentialIssuanceConfig;
             if (issuance is null) continue;
 
+            // This block is the deprecation handler for SorchaInternal — it references the obsolete
+            // value deliberately, to warn authors and to treat it as SorchaLocalWallet at runtime.
+#pragma warning disable CS0618
             // SorchaInternal is deprecated — warn blueprint authors to migrate
             if (issuance.TargetAudience == Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaInternal)
             {
@@ -3526,7 +3533,10 @@ public class PublishService(
             // Apply SorchaLocalWallet validation to both SorchaLocalWallet and deprecated SorchaInternal
             if (issuance.TargetAudience is not (Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaLocalWallet
                 or Sorcha.Blueprint.Models.Credentials.TargetAudience.SorchaInternal))
+            {
+#pragma warning restore CS0618
                 continue;
+            }
 
             // VAL_BP_CRED_001 — recipientParticipantId must resolve
             var recipientId = issuance.RecipientParticipantId;

--- a/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
+++ b/src/Services/Sorcha.Blueprint.Service/Services/Implementation/ActionExecutionService.cs
@@ -600,9 +600,13 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
         // and SorchaLocalWallet path).
         var issuerOrgName = callerIssuerOrgName;
         var issuerTenantId = callerIssuerTenantId;
+        // Accept the deprecated SorchaInternal alongside SorchaLocalWallet so pre-migration
+        // blueprints still resolve to the local-wallet delivery path.
+#pragma warning disable CS0618
         if (actionDef.CredentialIssuanceConfig != null
             && actionDef.CredentialIssuanceConfig.TargetAudience is TargetAudience.SorchaLocalWallet
                 or TargetAudience.SorchaInternal)
+#pragma warning restore CS0618
         {
             var recipientId = actionDef.CredentialIssuanceConfig.RecipientParticipantId;
             if (string.IsNullOrWhiteSpace(recipientId)
@@ -2222,7 +2226,9 @@ public class ActionExecutionService : IActionExecutionService, IPresentationRout
                 statusListUrl: preAllocatedStatusListUrl,
                 statusListIndex: preAllocatedStatusListIndex,
                 statusListPurpose: preAllocatedStatusListUrl != null ? "revocation" : null,
+#pragma warning disable CS0618 // accept deprecated SorchaInternal for backward-compat (treated as local-wallet delivery)
                 skipRecipientStore: config.TargetAudience is TargetAudience.SorchaLocalWallet or TargetAudience.SorchaInternal,
+#pragma warning restore CS0618
                 issuerOrgName: issuerOrgName,
                 tenantId: issuerTenantId,
                 holderJwk: holderJwk,

--- a/src/Services/Sorcha.Peer.Service/Replication/DocketFinalizationService.cs
+++ b/src/Services/Sorcha.Peer.Service/Replication/DocketFinalizationService.cs
@@ -265,9 +265,12 @@ public class DocketFinalizationService
                 return;
 
             // Fall back to legacy ProposerSignature extraction for pre-086 registers
-            _validatorKeyCache.ExtractFromGenesisDocket(registerId, genesisDocket.Data);
-            if (_validatorKeyCache.HasKey(registerId))
-                return;
+            if (genesisDocket.Data is { } genesisData)
+            {
+                _validatorKeyCache.ExtractFromGenesisDocket(registerId, genesisData);
+                if (_validatorKeyCache.HasKey(registerId))
+                    return;
+            }
 
             _logger.LogDebug(
                 "Strategy 1 did not yield a validator roster for register {RegisterId}; falling through to Register Service",

--- a/src/Services/Sorcha.Tenant.Service/Services/ScribanEmailTemplateRenderer.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/ScribanEmailTemplateRenderer.cs
@@ -151,7 +151,7 @@ public sealed class ScribanEmailTemplateRenderer : IEmailTemplateRenderer
                 $"Available: {string.Join(", ", _sources.Keys)}");
         }
 
-        public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
+        public ValueTask<string?> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
             => new(Load(context, callerSpan, templatePath));
     }
 }

--- a/src/Services/Sorcha.Tenant.Service/Services/SmtpEmailSender.cs
+++ b/src/Services/Sorcha.Tenant.Service/Services/SmtpEmailSender.cs
@@ -59,7 +59,7 @@ public class SmtpEmailSender : IEmailSender
 
             if (!string.IsNullOrEmpty(_settings.SmtpUsername))
             {
-                await client.AuthenticateAsync(_settings.SmtpUsername, _settings.SmtpPassword, cancellationToken);
+                await client.AuthenticateAsync(_settings.SmtpUsername, _settings.SmtpPassword ?? string.Empty, cancellationToken);
             }
 
             await client.SendAsync(message, cancellationToken);

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,7 +2,15 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <LangVersion>14</LangVersion>
-    <NoWarn>$(NoWarn);xUnit1051;CS1591</NoWarn>
+    <!--
+      NU1608: aggregating test projects pull both Fido2.AspNet (→ NSec.Cryptography, which pins
+      native libsodium < 1.0.21) and Sodium.Core 1.4.1 (→ libsodium 1.0.22) into one closure, so
+      the unified libsodium 1.0.22 trips NSec's conservative upper bound. libsodium keeps ABI
+      compatibility within 1.0.x and both crypto libs run against 1.0.22 (suites pass). The
+      conflict is unresolvable here (NSec is transitive via Fido2, can't be re-pinned), and only
+      surfaces in test closures — never in a shipped service — so it is suppressed for tests only.
+    -->
+    <NoWarn>$(NoWarn);xUnit1051;CS1591;NU1608</NoWarn>
     <!--
       Pin every test project to Microsoft.Testing.Platform so `dotnet test` dispatches the
       same way for all projects. Without this, MSBuild's heuristic on Linux dotnet 10 SDK

--- a/tests/Sorcha.Blueprint.Engine.Tests/DisclosureValidationTests.cs
+++ b/tests/Sorcha.Blueprint.Engine.Tests/DisclosureValidationTests.cs
@@ -524,7 +524,7 @@ public class DisclosureValidationTests
         // Arrange
         var blueprint = CreateValidBlueprint();
         var action = blueprint.Actions[0];
-        action.Sender = blueprint.Participants[0].WalletAddress;
+        action.Sender = blueprint.Participants[0].WalletAddress!;
         action.Disclosures = new List<BpModels.Disclosure>
         {
             // Sender can see their own data

--- a/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
+++ b/tests/Sorcha.Blueprint.Service.Tests/Services/ActionExecutionServiceTests.cs
@@ -644,9 +644,9 @@ public class ActionExecutionServiceTests
         var instance = CreateTestInstance(instanceId, "blueprint-1");
         var blueprint = CreateTestBlueprint();
         var action = blueprint.Actions!.First(a => a.Id == actionId);
-        action.Calculations = new Dictionary<string, System.Text.Json.Nodes.JsonNode?>
+        action.Calculations = new Dictionary<string, System.Text.Json.Nodes.JsonNode>
         {
-            ["total"] = System.Text.Json.Nodes.JsonNode.Parse("""{"+":[{"var":"a"},{"var":"b"}]}""")
+            ["total"] = System.Text.Json.Nodes.JsonNode.Parse("""{"+":[{"var":"a"},{"var":"b"}]}""")!
         };
 
         SetupCommonMocks(instanceId, instance, blueprint, action);

--- a/tests/Sorcha.Register.Service.Tests/SignalRHubTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/SignalRHubTests.cs
@@ -76,7 +76,7 @@ public class SignalRHubTests : IClassFixture<RegisterServiceWebApplicationFactor
 
         // Act
         var exception = await Record.ExceptionAsync(async () =>
-            await _hubConnection.InvokeAsync("UnsubscribeFromRegister", registerId));
+            await _hubConnection!.InvokeAsync("UnsubscribeFromRegister", registerId));
 
         // Assert
         exception.Should().BeNull();
@@ -163,7 +163,7 @@ public class SignalRHubTests : IClassFixture<RegisterServiceWebApplicationFactor
         });
 
         // Subscribe only to register 1
-        await _hubConnection.InvokeAsync("SubscribeToRegister", reg1.Id);
+        await _hubConnection!.InvokeAsync("SubscribeToRegister", reg1.Id);
 
         // Act - Submit transaction to register 1
         var tx = CreateValidTransaction(reg1.Id);

--- a/tests/Sorcha.UI.Core.Tests/Models/Blueprints/TargetAudienceSerialisationTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Models/Blueprints/TargetAudienceSerialisationTests.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+// These tests intentionally serialise/deserialise the deprecated TargetAudience.SorchaInternal
+// value to guarantee backward-compatible wire behaviour for pre-migration blueprints.
+#pragma warning disable CS0618
 using System.Text.Json;
 
 using FluentAssertions;

--- a/tests/Sorcha.UI.E2E.Tests/Docker/HaipQrComponentTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/HaipQrComponentTests.cs
@@ -43,7 +43,7 @@ public class HaipQrComponentTests : MultiUserTestBase
 
     [Test]
     [Order(1)]
-    [Timeout(120_000)]
+    [CancelAfter(120_000)]
     public async Task CredentialOfferQrCard_RendersQrCode_AndShowsMetadata()
     {
         // Arrange — create a credential offer via the HAIP Service API
@@ -72,7 +72,7 @@ public class HaipQrComponentTests : MultiUserTestBase
 
     [Test]
     [Order(2)]
-    [Timeout(60_000)]
+    [CancelAfter(60_000)]
     public async Task CredentialOfferStatus_ReturnsPendingState()
     {
         // Arrange — create an offer
@@ -98,7 +98,7 @@ public class HaipQrComponentTests : MultiUserTestBase
 
     [Test]
     [Order(3)]
-    [Timeout(120_000)]
+    [CancelAfter(120_000)]
     public async Task PresentationRequestQrCard_RendersQrCode_AndShowsMetadata()
     {
         // Arrange — create a presentation request via the HAIP Service API
@@ -128,7 +128,7 @@ public class HaipQrComponentTests : MultiUserTestBase
 
     [Test]
     [Order(4)]
-    [Timeout(60_000)]
+    [CancelAfter(60_000)]
     public async Task VerificationResult_ReturnsPendingState()
     {
         // Arrange — create a request

--- a/tests/Sorcha.Validator.Service.Tests/Services/PolicyUpdateProcessorTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/PolicyUpdateProcessorTests.cs
@@ -88,7 +88,7 @@ public class PolicyUpdateProcessorTests
         var controlTx = result[0];
         controlTx.Payload.Should().BeOfType<PolicyUpdatePayload>();
         var policyPayload = (PolicyUpdatePayload)controlTx.Payload;
-        policyPayload.Policy.Version.Should().Be(2);
+        policyPayload.Policy!.Version.Should().Be(2);
         policyPayload.UpdatedBy.Should().Be("did:sorcha:admin-001");
     }
 

--- a/tests/Sorcha.Wallet.Service.Tests/Encryption/EncryptionProviderConfigurationTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Encryption/EncryptionProviderConfigurationTests.cs
@@ -1,3 +1,6 @@
+// These tests intentionally exercise the deprecated IEncryptionProvider contract until it is
+// removed; new code uses IKeyProtectionProvider. Suppress the obsolete-usage warning file-wide.
+#pragma warning disable CS0618
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Sorcha.Wallet.Core.Encryption.Configuration;

--- a/tests/Sorcha.Wallet.Service.Tests/Encryption/EncryptionProviderContractTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Encryption/EncryptionProviderContractTests.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+// This contract suite intentionally targets the deprecated IEncryptionProvider until it is
+// removed; new code uses IKeyProtectionProvider. Suppress the obsolete-usage warning file-wide.
+#pragma warning disable CS0618
 using FluentAssertions;
 using Sorcha.Wallet.Core.Encryption.Interfaces;
 

--- a/tests/Sorcha.Wallet.Service.Tests/Encryption/LocalEncryptionProviderContractTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Encryption/LocalEncryptionProviderContractTests.cs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+// Runs the deprecated-IEncryptionProvider contract suite; intentional until the interface is
+// removed (new code uses IKeyProtectionProvider). Suppress the obsolete-usage warning file-wide.
+#pragma warning disable CS0618
 using Microsoft.Extensions.Logging.Abstractions;
 using Sorcha.Wallet.Core.Encryption.Interfaces;
 using Sorcha.Wallet.Core.Encryption.Providers;


### PR DESCRIPTION
## Summary
Follow-up to #953. Clears the **41 residual** code-quality warnings → solution now builds **0 errors / 0 warnings** (from ~1,300 at the start of this effort).

### Fixed properly
- **Nullability (11)** — `ReceiptValidator` (null-forgiving behind an existing `_verifySignature != null` guard), Blueprint disclosure payload (coalesce null→empty map, used at two sites), `DocketFinalizationService` (null-guard genesis `Data`), `SmtpEmailSender` (coalesce password), `ScribanEmailTemplateRenderer.LoadAsync` (return type matched to `ITemplateLoader`'s `string?`), plus test-side `!` / dictionary type alignment.
- **CS0618 `TimeoutAttribute` → `CancelAfterAttribute`** (NUnit, ×4) — the documented replacement.
- **CS0649** — `_testHookRef` scoped under its `#if DEBUG||E2E_TEST_HOOKS` (assignment is already conditional, so it's genuinely never-assigned in Release); PWA context-peek placeholders suppressed with a note (wired to UI, populated by a future feature).

### Suppressed as intentional (justified inline)
- **CS0618 backward-compat** — deprecated `TargetAudience.SorchaInternal` is still **accepted/handled** for pre-migration blueprints (prod handlers + serialisation tests); `IEncryptionProvider` contract tests deliberately cover the deprecated interface until removal. ⚠️ Flipping the `SorchaInternal` **default** to `SorchaLocalWallet` is a separate *behavioural* change, intentionally out of scope.
- **NU1608 (tests only)** — `Fido2 → NSec` pins libsodium `<1.0.21` while `Sodium.Core 1.4.1` pulls `1.0.22`; ABI-compatible within 1.0.x, conflict only in aggregating test closures, NSec is transitive (can't re-pin). Suppressed in `tests/Directory.Build.props`.

### Verification
`dotnet build -c Release` → **0 errors, 0 warnings**. All touched suites green: Tenant 1248, Blueprint.Service 875, Validator.Service 1007, Wallet.Service 839, UI.Core 1337, Peer 710, Register 312, Validator.Core 300, Blueprint.Engine 561, Wallet.Pwa 162, ServiceClients 231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)