### PR TITLE
fix(www): marketing nav/login/docs links, opaque deck panels + gateway CSP for marketing pages

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -133,6 +133,6 @@ A complete walkthrough transcript with input/output payloads will be added to `w
 - **`/.well-known/mcp.json`** — live machine-readable manifest.
 - **`/api/mcp/tools`** — flat catalogue with one entry per tool (name, category, short description). The full per-tool description (≥ 2 sentences with disambiguation per FR-017) lives on the running MCP server and is returned by the standard MCP `list_tools` request.
 - **`STANDARDS.md`** — the standards posture every tool indirectly relies on (BIP32/39/44 wallet keys, ML-DSA signatures, OpenID4VC issuance, etc.).
-- **`docs/architecture.md`** *(forthcoming, Phase 8)* — full system architecture.
-- **`docs/quickstart.md`** *(forthcoming, Phase 7)* — agent-runnable setup.
+- **[Architecture overview](./architecture.md)** — full system architecture.
+- **[Quickstart](./quickstart.md)** — agent-runnable setup.
 - **`walkthroughs/TradeFinance/`** and **`walkthroughs/AssuredIdentity/`** — runnable end-to-end demonstrations of the patterns the MCP tools drive.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,7 +94,7 @@ curl -s http://localhost/llms.txt
 
 - **Agent integration.** Read `docs/mcp-server.md` for the MCP connection guide. The 36 tools across admin / designer / participant slices are how an AI agent drives the platform.
 - **Walkthroughs.** `walkthroughs/TradeFinance/run.ps1` and `walkthroughs/AssuredIdentity/run-agents.ps1` are runnable end-to-end demonstrations of the cryptographic-proof workflows the platform is designed for.
-- **Deeper reading.** `STANDARDS.md` for the standards posture, `docs/architecture.md` (Phase 8 of spec 117) for the system architecture, `llms.txt` for the LLM-led entry point.
+- **Deeper reading.** `STANDARDS.md` for the standards posture, [the architecture overview](./architecture.md) for the system architecture, `llms.txt` for the LLM-led entry point.
 
 ## Reporting setup-script issues
 

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
@@ -39,7 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/compare.html
@@ -45,6 +45,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/contact.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/contact.html
@@ -39,7 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/contact.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/contact.html
@@ -45,6 +45,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
@@ -39,7 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/designer-overview.html
@@ -45,6 +45,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
@@ -55,7 +55,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/developers.html
@@ -61,6 +61,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/docs.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/docs.html
@@ -39,7 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link" aria-current="page">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/docs.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/docs.html
@@ -45,6 +45,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -74,6 +74,7 @@
                 <a href="https://github.com/Sorcha-Platform/Sorcha" class="nav-icon" target="_blank" rel="noopener" aria-label="Sorcha on GitHub — MIT licensed, open source" title="Sorcha on GitHub — MIT licensed, open source">
                     <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
                 </a>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks">

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/index.html
@@ -65,7 +65,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
@@ -199,7 +199,7 @@
             </div>
             <div class="panel-foot">
                 <div class="foot-actions">
-                    <a href="/docs" class="btn btn-primary btn-lg">Read the technical architecture →</a>
+                    <a href="https://docs.sorcha.dev" class="btn btn-primary btn-lg">Read the technical architecture →</a>
                 </div>
                 <span class="leads-to"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3h6a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1h-6"/><path d="M3 12h12"/><path d="m11 8 4 4-4 4"/></svg>Opens <code>sorcha.dev/docs</code></span>
             </div>
@@ -401,7 +401,7 @@
             <div class="panel-foot">
                 <div class="foot-actions">
                     <a href="https://github.com/Sorcha-Platform/Sorcha" class="btn btn-primary btn-lg" target="_blank" rel="noopener">View on GitHub →</a>
-                    <a href="/docs" class="btn btn-outline">Read the docs →</a>
+                    <a href="https://docs.sorcha.dev" class="btn btn-outline">Read the docs →</a>
                     <a href="https://github.com/Sorcha-Platform/Sorcha#quick-start" class="btn btn-text" target="_blank" rel="noopener">Self-hosting guide →</a>
                 </div>
                 <span class="leads-to"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3h6a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1h-6"/><path d="M3 12h12"/><path d="m11 8 4 4-4 4"/></svg>Opens <code>github.com/Sorcha-Platform/Sorcha</code></span>
@@ -462,7 +462,7 @@
             <div class="footer-col">
                 <h4>Developers</h4>
                 <a href="https://github.com/Sorcha-Platform/Sorcha" target="_blank" rel="noopener">GitHub</a>
-                <a href="/docs">Documentation</a>
+                <a href="https://docs.sorcha.dev">Documentation</a>
                 <a href="/compare">Compare</a>
                 <a href="#open-standards">Standards</a>
                 <a href="https://github.com/Sorcha-Platform/Sorcha#quick-start" target="_blank" rel="noopener">Self-hosting</a>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/landing.css
@@ -170,7 +170,7 @@ h5 { font-size: 18px; font-weight: 600; line-height: 1.4; }
 .btn[disabled], .btn[aria-disabled="true"] { opacity: .45; pointer-events: none; box-shadow: none; }
 
 /* ===========================  SECTION SHELLS  ============================ */
-.section { padding: var(--sp-9) 28px; border-top: 1px solid var(--border); }
+.section { padding: var(--sp-9) 28px; border-top: 1px solid var(--border); background: var(--bg); }
 .section-alt { background: var(--surface-alt); }
 .section-head { max-width: 760px; margin: 0 auto var(--sp-7); text-align: center; }
 .section-eyebrow {

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/solutions.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/solutions.html
@@ -39,7 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/solutions.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/solutions.html
@@ -45,6 +45,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/wallet-info.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/wallet-info.html
@@ -39,7 +39,7 @@
                 <a href="/designer-overview" class="nav-link">For organisations</a>
                 <a href="/wallet-info" class="nav-link">For citizens</a>
                 <a href="/developers" class="nav-link">Developers</a>
-                <a href="/docs" class="nav-link">Docs</a>
+                <a href="https://docs.sorcha.dev" class="nav-link">Docs</a>
                 <a href="/#open-standards" class="nav-link">Standards</a>
                 <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle light or dark theme" title="Toggle light or dark theme">
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>

--- a/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/wallet-info.html
+++ b/src/Apps/Sorcha.UI/Sorcha.UI.Web/wwwroot/wallet-info.html
@@ -45,6 +45,7 @@
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
+                <a href="https://n1.sorcha.dev/app" class="btn btn-outline">Login</a>
                 <a href="/wallet/" class="btn btn-primary">Open Wallet</a>
             </div>
             <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="navLinks"><span></span><span></span><span></span></button>

--- a/src/Common/Sorcha.ServiceDefaults/Extensions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/Extensions.cs
@@ -305,6 +305,20 @@ public static class Extensions
                 path.StartsWith("/favicon", StringComparison.OrdinalIgnoreCase) ||
                 path.StartsWith("/icon-", StringComparison.OrdinalIgnoreCase) ||
                 path.EndsWith(".css", StringComparison.OrdinalIgnoreCase) ||
+                // Static marketing pages served by ui-web at clean extensionless
+                // URLs (Sorcha.UI.Web `marketingPages`) plus the /docs landing.
+                // These are HTML that load landing.css/landing.js + GA, so they
+                // need the relaxed UI CSP, not the API default. (/wallet-info and
+                // /designer-overview also match the /wallet and /design prefixes
+                // above, but are listed here so the marketing set is explicit and
+                // not dependent on that overlap.)
+                path.Equals("/developers", StringComparison.OrdinalIgnoreCase) ||
+                path.Equals("/solutions", StringComparison.OrdinalIgnoreCase) ||
+                path.Equals("/compare", StringComparison.OrdinalIgnoreCase) ||
+                path.Equals("/contact", StringComparison.OrdinalIgnoreCase) ||
+                path.Equals("/docs", StringComparison.OrdinalIgnoreCase) ||
+                path.Equals("/wallet-info", StringComparison.OrdinalIgnoreCase) ||
+                path.Equals("/designer-overview", StringComparison.OrdinalIgnoreCase) ||
                 path.Equals("/", StringComparison.OrdinalIgnoreCase))
             {
                 // UI apps (Blazor WASM, Scalar) require scripts and styles to function


### PR DESCRIPTION
Batch of small marketing-site fixes.

## Changes
- **Opaque deck panels** (`landing.css`) — plain `.section` panels had no background, so stacked deck panels were transparent and the pinned section showed through. Added `background: var(--bg)`; `.section-alt`/`.section-ink` still override.
- **Login button** in the nav of all 8 marketing pages — outline `btn`, before "Open Wallet", linking to the absolute `https://n1.sorcha.dev/app` (the app isn't hosted on www; absolute URL also works same-origin from n1).
- **Docs links → `https://docs.sorcha.dev`** — repointed all 11 `/docs` links (nav, footer, body CTAs) across the pages; docs are hosted at docs.sorcha.dev, not served at `/docs` on www. Dropped the now-stale `aria-current` on docs.html's nav link.
- **Docs link cleanup** (`mcp-server.md`, `quickstart.md`) — replaced "forthcoming" placeholders with real links to existing `architecture.md`/`quickstart.md`.
- **Gateway CSP fix** (`Sorcha.ServiceDefaults/Extensions.cs`) — `UseApiSecurityHeaders` served `/developers`, `/solutions`, `/compare`, `/contact`, `/docs` with the strict `default-src 'none'` CSP (they matched no allowlist prefix), blocking all CSS/JS/images/fonts/GA → pages rendered broken. Added the marketing routes to the relaxed-UI-CSP allowlist. Verified live on n1 that these paths returned the strict CSP while `/` and `/wallet-info` returned the UI CSP.

## Deploy note
The CSP fix is server-side and needs an **api-gateway** rebuild+redeploy; the static changes need **ui-web**. Both ship via Docker Publish on merge; n1 will be updated after.

## Verification
ServiceDefaults builds clean (0/0). Static changes verified by grep across all 8 pages. CSP root cause confirmed by live header inspection on n1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)