### PR TITLE
feat(149): wallet-aware PairingTakeover — route walletless citizens to web wallet creation

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -1263,6 +1263,7 @@ Four citizen routes outside the F126 council-page gate, all sharing the existing
 | `POST /api/auth/enrol-session/short-code` | bearer | Mint a 6-digit numeric short code wrapping a standalone enrol-session token. 5-min TTL, single-use, 5-attempts-per-code rate-limit. Used by the takeover sub-affordance + mobile-web install fallback. |
 | `POST /api/auth/enrol-session/redeem-short-code` | anonymous | Redeem a 6-digit code → underlying enrol-session redeem result. |
 | `GET /api/v1/me/devices/has-any` | bearer | Aggregate read returning `{ hasAnyDevice, latestEnrolledAt }`. Drives the takeover trigger + nag-banner trigger. |
+| `GET /api/v1/wallet/exists` | consumer-tier | **(F149)** Aggregate read returning `{ hasWallet }`. ALWAYS 200 for an authenticated consumer (no 401/404 ambiguity). Drives the wallet-aware branch of `PairingTakeover`. |
 | `POST /api/auth/pairing-resumption-email` | bearer, rate-limited | Dispatches the "Email me a link" magic-link to the caller's account email. |
 | `GET /api/auth/pairing-resumption/redeem?token={id}` | anonymous | Redeems the magic-link → 302 to `/auth/login?returnUrl=/setup/add-device&email=...&reason=pairing-resumption`. Single-use. |
 
@@ -1277,7 +1278,7 @@ Four citizen routes outside the F126 council-page gate, all sharing the existing
 
 ### Components (Sorcha.UI.Components.User)
 
-- **`PairingTakeover`** (`Sorcha.Wallet.Pwa/Components/PairingTakeover.razor` — **PWA-local, NOT in Components.User**) — full-page overlay mounted in `Sorcha.Wallet.Pwa/MainLayout.razor` outside `MudLayout`. Renders when `HasAnyDevice == false`. Primary action invokes `IEnrolmentService.EnrolAsync` against the existing PWA session; secondary disclosure accepts a 6-digit code for cross-device-to-this-device pairing. Auto-dismisses on probe-change OR `CitizenWalletHubConnection.OnDeviceEnrolled`.
+- **`PairingTakeover`** (`Sorcha.Wallet.Pwa/Components/PairingTakeover.razor` — **PWA-local, NOT in Components.User**) — full-page overlay mounted in `Sorcha.Wallet.Pwa/MainLayout.razor` outside `MudLayout`. Renders when `HasAnyDevice == false`. **(F149) Wallet-aware:** when there is no device here it runs a one-shot `IHasWalletProbe.HasWalletAsync`; a walletless citizen sees a "Create your wallet first" body that force-loads the web `/wallets/create` handoff (companion-first), while a wallet owner gets the pair body below. The overlay stays hidden until both the device check and the wallet check resolve (no flash). Pair-body primary action invokes `IEnrolmentService.EnrolAsync` against the existing PWA session; secondary disclosure accepts a 6-digit code for cross-device-to-this-device pairing. Auto-dismisses on probe-change OR `CitizenWalletHubConnection.OnDeviceEnrolled`.
 - **`PairingHandoffSurface`** (`Components/Pairing/`) — hosted at `/setup/add-device`. Switches on `IPwaInstallabilityProbe` verdict between the QR variant (desktop) and the install variant (mobile, with always-visible short code). Common Skip + "Email me a link" affordances.
 - **`PairingNagBanner`** (`Components/Pairing/`) — persistent dismissable banner mounted in `Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor`. Renders when `HasAnyDevice == false`. CTA → `/setup/add-device`.
 
@@ -1299,6 +1300,31 @@ Four citizen routes outside the F126 council-page gate, all sharing the existing
 - Wallet PWA: `Components/PairingTakeover.razor`; `Services/CitizenWalletHubConnection.cs` (OnDeviceEnrolled); `Services/Enrolment/{IPairingShortCodeRedeemer,PairingShortCodeRedeemer}.cs`
 - Sorcha.UI.Components.User: `Components/Pairing/{PairingHandoffSurface,PairingNagBanner}.razor`; `Services/User/Devices/{IHasPairedDeviceProbe,HasPairedDeviceProbe}.cs`; `Services/User/Pairing/{IPwaInstallabilityProbe,PwaInstallabilityProbe}.cs` (`PairingTakeover.razor` is PWA-local — listed under Wallet PWA above)
 - Sorcha.UI.Web.Client: `Pages/Setup/AddDevice.razor`; `Pages/Get.razor`; `wwwroot/js/pwa-install-probe.js`
+
+### Feature 149 — wallet-aware PairingTakeover (companion-first P0)
+
+Closes the cold-start dead-end where a signed-in but walletless citizen tapped "Set up this
+device" → enrol 404. Companion-first: the web app owns wallet creation, so the PWA routes the
+citizen there instead of building in-PWA wallet creation.
+
+- **Endpoint:** `GET /api/v1/wallet/exists` → `200 { hasWallet }` (consumer-tier, always 200) in
+  `Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs` (`WalletExists` handler; projects
+  `ResolveCitizenContextAsync` → `walletAddress is not null`). DTO `WalletExistsResponse` in
+  `Sorcha.CitizenWallet.Abstractions/Models/`.
+- **Why not reuse holder-keys/enrol 404:** `holder-keys` 401s on no-wallet and 404s on
+  *wallet-but-no-key* (the opposite signal); the no-wallet status is inconsistent across the
+  citizen surface. A dedicated boolean endpoint is unambiguous.
+- **Client:** `IHasWalletProbe` + `HasWalletProbe` (`Sorcha.Wallet.Pwa/Services/Wallet/`,
+  PWA-local). **One-shot** (`Task<bool> HasWalletAsync` only — no `Changed`/`Refresh`): walletless
+  is a terminal cold-start state (false→true once, never back). **Fail-safe `true`** on any
+  transient failure (network / non-2xx / empty / malformed body) so a real wallet owner is never
+  routed to create a second wallet. Registered with the Bearer + ServerClock handler chain.
+- **State machine** (`PairingTakeover`): hidden while `HasAnyDevice == null` OR `_hasWallet ==
+  null`; `HasAnyDevice == true` → hidden; `false`+`_hasWallet == false` → create-wallet body;
+  `false`+`_hasWallet == true` → existing pair body (unchanged). The wallet check runs once, only
+  when there is no device here.
+- **Tests:** `CitizenWalletExistsEndpointTests` (Wallet Service, reflection handler invocation);
+  `HasWalletProbeTests` + `PairingTakeoverTests` (PWA, bUnit).
 
 ---
 

--- a/docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md
+++ b/docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md
@@ -89,10 +89,11 @@ this proven spine.
 ## 4. Companion-first roadmap
 
 ### P0 — correctness / safety (do first)
-1. **Make PairingTakeover wallet-aware.** Detect "has a wallet?" (not just "has a device?") and
-   route a walletless citizen to the web wallet-creation handoff instead of offering "Set up this
-   device" (which dead-ends). Same pattern as the tour suppression + signup link. *(This is the
-   PairingTakeover discussion item.)*
+1. **Make PairingTakeover wallet-aware.** ✅ **DONE (Feature 149).** Detect "has a wallet?" (not
+   just "has a device?") via `GET /api/v1/wallet/exists` + one-shot `IHasWalletProbe`, and route a
+   walletless citizen to the web `/wallets/create` handoff instead of offering "Set up this device"
+   (which dead-ended at the enrol 404). Same companion-first pattern as the tour suppression +
+   signup link. Design: `docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md`.
 2. **Make recovery honest.** Decide: implement passkey-recovery verification, OR explicitly scope
    recovery to the web app for now and make the PWA's messaging/affordances match (no dead
    recovery paths, a clear "recover on the web" route). Companion-first leans toward the latter

--- a/docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md
+++ b/docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md
@@ -1,0 +1,222 @@
+# Wallet-aware PairingTakeover (companion-first P0 #1)
+
+**Date:** 2026-06-06
+**Status:** Approved — ready for implementation plan
+**Feature area:** Citizen Wallet PWA (Feature 128 cold-start onboarding)
+**Roadmap item:** P0 #1 in `docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md`
+**Decision owner:** Stuart Fraser
+
+---
+
+## 1. Problem
+
+`PairingTakeover` (`src/Apps/Sorcha.Wallet.Pwa/Components/PairingTakeover.razor`) is a
+full-screen overlay shown to any signed-in citizen with **no paired device on this hardware** —
+it gates on `IHasPairedDeviceProbe.HasAnyDevice == false`. Its only primary action ("Set up this
+device") calls `IEnrolmentService.EnrolAsync` → `POST /api/v1/wallet/devices/enrol`.
+
+But **device enrolment requires a wallet to already exist.** `ResolveCitizenContextAsync` returns
+a null wallet when none resolves for the caller, and the enrol endpoint then returns **404**. So a
+citizen who reaches the PWA *without* having created a wallet on the web (signed up on web but never
+created a wallet, or landed in the PWA first) taps "Set up this device" → 404 → the generic
+`"Couldn't pair this device…"` error → **dead-end with no way forward**.
+
+The consumer-tier JWT (Feature 136) carries `org_id` but **omits wallet binding**, so "does this
+citizen have a wallet?" is a **server fact** — it cannot be read from the token.
+
+This is the companion-first direction in action: the **web app owns wallet creation**; the PWA must
+*route* a walletless citizen to the web rather than dead-end them. (Same shape as the already-shipped
+guided-tour suppression and the sign-in "Create an account → web signup" link.)
+
+### Key design constraint (from brainstorm)
+
+**Walletless is a one-shot, terminal cold-start state.** Creating a wallet is essentially the first
+thing a citizen does, and once a wallet exists it is impossible to drop back to zero wallets. So the
+"has wallet?" signal only ever transitions `false → true`, once, and never back. This is why the
+detection does **not** need a live event-driven probe — a single check is sufficient and correct.
+
+---
+
+## 2. Detection mechanism (decided)
+
+We considered piggy-backing on an existing endpoint's failure mode and **rejected it** after
+verifying the actual behaviour:
+
+- `GET /api/v1/wallet/holder-keys` returns **401** when no wallet resolves (`platformUserId is null
+  || citizenWallet is null`) and **404** only when a wallet *exists* but no holder/delivery key is
+  derivable yet. Its 404 therefore means the *opposite* of walletless — it fires for the
+  has-wallet/no-device citizen we explicitly want to keep on the pair flow. (The endpoint's XML doc
+  claiming "404 when no wallet resolves" is wrong vs. its implementation.)
+- The no-wallet signal is also **inconsistent across the citizen surface**: enrol 404s on no-wallet,
+  holder-keys 401s. Coupling takeover logic to any one endpoint's failure mode is fragile.
+
+**Decision:** add a tiny, purpose-built endpoint that returns an explicit boolean and always 200,
+consumed by a one-shot client check.
+
+---
+
+## 3. Design
+
+### 3.1 Server — new existence endpoint
+
+A new consumer-tier endpoint in `CitizenWalletEndpoints.cs`, mounted on the existing
+`/api/v1/wallet` group (so it inherits `RequireConsumerAudience` + `RateLimitPolicies.Strict`):
+
+```
+GET /api/v1/wallet/exists  →  200 { "hasWallet": bool }
+```
+
+- Handler resolves the citizen via `ResolveCitizenContextAsync` and returns
+  `Results.Ok(new WalletExistsResponse { HasWallet = walletAddress is not null })`.
+- **Always 200** for an authenticated consumer — it deliberately avoids the 401/404 ambiguity that
+  made the other endpoints unusable for this purpose. An unauthenticated or non-consumer caller is
+  still rejected upstream by the `RequireConsumerAudience` gate (401/403); a *signed-in* citizen
+  always receives a clean boolean.
+- New response record `WalletExistsResponse { bool HasWallet }` in
+  `Sorcha.CitizenWallet.Abstractions.Models` (sibling to `HasAnyDeviceResponse`), XML-documented.
+- OpenAPI metadata: `.WithName("CitizenWalletExists")`, `.WithSummary(...)`, `.WithDescription(...)`,
+  `.Produces<WalletExistsResponse>(StatusCodes.Status200OK)`,
+  `.Produces(StatusCodes.Status401Unauthorized)`. License header on the new model file.
+
+### 3.2 Client — one-shot probe (not an event probe)
+
+New PWA-local service:
+
+```csharp
+public interface IHasWalletProbe
+{
+    /// One-shot: does the signed-in citizen have a wallet? Walletless is a
+    /// terminal cold-start state (false → true, once, never back), so there is
+    /// deliberately no Changed/EnsureLoadedAsync/Refresh contract.
+    Task<bool> HasWalletAsync(CancellationToken ct = default);
+}
+```
+
+- Typed-HttpClient implementation `HasWalletProbe` calling `GET /api/v1/wallet/exists`.
+- Lives in `src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/` — **PWA-local**; the web host does not need
+  it (only `PairingTakeover` consumes it). Namespace at subject level per the F123 convention.
+- Registered in `Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs` with the **same handler
+  chain as the device probe**: `BearerTokenHandler` + `ServerClockHandler`, base address =
+  `gatewayBaseAddress`.
+- **Fail-safe direction:** on a network/transient failure (`HttpRequestException`, timeout, non-2xx,
+  empty body) the probe returns **`true`** — i.e. *assume the citizen has a wallet* and fall through
+  to the existing pair flow (which has its own error handling). Rationale: we must never (a) block a
+  real wallet-owner behind a flaky existence check, nor (b) falsely send a wallet-owner to create a
+  second wallet. The cost of a false `true` is only that a genuinely walletless citizen sees the
+  enrol path's existing 404 message instead of the new create-wallet copy — strictly no worse than
+  today's behaviour.
+
+### 3.3 PairingTakeover — three explicit states
+
+State resolution order, gated so the overlay **never dead-ends and never flashes**:
+
+| Order | Condition | UI |
+|---|---|---|
+| — | device probe `HasAnyDevice == null` (initial fetch in flight) | hidden (unchanged) |
+| — | `HasAnyDevice == true` | hidden — device already paired here (unchanged) |
+| 1 | `HasAnyDevice == false` **and** `hasWallet == false` | **Create-wallet state** (new) |
+| 2 | `HasAnyDevice == false` **and** `hasWallet == true` | **Pair state** (today's UI, unchanged) |
+
+**Flow:** `OnInitializedAsync` subscribes + awaits the device probe exactly as today. When the device
+probe resolves to `false`, the component awaits the one-shot `HasWalletAsync` **once** and stores the
+result in a nullable `bool? _hasWallet` field before choosing which body to render. While that single
+call is in flight, `_hasWallet == null` and the overlay stays **hidden** (the same "don't flash"
+rule that already applies to the null device-probe window). Visibility predicate becomes:
+
+```
+_isVisible = Probe.HasAnyDevice == false && _hasWallet is not null;
+// body chosen by _hasWallet.Value
+```
+
+The existing dismissal sources (local pair-success, remote `DeviceEnrolled` hub event,
+`Probe.Changed`) are unchanged and only matter in the pair state.
+
+**Create-wallet state** — new body rendered inside the same `sorcha-welcome-overlay` /
+`sorcha-welcome-content` frame (re-uses `welcome-takeover.css`, consistent with the pair state):
+
+- Headline: **"Create your wallet first"**
+- Subhead: *"Your Sorcha wallet lives in your account on the web. Create it there, then come back
+  here to pair this phone and hold your credentials."*
+- Primary button **"Create your wallet"** → `GoToWebWalletCreation()`:
+
+  ```csharp
+  // Wallet creation lives on the web host at origin-root /wallets/create (the
+  // PWA is mounted under /wallet/, so build the absolute origin URL rather than
+  // a leading-slash path). forceLoad because it leaves the PWA for the web app.
+  var origin = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
+  Nav.NavigateTo($"{origin}/wallets/create", forceLoad: true);
+  ```
+
+  This is byte-for-byte the `SignIn.razor` `GoToWebSignup` precedent (verified to exist at
+  `/wallets/create` on the web host: `Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor`).
+- **No short-code panel** in this state — redeeming a pairing code still requires a wallet, so it
+  would dead-end identically. The short-code affordance stays only in the pair state.
+- Test hooks: `data-testid="pairing-takeover-create-wallet"` (container) and
+  `data-testid="pairing-takeover-create-wallet-button"` (primary CTA).
+
+**Fire-and-forget return** (decided): the citizen creates the wallet on the web, returns to the PWA,
+the takeover re-initialises, the one-shot check now returns `true`, and they get the pair flow. No
+cross-host return URL, no web-side changes — matching the companion-first signup-link precedent.
+
+---
+
+## 4. Testing (TDD)
+
+- **`HasWalletProbeTests`** (`tests/Sorcha.Wallet.Pwa.Tests/Services/`) — mocked `HttpMessageHandler`
+  in the `EnrolmentServiceTests` style:
+  - `200 {hasWallet:true}` → `HasWalletAsync` returns `true`.
+  - `200 {hasWallet:false}` → returns `false`.
+  - transient failure (throw / 500 / empty body) → returns `true` (fail-safe).
+- **`PairingTakeoverTests`** (`tests/Sorcha.Wallet.Pwa.Tests/Components/`, `ComponentTestFixture`):
+  - device probe `false` + wallet probe `false` → renders the create-wallet body
+    (`pairing-takeover-create-wallet` present); the enrol primary button is **absent**.
+  - device probe `false` + wallet probe `true` → renders the existing pair body
+    (`pairing-takeover-primary-button` present); create-wallet body absent.
+  - wallet probe in flight (`_hasWallet == null`) → overlay hidden (no `pairing-takeover` node).
+  - device probe `true` → hidden (regression guard, unchanged behaviour).
+  - MudBlazor overlay/expansion/text content rendered via the provider-host pattern
+    (`MudPopoverProvider` / `MudDialogProvider`) where the component tree needs it, per
+    `tests/Sorcha.UI.Core.Tests/TestHosts/GuidedTourHost.razor`.
+- **E2E** under `tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/` — added only if feasible.
+  Authenticated PWA state lives in IndexedDB (issue #700), so an authenticated walletless E2E may
+  self-`Assert.Ignore`. The `data-testid` hooks are added regardless; the PR is **not** blocked on a
+  green authenticated E2E.
+
+---
+
+## 5. Guardrails honoured
+
+- **Notification routing:** no `ISnackbar` (CI gate `scripts/check-no-snackbar.ps1`); the
+  create-wallet state surfaces no toast — errors, if any, stay inline `MudAlert` as in the pair
+  state. Actor's-own-action feedback only.
+- License header on the 3 new files (`WalletExistsResponse`, `IHasWalletProbe`, `HasWalletProbe`).
+- **No hard-coded `<Version>`** anywhere (unified build-time versioning).
+- All work on `feature/pwa-pairing-takeover-wallet-aware` → phased atomic commits → **one PR**.
+- **Clean-break** — the endpoint is brand-new, no back-compat shim. No EF/schema change (read-only
+  resolution of an existing column), so no migration.
+- **Doc-sync:** update the F128 entry in `.claude/skills/sorcha-architecture/SKILL.md` (new
+  `/api/v1/wallet/exists` surface + the wallet-aware takeover state machine) and tick P0 #1 in the
+  companion-first roadmap.
+
+---
+
+## 6. Out of scope (YAGNI / separate items)
+
+- Round-trip return URL from web `/wallets/create` back to the PWA pair flow.
+- A full event-driven `IHasWalletProbe` (Changed/EnsureLoadedAsync/Refresh) — unjustified for a
+  one-shot terminal state.
+- Any web-side change to `/wallets/create`.
+- Recovery honesty (roadmap **P0 #2**) — tracked separately.
+- In-PWA wallet creation / signup / recovery — the self-contained PWA milestone (roadmap §5).
+
+---
+
+## 7. Definition of done
+
+- A walletless signed-in citizen in the PWA gets a clear "create your wallet on the web" path (no
+  dead-end), and after creating one can return and pair the device.
+- A citizen who **has** a wallet but no device here still gets the existing pair flow, unchanged.
+- New behaviour is covered by bUnit (component states) + the probe unit tests; E2E hooks present.
+- Single PR, green CI (`build-and-test` + `claude-review`), code-reviewed, then validated on n1
+  (pull + recreate `sorcha-wallet-pwa`, confirm new build badge, walk the walletless + has-wallet
+  paths) using the `n1-deploy` skill.

--- a/specs/149-pwa-pairing-takeover-wallet-aware/contracts/wallet-exists.openapi.yaml
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/contracts/wallet-exists.openapi.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Citizen Wallet — Wallet Existence
+  version: "1.0.0"
+  description: >
+    Feature 149. Reports whether the signed-in citizen has a wallet, so the
+    Citizen Wallet PWA's PairingTakeover can route a walletless citizen to web
+    wallet creation instead of dead-ending at the device-enrol 404.
+
+paths:
+  /api/v1/wallet/exists:
+    get:
+      operationId: CitizenWalletExists
+      summary: Does the signed-in citizen have a wallet?
+      description: >
+        Consumer-tier. Resolves the caller's wallet via the standard citizen
+        context resolution and returns an explicit boolean. ALWAYS returns 200
+        for an authenticated consumer (no 401/404 ambiguity) so the PWA gets a
+        clean signal. An unauthenticated or non-consumer caller is rejected at
+        the RequireConsumerAudience gate (401/403). Leaks no wallet address/PII.
+      tags: [Citizen Wallet]
+      security:
+        - consumerBearer: []
+      responses:
+        "200":
+          description: Wallet existence resolved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletExistsResponse"
+              examples:
+                hasWallet:
+                  value: { hasWallet: true }
+                walletless:
+                  value: { hasWallet: false }
+        "401":
+          description: Not authenticated / not a consumer-tier token.
+
+components:
+  securitySchemes:
+    consumerBearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Installation consumer-tier token ({installation}:consumer).
+  schemas:
+    WalletExistsResponse:
+      type: object
+      additionalProperties: false
+      required: [hasWallet]
+      properties:
+        hasWallet:
+          type: boolean
+          description: true when a wallet resolves for the calling citizen.

--- a/specs/149-pwa-pairing-takeover-wallet-aware/data-model.md
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/data-model.md
@@ -1,0 +1,37 @@
+# Phase 1 Data Model: Wallet-aware PairingTakeover
+
+No persisted entities. No EF/schema change. The feature reads existing wallet data via
+`IWalletRepository` through `ResolveCitizenContextAsync` and adds one transport DTO.
+
+## DTO — WalletExistsResponse
+
+Location: `src/Common/Sorcha.CitizenWallet.Abstractions/Models/WalletExistsResponse.cs`
+(sibling to `HasAnyDeviceResponse`).
+
+| Field | Type | Description |
+|---|---|---|
+| `HasWallet` | `bool` | `true` when a wallet resolves for the calling citizen (`walletAddress is not null`), else `false`. |
+
+- Immutable `record` with `init` accessor; XML-documented; license header.
+- Deliberately carries **no** wallet address or other PII — boolean only.
+
+## Client transient state (PairingTakeover)
+
+Not persisted; component-local fields driving the 3-state machine:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `Probe.HasAnyDevice` | `bool?` | existing device probe; `null` = in flight |
+| `_hasWallet` | `bool?` | result of the one-shot `HasWalletAsync`; `null` = not yet resolved |
+
+### State transitions (visibility + body)
+
+```
+HasAnyDevice == null                      → hidden (device check in flight)
+HasAnyDevice == true                      → hidden (device already paired here)
+HasAnyDevice == false & _hasWallet == null→ hidden (wallet check in flight)  [no flash]
+HasAnyDevice == false & _hasWallet == false→ visible: CREATE-WALLET body
+HasAnyDevice == false & _hasWallet == true → visible: PAIR body (unchanged)
+```
+
+`_hasWallet` is fetched once, immediately after the device probe resolves to `false`.

--- a/specs/149-pwa-pairing-takeover-wallet-aware/plan.md
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: Wallet-aware PairingTakeover
+
+**Branch**: `149-pwa-pairing-takeover-wallet-aware` | **Date**: 2026-06-06 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/149-pwa-pairing-takeover-wallet-aware/spec.md`
+**Design**: `docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md`
+
+## Summary
+
+Make the Citizen Wallet PWA `PairingTakeover` overlay wallet-aware. Add a tiny consumer-tier
+endpoint `GET /api/v1/wallet/exists → 200 { hasWallet }` (always 200, no auth-ambiguity), consume it
+from a PWA-local one-shot `IHasWalletProbe`, and add a third "create-wallet" state to the takeover
+that routes a walletless citizen to the web host's `/wallets/create` (fire-and-forget force-load,
+mirroring the existing web-signup handoff). Citizens who already have a wallet keep today's pair flow
+unchanged. The wallet check is one-shot because walletless is a terminal cold-start state.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10
+
+**Primary Dependencies**: ASP.NET Core Minimal APIs (Wallet Service); Blazor WebAssembly +
+MudBlazor (PWA); bUnit + xUnit + FluentAssertions (tests)
+
+**Storage**: N/A — read-only resolution of an existing wallet record via `IWalletRepository`
+through `ResolveCitizenContextAsync`. No schema/EF change, no migration.
+
+**Testing**: xUnit + bUnit (`Sorcha.UI.Testing.ComponentTestFixture`) for the PWA component and the
+probe; mocked `HttpMessageHandler` for the typed client; optional Playwright E2E under
+`tests/Sorcha.UI.E2E.Tests/Docker/CitizenWallet/`.
+
+**Target Platform**: Wallet Service (containerised .NET) + PWA (Blazor WASM, browser, mounted under
+`/wallet/`).
+
+**Project Type**: Web — backend service endpoint + frontend (PWA) component/service.
+
+**Performance Goals**: One extra lightweight GET per cold-start takeover render; negligible.
+
+**Constraints**: No `ISnackbar` (CI gate); consumer-tier audience only; companion-first (no in-PWA
+wallet creation); no flashing of intermediate UI states; fail-safe on transient errors.
+
+**Scale/Scope**: 3 new files (response model, probe interface, probe impl) + 1 new endpoint + edits
+to `PairingTakeover.razor` and PWA DI registration. 2 new test files. Doc-sync to the
+`sorcha-architecture` skill + roadmap.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Microservices-First** — PASS. The existence endpoint lives in the Wallet Service (owner of
+  wallet data); the PWA talks only to the Wallet Service via the gateway. No upward/cross coupling.
+- **II. Security First** — PASS. Endpoint is consumer-tier (`RequireConsumerAudience`) +
+  `RateLimitPolicies.Strict`. Returns only a boolean; leaks no wallet address/PII. No secrets.
+- **III. API Documentation** — PASS. Endpoint gets `.WithName/.WithSummary/.WithDescription` +
+  `.Produces<WalletExistsResponse>`; new model carries XML docs. Built-in OpenAPI (no Swagger).
+- **IV. Testing Requirements** — PASS. xUnit + bUnit; AAA; deterministic mocked handler;
+  component-state coverage for all branches; >85% target for the new code.
+- **V. Code Quality** — PASS. async/await, DI, nullable enabled, no warnings; matches existing
+  citizen-endpoint and probe patterns.
+- **VI. Blueprint Standards** — N/A (no blueprints).
+- **VII. Domain-Driven Design** — PASS. Uses existing ubiquitous terms (Wallet, citizen).
+- **VIII. Observability** — PASS. Endpoint inherits service telemetry/health; probe logs transient
+  failures via `ILogger` (structured, no string interpolation). No new meters required.
+
+**Result: PASS — no violations, Complexity Tracking not required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/149-pwa-pairing-takeover-wallet-aware/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (wallet-exists.openapi.yaml)
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Common/Sorcha.CitizenWallet.Abstractions/
+│   └── Models/
+│       └── WalletExistsResponse.cs                 # NEW — { bool HasWallet }
+├── Services/Sorcha.Wallet.Service/
+│   └── Endpoints/
+│       └── CitizenWalletEndpoints.cs               # EDIT — map GET /api/v1/wallet/exists + handler
+└── Apps/Sorcha.Wallet.Pwa/
+    ├── Services/Wallet/
+    │   ├── IHasWalletProbe.cs                       # NEW — one-shot Task<bool> HasWalletAsync
+    │   └── HasWalletProbe.cs                        # NEW — typed-HttpClient impl, fail-safe true
+    ├── Components/
+    │   └── PairingTakeover.razor                    # EDIT — 3-state machine + create-wallet body
+    └── Extensions/
+        └── ServiceCollectionExtensions.cs          # EDIT — register HasWalletProbe HttpClient
+
+tests/
+└── Sorcha.Wallet.Pwa.Tests/
+    ├── Services/
+    │   └── HasWalletProbeTests.cs                   # NEW — 200 true / 200 false / transient→true
+    └── Components/
+        └── PairingTakeoverTests.cs                  # NEW — walletless / has-wallet / in-flight / has-device
+```
+
+**Structure Decision**: Web split across an existing backend service
+(`Sorcha.Wallet.Service`) and the existing PWA frontend (`Sorcha.Wallet.Pwa`), with the shared DTO
+in the existing `Sorcha.CitizenWallet.Abstractions` contract assembly. No new projects.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/149-pwa-pairing-takeover-wallet-aware/quickstart.md
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart: Wallet-aware PairingTakeover
+
+## What changed
+
+The PWA pairing takeover now distinguishes "no wallet yet" from "no device here":
+
+- **Walletless** signed-in citizen → "Create your wallet first" → button force-loads the web
+  `/wallets/create` page. After creating a wallet on the web and returning to the PWA, they get the
+  pair flow.
+- **Has wallet, no device here** → existing pair flow, unchanged.
+
+## Try it (local Docker stack)
+
+1. Bring up the stack (`docker-compose up -d`) and open the PWA under `/wallet`.
+2. **Walletless path:** sign in as a citizen who has an account but no wallet. The takeover shows
+   the create-wallet state; tapping "Create your wallet" lands on the web `/wallets/create`.
+3. **Has-wallet path:** sign in as a citizen who already created a wallet (web) but hasn't paired
+   this browser. The takeover shows "Set up this device" + the short-code panel, as before.
+
+## Verify the endpoint directly
+
+```bash
+# With a consumer-tier bearer token for the citizen:
+curl -s -H "Authorization: Bearer $CONSUMER_JWT" \
+  http://localhost/api/v1/wallet/exists
+# → {"hasWallet":false}  (walletless)  or  {"hasWallet":true}
+```
+
+## Run the tests
+
+```bash
+dotnet test tests/Sorcha.Wallet.Pwa.Tests \
+  --filter "FullyQualifiedName~HasWalletProbeTests|FullyQualifiedName~PairingTakeoverTests"
+```
+
+## n1 validation (post-merge, post-Docker-Publish)
+
+Use the `n1-deploy` skill: pull + recreate `sorcha-wallet-pwa`, confirm the new build badge version,
+then walk both paths (walletless → web create handoff; has-wallet → pair flow).

--- a/specs/149-pwa-pairing-takeover-wallet-aware/research.md
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/research.md
@@ -1,0 +1,80 @@
+# Phase 0 Research: Wallet-aware PairingTakeover
+
+All open questions were resolved during the brainstorm (see the design doc). No outstanding
+NEEDS CLARIFICATION.
+
+## Decision 1 — Wallet-existence detection mechanism
+
+**Decision:** Add a purpose-built `GET /api/v1/wallet/exists → 200 { hasWallet }` endpoint; consume
+it from a one-shot client check.
+
+**Rationale:** "Has wallet?" is a server fact (the consumer JWT carries no wallet binding). A
+dedicated boolean endpoint is unambiguous and decoupled from unrelated endpoints' failure modes.
+
+**Alternatives considered:**
+- *Reuse `holder-keys` 404* — **rejected.** Verified in `CitizenWalletEndpoints.GetHolderKeys`:
+  no-wallet returns **401** (`platformUserId is null || citizenWallet is null`), and **404** fires
+  only when a wallet *exists* but no holder/delivery key is derivable. Its 404 means the *opposite*
+  of walletless (it matches the has-wallet/no-device citizen we must keep on the pair flow). The
+  endpoint's XML doc is wrong vs. its implementation.
+- *Interpret enrol 404 inline* — **rejected.** Makes the user click into a failure first; couples
+  takeover logic to the enrol endpoint; the enrol 404 is documented as "indistinguishable from
+  non-existence".
+
+## Decision 2 — One-shot check vs. event-driven probe
+
+**Decision:** `IHasWalletProbe` exposes only `Task<bool> HasWalletAsync(CancellationToken)`. No
+`Changed` / `EnsureLoadedAsync` / `Refresh`.
+
+**Rationale:** Walletless is a **terminal cold-start state** — creating a wallet is essentially the
+first action a citizen takes, and once a wallet exists it can never drop back to zero. The signal
+transitions `false → true` exactly once, so a live change-notification contract (as on
+`IHasPairedDeviceProbe`, where devices can be revoked) would be dead weight (YAGNI).
+
+**Alternatives considered:** Full `IHasPairedDeviceProbe`-style probe — rejected as unjustified
+plumbing for a one-shot signal.
+
+## Decision 3 — Fail-safe direction on transient existence-check failure
+
+**Decision:** On network/timeout/non-2xx/empty body, `HasWalletAsync` returns **`true`** (assume the
+citizen has a wallet → fall through to the existing pair flow).
+
+**Rationale:** Two failure modes weighed: a false `false` would wrongly tell a wallet-owner to
+create a *second* wallet (bad, confusing, companion-first violation); a false `true` only means a
+genuinely walletless citizen sees the pre-existing enrol 404 message — identical to today's
+behaviour, i.e. no regression. We optimise to never harm the wallet-owner.
+
+## Decision 4 — Walletless return flow
+
+**Decision:** Fire-and-forget: force-load `{origin}/wallets/create` (absolute origin, `forceLoad`),
+byte-for-byte the `SignIn.razor` `GoToWebSignup` precedent. The citizen returns to the PWA manually;
+the takeover re-runs its one-shot check on next load.
+
+**Rationale:** Matches the established companion-first handoff; avoids cross-host return-URL wiring
+and any web-side change to `/wallets/create`. Verified the route exists:
+`src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Wallets/CreateWallet.razor` → `@page "/wallets/create"`.
+
+**Alternatives considered:** Round-trip return URL — rejected (new cross-host work; no UX payoff that
+justifies it for a one-time action).
+
+## Decision 5 — Component placement
+
+**Decision:** `IHasWalletProbe` + `HasWalletProbe` live PWA-local in
+`src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/`.
+
+**Rationale:** Only `PairingTakeover` (PWA) consumes the signal; the web host does not need it.
+Contrast `IHasPairedDeviceProbe`, which lives in shared `Sorcha.UI.Components.User` because the web
+nag-banner also uses it. Keep the new surface minimal.
+
+## Pattern references (existing code to mirror)
+
+- Endpoint shape, auth, OpenAPI metadata, `ResolveCitizenContextAsync`:
+  `src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs`.
+- Typed-client + handler chain registration:
+  `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs` (device-probe block,
+  `BearerTokenHandler` + `ServerClockHandler`).
+- Web handoff: `src/Apps/Sorcha.Wallet.Pwa/Pages/SignIn.razor` `GoToWebSignup`.
+- DTO sibling: `src/Common/Sorcha.CitizenWallet.Abstractions/Models/HasAnyDeviceResponse.cs`.
+- bUnit fixture: `tests/Sorcha.Wallet.Pwa.Tests/Components/OfflineBannerTests.cs`
+  (`ComponentTestFixture`); provider-host pattern at
+  `tests/Sorcha.UI.Core.Tests/TestHosts/GuidedTourHost.razor`.

--- a/specs/149-pwa-pairing-takeover-wallet-aware/spec.md
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Wallet-aware PairingTakeover
+
+**Feature Branch**: `149-pwa-pairing-takeover-wallet-aware`
+**Created**: 2026-06-06
+**Status**: Approved
+**Design**: `docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md`
+**Roadmap**: P0 #1 in `docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md`
+
+## Summary
+
+The Citizen Wallet PWA's `PairingTakeover` overlay currently assumes every signed-in citizen
+already has a wallet, and offers only "Set up this device". A citizen who reaches the PWA without
+a web-created wallet hits a 404 dead-end. This feature makes the takeover **wallet-aware**: it
+detects whether the citizen has a wallet and, when they do not, routes them to create one on the
+web app (companion-first) instead of dead-ending — while leaving the existing pair flow unchanged
+for citizens who already have a wallet.
+
+## User Scenarios & Testing
+
+### US1 — Walletless citizen is routed to web wallet creation (P0)
+
+A citizen signs into the PWA but has never created a wallet on the web. Instead of being offered a
+"Set up this device" action that fails with a 404, the takeover shows a **create-wallet** state
+that explains the wallet lives on the web and provides a button that takes them to the web
+wallet-creation page.
+
+**Acceptance:**
+1. **Given** a signed-in citizen with no wallet and no paired device, **When** the takeover
+   resolves, **Then** it shows the create-wallet state (headline "Create your wallet first") and
+   does **not** show the "Set up this device" enrol button.
+2. **Given** the create-wallet state, **When** the citizen taps "Create your wallet", **Then** the
+   browser force-loads the web host's `/wallets/create` page at the origin root.
+3. **Given** the citizen has created a wallet on the web and returns to the PWA, **When** the
+   takeover re-initialises, **Then** it shows the existing pair flow (because a wallet now exists).
+
+### US2 — Citizen with a wallet still gets the pair flow unchanged (P0)
+
+A citizen who already has a wallet but no paired device on this hardware must see exactly today's
+pairing experience.
+
+**Acceptance:**
+1. **Given** a signed-in citizen with a wallet but no device on this hardware, **When** the takeover
+   resolves, **Then** it shows the existing pair state ("Set up this device" + short-code panel),
+   unchanged.
+2. **Given** a citizen with a paired device on this hardware, **When** the PWA loads, **Then** the
+   takeover stays hidden (unchanged).
+
+### US3 — No flashing during detection (P0)
+
+The overlay must never briefly flash the wrong state while server checks are in flight.
+
+**Acceptance:**
+1. **Given** the device check or the wallet check is still in flight, **When** the component renders,
+   **Then** the overlay is hidden (no partial/incorrect state shown).
+
+### Edge cases
+
+- **Existence check fails (network/transient):** the takeover falls through to the existing pair
+  flow (fail-safe). A genuinely walletless citizen would then see the pre-existing enrol 404 message
+  — no worse than today; never a false "create a second wallet" prompt for a wallet owner.
+- **Short-code pairing in the walletless state:** not offered — redeeming a pairing code also
+  requires a wallet, so it is omitted from the create-wallet state.
+
+## Requirements
+
+### Functional
+
+- **FR-001:** The system MUST expose a consumer-tier endpoint that reports, for the signed-in
+  citizen, whether a wallet exists, returning an explicit boolean with HTTP 200 (no 401/404
+  ambiguity for an authenticated consumer).
+- **FR-002:** The PWA MUST determine wallet existence via a single ("one-shot") check; it MUST NOT
+  require a live change-notification contract for this signal (walletless is a terminal cold-start
+  state that only transitions false→true once).
+- **FR-003:** When a signed-in citizen has no paired device on this hardware **and** no wallet, the
+  takeover MUST present a create-wallet state that routes to the web wallet-creation page and MUST
+  NOT present the device-enrol action.
+- **FR-004:** The create-wallet route MUST force-load the web host's `/wallets/create` at the origin
+  root (absolute origin), matching the existing web-signup handoff precedent.
+- **FR-005:** When a signed-in citizen has no paired device on this hardware **but** has a wallet,
+  the takeover MUST present the existing pair flow unchanged.
+- **FR-006:** The takeover MUST remain hidden while either the device check or the wallet check is
+  in flight (no flashing).
+- **FR-007:** On a transient failure of the wallet-existence check, the takeover MUST fall through to
+  the pair flow (fail-safe), never falsely routing a wallet owner to create another wallet.
+- **FR-008:** All new behaviour MUST follow Sorcha notification routing (no `ISnackbar`; inline
+  feedback only) and carry license headers on new files.
+
+### Key entities
+
+- **WalletExistsResponse** — response of the existence endpoint: `{ hasWallet: bool }`.
+
+## Success Criteria
+
+- **SC-001:** A walletless signed-in citizen in the PWA reaches a working "create your wallet on the
+  web" path with zero dead-ends, and after creating a wallet can return and pair the device.
+- **SC-002:** A citizen who has a wallet but no device on this hardware experiences no change to the
+  pair flow.
+- **SC-003:** No state flashes during detection; the wrong body is never shown.
+- **SC-004:** New behaviour is covered by automated tests (component states + existence-probe unit
+  tests), CI is green (`build-and-test` + `claude-review`), and the change ships in a single PR.

--- a/specs/149-pwa-pairing-takeover-wallet-aware/tasks.md
+++ b/specs/149-pwa-pairing-takeover-wallet-aware/tasks.md
@@ -1,0 +1,149 @@
+# Tasks: Wallet-aware PairingTakeover
+
+**Feature**: 149-pwa-pairing-takeover-wallet-aware
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md)
+**Approach**: Test-driven (tests written before/with implementation per task).
+
+All three user stories are P0 and converge on the same `PairingTakeover` component, so the shared
+plumbing (DTO + endpoint + probe) is foundational. US1 delivers the new walletless routing (MVP);
+US2 and US3 are guarded by regression/behaviour tests on the same component edit.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm branch `149-pwa-pairing-takeover-wallet-aware` is checked out and the solution
+  builds clean: `dotnet build src/Services/Sorcha.Wallet.Service` and
+  `dotnet build src/Apps/Sorcha.Wallet.Pwa` succeed before changes.
+
+---
+
+## Phase 2: Foundational (blocking prerequisites for all user stories)
+
+**The DTO, endpoint, and probe are shared by every user story and must land first.**
+
+- [ ] T002 [P] Add `WalletExistsResponse` record (`bool HasWallet`, XML docs, license header) in
+  `src/Common/Sorcha.CitizenWallet.Abstractions/Models/WalletExistsResponse.cs`, modelled on
+  `HasAnyDeviceResponse.cs`.
+- [ ] T003 Map `GET /api/v1/wallet/exists` on the existing `/api/v1/wallet` group in
+  `src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs`: a `WalletExists`
+  handler that calls `ResolveCitizenContextAsync` and returns
+  `Results.Ok(new WalletExistsResponse { HasWallet = walletAddress is not null })` (always 200 for
+  an authenticated consumer). Add `.WithName("CitizenWalletExists")` / `.WithSummary` /
+  `.WithDescription` / `.Produces<WalletExistsResponse>(200)` / `.Produces(401)`. Depends on T002.
+- [ ] T004 [P] Add the one-shot probe interface `IHasWalletProbe`
+  (`Task<bool> HasWalletAsync(CancellationToken ct = default)`, XML doc explaining the one-shot /
+  terminal-state rationale, license header) in
+  `src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/IHasWalletProbe.cs`.
+- [ ] T005 [P] Write `HasWalletProbeTests` in
+  `tests/Sorcha.Wallet.Pwa.Tests/Services/HasWalletProbeTests.cs` (mocked `HttpMessageHandler`,
+  `EnrolmentServiceTests` style): `200 {hasWallet:true}` → `true`; `200 {hasWallet:false}` →
+  `false`; transient failure (throw / 500 / empty body) → `true` (fail-safe). Tests fail until T006.
+- [ ] T006 Implement `HasWalletProbe` (typed `HttpClient`, `GET /api/v1/wallet/exists`, fail-safe
+  returns `true` on `HttpRequestException`/timeout/non-2xx/empty body, structured `ILogger`
+  warnings, license header) in `src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/HasWalletProbe.cs`.
+  Make T005 green. Depends on T004.
+- [ ] T007 Register the probe typed-client in
+  `src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs`
+  (`AddHttpClient<IHasWalletProbe, HasWalletProbe>` with `gatewayBaseAddress` +
+  `BearerTokenHandler` + `ServerClockHandler`, mirroring the `IHasPairedDeviceProbe` block).
+  Depends on T006.
+
+**Checkpoint:** endpoint + probe exist and probe unit tests pass; PWA + service build clean.
+
+---
+
+## Phase 3: User Story 1 — Walletless citizen routed to web wallet creation (P0) — MVP
+
+**Goal:** A walletless signed-in citizen sees a create-wallet state and is routed to web
+`/wallets/create` instead of dead-ending. **Independent test:** bUnit render with device probe
+`false` + wallet probe `false` shows the create-wallet body and not the enrol button.
+
+- [ ] T008 [US1] Write `PairingTakeoverTests` walletless case in
+  `tests/Sorcha.Wallet.Pwa.Tests/Components/PairingTakeoverTests.cs` (`ComponentTestFixture`,
+  provider-host pattern as needed): device probe `false` + injected fake `IHasWalletProbe` →
+  `false` renders `data-testid="pairing-takeover-create-wallet"` and asserts
+  `pairing-takeover-primary-button` (enrol) is **absent**. Fails until T009.
+- [ ] T009 [US1] Edit `src/Apps/Sorcha.Wallet.Pwa/Components/PairingTakeover.razor`: inject
+  `IHasWalletProbe`; add `bool? _hasWallet`; after the device probe resolves to `false`, await
+  `HasWalletAsync` once and store it; render the new create-wallet body (headline "Create your
+  wallet first", the agreed subhead, a `data-testid="pairing-takeover-create-wallet-button"`
+  primary button calling `GoToWebWalletCreation()`, no short-code panel) when `_hasWallet == false`.
+  Make T008 green. Depends on T007.
+- [ ] T010 [US1] Add `GoToWebWalletCreation()` to `PairingTakeover.razor` `@code` — inject
+  `NavigationManager`, force-load `{origin}/wallets/create` (absolute origin via
+  `new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority)`, `forceLoad: true`), mirroring
+  `SignIn.razor` `GoToWebSignup`. Covered by the US1 component test's button-presence assertion.
+
+**Checkpoint:** US1 independently demonstrable — walletless render routes to web create.
+
+---
+
+## Phase 4: User Story 2 — Citizen with a wallet keeps the pair flow (P0)
+
+**Goal:** No regression to the existing pair experience. **Independent test:** bUnit render with
+device probe `false` + wallet probe `true` shows the existing pair body.
+
+- [ ] T011 [US2] Add `PairingTakeoverTests` has-wallet case: device probe `false` + fake probe
+  `true` renders `pairing-takeover-primary-button` and the short-code panel, and the create-wallet
+  body is **absent**. (Implementation already satisfied by T009's state machine; this is the
+  regression guard.) Depends on T009.
+- [ ] T012 [US2] Add `PairingTakeoverTests` has-device case: device probe `true` renders nothing
+  (`pairing-takeover` node absent) — guards the unchanged "already paired here" path. Depends on
+  T009.
+
+**Checkpoint:** existing pair flow proven unchanged for wallet owners.
+
+---
+
+## Phase 5: User Story 3 — No flashing during detection (P0)
+
+**Goal:** The overlay never shows a wrong/partial state while checks are in flight. **Independent
+test:** bUnit render with `_hasWallet` unresolved shows nothing.
+
+- [ ] T013 [US3] Add `PairingTakeoverTests` in-flight case: device probe `false` + a fake
+  `IHasWalletProbe` whose `HasWalletAsync` is held pending → before completion the `pairing-takeover`
+  node is absent; after completion it appears. Confirms the visibility predicate
+  `HasAnyDevice == false && _hasWallet is not null`. Depends on T009.
+
+**Checkpoint:** no-flash behaviour verified across all detection windows.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T014 [P] Doc-sync: update the F128 entry in `.claude/skills/sorcha-architecture/SKILL.md`
+  (new `GET /api/v1/wallet/exists` surface + wallet-aware takeover state machine) and tick P0 #1 in
+  `docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md`.
+- [ ] T015 Verify guardrails: `scripts/check-no-snackbar.ps1` passes; no hard-coded `<Version>`;
+  license headers on the 3 new files; nullable/no-warning Release build.
+- [ ] T016 Full verification: `dotnet build` (Wallet Service + PWA + tests) warning-free and
+  `dotnet test tests/Sorcha.Wallet.Pwa.Tests` green (full project run — MTP ignores `--filter` per
+  repo convention). Record results for the PR description.
+
+---
+
+## Dependencies & order
+
+- Phase 1 → Phase 2 → Phase 3 (US1, MVP) → Phases 4 & 5 (US2, US3 — both depend only on T009) →
+  Phase 6.
+- US2 (T011, T012) and US3 (T013) are independent of each other once T009 lands; can be written in
+  parallel.
+
+## Parallel opportunities
+
+- T002 and T004 are `[P]` (different files, no interdep).
+- T005 `[P]` (test file) can be written alongside T004.
+- After T009: T011, T012, T013 are independent test additions to the same file — write sequentially
+  to avoid edit conflicts, but they have no logic interdependencies.
+- T014 `[P]` (docs) can proceed any time after the surface is settled.
+
+## MVP scope
+
+**Phase 2 + Phase 3 (US1)** = the shippable MVP: the walletless dead-end is removed and citizens are
+routed to web wallet creation. Phases 4–5 are regression/quality guards; Phase 6 is polish/doc-sync.
+
+## Format validation
+
+All tasks use `- [ ] Tnnn [P?] [USn?] description + file path`; setup/foundational/polish carry no
+story label; user-story tasks carry `[US1]`/`[US2]`/`[US3]`.

--- a/src/Apps/Sorcha.Wallet.Pwa/Components/PairingTakeover.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Components/PairingTakeover.razor
@@ -35,11 +35,14 @@
 @using Sorcha.UI.Core.Services.User.Devices
 @using Sorcha.Wallet.Pwa.Services
 @using Sorcha.Wallet.Pwa.Services.Enrolment
+@using Sorcha.Wallet.Pwa.Services.Wallet
 @inject IHasPairedDeviceProbe Probe
+@inject IHasWalletProbe HasWallet
 @inject IEnrolmentService Enrolment
 @inject IPairingShortCodeRedeemer ShortCodeRedeemer
 @inject IAccessTokenStore TokenStore
 @inject CitizenWalletHubConnection Hub
+@inject NavigationManager Nav
 @inject ILogger<PairingTakeover> Logger
 @implements IDisposable
 
@@ -48,69 +51,95 @@
     <div class="sorcha-welcome-overlay" role="dialog" aria-modal="true"
          aria-labelledby="sorcha-pair-headline" data-testid="pairing-takeover">
         <div class="sorcha-welcome-content">
-            <h2 id="sorcha-pair-headline" class="sorcha-welcome-headline">
-                Set up this device
-            </h2>
-            <p class="sorcha-welcome-subhead">
-                This phone hasn't been paired to your Sorcha account yet.
-                Pair it now so it can hold your credentials.
-            </p>
-
-            @if (_error is not null)
+            @if (_hasWallet == false)
             {
-                <MudAlert Severity="Severity.Warning" Class="mb-3" data-testid="pairing-takeover-error">
-                    @_error
-                </MudAlert>
-            }
-
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large"
-                       FullWidth="true" Class="mt-2"
-                       OnClick="HandlePrimaryAsync"
-                       Disabled="@_busy"
-                       data-testid="pairing-takeover-primary-button">
-                @if (_busy && _busyReason == BusyReason.LocalPair)
-                {
-                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                    <span>Setting up…</span>
-                }
-                else
-                {
-                    <span>Set up this device</span>
-                }
-            </MudButton>
-
-            <MudExpansionPanel Class="mt-3" data-testid="pairing-takeover-shortcode-panel">
-                <TitleContent>
-                    <span>Already started on another device?</span>
-                </TitleContent>
-                <ChildContent>
-                    <p class="mud-typography-body2 mb-2">
-                        Enter the 6-digit pairing code shown on your other device.
+                @* Feature 149 — walletless cold-start. The web app owns wallet
+                   creation (companion-first), so route the citizen there rather
+                   than offer device enrolment (which 404s without a wallet). *@
+                <div data-testid="pairing-takeover-create-wallet">
+                    <h2 id="sorcha-pair-headline" class="sorcha-welcome-headline">
+                        Create your wallet first
+                    </h2>
+                    <p class="sorcha-welcome-subhead">
+                        Your Sorcha wallet lives in your account on the web. Create it
+                        there, then come back here to pair this phone and hold your
+                        credentials.
                     </p>
-                    <MudTextField @bind-Value="_shortCode"
-                                  Label="Pairing code"
-                                  Variant="Variant.Outlined"
-                                  MaxLength="6"
-                                  InputType="InputType.Number"
-                                  Disabled="@_busy"
-                                  data-testid="pairing-takeover-shortcode-input" />
-                    <MudButton Variant="Variant.Filled" Color="Color.Secondary"
-                               Class="mt-2"
-                               OnClick="HandleShortCodeAsync"
-                               Disabled="@(_busy || string.IsNullOrWhiteSpace(_shortCode))"
-                               data-testid="pairing-takeover-shortcode-submit">
-                        @if (_busy && _busyReason == BusyReason.ShortCode)
-                        {
-                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                            <span>Redeeming…</span>
-                        }
-                        else
-                        {
-                            <span>Pair with code</span>
-                        }
+
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large"
+                               FullWidth="true" Class="mt-2"
+                               OnClick="GoToWebWalletCreation"
+                               data-testid="pairing-takeover-create-wallet-button">
+                        <span>Create your wallet</span>
                     </MudButton>
-                </ChildContent>
-            </MudExpansionPanel>
+                </div>
+            }
+            else
+            {
+                <h2 id="sorcha-pair-headline" class="sorcha-welcome-headline">
+                    Set up this device
+                </h2>
+                <p class="sorcha-welcome-subhead">
+                    This phone hasn't been paired to your Sorcha account yet.
+                    Pair it now so it can hold your credentials.
+                </p>
+
+                @if (_error is not null)
+                {
+                    <MudAlert Severity="Severity.Warning" Class="mb-3" data-testid="pairing-takeover-error">
+                        @_error
+                    </MudAlert>
+                }
+
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large"
+                           FullWidth="true" Class="mt-2"
+                           OnClick="HandlePrimaryAsync"
+                           Disabled="@_busy"
+                           data-testid="pairing-takeover-primary-button">
+                    @if (_busy && _busyReason == BusyReason.LocalPair)
+                    {
+                        <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                        <span>Setting up…</span>
+                    }
+                    else
+                    {
+                        <span>Set up this device</span>
+                    }
+                </MudButton>
+
+                <MudExpansionPanel Class="mt-3" data-testid="pairing-takeover-shortcode-panel">
+                    <TitleContent>
+                        <span>Already started on another device?</span>
+                    </TitleContent>
+                    <ChildContent>
+                        <p class="mud-typography-body2 mb-2">
+                            Enter the 6-digit pairing code shown on your other device.
+                        </p>
+                        <MudTextField @bind-Value="_shortCode"
+                                      Label="Pairing code"
+                                      Variant="Variant.Outlined"
+                                      MaxLength="6"
+                                      InputType="InputType.Number"
+                                      Disabled="@_busy"
+                                      data-testid="pairing-takeover-shortcode-input" />
+                        <MudButton Variant="Variant.Filled" Color="Color.Secondary"
+                                   Class="mt-2"
+                                   OnClick="HandleShortCodeAsync"
+                                   Disabled="@(_busy || string.IsNullOrWhiteSpace(_shortCode))"
+                                   data-testid="pairing-takeover-shortcode-submit">
+                            @if (_busy && _busyReason == BusyReason.ShortCode)
+                            {
+                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                                <span>Redeeming…</span>
+                            }
+                            else
+                            {
+                                <span>Pair with code</span>
+                            }
+                        </MudButton>
+                    </ChildContent>
+                </MudExpansionPanel>
+            }
         </div>
     </div>
 }
@@ -122,6 +151,11 @@
     private string? _error;
     private string _shortCode = string.Empty;
 
+    // Feature 149 — one-shot wallet existence. null = not yet resolved (keep
+    // the overlay hidden, no flash); false = create-wallet state; true = pair.
+    private bool? _hasWallet;
+    private bool _walletCheckStarted;
+
     private enum BusyReason { None, LocalPair, ShortCode }
 
     protected override async Task OnInitializedAsync()
@@ -131,12 +165,31 @@
 
         await Probe.EnsureLoadedAsync();
         UpdateVisibility();
+        await EnsureWalletCheckedAsync();
     }
 
     private void HandleProbeChanged()
     {
         UpdateVisibility();
         InvokeAsync(StateHasChanged);
+        // A late device-probe resolution to "no device" still needs the wallet
+        // check before we choose which body to show.
+        _ = InvokeAsync(EnsureWalletCheckedAsync);
+    }
+
+    // Resolve wallet existence exactly once, only when there is no device on
+    // this hardware (the only state in which the takeover renders a body).
+    private async Task EnsureWalletCheckedAsync()
+    {
+        if (_walletCheckStarted || Probe.HasAnyDevice != false)
+        {
+            return;
+        }
+
+        _walletCheckStarted = true;
+        _hasWallet = await HasWallet.HasWalletAsync();
+        UpdateVisibility();
+        await InvokeAsync(StateHasChanged);
     }
 
     private async void HandleHubDeviceEnrolled(Guid _)
@@ -155,11 +208,22 @@
 
     private void UpdateVisibility()
     {
-        // Show only when the probe has resolved AND reports no paired device.
-        // While HasAnyDevice == null (initial fetch in flight) keep the
-        // takeover hidden — flashing the takeover for ~100ms during signup
-        // is a worse UX than briefly missing it.
-        _isVisible = Probe.HasAnyDevice == false;
+        // Show only when the device probe reports no paired device AND the
+        // one-shot wallet check has resolved. While either is in flight
+        // (HasAnyDevice == null, or _hasWallet == null) keep the takeover
+        // hidden — flashing the wrong body is a worse UX than briefly missing
+        // the overlay.
+        _isVisible = Probe.HasAnyDevice == false && _hasWallet is not null;
+    }
+
+    // Feature 149 — wallet creation lives on the web host at origin-root
+    // /wallets/create (the PWA is mounted under /wallet/, so build the absolute
+    // origin URL rather than a leading-slash path). forceLoad because it leaves
+    // the PWA for the web app entirely. Mirrors SignIn.razor GoToWebSignup.
+    private void GoToWebWalletCreation()
+    {
+        var origin = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
+        Nav.NavigateTo($"{origin}/wallets/create", forceLoad: true);
     }
 
     private async Task HandlePrimaryAsync()

--- a/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Extensions/ServiceCollectionExtensions.cs
@@ -202,6 +202,15 @@ public static class ServiceCollectionExtensions
             .AddHttpMessageHandler<BearerTokenHandler>()
             .AddHttpMessageHandler<ServerClockHandler>();
 
+        // Feature 149 — one-shot "does this citizen have a wallet?" probe that
+        // drives the wallet-aware branch of the PairingTakeover. Same handler
+        // chain as the device probe (BearerTokenHandler + ServerClockHandler).
+        services.AddHttpClient<Sorcha.Wallet.Pwa.Services.Wallet.IHasWalletProbe,
+                               Sorcha.Wallet.Pwa.Services.Wallet.HasWalletProbe>(c =>
+            c.BaseAddress = new Uri(gatewayBaseAddress))
+            .AddHttpMessageHandler<BearerTokenHandler>()
+            .AddHttpMessageHandler<ServerClockHandler>();
+
         // Feature 128 US1 — PWA-side short-code redeemer for the PairingTakeover
         // sub-affordance ("Already started on another device?"). Anonymous
         // call: the 6-digit code is the credential for this single endpoint.

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/HasWalletProbe.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/HasWalletProbe.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Sorcha.CitizenWallet.Abstractions.Models;
+
+namespace Sorcha.Wallet.Pwa.Services.Wallet;
+
+/// <summary>
+/// HTTP implementation of <see cref="IHasWalletProbe"/>. Typed
+/// <see cref="HttpClient"/> — base address is the gateway origin; the caller
+/// registers the typed client with its existing bearer-token + server-clock
+/// handlers.
+/// </summary>
+public sealed class HasWalletProbe : IHasWalletProbe
+{
+    private const string Endpoint = "/api/v1/wallet/exists";
+
+    private readonly HttpClient _http;
+    private readonly ILogger<HasWalletProbe> _logger;
+
+    public HasWalletProbe(HttpClient http, ILogger<HasWalletProbe> logger)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HasWalletAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var response = await _http.GetAsync(Endpoint, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                // Non-success (incl. a 401 if the session lapsed mid-flight) —
+                // fail safe: assume a wallet exists so the takeover falls through
+                // to the pair flow rather than wrongly offering to create one.
+                _logger.LogDebug("HasWalletProbe got {Status} — assuming wallet exists (fail-safe)", response.StatusCode);
+                return true;
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<WalletExistsResponse>(cancellationToken: ct)
+                .ConfigureAwait(false);
+            if (payload is null)
+            {
+                _logger.LogWarning("HasWalletProbe received empty body — assuming wallet exists (fail-safe)");
+                return true;
+            }
+
+            return payload.HasWallet;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "HasWalletProbe network error — assuming wallet exists (fail-safe)");
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            // Empty or malformed body — ReadFromJsonAsync throws rather than
+            // returning null. Fail safe to the pair flow.
+            _logger.LogWarning(ex, "HasWalletProbe got a non-JSON body — assuming wallet exists (fail-safe)");
+            return true;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogWarning("HasWalletProbe timed out — assuming wallet exists (fail-safe)");
+            return true;
+        }
+    }
+}

--- a/src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/IHasWalletProbe.cs
+++ b/src/Apps/Sorcha.Wallet.Pwa/Services/Wallet/IHasWalletProbe.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.Wallet.Pwa.Services.Wallet;
+
+/// <summary>
+/// One-shot "does the signed-in citizen have a wallet?" signal (Feature 149).
+/// Drives the wallet-aware branch of the F128 pairing takeover: a walletless
+/// citizen is routed to web wallet creation instead of dead-ending at the
+/// device-enrol 404. Calls <c>GET /api/v1/wallet/exists</c>.
+/// </summary>
+/// <remarks>
+/// Deliberately has no <c>Changed</c> / <c>EnsureLoadedAsync</c> / <c>Refresh</c>
+/// contract (unlike <c>IHasPairedDeviceProbe</c>, where devices can be revoked).
+/// "Walletless" is a terminal cold-start state: creating a wallet is essentially
+/// the first thing a citizen does, and once a wallet exists it can never drop
+/// back to zero. The signal transitions <c>false → true</c> exactly once, so a
+/// single check is sufficient and correct.
+/// </remarks>
+public interface IHasWalletProbe
+{
+    /// <summary>
+    /// Resolves whether the signed-in citizen has a wallet. On a transient
+    /// failure (network error, timeout, non-success status, empty body) this
+    /// returns <c>true</c> (fail-safe) so the takeover falls through to the
+    /// existing pair flow — never falsely routing a wallet owner to create a
+    /// second wallet.
+    /// </summary>
+    Task<bool> HasWalletAsync(CancellationToken ct = default);
+}

--- a/src/Common/Sorcha.CitizenWallet.Abstractions/Models/WalletExistsResponse.cs
+++ b/src/Common/Sorcha.CitizenWallet.Abstractions/Models/WalletExistsResponse.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+namespace Sorcha.CitizenWallet.Abstractions.Models;
+
+/// <summary>
+/// Response body for <c>GET /api/v1/wallet/exists</c> (Feature 149). Lets the
+/// Citizen Wallet PWA's pairing takeover distinguish "no wallet yet" (route the
+/// citizen to web wallet creation) from "wallet exists, no device here" (offer
+/// the pair flow). Carries a boolean only — never a wallet address or other PII.
+/// </summary>
+public sealed record WalletExistsResponse
+{
+    /// <summary>
+    /// <c>true</c> when a wallet resolves for the calling citizen, else
+    /// <c>false</c>.
+    /// </summary>
+    public bool HasWallet { get; init; }
+}

--- a/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
+++ b/src/Services/Sorcha.Wallet.Service/Endpoints/CitizenWalletEndpoints.cs
@@ -72,6 +72,19 @@ public static class CitizenWalletEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
 
+        group.MapGet("/exists", WalletExists)
+            .WithName("CitizenWalletExists")
+            .WithSummary("Does the signed-in citizen have a wallet?")
+            .WithDescription(
+                "Feature 149. Reports whether a wallet resolves for the caller so the Citizen " +
+                "Wallet PWA's pairing takeover can route a walletless citizen to web wallet " +
+                "creation instead of dead-ending at the device-enrol 404. ALWAYS returns 200 " +
+                "with an explicit boolean for an authenticated consumer (no 401/404 ambiguity); " +
+                "an unauthenticated or non-consumer caller is rejected at the audience gate. " +
+                "Carries a boolean only — never a wallet address or other PII.")
+            .Produces<WalletExistsResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
+
         group.MapPost("/devices/renew-delegation", RenewDelegation)
             .WithName("RenewCitizenDeviceDelegation")
             .WithSummary("Renew the device delegation credential")
@@ -385,6 +398,15 @@ public static class CitizenWalletEndpoints
         var holderKeyId = await holderKeys.GetHolderJwkThumbprintAsync(citizenWallet, ct);
         var snapshot = await sync.ListAllCredentialsAsync(platformUserId.Value, holderKeyId, ct);
         return Results.Ok(snapshot);
+    }
+
+    private static async Task<IResult> WalletExists(
+        HttpContext context,
+        IWalletRepository walletRepository,
+        CancellationToken ct)
+    {
+        var (_, walletAddress, _) = await ResolveCitizenContextAsync(context.User, walletRepository, ct);
+        return Results.Ok(new WalletExistsResponse { HasWallet = walletAddress is not null });
     }
 
     private static async Task<IResult> GetHolderKeys(

--- a/tests/Sorcha.Wallet.Pwa.Tests/Components/PairingTakeoverTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Components/PairingTakeoverTests.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Bunit;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Sorcha.UI.Core.Services.User.Devices;
+using Sorcha.UI.Testing;
+using Sorcha.Wallet.Pwa.Components;
+using Sorcha.Wallet.Pwa.Services;
+using Sorcha.Wallet.Pwa.Services.Enrolment;
+using Sorcha.Wallet.Pwa.Services.Wallet;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Components;
+
+/// <summary>
+/// Feature 149 — bUnit tests for the wallet-aware <see cref="PairingTakeover"/>.
+/// Covers the three-state machine: walletless → create-wallet body (US1);
+/// has-wallet → existing pair body (US2); has-device → hidden (US2); and the
+/// no-flash rule while the wallet check is in flight (US3).
+/// </summary>
+public sealed class PairingTakeoverTests : ComponentTestFixture
+{
+    private const string CreateWallet = "[data-testid=pairing-takeover-create-wallet]";
+    private const string CreateWalletButton = "[data-testid=pairing-takeover-create-wallet-button]";
+    private const string PrimaryButton = "[data-testid=pairing-takeover-primary-button]";
+    private const string Overlay = "[data-testid=pairing-takeover]";
+
+    private readonly FakeHasPairedDeviceProbe _deviceProbe = new();
+    private readonly FakeHasWalletProbe _walletProbe = new();
+
+    public PairingTakeoverTests()
+    {
+        Services.AddSingleton<IHasPairedDeviceProbe>(_deviceProbe);
+        Services.AddSingleton<IHasWalletProbe>(_walletProbe);
+        ProvideMock<IEnrolmentService>();
+        ProvideMock<IPairingShortCodeRedeemer>();
+        ProvideMock<IAccessTokenStore>();
+        Services.AddSingleton(new CitizenWalletHubConnection(
+            "https://test.example", new Mock<IAccessTokenStore>().Object,
+            NullLogger<CitizenWalletHubConnection>.Instance));
+    }
+
+    // US1 — walletless citizen sees the create-wallet body, not the enrol button.
+    [Fact]
+    public void WalletlessNoDevice_RendersCreateWalletState_NotEnrolButton()
+    {
+        _deviceProbe.HasAnyDevice = false;
+        _walletProbe.Result = false;
+
+        var cut = Render<PairingTakeover>();
+
+        cut.FindAll(CreateWallet).Should().NotBeEmpty("a walletless citizen must be routed to create a wallet");
+        cut.FindAll(CreateWalletButton).Should().NotBeEmpty();
+        cut.FindAll(PrimaryButton).Should().BeEmpty("the dead-ending enrol button must not be offered when there is no wallet");
+    }
+
+    // US2 — citizen with a wallet but no device here sees the existing pair flow.
+    [Fact]
+    public void HasWalletNoDevice_RendersPairState_NotCreateWallet()
+    {
+        _deviceProbe.HasAnyDevice = false;
+        _walletProbe.Result = true;
+
+        var cut = Render<PairingTakeover>();
+
+        cut.FindAll(PrimaryButton).Should().NotBeEmpty("a wallet owner must still get the pair flow");
+        cut.FindAll(CreateWallet).Should().BeEmpty();
+    }
+
+    // US2 — a device already paired here keeps the takeover hidden.
+    [Fact]
+    public void HasDevice_RendersNothing()
+    {
+        _deviceProbe.HasAnyDevice = true;
+        _walletProbe.Result = false;
+
+        var cut = Render<PairingTakeover>();
+
+        cut.FindAll(Overlay).Should().BeEmpty();
+    }
+
+    // US3 — while the wallet check is in flight, nothing is shown (no flash);
+    // once it resolves to walletless, the create-wallet body appears.
+    [Fact]
+    public void WalletCheckInFlight_RendersNothing_ThenCreateWalletOnResolve()
+    {
+        _deviceProbe.HasAnyDevice = false;
+        _walletProbe.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var cut = Render<PairingTakeover>();
+
+        cut.FindAll(Overlay).Should().BeEmpty("the overlay must not flash while the wallet check is pending");
+
+        _walletProbe.Gate.SetResult(false);
+
+        cut.WaitForAssertion(() => cut.FindAll(CreateWallet).Should().NotBeEmpty());
+    }
+
+    private sealed class FakeHasPairedDeviceProbe : IHasPairedDeviceProbe
+    {
+        public bool? HasAnyDevice { get; set; }
+        public DateTimeOffset? LatestEnrolledAt { get; set; }
+        public event Action? Changed;
+        public Task EnsureLoadedAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RefreshAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task RaiseLocalPairCompleted(CancellationToken ct = default)
+        {
+            HasAnyDevice = true;
+            Changed?.Invoke();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeHasWalletProbe : IHasWalletProbe
+    {
+        public bool Result { get; set; }
+        public TaskCompletionSource<bool>? Gate { get; set; }
+        public Task<bool> HasWalletAsync(CancellationToken ct = default) =>
+            Gate is not null ? Gate.Task : Task.FromResult(Result);
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/HasWalletProbeTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/HasWalletProbeTests.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Sorcha.Wallet.Pwa.Services.Wallet;
+using Xunit;
+
+namespace Sorcha.Wallet.Pwa.Tests.Services;
+
+/// <summary>
+/// Feature 149 — covers <see cref="HasWalletProbe"/> HTTP-shape handling:
+/// 200 true / 200 false parsing and the fail-safe (transient failure → true)
+/// that keeps a real wallet owner on the existing pair flow.
+/// </summary>
+public sealed class HasWalletProbeTests
+{
+    [Fact]
+    public async Task HasWalletAsync_200_True_ReturnsTrue()
+    {
+        var handler = new StubHandler((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/v1/wallet/exists");
+            return Ok("""{"hasWallet":true}""");
+        });
+
+        var result = await Create(handler).HasWalletAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HasWalletAsync_200_False_ReturnsFalse()
+    {
+        var handler = new StubHandler((_, _) => Ok("""{"hasWallet":false}"""));
+
+        var result = await Create(handler).HasWalletAsync();
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HasWalletAsync_NetworkError_FailsSafeTrue()
+    {
+        var handler = new StubHandler((_, _) => throw new HttpRequestException("offline"));
+
+        var result = await Create(handler).HasWalletAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HasWalletAsync_ServerError_FailsSafeTrue()
+    {
+        var handler = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.InternalServerError));
+
+        var result = await Create(handler).HasWalletAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HasWalletAsync_EmptyBody_FailsSafeTrue()
+    {
+        var handler = new StubHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("", Encoding.UTF8, "application/json")
+            });
+
+        var result = await Create(handler).HasWalletAsync();
+
+        result.Should().BeTrue();
+    }
+
+    private static HasWalletProbe Create(StubHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://test.example.com") };
+        return new HasWalletProbe(http, NullLogger<HasWalletProbe>.Instance);
+    }
+
+    private static HttpResponseMessage Ok(string json) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _respond;
+        public StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond) => _respond = respond;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+            Task.FromResult(_respond(request, ct));
+    }
+}

--- a/tests/Sorcha.Wallet.Pwa.Tests/Services/HasWalletProbeTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Services/HasWalletProbeTests.cs
@@ -66,6 +66,20 @@ public sealed class HasWalletProbeTests
     }
 
     [Fact]
+    public async Task HasWalletAsync_MalformedJson_FailsSafeTrue()
+    {
+        var handler = new StubHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<html>not json</html>", Encoding.UTF8, "application/json")
+            });
+
+        var result = await Create(handler).HasWalletAsync();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task HasWalletAsync_EmptyBody_FailsSafeTrue()
     {
         var handler = new StubHandler((_, _) =>

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletExistsEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletExistsEndpointTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Moq;
 using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Wallet.Core.Domain;
 using Sorcha.Wallet.Core.Repositories.Interfaces;
 using Sorcha.Wallet.Service.Endpoints;
 using Xunit;
@@ -56,6 +57,36 @@ public sealed class CitizenWalletExistsEndpointTests
     public async Task WalletExists_WhenWalletAddressClaimPresent_ReturnsOkTrue()
     {
         var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+
+        var result = await InvokeAsync(ctx);
+
+        var ok = result.Should().BeOfType<Ok<WalletExistsResponse>>().Subject;
+        ok.Value!.HasWallet.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WalletExists_WhenRepositoryOwnsWallet_ReturnsOkTrue()
+    {
+        // Production path: F136 consumer tokens omit the wallet_address claim, so
+        // a real "has wallet" result is reached via the GetByOwnerAsync fallback.
+        _walletRepository
+            .Setup(r => r.GetByOwnerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new WalletEntity
+                {
+                    Address = CitizenWallet,
+                    EncryptedPrivateKey = "k",
+                    EncryptionKeyId = "kid",
+                    Algorithm = "ED25519",
+                    Owner = PlatformUserId.ToString(),
+                    Tenant = "default",
+                    Name = "citizen",
+                    Status = WalletStatus.Active
+                }
+            });
+
+        var ctx = BuildHttpContext(PlatformUserId, walletAddress: null);
 
         var result = await InvokeAsync(ctx);
 

--- a/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletExistsEndpointTests.cs
+++ b/tests/Sorcha.Wallet.Service.Tests/Endpoints/CitizenWalletExistsEndpointTests.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Sorcha Contributors
+
+using System.Reflection;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using Sorcha.CitizenWallet.Abstractions.Models;
+using Sorcha.Wallet.Core.Repositories.Interfaces;
+using Sorcha.Wallet.Service.Endpoints;
+using Xunit;
+using WalletEntity = Sorcha.Wallet.Core.Domain.Entities.Wallet;
+
+namespace Sorcha.Wallet.Service.Tests.Endpoints;
+
+/// <summary>
+/// Feature 149 — tests for the <see cref="CitizenWalletEndpoints"/>
+/// <c>WalletExists</c> handler. Reflection-based static-handler invocation
+/// (same pattern as <see cref="CitizenWalletEnrolEndpointTests"/>). The handler
+/// must ALWAYS return 200 with an explicit boolean for an authenticated caller —
+/// no 401/404 ambiguity — so the PWA gets a clean walletless signal.
+/// </summary>
+public sealed class CitizenWalletExistsEndpointTests
+{
+    private static readonly Guid PlatformUserId = Guid.NewGuid();
+    private const string CitizenWallet = "ws1qcitizen1";
+
+    private readonly Mock<IWalletRepository> _walletRepository = new();
+
+    private static HttpContext BuildHttpContext(Guid? platformUserId, string? walletAddress)
+    {
+        var ctx = new DefaultHttpContext();
+        var claims = new List<Claim>();
+        if (platformUserId is not null)
+            claims.Add(new Claim("platform_user_id", platformUserId.Value.ToString()));
+        if (walletAddress is not null)
+            claims.Add(new Claim("wallet_address", walletAddress));
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        return ctx;
+    }
+
+    private async Task<IResult> InvokeAsync(HttpContext context)
+    {
+        var method = typeof(CitizenWalletEndpoints).GetMethod(
+            "WalletExists",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        method.Should().NotBeNull("WalletExists handler should exist");
+
+        var result = method.Invoke(null, [context, _walletRepository.Object, CancellationToken.None]);
+        return await (Task<IResult>)result!;
+    }
+
+    [Fact]
+    public async Task WalletExists_WhenWalletAddressClaimPresent_ReturnsOkTrue()
+    {
+        var ctx = BuildHttpContext(PlatformUserId, CitizenWallet);
+
+        var result = await InvokeAsync(ctx);
+
+        var ok = result.Should().BeOfType<Ok<WalletExistsResponse>>().Subject;
+        ok.Value!.HasWallet.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WalletExists_WhenNoWalletResolves_ReturnsOkFalse()
+    {
+        // No wallet_address claim and the repository owns no wallet for the caller.
+        _walletRepository
+            .Setup(r => r.GetByOwnerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WalletEntity>());
+
+        var ctx = BuildHttpContext(PlatformUserId, walletAddress: null);
+
+        var result = await InvokeAsync(ctx);
+
+        var ok = result.Should().BeOfType<Ok<WalletExistsResponse>>().Subject;
+        ok.Value!.HasWallet.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Makes the Citizen Wallet PWA's `PairingTakeover` overlay **wallet-aware** (companion-first roadmap **P0 #1**). Previously the takeover assumed every signed-in citizen had a wallet and offered only "Set up this device" → device enrol, which returns **404 for a walletless citizen** → dead-end with no way forward. The consumer-tier JWT (F136) carries no wallet binding, so "has wallet?" is a server fact.

Now the takeover distinguishes three states:
- **Walletless** → a new "Create your wallet first" body that force-loads the web `/wallets/create` handoff (companion-first; the web app owns wallet creation). No in-PWA wallet creation.
- **Has wallet, no device here** → the existing pair flow, **unchanged**.
- **Either check in flight** → hidden (no flashing).

### What changed
- **New endpoint** `GET /api/v1/wallet/exists` → `200 { hasWallet }` (consumer-tier, **always 200** for an authenticated consumer — no 401/404 ambiguity). Boolean only, no PII. (`CitizenWalletEndpoints.WalletExists` + `WalletExistsResponse` DTO.)
  - Chosen over reusing `holder-keys`/enrol 404: `holder-keys` 401s on no-wallet and 404s on *wallet-but-no-key* (the opposite signal). A dedicated boolean endpoint is unambiguous.
- **One-shot probe** `IHasWalletProbe` + `HasWalletProbe` (PWA-local). No `Changed`/`Refresh` — walletless is a terminal cold-start state (false→true once, never back). **Fail-safe `true`** on any transient failure (network / non-2xx / empty / malformed JSON / timeout) so a real wallet owner is never routed to create a second wallet.
- **`PairingTakeover.razor`** three-state machine; wallet check runs once, only when there is no device here.
- **Doc-sync**: `sorcha-architecture` skill (F149 surface) + roadmap P0 #1 ticked.

Design / spec / plan / tasks: `docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md`, `specs/149-pwa-pairing-takeover-wallet-aware/`.

No schema/EF change (read-only resolution of existing data) → no migration. Clean-break, additive.

## Test Plan
- [x] `CitizenWalletExistsEndpointTests` — 200 true (via repo fallback, the real F136 consumer-token path), 200 true (claim path), 200 false. Wallet.Service **842/842** green.
- [x] `HasWalletProbeTests` — 200 true / 200 false / network / 500 / empty body / malformed JSON all fail-safe to true.
- [x] `PairingTakeoverTests` (bUnit) — walletless→create-wallet (no enrol button), has-wallet→pair body, has-device→hidden, in-flight→hidden then resolves. PWA **205/205** green.
- [x] Release build 0 warnings / 0 errors across Wallet Service + PWA + Abstractions.
- [x] Snackbar CI gate green; no hard-coded `<Version>`; license headers on new files.
- [ ] **n1 validation (post-merge + Docker Publish):** pull + recreate `sorcha-wallet-pwa`, confirm new build badge, walk the walletless (→ web `/wallets/create`) and has-wallet (→ pair) paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)