### PR TITLE
fix(register): [#917] fail bootstrap loud when a seed blueprint never seals

### DIFF
--- a/src/Common/Sorcha.ServiceDefaults/SystemRegisterOptions.cs
+++ b/src/Common/Sorcha.ServiceDefaults/SystemRegisterOptions.cs
@@ -61,4 +61,20 @@ public class SystemRegisterOptions
     /// Interval in seconds between retries during the backoff-polling phase (SyncOnly mode).
     /// </summary>
     public int BackoffIntervalSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Timeout in seconds to wait for a seed blueprint publish to seal into the system
+    /// register before the publish is considered failed (Auto / GenesisFile modes).
+    /// Each seed must seal before the next is published so the chain head stays fresh
+    /// (issue #917).
+    /// </summary>
+    public int BlueprintSealTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Number of times the bootstrapper re-publishes a seed blueprint that fails to seal
+    /// within <see cref="BlueprintSealTimeoutSeconds"/> before failing the bootstrap loudly.
+    /// A half-seeded system register is a correctness bug, not a degraded mode — bootstrap
+    /// must not report success when a seed never sealed (issue #917 resilience follow-up).
+    /// </summary>
+    public int BlueprintSeedMaxPublishAttempts { get; set; } = 3;
 }

--- a/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
+++ b/src/Services/Sorcha.Register.Service/Services/SystemRegisterBootstrapper.cs
@@ -26,8 +26,10 @@ public class SystemRegisterBootstrapper : BackgroundService
     private static readonly TimeSpan GenesisTimeout = TimeSpan.FromSeconds(30);
 
     // #917: each seed blueprint must be sealed before the next is published, so the
-    // chain head is fresh when the next publish reads it. Mirrors GenesisTimeout.
-    private static readonly TimeSpan BlueprintSealTimeout = TimeSpan.FromSeconds(30);
+    // chain head is fresh when the next publish reads it. Timeout + retry attempts are
+    // configurable via SystemRegisterOptions (mirror GenesisTimeout by default).
+    private TimeSpan BlueprintSealTimeout => TimeSpan.FromSeconds(_options.BlueprintSealTimeoutSeconds);
+    private int BlueprintSeedMaxPublishAttempts => Math.Max(1, _options.BlueprintSeedMaxPublishAttempts);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SystemRegisterBootstrapper"/> class.
@@ -485,14 +487,7 @@ public class SystemRegisterBootstrapper : BackgroundService
                 continue;
             }
 
-            _logger.LogInformation("Seeding blueprint: {BlueprintId}", blueprintId);
             var blueprint = LoadBlueprintFromCatalog(blueprintId);
-            await systemRegisterService.PublishBlueprintAsync(
-                blueprintId,
-                blueprint,
-                "system",
-                new Dictionary<string, string> { ["seedReason"] = "bootstrap" },
-                cancellationToken);
 
             // #917: wait for this publish to SEAL before submitting the next. Blueprint
             // publishes chain via previousTxId = the latest *sealed* transaction
@@ -502,8 +497,47 @@ public class SystemRegisterBootstrapper : BackgroundService
             // two txs claimed the same predecessor; the validator can only seal one linear
             // successor and silently dropped the forked sibling, leaving the owner SSR
             // missing register-governance-v1. Sealing each seed first keeps the head fresh.
-            await WaitForBlueprintSealedAsync(systemRegisterService, blueprintId, cancellationToken);
-            _logger.LogInformation("Blueprint {BlueprintId} seeded and sealed", blueprintId);
+            //
+            // #917 resilience follow-up: a seal timeout is NOT a soft warning. A seed that
+            // never seals leaves a half-built system register; swallowing it let bootstrap
+            // report "completed" over a broken SSR. Re-publish up to the attempt cap, then
+            // fail loud so the failure surfaces (and, in Auto mode, feeds the outer retry).
+            var sealed_ = false;
+            for (int attempt = 1; attempt <= BlueprintSeedMaxPublishAttempts; attempt++)
+            {
+                _logger.LogInformation(
+                    "Seeding blueprint: {BlueprintId} (attempt {Attempt}/{MaxAttempts})",
+                    blueprintId, attempt, BlueprintSeedMaxPublishAttempts);
+
+                await systemRegisterService.PublishBlueprintAsync(
+                    blueprintId,
+                    blueprint,
+                    "system",
+                    new Dictionary<string, string> { ["seedReason"] = "bootstrap" },
+                    cancellationToken);
+
+                if (await WaitForBlueprintSealedAsync(systemRegisterService, blueprintId, cancellationToken))
+                {
+                    sealed_ = true;
+                    _logger.LogInformation("Blueprint {BlueprintId} seeded and sealed", blueprintId);
+                    break;
+                }
+
+                _logger.LogWarning(
+                    "Seed blueprint {BlueprintId} did not seal within {Timeout}s on attempt " +
+                    "{Attempt}/{MaxAttempts}.",
+                    blueprintId, BlueprintSealTimeout.TotalSeconds, attempt, BlueprintSeedMaxPublishAttempts);
+            }
+
+            if (!sealed_)
+            {
+                throw new InvalidOperationException(
+                    $"Seed blueprint '{blueprintId}' failed to seal after " +
+                    $"{BlueprintSeedMaxPublishAttempts} publish attempt(s) " +
+                    $"({BlueprintSealTimeout.TotalSeconds}s each). The system register would be " +
+                    "left incomplete; aborting bootstrap rather than reporting a half-seeded register " +
+                    "as successful (issue #917).");
+            }
         }
     }
 
@@ -513,7 +547,11 @@ public class SystemRegisterBootstrapper : BackgroundService
     /// timeout elapses. Keeps the chain head fresh between sequential seed publishes
     /// so they cannot fork on a stale predecessor (issue #917).
     /// </summary>
-    private async Task WaitForBlueprintSealedAsync(
+    /// <returns>
+    /// <c>true</c> if the blueprint sealed before the timeout; <c>false</c> if it timed out.
+    /// The caller decides how to react (retry / fail-loud) — a timeout is never swallowed here.
+    /// </returns>
+    private async Task<bool> WaitForBlueprintSealedAsync(
         SystemRegisterService systemRegisterService,
         string blueprintId,
         CancellationToken cancellationToken)
@@ -526,17 +564,13 @@ public class SystemRegisterBootstrapper : BackgroundService
 
             if (await systemRegisterService.BlueprintExistsAsync(blueprintId, cancellationToken))
             {
-                return;
+                return true;
             }
 
             await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
         }
 
-        _logger.LogWarning(
-            "Timed out after {Timeout}s waiting for seed blueprint {BlueprintId} to seal. " +
-            "Subsequent seeds may chain off a stale head and be dropped by the validator, " +
-            "leaving the system register incomplete.",
-            BlueprintSealTimeout.TotalSeconds, blueprintId);
+        return false;
     }
 
     /// <summary>

--- a/tests/Sorcha.Register.Service.Tests/Services/SystemRegisterBootstrapperTests.cs
+++ b/tests/Sorcha.Register.Service.Tests/Services/SystemRegisterBootstrapperTests.cs
@@ -68,7 +68,9 @@ public class SystemRegisterBootstrapperTests
 
     private SystemRegisterBootstrapper CreateBootstrapper(
         SystemRegisterOptions options,
-        ILogger<SystemRegisterBootstrapper>? logger = null)
+        ILogger<SystemRegisterBootstrapper>? logger = null,
+        ISystemWalletSigningService? signingService = null,
+        IHashProvider? hashProvider = null)
     {
         var registerManager = new RegisterManager(_mockRepository.Object, _mockEventPublisher.Object);
         var transactionManager = new TransactionManager(_mockRepository.Object, _mockEventPublisher.Object);
@@ -78,8 +80,8 @@ public class SystemRegisterBootstrapperTests
             registerManager,
             transactionManager,
             _validatorClient.Object,
-            new Mock<ISystemWalletSigningService>().Object,
-            new Mock<IHashProvider>().Object);
+            signingService ?? new Mock<ISystemWalletSigningService>().Object,
+            hashProvider ?? new Mock<IHashProvider>().Object);
 
         var genesisOptions = Options.Create(new SystemRegisterOptions { GenesisFile = options.GenesisFile });
         var genesisIngestion = new GenesisIngestionService(
@@ -504,6 +506,118 @@ public class SystemRegisterBootstrapperTests
                 It.IsAny<Exception?>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    // ========================================================================
+    // #917 resilience: seed-blueprint seal must fail loud, not be swallowed
+    // ========================================================================
+
+    [Fact]
+    public async Task GenesisFile_SeedBlueprintNeverSeals_RetriesThenFailsLoud()
+    {
+        // Arrange: register exists (skip ingestion) so bootstrap proceeds to seeding.
+        _mockRepository
+            .Setup(r => r.GetRegisterAsync(SystemRegisterConstants.SystemRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Sorcha.Register.Models.Register
+            {
+                Id = SystemRegisterConstants.SystemRegisterId,
+                Name = SystemRegisterConstants.SystemRegisterName,
+                Height = 1
+            });
+
+        // No transactions on the register => every seed blueprint is "missing" AND no
+        // publish ever appears as sealed (BlueprintExistsAsync stays false). This is the
+        // half-seeded SSR the swallow bug used to report as success.
+        _mockRepository
+            .Setup(r => r.GetTransactionsAsync(SystemRegisterConstants.SystemRegisterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Sorcha.Register.Models.TransactionModel>().AsQueryable());
+
+        // Make a seed template discoverable so LoadBlueprintFromCatalog succeeds and the
+        // publish path is actually exercised (the bug is post-publish, in the seal wait).
+        WriteSeedTemplate("register-creation-v1");
+
+        // Publish must SUCCEED so we isolate the seal-wait swallow (not a publish failure,
+        // which already propagated before this fix).
+        _validatorClient
+            .Setup(v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TransactionSubmissionResult
+            {
+                Success = true,
+                TransactionId = "seed-tx",
+                RegisterId = SystemRegisterConstants.SystemRegisterId
+            });
+
+        var signing = new Mock<ISystemWalletSigningService>();
+        signing
+            .Setup(s => s.SignAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SystemSignResult
+            {
+                Signature = new byte[64],
+                PublicKey = new byte[32],
+                Algorithm = "ED25519",
+                WalletAddress = "sys-wallet"
+            });
+
+        var hash = new Mock<IHashProvider>();
+        hash
+            .Setup(h => h.ComputeHash(It.IsAny<byte[]>(), It.IsAny<Sorcha.Cryptography.Enums.HashType>()))
+            .Returns(new byte[32]);
+
+        var logger = new Mock<ILogger<SystemRegisterBootstrapper>>();
+        var bootstrapper = CreateBootstrapper(
+            new SystemRegisterOptions
+            {
+                BootstrapMode = BootstrapMode.GenesisFile,
+                BlueprintSealTimeoutSeconds = 1,
+                BlueprintSeedMaxPublishAttempts = 2
+            },
+            logger.Object,
+            signing.Object,
+            hash.Object);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // Act
+        await RunBootstrapperAsync(bootstrapper, cts.Token);
+
+        // Assert: the unsealed seed was re-published up to the attempt cap (retry happened).
+        _validatorClient.Verify(
+            v => v.SubmitTransactionAsync(It.IsAny<TransactionSubmission>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "the unsealed seed should be re-published BlueprintSeedMaxPublishAttempts times");
+
+        // Assert: bootstrap FAILED LOUD — an error/critical was logged...
+        logger.Verify(
+            l => l.Log(
+                It.IsIn(LogLevel.Critical, LogLevel.Error),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+
+        // ...and it did NOT falsely report success.
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("bootstrap completed")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never,
+            "a half-seeded system register must not be reported as a completed bootstrap");
+    }
+
+    private static void WriteSeedTemplate(string blueprintId)
+    {
+        // LoadBlueprintFromCatalog probes AppContext.BaseDirectory/blueprints/templates first.
+        var dir = Path.Combine(AppContext.BaseDirectory, "blueprints", "templates");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(
+            Path.Combine(dir, $"{blueprintId}.json"),
+            "{\"title\":\"seed-test\",\"participants\":[],\"actions\":[]}");
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Resilience follow-up to #917 (tracked as deferred in project memory). The system-register bootstrapper previously logged a warning and **proceeded** when a seed blueprint publish timed out waiting to seal — leaving a half-built system register while reporting bootstrap as `completed`. A half-seeded SSR is a correctness bug, not a degraded mode.

## Changes

- `WaitForBlueprintSealedAsync` now **returns `bool`** (sealed vs. timed-out) instead of swallowing the timeout with a warning. The caller decides how to react.
- `SeedBlueprintsIfMissingAsync` **re-publishes** a seed up to a configurable attempt cap, then **throws `InvalidOperationException`** so the failure surfaces loudly (and, in Auto mode, feeds the outer retry loop).
- New `SystemRegisterOptions`:
  - `BlueprintSealTimeoutSeconds` (default 30) — replaces the old hard-coded `BlueprintSealTimeout` constant
  - `BlueprintSeedMaxPublishAttempts` (default 3) — retry cap

## Tests

`Sorcha.Register.Service.Tests`: **313 passed / 0 failed / 9 skipped** locally. +120 lines of new bootstrapper coverage.

> Note: the docs-links portion implied by the branch name is intentionally **not** in this PR — scoped to the seal-faildown fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)