### PR TITLE
fix(149): create-wallet CTA targets /app/wallets/create (404 fix found in n1 browser validation)

### DIFF
--- a/.claude/skills/sorcha-architecture/SKILL.md
+++ b/.claude/skills/sorcha-architecture/SKILL.md
@@ -1278,7 +1278,7 @@ Four citizen routes outside the F126 council-page gate, all sharing the existing
 
 ### Components (Sorcha.UI.Components.User)
 
-- **`PairingTakeover`** (`Sorcha.Wallet.Pwa/Components/PairingTakeover.razor` — **PWA-local, NOT in Components.User**) — full-page overlay mounted in `Sorcha.Wallet.Pwa/MainLayout.razor` outside `MudLayout`. Renders when `HasAnyDevice == false`. **(F149) Wallet-aware:** when there is no device here it runs a one-shot `IHasWalletProbe.HasWalletAsync`; a walletless citizen sees a "Create your wallet first" body that force-loads the web `/wallets/create` handoff (companion-first), while a wallet owner gets the pair body below. The overlay stays hidden until both the device check and the wallet check resolve (no flash). Pair-body primary action invokes `IEnrolmentService.EnrolAsync` against the existing PWA session; secondary disclosure accepts a 6-digit code for cross-device-to-this-device pairing. Auto-dismisses on probe-change OR `CitizenWalletHubConnection.OnDeviceEnrolled`.
+- **`PairingTakeover`** (`Sorcha.Wallet.Pwa/Components/PairingTakeover.razor` — **PWA-local, NOT in Components.User**) — full-page overlay mounted in `Sorcha.Wallet.Pwa/MainLayout.razor` outside `MudLayout`. Renders when `HasAnyDevice == false`. **(F149) Wallet-aware:** when there is no device here it runs a one-shot `IHasWalletProbe.HasWalletAsync`; a walletless citizen sees a "Create your wallet first" body that force-loads the web `/app/wallets/create` handoff (the web Blazor client is under the /app base path — NOT origin-root) (companion-first), while a wallet owner gets the pair body below. The overlay stays hidden until both the device check and the wallet check resolve (no flash). Pair-body primary action invokes `IEnrolmentService.EnrolAsync` against the existing PWA session; secondary disclosure accepts a 6-digit code for cross-device-to-this-device pairing. Auto-dismisses on probe-change OR `CitizenWalletHubConnection.OnDeviceEnrolled`.
 - **`PairingHandoffSurface`** (`Components/Pairing/`) — hosted at `/setup/add-device`. Switches on `IPwaInstallabilityProbe` verdict between the QR variant (desktop) and the install variant (mobile, with always-visible short code). Common Skip + "Email me a link" affordances.
 - **`PairingNagBanner`** (`Components/Pairing/`) — persistent dismissable banner mounted in `Sorcha.UI.Web.Client/Components/Layout/MainLayout.razor`. Renders when `HasAnyDevice == false`. CTA → `/setup/add-device`.
 
@@ -1324,7 +1324,13 @@ citizen there instead of building in-PWA wallet creation.
   `false`+`_hasWallet == true` → existing pair body (unchanged). The wallet check runs once, only
   when there is no device here.
 - **Tests:** `CitizenWalletExistsEndpointTests` (Wallet Service, reflection handler invocation);
-  `HasWalletProbeTests` + `PairingTakeoverTests` (PWA, bUnit).
+  `HasWalletProbeTests` + `PairingTakeoverTests` (PWA, bUnit — incl. a nav-target assertion for
+  `/app/wallets/create`).
+- **Web-base-path gotcha (fix PR after #978):** the create-wallet CTA must target
+  `{origin}/app/wallets/create`, not origin-root `/wallets/create` (404 on n1) — the web Blazor
+  client is mounted under `/app`. This differs from `SignIn.razor` `GoToWebSignup`, whose
+  `/auth/signup` IS a root-level tenant-service Razor page. Don't assume web routes are at origin
+  root just because a sibling handoff is.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md
+++ b/docs/superpowers/specs/2026-06-06-pwa-pairing-takeover-wallet-aware-design.md
@@ -2,6 +2,13 @@
 
 **Date:** 2026-06-06
 **Status:** Approved — ready for implementation plan
+
+> **Correction (2026-06-07, fix after #978):** the create-wallet CTA target below is written as
+> `{origin}/wallets/create`, mirroring `GoToWebSignup`. That was wrong — on-n1 browser validation
+> showed it 404s because the web Blazor client is mounted under the **`/app`** base path. The
+> shipped code targets **`{origin}/app/wallets/create`**. (`/auth/signup` had no `/app` prefix
+> because it is a root-level tenant-service Razor page, not an `/app` WASM route — a distinction I
+> missed.) Read every `/wallets/create` below as `/app/wallets/create`.
 **Feature area:** Citizen Wallet PWA (Feature 128 cold-start onboarding)
 **Roadmap item:** P0 #1 in `docs/superpowers/specs/2026-06-06-citizen-wallet-companion-roadmap.md`
 **Decision owner:** Stuart Fraser

--- a/src/Apps/Sorcha.Wallet.Pwa/Components/PairingTakeover.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Components/PairingTakeover.razor
@@ -216,14 +216,16 @@
         _isVisible = Probe.HasAnyDevice == false && _hasWallet is not null;
     }
 
-    // Feature 149 — wallet creation lives on the web host at origin-root
-    // /wallets/create (the PWA is mounted under /wallet/, so build the absolute
-    // origin URL rather than a leading-slash path). forceLoad because it leaves
-    // the PWA for the web app entirely. Mirrors SignIn.razor GoToWebSignup.
+    // Feature 149 — wallet creation lives on the web host's Blazor client, which
+    // is mounted under the /app base path (the PWA is under /wallet/). So the
+    // target is {origin}/app/wallets/create — NOT origin-root /wallets/create
+    // (that 404s; caught in on-n1 browser validation). Note this differs from
+    // GoToWebSignup, whose /auth/signup is a root-level tenant-service page, not
+    // an /app WASM route. forceLoad because it leaves the PWA for the web app.
     private void GoToWebWalletCreation()
     {
         var origin = new Uri(Nav.BaseUri).GetLeftPart(UriPartial.Authority);
-        Nav.NavigateTo($"{origin}/wallets/create", forceLoad: true);
+        Nav.NavigateTo($"{origin}/app/wallets/create", forceLoad: true);
     }
 
     private async Task HandlePrimaryAsync()

--- a/tests/Sorcha.Wallet.Pwa.Tests/Components/PairingTakeoverTests.cs
+++ b/tests/Sorcha.Wallet.Pwa.Tests/Components/PairingTakeoverTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Sorcha Contributors
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Bunit;
@@ -59,6 +60,23 @@ public sealed class PairingTakeoverTests : ComponentTestFixture
         cut.FindAll(CreateWallet).Should().NotBeEmpty("a walletless citizen must be routed to create a wallet");
         cut.FindAll(CreateWalletButton).Should().NotBeEmpty();
         cut.FindAll(PrimaryButton).Should().BeEmpty("the dead-ending enrol button must not be offered when there is no wallet");
+    }
+
+    // US1 — the create-wallet CTA force-loads the web host's wallet-creation
+    // page, which lives under the WASM client base path /app (NOT origin-root;
+    // that distinction is what the on-n1 browser check caught).
+    [Fact]
+    public void CreateWalletButton_NavigatesToWebAppWalletCreation()
+    {
+        _deviceProbe.HasAnyDevice = false;
+        _walletProbe.Result = false;
+        var nav = Services.GetRequiredService<Bunit.TestDoubles.BunitNavigationManager>();
+
+        var cut = Render<PairingTakeover>();
+        cut.Find(CreateWalletButton).Click();
+
+        nav.History.Should().NotBeEmpty();
+        nav.History.Last().Uri.Should().EndWith("/app/wallets/create");
     }
 
     // US2 — citizen with a wallet but no device here sees the existing pair flow.


### PR DESCRIPTION
## Summary

Follow-up to #978. On-n1 **browser validation** of the walletless path caught a real bug: the new "Create your wallet" CTA force-loaded `{origin}/wallets/create`, which **404s** on n1. The web Blazor client is mounted under the **`/app`** base path, so the wallet-creation route is `/app/wallets/create`.

Root cause: I mirrored `SignIn.razor` `GoToWebSignup`, but `/auth/signup` is a **root-level tenant-service Razor page**, whereas wallet creation is an **`/app` WASM client route** — different base paths.

The takeover UI itself was correct end-to-end (verified in-browser: signed in as a walletless citizen → "Create your wallet first" rendered with the right copy and CTA, no enrol dead-end, and `GET /api/v1/wallet/exists` returned `{hasWallet:false}` for the real consumer token). Only the CTA target path was wrong.

## Changes
- `PairingTakeover.GoToWebWalletCreation` → `{origin}/app/wallets/create`.
- New bUnit test asserts the **navigation target** (the original tests only asserted button presence, which is why this slipped through).
- Doc-sync: `sorcha-architecture` skill gotcha + design-doc correction note.

## Test Plan
- [x] `PairingTakeoverTests.CreateWalletButton_NavigatesToWebAppWalletCreation` — RED on `/wallets/create`, GREEN on `/app/wallets/create`. PWA **206/206**.
- [x] Release build 0/0.
- [ ] Re-verify on n1 in-browser after merge + Docker Publish + recreate: CTA lands on the web wallet-creation page (not 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)