### PR TITLE
chore(deps): upgrade deferred major NuGets + default to SorchaLocalWallet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,20 +8,17 @@
     <PackageVersion Include="Anthropic.SDK" Version="5.10.0" />
     <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.8" />
-    <!-- ModelContextProtocol 1.1.0 → 1.3.0 available; held (pre-stable SDK, breaking-change risk) for a dedicated bump. -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.1.0" />
-    <!-- .NET Aspire. 13.4.2 available but transitively requires ModelContextProtocol ≥ 1.3.0,
-         which would force the deferred MCP major (used directly by Sorcha.McpServer). Held at 13.3.3 —
-         bump Aspire + ModelContextProtocol together in the deferred follow-up. -->
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.3" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.3" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.3" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.3" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.3.3" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <!-- .NET Aspire — bumped with ModelContextProtocol 1.3.0 (Aspire 13.4.2 transitively requires MCP ≥ 1.3.0). -->
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.2" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.4.2" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.4.2" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.4.2" />
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
@@ -64,13 +61,13 @@
     <PackageVersion Include="Grpc.Tools" Version="2.81.0" />
     <!-- SD-JWT -->
     <PackageVersion Include="HeroSD-JWT" Version="1.1.7" />
-    <!-- JSON Processing. JsonLogic 6.1.0 / JsonSchema.Net 9.2.1 / JsonSchema.Net.Generation 7.3.9 available;
-         held for a dedicated bump — JsonSchema.Net evaluation is sensitive (CLAUDE.md Pattern #4). -->
+    <!-- JSON Processing. JsonSchema.Net evaluation is sensitive (CLAUDE.md Pattern #4) — covered by
+         blueprint schema-evaluation + generation tests. -->
     <PackageVersion Include="JsonE.Net" Version="3.0.1" />
-    <PackageVersion Include="JsonLogic" Version="6.0.1" />
+    <PackageVersion Include="JsonLogic" Version="6.1.0" />
     <PackageVersion Include="JsonPath.Net" Version="3.0.2" />
-    <PackageVersion Include="JsonSchema.Net" Version="9.1.3" />
-    <PackageVersion Include="JsonSchema.Net.Generation" Version="7.1.3" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.2.1" />
+    <PackageVersion Include="JsonSchema.Net.Generation" Version="7.3.9" />
     <!-- Microsoft ASP.NET Core -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
@@ -136,10 +133,10 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
     <!-- Testing - Mocking -->
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <!-- Blazor UI. MudBlazor 9.5.0 available; held for a dedicated bump (UI minor, breaking-change prone). -->
-    <PackageVersion Include="MudBlazor" Version="9.2.0" />
-    <!-- Crypto - Bitcoin. NBitcoin 10.0.4 available; held — major bump on the wallet crypto core, needs dedicated validation. -->
-    <PackageVersion Include="NBitcoin" Version="9.0.5" />
+    <!-- Blazor UI -->
+    <PackageVersion Include="MudBlazor" Version="9.5.0" />
+    <!-- Crypto - Bitcoin. Major bump (9 → 10) on the wallet crypto core — covered by Cryptography/Wallet tests. -->
+    <PackageVersion Include="NBitcoin" Version="10.0.4" />
     <!-- Load Testing -->
     <PackageVersion Include="NBomber" Version="6.4.1" />
     <PackageVersion Include="NBomber.Http" Version="6.2.0" />
@@ -216,8 +213,8 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
-    <!-- YAML. YamlDotNet 18.0.0 available; held — major bump (16 → 18), needs dedicated validation. -->
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <!-- YAML -->
+    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
     <!-- Reverse Proxy -->
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
     <!-- Blazor Diagrams -->

--- a/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
+++ b/src/Common/Sorcha.Blueprint.Models/Credentials/CredentialIssuanceConfig.cs
@@ -83,19 +83,20 @@ public class CredentialIssuanceConfig
     public CredentialDisplayConfig? DisplayConfig { get; set; }
 
     /// <summary>
-    /// Where the issued credential is delivered. Default: <see cref="TargetAudience.SorchaInternal"/>.
+    /// Where the issued credential is delivered. Default: <see cref="TargetAudience.SorchaLocalWallet"/>.
     /// Set to <see cref="TargetAudience.HaipExternalWallet"/> to issue via the HAIP OpenID4VCI
     /// path (spec 097) instead of writing to a Sorcha participant's wallet.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="TargetAudience.SorchaLocalWallet"/> (was the deprecated
+    /// <see cref="TargetAudience.SorchaInternal"/>). The runtime already maps SorchaInternal to
+    /// SorchaLocalWallet, so configs that omit this field — previously defaulting to the
+    /// deprecated value — keep identical delivery behaviour; they just resolve to the
+    /// non-deprecated value directly.
+    /// </remarks>
     [JsonPropertyName("targetAudience")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    // Default retained as SorchaInternal for backward compatibility with existing serialised
-    // configs. Flipping the default to SorchaLocalWallet is a deliberate behavioural change
-    // (alters credential delivery for configs that omit the field) tracked separately, not a
-    // warning-cleanup edit.
-#pragma warning disable CS0618
-    public TargetAudience TargetAudience { get; set; } = TargetAudience.SorchaInternal;
-#pragma warning restore CS0618
+    public TargetAudience TargetAudience { get; set; } = TargetAudience.SorchaLocalWallet;
 
     /// <summary>
     /// Credential format to mint (feature 135). Default <see cref="CredentialFormat.SdJwtVc"/>.


### PR DESCRIPTION
## Summary
Picks up the work deferred from the dependency-hygiene effort. Two changes, **both validated locally** (build 0 errors / **0 warnings**; full non-infra suite **40/40 projects green**).

### 1. Upgrade the deferred major bumps
| Package | Change | Notes |
|---|---|---|
| **NBitcoin** | 9.0.5 → 10.0.4 | Derivation **byte-identical** — our surface is the stable BIP32/39/44 core (`Mnemonic`/`KeyPath`/`ExtKey`/`Base58`/`.Derive`/`Wordlist`/`PubKey`); still targets netstandard2.0. Proven by Cryptography (396), Wallet.Core, Wallet.Service (839), Wallet.Pwa suites. |
| **JsonSchema.Net** | 9.1.3 → 9.2.1 | + `.Generation` 7.1.3 → 7.3.9, `JsonLogic` 6.0.1 → 6.1.0 — blueprint schema-eval/generation suites green. |
| **YamlDotNet** | 16.3.0 → 18.0.0 | |
| **MudBlazor** | 9.2.0 → 9.5.0 | |
| **Aspire** | 13.3.3 → 13.4.2 | coupled with **ModelContextProtocol(.AspNetCore) 1.1.0 → 1.3.0** (Aspire 13.4.2 transitively requires MCP ≥ 1.3.0). |

No new warnings — **0 obsolete-API usages** introduced by any bump.

### 2. Default credential delivery → `SorchaLocalWallet`
Flips `CredentialIssuanceConfig.TargetAudience` default from the deprecated `SorchaInternal` to `SorchaLocalWallet`. **Behaviourally identical**: the runtime already maps `SorchaInternal → SorchaLocalWallet` (and `SorchaInternal` "breaks on multi-node"), so configs that omit the field — previously defaulting to the deprecated value — keep the same delivery path, now via the non-deprecated value. Removes the last CS0618 suppression on the default.

### Verification / due diligence
- **Is NBitcoin 10 a breaking change for us?** No. NBitcoin 10's breaking changes are legacy/protocol-class removals + dropping old TFMs (still ships netstandard2.0). None of the APIs we use were removed or obsoleted — a removed API would be a compile error, an obsoleted one a CS0618 warning; build is 0/0. The HD-derivation tests (`MnemonicTests`, `DerivationPathTests`, `SorchaDerivationPathsTests`, `WalletManagerTests`, `KeyManagerTests`) pass → derivation unchanged.
- Build `-c Release`: **0 errors, 0 warnings**.
- Full non-infra suite: **40/40 projects pass** (incl. Tenant 1248, Validator.Service 1007, Wallet.Service 839, UI.Core 1337, Blueprint.Service 875).

🤖 Generated with [Claude Code](https://claude.com/claude-code)