### PR TITLE
feat(pwa): Home→Settings design P2/P3 — Cards tab, detail redesign, status pill, claims

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialStatus.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialStatus.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.UI.Core.Components.Wallet;
+
+/// <summary>
+/// Plain-language lifecycle state shown on a <see cref="CredentialWalletCard"/>
+/// as a status pill. Leads with status (✓ Valid / Expires soon / Revoked) so a
+/// citizen never has to read a raw status-list pointer to know if a card works.
+/// </summary>
+public enum CredentialStatus
+{
+    /// <summary>No pill rendered (status unknown / not surfaced).</summary>
+    None = 0,
+
+    /// <summary>Active and presentable.</summary>
+    Valid = 1,
+
+    /// <summary>Valid but approaching its expiry date.</summary>
+    ExpiringSoon = 2,
+
+    /// <summary>Revoked or expired — no longer presentable.</summary>
+    Revoked = 3,
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialWalletCard.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialWalletCard.razor
@@ -13,7 +13,7 @@
 @namespace Sorcha.UI.Core.Components.Wallet
 
 <button type="button"
-        class="credential-wallet-card"
+        class="@RootClass"
         style="@RootStyle"
         aria-label="@AccessibleName"
         data-testid="@TestIdResolved"
@@ -29,7 +29,20 @@
         }
     </div>
     <div class="credential-wallet-card__bottom">
-        <div class="credential-wallet-card__meta">@Meta</div>
+        <div class="credential-wallet-card__bottom-left">
+            @if (Status != CredentialStatus.None)
+            {
+                <div class="credential-wallet-card__status credential-wallet-card__status--@StatusModifier"
+                     data-testid="@($"{TestIdResolved}-status")">
+                    <span class="credential-wallet-card__status-dot" aria-hidden="true"></span>
+                    <span class="credential-wallet-card__status-label">@EffectiveStatusText</span>
+                </div>
+            }
+            @if (!string.IsNullOrWhiteSpace(Meta))
+            {
+                <div class="credential-wallet-card__meta">@Meta</div>
+            }
+        </div>
         <div class="credential-wallet-card__qr" aria-hidden="true">
             @* Decorative faux QR — 4×4 grid of dark cells. *@
             @for (var i = 0; i < 16; i++)
@@ -53,6 +66,12 @@
     /// <summary>Single meta line at the bottom (e.g. "Demo · For testing only").</summary>
     [Parameter] public string? Meta { get; set; }
 
+    /// <summary>Lifecycle status surfaced as a pill. <see cref="CredentialStatus.None"/> hides it.</summary>
+    [Parameter] public CredentialStatus Status { get; set; } = CredentialStatus.None;
+
+    /// <summary>Optional status pill text override (e.g. "Expires in 3 days"). Defaults per status.</summary>
+    [Parameter] public string? StatusText { get; set; }
+
     /// <summary>Accent colour used as the gradient base. Defaults to brand blue.</summary>
     [Parameter] public string Accent { get; set; } = "#667eea";
 
@@ -67,10 +86,36 @@
 
     private string TestIdResolved => TestId ?? "credential-wallet-card";
 
-    private string AccessibleName =>
-        string.IsNullOrWhiteSpace(Issuer)
-            ? $"{Name} — open credential"
-            : $"{Name}, {Issuer} — open credential";
+    private string RootClass =>
+        "credential-wallet-card"
+        + (Status == CredentialStatus.Revoked ? " credential-wallet-card--revoked" : "");
+
+    private string StatusModifier => Status switch
+    {
+        CredentialStatus.Valid => "valid",
+        CredentialStatus.ExpiringSoon => "expiring",
+        CredentialStatus.Revoked => "revoked",
+        _ => "none",
+    };
+
+    private string EffectiveStatusText => StatusText ?? Status switch
+    {
+        CredentialStatus.Valid => "Valid",
+        CredentialStatus.ExpiringSoon => "Expiring soon",
+        CredentialStatus.Revoked => "Revoked",
+        _ => "",
+    };
+
+    private string AccessibleName
+    {
+        get
+        {
+            var name = string.IsNullOrWhiteSpace(Issuer)
+                ? $"{Name} — open credential"
+                : $"{Name}, {Issuer} — open credential";
+            return Status == CredentialStatus.None ? name : $"{name} ({EffectiveStatusText})";
+        }
+    }
 
     private string RootStyle =>
         $"--cwc-accent: {Accent};"

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialWalletCard.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialWalletCard.razor.css
@@ -88,6 +88,14 @@
     gap: 12px;
 }
 
+.credential-wallet-card__bottom-left {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+}
+
 .credential-wallet-card__meta {
     font-size: 11px;
     font-weight: 400;
@@ -96,6 +104,60 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: 100%;
+}
+
+/* Status pill — leads with plain-language lifecycle state. Translucent on the
+   gradient; the dot carries the success/warn/error colour, the label stays
+   white for contrast. */
+.credential-wallet-card__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    padding: 3px 9px 3px 7px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, .18);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: -.005em;
+}
+
+.credential-wallet-card__status-dot {
+    flex: 0 0 auto;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #fff;
+}
+
+.credential-wallet-card__status-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.credential-wallet-card__status--valid .credential-wallet-card__status-dot {
+    background: var(--sorcha-accent, #48bb78);
+}
+
+.credential-wallet-card__status--expiring .credential-wallet-card__status-dot {
+    background: var(--sorcha-warn, #d69e2e);
+}
+
+.credential-wallet-card__status--revoked {
+    /* Solid-dark pill so a dead card reads as inactive, not "fine". */
+    background: rgba(0, 0, 0, .32);
+}
+
+.credential-wallet-card__status--revoked .credential-wallet-card__status-dot {
+    background: var(--mud-palette-error, #e53e3e);
+}
+
+/* Revoked cards dim back so they read as inactive without disappearing. */
+.credential-wallet-card--revoked {
+    opacity: .82;
+    filter: saturate(.7);
 }
 
 .credential-wallet-card__qr {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor
@@ -46,14 +46,13 @@
 
     private sealed record Tab(string Route, string Label, string Icon, string TestId);
 
-    // FOLLOWUP #3 (27 May 2026) — tab 2 is "Cards" with a CreditCard icon
-    // (was "Devices" with a PhoneIphone). Route stays /devices for now since
-    // that's the existing destination page; rename / split lands when a
-    // dedicated cards listing page exists.
+    // Tab 2 "Cards" routes to the dedicated /cards listing page. (It briefly
+    // pointed at /devices before that page existed; Devices is now reached via
+    // Settings → Devices, resolving the tab→destination IA mismatch.)
     private static readonly Tab[] Tabs =
     [
         new("", "Home", Icons.Material.Filled.Home, "footer-nav-home"),
-        new("devices", "Cards", Icons.Material.Filled.CreditCard, "footer-nav-cards"),
+        new("cards", "Cards", Icons.Material.Filled.CreditCard, "footer-nav-cards"),
         new("activity", "Activity", Icons.Material.Filled.History, "footer-nav-activity"),
         new("settings", "Settings", Icons.Material.Filled.Settings, "footer-nav-settings"),
     ];

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor
@@ -1,0 +1,94 @@
+@*
+    SPDX-License-Identifier: MIT
+    Copyright (c) 2026 Sorcha Contributors
+
+    Cards (Feature 141 follow-on). The "manage all my cards" destination behind
+    the floating-nav Cards tab. Shows every held credential full-size in a single
+    thumb-scrollable column (vs. Home's glanceable peek/fan), each leading with a
+    plain-language status pill. Devices is reached from Settings, not here —
+    this resolves the prior tab→/devices IA mismatch.
+*@
+@page "/cards"
+@layout MainLayout
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+@using Sorcha.UI.Core.Components.Wallet
+@using Sorcha.Wallet.Pwa.Services
+@inject ICredentialCache Credentials
+@inject NavigationManager Nav
+
+<PageTitle>Your cards · Sorcha Wallet</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="pt-4">
+    <div class="cards-header">
+        <MudText Typo="Typo.h5">Your cards</MudText>
+        @if (_credentials is { Count: > 0 })
+        {
+            <span class="cards-header__count" data-testid="cards-count">@_credentials.Count</span>
+        }
+    </div>
+
+    @if (_credentials is null)
+    {
+        @* Shape-matched skeletons so the layout doesn't jump on load. *@
+        <div class="cards-list" data-testid="cards-loading">
+            @for (var i = 0; i < 3; i++)
+            {
+                <div class="credential-card-skeleton" aria-hidden="true"></div>
+            }
+        </div>
+    }
+    else if (_credentials.Count == 0)
+    {
+        <div class="cards-empty" data-testid="cards-empty">
+            <div class="cards-empty__ghost">
+                <MudIcon Icon="@Icons.Material.Filled.CreditCard" Size="Size.Large" />
+                <MudText Typo="Typo.subtitle1" Class="mt-2">No cards yet</MudText>
+                <MudText Typo="Typo.body2" Class="mud-text-secondary">
+                    Credentials you're issued will appear here as cards.
+                </MudText>
+            </div>
+            <button type="button" class="cards-add-cta" data-testid="cards-add-empty"
+                    @onclick="@(() => Nav.NavigateTo("applications"))">
+                <MudIcon Icon="@Icons.Material.Filled.Add" Size="Size.Small" />
+                <span>Add a credential</span>
+            </button>
+        </div>
+    }
+    else
+    {
+        <div class="cards-list" data-testid="cards-list">
+            @foreach (var c in _credentials)
+            {
+                var (status, statusText) =
+                    CredentialDisplay.ExpiryStatus(SdJwtReader.ReadExpiry(c.RawSdJwt), DateTimeOffset.UtcNow);
+                <CredentialWalletCard Issuer="@CredentialDisplay.Issuer(c)"
+                                      Name="@CredentialDisplay.Name(c)"
+                                      TypeLabel="@CredentialDisplay.TypeChip(c)"
+                                      Meta="@MetaFor(c)"
+                                      Status="@status"
+                                      StatusText="@statusText"
+                                      TestId="@($"cards-card-{c.Id}")"
+                                      OnActivated="@(() => Nav.NavigateTo($"credentials/{c.Id}"))" />
+            }
+            @* Dashed "add" affordance after the list. *@
+            <button type="button" class="cards-add-tile" data-testid="cards-add-tile"
+                    @onclick="@(() => Nav.NavigateTo("applications"))">
+                <MudIcon Icon="@Icons.Material.Filled.Add" />
+                <span>Add a card</span>
+            </button>
+        </div>
+    }
+</MudContainer>
+
+@code {
+    private IReadOnlyList<CachedCredential>? _credentials;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _credentials = await Credentials.ListAsync();
+    }
+
+    private static string MetaFor(CachedCredential c) =>
+        CredentialDisplay.IsDemo(c) ? "Demo · For testing only" : c.Vct;
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor.css
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: MIT
+   Copyright (c) 2026 Sorcha Contributors
+   Cards listing screen. Single thumb-scrollable column of full credential
+   cards. Surfaces/text follow the active MudBlazor palette (light/dark). */
+
+.cards-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.cards-header__count {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--mud-palette-text-secondary, #5a607a);
+}
+
+.cards-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* The shared card insets -24px to sit into the Home hero; there's no hero here,
+   so neutralise it (::deep pierces into the child component). */
+.cards-list ::deep .credential-wallet-card {
+    margin-top: 0;
+}
+
+/* ── Skeleton ─────────────────────────────────────────────────────────── */
+.credential-card-skeleton {
+    height: 158px;
+    border-radius: 16px;
+    background: linear-gradient(100deg,
+        var(--mud-palette-action-default-hover, rgba(120, 130, 170, .10)) 30%,
+        var(--mud-palette-lines-default, rgba(120, 130, 170, .18)) 50%,
+        var(--mud-palette-action-default-hover, rgba(120, 130, 170, .10)) 70%);
+    background-size: 200% 100%;
+    animation: cards-shimmer 1.3s ease-in-out infinite;
+}
+
+@keyframes cards-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+/* ── Empty state ──────────────────────────────────────────────────────── */
+.cards-empty {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.cards-empty__ghost {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 2px;
+    padding: 32px 20px;
+    border-radius: 16px;
+    border: 2px dashed var(--mud-palette-lines-default, rgba(120, 130, 170, .35));
+    color: var(--mud-palette-text-secondary, #5a607a);
+}
+
+/* ── Add affordances ──────────────────────────────────────────────────── */
+.cards-add-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 46px;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 700;
+    color: #fff;
+    background: var(--sorcha-gradient, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+}
+
+.cards-add-tile {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    height: 56px;
+    border-radius: 16px;
+    border: 2px dashed var(--mud-palette-lines-default, rgba(120, 130, 170, .35));
+    background: transparent;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--mud-palette-text-secondary, #5a607a);
+}
+
+.cards-add-tile:hover,
+.cards-add-cta:hover {
+    filter: brightness(1.03);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .credential-card-skeleton {
+        animation: none;
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/CredentialDetail.razor
@@ -2,17 +2,19 @@
     SPDX-License-Identifier: MIT
     Copyright (c) 2026 Sorcha Contributors
 
-    Credential detail (Feature 114, T111). Tap-through from a Home card —
-    shows full attribute list, issuer, expiry, status-list pointer, and the
-    raw SD-JWT for debugging. Disclosure-by-disclosure unpacking lands when
-    the libsodium bridge ships and the engine can decode disclosures
-    locally; v1 surfaces the available claim names as the wallet already
-    parses them from the cached credential.
+    Credential detail (Feature 114, T111). Tap-through from a card — leads with
+    plain-language status and the decoded claims (name → value), and tucks the
+    machine identifiers (issuer DID, credential id) and the raw SD-JWT behind
+    collapsed "Details" expanders with copy-to-clipboard. Claims are decoded in
+    pure .NET from the SD-JWT disclosures (no libsodium bridge needed — that is
+    the at-rest cache cipher, a separate concern).
 *@
 @page "/credentials/{Id:guid}"
 @layout MainLayout
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize]
+@using Sorcha.UI.Core.Components.Forms
+@using Sorcha.UI.Core.Components.Wallet
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Presentation
 @inject ICredentialCache Credentials
@@ -42,38 +44,62 @@
         <MudCard Class="mb-3">
             <MudCardHeader>
                 <CardHeaderContent>
-                    <MudText Typo="Typo.h6">@(_credential.DisplayLabel ?? _credential.Vct)</MudText>
-                    <MudText Typo="Typo.caption" Color="Color.Secondary">@_credential.Vct</MudText>
+                    <MudText Typo="Typo.h6">@_title</MudText>
+                    @if (_caption is not null)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@_caption</MudText>
+                    }
                 </CardHeaderContent>
             </MudCardHeader>
             <MudCardContent>
-                <MudList T="string" Dense="true">
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.Fingerprint">
-                        <MudText Typo="Typo.body2">
-                            <strong>Credential id:</strong> @_credential.Id
-                        </MudText>
-                    </MudListItem>
-                    @if (!string.IsNullOrEmpty(_credential.IssuerDid))
-                    {
-                        <MudListItem T="string" Icon="@Icons.Material.Filled.Business">
-                            <MudText Typo="Typo.body2">
-                                <strong>Issuer:</strong> @_credential.IssuerDid
-                            </MudText>
-                        </MudListItem>
-                    }
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.Description">
-                        <MudText Typo="Typo.body2">
-                            <strong>Disclosable claims:</strong>
-                            @(_credential.AvailableClaimNames.Count == 0
-                                ? "(none yet — disclosures decoded when libsodium bridge ships)"
-                                : string.Join(", ", _credential.AvailableClaimNames))
-                        </MudText>
-                    </MudListItem>
-                </MudList>
+                @* Lead with plain-language status. *@
+                <div class="d-flex align-center gap-1 mb-3" data-testid="credential-detail-status">
+                    <MudIcon Icon="@_statusIcon" Color="@_statusColor" Size="Size.Small" />
+                    <MudText Typo="Typo.body1" Color="@_statusColor">@_statusText</MudText>
+                </div>
+
+                @if (_claims.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary" data-testid="credential-detail-no-claims">
+                        This credential discloses no individual claims.
+                    </MudText>
+                }
+                else
+                {
+                    <MudList T="string" Dense="true" data-testid="credential-detail-claims">
+                        @foreach (var claim in _claims)
+                        {
+                            <MudListItem T="string">
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@PrettyName(claim.Name)</MudText>
+                                <MudText Typo="Typo.body1">@claim.Value</MudText>
+                            </MudListItem>
+                        }
+                    </MudList>
+                }
             </MudCardContent>
         </MudCard>
 
-        <MudExpansionPanels Class="mb-3">
+        @* Progressive disclosure — machine identifiers stay collapsed. *@
+        <MudExpansionPanels Class="mb-3" data-testid="credential-detail-details">
+            <MudExpansionPanel Text="Details">
+                <div class="mb-3">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Credential ID</MudText>
+                    <div class="d-flex align-center gap-1">
+                        <MudText Typo="Typo.body2" Style="word-break:break-all; font-family:monospace;">@_credential.Id</MudText>
+                        <CopyButton Value="@_credential.Id.ToString()" Variant="CopyButtonVariant.IconButton" Label="Copy credential ID" />
+                    </div>
+                </div>
+                @if (!string.IsNullOrEmpty(_credential.IssuerDid))
+                {
+                    <div class="mb-1">
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">Issued by</MudText>
+                        <div class="d-flex align-center gap-1">
+                            <MudText Typo="Typo.body2" Style="word-break:break-all; font-family:monospace;">@_credential.IssuerDid</MudText>
+                            <CopyButton Value="@_credential.IssuerDid" Variant="CopyButtonVariant.IconButton" Label="Copy issuer DID" />
+                        </div>
+                    </div>
+                }
+            </MudExpansionPanel>
             <MudExpansionPanel Text="Raw SD-JWT (debug)">
                 <MudText Typo="Typo.caption" Style="word-break:break-all; font-family:monospace;">
                     @_credential.RawSdJwt
@@ -96,10 +122,43 @@
     private CachedCredential? _credential;
     private bool _loading = true;
 
+    private string _title = "";
+    private string? _caption;
+    private IReadOnlyList<DisclosedClaim> _claims = Array.Empty<DisclosedClaim>();
+    private string _statusText = "Valid";
+    private string _statusIcon = Icons.Material.Filled.CheckCircle;
+    private Color _statusColor = Color.Success;
+
     protected override async Task OnInitializedAsync()
     {
         var all = await Credentials.ListAsync();
         _credential = all.FirstOrDefault(c => c.Id == Id);
         _loading = false;
+
+        if (_credential is null) return;
+
+        _title = CredentialDisplay.Name(_credential);
+        // Only show a caption when it adds information beyond the title.
+        var issuer = CredentialDisplay.Issuer(_credential);
+        _caption = string.Equals(issuer, _title, StringComparison.OrdinalIgnoreCase) ? null : issuer;
+
+        _claims = SdJwtReader.ReadDisclosedClaims(_credential.RawSdJwt);
+
+        var (status, text) = CredentialDisplay.ExpiryStatus(
+            SdJwtReader.ReadExpiry(_credential.RawSdJwt), DateTimeOffset.UtcNow);
+        (_statusText, _statusIcon, _statusColor) = status switch
+        {
+            CredentialStatus.ExpiringSoon => (text ?? "Expiring soon", Icons.Material.Filled.Schedule, Color.Warning),
+            CredentialStatus.Revoked => (text ?? "Expired", Icons.Material.Filled.Cancel, Color.Error),
+            _ => ("Valid", Icons.Material.Filled.CheckCircle, Color.Success),
+        };
+    }
+
+    private static string PrettyName(string name)
+    {
+        // snake_case / camelCase claim key → readable label.
+        var spaced = name.Replace('_', ' ').Replace('-', ' ').Trim();
+        if (spaced.Length == 0) return name;
+        return char.ToUpperInvariant(spaced[0]) + spaced[1..];
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
@@ -48,12 +48,7 @@
                 <MudText Typo="Typo.body1">Auth methods</MudText>
                 <MudText Typo="Typo.caption" Class="mud-text-secondary">Passkeys, social logins, and recovery email.</MudText>
             </MudListItem>
-            <MudListItem T="string" Icon="@Icons.Material.Filled.History"
-                         OnClick="@GoActivity"
-                         data-testid="settings-link-activity">
-                <MudText Typo="Typo.body1">Activity</MudText>
-                <MudText Typo="Typo.caption" Class="mud-text-secondary">Recent credential and verification events.</MudText>
-            </MudListItem>
+            @* Activity lives in its own floating-nav tab — no duplicate row here. *@
         </MudList>
     </MudPaper>
 
@@ -156,7 +151,6 @@
     private void GoProfile() => Nav.NavigateTo("profile");
     private void GoDevices() => Nav.NavigateTo("devices");
     private void GoAuthMethods() => Nav.NavigateTo("auth-methods");
-    private void GoActivity() => Nav.NavigateTo("activity");
 
     private bool _replayConfirmed;
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/CredentialDisplay.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/CredentialDisplay.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using Sorcha.UI.Core.Components.Wallet;
 using Sorcha.UI.Core.Models.Presentation;
 
 namespace Sorcha.Wallet.Pwa.Services;
@@ -71,6 +72,25 @@ public static class CredentialDisplay
             spaced = spaced[..^" Credential".Length];
 
         return spaced.Length == 0 ? "Credential" : spaced;
+    }
+
+    /// <summary>
+    /// Derive a card status pill from a credential's expiry. No expiry known →
+    /// presumed Valid (a held credential works until a status check says
+    /// otherwise — revocation is a separate, status-list concern). Within
+    /// 14 days → ExpiringSoon; already past → Revoked/"Expired".
+    /// </summary>
+    public static (CredentialStatus Status, string? Text) ExpiryStatus(
+        DateTimeOffset? expiry, DateTimeOffset nowUtc)
+    {
+        if (expiry is null) return (CredentialStatus.Valid, null);
+        if (expiry.Value <= nowUtc) return (CredentialStatus.Revoked, "Expired");
+
+        var days = (int)Math.Ceiling((expiry.Value - nowUtc).TotalDays);
+        if (days <= 14)
+            return (CredentialStatus.ExpiringSoon, days <= 1 ? "Expires today" : $"Expires in {days} days");
+
+        return (CredentialStatus.Valid, null);
     }
 
     /// <summary>

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/SdJwtReader.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/SdJwtReader.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>One disclosed SD-JWT claim — a human name and its rendered value.</summary>
+public sealed record DisclosedClaim(string Name, string Value);
+
+/// <summary>
+/// Reads the disclosed claims and expiry out of a cached SD-JWT VC, in pure
+/// .NET (Base64Url → JSON of <c>[salt, name, value]</c>). This does NOT need
+/// the libsodium / xchacha bridge — that's the at-rest cache cipher, a separate
+/// concern from decoding the (already-plaintext) disclosure segments.
+/// </summary>
+public static class SdJwtReader
+{
+    /// <summary>
+    /// Returns the name→value pairs the wallet holds for this credential.
+    /// Skips array-element disclosures (2-tuples, no name) and any segment that
+    /// fails to decode. Order is the on-wire disclosure order.
+    /// </summary>
+    public static IReadOnlyList<DisclosedClaim> ReadDisclosedClaims(string? rawSdJwt)
+    {
+        var result = new List<DisclosedClaim>();
+        if (string.IsNullOrWhiteSpace(rawSdJwt)) return result;
+
+        var segments = rawSdJwt.Split('~');
+        if (segments.Length < 2) return result;
+
+        // A trailing key-binding JWT (3 dot-separated parts) is not a disclosure.
+        var last = segments[^1];
+        var hasKbJwt = !string.IsNullOrEmpty(last) && last.Count(c => c == '.') == 2;
+        var disclosureCount = segments.Length - 1 - (hasKbJwt ? 1 : 0);
+
+        for (var i = 1; i <= disclosureCount; i++)
+        {
+            var seg = segments[i];
+            if (string.IsNullOrEmpty(seg)) continue;
+            try
+            {
+                var bytes = Base64Url.DecodeFromChars(seg);
+                using var doc = JsonDocument.Parse(bytes);
+                var root = doc.RootElement;
+                if (root.ValueKind != JsonValueKind.Array || root.GetArrayLength() != 3) continue;
+
+                var name = root[1].GetString();
+                if (string.IsNullOrEmpty(name)) continue;
+                result.Add(new DisclosedClaim(name, JsonValueToString(root[2])));
+            }
+            catch
+            {
+                // Undecodable / malformed disclosure — skip, don't break the page.
+            }
+        }
+        return result;
+    }
+
+    /// <summary>Reads the credential's <c>exp</c> claim (the JWT body before the first '~').</summary>
+    public static DateTimeOffset? ReadExpiry(string? rawSdJwt)
+    {
+        if (string.IsNullOrWhiteSpace(rawSdJwt)) return null;
+
+        var jwt = rawSdJwt.Split('~')[0];
+        var parts = jwt.Split('.');
+        if (parts.Length < 2) return null;
+
+        try
+        {
+            var bytes = Base64Url.DecodeFromChars(parts[1]);
+            using var doc = JsonDocument.Parse(bytes);
+            if (doc.RootElement.TryGetProperty("exp", out var exp) && exp.ValueKind == JsonValueKind.Number)
+                return DateTimeOffset.FromUnixTimeSeconds(exp.GetInt64());
+        }
+        catch
+        {
+            // Not a decodable JWT body — treat as "no expiry known".
+        }
+        return null;
+    }
+
+    private static string JsonValueToString(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString() ?? string.Empty,
+        JsonValueKind.True => "Yes",
+        JsonValueKind.False => "No",
+        JsonValueKind.Null => string.Empty,
+        JsonValueKind.Number => value.GetRawText(),
+        _ => value.GetRawText(),
+    };
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Wallet/CredentialWalletCardTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Wallet/CredentialWalletCardTests.cs
@@ -52,4 +52,48 @@ public sealed class CredentialWalletCardTests : ComponentTestFixture
 
         cut.Find(".credential-wallet-card__type-chip").TextContent.Trim().Should().Be("ID");
     }
+
+    [Fact]
+    public void StatusNone_RendersNoPill()
+    {
+        var cut = Render<CredentialWalletCard>(ps => ps
+            .Add(p => p.Issuer, "sorcha.dev").Add(p => p.Name, "Assured Identity"));
+
+        cut.FindAll(".credential-wallet-card__status").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidStatus_RendersValidPill()
+    {
+        var cut = Render<CredentialWalletCard>(ps => ps
+            .Add(p => p.Issuer, "sorcha.dev").Add(p => p.Name, "Assured Identity")
+            .Add(p => p.Status, CredentialStatus.Valid));
+
+        var pill = cut.Find(".credential-wallet-card__status");
+        pill.ClassList.Should().Contain("credential-wallet-card__status--valid");
+        pill.TextContent.Trim().Should().Be("Valid");
+    }
+
+    [Fact]
+    public void ExpiringStatus_UsesStatusTextOverride()
+    {
+        var cut = Render<CredentialWalletCard>(ps => ps
+            .Add(p => p.Issuer, "sorcha.dev").Add(p => p.Name, "Assured Identity")
+            .Add(p => p.Status, CredentialStatus.ExpiringSoon)
+            .Add(p => p.StatusText, "Expires in 3 days"));
+
+        cut.Find(".credential-wallet-card__status").TextContent.Trim().Should().Be("Expires in 3 days");
+    }
+
+    [Fact]
+    public void RevokedStatus_DimsCard_AndShowsRevokedPill()
+    {
+        var cut = Render<CredentialWalletCard>(ps => ps
+            .Add(p => p.Issuer, "sorcha.dev").Add(p => p.Name, "Assured Identity")
+            .Add(p => p.Status, CredentialStatus.Revoked));
+
+        cut.Find(".credential-wallet-card").ClassList.Should().Contain("credential-wallet-card--revoked");
+        cut.Find(".credential-wallet-card__status").ClassList
+            .Should().Contain("credential-wallet-card__status--revoked");
+    }
 }

--- a/tests/Sorcha.UI.Core.Tests/Components/Wallet/WalletChromeComponentTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Wallet/WalletChromeComponentTests.cs
@@ -167,7 +167,7 @@ public sealed class WalletChromeComponentTests : BunitContext
     [Fact]
     public void FloatingTabBar_ActiveTab_IsHighlightedAndLabelled_OthersIconOnly()
     {
-        var cut = Render<FloatingTabBar>(ps => ps.Add(p => p.ActiveRoute, "devices"));
+        var cut = Render<FloatingTabBar>(ps => ps.Add(p => p.ActiveRoute, "cards"));
 
         var cards = cut.Find("[data-testid='footer-nav-cards']");
         cards.ClassList.Should().Contain("tab-pill--active");

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletNavigationTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/CitizenWalletNavigationTests.cs
@@ -64,7 +64,7 @@ public class CitizenWalletNavigationTests : AuthenticatedCitizenWalletTestBase
     {
         get
         {
-            yield return new TestCaseData("footer-nav-devices", "devices").SetName("Footer Devices → /wallet/devices");
+            yield return new TestCaseData("footer-nav-cards", "cards").SetName("Footer Cards → /wallet/cards");
             yield return new TestCaseData("footer-nav-activity", "activity").SetName("Footer Activity → /wallet/activity");
             yield return new TestCaseData("footer-nav-settings", "settings").SetName("Footer Settings → /wallet/settings");
         }

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/WalletHomeResponsiveTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/WalletHomeResponsiveTests.cs
@@ -92,7 +92,7 @@ public class WalletHomeResponsiveTests : AuthenticatedCitizenWalletTestBase
         foreach (var (id, name) in new[]
                  {
                      ("footer-nav-home", "Home"),
-                     ("footer-nav-devices", "Devices"),
+                     ("footer-nav-cards", "Cards"),
                      ("footer-nav-activity", "Activity"),
                      ("footer-nav-settings", "Settings"),
                  })

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/CardsPageTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/CardsPageTests.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+using CardsPage = Sorcha.Wallet.Pwa.Pages.Cards;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// bUnit tests for the Cards listing page — the dedicated "manage all my cards"
+/// destination behind the floating-nav Cards tab.
+/// </summary>
+public sealed class CardsPageTests : ComponentTestFixture
+{
+    private readonly Mock<ICredentialCache> _cache = new();
+
+    public CardsPageTests() => Services.AddSingleton(_cache.Object);
+
+    private static CachedCredential Cred(string name) => new()
+    {
+        Id = Guid.NewGuid(),
+        Vct = "AssuredIdentityCredential",
+        RawSdJwt = "eyJ.body.sig~",
+        AvailableClaimNames = new List<string>(),
+        DisplayLabel = name,
+    };
+
+    [Fact]
+    public void NoCredentials_ShowsEmptyStateWithAddCta()
+    {
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CachedCredential>());
+
+        var cut = Render<CardsPage>();
+
+        cut.FindAll("[data-testid=cards-empty]").Should().ContainSingle();
+        cut.FindAll("[data-testid=cards-add-empty]").Should().ContainSingle();
+        cut.FindAll("[data-testid=cards-list]").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithCredentials_RendersFullCardsPlusAddTile_AndCount()
+    {
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CachedCredential> { Cred("Treasury"), Cred("Operations") });
+
+        var cut = Render<CardsPage>();
+
+        cut.FindAll("[data-testid=cards-list]").Should().ContainSingle();
+        cut.FindAll(".credential-wallet-card").Should().HaveCount(2);
+        cut.FindAll("[data-testid=cards-add-tile]").Should().ContainSingle();
+        cut.Find("[data-testid=cards-count]").TextContent.Trim().Should().Be("2");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Pages/CredentialDetailTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Pages/CredentialDetailTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using MudBlazor;
+using Sorcha.UI.Core.Models.Presentation;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+using DetailPage = Sorcha.Wallet.Pwa.Pages.CredentialDetail;
+
+namespace Sorcha.Wallet.Pwa.Tests.Pages;
+
+/// <summary>
+/// bUnit tests for the redesigned credential detail page: decoded claims,
+/// progressive disclosure of machine identifiers, and no stale "libsodium" copy.
+/// </summary>
+public sealed class CredentialDetailTests : ComponentTestFixture
+{
+    private readonly Mock<ICredentialCache> _cache = new();
+
+    public CredentialDetailTests() => Services.AddSingleton(_cache.Object);
+
+    // The detail page uses MudExpansionPanels, which asserts a MudPopoverProvider
+    // in the tree (provided by MainLayout in the app).
+    private static RenderFragment PageWithProvider(Guid id) => b =>
+    {
+        b.OpenComponent<MudPopoverProvider>(0);
+        b.CloseComponent();
+        b.OpenComponent<DetailPage>(1);
+        b.AddAttribute(2, nameof(DetailPage.Id), id);
+        b.CloseComponent();
+    };
+
+    private static string Disclosure(string name, string value) =>
+        Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new[] { "salt", name, value }));
+
+    private static CachedCredential CredWithClaims(Guid id)
+    {
+        var exp = DateTimeOffset.UtcNow.AddDays(90).ToUnixTimeSeconds();
+        var jwt = "eyJhbGciOiJFUzI1NiJ9." +
+                  Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new { exp })) + ".sig";
+        var raw = jwt + "~" + Disclosure("given_name", "Ada") + "~" + Disclosure("family_name", "Lovelace") + "~";
+        return new CachedCredential
+        {
+            Id = id,
+            Vct = "AssuredIdentityCredential",
+            RawSdJwt = raw,
+            AvailableClaimNames = new List<string> { "given_name", "family_name" },
+            IssuerDid = "did:sorcha:org:WS11QRNVabcdefghijHGNRK",
+            DisplayLabel = "Assured Identity",
+        };
+    }
+
+    [Fact]
+    public void RendersDecodedClaims_AndDetailsExpander_NoLibsodiumCopy()
+    {
+        var id = Guid.NewGuid();
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CachedCredential> { CredWithClaims(id) });
+
+        var cut = Render(PageWithProvider(id));
+
+        // Decoded claim values are shown (name → value), not just claim names.
+        var claims = cut.Find("[data-testid=credential-detail-claims]").TextContent;
+        claims.Should().Contain("Ada");
+        claims.Should().Contain("Lovelace");
+
+        // Machine identifiers live behind the Details expander.
+        cut.FindAll("[data-testid=credential-detail-details]").Should().ContainSingle();
+
+        // Plain-language status leads.
+        cut.Find("[data-testid=credential-detail-status]").TextContent.Should().Contain("Valid");
+
+        // The stale "libsodium bridge" hedge is gone.
+        cut.Markup.Should().NotContain("libsodium");
+    }
+
+    [Fact]
+    public void MissingCredential_ShowsNotFound()
+    {
+        _cache.Setup(c => c.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CachedCredential>());
+
+        var cut = Render(PageWithProvider(Guid.NewGuid()));
+
+        cut.Markup.Should().Contain("Credential not found");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/CredentialDisplayTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/CredentialDisplayTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Sorcha.UI.Core.Components.Wallet;
 using Sorcha.UI.Core.Models.Presentation;
 using Sorcha.Wallet.Pwa.Services;
 using Xunit;
@@ -92,5 +93,37 @@ public sealed class CredentialDisplayTests
         CredentialDisplay.TypeChip(Cred(vct: "DrivingLicenceCredential")).Should().Be("DL");
         // Unknown type → no chip (a wrong-looking chip is worse than none).
         CredentialDisplay.TypeChip(Cred(vct: "SomeObscureThing")).Should().BeNull();
+    }
+
+    [Fact]
+    public void ExpiryStatus_NoExpiry_IsValid()
+    {
+        var now = DateTimeOffset.UtcNow;
+        CredentialDisplay.ExpiryStatus(null, now).Should().Be((CredentialStatus.Valid, (string?)null));
+    }
+
+    [Fact]
+    public void ExpiryStatus_FarFuture_IsValid()
+    {
+        var now = DateTimeOffset.UtcNow;
+        CredentialDisplay.ExpiryStatus(now.AddDays(90), now).Status.Should().Be(CredentialStatus.Valid);
+    }
+
+    [Fact]
+    public void ExpiryStatus_WithinTwoWeeks_IsExpiringSoon_WithText()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var (status, text) = CredentialDisplay.ExpiryStatus(now.AddDays(3), now);
+        status.Should().Be(CredentialStatus.ExpiringSoon);
+        text.Should().Be("Expires in 3 days");
+    }
+
+    [Fact]
+    public void ExpiryStatus_Past_IsRevokedExpired()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var (status, text) = CredentialDisplay.ExpiryStatus(now.AddDays(-1), now);
+        status.Should().Be(CredentialStatus.Revoked);
+        text.Should().Be("Expired");
     }
 }

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/SdJwtReaderTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/SdJwtReaderTests.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Buffers.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Sorcha.Wallet.Pwa.Services;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="SdJwtReader"/> — pure-.NET SD-JWT disclosure +
+/// expiry decoding (the credential detail page reuses this; no libsodium).
+/// </summary>
+public sealed class SdJwtReaderTests
+{
+    private static string Disclosure(string salt, string name, object value) =>
+        Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(new[] { salt, name, value?.ToString() ?? "" }));
+
+    private static string JwtBody(object payload) =>
+        "eyJhbGciOiJFUzI1NiJ9." +
+        Base64Url.EncodeToString(JsonSerializer.SerializeToUtf8Bytes(payload)) +
+        ".c2ln";
+
+    [Fact]
+    public void ReadDisclosedClaims_ReturnsNameValuePairs_SkippingKbJwtAndEmpties()
+    {
+        var sd = JwtBody(new { vct = "AssuredIdentityCredential" })
+            + "~" + Disclosure("s1", "given_name", "Ada")
+            + "~" + Disclosure("s2", "family_name", "Lovelace")
+            + "~";
+
+        var claims = SdJwtReader.ReadDisclosedClaims(sd);
+
+        claims.Should().HaveCount(2);
+        claims.Should().ContainEquivalentOf(new DisclosedClaim("given_name", "Ada"));
+        claims.Should().ContainEquivalentOf(new DisclosedClaim("family_name", "Lovelace"));
+    }
+
+    [Fact]
+    public void ReadDisclosedClaims_EmptyOrNull_ReturnsEmpty()
+    {
+        SdJwtReader.ReadDisclosedClaims(null).Should().BeEmpty();
+        SdJwtReader.ReadDisclosedClaims("").Should().BeEmpty();
+        SdJwtReader.ReadDisclosedClaims("just.a.jwt").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReadExpiry_ReadsExpClaim()
+    {
+        var exp = DateTimeOffset.UtcNow.AddDays(30).ToUnixTimeSeconds();
+        var sd = JwtBody(new { exp }) + "~";
+
+        SdJwtReader.ReadExpiry(sd)!.Value.ToUnixTimeSeconds().Should().Be(exp);
+    }
+
+    [Fact]
+    public void ReadExpiry_NoExp_ReturnsNull()
+    {
+        var sd = JwtBody(new { vct = "X" }) + "~";
+        SdJwtReader.ReadExpiry(sd).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Completes the 6 Jun wallet design review (P2/P3) in one PR, building on the merged P1 (#968). Incorporates the design-AI spec for the new Cards screen.

### Cards listing page + tab IA (P2)
New `/cards` — the "manage all my cards" destination. Single thumb-scrollable column of **full** credential cards (vs Home's peek/fan), each leading with a **status pill**; "Your cards" + count header; shape-matched **skeleton** loading; ghost empty-state with an "Add a credential" CTA; dashed "Add a card" tile. Reuses `CredentialWalletCard`. **Floating-nav tab 2 now routes to `/cards`** (was `/devices` — the longstanding IA mismatch); Devices is reached via Settings.

### Card status pill (P2)
`CredentialWalletCard` gains a `CredentialStatus` enum + `StatusText` → a `__status` pill (success/warn/error dot), revoked dimming. Home and Cards share the one component. **Data:** status is computed from the SD-JWT `exp` (real) — Valid / "Expires in N days" / Expired. *Revocation (status-list) is wired in the enum but not yet populated — a follow-up needing a per-card async lookup; not faked.*

### Credential detail redesign (P2)
Leads with plain-language status; shows **decoded claims** as name→value rows (new pure-.NET `SdJwtReader`); suppresses the redundant VCT caption; moves Credential ID + issuer DID behind a collapsed **Details** expander, word-broken, each with a `CopyButton`.

### P3
- "libsodium bridge" hedge removed — disclosures decode in pure .NET (`SdJwtReader`); libsodium is the at-rest cache cipher, a separate concern.
- Settings: dropped the duplicate **Activity** row (it's a floating-nav tab); Devices stays.

## Testing
- New: `SdJwtReader` (4), `ExpiryStatus` (4), card status pill (5), Cards page (2), detail page (2).
- Full suites green: **PWA 192/192**, **UI.Core 1364/1364**. UI sln + E2E build 0/0; snackbar gate passes. Fixed two stale `footer-nav-devices` test assertions → `footer-nav-cards`.

## Not verified / follow-ups
- CSS-only visuals (status pill, skeleton, Cards layout, revoked dimming) aren't bUnit-checkable — covered structurally + by the Docker-gated Playwright responsive tests, which I couldn't run locally. Worth a look on the next n1 deploy.
- Revocation status needs status-list plumbing (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)