### PR TITLE
fix(pwa): R2 — viewport-aware inbox, humanized titles, card meta/align, Settings

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
@@ -8,6 +8,7 @@
 @inject ILogger<InboxPanel> Logger
 @using Microsoft.Extensions.Logging
 @using Sorcha.UI.Core.Services
+@using Sorcha.UI.Core.Components.Wallet
 @using MudBlazor
 
 @*
@@ -22,7 +23,7 @@
     from MainLayout. Future Phase-10 work consolidates them.
 *@
 
-<MudDrawer @bind-Open="IsOpen" Anchor="Anchor.End" Elevation="4" Width="420px" Variant="@DrawerVariant.Temporary">
+<MudDrawer @bind-Open="IsOpen" Anchor="Anchor.End" Elevation="4" Width="420px" Variant="@DrawerVariant.Temporary" data-testid="inbox-drawer">
     <MudDrawerHeader>
         <MudText Typo="Typo.h6">Inbox</MudText>
         <MudSpacer />
@@ -77,7 +78,9 @@
                                      Color="@SeverityColor(entry.Severity)"
                                      Size="Size.Small" />
                             <MudText Typo="Typo.body2">
-                                <strong>@entry.Title</strong>
+                                @* Fallback humanizer: a server-written friendly title passes through;
+                                   a raw VCT token (e.g. AssuredIdentityCredential) is humanized. *@
+                                <strong>@CredentialDisplay.HumanizeCredentialMentions(entry.Title)</strong>
                             </MudText>
                             @if (isUnread)
                             {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor.css
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: MIT
+   Copyright (c) 2026 Sorcha Contributors
+
+   Viewport-aware inbox drawer. The hard-coded 420px width pushed the drawer's
+   left edge off-screen on a phone (~390px), clipping the header, category
+   chips, and every entry's title + timestamp. Cap to the viewport: a 420px
+   side panel on tablet/desktop, a full-width sheet on phones. */
+::deep .mud-drawer {
+    width: min(420px, 100vw) !important;
+    max-width: 100vw;
+}

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialDisplay.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialDisplay.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Text;
-using Sorcha.UI.Core.Components.Wallet;
+using System.Text.RegularExpressions;
 using Sorcha.UI.Core.Models.Presentation;
 
-namespace Sorcha.Wallet.Pwa.Services;
+namespace Sorcha.UI.Core.Components.Wallet;
 
 /// <summary>
 /// Derives the human-readable text shown on a wallet credential card / peek
@@ -91,6 +91,35 @@ public static class CredentialDisplay
             return (CredentialStatus.ExpiringSoon, days <= 1 ? "Expires today" : $"Expires in {days} days");
 
         return (CredentialStatus.Valid, null);
+    }
+
+    // Matches a PascalCase credential-type token (ending in "Credential"),
+    // optionally preceded by the article "a"/"an" so we can correct it.
+    private static readonly Regex CredentialMention =
+        new(@"\b(?:(a|an)\s+)?([A-Z][A-Za-z0-9]+Credential)\b",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Humanize any raw PascalCase credential-type tokens embedded in a free-text
+    /// string (e.g. a server-composed inbox title), fixing the preceding article.
+    /// "…issued you a AssuredIdentityCredential" → "…issued you an Assured Identity
+    /// credential". A no-op when the text carries no such token, so a friendly
+    /// title written by the issuer passes through unchanged.
+    /// </summary>
+    public static string HumanizeCredentialMentions(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return text ?? string.Empty;
+
+        return CredentialMention.Replace(text, m =>
+        {
+            var humanized = Humanize(m.Groups[2].Value);
+            var phrase = $"{humanized} credential";
+            if (!m.Groups[1].Success) return phrase;
+
+            var startsVowel = humanized.Length > 0 && "aeiouAEIOU".IndexOf(humanized[0]) >= 0;
+            var article = startsVowel ? "an" : "a";
+            return $"{article} {phrase}";
+        });
     }
 
     /// <summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialWalletCard.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/CredentialWalletCard.razor.css
@@ -39,9 +39,14 @@
 
 .credential-wallet-card__heading {
     min-width: 0;
+    /* The card is a <button> (UA default text-align:center) — force left so the
+       eyebrow + name sit flush to the padding like a physical wallet card,
+       rather than clustering centre with the chip/QR hugging the corners. */
+    text-align: left;
 }
 
 .credential-wallet-card__eyebrow {
+    text-align: left;
     font-size: 10px;
     font-weight: 700;
     letter-spacing: .12em;
@@ -57,6 +62,7 @@
 }
 
 .credential-wallet-card__name {
+    text-align: left;
     font-size: 18px;
     font-weight: 800;
     letter-spacing: -.01em;

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor
@@ -90,5 +90,5 @@
     }
 
     private static string MetaFor(CachedCredential c) =>
-        CredentialDisplay.IsDemo(c) ? "Demo · For testing only" : c.Vct;
+        CredentialDisplay.IsDemo(c) ? "Demo · For testing only" : "";
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
@@ -579,11 +579,11 @@
     // Card accent — brand blue today; later, pull from issuer registry / theme.
     private static string AccentFor(CachedCredential c) => "#667eea";
 
-    // The bottom meta line. Issuer eyebrow / name / type chip are derived by the
-    // shared CredentialDisplay helper (unit-tested); the demo meta callout stays
-    // here as it is purely presentational.
+    // The bottom meta line. The card name already carries the (humanized) type
+    // and the eyebrow the issuer, so a real credential needs no meta — only the
+    // demo callout is surfaced (echoing the raw VCT here was redundant + ugly).
     private static string MetaFor(CachedCredential c) =>
-        CredentialDisplay.IsDemo(c) ? "Demo · For testing only" : c.Vct;
+        CredentialDisplay.IsDemo(c) ? "Demo · For testing only" : "";
 
     /// <summary>
     /// Coarse "x ago" rendering for the last-synced hint. Computed at render

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
@@ -107,19 +107,9 @@
         </MudCardContent>
     </MudCard>
 
-    <MudCard Class="mb-3">
-        <MudCardHeader>
-            <CardHeaderContent>
-                <MudText Typo="Typo.subtitle1">Session</MudText>
-            </CardHeaderContent>
-        </MudCardHeader>
-        <MudCardContent>
-            <MudButton StartIcon="@Icons.Material.Filled.Lock"
-                       Variant="Variant.Outlined" Disabled="true">
-                Lock now (biometric gate — tier 4 polish)
-            </MudButton>
-        </MudCardContent>
-    </MudCard>
+    @* The "Lock now (biometric gate)" placeholder card was removed — it was a
+       permanently-disabled dev-copy button. The biometric lock surfaces here
+       again when the feature ships. *@
 
     @* Feature 125 / PR-F (T108) — Replay tour. Resets the per-device
        TourDismissedAt flag so MainLayout fires the guided tour again on

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
@@ -24,10 +24,12 @@ html, body {
     color: var(--mud-palette-text-primary, #0f1024);
 }
 
-/* Feature 141 — reserve space for the floating tab bar (56px bar + 14px inset
-   + breathing room + iOS home indicator) so page content is never obscured. */
+/* Feature 141 — reserve space for the floating tab bar so page content is never
+   obscured: 56px bar + 14px bottom inset + its ~36px drop-shadow + breathing
+   room + iOS home indicator. (Bumped from 92px — the last Settings block was
+   peeking under the bar's shadow.) */
 .wallet-content {
-    padding-bottom: calc(92px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(116px + env(safe-area-inset-bottom, 0px));
 }
 
 /* On Home the gradient hero is the header (no app bar), so content starts at

--- a/tests/Sorcha.UI.Core.Tests/Components/Inbox/InboxPanelTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Inbox/InboxPanelTests.cs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MudBlazor;
+using Sorcha.UI.Core.Components.Inbox;
+using Sorcha.UI.Core.Services;
+using Sorcha.UI.Testing;
+using Xunit;
+
+namespace Sorcha.UI.Core.Tests.Components.Inbox;
+
+/// <summary>
+/// bUnit tests for the inbox drawer. Guards the wallet-side title humanizer:
+/// a server-composed title carrying a raw PascalCase VCT is rendered humanized,
+/// never as the machine token.
+/// </summary>
+public sealed class InboxPanelTests : ComponentTestFixture
+{
+    private readonly Mock<IInboxApiService> _api = new();
+
+    public InboxPanelTests()
+    {
+        Services.AddLogging();
+        Services.AddSingleton(_api.Object);
+        // TenantHubConnection is sealed but does not connect in its ctor — a real
+        // instance is fine; InboxPanel only subscribes to its OnInboxEntryAdded event.
+        Services.AddSingleton(new TenantHubConnection(
+            "http://test.local",
+            () => Task.FromResult<string?>(null),
+            NullLogger<TenantHubConnection>.Instance,
+            _api.Object));
+    }
+
+    private static InboxEntryDto Entry(string title) => new()
+    {
+        Id = Guid.NewGuid(),
+        PlatformUserId = Guid.NewGuid(),
+        Category = "Credential",
+        Severity = "Info",
+        CorrelationKey = "k",
+        DetailHref = "",
+        SourceEventId = Guid.NewGuid(),
+        OccurredAt = DateTimeOffset.UtcNow,
+        Title = title,
+    };
+
+    private RenderFragment OpenPanelWith(string title) => builder =>
+    {
+        _api.Setup(a => a.ListAsync(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InboxPageDto(new List<InboxEntryDto> { Entry(title) }, 1, 50, 1));
+
+        builder.OpenComponent<MudPopoverProvider>(0);
+        builder.CloseComponent();
+        builder.OpenComponent<InboxPanel>(1);
+        builder.AddAttribute(2, nameof(InboxPanel.IsOpen), true);
+        builder.CloseComponent();
+    };
+
+    [Fact]
+    public void RawVctInTitle_RendersHumanized_NeverPascalToken()
+    {
+        var cut = Render(OpenPanelWith("Acme Verification Co. issued you a AssuredIdentityCredential"));
+
+        cut.Markup.Should().Contain("Assured Identity credential");
+        cut.Markup.Should().NotContain("AssuredIdentityCredential");
+    }
+
+    [Fact]
+    public void FriendlyTitle_PassesThroughUnchanged()
+    {
+        var cut = Render(OpenPanelWith("Your council application was approved"));
+
+        cut.Markup.Should().Contain("Your council application was approved");
+    }
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Wallet/CredentialWalletCardTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Wallet/CredentialWalletCardTests.cs
@@ -32,6 +32,20 @@ public sealed class CredentialWalletCardTests : ComponentTestFixture
     }
 
     [Fact]
+    public void EmptyMeta_OmitsMetaLine()
+    {
+        // The card name carries the type and the eyebrow the issuer, so a real
+        // credential passes no meta — it must not render an empty meta node
+        // (and certainly never the raw VCT).
+        var cut = Render<CredentialWalletCard>(ps => ps
+            .Add(p => p.Issuer, "sorcha.dev")
+            .Add(p => p.Name, "Assured Identity")
+            .Add(p => p.Meta, ""));
+
+        cut.FindAll(".credential-wallet-card__meta").Should().BeEmpty();
+    }
+
+    [Fact]
     public void NullTypeLabel_OmitsChip()
     {
         var cut = Render<CredentialWalletCard>(ps => ps

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaInboxTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaInboxTests.cs
@@ -104,6 +104,32 @@ public class PwaInboxTests : AuthenticatedCitizenWalletTestBase
             new() { Timeout = 3000 });
     }
 
+    [Test]
+    [Retry(2)]
+    public async Task InboxDrawer_AtPhoneWidth_DoesNotClipLeftEdge()
+    {
+        // The 420px drawer used to push its left edge off a ~360px phone,
+        // clipping the header, chips, and entry timestamps. It's now capped to
+        // min(420px, 100vw).
+        await Page.SetViewportSizeAsync(360, 780);
+        await NavigateToWalletAndWaitForBlazorAsync();
+        await Wallet.WaitForReadyAsync();
+        await Wallet.TopBarInboxButton.ClickAsync();
+
+        var drawer = Page.Locator("[data-testid='inbox-drawer']").First;
+        await Assertions.Expect(drawer).ToBeVisibleAsync(new() { Timeout = 3000 });
+
+        // No descendant of the drawer bleeds off the left edge of the viewport.
+        var minLeft = await drawer.EvaluateAsync<double>(
+            "el => Math.min(...[el, ...el.querySelectorAll('*')].map(n => n.getBoundingClientRect().left))");
+        Assert.That(minLeft, Is.GreaterThanOrEqualTo(-0.5),
+            $"Inbox drawer content clips off the left edge ({minLeft}px).");
+
+        var overflow = await Page.EvaluateAsync<int>(
+            "() => document.documentElement.scrollWidth - window.innerWidth");
+        Assert.That(overflow, Is.LessThanOrEqualTo(1), $"Page overflows horizontally by {overflow}px.");
+    }
+
     /// <summary>
     /// Placeholder for the realtime sync test. Asserts that a server-issued
     /// credential lands in the PWA inbox panel within 3 seconds via the

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/CredentialDisplayTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/CredentialDisplayTests.cs
@@ -126,4 +126,26 @@ public sealed class CredentialDisplayTests
         status.Should().Be(CredentialStatus.Revoked);
         text.Should().Be("Expired");
     }
+
+    [Fact]
+    public void HumanizeCredentialMentions_HumanizesTokenAndFixesArticle()
+    {
+        CredentialDisplay.HumanizeCredentialMentions(
+                "Acme Verification Co. issued you a AssuredIdentityCredential")
+            .Should().Be("Acme Verification Co. issued you an Assured Identity credential");
+    }
+
+    [Fact]
+    public void HumanizeCredentialMentions_NoArticle_StillHumanizes()
+    {
+        CredentialDisplay.HumanizeCredentialMentions("New: DrivingLicenceCredential")
+            .Should().Be("New: Driving Licence credential");
+    }
+
+    [Fact]
+    public void HumanizeCredentialMentions_FriendlyTitle_Unchanged()
+    {
+        const string friendly = "Your council application was approved";
+        CredentialDisplay.HumanizeCredentialMentions(friendly).Should().Be(friendly);
+    }
 }


### PR DESCRIPTION
## Summary

Round-2 design tweaks for the Citizen Wallet PWA: the inbox drawer viewport fix (main item) plus four small follow-ons.

### 1. Inbox drawer not viewport-aware (main)
`InboxPanel` was a hard-coded **420px** right-anchored `MudDrawer`, so on a ~360px phone its left edge sat off-screen — header, category chips, and every entry title/timestamp clipped. Capped to **`min(420px, 100vw)`** via CSS isolation: 420px side panel on tablet/desktop, full-width sheet on phones.

### 2. Inbox titles showed the raw VCT
"…issued you a **AssuredIdentityCredential**" → "…issued you **an Assured Identity credential**" (humanized on render, article fixed). A friendly server-written title passes through unchanged — the wallet humanizer is the fallback. **Centralized**: `CredentialDisplay` moved from the PWA into shared `Components.User` (`Sorcha.UI.Core.Components.Wallet`) so Home, Cards, detail, and inbox share one `Humanize`. PWA pages already import that namespace — zero call-site churn.

### 3. Card meta echoed the raw VCT
Dropped — the name carries the (humanized) type and the eyebrow the issuer, so non-demo cards surface no meta (the card already omits an empty meta node).

### 4. Settings
Removed the permanently-disabled "Lock now (biometric gate — tier 4 polish)" placeholder card; bumped `.wallet-content` bottom reserve 92px → 116px so the last block clears the floating bar + its shadow.

### 5. Card content centre-crunched
The card is a `<button>` (UA default `text-align:center`); forced `text-align:left` on the heading/eyebrow/name so they sit flush-left like a physical wallet card.

## Testing
- New: `HumanizeCredentialMentions` (3), `InboxPanel` bUnit render (2 — humanized vs friendly title), card meta-omit (1), Playwright inbox@360 no-left-clip guard.
- Full suites green: **PWA 195/195**, **UI.Core 1367/1367**. UI sln + E2E build 0/0; snackbar gate passes.

## Not verified / notes
- CSS-only fixes (drawer width, card left-align, Settings padding) aren't bUnit-checkable — covered by the Docker-gated Playwright tests I can't run locally; eyeball on next n1 deploy.
- **Settings@phone overlap** has no Playwright guard: the PWA holds its token in IndexedDB, which the test harness can't auth into (issue #700), so `/settings` can't be reached authenticated in E2E. Covered structurally by the padding bump.
- The inbox title fix is the wallet-side **fallback**; a server-side friendly title (`WalletInboxWriter`) remains the ideal and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)