### PR TITLE
feat(ui): make the citizen wallet PWA discoverable from web + landing

### DIFF
--- a/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/UserProfileMenu.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Core/Components/Shared/UserProfileMenu.razor
@@ -54,6 +54,13 @@
                  data-testid="user-menu-my-devices">
         My Devices
     </MudMenuItem>
+    @* The citizen wallet PWA is a separate app at origin-root /wallet/,
+       so this is a full-page navigation (forceLoad), not client routing. *@
+    <MudMenuItem Icon="@Icons.Material.Filled.AccountBalanceWallet"
+                 OnClick="@(() => Navigation.NavigateTo("/wallet/", forceLoad: true))"
+                 data-testid="user-menu-open-wallet">
+        Open my wallet
+    </MudMenuItem>
     <MudMenuItem Icon="@Icons.Material.Filled.Token" OnClick="OpenJwtViewer">
         View Token
     </MudMenuItem>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Get.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Get.razor
@@ -21,7 +21,9 @@
    layout's AuthorizeView keeps the nav chrome minimal for cold
    visitors. *@
 
+@using Sorcha.UI.Core.Services
 @inject NavigationManager Nav
+@inject IQrPresentationService Qr
 
 <PageTitle>Get started with Sorcha</PageTitle>
 
@@ -31,37 +33,42 @@
             Welcome to Sorcha
         </MudText>
 
-        <MudText Typo="Typo.body1" Class="mb-4">
-            Sorcha is a wallet for services that use the Sorcha platform.
-            Your credentials live on your phone — when a council, service,
-            or organisation issues you a credential, it arrives directly
-            in your wallet.
-        </MudText>
-
         <MudText Typo="Typo.body1" Class="mb-6">
-            To get started, sign up at the council or service that asked
-            you to install the wallet, then come back here to sign in.
+            The Sorcha Wallet keeps your credentials on your own device.
+            When a council, service, or organisation issues you a
+            credential, it arrives directly in your wallet — ready to
+            present whenever you need to prove something.
         </MudText>
 
-        <MudDivider Class="my-4" />
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Size="Size.Large"
+                   FullWidth="true"
+                   StartIcon="@Icons.Material.Filled.AccountBalanceWallet"
+                   OnClick="@(() => Nav.NavigateTo(_walletUrl, forceLoad: true))"
+                   data-testid="get-landing-open-wallet">
+            Open Wallet
+        </MudButton>
 
-        <MudText Typo="Typo.h6" Class="mb-2">
-            Find services that use Sorcha
+        <MudDivider Class="my-6" />
+
+        <MudText Typo="Typo.h6" Class="mb-3">
+            Install on your phone
         </MudText>
-        <MudList T="string" Class="mb-6">
-            <MudListItem T="string" Icon="@Icons.Material.Filled.AccountBalance"
-                         OnClick="@(() => Nav.NavigateTo("https://strathcarron.gov", forceLoad: true))"
-                         data-testid="get-landing-strathcarron">
-                Strathcarron Council
-            </MudListItem>
-        </MudList>
+        <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+            Scan this code with your phone's camera to open the wallet,
+            then use "Add to Home Screen" to install it.
+        </MudText>
+        <div class="d-flex justify-center mb-2" data-testid="get-landing-qr">
+            @((MarkupString)_walletQrSvg)
+        </div>
 
-        <MudDivider Class="my-4" />
+        <MudDivider Class="my-6" />
 
         <MudText Typo="Typo.h6" Class="mb-3">
             Already have an account?
         </MudText>
-        <MudButton Variant="Variant.Filled"
+        <MudButton Variant="Variant.Outlined"
                    Color="Color.Primary"
                    Size="Size.Large"
                    FullWidth="true"
@@ -79,6 +86,18 @@
 </MudContainer>
 
 @code {
+    private string _walletUrl = "/wallet/";
+    private string _walletQrSvg = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        // The wallet PWA lives at origin-root /wallet/ (a separate WASM
+        // app behind the gateway), not under this app's base path — so
+        // resolve an absolute origin URL for both the CTA and the QR.
+        _walletUrl = new Uri(new Uri(Nav.BaseUri), "/wallet/").ToString();
+        _walletQrSvg = Qr.GenerateSvgFromUri(_walletUrl, pixelsPerModule: 6);
+    }
+
     private void HandleSignIn()
     {
         // F128 US4 — sign-in returnUrl pinned to the F128 handoff so a

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/MyDevices.razor
@@ -74,9 +74,19 @@
     else if (_devices is null || _devices.Count == 0)
     {
         <MudAlert Severity="Severity.Info" data-testid="my-devices-empty">
-            No wallet devices enrolled yet. Once you enrol from the citizen
-            wallet PWA, devices will appear here.
+            No wallet devices enrolled yet. Open the citizen wallet on your
+            device to enrol it, then it will appear here.
         </MudAlert>
+        @* The citizen wallet PWA is a separate app at origin-root /wallet/,
+           so this is a full-page navigation (forceLoad), not client routing. *@
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Primary"
+                   Class="mt-3"
+                   StartIcon="@Icons.Material.Filled.AccountBalanceWallet"
+                   OnClick="@(() => Nav.NavigateTo("/wallet/", forceLoad: true))"
+                   data-testid="my-devices-open-wallet">
+            Open the wallet
+        </MudButton>
     }
     else
     {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -68,6 +68,7 @@
                 <a href="#sectors" class="nav-link">Sectors</a>
                 <a href="#toolkit" class="nav-link">Toolkit</a>
                 <a href="#developers" class="nav-link">Developers</a>
+                <a href="/wallet/" class="nav-link">Wallet</a>
                 <a href="/app/help" class="nav-link">Help</a>
                 <a href="/auth/login" class="btn btn-primary">Sign In</a>
             </div>
@@ -94,7 +95,11 @@
                 — without trusting the platform.
             </p>
             <div class="hero-actions">
-                <a href="https://github.com/Sorcha-Platform" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
+                <a href="/wallet/" class="btn btn-primary btn-lg">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M21 18v1c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2V5c0-1.1.89-2 2-2h14c1.1 0 2 .9 2 2v1h-9c-1.11 0-2 .9-2 2v8c0 1.1.89 2 2 2h9zm-9-2h10V8H12v8zm4-2.5c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5z"/></svg>
+                    Open Wallet
+                </a>
+                <a href="https://github.com/Sorcha-Platform" class="btn btn-outline btn-lg" target="_blank" rel="noopener">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
                     View on GitHub
                 </a>


### PR DESCRIPTION
## Problem

The citizen wallet PWA (`/wallet/`) had **zero inbound links** from anywhere — the marketing landing, the web app, even the purpose-built `/get` cold-landing page never linked to it. The only way to reach the wallet was to type the URL. Separately, `/get` hard-coded a `strathcarron.gov` demo council, which is just a sample site and not core to the product.

## Changes (5 quick wins, one PR)

1. **Landing hero — balanced audience split** (`index.html`, static): "Open Wallet" is now the primary hero CTA (→ `/wallet/`); the existing GitHub / Read-the-Architecture buttons become the builder path. Added a "Wallet" link to the top nav.
2. **`/get` is now a real wallet front door** (`Get.razor`): removed the hard-coded Strathcarron service directory. Page is now: what-the-wallet-is → **Open Wallet** → **Install on your phone (QR)** → secondary Sign in. The F128 cold-landing sign-in attribution (`reason=cold-landing`) is preserved.
3. **Install QR on `/get`**: rendered via the existing `IQrPresentationService` (QRCoder) → inline SVG, no new dependency, no JS interop.
4. **Web → PWA bridge**: "Open my wallet" item in `UserProfileMenu`; the `MyDevices` empty state's dead-end sentence ("enrol from the citizen wallet PWA") is now an actual **Open the wallet** button.

All cross-app navigations use `forceLoad: true` because `/wallet/` is a separate WASM app behind the gateway — client-side routing would 404.

## Out of scope (deferred to the longer-term reposition)

Marketing copy/narrative rewrite, PWA-side "Add to Home Screen" prompt, the unified launcher, and a cross-surface app switcher.

## Verification

- `dotnet build Sorcha.UI.Web.Client` — succeeded, 0 warnings, 0 errors (transitively covers `Sorcha.UI.Core`).
- No `ISnackbar` / `Snackbar.Add` introduced (Pattern #12 ratchet safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)