### PR TITLE
fix(register): verify docket/tx on duplicate-key, reject divergence (#814)

### DIFF
--- a/src/Services/Sorcha.Register.Service/Program.cs
+++ b/src/Services/Sorcha.Register.Service/Program.cs
@@ -1596,9 +1596,37 @@ docketsGroup.MapPost("/", async (
             }
             catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Category == MongoDB.Driver.ServerErrorCategory.DuplicateKey)
             {
-                logger.LogWarning("[TRACKDIAG register] tx {TxId} ALREADY EXISTS — docket write-back skipped (pre-persisted version kept)", tx.TxId);
-                // Transaction already exists (e.g., genesis transactions stored during register creation).
-                // This is expected for docket write-back of transactions that were pre-persisted.
+                // A transaction with this TxId already exists. This is legitimate for an idempotent
+                // docket write-back (genesis transactions pre-persisted during register creation, or a
+                // validator retry after a lost response) — but ONLY when the persisted transaction is
+                // the same one. A same-TxId / different-signature collision is a real integrity
+                // divergence; masking it as success silently drops the incoming transaction (#814), so
+                // verify the signature matches before treating the duplicate as a no-op.
+                var existingTx = await repository.GetTransactionAsync(registerId, tx.TxId);
+                if (DocketWriteReconciliation.ReconcileTransaction(existingTx, tx)
+                    == DocketWriteReconciliation.Verdict.IdempotentMatch)
+                {
+                    logger.LogDebug(
+                        "[register] tx {TxId} already persisted with matching signature — idempotent write-back, re-insert skipped",
+                        tx.TxId);
+                }
+                else
+                {
+                    logger.LogCritical(
+                        "[register] INTEGRITY DIVERGENCE writing docket {DocketNumber} for register {RegisterId}: " +
+                        "transaction {TxId} already exists with a different signature " +
+                        "(existing={ExistingSignature}, incoming={IncomingSignature}). Rejecting the docket write " +
+                        "rather than silently dropping the transaction (#814).",
+                        request.DocketNumber, registerId, tx.TxId,
+                        existingTx?.Signature ?? "<missing>", tx.Signature);
+                    return Results.Conflict(new
+                    {
+                        error = "Transaction integrity divergence",
+                        registerId,
+                        docketNumber = request.DocketNumber,
+                        txId = tx.TxId,
+                    });
+                }
             }
 
             // Index participant transactions for fast address/ID lookups
@@ -1628,8 +1656,35 @@ docketsGroup.MapPost("/", async (
     }
     catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Category == MongoDB.Driver.ServerErrorCategory.DuplicateKey)
     {
-        // Docket already written (idempotent retry from Validator). Return success.
-        inserted = docket;
+        // A docket already occupies this number (the docket number is the Mongo _id). Treat it as a
+        // successful idempotent retry ONLY when the persisted docket is the SAME docket — i.e. its
+        // hash matches. A same-number / different-hash collision means a divergent docket was built
+        // on a stale chain head; masking it as success silently drops this docket's transactions
+        // (#814), so verify the hash before returning success and reject on divergence.
+        var existingDocket = await repository.GetDocketAsync(registerId, (ulong)request.DocketNumber);
+        if (DocketWriteReconciliation.ReconcileDocket(existingDocket, docket)
+            == DocketWriteReconciliation.Verdict.IdempotentMatch)
+        {
+            logger.LogInformation(
+                "Docket {DocketNumber} for register {RegisterId} already written with matching hash — idempotent retry, treating as success",
+                request.DocketNumber, registerId);
+            inserted = existingDocket!;
+        }
+        else
+        {
+            logger.LogCritical(
+                "[register] INTEGRITY DIVERGENCE writing docket {DocketNumber} for register {RegisterId}: " +
+                "a different docket already occupies this number (existing hash={ExistingHash}, incoming hash={IncomingHash}). " +
+                "Rejecting rather than silently dropping this docket's transactions (#814).",
+                request.DocketNumber, registerId,
+                existingDocket?.Hash ?? "<missing>", docket.Hash);
+            return Results.Conflict(new
+            {
+                error = "Docket integrity divergence",
+                registerId,
+                docketNumber = request.DocketNumber,
+            });
+        }
     }
 
     // Update register height (height = number of dockets written, i.e., DocketNumber + 1)
@@ -1775,6 +1830,7 @@ docketsGroup.MapPost("/", async (
 
     return Results.Created($"/api/registers/{registerId}/dockets/{inserted.Id}", inserted);
 })
+.Produces(StatusCodes.Status409Conflict)
 .WithName("WriteDocket")
 .WithSummary("Write a confirmed docket")
 .WithDescription("Writes a consensus-confirmed docket to the register. Used by Validator Service.")

--- a/src/Services/Sorcha.Register.Service/README.md
+++ b/src/Services/Sorcha.Register.Service/README.md
@@ -465,7 +465,7 @@ Open `coverage/index.html` in your browser.
 The Register Service integrates with the Validator Service for:
 - **Docket Write-Back**: Validator builds dockets from mempool transactions and writes sealed dockets (with transactions) back to the Register via `POST /api/registers/{id}/dockets`
 - **Register Height Tracking**: Height is updated on each docket write (count-based: height = number of dockets written)
-- **Idempotent Writes**: Duplicate docket/transaction inserts are handled gracefully for retry safety
+- **Idempotent Writes**: A duplicate docket/transaction insert (same docket number or transaction id) is treated as a successful idempotent retry **only when the persisted record matches** — the docket hash (or transaction signature) is compared before returning success. A same-number/different-hash docket (or same-id/different-signature transaction) is a genuine integrity divergence: the write is rejected with `409 Conflict` and a `LogCritical` entry rather than silently dropping the incoming docket's transactions (issue #814)
 - **Register Monitoring**: Validator queries register height and latest docket to determine next docket number and chain from previous hash
 
 **Communication**: HTTP REST API (Validator → Register for writes, Register → Validator for genesis submission)

--- a/src/Services/Sorcha.Register.Service/Services/DocketWriteReconciliation.cs
+++ b/src/Services/Sorcha.Register.Service/Services/DocketWriteReconciliation.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Sorcha.Register.Models;
+
+namespace Sorcha.Register.Service.Services;
+
+/// <summary>
+/// Decides whether a duplicate-key collision on a docket or transaction write is a benign
+/// idempotent retry or a genuine integrity divergence.
+/// </summary>
+/// <remarks>
+/// The docket-write endpoint receives sealed dockets from the Validator Service. A docket's
+/// number is its Mongo <c>_id</c>, so a re-submitted docket number throws a duplicate-key error.
+/// That is legitimate when the validator simply retries after a lost response (the persisted
+/// record is byte-for-byte the same). It is NOT legitimate when a <em>different</em> docket
+/// (different hash) — or a transaction with the same id but a different signature — already
+/// occupies that slot: that means a divergent record was built on a stale chain head. Masking
+/// such a collision as success silently drops the incoming docket's transactions (issue #814),
+/// so the endpoint must verify the persisted record matches before treating the duplicate as a
+/// no-op, and reject loudly otherwise.
+/// </remarks>
+internal static class DocketWriteReconciliation
+{
+    /// <summary>The outcome of reconciling a duplicate-key collision against the persisted record.</summary>
+    internal enum Verdict
+    {
+        /// <summary>The persisted record is the same one being written — a safe idempotent retry.</summary>
+        IdempotentMatch,
+
+        /// <summary>A different record already occupies the slot — a genuine integrity divergence.</summary>
+        Divergence,
+    }
+
+    /// <summary>
+    /// Reconciles a duplicate docket-number collision. A match requires the persisted docket to
+    /// exist and carry the same hash as the incoming docket.
+    /// </summary>
+    internal static Verdict ReconcileDocket(Docket? existing, Docket incoming)
+    {
+        ArgumentNullException.ThrowIfNull(incoming);
+
+        return existing is not null
+            && !string.IsNullOrEmpty(existing.Hash)
+            && string.Equals(existing.Hash, incoming.Hash, StringComparison.Ordinal)
+                ? Verdict.IdempotentMatch
+                : Verdict.Divergence;
+    }
+
+    /// <summary>
+    /// Reconciles a duplicate transaction-id collision. A match requires the persisted transaction
+    /// to exist and carry the same signature as the incoming transaction.
+    /// </summary>
+    internal static Verdict ReconcileTransaction(TransactionModel? existing, TransactionModel incoming)
+    {
+        ArgumentNullException.ThrowIfNull(incoming);
+
+        return existing is not null
+            && !string.IsNullOrEmpty(existing.Signature)
+            && string.Equals(existing.Signature, incoming.Signature, StringComparison.Ordinal)
+                ? Verdict.IdempotentMatch
+                : Verdict.Divergence;
+    }
+}

--- a/tests/Sorcha.Register.Service.Tests/Unit/DocketWriteReconciliationTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Unit/DocketWriteReconciliationTests.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using FluentAssertions;
+using Sorcha.Register.Models;
+using Sorcha.Register.Service.Services;
+using Xunit;
+
+namespace Sorcha.Register.Service.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="DocketWriteReconciliation"/> — the decision that turns a
+/// duplicate-key collision on the docket-write endpoint into either a benign idempotent retry or
+/// a loud integrity divergence (issue #814). Masking a divergence as success silently dropped a
+/// docket's transactions, so the matching/divergence boundary is verified here directly.
+/// </summary>
+public class DocketWriteReconciliationTests
+{
+    private static Docket DocketWithHash(string hash, ulong number = 7) => new()
+    {
+        Id = number,
+        RegisterId = "reg-1",
+        Hash = hash,
+    };
+
+    private static TransactionModel TxWithSignature(string signature, string txId = "tx-1") => new()
+    {
+        TxId = txId,
+        RegisterId = "reg-1",
+        Signature = signature,
+    };
+
+    // ---- Docket reconciliation ----
+
+    [Fact]
+    public void ReconcileDocket_SameHash_ReturnsIdempotentMatch()
+    {
+        var existing = DocketWithHash("abc123");
+        var incoming = DocketWithHash("abc123");
+
+        DocketWriteReconciliation.ReconcileDocket(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.IdempotentMatch);
+    }
+
+    [Fact]
+    public void ReconcileDocket_DifferentHash_ReturnsDivergence()
+    {
+        var existing = DocketWithHash("abc123");
+        var incoming = DocketWithHash("deadbeef");
+
+        DocketWriteReconciliation.ReconcileDocket(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+
+    [Fact]
+    public void ReconcileDocket_NoExistingRecord_ReturnsDivergence()
+    {
+        // A duplicate-key error with no readable existing record is not a verified match —
+        // fail loud rather than assume success.
+        DocketWriteReconciliation.ReconcileDocket(null, DocketWithHash("abc123"))
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+
+    [Fact]
+    public void ReconcileDocket_ExistingHasEmptyHash_ReturnsDivergence()
+    {
+        var existing = DocketWithHash(string.Empty);
+        var incoming = DocketWithHash("abc123");
+
+        DocketWriteReconciliation.ReconcileDocket(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+
+    [Fact]
+    public void ReconcileDocket_HashComparisonIsCaseSensitive()
+    {
+        var existing = DocketWithHash("ABC123");
+        var incoming = DocketWithHash("abc123");
+
+        DocketWriteReconciliation.ReconcileDocket(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+
+    // ---- Transaction reconciliation ----
+
+    [Fact]
+    public void ReconcileTransaction_SameSignature_ReturnsIdempotentMatch()
+    {
+        var existing = TxWithSignature("sig-aaa");
+        var incoming = TxWithSignature("sig-aaa");
+
+        DocketWriteReconciliation.ReconcileTransaction(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.IdempotentMatch);
+    }
+
+    [Fact]
+    public void ReconcileTransaction_DifferentSignature_ReturnsDivergence()
+    {
+        // Same TxId, different signature — the exact silent-loss case from #814.
+        var existing = TxWithSignature("sig-aaa");
+        var incoming = TxWithSignature("sig-bbb");
+
+        DocketWriteReconciliation.ReconcileTransaction(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+
+    [Fact]
+    public void ReconcileTransaction_NoExistingRecord_ReturnsDivergence()
+    {
+        DocketWriteReconciliation.ReconcileTransaction(null, TxWithSignature("sig-aaa"))
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+
+    [Fact]
+    public void ReconcileTransaction_ExistingHasEmptySignature_ReturnsDivergence()
+    {
+        var existing = TxWithSignature(string.Empty);
+        var incoming = TxWithSignature("sig-aaa");
+
+        DocketWriteReconciliation.ReconcileTransaction(existing, incoming)
+            .Should().Be(DocketWriteReconciliation.Verdict.Divergence);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the silent-data-loss vector behind #814. The docket-write endpoint (`POST /api/registers/{id}/dockets`, validator → register) previously masked **every** `DuplicateKey` collision as a `201` success. Because a docket's number is its Mongo `_id`, a re-submitted docket number — or a transaction id re-submitted with a different signature — was silently accepted and the incoming docket's transactions were dropped with **no signal**. This matches the #814 symptom exactly: the validator logs `"wrote N transactions to register"` (it got a 2xx) but the transaction never appears in Mongo.

## What this is (and isn't)

This is **step 1 of 2** — a *defensive* fix that converts the failure from **silent to loud**. It does **not** yet fix the idle-specific trigger that causes the validator to collide on a docket number after ~1h idle; that needs a live n1 repro with diagnostics (step 2). This change is correct and valuable on its own — had it been in place, #814 would have surfaced the first time it happened instead of silently losing a transaction.

## Change

On `DuplicateKey`, read the persisted record and compare its strong identity field before deciding:

| Case | Old behavior | New behavior |
|------|-------------|--------------|
| Same docket number, **same hash** | 201 (blind) | 201 — verified idempotent retry |
| Same docket number, **different hash** | 201 (silent loss) | **409 Conflict + `LogCritical`** |
| Same tx id, **same signature** | swallowed | skipped — verified idempotent (preserves genesis-pre-persist) |
| Same tx id, **different signature** | swallowed (silent loss) | **409 Conflict + `LogCritical`** |

The match/divergence decision is extracted into `DocketWriteReconciliation` (pure, unit-tested), because the endpoint's Mongo-specific `catch` is not exercised by the in-memory WAF tests — a pre-existing test gap.

## Root-cause notes (for the record)

Confirmed by code review: the validator derives its next docket number **fresh** from `ReadLatestDocketAsync` → `register.Height` (no cache), so naive validator-side height staleness is *not* the trigger. Two hypotheses from the original issue were **refuted**: (1) Mongo crash + lost acknowledged writes (no evidence — containers healthy, no restart), (2) validator cached height. The remaining idle-trigger candidate (heartbeat/registration TTL interaction on resume, or a stale latest-docket read) is deferred to step 2 with live diagnostics.

## Tests

- 9 new unit tests in `DocketWriteReconciliationTests` (match / divergence / missing record / empty hash-or-signature / case-sensitivity, for both docket and transaction paths)
- Full `Sorcha.Register.Service.Tests` suite green (312 passed, 9 skipped)

## Docs

- Register Service README — "Idempotent Writes" bullet updated
- OpenAPI: endpoint now advertises `409 Conflict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)