### PR TITLE
fix(pwa): login-page chrome gating, tour suppression + loop fix, build badge, signup link

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Onboarding/GuidedTourScaffold.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Onboarding/GuidedTourScaffold.razor
@@ -57,6 +57,13 @@
     [Parameter] public EventCallback OnDismissedEarly { get; set; }
 
     private bool _open;
+    // Latched true once the tour has opened for the current ShouldRun activation, so a
+    // parent re-render (MainLayout re-renders constantly — theme, inbox, context) can't
+    // reopen the tour after the user finished or skipped it. Without this, completing the
+    // tour reset StepIndex to 0 with ShouldRun still briefly true (the host persists the
+    // dismissal flag asynchronously), so OnParametersSet re-opened it at step 1 in a loop.
+    // Reset when the host lowers ShouldRun (e.g. Settings → Replay tour), allowing a re-run.
+    private bool _hasRun;
     private int StepIndex { get; set; }
 
     private GuidedTourStep? CurrentStep =>
@@ -74,13 +81,17 @@
 
     protected override void OnParametersSet()
     {
-        if (ShouldRun && Steps is { Count: > 0 } && !_open && StepIndex == 0)
+        if (ShouldRun && Steps is { Count: > 0 } && !_open && !_hasRun)
         {
             _open = true;
+            _hasRun = true;
         }
         else if (!ShouldRun)
         {
+            // Host reset the dismissal flag (e.g. Settings → Replay tour) → allow a fresh run.
             _open = false;
+            _hasRun = false;
+            StepIndex = 0;
         }
     }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -11,6 +11,7 @@
     active organisational context is always visible. The chip is non-
     interactive when the user only holds the Personal context.
 *@
+@using System.Reflection
 @using Microsoft.AspNetCore.Components.Authorization
 @using Sorcha.UI.Components.User.Components.Context
 @using Sorcha.UI.Components.User.Components.Onboarding
@@ -62,7 +63,12 @@
 <MudLayout>
     @* Feature 141 — the top app bar is suppressed on Home: there the gradient
        hero owns the header row (org switcher + bell + scan). Every other
-       wallet page keeps the standard app bar. *@
+       wallet page keeps the standard app bar.
+       Gated on auth: the bar's affordances (org/context picker, inbox bell,
+       Present) are all signed-in surfaces, so the whole bar must NOT render on
+       /signin or other unauthenticated screens. *@
+    <AuthorizeView>
+        <Authorized>
     @if (!_isHome)
     {
         <MudAppBar Elevation="1">
@@ -96,6 +102,8 @@
                            aria-label="Present a credential" />
         </MudAppBar>
     }
+        </Authorized>
+    </AuthorizeView>
     <MudMainContent Class="@(_isHome ? "wallet-content wallet-content--home" : "wallet-content")">
         @* Shell-level connectivity strip. Renders only when the device is
            offline so the citizen knows cached cards may be stale and that
@@ -130,9 +138,21 @@
 @* Feature 141 — floating pill nav. Rendered OUTSIDE <MudLayout> so no element
    in the Mud tree (which sets transform/contain on its content region) becomes
    the containing block for the bar's position:fixed and pushes it off-screen on
-   the app-bar-less Home page. Shell-level — appears on every primary screen. *@
-<FloatingTabBar ActiveRoute="@_activeRoute" Dark="@_isDark" OnNavigate="HandleTabNavigate" />
+   the app-bar-less Home page. Gated on auth: the tabs (Home/Cards/Activity/
+   Settings) are signed-in navigation, so they must NOT show on /signin or other
+   unauthenticated screens. Same AuthorizeView gate the PairingTakeover uses. *@
+<AuthorizeView>
+    <Authorized>
+        <FloatingTabBar ActiveRoute="@_activeRoute" Dark="@_isDark" OnNavigate="HandleTabNavigate" />
+    </Authorized>
+</AuthorizeView>
 </CascadingValue>
+
+@* Build-version badge — fixed bottom-right, shown on every screen (including the
+   sign-in page) so the running build is verifiable at a glance after a deploy.
+   Decorative + non-interactive; the version is stamped at build time by the
+   unified-versioning standard (root Directory.Build.props). *@
+<div class="sorcha-build-badge" aria-hidden="true">v@AppVersion</div>
 
 @code {
     private IReadOnlyList<UserOrgMembership> _memberships = Array.Empty<UserOrgMembership>();
@@ -152,6 +172,21 @@
     private bool _isDark;
     private bool _isHome = true;
     private string _activeRoute = "";
+
+    // Build version for the bottom-right badge. Stamped at build time by the unified
+    // versioning standard (root Directory.Build.props): 2.<run>.<attempt> on CI images,
+    // 2.0.0-dev locally. InformationalVersion may carry a "+<commit>" suffix — trim it.
+    private static readonly string AppVersion = ResolveAppVersion();
+
+    private static string ResolveAppVersion()
+    {
+        var asm = typeof(MainLayout).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var trimmed = info?.Split('+')[0];
+        return string.IsNullOrWhiteSpace(trimmed)
+            ? (asm.GetName().Version?.ToString() ?? "dev")
+            : trimmed;
+    }
 
     // ── Shell surface for the Home hero (Feature 141) ──────────────────────
     // The Home page cascades to this layout instance so its gradient hero can
@@ -312,10 +347,13 @@
 
     private async Task EvaluateTourEligibilityAsync()
     {
-        // Tour fires once per device — gated on TourDismissedAt being null.
-        // The flag is reset to null by Settings → Replay tour.
-        var flags = await WalletFlags.GetAsync();
-        _tourShouldRun = flags?.TourDismissedAt is null;
+        // Guided tour SUPPRESSED in the PWA for now. Wallet creation happens only in
+        // the full web app today, so a first-run "set up your wallet" tour here fires
+        // before the citizen has anything to tour and is confusing. Re-enable when the
+        // PWA can create wallets — see backlog (pwa-reenable-onboarding-tour). The flag
+        // load is kept (cheap, keeps the wiring warm) so re-enabling is a one-line revert.
+        _ = await WalletFlags.GetAsync();
+        _tourShouldRun = false;   // re-enable: = (await WalletFlags.GetAsync())?.TourDismissedAt is null
         StateHasChanged();
     }
 

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Settings.razor
@@ -16,7 +16,6 @@
 @inject IJSRuntime Js
 @inject IAuthService Auth
 @inject NavigationManager Nav
-@inject IWalletFlagsStore WalletFlags
 @inject ILogger<Settings> Logger
 @inject WalletAuthenticationStateProvider AuthState
 
@@ -111,30 +110,11 @@
        permanently-disabled dev-copy button. The biometric lock surfaces here
        again when the feature ships. *@
 
-    @* Feature 125 / PR-F (T108) — Replay tour. Resets the per-device
-       TourDismissedAt flag so MainLayout fires the guided tour again on
-       the next page load. *@
-    <MudCard Class="mb-3" data-testid="settings-replay-tour-card">
-        <MudCardContent>
-            <MudText Typo="Typo.subtitle1" Class="mb-2">Tour</MudText>
-            <MudText Typo="Typo.body2" Class="mud-text-secondary mb-2">
-                Take the introductory walk-through again.
-            </MudText>
-            <MudButton Variant="Variant.Text"
-                       Color="Color.Primary"
-                       StartIcon="@Icons.Material.Filled.Replay"
-                       OnClick="@ReplayTourAsync"
-                       data-testid="settings-replay-tour-button">
-                Replay tour
-            </MudButton>
-            @if (_replayConfirmed)
-            {
-                <MudText Typo="Typo.body2" Class="mud-text-secondary mt-2">
-                    The tour will run next time you open the wallet's home.
-                </MudText>
-            }
-        </MudCardContent>
-    </MudCard>
+    @* Feature 125 / PR-F (T108) — "Replay tour" card removed while the guided tour is
+       suppressed in the PWA (see MainLayout.EvaluateTourEligibilityAsync). Replaying
+       would reset the dismissal flag but no tour would run — a dead affordance. Restore
+       this card together with the tour when the PWA can create wallets — see backlog
+       (pwa-reenable-onboarding-tour). *@
 </MudContainer>
 
 @code {
@@ -142,17 +122,9 @@
     private void GoDevices() => Nav.NavigateTo("devices");
     private void GoAuthMethods() => Nav.NavigateTo("auth-methods");
 
-    private bool _replayConfirmed;
-
-    private async Task ReplayTourAsync()
-    {
-        var current = await WalletFlags.GetAsync();
-        var reset = new WalletFlagsRecord(
-            WelcomedAt: current?.WelcomedAt,
-            TourDismissedAt: null);
-        await WalletFlags.SetAsync(reset);
-        _replayConfirmed = true;
-    }
+    // ReplayTourAsync removed with the "Replay tour" card while the guided tour is
+    // suppressed in the PWA. Restore both when re-enabling — see backlog
+    // (pwa-reenable-onboarding-tour).
 
     private StorageInfo? _storage;
     private string? _signedInEmail;

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor
@@ -60,6 +60,22 @@
                        OnClick="SignInWithPasswordAsync" Disabled="@_busy" data-testid="signin-password-submit">
                 @(_busy ? "Signing in…" : "Sign in")
             </MudButton>
+
+            @* Signup isn't available in the PWA yet (wallets are created on the web).
+               Send new users to the web signup page, then they come back to sign in. *@
+            <MudDivider Class="my-2" />
+            <div class="d-flex flex-column align-center">
+                <MudText Typo="Typo.body2" Class="mud-text-secondary mb-1">New to Sorcha?</MudText>
+                <MudButton Variant="Variant.Text" Color="Color.Primary"
+                           EndIcon="@Icons.Material.Filled.OpenInNew"
+                           OnClick="GoToWebSignup" Disabled="@_busy"
+                           data-testid="signin-signup-link">
+                    Create an account
+                </MudButton>
+                <MudText Typo="Typo.caption" Class="mud-text-secondary mt-1" Align="Align.Center">
+                    You'll sign up on the Sorcha website, then come back here to sign in.
+                </MudText>
+            </div>
         }
         else
         {
@@ -137,6 +153,16 @@
     {
         var target = string.IsNullOrEmpty(ReturnUrl) ? "" : ReturnUrl!;
         Nav.NavigateTo(target);
+    }
+
+    // Signup lives on the web host at origin-root /auth/signup (the PWA is mounted
+    // under /wallet/, so build the absolute origin URL rather than a leading-slash
+    // path — leading slashes are the exact PWA nav ambiguity PR #698 fixed). forceLoad
+    // because it leaves the PWA for the web app entirely.
+    private void GoToWebSignup()
+    {
+        var origin = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
+        Nav.NavigateTo($"{origin}/auth/signup", forceLoad: true);
     }
 
     private async Task SignInWithPasskeyAsync()

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
@@ -32,6 +32,25 @@ html, body {
     padding-bottom: calc(116px + env(safe-area-inset-bottom, 0px));
 }
 
+/* Build-version badge — fixed bottom-right corner on every screen so the running
+   build is verifiable after a deploy. Tiny, muted, non-interactive; sits in the
+   corner clear of the centred floating tab bar. */
+.sorcha-build-badge {
+    position: fixed;
+    right: 6px;
+    bottom: calc(3px + env(safe-area-inset-bottom, 0px));
+    z-index: 1300;
+    font-size: 10px;
+    line-height: 1;
+    font-weight: 600;
+    letter-spacing: .02em;
+    font-variant-numeric: tabular-nums;
+    color: var(--mud-palette-text-disabled, rgba(0, 0, 0, .45));
+    opacity: .6;
+    pointer-events: none;
+    user-select: none;
+}
+
 /* On Home the gradient hero is the header (no app bar), so content starts at
    the very top — drop MudMainContent's app-bar top padding. */
 .wallet-content--home {


### PR DESCRIPTION
Batch of PWA login-page fixes from live testing.

## Login page no longer shows signed-in chrome
- **Top app bar** (org/context picker, inbox bell, Present) and the **floating tab bar** (Home/Cards/Activity/Settings) are now gated behind `AuthorizeView` — they no longer render on `/signin` or other unauthenticated screens. (Same gate `PairingTakeover` uses.)

## "Create an account" link on sign-in
- Signup isn't available in the PWA (wallets are created on the web). The sign-in screen now offers **"New to Sorcha? Create an account"**, which force-loads the web signup page at origin-root `/auth/signup` (verified real — Tenant Service `Pages/Auth/Signup.cshtml`), built from the origin to avoid the leading-slash PWA-nav ambiguity.

## Guided tour suppressed in the PWA (+ loop fixed)
- The 5-stage *"Welcome to your Sorcha Wallet"* tour fired prematurely (wallet creation is web-app-only today) **and** looped — `OnParametersSet` re-opened it at step 1 forever because completion reset `StepIndex=0` while the host persisted the dismissal flag asynchronously.
- **Suppressed** the tour in the PWA (one-line revert when PWA wallet creation lands — backlog `pwa-reenable-onboarding-tour`); removed the now-dead Settings "Replay tour" card.
- **Fixed** the shared `GuidedTourScaffold` reopen-loop with a one-shot `_hasRun` latch (opens once per `ShouldRun` activation; resets on Replay). The `WelcomeTakeover` first-credential card was deliberately left enabled.
- Investigated the web app: its "Welcome to Sorcha!" is a static banner on `/wallets/create` (legitimate, during actual wallet creation) — not the same surface, no loop.

## Build-version badge
- Fixed **bottom-right** badge on every screen (incl. sign-in) so the running build is verifiable after a deploy. Reads `AssemblyInformationalVersion` via reflection (stamped by unified versioning: `2.<run>.<attempt>` / `2.0.0-dev`).

## Verification
- UI.Core **1368/1368**, Wallet PWA **195/195** green. (No bUnit test for the tour loop — inline `MudDialog` content doesn't render in the current bUnit fixture; noted in the backlog for when the harness + re-enable land.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)