### PR TITLE
fix(validator): governance-blueprint publish misclassified as governance op (#917)

### DIFF
--- a/src/Services/Sorcha.Validator.Service/Services/RightsEnforcementService.cs
+++ b/src/Services/Sorcha.Validator.Service/Services/RightsEnforcementService.cs
@@ -188,6 +188,19 @@ public class RightsEnforcementService : IRightsEnforcementService
     /// </summary>
     private static bool IsGovernanceTransaction(Transaction transaction)
     {
+        // A blueprint PUBLISH (transactionType "BlueprintPublish") is a system seed, never a
+        // governance roster-operation — even when the blueprint being published IS
+        // register-governance-v1. Genuine governance operations carry transactionType
+        // "GovernanceOperation" with a ControlTransactionPayload, not a blueprint body, and
+        // an empty BlueprintId. Without this guard the one-time bootstrap publish of the
+        // governance blueprint matches the GovernanceBlueprintId check below and is rejected
+        // VAL_PERM_002 (the system blueprint-publish key is not a roster member), silently
+        // dropping register-governance-v1 from the system register. (#917 — real root cause;
+        // the prior seal-wait fix targeted a stale-head fork that was never the actual cause.)
+        if (transaction.Metadata.TryGetValue("transactionType", out var seedType) &&
+            string.Equals(seedType, "BlueprintPublish", StringComparison.OrdinalIgnoreCase))
+            return false;
+
         // Check if the blueprint ID matches the governance blueprint
         if (string.Equals(transaction.BlueprintId, GovernanceBlueprintId, StringComparison.OrdinalIgnoreCase))
             return true;

--- a/tests/Sorcha.Validator.Service.Tests/Services/RightsEnforcementServiceTests.cs
+++ b/tests/Sorcha.Validator.Service.Tests/Services/RightsEnforcementServiceTests.cs
@@ -232,6 +232,54 @@ public class RightsEnforcementServiceTests
         result.Errors.Should().Contain(e => e.Message.Contains("Auditor"));
     }
 
+    // --- Governance BLUEPRINT publish is NOT a governance operation (#917) ---
+
+    [Fact]
+    public async Task ValidateGovernanceRightsAsync_GovernanceBlueprintPublish_NotTreatedAsGovernanceOp()
+    {
+        // The one-time bootstrap publish of the register-governance-v1 *blueprint* carries
+        // BlueprintId == register-governance-v1, but it is a system seed (transactionType
+        // "BlueprintPublish"), signed by the system blueprint-publish key which is NOT a roster
+        // member. It must NOT be misclassified as a governance roster-operation and rejected
+        // VAL_PERM_002 — that drops the governance blueprint from the system register at bootstrap.
+        var roster = CreateRoster(
+            (OwnerPublicKey, RegisterRole.Owner, "did:sorcha:w:owner1"));
+        _rosterServiceMock
+            .Setup(r => r.GetCurrentRosterAsync("test-register", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(roster);
+
+        var payloadElement = JsonSerializer.Deserialize<JsonElement>("{\"title\":\"Register Governance\"}");
+        var tx = new Transaction
+        {
+            TransactionId = Guid.NewGuid().ToString(),
+            RegisterId = "test-register",
+            BlueprintId = RightsEnforcementService.GovernanceBlueprintId,
+            ActionId = "blueprint-publish",
+            Payload = payloadElement,
+            PayloadHash = "hash",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Signatures =
+            [
+                new Signature
+                {
+                    PublicKey = UnknownPublicKey, // system blueprint-publish key — not a roster member
+                    SignatureValue = new byte[64],
+                    Algorithm = "ED25519",
+                    SignedAt = DateTimeOffset.UtcNow
+                }
+            ],
+            Metadata = new Dictionary<string, string> { ["transactionType"] = "BlueprintPublish" }
+        };
+
+        var result = await _service.ValidateGovernanceRightsAsync(tx);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().NotContain(e => e.Code == "VAL_PERM_002");
+        _rosterServiceMock.Verify(
+            r => r.GetCurrentRosterAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // --- Metadata-based Control detection ---
 
     [Fact]


### PR DESCRIPTION
## Root cause of #917 (reproduced live on a fresh n1 genesis)

A fresh Auto bootstrap left the system register with **3 of 4** governance blueprints — `register-governance-v1` missing — making every SyncOnly replica incomplete too.

`RightsEnforcementService.IsGovernanceTransaction` treats **any** tx with `BlueprintId == "register-governance-v1"` as a governance roster-operation. But the one-time bootstrap **publish of the `register-governance-v1` blueprint** carries exactly that `BlueprintId`, so it was routed through `ValidateGovernanceRightsAsync`, which requires the submitter (the system *blueprint-publish* key) to be a member of the genesis admin roster — it isn't → **`VAL_PERM_002`**. The other three seed blueprints don't match the id, skip enforcement, and seal; governance is silently dropped.

**This is not the stale-head fork the prior #961 fix assumed** — the tx is *rejected*, not forked, so the seal-wait could never help. Verified live on n1: governance rejected on the initial bootstrap **and** again on a register-service restart-retry (same `VAL_PERM_002`, new txId) → deterministic.

## Fix
`IsGovernanceTransaction` returns `false` for blueprint publishes (`transactionType == "BlueprintPublish"`). Genuine governance operations carry `transactionType == "GovernanceOperation"` + empty `BlueprintId` (register-service `Program.cs:2345`) and are unaffected.

## Test (failing-first)
Added `ValidateGovernanceRightsAsync_GovernanceBlueprintPublish_NotTreatedAsGovernanceOp`: a `register-governance-v1` blueprint publish signed by a non-roster key must pass (not `VAL_PERM_002`) and must not even query the roster. RED before the fix, GREEN after. Validator suite **987/987**.

## Follow-up (separate, not in this PR)
`SystemRegisterBootstrapper.WaitForBlueprintSealedAsync` treats a seal-timeout as a soft warning and proceeds, so a rejected seed is silently lost and bootstrap reports "completed" — should retry / fail-loud so a half-seeded SSR can't pass as success.

Found while testing a clean stack from a fresh genesis on n1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)