### PR TITLE
fix(pwa): quiet expected-401 console noise + redirect to /signin on dead session (+ R2 follow-on tests)

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TenantHubConnection.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/TenantHubConnection.cs
@@ -163,8 +163,40 @@ public sealed class TenantHubConnection : IAsyncDisposable
         catch (Exception ex)
         {
             UpdateConnectionState(ConnectionStatus.Disconnected, ex.Message);
-            _logger.LogError(ex, "Failed to connect to TenantHub at {HubUrl}", _hubUrl);
+
+            // A signed-out / expired-session caller fails the negotiate with a
+            // 401 — which the WASM fetch handler surfaces as an OperationCanceled.
+            // Auto-reconnect and the REST polling fallback recover this, so it is
+            // an expected state, not an error: log it quietly so it doesn't alarm
+            // the browser console. Genuine connect failures still log at Error.
+            if (IsExpectedAuthOrTransientFailure(ex, cancellationToken))
+            {
+                _logger.LogInformation(
+                    "TenantHub not connected at {HubUrl} (no valid session or transient negotiate failure): {Reason}",
+                    _hubUrl, ex.Message);
+            }
+            else
+            {
+                _logger.LogError(ex, "Failed to connect to TenantHub at {HubUrl}", _hubUrl);
+            }
         }
+    }
+
+    // Classifies a connect failure as the expected "no usable session yet" case
+    // (signed out / token expired) rather than a real fault. A 401/403 anywhere
+    // in the chain, or a cancellation we did NOT request (the WASM representation
+    // of an aborted negotiate), both mean "couldn't authenticate the hub" — which
+    // reconnect + the polling fallback already handle.
+    private static bool IsExpectedAuthOrTransientFailure(Exception ex, CancellationToken ct)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is HttpRequestException { StatusCode: System.Net.HttpStatusCode.Unauthorized or System.Net.HttpStatusCode.Forbidden })
+                return true;
+            if (e is OperationCanceledException && !ct.IsCancellationRequested)
+                return true;
+        }
+        return false;
     }
 
     /// <summary>Stops and disposes the connection.</summary>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/UserPreferencesService.cs
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Services/Shared/UserPreferencesService.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Sorcha Contributors
 
+using System.Net;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
 using Sorcha.UI.Core.Models;
@@ -39,9 +40,35 @@ public class UserPreferencesService : IUserPreferencesService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get user preferences");
+            LogPreferenceFailure(ex, "get user preferences");
             return new UserPreferencesDto();
         }
+    }
+
+    // A signed-out (or expired-session) caller gets a 401/403 here. That is an
+    // expected, fully-handled outcome — we return defaults — so it must not log
+    // at Error and alarm the browser console. Genuine failures (5xx, network)
+    // still surface at Error. See also TenantHubConnection.StartAsync.
+    private void LogPreferenceFailure(Exception ex, string action)
+    {
+        if (IsExpectedAuthFailure(ex))
+        {
+            _logger.LogDebug(ex, "Skipping {Action}: no valid session (auth failure).", action);
+        }
+        else
+        {
+            _logger.LogError(ex, "Failed to {Action}", action);
+        }
+    }
+
+    private static bool IsExpectedAuthFailure(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is HttpRequestException { StatusCode: HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden })
+                return true;
+        }
+        return false;
     }
 
     public async Task<UserPreferencesDto> UpdateUserPreferencesAsync(UpdateUserPreferencesRequest request)
@@ -55,7 +82,7 @@ public class UserPreferencesService : IUserPreferencesService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to update user preferences");
+            LogPreferenceFailure(ex, "update user preferences");
             return new UserPreferencesDto();
         }
     }
@@ -69,7 +96,7 @@ public class UserPreferencesService : IUserPreferencesService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get default wallet");
+            LogPreferenceFailure(ex, "get default wallet");
             return null;
         }
     }
@@ -84,7 +111,7 @@ public class UserPreferencesService : IUserPreferencesService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to set default wallet");
+            LogPreferenceFailure(ex, "set default wallet");
         }
     }
 
@@ -97,7 +124,7 @@ public class UserPreferencesService : IUserPreferencesService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to clear default wallet");
+            LogPreferenceFailure(ex, "clear default wallet");
         }
     }
 }

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -134,12 +134,17 @@ public static class ServiceCollectionExtensions
         // instead of mocking IJSRuntime (brittle — F114 lesson).
         services.AddSingleton<IPasskeyInterop, PasskeyInterop>();
 
+        // Raised by BearerTokenHandler when an unrecoverable 401 clears the
+        // session; MainLayout subscribes and redirects to /signin.
+        services.AddSingleton<ISessionExpiryNotifier, SessionExpiryNotifier>();
+
         // Unauthenticated client used ONLY by BearerTokenHandler to refresh — must NOT carry the
         // bearer handler (no recursion).
         services.AddHttpClient("AuthRefresh", c => c.BaseAddress = new Uri(gatewayBaseAddress));
         services.AddTransient(sp => new BearerTokenHandler(
             sp.GetRequiredService<IAccessTokenStore>(),
-            sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthRefresh")));
+            sp.GetRequiredService<IHttpClientFactory>().CreateClient("AuthRefresh"),
+            sp.GetRequiredService<ISessionExpiryNotifier>()));
 
         // Auth surface: a separate HttpClient that does NOT inject the bearer token
         // (so sign-in requests don't carry stale tokens). Still observes the server

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -31,6 +31,8 @@
 @inject TenantHubConnection TenantHub
 @inject IAccessTokenStore AccessTokens
 @inject IThemeService ThemeService
+@inject WalletAuthenticationStateProvider AuthState
+@inject ISessionExpiryNotifier SessionExpiry
 
 @* Feature 141 — dark mode now follows IThemeService (previously the provider
    was unbound, so the wallet never rendered dark). *@
@@ -174,6 +176,7 @@
         // suppression, and resolve dark mode from the user's theme preference.
         UpdateRoute();
         Nav.LocationChanged += HandleLocationChanged;
+        SessionExpiry.SessionExpired += HandleSessionExpired;
         ThemeService.OnThemeChanged += HandleThemeChanged;
         await ThemeService.InitializeAsync();
         _isDark = ThemeService.IsDarkMode;
@@ -208,6 +211,21 @@
         _isDark = ThemeService.IsDarkMode;
         InvokeAsync(StateHasChanged);
     }
+
+    /// <summary>
+    /// The stored token was rejected and could not be refreshed (BearerTokenHandler
+    /// cleared it). Re-evaluate the gate and send the citizen to sign-in rather than
+    /// leaving the shell running against a dead session. Preserves where they were
+    /// via returnUrl; no-ops if already on the sign-in screen.
+    /// </summary>
+    private void HandleSessionExpired() => InvokeAsync(() =>
+    {
+        AuthState.NotifyChanged();
+        var rel = Nav.ToBaseRelativePath(Nav.Uri);
+        var path = rel.Split('?', '#')[0].Trim('/');
+        if (path.Equals("signin", StringComparison.OrdinalIgnoreCase)) return;
+        Nav.NavigateTo($"signin?returnUrl={Uri.EscapeDataString(rel)}");
+    });
 
     /// <summary>Feature 141 — floating-bar navigation (base-relative; Home = "").</summary>
     private void HandleTabNavigate(string route) => Nav.NavigateTo(route);
@@ -351,6 +369,7 @@
     {
         UserContext.OnContextChanged -= HandleContextChanged;
         Nav.LocationChanged -= HandleLocationChanged;
+        SessionExpiry.SessionExpired -= HandleSessionExpired;
         ThemeService.OnThemeChanged -= HandleThemeChanged;
         if (_inboxHubStarted)
         {

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
@@ -9,16 +9,20 @@ using System.Text.Json.Serialization;
 namespace Sorcha.Wallet.Pwa.Services;
 
 /// <summary>
-/// Attaches the wallet's bearer token to every outbound request. On a 401 with a
-/// stored refresh token, transparently refreshes once (POST /api/auth/token/refresh —
-/// re-mints the same tier per F136, so a Consumer refresh stays Consumer) and
-/// retries. A failed refresh clears the session so the gate sends the citizen to
-/// /signin on the next navigation.
+/// Attaches the wallet's bearer token to every outbound request. On a 401 for a
+/// request that carried a token, transparently refreshes once when a refresh
+/// token is held (POST /api/auth/token/refresh — re-mints the same tier per F136,
+/// so a Consumer refresh stays Consumer) and retries. If there is no refresh
+/// token, or the refresh fails, the stored session is dead: it is cleared and
+/// <see cref="ISessionExpiryNotifier.NotifyExpired"/> fires so the shell sends the
+/// citizen to /signin immediately, rather than leaving the page running against a
+/// dead session (failing hub, empty preferences, repeated 401s in the console).
 /// </summary>
 public sealed class BearerTokenHandler : DelegatingHandler
 {
     private readonly IAccessTokenStore _store;
     private readonly HttpClient _refreshHttp;
+    private readonly ISessionExpiryNotifier _sessionExpiry;
 
     /// <summary>Initialises a new instance.</summary>
     /// <param name="store">The token store that holds the citizen's JWT and refresh token.</param>
@@ -27,10 +31,12 @@ public sealed class BearerTokenHandler : DelegatingHandler
     /// for the refresh call. This client MUST NOT have <see cref="BearerTokenHandler"/>
     /// in its pipeline — adding it would create infinite recursion on 401.
     /// </param>
-    public BearerTokenHandler(IAccessTokenStore store, HttpClient refreshHttp)
+    /// <param name="sessionExpiry">Raised when an unrecoverable 401 clears the stored session.</param>
+    public BearerTokenHandler(IAccessTokenStore store, HttpClient refreshHttp, ISessionExpiryNotifier sessionExpiry)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
         _refreshHttp = refreshHttp ?? throw new ArgumentNullException(nameof(refreshHttp));
+        _sessionExpiry = sessionExpiry ?? throw new ArgumentNullException(nameof(sessionExpiry));
     }
 
     /// <inheritdoc />
@@ -43,23 +49,32 @@ public sealed class BearerTokenHandler : DelegatingHandler
 
         var response = await base.SendAsync(request, ct);
 
+        // Only react to auth failures on requests that actually carried a token —
+        // an anonymous call getting a 401 has no session to refresh or clear.
         if (response.StatusCode != HttpStatusCode.Unauthorized
-            || string.IsNullOrEmpty(record?.RefreshToken))
+            || record is null || string.IsNullOrEmpty(record.AccessToken))
         {
             return response;
         }
 
-        var refreshed = await TryRefreshAsync(record.RefreshToken, record.Email, ct);
-        if (refreshed is null)
+        // One-shot refresh when we hold a refresh token.
+        if (!string.IsNullOrEmpty(record.RefreshToken))
         {
-            await _store.ClearAsync(ct); // gate redirects to /signin on next navigation
-            return response;
+            var refreshed = await TryRefreshAsync(record.RefreshToken, record.Email, ct);
+            if (refreshed is not null)
+            {
+                response.Dispose();
+                var retry = await CloneAsync(request, ct);
+                retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+                return await base.SendAsync(retry, ct);
+            }
         }
 
-        response.Dispose();
-        var retry = await CloneAsync(request, ct);
-        retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
-        return await base.SendAsync(retry, ct);
+        // No refresh token, or the refresh failed → the stored session is dead.
+        // Clear it and signal the shell to redirect to /signin now.
+        await _store.ClearAsync(ct);
+        _sessionExpiry.NotifyExpired();
+        return response;
     }
 
     // No refresh lock: WASM is single-threaded. Concurrent 401s can interleave across awaits and

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/ISessionExpiryNotifier.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/ISessionExpiryNotifier.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Pwa.Services;
+
+/// <summary>
+/// Signals that the stored wallet session was rejected by the server and could
+/// not be refreshed (the token is expired / revoked / has no refresh token).
+/// Raised by <see cref="BearerTokenHandler"/> after it clears the dead token;
+/// the shell (MainLayout) subscribes and redirects the citizen to <c>/signin</c>
+/// rather than leaving the page running against a dead session (a failing hub,
+/// empty preferences, repeated 401s in the console).
+/// </summary>
+/// <remarks>
+/// Mirrors the <c>ServerClockHandler → IServerClockObserver</c> seam: an HTTP
+/// message handler can't take a UI dependency (NavigationManager) cleanly, so it
+/// publishes a signal a UI component consumes. Singleton — one event reaches
+/// every subscriber across the single-user WASM app.
+/// </remarks>
+public interface ISessionExpiryNotifier
+{
+    /// <summary>Fired when an unrecoverable 401 clears the stored session.</summary>
+    event Action? SessionExpired;
+
+    /// <summary>Raises <see cref="SessionExpired"/>.</summary>
+    void NotifyExpired();
+}
+
+/// <inheritdoc />
+public sealed class SessionExpiryNotifier : ISessionExpiryNotifier
+{
+    /// <inheritdoc />
+    public event Action? SessionExpired;
+
+    /// <inheritdoc />
+    public void NotifyExpired() => SessionExpired?.Invoke();
+}

--- a/tests/Sorcha.UI.Core.Tests/Components/Wallet/CredentialWalletCardTests.cs
+++ b/tests/Sorcha.UI.Core.Tests/Components/Wallet/CredentialWalletCardTests.cs
@@ -32,6 +32,34 @@ public sealed class CredentialWalletCardTests : ComponentTestFixture
     }
 
     [Fact]
+    public void Heading_WrapsEyebrowAndName_LeftAlignContract()
+    {
+        // The centre-crunch fix left-aligns the card via scoped CSS that targets
+        // .credential-wallet-card__heading and its __eyebrow / __name children
+        // (the <button> default is text-align:center). bUnit (AngleSharp) has no
+        // layout/CSS engine, so the *computed* text-align can't be asserted here —
+        // that lives in the Playwright Home@360px coverage once the #700 card
+        // fixture lands. What we CAN pin is the markup the scoped selectors bind
+        // to: a single heading wrapper containing both the eyebrow and the name,
+        // so a refactor can't rename the nodes out from under the left-align CSS.
+        var cut = Render<CredentialWalletCard>(ps => ps
+            .Add(p => p.Issuer, "sorcha.dev")
+            .Add(p => p.Name, "Assured Identity"));
+
+        var heading = cut.Find(".credential-wallet-card__heading");
+        heading.QuerySelector(".credential-wallet-card__eyebrow")
+            .Should().NotBeNull("the eyebrow must live inside the heading the left-align CSS targets");
+        heading.QuerySelector(".credential-wallet-card__name")
+            .Should().NotBeNull("the name must live inside the heading the left-align CSS targets");
+
+        // The chip is a sibling of the heading (the space-between top row), not a
+        // child — so the heading text stays flush-left rather than centring.
+        var top = cut.Find(".credential-wallet-card__top");
+        top.QuerySelector(":scope > .credential-wallet-card__heading")
+            .Should().NotBeNull("the heading must be a direct child of the space-between top row");
+    }
+
+    [Fact]
     public void EmptyMeta_OmitsMetaLine()
     {
         // The card name carries the type and the eyebrow the issuer, so a real

--- a/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaSettingsTests.cs
+++ b/tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/PwaSettingsTests.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using Microsoft.Playwright;
+using Sorcha.UI.E2E.Tests.Infrastructure;
+using Sorcha.UI.E2E.Tests.PageObjects;
+
+namespace Sorcha.UI.E2E.Tests.Docker.CitizenWallet;
+
+/// <summary>
+/// Round-2 PWA polish regression guard (PR #970). The Settings page lives inside
+/// <c>.wallet-content</c>, whose bottom reserve was bumped 92px → 116px so the
+/// last block clears the floating tab bar plus its drop-shadow. This test pins
+/// that contract: at a short phone viewport, scrolled to the very bottom, the
+/// last Settings block must sit fully above the floating bar.
+/// </summary>
+/// <remarks>
+/// Settings is <c>[Authorize]</c>-gated. In environments without the citizen
+/// enrolment fixture (issue #700) the page redirects to <c>/signin</c> and the
+/// Settings content never renders — the test then ignores itself rather than
+/// failing, the same pattern <c>CitizenWalletNavigationTests</c> uses for
+/// auth-gated surfaces. It becomes a live guard once the #700 fixture lands.
+/// </remarks>
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+[Category("Docker")]
+[Category("CitizenWallet")]
+public class PwaSettingsTests : AuthenticatedCitizenWalletTestBase
+{
+    private CitizenWalletPage Wallet => new(Page);
+
+    [Test]
+    [Retry(2)]
+    public async Task Settings_LastBlock_ClearsFloatingTabBar_AtPhoneHeight()
+    {
+        // A short viewport guarantees the page scrolls, so the last block can
+        // collide with the bottom-fixed floating bar if the reserve is too small.
+        await Page.SetViewportSizeAsync(390, 680);
+        await NavigateToWalletAndWaitForBlazorAsync("/settings");
+
+        // The Replay-tour card is the last block on the page.
+        var lastBlock = Page.Locator("[data-testid='settings-replay-tour-card']");
+        if (await lastBlock.CountAsync() == 0)
+        {
+            Assert.Ignore(
+                "Settings content not rendered — the page is [Authorize]-gated and " +
+                "redirected to /signin. Needs the issue #700 enrolment fixture.");
+        }
+
+        // Scroll to the absolute bottom — the worst case for bottom-bar overlap.
+        await Page.EvaluateAsync(
+            "() => window.scrollTo(0, document.documentElement.scrollHeight)");
+
+        var cardBox = await lastBlock.BoundingBoxAsync();
+        var bar = Wallet.FloatingTabBar;
+        await Assertions.Expect(bar).ToBeVisibleAsync(new() { Timeout = 3000 });
+        var barBox = await bar.BoundingBoxAsync();
+
+        Assert.That(cardBox, Is.Not.Null, "Last Settings block has no layout box.");
+        Assert.That(barBox, Is.Not.Null, "Floating tab bar has no layout box.");
+
+        // The last block's bottom edge must not dip below the bar's top edge
+        // (1px rounding tolerance). If it does, the .wallet-content bottom
+        // reserve is too small and the block peeks under the bar.
+        var cardBottom = cardBox!.Y + cardBox.Height;
+        Assert.That(cardBottom, Is.LessThanOrEqualTo(barBox!.Y + 1),
+            $"Last Settings block (bottom {cardBottom}px) overlaps the floating " +
+            $"tab bar (top {barBox.Y}px) — .wallet-content bottom reserve too small.");
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -185,7 +185,7 @@ public sealed class AuthAndBearerTests
         });
         var noRefreshHttp = new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage()))
             { BaseAddress = new Uri("https://localhost/") };
-        var bearer = new BearerTokenHandler(store, noRefreshHttp) { InnerHandler = inner };
+        var bearer = new BearerTokenHandler(store, noRefreshHttp, new SpySessionExpiryNotifier()) { InnerHandler = inner };
         var http = new HttpClient(bearer) { BaseAddress = new Uri("https://localhost/") };
 
         await http.GetAsync("api/v1/wallet/sync");
@@ -205,7 +205,7 @@ public sealed class AuthAndBearerTests
         });
         var noRefreshHttp = new HttpClient(new StubHttpHandler((_, _) => new HttpResponseMessage()))
             { BaseAddress = new Uri("https://localhost/") };
-        var bearer = new BearerTokenHandler(store, noRefreshHttp) { InnerHandler = inner };
+        var bearer = new BearerTokenHandler(store, noRefreshHttp, new SpySessionExpiryNotifier()) { InnerHandler = inner };
         var http = new HttpClient(bearer) { BaseAddress = new Uri("https://localhost/") };
 
         await http.GetAsync("api/v1/wallet/sync");
@@ -286,6 +286,17 @@ public sealed class AuthAndBearerTests
         {
             PurgeCount++;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SpySessionExpiryNotifier : ISessionExpiryNotifier
+    {
+        public int ExpiredCount { get; private set; }
+        public event Action? SessionExpired;
+        public void NotifyExpired()
+        {
+            ExpiredCount++;
+            SessionExpired?.Invoke();
         }
     }
 
@@ -370,7 +381,7 @@ public sealed class AuthAndBearerTests
             Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
             { BaseAddress = new Uri("https://gw.test/") };
 
-        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var handler = new BearerTokenHandler(store, refreshHttp, new SpySessionExpiryNotifier()) { InnerHandler = inner };
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
 
         var resp = await client.GetAsync("api/v1/wallet/credentials");
@@ -380,24 +391,28 @@ public sealed class AuthAndBearerTests
     }
 
     [Fact]
-    public async Task BearerTokenHandler_On401_WithNoRefreshToken_Returns401Untouched()
+    public async Task BearerTokenHandler_On401_WithNoRefreshToken_ClearsSessionAndSignalsExpiry()
     {
         var store = new InMemoryAccessTokenStore();
         await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", null));
 
         var inner = new SequencedHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized));
+        // Refresh must NOT be attempted when there is no refresh token.
         var refreshHttp = new HttpClient(new CapturingHandler(_ =>
-            Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
+            Task.FromException<HttpResponseMessage>(new InvalidOperationException("refresh must not be called"))))
             { BaseAddress = new Uri("https://gw.test/") };
+        var notifier = new SpySessionExpiryNotifier();
 
-        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var handler = new BearerTokenHandler(store, refreshHttp, notifier) { InnerHandler = inner };
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
 
         var resp = await client.GetAsync("api/v1/wallet/credentials");
 
         resp.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
-        // Token should be unchanged (no refresh attempted, no clear)
-        (await store.GetAsync())!.AccessToken.Should().Be("old");
+        // A 401 on a request that carried a token, with no refresh token, means the
+        // stored session is dead — clear it and signal the shell to redirect to /signin.
+        (await store.GetAsync()).Should().BeNull("a 401 with no refresh token clears the dead session");
+        notifier.ExpiredCount.Should().Be(1, "the shell must be told to send the citizen to /signin");
     }
 
     [Fact]
@@ -427,7 +442,7 @@ public sealed class AuthAndBearerTests
             Task.FromResult(JsonOk("{\"access_token\":\"new\",\"refresh_token\":\"rt2\",\"expires_in\":3600}"))))
             { BaseAddress = new Uri("https://gw.test/") };
 
-        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var handler = new BearerTokenHandler(store, refreshHttp, new SpySessionExpiryNotifier()) { InnerHandler = inner };
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
 
         var resp = await client.PostAsync("api/v1/wallet/something",
@@ -448,14 +463,16 @@ public sealed class AuthAndBearerTests
         var refreshHttp = new HttpClient(new CapturingHandler(_ =>
             Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized))))
             { BaseAddress = new Uri("https://gw.test/") };
+        var notifier = new SpySessionExpiryNotifier();
 
-        var handler = new BearerTokenHandler(store, refreshHttp) { InnerHandler = inner };
+        var handler = new BearerTokenHandler(store, refreshHttp, notifier) { InnerHandler = inner };
         var client = new HttpClient(handler) { BaseAddress = new Uri("https://gw.test/") };
 
         var resp = await client.GetAsync("api/v1/wallet/credentials");
 
         resp.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
         (await store.GetAsync()).Should().BeNull("failed refresh must clear the session");
+        notifier.ExpiredCount.Should().Be(1, "a failed refresh must signal the shell to redirect to /signin");
     }
 
     private sealed class CapturingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler


### PR DESCRIPTION
## Why

Console errors on `n1.sorcha.dev/wallet`: `UserPreferencesService` 401, `TenantHubConnection` connect cancelled, plus a benign source-map parse error. Triaged live — the **server is healthy** (with a valid token, `/api/preferences` → 200 and `/hubs/tenant` negotiate → 200). The real issues were **client-side**:

1. Expected, already-handled auth failures were logged at **Error** level → alarming red console stacks.
2. A stale/expired token in IndexedDB left the shell running **degraded** (failing hub, empty prefs, repeating 401s) instead of re-authenticating.

None of this came from the R2 deploy (#970) — that was UI-only.

## What

**Quiet expected auth-failure noise (shared `Sorcha.UI.Components.User`, benefits web + PWA):**
- `UserPreferencesService` — 401/403 logs at `Debug` (it already returns defaults); genuine faults still `Error`.
- `TenantHubConnection.StartAsync` — an auth/cancelled-negotiate failure logs at `Information` (auto-reconnect + REST polling fallback recover it); genuine faults still `Error`.

**Proactively re-authenticate on a dead session (PWA):**
- `BearerTokenHandler` — on any unrecoverable 401 for a request that carried a token (no refresh token, or refresh failed), clear the dead session **and** raise the new `ISessionExpiryNotifier`. (Previously a 401 with no refresh token returned the stale token untouched.)
- `MainLayout` subscribes → `NotifyChanged()` + redirect to `/signin` (returnUrl preserved; no-op if already there).

**The two R2 regression guards missing from #970:**
- `PwaSettingsTests` — last Settings block clears the floating tab bar at phone height (self-ignores when `[Authorize]` redirects to `/signin`; activates with the #700 enrolment fixture).
- `CredentialWalletCardTests` — bUnit structural guard for the left-align heading contract (computed `text-align` needs a browser; documented inline).
- `AuthAndBearerTests` — updated for the clear-and-signal behavior; notifier assertions added.

## Verification
- Wallet PWA suite **195/195**, UI.Core **1368/1368** green locally.
- Server-side auth pipeline probed healthy on n1 (preferences 200, hub negotiate 200 with a valid token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)