### PR TITLE
feat(ui): frontend UX hardening — error boundary, a11y, in-flight state, org context

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Feedback/InlineFeedbackHost.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Feedback/InlineFeedbackHost.razor
@@ -20,7 +20,11 @@
     responsibility (wrap in a div with appropriate Class).
 *@
 
-<div class="inline-feedback-host" data-testid="inline-feedback-host">
+@* aria-live="polite" + aria-atomic="false" so assistive tech announces each
+   feedback message as it is added without interrupting the user. Error alerts
+   additionally carry role="alert" (assertive) so failures are announced
+   immediately. *@
+<div class="inline-feedback-host" data-testid="inline-feedback-host" aria-live="polite" aria-atomic="false">
     @foreach (var entry in _snapshot)
     {
         <MudAlert Severity="@MapSeverity(entry.Severity)"
@@ -28,6 +32,7 @@
                   CloseIconClicked="@(() => Feedback.Dismiss(entry.Id))"
                   Dense="true"
                   Class="mb-2"
+                  role="@(entry.Severity == InlineFeedbackSeverity.Error ? "alert" : "status")"
                   data-testid="@($"inline-feedback-{entry.Id:N}")">
             @if (!string.IsNullOrWhiteSpace(entry.DetailHref))
             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/AppErrorBoundary.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/AppErrorBoundary.razor
@@ -1,0 +1,84 @@
+@* SPDX-License-Identifier: MIT *@
+@* Copyright (c) 2026 Sorcha Contributors *@
+
+@implements IDisposable
+@using Microsoft.AspNetCore.Components.Routing
+@inject NavigationManager Navigation
+
+@*
+    Application-wide error boundary. Wraps the routed @Body in each host's
+    MainLayout so an unhandled exception in any page renders a friendly
+    recovery panel instead of blanking the whole layout (Blazor's default
+    behaviour for an unhandled render/lifecycle exception).
+
+    - Auto-recovers on navigation, so moving away from a broken page clears
+      the error UI without a full reload.
+    - "Try again" re-renders the current page (cheap retry for transient
+      failures); "Reload" performs a hard reload for a clean slate.
+
+    The built-in <ErrorBoundary> already logs the exception via the framework
+    logger, so this wrapper does not re-log.
+*@
+
+<ErrorBoundary @ref="_boundary">
+    <ChildContent>
+        @ChildContent
+    </ChildContent>
+    <ErrorContent Context="exception">
+        <MudPaper Class="pa-8 my-4 mx-auto text-center"
+                  Elevation="2"
+                  Style="max-width: 560px;"
+                  role="alert"
+                  data-testid="app-error-boundary">
+            <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Color="Color.Error" Size="Size.Large" Class="mb-3" />
+            <MudText Typo="Typo.h5" Class="mb-2">Something went wrong</MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+                This page hit an unexpected error. You can try again, or reload the app.
+            </MudText>
+            <MudStack Row="true" Justify="Justify.Center" Spacing="2">
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Refresh"
+                           OnClick="Recover"
+                           data-testid="app-error-retry">
+                    Try again
+                </MudButton>
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Default"
+                           StartIcon="@Icons.Material.Filled.RestartAlt"
+                           OnClick="Reload"
+                           data-testid="app-error-reload">
+                    Reload
+                </MudButton>
+            </MudStack>
+        </MudPaper>
+    </ErrorContent>
+</ErrorBoundary>
+
+@code {
+    private ErrorBoundary? _boundary;
+
+    /// <summary>The routed content to guard (typically <c>@Body</c>).</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        Navigation.LocationChanged += OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        // Recover so navigating away from a broken page restores normal
+        // rendering instead of leaving the error panel pinned in place.
+        _boundary?.Recover();
+    }
+
+    private void Recover() => _boundary?.Recover();
+
+    private void Reload() => Navigation.NavigateTo(Navigation.Uri, forceLoad: true);
+
+    public void Dispose()
+    {
+        Navigation.LocationChanged -= OnLocationChanged;
+    }
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Wallets/WalletListPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Wallets/WalletListPanel.razor
@@ -119,7 +119,14 @@
                                 }
                                 <MudIconButton Icon="@Icons.Material.Filled.QrCode2" Size="Size.Small" Title="Show QR Code" OnClick="() => OnShowQrCode.InvokeAsync(context)" />
                                 <MudIconButton Icon="@Icons.Material.Filled.Share" Size="Size.Small" Title="Copy Address" OnClick="() => OnCopyAddress.InvokeAsync(context)" />
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" Title="Delete" OnClick="() => OnDelete.InvokeAsync(context)" />
+                                @if (DeletingAddress == context.Address)
+                                {
+                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Error" Class="mx-2" />
+                                }
+                                else
+                                {
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" Title="Delete" aria-label="@($"Delete wallet {context.Name}")" Disabled="@(DeletingAddress != null)" OnClick="() => OnDelete.InvokeAsync(context)" />
+                                }
                             </MudStack>
                         </MudTd>
                     </RowTemplate>
@@ -199,7 +206,14 @@
                                 </MudButton>
                             </span>
                             <span @onclick:stopPropagation="true">
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => OnDelete.InvokeAsync(wallet)" />
+                                @if (DeletingAddress == wallet.Address)
+                                {
+                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" Color="Color.Error" Class="mx-2" />
+                                }
+                                else
+                                {
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" Title="Delete" aria-label="@($"Delete wallet {wallet.Name}")" Disabled="@(DeletingAddress != null)" OnClick="() => OnDelete.InvokeAsync(wallet)" />
+                                }
                             </span>
                         </MudCardActions>
                     </MudCard>
@@ -250,6 +264,12 @@
     [Parameter] public bool IsLoading { get; set; }
     [Parameter] public string? Error { get; set; }
     [Parameter] public string? DefaultWalletAddress { get; set; }
+    /// <summary>
+    /// Address of the wallet currently being deleted. While set, that row shows
+    /// an in-progress spinner and every delete button is disabled to prevent a
+    /// double-submit. Null when no delete is in flight.
+    /// </summary>
+    [Parameter] public string? DeletingAddress { get; set; }
     [Parameter] public bool ShowDefaultIndicator { get; set; } = true;
     [Parameter] public bool ShowOwnerColumn { get; set; }
     [Parameter] public bool ShowCreateButton { get; set; } = true;

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor
@@ -29,7 +29,7 @@
 <CascadingAuthenticationState>
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" aria-label="Toggle navigation menu" />
         <MudText Typo="Typo.h5" Class="ml-3" Style="cursor: pointer;" @onclick="@(() => Navigation.NavigateTo("dashboard"))">Sorcha</MudText>
         <MudSpacer />
         <AuthorizeView>
@@ -39,6 +39,7 @@
                    after retirement of the legacy ActivityLogPanel + PendingActionInbox
                    in PRs #538 / this PR. *@
                 <MudIconButton Icon="@Icons.Material.Filled.Notifications" Color="Color.Inherit" OnClick="@ToggleInboxPanel" Title="Inbox"
+                               aria-label="@($"Inbox{(_inboxUnreadCount > 0 ? $", {_inboxUnreadCount} unread" : string.Empty)}")"
                                Class="@(_badgeWiggle ? "inbox-bell-wiggle" : null)">
                     @if (_inboxUnreadCount > 0)
                     {
@@ -270,7 +271,11 @@
                occupies no vertical space) until a page surfaces a message
                via IInlineFeedback. *@
             <Sorcha.UI.Core.Components.Feedback.InlineFeedbackHost />
-            @Body
+            @* Guard the routed page so an unhandled error renders a recovery
+               panel instead of blanking the layout. Auto-recovers on nav. *@
+            <Sorcha.UI.Core.Components.Shared.AppErrorBoundary>
+                @Body
+            </Sorcha.UI.Core.Components.Shared.AppErrorBoundary>
         </MudContainer>
     </MudMainContent>
     <StatusFooter />

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Index.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Participants/Index.razor
@@ -5,7 +5,10 @@
 @using Sorcha.UI.Core.Components.Participants
 @using Sorcha.UI.Core.Models.Participants
 @using Sorcha.UI.Core.Services.Participants
+@using Sorcha.UI.Core.Services.Feedback
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using System.Security.Claims
 @attribute [Authorize(Roles = "Administrator,SystemAdmin,Auditor")]
 
 <PageTitle>Participants</PageTitle>
@@ -85,11 +88,16 @@
     [Inject] private IParticipantApiService ParticipantService { get; set; } = default!;
     [Inject] private IDialogService DialogService { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
+    [Inject] private IInlineFeedback Feedback { get; set; } = default!;
+
+    [CascadingParameter] private Task<AuthenticationState>? AuthenticationState { get; set; }
 
     private Sorcha.UI.Core.Components.Participants.ParticipantList? _participantList;
     private List<ParticipantDetailViewModel>? _myProfiles;
 
-    // TODO: Get from user context or configuration
+    // Resolved from the active org_id claim on the user's token (the org the
+    // user is currently scoped to), falling back to the org of their first
+    // participant profile when the claim is absent.
     private Guid _organizationId = Guid.Empty;
 
     private List<BreadcrumbItem> _breadcrumbs = new()
@@ -100,7 +108,21 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ResolveOrganizationIdAsync();
         await LoadMyProfilesAsync();
+    }
+
+    private async Task ResolveOrganizationIdAsync()
+    {
+        if (AuthenticationState == null) return;
+
+        var authState = await AuthenticationState;
+        var orgIdClaim = authState.User.Claims
+            .FirstOrDefault(c => c.Type == "org_id" || c.Type == "organization_id");
+        if (orgIdClaim != null && Guid.TryParse(orgIdClaim.Value, out var orgId))
+        {
+            _organizationId = orgId;
+        }
     }
 
     private async Task LoadMyProfilesAsync()
@@ -109,15 +131,19 @@
         {
             _myProfiles = await ParticipantService.GetMyProfilesAsync();
 
-            // If user has profiles, use the first organization
-            if (_myProfiles.Count > 0)
+            // Fall back to the first profile's organization only when the token
+            // did not carry an active org_id claim.
+            if (_organizationId == Guid.Empty && _myProfiles.Count > 0)
             {
                 _organizationId = _myProfiles[0].OrganizationId;
             }
         }
-        catch
+        catch (Exception)
         {
             _myProfiles = new();
+            Feedback.ShowError(
+                "Failed to load your participant profiles. Please refresh to try again.",
+                autoDismissMs: 0);
         }
     }
 
@@ -141,7 +167,11 @@
     private async Task ShowEditDialog(ParticipantListItemViewModel participant)
     {
         var detail = await ParticipantService.GetParticipantAsync(_organizationId, participant.Id);
-        if (detail == null) return;
+        if (detail == null)
+        {
+            Feedback.ShowError("Could not load that participant's details. Please try again.");
+            return;
+        }
 
         var parameters = new DialogParameters
         {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/WalletAdmin.razor
@@ -26,6 +26,7 @@
                      ShowRecoverButton="true"
                      EmptyTitle="No Organisation Wallets"
                      EmptyDescription="No wallets found in this organisation"
+                     DeletingAddress="@_deletingAddress"
                      OnShowQrCode="ShowQrCode"
                      OnCopyAddress="CopyAddress"
                      OnDelete="ConfirmDelete"
@@ -36,6 +37,7 @@
     private List<WalletDto> wallets = new();
     private bool isLoading = true;
     private string? error;
+    private string? _deletingAddress;
 
     protected override async Task OnInitializedAsync()
     {
@@ -124,6 +126,10 @@
 
     private async Task DeleteWalletAsync(WalletDto wallet)
     {
+        // Guard against a re-entrant delete while one is already in flight.
+        if (_deletingAddress != null) return;
+
+        _deletingAddress = wallet.Address;
         try
         {
             var success = await WalletService.DeleteWalletAsync(wallet.Address);
@@ -140,6 +146,10 @@
         catch (Exception ex)
         {
             Feedback.ShowError($"Failed to delete wallet: {ex.Message}", autoDismissMs: 0);
+        }
+        finally
+        {
+            _deletingAddress = null;
         }
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -99,7 +99,11 @@
            at the top of the content region. Stays empty (and occupies no
            vertical space) until a page surfaces a message via IInlineFeedback. *@
         <Sorcha.UI.Core.Components.Feedback.InlineFeedbackHost />
-        @Body
+        @* Guard the routed page so an unhandled error renders a recovery
+           panel instead of blanking the wallet shell. Auto-recovers on nav. *@
+        <Sorcha.UI.Core.Components.Shared.AppErrorBoundary>
+            @Body
+        </Sorcha.UI.Core.Components.Shared.AppErrorBoundary>
     </MudMainContent>
     @* Feature 141 — floating pill nav replaces the flush bottom rail. Shell-
        level, so it appears on every primary wallet screen. *@


### PR DESCRIPTION
## Summary

A focused frontend robustness/UX pass picking off four high-impact, frontend-only items surfaced by a codebase survey. No backend changes; builds clean (UI solution 0/0, PWA 0/0); snackbar CI gate passes.

### 1. Global `AppErrorBoundary` (web + PWA)
A page that threw during render/lifecycle previously **blanked the entire layout**. New reusable `AppErrorBoundary` in `Sorcha.UI.Core` (shared by both hosts) renders a recovery panel with **Try again** (Recover) and **Reload** (hard reload), and **auto-recovers on navigation**. Wrapped around `@Body` in both `MainLayout`s. Panel carries `role="alert"`.

### 2. Wire org context to Participants page
`Participants/Index.razor` hardcoded `OrganizationId = Guid.Empty`, so the Organization Participants tab perpetually showed *"No organization selected."* Now resolves the active org from the `org_id` claim (the established pattern across admin/identity pages), falling back to the first profile's org. Also surfaces two previously-**silent** failures via `IInlineFeedback`.

### 3. Accessibility pass
- `InlineFeedbackHost` (the platform-wide feedback surface) now has an **ARIA live region** (`aria-live="polite"`, error alerts `role="alert"`) so screen-reader users actually hear success/error messages.
- `aria-label` on the web shell's menu toggle and inbox bell (bell announces unread count).
- Labelled the wallet **card-view delete button**, which previously had neither `Title` nor `aria-label`.

### 4. In-flight state for wallet deletion
Deleting a wallet gave no feedback during the round-trip (double-click hazard). The active row now swaps its delete button for a spinner, all delete buttons disable while a delete is in flight, and `WalletAdmin` guards against re-entrant deletes.

## Testing
- `dotnet build src/Apps/Sorcha.UI/Sorcha.UI.sln` → **0 warnings, 0 errors**
- `dotnet build Sorcha.Wallet.Pwa` → **0/0**
- `scripts/check-no-snackbar.ps1` → **passes** (all feedback via `IInlineFeedback`)
- The two `Sorcha.UI.*.Tests` projects are empty scaffolds (no bUnit infra), so there are no component tests to run or extend. Changes have **not** been live-rendered.

## Out of scope (backend-blocked, noted for follow-up)
Org-scoped wallet admin API, credential Pending/Declined states, blueprint-object validation endpoint — each needs a backend change first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)