### PR TITLE
fix(pwa): don't clear session on per-endpoint 401 — fixes post-login "Authorizing…" loop

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/BearerTokenHandler.cs
@@ -12,11 +12,12 @@ namespace Sorcha.Wallet.Pwa.Services;
 /// Attaches the wallet's bearer token to every outbound request. On a 401 for a
 /// request that carried a token, transparently refreshes once when a refresh
 /// token is held (POST /api/auth/token/refresh — re-mints the same tier per F136,
-/// so a Consumer refresh stays Consumer) and retries. If there is no refresh
-/// token, or the refresh fails, the stored session is dead: it is cleared and
+/// so a Consumer refresh stays Consumer) and retries. Only a <em>failed refresh</em>
+/// is treated as session death: the token is cleared and
 /// <see cref="ISessionExpiryNotifier.NotifyExpired"/> fires so the shell sends the
-/// citizen to /signin immediately, rather than leaving the page running against a
-/// dead session (failing hub, empty preferences, repeated 401s in the console).
+/// citizen to /signin. A 401 with no refresh token is left untouched — it may be a
+/// per-endpoint authorization gap, not an expired session, so the token must NOT be
+/// cleared (doing so nukes good sessions); the auth gate handles true clock expiry.
 /// </summary>
 public sealed class BearerTokenHandler : DelegatingHandler
 {
@@ -57,20 +58,28 @@ public sealed class BearerTokenHandler : DelegatingHandler
             return response;
         }
 
-        // One-shot refresh when we hold a refresh token.
-        if (!string.IsNullOrEmpty(record.RefreshToken))
+        // With no refresh token we CANNOT conclude the session is dead: a 401 from a
+        // single endpoint can be a per-endpoint authorization gap (e.g. a consumer-tier
+        // token hitting a platform-only resource), and the token may still be valid for
+        // the wallet's own surfaces. Leave it untouched — the auth gate
+        // (WalletAuthenticationStateProvider) already redirects to /signin once the
+        // token expires by clock. Clearing here on every 401 nukes good sessions.
+        if (string.IsNullOrEmpty(record.RefreshToken))
         {
-            var refreshed = await TryRefreshAsync(record.RefreshToken, record.Email, ct);
-            if (refreshed is not null)
-            {
-                response.Dispose();
-                var retry = await CloneAsync(request, ct);
-                retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
-                return await base.SendAsync(retry, ct);
-            }
+            return response;
         }
 
-        // No refresh token, or the refresh failed → the stored session is dead.
+        // We hold a refresh token: a 401 means the access token should be re-minted.
+        var refreshed = await TryRefreshAsync(record.RefreshToken, record.Email, ct);
+        if (refreshed is not null)
+        {
+            response.Dispose();
+            var retry = await CloneAsync(request, ct);
+            retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", refreshed.AccessToken);
+            return await base.SendAsync(retry, ct);
+        }
+
+        // Refresh failed → the token can't be renewed, so the session really is dead.
         // Clear it and signal the shell to redirect to /signin now.
         await _store.ClearAsync(ct);
         _sessionExpiry.NotifyExpired();

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/AuthAndBearerTests.cs
@@ -391,7 +391,7 @@ public sealed class AuthAndBearerTests
     }
 
     [Fact]
-    public async Task BearerTokenHandler_On401_WithNoRefreshToken_ClearsSessionAndSignalsExpiry()
+    public async Task BearerTokenHandler_On401_WithNoRefreshToken_LeavesSessionUntouched()
     {
         var store = new InMemoryAccessTokenStore();
         await store.SetAsync(new AccessTokenRecord("old", DateTimeOffset.UtcNow.AddHours(1), "a@b.test", null));
@@ -409,10 +409,12 @@ public sealed class AuthAndBearerTests
         var resp = await client.GetAsync("api/v1/wallet/credentials");
 
         resp.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
-        // A 401 on a request that carried a token, with no refresh token, means the
-        // stored session is dead — clear it and signal the shell to redirect to /signin.
-        (await store.GetAsync()).Should().BeNull("a 401 with no refresh token clears the dead session");
-        notifier.ExpiredCount.Should().Be(1, "the shell must be told to send the citizen to /signin");
+        // A 401 with no refresh token may be a per-endpoint authorization gap, NOT an
+        // expired session — so the token must stay put (clearing it nukes good sessions
+        // and caused the post-login "Authorizing…" loop). The clock-expiry gate handles
+        // genuinely dead sessions.
+        (await store.GetAsync())!.AccessToken.Should().Be("old", "a per-endpoint 401 must not clear the session");
+        notifier.ExpiredCount.Should().Be(0, "no refresh token + single 401 is not proof of session death");
     }
 
     [Fact]


### PR DESCRIPTION
## Regression fix for #971

#971 made `BearerTokenHandler` clear the entire session **and** redirect to `/signin` on **any** unrecoverable 401 — including a 401 with no refresh token. A consumer-tier token legitimately 401s on platform-only startup endpoints (`/api/preferences`, the inbox), so the **first** such 401 after login destroyed the freshly-minted session → redirect → re-login → 401 → clear … the wallet sat stuck on **"Authorizing…"**.

## Fix
A single endpoint 401 is **not** proof the session is dead. Restore conservative handling:
- **401 with no refresh token** → leave the token untouched. The clock-expiry gate (`WalletAuthenticationStateProvider`) still redirects genuinely-expired sessions.
- **401 with a refresh token** → refresh + retry; only a **failed refresh** (token can't be renewed = truly dead) clears the session and fires `ISessionExpiryNotifier` → `/signin`.

The log-noise downgrades from #971 (`UserPreferencesService` / `TenantHubConnection` expected-401 → Debug/Info) are unaffected and stay.

## Verification
- Wallet PWA suite **195/195** green; `..._WithNoRefreshToken_LeavesSessionUntouched` now asserts the safe behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)