### PR TITLE
fix(ci): stamp real build version into PWA image (badge was 2.0.0-dev)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -141,6 +141,13 @@ jobs:
           file: ${{ steps.resolve.outputs.dockerfile }}
           push: true
           platforms: linux/amd64
+          # Pass the run identifiers into the build so the published assembly's
+          # version matches the :2.<run>.<attempt> image tag below (the root
+          # Directory.Build.props derives the version from these env vars).
+          # Dockerfiles that don't declare the matching ARG simply ignore these.
+          build-args: |
+            GITHUB_RUN_NUMBER=${{ github.run_number }}
+            GITHUB_RUN_ATTEMPT=${{ github.run_attempt }}
           # Unified version scheme: 2.<run_number>.<run_attempt> (matches the
           # .NET assembly version derived in the root Directory.Build.props).
           tags: |

--- a/src/Apps/Sorcha.Wallet.Pwa/Dockerfile
+++ b/src/Apps/Sorcha.Wallet.Pwa/Dockerfile
@@ -23,6 +23,16 @@ RUN dotnet restore "src/Apps/Sorcha.Wallet.Pwa/Sorcha.Wallet.Pwa.csproj"
 
 COPY src/ ./src/
 
+# Unified versioning: the root Directory.Build.props derives the version from
+# GITHUB_RUN_NUMBER / GITHUB_RUN_ATTEMPT (else 2.0.0-dev). MSBuild reads env vars
+# as properties, so surfacing the build-args as ENV here makes the published
+# assembly carry 2.<run>.<attempt> — matching the image tag. Declared AFTER
+# restore so the (cacheable) restore layer isn't invalidated every run.
+ARG GITHUB_RUN_NUMBER
+ARG GITHUB_RUN_ATTEMPT
+ENV GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}
+ENV GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
+
 WORKDIR "/src/src/Apps/Sorcha.Wallet.Pwa"
 RUN dotnet publish "Sorcha.Wallet.Pwa.csproj" -c Release -o /app/publish /p:UseAppHost=false
 


### PR DESCRIPTION
## Summary

Follow-on to the badge fix (#982). With the literal `v@AppVersion` resolved, the badge on n1 showed **`v2.0.0-dev`** — the *local* fallback — on a CI-built image. Root cause: `docker-publish.yml` tags images `:2.<run>.<attempt>` but never passed those values as **build-args**, so the `dotnet publish` inside the Dockerfile saw no `GITHUB_RUN_*` env and the root `Directory.Build.props` fell back to `2.0.0-dev`. The image *tag* and the *embedded* version diverged.

## Changes
- **`docker-publish.yml`**: pass `GITHUB_RUN_NUMBER` / `GITHUB_RUN_ATTEMPT` as `build-args` to all matrix builds (Dockerfiles that don't declare the matching `ARG` ignore them harmlessly).
- **PWA `Dockerfile`**: `ARG` + `ENV` the two run identifiers before `dotnet publish` (placed after `restore` so the cacheable restore layer isn't invalidated each run). MSBuild reads env vars as properties, so the published assembly carries `2.<run>.<attempt>`.

## Verification
```
dotnet msbuild …/Sorcha.Wallet.Pwa.csproj -getProperty:Version
  (no env)                              → 2.0.0-dev
  GITHUB_RUN_NUMBER=9999 ATTEMPT=2      → 2.9999.2
```

## Scope note
Only the PWA Dockerfile gets the `ARG` block here (it's the image that surfaces the badge). Other service images still embed `2.0.0-dev` internally (their image *tags* are still correct). The same 4-line `ARG`/`ENV` block can be added to the other Dockerfiles if we want their assemblies/telemetry to report the real version too — happy to do that as a follow-up.

## Test Plan
- [x] Local `msbuild -getProperty:Version` confirms env→version derivation.
- [ ] Post-deploy: badge on https://n1.sorcha.dev/wallet shows `v2.<run>.<attempt>`, not `v2.0.0-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)