### PR TITLE
Various web updates: /docs page, palette cleanup, spacing-token fix

### DIFF
--- a/docs/site/compare.html
+++ b/docs/site/compare.html
@@ -76,9 +76,9 @@
             </p>
         </div>
 
-        <div class="container" style="margin-top:var(--space-4)">
+        <div class="container" style="margin-top:var(--sp-4)">
             <table class="compare-table">
-                <caption class="compare-note" style="text-align:left;margin-bottom:var(--space-2)">Sorcha's reading of the field, June 2026. Vendor capabilities change — verify directly with each project.</caption>
+                <caption class="compare-note" style="text-align:left;margin-bottom:var(--sp-2)">Sorcha's reading of the field, June 2026. Vendor capabilities change — verify directly with each project.</caption>
                 <thead>
                     <tr>
                         <th scope="col">Capability</th>

--- a/docs/site/compare.html
+++ b/docs/site/compare.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/docs/site/contact.html
+++ b/docs/site/contact.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/docs/site/designer-overview.html
+++ b/docs/site/designer-overview.html
@@ -61,7 +61,7 @@
             </p>
         </div>
 
-        <div class="container" style="margin-top:var(--space-4)">
+        <div class="container" style="margin-top:var(--sp-4)">
             <div class="stages">
                 <div class="stage"><span class="stage-label">Describe</span><p>Say what the process does, in plain language. The Designer turns your description into a candidate workflow.</p></div>
                 <div class="stage"><span class="stage-label">Understand</span><p>See the participants, actions and disclosures the platform derived — and adjust them before you commit.</p></div>
@@ -70,7 +70,7 @@
             </div>
         </div>
 
-        <div class="container-prose" style="margin-top:var(--space-6)">
+        <div class="container-prose" style="margin-top:var(--sp-6)">
             <h2>Why rehearsal matters</h2>
             <p>
                 A multi-party workflow touches participants, schemas, routing and disclosure rules. The

--- a/docs/site/designer-overview.html
+++ b/docs/site/designer-overview.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/docs/site/developers.html
+++ b/docs/site/developers.html
@@ -55,6 +55,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/docs/site/developers.html
+++ b/docs/site/developers.html
@@ -78,7 +78,7 @@
             </p>
         </div>
 
-        <div class="container" style="margin-top:var(--space-4)">
+        <div class="container" style="margin-top:var(--sp-4)">
             <div class="chips" style="justify-content:flex-start">
                 <span class="chip mono">.NET 10</span>
                 <span class="chip mono">.NET Aspire</span>
@@ -90,7 +90,7 @@
             </div>
         </div>
 
-        <div class="container-prose" style="margin-top:var(--space-6)">
+        <div class="container-prose" style="margin-top:var(--sp-6)">
             <h2>The services</h2>
             <p>
                 Eight single-responsibility services, each doing one job: <strong>Blueprint</strong>

--- a/docs/site/docs.html
+++ b/docs/site/docs.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright (c) 2026 Sorcha Contributors -->
+<html lang="en" data-theme="light" data-accent="violet">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>(function(){try{var t=localStorage.getItem('sorcha-theme');if(t!=='light'&&t!=='dark')t='light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+    <title>Sorcha documentation — how it works, from first principles</title>
+    <meta name="description" content="A calm introduction to Sorcha: the core idea, the key concepts, the eight services, and the standards and cryptography underneath — before the API reference or self-hosting guide.">
+    <link rel="canonical" href="https://www.sorcha.dev/docs">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Sorcha">
+    <meta property="og:title" content="Sorcha documentation — how it works, from first principles">
+    <meta property="og:description" content="A calm introduction to Sorcha: the core idea, the key concepts, the eight services, and the standards and cryptography underneath — before the API reference or self-hosting guide.">
+    <meta property="og:url" content="https://www.sorcha.dev/docs">
+    <meta property="og:image" content="https://www.sorcha.dev/og-default.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="icon" type="image/svg+xml" href="sorcha-icon.svg">
+    <link rel="shortcut icon" href="sorcha.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="landing.css">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B2MKVEP45T"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:'denied',wait_for_update:500});
+        gtag('js', new Date()); gtag('config','G-B2MKVEP45T',{anonymize_ip:true});
+    </script>
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <nav class="nav" aria-label="Primary">
+        <div class="nav-container">
+            <a href="/" class="nav-brand"><span class="brand-icon">S</span><span>Sorcha</span></a>
+            <div class="nav-links" id="navLinks">
+                <a href="/designer-overview" class="nav-link">For organisations</a>
+                <a href="/wallet-info" class="nav-link">For citizens</a>
+                <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link" aria-current="page">Docs</a>
+                <a href="/#open-standards" class="nav-link">Standards</a>
+                <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
+                    <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                    <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                </button>
+                <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
+            </div>
+            <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>
+        </div>
+    </nav>
+
+    <main id="main">
+        <section class="prose">
+            <div class="container-prose">
+                <span class="section-eyebrow">Documentation</span>
+                <h1>Sorcha, from first principles.</h1>
+                <p class="lead">
+                    A calm introduction to how Sorcha works — the core idea, the moving parts, and the
+                    standards underneath — before you head into the API reference or the self-hosting
+                    guide. Read this first; then go deeper.
+                </p>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="what-h">
+            <div class="container-prose">
+                <h2 id="what-h">What Sorcha is</h2>
+                <p>
+                    Sorcha is open-source cryptographic proof infrastructure for multi-party workflows. It
+                    replaces asserted trust — an operator's word that something happened — with verifiable
+                    proof that anyone can check. It issues and verifies verifiable credentials and
+                    orchestrates the signed, tamper-evident workflow around them. It is built on .NET 10 and
+                    .NET Aspire, MIT-licensed, and self-hostable with Docker.
+                </p>
+            </div>
+        </section>
+
+        <section class="section section-alt" aria-labelledby="core-h">
+            <div class="container-prose">
+                <h2 id="core-h">The core idea</h2>
+                <p>
+                    Most systems ask you to trust the operator. Sorcha asks you to trust the evidence. Every
+                    action is signed by the participant who took it, recorded in an append-only,
+                    Merkle-linked register, disclosed only to the parties entitled to see it, and
+                    independently verifiable by anyone. The same four steps run under every workflow.
+                </p>
+            </div>
+            <div class="container" style="margin-top:var(--space-4)">
+                <div class="steps">
+                    <div class="step">
+                        <div class="step-num">01</div><h3>Sign</h3>
+                        <p>Each participant holds their own keys. Every action is signed by the person or organisation who took it — accountability is built in, not bolted on.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step-num">02</div><h3>Record</h3>
+                        <p>Signed actions are written to an append-only register, each entry Merkle-chained to the last. Nothing can be altered or quietly removed.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step-num">03</div><h3>Disclose</h3>
+                        <p>Each party sees only the fields they're entitled to — and each party's data is encrypted to a key only they hold (per-recipient key wrapping). The platform cannot read what it was not given access to.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step-num">04</div><h3>Verify</h3>
+                        <p>Any party can check the signatures and the chain themselves. Trust comes from the evidence, not from us.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="concepts-h">
+            <div class="container-prose">
+                <h2 id="concepts-h">Key concepts</h2>
+                <p>The vocabulary worth knowing before the deeper docs.</p>
+                <ul>
+                    <li><strong>Blueprint</strong> — a workflow definition: the participants, the actions they can take, and the order things happen in. Authored as JSON or YAML and published before any work begins.</li>
+                    <li><strong>Register</strong> — the append-only ledger a workflow's actions are written to. Each entry is Merkle-linked to the one before, so the history is tamper-evident.</li>
+                    <li><strong>Wallet</strong> — holds a participant's keys, signs their actions, and holds the verifiable credentials issued to them. Keys derive from a hierarchical-deterministic seed (BIP-32/39/44).</li>
+                    <li><strong>Participant / Peer</strong> — a participant is a party in a workflow (a person or organisation); a peer is a node in the decentralised network that replicates registers so no single party can erase them.</li>
+                    <li><strong>Credential</strong> — a verifiable credential: a signed, tamper-evident claim a holder can present and a verifier can check, following W3C Verifiable Credentials 2.0 and the SD-JWT VC profile.</li>
+                    <li><strong>Presentation</strong> — the act of showing one or more credentials to a relying party, who verifies them directly (OpenID4VP).</li>
+                    <li><strong>Disclosure</strong> — selective disclosure: each recipient sees only the fields they are entitled to, and that data is sealed to a key only they hold.</li>
+                    <li><strong><code class="mono">did:sorcha</code></strong> — Sorcha's decentralised identifier method, used to name and resolve participants and their keys.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section section-alt" aria-labelledby="system-h">
+            <div class="container-prose">
+                <h2 id="system-h">The system at a glance</h2>
+                <p>
+                    Eight single-responsibility services, each doing one job. They compose into the platform;
+                    the API Gateway is the only part the outside world talks to directly.
+                </p>
+                <ul>
+                    <li><strong>Blueprint</strong> — workflow definitions.</li>
+                    <li><strong>Wallet</strong> — keys, signing, and credential holding.</li>
+                    <li><strong>Register</strong> — append-only Merkle ledgers.</li>
+                    <li><strong>Validator</strong> — quorum consensus over what is admitted to a register.</li>
+                    <li><strong>Peer</strong> — decentralised replication across the network.</li>
+                    <li><strong>Tenant</strong> — multi-tenancy, identity, and access.</li>
+                    <li><strong>API Gateway</strong> — the single external surface in front of the services.</li>
+                    <li><strong>HAIP</strong> — the boundary to the OpenID4VC wallet ecosystem.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="standards-h">
+            <div class="container-prose">
+                <h2 id="standards-h">Standards and cryptography</h2>
+                <div class="chips" style="justify-content:flex-start">
+                    <span class="chip mono">ML-DSA (FIPS 204)</span>
+                    <span class="chip mono">ML-KEM (FIPS 203)</span>
+                    <span class="chip mono">SLH-DSA (FIPS 205)</span>
+                    <span class="chip mono">BIP-32/39/44</span>
+                    <span class="chip mono">Merkle + SHA-256</span>
+                    <span class="chip mono">OpenID4VCI</span>
+                    <span class="chip mono">OpenID4VP</span>
+                    <span class="chip mono">SD-JWT VC</span>
+                    <span class="chip mono">W3C VC 2.0</span>
+                    <span class="chip mono">did:sorcha</span>
+                </div>
+                <p style="margin-top:var(--space-4)">
+                    Signing defaults to <strong>ML-DSA (FIPS 204)</strong>, a post-quantum signature scheme,
+                    with <strong>ML-KEM (FIPS 203)</strong> for key encapsulation and SLH-DSA (FIPS 205)
+                    primitives also present. Wallets derive keys with BIP-32/39/44; registers chain their
+                    entries with Merkle dockets and SHA-256. At the wallet boundary the HAIP service speaks
+                    OpenID4VCI, OpenID4VP and SD-JWT VC, issuing W3C Verifiable Credentials 2.0 named with
+                    the <code class="mono">did:sorcha</code> method. The Developers page carries the full
+                    list and the rationale.
+                </p>
+            </div>
+        </section>
+
+        <section class="section section-alt" aria-labelledby="principles-h">
+            <div class="container-prose">
+                <h2 id="principles-h">Design principles</h2>
+                <ul>
+                    <li><strong>Trust from evidence, not operators.</strong> Verification rests on signatures and the chain, not on trusting whoever runs the system.</li>
+                    <li><strong>Open standards over proprietary lock-in.</strong> Every protocol and primitive is a published standard you can implement against.</li>
+                    <li><strong>Post-quantum by default.</strong> The default signing path is ML-DSA, so records stay verifiable as cryptography moves on.</li>
+                    <li><strong>Participant-held keys.</strong> Each party holds their own keys and signs their own actions; the platform never signs on their behalf.</li>
+                    <li><strong>Rehearse before go-live.</strong> A workflow is rehearsed and validated before it can be published and run for real.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="next-h">
+            <div class="container-prose">
+                <h2 id="next-h">Where to go next</h2>
+                <p>Pick the path that fits what you're deciding.</p>
+            </div>
+            <div class="container" style="margin-top:var(--space-4)">
+                <div class="doors">
+                    <a class="door" href="/developers">
+                        <h3>Developers</h3>
+                        <p>The build-and-run path: the services, the API, the cryptography, and the self-hosting quick-start.</p>
+                        <span class="door-cta">Build on Sorcha →</span>
+                    </a>
+                    <a class="door" href="/designer-overview">
+                        <h3>The Designer</h3>
+                        <p>How an organisation describes a multi-party workflow and takes it live — describe, understand, rehearse, go live.</p>
+                        <span class="door-cta">See the Designer →</span>
+                    </a>
+                    <a class="door" href="/solutions">
+                        <h3>Solutions</h3>
+                        <p>Where proof fits: government-aligned identity, product passports, AI-decision audit trails, and trade finance.</p>
+                        <span class="door-cta">Explore solutions →</span>
+                    </a>
+                </div>
+            </div>
+            <div class="container-prose">
+                <div class="actions">
+                    <a href="https://github.com/Sorcha-Platform/Sorcha#quick-start" class="btn btn-primary btn-lg" target="_blank" rel="noopener">Self-hosting quick-start →</a>
+                    <a href="https://github.com/Sorcha-Platform/Sorcha/tree/master/docs" class="btn btn-outline btn-lg" target="_blank" rel="noopener">Browse the repo docs →</a>
+                    <a href="https://github.com/Sorcha-Platform/Sorcha" class="btn btn-text" target="_blank" rel="noopener">View on GitHub →</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-base">© Sorcha · Open source, MIT licensed · <a href="/" style="color:inherit">Home</a> · <a href="/developers" style="color:inherit">Developers</a> · <a href="https://github.com/Sorcha-Platform/Sorcha" style="color:inherit" target="_blank" rel="noopener">GitHub</a> · <button type="button" onclick="if(window.openConsent)window.openConsent()" style="background:none;border:none;color:inherit;cursor:pointer;font:inherit">Cookie settings</button></div>
+    </footer>
+
+    <script src="landing.js"></script>
+    <script src="consent-banner.js"></script>
+</body>
+</html>

--- a/docs/site/docs.html
+++ b/docs/site/docs.html
@@ -87,7 +87,7 @@
                     independently verifiable by anyone. The same four steps run under every workflow.
                 </p>
             </div>
-            <div class="container" style="margin-top:var(--space-4)">
+            <div class="container" style="margin-top:var(--sp-5)">
                 <div class="steps">
                     <div class="step">
                         <div class="step-num">01</div><h3>Sign</h3>
@@ -161,7 +161,7 @@
                     <span class="chip mono">W3C VC 2.0</span>
                     <span class="chip mono">did:sorcha</span>
                 </div>
-                <p style="margin-top:var(--space-4)">
+                <p style="margin-top:var(--sp-5)">
                     Signing defaults to <strong>ML-DSA (FIPS 204)</strong>, a post-quantum signature scheme,
                     with <strong>ML-KEM (FIPS 203)</strong> for key encapsulation and SLH-DSA (FIPS 205)
                     primitives also present. Wallets derive keys with BIP-32/39/44; registers chain their
@@ -191,7 +191,7 @@
                 <h2 id="next-h">Where to go next</h2>
                 <p>Pick the path that fits what you're deciding.</p>
             </div>
-            <div class="container" style="margin-top:var(--space-4)">
+            <div class="container" style="margin-top:var(--sp-5)">
                 <div class="doors">
                     <a class="door" href="/developers">
                         <h3>Developers</h3>

--- a/docs/site/solutions.html
+++ b/docs/site/solutions.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/docs/site/wallet-info.html
+++ b/docs/site/wallet-info.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/scripts/copy-landing-to-site.js
+++ b/scripts/copy-landing-to-site.js
@@ -31,6 +31,7 @@ const pages = [
   { file: 'solutions.html' },
   { file: 'compare.html' },
   { file: 'developers.html' },
+  { file: 'docs.html' },
   { file: 'contact.html' },
 ]
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Inbox/InboxPanel.razor
@@ -71,7 +71,7 @@
             {
                 var isUnread = entry.ReadAt is null;
                 <MudListItem T="InboxEntryDto"
-                             Style="@(isUnread ? "background-color: rgba(102,126,234,0.06);" : "")">
+                             Style="@(isUnread ? "background-color: rgba(79,70,229,0.06);" : "")">
                     <div class="d-flex flex-column gap-1" @onclick="() => OnEntryClickedAsync(entry)">
                         <div class="d-flex align-center gap-2">
                             <MudIcon Icon="@IconForCategory(entry.Category)"

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/BigActionButton.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/BigActionButton.razor.css
@@ -73,7 +73,7 @@
         color-mix(in srgb, #4F46E5 88%, white) 0%,
         #4F46E5 45%,
         color-mix(in srgb, #4F46E5 72%, black) 100%);
-    box-shadow: 0 10px 22px rgba(102, 126, 234, .40), 0 2px 4px rgba(0, 0, 0, .12);
+    box-shadow: 0 10px 22px rgba(79, 70, 229, .40), 0 2px 4px rgba(0, 0, 0, .12);
 }
 
 /* ── Ghost: PURPLE saturated gradient, content RIGHT-aligned (mirror) ───── */
@@ -84,7 +84,7 @@
         color-mix(in srgb, #818CF8 88%, white) 0%,
         #818CF8 45%,
         color-mix(in srgb, #818CF8 72%, black) 100%);
-    box-shadow: 0 10px 22px rgba(118, 75, 162, .40), 0 2px 4px rgba(0, 0, 0, .12);
+    box-shadow: 0 10px 22px rgba(129, 140, 248, .40), 0 2px 4px rgba(0, 0, 0, .12);
 }
 
 /* Reduced motion: no press scaling (handoff a11y note + FR-023). */

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Components.User/Components/Wallet/FloatingTabBar.razor.css
@@ -47,7 +47,7 @@
 
 .tab-pill--active {
     padding: 8px 12px;
-    background: linear-gradient(135deg, rgba(102, 126, 234, .13), rgba(118, 75, 162, .13));
+    background: linear-gradient(135deg, rgba(79, 70, 229, .13), rgba(129, 140, 248, .13));
     color: var(--mud-palette-primary, #4F46E5);
 }
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web.Client/Pages/Blueprints.razor
@@ -176,7 +176,7 @@
     }
 
     @@keyframes highlight-fade {
-        0% { background-color: rgba(102, 126, 234, 0.2); }
+        0% { background-color: rgba(79, 70, 229, 0.2); }
         100% { background-color: transparent; }
     }
 </style>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
@@ -76,9 +76,9 @@
             </p>
         </div>
 
-        <div class="container" style="margin-top:var(--space-4)">
+        <div class="container" style="margin-top:var(--sp-4)">
             <table class="compare-table">
-                <caption class="compare-note" style="text-align:left;margin-bottom:var(--space-2)">Sorcha's reading of the field, June 2026. Vendor capabilities change — verify directly with each project.</caption>
+                <caption class="compare-note" style="text-align:left;margin-bottom:var(--sp-2)">Sorcha's reading of the field, June 2026. Vendor capabilities change — verify directly with each project.</caption>
                 <thead>
                     <tr>
                         <th scope="col">Capability</th>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/contact.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/contact.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
@@ -61,7 +61,7 @@
             </p>
         </div>
 
-        <div class="container" style="margin-top:var(--space-4)">
+        <div class="container" style="margin-top:var(--sp-4)">
             <div class="stages">
                 <div class="stage"><span class="stage-label">Describe</span><p>Say what the process does, in plain language. The Designer turns your description into a candidate workflow.</p></div>
                 <div class="stage"><span class="stage-label">Understand</span><p>See the participants, actions and disclosures the platform derived — and adjust them before you commit.</p></div>
@@ -70,7 +70,7 @@
             </div>
         </div>
 
-        <div class="container-prose" style="margin-top:var(--space-6)">
+        <div class="container-prose" style="margin-top:var(--sp-6)">
             <h2>Why rehearsal matters</h2>
             <p>
                 A multi-party workflow touches participants, schemas, routing and disclosure rules. The

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
@@ -55,6 +55,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
@@ -78,7 +78,7 @@
             </p>
         </div>
 
-        <div class="container" style="margin-top:var(--space-4)">
+        <div class="container" style="margin-top:var(--sp-4)">
             <div class="chips" style="justify-content:flex-start">
                 <span class="chip mono">.NET 10</span>
                 <span class="chip mono">.NET Aspire</span>
@@ -90,7 +90,7 @@
             </div>
         </div>
 
-        <div class="container-prose" style="margin-top:var(--space-6)">
+        <div class="container-prose" style="margin-top:var(--sp-6)">
             <h2>The services</h2>
             <p>
                 Eight single-responsibility services, each doing one job: <strong>Blueprint</strong>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/docs.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/docs.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright (c) 2026 Sorcha Contributors -->
+<html lang="en" data-theme="light" data-accent="violet">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>(function(){try{var t=localStorage.getItem('sorcha-theme');if(t!=='light'&&t!=='dark')t='light';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+    <title>Sorcha documentation — how it works, from first principles</title>
+    <meta name="description" content="A calm introduction to Sorcha: the core idea, the key concepts, the eight services, and the standards and cryptography underneath — before the API reference or self-hosting guide.">
+    <link rel="canonical" href="https://www.sorcha.dev/docs">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Sorcha">
+    <meta property="og:title" content="Sorcha documentation — how it works, from first principles">
+    <meta property="og:description" content="A calm introduction to Sorcha: the core idea, the key concepts, the eight services, and the standards and cryptography underneath — before the API reference or self-hosting guide.">
+    <meta property="og:url" content="https://www.sorcha.dev/docs">
+    <meta property="og:image" content="https://www.sorcha.dev/og-default.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="icon" type="image/svg+xml" href="sorcha-icon.svg">
+    <link rel="shortcut icon" href="sorcha.ico">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="landing.css">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B2MKVEP45T"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:'denied',wait_for_update:500});
+        gtag('js', new Date()); gtag('config','G-B2MKVEP45T',{anonymize_ip:true});
+    </script>
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <nav class="nav" aria-label="Primary">
+        <div class="nav-container">
+            <a href="/" class="nav-brand"><span class="brand-icon">S</span><span>Sorcha</span></a>
+            <div class="nav-links" id="navLinks">
+                <a href="/designer-overview" class="nav-link">For organisations</a>
+                <a href="/wallet-info" class="nav-link">For citizens</a>
+                <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link" aria-current="page">Docs</a>
+                <a href="/#open-standards" class="nav-link">Standards</a>
+                <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
+                    <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                    <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                </button>
+                <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
+            </div>
+            <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>
+        </div>
+    </nav>
+
+    <main id="main">
+        <section class="prose">
+            <div class="container-prose">
+                <span class="section-eyebrow">Documentation</span>
+                <h1>Sorcha, from first principles.</h1>
+                <p class="lead">
+                    A calm introduction to how Sorcha works — the core idea, the moving parts, and the
+                    standards underneath — before you head into the API reference or the self-hosting
+                    guide. Read this first; then go deeper.
+                </p>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="what-h">
+            <div class="container-prose">
+                <h2 id="what-h">What Sorcha is</h2>
+                <p>
+                    Sorcha is open-source cryptographic proof infrastructure for multi-party workflows. It
+                    replaces asserted trust — an operator's word that something happened — with verifiable
+                    proof that anyone can check. It issues and verifies verifiable credentials and
+                    orchestrates the signed, tamper-evident workflow around them. It is built on .NET 10 and
+                    .NET Aspire, MIT-licensed, and self-hostable with Docker.
+                </p>
+            </div>
+        </section>
+
+        <section class="section section-alt" aria-labelledby="core-h">
+            <div class="container-prose">
+                <h2 id="core-h">The core idea</h2>
+                <p>
+                    Most systems ask you to trust the operator. Sorcha asks you to trust the evidence. Every
+                    action is signed by the participant who took it, recorded in an append-only,
+                    Merkle-linked register, disclosed only to the parties entitled to see it, and
+                    independently verifiable by anyone. The same four steps run under every workflow.
+                </p>
+            </div>
+            <div class="container" style="margin-top:var(--sp-5)">
+                <div class="steps">
+                    <div class="step">
+                        <div class="step-num">01</div><h3>Sign</h3>
+                        <p>Each participant holds their own keys. Every action is signed by the person or organisation who took it — accountability is built in, not bolted on.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step-num">02</div><h3>Record</h3>
+                        <p>Signed actions are written to an append-only register, each entry Merkle-chained to the last. Nothing can be altered or quietly removed.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step-num">03</div><h3>Disclose</h3>
+                        <p>Each party sees only the fields they're entitled to — and each party's data is encrypted to a key only they hold (per-recipient key wrapping). The platform cannot read what it was not given access to.</p>
+                    </div>
+                    <div class="step">
+                        <div class="step-num">04</div><h3>Verify</h3>
+                        <p>Any party can check the signatures and the chain themselves. Trust comes from the evidence, not from us.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="concepts-h">
+            <div class="container-prose">
+                <h2 id="concepts-h">Key concepts</h2>
+                <p>The vocabulary worth knowing before the deeper docs.</p>
+                <ul>
+                    <li><strong>Blueprint</strong> — a workflow definition: the participants, the actions they can take, and the order things happen in. Authored as JSON or YAML and published before any work begins.</li>
+                    <li><strong>Register</strong> — the append-only ledger a workflow's actions are written to. Each entry is Merkle-linked to the one before, so the history is tamper-evident.</li>
+                    <li><strong>Wallet</strong> — holds a participant's keys, signs their actions, and holds the verifiable credentials issued to them. Keys derive from a hierarchical-deterministic seed (BIP-32/39/44).</li>
+                    <li><strong>Participant / Peer</strong> — a participant is a party in a workflow (a person or organisation); a peer is a node in the decentralised network that replicates registers so no single party can erase them.</li>
+                    <li><strong>Credential</strong> — a verifiable credential: a signed, tamper-evident claim a holder can present and a verifier can check, following W3C Verifiable Credentials 2.0 and the SD-JWT VC profile.</li>
+                    <li><strong>Presentation</strong> — the act of showing one or more credentials to a relying party, who verifies them directly (OpenID4VP).</li>
+                    <li><strong>Disclosure</strong> — selective disclosure: each recipient sees only the fields they are entitled to, and that data is sealed to a key only they hold.</li>
+                    <li><strong><code class="mono">did:sorcha</code></strong> — Sorcha's decentralised identifier method, used to name and resolve participants and their keys.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section section-alt" aria-labelledby="system-h">
+            <div class="container-prose">
+                <h2 id="system-h">The system at a glance</h2>
+                <p>
+                    Eight single-responsibility services, each doing one job. They compose into the platform;
+                    the API Gateway is the only part the outside world talks to directly.
+                </p>
+                <ul>
+                    <li><strong>Blueprint</strong> — workflow definitions.</li>
+                    <li><strong>Wallet</strong> — keys, signing, and credential holding.</li>
+                    <li><strong>Register</strong> — append-only Merkle ledgers.</li>
+                    <li><strong>Validator</strong> — quorum consensus over what is admitted to a register.</li>
+                    <li><strong>Peer</strong> — decentralised replication across the network.</li>
+                    <li><strong>Tenant</strong> — multi-tenancy, identity, and access.</li>
+                    <li><strong>API Gateway</strong> — the single external surface in front of the services.</li>
+                    <li><strong>HAIP</strong> — the boundary to the OpenID4VC wallet ecosystem.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="standards-h">
+            <div class="container-prose">
+                <h2 id="standards-h">Standards and cryptography</h2>
+                <div class="chips" style="justify-content:flex-start">
+                    <span class="chip mono">ML-DSA (FIPS 204)</span>
+                    <span class="chip mono">ML-KEM (FIPS 203)</span>
+                    <span class="chip mono">SLH-DSA (FIPS 205)</span>
+                    <span class="chip mono">BIP-32/39/44</span>
+                    <span class="chip mono">Merkle + SHA-256</span>
+                    <span class="chip mono">OpenID4VCI</span>
+                    <span class="chip mono">OpenID4VP</span>
+                    <span class="chip mono">SD-JWT VC</span>
+                    <span class="chip mono">W3C VC 2.0</span>
+                    <span class="chip mono">did:sorcha</span>
+                </div>
+                <p style="margin-top:var(--sp-5)">
+                    Signing defaults to <strong>ML-DSA (FIPS 204)</strong>, a post-quantum signature scheme,
+                    with <strong>ML-KEM (FIPS 203)</strong> for key encapsulation and SLH-DSA (FIPS 205)
+                    primitives also present. Wallets derive keys with BIP-32/39/44; registers chain their
+                    entries with Merkle dockets and SHA-256. At the wallet boundary the HAIP service speaks
+                    OpenID4VCI, OpenID4VP and SD-JWT VC, issuing W3C Verifiable Credentials 2.0 named with
+                    the <code class="mono">did:sorcha</code> method. The Developers page carries the full
+                    list and the rationale.
+                </p>
+            </div>
+        </section>
+
+        <section class="section section-alt" aria-labelledby="principles-h">
+            <div class="container-prose">
+                <h2 id="principles-h">Design principles</h2>
+                <ul>
+                    <li><strong>Trust from evidence, not operators.</strong> Verification rests on signatures and the chain, not on trusting whoever runs the system.</li>
+                    <li><strong>Open standards over proprietary lock-in.</strong> Every protocol and primitive is a published standard you can implement against.</li>
+                    <li><strong>Post-quantum by default.</strong> The default signing path is ML-DSA, so records stay verifiable as cryptography moves on.</li>
+                    <li><strong>Participant-held keys.</strong> Each party holds their own keys and signs their own actions; the platform never signs on their behalf.</li>
+                    <li><strong>Rehearse before go-live.</strong> A workflow is rehearsed and validated before it can be published and run for real.</li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section" aria-labelledby="next-h">
+            <div class="container-prose">
+                <h2 id="next-h">Where to go next</h2>
+                <p>Pick the path that fits what you're deciding.</p>
+            </div>
+            <div class="container" style="margin-top:var(--sp-5)">
+                <div class="doors">
+                    <a class="door" href="/developers">
+                        <h3>Developers</h3>
+                        <p>The build-and-run path: the services, the API, the cryptography, and the self-hosting quick-start.</p>
+                        <span class="door-cta">Build on Sorcha →</span>
+                    </a>
+                    <a class="door" href="/designer-overview">
+                        <h3>The Designer</h3>
+                        <p>How an organisation describes a multi-party workflow and takes it live — describe, understand, rehearse, go live.</p>
+                        <span class="door-cta">See the Designer →</span>
+                    </a>
+                    <a class="door" href="/solutions">
+                        <h3>Solutions</h3>
+                        <p>Where proof fits: government-aligned identity, product passports, AI-decision audit trails, and trade finance.</p>
+                        <span class="door-cta">Explore solutions →</span>
+                    </a>
+                </div>
+            </div>
+            <div class="container-prose">
+                <div class="actions">
+                    <a href="https://github.com/Sorcha-Platform/Sorcha#quick-start" class="btn btn-primary btn-lg" target="_blank" rel="noopener">Self-hosting quick-start →</a>
+                    <a href="https://github.com/Sorcha-Platform/Sorcha/tree/master/docs" class="btn btn-outline btn-lg" target="_blank" rel="noopener">Browse the repo docs →</a>
+                    <a href="https://github.com/Sorcha-Platform/Sorcha" class="btn btn-text" target="_blank" rel="noopener">View on GitHub →</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-base">© Sorcha · Open source, MIT licensed · <a href="/" style="color:inherit">Home</a> · <a href="/developers" style="color:inherit">Developers</a> · <a href="https://github.com/Sorcha-Platform/Sorcha" style="color:inherit" target="_blank" rel="noopener">GitHub</a> · <button type="button" onclick="if(window.openConsent)window.openConsent()" style="background:none;border:none;color:inherit;cursor:pointer;font:inherit">Cookie settings</button></div>
+    </footer>
+
+    <script src="landing.js"></script>
+    <script src="consent-banner.js"></script>
+</body>
+</html>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -65,6 +65,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
@@ -358,7 +359,7 @@
             <div class="section-head" style="margin-bottom:0">
                 <div class="hero-actions" style="justify-content:center">
                     <a href="https://github.com/Sorcha-Platform/Sorcha" class="btn btn-primary" target="_blank" rel="noopener">View on GitHub →</a>
-                    <a href="/developers" class="btn btn-outline">Read the docs →</a>
+                    <a href="/docs" class="btn btn-outline">Read the docs →</a>
                     <a href="https://github.com/Sorcha-Platform/Sorcha#quick-start" class="btn btn-text" target="_blank" rel="noopener">Self-hosting guide →</a>
                 </div>
             </div>
@@ -414,7 +415,7 @@
             <div class="footer-col">
                 <h4>Developers</h4>
                 <a href="https://github.com/Sorcha-Platform/Sorcha" target="_blank" rel="noopener">GitHub</a>
-                <a href="/developers">Documentation</a>
+                <a href="/docs">Documentation</a>
                 <a href="/compare">Compare</a>
                 <a href="#open-standards">Standards</a>
                 <a href="https://github.com/Sorcha-Platform/Sorcha#quick-start" target="_blank" rel="noopener">Self-hosting</a>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -218,7 +218,7 @@
                 <div class="stage reveal"><span class="stage-label">Rehearse</span><p>Run it against sample data; nothing is committed.</p></div>
                 <div class="stage reveal"><span class="stage-label">Go live</span><p>Publish only once rehearsal passes — gated server-side, so you can't skip it.</p></div>
             </div>
-            <div class="section-head" style="margin-top:var(--space-5);margin-bottom:0">
+            <div class="section-head" style="margin-top:var(--sp-5);margin-bottom:0">
                 <a href="/designer-overview" class="btn btn-primary">See how the Designer works →</a>
             </div>
         </div>
@@ -237,12 +237,12 @@
                         only that. Whoever you show them to can check they're genuine, without phoning
                         anyone to confirm.
                     </p>
-                    <div class="hero-actions" style="margin-top:var(--space-4)">
+                    <div class="hero-actions" style="margin-top:var(--sp-4)">
                         <a href="/wallet/" class="btn btn-primary">Open the Wallet →</a>
                         <a href="/app/get" class="btn btn-outline">Install on your phone</a>
                     </div>
                 </div>
-                <ul style="list-style:none;display:flex;flex-direction:column;gap:var(--space-3)">
+                <ul style="list-style:none;display:flex;flex-direction:column;gap:var(--sp-3)">
                     <li class="card reveal"><h3 style="font-size:1.1rem">Hold credentials offline</h3><p>On your device, not a server you have to trust.</p></li>
                     <li class="card reveal"><h3 style="font-size:1.1rem">Present only what's requested</h3><p>Selective disclosure by design — show one field, keep the rest private.</p></li>
                     <li class="card reveal"><h3 style="font-size:1.1rem">Built on open standards</h3><p>OpenID4VP and SD-JWT VC — not a walled garden.</p></li>
@@ -329,7 +329,7 @@
                     <p>A buyer's wallet signature on an invoice is the trust anchor for a lender — no intermediary needs to vouch for the data, and no blockchain token is required.</p>
                 </div>
             </div>
-            <div class="section-head" style="margin-top:var(--space-5);margin-bottom:0">
+            <div class="section-head" style="margin-top:var(--sp-5);margin-bottom:0">
                 <a href="/solutions" class="btn btn-outline">Explore solutions →</a>
             </div>
         </div>
@@ -347,7 +347,7 @@
                     10,000 tests. Read it, run it, build on it.
                 </p>
             </div>
-            <div class="chips" style="margin-bottom:var(--space-5)">
+            <div class="chips" style="margin-bottom:var(--sp-5)">
                 <span class="chip mono">.NET 10</span>
                 <span class="chip mono">.NET Aspire</span>
                 <span class="chip mono">MIT</span>
@@ -377,7 +377,7 @@
                 proof-based infrastructure for a regulated, multi-party workflow, this is the point to
                 start a conversation.
             </p>
-            <div class="hero-actions" style="justify-content:center;margin-top:var(--space-4)">
+            <div class="hero-actions" style="justify-content:center;margin-top:var(--sp-4)">
                 <a href="/contact" class="btn btn-primary">Start evaluating →</a>
                 <a href="https://github.com/Sorcha-Platform/Sorcha/blob/master/docs/reference/development-status.md" class="btn btn-text" target="_blank" rel="noopener">Read the development status →</a>
             </div>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/solutions.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/solutions.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/wallet-info.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/wallet-info.html
@@ -39,6 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
+                <a href="/docs" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Cards.razor.css
@@ -78,7 +78,7 @@
     font-size: 14px;
     font-weight: 700;
     color: #fff;
-    background: var(--sorcha-gradient, linear-gradient(135deg, #667eea 0%, #764ba2 100%));
+    background: var(--sorcha-gradient, linear-gradient(135deg, #4F46E5 0%, #818CF8 100%));
 }
 
 .cards-add-tile {

--- a/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
+++ b/src/Apps/Sorcha.Wallet.Pwa/Pages/Index.razor
@@ -576,8 +576,8 @@
         }
     }
 
-    // Card accent — brand blue today; later, pull from issuer registry / theme.
-    private static string AccentFor(CachedCredential c) => "#667eea";
+    // Card accent — brand indigo today; later, pull from issuer registry / theme.
+    private static string AccentFor(CachedCredential c) => "#4F46E5";
 
     // The bottom meta line. The card name already carries the (humanized) type
     // and the eyebrow the issuer, so a real credential needs no meta — only the

--- a/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
+++ b/src/Apps/Sorcha.Wallet.Pwa/wwwroot/css/app.css
@@ -9,7 +9,7 @@
    in its var() usage so it renders correctly even when hosted somewhere that
    does not define these (e.g. the /app web host render-sanity path, FR-025). */
 :root {
-    --sorcha-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    --sorcha-gradient: linear-gradient(135deg, #4F46E5 0%, #818CF8 100%);
     --sorcha-accent: #48bb78;
     --sorcha-warn: #d69e2e;
 }

--- a/src/Services/Sorcha.ApiGateway/Program.cs
+++ b/src/Services/Sorcha.ApiGateway/Program.cs
@@ -339,6 +339,13 @@ app.MapGet("/gateway", async (HealthAggregationService healthService, DashboardS
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sorcha API Gateway Status</title>
     <style>
+        :root {
+            /* Production brand palette (matches docs/design-system + SorchaMudTheme) */
+            --brand-indigo: #4F46E5;
+            --brand-violet: #818CF8;
+            --brand-gradient: linear-gradient(135deg, #4F46E5 0%, #818CF8 100%);
+            --success: #047857;
+        }
         * {
             margin: 0;
             padding: 0;
@@ -346,7 +353,7 @@ app.MapGet("/gateway", async (HealthAggregationService healthService, DashboardS
         }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--brand-gradient);
             min-height: 100vh;
             display: flex;
             align-items: center;
@@ -362,7 +369,7 @@ app.MapGet("/gateway", async (HealthAggregationService healthService, DashboardS
             overflow: hidden;
         }
         .header {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--brand-gradient);
             color: white;
             padding: 40px;
             text-align: center;
@@ -388,10 +395,10 @@ app.MapGet("/gateway", async (HealthAggregationService healthService, DashboardS
             background: #f8f9fa;
             padding: 24px;
             border-radius: 12px;
-            border-left: 4px solid #667eea;
+            border-left: 4px solid var(--brand-indigo);
         }
         .stat-card h3 {
-            color: #667eea;
+            color: var(--brand-indigo);
             font-size: 0.875rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
@@ -424,7 +431,7 @@ app.MapGet("/gateway", async (HealthAggregationService healthService, DashboardS
             border-left: 4px solid #e2e8f0;
         }
         .service-item.healthy {
-            border-left-color: #48bb78;
+            border-left-color: var(--success);
         }
         .service-item.unhealthy {
             border-left-color: #f56565;
@@ -463,20 +470,20 @@ app.MapGet("/gateway", async (HealthAggregationService healthService, DashboardS
             transition: all 0.2s;
         }
         .btn-primary {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--brand-gradient);
             color: white;
         }
         .btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 10px 20px rgba(102, 126, 234, 0.4);
+            box-shadow: 0 10px 20px rgba(79, 70, 229, 0.4);
         }
         .btn-secondary {
             background: white;
-            color: #667eea;
-            border: 2px solid #667eea;
+            color: var(--brand-indigo);
+            border: 2px solid var(--brand-indigo);
         }
         .btn-secondary:hover {
-            background: #667eea;
+            background: var(--brand-indigo);
             color: white;
         }
         .footer {

--- a/src/Services/Sorcha.Tenant.Service/wwwroot/css/auth.css
+++ b/src/Services/Sorcha.Tenant.Service/wwwroot/css/auth.css
@@ -1,8 +1,8 @@
 /* Auth page styles — cloned from Sorcha.UI Blazor components */
 
 :root {
-    --primary-color: #667eea;
-    --secondary-color: #764ba2;
+    --primary-color: #4F46E5;
+    --secondary-color: #818CF8;
     --btn-primary: #1b6ec2;
     --btn-primary-hover: #1861ac;
     --bg-color: #f8f9fa;


### PR DESCRIPTION
## Various web updates

A batch of marketing-site + shared-UI polish on `feature/various-web-updates`. Five focused commits.

### New: `/docs` introduction page
A calm, structured scene-setter that explains Sorcha's methods, systems and design before a reader heads into the API reference or self-hosting guide. New `wwwroot/docs.html` (route `/docs`), following the `developers.html` / `solutions.html` pattern exactly — same head block, nav, footer; canonical/OG → `https://www.sorcha.dev/docs`.

Sections: **What Sorcha is** · **The core idea** (mirrors the landing's Sign → Record → Disclose → Verify model) · **Key concepts** (Blueprint, Register, Wallet, Participant/Peer, Credential, Presentation, Disclosure, `did:sorcha`) · **The system at a glance** (the eight services) · **Standards and cryptography** · **Design principles** · **Where to go next** (router doors + actions).

- Reuses only existing `landing.css` classes — **no new CSS**.
- Added **Docs** to the primary nav across all marketing pages; repointed the landing's "Read the docs" CTA + footer "Documentation" at `/docs`.
- Registered `docs.html` in `scripts/copy-landing-to-site.js`; regenerated `docs/site`.
- Every technical claim sourced from `developers.html`, `solutions.html`, the landing, `CLAUDE.md`, and the `sorcha-architecture` skill.

### Palette cleanup — retire residual legacy indigo/violet
The visual-system overhaul updated component bases to the new palette (`#4F46E5` / `#818CF8`) but left several tints, shadows and surfaces on the old `#667eea`/`#764ba2` / `rgba(102,126,234)` values. Fixed across:
- **Wallet + PWA** — `BigActionButton` shadow tints, `FloatingTabBar` active pill, `InboxPanel` unread row, `Blueprints` highlight keyframe, PWA `--sorcha-gradient` + `Cards` fallback + `Index.AccentFor`. (Semantic green/amber tokens left untouched.)
- **Tenant auth pages** (`auth.css`) — server-rendered `/auth/login` + `/auth/signup` were entirely on the old palette; two-variable fix re-skins the whole surface.
- **`/gateway` ops status page** — moved the embedded HTML page onto a `:root` token block; legacy green `#48bb78` → design-system success `#047857`. Build verified 0/0.

### Fix: latent `var(--space-N)` spacing typo
`landing.css` defines the spacing scale as `--sp-1..--sp-9`; several inline styles referenced a non-existent `--space-N`, so those margins were silently dropped. Replaced every `var(--space-N)` with the real `var(--sp-N)` across `index.html` (6), `developers.html` (2), `compare.html` (2), `designer-overview.html` (2).

### Verification
- **Dark-mode QA** of `/app` on n1 (live): theme resolves correctly to the new palette in light + dark across dashboard, settings, transactions, new-submissions — zero light-assuming surfaces.
- **`/docs` rendered** in light + dark via local preview — one `h1`, semantic `region` landmarks, skip-link, `lang="en"`.
- **Spacing-fix pages** re-checked in-browser — improved spacing, no regression.

### Notes
- Server-rendered fixes (`auth.css`, `/gateway`) need a tenant-service / api-gateway deploy to show on n1. `gh-pages.yml` already globs `wwwroot/*.html`, so `/docs` deploys to www automatically.
- n1's `wallet-pwa` image is currently stale (pre-theme); a re-pull there is tracked separately, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
