### PR TITLE
fix(test): serialise register WebApplicationFactory hosts to fix CI flake (#918)

### DIFF
--- a/tests/Sorcha.Register.Service.Tests/BatchPublicKeyResolutionTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/BatchPublicKeyResolutionTests.cs
@@ -18,6 +18,7 @@ namespace Sorcha.Register.Service.Tests;
 /// Integration tests for the batch public key resolution endpoint (T011).
 /// Tests the POST /api/registers/{registerId}/participants/resolve-public-keys endpoint.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class BatchPublicKeyResolutionTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/InclusionProofEndpointTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/InclusionProofEndpointTests.cs
@@ -17,6 +17,7 @@ namespace Sorcha.Register.Service.Tests.Endpoints;
 /// Integration tests for Merkle inclusion proof endpoints (T031).
 /// Covers GET inclusion proof generation and POST proof verification.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class InclusionProofEndpointTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/ReceiptEndpointTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/ReceiptEndpointTests.cs
@@ -18,6 +18,7 @@ namespace Sorcha.Register.Service.Tests.Endpoints;
 /// Covers GET receipt by txId, GET docket receipts with pagination,
 /// POST batch receipts, and POST receipt verification.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class ReceiptEndpointTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/RegisterDevModeToggleTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/RegisterDevModeToggleTests.cs
@@ -16,6 +16,7 @@ namespace Sorcha.Register.Service.Tests.Endpoints;
 /// Tests for the DevMode toggle endpoint (PUT /api/registers/{registerId}/devmode).
 /// Verifies enabling, disabling, 404 for unknown registers, and authorization requirements.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class RegisterDevModeToggleTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/RegisterInitiateDevModeTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/RegisterInitiateDevModeTests.cs
@@ -15,6 +15,7 @@ namespace Sorcha.Register.Service.Tests.Endpoints;
 /// Verifies that the DevMode property on InitiateRegisterCreationRequest is correctly
 /// propagated to the pending registration.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class RegisterInitiateDevModeTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/RevocationEndpointTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/RevocationEndpointTests.cs
@@ -15,6 +15,7 @@ namespace Sorcha.Register.Service.Tests.Endpoints;
 /// Integration tests for revocation and transaction status endpoints (T039).
 /// Covers POST revoke transaction, and GET transaction lifecycle status.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class RevocationEndpointTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Endpoints/VerificationBundleTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Endpoints/VerificationBundleTests.cs
@@ -17,6 +17,7 @@ namespace Sorcha.Register.Service.Tests.Endpoints;
 /// Integration tests for verification bundle endpoints (T044).
 /// Covers GET bundle export and POST bundle verification.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class VerificationBundleTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/Helpers/RegisterWebAppCollection.cs
+++ b/tests/Sorcha.Register.Service.Tests/Helpers/RegisterWebAppCollection.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests.Helpers;
+
+/// <summary>
+/// Groups every <see cref="RegisterServiceWebApplicationFactory"/>-hosted integration
+/// test class into a single xUnit collection so their ASP.NET hosts do NOT start
+/// concurrently (issue #918).
+/// </summary>
+/// <remarks>
+/// By default xUnit treats each test class as its own collection and runs collections
+/// in parallel, so the 13 <c>IClassFixture&lt;RegisterServiceWebApplicationFactory&gt;</c>
+/// classes booted 13 hosts at once. Locally (Debug) that is fine, but on the constrained
+/// Release CI runner the concurrent startups starved the thread pool and the system-register
+/// genesis bootstrap raced the first request, intermittently failing the register query /
+/// creation / hub tests and red-flagging <c>build-and-test</c> on essentially every PR.
+///
+/// This definition carries NO <c>ICollectionFixture</c> — each class keeps its own
+/// <c>IClassFixture</c> host, preserving per-class storage isolation. The collection only
+/// serialises host startup. <c>DisableParallelization = true</c> additionally keeps these
+/// heavy host tests out of the parallel phase entirely, so they never contend with the
+/// rest of the assembly either.
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RegisterWebAppCollection
+{
+    /// <summary>The collection name referenced by <c>[Collection(...)]</c> on each host test class.</summary>
+    public const string Name = "RegisterWebApp";
+}

--- a/tests/Sorcha.Register.Service.Tests/ParticipantResolveEndpointTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/ParticipantResolveEndpointTests.cs
@@ -15,6 +15,7 @@ namespace Sorcha.Register.Service.Tests;
 /// Tests for the GET /api/registers/{registerId}/participants/resolve endpoint.
 /// Verifies participant resolution by blueprint role ID and organisation name.
 /// </summary>
+[Collection("RegisterWebApp")]
 public class ParticipantResolveEndpointTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly HttpClient _client;

--- a/tests/Sorcha.Register.Service.Tests/QueryApiTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/QueryApiTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Sorcha.Register.Service.Tests;
 
+[Collection("RegisterWebApp")]
 public class QueryApiTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly HttpClient _client;

--- a/tests/Sorcha.Register.Service.Tests/RegisterApiTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/RegisterApiTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Sorcha.Register.Service.Tests;
 
+[Collection("RegisterWebApp")]
 public class RegisterApiTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/RegisterCreationApiTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/RegisterCreationApiTests.cs
@@ -18,6 +18,7 @@ namespace Sorcha.Register.Service.Tests;
 /// <summary>
 /// Integration tests for register creation API endpoints (two-phase initiate/finalize flow).
 /// </summary>
+[Collection("RegisterWebApp")]
 public class RegisterCreationApiTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/SignalRHubTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/SignalRHubTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Sorcha.Register.Service.Tests;
 
+[Collection("RegisterWebApp")]
 public class SignalRHubTests : IClassFixture<RegisterServiceWebApplicationFactory>, IAsyncLifetime
 {
     private readonly RegisterServiceWebApplicationFactory _factory;

--- a/tests/Sorcha.Register.Service.Tests/TransactionApiTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/TransactionApiTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Sorcha.Register.Service.Tests;
 
+[Collection("RegisterWebApp")]
 public class TransactionApiTests : IClassFixture<RegisterServiceWebApplicationFactory>
 {
     private readonly HttpClient _client;


### PR DESCRIPTION
Closes #918.

## Problem

`build-and-test` (Release CI) failed **nondeterministically** on register-service `WebApplicationFactory` integration tests while the same tests passed **303/0 locally** (Debug) — red-flagging the required gate on essentially every code PR and forcing reruns / admin-merges. The issue caught it across three sibling PRs on the same base: #914 (doesn't even touch register-service) and #916 failed; #915 passed — same flake, different roll.

## Root cause

The 13 register integration test classes each use `IClassFixture<RegisterServiceWebApplicationFactory>`, so each gets its own ASP.NET host. xUnit's unit of parallelism is the **test collection**, and by default *every test class is its own collection* — so all 13 hosts boot **concurrently**. On the constrained Release CI runner the simultaneous startups starve the thread pool and the system-register genesis-bootstrap hosted service races the first request (the CI logs show `[STORAGE-FALLBACK] InMemoryAtomicDistributedCache` around the failures). Locally there's enough headroom that it never surfaces.

The earlier env-var race (#904) was already fixed by moving the process-global config into the factory's static ctor; this is the remaining, separate concurrency problem.

## Fix

Add a single `[CollectionDefinition("RegisterWebApp", DisableParallelization = true)]` (new `Helpers/RegisterWebAppCollection.cs`) and tag all 13 host classes with `[Collection("RegisterWebApp")]`, so their hosts start **serially** instead of 13-at-once.

Key property: the collection carries **no** `ICollectionFixture`, so every class keeps its own `IClassFixture` host — **per-class storage isolation is unchanged**. Only host-startup concurrency is removed. (`RegisterHubAuthorizeTests` is excluded — it's `[Fact(Skip)]` with no host.)

Trade-off: these heavy host tests now run serially (~1m05s for the project) in exchange for a deterministically-green required gate.

## Verification
Local full run after the change: **Failed: 0, Passed: 303, Skipped: 9, Total: 312** — identical to the pre-change baseline, confirming the collection grouping preserves isolation and breaks nothing. The real proof is CI staying green across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)