### PR TITLE
fix(pwa): build badge showed literal 'v@AppVersion' instead of the version

### DIFF
--- a/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/MainLayout.razor
@@ -152,7 +152,10 @@
    sign-in page) so the running build is verifiable at a glance after a deploy.
    Decorative + non-interactive; the version is stamped at build time by the
    unified-versioning standard (root Directory.Build.props). *@
-<div class="sorcha-build-badge" aria-hidden="true">v@AppVersion</div>
+@* NB: v@(AppVersion) — the explicit @(...) form is required. The implicit
+   "v@AppVersion" reads as an email address to Razor's @-heuristic and renders
+   literally (the bug this fixes). *@
+<div class="sorcha-build-badge" aria-hidden="true">v@(AppVersion)</div>
 
 @code {
     private IReadOnlyList<UserOrgMembership> _memberships = Array.Empty<UserOrgMembership>();


### PR DESCRIPTION
## Summary

The PWA build-version badge (bottom-right, on every screen) rendered the literal text **`v@AppVersion`** instead of the version number. Cause: the markup `v@AppVersion` is read by Razor's `@`-heuristic as an **email address** (`v@AppVersion`), so it's emitted as a literal rather than evaluating the `AppVersion` expression.

Fix: use the explicit `v@(AppVersion)` form, which always parses as code.

`ResolveAppVersion()` (reflection on `AssemblyInformationalVersion`, `+commit` trimmed) was already correct — only the markup was wrong.

## Verification
Inspected the generated Razor C# (forced `EmitCompilerGeneratedFiles`): the badge now emits
```
__builder.AddContent(89, "v");
__builder.AddContent(90, AppVersion …);   // the field VALUE (code), not a literal
```
where before `v@AppVersion` was a single literal string. Build 0 warnings / 0 errors.

(No bUnit test added: MainLayout's dependency graph makes a full render disproportionate for a one-token Razor-parsing fix, and a source-grep test would be brittle. Guarded instead by an inline comment documenting the email-heuristic trap + post-deploy browser check.)

## Test Plan
- [x] Generated-Razor inspection confirms expression evaluation.
- [x] Release build 0/0.
- [ ] Post-deploy: badge on https://n1.sorcha.dev/wallet shows `v2.<run>.<attempt>`, not `v@AppVersion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)