### PR TITLE
fix(tenant/trust): normalize CRL serials to minimal DER INTEGER (#817)

### DIFF
--- a/src/Services/Sorcha.Tenant.Service/Trust/TenantCrlBuilder.cs
+++ b/src/Services/Sorcha.Tenant.Service/Trust/TenantCrlBuilder.cs
@@ -65,8 +65,13 @@ public static class TenantCrlBuilder
                 continue;
             var serialBytes = Convert.FromHexString(serialHex);
             // The builder takes serial bytes in big-endian form — the same order
-            // X509CertificateBuilder emits them, so no reversal is needed.
-            builder.AddEntry(serialBytes, revokedAt);
+            // X509CertificateBuilder emits them, so no reversal is needed. They
+            // MUST, however, be a minimal DER INTEGER: org-cert serials are stored
+            // as the raw 16-byte RNG buffer, so a leading 0x00 (redundant positive
+            // padding) makes AddEntry throw "invalid serial number ... redundant
+            // leading bytes", and a leading high-bit byte would be silently encoded
+            // as a negative integer that never matches the certificate (#817).
+            builder.AddEntry(NormalizeSerial(serialBytes), revokedAt);
         }
 
         var now = DateTimeOffset.UtcNow;
@@ -91,5 +96,38 @@ public static class TenantCrlBuilder
             authorityKeyIdentifier: aki);
 
         return (crlDer, nextUpdate);
+    }
+
+    /// <summary>
+    /// Normalises a big-endian serial number to the minimal, positive DER INTEGER
+    /// encoding required by <see cref="CertificateRevocationListBuilder.AddEntry(System.ReadOnlySpan{byte}, System.DateTimeOffset)"/>.
+    /// Strips redundant leading <c>0x00</c> / <c>0xFF</c> padding and prepends a
+    /// single <c>0x00</c> sign byte when the high bit is set, so the encoded serial
+    /// matches the certificate's own (always-positive) serial. See issue #817.
+    /// </summary>
+    internal static byte[] NormalizeSerial(byte[] serial)
+    {
+        var start = 0;
+        // Drop redundant leading 0x00 (positive padding) — a leading zero is only
+        // permitted when the next byte's high bit is set (to keep the value positive).
+        while (start < serial.Length - 1 && serial[start] == 0x00 && (serial[start + 1] & 0x80) == 0)
+            start++;
+        // Drop redundant leading 0xFF (negative padding) — defensive; serials are
+        // generated positive, but normalise faithfully if one ever arrives signed.
+        while (start < serial.Length - 1 && serial[start] == 0xFF && (serial[start + 1] & 0x80) != 0)
+            start++;
+
+        var trimmed = serial.AsSpan(start);
+
+        // A high bit on the leading byte would be read as a negative integer.
+        // Certificate serials are positive, so prepend a 0x00 sign byte.
+        if ((trimmed[0] & 0x80) != 0)
+        {
+            var prefixed = new byte[trimmed.Length + 1];
+            trimmed.CopyTo(prefixed.AsSpan(1));
+            return prefixed;
+        }
+
+        return trimmed.ToArray();
     }
 }

--- a/tests/Sorcha.Tenant.Service.Tests/Trust/TenantCrlBuilderTests.cs
+++ b/tests/Sorcha.Tenant.Service.Tests/Trust/TenantCrlBuilderTests.cs
@@ -58,6 +58,58 @@ public class TenantCrlBuilderTests
     }
 
     [Fact]
+    public void Build_SerialWithRedundantLeadingZero_DoesNotThrow()
+    {
+        // Regression for #817. Org-cert serials are stored as the raw 16-byte
+        // buffer (X509CertificateBuilder.BuildOrgCert), so a serial whose first
+        // byte is 0x00 carries a redundant leading zero. CertificateRevocation
+        // ListBuilder.AddEntry demands a minimal DER INTEGER and threw
+        // "serial number is invalid ... redundant leading bytes" on those serials
+        // — an intermittent CI flake whenever the RNG produced a leading zero.
+        var (rootDer, rootKey) = BuildRoot();
+        var rawSerial = "000A0B0C0D0E0F1011121314151617";   // leading 0x00, next byte high-bit clear
+        var minimalSerial = "0A0B0C0D0E0F1011121314151617";  // what a normalised DER INTEGER carries
+
+        var act = () => TenantCrlBuilder.Build(
+            rootDer, rootKey,
+            new[] { (rawSerial, DateTimeOffset.UtcNow) },
+            crlNumber: 3);
+
+        act.Should().NotThrow("redundant leading zeros must be normalised before AddEntry");
+
+        var (crlDer, _) = act();
+        _ = CertificateRevocationListBuilder.Load(crlDer, out var crlNumber);
+        crlNumber.Should().Be(3);
+        IndexOfSequence(crlDer, Convert.FromHexString(minimalSerial)).Should().BeGreaterThanOrEqualTo(0,
+            "the CRL must embed the minimally-encoded serial so it matches the certificate's own DER INTEGER");
+    }
+
+    [Fact]
+    public void Build_SerialWithHighBitSet_EmbedsPositiveInteger()
+    {
+        // Regression for #817. A serial whose first byte has the high bit set is a
+        // valid minimal encoding of a *negative* integer, so AddEntry accepts it
+        // silently and would embed a negative serial that never matches the
+        // certificate's positive serial. Builder must prepend a 0x00 sign byte.
+        var (rootDer, rootKey) = BuildRoot();
+        var rawSerial = "80AABBCCDDEEFF00112233445566";      // high bit set => looks negative
+        var positiveSerial = "0080AABBCCDDEEFF00112233445566"; // DER positive INTEGER with sign byte
+
+        var act = () => TenantCrlBuilder.Build(
+            rootDer, rootKey,
+            new[] { (rawSerial, DateTimeOffset.UtcNow) },
+            crlNumber: 4);
+
+        act.Should().NotThrow();
+
+        var (crlDer, _) = act();
+        _ = CertificateRevocationListBuilder.Load(crlDer, out var crlNumber);
+        crlNumber.Should().Be(4);
+        IndexOfSequence(crlDer, Convert.FromHexString(positiveSerial)).Should().BeGreaterThanOrEqualTo(0,
+            "the CRL must embed the serial as a positive DER INTEGER (leading 0x00 sign byte)");
+    }
+
+    [Fact]
     public void Build_Signature_VerifiesUnderRootPublicKey()
     {
         // The CRL must be signed by the root CA — a verifier that fetches it and


### PR DESCRIPTION
## Summary

Fixes #817 — the intermittent `InternalCaTrustProviderTests.RevokeOrgCert_MarksRevoked_AndCrlVersionIncrements` flake that red-flagged `build-and-test` on unrelated PRs (e.g. #815).

`TenantCrlBuilder.Build` passed raw serial bytes straight to `CertificateRevocationListBuilder.AddEntry`, which (via `System.Formats.Asn1.AsnWriter`) requires a **minimal big-endian DER INTEGER**. Org-cert serials are persisted as the raw 16-byte RNG buffer (`X509CertificateBuilder.BuildOrgCert` → `Convert.ToHexString(serialBytes)`), so whenever the RNG produced a leading `0x00` byte the serial carried redundant positive padding and `AddEntry` threw:

> The provided serial number is invalid. Ensure the input is in big-endian byte order and that all redundant leading bytes have been removed.

Because the serial is random, this only fired ~1/512 of the time — a textbook "random input exposes a latent encoding bug" flake.

## Fix

New `NormalizeSerial` helper applied before `AddEntry`:
- strips redundant leading `0x00` (positive padding) and `0xFF` (negative padding) bytes
- prepends a single `0x00` sign byte when the high bit is set, keeping the serial a **positive** DER INTEGER that matches the certificate's own serial

The high-bit case is a real correctness fix, not just throw-avoidance: without the sign byte, a high-bit-set serial is silently encoded as a *negative* integer that would never match the (positive) certificate serial during revocation checks.

## Tests

Two **deterministic** regression tests added to `TenantCrlBuilderTests` (the issue explicitly asked for both shapes):
- `Build_SerialWithRedundantLeadingZero_DoesNotThrow` — fails by **throwing** against current code
- `Build_SerialWithHighBitSet_EmbedsPositiveInteger` — fails by **assertion** against current code (no throw, but the serial is mis-encoded), proving a throw-only test would give a false green

### Verification
- `TenantCrlBuilderTests`: **7/7 pass** (5 existing + 2 new); both new tests confirmed red before the fix
- `InternalCaTrustProviderTests` (real org-cert revocation path): **16/16 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)