### PR TITLE
fix(test): repair `dotnet test --filter` on E2E + silence MTP0001 (#587, #818)

### DIFF
--- a/.claude/skills/sorcha-ui/SKILL.md
+++ b/.claude/skills/sorcha-ui/SKILL.md
@@ -168,6 +168,14 @@ dotnet test tests/Sorcha.UI.E2E.Tests --filter "Category=Smoke"
 dotnet test tests/Sorcha.UI.E2E.Tests --filter "Category=Docker"
 ```
 
+> **`--filter` gotcha (issue #818):** these filtered runs only work because `Sorcha.UI.E2E.Tests.csproj`
+> sets `UseMicrosoftTestingPlatformRunner=false`. The shared `tests/Directory.Build.props` forces
+> Microsoft.Testing.Platform on every test project (correct for the xunit.v3 suite), but this project
+> is NUnit/VSTest with no MTP runner — under forced MTP a `--filter` run silently matched nothing and
+> exited 0, so a broken test could "pass" without executing. If you ever see a filtered E2E run report
+> success while running 0 tests, that opt-out has been lost. Confirm discovery with
+> `dotnet test tests/Sorcha.UI.E2E.Tests --list-tests`.
+
 ### Step 5: Check Artifacts on Failure
 
 Screenshots are saved to `tests/Sorcha.UI.E2E.Tests/bin/Debug/net10.0/screenshots/` on any test failure. Console errors and network failures are reported in the test output.

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -17,8 +17,23 @@
       picks VSTest invocation for some xunit.v3 projects whose exe entry point is MTP-only,
       producing "The argument …Tests.dll is invalid" at host startup. Forcing MTP makes the
       runner choice deterministic across the suite.
+
+      NOTE: this is correct only for the xunit.v3 projects, which ship an MTP entry point.
+      NUnit / VSTest projects (e.g. Sorcha.UI.E2E.Tests) have no MTP runner, so forcing MTP
+      makes a filtered "dotnet test" run silently match nothing and exit 0 (issue #818). Those
+      projects opt back out locally by setting UseMicrosoftTestingPlatformRunner=false in
+      their own .csproj.
     -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+      MTP0001 (issue #587): when MTP is the runner, the "dotnet test" CLI still injects its
+      own VSTest-only properties (VSTestTestAdapterPath, plus VSTestTestCaseFilter when a
+      filter is passed). The MTP MSBuild target then warns that they are ignored, on every
+      test build. The properties are the SDK driver's, not ours (there is no offending file
+      in this repo), so the only lever is to demote the warning to a message until the SDK
+      stops emitting them for MTP projects. See https://aka.ms/mtp0001.
+    -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MTP0001</MSBuildWarningsAsMessages>
   </PropertyGroup>
 </Project>

--- a/tests/Sorcha.UI.E2E.Tests/Sorcha.UI.E2E.Tests.csproj
+++ b/tests/Sorcha.UI.E2E.Tests/Sorcha.UI.E2E.Tests.csproj
@@ -5,6 +5,18 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <!--
+      Issue #818: tests/Directory.Build.props forces Microsoft.Testing.Platform on every test
+      project, which is correct for the xunit.v3 suite. This project is NUnit + NUnit3TestAdapter
+      (VSTest) and has no MTP runner, so under forced MTP a filtered "dotnet test" run (e.g.
+      "FullyQualifiedName~X") matched nothing and exited 0: a silent false-positive in which an
+      unconditional Assert.Fail "passed". Opt back out to VSTest dispatch so a filtered
+      "dotnet test" enumerates and runs NUnit tests correctly. CI does not run this project via
+      "dotnet test" (it is in nuget-ci.yml's INFRA skip-list, needs browsers/Docker), so this
+      only affects local filtered runs.
+    -->
+    <UseMicrosoftTestingPlatformRunner>false</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves the xUnit-v3 / Microsoft.Testing.Platform migration debt in the test harness. Two independent symptoms, same root area.

## #818 — `dotnet test --filter` silently runs 0 tests on the E2E project

`tests/Directory.Build.props` forces `UseMicrosoftTestingPlatformRunner=true` on **every** test project. That's correct for the xunit.v3 suite (their binaries are MTP-native), but `Sorcha.UI.E2E.Tests` is **NUnit + NUnit3TestAdapter (VSTest)** with no MTP runner. Under forced MTP, a filtered `dotnet test` matched nothing and exited **0** — a silent false-positive where even an unconditional `Assert.Fail` 'passed' without executing (it bit during PR #815).

**Fix:** opt that one project back out to VSTest dispatch (`UseMicrosoftTestingPlatformRunner=false` + `TestingPlatformDotnetTestSupport=false` in its `.csproj`), with an explanatory comment. The shared props now also document that NUnit/VSTest projects must opt out.

**CI-safe:** `nuget-ci.yml` does not run this project via `dotnet test` — it's in the `INFRA` skip-list (needs browsers/Docker). This only affects local filtered runs.

The `sorcha-ui` skill already documents `dotnet test ... --filter "Category=..."` commands — exactly the ones that were no-opping — so the gotcha is recorded right there.

## #587 — MTP0001 warning on every test build

When MTP is the runner, the `dotnet test` CLI still injects its own VSTest-only properties (`VSTestTestAdapterPath`, plus `VSTestTestCaseFilter` when a filter is passed); the MTP MSBuild target then warns they're ignored, on every build. The properties are the SDK driver's, not ours (no offending file exists in the repo), so the only lever is to demote the warning — `<MSBuildWarningsAsMessages>...;MTP0001</MSBuildWarningsAsMessages>` in `tests/Directory.Build.props` (the issue's recommended option 1). Revert when the SDK stops emitting them (https://aka.ms/mtp0001).

## Verification
- **#587:** `dotnet test <project> --filter ...` → **0** `warning MTP0001` occurrences (was 1 per project per build).
- **#818:** `dotnet test tests/Sorcha.UI.E2E.Tests --list-tests` now enumerates real NUnit tests (e.g. `IndexedDbWipe_ClearsEveryObjectStore`) via the VSTest runner banner — discovery works, so filtering works.

Closes #587, closes #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)