### PR TITLE
fix(www): redirect www.sorcha.dev/wallet -> n1.sorcha.dev/wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,6 +241,8 @@ docs/services/peer-service.md
 docs/site/index.html
 docs/site/landing.css
 docs/site/landing.js
+docs/site/consent-banner.js
+docs/site/wallet/
 
 # Playwright
 /test-results/

--- a/scripts/copy-landing-to-site.js
+++ b/scripts/copy-landing-to-site.js
@@ -33,6 +33,41 @@ const linkRewrites = [
 // Injected into <head> so the public page advertises the canonical URL.
 const canonicalTag = '    <link rel="canonical" href="https://www.sorcha.dev">\n'
 
+// Standalone redirect stubs emitted into the published site. The landing page
+// links to /wallet/ (the live citizen wallet PWA), but www.sorcha.dev is a
+// static GitHub Pages host with no such path — it 404s. Bounce both the
+// in-page links and anyone typing the URL directly to the deployed app on n1.
+const redirects = [
+  { path: 'wallet', to: 'https://n1.sorcha.dev/wallet' },
+]
+
+function redirectHtml(to) {
+  // location.replace preserves any query/hash and keeps the stub out of history;
+  // the meta-refresh is the no-JS fallback. noindex so the stub isn't indexed.
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting to the Sorcha Wallet…</title>
+  <meta name="robots" content="noindex">
+  <link rel="canonical" href="${to}">
+  <meta http-equiv="refresh" content="0; url=${to}">
+  <script>location.replace(${JSON.stringify(to)} + location.search + location.hash)</script>
+</head>
+<body>
+  <p>Redirecting to <a href="${to}">${to}</a>…</p>
+</body>
+</html>
+`
+}
+
+function writeRedirect({ path: routePath, to }) {
+  const destPath = path.join(destDir, routePath, 'index.html')
+  fs.mkdirSync(path.dirname(destPath), { recursive: true })
+  fs.writeFileSync(destPath, redirectHtml(to))
+  console.log(`Wrote redirect /${routePath}/ -> ${to}`)
+}
+
 function rewriteIndex(html) {
   let out = html
   for (const { from, to } of linkRewrites) {
@@ -64,3 +99,4 @@ function copy(file, transform) {
 
 copy('index.html', rewriteIndex)
 for (const file of verbatim) copy(file)
+for (const redirect of redirects) writeRedirect(redirect)


### PR DESCRIPTION
## Summary

`www.sorcha.dev/wallet` returns a **GitHub Pages 404**. The landing page links to `/wallet/` (the nav "Wallet" item and the "Open Wallet" CTA), but `www.sorcha.dev` is a static GitHub Pages host (deployed from `docs/site/` by the `gh-pages.yml` workflow) with no `/wallet` path — so both the in-page links and anyone typing the URL hit a 404.

Fix: `scripts/copy-landing-to-site.js` (the sole writer of `docs/site/`) now emits a `/wallet/index.html` redirect stub that bounces to `https://n1.sorcha.dev/wallet` via `location.replace` (preserving query/hash) with a `meta http-equiv="refresh"` no-JS fallback and `noindex`. GitHub Pages serves it for both `/wallet` (301→`/wallet/`) and `/wallet/`, covering the nav link, the CTA, and direct navigation.

Also adds the generated `consent-banner.js` (a pre-existing gitignore gap) and `wallet/` to `.gitignore`, consistent with the other generated landing outputs.

## Test Plan
- [x] Ran `node scripts/copy-landing-to-site.js` → emits `docs/site/wallet/index.html` with the correct redirect target; existing copies unaffected.
- [x] Confirmed generated outputs are gitignored (only the script + `.gitignore` are committed; CI regenerates the rest).
- [ ] After merge + `Deploy GitHub Pages`: browser-verify `https://www.sorcha.dev/wallet` redirects to `https://n1.sorcha.dev/wallet` (no 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)