### PR TITLE
spec(149): Sorcha Conformance Oracle — the 'ultimate proof' [DRAFT]

### DIFF
--- a/docs/superpowers/specs/2026-06-06-sorcha-conformance-oracle-design.md
+++ b/docs/superpowers/specs/2026-06-06-sorcha-conformance-oracle-design.md
@@ -1,0 +1,177 @@
+# Sorcha Conformance Oracle (SCO) — Design
+
+**Date:** 2026-06-06
+**Status:** Design approved (brainstorming) — pending speckit spec
+**Author:** brainstorming session (Stuart + Claude)
+
+## Problem
+
+Sorcha has 143 spec'd features across 7 backend services, ~20 actor-based walkthroughs, and 11,088 tests — yet the v1-readiness assessment (2026-06-05, see `MEMORY.md` → v1-readiness-assessment) found that **the platform's correctness under realistic conditions is unproven**: CI green validates only unit/in-memory paths (9 integration-test projects are excluded from CI by design), and the recurring "seal-window" bug family (#119, #787, #814, #917, #585) shows the distributed seal/consensus/replication paths break in ways unit mocks never expose.
+
+We want **one "ultimate proof"** — a test that exercises *every* feature of Sorcha at least once and, for each, asserts that the platform's actual guarantees hold. It is both the confirmation instrument ("does our solution work?") and, as a side effect, a live v1 correctness dashboard.
+
+## Decisions (locked during brainstorming)
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Primary purpose | **Correctness proof** — coverage of every feature is the axis, but each touch makes a real assertion of a guarantee, not just "it ran" |
+| 2 | Top-level structure | **Invariant oracle + coverage** — define global invariants once; drive operations that touch every feature; re-assert ALL invariants after every operation |
+| 3 | Substrate | **Layered: abstract model + fault-injection harness** — model proves design correctness; harness proves the running implementation conforms. Model buildable first. |
+| 4 | Treatment of known gaps | **Two-tier: gate + tracked-red** — MUST-hold-today invariants gate CI; known-gap invariants are tracked-red (expected-fail + issue link) and form the live v1 backlog |
+| 5 | Coverage scope | **Backend capability correctness + thin surface smoke** — full correctness depth on backend capabilities; presence-check smoke over UI/PWA/CLI/MCP surfaces |
+| 6 | Model realization | **A + formal consensus core** — C# executable reference model + property-based driver as the backbone; TLA+ applied surgically to the consensus/seal core |
+
+The scenario(s) may be **synthetic/contrived** (engineered to hit every capability), not necessarily realistic business workflows — but the proof itself is a usable, runnable instrument.
+
+## Architecture
+
+Two declarative pillars (the "what") feed a four-stage execution pipeline (the "how"), producing a two-tier verdict.
+
+```
+   Capability Registry            Invariant Catalogue
+   (coverage axis —               (the oracle —
+    every feature)                 tagged Gate/Aspirational)
+        |  every capability → ≥1 op       | every op re-checks ALL invariants
+        |  every invariant → ≥1 capability|
+        v                                 v
+              Operation Driver (the alphabet)
+   (a) curated synthetic mega-sequence → hits every capability
+   (b) property-based generator → randomized ops + fault events
+        |                                       |
+        v                                       v
+   Reference Model            conform     Fault-Injection Harness
+   (pure C#, no I/O)        <--------->    (Testcontainers/Aspire; clock,
+   + TLA+ consensus core      same ops      crashes, slow/partitioned peers,
+   (TLC, exhaustive)                        concurrent seals)
+   = design correctness                    = implementation correctness
+                                                 |  + Thin Surface Smoke
+                                                 v
+                          Two-Tier Verdict
+              • Gate: all Gate invariants green + 100% capability
+                coverage + TLA+ core passes  → CI-blocking
+              • Tracked-red: aspirational fails w/ issue links
+                → live v1 correctness dashboard
+```
+
+**Binding rule — bidirectional completeness:** every capability maps to ≥1 operation (no untested feature), and every invariant maps to ≥1 capability that can violate it (no dead invariant). Fully traceable both ways.
+
+### Components
+
+1. **Capability Registry** — single source-of-truth manifest of every backend capability + every UI/PWA/CLI/MCP surface, each linked to invariants and operations.
+2. **Invariant Catalogue** — global invariants as predicates, each tagged `Gate` or `Aspirational(#issue)`.
+3. **Operation Driver** — the operation alphabet; curated mega-sequence (coverage) + property-based generator (exploration incl. faults).
+4. **Reference Model** — pure in-memory executable "spec Sorcha"; invariants checked after every op → design correctness.
+5. **Formal consensus core (TLA+)** — exhaustive model-check of chain integrity + consensus safety + seal ordering.
+6. **Fault-Injection Harness** — replays the same ops against the real stack under adversarial conditions; invariants checked on observable state → implementation correctness.
+7. **Two-Tier Verdict** — Gate result (CI gate) + Tracked-red list (v1 dashboard).
+
+## Pillar A — Capability Registry
+
+The 143 spec folders dedupe to **~70–90 distinct capabilities across 13 domains** (many specs are iterations/fixes/UI-polish of one capability). Entry schema:
+
+```
+CapabilityId    e.g. CAP-LEDGER-007
+Name            "Docket seal chains to predecessor"
+Domain          Register | Ledger | Consensus | Crypto | Payload | Credentials |
+                Identity | Tenancy | Blueprint | Trust | Replication | Platform |
+                CitizenWallet | Surface
+OwningService   Register | Validator | Wallet | Tenant | Blueprint | Peer | Gateway
+Specs[]         spec folders subsumed (traceability back to the 143)
+Surface         Backend | UI | PWA | CLI | MCP
+Status          Implemented | Stub | Deferred
+Invariants[]    invariants this capability can exercise/violate
+Operations[]    driver ops that exercise it
+```
+
+**The 13 domains:** Register lifecycle & genesis · Ledger & docket sealing · Consensus & validator · Cryptography & wallets · Payload encryption & content types · Verifiable credentials & presentations · Identity & auth · Multi-tenant & org topology · Blueprint & workflow engine · Trust & verification · Replication & P2P · Platform services (email/notifications/storage/cache/rate-limit/MCP/CLI) · Citizen Wallet PWA. Surfaces are flagged `Surface` and get thin-smoke, not deep correctness.
+
+**Coverage rule:** CI fails if any `Implemented` capability has zero exercising operations. `Stub`/`Deferred` capabilities are registered too and map to aspirational invariants — so the registry also enumerates the correctness debt.
+
+## Pillar B — Invariant Catalogue
+
+Each invariant is a predicate checked after **every** operation, on both model and real system. Entry schema:
+
+```
+InvariantId         e.g. I-CHAIN
+Statement           plain-English + formal predicate
+Family              Chain | Crypto | Disclosure | Authz | Lifecycle | Idempotency |
+                    ConsensusSafety | Replication | Replay | Durability | StorageFailFast
+DAD                 Disclosure | Alteration | Destruction | n/a
+Tier                Gate | Aspirational
+Issue               #issue (if aspirational/gap)
+ModelCheck          predicate over model state
+HarnessCheck        projection of observable system state + predicate
+Capabilities[]      capabilities that exercise this invariant
+```
+
+| ID | Invariant (plain) | DAD | Tier |
+|----|----|----|----|
+| **I-CHAIN** | Every sealed tx links to a sealed predecessor; docket N hash-chains to N−1; height monotonic; no two dockets at one height; no sealed tx dropped | A | Gate |
+| **I-CRYPTO** | Every tx/docket/vote/credential/delegation signature verifies vs declared key; issuer→holder→device chain valid; tamper ⇒ rejected | A | Gate |
+| **I-DISCLOSE** | SD-JWT presentation reveals only consented claims; payload decryptable only by authorized; no plaintext outside DevMode | D | Gate |
+| **I-AUTHZ** | JWT tier/audience boundary enforced (consumer/platform/service/enrol); admin ⇒ platform+role; /internal ⇒ service; no escalation | n/a | Gate |
+| **I-LIFECYCLE** | Instance / credential / presentation (F111 timebound) state machines take only spec-legal transitions | n/a | Gate |
+| **I-IDEM** | Retried writes don't double-apply; same-number+same-hash docket = idempotent, divergent = rejected (#814); welcome-email-once | A | Gate |
+| **I-STORAGE-FF** | Audited storage interfaces are persistent in Prod/Staging (F113 fail-fast) | n/a | Gate |
+| **I-CONSENSUS** | No conflicting dockets sealed at a height under concurrent proposers; votes verified end-to-end incl. upstream collector; abandoned-docket txs always return to pool | A | Aspir. (B-01, #787) |
+| **I-CONVERGE** | Replicated register converges; SyncOnly replica SSR == owner SSR; survives node loss | D | Aspir. (#917, #585) |
+| **I-REPLAY** | A sealed tx cannot be re-applied (monotonic per-sender sequence) | A | Aspir. (B-02) |
+| **I-DURABLE** | A sealed docket survives an immediate node crash (w:majority + journal) | D | Aspir. (Mongo w:1) |
+| **I-AUDIT** | Validator reconstructs historical control-blueprint config to validate old dockets | A | Aspir. (ControlBlueprintVersionResolver stub) |
+| **I-REVOKE** | Org-key / credential revocation propagates and is enforced | n/a | Aspir. (DID-revocation stub) |
+
+**DAD mapping:** I-CHAIN/I-IDEM/I-REPLAY = **Alteration**; I-DISCLOSE = **Disclosure**; I-CONVERGE/I-DURABLE = **Destruction**. The catalogue is a machine-checkable encoding of Sorcha's founding security claim, plus the crypto/authz/lifecycle invariants that protect it. The 7 Gate invariants are the no-regression floor; the 6 Aspirational ones are the executable v1 correctness backlog.
+
+## Execution pipeline
+
+### 3a. Operation Driver
+One operation set (`CreateRegister`, `SubmitTx`, `BuildDocket`, `Seal`, `CastVote`, `IssueCredential`, `Present`, `Revoke`, `Replicate`, `EnrolDevice`, `InviteParticipant`, `CrashNode`, `AdvanceClock`, `PartitionPeer`, …), each tagged with the capabilities it exercises, runnable against both model and harness. Two modes:
+- **Curated mega-sequence** — deterministic scripted run touching every `Implemented` capability ≥1, ordered as a synthetic council-universe storyline so it reads.
+- **Property-based generator** (CsCheck) — randomized op+fault sequences with shrinking; failing sequences minimized and pinned as regression seeds.
+
+### 3b. Reference Model (design correctness)
+Pure in-memory `ISorchaModel` (no I/O) implementing only legal transitions; re-checks the entire Invariant Catalogue after every op. Fast (xUnit), cheapest place to catch design-level violations.
+
+### 3c. Formal consensus core (TLA+/TLC)
+Chain-integrity + consensus-safety + seal-ordering subset (`I-CHAIN`, `I-CONSENSUS`, `I-CONVERGE`) modeled in TLA+, exhaustively model-checked within bounds (≤3 validators, ≤4 dockets, concurrent proposers, message reorder/loss). The only layer that *proves* (not samples) safety in the #119/#787/#917 space. A sync test asserts the C# model's transition table matches the TLA+ actions.
+
+### 3d. Fault-Injection Harness (implementation correctness)
+Replays the same op sequences against the real stack (Testcontainers/Aspire: real Mongo/Postgres/Redis + multiple validator/peer instances) with controllable clock, induced crashes, slow/partitioned peers, forced concurrent seals. After each op, projects observable state (ledger reads, API responses, OTel signals) and checks the Invariant Catalogue; where feasible asserts model⇄implementation refinement. This is where Aspirational invariants get teeth and where the "distributed paths only tested locally" gap closes.
+
+### 3e. Thin Surface Smoke
+One presence-check per `Surface` capability (CLI command → expected ledger effect; PWA enrol → device registered; `/.well-known/*` served). No deep UI behavior.
+
+### 3f. Two-Tier Verdict
+- **Gate** (CI-blocking): all `Gate` invariants hold across the model run; TLA+ core passes; harness happy-path + bounded-fault run green; **100% of `Implemented` capabilities covered**.
+- **Tracked-red** (dashboard, non-blocking): each `Aspirational` invariant's pass/fail + issue link — the live v1 backlog. Red→green = a gap genuinely closed; a Gate invariant red = release-stopper.
+
+One run, two readings.
+
+## Build order (model-first; value at every phase)
+
+| Phase | Deliverable | Infra | Notes |
+|---|---|---|---|
+| **P0 — Pillars** | Capability Registry (143 → ~70–90 capabilities) + Invariant Catalogue, declarative | None | The abstract coverage map + executable spec; supersedes the stale May-16 roadmap; Aspirational set = v1 backlog |
+| **P1 — Reference Model** | Pure C# `ISorchaModel` + curated mega-sequence + invariant predicates; 100% capability coverage at model level | None | The "ultimate proof" in abstract runnable form; design correctness from day one |
+| **P2 — Property-based driver** | CsCheck generator over the model; shrinking; pinned seed corpus | None | Flushes design-level races the scripted path misses |
+| **P3 — Formal consensus core** | TLA+ spec of I-CHAIN/I-CONSENSUS/I-CONVERGE + TLC check + C#↔TLA+ sync test | TLA+ | Exhaustive safety proof of the #119/#787/#917 space; parallel with P2 |
+| **P4 — Fault harness** | Conformance harness: black-box happy path (reuse walkthroughs), then fault injection (clock, crashes, slow/partitioned peers, concurrent seals) | Testcontainers/Aspire | Implementation correctness; **subsumes deferred #585 / roadmap Q-03 cross-node harness** |
+| **P5 — Surfaces + verdict + CI** | Thin UI/PWA/CLI/MCP smoke; two-tier verdict report; CI gate + tracked-red dashboard | reuse P4 | The complete gated instrument |
+
+**Character:** P0→P1→P2 are pure-abstract (no infra — land fast, low risk). P3 parallelizes. P4→P5 are the heavy lift and *are* the cross-node test infra the assessment flagged as the highest-leverage v1 investment.
+
+**Stopping points:** after P0 — coverage map + correctness backlog; after P2 — full design-correctness proof with coverage; after P4 — implementation-correctness under faults.
+
+**Readiness linkage:** P0–P2 suffice to make a credible *controlled single-validator v1* claim. P4 is what flips the multi-validator/durability/replication Aspirational invariants from tracked-red to gate-able — i.e. what would let you make a credible *public multi-validator v1* claim.
+
+## Non-goals
+- Not a replacement for the existing unit suite or walkthroughs — it sits above them and reuses the walkthrough infra in P4.
+- Not deep UI/UX behavioral testing (surfaces get presence-smoke only).
+- Not a realistic business-scenario demo (scenarios are synthetic, engineered for coverage).
+- Does not itself *fix* any correctness gap — it makes gaps loud and gate-able.
+
+## Open questions for spec phase
+- Exact capability count after dedup (P0 will produce the authoritative list).
+- TLA+ bound sizes for tractable TLC runtime.
+- Whether P4 runs nightly (heavy) vs per-PR (gate subset) — likely gate subset per-PR, full fault matrix nightly.
+- Where the C# model + harness projects live in the solution (`tests/Sorcha.ConformanceOracle.*`?).

--- a/specs/149-conformance-oracle/checklists/requirements.md
+++ b/specs/149-conformance-oracle/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Sorcha Conformance Oracle (SCO)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Concrete realization technologies (reference-model language, formal-spec language for the consensus core, containerized harness) are deliberately held in the **Assumptions** section as fixed design constraints, with full detail in `docs/superpowers/specs/2026-06-06-sorcha-conformance-oracle-design.md`, to keep the FRs and Success Criteria behavioral and technology-agnostic.
+- Zero [NEEDS CLARIFICATION] markers: ambiguous points (harness cadence, Aspirational→Gate promotion policy, capability count, consensus bound sizes) were resolved with documented reasonable defaults in Assumptions rather than blocking the spec.
+- All items pass on first validation pass. Spec is ready for `/speckit.clarify` (optional) or `/speckit.plan`.

--- a/specs/149-conformance-oracle/spec.md
+++ b/specs/149-conformance-oracle/spec.md
@@ -1,0 +1,191 @@
+# Feature Specification: Sorcha Conformance Oracle (SCO)
+
+**Feature Branch**: `149-conformance-oracle`
+
+**Created**: 2026-06-06
+
+**Status**: Draft
+
+**Input**: User description: "Sorcha Conformance Oracle — the 'ultimate proof': a correctness oracle that exercises every Sorcha capability at least once and asserts the platform's guarantees hold after every operation."
+
+> Full design rationale and the locked brainstorming decisions: `docs/superpowers/specs/2026-06-06-sorcha-conformance-oracle-design.md`.
+
+## Overview
+
+Sorcha has 143 spec'd features and 11,088 tests, yet its correctness *under realistic conditions* is unproven: CI validates only unit/in-memory paths, and a recurring family of distributed "seal-window" defects (#119, #787, #814, #917, #585) shows the seal/consensus/replication paths fail in ways unit mocks never expose. The Conformance Oracle is a single instrument that (a) demonstrates every capability is exercised at least once, and (b) asserts the platform's core guarantees still hold after every operation — serving as both a confidence instrument and a live v1-correctness dashboard.
+
+The "users" of this feature are the **engineering team** and the **release decision-maker**.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Complete, traceable map of capabilities and guarantees (Priority: P1)
+
+An engineer needs a single authoritative catalogue of *every* distinct Sorcha capability (deduplicated from the 143 spec folders) and *every* guarantee the platform claims, with each capability traceable back to its originating specs and forward to the guarantees it can affect.
+
+**Why this priority**: Without an agreed coverage axis and guarantee set, "exercises every feature" and "asserts correctness" are undefined. This artifact alone supersedes the stale May-2026 roadmap and enumerates the correctness debt. It requires no test infrastructure.
+
+**Independent Test**: Produce the Capability Registry and Invariant Catalogue; verify every one of the 143 specs maps to ≥1 capability, every capability links to ≥1 guarantee (or is explicitly surface-smoke-only), and every guarantee links to ≥1 capability that can violate it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the 143 spec folders, **When** the registry is built, **Then** each spec is traceable to one or more capabilities and no spec is unmapped.
+2. **Given** the Invariant Catalogue, **When** it is reviewed, **Then** every guarantee is tagged either Gate (must hold today) or Aspirational (known gap) with a linked issue for each Aspirational entry.
+3. **Given** the two pillars, **When** cross-checked, **Then** there are no dead guarantees (no exercising capability) and no orphan capabilities (no linked guarantee and not marked surface-smoke-only).
+
+---
+
+### User Story 2 - Design-correctness proof with full coverage (Priority: P1)
+
+An engineer runs a single proof that drives a deterministic sequence of operations touching every implemented capability at least once and, after every operation, re-checks the entire guarantee set against an abstract reference of how Sorcha *should* behave.
+
+**Why this priority**: This is the "ultimate proof" in its purest, fastest form — design-level correctness plus 100% capability coverage, runnable with no infrastructure on every change. It is the core deliverable.
+
+**Independent Test**: Run the proof; confirm it reports 100% coverage of implemented capabilities and that every Gate guarantee holds across the run; introduce a deliberate defect into the reference behavior and confirm the proof fails loudly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operation sequence, **When** the proof runs to completion, **Then** every implemented capability is recorded as exercised ≥1 and the coverage result is 100%.
+2. **Given** any operation in the sequence, **When** it completes, **Then** all Gate guarantees are re-asserted and hold.
+3. **Given** a deliberately injected guarantee violation, **When** the proof runs, **Then** it fails and names the violated guarantee and the operation that triggered it.
+4. **Given** an implemented capability with no operation that exercises it, **When** the proof runs, **Then** coverage is <100% and the proof fails.
+
+---
+
+### User Story 3 - Adversarial exploration beyond the scripted path (Priority: P2)
+
+An engineer wants assurance that guarantees hold not just along one curated storyline but across many randomized operation-and-fault orderings, with any counterexample automatically minimized to the smallest reproducing sequence.
+
+**Why this priority**: A single linear path proves little about ordering and concurrency. Randomized exploration finds violations the scripted path misses; minimized counterexamples become permanent regression seeds.
+
+**Independent Test**: Run the explorer for a bounded budget; confirm it explores varied orderings including fault events, and that any discovered violation is reported as a minimized, replayable sequence pinned as a regression seed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a randomized run budget, **When** the explorer runs, **Then** it generates varied operation/fault orderings and re-checks all guarantees after each step.
+2. **Given** a discovered violation, **When** the explorer halts, **Then** it emits the minimized reproducing sequence and adds it to the persistent seed corpus.
+
+---
+
+### User Story 4 - Exhaustive proof of the consensus & sealing core (Priority: P2)
+
+A release decision-maker needs exhaustive (not sampled) assurance that the chain-integrity, consensus-safety, and seal-ordering guarantees cannot be violated within bounded conditions — the exact area of the recurring seal-window defects.
+
+**Why this priority**: Randomized testing samples; it cannot prove the absence of a race. The seal/consensus core is the highest-risk, most-defect-prone area and is small enough to verify exhaustively within bounds.
+
+**Independent Test**: Run the exhaustive check over the bounded state space (small numbers of validators and dockets, with message reordering/loss and concurrent proposals); confirm it explores all reachable states and reports no safety violation, and that it is kept in lock-step with the reference behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** the bounded configuration, **When** the exhaustive check runs, **Then** it explores all reachable states and reports either a concrete violating trace or a clean pass.
+2. **Given** the reference behavior and the exhaustive model, **When** compared, **Then** their operation alphabets and guarantee statements are verified to match (no divergence between the two representations).
+
+---
+
+### User Story 5 - Implementation conformance under adversarial conditions (Priority: P2)
+
+An engineer replays the same operation sequences against the real running platform under induced faults — node crashes, slow or partitioned peers, concurrent seals, clock advancement — and confirms the platform's observable behavior conforms to the same guarantees.
+
+**Why this priority**: Design correctness is necessary but not sufficient; the running implementation must conform. This is where the Aspirational guarantees gain teeth and where the long-standing "distributed paths are only tested by hand" gap is closed. It is also the cross-node test harness previously deferred (#585).
+
+**Independent Test**: Run the harness against a real multi-node deployment with fault injection enabled; confirm guarantees are checked on observable platform state after each operation, and that a known gap (e.g. durability under crash) reproduces as a tracked-red result rather than a silent pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** a real multi-node deployment, **When** the operation sequence is replayed with faults injected, **Then** each Gate guarantee is checked against observable state and any violation is reported with the triggering operation and fault.
+2. **Given** a known correctness gap, **When** the harness runs, **Then** the corresponding Aspirational guarantee is reported as tracked-red with its issue link, not as a pass.
+3. **Given** the same seed and fault schedule, **When** the harness is re-run, **Then** the result is reproducible (no nondeterministic pass/fail).
+
+---
+
+### User Story 6 - Two-tier verdict, surface smoke, and CI gate (Priority: P3)
+
+A release decision-maker reads one verdict that (a) gates merges on regression of any guarantee that must hold today plus full capability coverage, and (b) presents the known-gap guarantees as a live backlog; each user-facing surface (web, PWA, CLI, MCP) is confirmed to reach the proven core.
+
+**Why this priority**: This turns the proof into an operational instrument — a CI gate plus a readiness dashboard — and extends coverage to the surfaces with lightweight presence checks. It depends on the earlier slices.
+
+**Independent Test**: Run the full instrument in CI; confirm a Gate violation or sub-100% coverage blocks merge, the Aspirational backlog renders with issue links, and each surface has a passing presence check.
+
+**Acceptance Scenarios**:
+
+1. **Given** a change that regresses a Gate guarantee, **When** CI runs, **Then** the merge is blocked and the verdict names the violation.
+2. **Given** the current platform, **When** the verdict is produced, **Then** the Aspirational guarantees are listed with pass/fail and issue links as a backlog board.
+3. **Given** each user-facing surface, **When** the smoke pass runs, **Then** each surface is confirmed to reach the backend correctly (presence, not deep behavior).
+4. **Given** an Aspirational guarantee that has begun to hold, **When** the verdict is produced, **Then** it is flagged for review for promotion to Gate (it is not auto-promoted).
+
+### Edge Cases
+
+- **New capability with no operation**: coverage drops below 100% and the proof fails until an exercising operation is added.
+- **Dead guarantee**: a guarantee with no exercising capability is flagged at build time, not silently carried.
+- **Aspirational guarantee unexpectedly passes**: flagged for human review for promotion; never auto-promoted to Gate.
+- **Gate guarantee flips to failing**: treated as a release-stopper, distinct from an Aspirational failure.
+- **Nondeterministic harness result under faults**: treated as a defect in the harness (must be reproducible from seed + fault schedule), not tolerated as flakiness.
+- **Surface that cannot reach the backend**: surface smoke fails even if backend correctness passes.
+- **Capability marked Deferred/Stub**: registered and mapped to an Aspirational guarantee; excluded from the 100%-coverage gate but shown in the backlog.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST maintain a Capability Registry enumerating every distinct backend capability (deduplicated from the 143 spec folders) and every user-facing surface, each with: originating specs, owning service, surface type, status (Implemented/Stub/Deferred), and links to the guarantees it can affect and the operations that exercise it.
+- **FR-002**: The system MUST maintain an Invariant Catalogue of platform guarantees, each expressed as a checkable predicate, tagged Gate or Aspirational, with an issue link for every Aspirational entry, and mapped to the security model it protects (Disclosure/Alteration/Destruction where applicable).
+- **FR-003**: The system MUST enforce bidirectional completeness: every spec maps to ≥1 capability; every implemented capability maps to ≥1 operation; every guarantee maps to ≥1 capability that can violate it.
+- **FR-004**: The system MUST provide an operation set ("alphabet") where each operation declares the capabilities it exercises and is runnable against both the abstract reference and the real platform.
+- **FR-005**: The system MUST provide a deterministic, curated operation sequence that exercises every Implemented capability at least once.
+- **FR-006**: The system MUST re-check the entire guarantee set after every operation, against an abstract reference of intended behavior (design correctness).
+- **FR-007**: The system MUST fail, and name the violated guarantee plus the triggering operation, whenever any guarantee being checked at that tier does not hold.
+- **FR-008**: The system MUST report capability coverage and MUST treat coverage below 100% of Implemented capabilities as a failure of the Gate tier.
+- **FR-009**: The system MUST provide a randomized explorer that generates varied operation-and-fault orderings, re-checks guarantees after each step, and emits a minimized, replayable counterexample for any violation, persisting it as a regression seed.
+- **FR-010**: The system MUST provide an exhaustive check of the chain-integrity, consensus-safety, and seal-ordering guarantees over a bounded state space including concurrent proposals and message reordering/loss.
+- **FR-011**: The system MUST verify that the exhaustive consensus representation and the abstract reference agree on their operation alphabet and guarantee statements (no divergence between the two).
+- **FR-012**: The system MUST provide a conformance harness that replays operation sequences against a real multi-node deployment under injected faults (node crash, slow/partitioned peer, concurrent seal, clock advance) and checks guarantees against observable platform state.
+- **FR-013**: The conformance harness MUST be reproducible: the same seed and fault schedule MUST produce the same verdict.
+- **FR-014**: The system MUST provide a presence-check ("smoke") for every user-facing surface confirming it reaches the backend correctly, without asserting deep surface behavior.
+- **FR-015**: The system MUST produce a two-tier verdict: a Gate result (all Gate guarantees hold + 100% Implemented-capability coverage + exhaustive consensus check passes) and a Tracked-red result (each Aspirational guarantee's status with its issue link).
+- **FR-016**: The Gate result MUST be usable as a merge-blocking signal; the Tracked-red result MUST be usable as a readiness/backlog dashboard.
+- **FR-017**: The system MUST flag (not auto-promote) any Aspirational guarantee that begins to hold, for human review toward Gate promotion.
+- **FR-018**: The system MUST register Stub/Deferred capabilities and map them to Aspirational guarantees, excluding them from the 100%-coverage gate while listing them in the backlog.
+- **FR-019**: The system MUST be runnable in stages such that the no-infrastructure layers (registry, catalogue, reference proof, randomized explorer) deliver value independently of the real-platform harness.
+
+### Key Entities *(include if feature involves data)*
+
+- **Capability**: a distinct unit of platform functionality. Attributes: id, name, domain, owning service, originating specs, surface type, status, linked guarantees, exercising operations.
+- **Invariant (Guarantee)**: a checkable property the platform must uphold. Attributes: id, statement, family, security-model mapping, tier (Gate/Aspirational), issue link, exercising capabilities.
+- **Operation**: a unit of behavior in the alphabet (including fault events). Attributes: id, exercised capabilities, applicability to reference vs real platform.
+- **Operation Sequence**: an ordered list of operations — either the curated coverage sequence or a generated/minimized exploration sequence.
+- **Coverage Ledger**: the record of which capabilities have been exercised in a run; basis for the 100% gate.
+- **Verdict**: the two-tier output — Gate (pass/fail + coverage) and Tracked-red (per-Aspirational status + issue links).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of the 143 spec folders are traceable to at least one registered capability.
+- **SC-002**: 100% of Implemented capabilities are exercised at least once by the curated proof; the proof fails if this drops below 100%.
+- **SC-003**: There are zero dead guarantees (no exercising capability) and zero orphan capabilities (no linked guarantee and not marked surface-smoke-only).
+- **SC-004**: 100% of guarantees are tagged Gate or Aspirational, and 100% of Aspirational guarantees carry an issue link.
+- **SC-005**: The no-infrastructure design-correctness proof completes quickly enough to run on every change (target: under a few minutes on a developer machine).
+- **SC-006**: A deliberately injected guarantee violation (mutation) is detected by the proof in 100% of seeded mutation cases — i.e. the proof demonstrably has teeth.
+- **SC-007**: The exhaustive consensus check explores its entire bounded state space and reports a definitive pass or a concrete violating trace (no "unknown").
+- **SC-008**: Every known correctness gap identified in the v1 assessment is represented by exactly one Aspirational guarantee that reproduces as tracked-red (no known gap silently passes).
+- **SC-009**: The conformance harness is reproducible: identical seed + fault schedule yields identical verdicts across repeated runs.
+- **SC-010**: Every user-facing surface (web, PWA, CLI, MCP) has a passing presence check.
+- **SC-011**: A regression of any Gate guarantee blocks a merge in CI within a single run.
+
+## Assumptions
+
+- **Realization technologies are fixed by design** (held here as constraints, not requirements): an abstract reference model and randomized explorer in the team's primary backend language; an exhaustive check of the consensus core in a formal specification language; a conformance harness using the existing containerized integration-test infrastructure. Detail lives in the design doc.
+- **Scenarios may be synthetic**: operation sequences are engineered for coverage, not required to be realistic business workflows.
+- **Surface coverage is shallow by intent**: surfaces get presence checks only; deep UI/UX behavior is out of scope.
+- **Cadence**: the no-infrastructure layers and the Gate subset run on every change; the full fault-injection matrix runs on a scheduled (e.g. nightly) basis to bound CI cost. (Default; revisit if CI budget allows per-change full runs.)
+- **Aspirational promotion is manual**: a passing Aspirational guarantee is flagged for review, never auto-promoted to Gate.
+- **The harness phase subsumes the previously deferred cross-node integration harness** (#585 / roadmap Q-03) rather than duplicating it.
+- **Capability count is approximate** (~70–90 after dedup); the registry build produces the authoritative list.
+- **The existing unit suite and walkthroughs remain**; the oracle sits above them and reuses walkthrough infrastructure in the harness phase. It does not replace them.
+- **The oracle does not fix correctness gaps**; it makes them loud, attributable, and gate-able.
+
+## Dependencies
+
+- The 143 spec folders and existing service code (source of the capability dedup and the guarantee statements).
+- The existing containerized integration-test infrastructure (basis for the conformance harness).
+- The existing walkthrough framework (reused by the harness for happy-path operation drivers).
+- Open issues representing known gaps (#119, #585, #787, #814, #917, B-01/B-02 and the stubs) — linked from Aspirational guarantees.


### PR DESCRIPTION
## Draft — design + spec only (no implementation)

The **Sorcha Conformance Oracle (SCO)**: one correctness instrument that exercises every Sorcha capability ≥1 and asserts the platform's guarantees (DAD model, chain integrity, consensus, crypto) hold after every operation. Born from the 2026-06-05 v1-readiness assessment, which found correctness is the unproven dimension and that CI-green validates only unit/in-memory paths.

### What's in this PR
- **Design doc** — `docs/superpowers/specs/2026-06-06-sorcha-conformance-oracle-design.md` (brainstormed; locked decisions table; full architecture)
- **Spec** — `specs/149-conformance-oracle/spec.md` (6 prioritized user stories mapping to build order P0–P5, 19 FRs, 11 success criteria) + passing quality checklist

### Shape (locked decisions)
- **Correctness proof**, not just coverage — every feature touch asserts a real guarantee
- **Invariant oracle + coverage** — global guarantees re-checked after every operation
- **Layered**: pure abstract reference model (design correctness) + fault-injection harness against the real stack (implementation correctness)
- **Two-tier verdict**: Gate (CI-blocking) + Tracked-red (live v1 correctness backlog)
- **Realization**: C# reference model + property-based driver, plus a **formal TLA+ consensus core** for the #119/#787/#917 seal-window family
- **Two pillars**: Capability Registry (143 specs → ~70–90 capabilities) + Invariant Catalogue (13 invariants: 7 Gate, 6 Aspirational, mapped to DAD)

### Build order (model-first, value at each phase)
P0 pillars → P1 reference model + curated mega-sequence → P2 property-based driver → P3 TLA+ consensus core → P4 fault-injection harness (subsumes the deferred #585 cross-node harness) → P5 surface smoke + verdict + CI.

### Status
Spec stage only. Next: `/speckit.plan` (suggest scoping the first plan to P0–P2, the no-infrastructure layers). Draft — not for merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)